### PR TITLE
allow login through grafana.com/launch

### DIFF
--- a/cmd/gcx/auth/command.go
+++ b/cmd/gcx/auth/command.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"unicode"
@@ -129,7 +130,7 @@ func runLogin(cmd *cobra.Command, opts *loginOpts) error {
 	if curCtx.Grafana.Server == "" {
 		// we didn't know the instance endpoint before signing in
 		if result.InstanceEndpoint == "" {
-			return fmt.Errorf("instance did not provide its endpoint url")
+			return errors.New("instance did not provide its endpoint url")
 		}
 		curCtx.Grafana.Server = result.InstanceEndpoint
 	}

--- a/cmd/gcx/auth/command.go
+++ b/cmd/gcx/auth/command.go
@@ -7,7 +7,6 @@ import (
 	"unicode"
 
 	configcmd "github.com/grafana/gcx/cmd/gcx/config"
-	"github.com/grafana/gcx/cmd/gcx/fail"
 	internalauth "github.com/grafana/gcx/internal/auth"
 	"github.com/grafana/gcx/internal/config"
 	"github.com/spf13/cobra"
@@ -75,12 +74,6 @@ your identity and RBAC permissions.
 If --server is provided, gcx uses that server for this login and saves it to
 the selected context. This lets you bootstrap auth without preconfiguring
 grafana.server.
-
-Without --server, the selected context must already define grafana.server. For
-example:
-	gcx config set contexts.my-stack.grafana.server https://my-stack.grafana.net
-	gcx config use-context my-stack
-
 ` + fmt.Sprintf(unsupportedCommandsWarningTemplate, "contexts.CONTEXT.grafana.token"),
 		Example: `  gcx auth login --server https://my-stack.grafana.net
   gcx auth login --context prod --server https://prod.grafana.net
@@ -108,15 +101,15 @@ func runLogin(cmd *cobra.Command, opts *loginOpts) error {
 
 	curCtx := cfg.GetCurrentContext()
 	if curCtx == nil || curCtx.Grafana == nil || curCtx.Grafana.Server == "" {
-		return fail.DetailedError{
-			Summary: "Grafana server not configured",
-			Details: fmt.Sprintf("Context %q does not define grafana.server.", cfg.CurrentContext),
-			Suggestions: []string{
-				fmt.Sprintf("Set it: gcx config set %s https://my-stack.grafana.net", formatConfigPathArg("contexts", cfg.CurrentContext, "grafana", "server")),
-				"Or pass it now: gcx auth login --server https://my-stack.grafana.net",
-				"Or switch context: gcx config use-context my-context",
-			},
-		}
+		// if no context or server is configured, we can redirect to gcom to figure out things
+		fmt.Fprintf(cmd.ErrOrStderr(), "No existing context found, using sign-in flow\n")
+
+		// create empty config to prevent nil pointers
+		ctx := &config.Context{Grafana: &config.GrafanaConfig{}}
+		cfg.SetContext(cfg.CurrentContext, true, *ctx)
+		curCtx = cfg.GetCurrentContext()
+	} else if curCtx.Grafana == nil {
+		curCtx.Grafana = &config.GrafanaConfig{}
 	}
 
 	flow := opts.NewFlow(curCtx.Grafana.Server, internalauth.Options{
@@ -133,6 +126,13 @@ func runLogin(cmd *cobra.Command, opts *loginOpts) error {
 	curCtx.Grafana.OAuthRefreshToken = result.RefreshToken
 	curCtx.Grafana.OAuthTokenExpiresAt = result.ExpiresAt
 	curCtx.Grafana.OAuthRefreshExpiresAt = result.RefreshExpiresAt
+	if curCtx.Grafana.Server == "" {
+		// we didn't know the instance endpoint before signing in
+		if result.InstanceEndpoint == "" {
+			return fmt.Errorf("instance did not provide its endpoint url")
+		}
+		curCtx.Grafana.Server = result.InstanceEndpoint
+	}
 
 	if err := config.Write(ctx, opts.Config.ConfigSource(), cfg); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)

--- a/cmd/gcx/auth/command_test.go
+++ b/cmd/gcx/auth/command_test.go
@@ -17,64 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLogin_missingServer(t *testing.T) {
-	cfg := `current-context: test
-contexts:
-  test:
-    grafana: {}`
-
-	configFile := testutils.CreateTempFile(t, cfg)
-
-	tc := testutils.CommandTestCase{
-		Cmd:     authcmd.Command(),
-		Command: []string{"login", "--config", configFile},
-		Assertions: []testutils.CommandAssertion{
-			testutils.CommandErrorContains("Error: Grafana server not configured"),
-			testutils.CommandErrorContains("Context \"test\" does not define grafana.server."),
-			testutils.CommandErrorContains("Set it: gcx config set contexts.test.grafana.server https://my-stack.grafana.net"),
-			testutils.CommandErrorContains("Or pass it now: gcx auth login --server https://my-stack.grafana.net"),
-		},
-	}
-	tc.Run(t)
-}
-
-func TestLogin_noContext(t *testing.T) {
-	configFile := testutils.CreateTempFile(t, "contexts:")
-
-	tc := testutils.CommandTestCase{
-		Cmd:     authcmd.Command(),
-		Command: []string{"login", "--config", configFile},
-		Assertions: []testutils.CommandAssertion{
-			testutils.CommandErrorContains("Error: Grafana server not configured"),
-			testutils.CommandErrorContains("Context \"default\" does not define grafana.server."),
-			testutils.CommandErrorContains("Set it: gcx config set contexts.default.grafana.server https://my-stack.grafana.net"),
-			testutils.CommandErrorContains("Or pass it now: gcx auth login --server https://my-stack.grafana.net"),
-		},
-	}
-	tc.Run(t)
-}
-
-func TestLogin_missingServerInContextWithSpecialChars(t *testing.T) {
-	cfg := `current-context: "prod env.v2"
-contexts:
-  "prod env.v2":
-    grafana: {}`
-
-	configFile := testutils.CreateTempFile(t, cfg)
-
-	tc := testutils.CommandTestCase{
-		Cmd:     authcmd.Command(),
-		Command: []string{"login", "--config", configFile},
-		Assertions: []testutils.CommandAssertion{
-			testutils.CommandErrorContains("Error: Grafana server not configured"),
-			testutils.CommandErrorContains("Context \"prod env.v2\" does not define grafana.server."),
-			testutils.CommandErrorContains("Set it: gcx config set 'contexts.prod env\\.v2.grafana.server' https://my-stack.grafana.net"),
-			testutils.CommandErrorContains("Or pass it now: gcx auth login --server https://my-stack.grafana.net"),
-		},
-	}
-	tc.Run(t)
-}
-
 // syncBuffer is a goroutine-safe bytes.Buffer for capturing output
 // from a command running in a separate goroutine.
 type syncBuffer struct {

--- a/docs/reference/cli/gcx_auth_login.md
+++ b/docs/reference/cli/gcx_auth_login.md
@@ -14,12 +14,6 @@ your identity and RBAC permissions.
 If --server is provided, gcx uses that server for this login and saves it to
 the selected context. This lets you bootstrap auth without preconfiguring
 grafana.server.
-
-Without --server, the selected context must already define grafana.server. For
-example:
-	gcx config set contexts.my-stack.grafana.server https://my-stack.grafana.net
-	gcx config use-context my-stack
-
 WARNING: OAuth login is experimental. The following commands require a service account token instead:
   - incidents
   - oncall

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -53,6 +53,10 @@ type Result struct {
 
 	// RefreshExpiresAt is the refresh token expiration time in RFC3339 format.
 	RefreshExpiresAt string
+
+	// InstanceEndpoint is the endpoint returned by the grafana instance itself
+	// Only used if the endpoint isn't available during auth (e.g. signing in through grafana.com)
+	InstanceEndpoint string
 }
 
 // defaultScopes are the scopes requested by gcx.
@@ -131,8 +135,13 @@ func (f *Flow) Run(ctx context.Context) (*Result, error) {
 		_ = server.Shutdown(shutdownCtx)
 	}()
 
+	authEndpoint := strings.TrimSuffix(f.endpoint, "/")
+	if authEndpoint == "" {
+		authEndpoint = "https://grafana.com/launch"
+	}
+
 	authURL := fmt.Sprintf("%s/a/grafana-assistant-app/cli/auth?callback_port=%d&state=%s&code_challenge=%s&code_challenge_method=S256",
-		strings.TrimSuffix(f.endpoint, "/"), port, url.QueryEscape(state), url.QueryEscape(codeChallenge))
+		authEndpoint, port, url.QueryEscape(state), url.QueryEscape(codeChallenge))
 
 	if hostname, err := os.Hostname(); err == nil && hostname != "" {
 		authURL += "&device_name=" + url.QueryEscape(hostname)
@@ -214,6 +223,18 @@ func (f *Flow) startCallbackServer(ctx context.Context, bindAddress string, port
 				return
 			}
 
+			instanceEndpoint := r.URL.Query().Get("instanceEndpoint")
+			if instanceEndpoint != "" {
+				// only check if explicitly specified
+				// a missing value is not critical if the user has manually specified the grafana url
+				_, err = url.Parse(instanceEndpoint)
+				if err != nil {
+					errCh <- fmt.Errorf("invalid endpoint url: %w", err)
+					renderErrorPage(w, "Invalid instance endpoint passed")
+					return
+				}
+			}
+
 			result := &Result{
 				Token:            exchangeResult.Data.Token,
 				Email:            exchangeResult.Data.Email,
@@ -222,6 +243,7 @@ func (f *Flow) startCallbackServer(ctx context.Context, bindAddress string, port
 				ExpiresAt:        exchangeResult.Data.ExpiresAt,
 				RefreshToken:     exchangeResult.Data.RefreshToken,
 				RefreshExpiresAt: exchangeResult.Data.RefreshExpiresAt,
+				InstanceEndpoint: instanceEndpoint,
 			}
 
 			resultCh <- result


### PR DESCRIPTION
This PR updates the `auth login` command to work without providing a server. It relies upon the `grafana.com/launch` functionality which presents the user with an instance picker and then redirects them to the auth page in their chosen stack.

It requires a slight modification in the auth page to provide the instance URL to correctly fill the context.

PR to add instanceEndpoint to auth redirect: https://github.com/grafana/grafana-assistant-app/pull/5926

https://github.com/user-attachments/assets/624461bb-da76-47b8-9a91-bba9fbd478d1

