### PR TITLE
feat(skills): improve list output, add installed status, and support single-skill install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,11 +239,17 @@ Run this checklist **before every commit** (not only before PR/push):
    ```bash
    go test ./...
    ```
-5. **Reference docs regenerated when command/output surface changes**
+5. **Reference docs regenerated** (CI runs `make reference-drift` which fails on any drift)
    ```bash
    GCX_AGENT_MODE=false make reference
    ```
-6. **No unstaged surprises**
+   This regenerates CLI reference, env-var reference, config reference, and linter-rules reference. Required when changes touch commands, flags, config fields, env vars, or linter rules.
+6. **Docs build succeeds** (CI runs `make docs` after the drift check)
+   ```bash
+   make docs
+   ```
+   If `devbox`/`mkdocs` is unavailable, skip — CI will catch build failures.
+7. **No unstaged surprises**
    ```bash
    git status
    ```

--- a/cmd/gcx/skills/command.go
+++ b/cmd/gcx/skills/command.go
@@ -81,11 +81,11 @@ func newInstallCommand(source fs.FS) *cobra.Command {
 		Use:   "install [SKILL]...",
 		Short: "Install bundled gcx skills into ~/.agents/skills",
 		Long:  "Install one or more bundled gcx Agent Skills into a user-level .agents directory for tools that follow the .agents skill convention. Use --all to install the entire bundle.",
-		Example: `  gcx skills install gcx
-  gcx skills install gcx setup-gcx debug-with-grafana
+		Example: `  gcx skills install setup-gcx
+  gcx skills install setup-gcx debug-with-grafana explore-datasources
   gcx skills install --all
   gcx skills install --all --dry-run
-  gcx skills install gcx --force`,
+  gcx skills install setup-gcx --force`,
 		Args: cobra.ArbitraryArgs,
 		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			names, err := bundledSkillNames(source)
@@ -439,8 +439,8 @@ func normalizeDescription(description string) string {
 }
 
 func fallbackSkillDescription(data []byte) string {
-	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
-	for _, line := range lines {
+	content := strings.ReplaceAll(string(data), "\r\n", "\n")
+	for line := range strings.SplitSeq(content, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
 			continue

--- a/cmd/gcx/skills/command.go
+++ b/cmd/gcx/skills/command.go
@@ -33,7 +33,7 @@ func Command() *cobra.Command {
 
 	cmd.AddCommand(newInstallCommand(claudeplugin.SkillsFS()))
 	cmd.AddCommand(newListCommand(claudeplugin.SkillsFS()))
-	cmd.AddCommand(newUninstallCommand())
+	cmd.AddCommand(newUninstallCommand(claudeplugin.SkillsFS()))
 
 	return cmd
 }
@@ -351,49 +351,6 @@ func isSkillInstalled(skillsDir string, name string) bool {
 	return err == nil && !info.IsDir()
 }
 
-func listInstalledSkills(root string) (listResult, error) {
-	root = filepath.Clean(root)
-	skillsDir := filepath.Join(root, "skills")
-	result := listResult{}
-
-	entries, err := os.ReadDir(skillsDir)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return result, nil
-		}
-		return listResult{}, err
-	}
-
-	result.Skills = make([]skillInfo, 0, len(entries))
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		skillPath := filepath.Join(skillsDir, entry.Name())
-		skillDocPath := filepath.Join(skillPath, "SKILL.md")
-		data, err := os.ReadFile(skillDocPath)
-		if err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				continue
-			}
-			return listResult{}, err
-		}
-
-		result.Skills = append(result.Skills, skillInfo{
-			Name:             entry.Name(),
-			ShortDescription: extractSkillShortDescription(data),
-		})
-	}
-
-	sort.Slice(result.Skills, func(i int, j int) bool {
-		return result.Skills[i].Name < result.Skills[j].Name
-	})
-	result.SkillCount = len(result.Skills)
-
-	return result, nil
-}
-
 type skillFrontMatter struct {
 	Description string `yaml:"description"`
 }
@@ -628,6 +585,7 @@ type uninstallOpts struct {
 	All    bool
 	Yes    bool
 	DryRun bool
+	Source fs.FS
 	IO     cmdio.Options
 }
 
@@ -637,12 +595,15 @@ func (o *uninstallOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 
 	flags.StringVar(&o.Dir, "dir", "~/.agents", "Root directory for the .agents installation")
-	flags.BoolVar(&o.All, "all", false, "Uninstall all skills in the target directory")
+	flags.BoolVar(&o.All, "all", false, "Uninstall all gcx-managed skills")
 	flags.BoolVarP(&o.Yes, "yes", "y", false, "Auto-approve uninstalling all skills")
 	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview the uninstall without removing files")
 }
 
 func (o *uninstallOpts) Validate(args []string) error {
+	if o.Source == nil {
+		return errors.New("skills source is not configured")
+	}
 	if o.All && len(args) > 0 {
 		return errors.New("skill names cannot be provided when --all is set")
 	}
@@ -652,18 +613,25 @@ func (o *uninstallOpts) Validate(args []string) error {
 	return o.IO.Validate()
 }
 
-func newUninstallCommand() *cobra.Command {
-	opts := &uninstallOpts{}
+func newUninstallCommand(source fs.FS) *cobra.Command {
+	opts := &uninstallOpts{Source: source}
 
 	cmd := &cobra.Command{
 		Use:   "uninstall [SKILL]...",
-		Short: "Uninstall installed skills from ~/.agents/skills",
-		Long:  "Remove one or more installed skills from a user-level .agents skills directory.",
-		Example: `  gcx skills uninstall grafanacloud-gcx
-  gcx skills uninstall grafanacloud-gcx skill-installer
+		Short: "Uninstall gcx-managed skills from ~/.agents/skills",
+		Long:  "Remove one or more gcx-managed skills from a user-level .agents skills directory. Only skills bundled with gcx can be uninstalled; non-gcx skills are never touched.",
+		Example: `  gcx skills uninstall setup-gcx
+  gcx skills uninstall setup-gcx debug-with-grafana
   gcx skills uninstall --all --yes
   gcx skills uninstall --all --yes --dry-run`,
 		Args: cobra.ArbitraryArgs,
+		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			names, err := bundledSkillNames(source)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+			return names, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(args); err != nil {
 				return err
@@ -675,7 +643,7 @@ func newUninstallCommand() *cobra.Command {
 			}
 
 			if opts.All && !opts.Yes && !cliOpts.AutoApprove {
-				return errors.New("refusing to uninstall all skills without --yes (or GCX_AUTO_APPROVE=1)")
+				return errors.New("refusing to uninstall all gcx skills without --yes (or GCX_AUTO_APPROVE=1)")
 			}
 
 			root, err := resolveInstallRoot(opts.Dir)
@@ -683,15 +651,24 @@ func newUninstallCommand() *cobra.Command {
 				return err
 			}
 
+			bundled, err := bundledSkillNames(opts.Source)
+			if err != nil {
+				return err
+			}
+			bundledSet := make(map[string]struct{}, len(bundled))
+			for _, name := range bundled {
+				bundledSet[name] = struct{}{}
+			}
+
 			targets := args
 			if opts.All {
-				listResult, err := listInstalledSkills(root)
-				if err != nil {
-					return err
-				}
-				targets = make([]string, 0, len(listResult.Skills))
-				for _, skill := range listResult.Skills {
-					targets = append(targets, skill.Name)
+				// --all only targets gcx-bundled skills, never non-gcx skills.
+				targets = bundled
+			} else {
+				for _, name := range args {
+					if _, ok := bundledSet[name]; !ok {
+						return fmt.Errorf("unknown skill %q (use 'gcx skills list' to see gcx-managed skills)", name)
+					}
 				}
 			}
 

--- a/cmd/gcx/skills/command.go
+++ b/cmd/gcx/skills/command.go
@@ -7,17 +7,20 @@ import (
 	goio "io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 
 	claudeplugin "github.com/grafana/gcx/claude-plugin"
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
 )
 
 // Command returns the top-level skills command group.
@@ -29,12 +32,15 @@ func Command() *cobra.Command {
 	}
 
 	cmd.AddCommand(newInstallCommand(claudeplugin.SkillsFS()))
+	cmd.AddCommand(newListCommand(claudeplugin.SkillsFS()))
+	cmd.AddCommand(newUninstallCommand())
 
 	return cmd
 }
 
 type installOpts struct {
 	Dir    string
+	All    bool
 	Force  bool
 	DryRun bool
 	Source fs.FS
@@ -49,13 +55,20 @@ func (o *installOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 
 	flags.StringVar(&o.Dir, "dir", defaultRoot, "Root directory for the .agents installation")
+	flags.BoolVar(&o.All, "all", false, "Install all bundled skills")
 	flags.BoolVar(&o.Force, "force", false, "Overwrite existing differing files managed by the gcx skills bundle")
 	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview the installation without writing files")
 }
 
-func (o *installOpts) Validate() error {
+func (o *installOpts) Validate(args []string) error {
 	if o.Source == nil {
 		return errors.New("skills source is not configured")
+	}
+	if o.All && len(args) > 0 {
+		return errors.New("skill names cannot be provided when --all is set")
+	}
+	if !o.All && len(args) == 0 {
+		return errors.New("provide at least one skill name or use --all")
 	}
 
 	return o.IO.Validate()
@@ -65,15 +78,24 @@ func newInstallCommand(source fs.FS) *cobra.Command {
 	opts := &installOpts{Source: source}
 
 	cmd := &cobra.Command{
-		Use:   "install",
-		Short: "Install the portable gcx skill bundle into ~/.agents/skills",
-		Long:  "Install the canonical portable gcx Agent Skills bundle into a user-level .agents directory for tools that follow the .agents skill convention.",
-		Example: `  gcx skills install
-  gcx skills install --dry-run
-  gcx skills install --dir ~/.agents --force`,
-		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := opts.Validate(); err != nil {
+		Use:   "install [SKILL]...",
+		Short: "Install bundled gcx skills into ~/.agents/skills",
+		Long:  "Install one or more bundled gcx Agent Skills into a user-level .agents directory for tools that follow the .agents skill convention. Use --all to install the entire bundle.",
+		Example: `  gcx skills install gcx
+  gcx skills install gcx setup-gcx debug-with-grafana
+  gcx skills install --all
+  gcx skills install --all --dry-run
+  gcx skills install gcx --force`,
+		Args: cobra.ArbitraryArgs,
+		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			names, err := bundledSkillNames(source)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+			return names, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(args); err != nil {
 				return err
 			}
 
@@ -82,7 +104,15 @@ func newInstallCommand(source fs.FS) *cobra.Command {
 				return err
 			}
 
-			result, err := installSkills(opts.Source, root, opts.Force, opts.DryRun)
+			var filter map[string]struct{}
+			if !opts.All {
+				filter = make(map[string]struct{}, len(args))
+				for _, name := range args {
+					filter[name] = struct{}{}
+				}
+			}
+
+			result, err := installSkills(opts.Source, root, filter, opts.Force, opts.DryRun)
 			if err != nil {
 				return err
 			}
@@ -94,6 +124,20 @@ func newInstallCommand(source fs.FS) *cobra.Command {
 	opts.setup(cmd.Flags())
 
 	return cmd
+}
+
+func bundledSkillNames(source fs.FS) ([]string, error) {
+	entries, err := fs.ReadDir(source, ".")
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	return names, nil
 }
 
 type installResult struct {
@@ -160,7 +204,274 @@ func (c *installTextCodec) Decode(_ goio.Reader, _ any) error {
 	return errors.New("install text codec does not support decoding")
 }
 
-func installSkills(source fs.FS, root string, force bool, dryRun bool) (installResult, error) {
+type listOpts struct {
+	Dir    string
+	Source fs.FS
+	IO     cmdio.Options
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("text")
+	o.IO.RegisterCustomCodec("text", &listTextCodec{})
+	o.IO.BindFlags(flags)
+
+	flags.StringVar(&o.Dir, "dir", "~/.agents", "Root directory for the .agents installation (used to check installed status)")
+}
+
+func (o *listOpts) Validate() error {
+	if o.Source == nil {
+		return errors.New("skills source is not configured")
+	}
+
+	return o.IO.Validate()
+}
+
+func newListCommand(source fs.FS) *cobra.Command {
+	opts := &listOpts{Source: source}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List skills bundled with the gcx binary",
+		Long:  "List skills bundled with the gcx binary, including each skill's short description and install status.",
+		Example: `  gcx skills list
+  gcx skills list -o json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			root, err := resolveInstallRoot(opts.Dir)
+			if err != nil {
+				return err
+			}
+
+			result, err := listBundledSkills(opts.Source, root)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), result)
+		},
+	}
+
+	opts.setup(cmd.Flags())
+
+	return cmd
+}
+
+type listResult struct {
+	Skills     []skillInfo `json:"skills"`
+	SkillCount int         `json:"skill_count"`
+}
+
+type skillInfo struct {
+	Name             string `json:"name"`
+	ShortDescription string `json:"short_description"`
+	Installed        bool   `json:"installed"`
+}
+
+type listTextCodec struct{}
+
+func (c *listTextCodec) Format() format.Format { return "text" }
+
+func (c *listTextCodec) Encode(dst goio.Writer, value any) error {
+	var result listResult
+	switch v := value.(type) {
+	case listResult:
+		result = v
+	case *listResult:
+		if v == nil {
+			return errors.New("nil list result")
+		}
+		result = *v
+	default:
+		return fmt.Errorf("list text codec: unsupported value %T", value)
+	}
+
+	fmt.Fprintf(dst, "%d skill(s) bundled with gcx\n\n", result.SkillCount)
+
+	if len(result.Skills) > 0 {
+		if err := renderSkillsTable(dst, result.Skills); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *listTextCodec) Decode(_ goio.Reader, _ any) error {
+	return errors.New("list text codec does not support decoding")
+}
+
+func listBundledSkills(source fs.FS, installRoot string) (listResult, error) {
+	result := listResult{}
+
+	entries, err := fs.ReadDir(source, ".")
+	if err != nil {
+		return listResult{}, err
+	}
+
+	skillsDir := filepath.Join(installRoot, "skills")
+
+	result.Skills = make([]skillInfo, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		skillDocPath := path.Join(entry.Name(), "SKILL.md")
+		data, err := fs.ReadFile(source, skillDocPath)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return listResult{}, err
+		}
+
+		installed := isSkillInstalled(skillsDir, entry.Name())
+
+		result.Skills = append(result.Skills, skillInfo{
+			Name:             entry.Name(),
+			ShortDescription: extractSkillShortDescription(data),
+			Installed:        installed,
+		})
+	}
+
+	sort.Slice(result.Skills, func(i int, j int) bool {
+		return result.Skills[i].Name < result.Skills[j].Name
+	})
+	result.SkillCount = len(result.Skills)
+
+	return result, nil
+}
+
+func isSkillInstalled(skillsDir string, name string) bool {
+	info, err := os.Stat(filepath.Join(skillsDir, name, "SKILL.md"))
+	return err == nil && !info.IsDir()
+}
+
+func listInstalledSkills(root string) (listResult, error) {
+	root = filepath.Clean(root)
+	skillsDir := filepath.Join(root, "skills")
+	result := listResult{}
+
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return result, nil
+		}
+		return listResult{}, err
+	}
+
+	result.Skills = make([]skillInfo, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		skillPath := filepath.Join(skillsDir, entry.Name())
+		skillDocPath := filepath.Join(skillPath, "SKILL.md")
+		data, err := os.ReadFile(skillDocPath)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return listResult{}, err
+		}
+
+		result.Skills = append(result.Skills, skillInfo{
+			Name:             entry.Name(),
+			ShortDescription: extractSkillShortDescription(data),
+		})
+	}
+
+	sort.Slice(result.Skills, func(i int, j int) bool {
+		return result.Skills[i].Name < result.Skills[j].Name
+	})
+	result.SkillCount = len(result.Skills)
+
+	return result, nil
+}
+
+type skillFrontMatter struct {
+	Description string `yaml:"description"`
+}
+
+func extractSkillShortDescription(data []byte) string {
+	description, err := extractSkillDescriptionFromMarkdown(data)
+	if err != nil {
+		return normalizeDescription(fallbackSkillDescription(data))
+	}
+
+	return normalizeDescription(description)
+}
+
+func extractSkillDescriptionFromMarkdown(data []byte) (string, error) {
+	content := strings.ReplaceAll(string(data), "\r\n", "\n")
+	lines := strings.Split(content, "\n")
+	if len(lines) < 3 || strings.TrimSpace(lines[0]) != "---" {
+		return "", errors.New("missing front matter")
+	}
+
+	end := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			end = i
+			break
+		}
+	}
+	if end < 0 {
+		return "", errors.New("unterminated front matter")
+	}
+
+	var meta skillFrontMatter
+	if err := yaml.Unmarshal([]byte(strings.Join(lines[1:end], "\n")), &meta); err != nil {
+		return "", err
+	}
+
+	return meta.Description, nil
+}
+
+func normalizeDescription(description string) string {
+	normalized := strings.Join(strings.Fields(description), " ")
+	return normalized
+}
+
+func fallbackSkillDescription(data []byte) string {
+	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "---") {
+			continue
+		}
+		return trimmed
+	}
+
+	return ""
+}
+
+func renderSkillsTable(dst goio.Writer, skills []skillInfo) error {
+	t := style.NewTable("SKILL", "INSTALLED", "DESCRIPTION")
+	for _, skill := range skills {
+		installed := "no"
+		if skill.Installed {
+			installed = "yes"
+		}
+		t.Row(skill.Name, installed, skill.ShortDescription)
+	}
+	return t.Render(dst)
+}
+
+// installSkills installs skills from source into root. When filter is nil all
+// skills are installed; otherwise only skills whose name is in the filter set.
+func installSkills(source fs.FS, root string, filter map[string]struct{}, force bool, dryRun bool) (installResult, error) {
 	if source == nil {
 		return installResult{}, errors.New("skills source is nil")
 	}
@@ -177,6 +488,23 @@ func installSkills(source fs.FS, root string, force bool, dryRun bool) (installR
 		return installResult{}, err
 	}
 
+	// Validate requested skill names exist in the bundle.
+	if filter != nil {
+		available, err := bundledSkillNames(source)
+		if err != nil {
+			return installResult{}, err
+		}
+		avail := make(map[string]struct{}, len(available))
+		for _, n := range available {
+			avail[n] = struct{}{}
+		}
+		for name := range filter {
+			if _, ok := avail[name]; !ok {
+				return installResult{}, fmt.Errorf("unknown skill %q (use 'gcx skills list' to see available skills)", name)
+			}
+		}
+	}
+
 	skillSet := make(map[string]struct{})
 
 	err := fs.WalkDir(source, ".", func(path string, d fs.DirEntry, walkErr error) error {
@@ -188,9 +516,19 @@ func installSkills(source fs.FS, root string, force bool, dryRun bool) (installR
 		}
 
 		parts := strings.Split(path, "/")
-		if len(parts) > 0 && parts[0] != "" {
-			skillSet[parts[0]] = struct{}{}
+		skillName := parts[0]
+
+		// Skip skills not in the filter.
+		if filter != nil {
+			if _, ok := filter[skillName]; !ok {
+				if d.IsDir() && len(parts) == 1 {
+					return fs.SkipDir
+				}
+				return nil
+			}
 		}
+
+		skillSet[skillName] = struct{}{}
 
 		targetPath := filepath.Join(result.SkillsDir, filepath.FromSlash(path))
 		if d.IsDir() {
@@ -283,6 +621,229 @@ func fileMode(source fs.FS, path string) fs.FileMode {
 		return perm
 	}
 	return 0o644
+}
+
+type uninstallOpts struct {
+	Dir    string
+	All    bool
+	Yes    bool
+	DryRun bool
+	IO     cmdio.Options
+}
+
+func (o *uninstallOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("text")
+	o.IO.RegisterCustomCodec("text", &uninstallTextCodec{})
+	o.IO.BindFlags(flags)
+
+	flags.StringVar(&o.Dir, "dir", "~/.agents", "Root directory for the .agents installation")
+	flags.BoolVar(&o.All, "all", false, "Uninstall all skills in the target directory")
+	flags.BoolVarP(&o.Yes, "yes", "y", false, "Auto-approve uninstalling all skills")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview the uninstall without removing files")
+}
+
+func (o *uninstallOpts) Validate(args []string) error {
+	if o.All && len(args) > 0 {
+		return errors.New("skill names cannot be provided when --all is set")
+	}
+	if !o.All && len(args) == 0 {
+		return errors.New("provide at least one skill name or use --all")
+	}
+	return o.IO.Validate()
+}
+
+func newUninstallCommand() *cobra.Command {
+	opts := &uninstallOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "uninstall [SKILL]...",
+		Short: "Uninstall installed skills from ~/.agents/skills",
+		Long:  "Remove one or more installed skills from a user-level .agents skills directory.",
+		Example: `  gcx skills uninstall grafanacloud-gcx
+  gcx skills uninstall grafanacloud-gcx skill-installer
+  gcx skills uninstall --all --yes
+  gcx skills uninstall --all --yes --dry-run`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(args); err != nil {
+				return err
+			}
+
+			cliOpts, err := config.LoadCLIOptions()
+			if err != nil {
+				return err
+			}
+
+			if opts.All && !opts.Yes && !cliOpts.AutoApprove {
+				return errors.New("refusing to uninstall all skills without --yes (or GCX_AUTO_APPROVE=1)")
+			}
+
+			root, err := resolveInstallRoot(opts.Dir)
+			if err != nil {
+				return err
+			}
+
+			targets := args
+			if opts.All {
+				listResult, err := listInstalledSkills(root)
+				if err != nil {
+					return err
+				}
+				targets = make([]string, 0, len(listResult.Skills))
+				for _, skill := range listResult.Skills {
+					targets = append(targets, skill.Name)
+				}
+			}
+
+			result, err := uninstallSkills(root, targets, opts.DryRun)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), result)
+		},
+	}
+
+	opts.setup(cmd.Flags())
+
+	return cmd
+}
+
+type uninstallResult struct {
+	Root           string   `json:"root"`
+	SkillsDir      string   `json:"skills_dir"`
+	Requested      []string `json:"requested"`
+	RequestedCount int      `json:"requested_count"`
+	Removed        []string `json:"removed"`
+	RemovedCount   int      `json:"removed_count"`
+	Missing        []string `json:"missing"`
+	MissingCount   int      `json:"missing_count"`
+	DryRun         bool     `json:"dry_run"`
+}
+
+type uninstallTextCodec struct{}
+
+func (c *uninstallTextCodec) Format() format.Format { return "text" }
+
+func (c *uninstallTextCodec) Encode(dst goio.Writer, value any) error {
+	var result uninstallResult
+	switch v := value.(type) {
+	case uninstallResult:
+		result = v
+	case *uninstallResult:
+		if v == nil {
+			return errors.New("nil uninstall result")
+		}
+		result = *v
+	default:
+		return fmt.Errorf("uninstall text codec: unsupported value %T", value)
+	}
+
+	status := "Uninstalled"
+	removedLabel := "REMOVED"
+	if result.DryRun {
+		status = "Would uninstall"
+		removedLabel = "WOULD REMOVE"
+	}
+
+	fmt.Fprintf(dst, "%s %d skill(s) from %s\n\n", status, result.RemovedCount, result.SkillsDir)
+
+	t := style.NewTable("FIELD", "VALUE")
+	t.Row("ROOT", result.Root)
+	t.Row("SKILLS DIR", result.SkillsDir)
+	t.Row("REQUESTED", strconv.Itoa(result.RequestedCount))
+	t.Row(removedLabel, strconv.Itoa(result.RemovedCount))
+	t.Row("MISSING", strconv.Itoa(result.MissingCount))
+	if err := t.Render(dst); err != nil {
+		return err
+	}
+
+	if len(result.Removed) > 0 {
+		_, _ = fmt.Fprintln(dst)
+		fmt.Fprintf(dst, "Removed: %s\n", strings.Join(result.Removed, ", "))
+	}
+	if len(result.Missing) > 0 {
+		fmt.Fprintf(dst, "Missing: %s\n", strings.Join(result.Missing, ", "))
+	}
+
+	return nil
+}
+
+func (c *uninstallTextCodec) Decode(_ goio.Reader, _ any) error {
+	return errors.New("uninstall text codec does not support decoding")
+}
+
+func uninstallSkills(root string, names []string, dryRun bool) (uninstallResult, error) {
+	root = filepath.Clean(root)
+	result := uninstallResult{
+		Root:      root,
+		SkillsDir: filepath.Join(root, "skills"),
+		DryRun:    dryRun,
+	}
+
+	seen := make(map[string]struct{}, len(names))
+	result.Requested = make([]string, 0, len(names))
+	for _, name := range names {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+		if err := validateSkillName(trimmed); err != nil {
+			return uninstallResult{}, err
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		result.Requested = append(result.Requested, trimmed)
+	}
+
+	sort.Strings(result.Requested)
+	result.RequestedCount = len(result.Requested)
+	result.Removed = make([]string, 0, len(result.Requested))
+	result.Missing = make([]string, 0, len(result.Requested))
+
+	for _, name := range result.Requested {
+		targetPath := filepath.Join(result.SkillsDir, name)
+		info, err := os.Stat(targetPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				result.Missing = append(result.Missing, name)
+				continue
+			}
+			return uninstallResult{}, err
+		}
+		if !info.IsDir() {
+			return uninstallResult{}, fmt.Errorf("destination path exists and is not a directory: %s", targetPath)
+		}
+
+		if !dryRun {
+			if err := os.RemoveAll(targetPath); err != nil {
+				return uninstallResult{}, err
+			}
+		}
+
+		result.Removed = append(result.Removed, name)
+	}
+
+	result.RemovedCount = len(result.Removed)
+	result.MissingCount = len(result.Missing)
+
+	return result, nil
+}
+
+func validateSkillName(name string) error {
+	if name == "." || name == ".." {
+		return fmt.Errorf("invalid skill name %q", name)
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, `\`) {
+		return fmt.Errorf("invalid skill name %q", name)
+	}
+	if filepath.Base(name) != name {
+		return fmt.Errorf("invalid skill name %q", name)
+	}
+
+	return nil
 }
 
 func defaultAgentsRoot() (string, error) {

--- a/cmd/gcx/skills/command_test.go
+++ b/cmd/gcx/skills/command_test.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -189,37 +188,6 @@ func TestInstallCommand_NoArgsNoAllReturnsError(t *testing.T) {
 	require.ErrorContains(t, err, "provide at least one skill name or use --all")
 }
 
-func TestListInstalledSkills_ListsOnlySkillDirectories(t *testing.T) {
-	t.Parallel()
-
-	root := filepath.Join(t.TempDir(), ".agents")
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "alpha"), 0o755))
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "beta"), 0o755))
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "notes"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "alpha", "SKILL.md"), []byte("alpha"), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "beta", "SKILL.md"), []byte("beta"), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "README.md"), []byte("docs"), 0o600))
-
-	result, err := listInstalledSkills(root)
-	require.NoError(t, err)
-	require.Equal(t, []skillInfo{
-		{Name: "alpha", ShortDescription: "alpha"},
-		{Name: "beta", ShortDescription: "beta"},
-	}, result.Skills)
-	require.Equal(t, 2, result.SkillCount)
-}
-
-func TestListInstalledSkills_MissingDirectoryReturnsEmpty(t *testing.T) {
-	t.Parallel()
-
-	root := filepath.Join(t.TempDir(), ".agents")
-
-	result, err := listInstalledSkills(root)
-	require.NoError(t, err)
-	require.Empty(t, result.Skills)
-	require.Zero(t, result.SkillCount)
-}
-
 func TestListBundledSkills_ReturnsSourceSkills(t *testing.T) {
 	t.Parallel()
 
@@ -251,25 +219,19 @@ func TestListBundledSkills_ShowsInstalledStatus(t *testing.T) {
 	require.False(t, result.Skills[1].Installed)
 }
 
-func TestListInstalledSkills_ParsesFrontMatterDescription(t *testing.T) {
+func TestExtractSkillShortDescription_ParsesFrontMatter(t *testing.T) {
 	t.Parallel()
 
-	root := filepath.Join(t.TempDir(), ".agents")
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "sample"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "sample", "SKILL.md"), []byte(`---
+	data := []byte(`---
 name: sample
 description: >
   Use this skill to do an example operation in a concise way.
 ---
 
 # Sample
-`), 0o600))
-
-	result, err := listInstalledSkills(root)
-	require.NoError(t, err)
-	require.Len(t, result.Skills, 1)
-	require.Equal(t, "sample", result.Skills[0].Name)
-	require.Equal(t, "Use this skill to do an example operation in a concise way.", result.Skills[0].ShortDescription)
+`)
+	desc := extractSkillShortDescription(data)
+	require.Equal(t, "Use this skill to do an example operation in a concise way.", desc)
 }
 
 func TestListCommand_JSONIncludesShortDescription(t *testing.T) {
@@ -347,7 +309,7 @@ func TestUninstallSkills_InvalidName(t *testing.T) {
 func TestUninstallCommand_AllRequiresApproval(t *testing.T) {
 	t.Setenv("GCX_AUTO_APPROVE", "0")
 
-	cmd := newUninstallCommand()
+	cmd := newUninstallCommand(testSkillsFS())
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	cmd.SetOut(stdout)
@@ -356,19 +318,23 @@ func TestUninstallCommand_AllRequiresApproval(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	require.ErrorContains(t, err, "refusing to uninstall all skills without --yes")
+	require.ErrorContains(t, err, "refusing to uninstall all gcx skills without --yes")
 }
 
-func TestUninstallCommand_AllWithYesRemovesInstalledSkills(t *testing.T) {
+func TestUninstallCommand_AllWithYesRemovesOnlyBundledSkills(t *testing.T) {
 	t.Setenv("GCX_AGENT_MODE", "false")
 	agent.ResetForTesting()
 	root := filepath.Join(t.TempDir(), ".agents")
+
+	// Install gcx-bundled skills (alpha, beta) and a non-gcx skill (external).
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "alpha"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "beta"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "external"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "alpha", "SKILL.md"), []byte("alpha"), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "beta", "SKILL.md"), []byte("beta"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "external", "SKILL.md"), []byte("not from gcx"), 0o600))
 
-	cmd := newUninstallCommand()
+	cmd := newUninstallCommand(testSkillsFS())
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	cmd.SetOut(stdout)
@@ -378,9 +344,27 @@ func TestUninstallCommand_AllWithYesRemovesInstalledSkills(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 	require.Contains(t, stdout.String(), "Uninstalled 2 skill(s)")
-	require.True(t, strings.Contains(stdout.String(), "Removed: alpha, beta") || strings.Contains(stdout.String(), "Removed: beta, alpha"))
 
+	// Bundled skills removed.
 	_, err = os.Stat(filepath.Join(root, "skills", "alpha"))
-	require.Error(t, err)
 	require.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(root, "skills", "beta"))
+	require.True(t, os.IsNotExist(err))
+
+	// Non-gcx skill is untouched.
+	_, err = os.Stat(filepath.Join(root, "skills", "external", "SKILL.md"))
+	require.NoError(t, err)
+}
+
+func TestUninstallCommand_RejectsNonBundledSkillName(t *testing.T) {
+	cmd := newUninstallCommand(testSkillsFS())
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"external"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unknown skill")
 }

--- a/cmd/gcx/skills/command_test.go
+++ b/cmd/gcx/skills/command_test.go
@@ -5,9 +5,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +27,7 @@ func TestInstallSkills_WritesBundleIntoSkillsSubdir(t *testing.T) {
 
 	root := filepath.Join(t.TempDir(), ".agents")
 
-	result, err := installSkills(testSkillsFS(), root, false, false)
+	result, err := installSkills(testSkillsFS(), root, nil, false, false)
 	require.NoError(t, err)
 
 	require.Equal(t, filepath.Clean(root), result.Root)
@@ -46,12 +48,45 @@ func TestInstallSkills_WritesBundleIntoSkillsSubdir(t *testing.T) {
 	require.Equal(t, []byte("beta-help"), data)
 }
 
+func TestInstallSkills_SingleSkill(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+	filter := map[string]struct{}{"alpha": {}}
+
+	result, err := installSkills(testSkillsFS(), root, filter, false, false)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"alpha"}, result.Skills)
+	require.Equal(t, 1, result.SkillCount)
+	require.Equal(t, 2, result.FileCount)
+	require.Equal(t, 2, result.Written)
+
+	data, err := os.ReadFile(filepath.Join(root, "skills", "alpha", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("alpha-skill"), data)
+
+	_, err = os.Stat(filepath.Join(root, "skills", "beta"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestInstallSkills_UnknownSkillReturnsError(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+	filter := map[string]struct{}{"nonexistent": {}}
+
+	_, err := installSkills(testSkillsFS(), root, filter, false, false)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unknown skill")
+}
+
 func TestInstallSkills_DryRunDoesNotWriteFiles(t *testing.T) {
 	t.Parallel()
 
 	root := filepath.Join(t.TempDir(), ".agents")
 
-	result, err := installSkills(testSkillsFS(), root, false, true)
+	result, err := installSkills(testSkillsFS(), root, nil, false, true)
 	require.NoError(t, err)
 	require.True(t, result.DryRun)
 	require.Equal(t, 4, result.Written)
@@ -69,7 +104,7 @@ func TestInstallSkills_ConflictingFileRequiresForce(t *testing.T) {
 	require.NoError(t, os.MkdirAll(target, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("local-change"), 0o600))
 
-	_, err := installSkills(testSkillsFS(), root, false, false)
+	_, err := installSkills(testSkillsFS(), root, nil, false, false)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "use --force to overwrite")
 }
@@ -82,7 +117,7 @@ func TestInstallSkills_ForceOverwritesDifferingFiles(t *testing.T) {
 	require.NoError(t, os.MkdirAll(target, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("local-change"), 0o600))
 
-	result, err := installSkills(testSkillsFS(), root, true, false)
+	result, err := installSkills(testSkillsFS(), root, nil, true, false)
 	require.NoError(t, err)
 	require.Equal(t, 3, result.Written)
 	require.Equal(t, 1, result.Overwritten)
@@ -92,7 +127,9 @@ func TestInstallSkills_ForceOverwritesDifferingFiles(t *testing.T) {
 	require.Equal(t, []byte("alpha-skill"), data)
 }
 
-func TestInstallCommand_UsesDefaultAgentsRootFromHome(t *testing.T) {
+func TestInstallCommand_AllInstallsEverything(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
@@ -102,7 +139,7 @@ func TestInstallCommand_UsesDefaultAgentsRootFromHome(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	cmd.SetOut(stdout)
 	cmd.SetErr(stderr)
-	cmd.SetArgs(nil)
+	cmd.SetArgs([]string{"--all"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -111,4 +148,239 @@ func TestInstallCommand_UsesDefaultAgentsRootFromHome(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("alpha-skill"), data)
 	require.Contains(t, stdout.String(), "Installed 2 skill(s)")
+}
+
+func TestInstallCommand_SingleSkillByName(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	cmd := newInstallCommand(testSkillsFS())
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"beta"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "Installed 1 skill(s)")
+
+	_, err = os.Stat(filepath.Join(home, ".agents", "skills", "alpha"))
+	require.True(t, os.IsNotExist(err))
+
+	data, err := os.ReadFile(filepath.Join(home, ".agents", "skills", "beta", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("beta-skill"), data)
+}
+
+func TestInstallCommand_NoArgsNoAllReturnsError(t *testing.T) {
+	cmd := newInstallCommand(testSkillsFS())
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "provide at least one skill name or use --all")
+}
+
+func TestListInstalledSkills_ListsOnlySkillDirectories(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "alpha"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "beta"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "notes"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "alpha", "SKILL.md"), []byte("alpha"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "beta", "SKILL.md"), []byte("beta"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "README.md"), []byte("docs"), 0o600))
+
+	result, err := listInstalledSkills(root)
+	require.NoError(t, err)
+	require.Equal(t, []skillInfo{
+		{Name: "alpha", ShortDescription: "alpha"},
+		{Name: "beta", ShortDescription: "beta"},
+	}, result.Skills)
+	require.Equal(t, 2, result.SkillCount)
+}
+
+func TestListInstalledSkills_MissingDirectoryReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+
+	result, err := listInstalledSkills(root)
+	require.NoError(t, err)
+	require.Empty(t, result.Skills)
+	require.Zero(t, result.SkillCount)
+}
+
+func TestListBundledSkills_ReturnsSourceSkills(t *testing.T) {
+	t.Parallel()
+
+	nonexistent := filepath.Join(t.TempDir(), "no-such-dir")
+	result, err := listBundledSkills(testSkillsFS(), nonexistent)
+	require.NoError(t, err)
+	require.Equal(t, []skillInfo{
+		{Name: "alpha", ShortDescription: "alpha-skill", Installed: false},
+		{Name: "beta", ShortDescription: "beta-skill", Installed: false},
+	}, result.Skills)
+	require.Equal(t, 2, result.SkillCount)
+}
+
+func TestListBundledSkills_ShowsInstalledStatus(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "alpha"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "alpha", "SKILL.md"), []byte("alpha-skill"), 0o600))
+
+	result, err := listBundledSkills(testSkillsFS(), root)
+	require.NoError(t, err)
+	require.Len(t, result.Skills, 2)
+
+	require.Equal(t, "alpha", result.Skills[0].Name)
+	require.True(t, result.Skills[0].Installed)
+
+	require.Equal(t, "beta", result.Skills[1].Name)
+	require.False(t, result.Skills[1].Installed)
+}
+
+func TestListInstalledSkills_ParsesFrontMatterDescription(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "sample"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "sample", "SKILL.md"), []byte(`---
+name: sample
+description: >
+  Use this skill to do an example operation in a concise way.
+---
+
+# Sample
+`), 0o600))
+
+	result, err := listInstalledSkills(root)
+	require.NoError(t, err)
+	require.Len(t, result.Skills, 1)
+	require.Equal(t, "sample", result.Skills[0].Name)
+	require.Equal(t, "Use this skill to do an example operation in a concise way.", result.Skills[0].ShortDescription)
+}
+
+func TestListCommand_JSONIncludesShortDescription(t *testing.T) {
+	source := fstest.MapFS{
+		"alpha/SKILL.md": {
+			Data: []byte(`---
+name: alpha
+description: alpha skill description
+---
+`),
+		},
+	}
+
+	cmd := newListCommand(source)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"-o", "json"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), `"name": "alpha"`)
+	require.Contains(t, stdout.String(), `"short_description": "alpha skill description"`)
+}
+
+func TestUninstallSkills_RemovesRequestedSkills(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "alpha"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "beta"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "alpha", "SKILL.md"), []byte("alpha"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "beta", "SKILL.md"), []byte("beta"), 0o600))
+
+	result, err := uninstallSkills(root, []string{"alpha", "missing"}, false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "missing"}, result.Requested)
+	require.Equal(t, []string{"alpha"}, result.Removed)
+	require.Equal(t, []string{"missing"}, result.Missing)
+	require.Equal(t, 1, result.RemovedCount)
+	require.Equal(t, 1, result.MissingCount)
+
+	_, err = os.Stat(filepath.Join(root, "skills", "alpha"))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestUninstallSkills_DryRunDoesNotRemoveFiles(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "alpha"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "alpha", "SKILL.md"), []byte("alpha"), 0o600))
+
+	result, err := uninstallSkills(root, []string{"alpha"}, true)
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha"}, result.Removed)
+	require.True(t, result.DryRun)
+
+	_, err = os.Stat(filepath.Join(root, "skills", "alpha", "SKILL.md"))
+	require.NoError(t, err)
+}
+
+func TestUninstallSkills_InvalidName(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), ".agents")
+
+	_, err := uninstallSkills(root, []string{"../alpha"}, false)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid skill name")
+}
+
+func TestUninstallCommand_AllRequiresApproval(t *testing.T) {
+	t.Setenv("GCX_AUTO_APPROVE", "0")
+
+	cmd := newUninstallCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"--all"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "refusing to uninstall all skills without --yes")
+}
+
+func TestUninstallCommand_AllWithYesRemovesInstalledSkills(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
+	root := filepath.Join(t.TempDir(), ".agents")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "alpha"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "skills", "beta"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "alpha", "SKILL.md"), []byte("alpha"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "skills", "beta", "SKILL.md"), []byte("beta"), 0o600))
+
+	cmd := newUninstallCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"--dir", root, "--all", "--yes"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "Uninstalled 2 skill(s)")
+	require.True(t, strings.Contains(stdout.String(), "Removed: alpha, beta") || strings.Contains(stdout.String(), "Removed: beta, alpha"))
+
+	_, err = os.Stat(filepath.Join(root, "skills", "alpha"))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
 }

--- a/docs/reference/cli/gcx_skills.md
+++ b/docs/reference/cli/gcx_skills.md
@@ -28,5 +28,5 @@ Install the canonical portable gcx Agent Skills bundle for .agents-compatible ag
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx skills install](gcx_skills_install.md)	 - Install bundled gcx skills into ~/.agents/skills
 * [gcx skills list](gcx_skills_list.md)	 - List skills bundled with the gcx binary
-* [gcx skills uninstall](gcx_skills_uninstall.md)	 - Uninstall installed skills from ~/.agents/skills
+* [gcx skills uninstall](gcx_skills_uninstall.md)	 - Uninstall gcx-managed skills from ~/.agents/skills
 

--- a/docs/reference/cli/gcx_skills_install.md
+++ b/docs/reference/cli/gcx_skills_install.md
@@ -13,11 +13,11 @@ gcx skills install [SKILL]... [flags]
 ### Examples
 
 ```
-  gcx skills install gcx
-  gcx skills install gcx setup-gcx debug-with-grafana
+  gcx skills install setup-gcx
+  gcx skills install setup-gcx debug-with-grafana explore-datasources
   gcx skills install --all
   gcx skills install --all --dry-run
-  gcx skills install gcx --force
+  gcx skills install setup-gcx --force
 ```
 
 ### Options

--- a/docs/reference/cli/gcx_skills_list.md
+++ b/docs/reference/cli/gcx_skills_list.md
@@ -1,15 +1,29 @@
-## gcx skills
+## gcx skills list
 
-Manage portable gcx Agent Skills
+List skills bundled with the gcx binary
 
 ### Synopsis
 
-Install the canonical portable gcx Agent Skills bundle for .agents-compatible agent harnesses.
+List skills bundled with the gcx binary, including each skill's short description and install status.
+
+```
+gcx skills list [flags]
+```
+
+### Examples
+
+```
+  gcx skills list
+  gcx skills list -o json
+```
 
 ### Options
 
 ```
-  -h, --help   help for skills
+      --dir string      Root directory for the .agents installation (used to check installed status) (default "~/.agents")
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands
@@ -25,8 +39,5 @@ Install the canonical portable gcx Agent Skills bundle for .agents-compatible ag
 
 ### SEE ALSO
 
-* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
-* [gcx skills install](gcx_skills_install.md)	 - Install bundled gcx skills into ~/.agents/skills
-* [gcx skills list](gcx_skills_list.md)	 - List skills bundled with the gcx binary
-* [gcx skills uninstall](gcx_skills_uninstall.md)	 - Uninstall installed skills from ~/.agents/skills
+* [gcx skills](gcx_skills.md)	 - Manage portable gcx Agent Skills
 

--- a/docs/reference/cli/gcx_skills_uninstall.md
+++ b/docs/reference/cli/gcx_skills_uninstall.md
@@ -1,10 +1,10 @@
 ## gcx skills uninstall
 
-Uninstall installed skills from ~/.agents/skills
+Uninstall gcx-managed skills from ~/.agents/skills
 
 ### Synopsis
 
-Remove one or more installed skills from a user-level .agents skills directory.
+Remove one or more gcx-managed skills from a user-level .agents skills directory. Only skills bundled with gcx can be uninstalled; non-gcx skills are never touched.
 
 ```
 gcx skills uninstall [SKILL]... [flags]
@@ -13,8 +13,8 @@ gcx skills uninstall [SKILL]... [flags]
 ### Examples
 
 ```
-  gcx skills uninstall grafanacloud-gcx
-  gcx skills uninstall grafanacloud-gcx skill-installer
+  gcx skills uninstall setup-gcx
+  gcx skills uninstall setup-gcx debug-with-grafana
   gcx skills uninstall --all --yes
   gcx skills uninstall --all --yes --dry-run
 ```
@@ -22,7 +22,7 @@ gcx skills uninstall [SKILL]... [flags]
 ### Options
 
 ```
-      --all             Uninstall all skills in the target directory
+      --all             Uninstall all gcx-managed skills
       --dir string      Root directory for the .agents installation (default "~/.agents")
       --dry-run         Preview the uninstall without removing files
   -h, --help            help for uninstall

--- a/docs/reference/cli/gcx_skills_uninstall.md
+++ b/docs/reference/cli/gcx_skills_uninstall.md
@@ -1,35 +1,34 @@
-## gcx skills install
+## gcx skills uninstall
 
-Install bundled gcx skills into ~/.agents/skills
+Uninstall installed skills from ~/.agents/skills
 
 ### Synopsis
 
-Install one or more bundled gcx Agent Skills into a user-level .agents directory for tools that follow the .agents skill convention. Use --all to install the entire bundle.
+Remove one or more installed skills from a user-level .agents skills directory.
 
 ```
-gcx skills install [SKILL]... [flags]
+gcx skills uninstall [SKILL]... [flags]
 ```
 
 ### Examples
 
 ```
-  gcx skills install gcx
-  gcx skills install gcx setup-gcx debug-with-grafana
-  gcx skills install --all
-  gcx skills install --all --dry-run
-  gcx skills install gcx --force
+  gcx skills uninstall grafanacloud-gcx
+  gcx skills uninstall grafanacloud-gcx skill-installer
+  gcx skills uninstall --all --yes
+  gcx skills uninstall --all --yes --dry-run
 ```
 
 ### Options
 
 ```
-      --all             Install all bundled skills
+      --all             Uninstall all skills in the target directory
       --dir string      Root directory for the .agents installation (default "~/.agents")
-      --dry-run         Preview the installation without writing files
-      --force           Overwrite existing differing files managed by the gcx skills bundle
-  -h, --help            help for install
+      --dry-run         Preview the uninstall without removing files
+  -h, --help            help for uninstall
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -y, --yes             Auto-approve uninstalling all skills
 ```
 
 ### Options inherited from parent commands

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -91,7 +91,9 @@ var commandAnnotations = map[string]annotation{
 	"gcx setup instrumentation status":   {Cost: "small"},
 
 	// skills
-	"gcx skills install": {Cost: "small"},
+	"gcx skills install":   {Cost: "small"},
+	"gcx skills list":      {Cost: "small"},
+	"gcx skills uninstall": {Cost: "small"},
 
 	// -----------------------------------------------------------------------
 	// Alert provider


### PR DESCRIPTION
Builds on top of the existing skills commands added by @javiermolinar 

- Replace raw tabwriter with style.NewTable for proper terminal-width rendering so descriptions no longer get cut off
- Remove redundant summary table from list output; show skills directly
- Add INSTALLED column to skills list showing install status per skill
- Change install command to accept individual skill names as arguments instead of always installing the entire bundle (use --all for that)
- Validate requested skill names against the bundle, with tab completion
- Add missing agent.token_cost annotations for list and uninstall commands
- Fix test flakiness from agent-mode auto-detection in Cursor via agent.ResetForTesting()

Made-with: Cursor