### PR TITLE
chore(tools): Fix macOS SDK lookup and update beads gitignore

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -21,6 +21,9 @@ push-state.json
 # Lock files (various runtime locks)
 *.lock
 
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
+
 # Local version tracking (prevents upgrade notification spam after git ops)
 .local_version
 
@@ -44,12 +47,16 @@ dolt-server.pid
 dolt-server.log
 dolt-server.lock
 dolt-server.port
+dolt-server.activity
 
 # Corrupt backup directories (created by bd doctor --fix recovery)
 *.corrupt.backup/
 
 # Backup data (auto-exported JSONL, local-only)
 backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
 
 # Legacy files (from pre-Dolt versions)
 *.db

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ test-*.yaml
 # Dolt database files (added by bd init)
 .dolt/
 *.db
+
+# Beads / Dolt files (added by bd init)
+.beads-credential-key

--- a/devbox.json
+++ b/devbox.json
@@ -10,7 +10,7 @@
     "init_hook": [
       "echo 'Entering Python venv' && . $VENV_DIR/bin/activate",
       "echo 'Installing dependencies...' && make deps",
-      "[ \"$(uname)\" = Darwin ] && for sdk in /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk; do [ -d \"$sdk\" ] && export SDKROOT=$sdk CGO_LDFLAGS=\"-isysroot $sdk\" && break; done || true"
+      "[ \"$(uname)\" = Darwin ] && { found=; for sdk in /Library/Developer/CommandLineTools/SDKs/MacOSX*.sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX*.sdk; do [ -d \"$sdk\" ] && head -10 \"$sdk/usr/lib/libSystem.tbd\" 2>/dev/null | grep '^targets:' | grep -q ' arm64-macos' && export SDKROOT=$sdk CGO_LDFLAGS=\"-isysroot $sdk\" && found=1 && break; done; [ -z \"$found\" ] && echo 'WARNING: No macOS SDK with arm64 support found — CGO linking may fail'; } || true"
     ]
   }
 }


### PR DESCRIPTION
### What

* Fix SDK lookup paths for the latest macOS Xcode SDK
* Update beads gitignore from the latest beads version

### Why

Housekeeping and making sure the binary builds on latest macOS.