### PR TITLE
chore: add Conventional Commits enforcement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!--
+PR title must follow Conventional Commits: <type>(<scope>): <description>
+Types: feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert
+Examples:
+  feat(slo): add burn-rate alerting
+  fix: resolve nil pointer in push pipeline
+-->
+
+## Summary
+
+<!-- What changed and why? -->
+
+## Test plan
+
+<!-- How was this tested? -->

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,48 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint-pr-title:
+    name: Conventional Commit check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const pattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+/;
+            const valid = pattern.test(title);
+
+            if (valid) {
+              console.log(`PR title is valid: "${title}"`);
+              return;
+            }
+
+            const body = [
+              `**PR title does not follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).**`,
+              ``,
+              `Expected format: \`<type>(<optional scope>): <description>\``,
+              ``,
+              `Allowed types: \`feat\`, \`fix\`, \`docs\`, \`style\`, \`refactor\`, \`perf\`, \`test\`, \`build\`, \`ci\`, \`chore\`, \`revert\``,
+              ``,
+              `Examples:`,
+              `- \`feat(slo): add burn-rate alerting\``,
+              `- \`fix: resolve nil pointer in push pipeline\``,
+              `- \`docs: update provider guide\``,
+            ].join('\n');
+
+            const enforce = '${{ vars.CC_ENFORCE }}' || 'warn';
+
+            if (enforce === 'require') {
+              core.setFailed(body);
+            } else {
+              core.warning(body);
+            }

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,14 @@
+
+# <type>(<scope>): <description>
+#
+# Types: feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert
+# Scope: optional, e.g. slo, providers, config
+#
+# Examples:
+#   feat(slo): add burn-rate alerting
+#   fix: resolve nil pointer in push pipeline
+#   docs: update provider guide
+#
+# Body (optional): explain what and why, not how
+#
+# Footer (optional): BREAKING CHANGE: <description>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ Grafana K8s API            Product REST APIs
 - **Config = kubectl kubeconfig**: Named contexts with server/auth/namespace, env var overrides
 - **Format-agnostic data fetching**: Commands fetch all data regardless of `--output` format; codecs control display, not data acquisition (see Pattern 13 in `docs/architecture/patterns.md`)
 - **PromQL via promql-builder**: Use `github.com/grafana/promql-builder/go/promql` for PromQL construction, not string formatting (see Pattern 14 in `docs/architecture/patterns.md`)
+- **Conventional Commits**: All PR titles (and thus squash-merge commits) must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format: `<type>(<scope>): <description>`. Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`. Scope is optional but encouraged.
 
 ## Essential Commands
 

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,11 @@ clean: ## Cleans the project.
 	rm -rf .devbox
 	rm -rf .venv
 
+.PHONY: setup
+setup: ## Sets up the local development environment (commit template, etc).
+	git config commit.template .gitmessage
+	@echo "Git commit template configured"
+
 .PHONY: check-binaries
 check-binaries: ## Check that the required binaries are present.
 	@go version >/dev/null 2>&1 || devbox version >/dev/null 2>&1 || (echo "ERROR: go or devbox is required. See https://www.jetify.com/devbox/docs/quickstart/"; exit 1)

--- a/docs/adrs/conventional-commits/001-pr-title-enforcement.md
+++ b/docs/adrs/conventional-commits/001-pr-title-enforcement.md
@@ -1,0 +1,93 @@
+# Conventional Commits via PR Title Enforcement
+
+**Created**: 2026-03-27
+**Status**: accepted
+**Bead**: none
+**Supersedes**: none
+
+## Context
+
+The gcx repo already follows Conventional Commits informally — recent history
+shows consistent use of `feat(scope):`, `fix:`, `docs:`, `ci:`, `chore:`,
+`build(deps):`. The goal is to codify and encourage the convention without
+blocking contributors unnecessarily.
+
+The repo is **squash-merge-only** with `PR_TITLE` as the squash commit title
+and `PR_BODY` as the commit body. Individual commits within a PR are discarded
+at merge time. This means PR title lint is the single meaningful enforcement
+point.
+
+Primary motivation is readability/consistency of the git log. Automated
+changelogs are a future option but not a driver today.
+
+## Decision
+
+Adopt a layered approach — four independent components that reinforce each
+other, all Go/shell-only (no Node.js dependencies):
+
+### 1. PR Title Lint (CI)
+
+A GitHub Actions workflow on `pull_request` events (`opened`, `edited`,
+`synchronize`) that checks the PR title against the Conventional Commits regex:
+
+```
+^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+
+```
+
+Two modes, controlled by a GitHub Actions variable `CC_ENFORCE`:
+- **`warn`** (default): Posts a warning annotation if the title doesn't match.
+  Does not block merge.
+- **`require`**: Fails the status check, blocks merge.
+
+Graduation path: flip `CC_ENFORCE` from `warn` to `require` when the team is
+comfortable.
+
+### 2. PR Template
+
+`.github/PULL_REQUEST_TEMPLATE.md` with a CC format reminder at the top and
+standard sections (Summary, Test plan).
+
+### 3. Git Commit Template
+
+`.gitmessage` at the repo root with CC format hints. A `make setup` target
+configures it for the local clone via `git config commit.template .gitmessage`.
+
+### 4. CLAUDE.md Convention Entry
+
+Add a convention entry so Claude Code and other AI agents format PR titles
+and commit messages using Conventional Commits.
+
+## Allowed Types
+
+| Type | Use for |
+|------|---------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `style` | Formatting, no logic change |
+| `refactor` | Code restructuring, no behavior change |
+| `perf` | Performance improvement |
+| `test` | Adding/updating tests |
+| `build` | Build system, dependencies |
+| `ci` | CI/CD configuration |
+| `chore` | Maintenance, tooling |
+| `revert` | Reverting a previous commit |
+
+Scope is optional but encouraged (e.g. `feat(slo):`, `fix(providers):`).
+
+## Alternatives Considered
+
+- **Git commit-msg hook**: Requires per-contributor setup, doesn't help agents
+  or GitHub web UI, bypassable with `--no-verify`. Irrelevant when squash-merge
+  discards individual commits.
+- **Full CI commit lint (every commit)**: Overkill when squash-merge makes only
+  the PR title matter. Annoying for WIP `fixup!` commits during development.
+- **Node.js commitlint**: Gold standard but adds a Node.js dependency to a
+  Go-only toolchain.
+
+## Consequences
+
+- PR titles become the single source of truth for commit messages.
+- The warn→require graduation path lets the team adopt incrementally.
+- Future automated changelog generation becomes straightforward since all
+  squash commits will follow CC format.


### PR DESCRIPTION
### What
- PR title lint workflow (warns by default, CC_ENFORCE=require to block)
- PR template with Conventional Commits format reminder
- Git commit template configured via `make setup`
- AGENTS.md convention entry documenting CC format requirements
- ADR documenting the decision and rationale

### Why
- Codify the Conventional Commits convention the repo already informally follows
- Keep the git log scannable and machine-readable
- Set up a graduation path to hard enforcement
- Enables automated changelog generation and semantic versioning

Generated with Claude Code