### PR TITLE
chore(release): v0.2.6 changelog

### DIFF
--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,18 +1,16 @@
 
 
-- Rename `faro` CLI command to `frontend`
-- Auto-derive context name from server URL during login
-- Add OAuth experimental warning to login flow
-- Add `assistant:chat` scope to OAuth flow
-- Add HTTP traffic debug logging
-- Add Sigil generations, scores, and judge commands
-- Add latency and reachability to synth checks status
-- Add access property to datasource list and get
-- Centralized agent annotations with consistency tests
-- Fix null stream labels and missing content in log queries
-- Improve human-readable logs query output
-- Require `--instant` flag for TraceQL instant metrics
-- Fall back to `/api/ds/query` for Loki and Prometheus
-- Resolve datasources across all API groups
-- Make config edit resilient to broken configs
-- Fix invalid CLI commands in docs and skills
+- Add `--limit` flag with default pagination (50) to all list commands
+- Add retry transport for rate limiting and transient HTTP errors
+- Unified HTTP client construction with debug logging
+- Set consistent User-Agent header on all HTTP clients
+- Add `alert instances list` with server-side state filtering
+- Route OnCall requests through OAuth proxy
+- Add `skills install` command for .agents-compatible harnesses
+- Add `--expr` flag alias for datasource query commands
+- Add curl-pipe installer script with shell-specific PATH instructions
+- Fix config context selection before env overrides in provider loaders
+- Fix SLO definitions commands not inheriting parent config loader
+- Restore shell tab-completion
+- Add Fish shell completion docs
+- Update Go and Docker dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v0.2.6 (2026-04-13)
+
+
+
+- Add `--limit` flag with default pagination (50) to all list commands
+- Add retry transport for rate limiting and transient HTTP errors
+- Unified HTTP client construction with debug logging
+- Set consistent User-Agent header on all HTTP clients
+- Add `alert instances list` with server-side state filtering
+- Route OnCall requests through OAuth proxy
+- Add `skills install` command for .agents-compatible harnesses
+- Add `--expr` flag alias for datasource query commands
+- Add curl-pipe installer script with shell-specific PATH instructions
+- Fix config context selection before env overrides in provider loaders
+- Fix SLO definitions commands not inheriting parent config loader
+- Restore shell tab-completion
+- Add Fish shell completion docs
+- Update Go and Docker dependencies
+
+
 ## v0.2.5 (2026-04-10)
 
 


### PR DESCRIPTION
## Summary
- Patch release v0.2.6 changelog update

## Release Notes
- Add `--limit` flag with default pagination (50) to all list commands
- Add retry transport for rate limiting and transient HTTP errors
- Unified HTTP client construction with debug logging
- Set consistent User-Agent header on all HTTP clients
- Add `alert instances list` with server-side state filtering
- Route OnCall requests through OAuth proxy
- Add `skills install` command for .agents-compatible harnesses
- Add `--expr` flag alias for datasource query commands
- Add curl-pipe installer script with shell-specific PATH instructions
- Fix config context selection before env overrides in provider loaders
- Fix SLO definitions commands not inheriting parent config loader
- Restore shell tab-completion
- Add Fish shell completion docs
- Update Go and Docker dependencies

## Next steps
After merging, tag the merge commit on main:
```bash
git checkout main && git pull
git tag v0.2.6
git push origin v0.2.6
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)