### PR TITLE
fix(output,fail): honor JSON field selection in Encode; map HTTP status errors

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -15,6 +15,15 @@ import (
 	k8sapi "k8s.io/apimachinery/pkg/api/errors"
 )
 
+// HTTPStatusError is implemented by errors that carry an HTTP status code and
+// a human-readable message from a remote API. Provider clients can implement
+// this interface so the fail package renders a clear summary instead of the
+// generic "Unexpected error".
+type HTTPStatusError interface {
+	error
+	HTTPStatusCode() int
+}
+
 func ErrorToDetailedError(err error) *DetailedError {
 	var converted bool
 	detailedErr := &DetailedError{}
@@ -24,14 +33,15 @@ func ErrorToDetailedError(err error) *DetailedError {
 
 	// Try to convert the error for common error categories
 	errorConverters := []func(err error) (*DetailedError, bool){
-		convertContextCanceled, // Context cancellation (must be first — cancellation can wrap other errors)
-		convertConfigErrors,    // Config-related
-		convertFSErrors,        // FS-related
-		convertResourcesErrors, // Resources-related
-		convertNetworkErrors,   // Network-related errors
-		convertAPIErrors,       // API-related errors
-		convertVersionErrors,   // Version incompatibility errors
-		convertLinterErrors,    // Linter-related errors
+		convertContextCanceled,  // Context cancellation (must be first — cancellation can wrap other errors)
+		convertConfigErrors,     // Config-related
+		convertFSErrors,         // FS-related
+		convertResourcesErrors,  // Resources-related
+		convertNetworkErrors,    // Network-related errors
+		convertAPIErrors,        // API-related errors
+		convertHTTPStatusErrors, // Provider HTTP status errors
+		convertVersionErrors,    // Version incompatibility errors
+		convertLinterErrors,     // Linter-related errors
 	}
 
 	for _, converter := range errorConverters {
@@ -218,6 +228,42 @@ func convertVersionErrors(err error) (*DetailedError, bool) {
 	}
 
 	return nil, false
+}
+
+func convertHTTPStatusErrors(err error) (*DetailedError, bool) {
+	var httpErr HTTPStatusError
+	if !errors.As(err, &httpErr) {
+		return nil, false
+	}
+
+	code := httpErr.HTTPStatusCode()
+	summary := fmt.Sprintf("API error (HTTP %d)", code)
+
+	switch code {
+	case 401, 403:
+		return &DetailedError{
+			Parent:  err,
+			Summary: summary,
+			Suggestions: []string{
+				"Make sure that the configured credentials are correct",
+				"Make sure that the configured credentials have enough permissions",
+			},
+			ExitCode: new(ExitAuthFailure),
+		}, true
+	case 404:
+		return &DetailedError{
+			Parent:  err,
+			Summary: summary,
+			Suggestions: []string{
+				"Make sure the resource ID is correct",
+			},
+		}, true
+	default:
+		return &DetailedError{
+			Parent:  err,
+			Summary: summary,
+		}, true
+	}
 }
 
 func convertContextCanceled(err error) (*DetailedError, bool) {

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -132,12 +133,54 @@ func (opts *Options) Codec() (format.Codec, error) { //nolint:ireturn
 }
 
 func (opts *Options) Encode(dst io.Writer, value any) error {
+	if opts.JSONDiscovery {
+		return opts.encodeJSONDiscovery(dst, value)
+	}
+
+	if len(opts.JSONFields) > 0 {
+		return NewFieldSelectCodec(opts.JSONFields).Encode(dst, value)
+	}
+
 	codec, err := opts.Codec()
 	if err != nil {
 		return err
 	}
 
 	return codec.Encode(dst, value)
+}
+
+// encodeJSONDiscovery marshals value to a map and prints available field names.
+func (opts *Options) encodeJSONDiscovery(dst io.Writer, value any) error {
+	m, err := toMap(value)
+	if err != nil {
+		m = firstElementAsMap(value)
+		if m == nil {
+			return err
+		}
+	}
+
+	for _, field := range DiscoverFields(m) {
+		fmt.Fprintln(dst, field)
+	}
+	return nil
+}
+
+// firstElementAsMap marshals value as JSON, and if it's an array, returns the
+// first element as a map. Returns nil if the value is not an array or is empty.
+func firstElementAsMap(value any) map[string]any {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil
+	}
+	var arr []json.RawMessage
+	if err := json.Unmarshal(data, &arr); err != nil || len(arr) == 0 {
+		return nil
+	}
+	var elem map[string]any
+	if err := json.Unmarshal(arr[0], &elem); err != nil {
+		return nil
+	}
+	return elem
 }
 
 // We have to return an interface here.


### PR DESCRIPTION
## Summary

### `internal/output/format.go`

- `Options.Encode` now respects `JSONDiscovery` and `JSONFields` when they are set from `--json ?` and `--json field1,field2`.
- Previously those flags were parsed into `Options` but `Encode` always used the default codec, so discovery and field selection did not work for commands that route through `output.Options`.

### `cmd/gcx/fail/convert.go`

- Introduces `fail.HTTPStatusError` and `convertHTTPStatusErrors` so provider clients can attach HTTP status to errors.
- Maps common status codes to clearer summaries and suggestions (e.g. auth vs not found).

**Docs:** `docs/reference/design-guide.md` (JSON field selection), `docs/architecture/cli-layer.md` (`io.Options`, field selection).

## Testing

```bash
go test ./cmd/gcx/fail/... ./internal/output/... -count=1
```