### PR TITLE
feat(pagination): add --limit flag with default pagination (50 items) to all list commands

### DIFF
--- a/cmd/gcx/datasources/list.go
+++ b/cmd/gcx/datasources/list.go
@@ -17,8 +17,9 @@ import (
 )
 
 type listOpts struct {
-	IO   cmdio.Options
-	Type string
+	IO    cmdio.Options
+	Type  string
+	Limit int
 }
 
 func (opts *listOpts) setup(flags *pflag.FlagSet) {
@@ -27,6 +28,7 @@ func (opts *listOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 
 	flags.StringVarP(&opts.Type, "type", "t", "", "Filter by datasource type (e.g., prometheus, loki)")
+	flags.IntVar(&opts.Limit, "limit", 50, "Maximum number of datasources to return")
 }
 
 func (opts *listOpts) Validate() error {
@@ -90,6 +92,9 @@ func listCmd(configOpts *cmdconfig.Options) *cobra.Command {
 						})
 					}
 				}
+				if opts.Limit > 0 && len(filtered) > opts.Limit {
+					filtered = filtered[:opts.Limit]
+				}
 				return outputDatasources(cmd, opts, filtered)
 			}
 
@@ -104,6 +109,10 @@ func listCmd(configOpts *cmdconfig.Options) *cobra.Command {
 					Default:  ds.IsDefault,
 					ReadOnly: ds.ReadOnly,
 				})
+			}
+
+			if opts.Limit > 0 && len(infos) > opts.Limit {
+				infos = infos[:opts.Limit]
 			}
 
 			return outputDatasources(cmd, opts, infos)

--- a/cmd/gcx/resources/get.go
+++ b/cmd/gcx/resources/get.go
@@ -101,9 +101,14 @@ func discoverFieldsViaOpenAPI(ctx context.Context, cfg config.NamespacedRESTConf
 	return schemaToFieldPaths(specSchema), nil
 }
 
+// defaultListLimit is the default number of items returned per resource type.
+// Use --limit=0 to fetch all items.
+const defaultListLimit = 200
+
 type getOpts struct {
 	IO      cmdio.Options
 	OnError OnErrorMode
+	Limit   int64
 }
 
 func (opts *getOpts) setup(flags *pflag.FlagSet) {
@@ -113,6 +118,8 @@ func (opts *getOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.RegisterCustomCodec("wide", &tableCodec{wide: true})
 	opts.IO.DefaultFormat("text")
 
+	flags.Int64Var(&opts.Limit, "limit", defaultListLimit, "Maximum number of items to fetch per resource type (0 for all)")
+
 	// Bind all the flags
 	opts.IO.BindFlags(flags)
 }
@@ -120,6 +127,10 @@ func (opts *getOpts) setup(flags *pflag.FlagSet) {
 func (opts *getOpts) Validate() error {
 	if err := opts.IO.Validate(); err != nil {
 		return err
+	}
+
+	if opts.Limit < 0 {
+		return errors.New("--limit must be a non-negative integer")
 	}
 
 	return opts.OnError.Validate()
@@ -223,6 +234,7 @@ func getCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			fetchReq := FetchRequest{
 				Config:      cfg,
 				StopOnError: opts.OnError.StopOnError(),
+				Limit:       opts.Limit,
 			}
 			// --json ? only needs one resource for field introspection; avoid
 			// a full list operation to satisfy NC-005.
@@ -274,6 +286,12 @@ func getCmd(configOpts *cmdconfig.Options) *cobra.Command {
 
 			if encodeErr != nil {
 				return encodeErr
+			}
+
+			if res.PullSummary.IsTruncated() {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"Showing first %d items per resource type. Use --limit=0 to fetch all.\n",
+					opts.Limit)
 			}
 
 			if opts.OnError.FailOnErrors() && res.PullSummary.FailedCount() > 0 {

--- a/cmd/gcx/resources/get.go
+++ b/cmd/gcx/resources/get.go
@@ -103,7 +103,7 @@ func discoverFieldsViaOpenAPI(ctx context.Context, cfg config.NamespacedRESTConf
 
 // defaultListLimit is the default number of items returned per resource type.
 // Use --limit=0 to fetch all items.
-const defaultListLimit = 200
+const defaultListLimit = 50
 
 type getOpts struct {
 	IO      cmdio.Options

--- a/docs/reference/cli/gcx_alert_groups_list.md
+++ b/docs/reference/cli/gcx_alert_groups_list.md
@@ -11,6 +11,7 @@ gcx alert groups list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for unlimited) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_alert_rules_list.md
+++ b/docs/reference/cli/gcx_alert_rules_list.md
@@ -13,6 +13,7 @@ gcx alert rules list [flags]
       --group string    Filter by group name
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for unlimited) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
       --state string    Filter by rule state (firing, pending, inactive)
 ```

--- a/docs/reference/cli/gcx_assistant_investigations_list.md
+++ b/docs/reference/cli/gcx_assistant_investigations_list.md
@@ -15,6 +15,7 @@ gcx assistant investigations list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of investigations to return (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
       --state string    Filter by investigation state (e.g. running, completed, cancelled)
 ```

--- a/docs/reference/cli/gcx_datasources_list.md
+++ b/docs/reference/cli/gcx_datasources_list.md
@@ -29,6 +29,7 @@ gcx datasources list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of datasources to return (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
   -t, --type string     Filter by datasource type (e.g., prometheus, loki)
 ```

--- a/docs/reference/cli/gcx_fleet_collectors_list.md
+++ b/docs/reference/cli/gcx_fleet_collectors_list.md
@@ -11,6 +11,7 @@ gcx fleet collectors list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_fleet_pipelines_list.md
+++ b/docs/reference/cli/gcx_fleet_pipelines_list.md
@@ -11,6 +11,7 @@ gcx fleet pipelines list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_frontend_apps_list.md
+++ b/docs/reference/cli/gcx_frontend_apps_list.md
@@ -11,6 +11,7 @@ gcx frontend apps list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for unlimited) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_incidents_list.md
+++ b/docs/reference/cli/gcx_incidents_list.md
@@ -11,7 +11,7 @@ gcx incidents list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int       Maximum number of incidents to return (default 100)
+      --limit int       Maximum number of incidents to return (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_k6_env-vars_list.md
+++ b/docs/reference/cli/gcx_k6_env-vars_list.md
@@ -11,6 +11,7 @@ gcx k6 env-vars list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_k6_load-tests_list.md
+++ b/docs/reference/cli/gcx_k6_load-tests_list.md
@@ -11,6 +11,7 @@ gcx k6 load-tests list [flags]
 ```
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int        Maximum number of items to return (0 for all) (default 50)
   -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
       --project-id int   Filter by project ID
 ```

--- a/docs/reference/cli/gcx_k6_load-zones_list.md
+++ b/docs/reference/cli/gcx_k6_load-zones_list.md
@@ -11,6 +11,7 @@ gcx k6 load-zones list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_k6_projects_list.md
+++ b/docs/reference/cli/gcx_k6_projects_list.md
@@ -11,6 +11,7 @@ gcx k6 projects list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_k6_runs_list.md
+++ b/docs/reference/cli/gcx_k6_runs_list.md
@@ -12,6 +12,7 @@ gcx k6 runs list [id-or-name] [flags]
   -h, --help             help for list
       --id int           Load test ID (skip name lookup)
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int        Maximum number of items to return (0 for all) (default 50)
   -o, --output string    Output format. One of: json, table, yaml (default "table")
       --project-id int   Project ID (required when looking up by name)
 ```

--- a/docs/reference/cli/gcx_k6_schedules_list.md
+++ b/docs/reference/cli/gcx_k6_schedules_list.md
@@ -11,6 +11,7 @@ gcx k6 schedules list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_k6_test-run_runs_list.md
+++ b/docs/reference/cli/gcx_k6_test-run_runs_list.md
@@ -12,6 +12,7 @@ gcx k6 test-run runs list [test-name] [flags]
   -h, --help             help for list
       --id int           Load test ID (skip name lookup)
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int        Maximum number of items to return (0 for all) (default 50)
   -o, --output string    Output format. One of: json, table, yaml (default "table")
       --project-id int   k6 Cloud project ID (required when using name lookup)
 ```

--- a/docs/reference/cli/gcx_kg_datasets_list.md
+++ b/docs/reference/cli/gcx_kg_datasets_list.md
@@ -11,6 +11,7 @@ gcx kg datasets list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_kg_entities_list.md
+++ b/docs/reference/cli/gcx_kg_entities_list.md
@@ -13,6 +13,7 @@ gcx kg entities list [flags]
       --env string         Environment scope
   -h, --help               help for list
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int          Maximum number of items to return (0 for all) (default 50)
       --namespace string   Namespace scope
   -o, --output string      Output format. One of: json, table, yaml (default "table")
       --page int           Page number (0-based)

--- a/docs/reference/cli/gcx_kg_entities_show.md
+++ b/docs/reference/cli/gcx_kg_entities_show.md
@@ -13,6 +13,7 @@ gcx kg entities show [name] [flags]
   -h, --help               help for show
       --insights-only      Only return entities with active insights (list mode)
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int          Maximum number of items to return (0 for all) (default 50)
       --namespace string   Namespace scope
   -o, --output string      Output format. One of: json, table, yaml (default "table")
       --page int           Page number, 0-based (list mode)

--- a/docs/reference/cli/gcx_kg_entity-types_list.md
+++ b/docs/reference/cli/gcx_kg_entity-types_list.md
@@ -11,6 +11,7 @@ gcx kg entity-types list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_kg_rules_list.md
+++ b/docs/reference/cli/gcx_kg_rules_list.md
@@ -11,6 +11,7 @@ gcx kg rules list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_kg_scopes_list.md
+++ b/docs/reference/cli/gcx_kg_scopes_list.md
@@ -11,6 +11,7 @@ gcx kg scopes list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, yaml (default "json")
 ```
 

--- a/docs/reference/cli/gcx_kg_search_entities.md
+++ b/docs/reference/cli/gcx_kg_search_entities.md
@@ -12,6 +12,7 @@ gcx kg search entities [flags]
       --env string         Environment scope
   -h, --help               help for entities
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int          Maximum number of items to return (0 for all) (default 50)
       --namespace string   Namespace scope
   -o, --output string      Output format. One of: json, yaml (default "json")
       --page int           Page number (0-based)

--- a/docs/reference/cli/gcx_kg_vendors_list.md
+++ b/docs/reference/cli/gcx_kg_vendors_list.md
@@ -11,6 +11,7 @@ gcx kg vendors list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, yaml (default "json")
 ```
 

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_list.md
@@ -12,6 +12,7 @@ gcx logs adaptive drop-rules list [flags]
       --expiration-filter string   Filter by expiration: all, active, or expired (default "all")
   -h, --help                       help for list
       --json string                Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int                  Maximum number of drop rules to return (0 for no limit) (default 50)
   -o, --output string              Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions_list.md
@@ -11,6 +11,7 @@ gcx logs adaptive exemptions list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of exemptions to return (0 for no limit) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_logs_adaptive_segments_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments_list.md
@@ -11,6 +11,7 @@ gcx logs adaptive segments list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of segments to return (0 for no limit) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_list.md
@@ -11,6 +11,7 @@ gcx metrics adaptive rules list [flags]
 ```
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int        Maximum number of rules to return (0 for no limit) (default 50)
   -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
       --segment string   Segment ID
 ```

--- a/docs/reference/cli/gcx_oncall_alert-groups_list-alerts.md
+++ b/docs/reference/cli/gcx_oncall_alert-groups_list-alerts.md
@@ -11,6 +11,7 @@ gcx oncall alert-groups list-alerts <alert-group-id> [flags]
 ```
   -h, --help            help for list-alerts
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_alert-groups_list.md
+++ b/docs/reference/cli/gcx_oncall_alert-groups_list.md
@@ -11,6 +11,7 @@ gcx oncall alert-groups list [flags]
 ```
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int        Maximum number of items to return (0 for all) (default 50)
       --max-age string   Exclude groups older than this duration (e.g. 1h, 24h, 7d)
   -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
 ```

--- a/docs/reference/cli/gcx_oncall_escalation-chains_list.md
+++ b/docs/reference/cli/gcx_oncall_escalation-chains_list.md
@@ -11,6 +11,7 @@ gcx oncall escalation-chains list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_escalation-policies_list.md
+++ b/docs/reference/cli/gcx_oncall_escalation-policies_list.md
@@ -11,6 +11,7 @@ gcx oncall escalation-policies list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_integrations_list.md
+++ b/docs/reference/cli/gcx_oncall_integrations_list.md
@@ -11,6 +11,7 @@ gcx oncall integrations list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_organizations_list.md
+++ b/docs/reference/cli/gcx_oncall_organizations_list.md
@@ -11,6 +11,7 @@ gcx oncall organizations list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_resolution-notes_list.md
+++ b/docs/reference/cli/gcx_oncall_resolution-notes_list.md
@@ -11,6 +11,7 @@ gcx oncall resolution-notes list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_routes_list.md
+++ b/docs/reference/cli/gcx_oncall_routes_list.md
@@ -11,6 +11,7 @@ gcx oncall routes list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_schedules_list.md
+++ b/docs/reference/cli/gcx_oncall_schedules_list.md
@@ -11,6 +11,7 @@ gcx oncall schedules list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_shift-swaps_list.md
+++ b/docs/reference/cli/gcx_oncall_shift-swaps_list.md
@@ -11,6 +11,7 @@ gcx oncall shift-swaps list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_shifts_list.md
+++ b/docs/reference/cli/gcx_oncall_shifts_list.md
@@ -11,6 +11,7 @@ gcx oncall shifts list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_slack-channels_list.md
+++ b/docs/reference/cli/gcx_oncall_slack-channels_list.md
@@ -11,6 +11,7 @@ gcx oncall slack-channels list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_teams_list.md
+++ b/docs/reference/cli/gcx_oncall_teams_list.md
@@ -11,6 +11,7 @@ gcx oncall teams list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_user-groups_list.md
+++ b/docs/reference/cli/gcx_oncall_user-groups_list.md
@@ -11,6 +11,7 @@ gcx oncall user-groups list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_users_list.md
+++ b/docs/reference/cli/gcx_oncall_users_list.md
@@ -11,6 +11,7 @@ gcx oncall users list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_oncall_webhooks_list.md
+++ b/docs/reference/cli/gcx_oncall_webhooks_list.md
@@ -11,6 +11,7 @@ gcx oncall webhooks list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_resources_get.md
+++ b/docs/reference/cli/gcx_resources_get.md
@@ -73,7 +73,7 @@ gcx resources get [RESOURCE_SELECTOR]... [flags]
 ```
   -h, --help              help for get
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int         Maximum number of items to fetch per resource type (0 for all) (default 200)
+      --limit int         Maximum number of items to fetch per resource type (0 for all) (default 50)
       --on-error string   How to handle errors during resource operations:
                             ignore — continue processing all resources and exit 0
                             fail   — continue processing all resources and exit 1 if any failed (default)

--- a/docs/reference/cli/gcx_resources_get.md
+++ b/docs/reference/cli/gcx_resources_get.md
@@ -73,6 +73,7 @@ gcx resources get [RESOURCE_SELECTOR]... [flags]
 ```
   -h, --help              help for get
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int         Maximum number of items to fetch per resource type (0 for all) (default 200)
       --on-error string   How to handle errors during resource operations:
                             ignore — continue processing all resources and exit 0
                             fail   — continue processing all resources and exit 1 if any failed (default)

--- a/docs/reference/cli/gcx_sigil_agents_list.md
+++ b/docs/reference/cli/gcx_sigil_agents_list.md
@@ -11,7 +11,7 @@ gcx sigil agents list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int       Maximum number of agents to return (default 100)
+      --limit int       Maximum number of agents to return (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_sigil_conversations_list.md
+++ b/docs/reference/cli/gcx_sigil_conversations_list.md
@@ -11,7 +11,7 @@ gcx sigil conversations list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int       Maximum number of conversations to return (0 for no limit) (default 100)
+      --limit int       Maximum number of conversations to return (0 for no limit) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_sigil_evaluators_list.md
+++ b/docs/reference/cli/gcx_sigil_evaluators_list.md
@@ -11,6 +11,7 @@ gcx sigil evaluators list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of evaluators to return (0 for no limit) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_sigil_rules_list.md
+++ b/docs/reference/cli/gcx_sigil_rules_list.md
@@ -11,6 +11,7 @@ gcx sigil rules list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of rules to return (0 for no limit) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_sigil_scores_list.md
+++ b/docs/reference/cli/gcx_sigil_scores_list.md
@@ -15,7 +15,7 @@ gcx sigil scores list <generation-id> [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int       Maximum number of scores to return (default 100)
+      --limit int       Maximum number of scores to return (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_sigil_templates_list.md
+++ b/docs/reference/cli/gcx_sigil_templates_list.md
@@ -21,6 +21,7 @@ gcx sigil templates list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of templates to return (0 for no limit) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
       --scope string    Filter by scope: "global" or "tenant"
 ```

--- a/docs/reference/cli/gcx_slo_definitions_list.md
+++ b/docs/reference/cli/gcx_slo_definitions_list.md
@@ -11,6 +11,7 @@ gcx slo definitions list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_slo_reports_list.md
+++ b/docs/reference/cli/gcx_slo_reports_list.md
@@ -11,6 +11,7 @@ gcx slo reports list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_synth_checks_list.md
+++ b/docs/reference/cli/gcx_synth_checks_list.md
@@ -26,6 +26,7 @@ gcx synth checks list [flags]
       --job string          Filter by job name glob pattern (e.g. --job 'shopk8s-*')
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --label stringArray   Filter by label key=value (repeatable, e.g. --label env=prod)
+      --limit int           Maximum number of items to return (0 for all) (default 50)
   -o, --output string       Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_synth_probes_list.md
+++ b/docs/reference/cli/gcx_synth_probes_list.md
@@ -11,6 +11,7 @@ gcx synth probes list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for all) (default 50)
   -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 

--- a/docs/reference/cli/gcx_traces_adaptive_policies_list.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_list.md
@@ -11,6 +11,7 @@ gcx traces adaptive policies list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of policies to return (0 for no limit) (default 50)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -281,6 +281,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/api v0.35.3 // indirect

--- a/internal/assistant/investigations/commands.go
+++ b/internal/assistant/investigations/commands.go
@@ -52,6 +52,7 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 type listOpts struct {
 	IO    cmdio.Options
 	State string
+	Limit int
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet) {
@@ -60,6 +61,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
 	flags.StringVar(&o.State, "state", "", "Filter by investigation state (e.g. running, completed, cancelled)")
+	flags.IntVar(&o.Limit, "limit", 50, "Maximum number of investigations to return")
 }
 
 func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
@@ -79,6 +81,9 @@ func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 			summaries, err := client.List(cmd.Context(), opts.State)
 			if err != nil {
 				return err
+			}
+			if opts.Limit > 0 && len(summaries) > opts.Limit {
+				summaries = summaries[:opts.Limit]
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), summaries)
 		},

--- a/internal/providers/alert/groups_commands.go
+++ b/internal/providers/alert/groups_commands.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -64,9 +65,7 @@ func newGroupsListCommand(loader GrafanaConfigLoader) *cobra.Command {
 				return err
 			}
 
-			if opts.Limit > 0 && int64(len(groups)) > opts.Limit {
-				groups = groups[:opts.Limit]
-			}
+			groups = adapter.TruncateSlice(groups, opts.Limit)
 
 			return opts.IO.Encode(cmd.OutOrStdout(), groups)
 		},

--- a/internal/providers/alert/groups_commands.go
+++ b/internal/providers/alert/groups_commands.go
@@ -27,13 +27,15 @@ func groupsCommands(loader GrafanaConfigLoader) *cobra.Command {
 }
 
 type groupsListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *groupsListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &GroupsTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for unlimited)")
 }
 
 func newGroupsListCommand(loader GrafanaConfigLoader) *cobra.Command {
@@ -60,6 +62,10 @@ func newGroupsListCommand(loader GrafanaConfigLoader) *cobra.Command {
 			groups, err := client.ListGroups(ctx)
 			if err != nil {
 				return err
+			}
+
+			if opts.Limit > 0 && int64(len(groups)) > opts.Limit {
+				groups = groups[:opts.Limit]
 			}
 
 			return opts.IO.Encode(cmd.OutOrStdout(), groups)

--- a/internal/providers/alert/resource_adapter.go
+++ b/internal/providers/alert/resource_adapter.go
@@ -83,7 +83,7 @@ func NewTypedCRUDRules(ctx context.Context, loader GrafanaConfigLoader) (*adapte
 	}
 
 	crud := &adapter.TypedCRUD[RuleStatus]{
-		ListFn: func(ctx context.Context) ([]RuleStatus, error) {
+		ListFn: func(ctx context.Context, limit int64) ([]RuleStatus, error) {
 			resp, err := client.List(ctx, ListOptions{})
 			if err != nil {
 				return nil, fmt.Errorf("failed to list alert rules: %w", err)
@@ -91,6 +91,9 @@ func NewTypedCRUDRules(ctx context.Context, loader GrafanaConfigLoader) (*adapte
 			var rules []RuleStatus
 			for _, group := range resp.Data.Groups {
 				rules = append(rules, group.Rules...)
+			}
+			if limit > 0 && int64(len(rules)) > limit {
+				rules = rules[:limit]
 			}
 			return rules, nil
 		},
@@ -121,10 +124,13 @@ func NewTypedCRUDGroups(ctx context.Context, loader GrafanaConfigLoader) (*adapt
 	}
 
 	crud := &adapter.TypedCRUD[RuleGroup]{
-		ListFn: func(ctx context.Context) ([]RuleGroup, error) {
+		ListFn: func(ctx context.Context, limit int64) ([]RuleGroup, error) {
 			groups, err := client.ListGroups(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to list alert rule groups: %w", err)
+			}
+			if limit > 0 && int64(len(groups)) > limit {
+				groups = groups[:limit]
 			}
 			return groups, nil
 		},

--- a/internal/providers/alert/resource_adapter.go
+++ b/internal/providers/alert/resource_adapter.go
@@ -92,10 +92,7 @@ func NewTypedCRUDRules(ctx context.Context, loader GrafanaConfigLoader) (*adapte
 			for _, group := range resp.Data.Groups {
 				rules = append(rules, group.Rules...)
 			}
-			if limit > 0 && int64(len(rules)) > limit {
-				rules = rules[:limit]
-			}
-			return rules, nil
+			return adapter.TruncateSlice(rules, limit), nil
 		},
 		GetFn: func(ctx context.Context, name string) (*RuleStatus, error) {
 			rule, err := client.GetRule(ctx, name)
@@ -124,16 +121,13 @@ func NewTypedCRUDGroups(ctx context.Context, loader GrafanaConfigLoader) (*adapt
 	}
 
 	crud := &adapter.TypedCRUD[RuleGroup]{
-		ListFn: func(ctx context.Context, limit int64) ([]RuleGroup, error) {
+		ListFn: adapter.LimitedListFn(func(ctx context.Context) ([]RuleGroup, error) {
 			groups, err := client.ListGroups(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to list alert rule groups: %w", err)
 			}
-			if limit > 0 && int64(len(groups)) > limit {
-				groups = groups[:limit]
-			}
 			return groups, nil
-		},
+		}),
 		GetFn: func(ctx context.Context, name string) (*RuleGroup, error) {
 			group, err := client.GetGroup(ctx, name)
 			if err != nil {

--- a/internal/providers/alert/rules_commands.go
+++ b/internal/providers/alert/rules_commands.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -95,9 +96,7 @@ func newRulesListCommand(loader GrafanaConfigLoader) *cobra.Command {
 				for _, g := range resp.Data.Groups {
 					rules = append(rules, g.Rules...)
 				}
-				if opts.Limit > 0 && int64(len(rules)) > opts.Limit {
-					rules = rules[:opts.Limit]
-				}
+				rules = adapter.TruncateSlice(rules, opts.Limit)
 				return codec.Encode(cmd.OutOrStdout(), rules)
 			}
 
@@ -108,9 +107,7 @@ func newRulesListCommand(loader GrafanaConfigLoader) *cobra.Command {
 					nonEmpty = append(nonEmpty, g)
 				}
 			}
-			if opts.Limit > 0 && int64(len(nonEmpty)) > opts.Limit {
-				nonEmpty = nonEmpty[:opts.Limit]
-			}
+			nonEmpty = adapter.TruncateSlice(nonEmpty, opts.Limit)
 			return opts.IO.Encode(cmd.OutOrStdout(), nonEmpty)
 		},
 	}

--- a/internal/providers/alert/rules_commands.go
+++ b/internal/providers/alert/rules_commands.go
@@ -37,6 +37,7 @@ type rulesListOpts struct {
 	GroupName string
 	FolderUID string
 	State     string
+	Limit     int64
 }
 
 func (o *rulesListOpts) setup(flags *pflag.FlagSet) {
@@ -47,6 +48,7 @@ func (o *rulesListOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVar(&o.GroupName, "group", "", "Filter by group name")
 	flags.StringVar(&o.FolderUID, "folder", "", "Filter by folder UID")
 	flags.StringVar(&o.State, "state", "", "Filter by rule state (firing, pending, inactive)")
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for unlimited)")
 }
 
 func newRulesListCommand(loader GrafanaConfigLoader) *cobra.Command {
@@ -93,6 +95,9 @@ func newRulesListCommand(loader GrafanaConfigLoader) *cobra.Command {
 				for _, g := range resp.Data.Groups {
 					rules = append(rules, g.Rules...)
 				}
+				if opts.Limit > 0 && int64(len(rules)) > opts.Limit {
+					rules = rules[:opts.Limit]
+				}
 				return codec.Encode(cmd.OutOrStdout(), rules)
 			}
 
@@ -102,6 +107,9 @@ func newRulesListCommand(loader GrafanaConfigLoader) *cobra.Command {
 				if len(g.Rules) > 0 {
 					nonEmpty = append(nonEmpty, g)
 				}
+			}
+			if opts.Limit > 0 && int64(len(nonEmpty)) > opts.Limit {
+				nonEmpty = nonEmpty[:opts.Limit]
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), nonEmpty)
 		},

--- a/internal/providers/faro/commands.go
+++ b/internal/providers/faro/commands.go
@@ -34,16 +34,7 @@ func NewTypedCRUD(ctx context.Context, loader RESTConfigLoader) (*adapter.TypedC
 	}
 
 	crud := &adapter.TypedCRUD[FaroApp]{
-		ListFn: func(ctx context.Context, limit int64) ([]FaroApp, error) {
-			items, err := client.List(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.List),
 
 		GetFn: func(ctx context.Context, name string) (*FaroApp, error) {
 			id, ok := adapter.ExtractIDFromSlug(name)

--- a/internal/providers/faro/commands.go
+++ b/internal/providers/faro/commands.go
@@ -34,8 +34,15 @@ func NewTypedCRUD(ctx context.Context, loader RESTConfigLoader) (*adapter.TypedC
 	}
 
 	crud := &adapter.TypedCRUD[FaroApp]{
-		ListFn: func(ctx context.Context) ([]FaroApp, error) {
-			return client.List(ctx)
+		ListFn: func(ctx context.Context, limit int64) ([]FaroApp, error) {
+			items, err := client.List(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
 		},
 
 		GetFn: func(ctx context.Context, name string) (*FaroApp, error) {
@@ -79,7 +86,8 @@ func NewTypedCRUD(ctx context.Context, loader RESTConfigLoader) (*adapter.TypedC
 // ---------------------------------------------------------------------------
 
 type listOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet) {
@@ -87,6 +95,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &AppTableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for unlimited)")
 }
 
 func newListCommand(loader RESTConfigLoader) *cobra.Command {
@@ -106,7 +115,7 @@ func newListCommand(loader RESTConfigLoader) *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, opts.Limit)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/faro/resource_adapter.go
+++ b/internal/providers/faro/resource_adapter.go
@@ -151,8 +151,15 @@ func NewFactoryFromConfig(cfg internalconfig.NamespacedRESTConfig) adapter.Facto
 // newTypedAdapter builds the TypedCRUD[FaroApp] adapter for the given client and namespace.
 func newTypedAdapter(client *Client, namespace string) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[FaroApp]{
-		ListFn: func(ctx context.Context) ([]FaroApp, error) {
-			return client.List(ctx)
+		ListFn: func(ctx context.Context, limit int64) ([]FaroApp, error) {
+			items, err := client.List(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
 		},
 
 		GetFn: func(ctx context.Context, name string) (*FaroApp, error) {

--- a/internal/providers/faro/resource_adapter.go
+++ b/internal/providers/faro/resource_adapter.go
@@ -151,16 +151,7 @@ func NewFactoryFromConfig(cfg internalconfig.NamespacedRESTConfig) adapter.Facto
 // newTypedAdapter builds the TypedCRUD[FaroApp] adapter for the given client and namespace.
 func newTypedAdapter(client *Client, namespace string) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[FaroApp]{
-		ListFn: func(ctx context.Context, limit int64) ([]FaroApp, error) {
-			items, err := client.List(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.List),
 
 		GetFn: func(ctx context.Context, name string) (*FaroApp, error) {
 			id, ok := adapter.ExtractIDFromSlug(name)

--- a/internal/providers/fleet/provider.go
+++ b/internal/providers/fleet/provider.go
@@ -217,6 +217,10 @@ func (h *fleetHelper) newPipelineListCommand() *cobra.Command {
 				return err
 			}
 
+			if opts.Limit > 0 && int64(len(pipelines)) > opts.Limit {
+				pipelines = pipelines[:opts.Limit]
+			}
+
 			// Table codec operates on raw []Pipeline for direct field access.
 			// Other formats (yaml/json) convert to K8s envelope Resources
 			// for consistency with get/pull and round-trip support.
@@ -241,7 +245,8 @@ func (h *fleetHelper) newPipelineListCommand() *cobra.Command {
 }
 
 type pipelineListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *pipelineListOpts) setup(flags *pflag.FlagSet) {
@@ -249,6 +254,8 @@ func (o *pipelineListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &PipelineTableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func (h *fleetHelper) newPipelineGetCommand() *cobra.Command { //nolint:dupl // Intentionally similar to collector get — distinct resource types.
@@ -536,6 +543,10 @@ func (h *fleetHelper) newCollectorListCommand() *cobra.Command {
 				return err
 			}
 
+			if opts.Limit > 0 && int64(len(collectors)) > opts.Limit {
+				collectors = collectors[:opts.Limit]
+			}
+
 			// Table codec operates on raw []Collector for direct field access.
 			// Other formats (yaml/json) convert to K8s envelope Resources
 			// for consistency with get/pull and round-trip support.
@@ -560,7 +571,8 @@ func (h *fleetHelper) newCollectorListCommand() *cobra.Command {
 }
 
 type collectorListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *collectorListOpts) setup(flags *pflag.FlagSet) {
@@ -568,6 +580,8 @@ func (o *collectorListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &CollectorTableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func (h *fleetHelper) newCollectorGetCommand() *cobra.Command { //nolint:dupl // Intentionally similar to pipeline get — distinct resource types.
@@ -1119,7 +1133,16 @@ func NewPipelineTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adapt
 	client := &Client{Client: base}
 
 	crud := &adapter.TypedCRUD[Pipeline]{
-		ListFn: client.ListPipelines,
+		ListFn: func(ctx context.Context, limit int64) ([]Pipeline, error) {
+			items, err := client.ListPipelines(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*Pipeline, error) {
 			return resolvePipeline(ctx, client, name)
 		},
@@ -1177,7 +1200,16 @@ func NewCollectorTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adap
 	client := &Client{Client: base}
 
 	crud := &adapter.TypedCRUD[Collector]{
-		ListFn: client.ListCollectors,
+		ListFn: func(ctx context.Context, limit int64) ([]Collector, error) {
+			items, err := client.ListCollectors(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*Collector, error) {
 			return resolveCollector(ctx, client, name)
 		},

--- a/internal/providers/fleet/provider.go
+++ b/internal/providers/fleet/provider.go
@@ -217,9 +217,7 @@ func (h *fleetHelper) newPipelineListCommand() *cobra.Command {
 				return err
 			}
 
-			if opts.Limit > 0 && int64(len(pipelines)) > opts.Limit {
-				pipelines = pipelines[:opts.Limit]
-			}
+			pipelines = adapter.TruncateSlice(pipelines, opts.Limit)
 
 			// Table codec operates on raw []Pipeline for direct field access.
 			// Other formats (yaml/json) convert to K8s envelope Resources
@@ -543,9 +541,7 @@ func (h *fleetHelper) newCollectorListCommand() *cobra.Command {
 				return err
 			}
 
-			if opts.Limit > 0 && int64(len(collectors)) > opts.Limit {
-				collectors = collectors[:opts.Limit]
-			}
+			collectors = adapter.TruncateSlice(collectors, opts.Limit)
 
 			// Table codec operates on raw []Collector for direct field access.
 			// Other formats (yaml/json) convert to K8s envelope Resources
@@ -1133,16 +1129,7 @@ func NewPipelineTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adapt
 	client := &Client{Client: base}
 
 	crud := &adapter.TypedCRUD[Pipeline]{
-		ListFn: func(ctx context.Context, limit int64) ([]Pipeline, error) {
-			items, err := client.ListPipelines(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.ListPipelines),
 		GetFn: func(ctx context.Context, name string) (*Pipeline, error) {
 			return resolvePipeline(ctx, client, name)
 		},
@@ -1200,16 +1187,7 @@ func NewCollectorTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adap
 	client := &Client{Client: base}
 
 	crud := &adapter.TypedCRUD[Collector]{
-		ListFn: func(ctx context.Context, limit int64) ([]Collector, error) {
-			items, err := client.ListCollectors(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.ListCollectors),
 		GetFn: func(ctx context.Context, name string) (*Collector, error) {
 			return resolveCollector(ctx, client, name)
 		},

--- a/internal/providers/incidents/commands.go
+++ b/internal/providers/incidents/commands.go
@@ -33,7 +33,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &IncidentTableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
-	flags.IntVar(&o.Limit, "limit", 100, "Maximum number of incidents to return")
+	flags.IntVar(&o.Limit, "limit", 50, "Maximum number of incidents to return")
 }
 
 func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
@@ -53,7 +53,7 @@ func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, int64(opts.Limit))
 			if err != nil {
 				return err
 			}

--- a/internal/providers/incidents/resource_adapter.go
+++ b/internal/providers/incidents/resource_adapter.go
@@ -137,8 +137,12 @@ func NewFactoryFromConfig(cfg internalconfig.NamespacedRESTConfig) adapter.Facto
 // newTypedAdapter builds the TypedCRUD[Incident] adapter for the given client and namespace.
 func newTypedAdapter(client *Client, namespace string) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[Incident]{
-		ListFn: func(ctx context.Context) ([]Incident, error) {
-			return client.List(ctx, IncidentQuery{})
+		ListFn: func(ctx context.Context, limit int64) ([]Incident, error) {
+			q := IncidentQuery{}
+			if limit > 0 {
+				q.Limit = int(limit)
+			}
+			return client.List(ctx, q)
 		},
 
 		GetFn: func(ctx context.Context, name string) (*Incident, error) {
@@ -179,8 +183,12 @@ func NewTypedCRUD(ctx context.Context, loader GrafanaConfigLoader, query Inciden
 	}
 
 	crud := &adapter.TypedCRUD[Incident]{
-		ListFn: func(ctx context.Context) ([]Incident, error) {
-			return client.List(ctx, query)
+		ListFn: func(ctx context.Context, limit int64) ([]Incident, error) {
+			q := query
+			if limit > 0 {
+				q.Limit = int(limit)
+			}
+			return client.List(ctx, q)
 		},
 
 		GetFn: func(ctx context.Context, name string) (*Incident, error) {

--- a/internal/providers/k6/commands.go
+++ b/internal/providers/k6/commands.go
@@ -167,7 +167,8 @@ func newProjectsCommand(loader CloudConfigLoader) *cobra.Command {
 }
 
 type projectsListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *projectsListOpts) setup(flags *pflag.FlagSet) {
@@ -175,6 +176,7 @@ func (o *projectsListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &ProjectTableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func newProjectsListCommand(loader CloudConfigLoader) *cobra.Command {
@@ -191,7 +193,7 @@ func newProjectsListCommand(loader CloudConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, opts.Limit)
 			if err != nil {
 				return err
 			}
@@ -523,6 +525,7 @@ func newTestsCommand(loader CloudConfigLoader) *cobra.Command {
 type testsListOpts struct {
 	IO        cmdio.Options
 	ProjectID int
+	Limit     int64
 }
 
 func (o *testsListOpts) setup(flags *pflag.FlagSet) {
@@ -531,6 +534,7 @@ func (o *testsListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
 	flags.IntVar(&o.ProjectID, "project-id", 0, "Filter by project ID")
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func newTestsListCommand(loader CloudConfigLoader) *cobra.Command {
@@ -559,6 +563,9 @@ func newTestsListCommand(loader CloudConfigLoader) *cobra.Command {
 					}
 				}
 				tests = filtered
+			}
+			if opts.Limit > 0 && int64(len(tests)) > opts.Limit {
+				tests = tests[:opts.Limit]
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), tests)
 		},
@@ -847,6 +854,7 @@ type runsListOpts struct {
 	IO        cmdio.Options
 	ProjectID int
 	TestID    int
+	Limit     int64
 }
 
 func (o *runsListOpts) setup(flags *pflag.FlagSet) {
@@ -855,6 +863,7 @@ func (o *runsListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 	flags.IntVar(&o.ProjectID, "project-id", 0, "Project ID (required when looking up by name)")
 	flags.IntVar(&o.TestID, "id", 0, "Load test ID (skip name lookup)")
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func newRunsListCommand(loader CloudConfigLoader) *cobra.Command {
@@ -895,6 +904,9 @@ func newRunsListCommand(loader CloudConfigLoader) *cobra.Command {
 			runs, err := client.ListTestRuns(ctx, loadTestID)
 			if err != nil {
 				return err
+			}
+			if opts.Limit > 0 && int64(len(runs)) > opts.Limit {
+				runs = runs[:opts.Limit]
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), runs)
 		},
@@ -974,13 +986,15 @@ func newEnvVarsCommand(loader CloudConfigLoader) *cobra.Command {
 }
 
 type envVarsListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *envVarsListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &EnvVarTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func newEnvVarsListCommand(loader CloudConfigLoader) *cobra.Command {
@@ -1000,6 +1014,9 @@ func newEnvVarsListCommand(loader CloudConfigLoader) *cobra.Command {
 			envVars, err := client.ListEnvVars(ctx)
 			if err != nil {
 				return err
+			}
+			if opts.Limit > 0 && int64(len(envVars)) > opts.Limit {
+				envVars = envVars[:opts.Limit]
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), envVars)
 		},
@@ -1271,13 +1288,15 @@ func (c *ScheduleTableCodec) Decode(_ io.Reader, _ any) error {
 }
 
 type schedulesListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *schedulesListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &ScheduleTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func newSchedulesListCommand(loader CloudConfigLoader) *cobra.Command {
@@ -1297,6 +1316,9 @@ func newSchedulesListCommand(loader CloudConfigLoader) *cobra.Command {
 			schedules, err := client.ListSchedules(ctx)
 			if err != nil {
 				return err
+			}
+			if opts.Limit > 0 && int64(len(schedules)) > opts.Limit {
+				schedules = schedules[:opts.Limit]
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), schedules)
 		},
@@ -1516,13 +1538,15 @@ func (c *LoadZoneTableCodec) Decode(_ io.Reader, _ any) error {
 }
 
 type loadZonesListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *loadZonesListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &LoadZoneTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func newLoadZonesListCommand(loader CloudConfigLoader) *cobra.Command {
@@ -1542,6 +1566,9 @@ func newLoadZonesListCommand(loader CloudConfigLoader) *cobra.Command {
 			zones, err := client.ListLoadZones(ctx)
 			if err != nil {
 				return err
+			}
+			if opts.Limit > 0 && int64(len(zones)) > opts.Limit {
+				zones = zones[:opts.Limit]
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), zones)
 		},
@@ -2033,6 +2060,7 @@ type testrunRunsListOpts struct {
 	IO        cmdio.Options
 	ProjectID int
 	ID        int
+	Limit     int64
 }
 
 func (o *testrunRunsListOpts) setup(flags *pflag.FlagSet) {
@@ -2041,6 +2069,7 @@ func (o *testrunRunsListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 	flags.IntVar(&o.ProjectID, "project-id", 0, "k6 Cloud project ID (required when using name lookup)")
 	flags.IntVar(&o.ID, "id", 0, "Load test ID (skip name lookup)")
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func newTestrunRunsListCommand(loader CloudConfigLoader) *cobra.Command {
@@ -2070,6 +2099,9 @@ func newTestrunRunsListCommand(loader CloudConfigLoader) *cobra.Command {
 			runs, err := client.ListTestRuns(ctx, test.ID)
 			if err != nil {
 				return err
+			}
+			if opts.Limit > 0 && int64(len(runs)) > opts.Limit {
+				runs = runs[:opts.Limit]
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), runs)
 		},

--- a/internal/providers/k6/commands.go
+++ b/internal/providers/k6/commands.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/grafana/gcx/internal/terminal"
 	"github.com/spf13/cobra"
@@ -564,9 +565,7 @@ func newTestsListCommand(loader CloudConfigLoader) *cobra.Command {
 				}
 				tests = filtered
 			}
-			if opts.Limit > 0 && int64(len(tests)) > opts.Limit {
-				tests = tests[:opts.Limit]
-			}
+			tests = adapter.TruncateSlice(tests, opts.Limit)
 			return opts.IO.Encode(cmd.OutOrStdout(), tests)
 		},
 	}
@@ -905,9 +904,7 @@ func newRunsListCommand(loader CloudConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if opts.Limit > 0 && int64(len(runs)) > opts.Limit {
-				runs = runs[:opts.Limit]
-			}
+			runs = adapter.TruncateSlice(runs, opts.Limit)
 			return opts.IO.Encode(cmd.OutOrStdout(), runs)
 		},
 	}
@@ -1015,9 +1012,7 @@ func newEnvVarsListCommand(loader CloudConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if opts.Limit > 0 && int64(len(envVars)) > opts.Limit {
-				envVars = envVars[:opts.Limit]
-			}
+			envVars = adapter.TruncateSlice(envVars, opts.Limit)
 			return opts.IO.Encode(cmd.OutOrStdout(), envVars)
 		},
 	}
@@ -1317,9 +1312,7 @@ func newSchedulesListCommand(loader CloudConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if opts.Limit > 0 && int64(len(schedules)) > opts.Limit {
-				schedules = schedules[:opts.Limit]
-			}
+			schedules = adapter.TruncateSlice(schedules, opts.Limit)
 			return opts.IO.Encode(cmd.OutOrStdout(), schedules)
 		},
 	}
@@ -1567,9 +1560,7 @@ func newLoadZonesListCommand(loader CloudConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if opts.Limit > 0 && int64(len(zones)) > opts.Limit {
-				zones = zones[:opts.Limit]
-			}
+			zones = adapter.TruncateSlice(zones, opts.Limit)
 			return opts.IO.Encode(cmd.OutOrStdout(), zones)
 		},
 	}
@@ -2100,9 +2091,7 @@ func newTestrunRunsListCommand(loader CloudConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if opts.Limit > 0 && int64(len(runs)) > opts.Limit {
-				runs = runs[:opts.Limit]
-			}
+			runs = adapter.TruncateSlice(runs, opts.Limit)
 			return opts.IO.Encode(cmd.OutOrStdout(), runs)
 		},
 	}

--- a/internal/providers/k6/resource_adapter.go
+++ b/internal/providers/k6/resource_adapter.go
@@ -129,16 +129,7 @@ func newSubResourceFactory(loader CloudConfigLoader, rd resourceDef) adapter.Fac
 
 func newProjectCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[Project]{
-		ListFn: func(ctx context.Context, limit int64) ([]Project, error) {
-			items, err := c.ListProjects(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(c.ListProjects),
 		GetFn: func(ctx context.Context, name string) (*Project, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -175,16 +166,7 @@ func newProjectCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Res
 
 func newLoadTestCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[LoadTest]{
-		ListFn: func(ctx context.Context, limit int64) ([]LoadTest, error) {
-			items, err := c.ListLoadTests(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(c.ListLoadTests),
 		GetFn: func(ctx context.Context, name string) (*LoadTest, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -221,16 +203,7 @@ func newLoadTestCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Re
 
 func newScheduleCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[Schedule]{
-		ListFn: func(ctx context.Context, limit int64) ([]Schedule, error) {
-			items, err := c.ListSchedules(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(c.ListSchedules),
 		GetFn: func(ctx context.Context, name string) (*Schedule, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -277,16 +250,7 @@ func newScheduleCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Re
 
 func newEnvVarCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[EnvVar]{
-		ListFn: func(ctx context.Context, limit int64) ([]EnvVar, error) {
-			items, err := c.ListEnvVars(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(c.ListEnvVars),
 		GetFn: func(ctx context.Context, name string) (*EnvVar, error) {
 			// EnvVars don't have a single-get endpoint; list-then-filter.
 			id, err := strconv.Atoi(name)
@@ -343,16 +307,7 @@ func newEnvVarCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Reso
 
 func newLoadZoneCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[LoadZone]{
-		ListFn: func(ctx context.Context, limit int64) ([]LoadZone, error) {
-			items, err := c.ListLoadZones(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(c.ListLoadZones),
 		GetFn: func(ctx context.Context, name string) (*LoadZone, error) {
 			// List-then-filter by name.
 			zones, err := c.ListLoadZones(ctx)
@@ -528,16 +483,7 @@ func NewTypedCRUDProject(ctx context.Context, loader CloudConfigLoader) (*adapte
 		return nil, "", err
 	}
 	crud := &adapter.TypedCRUD[Project]{
-		ListFn: func(ctx context.Context, limit int64) ([]Project, error) {
-			items, err := client.ListProjects(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.ListProjects),
 		GetFn: func(ctx context.Context, name string) (*Project, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -576,16 +522,7 @@ func NewTypedCRUDLoadTest(ctx context.Context, loader CloudConfigLoader) (*adapt
 		return nil, "", err
 	}
 	crud := &adapter.TypedCRUD[LoadTest]{
-		ListFn: func(ctx context.Context, limit int64) ([]LoadTest, error) {
-			items, err := client.ListAllLoadTests(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.ListAllLoadTests),
 		GetFn: func(ctx context.Context, name string) (*LoadTest, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -624,16 +561,7 @@ func NewTypedCRUDSchedule(ctx context.Context, loader CloudConfigLoader) (*adapt
 		return nil, "", err
 	}
 	crud := &adapter.TypedCRUD[Schedule]{
-		ListFn: func(ctx context.Context, limit int64) ([]Schedule, error) {
-			items, err := client.ListSchedules(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.ListSchedules),
 		GetFn: func(ctx context.Context, name string) (*Schedule, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -681,16 +609,7 @@ func NewTypedCRUDEnvVar(ctx context.Context, loader CloudConfigLoader) (*adapter
 		return nil, "", err
 	}
 	crud := &adapter.TypedCRUD[EnvVar]{
-		ListFn: func(ctx context.Context, limit int64) ([]EnvVar, error) {
-			items, err := client.ListEnvVars(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.ListEnvVars),
 		GetFn: func(ctx context.Context, name string) (*EnvVar, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -747,16 +666,7 @@ func NewTypedCRUDLoadZone(ctx context.Context, loader CloudConfigLoader) (*adapt
 		return nil, "", err
 	}
 	crud := &adapter.TypedCRUD[LoadZone]{
-		ListFn: func(ctx context.Context, limit int64) ([]LoadZone, error) {
-			items, err := client.ListLoadZones(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.ListLoadZones),
 		GetFn: func(ctx context.Context, name string) (*LoadZone, error) {
 			zones, err := client.ListLoadZones(ctx)
 			if err != nil {

--- a/internal/providers/k6/resource_adapter.go
+++ b/internal/providers/k6/resource_adapter.go
@@ -129,7 +129,16 @@ func newSubResourceFactory(loader CloudConfigLoader, rd resourceDef) adapter.Fac
 
 func newProjectCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[Project]{
-		ListFn: c.ListProjects,
+		ListFn: func(ctx context.Context, limit int64) ([]Project, error) {
+			items, err := c.ListProjects(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*Project, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -166,7 +175,16 @@ func newProjectCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Res
 
 func newLoadTestCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[LoadTest]{
-		ListFn: c.ListLoadTests,
+		ListFn: func(ctx context.Context, limit int64) ([]LoadTest, error) {
+			items, err := c.ListLoadTests(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*LoadTest, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -203,7 +221,16 @@ func newLoadTestCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Re
 
 func newScheduleCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[Schedule]{
-		ListFn: c.ListSchedules,
+		ListFn: func(ctx context.Context, limit int64) ([]Schedule, error) {
+			items, err := c.ListSchedules(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*Schedule, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -250,7 +277,16 @@ func newScheduleCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Re
 
 func newEnvVarCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[EnvVar]{
-		ListFn: c.ListEnvVars,
+		ListFn: func(ctx context.Context, limit int64) ([]EnvVar, error) {
+			items, err := c.ListEnvVars(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*EnvVar, error) {
 			// EnvVars don't have a single-get endpoint; list-then-filter.
 			id, err := strconv.Atoi(name)
@@ -307,7 +343,16 @@ func newEnvVarCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Reso
 
 func newLoadZoneCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[LoadZone]{
-		ListFn: c.ListLoadZones,
+		ListFn: func(ctx context.Context, limit int64) ([]LoadZone, error) {
+			items, err := c.ListLoadZones(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*LoadZone, error) {
 			// List-then-filter by name.
 			zones, err := c.ListLoadZones(ctx)
@@ -483,7 +528,16 @@ func NewTypedCRUDProject(ctx context.Context, loader CloudConfigLoader) (*adapte
 		return nil, "", err
 	}
 	crud := &adapter.TypedCRUD[Project]{
-		ListFn: client.ListProjects,
+		ListFn: func(ctx context.Context, limit int64) ([]Project, error) {
+			items, err := client.ListProjects(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*Project, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -522,7 +576,16 @@ func NewTypedCRUDLoadTest(ctx context.Context, loader CloudConfigLoader) (*adapt
 		return nil, "", err
 	}
 	crud := &adapter.TypedCRUD[LoadTest]{
-		ListFn: client.ListAllLoadTests,
+		ListFn: func(ctx context.Context, limit int64) ([]LoadTest, error) {
+			items, err := client.ListAllLoadTests(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*LoadTest, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -561,7 +624,16 @@ func NewTypedCRUDSchedule(ctx context.Context, loader CloudConfigLoader) (*adapt
 		return nil, "", err
 	}
 	crud := &adapter.TypedCRUD[Schedule]{
-		ListFn: client.ListSchedules,
+		ListFn: func(ctx context.Context, limit int64) ([]Schedule, error) {
+			items, err := client.ListSchedules(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*Schedule, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -609,7 +681,16 @@ func NewTypedCRUDEnvVar(ctx context.Context, loader CloudConfigLoader) (*adapter
 		return nil, "", err
 	}
 	crud := &adapter.TypedCRUD[EnvVar]{
-		ListFn: client.ListEnvVars,
+		ListFn: func(ctx context.Context, limit int64) ([]EnvVar, error) {
+			items, err := client.ListEnvVars(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*EnvVar, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {
@@ -666,7 +747,16 @@ func NewTypedCRUDLoadZone(ctx context.Context, loader CloudConfigLoader) (*adapt
 		return nil, "", err
 	}
 	crud := &adapter.TypedCRUD[LoadZone]{
-		ListFn: client.ListLoadZones,
+		ListFn: func(ctx context.Context, limit int64) ([]LoadZone, error) {
+			items, err := client.ListLoadZones(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*LoadZone, error) {
 			zones, err := client.ListLoadZones(ctx)
 			if err != nil {

--- a/internal/providers/kg/adapters_test.go
+++ b/internal/providers/kg/adapters_test.go
@@ -16,7 +16,7 @@ func TestDatasetAdapter_List(t *testing.T) {
 	crud := &adapter.TypedCRUD[kg.DatasetItem]{
 		Namespace:  "stack-1",
 		Descriptor: kg.DatasetDescriptor(),
-		ListFn: func(_ context.Context) ([]kg.DatasetItem, error) {
+		ListFn: func(_ context.Context, _ int64) ([]kg.DatasetItem, error) {
 			return []kg.DatasetItem{
 				{Name: "kubernetes", Detected: true, Enabled: true, Configured: true},
 				{Name: "otel", Detected: true, Enabled: false, Configured: false},
@@ -40,7 +40,7 @@ func TestDatasetAdapter_GetFallback(t *testing.T) {
 	crud := &adapter.TypedCRUD[kg.DatasetItem]{
 		Namespace:  "stack-1",
 		Descriptor: kg.DatasetDescriptor(),
-		ListFn: func(_ context.Context) ([]kg.DatasetItem, error) {
+		ListFn: func(_ context.Context, _ int64) ([]kg.DatasetItem, error) {
 			return []kg.DatasetItem{
 				{Name: "kubernetes", Detected: true, Enabled: true},
 				{Name: "otel", Detected: false, Enabled: false},
@@ -68,7 +68,7 @@ func TestVendorAdapter_List(t *testing.T) {
 	crud := &adapter.TypedCRUD[kg.Vendor]{
 		Namespace:  "stack-1",
 		Descriptor: kg.VendorDescriptor(),
-		ListFn: func(_ context.Context) ([]kg.Vendor, error) {
+		ListFn: func(_ context.Context, _ int64) ([]kg.Vendor, error) {
 			return []kg.Vendor{
 				{Name: "nginx", Enabled: true},
 				{Name: "redis", Enabled: false},
@@ -91,7 +91,7 @@ func TestEntityTypeAdapter_List(t *testing.T) {
 	crud := &adapter.TypedCRUD[kg.EntityType]{
 		Namespace:  "stack-1",
 		Descriptor: kg.EntityTypeDescriptor(),
-		ListFn: func(_ context.Context) ([]kg.EntityType, error) {
+		ListFn: func(_ context.Context, _ int64) ([]kg.EntityType, error) {
 			return []kg.EntityType{
 				{Name: "Service", Count: 42},
 				{Name: "Namespace", Count: 5},
@@ -118,7 +118,7 @@ func TestScopeAdapter_List(t *testing.T) {
 	crud := &adapter.TypedCRUD[kg.Scope]{
 		Namespace:  "stack-1",
 		Descriptor: kg.ScopeDescriptor(),
-		ListFn: func(_ context.Context) ([]kg.Scope, error) {
+		ListFn: func(_ context.Context, _ int64) ([]kg.Scope, error) {
 			return []kg.Scope{
 				{Name: "env", Values: []string{"prod", "staging"}},
 				{Name: "site", Values: []string{"us-east"}},
@@ -140,7 +140,7 @@ func TestRuleAdapter_List(t *testing.T) {
 	crud := &adapter.TypedCRUD[kg.Rule]{
 		Namespace:  "stack-1",
 		Descriptor: kg.RuleDescriptor(),
-		ListFn: func(_ context.Context) ([]kg.Rule, error) {
+		ListFn: func(_ context.Context, _ int64) ([]kg.Rule, error) {
 			return []kg.Rule{
 				{Name: "service:http_requests:rate5m", Expr: "sum(rate(http_requests_total[5m])) by (service)", Record: "service:http_requests:rate5m"},
 				{Name: "high-error-rate", Alert: "HighErrorRate", Expr: "rate(http_errors_total[5m]) > 0.1"},

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -360,6 +360,9 @@ func newDatasetsCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if listOpts.Limit > 0 && int64(len(result.Items)) > listOpts.Limit {
+				result.Items = result.Items[:listOpts.Limit]
+			}
 			return listOpts.IO.Encode(cmd.OutOrStdout(), result)
 		},
 	}
@@ -402,13 +405,15 @@ func newDatasetsCommand(loader RESTConfigLoader) *cobra.Command {
 }
 
 type datasetsListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *datasetsListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &DatasetTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 // DatasetTableCodec renders datasets as a table.
@@ -436,8 +441,6 @@ func (c *DatasetTableCodec) Decode(_ io.Reader, _ any) error {
 // Vendors command
 // ---------------------------------------------------------------------------
 
-//nolint:dupl
-//nolint:dupl
 func newVendorsCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vendors",
@@ -464,6 +467,9 @@ func newVendorsCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if listOpts.Limit > 0 && int64(len(vendors)) > listOpts.Limit {
+				vendors = vendors[:listOpts.Limit]
+			}
 			return listOpts.IO.Encode(cmd.OutOrStdout(), vendors)
 		},
 	}
@@ -474,12 +480,14 @@ func newVendorsCommand(loader RESTConfigLoader) *cobra.Command {
 }
 
 type vendorsListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *vendorsListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("json")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 // ---------------------------------------------------------------------------
@@ -505,7 +513,7 @@ func newRulesCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, rulesListOpts.Limit)
 			if err != nil {
 				return err
 			}
@@ -619,13 +627,15 @@ func newRulesCommand(loader RESTConfigLoader) *cobra.Command {
 }
 
 type rulesListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *rulesListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &RuleTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 type rulesGetOpts struct {
@@ -819,6 +829,7 @@ func newKPIDisplayCommand(loader RESTConfigLoader) *cobra.Command {
 // Entities commands
 // ---------------------------------------------------------------------------
 
+//nolint:dupl // entities list mirrors search entities with different flags
 func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "entities",
@@ -864,6 +875,9 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if ioOpts.Limit > 0 && int64(len(results)) > ioOpts.Limit {
+				results = results[:ioOpts.Limit]
+			}
 			return ioOpts.IO.Encode(cmd.OutOrStdout(), results)
 		},
 	}
@@ -904,6 +918,9 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if listOpts.Limit > 0 && int64(len(results)) > listOpts.Limit {
+				results = results[:listOpts.Limit]
+			}
 			return listOpts.IO.Encode(cmd.OutOrStdout(), results)
 		},
 	}
@@ -939,13 +956,15 @@ func showSingleEntity(cmd *cobra.Command, client *Client, entityType, name strin
 }
 
 type entitiesShowOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *entitiesShowOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &EntityTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 // EntityTableCodec renders search results as a table.
@@ -1014,13 +1033,15 @@ func newEntityTypesCommand(loader RESTConfigLoader) *cobra.Command {
 }
 
 type entityTypesListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *entityTypesListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &EntityTypeTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 // EntityTypeTableCodec renders entity types as a table.
@@ -1091,12 +1112,14 @@ func newScopesCommand(loader RESTConfigLoader) *cobra.Command {
 }
 
 type scopesListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *scopesListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("json")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 // ---------------------------------------------------------------------------
@@ -1427,6 +1450,7 @@ func filterBySeverity(results []SearchResult, sev string) []SearchResult {
 // Search commands
 // ---------------------------------------------------------------------------
 
+//nolint:dupl // search entities mirrors entities list with different flags
 func newSearchCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search",
@@ -1561,6 +1585,9 @@ func newSearchCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if searchEntitiesOpts.Limit > 0 && int64(len(results)) > searchEntitiesOpts.Limit {
+				results = results[:searchEntitiesOpts.Limit]
+			}
 			return searchEntitiesOpts.IO.Encode(cmd.OutOrStdout(), results)
 		},
 	}
@@ -1582,12 +1609,14 @@ func newSearchCommand(loader RESTConfigLoader) *cobra.Command {
 }
 
 type searchEntitiesListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *searchEntitiesListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("json")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -360,9 +361,7 @@ func newDatasetsCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if listOpts.Limit > 0 && int64(len(result.Items)) > listOpts.Limit {
-				result.Items = result.Items[:listOpts.Limit]
-			}
+			result.Items = adapter.TruncateSlice(result.Items, listOpts.Limit)
 			return listOpts.IO.Encode(cmd.OutOrStdout(), result)
 		},
 	}
@@ -467,9 +466,7 @@ func newVendorsCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if listOpts.Limit > 0 && int64(len(vendors)) > listOpts.Limit {
-				vendors = vendors[:listOpts.Limit]
-			}
+			vendors = adapter.TruncateSlice(vendors, listOpts.Limit)
 			return listOpts.IO.Encode(cmd.OutOrStdout(), vendors)
 		},
 	}
@@ -829,7 +826,6 @@ func newKPIDisplayCommand(loader RESTConfigLoader) *cobra.Command {
 // Entities commands
 // ---------------------------------------------------------------------------
 
-//nolint:dupl // entities list mirrors search entities with different flags
 func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "entities",
@@ -875,9 +871,7 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if ioOpts.Limit > 0 && int64(len(results)) > ioOpts.Limit {
-				results = results[:ioOpts.Limit]
-			}
+			results = adapter.TruncateSlice(results, ioOpts.Limit)
 			return ioOpts.IO.Encode(cmd.OutOrStdout(), results)
 		},
 	}
@@ -918,9 +912,7 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if listOpts.Limit > 0 && int64(len(results)) > listOpts.Limit {
-				results = results[:listOpts.Limit]
-			}
+			results = adapter.TruncateSlice(results, listOpts.Limit)
 			return listOpts.IO.Encode(cmd.OutOrStdout(), results)
 		},
 	}
@@ -1450,7 +1442,6 @@ func filterBySeverity(results []SearchResult, sev string) []SearchResult {
 // Search commands
 // ---------------------------------------------------------------------------
 
-//nolint:dupl // search entities mirrors entities list with different flags
 func newSearchCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search",
@@ -1585,9 +1576,7 @@ func newSearchCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if searchEntitiesOpts.Limit > 0 && int64(len(results)) > searchEntitiesOpts.Limit {
-				results = results[:searchEntitiesOpts.Limit]
-			}
+			results = adapter.TruncateSlice(results, searchEntitiesOpts.Limit)
 			return searchEntitiesOpts.IO.Encode(cmd.OutOrStdout(), results)
 		},
 	}

--- a/internal/providers/kg/resource_adapter.go
+++ b/internal/providers/kg/resource_adapter.go
@@ -157,16 +157,7 @@ func NewAdapterFactory(loader RESTConfigLoader) adapter.Factory {
 		}
 
 		crud := &adapter.TypedCRUD[Rule]{
-			ListFn: func(ctx context.Context, limit int64) ([]Rule, error) {
-				items, err := client.ListRules(ctx)
-				if err != nil {
-					return nil, err
-				}
-				if limit > 0 && int64(len(items)) > limit {
-					items = items[:limit]
-				}
-				return items, nil
-			},
+			ListFn: adapter.LimitedListFn(client.ListRules),
 			GetFn: func(ctx context.Context, name string) (*Rule, error) {
 				return client.GetRule(ctx, name)
 			},
@@ -190,16 +181,7 @@ func NewTypedCRUD(ctx context.Context, loader RESTConfigLoader) (*adapter.TypedC
 	}
 
 	crud := &adapter.TypedCRUD[Rule]{
-		ListFn: func(ctx context.Context, limit int64) ([]Rule, error) {
-			items, err := client.ListRules(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.ListRules),
 		GetFn: func(ctx context.Context, name string) (*Rule, error) {
 			return client.GetRule(ctx, name)
 		},
@@ -383,16 +365,9 @@ func newListOnlyFactory[T adapter.ResourceNamer](
 			return nil, fmt.Errorf("kg: failed to create client: %w", err)
 		}
 		crud := &adapter.TypedCRUD[T]{
-			ListFn: func(ctx context.Context, limit int64) ([]T, error) {
-				items, err := listFn(client, ctx)
-				if err != nil {
-					return nil, err
-				}
-				if limit > 0 && int64(len(items)) > limit {
-					items = items[:limit]
-				}
-				return items, nil
-			},
+			ListFn: adapter.LimitedListFn(func(ctx context.Context) ([]T, error) {
+				return listFn(client, ctx)
+			}),
 			Namespace:  cfg.Namespace,
 			Descriptor: desc,
 		}

--- a/internal/providers/kg/resource_adapter.go
+++ b/internal/providers/kg/resource_adapter.go
@@ -157,8 +157,15 @@ func NewAdapterFactory(loader RESTConfigLoader) adapter.Factory {
 		}
 
 		crud := &adapter.TypedCRUD[Rule]{
-			ListFn: func(ctx context.Context) ([]Rule, error) {
-				return client.ListRules(ctx)
+			ListFn: func(ctx context.Context, limit int64) ([]Rule, error) {
+				items, err := client.ListRules(ctx)
+				if err != nil {
+					return nil, err
+				}
+				if limit > 0 && int64(len(items)) > limit {
+					items = items[:limit]
+				}
+				return items, nil
 			},
 			GetFn: func(ctx context.Context, name string) (*Rule, error) {
 				return client.GetRule(ctx, name)
@@ -183,8 +190,15 @@ func NewTypedCRUD(ctx context.Context, loader RESTConfigLoader) (*adapter.TypedC
 	}
 
 	crud := &adapter.TypedCRUD[Rule]{
-		ListFn: func(ctx context.Context) ([]Rule, error) {
-			return client.ListRules(ctx)
+		ListFn: func(ctx context.Context, limit int64) ([]Rule, error) {
+			items, err := client.ListRules(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
 		},
 		GetFn: func(ctx context.Context, name string) (*Rule, error) {
 			return client.GetRule(ctx, name)
@@ -369,8 +383,15 @@ func newListOnlyFactory[T adapter.ResourceNamer](
 			return nil, fmt.Errorf("kg: failed to create client: %w", err)
 		}
 		crud := &adapter.TypedCRUD[T]{
-			ListFn: func(ctx context.Context) ([]T, error) {
-				return listFn(client, ctx)
+			ListFn: func(ctx context.Context, limit int64) ([]T, error) {
+				items, err := listFn(client, ctx)
+				if err != nil {
+					return nil, err
+				}
+				if limit > 0 && int64(len(items)) > limit {
+					items = items[:limit]
+				}
+				return items, nil
 			},
 			Namespace:  cfg.Namespace,
 			Descriptor: desc,

--- a/internal/providers/logs/adaptive/commands.go
+++ b/internal/providers/logs/adaptive/commands.go
@@ -531,7 +531,8 @@ func (h *logsHelper) exemptionsCommand() *cobra.Command {
 // exemptions list
 
 type exemptionsListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *exemptionsListOpts) setup(cmd *cobra.Command) {
@@ -539,8 +540,10 @@ func (o *exemptionsListOpts) setup(cmd *cobra.Command) {
 	o.IO.RegisterCustomCodec("wide", &exemptionsTableCodec{wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(cmd.Flags())
+	cmd.Flags().Int64Var(&o.Limit, "limit", 50, "Maximum number of exemptions to return (0 for no limit)")
 }
 
+//nolint:dupl // exemptions and segments list follow identical TypedCRUD pattern
 func (h *logsHelper) exemptionsListCommand() *cobra.Command {
 	opts := &exemptionsListOpts{}
 	cmd := &cobra.Command{
@@ -557,7 +560,7 @@ func (h *logsHelper) exemptionsListCommand() *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, opts.Limit)
 			if err != nil {
 				return err
 			}
@@ -778,7 +781,8 @@ func (h *logsHelper) segmentsCommand() *cobra.Command {
 // segments list
 
 type segmentsListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *segmentsListOpts) setup(cmd *cobra.Command) {
@@ -786,8 +790,10 @@ func (o *segmentsListOpts) setup(cmd *cobra.Command) {
 	o.IO.RegisterCustomCodec("wide", &segmentsTableCodec{wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(cmd.Flags())
+	cmd.Flags().Int64Var(&o.Limit, "limit", 50, "Maximum number of segments to return (0 for no limit)")
 }
 
+//nolint:dupl // segments and exemptions list follow identical TypedCRUD pattern
 func (h *logsHelper) segmentsListCommand() *cobra.Command {
 	opts := &segmentsListOpts{}
 	cmd := &cobra.Command{
@@ -804,7 +810,7 @@ func (h *logsHelper) segmentsListCommand() *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, opts.Limit)
 			if err != nil {
 				return err
 			}
@@ -1041,6 +1047,7 @@ func (h *logsHelper) dropRulesCommand() *cobra.Command {
 type dropRulesListOpts struct {
 	IO               cmdio.Options
 	ExpirationFilter string
+	Limit            int64
 }
 
 func (o *dropRulesListOpts) setup(cmd *cobra.Command) {
@@ -1050,6 +1057,7 @@ func (o *dropRulesListOpts) setup(cmd *cobra.Command) {
 	o.IO.RegisterCustomCodec("wide", &dropRulesTableCodec{wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(cmd.Flags())
+	cmd.Flags().Int64Var(&o.Limit, "limit", 50, "Maximum number of drop rules to return (0 for no limit)")
 }
 
 func (h *logsHelper) dropRulesListCommand() *cobra.Command {
@@ -1074,6 +1082,9 @@ func (h *logsHelper) dropRulesListCommand() *cobra.Command {
 			})
 			if err != nil {
 				return err
+			}
+			if opts.Limit > 0 && int64(len(rules)) > opts.Limit {
+				rules = rules[:opts.Limit]
 			}
 
 			out := any(rules)

--- a/internal/providers/logs/adaptive/commands.go
+++ b/internal/providers/logs/adaptive/commands.go
@@ -1083,9 +1083,7 @@ func (h *logsHelper) dropRulesListCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if opts.Limit > 0 && int64(len(rules)) > opts.Limit {
-				rules = rules[:opts.Limit]
-			}
+			rules = adapter.TruncateSlice(rules, opts.Limit)
 
 			out := any(rules)
 			if opts.IO.JSONDiscovery {

--- a/internal/providers/logs/adaptive/resource_adapter.go
+++ b/internal/providers/logs/adaptive/resource_adapter.go
@@ -78,7 +78,16 @@ func buildLogsTypedCRUD[T adapter.ResourceNamer](
 	del func(context.Context, string) error,
 ) *adapter.TypedCRUD[T] {
 	return &adapter.TypedCRUD[T]{
-		ListFn:      list,
+		ListFn: func(ctx context.Context, limit int64) ([]T, error) {
+			items, err := list(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn:       get,
 		CreateFn:    create,
 		UpdateFn:    update,

--- a/internal/providers/logs/adaptive/resource_adapter.go
+++ b/internal/providers/logs/adaptive/resource_adapter.go
@@ -78,16 +78,7 @@ func buildLogsTypedCRUD[T adapter.ResourceNamer](
 	del func(context.Context, string) error,
 ) *adapter.TypedCRUD[T] {
 	return &adapter.TypedCRUD[T]{
-		ListFn: func(ctx context.Context, limit int64) ([]T, error) {
-			items, err := list(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn:      adapter.LimitedListFn(list),
 		GetFn:       get,
 		CreateFn:    create,
 		UpdateFn:    update,

--- a/internal/providers/metrics/adaptive/commands.go
+++ b/internal/providers/metrics/adaptive/commands.go
@@ -507,6 +507,7 @@ type rulesListOpts struct {
 	cmdio.Options
 
 	Segment string
+	Limit   int64
 }
 
 func (o *rulesListOpts) setup(flags *pflag.FlagSet) {
@@ -515,6 +516,7 @@ func (o *rulesListOpts) setup(flags *pflag.FlagSet) {
 	o.RegisterCustomCodec("wide", &rulesTableCodec{wide: true})
 	o.BindFlags(flags)
 	flags.StringVar(&o.Segment, "segment", "", "Segment ID")
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of rules to return (0 for no limit)")
 }
 
 func (h *metricsHelper) rulesListCommand() *cobra.Command {
@@ -533,7 +535,7 @@ func (h *metricsHelper) rulesListCommand() *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, opts.Limit)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/metrics/adaptive/resource_adapter.go
+++ b/internal/providers/metrics/adaptive/resource_adapter.go
@@ -125,7 +125,7 @@ func (em *etagManager) withETag(ctx context.Context, fn func(etag string) (strin
 	return nil
 }
 
-func (em *etagManager) list(ctx context.Context) ([]MetricRule, error) {
+func (em *etagManager) list(ctx context.Context, limit int64) ([]MetricRule, error) {
 	em.mu.Lock()
 	defer em.mu.Unlock()
 	rules, etag, err := em.client.ListRules(ctx, em.segment)
@@ -133,6 +133,9 @@ func (em *etagManager) list(ctx context.Context) ([]MetricRule, error) {
 		return nil, err
 	}
 	em.etag = etag
+	if limit > 0 && int64(len(rules)) > limit {
+		rules = rules[:limit]
+	}
 	return rules, nil
 }
 

--- a/internal/providers/metrics/adaptive/resource_adapter.go
+++ b/internal/providers/metrics/adaptive/resource_adapter.go
@@ -133,10 +133,7 @@ func (em *etagManager) list(ctx context.Context, limit int64) ([]MetricRule, err
 		return nil, err
 	}
 	em.etag = etag
-	if limit > 0 && int64(len(rules)) > limit {
-		rules = rules[:limit]
-	}
-	return rules, nil
+	return adapter.TruncateSlice(rules, limit), nil
 }
 
 func (em *etagManager) get(ctx context.Context, name string) (*MetricRule, error) {

--- a/internal/providers/oncall/commands.go
+++ b/internal/providers/oncall/commands.go
@@ -25,10 +25,12 @@ import (
 type listOpts struct {
 	IO       cmdio.Options
 	Resource string // resource name for codec selection (e.g. "integrations")
+	Limit    int64
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet, resource string) {
 	o.Resource = resource
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 	switch resource {
 	case "integrations":
 		o.IO.RegisterCustomCodec("table", &IntegrationTableCodec{})
@@ -114,7 +116,7 @@ func newListSubcommand[T adapter.ResourceNamer](
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, listOpts.Limit)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/oncall/commands_extra.go
+++ b/internal/providers/oncall/commands_extra.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -54,9 +55,7 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if opts.Limit > 0 && int64(len(items)) > opts.Limit {
-				items = items[:opts.Limit]
-			}
+			items = adapter.TruncateSlice(items, opts.Limit)
 
 			objs, err := itemsToUnstructured(items, "AlertGroup", "id", namespace)
 			if err != nil {
@@ -117,9 +116,7 @@ func newAlertGroupListAlertsCommand(loader OnCallConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if opts.Limit > 0 && int64(len(items)) > opts.Limit {
-				items = items[:opts.Limit]
-			}
+			items = adapter.TruncateSlice(items, opts.Limit)
 
 			objs, err := itemsToUnstructured(items, "Alert", "id", namespace)
 			if err != nil {

--- a/internal/providers/oncall/commands_extra.go
+++ b/internal/providers/oncall/commands_extra.go
@@ -54,6 +54,9 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if opts.Limit > 0 && int64(len(items)) > opts.Limit {
+				items = items[:opts.Limit]
+			}
 
 			objs, err := itemsToUnstructured(items, "AlertGroup", "id", namespace)
 			if err != nil {
@@ -113,6 +116,9 @@ func newAlertGroupListAlertsCommand(loader OnCallConfigLoader) *cobra.Command {
 			items, err := client.ListAlerts(cmd.Context(), args[0])
 			if err != nil {
 				return err
+			}
+			if opts.Limit > 0 && int64(len(items)) > opts.Limit {
+				items = items[:opts.Limit]
 			}
 
 			objs, err := itemsToUnstructured(items, "Alert", "id", namespace)

--- a/internal/providers/oncall/resource_adapter.go
+++ b/internal/providers/oncall/resource_adapter.go
@@ -90,7 +90,16 @@ func buildOnCallRegistration[T adapter.ResourceNamer](
 			}
 
 			if listFn != nil {
-				crud.ListFn = func(ctx context.Context) ([]T, error) { return listFn(ctx, client) }
+				crud.ListFn = func(ctx context.Context, limit int64) ([]T, error) {
+					items, err := listFn(ctx, client)
+					if err != nil {
+						return nil, err
+					}
+					if limit > 0 && int64(len(items)) > limit {
+						items = items[:limit]
+					}
+					return items, nil
+				}
 			}
 
 			if getFn != nil {
@@ -610,7 +619,16 @@ func NewTypedCRUD[T adapter.ResourceNamer](
 	}
 
 	crud := &adapter.TypedCRUD[T]{
-		ListFn:      func(ctx context.Context) ([]T, error) { return listFn(ctx, client) },
+		ListFn: func(ctx context.Context, limit int64) ([]T, error) {
+			items, err := listFn(ctx, client)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		StripFields: []string{"id", "password", "authorization_header"},
 		Namespace:   namespace,
 	}

--- a/internal/providers/oncall/resource_adapter.go
+++ b/internal/providers/oncall/resource_adapter.go
@@ -90,16 +90,9 @@ func buildOnCallRegistration[T adapter.ResourceNamer](
 			}
 
 			if listFn != nil {
-				crud.ListFn = func(ctx context.Context, limit int64) ([]T, error) {
-					items, err := listFn(ctx, client)
-					if err != nil {
-						return nil, err
-					}
-					if limit > 0 && int64(len(items)) > limit {
-						items = items[:limit]
-					}
-					return items, nil
-				}
+				crud.ListFn = adapter.LimitedListFn(func(ctx context.Context) ([]T, error) {
+					return listFn(ctx, client)
+				})
 			}
 
 			if getFn != nil {
@@ -619,16 +612,9 @@ func NewTypedCRUD[T adapter.ResourceNamer](
 	}
 
 	crud := &adapter.TypedCRUD[T]{
-		ListFn: func(ctx context.Context, limit int64) ([]T, error) {
-			items, err := listFn(ctx, client)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(func(ctx context.Context) ([]T, error) {
+			return listFn(ctx, client)
+		}),
 		StripFields: []string{"id", "password", "authorization_header"},
 		Namespace:   namespace,
 	}

--- a/internal/providers/sigil/agents/commands.go
+++ b/internal/providers/sigil/agents/commands.go
@@ -49,7 +49,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &ListTableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
-	flags.IntVar(&o.Limit, "limit", 100, "Maximum number of agents to return")
+	flags.IntVar(&o.Limit, "limit", 50, "Maximum number of agents to return")
 }
 
 func newListCommand(loader *providers.ConfigLoader) *cobra.Command {

--- a/internal/providers/sigil/conversations/commands.go
+++ b/internal/providers/sigil/conversations/commands.go
@@ -52,7 +52,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &TableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
-	flags.IntVar(&o.Limit, "limit", 100, "Maximum number of conversations to return (0 for no limit)")
+	flags.IntVar(&o.Limit, "limit", 50, "Maximum number of conversations to return (0 for no limit)")
 }
 
 func newListCommand(loader *providers.ConfigLoader) *cobra.Command {

--- a/internal/providers/sigil/eval/evaluators/commands.go
+++ b/internal/providers/sigil/eval/evaluators/commands.go
@@ -43,7 +43,8 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 // --- list ---
 
 type listOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet) {
@@ -51,6 +52,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &TableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of evaluators to return (0 for no limit)")
 }
 
 func newListCommand() *cobra.Command {
@@ -69,7 +71,7 @@ func newListCommand() *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, opts.Limit)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/sigil/eval/evaluators/resource_adapter.go
+++ b/internal/providers/sigil/eval/evaluators/resource_adapter.go
@@ -58,16 +58,7 @@ func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.EvaluatorDefinit
 	client := NewClient(base)
 
 	crud := &adapter.TypedCRUD[eval.EvaluatorDefinition]{
-		ListFn: func(ctx context.Context, limit int64) ([]eval.EvaluatorDefinition, error) {
-			items, err := client.List(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.List),
 		GetFn: func(ctx context.Context, name string) (*eval.EvaluatorDefinition, error) {
 			return client.Get(ctx, name)
 		},

--- a/internal/providers/sigil/eval/evaluators/resource_adapter.go
+++ b/internal/providers/sigil/eval/evaluators/resource_adapter.go
@@ -58,7 +58,16 @@ func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.EvaluatorDefinit
 	client := NewClient(base)
 
 	crud := &adapter.TypedCRUD[eval.EvaluatorDefinition]{
-		ListFn: client.List,
+		ListFn: func(ctx context.Context, limit int64) ([]eval.EvaluatorDefinition, error) {
+			items, err := client.List(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*eval.EvaluatorDefinition, error) {
 			return client.Get(ctx, name)
 		},

--- a/internal/providers/sigil/eval/rules/commands.go
+++ b/internal/providers/sigil/eval/rules/commands.go
@@ -42,7 +42,8 @@ func Commands() *cobra.Command {
 // --- list ---
 
 type listOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet) {
@@ -50,6 +51,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &TableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of rules to return (0 for no limit)")
 }
 
 func newListCommand() *cobra.Command {
@@ -68,7 +70,7 @@ func newListCommand() *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, opts.Limit)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/sigil/eval/rules/resource_adapter.go
+++ b/internal/providers/sigil/eval/rules/resource_adapter.go
@@ -57,7 +57,16 @@ func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.RuleDefinition],
 	client := NewClient(base)
 
 	crud := &adapter.TypedCRUD[eval.RuleDefinition]{
-		ListFn: client.List,
+		ListFn: func(ctx context.Context, limit int64) ([]eval.RuleDefinition, error) {
+			items, err := client.List(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*eval.RuleDefinition, error) {
 			return client.Get(ctx, name)
 		},

--- a/internal/providers/sigil/eval/rules/resource_adapter.go
+++ b/internal/providers/sigil/eval/rules/resource_adapter.go
@@ -57,16 +57,7 @@ func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.RuleDefinition],
 	client := NewClient(base)
 
 	crud := &adapter.TypedCRUD[eval.RuleDefinition]{
-		ListFn: func(ctx context.Context, limit int64) ([]eval.RuleDefinition, error) {
-			items, err := client.List(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.List),
 		GetFn: func(ctx context.Context, name string) (*eval.RuleDefinition, error) {
 			return client.Get(ctx, name)
 		},

--- a/internal/providers/sigil/eval/templates/commands.go
+++ b/internal/providers/sigil/eval/templates/commands.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/sigil/eval"
 	"github.com/grafana/gcx/internal/providers/sigil/sigilhttp"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -75,9 +76,7 @@ func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if opts.Limit > 0 && int64(len(templates)) > opts.Limit {
-				templates = templates[:opts.Limit]
-			}
+			templates = adapter.TruncateSlice(templates, opts.Limit)
 			return opts.IO.Encode(cmd.OutOrStdout(), templates)
 		},
 	}

--- a/internal/providers/sigil/eval/templates/commands.go
+++ b/internal/providers/sigil/eval/templates/commands.go
@@ -41,6 +41,7 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 type listOpts struct {
 	IO    cmdio.Options
 	Scope string
+	Limit int64
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet) {
@@ -49,6 +50,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
 	flags.StringVar(&o.Scope, "scope", "", `Filter by scope: "global" or "tenant"`)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of templates to return (0 for no limit)")
 }
 
 func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
@@ -72,6 +74,9 @@ func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 			templates, err := client.List(cmd.Context(), opts.Scope)
 			if err != nil {
 				return err
+			}
+			if opts.Limit > 0 && int64(len(templates)) > opts.Limit {
+				templates = templates[:opts.Limit]
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), templates)
 		},

--- a/internal/providers/sigil/scores/commands.go
+++ b/internal/providers/sigil/scores/commands.go
@@ -45,7 +45,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &TableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
-	flags.IntVar(&o.Limit, "limit", 100, "Maximum number of scores to return")
+	flags.IntVar(&o.Limit, "limit", 50, "Maximum number of scores to return")
 }
 
 func newListCommand(loader *providers.ConfigLoader) *cobra.Command {

--- a/internal/providers/slo/definitions/commands.go
+++ b/internal/providers/slo/definitions/commands.go
@@ -50,7 +50,8 @@ func Commands(loader GrafanaConfigLoader) *cobra.Command {
 // ---------------------------------------------------------------------------
 
 type listOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet) {
@@ -58,6 +59,8 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &sloTableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
@@ -77,7 +80,7 @@ func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, opts.Limit)
 			if err != nil {
 				return err
 			}
@@ -239,7 +242,7 @@ func newPullCommand(loader GrafanaConfigLoader) *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, 0)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/slo/definitions/resource_adapter.go
+++ b/internal/providers/slo/definitions/resource_adapter.go
@@ -84,16 +84,7 @@ func NewTypedCRUD(ctx context.Context, loader GrafanaConfigLoader) (*adapter.Typ
 
 	//nolint:dupl // Duplicate TypedCRUD initialization intentional between factory functions.
 	crud := &adapter.TypedCRUD[Slo]{
-		ListFn: func(ctx context.Context, limit int64) ([]Slo, error) {
-			items, err := client.List(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.List),
 		GetFn: func(ctx context.Context, name string) (*Slo, error) {
 			return client.Get(ctx, name)
 		},
@@ -155,16 +146,7 @@ func NewFactoryFromConfig(cfg internalconfig.NamespacedRESTConfig) adapter.Facto
 
 		//nolint:dupl // Duplicate TypedCRUD initialization intentional between factory functions.
 		crud := &adapter.TypedCRUD[Slo]{
-			ListFn: func(ctx context.Context, limit int64) ([]Slo, error) {
-				items, err := client.List(ctx)
-				if err != nil {
-					return nil, err
-				}
-				if limit > 0 && int64(len(items)) > limit {
-					items = items[:limit]
-				}
-				return items, nil
-			},
+			ListFn: adapter.LimitedListFn(client.List),
 			GetFn: func(ctx context.Context, name string) (*Slo, error) {
 				return client.Get(ctx, name)
 			},

--- a/internal/providers/slo/definitions/resource_adapter.go
+++ b/internal/providers/slo/definitions/resource_adapter.go
@@ -84,7 +84,16 @@ func NewTypedCRUD(ctx context.Context, loader GrafanaConfigLoader) (*adapter.Typ
 
 	//nolint:dupl // Duplicate TypedCRUD initialization intentional between factory functions.
 	crud := &adapter.TypedCRUD[Slo]{
-		ListFn: client.List,
+		ListFn: func(ctx context.Context, limit int64) ([]Slo, error) {
+			items, err := client.List(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*Slo, error) {
 			return client.Get(ctx, name)
 		},
@@ -146,7 +155,16 @@ func NewFactoryFromConfig(cfg internalconfig.NamespacedRESTConfig) adapter.Facto
 
 		//nolint:dupl // Duplicate TypedCRUD initialization intentional between factory functions.
 		crud := &adapter.TypedCRUD[Slo]{
-			ListFn: client.List,
+			ListFn: func(ctx context.Context, limit int64) ([]Slo, error) {
+				items, err := client.List(ctx)
+				if err != nil {
+					return nil, err
+				}
+				if limit > 0 && int64(len(items)) > limit {
+					items = items[:limit]
+				}
+				return items, nil
+			},
 			GetFn: func(ctx context.Context, name string) (*Slo, error) {
 				return client.Get(ctx, name)
 			},

--- a/internal/providers/slo/definitions/status.go
+++ b/internal/providers/slo/definitions/status.go
@@ -107,7 +107,7 @@ grafana_slo_* metrics.`,
 				}
 				slos = []Slo{typedObj.Spec}
 			} else {
-				typedObjs, err := crud.List(ctx)
+				typedObjs, err := crud.List(ctx, 0)
 				if err != nil {
 					return err
 				}

--- a/internal/providers/slo/definitions/timeline.go
+++ b/internal/providers/slo/definitions/timeline.go
@@ -127,7 +127,7 @@ grafana_slo_sli_window metrics.`,
 				}
 				slos = []Slo{s.Spec}
 			} else {
-				typedObjs, err := crud.List(ctx)
+				typedObjs, err := crud.List(ctx, 0)
 				if err != nil {
 					return err
 				}

--- a/internal/providers/slo/reports/commands.go
+++ b/internal/providers/slo/reports/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -90,9 +91,7 @@ func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
 				return err
 			}
 
-			if opts.Limit > 0 && int64(len(rpts)) > opts.Limit {
-				rpts = rpts[:opts.Limit]
-			}
+			rpts = adapter.TruncateSlice(rpts, opts.Limit)
 
 			// Table codec operates on raw []Report for direct field access.
 			// Other formats (yaml/json) convert to K8s envelope Resources

--- a/internal/providers/slo/reports/commands.go
+++ b/internal/providers/slo/reports/commands.go
@@ -50,7 +50,8 @@ func Commands(loader GrafanaConfigLoader) *cobra.Command {
 // ---------------------------------------------------------------------------
 
 type listOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet) {
@@ -58,6 +59,8 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &reportTableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
@@ -85,6 +88,10 @@ func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
 			rpts, err := client.List(ctx)
 			if err != nil {
 				return err
+			}
+
+			if opts.Limit > 0 && int64(len(rpts)) > opts.Limit {
+				rpts = rpts[:opts.Limit]
 			}
 
 			// Table codec operates on raw []Report for direct field access.

--- a/internal/providers/synth/checks/commands.go
+++ b/internal/providers/synth/checks/commands.go
@@ -50,6 +50,7 @@ type listOpts struct {
 	IO         cmdio.Options
 	Labels     []string
 	JobPattern string
+	Limit      int64
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet) {
@@ -60,6 +61,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 
 	flags.StringArrayVar(&o.Labels, "label", nil, "Filter by label key=value (repeatable, e.g. --label env=prod)")
 	flags.StringVar(&o.JobPattern, "job", "", "Filter by job name glob pattern (e.g. --job 'shopk8s-*')")
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func newListCommand(loader smcfg.Loader) *cobra.Command {
@@ -96,7 +98,7 @@ func newListCommand(loader smcfg.Loader) *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, opts.Limit)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/synth/checks/resource_adapter.go
+++ b/internal/providers/synth/checks/resource_adapter.go
@@ -70,7 +70,7 @@ func NewTypedCRUD(ctx context.Context, loader smcfg.Loader) (*adapter.TypedCRUD[
 	probesClient := probes.NewClient(ctx, baseURL, token)
 
 	crud := &adapter.TypedCRUD[checkResource]{
-		ListFn: func(ctx context.Context) ([]checkResource, error) {
+		ListFn: func(ctx context.Context, limit int64) ([]checkResource, error) {
 			checkList, err := checksClient.List(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to list checks: %w", err)
@@ -84,6 +84,10 @@ func NewTypedCRUD(ctx context.Context, loader smcfg.Loader) (*adapter.TypedCRUD[
 			result := make([]checkResource, 0, len(checkList))
 			for _, check := range checkList {
 				result = append(result, checkToResource(check, nameMap))
+			}
+
+			if limit > 0 && int64(len(result)) > limit {
+				result = result[:limit]
 			}
 
 			return result, nil

--- a/internal/providers/synth/checks/resource_adapter.go
+++ b/internal/providers/synth/checks/resource_adapter.go
@@ -86,11 +86,7 @@ func NewTypedCRUD(ctx context.Context, loader smcfg.Loader) (*adapter.TypedCRUD[
 				result = append(result, checkToResource(check, nameMap))
 			}
 
-			if limit > 0 && int64(len(result)) > limit {
-				result = result[:limit]
-			}
-
-			return result, nil
+			return adapter.TruncateSlice(result, limit), nil
 		},
 
 		GetFn: func(ctx context.Context, name string) (*checkResource, error) {

--- a/internal/providers/synth/probes/commands.go
+++ b/internal/providers/synth/probes/commands.go
@@ -39,13 +39,16 @@ func Commands(loader smcfg.Loader) *cobra.Command {
 // ---------------------------------------------------------------------------
 
 type listOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &probeTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
 }
 
 func newListCommand(loader smcfg.Loader) *cobra.Command {
@@ -65,7 +68,7 @@ func newListCommand(loader smcfg.Loader) *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, opts.Limit)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/synth/probes/resource_adapter.go
+++ b/internal/providers/synth/probes/resource_adapter.go
@@ -58,16 +58,7 @@ func NewTypedCRUD(ctx context.Context, loader smcfg.Loader) (*adapter.TypedCRUD[
 	client := NewClient(ctx, baseURL, token)
 
 	crud := &adapter.TypedCRUD[Probe]{
-		ListFn: func(ctx context.Context, limit int64) ([]Probe, error) {
-			items, err := client.List(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.List),
 		GetFn: func(ctx context.Context, name string) (*Probe, error) {
 			id, err := strconv.ParseInt(name, 10, 64)
 			if err != nil {

--- a/internal/providers/synth/probes/resource_adapter.go
+++ b/internal/providers/synth/probes/resource_adapter.go
@@ -58,7 +58,16 @@ func NewTypedCRUD(ctx context.Context, loader smcfg.Loader) (*adapter.TypedCRUD[
 	client := NewClient(ctx, baseURL, token)
 
 	crud := &adapter.TypedCRUD[Probe]{
-		ListFn: client.List,
+		ListFn: func(ctx context.Context, limit int64) ([]Probe, error) {
+			items, err := client.List(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
+		},
 		GetFn: func(ctx context.Context, name string) (*Probe, error) {
 			id, err := strconv.ParseInt(name, 10, 64)
 			if err != nil {

--- a/internal/providers/traces/adaptive/commands.go
+++ b/internal/providers/traces/adaptive/commands.go
@@ -279,7 +279,8 @@ func (h *tracesHelper) policiesCommand() *cobra.Command {
 // ---------------------------------------------------------------------------
 
 type policiesListOpts struct {
-	IO cmdio.Options
+	IO    cmdio.Options
+	Limit int64
 }
 
 func (o *policiesListOpts) setup(flags *pflag.FlagSet) {
@@ -287,6 +288,7 @@ func (o *policiesListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("wide", &policyTableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of policies to return (0 for no limit)")
 }
 
 func (h *tracesHelper) policiesListCommand() *cobra.Command {
@@ -306,7 +308,7 @@ func (h *tracesHelper) policiesListCommand() *cobra.Command {
 				return err
 			}
 
-			typedObjs, err := crud.List(ctx)
+			typedObjs, err := crud.List(ctx, opts.Limit)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/traces/adaptive/resource_adapter.go
+++ b/internal/providers/traces/adaptive/resource_adapter.go
@@ -66,16 +66,7 @@ func NewPolicyTypedCRUD(ctx context.Context, loader *providers.ConfigLoader) (*a
 	client := NewClient(signalAuth.BaseURL, signalAuth.TenantID, signalAuth.APIToken, signalAuth.HTTPClient)
 
 	crud := &adapter.TypedCRUD[Policy]{
-		ListFn: func(ctx context.Context, limit int64) ([]Policy, error) {
-			items, err := client.ListPolicies(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if limit > 0 && int64(len(items)) > limit {
-				items = items[:limit]
-			}
-			return items, nil
-		},
+		ListFn: adapter.LimitedListFn(client.ListPolicies),
 		GetFn: func(ctx context.Context, name string) (*Policy, error) {
 			return client.GetPolicy(ctx, name)
 		},

--- a/internal/providers/traces/adaptive/resource_adapter.go
+++ b/internal/providers/traces/adaptive/resource_adapter.go
@@ -66,8 +66,15 @@ func NewPolicyTypedCRUD(ctx context.Context, loader *providers.ConfigLoader) (*a
 	client := NewClient(signalAuth.BaseURL, signalAuth.TenantID, signalAuth.APIToken, signalAuth.HTTPClient)
 
 	crud := &adapter.TypedCRUD[Policy]{
-		ListFn: func(ctx context.Context) ([]Policy, error) {
-			return client.ListPolicies(ctx)
+		ListFn: func(ctx context.Context, limit int64) ([]Policy, error) {
+			items, err := client.ListPolicies(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if limit > 0 && int64(len(items)) > limit {
+				items = items[:limit]
+			}
+			return items, nil
 		},
 		GetFn: func(ctx context.Context, name string) (*Policy, error) {
 			return client.GetPolicy(ctx, name)

--- a/internal/resources/adapter/typed.go
+++ b/internal/resources/adapter/typed.go
@@ -37,7 +37,8 @@ type TypedCRUD[T ResourceNamer] struct {
 	// ListFn lists all items of this type.
 	// Nil means list is unsupported (returns errors.ErrUnsupported).
 	// Also used as a fallback for Get when GetFn is nil.
-	ListFn func(ctx context.Context) ([]T, error)
+	// The limit parameter caps the number of items returned (0 means no limit).
+	ListFn func(ctx context.Context, limit int64) ([]T, error)
 
 	// GetFn returns a single item by name.
 	// Nil means get falls back to ListFn + client-side name filtering.
@@ -91,14 +92,15 @@ func (c *TypedCRUD[T]) restoreName(name string, item *T) {
 
 // --- Typed public methods ---
 
-// List returns all items as TypedObject[T] with correct TypeMeta and ObjectMeta.
+// List returns items as TypedObject[T] with correct TypeMeta and ObjectMeta.
+// The limit parameter caps the number of items returned (0 means no limit).
 // Returns errors.ErrUnsupported when ListFn is nil.
-func (c *TypedCRUD[T]) List(ctx context.Context) ([]TypedObject[T], error) {
+func (c *TypedCRUD[T]) List(ctx context.Context, limit int64) ([]TypedObject[T], error) {
 	if c.ListFn == nil {
 		return nil, errors.ErrUnsupported
 	}
 
-	items, err := c.ListFn(ctx)
+	items, err := c.ListFn(ctx, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +134,7 @@ func (c *TypedCRUD[T]) Get(ctx context.Context, name string) (*TypedObject[T], e
 		return nil, errors.ErrUnsupported
 	}
 
-	items, err := c.ListFn(ctx)
+	items, err := c.ListFn(ctx, 0) // no limit — need all items for name lookup
 	if err != nil {
 		return nil, err
 	}
@@ -304,12 +306,12 @@ func (a *typedAdapter[T]) Example() json.RawMessage {
 	return a.example
 }
 
-func (a *typedAdapter[T]) List(ctx context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (a *typedAdapter[T]) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	if a.crud.ListFn == nil {
 		return nil, errors.ErrUnsupported
 	}
 
-	items, err := a.crud.ListFn(ctx)
+	items, err := a.crud.ListFn(ctx, opts.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resources/adapter/typed.go
+++ b/internal/resources/adapter/typed.go
@@ -14,6 +14,27 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// TruncateSlice returns at most limit items from the slice.
+// When limit is 0 or negative, the original slice is returned unchanged.
+func TruncateSlice[T any](items []T, limit int64) []T {
+	if limit > 0 && int64(len(items)) > limit {
+		return items[:limit]
+	}
+	return items
+}
+
+// LimitedListFn wraps a simple list function (no limit parameter) into the
+// ListFn signature expected by TypedCRUD, applying client-side truncation.
+func LimitedListFn[T any](fn func(ctx context.Context) ([]T, error)) func(ctx context.Context, limit int64) ([]T, error) {
+	return func(ctx context.Context, limit int64) ([]T, error) {
+		items, err := fn(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return TruncateSlice(items, limit), nil
+	}
+}
+
 // ErrNotFound is returned by TypedCRUD.Get when a resource does not exist.
 // Provider GetFn implementations should wrap this sentinel (via fmt.Errorf
 // with %w) so that the adapter layer can convert provider-specific not-found

--- a/internal/resources/adapter/typed_test.go
+++ b/internal/resources/adapter/typed_test.go
@@ -45,7 +45,7 @@ func newWidgetCRUD(widgets []TestWidget) *adapter.TypedCRUD[TestWidget] {
 		StripFields: []string{"id", "secret"},
 		Descriptor:  widgetDesc,
 		Aliases:     []string{"wdg"},
-		ListFn: func(_ context.Context) ([]TestWidget, error) {
+		ListFn: func(_ context.Context, _ int64) ([]TestWidget, error) {
 			return widgets, nil
 		},
 		GetFn: func(_ context.Context, name string) (*TestWidget, error) {
@@ -262,7 +262,7 @@ func TestTypedCRUD_NilListFn(t *testing.T) {
 	}
 
 	t.Run("typed List returns ErrUnsupported", func(t *testing.T) {
-		_, err := crud.List(t.Context())
+		_, err := crud.List(t.Context(), 0)
 		assert.ErrorIs(t, err, errors.ErrUnsupported)
 	})
 
@@ -292,7 +292,7 @@ func TestTypedCRUD_NilGetFn_FallbackToList(t *testing.T) {
 		Namespace:  "stack-1",
 		Descriptor: widgetDesc,
 		Aliases:    []string{"wdg"},
-		ListFn: func(_ context.Context) ([]TestWidget, error) {
+		ListFn: func(_ context.Context, _ int64) ([]TestWidget, error) {
 			return widgets, nil
 		},
 		// GetFn intentionally nil — should fall back to list + filter
@@ -331,7 +331,7 @@ func TestTypedCRUD_NilGetFn_FallbackToList(t *testing.T) {
 	})
 
 	t.Run("List still works normally", func(t *testing.T) {
-		result, err := crud.List(t.Context())
+		result, err := crud.List(t.Context(), 0)
 		require.NoError(t, err)
 		assert.Len(t, result, 3)
 	})
@@ -351,7 +351,7 @@ func TestTypedCRUD_NilGetFn_NilListFn(t *testing.T) {
 	})
 
 	t.Run("typed List returns ErrUnsupported", func(t *testing.T) {
-		_, err := crud.List(t.Context())
+		_, err := crud.List(t.Context(), 0)
 		assert.ErrorIs(t, err, errors.ErrUnsupported)
 	})
 }
@@ -522,7 +522,7 @@ func TestTypedCRUD_TypedList(t *testing.T) {
 	}
 	crud := newWidgetCRUD(widgets)
 
-	result, err := crud.List(t.Context())
+	result, err := crud.List(t.Context(), 0)
 	require.NoError(t, err)
 	require.Len(t, result, 2)
 
@@ -599,7 +599,7 @@ func TestTypedCRUD_ResourceIdentity(t *testing.T) {
 	}
 	crud := &adapter.TypedCRUD[TestWidget]{
 		Namespace: "stack-1",
-		ListFn:    func(_ context.Context) ([]TestWidget, error) { return widgets, nil },
+		ListFn:    func(_ context.Context, _ int64) ([]TestWidget, error) { return widgets, nil },
 		GetFn: func(_ context.Context, name string) (*TestWidget, error) {
 			return &widgets[0], nil
 		},
@@ -607,7 +607,7 @@ func TestTypedCRUD_ResourceIdentity(t *testing.T) {
 	}
 
 	// Test typed List uses GetResourceName()
-	result, err := crud.List(t.Context())
+	result, err := crud.List(t.Context(), 0)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Equal(t, "w-1", result[0].GetName(), "should use GetResourceName() from ResourceIdentity")

--- a/internal/resources/dynamic/namespaced_client.go
+++ b/internal/resources/dynamic/namespaced_client.go
@@ -39,10 +39,20 @@ func NewNamespacedClient(namespace string, client dynamic.Interface) *Namespaced
 }
 
 // List lists resources from the server.
-// It automatically handles pagination to return all resources using the client-go pager.
+//
+// When opts.Limit > 0, a single direct API call is made and the response
+// (including its Continue token) is returned as-is. This enables callers
+// to detect truncated results and display pagination hints.
+//
+// When opts.Limit == 0, the client-go pager fetches all pages transparently.
 func (c *NamespacedClient) List(
 	ctx context.Context, desc resources.Descriptor, opts metav1.ListOptions,
 ) (*unstructured.UnstructuredList, error) {
+	if opts.Limit > 0 {
+		res, err := c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).List(ctx, opts)
+		return res, ParseStatusError(err)
+	}
+
 	pager := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).List(ctx, opts)
 	})

--- a/internal/resources/dynamic/namespaced_client_test.go
+++ b/internal/resources/dynamic/namespaced_client_test.go
@@ -1,0 +1,196 @@
+package dynamic_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/resources/dynamic"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// testDescriptor creates a Descriptor for the dashboard resource type used in tests.
+func testDescriptor() resources.Descriptor {
+	return resources.Descriptor{
+		GroupVersion: schema.GroupVersion{Group: "dashboard.grafana.app", Version: "v1"},
+		Kind:         "Dashboard",
+		Singular:     "dashboard",
+		Plural:       "dashboards",
+	}
+}
+
+// testDashboard creates a minimal unstructured dashboard object for testing.
+func testDashboard(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "dashboard.grafana.app/v1",
+			"kind":       "Dashboard",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Dashboard " + name,
+			},
+		},
+	}
+}
+
+// newFakeClientWithPagination creates a fake dynamic client with a custom reactor
+// that simulates server-side pagination. The standard fake ObjectTracker does not
+// honour Limit/Continue, so we intercept list calls and paginate manually.
+func newFakeClientWithPagination(objects []*unstructured.Unstructured) *fake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+
+	gvk := testDescriptor().GroupVersionKind()
+	listGVK := gvk.GroupVersion().WithKind(gvk.Kind + "List")
+	scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+
+	runtimeObjects := make([]runtime.Object, len(objects))
+	for i, obj := range objects {
+		runtimeObjects[i] = obj.DeepCopy()
+	}
+
+	client := fake.NewSimpleDynamicClient(scheme, runtimeObjects...)
+
+	// Prepend a reactor that simulates pagination. When Limit > 0 the reactor
+	// returns at most Limit items and sets a Continue token when more items
+	// exist. When Limit == 0 it returns every item with no Continue token.
+	client.PrependReactor("list", "dashboards", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		listAction, ok := action.(k8stesting.ListActionImpl)
+		if !ok {
+			return false, nil, nil
+		}
+
+		limit := listAction.ListOptions.Limit
+		continueToken := listAction.ListOptions.Continue
+
+		// Build the full item list filtered by namespace.
+		allItems := make([]unstructured.Unstructured, 0, len(objects))
+		for _, obj := range objects {
+			ns := listAction.GetNamespace()
+			if ns == "" || obj.GetNamespace() == ns {
+				allItems = append(allItems, *obj.DeepCopy())
+			}
+		}
+
+		// Decode start index from continue token.
+		startIdx := 0
+		if continueToken != "" {
+			if _, err := fmt.Sscanf(continueToken, "%d", &startIdx); err != nil {
+				return true, nil, fmt.Errorf("invalid continue token: %s", continueToken)
+			}
+		}
+
+		// No limit: return everything from startIdx.
+		if limit == 0 {
+			result := &unstructured.UnstructuredList{
+				Object: map[string]any{
+					"apiVersion": gvk.GroupVersion().String(),
+					"kind":       listGVK.Kind,
+				},
+			}
+			if startIdx < len(allItems) {
+				result.Items = allItems[startIdx:]
+			}
+			return true, result, nil
+		}
+
+		// Apply limit.
+		endIdx := min(startIdx+int(limit), len(allItems))
+
+		result := &unstructured.UnstructuredList{
+			Object: map[string]any{
+				"apiVersion": gvk.GroupVersion().String(),
+				"kind":       listGVK.Kind,
+			},
+		}
+		if startIdx < len(allItems) {
+			result.Items = allItems[startIdx:endIdx]
+		}
+
+		// Set continue token when more items remain.
+		if endIdx < len(allItems) {
+			result.SetContinue(strconv.Itoa(endIdx))
+		}
+
+		return true, result, nil
+	})
+
+	return client
+}
+
+func TestNamespacedClient_List(t *testing.T) {
+	tests := []struct {
+		name            string
+		objectCount     int
+		limit           int64
+		wantItemCount   int
+		wantHasContinue bool
+	}{
+		{
+			name:            "list with limit returns limited items and preserves continue token",
+			objectCount:     10,
+			limit:           3,
+			wantItemCount:   3,
+			wantHasContinue: true,
+		},
+		{
+			name:            "list without limit returns all items",
+			objectCount:     5,
+			limit:           0,
+			wantItemCount:   5,
+			wantHasContinue: false,
+		},
+		{
+			name:            "list with limit larger than total returns all items",
+			objectCount:     3,
+			limit:           10,
+			wantItemCount:   3,
+			wantHasContinue: false,
+		},
+		{
+			name:            "list with limit=1 returns single item",
+			objectCount:     5,
+			limit:           1,
+			wantItemCount:   1,
+			wantHasContinue: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := require.New(t)
+
+			objects := make([]*unstructured.Unstructured, tc.objectCount)
+			for i := range tc.objectCount {
+				objects[i] = testDashboard(fmt.Sprintf("dash-%d", i))
+			}
+
+			fakeClient := newFakeClientWithPagination(objects)
+			client := dynamic.NewNamespacedClient("default", fakeClient)
+
+			desc := testDescriptor()
+			opts := metav1.ListOptions{Limit: tc.limit}
+
+			result, err := client.List(context.Background(), desc, opts)
+			req.NoError(err)
+			req.NotNil(result)
+			req.Len(result.Items, tc.wantItemCount)
+
+			hasContinue := result.GetContinue() != ""
+			req.Equal(tc.wantHasContinue, hasContinue,
+				"expected continue token present=%v, got continue=%q",
+				tc.wantHasContinue, result.GetContinue())
+		})
+	}
+}

--- a/internal/resources/remote/puller.go
+++ b/internal/resources/remote/puller.go
@@ -136,6 +136,9 @@ func (p *Puller) Pull(ctx context.Context, req PullRequest) (*OperationSummary, 
 						summary.RecordFailure(nil, err)
 					}
 				} else {
+					if res.GetContinue() != "" {
+						summary.RecordTruncated()
+					}
 					partialRes[idx] = res.Items
 				}
 			case resources.FilterTypeMultiple:

--- a/internal/resources/remote/puller_test.go
+++ b/internal/resources/remote/puller_test.go
@@ -20,6 +20,8 @@ type mockPullClient struct {
 	listResults map[string][]unstructured.Unstructured
 	// listErrors maps descriptor plural to the error returned by List.
 	listErrors map[string]error
+	// continueToken, when non-empty, is set on the returned list to simulate truncated results.
+	continueToken string
 }
 
 func (m *mockPullClient) Get(
@@ -44,7 +46,11 @@ func (m *mockPullClient) List(
 	}
 
 	items := m.listResults[desc.Plural]
-	return &unstructured.UnstructuredList{Items: items}, nil
+	res := &unstructured.UnstructuredList{Items: items}
+	if m.continueToken != "" {
+		res.SetContinue(m.continueToken)
+	}
+	return res, nil
 }
 
 // mockPullRegistry implements PullRegistry for testing.
@@ -89,10 +95,13 @@ func TestPuller_Pull(t *testing.T) {
 		listResults      map[string][]unstructured.Unstructured
 		listErrors       map[string]error
 		stopOnError      bool
+		limit            int64
+		continueToken    string
 		wantError        bool
 		wantSuccessCount int
 		wantFailedCount  int
 		wantSkippedCount int
+		wantTruncated    bool
 	}{
 		{
 			name: "all resources succeed",
@@ -186,6 +195,54 @@ func TestPuller_Pull(t *testing.T) {
 			wantFailedCount:  1,
 			wantSkippedCount: 0,
 		},
+		{
+			name: "list with limit and more results available",
+			listResults: map[string][]unstructured.Unstructured{
+				"dashboards": {
+					makeUnstructuredDashboard("d-1"),
+					makeUnstructuredDashboard("d-2"),
+					makeUnstructuredDashboard("d-3"),
+					makeUnstructuredDashboard("d-4"),
+					makeUnstructuredDashboard("d-5"),
+				},
+			},
+			limit:            5,
+			continueToken:    "next-page-token",
+			wantSuccessCount: 5,
+			wantTruncated:    true,
+		},
+		{
+			name: "list with limit and no more results",
+			listResults: map[string][]unstructured.Unstructured{
+				"dashboards": {
+					makeUnstructuredDashboard("d-1"),
+					makeUnstructuredDashboard("d-2"),
+					makeUnstructuredDashboard("d-3"),
+				},
+			},
+			limit:            5,
+			wantSuccessCount: 3,
+			wantTruncated:    false,
+		},
+		{
+			name: "list without limit is not truncated",
+			listResults: map[string][]unstructured.Unstructured{
+				"dashboards": {
+					makeUnstructuredDashboard("d-1"),
+					makeUnstructuredDashboard("d-2"),
+					makeUnstructuredDashboard("d-3"),
+					makeUnstructuredDashboard("d-4"),
+					makeUnstructuredDashboard("d-5"),
+					makeUnstructuredDashboard("d-6"),
+					makeUnstructuredDashboard("d-7"),
+					makeUnstructuredDashboard("d-8"),
+					makeUnstructuredDashboard("d-9"),
+					makeUnstructuredDashboard("d-10"),
+				},
+			},
+			wantSuccessCount: 10,
+			wantTruncated:    false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -193,8 +250,9 @@ func TestPuller_Pull(t *testing.T) {
 			req := require.New(t)
 
 			mockClient := &mockPullClient{
-				listResults: tc.listResults,
-				listErrors:  tc.listErrors,
+				listResults:   tc.listResults,
+				listErrors:    tc.listErrors,
+				continueToken: tc.continueToken,
 			}
 
 			desc := dashboardDescriptor()
@@ -214,6 +272,7 @@ func TestPuller_Pull(t *testing.T) {
 				},
 				Resources:   dest,
 				StopOnError: tc.stopOnError,
+				Limit:       tc.limit,
 			}
 
 			summary, err := puller.Pull(context.Background(), pullReq)
@@ -238,6 +297,9 @@ func TestPuller_Pull(t *testing.T) {
 					req.Error(failure.Error)
 				}
 			}
+
+			// Verify truncation tracking.
+			req.Equal(tc.wantTruncated, summary.IsTruncated())
 
 			// For success cases, verify the destination received the resources.
 			if tc.wantSuccessCount > 0 {

--- a/internal/resources/remote/summary.go
+++ b/internal/resources/remote/summary.go
@@ -13,6 +13,7 @@ type OperationSummary struct {
 	successCount atomic.Int64
 	failedCount  atomic.Int64
 	skippedCount atomic.Int64
+	truncated    atomic.Bool
 	mu           sync.Mutex
 	failures     []OperationFailure
 }
@@ -66,6 +67,16 @@ func (s *OperationSummary) FailedCount() int {
 // does not support the requested operation.
 func (s *OperationSummary) SkippedCount() int {
 	return int(s.skippedCount.Load())
+}
+
+// RecordTruncated records that a list response was truncated (more items available).
+func (s *OperationSummary) RecordTruncated() {
+	s.truncated.Store(true)
+}
+
+// IsTruncated reports whether any list response was truncated.
+func (s *OperationSummary) IsTruncated() bool {
+	return s.truncated.Load()
 }
 
 // Failures returns all recorded operation failures.

--- a/internal/resources/remote/summary_test.go
+++ b/internal/resources/remote/summary_test.go
@@ -88,6 +88,62 @@ func TestOperationSummary_Failures(t *testing.T) {
 	}
 }
 
+func TestOperationSummary_Truncated(t *testing.T) {
+	tests := []struct {
+		name           string
+		truncatedCalls int
+		wantTruncated  bool
+	}{
+		{
+			name:           "not truncated by default",
+			truncatedCalls: 0,
+			wantTruncated:  false,
+		},
+		{
+			name:           "truncated after RecordTruncated",
+			truncatedCalls: 1,
+			wantTruncated:  true,
+		},
+		{
+			name:           "multiple RecordTruncated calls",
+			truncatedCalls: 3,
+			wantTruncated:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			summary := &remote.OperationSummary{}
+
+			for range tc.truncatedCalls {
+				summary.RecordTruncated()
+			}
+
+			require.Equal(t, tc.wantTruncated, summary.IsTruncated())
+		})
+	}
+}
+
+func TestOperationSummary_TruncatedThreadSafety(t *testing.T) {
+	const goroutines = 50
+
+	summary := &remote.OperationSummary{}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			summary.RecordTruncated()
+		}()
+	}
+
+	wg.Wait()
+
+	require.True(t, summary.IsTruncated())
+}
+
 func TestOperationSummary_FailureContents(t *testing.T) {
 	summary := &remote.OperationSummary{}
 	err := errors.New("something went wrong")


### PR DESCRIPTION
## Summary

Standardizes pagination across the entire gcx CLI by adding a `--limit` flag with a default of 50 items to **every** list command.

### Changes

**Core adapter change:**
- `TypedCRUD[T].ListFn` signature now accepts `limit int64`, propagating through the adapter layer to all provider commands
- `typedAdapter.List()` passes `metav1.ListOptions.Limit` through to ListFn (was previously ignored)

**Provider list commands (all get `--limit 50`):**
- K8s resources: `gcx resources get`
- SLO: definitions, reports
- Synthetic Monitoring: checks, probes
- OnCall: all resource types (integrations, schedules, etc.)
- K6: projects, tests, runs, schedules, env-vars, load-zones
- Knowledge Graph: datasets, vendors, rules, entities, entity-types, scopes, search
- Fleet: pipelines, collectors
- Frontend (Faro): apps
- Alert: rules, groups
- Logs Adaptive: exemptions, segments, drop rules
- Metrics Adaptive: rules
- Traces Adaptive: policies
- Sigil: conversations, agents, scores, evaluators, rules, templates
- Incidents: list (100→50), activity (already 50)

**Standalone commands:**
- `gcx datasources list`
- `gcx assistant investigations list`

### Behavior
- `--limit 50` is the default for all list commands
- `--limit 0` fetches all items (no truncation)
- Client-side truncation for providers without server-side pagination
- Server-side limit for K8s resources (via `metav1.ListOptions.Limit`)

## Test plan
- [x] `go build ./...` compiles
- [x] `go test -race -count=1 ./...` passes (all tests green)
- [x] `golangci-lint` passes (only pre-existing gosec issues in style package)
- [x] CLI reference docs regenerated with new `--limit` flags
- [ ] Manual: `gcx resources get dashboards --limit 5` returns at most 5
- [ ] Manual: `gcx slo definitions list --limit 0` fetches all

🤖 Generated with [Claude Code](https://claude.com/claude-code)