### PR TITLE
skill(migrate-provider): parity audit, smoke gates, format compliance, prerequisites

### DIFF
--- a/.claude/skills/migrate-provider/SKILL.md
+++ b/.claude/skills/migrate-provider/SKILL.md
@@ -104,8 +104,8 @@ guess from naming patterns.
 
 | Command type | Default format | Required codecs | K8s wrapping |
 |-------------|---------------|-----------------|--------------|
-| `list` | `text` | `table` + `wide` | json/yaml output must use `ToResource` for K8s envelope |
-| `get` | `text` | `table` (single-row) | json/yaml via `ToResource` K8s envelope |
+| `list` | `table` | `table` + `wide` | json/yaml output must use `ToResource` for K8s envelope |
+| `get` | `table` | `table` (single-row) | json/yaml via `ToResource` K8s envelope |
 | `create` | Status message | — | Return created resource in json/yaml if `-o` specified |
 | Operational / query | Varies | Per-command | Exception: may skip K8s wrapping if data is not a resource |
 
@@ -133,7 +133,7 @@ produce a structured diff. Use jq pipelines to normalize and compare:
 ```bash
 # List — compare IDs
 GCX_IDS=$(gcx --context=<ctx> {resource} list -o json | jq -r '.[].id // .[].uid' | sort)
-GCTL_IDS=$(grafanactl --context=<ctx> {resource} list -o json | jq -r '.items[].metadata.name' | sort)
+GCTL_IDS=$(grafanactl --context=<ctx> {resource} list -o json | jq -r '.[].metadata.name' | sort)
 diff <(echo "$GCX_IDS") <(echo "$GCTL_IDS")
 
 # Get — compare key fields
@@ -239,7 +239,7 @@ Phase 3: Schema + example
 
 Phase 4: Provider commands (format-compliant per design-guide.md §1.3)
 [ ] CRUD: list (table + wide codecs), get, create -f, close
-[ ] list default format is "text" (not "json")
+[ ] list default format is "table" (not "json")
 [ ] wide codec registered with additional detail columns
 [ ] json/yaml output wraps through ToResource (K8s envelope)
 [ ] Ancillary commands wired

--- a/.claude/skills/migrate-provider/commands-reference.md
+++ b/.claude/skills/migrate-provider/commands-reference.md
@@ -11,13 +11,13 @@ All provider commands must comply with the default format rules:
 
 | Command type | Default format | Required codecs | K8s wrapping for json/yaml |
 |-------------|---------------|-----------------|---------------------------|
-| `list` | `text` | `table` + `wide` | Yes — wrap via `ToResource` |
-| `get` | `text` | `table` (single-row) | Yes — wrap via `ToResource` |
+| `list` | `table` | `table` + `wide` | Yes — wrap via `ToResource` |
+| `get` | `table` | `table` (single-row) | Yes — wrap via `ToResource` |
 | `create -f` | Status message | — | Return created resource if `-o` specified |
 | `close` / operational | Status message | — | No |
 
 **Key rules:**
-- `list` and `get` **must** call `ioOpts.DefaultFormat("text")` — do NOT leave `json` as default
+- `list` and `get` **must** call `ioOpts.DefaultFormat("table")` — do NOT leave `json` as default
 - `list` and `get` **must** register both `table` and `wide` codecs via `RegisterCustomCodec`
 - `table` columns: key identifying fields (ID/UID, name/title, status)
 - `wide` columns: everything in `table` + additional detail (timestamps, labels, counts)

--- a/.claude/skills/migrate-provider/gcx-provider-recipe.md
+++ b/.claude/skills/migrate-provider/gcx-provider-recipe.md
@@ -252,7 +252,7 @@ CTX=dev  # adjust to your context
 
 # --- List: compare resource IDs ---
 GCX_IDS=$(gcx --context=$CTX {resource} list -o json | jq -r '.[].id // .[].uid' | sort)
-GCTL_IDS=$(grafanactl --context=$CTX {resource} list -o json | jq -r '.items[].metadata.name' | sort)
+GCTL_IDS=$(grafanactl --context=$CTX {resource} list -o json | jq -r '.[].metadata.name' | sort)
 echo "=== List ID diff ==="
 diff <(echo "$GCX_IDS") <(echo "$GCTL_IDS") && echo "MATCH" || echo "MISMATCH"
 
@@ -276,7 +276,7 @@ grafanactl --context=$CTX {resource} {subcommand} -o json | jq length
 
 # --- Schema + example ---
 echo "=== Schema ==="
-grafanactl --context=$CTX resources schemas -o json | jq '.[] | select(.group | test("{group}"))' | head -5
+grafanactl --context=$CTX resources schemas -o json | jq 'to_entries[] | select(.key | test("{group}")) | .value' | head -5
 echo "=== Example ==="
 grafanactl --context=$CTX resources examples {alias} | head -10
 


### PR DESCRIPTION
### What
- Add Phase 1.5 feature parity audit requiring a gcx→grafanactl command mapping table before any code is written
- Restructure Phase 5 with STOP gate language and structured jq diff template
- Add output format compliance rules in Phase 4 referencing design-guide.md §1.3
- Add Prerequisites section documenting gcx binary, context, directory, and live API requirements

### Why
- Feature parity audit prevents implementing incomplete providers and ensures gcx→grafanactl command mapping is explicit and validated before implementation
- STOP gate language clarifies blocking failure conditions vs. warnings
- Format compliance rules eliminate ambiguity about output format requirements and reference the source of truth (design-guide.md)
- Prerequisites document ensures implementers know all required tools, contexts, and API dependencies upfront

Generated with Claude Code