### PR TITLE
fix: `gcx dev serve` does not exit on ctrl+c

### DIFF
--- a/cmd/gcx/resources/serve.go
+++ b/cmd/gcx/resources/serve.go
@@ -175,7 +175,7 @@ support for file notifications.
 				}
 
 				// Start listening for events.
-				go watcher.Watch()
+				watcher.Watch(cmd.Context())
 			}
 
 			serverCfg := server.Config{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -142,8 +143,23 @@ func (s *Server) Start(ctx context.Context) error {
 	r.Get("/gcx/{group}/{version}/{kind}/{name}", s.iframeHandler)
 	r.Handle("/gcx/assets/*", http.StripPrefix("/gcx/assets/", http.FileServer(http.FS(assetsFS))))
 
-	//nolint:gosec
-	return http.ListenAndServe(fmt.Sprintf("%s:%d", s.config.ListenAddr, s.config.Port), r)
+	httpServer := &http.Server{
+		Addr:              fmt.Sprintf("%s:%d", s.config.ListenAddr, s.config.Port),
+		Handler:           r,
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		if err := httpServer.Shutdown(context.WithoutCancel(ctx)); err != nil {
+			logging.FromContext(ctx).Warn("server shutdown error", "err", err)
+		}
+	}()
+
+	if err := httpServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
 }
 
 func (s *Server) applyStaticProxyConfig(r chi.Router, config handlers.StaticProxyConfig) {

--- a/internal/server/watch/watcher.go
+++ b/internal/server/watch/watcher.go
@@ -62,10 +62,13 @@ func (w *Watcher) Add(watchPaths ...string) error {
 	return nil
 }
 
-func (w *Watcher) Watch() {
+func (w *Watcher) Watch(ctx context.Context) {
 	go func() {
+		defer w.notifier.Close()
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case event, ok := <-w.notifier.Events:
 				if !ok {
 					return


### PR DESCRIPTION
Fixes #474

## Problem

Pressing Ctrl+C while running \`gcx dev serve\` does not terminate the process. The server keeps listening on its port and must be killed manually.

## Root Cause

Two issues in the serve path:

1. \`internal/server/server.go\`: The package-level \`http.ListenAndServe\` has no context awareness and blocks indefinitely, ignoring cancellation signals.
2. \`internal/server/watch/watcher.go\`: The \`Watch\` goroutine has no \`ctx.Done()\` case, so the \`fsnotify\` watcher and its file descriptors are never released.

## Changes

- **\`internal/server/server.go\`**: Replace \`http.ListenAndServe\` with an \`http.Server\` that shuts down gracefully when the context is cancelled. A goroutine watches \`ctx.Done()\` and calls \`Shutdown\` with \`context.WithoutCancel(ctx)\` to preserve context values while dropping the cancellation signal. \`http.ErrServerClosed\` is treated as a clean exit. Sets \`ReadHeaderTimeout\` to satisfy gosec G112. Removes the now-unnecessary \`//nolint:gosec\` suppression (gosec G114 targets the package-level function, not \`http.Server\`).
- **\`internal/server/watch/watcher.go\`**: Add a \`context.Context\` parameter to \`Watch\`. The select loop gains a \`ctx.Done()\` case and \`defer w.notifier.Close()\` to release file descriptors on exit.
- **\`cmd/gcx/resources/serve.go\`**: Update the \`Watch\` call to pass \`cmd.Context()\`. Remove the redundant \`go\` prefix as \`Watch\` already spawns an internal goroutine.

## Testing

```bash
# Build
make build

# Run Server
./bin/gcx dev serve .

# In a second terminal, watch for the process while you Ctrl+C in the first
watch -n 1 "pgrep -l gcx"

Press Ctrl+C -- process exits immediately
# Hit Ctrl+C — the process should exit immediately with no zombie process

# Confirm port is released
lsof -i :8080
```
