### PR TITLE
Add --expr flag alias for datasource query commands

### DIFF
--- a/cmd/gcx/datasources/query.go
+++ b/cmd/gcx/datasources/query.go
@@ -21,7 +21,7 @@ func QueryCmd(configOpts *cmdconfig.Options) *cobra.Command {
 	var limit int
 
 	cmd := &cobra.Command{
-		Use:   "query DATASOURCE_UID EXPR",
+		Use:   "query DATASOURCE_UID [EXPR]",
 		Short: "Execute a query against any datasource (auto-detects type)",
 		Long: `Execute a query against any datasource, automatically detecting the datasource type.
 
@@ -41,7 +41,7 @@ that do not have a dedicated subcommand.`,
   # Pyroscope via auto-detect
   gcx datasources query pyro-001 '{service_name="frontend"}' \
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --from now-1h --to now`,
-		Args: cobra.ExactArgs(2),
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := shared.Validate(); err != nil {
 				return err
@@ -49,7 +49,10 @@ that do not have a dedicated subcommand.`,
 
 			ctx := cmd.Context()
 			datasourceUID := args[0]
-			expr := args[1]
+			expr, err := shared.ResolveExpr(args, 1)
+			if err != nil {
+				return err
+			}
 
 			cfg, err := configOpts.LoadGrafanaConfig(ctx)
 			if err != nil {

--- a/cmd/gcx/datasources/query_test.go
+++ b/cmd/gcx/datasources/query_test.go
@@ -199,8 +199,26 @@ func TestSinceWithoutToDefaultsEndToNowOnQueryCommand(t *testing.T) {
 	assert.WithinDuration(t, end.Add(-time.Hour), start, time.Second)
 }
 
-// TestQueryRequiresBothArgs verifies that query requires exactly 2 positional args.
-func TestQueryRequiresBothArgs(t *testing.T) {
+// TestQueryRequiresDatasourceUID verifies that query requires at least a datasource UID.
+func TestQueryRequiresDatasourceUID(t *testing.T) {
 	err := executeQueryCommand(t, datasources.QueryCmd(newConfigOpts()), []string{"query"})
 	require.Error(t, err)
+}
+
+func TestExprFlagSmoke_DatasourcesQuery(t *testing.T) {
+	t.Run("--expr accepted instead of positional", func(t *testing.T) {
+		cmd := datasources.QueryCmd(newConfigOpts())
+		err := executeQueryCommand(t, cmd, []string{"query", "uid", "--expr", "up"})
+		if err != nil {
+			assert.NotContains(t, err.Error(), "expression is required")
+			assert.NotContains(t, err.Error(), "accepts")
+		}
+	})
+
+	t.Run("both positional and --expr rejected", func(t *testing.T) {
+		cmd := datasources.QueryCmd(newConfigOpts())
+		err := executeQueryCommand(t, cmd, []string{"query", "uid", "up", "--expr", "up"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
 }

--- a/docs/reference/cli/gcx_datasources_query.md
+++ b/docs/reference/cli/gcx_datasources_query.md
@@ -14,7 +14,7 @@ client is used automatically. This is the escape hatch for datasource types
 that do not have a dedicated subcommand.
 
 ```
-gcx datasources query DATASOURCE_UID EXPR [flags]
+gcx datasources query DATASOURCE_UID [EXPR] [flags]
 ```
 
 ### Examples
@@ -35,6 +35,7 @@ gcx datasources query DATASOURCE_UID EXPR [flags]
 ### Options
 
 ```
+      --expr string           Query expression (alternative to positional argument)
       --from string           Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                  help for query
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_logs_metrics.md
+++ b/docs/reference/cli/gcx_logs_metrics.md
@@ -16,7 +16,7 @@ Instant vs range is deduced from time flags: no time flags = instant query,
 --since or --from/--to = range query.
 
 ```
-gcx logs metrics EXPR [flags]
+gcx logs metrics [EXPR] [flags]
 ```
 
 ### Examples
@@ -40,6 +40,7 @@ gcx logs metrics EXPR [flags]
 
 ```
   -d, --datasource string   Datasource UID (required unless datasources.loki is configured)
+      --expr string         Query expression (alternative to positional argument)
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for metrics
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_logs_query.md
+++ b/docs/reference/cli/gcx_logs_query.md
@@ -15,7 +15,7 @@ bodies or -o json for the full structured response.
 Default --limit is 50; use --limit 0 for no cap.
 
 ```
-gcx logs query EXPR [flags]
+gcx logs query [EXPR] [flags]
 ```
 
 ### Examples
@@ -39,6 +39,7 @@ gcx logs query EXPR [flags]
 
 ```
   -d, --datasource string   Datasource UID (required unless datasources.loki is configured)
+      --expr string         Query expression (alternative to positional argument)
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_metrics_query.md
+++ b/docs/reference/cli/gcx_metrics_query.md
@@ -6,11 +6,12 @@ Execute a PromQL query against a Prometheus datasource
 
 Execute a PromQL query against a Prometheus datasource.
 
-EXPR is the PromQL expression to evaluate.
+EXPR is the PromQL expression to evaluate, passed as a positional argument or
+via --expr (familiar to promtool users).
 Datasource is resolved from -d flag or datasources.prometheus in your context.
 
 ```
-gcx metrics query EXPR [flags]
+gcx metrics query [EXPR] [flags]
 ```
 
 ### Examples
@@ -34,6 +35,7 @@ gcx metrics query EXPR [flags]
 
 ```
   -d, --datasource string   Datasource UID (required unless datasources.prometheus is configured)
+      --expr string         Query expression (alternative to positional argument)
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_profiles_metrics.md
+++ b/docs/reference/cli/gcx_profiles_metrics.md
@@ -17,7 +17,7 @@ EXPR is the label selector (e.g., '{service_name="frontend"}').
 Datasource is resolved from -d flag or datasources.pyroscope in your context.
 
 ```
-gcx profiles metrics EXPR [flags]
+gcx profiles metrics [EXPR] [flags]
 ```
 
 ### Examples
@@ -42,6 +42,7 @@ gcx profiles metrics EXPR [flags]
 ```
       --aggregation string    Aggregation type: 'sum' or 'average'
   -d, --datasource string     Datasource UID (required unless datasources.pyroscope is configured)
+      --expr string           Query expression (alternative to positional argument)
       --from string           Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
       --group-by strings      Group series by label (repeatable, defaults to service_name)
   -h, --help                  help for metrics

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -10,7 +10,7 @@ EXPR is the label selector (e.g., '{service_name="frontend"}').
 Datasource is resolved from -d flag or datasources.pyroscope in your context.
 
 ```
-gcx profiles query EXPR [flags]
+gcx profiles query [EXPR] [flags]
 ```
 
 ### Examples
@@ -34,6 +34,7 @@ gcx profiles query EXPR [flags]
 
 ```
   -d, --datasource string     Datasource UID (required unless datasources.pyroscope is configured)
+      --expr string           Query expression (alternative to positional argument)
       --from string           Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                  help for query
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_traces_metrics.md
+++ b/docs/reference/cli/gcx_traces_metrics.md
@@ -15,7 +15,7 @@ even when a time range is provided. If no time flags are set, gcx queries the
 last hour by default.
 
 ```
-gcx traces metrics TRACEQL [flags]
+gcx traces metrics [TRACEQL] [flags]
 ```
 
 ### Examples
@@ -42,6 +42,7 @@ gcx traces metrics TRACEQL [flags]
 
 ```
   -d, --datasource string   Datasource UID (required unless datasources.tempo is configured)
+      --expr string         Query expression (alternative to positional argument)
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for metrics
       --instant             Run an instant query over the selected time range instead of a range query

--- a/docs/reference/cli/gcx_traces_query.md
+++ b/docs/reference/cli/gcx_traces_query.md
@@ -10,7 +10,7 @@ TRACEQL is the TraceQL expression to evaluate.
 Datasource is resolved from -d flag or datasources.tempo in your context.
 
 ```
-gcx traces query TRACEQL [flags]
+gcx traces query [TRACEQL] [flags]
 ```
 
 ### Examples
@@ -37,6 +37,7 @@ gcx traces query TRACEQL [flags]
 
 ```
   -d, --datasource string   Datasource UID (required unless datasources.tempo is configured)
+      --expr string         Query expression (alternative to positional argument)
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/internal/datasources/query/opts.go
+++ b/internal/datasources/query/opts.go
@@ -91,6 +91,14 @@ type SharedOpts struct {
 
 	IO   cmdio.Options
 	Step string
+	Expr string
+}
+
+// SetupExprFlag registers the --expr flag on the given flag set.
+// Exposed separately from Setup for commands that register flags manually
+// (e.g., logs query, profiles metrics).
+func (opts *SharedOpts) SetupExprFlag(flags *pflag.FlagSet) {
+	flags.StringVar(&opts.Expr, "expr", "", "Query expression (alternative to positional argument)")
 }
 
 // Setup registers shared query flags on the given flag set.
@@ -99,7 +107,26 @@ func (opts *SharedOpts) Setup(flags *pflag.FlagSet, enableGraph bool) {
 	opts.IO.BindFlags(flags)
 
 	opts.SetupTimeFlags(flags)
+	opts.SetupExprFlag(flags)
 	flags.StringVar(&opts.Step, "step", "", "Query step (e.g., '15s', '1m')")
+}
+
+// ResolveExpr resolves the query expression from either the --expr flag or a
+// positional argument at exprArgIndex. Exactly one source must provide the expression.
+func (opts *SharedOpts) ResolveExpr(args []string, exprArgIndex int) (string, error) {
+	haveFlag := opts.Expr != ""
+	haveArg := exprArgIndex < len(args)
+
+	if haveFlag && haveArg {
+		return "", errors.New("provide the expression as a positional argument or via --expr, not both")
+	}
+	if !haveFlag && !haveArg {
+		return "", errors.New("expression is required: provide it as a positional argument or via --expr")
+	}
+	if haveFlag {
+		return opts.Expr, nil
+	}
+	return args[exprArgIndex], nil
 }
 
 // Validate validates shared flags and resolves --since into From/To.

--- a/internal/datasources/query/opts_test.go
+++ b/internal/datasources/query/opts_test.go
@@ -178,6 +178,84 @@ func TestSharedOptsSetup_GraphSupport(t *testing.T) {
 	})
 }
 
+func TestResolveExpr(t *testing.T) {
+	tests := []struct {
+		name         string
+		flagExpr     string
+		args         []string
+		exprArgIndex int
+		want         string
+		wantErr      string
+	}{
+		{
+			name:         "positional arg only",
+			args:         []string{"up"},
+			exprArgIndex: 0,
+			want:         "up",
+		},
+		{
+			name:         "flag only",
+			flagExpr:     "up",
+			args:         []string{},
+			exprArgIndex: 0,
+			want:         "up",
+		},
+		{
+			name:         "both provided",
+			flagExpr:     "up",
+			args:         []string{"up"},
+			exprArgIndex: 0,
+			wantErr:      "provide the expression as a positional argument or via --expr, not both",
+		},
+		{
+			name:         "neither provided",
+			args:         []string{},
+			exprArgIndex: 0,
+			wantErr:      "expression is required: provide it as a positional argument or via --expr",
+		},
+		{
+			name:         "generic command positional (arg index 1)",
+			args:         []string{"uid", "up"},
+			exprArgIndex: 1,
+			want:         "up",
+		},
+		{
+			name:         "generic command flag (arg index 1 absent)",
+			flagExpr:     "up",
+			args:         []string{"uid"},
+			exprArgIndex: 1,
+			want:         "up",
+		},
+		{
+			name:         "generic command both (arg index 1)",
+			flagExpr:     "up",
+			args:         []string{"uid", "up"},
+			exprArgIndex: 1,
+			wantErr:      "not both",
+		},
+		{
+			name:         "generic command neither (arg index 1 absent, no flag)",
+			args:         []string{"uid"},
+			exprArgIndex: 1,
+			wantErr:      "expression is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &dsquery.SharedOpts{Expr: tt.flagExpr}
+			got, err := opts.ResolveExpr(tt.args, tt.exprArgIndex)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestResolveDatasourceFlag(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/providers/logs/expr_test.go
+++ b/internal/providers/logs/expr_test.go
@@ -1,0 +1,58 @@
+//nolint:testpackage // Tests verify unexported command constructor wiring.
+package logs
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func execCmd(t *testing.T, cmd *cobra.Command, args []string) error {
+	t.Helper()
+	root := &cobra.Command{Use: "test"}
+	root.AddCommand(cmd)
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs(args)
+	return root.Execute()
+}
+
+func TestExprFlagSmoke_LogsQuery(t *testing.T) {
+	t.Run("--expr accepted instead of positional", func(t *testing.T) {
+		cmd := queryCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"query", "--expr", `{job="x"}`})
+		if err != nil {
+			assert.NotContains(t, err.Error(), "expression is required")
+			assert.NotContains(t, err.Error(), "accepts")
+		}
+	})
+
+	t.Run("both positional and --expr rejected", func(t *testing.T) {
+		cmd := queryCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"query", `{job="x"}`, "--expr", `{job="x"}`})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
+}
+
+func TestExprFlagSmoke_LogsMetrics(t *testing.T) {
+	t.Run("--expr accepted instead of positional", func(t *testing.T) {
+		cmd := metricsCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"metrics", "--expr", `rate({job="x"}[5m])`})
+		if err != nil {
+			assert.NotContains(t, err.Error(), "expression is required")
+			assert.NotContains(t, err.Error(), "accepts")
+		}
+	})
+
+	t.Run("both positional and --expr rejected", func(t *testing.T) {
+		cmd := metricsCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"metrics", `rate({job="x"}[5m])`, "--expr", `rate({job="x"}[5m])`})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
+}

--- a/internal/providers/logs/metrics.go
+++ b/internal/providers/logs/metrics.go
@@ -19,7 +19,7 @@ func metricsCmd(loader *providers.ConfigLoader) *cobra.Command {
 	var datasource string
 
 	cmd := &cobra.Command{
-		Use:   "metrics EXPR",
+		Use:   "metrics [EXPR]",
 		Short: "Execute a metric LogQL query against a Loki datasource",
 		Long: `Execute a metric LogQL query and return time-series results.
 
@@ -43,7 +43,7 @@ Instant vs range is deduced from time flags: no time flags = instant query,
 
   # Output as JSON
   gcx logs metrics 'rate({job="varlogs"}[5m])' --since 1h -o json`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := shared.Validate(); err != nil {
 				return err
@@ -70,7 +70,10 @@ Instant vs range is deduced from time flags: no time flags = instant query,
 				return err
 			}
 
-			expr := args[0]
+			expr, err := shared.ResolveExpr(args, 0)
+			if err != nil {
+				return err
+			}
 
 			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
 			if err != nil {

--- a/internal/providers/logs/query.go
+++ b/internal/providers/logs/query.go
@@ -20,7 +20,7 @@ func queryCmd(loader *providers.ConfigLoader) *cobra.Command {
 	var datasource string
 
 	cmd := &cobra.Command{
-		Use:   "query EXPR",
+		Use:   "query [EXPR]",
 		Short: "Execute a LogQL query against a Loki datasource",
 		Long: `Execute a LogQL query against a Loki datasource.
 
@@ -31,7 +31,7 @@ Default table output is optimized for humans. Use -o raw for original line
 bodies or -o json for the full structured response.
 
 Default --limit is 50; use --limit 0 for no cap.`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := shared.Validate(); err != nil {
 				return err
@@ -58,7 +58,10 @@ Default --limit is 50; use --limit 0 for no cap.`,
 				return err
 			}
 
-			expr := args[0]
+			expr, err := shared.ResolveExpr(args, 0)
+			if err != nil {
+				return err
+			}
 
 			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
 			if err != nil {
@@ -101,6 +104,7 @@ Default --limit is 50; use --limit 0 for no cap.`,
 	shared.IO.BindFlags(cmd.Flags())
 	shared.SetupTimeFlags(cmd.Flags())
 	cmd.Flags().StringVar(&shared.Step, "step", "", "Query step (e.g., '15s', '1m')")
+	shared.SetupExprFlag(cmd.Flags())
 	cmd.Flags().StringVarP(&datasource, "datasource", "d", "", "Datasource UID (required unless datasources.loki is configured)")
 	cmd.Flags().IntVar(&limit, "limit", dsquery.DefaultLokiLimit, "Maximum number of log lines to return (0 means no limit)")
 

--- a/internal/providers/metrics/expr_test.go
+++ b/internal/providers/metrics/expr_test.go
@@ -1,0 +1,40 @@
+//nolint:testpackage // Tests verify unexported command constructor wiring.
+package metrics
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func execCmd(t *testing.T, cmd *cobra.Command, args []string) error {
+	t.Helper()
+	root := &cobra.Command{Use: "test"}
+	root.AddCommand(cmd)
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs(args)
+	return root.Execute()
+}
+
+func TestExprFlagSmoke_MetricsQuery(t *testing.T) {
+	t.Run("--expr accepted instead of positional", func(t *testing.T) {
+		cmd := queryCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"query", "--expr", "up"})
+		if err != nil {
+			assert.NotContains(t, err.Error(), "expression is required")
+			assert.NotContains(t, err.Error(), "accepts")
+		}
+	})
+
+	t.Run("both positional and --expr rejected", func(t *testing.T) {
+		cmd := queryCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"query", "up", "--expr", "up"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
+}

--- a/internal/providers/metrics/query.go
+++ b/internal/providers/metrics/query.go
@@ -19,13 +19,14 @@ func queryCmd(loader *providers.ConfigLoader) *cobra.Command {
 	var datasource string
 
 	cmd := &cobra.Command{
-		Use:   "query EXPR",
+		Use:   "query [EXPR]",
 		Short: "Execute a PromQL query against a Prometheus datasource",
 		Long: `Execute a PromQL query against a Prometheus datasource.
 
-EXPR is the PromQL expression to evaluate.
+EXPR is the PromQL expression to evaluate, passed as a positional argument or
+via --expr (familiar to promtool users).
 Datasource is resolved from -d flag or datasources.prometheus in your context.`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := shared.Validate(); err != nil {
 				return err
@@ -52,7 +53,10 @@ Datasource is resolved from -d flag or datasources.prometheus in your context.`,
 				return err
 			}
 
-			expr := args[0]
+			expr, err := shared.ResolveExpr(args, 0)
+			if err != nil {
+				return err
+			}
 
 			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
 			if err != nil {

--- a/internal/providers/profiles/expr_test.go
+++ b/internal/providers/profiles/expr_test.go
@@ -1,0 +1,58 @@
+//nolint:testpackage // Tests verify unexported command constructor wiring.
+package profiles
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func execCmd(t *testing.T, cmd *cobra.Command, args []string) error {
+	t.Helper()
+	root := &cobra.Command{Use: "test"}
+	root.AddCommand(cmd)
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs(args)
+	return root.Execute()
+}
+
+func TestExprFlagSmoke_ProfilesQuery(t *testing.T) {
+	t.Run("--expr accepted instead of positional", func(t *testing.T) {
+		cmd := queryCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"query", "--expr", "{}", "--profile-type", "process_cpu:cpu:nanoseconds:cpu:nanoseconds"})
+		if err != nil {
+			assert.NotContains(t, err.Error(), "expression is required")
+			assert.NotContains(t, err.Error(), "accepts")
+		}
+	})
+
+	t.Run("both positional and --expr rejected", func(t *testing.T) {
+		cmd := queryCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"query", "{}", "--expr", "{}", "--profile-type", "process_cpu:cpu:nanoseconds:cpu:nanoseconds"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
+}
+
+func TestExprFlagSmoke_ProfilesMetrics(t *testing.T) {
+	t.Run("--expr accepted instead of positional", func(t *testing.T) {
+		cmd := metricsCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"metrics", "--expr", "{}", "--profile-type", "process_cpu:cpu:nanoseconds:cpu:nanoseconds"})
+		if err != nil {
+			assert.NotContains(t, err.Error(), "expression is required")
+			assert.NotContains(t, err.Error(), "accepts")
+		}
+	})
+
+	t.Run("both positional and --expr rejected", func(t *testing.T) {
+		cmd := metricsCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"metrics", "{}", "--expr", "{}", "--profile-type", "process_cpu:cpu:nanoseconds:cpu:nanoseconds"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
+}

--- a/internal/providers/profiles/query.go
+++ b/internal/providers/profiles/query.go
@@ -22,13 +22,13 @@ func queryCmd(loader *providers.ConfigLoader) *cobra.Command {
 	var datasource string
 
 	cmd := &cobra.Command{
-		Use:   "query EXPR",
+		Use:   "query [EXPR]",
 		Short: "Execute a profiling query against a Pyroscope datasource",
 		Long: `Execute a profiling query against a Pyroscope datasource.
 
 EXPR is the label selector (e.g., '{service_name="frontend"}').
 Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := shared.Validate(); err != nil {
 				return err
@@ -59,7 +59,10 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 				return err
 			}
 
-			expr := args[0]
+			expr, err := shared.ResolveExpr(args, 0)
+			if err != nil {
+				return err
+			}
 
 			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
 			if err != nil {

--- a/internal/providers/profiles/series.go
+++ b/internal/providers/profiles/series.go
@@ -41,6 +41,7 @@ func (opts *pyroscopeMetricsOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.shared.Step, "step", "", "Query step (e.g., '15s', '1m')")
 	flags.StringVar(&opts.shared.Since, "since", "", "Duration before --to (or now if omitted); mutually exclusive with --from")
 
+	opts.shared.SetupExprFlag(flags)
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.pyroscope is configured)")
 	flags.BoolVar(&opts.Top, "top", false, "Aggregate into a ranked leaderboard (equivalent to profilecli query top)")
 	flags.StringVar(&opts.ProfileType, "profile-type", "", "Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)")
@@ -68,7 +69,7 @@ func metricsCmd(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &pyroscopeMetricsOpts{}
 
 	cmd := &cobra.Command{
-		Use:   "metrics EXPR",
+		Use:   "metrics [EXPR]",
 		Short: "Query profile time-series data from a Pyroscope datasource",
 		Long: `Query profile time-series data via SelectSeries from a Pyroscope datasource.
 
@@ -101,7 +102,7 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
   gcx profiles metrics '{service_name="frontend"}' \
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds \
     --since 1h --step 1m -o graph`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err
@@ -128,7 +129,10 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 				return err
 			}
 
-			expr := args[0]
+			expr, err := opts.shared.ResolveExpr(args, 0)
+			if err != nil {
+				return err
+			}
 
 			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
 			if err != nil {

--- a/internal/providers/traces/expr_test.go
+++ b/internal/providers/traces/expr_test.go
@@ -1,0 +1,58 @@
+//nolint:testpackage // Tests verify unexported command constructor wiring.
+package traces
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func execCmd(t *testing.T, cmd *cobra.Command, args []string) error {
+	t.Helper()
+	root := &cobra.Command{Use: "test"}
+	root.AddCommand(cmd)
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs(args)
+	return root.Execute()
+}
+
+func TestExprFlagSmoke_TracesQuery(t *testing.T) {
+	t.Run("--expr accepted instead of positional", func(t *testing.T) {
+		cmd := queryCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"query", "--expr", "{ }"})
+		if err != nil {
+			assert.NotContains(t, err.Error(), "expression is required")
+			assert.NotContains(t, err.Error(), "accepts")
+		}
+	})
+
+	t.Run("both positional and --expr rejected", func(t *testing.T) {
+		cmd := queryCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"query", "{ }", "--expr", "{ }"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
+}
+
+func TestExprFlagSmoke_TracesMetrics(t *testing.T) {
+	t.Run("--expr accepted instead of positional", func(t *testing.T) {
+		cmd := metricsCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"metrics", "--expr", "{ } | rate()"})
+		if err != nil {
+			assert.NotContains(t, err.Error(), "expression is required")
+			assert.NotContains(t, err.Error(), "accepts")
+		}
+	})
+
+	t.Run("both positional and --expr rejected", func(t *testing.T) {
+		cmd := metricsCmd(&providers.ConfigLoader{})
+		err := execCmd(t, cmd, []string{"metrics", "{ } | rate()", "--expr", "{ } | rate()"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
+}

--- a/internal/providers/traces/metrics.go
+++ b/internal/providers/traces/metrics.go
@@ -23,7 +23,7 @@ func metricsCmd(loader *providers.ConfigLoader) *cobra.Command {
 	var instant bool
 
 	cmd := &cobra.Command{
-		Use:   "metrics TRACEQL",
+		Use:   "metrics [TRACEQL]",
 		Short: "Execute a TraceQL metrics query",
 		Long: `Execute a TraceQL metrics query against a Tempo datasource.
 
@@ -49,7 +49,7 @@ last hour by default.`,
 
   # Output as JSON
   gcx traces metrics -d tempo-001 '{ } | rate()' -o json`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := shared.Validate(); err != nil {
 				return err
@@ -76,7 +76,10 @@ last hour by default.`,
 				return err
 			}
 
-			expr := args[0]
+			expr, err := shared.ResolveExpr(args, 0)
+			if err != nil {
+				return err
+			}
 
 			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
 			if err != nil {

--- a/internal/providers/traces/search.go
+++ b/internal/providers/traces/search.go
@@ -21,7 +21,7 @@ func queryCmd(loader *providers.ConfigLoader) *cobra.Command {
 	var datasource string
 
 	cmd := &cobra.Command{
-		Use:     "query TRACEQL",
+		Use:     "query [TRACEQL]",
 		Aliases: []string{"search"},
 		Short:   "Search for traces using a TraceQL query",
 		Long: `Search for traces using a TraceQL query against a Tempo datasource.
@@ -43,7 +43,7 @@ Datasource is resolved from -d flag or datasources.tempo in your context.`,
 
   # Output as JSON
   gcx traces query -d tempo-001 '{ span.http.status_code >= 500 }' -o json`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := shared.Validate(); err != nil {
 				return err
@@ -70,7 +70,10 @@ Datasource is resolved from -d flag or datasources.tempo in your context.`,
 				return err
 			}
 
-			expr := args[0]
+			expr, err := shared.ResolveExpr(args, 0)
+			if err != nil {
+				return err
+			}
 
 			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
 			if err != nil {


### PR DESCRIPTION

## Summary

closes https://github.com/grafana/gcx/issues/323

- Add `--expr` flag as an alternative to the positional query expression argument across all 8 datasource query commands
- Both forms work but not simultaneously — positional remains the primary interface
- `--expr` improves discoverability for users familiar with `promtool` conventions

Closes #323

## How to review this PR

**Commit 1 — `feat(query): add ResolveExpr and SetupExprFlag to SharedOpts`**

Shared infrastructure in `internal/datasources/query/opts.go`:
- `Expr` field on `SharedOpts`
- `SetupExprFlag()` method to register the `--expr` flag
- `ResolveExpr()` method that resolves the expression from either `--expr` or a positional arg, erroring if both or neither are provided
- 8 table-driven unit tests in `opts_test.go`

**Commit 2 — `feat(query): wire --expr flag across all query commands`**

Mechanical wiring across all 8 commands (3 changes each):
- `Args`: `ExactArgs(N)` → `RangeArgs(N-1, N)`
- `Use`: `EXPR` → `[EXPR]`
- Expression resolution: `args[0]` → `shared.ResolveExpr(args, 0)`

Plus smoke tests (`expr_test.go` in each provider package) verifying the flag is accepted and that providing both positional + flag is rejected. Generated CLI reference docs updated.

## Test plan

- [x] `TestResolveExpr` — unit tests for all branches (flag only, arg only, both, neither, arg index 0 and 1)
- [x] `TestExprFlagSmoke_*` — one smoke test per command (8 commands × 2 subtests = 16 tests)
- [x] Existing tests pass unchanged (backward compatible — positional args still work)
- [x] `make lint` clean
- [x] `make tests` pass with race detection