### PR TITLE
fix: apply selected context before env overrides in provider loaders

### DIFF
--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -60,6 +60,43 @@ type ConfigLoader struct {
 	ctxName    string
 }
 
+func (l *ConfigLoader) resolvedContextName(ctx context.Context) string {
+	if l.ctxName != "" {
+		return l.ctxName
+	}
+	return config.ContextNameFromCtx(ctx)
+}
+
+func contextSelectionOverride(ctxName string) config.Override {
+	return func(cfg *config.Config) error {
+		if ctxName == "" {
+			return nil
+		}
+		if !cfg.HasContext(ctxName) {
+			return config.ContextNotFound(ctxName)
+		}
+		cfg.CurrentContext = ctxName
+		return nil
+	}
+}
+
+func cloudEnvOverride(cfg *config.Config) error {
+	if cfg.CurrentContext == "" {
+		cfg.CurrentContext = config.DefaultContextName
+	}
+
+	if !cfg.HasContext(cfg.CurrentContext) {
+		cfg.SetContext(cfg.CurrentContext, true, config.Context{})
+	}
+
+	curCtx := cfg.Contexts[cfg.CurrentContext]
+	if curCtx.Cloud == nil {
+		curCtx.Cloud = &config.CloudConfig{}
+	}
+
+	return env.Parse(curCtx)
+}
+
 // BindFlags registers --config and --context flags on the given flag set.
 func (l *ConfigLoader) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&l.configFile, "config", "", "Path to the configuration file to use")
@@ -138,24 +175,9 @@ func envOverride(cfg *config.Config) error {
 // env var overrides and context flags. It mirrors the logic in
 // cmd/gcx/config.Options.LoadGrafanaConfig.
 func (l *ConfigLoader) LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error) {
-	overrides := []config.Override{envOverride}
-
-	// Resolve context name: explicit flag takes priority, then context.Context carrier
-	// (set by resource commands to honour the --context flag for provider adapters).
-	ctxName := l.ctxName
-	if ctxName == "" {
-		ctxName = config.ContextNameFromCtx(ctx)
-	}
-	if ctxName != "" {
-		overrides = append(overrides, func(cfg *config.Config) error {
-			if !cfg.HasContext(ctxName) {
-				return config.ContextNotFound(ctxName)
-			}
-			cfg.CurrentContext = ctxName
-			return nil
-		})
-	}
-
+	ctxName := l.resolvedContextName(ctx)
+	overrides := []config.Override{contextSelectionOverride(ctxName), envOverride}
+	
 	// Validate after loading.
 	overrides = append(overrides, func(cfg *config.Config) error {
 		if !cfg.HasContext(cfg.CurrentContext) {
@@ -184,44 +206,8 @@ func (l *ConfigLoader) LoadGrafanaConfig(ctx context.Context) (config.Namespaced
 // It validates that cloud.token is present, resolves the stack slug and GCOM URL,
 // calls the GCOM API to discover stack info, and returns a CloudRESTConfig.
 func (l *ConfigLoader) LoadCloudConfig(ctx context.Context) (CloudRESTConfig, error) {
-	overrides := []config.Override{
-		// Apply env vars into the current context.
-		func(cfg *config.Config) error {
-			if cfg.CurrentContext == "" {
-				cfg.CurrentContext = config.DefaultContextName
-			}
-
-			if !cfg.HasContext(cfg.CurrentContext) {
-				cfg.SetContext(cfg.CurrentContext, true, config.Context{})
-			}
-
-			curCtx := cfg.Contexts[cfg.CurrentContext]
-			if curCtx.Cloud == nil {
-				curCtx.Cloud = &config.CloudConfig{}
-			}
-
-			if err := env.Parse(curCtx); err != nil {
-				return err
-			}
-
-			return nil
-		},
-	}
-
-	// Resolve context name.
-	ctxName := l.ctxName
-	if ctxName == "" {
-		ctxName = config.ContextNameFromCtx(ctx)
-	}
-	if ctxName != "" {
-		overrides = append(overrides, func(cfg *config.Config) error {
-			if !cfg.HasContext(ctxName) {
-				return config.ContextNotFound(ctxName)
-			}
-			cfg.CurrentContext = ctxName
-			return nil
-		})
-	}
+	ctxName := l.resolvedContextName(ctx)
+	overrides := []config.Override{contextSelectionOverride(ctxName), cloudEnvOverride}
 
 	loaded, err := config.LoadLayered(ctx, l.configFile, overrides...)
 	if err != nil {
@@ -292,22 +278,8 @@ func (l *ConfigLoader) configSource() config.Source {
 // the named provider from the config file, applying GRAFANA_PROVIDER_<NAME>_<KEY>
 // env var overrides. Returns (providerConfig, namespace, error).
 func (l *ConfigLoader) LoadProviderConfig(ctx context.Context, providerName string) (map[string]string, string, error) {
-	overrides := []config.Override{envOverride}
-
-	// Resolve context name.
-	ctxName := l.ctxName
-	if ctxName == "" {
-		ctxName = config.ContextNameFromCtx(ctx)
-	}
-	if ctxName != "" {
-		overrides = append(overrides, func(cfg *config.Config) error {
-			if !cfg.HasContext(ctxName) {
-				return config.ContextNotFound(ctxName)
-			}
-			cfg.CurrentContext = ctxName
-			return nil
-		})
-	}
+	ctxName := l.resolvedContextName(ctx)
+	overrides := []config.Override{contextSelectionOverride(ctxName), envOverride}
 
 	// Minimal validation: context must exist.
 	overrides = append(overrides, func(cfg *config.Config) error {

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -176,15 +176,16 @@ func envOverride(cfg *config.Config) error {
 // cmd/gcx/config.Options.LoadGrafanaConfig.
 func (l *ConfigLoader) LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error) {
 	ctxName := l.resolvedContextName(ctx)
-	overrides := []config.Override{contextSelectionOverride(ctxName), envOverride}
-	
-	// Validate after loading.
-	overrides = append(overrides, func(cfg *config.Config) error {
-		if !cfg.HasContext(cfg.CurrentContext) {
-			return config.ContextNotFound(cfg.CurrentContext)
-		}
-		return cfg.GetCurrentContext().Validate()
-	})
+	overrides := []config.Override{
+		contextSelectionOverride(ctxName),
+		envOverride,
+		func(cfg *config.Config) error {
+			if !cfg.HasContext(cfg.CurrentContext) {
+				return config.ContextNotFound(cfg.CurrentContext)
+			}
+			return cfg.GetCurrentContext().Validate()
+		},
+	}
 
 	loaded, err := config.LoadLayered(ctx, l.configFile, overrides...)
 	if err != nil {
@@ -279,15 +280,16 @@ func (l *ConfigLoader) configSource() config.Source {
 // env var overrides. Returns (providerConfig, namespace, error).
 func (l *ConfigLoader) LoadProviderConfig(ctx context.Context, providerName string) (map[string]string, string, error) {
 	ctxName := l.resolvedContextName(ctx)
-	overrides := []config.Override{contextSelectionOverride(ctxName), envOverride}
-
-	// Minimal validation: context must exist.
-	overrides = append(overrides, func(cfg *config.Config) error {
-		if !cfg.HasContext(cfg.CurrentContext) {
-			return config.ContextNotFound(cfg.CurrentContext)
-		}
-		return nil
-	})
+	overrides := []config.Override{
+		contextSelectionOverride(ctxName),
+		envOverride,
+		func(cfg *config.Config) error {
+			if !cfg.HasContext(cfg.CurrentContext) {
+				return config.ContextNotFound(cfg.CurrentContext)
+			}
+			return nil
+		},
+	}
 
 	loaded, err := config.LoadLayered(ctx, l.configFile, overrides...)
 	if err != nil {

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -97,6 +97,14 @@ func cloudEnvOverride(cfg *config.Config) error {
 	return env.Parse(curCtx)
 }
 
+// contextMustExist is a config.Override that validates the current context exists.
+func contextMustExist(cfg *config.Config) error {
+	if !cfg.HasContext(cfg.CurrentContext) {
+		return config.ContextNotFound(cfg.CurrentContext)
+	}
+	return nil
+}
+
 // BindFlags registers --config and --context flags on the given flag set.
 func (l *ConfigLoader) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&l.configFile, "config", "", "Path to the configuration file to use")
@@ -179,10 +187,8 @@ func (l *ConfigLoader) LoadGrafanaConfig(ctx context.Context) (config.Namespaced
 	overrides := []config.Override{
 		contextSelectionOverride(ctxName),
 		envOverride,
+		contextMustExist,
 		func(cfg *config.Config) error {
-			if !cfg.HasContext(cfg.CurrentContext) {
-				return config.ContextNotFound(cfg.CurrentContext)
-			}
 			return cfg.GetCurrentContext().Validate()
 		},
 	}
@@ -190,10 +196,6 @@ func (l *ConfigLoader) LoadGrafanaConfig(ctx context.Context) (config.Namespaced
 	loaded, err := config.LoadLayered(ctx, l.configFile, overrides...)
 	if err != nil {
 		return config.NamespacedRESTConfig{}, err
-	}
-
-	if !loaded.HasContext(loaded.CurrentContext) {
-		return config.NamespacedRESTConfig{}, fmt.Errorf("context %q not found", loaded.CurrentContext)
 	}
 
 	restCfg := loaded.GetCurrentContext().ToRESTConfig(ctx)
@@ -213,10 +215,6 @@ func (l *ConfigLoader) LoadCloudConfig(ctx context.Context) (CloudRESTConfig, er
 	loaded, err := config.LoadLayered(ctx, l.configFile, overrides...)
 	if err != nil {
 		return CloudRESTConfig{}, err
-	}
-
-	if !loaded.HasContext(loaded.CurrentContext) {
-		return CloudRESTConfig{}, fmt.Errorf("context %q not found", loaded.CurrentContext)
 	}
 
 	curCtx := loaded.GetCurrentContext()
@@ -283,21 +281,12 @@ func (l *ConfigLoader) LoadProviderConfig(ctx context.Context, providerName stri
 	overrides := []config.Override{
 		contextSelectionOverride(ctxName),
 		envOverride,
-		func(cfg *config.Config) error {
-			if !cfg.HasContext(cfg.CurrentContext) {
-				return config.ContextNotFound(cfg.CurrentContext)
-			}
-			return nil
-		},
+		contextMustExist,
 	}
 
 	loaded, err := config.LoadLayered(ctx, l.configFile, overrides...)
 	if err != nil {
 		return nil, "", err
-	}
-
-	if !loaded.HasContext(loaded.CurrentContext) {
-		return nil, "", fmt.Errorf("context %q not found", loaded.CurrentContext)
 	}
 
 	curCtx := loaded.GetCurrentContext()
@@ -389,30 +378,12 @@ func (l *ConfigLoader) datasourceWriteSource() (config.Source, error) {
 // SaveProviderConfig persists a single key-value pair to
 // contexts.[current].providers.[providerName].[key] in the config file.
 func (l *ConfigLoader) SaveProviderConfig(ctx context.Context, providerName, key, value string) error {
-	overrides := []config.Override{envOverride}
-
-	// Resolve context name.
-	ctxName := l.ctxName
-	if ctxName == "" {
-		ctxName = config.ContextNameFromCtx(ctx)
+	ctxName := l.resolvedContextName(ctx)
+	overrides := []config.Override{
+		contextSelectionOverride(ctxName),
+		envOverride,
+		contextMustExist,
 	}
-	if ctxName != "" {
-		overrides = append(overrides, func(cfg *config.Config) error {
-			if !cfg.HasContext(ctxName) {
-				return config.ContextNotFound(ctxName)
-			}
-			cfg.CurrentContext = ctxName
-			return nil
-		})
-	}
-
-	// Minimal validation: context must exist.
-	overrides = append(overrides, func(cfg *config.Config) error {
-		if !cfg.HasContext(cfg.CurrentContext) {
-			return config.ContextNotFound(cfg.CurrentContext)
-		}
-		return nil
-	})
 
 	loaded, err := config.LoadLayered(ctx, l.configFile, overrides...)
 	if err != nil {
@@ -439,30 +410,12 @@ func (l *ConfigLoader) SaveProviderConfig(ctx context.Context, providerName, key
 // LoadFullConfig loads the full config from the config file, applying env var
 // overrides and context flags. Returns a pointer to the resolved Config.
 func (l *ConfigLoader) LoadFullConfig(ctx context.Context) (*config.Config, error) {
-	overrides := []config.Override{envOverride}
-
-	// Resolve context name.
-	ctxName := l.ctxName
-	if ctxName == "" {
-		ctxName = config.ContextNameFromCtx(ctx)
+	ctxName := l.resolvedContextName(ctx)
+	overrides := []config.Override{
+		contextSelectionOverride(ctxName),
+		envOverride,
+		contextMustExist,
 	}
-	if ctxName != "" {
-		overrides = append(overrides, func(cfg *config.Config) error {
-			if !cfg.HasContext(ctxName) {
-				return config.ContextNotFound(ctxName)
-			}
-			cfg.CurrentContext = ctxName
-			return nil
-		})
-	}
-
-	// Minimal validation: context must exist.
-	overrides = append(overrides, func(cfg *config.Config) error {
-		if !cfg.HasContext(cfg.CurrentContext) {
-			return config.ContextNotFound(cfg.CurrentContext)
-		}
-		return nil
-	})
 
 	loaded, err := config.LoadLayered(ctx, l.configFile, overrides...)
 	if err != nil {

--- a/internal/providers/configloader_test.go
+++ b/internal/providers/configloader_test.go
@@ -706,3 +706,62 @@ current-context: default
 	assert.Equal(t, "https://fleet.example.com", got.Stack.AgentManagementInstanceURL)
 	assert.Equal(t, "default", got.Namespace)
 }
+
+func TestConfigLoader_LoadGrafanaConfig_ContextOverrideBeforeEnvVars(t *testing.T) {
+	cfgFile := writeConfigFile(t, `
+contexts:
+  prod:
+    grafana:
+      server: https://prod.grafana.net
+      token: prod-token
+  staging:
+    grafana:
+      server: https://staging.grafana.net
+      token: staging-token
+current-context: prod
+`)
+	t.Setenv("GRAFANA_TOKEN", "env-token")
+
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(cfgFile)
+	loader.SetContextName("staging")
+
+	restCfg, err := loader.LoadGrafanaConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "https://staging.grafana.net", restCfg.Host)
+	assert.Equal(t, "env-token", restCfg.BearerToken)
+	assert.NotEqual(t, "https://prod.grafana.net", restCfg.Host)
+}
+
+func TestConfigLoader_LoadCloudConfig_ContextOverrideBeforeEnvVars(t *testing.T) {
+	wantStack := cloud.StackInfo{ID: 7, Slug: "staging-stack", Name: "Staging"}
+	srv := newMockGCOMServer(t, wantStack)
+	defer srv.Close()
+
+	cfgFile := writeConfigFile(t, `
+contexts:
+  prod:
+    cloud:
+      token: prod-token
+      stack: prod-stack
+      api-url: `+srv.URL+`
+  staging:
+    cloud:
+      token: staging-token
+      stack: staging-stack
+      api-url: `+srv.URL+`
+current-context: prod
+`)
+	t.Setenv("GRAFANA_CLOUD_TOKEN", "env-cloud-token")
+
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(cfgFile)
+	loader.SetContextName("staging")
+
+	cloudCfg, err := loader.LoadCloudConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "env-cloud-token", cloudCfg.Token)
+	assert.Equal(t, "staging-stack", cloudCfg.Stack.Slug)
+	assert.Equal(t, 7, cloudCfg.Stack.ID)
+	assert.NotEqual(t, "prod-stack", cloudCfg.Stack.Slug)
+}

--- a/internal/providers/configloader_test.go
+++ b/internal/providers/configloader_test.go
@@ -707,6 +707,62 @@ current-context: default
 	assert.Equal(t, "default", got.Namespace)
 }
 
+func TestConfigLoader_SaveProviderConfig_ContextOverrideBeforeEnvVars(t *testing.T) {
+	cfgFile := writeConfigFile(t, `
+contexts:
+  prod:
+    providers:
+      synth:
+        sm-url: https://prod.sm
+  staging:
+    providers:
+      synth:
+        sm-url: https://staging.sm
+current-context: prod
+`)
+	t.Setenv("GRAFANA_PROVIDER_SYNTH_SM-TOKEN", "env-sm-token")
+
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(cfgFile)
+	loader.SetContextName("staging")
+
+	err := loader.SaveProviderConfig(context.Background(), "synth", "extra-key", "extra-val")
+	require.NoError(t, err)
+
+	// Reload and verify the save targeted the staging context.
+	got, _, err := loader.LoadProviderConfig(context.Background(), "synth")
+	require.NoError(t, err)
+	assert.Equal(t, "https://staging.sm", got["sm-url"])
+	assert.Equal(t, "extra-val", got["extra-key"])
+	assert.Equal(t, "env-sm-token", got["sm-token"])
+}
+
+func TestConfigLoader_LoadFullConfig_ContextOverrideBeforeEnvVars(t *testing.T) {
+	cfgFile := writeConfigFile(t, `
+contexts:
+  prod:
+    grafana:
+      server: https://prod.grafana.net
+      token: prod-token
+  staging:
+    grafana:
+      server: https://staging.grafana.net
+      token: staging-token
+current-context: prod
+`)
+	t.Setenv("GRAFANA_TOKEN", "env-token")
+
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(cfgFile)
+	loader.SetContextName("staging")
+
+	cfg, err := loader.LoadFullConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "staging", cfg.CurrentContext)
+	assert.Equal(t, "env-token", cfg.Contexts["staging"].Grafana.APIToken)
+	assert.Equal(t, "https://staging.grafana.net", cfg.Contexts["staging"].Grafana.Server)
+}
+
 func TestConfigLoader_LoadGrafanaConfig_ContextOverrideBeforeEnvVars(t *testing.T) {
 	cfgFile := writeConfigFile(t, `
 contexts:


### PR DESCRIPTION
fixes #210 
Env variables were being applied to the default context instead of the one selected via --context. 
Moved context selection to run before env override injection in all three config loaders