### PR TITLE
feat(slide): add marketing bento-box slide with verified CLI commands

### DIFF
--- a/.claude/skills/generate-slide/SKILL.md
+++ b/.claude/skills/generate-slide/SKILL.md
@@ -9,13 +9,13 @@ description: >
 
 # Generate gcx Marketing Slide
 
-Regenerate `slide.html` — a 1440x900 "bento box" marketing slide — so that every
-command shown is verified against the live binary and all stats are accurate.
+Regenerate `docs/bento_marketing_slide.html` — a 1440x900 "bento box" marketing slide — so
+that every command shown is verified against the live binary and all stats are accurate.
 
 ## Prerequisites
 
 - Go toolchain available
-- `slide.html` must exist at the repo root
+- `docs/bento_marketing_slide.html` must exist
 
 ## Workflow
 
@@ -95,8 +95,8 @@ Pick the best commands per card from the help-tree output. Selection criteria:
 
 ### Stage 4: Update slide.html
 
-Update `slide.html` preserving the exact layout and styling. Only modify HTML content
-inside card elements and the stats bar — never touch CSS or grid structure.
+Update `docs/bento_marketing_slide.html` preserving the exact layout and styling. Only modify
+HTML content inside card elements and the stats bar — never touch CSS or grid structure.
 
 #### Layout
 
@@ -149,7 +149,7 @@ Update with exact counts from Stage 1:
 
 ### Stage 5: Verify
 
-1. Open `slide.html` in a browser: `open slide.html`
+1. Open in a browser: `open docs/bento_marketing_slide.html`
 2. Check at 1440x900 viewport — no text overflow, no layout breaks
 3. Confirm narrow cards (3fr) don't have lines wrapping or clipping
 

--- a/.claude/skills/generate-slide/SKILL.md
+++ b/.claude/skills/generate-slide/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: generate-slide
+description: >
+  Regenerate the gcx marketing bento-box slide (slide.html) with verified commands
+  from the current codebase. Builds a fresh binary and reflects against the actual
+  command tree. Use when the user says "regenerate slide", "update slide",
+  "generate slide", or "/generate-slide".
+---
+
+# Generate gcx Marketing Slide
+
+Regenerate `slide.html` — a 1440x900 "bento box" marketing slide — so that every
+command shown is verified against the live binary and all stats are accurate.
+
+## Prerequisites
+
+- Go toolchain available
+- `slide.html` must exist at the repo root
+
+## Workflow
+
+### Stage 1: Build & Reflect
+
+Build a fresh gcx binary and extract the full command catalog and stats.
+
+```bash
+# 1. Build
+go build -buildvcs=false -o bin/gcx ./cmd/gcx/
+
+# 2. Extract the full flat command catalog (commands + resource_types)
+./bin/gcx commands --flat -o json > /tmp/gcx-catalog.json
+
+# 3. Extract counts from the catalog
+python3 -c "
+import json, sys
+d = json.load(open('/tmp/gcx-catalog.json'))
+cmds = d.get('commands', [])
+rt = d.get('resource_types', [])
+leaves = [c for c in cmds if c.get('token_cost')]
+print(f'Total commands: {len(cmds)}')
+print(f'Leaf commands (with token_cost): {len(leaves)}')
+print(f'Resource types: {len(rt)}')
+"
+
+# 4. Get provider count
+./bin/gcx providers list -o json | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(f'Providers: {len(d)}')
+for p in d: print(f'  - {p[\"name\"]}')
+"
+
+# 5. Get the human-readable command tree (for selecting showcase commands)
+./bin/gcx help-tree --depth 3 -o text
+```
+
+### Stage 2: Verify Card Commands
+
+For each card topic, extract the relevant subtree from the binary and confirm
+every command shown on the slide actually exists.
+
+```bash
+# Per-card verification — run one per card topic:
+./bin/gcx help-tree kg --depth 3 -o text           # Card 1: Knowledge Graph
+./bin/gcx help-tree assistant --depth 3 -o text     # Card 2: Grafana Assistant
+./bin/gcx help-tree fleet --depth 3 -o text         # Card 3: Fleet Management
+./bin/gcx help-tree frontend --depth 3 -o text      # Card 4a: App O11y (frontend/faro)
+./bin/gcx help-tree appo11y --depth 3 -o text       # Card 4b: App O11y (appo11y)
+./bin/gcx help-tree incidents --depth 3 -o text     # Card 5a: Incident Response
+./bin/gcx help-tree oncall --depth 3 -o text        # Card 5b: Incident Response (OnCall)
+./bin/gcx help-tree synth --depth 3 -o text         # Card 5c: Incident Response (Synth)
+./bin/gcx help-tree setup --depth 3 -o text         # Card 6: K8s Observability
+./bin/gcx help-tree metrics adaptive --depth 3 -o text  # Card 7a: Adaptive Telemetry
+./bin/gcx help-tree logs adaptive --depth 3 -o text     # Card 7b: Adaptive Telemetry
+./bin/gcx help-tree traces adaptive --depth 3 -o text   # Card 7c: Adaptive Telemetry
+./bin/gcx help-tree slo --depth 3 -o text           # Card 8: Agent-Ready Platform
+./bin/gcx help-tree profiles --depth 3 -o text      # Card 8: Agent-Ready Platform
+```
+
+For each card, compare the commands currently in `slide.html` against the help-tree
+output. Flag any command that does not appear in the tree — it must be replaced.
+
+### Stage 3: Select Showcase Commands
+
+Pick the best commands per card from the help-tree output. Selection criteria:
+
+- **Exists in tree**: The command must appear in the `help-tree` output. No invented commands.
+- **Compelling**: Prefer the most impressive capability per product (queries, inspections,
+  create/apply operations over plain list commands)
+- **Fits width**: Narrow 3fr cards allow ~42 monospace characters. Wide 5fr and 1fr cards
+  allow ~80 characters including inline comments.
+- **Diverse verbs**: Vary the actions across cards (list, get, create, query, inspect,
+  status, apply, show) — avoid walls of `list` commands.
+- **Flag accuracy**: Only use flags that appear in the help-tree output for that command.
+
+### Stage 4: Update slide.html
+
+Update `slide.html` preserving the exact layout and styling. Only modify HTML content
+inside card elements and the stats bar — never touch CSS or grid structure.
+
+#### Layout
+
+```
+Header:  [gcx logo]  [tagline]                          [gcx auth login badge]
+
+Row 1:   [ Card 1: Knowledge Graph (1fr)     ] [ Card 2: Grafana Assistant (1fr)   ]
+
+Row 2:   [ Card 3: Fleet Mgmt (5fr)  ] [ Card 4: App O11y (3fr) ] [ Card 5: IRM (3fr) ]
+
+Row 3:   [ Card 6: K8s O11y (5fr)    ] [ Card 7: Adaptive (3fr) ] [ Card 8: Agent (3fr)]
+
+Stats:   [ 1 binary ] [ N+ resource types ] [ N+ commands ] [ N products ]
+```
+
+#### Card Topic Mapping
+
+| Card | Provider(s) to query | Badge |
+|------|---------------------|-------|
+| 1. Knowledge Graph | `kg` | badge-green "Dependencies & Health" |
+| 2. Grafana Assistant | `assistant`, `auth` | badge-orange "AI-Powered" |
+| 3. Fleet Management | `fleet` | badge-green "Infrastructure" |
+| 4. App O11y | `frontend` (faro), `appo11y` | badge-green "End to End Observability" |
+| 5. Incident Response | `incidents`, `oncall`, `synth`, `k6` | badge-filled-orange "IRM" |
+| 6. K8s Observability | `setup instrumentation`, `fleet` | badge-green "Kubernetes" |
+| 7. Adaptive Telemetry | `metrics adaptive`, `logs adaptive`, `traces adaptive` | badge-orange "Cost Control" |
+| 8. Agent-Ready Platform | `slo`, `profiles`, `resources`, `assistant` | badge-filled-orange "A2A" |
+
+#### Styling Reference
+
+- Body: `#0b0c0e`, Cards: `#14161a` bg / `#1e2127` border / 10px radius
+- Code blocks: `#0e1014` bg / `#2a2d33` left-border / JetBrains Mono 12.5px / line-height 1.7
+- Syntax highlighting spans:
+  - `.c-bin` (`#6E9FFF`): the `gcx` binary name
+  - `.c-cmd` (`#c8ccd0`): provider/group name
+  - `.c-kw` (`#c8ccd0`, weight 500): action/subcommand
+  - `.c-flag` (`#6E9FFF`): flags like `--type`
+  - `.c-val` (`#ff9830`): values and strings
+  - `.c-cmt` (`#4a4f57`): inline comments
+- Code line format: `<div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">provider</span> <span class="c-kw">action</span> ...</div>`
+- Bullet lists use `<ul class="feature-list">` with gradient `>` markers
+
+#### Stats Bar
+
+Update with exact counts from Stage 1:
+- `1` binary (always)
+- Leaf command count rounded down to nearest 50, with `+` suffix (e.g. `250+`)
+- Resource type count rounded down to nearest 5, with `+` suffix (e.g. `60+`)
+- Exact provider count from `gcx providers list`
+
+### Stage 5: Verify
+
+1. Open `slide.html` in a browser: `open slide.html`
+2. Check at 1440x900 viewport — no text overflow, no layout breaks
+3. Confirm narrow cards (3fr) don't have lines wrapping or clipping
+
+## Guard Rails
+
+- Build fresh before every regeneration — never rely on stale data
+- Every command on the slide must appear in `gcx help-tree` output
+- Every flag on the slide must appear in the help-tree output for that specific command
+- Keep inline comments short in narrow cards — omit if they'd cause overflow
+- Preserve CSS/styling — only modify HTML content
+- Do not change the grid structure, card count, or row ratios

--- a/docs/bento_marketing_slide.html
+++ b/docs/bento_marketing_slide.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Regenerate this slide with /generate-slide in Claude Code, or see .claude/skills/generate-slide/SKILL.md -->
 <html lang="en">
 <head>
 <meta charset="UTF-8">

--- a/docs/bento_marketing_slide.html
+++ b/docs/bento_marketing_slide.html
@@ -232,7 +232,7 @@
 <div class="header">
   <div class="header-left">
     <div class="logo">gcx</div>
-    <div class="tagline">The CLI for Grafana Cloud. Built for humans. Optimized for agents.</div>
+    <div class="tagline">The CLI for Grafana Cloud. Optimized for agents.</div>
   </div>
   <div class="init-badge">gcx auth login</div>
 </div>

--- a/slide.html
+++ b/slide.html
@@ -1,0 +1,364 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1440, height=900">
+<title>gcx — The CLI for Grafana Cloud</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    background: #0b0c0e;
+    color: #c8ccd0;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    width: 1440px;
+    height: 900px;
+    overflow: hidden;
+    padding: 28px 36px 20px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ── Header ── */
+  .header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 20px;
+    flex-shrink: 0;
+  }
+  .header-left {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+  }
+  .logo {
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 800;
+    font-size: 38px;
+    font-style: italic;
+    background: linear-gradient(90deg, #F2495C, #EAB839);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .tagline {
+    font-size: 17px;
+    color: #7b8087;
+    font-weight: 400;
+  }
+  .init-badge {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 15px;
+    color: #8a9199;
+    border: 1px solid #33373d;
+    border-radius: 6px;
+    padding: 6px 14px;
+    background: #14161a;
+  }
+
+  /* ── Grid ── */
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto auto;
+    gap: 12px;
+    flex: 1;
+    min-height: 0;
+  }
+
+  /* ── Cards ── */
+  .card {
+    background: #14161a;
+    border: 1px solid #1e2127;
+    border-radius: 10px;
+    padding: 16px 20px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    padding: 3px 10px;
+    border-radius: 4px;
+    margin-bottom: 6px;
+    width: fit-content;
+  }
+  .badge-green {
+    color: #6E9FFF;
+    border: 1px solid #3b5a99;
+    background: rgba(110, 159, 255, 0.06);
+  }
+  .badge-orange {
+    color: #ff9830;
+    background: rgba(255, 152, 48, 0.12);
+    border: 1px solid #6b4420;
+  }
+  .badge-filled-orange {
+    color: #fff;
+    background: #a14e1a;
+    border: 1px solid #a14e1a;
+  }
+
+  .card h2 {
+    font-size: 19px;
+    font-weight: 700;
+    margin-bottom: 4px;
+    color: #e8ecf0;
+  }
+  .card h2 .accent {
+    background: linear-gradient(90deg, #F2495C, #EAB839);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .card .desc {
+    font-size: 13px;
+    color: #7b8087;
+    line-height: 1.45;
+    margin-bottom: 10px;
+  }
+
+  /* ── Code blocks ── */
+  .code-block {
+    background: #0e1014;
+    border-left: 3px solid #2a2d33;
+    border-radius: 6px;
+    padding: 10px 14px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12.5px;
+    line-height: 1.7;
+    overflow: hidden;
+    flex: 1;
+  }
+  .code-block .line {
+    white-space: nowrap;
+  }
+  .c-bin   { color: #6E9FFF; }           /* gcx */
+  .c-cmd   { color: #c8ccd0; }          /* subcommand */
+  .c-kw    { color: #c8ccd0; font-weight: 500; }  /* action */
+  .c-flag  { color: #6E9FFF; }          /* --flag */
+  .c-val   { color: #ff9830; }          /* values / strings */
+  .c-cmt   { color: #4a4f57; }          /* comments */
+
+  /* ── Bullet lists (small cards) ── */
+  .feature-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .feature-list li {
+    font-size: 13.5px;
+    line-height: 1.65;
+    color: #b0b5bb;
+  }
+  .feature-list li::before {
+    content: ">";
+    background: linear-gradient(90deg, #F2495C, #EAB839);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    font-weight: 700;
+    margin-right: 8px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+  }
+
+  /* ── Row layouts ── */
+  .row-2 { grid-column: 1 / -1; display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  .row-3 { grid-column: 1 / -1; display: grid; grid-template-columns: 5fr 3fr 3fr; gap: 12px; }
+
+  /* ── Stats bar ── */
+  .stats-bar {
+    display: flex;
+    justify-content: center;
+    align-items: baseline;
+    gap: 0;
+    padding-top: 16px;
+    flex-shrink: 0;
+  }
+  .stat {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 0 36px;
+  }
+  .stat:not(:last-child) {
+    border-right: 1px solid #2a2d33;
+  }
+  .stat .num {
+    font-family: 'Inter', sans-serif;
+    font-weight: 800;
+    font-size: 28px;
+  }
+  .stat .label {
+    font-size: 14px;
+    color: #5a5f66;
+    font-weight: 400;
+  }
+  .stat:nth-child(1) .num { color: #c8ccd0; }
+  .stat:nth-child(2) .num {
+    background: linear-gradient(90deg, #F2495C, #EAB839);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .stat:nth-child(3) .num {
+    background: linear-gradient(90deg, #F2495C, #EAB839);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .stat:nth-child(4) .num {
+    background: linear-gradient(90deg, #F2495C, #EAB839);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    font-style: italic;
+  }
+</style>
+</head>
+<body>
+
+<!-- Header -->
+<div class="header">
+  <div class="header-left">
+    <div class="logo">gcx</div>
+    <div class="tagline">The CLI for Grafana Cloud. Built for humans. Optimized for agents.</div>
+  </div>
+  <div class="init-badge">gcx auth login</div>
+</div>
+
+<!-- Row 1: Knowledge Graph + Grafana Assistant -->
+<div class="row-2">
+
+  <div class="card">
+    <span class="badge badge-green">Dependencies &amp; Health</span>
+    <h2><span class="accent">Knowledge Graph</span></h2>
+    <p class="desc">Map service dependencies, detect anomalies, and assert health across your entire stack.</p>
+    <div class="code-block">
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">kg</span> <span class="c-kw">entities list</span> <span class="c-flag">--type</span> <span class="c-val">Service</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">kg</span> <span class="c-kw">inspect</span> <span class="c-val">Service--checkout</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">kg</span> <span class="c-kw">insights active</span> <span class="c-flag">--severity</span> <span class="c-val">critical</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">kg</span> <span class="c-kw">health</span> <span class="c-flag">--type</span> <span class="c-val">Service</span></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <span class="badge badge-orange">AI-Powered</span>
+    <h2><span class="accent">Grafana</span> Assistant</h2>
+    <p class="desc">Conversational AI for your stack. Streaming responses, conversation threading, and local tool execution.</p>
+    <div class="code-block">
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">auth</span> <span class="c-kw">login</span>                            <span class="c-cmt"># browser OAuth login</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">assistant</span> <span class="c-kw">prompt</span> <span class="c-val">"what alerts fired?"</span>  <span class="c-cmt"># ask anything</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">assistant</span> <span class="c-kw">prompt</span> <span class="c-flag">--continue</span> <span class="c-val">"dig in"</span>  <span class="c-cmt"># threaded follow-up</span></div>
+    </div>
+  </div>
+
+</div>
+
+<!-- Row 2: Fleet + App O11y + Incident Response -->
+<div class="row-3">
+
+  <div class="card">
+    <span class="badge badge-green">Infrastructure</span>
+    <h2><span class="accent">Fleet</span> Management</h2>
+    <p class="desc">Alloy collectors, pipelines, and K8s instrumentation at scale.</p>
+    <div class="code-block">
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">fleet</span> <span class="c-kw">collectors list</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">fleet</span> <span class="c-kw">pipelines get</span> <span class="c-val">prod</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">fleet</span> <span class="c-kw">pipelines create</span> <span class="c-flag">-f</span> <span class="c-val">pipeline.yaml</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">fleet</span> <span class="c-kw">tenant limits</span></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <span class="badge badge-green">End to End Observability</span>
+    <h2><span class="accent">App</span> O11y</h2>
+    <div class="code-block">
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">frontend</span> <span class="c-kw">apps list</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">frontend</span> <span class="c-kw">apps apply-sourcemap</span> <span class="c-val">my-app</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">appo11y</span> <span class="c-kw">overrides get</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">appo11y</span> <span class="c-kw">settings get</span></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <span class="badge badge-filled-orange">IRM</span>
+    <h2>Incident <span class="accent">Response</span></h2>
+    <div class="code-block">
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">incidents</span> <span class="c-kw">list</span> <span class="c-flag">--limit</span> <span class="c-val">5</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">oncall</span> <span class="c-kw">schedules list</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">oncall</span> <span class="c-kw">escalation-chains list</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">synth</span> <span class="c-kw">checks status</span></div>
+    </div>
+  </div>
+
+</div>
+
+<!-- Row 3: K8s Observability + Adaptive Telemetry + Agent-Ready -->
+<div class="row-3">
+
+  <div class="card">
+    <span class="badge badge-green">Kubernetes</span>
+    <h2><span class="accent">K8s Observability</span> — zero to full-stack</h2>
+    <div class="code-block">
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">setup</span> <span class="c-kw">instrumentation status</span> <span class="c-flag">--cluster</span> <span class="c-val">prod</span>    <span class="c-cmt"># what's instrumented</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">setup</span> <span class="c-kw">instrumentation discover</span> <span class="c-flag">--cluster</span> <span class="c-val">prod</span>  <span class="c-cmt"># auto-discover services</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">setup</span> <span class="c-kw">instrumentation apply</span> <span class="c-flag">-f</span> <span class="c-val">manifest.yaml</span>    <span class="c-cmt"># deploy instrumentation</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">fleet</span> <span class="c-kw">pipelines list</span>                          <span class="c-cmt"># pipeline configs</span></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <span class="badge badge-orange">Cost Control</span>
+    <h2><span class="accent">Adaptive</span> Telemetry</h2>
+    <div class="code-block">
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">metrics</span> <span class="c-kw">adaptive recommendations show</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">logs</span> <span class="c-kw">adaptive patterns show</span></div>
+      <div class="line"><span class="c-bin">gcx</span> <span class="c-cmd">traces</span> <span class="c-kw">adaptive policies list</span></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <span class="badge badge-filled-orange">A2A</span>
+    <h2><span class="accent">Agent-Ready</span> Platform</h2>
+    <ul class="feature-list">
+      <li>JSON output everywhere (<code>-o json</code>)</li>
+      <li>Self-describing CLI (<code>gcx resources schemas</code>)</li>
+      <li>AI investigation workflows</li>
+      <li>SLO management &amp; profiling</li>
+    </ul>
+  </div>
+
+</div>
+
+<!-- Stats bar -->
+<div class="stats-bar">
+  <div class="stat">
+    <span class="num">1</span>
+    <span class="label">binary</span>
+  </div>
+  <div class="stat">
+    <span class="num">60+</span>
+    <span class="label">resource types</span>
+  </div>
+  <div class="stat">
+    <span class="num">250+</span>
+    <span class="label">commands</span>
+  </div>
+  <div class="stat">
+    <span class="num">15</span>
+    <span class="label">Grafana Cloud products</span>
+  </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add a 1440x900 HTML marketing "bento box" slide (`slide.html`) showcasing gcx capabilities across 8 product cards with syntax-highlighted CLI commands
- All commands verified against the actual binary via `gcx commands --flat` and `gcx help-tree` — stats reflect real counts (250+ leaf commands, 60+ resource types, 15 providers)
- Add a `/generate-slide` skill (`.claude/skills/generate-slide/SKILL.md`) that builds a fresh binary and regenerates the slide from the live command tree, so it stays accurate as gcx evolves

## Test plan
- [ ] Open `slide.html` in a browser at 1440x900 viewport — verify no text overflow or layout breaks
- [ ] Verify commands shown match `./bin/gcx help-tree <provider> --depth 3 -o text` output
- [ ] Test the skill by running `/generate-slide` in a new Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)