### PR TITLE
feat(auth): auto-derive context name from server URL during login

### DIFF
--- a/cmd/gcx/auth/command.go
+++ b/cmd/gcx/auth/command.go
@@ -146,6 +146,11 @@ func runLogin(cmd *cobra.Command, opts *loginOpts) error {
 }
 
 func loadLoginConfig(ctx context.Context, opts *loginOpts) (config.Config, error) {
+	// Auto-derive context name from server URL when no explicit --context given.
+	if opts.Server != "" && opts.Config.Context == "" {
+		opts.Config.Context = config.ContextNameFromServerURL(opts.Server)
+	}
+
 	var overrides []config.Override
 	if opts.Server != "" && opts.Config.Context != "" {
 		targetContext := opts.Config.Context

--- a/cmd/gcx/auth/command_internal_test.go
+++ b/cmd/gcx/auth/command_internal_test.go
@@ -24,7 +24,7 @@ func (f fakeFlow) Run(context.Context) (*internalauth.Result, error) {
 	return f.result, f.err
 }
 
-func TestRunLogin_serverBootstrapsDefaultContext(t *testing.T) {
+func TestRunLogin_serverDerivesContextFromURL(t *testing.T) {
 	configFile := testutils.CreateTempFile(t, "contexts:\n")
 
 	newFlow := func(server string, _ internalauth.Options) authFlow {
@@ -54,18 +54,57 @@ func TestRunLogin_serverBootstrapsDefaultContext(t *testing.T) {
 
 	require.NoError(t, runLogin(cmd, opts))
 	assert.Contains(t, stderr.String(), "WARNING: OAuth login is experimental")
-	assert.Contains(t, stdout.String(), "Authenticated as user@example.com. Tokens saved to context \"default\".")
+	assert.Contains(t, stdout.String(), "Authenticated as user@example.com. Tokens saved to context \"ops\".")
 
 	saved, err := config.Load(t.Context(), config.ExplicitConfigFile(configFile))
 	require.NoError(t, err)
-	assert.Equal(t, "default", saved.CurrentContext)
-	require.Contains(t, saved.Contexts, "default")
-	require.NotNil(t, saved.Contexts["default"])
-	require.NotNil(t, saved.Contexts["default"].Grafana)
-	assert.Equal(t, "https://ops.grafana.net", saved.Contexts["default"].Grafana.Server)
-	assert.Equal(t, "https://proxy.grafana.net", saved.Contexts["default"].Grafana.ProxyEndpoint)
-	assert.Equal(t, "gat_test_token", saved.Contexts["default"].Grafana.OAuthToken)
-	assert.Equal(t, "gar_test_refresh", saved.Contexts["default"].Grafana.OAuthRefreshToken)
+	assert.Equal(t, "ops", saved.CurrentContext)
+	require.Contains(t, saved.Contexts, "ops")
+	require.NotNil(t, saved.Contexts["ops"])
+	require.NotNil(t, saved.Contexts["ops"].Grafana)
+	assert.Equal(t, "https://ops.grafana.net", saved.Contexts["ops"].Grafana.Server)
+	assert.Equal(t, "https://proxy.grafana.net", saved.Contexts["ops"].Grafana.ProxyEndpoint)
+	assert.Equal(t, "gat_test_token", saved.Contexts["ops"].Grafana.OAuthToken)
+	assert.Equal(t, "gar_test_refresh", saved.Contexts["ops"].Grafana.OAuthRefreshToken)
+}
+
+func TestRunLogin_serverNonGrafanaNetUsesHostname(t *testing.T) {
+	configFile := testutils.CreateTempFile(t, "contexts:\n")
+
+	newFlow := func(server string, _ internalauth.Options) authFlow {
+		require.Equal(t, "https://grafana.mycompany.com", server)
+		return fakeFlow{result: &internalauth.Result{
+			Email:            "user@example.com",
+			APIEndpoint:      "https://proxy.grafana.net",
+			Token:            "gat_test_token",
+			RefreshToken:     "gar_test_refresh",
+			ExpiresAt:        time.Now().Add(time.Hour).Format(time.RFC3339),
+			RefreshExpiresAt: time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+		}}
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+
+	opts := &loginOpts{
+		Config:  configcmd.Options{ConfigFile: configFile},
+		Server:  "https://grafana.mycompany.com",
+		NewFlow: newFlow,
+	}
+
+	require.NoError(t, runLogin(cmd, opts))
+	assert.Contains(t, stdout.String(), `Tokens saved to context "grafana.mycompany.com".`)
+
+	saved, err := config.Load(t.Context(), config.ExplicitConfigFile(configFile))
+	require.NoError(t, err)
+	assert.Equal(t, "grafana.mycompany.com", saved.CurrentContext)
+	require.Contains(t, saved.Contexts, "grafana.mycompany.com")
+	require.NotNil(t, saved.Contexts["grafana.mycompany.com"].Grafana)
+	assert.Equal(t, "https://grafana.mycompany.com", saved.Contexts["grafana.mycompany.com"].Grafana.Server)
 }
 
 func TestRunLogin_serverCreatesMissingExplicitContext(t *testing.T) {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -129,9 +129,17 @@ func (context *Context) ResolveStackSlug() string {
 		return ""
 	}
 
-	parsed, err := url.Parse(context.Grafana.Server)
+	slug, _ := stackSlugFromServerURL(context.Grafana.Server)
+	return slug
+}
+
+// stackSlugFromServerURL attempts to extract a Grafana Cloud stack slug from
+// a server URL. It returns the slug and true for *.grafana.net and
+// *.grafana-dev.net URLs, or ("", false) for anything else.
+func stackSlugFromServerURL(serverURL string) (string, bool) {
+	parsed, err := url.Parse(serverURL)
 	if err != nil {
-		return ""
+		return "", false
 	}
 
 	host := parsed.Hostname()
@@ -142,11 +150,32 @@ func (context *Context) ResolveStackSlug() string {
 			if i := strings.Index(slug, "."); i >= 0 {
 				slug = slug[:i]
 			}
-			return slug
+			if slug == "" {
+				continue
+			}
+			return slug, true
 		}
 	}
 
-	return ""
+	return "", false
+}
+
+// ContextNameFromServerURL derives a context name from a Grafana server URL.
+// For Grafana Cloud URLs (*.grafana.net, *.grafana-dev.net), it returns the
+// stack slug (e.g. "mystack" from "https://mystack.grafana.net").
+// For other URLs, it returns the hostname.
+// Returns DefaultContextName if the URL cannot be parsed.
+func ContextNameFromServerURL(serverURL string) string {
+	if slug, ok := stackSlugFromServerURL(serverURL); ok {
+		return slug
+	}
+
+	parsed, err := url.Parse(serverURL)
+	if err != nil || parsed.Hostname() == "" {
+		return DefaultContextName
+	}
+
+	return parsed.Hostname()
 }
 
 // ResolveGCOMURL returns the Grafana Cloud API (GCOM) base URL for this context.

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -315,6 +315,57 @@ func TestContext_ResolveStackSlug(t *testing.T) {
 	}
 }
 
+func TestContextNameFromServerURL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "grafana.net URL returns stack slug",
+			url:      "https://mystack.grafana.net",
+			expected: "mystack",
+		},
+		{
+			name:     "grafana-dev.net URL returns stack slug",
+			url:      "https://mystack.grafana-dev.net",
+			expected: "mystack",
+		},
+		{
+			name:     "regional grafana.net URL returns first component",
+			url:      "https://mystack.us.grafana.net",
+			expected: "mystack",
+		},
+		{
+			name:     "non-grafana URL returns hostname",
+			url:      "https://grafana.mycompany.com",
+			expected: "grafana.mycompany.com",
+		},
+		{
+			name:     "localhost URL returns hostname",
+			url:      "http://localhost:3000",
+			expected: "localhost",
+		},
+		{
+			name:     "empty string returns default",
+			url:      "",
+			expected: "default",
+		},
+		{
+			name:     "unparseable URL returns default",
+			url:      "://invalid",
+			expected: "default",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := require.New(t)
+			req.Equal(tc.expected, config.ContextNameFromServerURL(tc.url))
+		})
+	}
+}
+
 func TestContext_ResolveGCOMURL(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- When `gcx auth login --server URL` is run without `--context`, the context name is now automatically derived from the server URL instead of falling back to `"default"`
- Grafana Cloud URLs (`*.grafana.net`) use the stack slug (e.g. `mystack`), other URLs use the hostname
- Explicit `--context` flag still takes precedence

## Changes
- `internal/config/types.go`: Extract `stackSlugFromServerURL` helper, add `ContextNameFromServerURL`, refactor `ResolveStackSlug` to use shared helper
- `cmd/gcx/auth/command.go`: 3-line derivation in `loadLoginConfig` when `--context` is omitted
- `internal/config/types_test.go`: Table-driven tests for `ContextNameFromServerURL`
- `cmd/gcx/auth/command_internal_test.go`: Updated + new login tests

## Test Plan
- [x] `TestContextNameFromServerURL` — covers grafana.net, grafana-dev.net, regional, non-GC, localhost, empty, invalid URLs
- [x] `TestRunLogin_serverDerivesContextFromURL` — verifies GC URL derives slug as context name
- [x] `TestRunLogin_serverNonGrafanaNetUsesHostname` — verifies non-GC URL uses hostname
- [x] `TestRunLogin_serverCreatesMissingExplicitContext` — explicit `--context` still works
- [x] `TestContext_ResolveStackSlug` — refactored method still passes all existing tests
- [x] Full test suite passes with race detection
- [x] Build succeeds

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)