### PR TITLE
Fix Watcher Error Channel Handling

### DIFF
--- a/internal/server/watch/watcher.go
+++ b/internal/server/watch/watcher.go
@@ -83,8 +83,9 @@ func (w *Watcher) Watch() {
 				}
 			case err, ok := <-w.notifier.Errors:
 				if !ok {
-					w.logger.Warn("watch error", logs.Err(err))
+					return
 				}
+				w.logger.Warn("watch error", logs.Err(err))
 			}
 		}
 	}()


### PR DESCRIPTION
Closes: #477 

## Summary

- When the `Errors` channel closed (`ok == false`), the code logged a nil error instead of returning, and the goroutine continued spinning on the closed channel indefinitely
- Real fsnotify errors (`ok == true`) were silently dropped
- Mirrors the existing `Events` channel case: return on close, log on real errors

## Test Plan

- [x] Run `go test ./internal/server/...`
- [x] Manually verify the dev server (`gcx dev serve`) starts, detects file changes, and shuts down cleanly