### PR TITLE
feat(oncall): route OnCall requests through OAuth proxy

### DIFF
--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -25,6 +25,11 @@ type NamespacedRESTConfig struct {
 	oauthTransport *auth.RefreshTransport
 }
 
+// IsOAuthProxy reports whether the config is using OAuth proxy mode.
+func (n *NamespacedRESTConfig) IsOAuthProxy() bool {
+	return n.oauthTransport != nil
+}
+
 // SetOnRefresh registers a callback that is invoked after a successful OAuth
 // token refresh. This allows the call site (which has access to the config
 // source) to persist refreshed tokens back to the config file.

--- a/internal/config/rest_test.go
+++ b/internal/config/rest_test.go
@@ -121,6 +121,37 @@ func TestNewNamespacedRESTConfig_OAuthProxyTrimsTrailingSlash(t *testing.T) {
 	}
 }
 
+func TestNamespacedRESTConfig_IsOAuthProxy(t *testing.T) {
+	t.Run("true when OAuth configured", func(t *testing.T) {
+		ctx := config.Context{
+			Grafana: &config.GrafanaConfig{
+				Server:        "https://mystack.grafana.net",
+				ProxyEndpoint: "https://mystack.grafana.net/a/grafana-assistant-app",
+				OAuthToken:    "gat_test-token",
+				StackID:       123,
+			},
+		}
+		restCfg := config.NewNamespacedRESTConfig(t.Context(), ctx)
+		if !restCfg.IsOAuthProxy() {
+			t.Fatal("expected IsOAuthProxy() to return true for OAuth config")
+		}
+	})
+
+	t.Run("false when token auth", func(t *testing.T) {
+		ctx := config.Context{
+			Grafana: &config.GrafanaConfig{
+				Server:   "https://mystack.grafana.net",
+				APIToken: "glsa_test-token",
+				StackID:  123,
+			},
+		}
+		restCfg := config.NewNamespacedRESTConfig(t.Context(), ctx)
+		if restCfg.IsOAuthProxy() {
+			t.Fatal("expected IsOAuthProxy() to return false for token auth config")
+		}
+	})
+}
+
 func TestNewNamespacedRESTConfig_OAuthProxySetsHost(t *testing.T) {
 	ctx := config.Context{
 		Grafana: &config.GrafanaConfig{

--- a/internal/providers/oncall/client.go
+++ b/internal/providers/oncall/client.go
@@ -36,31 +36,45 @@ const (
 
 // Client is an HTTP client for the Grafana OnCall API.
 type Client struct {
-	oncallURL  string
-	stackURL   string
-	token      string
-	httpClient *http.Client
+	oncallURL    string
+	stackURL     string
+	token        string
+	httpClient   *http.Client
+	isOAuthProxy bool
 }
 
 // NewClient creates a new OnCall client from the given REST config and OnCall API URL.
 // oncallURL is the OnCall API base URL (e.g., https://oncall-prod-us-central-0.grafana.net/oncall).
 // cfg is the namespaced REST config providing auth, TLS, and the stack URL.
 func NewClient(oncallURL string, cfg config.NamespacedRESTConfig) (*Client, error) {
-	// OnCall API uses its own auth (raw token in Authorization header), not the
-	// Grafana bearer token. Using rest.HTTPClientFor() would inject the Grafana
-	// bearer token via the k8s transport round-tripper, causing 404/auth errors.
-	httpClient := providers.ExternalHTTPClient()
+	var httpClient *http.Client
+	var token string
+	isOAuthProxy := cfg.IsOAuthProxy()
 
-	token := cfg.BearerToken
-	if strings.HasPrefix(token, "Bearer ") {
-		slog.Warn("OnCall token already contains 'Bearer ' prefix — this may be a misconfiguration; the token is used as-is without an additional prefix")
+	if isOAuthProxy {
+		// OAuth mode: route through the assistant external provider proxy.
+		// Use the k8s HTTP client which has the RefreshTransport (gat_ auth).
+		// The proxy adds the real OnCall auth (SA token) on the server side.
+		var err error
+		httpClient, err = rest.HTTPClientFor(&cfg.Config)
+		if err != nil {
+			return nil, fmt.Errorf("oncall: create oauth http client: %w", err)
+		}
+	} else {
+		// Direct mode: use standalone HTTP client with SA token.
+		httpClient = providers.ExternalHTTPClient()
+		token = cfg.BearerToken
+		if strings.HasPrefix(token, "Bearer ") {
+			slog.Warn("OnCall token already contains 'Bearer ' prefix — this may be a misconfiguration; the token is used as-is without an additional prefix")
+		}
 	}
 
 	return &Client{
-		oncallURL:  strings.TrimRight(oncallURL, "/"),
-		stackURL:   cfg.Host,
-		token:      token,
-		httpClient: httpClient,
+		oncallURL:    strings.TrimRight(oncallURL, "/"),
+		stackURL:     cfg.Host,
+		token:        token,
+		httpClient:   httpClient,
+		isOAuthProxy: isOAuthProxy,
 	}, nil
 }
 
@@ -70,10 +84,14 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body io.Rea
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	// OnCall API uses raw token auth (no "Bearer" prefix), matching the cloud CLI's WithRawTokenAuth().
-	req.Header.Set("Authorization", c.token)
+	// When calling directly, set OnCall's raw token auth (no "Bearer" prefix).
+	// When proxying through the oauth server, the RefreshTransport adds the
+	// gat_ token and the proxy adds OnCall auth server-side.
+	if c.token != "" {
+		req.Header.Set("Authorization", c.token)
+	}
 	req.Header.Set("Content-Type", "application/json")
-	if c.stackURL != "" {
+	if c.stackURL != "" && !c.isOAuthProxy {
 		req.Header.Set("X-Grafana-Url", c.stackURL)
 	}
 
@@ -151,7 +169,10 @@ func iterResources[T any](c *Client, ctx context.Context, path, resourceType str
 				return
 			}
 			baseURL, _ := url.Parse(c.oncallURL)
-			if nextURL.Host != "" && nextURL.Host != baseURL.Host {
+			// When using the OAuth proxy, the pagination URL points to the real
+			// OnCall host which differs from the proxy base URL, so skip the host
+			// check.
+			if nextURL.Host != "" && nextURL.Host != baseURL.Host && !c.isOAuthProxy {
 				var z T
 				yield(z, fmt.Errorf("oncall: pagination URL host %q does not match base URL host %q", nextURL.Host, baseURL.Host))
 				return
@@ -159,7 +180,21 @@ func iterResources[T any](c *Client, ctx context.Context, path, resourceType str
 			// The API returns an absolute path that may include the oncallURL
 			// path prefix (e.g. "/oncall/api/v1/..."). Strip the base path so
 			// doRequest (which prepends oncallURL) doesn't double it.
-			next = strings.TrimPrefix(nextURL.Path, baseURL.Path)
+			//
+			// When using the OAuth proxy, the base URL is the proxy, not the real
+			// OnCall host. Extract the relative API path by finding the /api/
+			// boundary — all OnCall API paths start with /api/v1/.
+			if c.isOAuthProxy {
+				// OnCall's base path (e.g. "/oncall") never contains "/api/",
+				// so the first match is always the start of the API route.
+				if idx := strings.Index(nextURL.Path, "/api/"); idx >= 0 {
+					next = nextURL.Path[idx:]
+				} else {
+					next = nextURL.Path
+				}
+			} else {
+				next = strings.TrimPrefix(nextURL.Path, baseURL.Path)
+			}
 			if nextURL.RawQuery != "" {
 				next += "?" + nextURL.RawQuery
 			}

--- a/internal/providers/oncall/client_test.go
+++ b/internal/providers/oncall/client_test.go
@@ -839,3 +839,97 @@ func TestCreateDirectEscalation(t *testing.T) {
 		t.Errorf("unexpected result: %+v", result)
 	}
 }
+
+func TestProxyMode_NoAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	// In proxy mode the client should not set its own Authorization header;
+	// the RefreshTransport (on the HTTP client) adds the gat_ token and
+	// the proxy adds OnCall auth server-side.
+	var receivedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"results": []map[string]any{{"id": "int1", "name": "Test"}},
+		})
+	}))
+	defer srv.Close()
+
+	// Create an OAuth-mode config via NewNamespacedRESTConfig.
+	cfg := config.NewNamespacedRESTConfig(t.Context(), config.Context{
+		Grafana: &config.GrafanaConfig{
+			Server:        "https://mystack.grafana.net",
+			ProxyEndpoint: srv.URL,
+			OAuthToken:    "gat_test",
+			StackID:       123,
+		},
+	})
+
+	client, err := oncall.NewClient(srv.URL, cfg)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = client.ListIntegrations(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The client should NOT have set Authorization (token is empty in proxy mode).
+	// The transport may add its own header, but the raw token should not appear.
+	if receivedAuth == "test-token" {
+		t.Error("proxy mode should not send the direct-mode token")
+	}
+}
+
+func TestProxyMode_PaginationSkipsHostCheck(t *testing.T) {
+	t.Parallel()
+
+	// Simulate paginated responses where the "next" URL points to a different
+	// host (the real OnCall API) than the proxy base URL.
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if page == 0 {
+			page++
+			nextURL := "https://oncall-prod.example.com/oncall/api/v1/integrations/?page=2"
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"results": []map[string]any{{"id": "int1", "name": "First"}},
+				"next":    &nextURL,
+			})
+			return
+		}
+		// Page 2 — returned when the client follows the pagination URL.
+		// In proxy mode, the path should be extracted correctly.
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"results": []map[string]any{{"id": "int2", "name": "Second"}},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := config.NewNamespacedRESTConfig(t.Context(), config.Context{
+		Grafana: &config.GrafanaConfig{
+			Server:        "https://mystack.grafana.net",
+			ProxyEndpoint: srv.URL,
+			OAuthToken:    "gat_test",
+			StackID:       123,
+		},
+	})
+
+	client, err := oncall.NewClient(srv.URL, cfg)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	// In direct mode this would fail because the pagination URL host differs
+	// from the client base URL. In proxy mode it should succeed.
+	results, err := client.ListIntegrations(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+}

--- a/internal/providers/oncall/provider.go
+++ b/internal/providers/oncall/provider.go
@@ -110,9 +110,16 @@ func (l *configLoader) LoadOnCallClient(ctx context.Context) (*Client, string, e
 		return nil, "", err
 	}
 
-	oncallURL, err := l.discoverOnCallURL(ctx, restCfg)
-	if err != nil {
-		return nil, "", err
+	var oncallURL string
+	if restCfg.IsOAuthProxy() {
+		// When using the OAuth proxy, route through the assistant external provider proxy.
+		// cfg.Host is "{proxyEndpoint}/api/cli/v1/proxy". Append the external provider path.
+		oncallURL = restCfg.Host + "/external/oncall"
+	} else {
+		oncallURL, err = l.discoverOnCallURL(ctx, restCfg)
+		if err != nil {
+			return nil, "", err
+		}
 	}
 
 	client, err := NewClient(oncallURL, restCfg)


### PR DESCRIPTION
## Summary

When using oauth, the OnCall client can't call the OnCall API directly (there is no SA token client-side). This routes requests through the assistant's new external provider proxy instead.

- Adds `IsOAuthProxy()` to `NamespacedRESTConfig` to detect OAuth proxy mode
- OnCall client uses the HTTP client (with `RefreshTransport` for gat_ token auth) in OAuth mode, instead of the standalone `ExternalHTTPClient()`, so it uses the oauth mechanisms and proxies requests to the oauth proxy.
- Handles pagination URL host mismatch: OnCall API returns pagination URLs pointing to the real OnCall host, which differs from the proxy base URL

## How it works

```
Direct mode:
  gcx OnCall client → oncall-prod.../oncall/api/v1/... (Authorization: {saToken})

OAuth mode (new):
  gcx OnCall client → {proxyEndpoint}/api/cli/v1/proxy/external/oncall/api/v1/...
                       (Authorization: Bearer gat_xxx via RefreshTransport)
       ↓
  Assistant proxy → discovers OnCall URL from Grafana plugin settings
       ↓
  Assistant proxy → oncall-prod.../oncall/api/v1/... (Authorization: {saToken})
```

## Context

Part of https://github.com/grafana/gcx/issues/430

Fixes 15 OnCall "Invalid token" failures when using `gcx resources get` with OAuth auth. The assistant-side proxy is in https://github.com/grafana/grafana-assistant-app/pull/5812.

## Test plan

- [x] `IsOAuthProxy()` returns true/false for OAuth vs token auth configs
- [x] Proxy mode client doesn't set its own Authorization header
- [x] Pagination works when next URL points to a different host than the proxy
- [x] All existing OnCall client tests continue to pass (direct mode unchanged)

For full e2e tests, we can wait until the backend is in dev & verify