### PR TITLE
feat(deeplink): add deep link URLs and --open flag for all resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ internal/
 │   ├── slo/        SLO provider (definitions, reports)
 │   ├── synth/      Synthetic Monitoring provider (checks, probes)
 │   └── traces/     Traces signal provider (Tempo queries + Adaptive Traces commands)
+├── deeplink/    Deep link URL template registry and browser opener
 ├── dashboards/  Dashboard Image Renderer client (PNG snapshots)
 ├── datasources/ Datasource HTTP client (legacy REST API)
 │   └── query/   Shared query CLI utils (time parsing, codecs, opts, resolve helpers — used by signal providers and GenericCmd)

--- a/cmd/gcx/resources/get.go
+++ b/cmd/gcx/resources/get.go
@@ -253,7 +253,7 @@ func getCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			resources.SortUnstructured(output.Items)
 
 			// Inject deep link URLs into each resource.
-			deeplink.InjectURLs(output.Items, cfg.Host)
+			deeplink.InjectURLs(output.Items, cfg.GrafanaURL)
 
 			// --json ? discovery fallback: print fields from a fetched sample.
 			if opts.IO.JSONDiscovery {

--- a/cmd/gcx/resources/get.go
+++ b/cmd/gcx/resources/get.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/deeplink"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources"
@@ -38,8 +39,8 @@ func printFieldDiscoveryResults(out io.Writer, obj map[string]any) {
 // schemaToFieldPaths converts an OpenAPI spec schema to field paths compatible
 // with the --json ? output format (top-level keys + spec.* sub-fields).
 func schemaToFieldPaths(specSchema map[string]any) []string {
-	// Always include the standard K8s envelope fields.
-	paths := []string{"apiVersion", "kind", "metadata", "spec", "status"}
+	// Always include the standard K8s envelope fields plus the deep link URL.
+	paths := []string{"apiVersion", "kind", "metadata", "spec", "status", "url"}
 
 	if props, ok := specSchema["properties"].(map[string]any); ok {
 		for key := range props {
@@ -109,6 +110,7 @@ type getOpts struct {
 	IO      cmdio.Options
 	OnError OnErrorMode
 	Limit   int64
+	Open    bool
 }
 
 func (opts *getOpts) setup(flags *pflag.FlagSet) {
@@ -122,6 +124,7 @@ func (opts *getOpts) setup(flags *pflag.FlagSet) {
 
 	// Bind all the flags
 	opts.IO.BindFlags(flags)
+	flags.BoolVar(&opts.Open, "open", false, "Open the resource in the default browser")
 }
 
 func (opts *getOpts) Validate() error {
@@ -249,6 +252,9 @@ func getCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			output := res.Resources.ToUnstructuredList()
 			resources.SortUnstructured(output.Items)
 
+			// Inject deep link URLs into each resource.
+			deeplink.InjectURLs(output.Items, cfg.Host)
+
 			// --json ? discovery fallback: print fields from a fetched sample.
 			if opts.IO.JSONDiscovery {
 				if len(output.Items) == 0 {
@@ -256,6 +262,19 @@ func getCmd(configOpts *cmdconfig.Options) *cobra.Command {
 				}
 				printFieldDiscoveryResults(cmd.OutOrStdout(), output.Items[0].Object)
 				return nil
+			}
+
+			// --open: open the resource in the default browser.
+			if opts.Open {
+				if !res.IsSingleTarget || len(output.Items) != 1 {
+					return errors.New("--open requires exactly one resource (e.g. gcx resources get dashboards/my-uid --open)")
+				}
+				url, _ := output.Items[0].Object["url"].(string)
+				if url == "" {
+					return fmt.Errorf("no deep link URL available for %s/%s", output.Items[0].GetKind(), output.Items[0].GetName())
+				}
+				cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
+				return deeplink.Open(url)
 			}
 
 			// --json field1,field2: use FieldSelectCodec for output.
@@ -377,6 +396,7 @@ func (c *tableCodec) Encode(output io.Writer, input any) error {
 			{Name: "VERSION", Type: "string", Priority: 1, Description: "The API version."},
 			{Name: "NAME", Type: "string", Format: "name", Priority: 0, Description: "The name of the resource."},
 			{Name: "AGE", Type: "string", Format: "date-time", Priority: 1, Description: "The age of the resource."},
+			{Name: "URL", Type: "string", Priority: 1, Description: "The deep link URL for the resource."},
 		},
 	}
 
@@ -384,6 +404,7 @@ func (c *tableCodec) Encode(output io.Writer, input any) error {
 	for _, r := range items.Items {
 		gvk := r.GroupVersionKind()
 		age := duration.HumanDuration(time.Since(r.GetCreationTimestamp().Time))
+		url, _ := r.Object["url"].(string)
 
 		table.Rows = append(table.Rows, metav1.TableRow{
 			Cells: []any{
@@ -392,6 +413,7 @@ func (c *tableCodec) Encode(output io.Writer, input any) error {
 				sanitizeCell(gvk.Version, noTruncate),
 				sanitizeCell(r.GetName(), noTruncate),
 				sanitizeCell(age, noTruncate),
+				sanitizeCell(url, noTruncate),
 			},
 			Object: runtime.RawExtension{Object: &r},
 		})

--- a/cmd/gcx/resources/get.go
+++ b/cmd/gcx/resources/get.go
@@ -273,7 +273,7 @@ func getCmd(configOpts *cmdconfig.Options) *cobra.Command {
 				if url == "" {
 					return fmt.Errorf("no deep link URL available for %s/%s", output.Items[0].GetKind(), output.Items[0].GetName())
 				}
-				cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
+				cmdio.Info(cmd.ErrOrStderr(), "Opening %s", url)
 				return deeplink.Open(url)
 			}
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -818,6 +818,12 @@ Each LGTM signal has its own provider in `internal/providers/{signal}/` that reg
 | `cmd/gcx/datasources/command.go` | `datasources` command group (list, get, prometheus, loki, pyroscope, tempo, generic subcommands) |
 | `cmd/gcx/datasources/query/` | Per-kind `query` subcommand constructors and shared infrastructure (codecs, time parsing) |
 
+### Deep Link URLs
+
+| File | Purpose |
+|------|---------|
+| `internal/deeplink/deeplink.go` | URL template registry, resolve, inject, browser open for resource deep links |
+
 ### Dashboard Image Renderer
 
 | File | Purpose |

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -69,6 +69,7 @@ gcx/
 │   │       ├── checks/       # Checks status, timeline, CRUD
 │   │       ├── probes/       # Probe listing
 │   │       └── smcfg/        # SM config loader interfaces
+│   ├── deeplink/             # Deep link URL template registry and browser opener
 │   ├── dashboards/           # Dashboard Image Renderer client (PNG snapshots)
 │   ├── datasources/          # Datasource HTTP client (legacy REST API)
 │   │   └── query/            # Shared query CLI utils (time parsing, codecs, opts, resolve helpers)

--- a/docs/reference/cli/gcx_assistant_investigations_get.md
+++ b/docs/reference/cli/gcx_assistant_investigations_get.md
@@ -11,6 +11,7 @@ gcx assistant investigations get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the investigation in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_alert-groups_get.md
+++ b/docs/reference/cli/gcx_oncall_alert-groups_get.md
@@ -11,6 +11,7 @@ gcx oncall alert-groups get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_alerts_get.md
+++ b/docs/reference/cli/gcx_oncall_alerts_get.md
@@ -11,6 +11,7 @@ gcx oncall alerts get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_escalation-chains_get.md
+++ b/docs/reference/cli/gcx_oncall_escalation-chains_get.md
@@ -11,6 +11,7 @@ gcx oncall escalation-chains get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_escalation-policies_get.md
+++ b/docs/reference/cli/gcx_oncall_escalation-policies_get.md
@@ -11,6 +11,7 @@ gcx oncall escalation-policies get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_integrations_get.md
+++ b/docs/reference/cli/gcx_oncall_integrations_get.md
@@ -11,6 +11,7 @@ gcx oncall integrations get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_organizations_get.md
+++ b/docs/reference/cli/gcx_oncall_organizations_get.md
@@ -11,6 +11,7 @@ gcx oncall organizations get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_resolution-notes_get.md
+++ b/docs/reference/cli/gcx_oncall_resolution-notes_get.md
@@ -11,6 +11,7 @@ gcx oncall resolution-notes get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_routes_get.md
+++ b/docs/reference/cli/gcx_oncall_routes_get.md
@@ -11,6 +11,7 @@ gcx oncall routes get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_schedules_get.md
+++ b/docs/reference/cli/gcx_oncall_schedules_get.md
@@ -11,6 +11,7 @@ gcx oncall schedules get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_shift-swaps_get.md
+++ b/docs/reference/cli/gcx_oncall_shift-swaps_get.md
@@ -11,6 +11,7 @@ gcx oncall shift-swaps get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_shifts_get.md
+++ b/docs/reference/cli/gcx_oncall_shifts_get.md
@@ -11,6 +11,7 @@ gcx oncall shifts get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_teams_get.md
+++ b/docs/reference/cli/gcx_oncall_teams_get.md
@@ -11,6 +11,7 @@ gcx oncall teams get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_users_get.md
+++ b/docs/reference/cli/gcx_oncall_users_get.md
@@ -11,6 +11,7 @@ gcx oncall users get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_oncall_webhooks_get.md
+++ b/docs/reference/cli/gcx_oncall_webhooks_get.md
@@ -11,6 +11,7 @@ gcx oncall webhooks get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open            Open the resource in the default browser
   -o, --output string   Output format. One of: json, yaml (default "yaml")
 ```
 

--- a/docs/reference/cli/gcx_resources_get.md
+++ b/docs/reference/cli/gcx_resources_get.md
@@ -78,6 +78,7 @@ gcx resources get [RESOURCE_SELECTOR]... [flags]
                             ignore — continue processing all resources and exit 0
                             fail   — continue processing all resources and exit 1 if any failed (default)
                             abort  — stop on the first error and exit 1 (default "fail")
+      --open              Open the resource in the default browser
   -o, --output string     Output format. One of: json, text, wide, yaml (default "text")
 ```
 

--- a/internal/assistant/investigations/commands.go
+++ b/internal/assistant/investigations/commands.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/grafana/gcx/internal/assistant/assistanthttp"
+	"github.com/grafana/gcx/internal/deeplink"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
@@ -95,12 +97,14 @@ func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 // --- get ---
 
 type getOpts struct {
-	IO cmdio.Options
+	IO   cmdio.Options
+	Open bool
 }
 
 func (o *getOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("yaml")
 	o.IO.BindFlags(flags)
+	flags.BoolVar(&o.Open, "open", false, "Open the investigation in the default browser")
 }
 
 func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
@@ -112,6 +116,15 @@ func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err
+			}
+			if opts.Open {
+				cfg, err := loader.LoadGrafanaConfig(cmd.Context())
+				if err != nil {
+					return err
+				}
+				url := strings.TrimRight(cfg.Host, "/") + "/a/grafana-assistant-app/investigations/" + args[0]
+				cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
+				return deeplink.Open(url)
 			}
 			client, err := newClient(cmd, loader)
 			if err != nil {

--- a/internal/assistant/investigations/commands.go
+++ b/internal/assistant/investigations/commands.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/grafana/gcx/internal/assistant/assistanthttp"
@@ -122,7 +121,10 @@ func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				url := strings.TrimRight(cfg.Host, "/") + "/a/grafana-assistant-app/investigations/" + args[0]
+				url := deeplink.Resolve(cfg.Host, deeplink.InvestigationGVK, args[0])
+				if url == "" {
+					return fmt.Errorf("no deep link URL available for investigation %s", args[0])
+				}
 				cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
 				return deeplink.Open(url)
 			}

--- a/internal/assistant/investigations/commands.go
+++ b/internal/assistant/investigations/commands.go
@@ -121,7 +121,7 @@ func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				url := deeplink.Resolve(cfg.Host, deeplink.InvestigationGVK, args[0])
+				url := deeplink.Resolve(cfg.GrafanaURL, deeplink.InvestigationGVK, args[0])
 				if url == "" {
 					return fmt.Errorf("no deep link URL available for investigation %s", args[0])
 				}

--- a/internal/assistant/investigations/commands.go
+++ b/internal/assistant/investigations/commands.go
@@ -121,11 +121,11 @@ func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				url := deeplink.Resolve(cfg.GrafanaURL, deeplink.InvestigationGVK, args[0])
+				url := deeplink.Resolve(cfg.GrafanaURL, deeplink.InvestigationGVK(), args[0])
 				if url == "" {
 					return fmt.Errorf("no deep link URL available for investigation %s", args[0])
 				}
-				cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
+				cmdio.Info(cmd.ErrOrStderr(), "Opening %s", url)
 				return deeplink.Open(url)
 			}
 			client, err := newClient(cmd, loader)

--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -21,6 +21,11 @@ type NamespacedRESTConfig struct {
 
 	Namespace string
 
+	// GrafanaURL is the user-facing Grafana server URL (e.g., "https://mystack.grafana.net").
+	// This is always the original grafana.server value, even when Host is rewritten
+	// to a proxy endpoint for OAuth mode. Use this for deep link URLs, not Host.
+	GrafanaURL string
+
 	// oauthTransport holds a reference to the RefreshTransport when OAuth proxy
 	// mode is active, allowing callers to wire the OnRefresh callback after
 	// construction (Option C: call-site wiring).
@@ -240,6 +245,7 @@ func NewNamespacedRESTConfig(ctx context.Context, cfg Context) NamespacedRESTCon
 	return NamespacedRESTConfig{
 		Config:         rcfg,
 		Namespace:      namespace,
+		GrafanaURL:     strings.TrimSuffix(cfg.Grafana.Server, "/"),
 		oauthTransport: oauthTransport,
 	}
 }

--- a/internal/deeplink/deeplink.go
+++ b/internal/deeplink/deeplink.go
@@ -25,8 +25,10 @@ var (
 	patterns = map[groupKind]string{}
 )
 
-// InvestigationGVK is the synthetic GVK for investigations (not adapter-backed).
-var InvestigationGVK = schema.GroupVersionKind{Group: "assistant.grafana.app", Version: "v1", Kind: "Investigation"}
+// InvestigationGVK returns the synthetic GVK for investigations (not adapter-backed).
+func InvestigationGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "assistant.grafana.app", Version: "v1", Kind: "Investigation"}
+}
 
 func init() { //nolint:gochecknoinits // Register K8s-native and non-adapter resource URL patterns.
 	// Dashboards and folders are served by Grafana core, not a provider plugin.
@@ -34,7 +36,7 @@ func init() { //nolint:gochecknoinits // Register K8s-native and non-adapter res
 	RegisterPattern(schema.GroupVersionKind{Group: "folder.grafana.app", Kind: "Folder"}, "/dashboards/f/{name}")
 
 	// Investigations are not adapter-backed but have a browser UI.
-	RegisterPattern(InvestigationGVK, "/a/grafana-assistant-app/investigations/{name}")
+	RegisterPattern(InvestigationGVK(), "/a/grafana-assistant-app/investigations/{name}")
 }
 
 // RegisterPattern associates a URL path template with a GVK.

--- a/internal/deeplink/deeplink.go
+++ b/internal/deeplink/deeplink.go
@@ -9,12 +9,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// registry maps GVK → URL path template (e.g., "/d/{name}").
+// groupKind is the version-agnostic lookup key for URL patterns.
+// API versions vary by Grafana server version (e.g., v0alpha1, v1alpha1, v1beta1),
+// but the deep link URL pattern is the same regardless of version.
+type groupKind struct {
+	Group string
+	Kind  string
+}
+
+// registry maps group+kind → URL path template (e.g., "/d/{name}").
 //
 //nolint:gochecknoglobals // Self-registration pattern (same as providers.registry).
 var (
 	mu       sync.RWMutex
-	patterns = map[schema.GroupVersionKind]string{}
+	patterns = map[groupKind]string{}
 )
 
 // InvestigationGVK is the synthetic GVK for investigations (not adapter-backed).
@@ -22,10 +30,8 @@ var InvestigationGVK = schema.GroupVersionKind{Group: "assistant.grafana.app", V
 
 func init() { //nolint:gochecknoinits // Register K8s-native and non-adapter resource URL patterns.
 	// Dashboards and folders are served by Grafana core, not a provider plugin.
-	RegisterPattern(schema.GroupVersionKind{Group: "dashboard.grafana.app", Version: "v1alpha1", Kind: "Dashboard"}, "/d/{name}")
-	RegisterPattern(schema.GroupVersionKind{Group: "dashboard.grafana.app", Version: "v1beta1", Kind: "Dashboard"}, "/d/{name}")
-	RegisterPattern(schema.GroupVersionKind{Group: "folder.grafana.app", Version: "v1alpha1", Kind: "Folder"}, "/dashboards/f/{name}")
-	RegisterPattern(schema.GroupVersionKind{Group: "folder.grafana.app", Version: "v1beta1", Kind: "Folder"}, "/dashboards/f/{name}")
+	RegisterPattern(schema.GroupVersionKind{Group: "dashboard.grafana.app", Kind: "Dashboard"}, "/d/{name}")
+	RegisterPattern(schema.GroupVersionKind{Group: "folder.grafana.app", Kind: "Folder"}, "/dashboards/f/{name}")
 
 	// Investigations are not adapter-backed but have a browser UI.
 	RegisterPattern(InvestigationGVK, "/a/grafana-assistant-app/investigations/{name}")
@@ -33,17 +39,18 @@ func init() { //nolint:gochecknoinits // Register K8s-native and non-adapter res
 
 // RegisterPattern associates a URL path template with a GVK.
 // The template uses {name} as a placeholder for the resource name.
+// The version component of the GVK is ignored — patterns match on group+kind only.
 func RegisterPattern(gvk schema.GroupVersionKind, template string) {
 	mu.Lock()
 	defer mu.Unlock()
-	patterns[gvk] = template
+	patterns[groupKind{Group: gvk.Group, Kind: gvk.Kind}] = template
 }
 
 // Resolve builds a full URL for the given GVK and resource name.
-// Returns "" if no pattern is registered for the GVK.
+// Returns "" if no pattern is registered for the GVK's group+kind.
 func Resolve(host string, gvk schema.GroupVersionKind, name string) string {
 	mu.RLock()
-	tmpl, ok := patterns[gvk]
+	tmpl, ok := patterns[groupKind{Group: gvk.Group, Kind: gvk.Kind}]
 	mu.RUnlock()
 	if !ok {
 		return ""
@@ -52,8 +59,8 @@ func Resolve(host string, gvk schema.GroupVersionKind, name string) string {
 }
 
 // InjectURL sets the top-level "url" field on an unstructured object
-// by looking up the GVK and name from the object itself.
-// No-op if no pattern is registered for the object's GVK.
+// by looking up the group+kind and name from the object itself.
+// No-op if no pattern is registered for the object's group+kind.
 func InjectURL(obj *unstructured.Unstructured, host string) {
 	url := Resolve(host, obj.GroupVersionKind(), obj.GetName())
 	if url != "" {

--- a/internal/deeplink/deeplink.go
+++ b/internal/deeplink/deeplink.go
@@ -1,0 +1,68 @@
+package deeplink
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/pkg/browser"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// registry maps GVK → URL path template (e.g., "/d/{name}").
+//
+//nolint:gochecknoglobals // Self-registration pattern (same as providers.registry).
+var (
+	mu       sync.RWMutex
+	patterns = map[schema.GroupVersionKind]string{}
+)
+
+func init() { //nolint:gochecknoinits // Register K8s-native resource URL patterns.
+	// Dashboards and folders are served by Grafana core, not a provider plugin.
+	RegisterPattern(schema.GroupVersionKind{Group: "dashboard.grafana.app", Version: "v1alpha1", Kind: "Dashboard"}, "/d/{name}")
+	RegisterPattern(schema.GroupVersionKind{Group: "dashboard.grafana.app", Version: "v1beta1", Kind: "Dashboard"}, "/d/{name}")
+	RegisterPattern(schema.GroupVersionKind{Group: "folder.grafana.app", Version: "v1alpha1", Kind: "Folder"}, "/dashboards/f/{name}")
+	RegisterPattern(schema.GroupVersionKind{Group: "folder.grafana.app", Version: "v1beta1", Kind: "Folder"}, "/dashboards/f/{name}")
+}
+
+// RegisterPattern associates a URL path template with a GVK.
+// The template uses {name} as a placeholder for the resource name.
+func RegisterPattern(gvk schema.GroupVersionKind, template string) {
+	mu.Lock()
+	defer mu.Unlock()
+	patterns[gvk] = template
+}
+
+// Resolve builds a full URL for the given GVK and resource name.
+// Returns "" if no pattern is registered for the GVK.
+func Resolve(host string, gvk schema.GroupVersionKind, name string) string {
+	mu.RLock()
+	tmpl, ok := patterns[gvk]
+	mu.RUnlock()
+	if !ok {
+		return ""
+	}
+	return strings.TrimRight(host, "/") + strings.ReplaceAll(tmpl, "{name}", name)
+}
+
+// InjectURL sets the top-level "url" field on an unstructured object
+// by looking up the GVK and name from the object itself.
+// No-op if no pattern is registered for the object's GVK.
+func InjectURL(obj *unstructured.Unstructured, host string) {
+	url := Resolve(host, obj.GroupVersionKind(), obj.GetName())
+	if url != "" {
+		obj.Object["url"] = url
+	}
+}
+
+// InjectURLs sets the "url" field on each unstructured object in the slice.
+func InjectURLs(items []unstructured.Unstructured, host string) {
+	for i := range items {
+		InjectURL(&items[i], host)
+	}
+}
+
+// Open opens the given URL in the default browser.
+func Open(url string) error {
+	return browser.OpenURL(url)
+}

--- a/internal/deeplink/deeplink.go
+++ b/internal/deeplink/deeplink.go
@@ -1,6 +1,8 @@
 package deeplink
 
 import (
+	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -57,7 +59,7 @@ func Resolve(host string, gvk schema.GroupVersionKind, name string) string {
 	if !ok {
 		return ""
 	}
-	return strings.TrimRight(host, "/") + strings.ReplaceAll(tmpl, "{name}", name)
+	return strings.TrimRight(host, "/") + strings.ReplaceAll(tmpl, "{name}", url.PathEscape(name))
 }
 
 // InjectURL sets the top-level "url" field on an unstructured object
@@ -78,6 +80,10 @@ func InjectURLs(items []unstructured.Unstructured, host string) {
 }
 
 // Open opens the given URL in the default browser.
-func Open(url string) error {
-	return browser.OpenURL(url)
+// Returns an error if the URL does not use http or https scheme.
+func Open(rawURL string) error {
+	if !strings.HasPrefix(rawURL, "https://") && !strings.HasPrefix(rawURL, "http://") {
+		return fmt.Errorf("refusing to open non-http URL: %s", rawURL)
+	}
+	return browser.OpenURL(rawURL)
 }

--- a/internal/deeplink/deeplink.go
+++ b/internal/deeplink/deeplink.go
@@ -17,12 +17,18 @@ var (
 	patterns = map[schema.GroupVersionKind]string{}
 )
 
-func init() { //nolint:gochecknoinits // Register K8s-native resource URL patterns.
+// InvestigationGVK is the synthetic GVK for investigations (not adapter-backed).
+var InvestigationGVK = schema.GroupVersionKind{Group: "assistant.grafana.app", Version: "v1", Kind: "Investigation"}
+
+func init() { //nolint:gochecknoinits // Register K8s-native and non-adapter resource URL patterns.
 	// Dashboards and folders are served by Grafana core, not a provider plugin.
 	RegisterPattern(schema.GroupVersionKind{Group: "dashboard.grafana.app", Version: "v1alpha1", Kind: "Dashboard"}, "/d/{name}")
 	RegisterPattern(schema.GroupVersionKind{Group: "dashboard.grafana.app", Version: "v1beta1", Kind: "Dashboard"}, "/d/{name}")
 	RegisterPattern(schema.GroupVersionKind{Group: "folder.grafana.app", Version: "v1alpha1", Kind: "Folder"}, "/dashboards/f/{name}")
 	RegisterPattern(schema.GroupVersionKind{Group: "folder.grafana.app", Version: "v1beta1", Kind: "Folder"}, "/dashboards/f/{name}")
+
+	// Investigations are not adapter-backed but have a browser UI.
+	RegisterPattern(InvestigationGVK, "/a/grafana-assistant-app/investigations/{name}")
 }
 
 // RegisterPattern associates a URL path template with a GVK.

--- a/internal/deeplink/deeplink_test.go
+++ b/internal/deeplink/deeplink_test.go
@@ -1,0 +1,129 @@
+package deeplink_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/deeplink"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestResolve(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "test.grafana.app", Version: "v1", Kind: "Widget"}
+	deeplink.RegisterPattern(gvk, "/a/test-app/widgets/{name}")
+
+	tests := []struct {
+		name     string
+		host     string
+		gvk      schema.GroupVersionKind
+		resName  string
+		expected string
+	}{
+		{
+			name:     "basic resolution",
+			host:     "https://mystack.grafana.net",
+			gvk:      gvk,
+			resName:  "widget-1",
+			expected: "https://mystack.grafana.net/a/test-app/widgets/widget-1",
+		},
+		{
+			name:     "host with trailing slash",
+			host:     "https://mystack.grafana.net/",
+			gvk:      gvk,
+			resName:  "widget-1",
+			expected: "https://mystack.grafana.net/a/test-app/widgets/widget-1",
+		},
+		{
+			name:     "unknown GVK returns empty",
+			host:     "https://mystack.grafana.net",
+			gvk:      schema.GroupVersionKind{Group: "unknown", Version: "v1", Kind: "Unknown"},
+			resName:  "foo",
+			expected: "",
+		},
+		{
+			name:     "empty name",
+			host:     "https://mystack.grafana.net",
+			gvk:      gvk,
+			resName:  "",
+			expected: "https://mystack.grafana.net/a/test-app/widgets/",
+		},
+		{
+			name:     "dashboard v1beta1",
+			host:     "https://mystack.grafana.net",
+			gvk:      schema.GroupVersionKind{Group: "dashboard.grafana.app", Version: "v1beta1", Kind: "Dashboard"},
+			resName:  "abc-123",
+			expected: "https://mystack.grafana.net/d/abc-123",
+		},
+		{
+			name:     "folder v1beta1",
+			host:     "https://mystack.grafana.net",
+			gvk:      schema.GroupVersionKind{Group: "folder.grafana.app", Version: "v1beta1", Kind: "Folder"},
+			resName:  "my-folder",
+			expected: "https://mystack.grafana.net/dashboards/f/my-folder",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deeplink.Resolve(tt.host, tt.gvk, tt.resName)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestInjectURL(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "test.grafana.app", Version: "v1", Kind: "Gadget"}
+	deeplink.RegisterPattern(gvk, "/a/test-app/gadgets/{name}")
+
+	t.Run("injects url for known GVK", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "test.grafana.app/v1",
+			"kind":       "Gadget",
+			"metadata":   map[string]any{"name": "gadget-42"},
+		}}
+		deeplink.InjectURL(obj, "https://mystack.grafana.net")
+		assert.Equal(t, "https://mystack.grafana.net/a/test-app/gadgets/gadget-42", obj.Object["url"])
+	})
+
+	t.Run("no-op for unknown GVK", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "unknown/v1",
+			"kind":       "Unknown",
+			"metadata":   map[string]any{"name": "thing"},
+		}}
+		deeplink.InjectURL(obj, "https://mystack.grafana.net")
+		_, exists := obj.Object["url"]
+		assert.False(t, exists)
+	})
+}
+
+func TestInjectURLs(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "batch.grafana.app", Version: "v1", Kind: "Job"}
+	deeplink.RegisterPattern(gvk, "/a/batch-app/jobs/{name}")
+
+	items := []unstructured.Unstructured{
+		{Object: map[string]any{
+			"apiVersion": "batch.grafana.app/v1",
+			"kind":       "Job",
+			"metadata":   map[string]any{"name": "job-1"},
+		}},
+		{Object: map[string]any{
+			"apiVersion": "unknown/v1",
+			"kind":       "Unknown",
+			"metadata":   map[string]any{"name": "nope"},
+		}},
+		{Object: map[string]any{
+			"apiVersion": "batch.grafana.app/v1",
+			"kind":       "Job",
+			"metadata":   map[string]any{"name": "job-2"},
+		}},
+	}
+
+	deeplink.InjectURLs(items, "https://mystack.grafana.net")
+
+	assert.Equal(t, "https://mystack.grafana.net/a/batch-app/jobs/job-1", items[0].Object["url"])
+	_, exists := items[1].Object["url"]
+	assert.False(t, exists)
+	assert.Equal(t, "https://mystack.grafana.net/a/batch-app/jobs/job-2", items[2].Object["url"])
+}

--- a/internal/deeplink/deeplink_test.go
+++ b/internal/deeplink/deeplink_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/gcx/internal/deeplink"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -76,6 +77,13 @@ func TestResolve(t *testing.T) {
 			resName:  "my-folder",
 			expected: "https://mystack.grafana.net/dashboards/f/my-folder",
 		},
+		{
+			name:     "name with special characters is path-escaped",
+			host:     "https://mystack.grafana.net",
+			gvk:      gvk,
+			resName:  "my widget/2024",
+			expected: "https://mystack.grafana.net/a/test-app/widgets/my%20widget%2F2024",
+		},
 	}
 
 	for _, tt := range tests {
@@ -84,6 +92,26 @@ func TestResolve(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func TestOpen(t *testing.T) {
+	t.Run("rejects javascript scheme", func(t *testing.T) {
+		err := deeplink.Open("javascript:alert(1)")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "refusing to open non-http URL")
+	})
+
+	t.Run("rejects file scheme", func(t *testing.T) {
+		err := deeplink.Open("file:///etc/passwd")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "refusing to open non-http URL")
+	})
+
+	t.Run("rejects schemeless URL", func(t *testing.T) {
+		err := deeplink.Open("mystack.grafana.net/d/abc")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "refusing to open non-http URL")
+	})
 }
 
 func TestInjectURL(t *testing.T) {

--- a/internal/deeplink/deeplink_test.go
+++ b/internal/deeplink/deeplink_test.go
@@ -49,6 +49,20 @@ func TestResolve(t *testing.T) {
 			expected: "https://mystack.grafana.net/a/test-app/widgets/",
 		},
 		{
+			name:     "version-agnostic: matches different version",
+			host:     "https://mystack.grafana.net",
+			gvk:      schema.GroupVersionKind{Group: "test.grafana.app", Version: "v2beta1", Kind: "Widget"},
+			resName:  "widget-1",
+			expected: "https://mystack.grafana.net/a/test-app/widgets/widget-1",
+		},
+		{
+			name:     "dashboard v0alpha1",
+			host:     "https://mystack.grafana.net",
+			gvk:      schema.GroupVersionKind{Group: "dashboard.grafana.app", Version: "v0alpha1", Kind: "Dashboard"},
+			resName:  "abc-123",
+			expected: "https://mystack.grafana.net/d/abc-123",
+		},
+		{
 			name:     "dashboard v1beta1",
 			host:     "https://mystack.grafana.net",
 			gvk:      schema.GroupVersionKind{Group: "dashboard.grafana.app", Version: "v1beta1", Kind: "Dashboard"},
@@ -56,9 +70,9 @@ func TestResolve(t *testing.T) {
 			expected: "https://mystack.grafana.net/d/abc-123",
 		},
 		{
-			name:     "folder v1beta1",
+			name:     "folder any version",
 			host:     "https://mystack.grafana.net",
-			gvk:      schema.GroupVersionKind{Group: "folder.grafana.app", Version: "v1beta1", Kind: "Folder"},
+			gvk:      schema.GroupVersionKind{Group: "folder.grafana.app", Version: "v99", Kind: "Folder"},
 			resName:  "my-folder",
 			expected: "https://mystack.grafana.net/dashboards/f/my-folder",
 		},

--- a/internal/httputils/debug_transport_test.go
+++ b/internal/httputils/debug_transport_test.go
@@ -1,9 +1,9 @@
 package httputils_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/grafana/gcx/internal/httputils"
@@ -18,7 +18,7 @@ func TestLoggingRoundTripper_Success(t *testing.T) {
 		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
 	})
 	rt := &httputils.LoggingRoundTripper{Base: base}
-	req := httptest.NewRequest(http.MethodGet, "http://example.com/api", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/api", nil)
 
 	resp, err := rt.RoundTrip(req)
 	if err != nil {
@@ -36,7 +36,7 @@ func TestLoggingRoundTripper_TransportError(t *testing.T) {
 		return nil, wantErr
 	})
 	rt := &httputils.LoggingRoundTripper{Base: base}
-	req := httptest.NewRequest(http.MethodGet, "http://example.com/api", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/api", nil)
 
 	resp, err := rt.RoundTrip(req)
 	if resp != nil {
@@ -52,7 +52,7 @@ func TestLoggingRoundTripper_5xx(t *testing.T) {
 		return &http.Response{StatusCode: http.StatusBadGateway, Body: http.NoBody}, nil
 	})
 	rt := &httputils.LoggingRoundTripper{Base: base}
-	req := httptest.NewRequest(http.MethodGet, "http://example.com/api", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/api", nil)
 
 	resp, err := rt.RoundTrip(req)
 	if err != nil {

--- a/internal/providers/alert/provider.go
+++ b/internal/providers/alert/provider.go
@@ -60,10 +60,11 @@ func (p *AlertProvider) TypedRegistrations() []adapter.Registration {
 	loader := &providers.ConfigLoader{}
 	return []adapter.Registration{
 		{
-			Factory:    NewRulesAdapterFactory(loader),
-			Descriptor: staticRulesDescriptor,
-			GVK:        staticRulesDescriptor.GroupVersionKind(),
-			Schema:     alertRuleSchema(),
+			Factory:     NewRulesAdapterFactory(loader),
+			Descriptor:  staticRulesDescriptor,
+			GVK:         staticRulesDescriptor.GroupVersionKind(),
+			Schema:      alertRuleSchema(),
+			URLTemplate: "/alerting/{name}/view",
 		},
 		{
 			Factory:    NewGroupsAdapterFactory(loader),

--- a/internal/providers/faro/provider.go
+++ b/internal/providers/faro/provider.go
@@ -71,11 +71,12 @@ func (p *FaroProvider) TypedRegistrations() []adapter.Registration {
 	loader := &providers.ConfigLoader{}
 	return []adapter.Registration{
 		{
-			Factory:    NewAdapterFactory(loader),
-			Descriptor: staticDescriptor,
-			GVK:        staticDescriptor.GroupVersionKind(),
-			Schema:     FaroAppSchema(),
-			Example:    FaroAppExample(),
+			Factory:     NewAdapterFactory(loader),
+			Descriptor:  staticDescriptor,
+			GVK:         staticDescriptor.GroupVersionKind(),
+			Schema:      FaroAppSchema(),
+			Example:     FaroAppExample(),
+			URLTemplate: "/a/grafana-faro-app/apps/{name}",
 		},
 	}
 }

--- a/internal/providers/fleet/provider.go
+++ b/internal/providers/fleet/provider.go
@@ -142,18 +142,20 @@ func (p *FleetProvider) TypedRegistrations() []adapter.Registration {
 	loader := &providers.ConfigLoader{}
 	return []adapter.Registration{
 		{
-			Factory:    NewPipelineAdapterFactory(loader),
-			Descriptor: PipelineDescriptor(),
-			GVK:        PipelineDescriptor().GroupVersionKind(),
-			Schema:     pipelineSchema(),
-			Example:    pipelineExample(),
+			Factory:     NewPipelineAdapterFactory(loader),
+			Descriptor:  PipelineDescriptor(),
+			GVK:         PipelineDescriptor().GroupVersionKind(),
+			Schema:      pipelineSchema(),
+			Example:     pipelineExample(),
+			URLTemplate: "/a/grafana-fleet-app/pipelines/{name}",
 		},
 		{
-			Factory:    NewCollectorAdapterFactory(loader),
-			Descriptor: CollectorDescriptor(),
-			GVK:        CollectorDescriptor().GroupVersionKind(),
-			Schema:     collectorSchema(),
-			Example:    collectorExample(),
+			Factory:     NewCollectorAdapterFactory(loader),
+			Descriptor:  CollectorDescriptor(),
+			GVK:         CollectorDescriptor().GroupVersionKind(),
+			Schema:      collectorSchema(),
+			Example:     collectorExample(),
+			URLTemplate: "/a/grafana-fleet-app/collectors/{name}",
 		},
 	}
 }

--- a/internal/providers/incidents/commands.go
+++ b/internal/providers/incidents/commands.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/gcx/internal/deeplink"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/style"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -360,11 +360,13 @@ func newOpenCommand(loader GrafanaConfigLoader) *cobra.Command {
 				return err
 			}
 
-			host := strings.TrimRight(restCfg.Host, "/")
-			url := fmt.Sprintf("%s/a/grafana-incident-app/incidents/%s", host, id)
+			url := deeplink.Resolve(restCfg.Host, staticDescriptor.GroupVersionKind(), id)
+			if url == "" {
+				return fmt.Errorf("no deep link URL available for incident %s", id)
+			}
 
 			cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
-			if err := browser.OpenURL(url); err != nil {
+			if err := deeplink.Open(url); err != nil {
 				return fmt.Errorf("failed to open browser: %w", err)
 			}
 

--- a/internal/providers/incidents/commands.go
+++ b/internal/providers/incidents/commands.go
@@ -366,11 +366,7 @@ func newOpenCommand(loader GrafanaConfigLoader) *cobra.Command {
 			}
 
 			cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
-			if err := deeplink.Open(url); err != nil {
-				return fmt.Errorf("failed to open browser: %w", err)
-			}
-
-			return nil
+			return deeplink.Open(url)
 		},
 	}
 	opts.setup(cmd.Flags())

--- a/internal/providers/incidents/commands.go
+++ b/internal/providers/incidents/commands.go
@@ -365,7 +365,7 @@ func newOpenCommand(loader GrafanaConfigLoader) *cobra.Command {
 				return fmt.Errorf("no deep link URL available for incident %s", id)
 			}
 
-			cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
+			cmdio.Info(cmd.ErrOrStderr(), "Opening %s", url)
 			return deeplink.Open(url)
 		},
 	}

--- a/internal/providers/incidents/commands.go
+++ b/internal/providers/incidents/commands.go
@@ -360,7 +360,7 @@ func newOpenCommand(loader GrafanaConfigLoader) *cobra.Command {
 				return err
 			}
 
-			url := deeplink.Resolve(restCfg.Host, staticDescriptor.GroupVersionKind(), id)
+			url := deeplink.Resolve(restCfg.GrafanaURL, staticDescriptor.GroupVersionKind(), id)
 			if url == "" {
 				return fmt.Errorf("no deep link URL available for incident %s", id)
 			}

--- a/internal/providers/incidents/provider.go
+++ b/internal/providers/incidents/provider.go
@@ -68,11 +68,12 @@ func (p *IncidentsProvider) TypedRegistrations() []adapter.Registration {
 	loader := &providers.ConfigLoader{}
 	return []adapter.Registration{
 		{
-			Factory:    NewAdapterFactory(loader),
-			Descriptor: staticDescriptor,
-			GVK:        staticDescriptor.GroupVersionKind(),
-			Schema:     incidentSchema(),
-			Example:    incidentExample(),
+			Factory:     NewAdapterFactory(loader),
+			Descriptor:  staticDescriptor,
+			GVK:         staticDescriptor.GroupVersionKind(),
+			Schema:      incidentSchema(),
+			Example:     incidentExample(),
+			URLTemplate: "/a/grafana-incident-app/incidents/{name}",
 		},
 	}
 }

--- a/internal/providers/k6/provider.go
+++ b/internal/providers/k6/provider.go
@@ -78,11 +78,12 @@ func (p *K6Provider) TypedRegistrations() []adapter.Registration {
 			Plural:   rd.plural,
 		}
 		registrations = append(registrations, adapter.Registration{
-			Factory:    newSubResourceFactory(loader, rd),
-			Descriptor: desc,
-			GVK:        desc.GroupVersionKind(),
-			Schema:     rd.schema,
-			Example:    rd.example,
+			Factory:     newSubResourceFactory(loader, rd),
+			Descriptor:  desc,
+			GVK:         desc.GroupVersionKind(),
+			Schema:      rd.schema,
+			Example:     rd.example,
+			URLTemplate: rd.urlTemplate,
 		})
 	}
 

--- a/internal/providers/k6/resource_adapter.go
+++ b/internal/providers/k6/resource_adapter.go
@@ -15,11 +15,12 @@ import (
 
 // resourceDef defines a single k6 sub-resource type for adapter registration.
 type resourceDef struct {
-	kind     string
-	singular string
-	plural   string
-	schema   json.RawMessage
-	example  json.RawMessage
+	kind        string
+	singular    string
+	plural      string
+	schema      json.RawMessage
+	example     json.RawMessage
+	urlTemplate string // Deep link URL template (e.g., "/a/k6-app/projects/{name}"). Empty means no deep link.
 }
 
 // allResources returns the definitions for all k6 resource types.
@@ -27,13 +28,15 @@ func allResources() []resourceDef {
 	return []resourceDef{
 		{
 			kind: "Project", singular: "project", plural: "projects",
-			schema:  projectSchema(),
-			example: projectExample(),
+			schema:      projectSchema(),
+			example:     projectExample(),
+			urlTemplate: "/a/k6-app/projects/{name}",
 		},
 		{
 			kind: "LoadTest", singular: "loadtest", plural: "loadtests",
-			schema:  loadTestSchema(),
-			example: loadTestExample(),
+			schema:      loadTestSchema(),
+			example:     loadTestExample(),
+			urlTemplate: "/a/k6-app/tests/{name}",
 		},
 		{
 			kind: "Schedule", singular: "schedule", plural: "schedules",

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1828,7 +1828,7 @@ func newOpenCommand(loader RESTConfigLoader) *cobra.Command {
 				return err
 			}
 			url := strings.TrimRight(cfg.GrafanaURL, "/") + "/a/grafana-asserts-app"
-			cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
+			cmdio.Info(cmd.ErrOrStderr(), "Opening %s", url)
 			return deeplink.Open(url)
 		},
 	}

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1829,10 +1829,7 @@ func newOpenCommand(loader RESTConfigLoader) *cobra.Command {
 			}
 			url := strings.TrimRight(cfg.Host, "/") + "/a/grafana-asserts-app"
 			cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
-			if err := deeplink.Open(url); err != nil {
-				return fmt.Errorf("failed to open browser: %w", err)
-			}
-			return nil
+			return deeplink.Open(url)
 		},
 	}
 }

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1827,7 +1827,7 @@ func newOpenCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			url := strings.TrimRight(cfg.Host, "/") + "/a/grafana-asserts-app"
+			url := strings.TrimRight(cfg.GrafanaURL, "/") + "/a/grafana-asserts-app"
 			cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
 			return deeplink.Open(url)
 		},

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -7,12 +7,12 @@ import (
 	"io"
 	"maps"
 	"os"
-	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/grafana/gcx/internal/deeplink"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources/adapter"
@@ -1827,10 +1827,9 @@ func newOpenCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			host := strings.TrimRight(cfg.Host, "/")
-			url := host + "/a/grafana-asserts-app"
+			url := strings.TrimRight(cfg.Host, "/") + "/a/grafana-asserts-app"
 			cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
-			if err := exec.CommandContext(cmd.Context(), "open", url).Start(); err != nil {
+			if err := deeplink.Open(url); err != nil {
 				return fmt.Errorf("failed to open browser: %w", err)
 			}
 			return nil

--- a/internal/providers/oncall/client.go
+++ b/internal/providers/oncall/client.go
@@ -43,6 +43,9 @@ type Client struct {
 	isOAuthProxy bool
 }
 
+// StackURL returns the Grafana server URL (used for deep links).
+func (c *Client) StackURL() string { return c.stackURL }
+
 // NewClient creates a new OnCall client from the given REST config and OnCall API URL.
 // oncallURL is the OnCall API base URL (e.g., https://oncall-prod-us-central-0.grafana.net/oncall).
 // cfg is the namespaced REST config providing auth, TLS, and the stack URL.

--- a/internal/providers/oncall/client.go
+++ b/internal/providers/oncall/client.go
@@ -37,14 +37,15 @@ const (
 // Client is an HTTP client for the Grafana OnCall API.
 type Client struct {
 	oncallURL    string
-	stackURL     string
+	stackURL     string // REST config host (may be proxy URL in OAuth mode)
+	grafanaURL   string // User-facing Grafana server URL (for deep links)
 	token        string
 	httpClient   *http.Client
 	isOAuthProxy bool
 }
 
-// StackURL returns the Grafana server URL (used for deep links).
-func (c *Client) StackURL() string { return c.stackURL }
+// GrafanaURL returns the user-facing Grafana server URL (used for deep links).
+func (c *Client) GrafanaURL() string { return c.grafanaURL }
 
 // NewClient creates a new OnCall client from the given REST config and OnCall API URL.
 // oncallURL is the OnCall API base URL (e.g., https://oncall-prod-us-central-0.grafana.net/oncall).
@@ -77,6 +78,7 @@ func NewClient(ctx context.Context, oncallURL string, cfg config.NamespacedRESTC
 	return &Client{
 		oncallURL:    strings.TrimRight(oncallURL, "/"),
 		stackURL:     cfg.Host,
+		grafanaURL:   cfg.GrafanaURL,
 		token:        token,
 		httpClient:   httpClient,
 		isOAuthProxy: isOAuthProxy,

--- a/internal/providers/oncall/commands.go
+++ b/internal/providers/oncall/commands.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/grafana/gcx/internal/deeplink"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources/adapter"
@@ -85,12 +86,14 @@ func (o *listOpts) setup(flags *pflag.FlagSet, resource string) {
 
 // getOpts configures a get subcommand.
 type getOpts struct {
-	IO cmdio.Options
+	IO   cmdio.Options
+	Open bool
 }
 
 func (o *getOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("yaml")
 	o.IO.BindFlags(flags)
+	flags.BoolVar(&o.Open, "open", false, "Open the resource in the default browser")
 }
 
 // newListSubcommand creates a "list" subcommand using TypedCRUD.
@@ -111,7 +114,7 @@ func newListSubcommand[T adapter.ResourceNamer](
 			}
 
 			ctx := cmd.Context()
-			crud, namespace, err := NewTypedCRUD(ctx, loader, listFn, getFn, opts...)
+			crud, namespace, host, err := NewTypedCRUD(ctx, loader, listFn, getFn, opts...)
 			if err != nil {
 				return err
 			}
@@ -148,6 +151,8 @@ func newListSubcommand[T adapter.ResourceNamer](
 				}}
 			}
 
+			deeplink.InjectURLs(objs, host)
+
 			return listOpts.IO.Encode(cmd.OutOrStdout(), objs)
 		},
 	}
@@ -171,7 +176,7 @@ func newGetSubcommand[T adapter.ResourceNamer](
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx, loader, func(_ context.Context, _ *Client) ([]T, error) { return nil, nil }, getFn)
+			crud, _, host, err := NewTypedCRUD(ctx, loader, func(_ context.Context, _ *Client) ([]T, error) { return nil, nil }, getFn)
 			if err != nil {
 				return err
 			}
@@ -179,6 +184,16 @@ func newGetSubcommand[T adapter.ResourceNamer](
 			typedObj, err := crud.Get(ctx, args[0])
 			if err != nil {
 				return err
+			}
+
+			if getOpts.Open {
+				gvk := crud.Descriptor.GroupVersionKind()
+				url := deeplink.Resolve(host, gvk, typedObj.Name)
+				if url == "" {
+					return fmt.Errorf("no deep link URL available for %s/%s", crud.Descriptor.Kind, typedObj.Name)
+				}
+				cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
+				return deeplink.Open(url)
 			}
 
 			return getOpts.IO.Encode(cmd.OutOrStdout(), typedObj.Spec)

--- a/internal/providers/oncall/commands.go
+++ b/internal/providers/oncall/commands.go
@@ -192,7 +192,7 @@ func newGetSubcommand[T adapter.ResourceNamer](
 				if url == "" {
 					return fmt.Errorf("no deep link URL available for %s/%s", crud.Descriptor.Kind, typedObj.Name)
 				}
-				cmdio.Info(cmd.OutOrStdout(), "Opening %s", url)
+				cmdio.Info(cmd.ErrOrStderr(), "Opening %s", url)
 				return deeplink.Open(url)
 			}
 

--- a/internal/providers/oncall/commands_extra.go
+++ b/internal/providers/oncall/commands_extra.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/grafana/gcx/internal/deeplink"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources/adapter"
@@ -61,6 +62,8 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			deeplink.InjectURLs(objs, client.StackURL())
 
 			return opts.IO.Encode(cmd.OutOrStdout(), objs)
 		},

--- a/internal/providers/oncall/commands_extra.go
+++ b/internal/providers/oncall/commands_extra.go
@@ -63,7 +63,7 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 				return err
 			}
 
-			deeplink.InjectURLs(objs, client.StackURL())
+			deeplink.InjectURLs(objs, client.GrafanaURL())
 
 			return opts.IO.Encode(cmd.OutOrStdout(), objs)
 		},

--- a/internal/providers/oncall/resource_adapter.go
+++ b/internal/providers/oncall/resource_adapter.go
@@ -30,9 +30,10 @@ func init() { //nolint:gochecknoinits // Natural key registration for cross-stac
 
 // resourceMeta holds metadata for registering an OnCall resource type.
 type resourceMeta struct {
-	Descriptor resources.Descriptor
-	Schema     json.RawMessage
-	Example    json.RawMessage
+	Descriptor  resources.Descriptor
+	Schema      json.RawMessage
+	Example     json.RawMessage
+	URLTemplate string // Deep link URL template (e.g., "/a/grafana-oncall-app/schedules/{name}").
 }
 
 // crudOption configures optional CRUD operations on a TypedCRUD instance.
@@ -107,10 +108,11 @@ func buildOnCallRegistration[T adapter.ResourceNamer](
 
 			return crud.AsAdapter(), nil
 		},
-		Descriptor: desc,
-		GVK:        desc.GroupVersionKind(),
-		Schema:     meta.Schema,
-		Example:    meta.Example,
+		Descriptor:  desc,
+		GVK:         desc.GroupVersionKind(),
+		Schema:      meta.Schema,
+		Example:     meta.Example,
+		URLTemplate: meta.URLTemplate,
 	}
 }
 
@@ -141,7 +143,8 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 	meta := onCallMeta("Integration", "integration", "integrations")
 	meta.Schema = adapter.SchemaFromType[Integration](meta.Descriptor)
 	meta.Example = integrationExample()
-	reg := buildOnCallRegistration(loader, meta,
+	meta.URLTemplate = "/a/grafana-oncall-app/integrations/{name}"
+	regs = append(regs, buildOnCallRegistration(loader, meta,
 		func(ctx context.Context, c *Client) ([]Integration, error) { return c.ListIntegrations(ctx) },
 		func(ctx context.Context, c *Client, name string) (*Integration, error) {
 			return c.GetIntegration(ctx, name)
@@ -155,15 +158,14 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 		withDelete[Integration](func(ctx context.Context, c *Client, name string) error {
 			return c.DeleteIntegration(ctx, name)
 		}),
-	)
-	reg.URLTemplate = "/a/grafana-oncall-app/integrations/{name}"
-	regs = append(regs, reg)
+	))
 
 	// 2. EscalationChain — full CRUD
 	meta = onCallMeta("EscalationChain", "escalationchain", "escalationchains")
 	meta.Schema = adapter.SchemaFromType[EscalationChain](meta.Descriptor)
 	meta.Example = escalationChainExample()
-	reg = buildOnCallRegistration(loader, meta,
+	meta.URLTemplate = "/a/grafana-oncall-app/escalation-chains/{name}"
+	regs = append(regs, buildOnCallRegistration(loader, meta,
 		func(ctx context.Context, c *Client) ([]EscalationChain, error) { return c.ListEscalationChains(ctx) },
 		func(ctx context.Context, c *Client, name string) (*EscalationChain, error) {
 			return c.GetEscalationChain(ctx, name)
@@ -177,9 +179,7 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 		withDelete[EscalationChain](func(ctx context.Context, c *Client, name string) error {
 			return c.DeleteEscalationChain(ctx, name)
 		}),
-	)
-	reg.URLTemplate = "/a/grafana-oncall-app/escalation-chains/{name}"
-	regs = append(regs, reg)
+	))
 
 	// 3. EscalationPolicy — full CRUD (list with empty filter)
 	meta = onCallMeta("EscalationPolicy", "escalationpolicy", "escalationpolicies")
@@ -207,7 +207,8 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 	meta = onCallMeta("Schedule", "schedule", "schedules")
 	meta.Schema = adapter.SchemaFromType[Schedule](meta.Descriptor)
 	meta.Example = scheduleExample()
-	reg = buildOnCallRegistration(loader, meta,
+	meta.URLTemplate = "/a/grafana-oncall-app/schedules/{name}"
+	regs = append(regs, buildOnCallRegistration(loader, meta,
 		func(ctx context.Context, c *Client) ([]Schedule, error) { return c.ListSchedules(ctx) },
 		func(ctx context.Context, c *Client, name string) (*Schedule, error) { return c.GetSchedule(ctx, name) },
 		withCreate(func(ctx context.Context, c *Client, item *Schedule) (*Schedule, error) {
@@ -219,9 +220,7 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 		withDelete[Schedule](func(ctx context.Context, c *Client, name string) error {
 			return c.DeleteSchedule(ctx, name)
 		}),
-	)
-	reg.URLTemplate = "/a/grafana-oncall-app/schedules/{name}"
-	regs = append(regs, reg)
+	))
 
 	// 5. Shift — CRUD with ShiftRequest conversion for create/update
 	meta = onCallMeta("Shift", "shift", "shifts")
@@ -273,7 +272,8 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 	meta = onCallMeta("OutgoingWebhook", "outgoingwebhook", "outgoingwebhooks")
 	meta.Schema = adapter.SchemaFromType[OutgoingWebhook](meta.Descriptor)
 	meta.Example = outgoingWebhookExample()
-	reg = buildOnCallRegistration(loader, meta,
+	meta.URLTemplate = "/a/grafana-oncall-app/outgoing-webhooks/{name}"
+	regs = append(regs, buildOnCallRegistration(loader, meta,
 		func(ctx context.Context, c *Client) ([]OutgoingWebhook, error) { return c.ListOutgoingWebhooks(ctx) },
 		func(ctx context.Context, c *Client, name string) (*OutgoingWebhook, error) {
 			return c.GetOutgoingWebhook(ctx, name)
@@ -287,14 +287,13 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 		withDelete[OutgoingWebhook](func(ctx context.Context, c *Client, name string) error {
 			return c.DeleteOutgoingWebhook(ctx, name)
 		}),
-	)
-	reg.URLTemplate = "/a/grafana-oncall-app/outgoing-webhooks/{name}"
-	regs = append(regs, reg)
+	))
 
 	// 8. AlertGroup — read-only + delete
 	meta = onCallMeta("AlertGroup", "alertgroup", "alertgroups")
 	meta.Schema = adapter.SchemaFromType[AlertGroup](meta.Descriptor)
-	reg = buildOnCallRegistration(loader, meta,
+	meta.URLTemplate = "/a/grafana-oncall-app/alert-groups/{name}"
+	regs = append(regs, buildOnCallRegistration(loader, meta,
 		func(ctx context.Context, c *Client) ([]AlertGroup, error) { return c.ListAlertGroups(ctx) }, // no filter
 		func(ctx context.Context, c *Client, name string) (*AlertGroup, error) {
 			return c.GetAlertGroup(ctx, name)
@@ -302,9 +301,7 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 		withDelete[AlertGroup](func(ctx context.Context, c *Client, name string) error {
 			return c.DeleteAlertGroup(ctx, name)
 		}),
-	)
-	reg.URLTemplate = "/a/grafana-oncall-app/alert-groups/{name}"
-	regs = append(regs, reg)
+	))
 
 	// 9. User — read-only
 	meta = onCallMeta("User", "oncalluser", "oncallusers")

--- a/internal/providers/oncall/resource_adapter.go
+++ b/internal/providers/oncall/resource_adapter.go
@@ -637,5 +637,5 @@ func NewTypedCRUD[T adapter.ResourceNamer](
 		opt(client, crud)
 	}
 
-	return crud, namespace, client.StackURL(), nil
+	return crud, namespace, client.GrafanaURL(), nil
 }

--- a/internal/providers/oncall/resource_adapter.go
+++ b/internal/providers/oncall/resource_adapter.go
@@ -141,7 +141,7 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 	meta := onCallMeta("Integration", "integration", "integrations")
 	meta.Schema = adapter.SchemaFromType[Integration](meta.Descriptor)
 	meta.Example = integrationExample()
-	regs = append(regs, buildOnCallRegistration(loader, meta,
+	reg := buildOnCallRegistration(loader, meta,
 		func(ctx context.Context, c *Client) ([]Integration, error) { return c.ListIntegrations(ctx) },
 		func(ctx context.Context, c *Client, name string) (*Integration, error) {
 			return c.GetIntegration(ctx, name)
@@ -155,13 +155,15 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 		withDelete[Integration](func(ctx context.Context, c *Client, name string) error {
 			return c.DeleteIntegration(ctx, name)
 		}),
-	))
+	)
+	reg.URLTemplate = "/a/grafana-oncall-app/integrations/{name}"
+	regs = append(regs, reg)
 
 	// 2. EscalationChain — full CRUD
 	meta = onCallMeta("EscalationChain", "escalationchain", "escalationchains")
 	meta.Schema = adapter.SchemaFromType[EscalationChain](meta.Descriptor)
 	meta.Example = escalationChainExample()
-	regs = append(regs, buildOnCallRegistration(loader, meta,
+	reg = buildOnCallRegistration(loader, meta,
 		func(ctx context.Context, c *Client) ([]EscalationChain, error) { return c.ListEscalationChains(ctx) },
 		func(ctx context.Context, c *Client, name string) (*EscalationChain, error) {
 			return c.GetEscalationChain(ctx, name)
@@ -175,7 +177,9 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 		withDelete[EscalationChain](func(ctx context.Context, c *Client, name string) error {
 			return c.DeleteEscalationChain(ctx, name)
 		}),
-	))
+	)
+	reg.URLTemplate = "/a/grafana-oncall-app/escalation-chains/{name}"
+	regs = append(regs, reg)
 
 	// 3. EscalationPolicy — full CRUD (list with empty filter)
 	meta = onCallMeta("EscalationPolicy", "escalationpolicy", "escalationpolicies")
@@ -203,7 +207,7 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 	meta = onCallMeta("Schedule", "schedule", "schedules")
 	meta.Schema = adapter.SchemaFromType[Schedule](meta.Descriptor)
 	meta.Example = scheduleExample()
-	regs = append(regs, buildOnCallRegistration(loader, meta,
+	reg = buildOnCallRegistration(loader, meta,
 		func(ctx context.Context, c *Client) ([]Schedule, error) { return c.ListSchedules(ctx) },
 		func(ctx context.Context, c *Client, name string) (*Schedule, error) { return c.GetSchedule(ctx, name) },
 		withCreate(func(ctx context.Context, c *Client, item *Schedule) (*Schedule, error) {
@@ -215,7 +219,9 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 		withDelete[Schedule](func(ctx context.Context, c *Client, name string) error {
 			return c.DeleteSchedule(ctx, name)
 		}),
-	))
+	)
+	reg.URLTemplate = "/a/grafana-oncall-app/schedules/{name}"
+	regs = append(regs, reg)
 
 	// 5. Shift — CRUD with ShiftRequest conversion for create/update
 	meta = onCallMeta("Shift", "shift", "shifts")
@@ -267,7 +273,7 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 	meta = onCallMeta("OutgoingWebhook", "outgoingwebhook", "outgoingwebhooks")
 	meta.Schema = adapter.SchemaFromType[OutgoingWebhook](meta.Descriptor)
 	meta.Example = outgoingWebhookExample()
-	regs = append(regs, buildOnCallRegistration(loader, meta,
+	reg = buildOnCallRegistration(loader, meta,
 		func(ctx context.Context, c *Client) ([]OutgoingWebhook, error) { return c.ListOutgoingWebhooks(ctx) },
 		func(ctx context.Context, c *Client, name string) (*OutgoingWebhook, error) {
 			return c.GetOutgoingWebhook(ctx, name)
@@ -281,12 +287,14 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 		withDelete[OutgoingWebhook](func(ctx context.Context, c *Client, name string) error {
 			return c.DeleteOutgoingWebhook(ctx, name)
 		}),
-	))
+	)
+	reg.URLTemplate = "/a/grafana-oncall-app/outgoing-webhooks/{name}"
+	regs = append(regs, reg)
 
 	// 8. AlertGroup — read-only + delete
 	meta = onCallMeta("AlertGroup", "alertgroup", "alertgroups")
 	meta.Schema = adapter.SchemaFromType[AlertGroup](meta.Descriptor)
-	regs = append(regs, buildOnCallRegistration(loader, meta,
+	reg = buildOnCallRegistration(loader, meta,
 		func(ctx context.Context, c *Client) ([]AlertGroup, error) { return c.ListAlertGroups(ctx) }, // no filter
 		func(ctx context.Context, c *Client, name string) (*AlertGroup, error) {
 			return c.GetAlertGroup(ctx, name)
@@ -294,7 +302,9 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 		withDelete[AlertGroup](func(ctx context.Context, c *Client, name string) error {
 			return c.DeleteAlertGroup(ctx, name)
 		}),
-	))
+	)
+	reg.URLTemplate = "/a/grafana-oncall-app/alert-groups/{name}"
+	regs = append(regs, reg)
 
 	// 9. User — read-only
 	meta = onCallMeta("User", "oncalluser", "oncallusers")
@@ -599,16 +609,17 @@ func shiftSwapExample() json.RawMessage {
 // NewTypedCRUD[T adapter.ResourceNamer] creates a TypedCRUD instance for CLI commands.
 // It mirrors buildOnCallRegistration but returns TypedCRUD directly instead of Registration.
 // This factory pattern allows commands to use typed methods without going through the adapter.
+// Returns (crud, namespace, grafanaHost, error).
 func NewTypedCRUD[T adapter.ResourceNamer](
 	ctx context.Context,
 	loader OnCallConfigLoader,
 	listFn func(ctx context.Context, client *Client) ([]T, error),
 	getFn func(ctx context.Context, client *Client, name string) (*T, error), // nil for list-only resources
 	opts ...crudOption[T],
-) (*adapter.TypedCRUD[T], string, error) {
+) (*adapter.TypedCRUD[T], string, string, error) {
 	client, namespace, err := loader.LoadOnCallClient(ctx)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to load OnCall config: %w", err)
+		return nil, "", "", fmt.Errorf("failed to load OnCall config: %w", err)
 	}
 
 	crud := &adapter.TypedCRUD[T]{
@@ -629,5 +640,5 @@ func NewTypedCRUD[T adapter.ResourceNamer](
 		opt(client, crud)
 	}
 
-	return crud, namespace, nil
+	return crud, namespace, client.StackURL(), nil
 }

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -1,6 +1,9 @@
 package providers
 
-import "github.com/grafana/gcx/internal/resources/adapter"
+import (
+	"github.com/grafana/gcx/internal/deeplink"
+	"github.com/grafana/gcx/internal/resources/adapter"
+)
 
 // registry holds all providers registered via Register().
 var registry []Provider //nolint:gochecknoglobals // Self-registration pattern requires package-level state.
@@ -13,6 +16,9 @@ func Register(p Provider) {
 	registry = append(registry, p)
 	for _, reg := range p.TypedRegistrations() {
 		adapter.Register(reg)
+		if reg.URLTemplate != "" {
+			deeplink.RegisterPattern(reg.GVK, reg.URLTemplate)
+		}
 	}
 }
 

--- a/internal/providers/sigil/provider.go
+++ b/internal/providers/sigil/provider.go
@@ -119,16 +119,18 @@ func (p *SigilProvider) TypedRegistrations() []adapter.Registration {
 
 	return []adapter.Registration{
 		{
-			Factory:    evaluators.NewLazyFactory(),
-			Descriptor: evalDesc,
-			GVK:        evalDesc.GroupVersionKind(),
-			Schema:     evaluators.EvaluatorSchema(),
+			Factory:     evaluators.NewLazyFactory(),
+			Descriptor:  evalDesc,
+			GVK:         evalDesc.GroupVersionKind(),
+			Schema:      evaluators.EvaluatorSchema(),
+			URLTemplate: "/a/grafana-sigil-app/evaluators/{name}",
 		},
 		{
-			Factory:    rules.NewLazyFactory(),
-			Descriptor: ruleDesc,
-			GVK:        ruleDesc.GroupVersionKind(),
-			Schema:     rules.RuleSchema(),
+			Factory:     rules.NewLazyFactory(),
+			Descriptor:  ruleDesc,
+			GVK:         ruleDesc.GroupVersionKind(),
+			Schema:      rules.RuleSchema(),
+			URLTemplate: "/a/grafana-sigil-app/rules/{name}",
 		},
 	}
 }

--- a/internal/providers/slo/provider.go
+++ b/internal/providers/slo/provider.go
@@ -63,11 +63,12 @@ func (p *SLOProvider) TypedRegistrations() []adapter.Registration {
 	desc := definitions.StaticDescriptor()
 	return []adapter.Registration{
 		{
-			Factory:    definitions.NewLazyFactory(),
-			Descriptor: desc,
-			GVK:        desc.GroupVersionKind(),
-			Schema:     definitions.SloSchema(),
-			Example:    definitions.SloExample(),
+			Factory:     definitions.NewLazyFactory(),
+			Descriptor:  desc,
+			GVK:         desc.GroupVersionKind(),
+			Schema:      definitions.SloSchema(),
+			Example:     definitions.SloExample(),
+			URLTemplate: "/a/grafana-slo-app/slo/{name}",
 		},
 	}
 }

--- a/internal/providers/synth/provider.go
+++ b/internal/providers/synth/provider.go
@@ -139,18 +139,20 @@ func (p *SynthProvider) TypedRegistrations() []adapter.Registration {
 	loader := &configLoader{}
 	return []adapter.Registration{
 		{
-			Factory:    checks.NewAdapterFactory(loader),
-			Descriptor: checks.StaticDescriptor(),
-			GVK:        checks.StaticGVK(),
-			Schema:     checkSchema(),
-			Example:    checkExample(),
+			Factory:     checks.NewAdapterFactory(loader),
+			Descriptor:  checks.StaticDescriptor(),
+			GVK:         checks.StaticGVK(),
+			Schema:      checkSchema(),
+			Example:     checkExample(),
+			URLTemplate: "/a/grafana-synthetic-monitoring-app/checks/{name}",
 		},
 		{
-			Factory:    probes.NewAdapterFactory(loader),
-			Descriptor: probes.StaticDescriptor(),
-			GVK:        probes.StaticGVK(),
-			Schema:     probeSchema(),
-			Example:    probeExample(),
+			Factory:     probes.NewAdapterFactory(loader),
+			Descriptor:  probes.StaticDescriptor(),
+			GVK:         probes.StaticGVK(),
+			Schema:      probeSchema(),
+			Example:     probeExample(),
+			URLTemplate: "/a/grafana-synthetic-monitoring-app/probes/{name}",
 		},
 	}
 }

--- a/internal/resources/adapter/register.go
+++ b/internal/resources/adapter/register.go
@@ -18,13 +18,14 @@ type RegistryAccess interface {
 // Registration holds a pre-resolved adapter factory with its descriptor and aliases.
 // Populated lazily by calling the factory once to extract descriptor metadata.
 type Registration struct {
-	Factory    Factory
-	Descriptor resources.Descriptor
-	Aliases    []string
-	GVK        schema.GroupVersionKind
-	Schema     json.RawMessage                // Required JSON Schema for this resource type (per CONSTITUTION.md). MAY be nil for read-only resources.
-	Example    json.RawMessage                // Required example manifest (YAML-compatible JSON, per CONSTITUTION.md). MAY be nil for read-only resources.
-	Operations map[string]agent.OperationHint // Agent metadata: per-operation token cost and hint, keyed by "get", "push", "pull", "delete".
+	Factory     Factory
+	Descriptor  resources.Descriptor
+	Aliases     []string
+	GVK         schema.GroupVersionKind
+	Schema      json.RawMessage                // Required JSON Schema for this resource type (per CONSTITUTION.md). MAY be nil for read-only resources.
+	Example     json.RawMessage                // Required example manifest (YAML-compatible JSON, per CONSTITUTION.md). MAY be nil for read-only resources.
+	Operations  map[string]agent.OperationHint // Agent metadata: per-operation token cost and hint, keyed by "get", "push", "pull", "delete".
+	URLTemplate string                         // URL path template for deep links (e.g., "/a/grafana-slo-app/slo/{name}"). Empty means no deep link.
 }
 
 // registrations holds all adapter registrations collected from providers.

--- a/internal/resources/adapter/typed.go
+++ b/internal/resources/adapter/typed.go
@@ -454,12 +454,13 @@ func isDryRun(dryRun []string) bool {
 
 // TypedRegistration bridges TypedCRUD to the existing Registration system.
 type TypedRegistration[T ResourceNamer] struct {
-	Descriptor resources.Descriptor
-	Aliases    []string
-	GVK        schema.GroupVersionKind
-	Schema     json.RawMessage
-	Example    json.RawMessage
-	Factory    func(ctx context.Context) (*TypedCRUD[T], error)
+	Descriptor  resources.Descriptor
+	Aliases     []string
+	GVK         schema.GroupVersionKind
+	Schema      json.RawMessage
+	Example     json.RawMessage
+	URLTemplate string // URL path template for deep links (e.g., "/a/grafana-oncall-app/schedules/{name}").
+	Factory     func(ctx context.Context) (*TypedCRUD[T], error)
 }
 
 // ToRegistration converts to a standard Registration.
@@ -477,10 +478,11 @@ func (r TypedRegistration[T]) ToRegistration() Registration {
 			}
 			return a, nil
 		},
-		Descriptor: r.Descriptor,
-		Aliases:    r.Aliases,
-		GVK:        r.GVK,
-		Schema:     r.Schema,
-		Example:    r.Example,
+		Descriptor:  r.Descriptor,
+		Aliases:     r.Aliases,
+		GVK:         r.GVK,
+		Schema:      r.Schema,
+		Example:     r.Example,
+		URLTemplate: r.URLTemplate,
 	}
 }


### PR DESCRIPTION
## Summary

- Add first-class deep link URL support across all gcx resource types
- New `--open` flag on get commands opens resources directly in the browser
- URL column visible in `-o wide` table output, queryable via `--json url`

## Changes

### New package: `internal/deeplink/`
- URL pattern registry mapping GVK → URL template (e.g., `/d/{name}`, `/a/grafana-oncall-app/schedules/{name}`)
- `Resolve()`, `InjectURL()`, `InjectURLs()` for URL computation and injection
- `Open()` for cross-platform browser launching via `github.com/pkg/browser`
- K8s-native patterns (Dashboard, Folder) hard-coded in init()

### Infrastructure
- `URLTemplate` field added to `adapter.Registration` and `adapter.TypedRegistration`
- `providers.Register()` auto-registers URL patterns from `URLTemplate`
- `resources get`: injects URLs post-fetch, adds `--open` flag, URL column (Priority 1)

### Provider URL templates (19 resource types)
| Provider | Resources with URLs |
|----------|-------------------|
| K8s native | Dashboard, Folder |
| SLO | SLO |
| OnCall | Integration, EscalationChain, Schedule, OutgoingWebhook, AlertGroup |
| Synth | Check, Probe |
| Incidents | Incident |
| K6 | Project, LoadTest |
| Alert | AlertRule |
| Fleet | Pipeline, Collector |
| Faro | FaroApp |
| Sigil | Evaluator, EvalRule |

### Command changes
- `--open` flag on: `resources get`, all OnCall get commands, `investigations get`
- Refactored incidents `open` subcommand and KG `open` command to use `deeplink.Open()`
- URL injection in OnCall and alert-group list commands

## Test Plan
- [x] New unit tests for `internal/deeplink/` (Resolve, InjectURL, InjectURLs)
- [x] All existing tests pass (`go test -race -count=1 ./...`)
- [x] Build succeeds (`go build ./...`)
- [x] Lint passes (only pre-existing gosec warnings remain)
- [x] Docs regenerated with `GCX_AGENT_MODE=false make docs`

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)