### PR TITLE
fix: improve loki query usage errors

### DIFF
--- a/cmd/gcx/datasources/query/loki.go
+++ b/cmd/gcx/datasources/query/loki.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/query/loki"
 	"github.com/spf13/cobra"
 )
@@ -36,7 +37,7 @@ EXPR is the LogQL expression to evaluate.`,
 
   # Output as JSON
   gcx datasources loki query loki-001 '{job="varlogs"}' -o json`,
-		Args: cobra.RangeArgs(1, 2),
+		Args: validateLokiQueryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := shared.Validate(); err != nil {
 				return err
@@ -97,4 +98,15 @@ EXPR is the LogQL expression to evaluate.`,
 	cmd.Flags().IntVar(&limit, "limit", 1000, "Maximum number of log lines to return (0 means no limit)")
 
 	return cmd
+}
+
+func validateLokiQueryArgs(cmd *cobra.Command, args []string) error {
+	switch len(args) {
+	case 0:
+		return fail.NewCommandUsageError(cmd, "EXPR is required", nil)
+	case 1, 2:
+		return nil
+	default:
+		return fail.NewCommandUsageError(cmd, "too many arguments: expected [DATASOURCE_UID] EXPR", nil)
+	}
 }

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -24,7 +24,8 @@ func ErrorToDetailedError(err error) *DetailedError {
 
 	// Try to convert the error for common error categories
 	errorConverters := []func(err error) (*DetailedError, bool){
-		convertContextCanceled, // Context cancellation (must be first — cancellation can wrap other errors)
+		convertUsageErrors,
+		convertContextCanceled, // Context cancellation (must be first among generic wrapped errors)
 		convertConfigErrors,    // Config-related
 		convertFSErrors,        // FS-related
 		convertResourcesErrors, // Resources-related
@@ -45,6 +46,24 @@ func ErrorToDetailedError(err error) *DetailedError {
 		Summary: "Unexpected error",
 		Parent:  err,
 	}
+}
+
+func convertUsageErrors(err error) (*DetailedError, bool) {
+	usageErr := &UsageError{}
+	if !errors.As(err, &usageErr) {
+		return nil, false
+	}
+
+	details := usageErr.Error()
+	if usageErr.Expected != "" {
+		details = fmt.Sprintf("%s\n\nExpected:\n  %s", details, usageErr.Expected)
+	}
+
+	return &DetailedError{
+		Summary:     "Invalid command usage",
+		Details:     details,
+		Suggestions: usageErr.Suggestions,
+	}, true
 }
 
 func convertConfigErrors(err error) (*DetailedError, bool) {

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/grafana"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8sapi "k8s.io/apimachinery/pkg/api/errors"
@@ -125,4 +126,26 @@ func TestErrorToDetailedError_ConverterOrdering(t *testing.T) {
 	require.NotNil(t, got)
 	require.NotNil(t, got.ExitCode, "ExitCode should be set")
 	assert.Equal(t, fail.ExitCancelled, *got.ExitCode, "context.Canceled should take precedence over auth errors")
+}
+
+func TestErrorToDetailedError_UsageErrorIncludesExpectedSyntax(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "gcx"}
+	datasourcesCmd := &cobra.Command{Use: "datasources"}
+	lokiCmd := &cobra.Command{Use: "loki"}
+	queryCmd := &cobra.Command{Use: "query [DATASOURCE_UID] EXPR"}
+	queryCmd.Flags().Bool("json", false, "")
+
+	rootCmd.AddCommand(datasourcesCmd)
+	datasourcesCmd.AddCommand(lokiCmd)
+	lokiCmd.AddCommand(queryCmd)
+
+	got := fail.ErrorToDetailedError(fail.NewCommandUsageError(queryCmd, "EXPR is required", nil))
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Invalid command usage", got.Summary)
+	assert.Contains(t, got.Details, "EXPR is required")
+	assert.Contains(t, got.Details, "Expected:")
+	assert.Contains(t, got.Details, "gcx datasources loki query [DATASOURCE_UID] EXPR [flags]")
+	require.Len(t, got.Suggestions, 1)
+	assert.Equal(t, "Run 'gcx datasources loki query --help' for full usage and examples", got.Suggestions[0])
 }

--- a/cmd/gcx/fail/usage.go
+++ b/cmd/gcx/fail/usage.go
@@ -1,0 +1,61 @@
+package fail
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// UsageError carries command-specific usage details without relying on Cobra's
+// default free-form error strings.
+type UsageError struct {
+	Message     string
+	Expected    string
+	Suggestions []string
+	Cause       error
+}
+
+func (e *UsageError) Error() string {
+	if strings.TrimSpace(e.Message) != "" {
+		return e.Message
+	}
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	return "invalid command usage"
+}
+
+func (e *UsageError) Unwrap() error {
+	return e.Cause
+}
+
+// NewCommandUsageError builds a UsageError enriched with the command's usage
+// line and a standard help suggestion.
+func NewCommandUsageError(cmd *cobra.Command, message string, cause error) *UsageError {
+	err := &UsageError{
+		Message: strings.TrimSpace(message),
+		Cause:   cause,
+	}
+
+	if err.Message == "" && cause != nil {
+		err.Message = cause.Error()
+	}
+	if err.Message == "" {
+		err.Message = "invalid command usage"
+	}
+
+	if cmd == nil {
+		return err
+	}
+
+	if expected := strings.TrimSpace(cmd.UseLine()); expected != "" {
+		err.Expected = expected
+	}
+
+	if commandPath := strings.TrimSpace(cmd.CommandPath()); commandPath != "" {
+		err.Suggestions = []string{fmt.Sprintf("Run '%s --help' for full usage and examples", commandPath)}
+	}
+
+	return err
+}


### PR DESCRIPTION
## Improve loki query usage errors

Before this change, `gcx datasources loki query` surfaced Cobra's generic positional arg error as an unexpected error:

```text
Error: Unexpected error
│
├─ Details:
│
│ requires at least 1 arg(s), only received 0
│
└─
```

That does not tell the user what is actually missing.

We first tried to handle this generically, but that approach is brittle because it depends on Cobra and pflag error strings. For positional arguments, Cobra does not expose enough structured information to say which argument is missing. The practical fix is to handle these cases in the affected commands and return explicit usage errors.

This PR updates `gcx datasources loki query` to return a specific usage error with the expected syntax and a help hint:

```text
❯ go run ./cmd/gcx datasources loki query
Error: Invalid command usage
│
│ EXPR is required
│
│ Expected:
│   gcx datasources loki query [DATASOURCE_UID] EXPR [flags]
│
├─ Suggestions:
│
│ • Run 'gcx datasources loki query --help' for full usage and examples
│
└─
```

This does not solve the issue for every command. It fixes Loki query and establishes the pattern for other commands with the same problem.
