### PR TITLE
fix(docs): add bd/dolt project root requirement to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,7 @@ bd close <id>         # Complete work
 
 ### Rules
 
+- Both `bd` and `dolt` commands MUST be executed from the repository root, not from worktrees
 - Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files


### PR DESCRIPTION
## Summary
- Add rule to AGENTS.md beads section clarifying that `bd` and `dolt` commands must be executed from the repository root, not from worktrees

## Test Plan
- [x] Docs-only change, no code affected
- [x] Verified no other hardcoded paths remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)