### PR TITLE
fix(slo): pass parent config loader to definitions commands

### DIFF
--- a/internal/providers/slo/definitions/commands.go
+++ b/internal/providers/slo/definitions/commands.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources"
@@ -20,21 +21,26 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// GrafanaConfigLoader can load a NamespacedRESTConfig from the active context.
+type GrafanaConfigLoader interface {
+	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
+}
+
 // Commands returns the definitions command group with CRUD subcommands.
-func Commands() *cobra.Command {
+func Commands(loader GrafanaConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "definitions",
 		Short:   "Manage SLO definitions.",
 		Aliases: []string{"def", "defs"},
 	}
 	cmd.AddCommand(
-		newListCommand(),
-		newGetCommand(),
-		newPushCommand(),
-		newPullCommand(),
-		newDeleteCommand(),
-		newStatusCommand(),
-		newTimelineCommand(),
+		newListCommand(loader),
+		newGetCommand(loader),
+		newPushCommand(loader),
+		newPullCommand(loader),
+		newDeleteCommand(loader),
+		newStatusCommand(loader),
+		newTimelineCommand(loader),
 	)
 	return cmd
 }
@@ -54,7 +60,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newListCommand() *cobra.Command {
+func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &listOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -66,7 +72,7 @@ func newListCommand() *cobra.Command {
 
 			ctx := cmd.Context()
 
-			crud, cfg, err := NewTypedCRUD(ctx)
+			crud, cfg, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -170,7 +176,7 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newGetCommand() *cobra.Command {
+func newGetCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &getOpts{}
 	cmd := &cobra.Command{
 		Use:   "get UUID",
@@ -184,7 +190,7 @@ func newGetCommand() *cobra.Command {
 			ctx := cmd.Context()
 			uuid := args[0]
 
-			crud, cfg, err := NewTypedCRUD(ctx)
+			crud, cfg, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -220,7 +226,7 @@ func (o *pullOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.OutputDir, "output-dir", "d", ".", "Directory to write SLO definition files to")
 }
 
-func newPullCommand() *cobra.Command {
+func newPullCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &pullOpts{}
 	cmd := &cobra.Command{
 		Use:   "pull",
@@ -228,7 +234,7 @@ func newPullCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			crud, cfg, err := NewTypedCRUD(ctx)
+			crud, cfg, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -286,7 +292,7 @@ func (o *pushOpts) setup(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview changes without making them")
 }
 
-func newPushCommand() *cobra.Command {
+func newPushCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &pushOpts{}
 	cmd := &cobra.Command{
 		Use:   "push FILE...",
@@ -295,7 +301,7 @@ func newPushCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -402,7 +408,7 @@ func (o *deleteOpts) setup(flags *pflag.FlagSet) {
 	flags.BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
 }
 
-func newDeleteCommand() *cobra.Command {
+func newDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &deleteOpts{}
 	cmd := &cobra.Command{
 		Use:   "delete UUID...",
@@ -426,7 +432,7 @@ func newDeleteCommand() *cobra.Command {
 				}
 			}
 
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/slo/definitions/resource_adapter.go
+++ b/internal/providers/slo/definitions/resource_adapter.go
@@ -69,13 +69,9 @@ func SloExample() json.RawMessage {
 	return b
 }
 
-// NewTypedCRUD creates a TypedCRUD for SLO definitions.
-// It loads config via ConfigLoader (same pattern as the adapter factory).
+// NewTypedCRUD creates a TypedCRUD for SLO definitions using the provided loader.
 // Returns both the CRUD instance and the config for additional operations like Prometheus queries.
-func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[Slo], internalconfig.NamespacedRESTConfig, error) {
-	var loader providers.ConfigLoader
-	loader.SetContextName(internalconfig.ContextNameFromCtx(ctx))
-
+func NewTypedCRUD(ctx context.Context, loader GrafanaConfigLoader) (*adapter.TypedCRUD[Slo], internalconfig.NamespacedRESTConfig, error) {
 	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
 		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to load REST config for SLO: %w", err)
@@ -128,7 +124,9 @@ func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[Slo], internalconfig.
 // and by SLOProvider.ResourceAdapters().
 func NewLazyFactory() adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
-		crud, _, err := NewTypedCRUD(ctx)
+		var loader providers.ConfigLoader
+		loader.SetContextName(internalconfig.ContextNameFromCtx(ctx))
+		crud, _, err := NewTypedCRUD(ctx, &loader)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/providers/slo/definitions/status.go
+++ b/internal/providers/slo/definitions/status.go
@@ -61,7 +61,7 @@ func (o *statusOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newStatusCommand() *cobra.Command {
+func newStatusCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &statusOpts{}
 	cmd := &cobra.Command{
 		Use:   "status [UUID]",
@@ -93,7 +93,7 @@ grafana_slo_* metrics.`,
 
 			ctx := cmd.Context()
 
-			crud, cfg, err := NewTypedCRUD(ctx)
+			crud, cfg, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/slo/definitions/timeline.go
+++ b/internal/providers/slo/definitions/timeline.go
@@ -70,7 +70,7 @@ func ValidateTimelineFlags(cmd *cobra.Command) error {
 	return nil
 }
 
-func newTimelineCommand() *cobra.Command {
+func newTimelineCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &timelineOpts{}
 	cmd := &cobra.Command{
 		Use:   "timeline [UUID]",
@@ -113,7 +113,7 @@ grafana_slo_sli_window metrics.`,
 
 			ctx := cmd.Context()
 
-			crud, cfg, err := NewTypedCRUD(ctx)
+			crud, cfg, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/slo/provider.go
+++ b/internal/providers/slo/provider.go
@@ -38,7 +38,7 @@ func (p *SLOProvider) Commands() []*cobra.Command {
 	// Bind config flags on the parent — all subcommands inherit these.
 	loader.BindFlags(sloCmd.PersistentFlags())
 
-	sloCmd.AddCommand(definitions.Commands())
+	sloCmd.AddCommand(definitions.Commands(loader))
 	sloCmd.AddCommand(reports.Commands(loader))
 
 	return []*cobra.Command{sloCmd}


### PR DESCRIPTION
SLO definitions commands (list, get, push, pull, delete, status, timeline) created their own `ConfigLoader` internally, ignoring the `--context` flag bound on the parent `slo` command. This meant `gcx slo definitions list --context <name>` always used the default context.

**Fix**: Mirror the pattern already used by the `reports` subpackage — accept a `GrafanaConfigLoader` interface from the parent and thread it through to `NewTypedCRUD`. The lazy factory (used by resource adapters) still creates its own loader from context, so that code path is unaffected.

## Changes

- `internal/providers/slo/definitions/commands.go` — accept `GrafanaConfigLoader` parameter instead of constructing one internally
- `internal/providers/slo/definitions/resource_adapter.go` — update adapter construction to pass the loader
- `internal/providers/slo/definitions/status.go` — same threading for status command
- `internal/providers/slo/definitions/timeline.go` — same threading for timeline command
- `internal/providers/slo/provider.go` — pass parent loader down when registering definitions commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)