### PR TITLE
login: add oauth experimental warning to help and post-auth output;

### DIFF
--- a/cmd/gcx/auth/command.go
+++ b/cmd/gcx/auth/command.go
@@ -82,9 +82,9 @@ example:
 	gcx config use-context my-stack
 
 ` + fmt.Sprintf(unsupportedCommandsWarningTemplate, "contexts.CONTEXT.grafana.token"),
-		Example: `gcx auth login --server https://my-stack.grafana.net
-gcx auth login --context prod --server https://prod.grafana.net
-gcx auth login`,
+		Example: `  gcx auth login --server https://my-stack.grafana.net
+  gcx auth login --context prod --server https://prod.grafana.net
+  gcx auth login`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/cmd/gcx/auth/command.go
+++ b/cmd/gcx/auth/command.go
@@ -14,6 +14,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
+var unsupportedCommandsWarningTemplate = `WARNING: OAuth login is experimental. The following commands require a service account token instead:
+  - incidents
+  - oncall
+  - faro
+  - slo
+  - resources (partial)
+
+To use a token: gcx config set %s TOKEN`
+
 // Command returns the `auth` command group.
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
@@ -55,7 +64,7 @@ func loginCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Args:  cobra.NoArgs,
-		Short: "Authenticate to a Grafana stack with OAuth",
+		Short: "(experimental) Authenticate to a Grafana stack with OAuth",
 		Long: `Opens a browser to authenticate with your Grafana stack using OAuth. This is an
 alternative to using an access token.
 
@@ -69,11 +78,13 @@ grafana.server.
 
 Without --server, the selected context must already define grafana.server. For
 example:
-	gcx config set contexts.<context>.grafana.server https://your-stack.grafana.net
-	gcx config use-context <context>`,
-		Example: `  gcx auth login --server https://your-stack.grafana.net
-  gcx auth login --context prod --server https://prod.grafana.net
-  gcx auth login`,
+	gcx config set contexts.my-stack.grafana.server https://my-stack.grafana.net
+	gcx config use-context my-stack
+
+` + fmt.Sprintf(unsupportedCommandsWarningTemplate, "contexts.CONTEXT.grafana.token"),
+		Example: `gcx auth login --server https://my-stack.grafana.net
+gcx auth login --context prod --server https://prod.grafana.net
+gcx auth login`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.Validate(); err != nil {
 				return err
@@ -101,9 +112,9 @@ func runLogin(cmd *cobra.Command, opts *loginOpts) error {
 			Summary: "Grafana server not configured",
 			Details: fmt.Sprintf("Context %q does not define grafana.server.", cfg.CurrentContext),
 			Suggestions: []string{
-				fmt.Sprintf("Set it: gcx config set %s https://your-stack.grafana.net", formatConfigPathArg("contexts", cfg.CurrentContext, "grafana", "server")),
-				"Or pass it now: gcx auth login --server https://your-stack.grafana.net",
-				"Or switch context: gcx config use-context <context>",
+				fmt.Sprintf("Set it: gcx config set %s https://my-stack.grafana.net", formatConfigPathArg("contexts", cfg.CurrentContext, "grafana", "server")),
+				"Or pass it now: gcx auth login --server https://my-stack.grafana.net",
+				"Or switch context: gcx config use-context my-context",
 			},
 		}
 	}
@@ -128,6 +139,8 @@ func runLogin(cmd *cobra.Command, opts *loginOpts) error {
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Authenticated as %s. Tokens saved to context %q.\n", result.Email, cfg.CurrentContext)
+	tokenPath := formatConfigPathArg("contexts", cfg.CurrentContext, "grafana", "token")
+	fmt.Fprintf(cmd.ErrOrStderr(), "\n"+unsupportedCommandsWarningTemplate+"\n", tokenPath)
 
 	return nil
 }

--- a/cmd/gcx/auth/command.go
+++ b/cmd/gcx/auth/command.go
@@ -64,7 +64,7 @@ func loginCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Args:  cobra.NoArgs,
-		Short: "(experimental) Authenticate to a Grafana stack with OAuth",
+		Short: "Authenticate to a Grafana stack with OAuth (experimental)",
 		Long: `Opens a browser to authenticate with your Grafana stack using OAuth. This is an
 alternative to using an access token.
 

--- a/cmd/gcx/auth/command.go
+++ b/cmd/gcx/auth/command.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var unsupportedCommandsWarningTemplate = `WARNING: OAuth login is experimental. The following commands require a service account token instead:
+const unsupportedCommandsWarningTemplate = `WARNING: OAuth login is experimental. The following commands require a service account token instead:
   - incidents
   - oncall
   - faro

--- a/cmd/gcx/auth/command_internal_test.go
+++ b/cmd/gcx/auth/command_internal_test.go
@@ -53,7 +53,7 @@ func TestRunLogin_serverBootstrapsDefaultContext(t *testing.T) {
 	}
 
 	require.NoError(t, runLogin(cmd, opts))
-	assert.Empty(t, stderr.String())
+	assert.Contains(t, stderr.String(), "WARNING: OAuth login is experimental")
 	assert.Contains(t, stdout.String(), "Authenticated as user@example.com. Tokens saved to context \"default\".")
 
 	saved, err := config.Load(t.Context(), config.ExplicitConfigFile(configFile))

--- a/cmd/gcx/auth/command_test.go
+++ b/cmd/gcx/auth/command_test.go
@@ -31,8 +31,8 @@ contexts:
 		Assertions: []testutils.CommandAssertion{
 			testutils.CommandErrorContains("Error: Grafana server not configured"),
 			testutils.CommandErrorContains("Context \"test\" does not define grafana.server."),
-			testutils.CommandErrorContains("Set it: gcx config set contexts.test.grafana.server https://your-stack.grafana.net"),
-			testutils.CommandErrorContains("Or pass it now: gcx auth login --server https://your-stack.grafana.net"),
+			testutils.CommandErrorContains("Set it: gcx config set contexts.test.grafana.server https://my-stack.grafana.net"),
+			testutils.CommandErrorContains("Or pass it now: gcx auth login --server https://my-stack.grafana.net"),
 		},
 	}
 	tc.Run(t)
@@ -47,8 +47,8 @@ func TestLogin_noContext(t *testing.T) {
 		Assertions: []testutils.CommandAssertion{
 			testutils.CommandErrorContains("Error: Grafana server not configured"),
 			testutils.CommandErrorContains("Context \"default\" does not define grafana.server."),
-			testutils.CommandErrorContains("Set it: gcx config set contexts.default.grafana.server https://your-stack.grafana.net"),
-			testutils.CommandErrorContains("Or pass it now: gcx auth login --server https://your-stack.grafana.net"),
+			testutils.CommandErrorContains("Set it: gcx config set contexts.default.grafana.server https://my-stack.grafana.net"),
+			testutils.CommandErrorContains("Or pass it now: gcx auth login --server https://my-stack.grafana.net"),
 		},
 	}
 	tc.Run(t)
@@ -68,8 +68,8 @@ contexts:
 		Assertions: []testutils.CommandAssertion{
 			testutils.CommandErrorContains("Error: Grafana server not configured"),
 			testutils.CommandErrorContains("Context \"prod env.v2\" does not define grafana.server."),
-			testutils.CommandErrorContains("Set it: gcx config set 'contexts.prod env\\.v2.grafana.server' https://your-stack.grafana.net"),
-			testutils.CommandErrorContains("Or pass it now: gcx auth login --server https://your-stack.grafana.net"),
+			testutils.CommandErrorContains("Set it: gcx config set 'contexts.prod env\\.v2.grafana.server' https://my-stack.grafana.net"),
+			testutils.CommandErrorContains("Or pass it now: gcx auth login --server https://my-stack.grafana.net"),
 		},
 	}
 	tc.Run(t)

--- a/docs/reference/cli/gcx_auth.md
+++ b/docs/reference/cli/gcx_auth.md
@@ -21,5 +21,5 @@ Manage authentication
 ### SEE ALSO
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
-* [gcx auth login](gcx_auth_login.md)	 - Authenticate to a Grafana stack with OAuth
+* [gcx auth login](gcx_auth_login.md)	 - Authenticate to a Grafana stack with OAuth (experimental)
 

--- a/docs/reference/cli/gcx_auth_login.md
+++ b/docs/reference/cli/gcx_auth_login.md
@@ -1,6 +1,6 @@
 ## gcx auth login
 
-Authenticate to a Grafana stack with OAuth
+Authenticate to a Grafana stack with OAuth (experimental)
 
 ### Synopsis
 
@@ -17,8 +17,17 @@ grafana.server.
 
 Without --server, the selected context must already define grafana.server. For
 example:
-	gcx config set contexts.<context>.grafana.server https://your-stack.grafana.net
-	gcx config use-context <context>
+	gcx config set contexts.my-stack.grafana.server https://my-stack.grafana.net
+	gcx config use-context my-stack
+
+WARNING: OAuth login is experimental. The following commands require a service account token instead:
+  - incidents
+  - oncall
+  - faro
+  - slo
+  - resources (partial)
+
+To use a token: gcx config set contexts.CONTEXT.grafana.token TOKEN
 
 ```
 gcx auth login [flags]
@@ -27,7 +36,7 @@ gcx auth login [flags]
 ### Examples
 
 ```
-  gcx auth login --server https://your-stack.grafana.net
+  gcx auth login --server https://my-stack.grafana.net
   gcx auth login --context prod --server https://prod.grafana.net
   gcx auth login
 ```


### PR DESCRIPTION
adds a warning like this to `auth login -h` and also after a user has authenticated with `auth login`:

```
WARNING: OAuth login is experimental. The following commands require a
  service account token instead:

  • incidents
  • oncall
  • faro
  • slo
  • resources (partial)

  To use a token: gcx config set contexts.CONTEXT.grafana.token TOKEN
```