### PR TITLE
chore(release): v0.2.5 changelog

### DIFF
--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,16 +1,18 @@
 
 
-- Add sigil evaluator/rule CRUD and templates commands
-- Add sigil agents and eval read-only commands
-- Add synthetic monitoring private probe management
-- Restructure adaptive metrics command layout
-- Promote `--json ?` as primary discovery for programmatic use
-- Reject stray arguments on group commands
-- Improve error messages for wrong/unknown commands
-- Fix graph output for non-series query results
-- Fix empty timestamp display in traces instant tables
-- Fix synth check status to use alertSensitivity thresholds
-- Include alerting enrichments in SLO definitions get/list
-- Add titles to all issues
-- Restructure docs into VISION, ARCHITECTURE, DESIGN split
-- Fix command syntax and install instructions in README
+- Rename `faro` CLI command to `frontend`
+- Auto-derive context name from server URL during login
+- Add OAuth experimental warning to login flow
+- Add `assistant:chat` scope to OAuth flow
+- Add HTTP traffic debug logging
+- Add Sigil generations, scores, and judge commands
+- Add latency and reachability to synth checks status
+- Add access property to datasource list and get
+- Centralized agent annotations with consistency tests
+- Fix null stream labels and missing content in log queries
+- Improve human-readable logs query output
+- Require `--instant` flag for TraceQL instant metrics
+- Fall back to `/api/ds/query` for Loki and Prometheus
+- Resolve datasources across all API groups
+- Make config edit resilient to broken configs
+- Fix invalid CLI commands in docs and skills

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## v0.2.5 (2026-04-10)
+
+
+
+- Rename `faro` CLI command to `frontend`
+- Auto-derive context name from server URL during login
+- Add OAuth experimental warning to login flow
+- Add `assistant:chat` scope to OAuth flow
+- Add HTTP traffic debug logging
+- Add Sigil generations, scores, and judge commands
+- Add latency and reachability to synth checks status
+- Add access property to datasource list and get
+- Centralized agent annotations with consistency tests
+- Fix null stream labels and missing content in log queries
+- Improve human-readable logs query output
+- Require `--instant` flag for TraceQL instant metrics
+- Fall back to `/api/ds/query` for Loki and Prometheus
+- Resolve datasources across all API groups
+- Make config edit resilient to broken configs
+- Fix invalid CLI commands in docs and skills
+
+
 ## v0.2.4 (2026-04-08)
 
 


### PR DESCRIPTION
## Summary
- Changelog and release notes for v0.2.5 patch release
- After merge, tag the merge commit on main and push the tag:
  ```bash
  git checkout main && git pull
  git tag v0.2.5
  git push origin v0.2.5
  ```

## Release highlights
- Rename `faro` CLI command to `frontend`
- Auto-derive context name from server URL during login
- Add Sigil generations, scores, and judge commands
- Fix null stream labels and missing content in log queries
- Improve human-readable logs query output
- Require `--instant` flag for TraceQL instant metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)