### PR TITLE
fix(logs): resolve null stream labels and missing log content in query output

### DIFF
--- a/internal/query/loki/client.go
+++ b/internal/query/loki/client.go
@@ -383,8 +383,16 @@ func convertGrafanaResponse(grafanaResp *GrafanaQueryResponse) *QueryResponse {
 		}
 
 		labelsIdx, hasLabels := fieldIndices["labels"]
+
 		timestampIdx, hasTimestamp := fieldIndices["timestamp"]
+		if !hasTimestamp {
+			timestampIdx, hasTimestamp = fieldIndices["Time"]
+		}
+
 		bodyIdx, hasBody := fieldIndices["body"]
+		if !hasBody {
+			bodyIdx, hasBody = fieldIndices["Line"]
+		}
 
 		// Handle log-lines format (per-line labels in values)
 		if hasLabels && hasTimestamp && hasBody {
@@ -454,18 +462,30 @@ func convertLegacyFormat(frame DataFrame, result *QueryResponse) {
 	}
 
 	var timeIdx, valueIdx = -1, -1
-	var labels map[string]string
+	labels := make(map[string]string)
+
+	var fallbackValueIdx = -1
+	contentFields := map[string]bool{
+		"Line": true, "line": true, "body": true, "Body": true, "value": true,
+	}
 
 	for i, field := range frame.Schema.Fields {
 		switch field.Type {
 		case "time":
 			timeIdx = i
 		case "string", "number":
-			valueIdx = i
+			if contentFields[field.Name] {
+				valueIdx = i
+			} else if fallbackValueIdx == -1 {
+				fallbackValueIdx = i
+			}
 		}
 		if len(field.Labels) > 0 {
 			labels = field.Labels
 		}
+	}
+	if valueIdx == -1 {
+		valueIdx = fallbackValueIdx
 	}
 
 	if timeIdx == -1 || valueIdx == -1 {
@@ -518,7 +538,7 @@ func extractStats(frameStats []FrameStat) *QueryStats {
 
 func parseLabels(v any) map[string]string {
 	if v == nil {
-		return nil
+		return map[string]string{}
 	}
 	if m, ok := v.(map[string]any); ok {
 		labels := make(map[string]string, len(m))
@@ -528,9 +548,18 @@ func parseLabels(v any) map[string]string {
 		return labels
 	}
 	if m, ok := v.(map[string]string); ok {
+		if m == nil {
+			return map[string]string{}
+		}
 		return m
 	}
-	return nil
+	if s, ok := v.(string); ok && len(s) > 0 && s[0] == '{' {
+		var labels map[string]string
+		if err := json.Unmarshal([]byte(s), &labels); err == nil {
+			return labels
+		}
+	}
+	return map[string]string{}
 }
 
 func labelsKey(labels map[string]string) string {

--- a/internal/query/loki/convert_test.go
+++ b/internal/query/loki/convert_test.go
@@ -1,0 +1,274 @@
+package loki_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/loki"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertGrafanaResponse_NewFieldNames(t *testing.T) {
+	// Grafana Loki plugin returns "Time" and "Line", not "timestamp" and "body".
+	// Confirmed against live thirdact context.
+	resp := loki.ConvertGrafanaResponse(&loki.GrafanaQueryResponse{
+		Results: map[string]loki.GrafanaResult{
+			"A": {
+				Frames: []loki.DataFrame{
+					{
+						Schema: loki.DataFrameSchema{
+							Fields: []loki.Field{
+								{Name: "labels", Type: "other"},
+								{Name: "Time", Type: "time"},
+								{Name: "Line", Type: "string"},
+								{Name: "tsNs", Type: "string"},
+								{Name: "id", Type: "string"},
+							},
+						},
+						Data: loki.DataFrameData{
+							Values: [][]any{
+								{map[string]any{"job": "grafana", "service_name": "my-svc"}},
+								{float64(1711893600000)},
+								{"level=info msg=\"HTTP request\" status=200"},
+								{"1711893600000000000"},
+								{"1711893600000000000_abc123"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, resp.Data.Result, 1)
+	entry := resp.Data.Result[0]
+
+	// Stream labels must be populated, not null
+	assert.Equal(t, map[string]string{"job": "grafana", "service_name": "my-svc"}, entry.Stream)
+
+	// Values must contain actual log content, not ID hashes
+	require.Len(t, entry.Values, 1)
+	assert.Equal(t, "level=info msg=\"HTTP request\" status=200", entry.Values[0][1])
+}
+
+func TestConvertGrafanaResponse_OldFieldNames(t *testing.T) {
+	// Backward compat: "timestamp", "body", "labels" field names.
+	resp := loki.ConvertGrafanaResponse(&loki.GrafanaQueryResponse{
+		Results: map[string]loki.GrafanaResult{
+			"A": {
+				Frames: []loki.DataFrame{
+					{
+						Schema: loki.DataFrameSchema{
+							Fields: []loki.Field{
+								{Name: "labels", Type: "other"},
+								{Name: "timestamp", Type: "time"},
+								{Name: "body", Type: "string"},
+							},
+						},
+						Data: loki.DataFrameData{
+							Values: [][]any{
+								{map[string]any{"app": "test"}},
+								{float64(1711893600000)},
+								{"hello world"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, resp.Data.Result, 1)
+	assert.Equal(t, map[string]string{"app": "test"}, resp.Data.Result[0].Stream)
+	assert.Equal(t, "hello world", resp.Data.Result[0].Values[0][1])
+}
+
+func TestConvertGrafanaResponse_MultipleStreams(t *testing.T) {
+	// Two log entries with different labels should produce two stream entries.
+	resp := loki.ConvertGrafanaResponse(&loki.GrafanaQueryResponse{
+		Results: map[string]loki.GrafanaResult{
+			"A": {
+				Frames: []loki.DataFrame{
+					{
+						Schema: loki.DataFrameSchema{
+							Fields: []loki.Field{
+								{Name: "labels", Type: "other"},
+								{Name: "Time", Type: "time"},
+								{Name: "Line", Type: "string"},
+							},
+						},
+						Data: loki.DataFrameData{
+							Values: [][]any{
+								{
+									map[string]any{"job": "a"},
+									map[string]any{"job": "b"},
+									map[string]any{"job": "a"},
+								},
+								{float64(1000), float64(2000), float64(3000)},
+								{"line-a1", "line-b1", "line-a2"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, resp.Data.Result, 2)
+
+	// First stream: job=a with 2 entries
+	assert.Equal(t, map[string]string{"job": "a"}, resp.Data.Result[0].Stream)
+	assert.Len(t, resp.Data.Result[0].Values, 2)
+
+	// Second stream: job=b with 1 entry
+	assert.Equal(t, map[string]string{"job": "b"}, resp.Data.Result[1].Stream)
+	assert.Len(t, resp.Data.Result[1].Values, 1)
+}
+
+func TestConvertGrafanaResponse_LegacyFormat(t *testing.T) {
+	// Legacy format: no "labels" field, labels in field metadata.
+	resp := loki.ConvertGrafanaResponse(&loki.GrafanaQueryResponse{
+		Results: map[string]loki.GrafanaResult{
+			"A": {
+				Frames: []loki.DataFrame{
+					{
+						Schema: loki.DataFrameSchema{
+							Fields: []loki.Field{
+								{Name: "time", Type: "time"},
+								{Name: "value", Type: "string", Labels: map[string]string{"job": "legacy"}},
+							},
+						},
+						Data: loki.DataFrameData{
+							Values: [][]any{
+								{float64(1711893600000)},
+								{"legacy log line"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, resp.Data.Result, 1)
+	assert.Equal(t, map[string]string{"job": "legacy"}, resp.Data.Result[0].Stream)
+	assert.Equal(t, "legacy log line", resp.Data.Result[0].Values[0][1])
+}
+
+func TestConvertGrafanaResponse_LegacyFormat_PrefersContentField(t *testing.T) {
+	// When falling to legacy format with "Line" and "id" fields,
+	// should prefer "Line" for content over "id".
+	resp := loki.ConvertGrafanaResponse(&loki.GrafanaQueryResponse{
+		Results: map[string]loki.GrafanaResult{
+			"A": {
+				Frames: []loki.DataFrame{
+					{
+						Schema: loki.DataFrameSchema{
+							Fields: []loki.Field{
+								{Name: "time", Type: "time"},
+								{Name: "Line", Type: "string"},
+								{Name: "id", Type: "string"},
+								{Name: "tsNs", Type: "string"},
+							},
+						},
+						Data: loki.DataFrameData{
+							Values: [][]any{
+								{float64(1711893600000)},
+								{"the actual log line"},
+								{"1711893600000000000_abc123"},
+								{"1711893600000000000"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, resp.Data.Result, 1)
+	assert.Equal(t, "the actual log line", resp.Data.Result[0].Values[0][1])
+}
+
+func TestParseLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want map[string]string
+	}{
+		{
+			name: "nil returns empty map",
+			in:   nil,
+			want: map[string]string{},
+		},
+		{
+			name: "map[string]any",
+			in:   map[string]any{"job": "grafana", "level": "info"},
+			want: map[string]string{"job": "grafana", "level": "info"},
+		},
+		{
+			name: "map[string]string",
+			in:   map[string]string{"job": "grafana"},
+			want: map[string]string{"job": "grafana"},
+		},
+		{
+			name: "JSON string",
+			in:   `{"job":"grafana","instance":"localhost"}`,
+			want: map[string]string{"job": "grafana", "instance": "localhost"},
+		},
+		{
+			name: "empty string returns empty map",
+			in:   "",
+			want: map[string]string{},
+		},
+		{
+			name: "non-parseable type returns empty map",
+			in:   42,
+			want: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := loki.ParseLabels(tt.in)
+			assert.NotNil(t, got, "parseLabels must never return nil")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStreamLabelsNeverNull(t *testing.T) {
+	// Even with nil labels, JSON output must not contain "stream":null.
+	resp := loki.ConvertGrafanaResponse(&loki.GrafanaQueryResponse{
+		Results: map[string]loki.GrafanaResult{
+			"A": {
+				Frames: []loki.DataFrame{
+					{
+						Schema: loki.DataFrameSchema{
+							Fields: []loki.Field{
+								{Name: "labels", Type: "other"},
+								{Name: "Time", Type: "time"},
+								{Name: "Line", Type: "string"},
+							},
+						},
+						Data: loki.DataFrameData{
+							Values: [][]any{
+								{nil}, // nil labels
+								{float64(1000)},
+								{"a log line"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, resp.Data.Result, 1)
+	assert.NotNil(t, resp.Data.Result[0].Stream)
+
+	// Verify JSON serialization doesn't contain "stream":null
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"stream":null`)
+}

--- a/internal/query/loki/export_test.go
+++ b/internal/query/loki/export_test.go
@@ -13,3 +13,13 @@ func (c *Client) BuildLabelValuesPath(datasourceUID, labelName string) string {
 func (c *Client) BuildSeriesPath(datasourceUID string) string {
 	return c.buildSeriesPath(datasourceUID)
 }
+
+// ConvertGrafanaResponse exposes convertGrafanaResponse for testing.
+func ConvertGrafanaResponse(resp *GrafanaQueryResponse) *QueryResponse {
+	return convertGrafanaResponse(resp)
+}
+
+// ParseLabels exposes parseLabels for testing.
+func ParseLabels(v any) map[string]string {
+	return parseLabels(v)
+}


### PR DESCRIPTION
## Summary
- `gcx logs query` returned `"stream": null` and hash/ID values instead of actual log content
- Root cause: field name mismatch — Grafana Loki returns `"Time"`/`"Line"` but code checked `"timestamp"`/`"body"`, causing fallthrough to legacy format which picked the wrong field
- Adds fallback field name matching, fixes `parseLabels` nil returns, hardens legacy format field selection

## Changes
- `internal/query/loki/client.go`: Fix field name matching in `convertGrafanaResponse`, fix `parseLabels` nil returns, improve `convertLegacyFormat` field selection
- `internal/query/loki/convert_test.go`: 7 new tests covering both field naming conventions, label parsing edge cases, and JSON null safety
- `internal/query/loki/export_test.go`: Expose internal functions for testing

## Test Plan
- [x] Tests pass locally (`go test -race -count=1 ./...`)
- [x] New tests cover both old (`timestamp`/`body`) and new (`Time`/`Line`) field names
- [x] Lint clean on new changes (`golangci-lint --new-from-rev=HEAD`: 0 issues)
- [x] Verified against live thirdact context — stream labels and log content now correct in JSON, YAML, and wide output

🤖 Generated with [Claude Code](https://claude.com/claude-code)