### PR TITLE
feat: set consistent User-Agent header on all HTTP clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,7 @@ internal/
 ├── format/      JSON/YAML codecs with format auto-detection
 ├── retry/       Retry transport (429, 502/503/504, transient connection errors — wraps all HTTP tiers)
 ├── httputils/   HTTP helpers (used by serve command's proxy)
+├── version/     Global version string (Set once from main; provides UserAgent() for HTTP clients)
 ├── secrets/     Redactor for config view
 └── logs/        slog/klog integration
 ```

--- a/cmd/gcx/main.go
+++ b/cmd/gcx/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/cmd/gcx/root"
 	"github.com/grafana/gcx/internal/agent"
+	appversion "github.com/grafana/gcx/internal/version"
 	"golang.org/x/mod/module"
 )
 
@@ -35,6 +36,7 @@ func main() {
 	preParseAgentFlag()
 
 	formattedVersion := formatVersion()
+	appversion.Set(version)
 	if err := root.ValidateArgs(root.Command(formattedVersion), os.Args[1:]); err != nil {
 		handleError(err)
 	}

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -526,8 +526,8 @@ and checked for drift in CI.
 
 ### Low Priority
 
-9. **UserAgent not applied to dynamic client.** `httputils.UserAgent` is defined
-   but not set on the k8s REST config (noted as TODO).
+9. ~~**UserAgent not applied to dynamic client.**~~ Resolved. `version.UserAgent()`
+   is now set on `rest.Config.UserAgent` and `UserAgentTransport` wraps all HTTP clients.
 
 10. **httputils naming confusion.** This package is used by the serve command's
     reverse proxy, not by the primary API client. The name could mislead newcomers

--- a/docs/architecture/client-api-layer.md
+++ b/docs/architecture/client-api-layer.md
@@ -418,11 +418,12 @@ values through constructor chains.
 
 Used by server-side HTTP handlers in `internal/server/handlers/`.
 
-### `constants.go`
+### `useragent.go`
 
-```go
-const UserAgent = "gcx"
-```
+`UserAgentTransport` wraps any `http.RoundTripper` and injects the `User-Agent`
+header (`gcx/{version} ({os}/{arch})`) via `version.UserAgent()` on every request.
+Used by `NewClient` (and thus `NewDefaultClient`) and `NewGCOMClient`. The k8s
+dynamic client gets User-Agent through `rest.Config.UserAgent`.
 
 ### Callers
 

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -84,6 +84,7 @@ gcx/
 │   │   ├── local/            # FSReader / FSWriter (disk I/O)
 │   │   ├── process/          # Processor pipeline (manager fields, server fields)
 │   │   └── remote/           # Puller, Pusher, Deleter (Grafana API ops)
+│   ├── version/              # Global version string (Set once from main; provides UserAgent() for HTTP clients)
 │   └── server/               # Local dev server for 'dev serve'
 │       ├── embed/            # Static assets (embedded via go:embed)
 │       ├── grafana/          # Grafana proxy and mock handlers

--- a/docs/reference/cli/gcx_skills.md
+++ b/docs/reference/cli/gcx_skills.md
@@ -15,11 +15,12 @@ Install the canonical portable gcx Agent Skills bundle for .agents-compatible ag
 ### Options inherited from parent commands
 
 ```
-      --agent            Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --context string   Name of the context to use (overrides current-context in config)
-      --no-color         Disable color output
-      --no-truncate      Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count    Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO

--- a/docs/reference/cli/gcx_skills_install.md
+++ b/docs/reference/cli/gcx_skills_install.md
@@ -32,11 +32,12 @@ gcx skills install [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent            Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --context string   Name of the context to use (overrides current-context in config)
-      --no-color         Disable color output
-      --no-truncate      Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count    Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/retry"
 )
 
@@ -73,7 +74,7 @@ func NewGCOMClient(baseURL, token string) (*GCOMClient, error) {
 
 	httpClient := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: &retry.Transport{},
+		Transport: &httputils.UserAgentTransport{Base: &retry.Transport{}},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if req.URL.Host != parsedBase.Host {
 				return fmt.Errorf("gcom client: refusing cross-domain redirect to %s (configured base: %s)",

--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/gcx/internal/auth"
 	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/retry"
+	"github.com/grafana/gcx/internal/version"
 	"k8s.io/client-go/rest"
 )
 
@@ -149,8 +150,7 @@ func parseRFC3339OrZero(s string) time.Time {
 // NewNamespacedRESTConfig creates a new namespaced REST config.
 func NewNamespacedRESTConfig(ctx context.Context, cfg Context) NamespacedRESTConfig {
 	rcfg := rest.Config{
-		// TODO add user agent
-		// UserAgent: cfg.UserAgent.ValueString(),
+		UserAgent:       version.UserAgent(),
 		Host:            strings.TrimSuffix(cfg.Grafana.Server, "/"),
 		APIPath:         "/apis",
 		TLSClientConfig: rest.TLSClientConfig{},

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-openapi/strfmt"
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/version"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 )
 
@@ -38,6 +39,9 @@ func ClientFromContext(ctx *config.Context) (*goapi.GrafanaHTTPAPI, error) {
 		Host:     grafanaURL.Host,
 		BasePath: strings.TrimLeft(grafanaURL.Path+"/api", "/"),
 		Schemes:  []string{grafanaURL.Scheme},
+		HTTPHeaders: map[string]string{
+			"User-Agent": version.UserAgent(),
+		},
 	}
 
 	if ctx.Grafana.TLS != nil {

--- a/internal/httputils/client.go
+++ b/internal/httputils/client.go
@@ -46,8 +46,9 @@ func NewClient(opts ClientOpts) *http.Client {
 	for _, mw := range middlewares {
 		rt = mw(rt)
 	}
-	// Outermost layer: retry for rate limiting (429) and transient errors.
+	// Outermost layers: User-Agent injection, then retry for rate limiting (429) and transient errors.
 	rt = &retry.Transport{Base: rt}
+	rt = &UserAgentTransport{Base: rt}
 	return &http.Client{Timeout: timeout, Transport: rt}
 }
 

--- a/internal/httputils/client_test.go
+++ b/internal/httputils/client_test.go
@@ -11,10 +11,15 @@ import (
 
 func TestNewDefaultClient_HasRetryAndLoggingTransport(t *testing.T) {
 	client := httputils.NewDefaultClient(context.Background())
-	// Outermost layer is retry.Transport.
-	retryRT, ok := client.Transport.(*retry.Transport)
+	// Outermost layer is UserAgentTransport.
+	uaRT, ok := client.Transport.(*httputils.UserAgentTransport)
 	if !ok {
-		t.Fatalf("expected outermost Transport to be *retry.Transport, got %T", client.Transport)
+		t.Fatalf("expected outermost Transport to be *httputils.UserAgentTransport, got %T", client.Transport)
+	}
+	// Next layer is retry.Transport.
+	retryRT, ok := uaRT.Base.(*retry.Transport)
+	if !ok {
+		t.Fatalf("expected UserAgentTransport.Base to be *retry.Transport, got %T", uaRT.Base)
 	}
 	// Inner layer is LoggingRoundTripper.
 	if _, ok := retryRT.Base.(*httputils.LoggingRoundTripper); !ok {
@@ -25,10 +30,15 @@ func TestNewDefaultClient_HasRetryAndLoggingTransport(t *testing.T) {
 func TestNewDefaultClient_WithPayloadLogging(t *testing.T) {
 	ctx := httputils.WithPayloadLogging(context.Background(), true)
 	client := httputils.NewDefaultClient(ctx)
-	// Outermost layer is retry.Transport.
-	retryRT, ok := client.Transport.(*retry.Transport)
+	// Outermost layer is UserAgentTransport.
+	uaRT, ok := client.Transport.(*httputils.UserAgentTransport)
 	if !ok {
-		t.Fatalf("expected outermost Transport to be *retry.Transport, got %T", client.Transport)
+		t.Fatalf("expected outermost Transport to be *httputils.UserAgentTransport, got %T", client.Transport)
+	}
+	// Next layer is retry.Transport.
+	retryRT, ok := uaRT.Base.(*retry.Transport)
+	if !ok {
+		t.Fatalf("expected UserAgentTransport.Base to be *retry.Transport, got %T", uaRT.Base)
 	}
 	// Inner layer is RequestResponseLoggingRoundTripper (payload logging enabled).
 	if _, ok := retryRT.Base.(*httputils.RequestResponseLoggingRoundTripper); !ok {
@@ -40,10 +50,15 @@ func TestNewClient_CustomMiddleware(t *testing.T) {
 	client := httputils.NewClient(httputils.ClientOpts{
 		Middlewares: []httputils.Middleware{httputils.RequestResponseLoggingMiddleware},
 	})
-	// Outermost layer is retry.Transport.
-	retryRT, ok := client.Transport.(*retry.Transport)
+	// Outermost layer is UserAgentTransport.
+	uaRT, ok := client.Transport.(*httputils.UserAgentTransport)
 	if !ok {
-		t.Fatalf("expected outermost Transport to be *retry.Transport, got %T", client.Transport)
+		t.Fatalf("expected outermost Transport to be *httputils.UserAgentTransport, got %T", client.Transport)
+	}
+	// Next layer is retry.Transport.
+	retryRT, ok := uaRT.Base.(*retry.Transport)
+	if !ok {
+		t.Fatalf("expected UserAgentTransport.Base to be *retry.Transport, got %T", uaRT.Base)
 	}
 	// Inner layer is the custom middleware.
 	if _, ok := retryRT.Base.(*httputils.RequestResponseLoggingRoundTripper); !ok {

--- a/internal/httputils/constants.go
+++ b/internal/httputils/constants.go
@@ -1,3 +1,0 @@
-package httputils
-
-const UserAgent = "gcx"

--- a/internal/httputils/useragent.go
+++ b/internal/httputils/useragent.go
@@ -1,0 +1,24 @@
+package httputils
+
+import (
+	"net/http"
+
+	"github.com/grafana/gcx/internal/version"
+)
+
+// UserAgentTransport injects the gcx User-Agent header into every outgoing request.
+type UserAgentTransport struct {
+	Base http.RoundTripper
+}
+
+func (t *UserAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	clone := req.Clone(req.Context())
+	clone.Header.Set("User-Agent", version.UserAgent())
+
+	return base.RoundTrip(clone)
+}

--- a/internal/httputils/useragent_test.go
+++ b/internal/httputils/useragent_test.go
@@ -1,0 +1,53 @@
+package httputils
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/grafana/gcx/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingTransport struct {
+	req *http.Request
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.req = req
+	return &http.Response{StatusCode: http.StatusOK}, nil
+}
+
+func TestUserAgentTransport_SetsHeader(t *testing.T) {
+	version.Set("2.0.0")
+	t.Cleanup(func() { version.Set("") })
+
+	rec := &recordingTransport{}
+	transport := &UserAgentTransport{Base: rec}
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Contains(t, rec.req.Header.Get("User-Agent"), "gcx/2.0.0")
+}
+
+func TestUserAgentTransport_DoesNotMutateOriginal(t *testing.T) {
+	version.Set("2.0.0")
+	t.Cleanup(func() { version.Set("") })
+
+	rec := &recordingTransport{}
+	transport := &UserAgentTransport{Base: rec}
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Custom", "keep")
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Empty(t, req.Header.Get("User-Agent"), "original request must not be mutated")
+	assert.Equal(t, "keep", rec.req.Header.Get("X-Custom"), "custom headers must be preserved")
+}

--- a/internal/httputils/useragent_test.go
+++ b/internal/httputils/useragent_test.go
@@ -1,9 +1,11 @@
-package httputils
+package httputils_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
+	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,7 +17,7 @@ type recordingTransport struct {
 
 func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	rt.req = req
-	return &http.Response{StatusCode: http.StatusOK}, nil
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
 }
 
 func TestUserAgentTransport_SetsHeader(t *testing.T) {
@@ -23,13 +25,14 @@ func TestUserAgentTransport_SetsHeader(t *testing.T) {
 	t.Cleanup(func() { version.Set("") })
 
 	rec := &recordingTransport{}
-	transport := &UserAgentTransport{Base: rec}
+	transport := &httputils.UserAgentTransport{Base: rec}
 
-	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
 	require.NoError(t, err)
 
-	_, err = transport.RoundTrip(req)
+	resp, err := transport.RoundTrip(req)
 	require.NoError(t, err)
+	defer resp.Body.Close()
 
 	assert.Contains(t, rec.req.Header.Get("User-Agent"), "gcx/2.0.0")
 }
@@ -39,14 +42,15 @@ func TestUserAgentTransport_DoesNotMutateOriginal(t *testing.T) {
 	t.Cleanup(func() { version.Set("") })
 
 	rec := &recordingTransport{}
-	transport := &UserAgentTransport{Base: rec}
+	transport := &httputils.UserAgentTransport{Base: rec}
 
-	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
 	require.NoError(t, err)
 	req.Header.Set("X-Custom", "keep")
 
-	_, err = transport.RoundTrip(req)
+	resp, err := transport.RoundTrip(req)
 	require.NoError(t, err)
+	defer resp.Body.Close()
 
 	assert.Empty(t, req.Header.Get("User-Agent"), "original request must not be mutated")
 	assert.Equal(t, "keep", rec.req.Header.Get("X-Custom"), "custom headers must be preserved")

--- a/internal/server/grafana/requests.go
+++ b/internal/server/grafana/requests.go
@@ -28,7 +28,6 @@ func AuthenticateAndProxyHandler(cfg *config.Context) http.HandlerFunc {
 		}
 
 		AuthenticateRequest(cfg.Grafana, req)
-		req.Header.Set("User-Agent", httputils.UserAgent)
 
 		var tlsCfg *tls.Config
 		if cfg.Grafana != nil && cfg.Grafana.TLS != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/logs"
+	"github.com/grafana/gcx/internal/version"
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/server/grafana"
 	"github.com/grafana/gcx/internal/server/handlers"
@@ -79,7 +80,7 @@ func (s *Server) Start(ctx context.Context) error {
 			grafana.AuthenticateRequest(s.context.Grafana, r.Out)
 
 			r.Out.Header.Del("Origin")
-			r.Out.Header.Set("User-Agent", httputils.UserAgent)
+			r.Out.Header.Set("User-Agent", version.UserAgent())
 		},
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,11 +19,11 @@ import (
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/logs"
-	"github.com/grafana/gcx/internal/version"
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/server/grafana"
 	"github.com/grafana/gcx/internal/server/handlers"
 	"github.com/grafana/gcx/internal/server/livereload"
+	"github.com/grafana/gcx/internal/version"
 	"github.com/grafana/grafana-app-sdk/logging"
 )
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,24 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var ver string //nolint:gochecknoglobals // Set once from main at startup.
+
+// Set stores the application version. Call from main() before HTTP clients are created.
+func Set(v string) { ver = v }
+
+// Get returns the raw version string, defaulting to "SNAPSHOT".
+func Get() string {
+	if ver == "" {
+		return "SNAPSHOT"
+	}
+	return ver
+}
+
+// UserAgent returns the formatted User-Agent: gcx/{version} ({os}/{arch}).
+func UserAgent() string {
+	return fmt.Sprintf("gcx/%s (%s/%s)", Get(), runtime.GOOS, runtime.GOARCH)
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,33 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGet_DefaultIsSNAPSHOT(t *testing.T) {
+	ver = "" // reset
+	assert.Equal(t, "SNAPSHOT", Get())
+}
+
+func TestSetAndGet(t *testing.T) {
+	Set("1.2.3")
+	t.Cleanup(func() { ver = "" })
+	assert.Equal(t, "1.2.3", Get())
+}
+
+func TestUserAgent(t *testing.T) {
+	Set("1.2.3")
+	t.Cleanup(func() { ver = "" })
+	expected := fmt.Sprintf("gcx/1.2.3 (%s/%s)", runtime.GOOS, runtime.GOARCH)
+	assert.Equal(t, expected, UserAgent())
+}
+
+func TestUserAgent_SNAPSHOT(t *testing.T) {
+	ver = ""
+	expected := fmt.Sprintf("gcx/SNAPSHOT (%s/%s)", runtime.GOOS, runtime.GOARCH)
+	assert.Equal(t, expected, UserAgent())
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,33 +1,34 @@
-package version
+package version_test
 
 import (
 	"fmt"
 	"runtime"
 	"testing"
 
+	"github.com/grafana/gcx/internal/version"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGet_DefaultIsSNAPSHOT(t *testing.T) {
-	ver = "" // reset
-	assert.Equal(t, "SNAPSHOT", Get())
+	version.Set("")
+	assert.Equal(t, "SNAPSHOT", version.Get())
 }
 
 func TestSetAndGet(t *testing.T) {
-	Set("1.2.3")
-	t.Cleanup(func() { ver = "" })
-	assert.Equal(t, "1.2.3", Get())
+	version.Set("1.2.3")
+	t.Cleanup(func() { version.Set("") })
+	assert.Equal(t, "1.2.3", version.Get())
 }
 
 func TestUserAgent(t *testing.T) {
-	Set("1.2.3")
-	t.Cleanup(func() { ver = "" })
+	version.Set("1.2.3")
+	t.Cleanup(func() { version.Set("") })
 	expected := fmt.Sprintf("gcx/1.2.3 (%s/%s)", runtime.GOOS, runtime.GOARCH)
-	assert.Equal(t, expected, UserAgent())
+	assert.Equal(t, expected, version.UserAgent())
 }
 
 func TestUserAgent_SNAPSHOT(t *testing.T) {
-	ver = ""
+	version.Set("")
 	expected := fmt.Sprintf("gcx/SNAPSHOT (%s/%s)", runtime.GOOS, runtime.GOARCH)
-	assert.Equal(t, expected, UserAgent())
+	assert.Equal(t, expected, version.UserAgent())
 }


### PR DESCRIPTION
## Summary

- Set `gcx/{version} ({os}/{arch})` User-Agent on all 25+ HTTP clients, up from 2
- New `internal/version` package makes version accessible to internal packages (same pattern as `internal/agent`)
- New `UserAgentTransport` composable RoundTripper follows existing `LoggedHTTPRoundTripper` / `RefreshTransport` pattern
- Three chokepoints cover the majority of clients automatically:
  - `rest.Config.UserAgent` for all k8s client-go based clients (11+)
  - `ExternalHTTPClient` transport wrapper for provider clients (7+)
  - `NewHTTPClient` transport wrapper for dev server clients
- Individual fixes for GCOM and Grafana OpenAPI clients
- Deleted bare `const UserAgent = "gcx"` constant

## Test plan

- [x] New unit tests for `internal/version` (Set/Get/UserAgent format, SNAPSHOT fallback)
- [x] New unit tests for `UserAgentTransport` (header injection, request clone non-mutation)
- [x] Full test suite passes with race detection (`go test -race -count=1 ./...` — 81 packages, 0 failures)
- [x] `go build ./...` compiles cleanly
- [ ] Manual: `bin/gcx --log-level=debug config view` — verify `User-Agent: gcx/SNAPSHOT (darwin/arm64)` in debug logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)