### PR TITLE
fix(logs): prefer log body field over id/tsNs in legacy Loki frames

### DIFF
--- a/internal/query/loki/client.go
+++ b/internal/query/loki/client.go
@@ -421,7 +421,11 @@ func convertLegacyFormat(frame DataFrame, result *QueryResponse) {
 		case "time":
 			timeIdx = i
 		case "string", "number":
-			valueIdx = i
+			// Prefer named body fields ("Line", "body") over generic string fields
+			// like "id" or "tsNs" which appear after the body in Loki data frames.
+			if valueIdx == -1 || field.Name == "Line" || field.Name == "body" {
+				valueIdx = i
+			}
 		}
 		if len(field.Labels) > 0 {
 			labels = field.Labels


### PR DESCRIPTION
In the legacy Grafana Loki data frame format (field names Time/Line/tsNs/id), convertLegacyFormat was assigning valueIdx to the last string-typed field, which is "id" (e.g. 1775564496989203231_94cf3bc) rather than "Line" (the actual log content). Loki queries therefore printed opaque identifiers instead of log lines.

Fix by preferring a field named "Line" or "body" when selecting the body field, only falling back to the first-seen string field if neither is present.