### PR TITLE
fix(completion): restore shell tab-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ go install github.com/grafana/gcx/cmd/gcx@latest
 ```bash
 gcx completion zsh > "${fpath[1]}/_gcx"   # zsh
 gcx completion bash > /etc/bash_completion.d/gcx  # bash
-gcx completion fish > ~/.config/fish/completions/gcx #fish
+gcx completion fish > ~/.config/fish/completions/gcx.fish  # fish
 ```
 
 **Verify:** `gcx --version`

--- a/cmd/gcx/root/command_test.go
+++ b/cmd/gcx/root/command_test.go
@@ -160,4 +160,11 @@ func TestValidateArgs_AllowsHelpAndCompletionCommands(t *testing.T) {
 	assert.NoError(t, root.ValidateArgs(rootCmd, []string{"help"}))
 	assert.NoError(t, root.ValidateArgs(rootCmd, []string{"help", "sigil"}))
 	assert.NoError(t, root.ValidateArgs(rootCmd, []string{"completion", "bash"}))
+
+	// Cobra's hidden shell helpers are registered lazily inside ExecuteC, so
+	// ValidateArgs must let them through to Cobra's normal dispatch.
+	assert.NoError(t, root.ValidateArgs(rootCmd, []string{"__complete", ""}))
+	assert.NoError(t, root.ValidateArgs(rootCmd, []string{"__complete", "sigil", ""}))
+	assert.NoError(t, root.ValidateArgs(rootCmd, []string{"__completeNoDesc", ""}))
+	assert.NoError(t, root.ValidateArgs(rootCmd, []string{"--agent", "__complete", ""}))
 }

--- a/cmd/gcx/root/validation.go
+++ b/cmd/gcx/root/validation.go
@@ -26,6 +26,16 @@ func ValidateArgs(rootCmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Cobra registers its hidden shell-completion helpers lazily inside
+	// ExecuteC, so they are absent from the command tree at validation time.
+	// Let them through to Cobra's normal dispatch.
+	if len(trimmedArgs) > 0 {
+		switch trimmedArgs[0] {
+		case cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd:
+			return nil
+		}
+	}
+
 	cmd, remaining, ok := traverseArgs(rootCmd, trimmedArgs)
 	if !ok || cmd == nil {
 		return nil

--- a/docs/reference/cli/gcx_alert_instances.md
+++ b/docs/reference/cli/gcx_alert_instances.md
@@ -11,12 +11,13 @@ Manage alert instances.
 ### Options inherited from parent commands
 
 ```
-      --agent            Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-      --no-color         Disable color output
-      --no-truncate      Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count    Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO

--- a/docs/reference/cli/gcx_alert_instances_list.md
+++ b/docs/reference/cli/gcx_alert_instances_list.md
@@ -21,12 +21,13 @@ gcx alert instances list [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent            Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-      --no-color         Disable color output
-      --no-truncate      Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count    Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
After `gcx completion <shell>` was installed, pressing TAB in bash, zsh, fish, etc. did nothing. Every shell invokes
the hidden `__complete` / `__completeNoDesc` helpers, and they hit `unknown command "__complete" for "gcx"`.

Cobra registers those helpers lazily inside `ExecuteC()`, so they were absent from the command tree. Let the two exported constants through to Cobra's normal dispatch and extend the validator test with the hidden-helper cases.

Also fix the fish example in the README, fish's autoloader only picks up files ending in `.fish`.