### PR TITLE
Use "k6" instead of "K6" in docstrings/UI

### DIFF
--- a/.claude/skills/migrate-provider/commands-reference.md
+++ b/.claude/skills/migrate-provider/commands-reference.md
@@ -170,7 +170,7 @@ func (c *Client) setAuth(req *http.Request) {
     req.Header.Set("Authorization", "Bearer "+c.providerToken)
 }
 
-// Token exchange (e.g., K6):
+// Token exchange (e.g., k6):
 func (c *Client) setAuth(req *http.Request) {
     req.Header.Set("Authorization", "Bearer "+c.exchangedToken)
 }

--- a/.claude/skills/migrate-provider/gcx-provider-recipe.md
+++ b/.claude/skills/migrate-provider/gcx-provider-recipe.md
@@ -402,9 +402,9 @@ that only surfaced during smoke testing:
 - Cursor-based pagination: the `contextPayload` field carries the cursor value
   between pages, not a separate cursor parameter.
 
-### Token Exchange Auth (K6)
+### Token Exchange Auth (k6)
 
-- K6 uses a **separate API domain** (`api.k6.io`), not the Grafana stack URL.
+- k6 uses a **separate API domain** (`api.k6.io`), not the Grafana stack URL.
 - Auth requires a two-step token exchange: AP token → k6 v3 token via
   `PUT /v3/account/grafana-app/start` with `X-Grafana-Key`, `X-Stack-Id`,
   `X-Grafana-Service-Token` headers.
@@ -533,7 +533,7 @@ that only surfaced during smoke testing:
 - OnCall API URL discovered via GCOM, not configured directly
 - Iterator-based pagination — port the pattern, don't simplify
 
-**K6** (multi-tenant auth):
+**k6** (multi-tenant auth):
 - Two auth modes: org-level and stack-level
 - Separate API domain (not Grafana stack URL)
 - Check gcx's `k6/client_envvar_test.go` for auth resolution logic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ internal/
 │   ├── faro/       Frontend Observability provider (apps CRUD, sourcemaps sub-resource) — CLI: `gcx frontend`
 │   ├── fleet/      Fleet Management provider (pipeline and collector resources)
 │   ├── incidents/  IRM Incidents provider
-│   ├── k6/         K6 Cloud provider (projects, tests, runs, envvars)
+│   ├── k6/         k6 Cloud provider (projects, tests, runs, envvars)
 │   ├── kg/         Knowledge Graph (Asserts) provider
 │   ├── logs/       Logs signal provider (Loki queries + Adaptive Logs commands)
 │   ├── metrics/    Metrics signal provider (Prometheus queries + Adaptive Metrics commands)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -152,7 +152,7 @@ Multiple auth mechanisms for different tiers.
 | **Basic auth** | Legacy Grafana instances | Username/password in `rest.Config` |
 | **Adaptive auth** | Signal provider adaptive telemetry APIs | `internal/auth/adaptive/` — GCOM-cached Basic auth shared across signal providers |
 
-**Precedence:** Token > OAuth > user/password. Explicit flags override env vars override config file. `httputils.NewDefaultClient(ctx)` must be used for APIs outside the Grafana server (K6 Cloud, OnCall, Synth, Fleet) — the k8s transport injects the Grafana bearer token on every request, which conflicts with product-specific auth.
+**Precedence:** Token > OAuth > user/password. Explicit flags override env vars override config file. `httputils.NewDefaultClient(ctx)` must be used for APIs outside the Grafana server (k6 Cloud, OnCall, Synth, Fleet) — the k8s transport injects the Grafana bearer token on every request, which conflicts with product-specific auth.
 
 **Deep-dive:** [client-api-layer.md](docs/architecture/client-api-layer.md), [config-system.md](docs/architecture/config-system.md).
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -147,7 +147,7 @@ agent mode detection, behavior changes, and opt-out mechanisms.
   credentials independently — this ensures consistent env var precedence,
   secret handling, and auth behavior across all providers.
 - **`httputils.NewDefaultClient(ctx)` for external APIs.** Provider clients
-  calling APIs outside the Grafana server (K6 Cloud, OnCall, Synth, Fleet —
+  calling APIs outside the Grafana server (k6 Cloud, OnCall, Synth, Fleet —
   any domain other than `cfg.Host`) must use `httputils.NewDefaultClient(ctx)`,
   never `rest.HTTPClientFor()`. The k8s transport round-tripper injects the
   Grafana bearer token on every outgoing request, which conflicts with the

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ gcx closes that gap. It connects your editor to your entire Grafana Cloud produc
 - **Grafana Assistant integration** — automated root-cause analysis, investigation summaries, and remediation suggestions powered by the Assistant
 - **Production-aware development** — query live metrics, logs, and traces without leaving your editor
 - **AI agent native** — JSON/YAML output, structured errors, predictable exit codes. Agent mode auto-detected for Claude Code, Copilot, Cursor, and others
-- **Full Grafana Cloud access** — dashboards, alerting, SLOs, Synthetic Monitoring, OnCall, K6, Fleet Management, Incidents, and more from a single CLI
+- **Full Grafana Cloud access** — dashboards, alerting, SLOs, Synthetic Monitoring, OnCall, k6, Fleet Management, Incidents, and more from a single CLI
 - **GitOps & CI/CD** — pull resources to files, version in git, push back with full round-trip fidelity
 - **Observability as code** — scaffold projects, import dashboards, lint with Rego rules, live-reload dev server
 - **Multi-environment** — named contexts to switch between dev, staging, and production
@@ -212,7 +212,7 @@ gcx provides dedicated commands for each Grafana Cloud product:
 | **Synthetic Monitoring** | `gcx synth` | `synth checks list`, `synth probes list` |
 | **OnCall** | `gcx oncall` | `oncall schedules list`, `oncall integrations list` |
 | **Alerting** | `gcx alert` | `alert rules list`, `alert groups list` |
-| **K6 Cloud** | `gcx k6` | `k6 load-tests list`, `k6 runs list` |
+| **k6 Cloud** | `gcx k6` | `k6 load-tests list`, `k6 runs list` |
 | **Fleet Management** | `gcx fleet` | `fleet pipelines list`, `fleet collectors list` |
 | **IRM Incidents** | `gcx incidents` | `incidents list`, `incidents create -f incident.yaml` |
 | **Knowledge Graph** | `gcx kg` | `kg status`, `kg search`, `kg entities show` |

--- a/VISION.md
+++ b/VISION.md
@@ -10,7 +10,7 @@ Grafana Cloud and the Grafana Assistant — in your terminal and your agentic co
 
 Agentic coding tools have changed how developers build software. But they're flying blind — code ships, observability comes later (if at all). Production context lives in Grafana dashboards, alert rules, and SLO definitions. Developer context lives in the editor. The two don't talk to each other.
 
-Meanwhile, Grafana Cloud has grown into a platform with dozens of products — SLOs, Synthetic Monitoring, OnCall, Fleet Management, K6, Incidents, Knowledge Graph, Adaptive Telemetry — each with its own API, its own auth story, its own CLI gap. Managing them requires context-switching between web UIs, curl commands, and Terraform configs.
+Meanwhile, Grafana Cloud has grown into a platform with dozens of products — SLOs, Synthetic Monitoring, OnCall, Fleet Management, k6, Incidents, Knowledge Graph, Adaptive Telemetry — each with its own API, its own auth story, its own CLI gap. Managing them requires context-switching between web UIs, curl commands, and Terraform configs.
 
 ## The Solution
 

--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -52,7 +52,7 @@ right group:
 | Alert rules and groups | `alert` | `gcx alert rules list` |
 | Synthetic Monitoring checks | `synth` | `gcx synth checks list` |
 | OnCall schedules, integrations | `oncall` | `gcx oncall schedules list` |
-| K6 load tests, projects, runs | `k6` | `gcx k6 load-tests list` |
+| k6 load tests, projects, runs | `k6` | `gcx k6 load-tests list` |
 | PromQL / Adaptive Metrics | `metrics` | `gcx metrics query 'up'` |
 | LogQL / Adaptive Logs | `logs` | `gcx logs query '{app="foo"}'` |
 | Profiling (Pyroscope) | `profiles` | `gcx profiles query` |

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -82,7 +82,7 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:           path.Base(os.Args[0]),
 		Short:         "Control plane for Grafana Cloud operations",
-		Long:          "gcx is a unified CLI for managing Grafana resources, dashboards, datasources, alerting, and Cloud product APIs (SLO, OnCall, Synthetic Monitoring, Fleet, K6, and more).",
+		Long:          "gcx is a unified CLI for managing Grafana resources, dashboards, datasources, alerting, and Cloud product APIs (SLO, OnCall, Synthetic Monitoring, Fleet, k6, and more).",
 		SilenceUsage:  true,
 		SilenceErrors: true, // We want to print errors ourselves
 		Version:       version,

--- a/docs/adrs/cloud-rest-config/001-cloud-config-and-gcom.md
+++ b/docs/adrs/cloud-rest-config/001-cloud-config-and-gcom.md
@@ -7,11 +7,11 @@
 
 ## Context
 
-gcx's config system was designed for Grafana instance auth: a single `grafana.server` URL + bearer token per context. Cloud providers (Fleet Management, OnCall, K6) need a different auth model:
+gcx's config system was designed for Grafana instance auth: a single `grafana.server` URL + bearer token per context. Cloud providers (Fleet Management, OnCall, k6) need a different auth model:
 
 - They authenticate with a **Grafana Cloud access policy token**, not a Grafana instance token.
 - Their service URLs are not static — they must be **discovered per stack** via the GCOM API (grafana.com).
-- Each provider was solving this independently: Fleet had `LoadFleetConfig` with its own `FLEET_URL`/`FLEET_TOKEN` env vars; OnCall and K6 were expected to do the same.
+- Each provider was solving this independently: Fleet had `LoadFleetConfig` with its own `FLEET_URL`/`FLEET_TOKEN` env vars; OnCall and k6 were expected to do the same.
 
 This created three problems:
 1. **No shared auth primitive** — every cloud provider would need its own config keys, env vars, and loader.

--- a/docs/adrs/provider-consolidation/001-consolidation-strategy.md
+++ b/docs/adrs/provider-consolidation/001-consolidation-strategy.md
@@ -9,7 +9,7 @@
 
 Two Grafana CLIs exist with complementary strengths:
 
-- **Cloud CLI** — broad product coverage (OnCall, K6, Fleet, Incidents, Knowledge Graph, ML, SCIM, etc.) and a polished agentic UX (agent annotations, `commands` JSON tree, agent-card, audit logging). Architecture is provider-per-command with hand-written adapters.
+- **Cloud CLI** — broad product coverage (OnCall, k6, Fleet, Incidents, Knowledge Graph, ML, SCIM, etc.) and a polished agentic UX (agent annotations, `commands` JSON tree, agent-card, audit logging). Architecture is provider-per-command with hand-written adapters.
 - **gcx** — solid architecture (K8s-compatible API tier, pluggable `Provider` + `ResourceAdapter` pattern, `TypedCRUD[T]` generic, push/pull/diff pipelines) but narrower product coverage (K8s-native resources only: dashboards, folders, datasources, alert rules, SLOs, synth).
 
 The team needs a **single CLI for GrafanaCon 2026** — one binary that covers all Grafana Cloud products with gcx's architectural discipline.
@@ -69,7 +69,7 @@ Work proceeds in dependency order, not by product:
 ```
 Phase 0: Foundation — TypedCRUD[T] generic (already built)
     ↓
-Phase 1: Complex Providers (OnCall, K6, Fleet, Incidents, KG, ML, SCIM, GCom)
+Phase 1: Complex Providers (OnCall, k6, Fleet, Incidents, KG, ML, SCIM, GCom)
     ↓ (parallelizable)
 Phase 2: UX/AX (agent annotations, commands tree, audit logging, config enhancements)
     ↓
@@ -102,7 +102,7 @@ Phase 1 and 2 are parallelizable. GrafanaCon critical path: Phase 0 (done) + Pha
 ### Negative
 - The cloud CLI's agentic UX features (agent annotations, `commands` tree, audit logging) must be ported into gcx — they don't come for free
 - Cloud CLI users must migrate to gcx; the cloud CLI will be deprecated
-- Complex providers (OnCall with 17 resource types, K6 with multi-tenant auth) require bespoke TypedCRUD wiring patterns
+- Complex providers (OnCall with 17 resource types, k6 with multi-tenant auth) require bespoke TypedCRUD wiring patterns
 
 ### Neutral
 - Cloud CLI resource clients are ported as-is; API types and HTTP clients are preserved

--- a/docs/adrs/typed-resource-adapter-compliance/001-typed-resource-adapter-foundation.md
+++ b/docs/adrs/typed-resource-adapter-compliance/001-typed-resource-adapter-foundation.md
@@ -216,7 +216,7 @@ spec map level and requires JSON→map→delete. The approach is hybrid:
   coexist until `StripFields` is resolved at a higher level.
 - **Provider command migration is breadth work**: ~8 providers, each with multiple CRUD
   commands. Mechanical but touches many files. Atomic commits per provider mitigate risk.
-- **`SetResourceName` error swallowing**: K6 and synth types with int IDs silently
+- **`SetResourceName` error swallowing**: k6 and synth types with int IDs silently
   discard parse errors, matching current `RestoreNameFn` behavior but baked into a
   formal interface.
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -4,7 +4,7 @@
 
 ## Executive Summary
 
-- **gcx is a unified CLI for managing Grafana resources** operating in two tiers: (1) a K8s resource tier using Grafana 12+'s Kubernetes-compatible API via `k8s.io/client-go` for dashboards, folders, and other K8s-native resources; (2) a Cloud provider tier with pluggable providers for Grafana Cloud products (SLO, Synthetic Monitoring, OnCall, Fleet Management, K6 Cloud, Knowledge Graph, IRM Incidents, Alerting) that use product-specific REST APIs.
+- **gcx is a unified CLI for managing Grafana resources** operating in two tiers: (1) a K8s resource tier using Grafana 12+'s Kubernetes-compatible API via `k8s.io/client-go` for dashboards, folders, and other K8s-native resources; (2) a Cloud provider tier with pluggable providers for Grafana Cloud products (SLO, Synthetic Monitoring, OnCall, Fleet Management, k6 Cloud, Knowledge Graph, IRM Incidents, Alerting) that use product-specific REST APIs.
 - **The architecture is a clean layered monolith** with strict separation: CLI wiring (`cmd/`) holds no business logic; all domain logic lives in `internal/` organized by feature (config, resources, server, providers).
 - **Context-based multi-environment configuration** follows the kubectl kubeconfig pattern, enabling management of multiple Grafana instances (dev, staging, prod, cloud) from a single config file.
 - **A composable processor pipeline** transforms resources during push and pull, keeping I/O and transformation concerns decoupled.
@@ -741,13 +741,13 @@ Each LGTM signal has its own provider in `internal/providers/{signal}/` that reg
 | `internal/setup/instrumentation/client.go` | Instrumentation API client (GET/SET app/k8s, discovery, monitoring) |
 | `internal/setup/instrumentation/compare.go` | Optimistic lock diff comparison logic |
 
-### K6 Cloud Provider
+### k6 Cloud Provider
 
 | File | Purpose |
 |------|---------|
 | `internal/providers/k6/provider.go` | `K6Provider` implementing the `providers.Provider` interface |
-| `internal/providers/k6/client.go` | K6 Cloud REST client (token exchange auth, projects, tests, runs, envvars) |
-| `internal/providers/k6/commands.go` | K6 CLI commands (projects, tests, runs, envvars, token) |
+| `internal/providers/k6/client.go` | k6 Cloud REST client (token exchange auth, projects, tests, runs, envvars) |
+| `internal/providers/k6/commands.go` | k6 CLI commands (projects, tests, runs, envvars, token) |
 | `internal/providers/k6/resource_adapter.go` | Resource adapter for k6 projects |
 
 ### IRM Incidents Provider

--- a/docs/architecture/client-api-layer.md
+++ b/docs/architecture/client-api-layer.md
@@ -429,7 +429,7 @@ dynamic client gets User-Agent through `rest.Config.UserAgent`.
 
 | Caller | Factory | Notes |
 |--------|---------|-------|
-| Provider clients (SLO, OnCall, Synth, Fleet, K6) | `NewDefaultClient(ctx)` | Via `CloudRESTConfig.HTTPClient(ctx)` when `RESTConfig` is nil; see note below |
+| Provider clients (SLO, OnCall, Synth, Fleet, k6) | `NewDefaultClient(ctx)` | Via `CloudRESTConfig.HTTPClient(ctx)` when `RESTConfig` is nil; see note below |
 | Assistant client | `NewDefaultClient(ctx)` | Direct call |
 | K8s tier (dynamic client, query clients) | `rest.Config.WrapTransport` | Chains `LoggingRoundTripper` via `NewNamespacedRESTConfig` |
 | Dev server (`internal/server`) | `NewClient(ClientOpts{...})` | Custom TLS from config context |

--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -257,10 +257,10 @@ query/stream endpoints that return Grafana-native response formats, not
 all three client paths without duplication.
 
 **Contrast with external APIs:** Provider clients calling **external** APIs
-(K6 Cloud, OnCall, Synth, Fleet — domains outside the Grafana server) must
+(k6 Cloud, OnCall, Synth, Fleet — domains outside the Grafana server) must
 **not** use `rest.HTTPClientFor`. The k8s transport round-tripper injects the
 Grafana bearer token on every outgoing request, which conflicts with the
-product's own auth mechanism (e.g. OnCall raw token, K6 X-Grafana-Key).
+product's own auth mechanism (e.g. OnCall raw token, k6 X-Grafana-Key).
 These providers use `httputils.NewDefaultClient(ctx)` — a fresh `*http.Client`
 per call with `LoggingRoundTripper` and no auth injection — and set their own
 auth headers per request.

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -59,7 +59,7 @@ gcx/
 │   │   ├── faro/             # Frontend Observability provider (apps CRUD, sourcemaps sub-resource) — CLI: `gcx frontend`
 │   │   ├── fleet/            # Fleet Management provider (pipeline and collector resources)
 │   │   ├── incidents/        # IRM Incidents provider
-│   │   ├── k6/              # K6 Cloud provider (projects, tests, runs, envvars)
+│   │   ├── k6/              # k6 Cloud provider (projects, tests, runs, envvars)
 │   │   ├── kg/               # Knowledge Graph (Asserts) provider
 │   │   ├── oncall/           # OnCall provider (schedules, integrations, escalation chains)
 │   │   ├── slo/              # SLO provider implementation

--- a/docs/design/naming.md
+++ b/docs/design/naming.md
@@ -58,3 +58,8 @@ code comments.
 
 See [environment-variables.md](environment-variables.md) for the canonical env var naming reference.
 See [patterns.md § Provider ConfigLoader](../architecture/patterns.md#provider-configloader) for how config key names map to env vars.
+
+### 9.6 Branding Consistency
+
+For k6-related tools specifically, make sure to use "k6" (lowercase "k") and not "K6". This is only relevant for docstrings, documentation and other user-facing strings.
+Examples: "k6 Open Source", "k6 Cloud".

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -4,7 +4,7 @@ Control plane for Grafana Cloud operations
 
 ### Synopsis
 
-gcx is a unified CLI for managing Grafana resources, dashboards, datasources, alerting, and Cloud product APIs (SLO, OnCall, Synthetic Monitoring, Fleet, K6, and more).
+gcx is a unified CLI for managing Grafana resources, dashboards, datasources, alerting, and Cloud product APIs (SLO, OnCall, Synthetic Monitoring, Fleet, k6, and more).
 
 ### Options
 
@@ -35,7 +35,7 @@ gcx is a unified CLI for managing Grafana resources, dashboards, datasources, al
 * [gcx frontend](gcx_frontend.md)	 - Manage Grafana Frontend Observability resources
 * [gcx help-tree](gcx_help-tree.md)	 - Print a compact command tree for agent context injection
 * [gcx incidents](gcx_incidents.md)	 - Manage Grafana Incident Response and Management (IRM) incidents
-* [gcx k6](gcx_k6.md)	 - Manage Grafana K6 Cloud projects, load tests, and schedules
+* [gcx k6](gcx_k6.md)	 - Manage Grafana k6 Cloud projects, load tests, and schedules
 * [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph entity types, rules, and datasets
 * [gcx logs](gcx_logs.md)	 - Query Loki datasources and manage Adaptive Logs
 * [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics

--- a/docs/reference/cli/gcx_k6.md
+++ b/docs/reference/cli/gcx_k6.md
@@ -1,6 +1,6 @@
 ## gcx k6
 
-Manage Grafana K6 Cloud projects, load tests, and schedules
+Manage Grafana k6 Cloud projects, load tests, and schedules
 
 ### Options
 
@@ -23,12 +23,12 @@ Manage Grafana K6 Cloud projects, load tests, and schedules
 ### SEE ALSO
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
-* [gcx k6 auth](gcx_k6_auth.md)	 - K6 authentication commands.
-* [gcx k6 env-vars](gcx_k6_env-vars.md)	 - Manage K6 Cloud environment variables.
-* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage K6 Cloud load tests.
-* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage K6 private load zones.
-* [gcx k6 projects](gcx_k6_projects.md)	 - Manage K6 Cloud projects.
-* [gcx k6 runs](gcx_k6_runs.md)	 - Manage K6 test runs.
-* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage K6 Cloud schedules.
+* [gcx k6 auth](gcx_k6_auth.md)	 - k6 authentication commands.
+* [gcx k6 env-vars](gcx_k6_env-vars.md)	 - Manage k6 Cloud environment variables.
+* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage k6 Cloud load tests.
+* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage k6 private load zones.
+* [gcx k6 projects](gcx_k6_projects.md)	 - Manage k6 Cloud projects.
+* [gcx k6 runs](gcx_k6_runs.md)	 - Manage k6 test runs.
+* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage k6 Cloud schedules.
 * [gcx k6 test-run](gcx_k6_test-run.md)	 - Manage k6 TestRun CRD manifests.
 

--- a/docs/reference/cli/gcx_k6_auth.md
+++ b/docs/reference/cli/gcx_k6_auth.md
@@ -1,6 +1,6 @@
 ## gcx k6 auth
 
-K6 authentication commands.
+k6 authentication commands.
 
 ### Options
 
@@ -22,6 +22,6 @@ K6 authentication commands.
 
 ### SEE ALSO
 
-* [gcx k6](gcx_k6.md)	 - Manage Grafana K6 Cloud projects, load tests, and schedules
+* [gcx k6](gcx_k6.md)	 - Manage Grafana k6 Cloud projects, load tests, and schedules
 * [gcx k6 auth token](gcx_k6_auth_token.md)	 - Print the authenticated k6 API token.
 

--- a/docs/reference/cli/gcx_k6_auth_token.md
+++ b/docs/reference/cli/gcx_k6_auth_token.md
@@ -26,5 +26,5 @@ gcx k6 auth token [flags]
 
 ### SEE ALSO
 
-* [gcx k6 auth](gcx_k6_auth.md)	 - K6 authentication commands.
+* [gcx k6 auth](gcx_k6_auth.md)	 - k6 authentication commands.
 

--- a/docs/reference/cli/gcx_k6_env-vars.md
+++ b/docs/reference/cli/gcx_k6_env-vars.md
@@ -1,6 +1,6 @@
 ## gcx k6 env-vars
 
-Manage K6 Cloud environment variables.
+Manage k6 Cloud environment variables.
 
 ### Options
 
@@ -22,9 +22,9 @@ Manage K6 Cloud environment variables.
 
 ### SEE ALSO
 
-* [gcx k6](gcx_k6.md)	 - Manage Grafana K6 Cloud projects, load tests, and schedules
-* [gcx k6 env-vars create](gcx_k6_env-vars_create.md)	 - Create a K6 environment variable from a file.
-* [gcx k6 env-vars delete](gcx_k6_env-vars_delete.md)	 - Delete a K6 environment variable.
-* [gcx k6 env-vars list](gcx_k6_env-vars_list.md)	 - List K6 environment variables.
-* [gcx k6 env-vars update](gcx_k6_env-vars_update.md)	 - Update a K6 environment variable.
+* [gcx k6](gcx_k6.md)	 - Manage Grafana k6 Cloud projects, load tests, and schedules
+* [gcx k6 env-vars create](gcx_k6_env-vars_create.md)	 - Create a k6 environment variable from a file.
+* [gcx k6 env-vars delete](gcx_k6_env-vars_delete.md)	 - Delete a k6 environment variable.
+* [gcx k6 env-vars list](gcx_k6_env-vars_list.md)	 - List k6 environment variables.
+* [gcx k6 env-vars update](gcx_k6_env-vars_update.md)	 - Update a k6 environment variable.
 

--- a/docs/reference/cli/gcx_k6_env-vars_create.md
+++ b/docs/reference/cli/gcx_k6_env-vars_create.md
@@ -1,6 +1,6 @@
 ## gcx k6 env-vars create
 
-Create a K6 environment variable from a file.
+Create a k6 environment variable from a file.
 
 ```
 gcx k6 env-vars create [flags]
@@ -27,5 +27,5 @@ gcx k6 env-vars create [flags]
 
 ### SEE ALSO
 
-* [gcx k6 env-vars](gcx_k6_env-vars.md)	 - Manage K6 Cloud environment variables.
+* [gcx k6 env-vars](gcx_k6_env-vars.md)	 - Manage k6 Cloud environment variables.
 

--- a/docs/reference/cli/gcx_k6_env-vars_delete.md
+++ b/docs/reference/cli/gcx_k6_env-vars_delete.md
@@ -1,6 +1,6 @@
 ## gcx k6 env-vars delete
 
-Delete a K6 environment variable.
+Delete a k6 environment variable.
 
 ```
 gcx k6 env-vars delete <id> [flags]
@@ -26,5 +26,5 @@ gcx k6 env-vars delete <id> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 env-vars](gcx_k6_env-vars.md)	 - Manage K6 Cloud environment variables.
+* [gcx k6 env-vars](gcx_k6_env-vars.md)	 - Manage k6 Cloud environment variables.
 

--- a/docs/reference/cli/gcx_k6_env-vars_list.md
+++ b/docs/reference/cli/gcx_k6_env-vars_list.md
@@ -1,6 +1,6 @@
 ## gcx k6 env-vars list
 
-List K6 environment variables.
+List k6 environment variables.
 
 ```
 gcx k6 env-vars list [flags]
@@ -29,5 +29,5 @@ gcx k6 env-vars list [flags]
 
 ### SEE ALSO
 
-* [gcx k6 env-vars](gcx_k6_env-vars.md)	 - Manage K6 Cloud environment variables.
+* [gcx k6 env-vars](gcx_k6_env-vars.md)	 - Manage k6 Cloud environment variables.
 

--- a/docs/reference/cli/gcx_k6_env-vars_update.md
+++ b/docs/reference/cli/gcx_k6_env-vars_update.md
@@ -1,6 +1,6 @@
 ## gcx k6 env-vars update
 
-Update a K6 environment variable.
+Update a k6 environment variable.
 
 ```
 gcx k6 env-vars update <id> [flags]
@@ -27,5 +27,5 @@ gcx k6 env-vars update <id> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 env-vars](gcx_k6_env-vars.md)	 - Manage K6 Cloud environment variables.
+* [gcx k6 env-vars](gcx_k6_env-vars.md)	 - Manage k6 Cloud environment variables.
 

--- a/docs/reference/cli/gcx_k6_load-tests.md
+++ b/docs/reference/cli/gcx_k6_load-tests.md
@@ -1,6 +1,6 @@
 ## gcx k6 load-tests
 
-Manage K6 Cloud load tests.
+Manage k6 Cloud load tests.
 
 ### Options
 
@@ -22,11 +22,11 @@ Manage K6 Cloud load tests.
 
 ### SEE ALSO
 
-* [gcx k6](gcx_k6.md)	 - Manage Grafana K6 Cloud projects, load tests, and schedules
-* [gcx k6 load-tests create](gcx_k6_load-tests_create.md)	 - Create a new K6 load test.
-* [gcx k6 load-tests delete](gcx_k6_load-tests_delete.md)	 - Delete a K6 load test.
-* [gcx k6 load-tests get](gcx_k6_load-tests_get.md)	 - Get a single K6 load test by ID or name.
-* [gcx k6 load-tests list](gcx_k6_load-tests_list.md)	 - List K6 Cloud load tests.
-* [gcx k6 load-tests update](gcx_k6_load-tests_update.md)	 - Update a K6 load test from a file.
-* [gcx k6 load-tests update-script](gcx_k6_load-tests_update-script.md)	 - Update the script of a K6 load test from a file.
+* [gcx k6](gcx_k6.md)	 - Manage Grafana k6 Cloud projects, load tests, and schedules
+* [gcx k6 load-tests create](gcx_k6_load-tests_create.md)	 - Create a new k6 load test.
+* [gcx k6 load-tests delete](gcx_k6_load-tests_delete.md)	 - Delete a k6 load test.
+* [gcx k6 load-tests get](gcx_k6_load-tests_get.md)	 - Get a single k6 load test by ID or name.
+* [gcx k6 load-tests list](gcx_k6_load-tests_list.md)	 - List k6 Cloud load tests.
+* [gcx k6 load-tests update](gcx_k6_load-tests_update.md)	 - Update a k6 load test from a file.
+* [gcx k6 load-tests update-script](gcx_k6_load-tests_update-script.md)	 - Update the script of a k6 load test from a file.
 

--- a/docs/reference/cli/gcx_k6_load-tests_create.md
+++ b/docs/reference/cli/gcx_k6_load-tests_create.md
@@ -1,6 +1,6 @@
 ## gcx k6 load-tests create
 
-Create a new K6 load test.
+Create a new k6 load test.
 
 ```
 gcx k6 load-tests create [flags]
@@ -32,5 +32,5 @@ gcx k6 load-tests create [flags]
 
 ### SEE ALSO
 
-* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage K6 Cloud load tests.
+* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage k6 Cloud load tests.
 

--- a/docs/reference/cli/gcx_k6_load-tests_delete.md
+++ b/docs/reference/cli/gcx_k6_load-tests_delete.md
@@ -1,6 +1,6 @@
 ## gcx k6 load-tests delete
 
-Delete a K6 load test.
+Delete a k6 load test.
 
 ```
 gcx k6 load-tests delete <id> [flags]
@@ -26,5 +26,5 @@ gcx k6 load-tests delete <id> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage K6 Cloud load tests.
+* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage k6 Cloud load tests.
 

--- a/docs/reference/cli/gcx_k6_load-tests_get.md
+++ b/docs/reference/cli/gcx_k6_load-tests_get.md
@@ -1,6 +1,6 @@
 ## gcx k6 load-tests get
 
-Get a single K6 load test by ID or name.
+Get a single k6 load test by ID or name.
 
 ```
 gcx k6 load-tests get <id-or-name> [flags]
@@ -29,5 +29,5 @@ gcx k6 load-tests get <id-or-name> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage K6 Cloud load tests.
+* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage k6 Cloud load tests.
 

--- a/docs/reference/cli/gcx_k6_load-tests_list.md
+++ b/docs/reference/cli/gcx_k6_load-tests_list.md
@@ -1,6 +1,6 @@
 ## gcx k6 load-tests list
 
-List K6 Cloud load tests.
+List k6 Cloud load tests.
 
 ```
 gcx k6 load-tests list [flags]
@@ -30,5 +30,5 @@ gcx k6 load-tests list [flags]
 
 ### SEE ALSO
 
-* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage K6 Cloud load tests.
+* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage k6 Cloud load tests.
 

--- a/docs/reference/cli/gcx_k6_load-tests_update-script.md
+++ b/docs/reference/cli/gcx_k6_load-tests_update-script.md
@@ -1,6 +1,6 @@
 ## gcx k6 load-tests update-script
 
-Update the script of a K6 load test from a file.
+Update the script of a k6 load test from a file.
 
 ```
 gcx k6 load-tests update-script <id> [flags]
@@ -27,5 +27,5 @@ gcx k6 load-tests update-script <id> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage K6 Cloud load tests.
+* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage k6 Cloud load tests.
 

--- a/docs/reference/cli/gcx_k6_load-tests_update.md
+++ b/docs/reference/cli/gcx_k6_load-tests_update.md
@@ -1,6 +1,6 @@
 ## gcx k6 load-tests update
 
-Update a K6 load test from a file.
+Update a k6 load test from a file.
 
 ```
 gcx k6 load-tests update <id> [flags]
@@ -27,5 +27,5 @@ gcx k6 load-tests update <id> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage K6 Cloud load tests.
+* [gcx k6 load-tests](gcx_k6_load-tests.md)	 - Manage k6 Cloud load tests.
 

--- a/docs/reference/cli/gcx_k6_load-zones.md
+++ b/docs/reference/cli/gcx_k6_load-zones.md
@@ -1,6 +1,6 @@
 ## gcx k6 load-zones
 
-Manage K6 private load zones.
+Manage k6 private load zones.
 
 ### Options
 
@@ -22,10 +22,10 @@ Manage K6 private load zones.
 
 ### SEE ALSO
 
-* [gcx k6](gcx_k6.md)	 - Manage Grafana K6 Cloud projects, load tests, and schedules
+* [gcx k6](gcx_k6.md)	 - Manage Grafana k6 Cloud projects, load tests, and schedules
 * [gcx k6 load-zones allowed-load-zones](gcx_k6_load-zones_allowed-load-zones.md)	 - Manage load zones allowed for a project.
 * [gcx k6 load-zones allowed-projects](gcx_k6_load-zones_allowed-projects.md)	 - Manage projects allowed to use a load zone.
 * [gcx k6 load-zones create](gcx_k6_load-zones_create.md)	 - Register a Private Load Zone.
 * [gcx k6 load-zones delete](gcx_k6_load-zones_delete.md)	 - Deregister a Private Load Zone.
-* [gcx k6 load-zones list](gcx_k6_load-zones_list.md)	 - List all K6 load zones.
+* [gcx k6 load-zones list](gcx_k6_load-zones_list.md)	 - List all k6 load zones.
 

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones.md
@@ -22,7 +22,7 @@ Manage load zones allowed for a project.
 
 ### SEE ALSO
 
-* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage K6 private load zones.
+* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage k6 private load zones.
 * [gcx k6 load-zones allowed-load-zones list](gcx_k6_load-zones_allowed-load-zones_list.md)	 - List load zones allowed for a project.
 * [gcx k6 load-zones allowed-load-zones update](gcx_k6_load-zones_allowed-load-zones_update.md)	 - Update load zones allowed for a project.
 

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-projects.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-projects.md
@@ -22,7 +22,7 @@ Manage projects allowed to use a load zone.
 
 ### SEE ALSO
 
-* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage K6 private load zones.
+* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage k6 private load zones.
 * [gcx k6 load-zones allowed-projects list](gcx_k6_load-zones_allowed-projects_list.md)	 - List projects allowed to use a load zone.
 * [gcx k6 load-zones allowed-projects update](gcx_k6_load-zones_allowed-projects_update.md)	 - Update projects allowed to use a load zone.
 

--- a/docs/reference/cli/gcx_k6_load-zones_create.md
+++ b/docs/reference/cli/gcx_k6_load-zones_create.md
@@ -31,5 +31,5 @@ gcx k6 load-zones create [flags]
 
 ### SEE ALSO
 
-* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage K6 private load zones.
+* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage k6 private load zones.
 

--- a/docs/reference/cli/gcx_k6_load-zones_delete.md
+++ b/docs/reference/cli/gcx_k6_load-zones_delete.md
@@ -26,5 +26,5 @@ gcx k6 load-zones delete <name> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage K6 private load zones.
+* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage k6 private load zones.
 

--- a/docs/reference/cli/gcx_k6_load-zones_list.md
+++ b/docs/reference/cli/gcx_k6_load-zones_list.md
@@ -1,6 +1,6 @@
 ## gcx k6 load-zones list
 
-List all K6 load zones.
+List all k6 load zones.
 
 ```
 gcx k6 load-zones list [flags]
@@ -29,5 +29,5 @@ gcx k6 load-zones list [flags]
 
 ### SEE ALSO
 
-* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage K6 private load zones.
+* [gcx k6 load-zones](gcx_k6_load-zones.md)	 - Manage k6 private load zones.
 

--- a/docs/reference/cli/gcx_k6_projects.md
+++ b/docs/reference/cli/gcx_k6_projects.md
@@ -1,6 +1,6 @@
 ## gcx k6 projects
 
-Manage K6 Cloud projects.
+Manage k6 Cloud projects.
 
 ### Options
 
@@ -22,10 +22,10 @@ Manage K6 Cloud projects.
 
 ### SEE ALSO
 
-* [gcx k6](gcx_k6.md)	 - Manage Grafana K6 Cloud projects, load tests, and schedules
-* [gcx k6 projects create](gcx_k6_projects_create.md)	 - Create a new K6 project from a file.
-* [gcx k6 projects delete](gcx_k6_projects_delete.md)	 - Delete a K6 project.
-* [gcx k6 projects get](gcx_k6_projects_get.md)	 - Get a single K6 project by ID or name.
-* [gcx k6 projects list](gcx_k6_projects_list.md)	 - List K6 Cloud projects.
-* [gcx k6 projects update](gcx_k6_projects_update.md)	 - Update a K6 project.
+* [gcx k6](gcx_k6.md)	 - Manage Grafana k6 Cloud projects, load tests, and schedules
+* [gcx k6 projects create](gcx_k6_projects_create.md)	 - Create a new k6 project from a file.
+* [gcx k6 projects delete](gcx_k6_projects_delete.md)	 - Delete a k6 project.
+* [gcx k6 projects get](gcx_k6_projects_get.md)	 - Get a single k6 project by ID or name.
+* [gcx k6 projects list](gcx_k6_projects_list.md)	 - List k6 Cloud projects.
+* [gcx k6 projects update](gcx_k6_projects_update.md)	 - Update a k6 project.
 

--- a/docs/reference/cli/gcx_k6_projects_create.md
+++ b/docs/reference/cli/gcx_k6_projects_create.md
@@ -1,6 +1,6 @@
 ## gcx k6 projects create
 
-Create a new K6 project from a file.
+Create a new k6 project from a file.
 
 ```
 gcx k6 projects create [flags]
@@ -29,5 +29,5 @@ gcx k6 projects create [flags]
 
 ### SEE ALSO
 
-* [gcx k6 projects](gcx_k6_projects.md)	 - Manage K6 Cloud projects.
+* [gcx k6 projects](gcx_k6_projects.md)	 - Manage k6 Cloud projects.
 

--- a/docs/reference/cli/gcx_k6_projects_delete.md
+++ b/docs/reference/cli/gcx_k6_projects_delete.md
@@ -1,6 +1,6 @@
 ## gcx k6 projects delete
 
-Delete a K6 project.
+Delete a k6 project.
 
 ```
 gcx k6 projects delete <id-or-name> [flags]
@@ -26,5 +26,5 @@ gcx k6 projects delete <id-or-name> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 projects](gcx_k6_projects.md)	 - Manage K6 Cloud projects.
+* [gcx k6 projects](gcx_k6_projects.md)	 - Manage k6 Cloud projects.
 

--- a/docs/reference/cli/gcx_k6_projects_get.md
+++ b/docs/reference/cli/gcx_k6_projects_get.md
@@ -1,6 +1,6 @@
 ## gcx k6 projects get
 
-Get a single K6 project by ID or name.
+Get a single k6 project by ID or name.
 
 ```
 gcx k6 projects get <id-or-name> [flags]
@@ -28,5 +28,5 @@ gcx k6 projects get <id-or-name> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 projects](gcx_k6_projects.md)	 - Manage K6 Cloud projects.
+* [gcx k6 projects](gcx_k6_projects.md)	 - Manage k6 Cloud projects.
 

--- a/docs/reference/cli/gcx_k6_projects_list.md
+++ b/docs/reference/cli/gcx_k6_projects_list.md
@@ -1,6 +1,6 @@
 ## gcx k6 projects list
 
-List K6 Cloud projects.
+List k6 Cloud projects.
 
 ```
 gcx k6 projects list [flags]
@@ -29,5 +29,5 @@ gcx k6 projects list [flags]
 
 ### SEE ALSO
 
-* [gcx k6 projects](gcx_k6_projects.md)	 - Manage K6 Cloud projects.
+* [gcx k6 projects](gcx_k6_projects.md)	 - Manage k6 Cloud projects.
 

--- a/docs/reference/cli/gcx_k6_projects_update.md
+++ b/docs/reference/cli/gcx_k6_projects_update.md
@@ -1,6 +1,6 @@
 ## gcx k6 projects update
 
-Update a K6 project.
+Update a k6 project.
 
 ```
 gcx k6 projects update <id-or-name> [flags]
@@ -27,5 +27,5 @@ gcx k6 projects update <id-or-name> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 projects](gcx_k6_projects.md)	 - Manage K6 Cloud projects.
+* [gcx k6 projects](gcx_k6_projects.md)	 - Manage k6 Cloud projects.
 

--- a/docs/reference/cli/gcx_k6_runs.md
+++ b/docs/reference/cli/gcx_k6_runs.md
@@ -1,6 +1,6 @@
 ## gcx k6 runs
 
-Manage K6 test runs.
+Manage k6 test runs.
 
 ### Options
 
@@ -22,6 +22,6 @@ Manage K6 test runs.
 
 ### SEE ALSO
 
-* [gcx k6](gcx_k6.md)	 - Manage Grafana K6 Cloud projects, load tests, and schedules
+* [gcx k6](gcx_k6.md)	 - Manage Grafana k6 Cloud projects, load tests, and schedules
 * [gcx k6 runs list](gcx_k6_runs_list.md)	 - List test runs for a load test.
 

--- a/docs/reference/cli/gcx_k6_runs_list.md
+++ b/docs/reference/cli/gcx_k6_runs_list.md
@@ -31,5 +31,5 @@ gcx k6 runs list [id-or-name] [flags]
 
 ### SEE ALSO
 
-* [gcx k6 runs](gcx_k6_runs.md)	 - Manage K6 test runs.
+* [gcx k6 runs](gcx_k6_runs.md)	 - Manage k6 test runs.
 

--- a/docs/reference/cli/gcx_k6_schedules.md
+++ b/docs/reference/cli/gcx_k6_schedules.md
@@ -1,6 +1,6 @@
 ## gcx k6 schedules
 
-Manage K6 Cloud schedules.
+Manage k6 Cloud schedules.
 
 ### Options
 
@@ -22,10 +22,10 @@ Manage K6 Cloud schedules.
 
 ### SEE ALSO
 
-* [gcx k6](gcx_k6.md)	 - Manage Grafana K6 Cloud projects, load tests, and schedules
-* [gcx k6 schedules create](gcx_k6_schedules_create.md)	 - Create a K6 schedule from a file.
-* [gcx k6 schedules delete](gcx_k6_schedules_delete.md)	 - Delete the schedule for a K6 load test.
-* [gcx k6 schedules get](gcx_k6_schedules_get.md)	 - Get a single K6 schedule by ID.
-* [gcx k6 schedules list](gcx_k6_schedules_list.md)	 - List all K6 schedules.
-* [gcx k6 schedules update](gcx_k6_schedules_update.md)	 - Update a K6 schedule from a file.
+* [gcx k6](gcx_k6.md)	 - Manage Grafana k6 Cloud projects, load tests, and schedules
+* [gcx k6 schedules create](gcx_k6_schedules_create.md)	 - Create a k6 schedule from a file.
+* [gcx k6 schedules delete](gcx_k6_schedules_delete.md)	 - Delete the schedule for a k6 load test.
+* [gcx k6 schedules get](gcx_k6_schedules_get.md)	 - Get a single k6 schedule by ID.
+* [gcx k6 schedules list](gcx_k6_schedules_list.md)	 - List all k6 schedules.
+* [gcx k6 schedules update](gcx_k6_schedules_update.md)	 - Update a k6 schedule from a file.
 

--- a/docs/reference/cli/gcx_k6_schedules_create.md
+++ b/docs/reference/cli/gcx_k6_schedules_create.md
@@ -1,6 +1,6 @@
 ## gcx k6 schedules create
 
-Create a K6 schedule from a file.
+Create a k6 schedule from a file.
 
 ```
 gcx k6 schedules create [flags]
@@ -28,5 +28,5 @@ gcx k6 schedules create [flags]
 
 ### SEE ALSO
 
-* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage K6 Cloud schedules.
+* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage k6 Cloud schedules.
 

--- a/docs/reference/cli/gcx_k6_schedules_delete.md
+++ b/docs/reference/cli/gcx_k6_schedules_delete.md
@@ -1,6 +1,6 @@
 ## gcx k6 schedules delete
 
-Delete the schedule for a K6 load test.
+Delete the schedule for a k6 load test.
 
 ```
 gcx k6 schedules delete <load-test-id> [flags]
@@ -26,5 +26,5 @@ gcx k6 schedules delete <load-test-id> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage K6 Cloud schedules.
+* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage k6 Cloud schedules.
 

--- a/docs/reference/cli/gcx_k6_schedules_get.md
+++ b/docs/reference/cli/gcx_k6_schedules_get.md
@@ -1,6 +1,6 @@
 ## gcx k6 schedules get
 
-Get a single K6 schedule by ID.
+Get a single k6 schedule by ID.
 
 ```
 gcx k6 schedules get <id> [flags]
@@ -28,5 +28,5 @@ gcx k6 schedules get <id> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage K6 Cloud schedules.
+* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage k6 Cloud schedules.
 

--- a/docs/reference/cli/gcx_k6_schedules_list.md
+++ b/docs/reference/cli/gcx_k6_schedules_list.md
@@ -1,6 +1,6 @@
 ## gcx k6 schedules list
 
-List all K6 schedules.
+List all k6 schedules.
 
 ```
 gcx k6 schedules list [flags]
@@ -29,5 +29,5 @@ gcx k6 schedules list [flags]
 
 ### SEE ALSO
 
-* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage K6 Cloud schedules.
+* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage k6 Cloud schedules.
 

--- a/docs/reference/cli/gcx_k6_schedules_update.md
+++ b/docs/reference/cli/gcx_k6_schedules_update.md
@@ -1,6 +1,6 @@
 ## gcx k6 schedules update
 
-Update a K6 schedule from a file.
+Update a k6 schedule from a file.
 
 ```
 gcx k6 schedules update <id> [flags]
@@ -27,5 +27,5 @@ gcx k6 schedules update <id> [flags]
 
 ### SEE ALSO
 
-* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage K6 Cloud schedules.
+* [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage k6 Cloud schedules.
 

--- a/docs/reference/cli/gcx_k6_test-run.md
+++ b/docs/reference/cli/gcx_k6_test-run.md
@@ -22,7 +22,7 @@ Manage k6 TestRun CRD manifests.
 
 ### SEE ALSO
 
-* [gcx k6](gcx_k6.md)	 - Manage Grafana K6 Cloud projects, load tests, and schedules
+* [gcx k6](gcx_k6.md)	 - Manage Grafana k6 Cloud projects, load tests, and schedules
 * [gcx k6 test-run emit](gcx_k6_test-run_emit.md)	 - Fetch a k6 Cloud test and emit Kubernetes TestRun CRD manifests.
 * [gcx k6 test-run runs](gcx_k6_test-run_runs.md)	 - Query k6 Cloud test run history.
 * [gcx k6 test-run status](gcx_k6_test-run_status.md)	 - Show the most recent test run status for a k6 load test.

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -151,7 +151,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx incidents severities list": {Cost: "small"},
 
 	// -----------------------------------------------------------------------
-	// K6 provider
+	// k6 provider
 	// -----------------------------------------------------------------------
 	"gcx k6 auth token":                           {Cost: "small"},
 	"gcx k6 env-vars create":                      {Cost: "small", Hint: "-f <manifest.yaml>"},

--- a/internal/agent/known_resources.go
+++ b/internal/agent/known_resources.go
@@ -111,7 +111,7 @@ func (b *resourceBuilder) build() KnownResource {
 
 // KnownResources is the static registry of well-known Grafana K8s resource types
 // that are NOT backed by provider adapters. Provider-backed types (SLO, OnCall, Fleet,
-// K6, KG, Incidents, Alert, Synth) are already registered via adapter.AllRegistrations().
+// k6, KG, Incidents, Alert, Synth) are already registered via adapter.AllRegistrations().
 //
 // This list was verified against a live Grafana 13.0 stack.
 var KnownResources = []KnownResource{ //nolint:gochecknoglobals // Static registry, same pattern as providers.registry.

--- a/internal/providers/k6/client.go
+++ b/internal/providers/k6/client.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	// DefaultAPIDomain is the default K6 Cloud API domain.
+	// DefaultAPIDomain is the default k6 Cloud API domain.
 	DefaultAPIDomain = "https://api.k6.io"
 
 	authPath       = "/v3/account/grafana-app/start"
@@ -29,7 +29,7 @@ const (
 	plzPath        = "/cloud-resources/v1/load-zones"
 )
 
-// Client is an HTTP client for the K6 Cloud API.
+// Client is an HTTP client for the k6 Cloud API.
 // It must be authenticated before use by calling Authenticate.
 type Client struct {
 	apiDomain string
@@ -39,7 +39,7 @@ type Client struct {
 	http      *http.Client
 }
 
-// NewClient creates a new K6 Cloud client with the given API domain.
+// NewClient creates a new k6 Cloud client with the given API domain.
 // If httpClient is nil, a default client with a 60-second timeout is used.
 func NewClient(ctx context.Context, apiDomain string, httpClient *http.Client) *Client {
 	if apiDomain == "" {
@@ -308,7 +308,7 @@ func (c *Client) ListLoadTests(ctx context.Context) ([]LoadTest, error) {
 }
 
 // listLoadTests fetches load tests from the given path, paginating through all pages.
-// The K6 v6 API uses OData-style pagination with $skip/$top parameters and @count.
+// The k6 v6 API uses OData-style pagination with $skip/$top parameters and @count.
 func (c *Client) listLoadTests(ctx context.Context, path string) ([]LoadTest, error) {
 	const pageSize = 100
 	var all []LoadTest

--- a/internal/providers/k6/commands.go
+++ b/internal/providers/k6/commands.go
@@ -154,7 +154,7 @@ func decodeYAMLOrJSON(data []byte, target any) error {
 func newProjectsCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "projects",
-		Short:   "Manage K6 Cloud projects.",
+		Short:   "Manage k6 Cloud projects.",
 		Aliases: []string{"project", "proj"},
 	}
 	cmd.AddCommand(
@@ -184,7 +184,7 @@ func newProjectsListCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &projectsListOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List K6 Cloud projects.",
+		Short: "List k6 Cloud projects.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err
@@ -299,7 +299,7 @@ func newProjectsGetCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &projectsGetOpts{}
 	cmd := &cobra.Command{
 		Use:   "get <id-or-name>",
-		Short: "Get a single K6 project by ID or name.",
+		Short: "Get a single k6 project by ID or name.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.IO.Validate(); err != nil {
@@ -347,7 +347,7 @@ func newProjectsCreateCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &projectsCreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a new K6 project from a file.",
+		Short: "Create a new k6 project from a file.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err
@@ -420,7 +420,7 @@ func newProjectsUpdateCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &projectsUpdateOpts{}
 	cmd := &cobra.Command{
 		Use:   "update <id-or-name>",
-		Short: "Update a K6 project.",
+		Short: "Update a k6 project.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.File == "" {
@@ -480,7 +480,7 @@ func newProjectsUpdateCommand(loader CloudConfigLoader) *cobra.Command {
 func newProjectsDeleteCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <id-or-name>",
-		Short: "Delete a K6 project.",
+		Short: "Delete a k6 project.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -509,7 +509,7 @@ func newProjectsDeleteCommand(loader CloudConfigLoader) *cobra.Command {
 func newTestsCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "load-tests",
-		Short:   "Manage K6 Cloud load tests.",
+		Short:   "Manage k6 Cloud load tests.",
 		Aliases: []string{"tests", "test"},
 	}
 	cmd.AddCommand(
@@ -542,7 +542,7 @@ func newTestsListCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &testsListOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List K6 Cloud load tests.",
+		Short: "List k6 Cloud load tests.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err
@@ -642,7 +642,7 @@ func newTestsGetCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &testsGetOpts{}
 	cmd := &cobra.Command{
 		Use:   "get <id-or-name>",
-		Short: "Get a single K6 load test by ID or name.",
+		Short: "Get a single k6 load test by ID or name.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.IO.Validate(); err != nil {
@@ -687,7 +687,7 @@ func newTestsCreateCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &testsCreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a new K6 load test.",
+		Short: "Create a new k6 load test.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err
@@ -728,7 +728,7 @@ func newTestsUpdateCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &testsUpdateOpts{}
 	cmd := &cobra.Command{
 		Use:   "update <id>",
-		Short: "Update a K6 load test from a file.",
+		Short: "Update a k6 load test from a file.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.File == "" {
@@ -777,7 +777,7 @@ func newTestsUpdateScriptCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &testsUpdateScriptOpts{}
 	cmd := &cobra.Command{
 		Use:   "update-script <id>",
-		Short: "Update the script of a K6 load test from a file.",
+		Short: "Update the script of a k6 load test from a file.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.File == "" {
@@ -813,7 +813,7 @@ func newTestsUpdateScriptCommand(loader CloudConfigLoader) *cobra.Command {
 func newTestsDeleteCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <id>",
-		Short: "Delete a K6 load test.",
+		Short: "Delete a k6 load test.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -842,7 +842,7 @@ func newTestsDeleteCommand(loader CloudConfigLoader) *cobra.Command {
 func newRunsCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "runs",
-		Short:   "Manage K6 test runs.",
+		Short:   "Manage k6 test runs.",
 		Aliases: []string{"run"},
 	}
 	cmd.AddCommand(newRunsListCommand(loader))
@@ -970,7 +970,7 @@ func resultStatusString(status int) string {
 func newEnvVarsCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "env-vars",
-		Short:   "Manage K6 Cloud environment variables.",
+		Short:   "Manage k6 Cloud environment variables.",
 		Aliases: []string{"envvars", "envvar", "env"},
 	}
 	cmd.AddCommand(
@@ -998,7 +998,7 @@ func newEnvVarsListCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &envVarsListOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List K6 environment variables.",
+		Short: "List k6 environment variables.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err
@@ -1063,7 +1063,7 @@ func newEnvVarsCreateCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &envVarsCreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a K6 environment variable from a file.",
+		Short: "Create a k6 environment variable from a file.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.File == "" {
 				return errors.New("--filename/-f is required")
@@ -1117,7 +1117,7 @@ func newEnvVarsUpdateCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &envVarsUpdateOpts{}
 	cmd := &cobra.Command{
 		Use:   "update <id>",
-		Short: "Update a K6 environment variable.",
+		Short: "Update a k6 environment variable.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.File == "" {
@@ -1166,7 +1166,7 @@ func newEnvVarsUpdateCommand(loader CloudConfigLoader) *cobra.Command {
 func newEnvVarsDeleteCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <id>",
-		Short: "Delete a K6 environment variable.",
+		Short: "Delete a k6 environment variable.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -1195,7 +1195,7 @@ func newEnvVarsDeleteCommand(loader CloudConfigLoader) *cobra.Command {
 func newAuthCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
-		Short: "K6 authentication commands.",
+		Short: "k6 authentication commands.",
 	}
 	cmd.AddCommand(newTokenCommand(loader))
 	return cmd
@@ -1228,7 +1228,7 @@ func newTokenCommand(loader CloudConfigLoader) *cobra.Command {
 func newSchedulesCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "schedules",
-		Short:   "Manage K6 Cloud schedules.",
+		Short:   "Manage k6 Cloud schedules.",
 		Aliases: []string{"schedule"},
 	}
 	cmd.AddCommand(
@@ -1298,7 +1298,7 @@ func newSchedulesListCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &schedulesListOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all K6 schedules.",
+		Short: "List all k6 schedules.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err
@@ -1333,7 +1333,7 @@ func newSchedulesGetCommand(loader CloudConfigLoader) *cobra.Command { //nolint:
 	opts := &schedulesGetOpts{}
 	cmd := &cobra.Command{
 		Use:   "get <id>",
-		Short: "Get a single K6 schedule by ID.",
+		Short: "Get a single k6 schedule by ID.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.IO.Validate(); err != nil {
@@ -1373,7 +1373,7 @@ func newSchedulesCreateCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &schedulesCreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a K6 schedule from a file.",
+		Short: "Create a k6 schedule from a file.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.LoadTestID == 0 {
 				return errors.New("--load-test-id is required")
@@ -1421,7 +1421,7 @@ func newSchedulesUpdateCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &schedulesUpdateOpts{}
 	cmd := &cobra.Command{
 		Use:   "update <id>",
-		Short: "Update a K6 schedule from a file.",
+		Short: "Update a k6 schedule from a file.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.File == "" {
@@ -1461,7 +1461,7 @@ func newSchedulesUpdateCommand(loader CloudConfigLoader) *cobra.Command {
 func newSchedulesDeleteCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <load-test-id>",
-		Short: "Delete the schedule for a K6 load test.",
+		Short: "Delete the schedule for a k6 load test.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -1490,7 +1490,7 @@ func newSchedulesDeleteCommand(loader CloudConfigLoader) *cobra.Command {
 func newLoadZonesCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "load-zones",
-		Short:   "Manage K6 private load zones.",
+		Short:   "Manage k6 private load zones.",
 		Aliases: []string{"load-zone", "lz"},
 	}
 	cmd.AddCommand(
@@ -1514,7 +1514,7 @@ func (c *LoadZoneTableCodec) Encode(w io.Writer, v any) error {
 		return errors.New("invalid data type for table codec: expected []LoadZone")
 	}
 
-	t := style.NewTable("ID", "NAME", "K6 LOAD ZONE ID")
+	t := style.NewTable("ID", "NAME", "k6 LOAD ZONE ID")
 
 	for _, z := range zones {
 		k6ID := z.K6LoadZoneID
@@ -1546,7 +1546,7 @@ func newLoadZonesListCommand(loader CloudConfigLoader) *cobra.Command {
 	opts := &loadZonesListOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all K6 load zones.",
+		Short: "List all k6 load zones.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err

--- a/internal/providers/k6/provider.go
+++ b/internal/providers/k6/provider.go
@@ -14,7 +14,7 @@ func init() { //nolint:gochecknoinits // Self-registration pattern (like databas
 	providers.Register(&K6Provider{})
 }
 
-// K6Provider manages K6 Cloud resources (projects, load tests, environment variables).
+// K6Provider manages k6 Cloud resources (projects, load tests, environment variables).
 type K6Provider struct{}
 
 // Name returns the unique identifier for this provider.
@@ -22,7 +22,7 @@ func (p *K6Provider) Name() string { return "k6" }
 
 // ShortDesc returns a one-line description of the provider.
 func (p *K6Provider) ShortDesc() string {
-	return "Manage Grafana K6 Cloud projects, load tests, and schedules"
+	return "Manage Grafana k6 Cloud projects, load tests, and schedules"
 }
 
 // Commands returns the Cobra commands contributed by this provider.
@@ -62,7 +62,7 @@ func (p *K6Provider) ConfigKeys() []providers.ConfigKey {
 	}
 }
 
-// TypedRegistrations returns adapter registrations for K6 resource types.
+// TypedRegistrations returns adapter registrations for k6 resource types.
 func (p *K6Provider) TypedRegistrations() []adapter.Registration {
 	loader := &providers.ConfigLoader{}
 	registrations := make([]adapter.Registration, 0, len(allResources()))

--- a/internal/providers/k6/resource_adapter.go
+++ b/internal/providers/k6/resource_adapter.go
@@ -78,9 +78,9 @@ func authenticatedClient(ctx context.Context, loader CloudConfigLoader) (*Client
 		}
 	}
 
-	// K6 API uses its own auth (X-Grafana-Key token exchange), not the Grafana
+	// k6 API uses its own auth (X-Grafana-Key token exchange), not the Grafana
 	// bearer token. Using rest.HTTPClientFor() would inject the Grafana bearer
-	// token via the k8s transport round-tripper, causing 401 from the K6 API.
+	// token via the k8s transport round-tripper, causing 401 from the k6 API.
 	httpClient := httputils.NewDefaultClient(ctx)
 
 	client := NewClient(ctx, domain, httpClient)
@@ -479,7 +479,7 @@ func loadZoneExample() json.RawMessage {
 // NewTypedCRUD factories for CLI commands
 // ---------------------------------------------------------------------------
 
-// NewTypedCRUD[Project] creates a TypedCRUD for K6 projects.
+// NewTypedCRUD[Project] creates a TypedCRUD for k6 projects.
 func NewTypedCRUDProject(ctx context.Context, loader CloudConfigLoader) (*adapter.TypedCRUD[Project], string, error) {
 	client, ns, err := authenticatedClient(ctx, loader)
 	if err != nil {
@@ -518,7 +518,7 @@ func NewTypedCRUDProject(ctx context.Context, loader CloudConfigLoader) (*adapte
 	return crud, ns, nil
 }
 
-// NewTypedCRUD[LoadTest] creates a TypedCRUD for K6 load tests.
+// NewTypedCRUD[LoadTest] creates a TypedCRUD for k6 load tests.
 func NewTypedCRUDLoadTest(ctx context.Context, loader CloudConfigLoader) (*adapter.TypedCRUD[LoadTest], string, error) {
 	client, ns, err := authenticatedClient(ctx, loader)
 	if err != nil {
@@ -557,7 +557,7 @@ func NewTypedCRUDLoadTest(ctx context.Context, loader CloudConfigLoader) (*adapt
 	return crud, ns, nil
 }
 
-// NewTypedCRUD[Schedule] creates a TypedCRUD for K6 schedules.
+// NewTypedCRUD[Schedule] creates a TypedCRUD for k6 schedules.
 func NewTypedCRUDSchedule(ctx context.Context, loader CloudConfigLoader) (*adapter.TypedCRUD[Schedule], string, error) {
 	client, ns, err := authenticatedClient(ctx, loader)
 	if err != nil {
@@ -605,7 +605,7 @@ func NewTypedCRUDSchedule(ctx context.Context, loader CloudConfigLoader) (*adapt
 	return crud, ns, nil
 }
 
-// NewTypedCRUD[EnvVar] creates a TypedCRUD for K6 environment variables.
+// NewTypedCRUD[EnvVar] creates a TypedCRUD for k6 environment variables.
 func NewTypedCRUDEnvVar(ctx context.Context, loader CloudConfigLoader) (*adapter.TypedCRUD[EnvVar], string, error) {
 	client, ns, err := authenticatedClient(ctx, loader)
 	if err != nil {
@@ -662,7 +662,7 @@ func NewTypedCRUDEnvVar(ctx context.Context, loader CloudConfigLoader) (*adapter
 	return crud, ns, nil
 }
 
-// NewTypedCRUD[LoadZone] creates a TypedCRUD for K6 load zones.
+// NewTypedCRUD[LoadZone] creates a TypedCRUD for k6 load zones.
 func NewTypedCRUDLoadZone(ctx context.Context, loader CloudConfigLoader) (*adapter.TypedCRUD[LoadZone], string, error) {
 	client, ns, err := authenticatedClient(ctx, loader)
 	if err != nil {

--- a/internal/providers/k6/types.go
+++ b/internal/providers/k6/types.go
@@ -19,7 +19,7 @@ func (ev *EnvVar) SetResourceName(name string) { ev.ID, _ = strconv.Atoi(name) }
 func (lz LoadZone) GetResourceName() string      { return lz.Name }
 func (lz *LoadZone) SetResourceName(name string) { lz.Name = name }
 
-// Project represents a K6 Cloud project (v6 API).
+// Project represents a k6 Cloud project (v6 API).
 //
 //nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
 type Project struct {
@@ -31,7 +31,7 @@ type Project struct {
 	Updated          string `json:"updated,omitempty"`
 }
 
-// LoadTest represents a K6 load test (v6 API).
+// LoadTest represents a k6 load test (v6 API).
 //
 //nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
 type LoadTest struct {
@@ -43,7 +43,7 @@ type LoadTest struct {
 	Updated   string `json:"updated,omitempty"`
 }
 
-// EnvVar represents a K6 Cloud environment variable.
+// EnvVar represents a k6 Cloud environment variable.
 //
 //nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
 type EnvVar struct {
@@ -64,7 +64,7 @@ type TestRunStatus struct {
 	ReferenceID  string `json:"reference_id,omitempty"`
 }
 
-// authResponse is the response from K6 authentication.
+// authResponse is the response from k6 authentication.
 type authResponse struct {
 	OrgID          string `json:"organization_id"`
 	V3GrafanaToken string `json:"v3_grafana_token"`
@@ -103,7 +103,7 @@ type testRunsResponse struct {
 	Value []TestRunStatus `json:"value"`
 }
 
-// Schedule represents a K6 schedule (v6 API).
+// Schedule represents a k6 schedule (v6 API).
 //
 //nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
 type Schedule struct {
@@ -134,7 +134,7 @@ type schedulesResponse struct {
 	Count int        `json:"@count,omitempty"`
 }
 
-// LoadZone represents a K6 private load zone.
+// LoadZone represents a k6 private load zone.
 //
 //nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
 type LoadZone struct {


### PR DESCRIPTION
A PR to change many occurrences of "K6" to "k6", in order to properly follow the branding for k6.
I've updated `naming.md` to hopefully make this more permanent.