### PR TITLE
feat: add a new skill command to install skills for .agents compatible harnesses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ cmd/gcx/
   commands/     Commands catalog (agent metadata)
   helptree/     Help tree for agent context
   setup/        Onboarding + instrumentation
+  skills/       Portable Agent Skills installer for .agents-compatible tools
   dev/          Developer tools (import, scaffold, generate, lint, serve)
   fail/         Structured error conversion
 

--- a/README.md
+++ b/README.md
@@ -98,14 +98,30 @@ gcx completion fish > ~/.config/fish/completions/gcx #fish
 
 **Verify:** `gcx --version`
 
-### AI Agent Plugin
+### Agent Skills
 
-A [Claude Code plugin](claude-plugin/README.md) is included with a portable
-Agent Skills bundle for gcx workflows: setup, dashboard GitOps, datasource
-exploration, alert investigation, structured debugging, SLO management,
-Synthetic Monitoring workflows, project scaffolding, resource generation and
-import, and end-to-end observability rollout. Install it alongside gcx to give
-your agent deep Grafana knowledge.
+gcx ships a portable Agent Skills bundle for setup, dashboard GitOps,
+datasource exploration, alert investigation, structured debugging, SLO
+management, Synthetic Monitoring workflows, project scaffolding, resource
+generation and import, and end-to-end observability rollout.
+
+**Claude Code**
+
+Use the dedicated [Claude Code plugin](claude-plugin/README.md):
+
+```text
+/plugin marketplace add grafana/gcx
+/plugin install gcx@gcx-marketplace
+```
+
+**Other `.agents`-compatible harnesses**
+
+For example: OpenAI Codex, OpenCode, and Pi. Install the same portable bundle
+into `~/.agents/skills` with:
+
+```bash
+gcx skills install
+```
 
 ## Quick Start
 

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -46,12 +46,11 @@ Once the plugin is installed, ask Claude to configure gcx:
 This skill walks through creating a named context pointing at your Grafana
 instance, verifying connectivity, and confirming your credentials are working.
 
-## Repository Contract
+## Skills
 
 `claude-plugin/skills/` is the current canonical portable Agent Skills bundle
-for gcx. The Claude plugin consumes that tree directly today, and future
-generic `.agents` installers should read from the same source rather than
-forking or duplicating skill content elsewhere in the repository.
+for gcx. The Claude plugin consumes that tree directly today, and the generic
+`.agents` installer exposed by `gcx skills install` reads from the same source.
 
 Claude-specific packaging remains under:
 
@@ -62,11 +61,9 @@ Do not add distributable gcx skills under repo-local `.agents/skills/`. Tools
 that follow the `.agents` convention treat that path as repo-context guidance
 for working on this repository, not as a globally installable skill bundle.
 
-## Skills
-
 Skills are triggered automatically when you describe what you want. You do not
 need to invoke them by name. The table below is the current inventory of the
-canonical portable skill bundle under `claude-plugin/skills/`.
+canonical portable skill bundle.
 
 | Skill | Purpose |
 |-------|---------|

--- a/claude-plugin/assets.go
+++ b/claude-plugin/assets.go
@@ -1,0 +1,20 @@
+package claudeplugin
+
+import (
+	"embed"
+	"io/fs"
+)
+
+const skillsRoot = "skills"
+
+//go:embed skills/**
+var embeddedSkills embed.FS
+
+// SkillsFS returns the canonical portable gcx skill bundle rooted at skills/.
+func SkillsFS() fs.FS {
+	sub, err := fs.Sub(embeddedSkills, skillsRoot)
+	if err != nil {
+		panic(err)
+	}
+	return sub
+}

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -20,6 +20,7 @@ import (
 	cmdproviders "github.com/grafana/gcx/cmd/gcx/providers"
 	"github.com/grafana/gcx/cmd/gcx/resources"
 	"github.com/grafana/gcx/cmd/gcx/setup"
+	skillscmd "github.com/grafana/gcx/cmd/gcx/skills"
 	"github.com/grafana/gcx/internal/agent"
 	internalconfig "github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/logs"
@@ -159,6 +160,7 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 	rootCmd.AddCommand(dashboards.Command())
 	rootCmd.AddCommand(dev.Command())
 	rootCmd.AddCommand(setup.Command())
+	rootCmd.AddCommand(skillscmd.Command())
 	rootCmd.AddCommand(datasources.Command())
 	rootCmd.AddCommand(resources.Command())
 

--- a/cmd/gcx/skills/command.go
+++ b/cmd/gcx/skills/command.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	claudeplugin "github.com/grafana/gcx/claude-plugin"
@@ -138,11 +139,11 @@ func (c *installTextCodec) Encode(dst goio.Writer, value any) error {
 	t := style.NewTable("FIELD", "VALUE")
 	t.Row("ROOT", result.Root)
 	t.Row("SKILLS DIR", result.SkillsDir)
-	t.Row("SKILLS", fmt.Sprintf("%d", result.SkillCount))
-	t.Row("FILES", fmt.Sprintf("%d", result.FileCount))
-	t.Row(writtenLabel, fmt.Sprintf("%d", result.Written))
-	t.Row("OVERWRITTEN", fmt.Sprintf("%d", result.Overwritten))
-	t.Row("UNCHANGED", fmt.Sprintf("%d", result.Unchanged))
+	t.Row("SKILLS", strconv.Itoa(result.SkillCount))
+	t.Row("FILES", strconv.Itoa(result.FileCount))
+	t.Row(writtenLabel, strconv.Itoa(result.Written))
+	t.Row("OVERWRITTEN", strconv.Itoa(result.Overwritten))
+	t.Row("UNCHANGED", strconv.Itoa(result.Unchanged))
 	if err := t.Render(dst); err != nil {
 		return err
 	}
@@ -227,7 +228,7 @@ func installSkills(source fs.FS, root string, force bool, dryRun bool) (installR
 	return result, nil
 }
 
-func syncFile(source fs.FS, sourcePath string, targetPath string, force bool, dryRun bool) (changed bool, overwritten bool, err error) {
+func syncFile(source fs.FS, sourcePath string, targetPath string, force bool, dryRun bool) (bool, bool, error) {
 	sourceData, err := fs.ReadFile(source, sourcePath)
 	if err != nil {
 		return false, false, err

--- a/cmd/gcx/skills/command.go
+++ b/cmd/gcx/skills/command.go
@@ -48,7 +48,7 @@ func (o *installOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("text", &installTextCodec{})
 	o.IO.BindFlags(flags)
 
-	flags.StringVar(&o.Dir, "dir", defaultRoot, "Root directory for the .agents installation (default: ~/.agents)")
+	flags.StringVar(&o.Dir, "dir", defaultRoot, "Root directory for the .agents installation")
 	flags.BoolVar(&o.Force, "force", false, "Overwrite existing differing files managed by the gcx skills bundle")
 	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview the installation without writing files")
 }

--- a/cmd/gcx/skills/command.go
+++ b/cmd/gcx/skills/command.go
@@ -1,0 +1,331 @@
+package skills
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	goio "io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	claudeplugin "github.com/grafana/gcx/claude-plugin"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// Command returns the top-level skills command group.
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skills",
+		Short: "Manage portable gcx Agent Skills",
+		Long:  "Install the canonical portable gcx Agent Skills bundle for .agents-compatible agent harnesses.",
+	}
+
+	cmd.AddCommand(newInstallCommand(claudeplugin.SkillsFS()))
+
+	return cmd
+}
+
+type installOpts struct {
+	Dir    string
+	Force  bool
+	DryRun bool
+	Source fs.FS
+	IO     cmdio.Options
+}
+
+func (o *installOpts) setup(flags *pflag.FlagSet) {
+	defaultRoot := "~/.agents"
+
+	o.IO.DefaultFormat("text")
+	o.IO.RegisterCustomCodec("text", &installTextCodec{})
+	o.IO.BindFlags(flags)
+
+	flags.StringVar(&o.Dir, "dir", defaultRoot, "Root directory for the .agents installation (default: ~/.agents)")
+	flags.BoolVar(&o.Force, "force", false, "Overwrite existing differing files managed by the gcx skills bundle")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview the installation without writing files")
+}
+
+func (o *installOpts) Validate() error {
+	if o.Source == nil {
+		return errors.New("skills source is not configured")
+	}
+
+	return o.IO.Validate()
+}
+
+func newInstallCommand(source fs.FS) *cobra.Command {
+	opts := &installOpts{Source: source}
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install the portable gcx skill bundle into ~/.agents/skills",
+		Long:  "Install the canonical portable gcx Agent Skills bundle into a user-level .agents directory for tools that follow the .agents skill convention.",
+		Example: `  gcx skills install
+  gcx skills install --dry-run
+  gcx skills install --dir ~/.agents --force`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			root, err := resolveInstallRoot(opts.Dir)
+			if err != nil {
+				return err
+			}
+
+			result, err := installSkills(opts.Source, root, opts.Force, opts.DryRun)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), result)
+		},
+	}
+
+	opts.setup(cmd.Flags())
+
+	return cmd
+}
+
+type installResult struct {
+	Root        string   `json:"root"`
+	SkillsDir   string   `json:"skills_dir"`
+	Skills      []string `json:"skills"`
+	SkillCount  int      `json:"skill_count"`
+	FileCount   int      `json:"file_count"`
+	Written     int      `json:"written"`
+	Overwritten int      `json:"overwritten"`
+	Unchanged   int      `json:"unchanged"`
+	DryRun      bool     `json:"dry_run"`
+	Force       bool     `json:"force"`
+}
+
+type installTextCodec struct{}
+
+func (c *installTextCodec) Format() format.Format { return "text" }
+
+func (c *installTextCodec) Encode(dst goio.Writer, value any) error {
+	var result installResult
+	switch v := value.(type) {
+	case installResult:
+		result = v
+	case *installResult:
+		if v == nil {
+			return errors.New("nil install result")
+		}
+		result = *v
+	default:
+		return fmt.Errorf("install text codec: unsupported value %T", value)
+	}
+
+	status := "Installed"
+	writtenLabel := "WRITTEN"
+	if result.DryRun {
+		status = "Would install"
+		writtenLabel = "WOULD WRITE"
+	}
+
+	fmt.Fprintf(dst, "%s %d skill(s) to %s\n\n", status, result.SkillCount, result.SkillsDir)
+
+	t := style.NewTable("FIELD", "VALUE")
+	t.Row("ROOT", result.Root)
+	t.Row("SKILLS DIR", result.SkillsDir)
+	t.Row("SKILLS", fmt.Sprintf("%d", result.SkillCount))
+	t.Row("FILES", fmt.Sprintf("%d", result.FileCount))
+	t.Row(writtenLabel, fmt.Sprintf("%d", result.Written))
+	t.Row("OVERWRITTEN", fmt.Sprintf("%d", result.Overwritten))
+	t.Row("UNCHANGED", fmt.Sprintf("%d", result.Unchanged))
+	if err := t.Render(dst); err != nil {
+		return err
+	}
+
+	if len(result.Skills) > 0 {
+		_, _ = fmt.Fprintln(dst)
+		fmt.Fprintf(dst, "Skill names: %s\n", strings.Join(result.Skills, ", "))
+	}
+
+	return nil
+}
+
+func (c *installTextCodec) Decode(_ goio.Reader, _ any) error {
+	return errors.New("install text codec does not support decoding")
+}
+
+func installSkills(source fs.FS, root string, force bool, dryRun bool) (installResult, error) {
+	if source == nil {
+		return installResult{}, errors.New("skills source is nil")
+	}
+
+	root = filepath.Clean(root)
+	result := installResult{
+		Root:      root,
+		SkillsDir: filepath.Join(root, "skills"),
+		DryRun:    dryRun,
+		Force:     force,
+	}
+
+	if err := ensureDirectory(result.SkillsDir, dryRun); err != nil {
+		return installResult{}, err
+	}
+
+	skillSet := make(map[string]struct{})
+
+	err := fs.WalkDir(source, ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == "." {
+			return nil
+		}
+
+		parts := strings.Split(path, "/")
+		if len(parts) > 0 && parts[0] != "" {
+			skillSet[parts[0]] = struct{}{}
+		}
+
+		targetPath := filepath.Join(result.SkillsDir, filepath.FromSlash(path))
+		if d.IsDir() {
+			return ensureDirectory(targetPath, dryRun)
+		}
+
+		result.FileCount++
+
+		if err := ensureDirectory(filepath.Dir(targetPath), dryRun); err != nil {
+			return err
+		}
+
+		changed, overwritten, err := syncFile(source, path, targetPath, force, dryRun)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			result.Unchanged++
+			return nil
+		}
+		if overwritten {
+			result.Overwritten++
+			return nil
+		}
+		result.Written++
+		return nil
+	})
+	if err != nil {
+		return installResult{}, err
+	}
+
+	result.Skills = sortedKeys(skillSet)
+	result.SkillCount = len(result.Skills)
+
+	return result, nil
+}
+
+func syncFile(source fs.FS, sourcePath string, targetPath string, force bool, dryRun bool) (changed bool, overwritten bool, err error) {
+	sourceData, err := fs.ReadFile(source, sourcePath)
+	if err != nil {
+		return false, false, err
+	}
+
+	existingData, err := os.ReadFile(targetPath)
+	switch {
+	case err == nil:
+		if bytes.Equal(existingData, sourceData) {
+			return false, false, nil
+		}
+		if !force {
+			return false, false, fmt.Errorf("destination file differs: %s (use --force to overwrite)", targetPath)
+		}
+		if dryRun {
+			return true, true, nil
+		}
+		return true, true, os.WriteFile(targetPath, sourceData, fileMode(source, sourcePath))
+	case errors.Is(err, os.ErrNotExist):
+		if dryRun {
+			return true, false, nil
+		}
+		return true, false, os.WriteFile(targetPath, sourceData, fileMode(source, sourcePath))
+	default:
+		return false, false, err
+	}
+}
+
+func ensureDirectory(path string, dryRun bool) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("destination path exists and is not a directory: %s", path)
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if dryRun {
+		return nil
+	}
+	return os.MkdirAll(path, 0o755)
+}
+
+func fileMode(source fs.FS, path string) fs.FileMode {
+	info, err := fs.Stat(source, path)
+	if err != nil {
+		return 0o644
+	}
+	if perm := info.Mode().Perm(); perm != 0 {
+		return perm
+	}
+	return 0o644
+}
+
+func defaultAgentsRoot() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".agents"), nil
+}
+
+func resolveInstallRoot(root string) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		defaultRoot, err := defaultAgentsRoot()
+		if err != nil {
+			return "", err
+		}
+		root = defaultRoot
+	}
+
+	if root == "~" || strings.HasPrefix(root, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("determine home directory: %w", err)
+		}
+		if root == "~" {
+			root = home
+		} else {
+			root = filepath.Join(home, root[2:])
+		}
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve install root %q: %w", root, err)
+	}
+
+	return filepath.Clean(absRoot), nil
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cmd/gcx/skills/command_test.go
+++ b/cmd/gcx/skills/command_test.go
@@ -1,4 +1,4 @@
-package skills
+package skills //nolint:testpackage // Tests exercise unexported installer helpers directly to cover conflict and dry-run behavior.
 
 import (
 	"bytes"
@@ -67,7 +67,7 @@ func TestInstallSkills_ConflictingFileRequiresForce(t *testing.T) {
 	root := filepath.Join(t.TempDir(), ".agents")
 	target := filepath.Join(root, "skills", "alpha")
 	require.NoError(t, os.MkdirAll(target, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("local-change"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("local-change"), 0o600))
 
 	_, err := installSkills(testSkillsFS(), root, false, false)
 	require.Error(t, err)
@@ -80,7 +80,7 @@ func TestInstallSkills_ForceOverwritesDifferingFiles(t *testing.T) {
 	root := filepath.Join(t.TempDir(), ".agents")
 	target := filepath.Join(root, "skills", "alpha")
 	require.NoError(t, os.MkdirAll(target, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("local-change"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("local-change"), 0o600))
 
 	result, err := installSkills(testSkillsFS(), root, true, false)
 	require.NoError(t, err)

--- a/cmd/gcx/skills/command_test.go
+++ b/cmd/gcx/skills/command_test.go
@@ -1,0 +1,114 @@
+package skills
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testSkillsFS() fs.FS {
+	return fstest.MapFS{
+		"alpha/SKILL.md":                     {Data: []byte("alpha-skill")},
+		"alpha/references/guide.md":          {Data: []byte("alpha-guide")},
+		"beta/SKILL.md":                      {Data: []byte("beta-skill")},
+		"beta/references/troubleshooting.md": {Data: []byte("beta-help")},
+	}
+}
+
+func TestInstallSkills_WritesBundleIntoSkillsSubdir(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+
+	result, err := installSkills(testSkillsFS(), root, false, false)
+	require.NoError(t, err)
+
+	require.Equal(t, filepath.Clean(root), result.Root)
+	require.Equal(t, filepath.Join(filepath.Clean(root), "skills"), result.SkillsDir)
+	require.Equal(t, []string{"alpha", "beta"}, result.Skills)
+	require.Equal(t, 2, result.SkillCount)
+	require.Equal(t, 4, result.FileCount)
+	require.Equal(t, 4, result.Written)
+	require.Zero(t, result.Overwritten)
+	require.Zero(t, result.Unchanged)
+
+	data, err := os.ReadFile(filepath.Join(root, "skills", "alpha", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("alpha-skill"), data)
+
+	data, err = os.ReadFile(filepath.Join(root, "skills", "beta", "references", "troubleshooting.md"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("beta-help"), data)
+}
+
+func TestInstallSkills_DryRunDoesNotWriteFiles(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+
+	result, err := installSkills(testSkillsFS(), root, false, true)
+	require.NoError(t, err)
+	require.True(t, result.DryRun)
+	require.Equal(t, 4, result.Written)
+
+	_, err = os.Stat(filepath.Join(root, "skills", "alpha", "SKILL.md"))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestInstallSkills_ConflictingFileRequiresForce(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+	target := filepath.Join(root, "skills", "alpha")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("local-change"), 0o644))
+
+	_, err := installSkills(testSkillsFS(), root, false, false)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "use --force to overwrite")
+}
+
+func TestInstallSkills_ForceOverwritesDifferingFiles(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+	target := filepath.Join(root, "skills", "alpha")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("local-change"), 0o644))
+
+	result, err := installSkills(testSkillsFS(), root, true, false)
+	require.NoError(t, err)
+	require.Equal(t, 3, result.Written)
+	require.Equal(t, 1, result.Overwritten)
+
+	data, err := os.ReadFile(filepath.Join(target, "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("alpha-skill"), data)
+}
+
+func TestInstallCommand_UsesDefaultAgentsRootFromHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	cmd := newInstallCommand(testSkillsFS())
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(home, ".agents", "skills", "alpha", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("alpha-skill"), data)
+	require.Contains(t, stdout.String(), "Installed 2 skill(s)")
+}

--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -106,6 +106,13 @@ gcx (root)
 │           ├── --filename / -f  Path to manifest file (required)
 │           └── --dry-run    Preview changes without applying
 │
+├── skills                   [cmd/gcx/skills/command.go]
+│   └── install             Install the canonical portable gcx Agent Skills bundle into a .agents root
+│       ├── --dir           .agents root directory (default: ~/.agents)
+│       ├── --force         Overwrite existing differing files
+│       ├── --dry-run       Preview installation without writing files
+│       └── --output / -o   text|json|yaml
+│
 └── dev                      [cmd/gcx/dev/command.go]
     ├── generate [FILE_PATH]... Generate typed Go stubs for new resources
     ├── import               Import existing Grafana resources as code

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -18,6 +18,7 @@ gcx/
 │       ├── helptree/        # 'help-tree' compact text tree for agent context injection
 │       ├── setup/            # 'setup' command area (onboarding, product config)
 │       │   └── instrumentation/  # Instrumentation subcommands (status, discover, show, apply)
+│       ├── skills/           # 'skills' subcommand (portable Agent Skills installer for .agents bundles)
 │       ├── dev/              # 'dev' subcommand (import, scaffold, generate, lint, serve)
 │       ├── providers/        # 'providers' subcommand implementation
 │       └── fail/             # Error → DetailedError conversion, exit codes

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -44,6 +44,7 @@ gcx is a unified CLI for managing Grafana resources, dashboards, datasources, al
 * [gcx resources](gcx_resources.md)	 - Manipulate Grafana resources
 * [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
 * [gcx sigil](gcx_sigil.md)	 - Manage Sigil AI observability resources
+* [gcx skills](gcx_skills.md)	 - Manage portable gcx Agent Skills
 * [gcx slo](gcx_slo.md)	 - Manage Grafana SLO definitions and reports
 * [gcx synth](gcx_synth.md)	 - Manage Grafana Synthetic Monitoring checks and probes
 * [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces

--- a/docs/reference/cli/gcx_skills.md
+++ b/docs/reference/cli/gcx_skills.md
@@ -1,0 +1,29 @@
+## gcx skills
+
+Manage portable gcx Agent Skills
+
+### Synopsis
+
+Install the canonical portable gcx Agent Skills bundle for .agents-compatible agent harnesses.
+
+### Options
+
+```
+  -h, --help   help for skills
+```
+
+### Options inherited from parent commands
+
+```
+      --agent            Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string   Name of the context to use (overrides current-context in config)
+      --no-color         Disable color output
+      --no-truncate      Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count    Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx skills install](gcx_skills_install.md)	 - Install the portable gcx skill bundle into ~/.agents/skills
+

--- a/docs/reference/cli/gcx_skills_install.md
+++ b/docs/reference/cli/gcx_skills_install.md
@@ -1,0 +1,45 @@
+## gcx skills install
+
+Install the portable gcx skill bundle into ~/.agents/skills
+
+### Synopsis
+
+Install the canonical portable gcx Agent Skills bundle into a user-level .agents directory for tools that follow the .agents skill convention.
+
+```
+gcx skills install [flags]
+```
+
+### Examples
+
+```
+  gcx skills install
+  gcx skills install --dry-run
+  gcx skills install --dir ~/.agents --force
+```
+
+### Options
+
+```
+      --dir string      Root directory for the .agents installation (default: ~/.agents) (default "~/.agents")
+      --dry-run         Preview the installation without writing files
+      --force           Overwrite existing differing files managed by the gcx skills bundle
+  -h, --help            help for install
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, text, yaml (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent            Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string   Name of the context to use (overrides current-context in config)
+      --no-color         Disable color output
+      --no-truncate      Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count    Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx skills](gcx_skills.md)	 - Manage portable gcx Agent Skills
+

--- a/docs/reference/cli/gcx_skills_install.md
+++ b/docs/reference/cli/gcx_skills_install.md
@@ -21,7 +21,7 @@ gcx skills install [flags]
 ### Options
 
 ```
-      --dir string      Root directory for the .agents installation (default: ~/.agents) (default "~/.agents")
+      --dir string      Root directory for the .agents installation (default "~/.agents")
       --dry-run         Preview the installation without writing files
       --force           Overwrite existing differing files managed by the gcx skills bundle
   -h, --help            help for install

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -90,6 +90,9 @@ var commandAnnotations = map[string]annotation{
 	"gcx setup instrumentation show":     {Cost: "medium", Hint: "<cluster> -o json"},
 	"gcx setup instrumentation status":   {Cost: "small"},
 
+	// skills
+	"gcx skills install": {Cost: "small"},
+
 	// -----------------------------------------------------------------------
 	// Alert provider
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
GCX is currently Claude Code centric. This PR aims for make it compatible with other agents like Codex, OpenCode, Pi etc. 

It adds a new command called skills that allow to install them from the ones defined in the claude-plugin as a canonical source.

The skills are installed in `~/.agents` folder

<img width="746" height="278" alt="image" src="https://github.com/user-attachments/assets/2c4d6dc8-0b70-409a-a482-2619779aa618" />
