### PR TITLE
fix(ci): wrap CI commands with devbox run to fix PATH

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Run golangci-lint
-        run: make lint
+        run: devbox run -- make lint
 
   tests:
     name: Tests
@@ -65,7 +65,7 @@ jobs:
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Tests
-        run: make tests
+        run: devbox run -- make tests
 
   docs:
     name: Documentation
@@ -83,8 +83,8 @@ jobs:
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Check for drift in the generated documentation references
-        run: make reference-drift
+        run: devbox run -- make reference-drift
         shell: bash
 
       - name: Build documentation
-        run: make docs
+        run: devbox run -- make docs

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -35,7 +35,7 @@ jobs:
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Build documentation
-        run: make docs
+        run: devbox run -- make docs
 
       - name: Upload pages artifact
         id: deployment


### PR DESCRIPTION
## Summary
- The `devbox-install-action` sets `DEVBOX_CONFIG_DIR` in the GitHub Actions environment, which causes the Makefile to skip the `devbox run` prefix — it assumes it's already inside a devbox shell
- But the CI `run:` steps don't execute inside a devbox shell, so `golangci-lint`, `mkdocs`, and other devbox-managed tools aren't on PATH
- Fix: wrap all CI `run:` commands with `devbox run --` in `ci.yaml` and `publish-docs.yaml`

## Changes
- `.github/workflows/ci.yaml`: Wrap `make lint`, `make tests`, `make reference-drift`, and `make docs` with `devbox run --`
- `.github/workflows/publish-docs.yaml`: Wrap `make docs` with `devbox run --`

## Test Plan
- [ ] CI Linters job passes (golangci-lint found on PATH)
- [ ] CI Tests job passes
- [ ] CI Documentation job passes (mkdocs found on PATH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)