### PR TITLE
feat(adaptive-metrics): add segments and exemptions commands

### DIFF
--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions.md
@@ -1,0 +1,31 @@
+## gcx metrics adaptive exemptions
+
+Manage Adaptive Metrics recommendation exemptions.
+
+### Options
+
+```
+  -h, --help   help for exemptions
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics adaptive](gcx_metrics_adaptive.md)	 - Manage Adaptive Metrics resources
+* [gcx metrics adaptive exemptions create](gcx_metrics_adaptive_exemptions_create.md)	 - Create a recommendation exemption.
+* [gcx metrics adaptive exemptions delete](gcx_metrics_adaptive_exemptions_delete.md)	 - Delete a recommendation exemption.
+* [gcx metrics adaptive exemptions get](gcx_metrics_adaptive_exemptions_get.md)	 - Get a recommendation exemption by ID.
+* [gcx metrics adaptive exemptions list](gcx_metrics_adaptive_exemptions_list.md)	 - List Adaptive Metrics recommendation exemptions.
+* [gcx metrics adaptive exemptions update](gcx_metrics_adaptive_exemptions_update.md)	 - Update a recommendation exemption.
+

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_create.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_create.md
@@ -1,0 +1,40 @@
+## gcx metrics adaptive exemptions create
+
+Create a recommendation exemption.
+
+```
+gcx metrics adaptive exemptions create [flags]
+```
+
+### Options
+
+```
+      --active-interval string    Active interval (e.g. 30d, 1h) (default "30d")
+      --disable-recommendations   Disable all recommendations for matched metrics
+  -h, --help                      help for create
+      --json string               Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --keep-labels strings       Labels to keep (comma-separated)
+      --managed-by string         Manager identifier
+      --match-type string         Match type: exact, prefix, or suffix (default "exact")
+      --metric string             Metric name or pattern
+  -o, --output string             Output format. One of: json, yaml (default "json")
+      --reason string             Reason for the exemption
+      --segment string            Segment ID
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics adaptive exemptions](gcx_metrics_adaptive_exemptions.md)	 - Manage Adaptive Metrics recommendation exemptions.
+

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_delete.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_delete.md
@@ -1,11 +1,17 @@
-## gcx metrics adaptive
+## gcx metrics adaptive exemptions delete
 
-Manage Adaptive Metrics resources
+Delete a recommendation exemption.
+
+```
+gcx metrics adaptive exemptions delete <id> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+  -h, --help             help for delete
+      --segment string   Segment ID
+      --yes              Skip confirmation prompt
 ```
 
 ### Options inherited from parent commands
@@ -22,9 +28,5 @@ Manage Adaptive Metrics resources
 
 ### SEE ALSO
 
-* [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
 * [gcx metrics adaptive exemptions](gcx_metrics_adaptive_exemptions.md)	 - Manage Adaptive Metrics recommendation exemptions.
-* [gcx metrics adaptive recommendations](gcx_metrics_adaptive_recommendations.md)	 - Manage metric recommendations.
-* [gcx metrics adaptive rules](gcx_metrics_adaptive_rules.md)	 - Manage aggregation rules.
-* [gcx metrics adaptive segments](gcx_metrics_adaptive_segments.md)	 - Manage Adaptive Metrics segments.
 

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_get.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_get.md
@@ -1,11 +1,18 @@
-## gcx metrics adaptive
+## gcx metrics adaptive exemptions get
 
-Manage Adaptive Metrics resources
+Get a recommendation exemption by ID.
+
+```
+gcx metrics adaptive exemptions get <id> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+  -h, --help             help for get
+      --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string    Output format. One of: json, table, wide, yaml (default "json")
+      --segment string   Segment ID
 ```
 
 ### Options inherited from parent commands
@@ -22,9 +29,5 @@ Manage Adaptive Metrics resources
 
 ### SEE ALSO
 
-* [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
 * [gcx metrics adaptive exemptions](gcx_metrics_adaptive_exemptions.md)	 - Manage Adaptive Metrics recommendation exemptions.
-* [gcx metrics adaptive recommendations](gcx_metrics_adaptive_recommendations.md)	 - Manage metric recommendations.
-* [gcx metrics adaptive rules](gcx_metrics_adaptive_rules.md)	 - Manage aggregation rules.
-* [gcx metrics adaptive segments](gcx_metrics_adaptive_segments.md)	 - Manage Adaptive Metrics segments.
 

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_list.md
@@ -1,11 +1,20 @@
-## gcx metrics adaptive
+## gcx metrics adaptive exemptions list
 
-Manage Adaptive Metrics resources
+List Adaptive Metrics recommendation exemptions.
+
+```
+gcx metrics adaptive exemptions list [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+      --all-segments     List exemptions across all segments
+  -h, --help             help for list
+      --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int        Maximum number of exemptions to return (0 for no limit)
+  -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
+      --segment string   Segment ID
 ```
 
 ### Options inherited from parent commands
@@ -22,9 +31,5 @@ Manage Adaptive Metrics resources
 
 ### SEE ALSO
 
-* [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
 * [gcx metrics adaptive exemptions](gcx_metrics_adaptive_exemptions.md)	 - Manage Adaptive Metrics recommendation exemptions.
-* [gcx metrics adaptive recommendations](gcx_metrics_adaptive_recommendations.md)	 - Manage metric recommendations.
-* [gcx metrics adaptive rules](gcx_metrics_adaptive_rules.md)	 - Manage aggregation rules.
-* [gcx metrics adaptive segments](gcx_metrics_adaptive_segments.md)	 - Manage Adaptive Metrics segments.
 

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_update.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_update.md
@@ -1,0 +1,40 @@
+## gcx metrics adaptive exemptions update
+
+Update a recommendation exemption.
+
+```
+gcx metrics adaptive exemptions update <id> [flags]
+```
+
+### Options
+
+```
+      --active-interval string    Active interval (e.g. 30d, 1h)
+      --disable-recommendations   Disable all recommendations for matched metrics
+  -h, --help                      help for update
+      --json string               Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --keep-labels strings       Labels to keep (comma-separated)
+      --managed-by string         Manager identifier
+      --match-type string         Match type: exact, prefix, or suffix
+      --metric string             Metric name or pattern
+  -o, --output string             Output format. One of: json, yaml (default "json")
+      --reason string             Reason for the exemption
+      --segment string            Segment ID
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics adaptive exemptions](gcx_metrics_adaptive_exemptions.md)	 - Manage Adaptive Metrics recommendation exemptions.
+

--- a/docs/reference/cli/gcx_metrics_adaptive_segments.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments.md
@@ -1,0 +1,31 @@
+## gcx metrics adaptive segments
+
+Manage Adaptive Metrics segments.
+
+### Options
+
+```
+  -h, --help   help for segments
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics adaptive](gcx_metrics_adaptive.md)	 - Manage Adaptive Metrics resources
+* [gcx metrics adaptive segments create](gcx_metrics_adaptive_segments_create.md)	 - Create an Adaptive Metrics segment.
+* [gcx metrics adaptive segments delete](gcx_metrics_adaptive_segments_delete.md)	 - Delete an Adaptive Metrics segment.
+* [gcx metrics adaptive segments get](gcx_metrics_adaptive_segments_get.md)	 - Get an Adaptive Metrics segment by ID.
+* [gcx metrics adaptive segments list](gcx_metrics_adaptive_segments_list.md)	 - List Adaptive Metrics segments.
+* [gcx metrics adaptive segments update](gcx_metrics_adaptive_segments_update.md)	 - Update an Adaptive Metrics segment.
+

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_create.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_create.md
@@ -1,11 +1,21 @@
-## gcx metrics adaptive
+## gcx metrics adaptive segments create
 
-Manage Adaptive Metrics resources
+Create an Adaptive Metrics segment.
+
+```
+gcx metrics adaptive segments create [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+      --auto-apply            Automatically apply recommendations
+      --fallback-to-default   Fall back to default segment when no rules match
+  -h, --help                  help for create
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --name string           Segment name (required)
+  -o, --output string         Output format. One of: json, yaml (default "json")
+      --selector string       PromQL label selector (required)
 ```
 
 ### Options inherited from parent commands
@@ -22,9 +32,5 @@ Manage Adaptive Metrics resources
 
 ### SEE ALSO
 
-* [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
-* [gcx metrics adaptive exemptions](gcx_metrics_adaptive_exemptions.md)	 - Manage Adaptive Metrics recommendation exemptions.
-* [gcx metrics adaptive recommendations](gcx_metrics_adaptive_recommendations.md)	 - Manage metric recommendations.
-* [gcx metrics adaptive rules](gcx_metrics_adaptive_rules.md)	 - Manage aggregation rules.
 * [gcx metrics adaptive segments](gcx_metrics_adaptive_segments.md)	 - Manage Adaptive Metrics segments.
 

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_delete.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_delete.md
@@ -1,11 +1,16 @@
-## gcx metrics adaptive
+## gcx metrics adaptive segments delete
 
-Manage Adaptive Metrics resources
+Delete an Adaptive Metrics segment.
+
+```
+gcx metrics adaptive segments delete <id> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+  -h, --help   help for delete
+      --yes    Skip confirmation prompt
 ```
 
 ### Options inherited from parent commands
@@ -22,9 +27,5 @@ Manage Adaptive Metrics resources
 
 ### SEE ALSO
 
-* [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
-* [gcx metrics adaptive exemptions](gcx_metrics_adaptive_exemptions.md)	 - Manage Adaptive Metrics recommendation exemptions.
-* [gcx metrics adaptive recommendations](gcx_metrics_adaptive_recommendations.md)	 - Manage metric recommendations.
-* [gcx metrics adaptive rules](gcx_metrics_adaptive_rules.md)	 - Manage aggregation rules.
 * [gcx metrics adaptive segments](gcx_metrics_adaptive_segments.md)	 - Manage Adaptive Metrics segments.
 

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_get.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_get.md
@@ -1,11 +1,17 @@
-## gcx metrics adaptive
+## gcx metrics adaptive segments get
 
-Manage Adaptive Metrics resources
+Get an Adaptive Metrics segment by ID.
+
+```
+gcx metrics adaptive segments get <id> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, table, wide, yaml (default "json")
 ```
 
 ### Options inherited from parent commands
@@ -22,9 +28,5 @@ Manage Adaptive Metrics resources
 
 ### SEE ALSO
 
-* [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
-* [gcx metrics adaptive exemptions](gcx_metrics_adaptive_exemptions.md)	 - Manage Adaptive Metrics recommendation exemptions.
-* [gcx metrics adaptive recommendations](gcx_metrics_adaptive_recommendations.md)	 - Manage metric recommendations.
-* [gcx metrics adaptive rules](gcx_metrics_adaptive_rules.md)	 - Manage aggregation rules.
 * [gcx metrics adaptive segments](gcx_metrics_adaptive_segments.md)	 - Manage Adaptive Metrics segments.
 

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_list.md
@@ -1,11 +1,18 @@
-## gcx metrics adaptive
+## gcx metrics adaptive segments list
 
-Manage Adaptive Metrics resources
+List Adaptive Metrics segments.
+
+```
+gcx metrics adaptive segments list [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of segments to return (0 for no limit)
+  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands
@@ -22,9 +29,5 @@ Manage Adaptive Metrics resources
 
 ### SEE ALSO
 
-* [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
-* [gcx metrics adaptive exemptions](gcx_metrics_adaptive_exemptions.md)	 - Manage Adaptive Metrics recommendation exemptions.
-* [gcx metrics adaptive recommendations](gcx_metrics_adaptive_recommendations.md)	 - Manage metric recommendations.
-* [gcx metrics adaptive rules](gcx_metrics_adaptive_rules.md)	 - Manage aggregation rules.
 * [gcx metrics adaptive segments](gcx_metrics_adaptive_segments.md)	 - Manage Adaptive Metrics segments.
 

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_update.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_update.md
@@ -1,11 +1,21 @@
-## gcx metrics adaptive
+## gcx metrics adaptive segments update
 
-Manage Adaptive Metrics resources
+Update an Adaptive Metrics segment.
+
+```
+gcx metrics adaptive segments update <id> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+      --auto-apply            Automatically apply recommendations
+      --fallback-to-default   Fall back to default segment when no rules match
+  -h, --help                  help for update
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --name string           Segment name
+  -o, --output string         Output format. One of: json, yaml (default "json")
+      --selector string       PromQL label selector
 ```
 
 ### Options inherited from parent commands
@@ -22,9 +32,5 @@ Manage Adaptive Metrics resources
 
 ### SEE ALSO
 
-* [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
-* [gcx metrics adaptive exemptions](gcx_metrics_adaptive_exemptions.md)	 - Manage Adaptive Metrics recommendation exemptions.
-* [gcx metrics adaptive recommendations](gcx_metrics_adaptive_recommendations.md)	 - Manage metric recommendations.
-* [gcx metrics adaptive rules](gcx_metrics_adaptive_rules.md)	 - Manage aggregation rules.
 * [gcx metrics adaptive segments](gcx_metrics_adaptive_segments.md)	 - Manage Adaptive Metrics segments.
 

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -264,6 +264,16 @@ var commandAnnotations = map[string]annotation{
 	"gcx metrics adaptive rules get":             {Cost: "small"},
 	"gcx metrics adaptive rules list":            {Cost: "small"},
 	"gcx metrics adaptive rules update":          {Cost: "small"},
+	"gcx metrics adaptive segments create":       {Cost: "small"},
+	"gcx metrics adaptive segments delete":       {Cost: "small"},
+	"gcx metrics adaptive segments get":          {Cost: "small"},
+	"gcx metrics adaptive segments list":         {Cost: "small"},
+	"gcx metrics adaptive segments update":       {Cost: "small"},
+	"gcx metrics adaptive exemptions create":     {Cost: "small"},
+	"gcx metrics adaptive exemptions delete":     {Cost: "small"},
+	"gcx metrics adaptive exemptions get":        {Cost: "small"},
+	"gcx metrics adaptive exemptions list":       {Cost: "small"},
+	"gcx metrics adaptive exemptions update":     {Cost: "small"},
 
 	// -----------------------------------------------------------------------
 	// OnCall provider

--- a/internal/providers/metrics/adaptive/client.go
+++ b/internal/providers/metrics/adaptive/client.go
@@ -52,19 +52,8 @@ func NewClient(ctx context.Context, baseURL string, tenantID int, apiToken strin
 	}
 }
 
-// doRequest builds and executes a GET request against the Adaptive Metrics API.
-func (c *Client) doRequest(ctx context.Context, path string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
-	if err != nil {
-		return nil, fmt.Errorf("metrics: create request: %w", err)
-	}
-	req.SetBasicAuth(strconv.Itoa(c.tenantID), c.apiToken)
-
-	return c.httpClient.Do(req)
-}
-
-// doMutatingRequest builds and executes a POST/PUT/DELETE request with an optional JSON body.
-func (c *Client) doMutatingRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+// doRequest builds and executes an HTTP request against the Adaptive Metrics API.
+func (c *Client) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
 	if err != nil {
 		return nil, fmt.Errorf("metrics: create request: %w", err)
@@ -83,7 +72,7 @@ func (c *Client) doMutatingRequest(ctx context.Context, method, path string, bod
 
 // ListSegments returns all Adaptive Metrics segments.
 func (c *Client) ListSegments(ctx context.Context) ([]MetricSegment, error) {
-	resp, err := c.doRequest(ctx, "/aggregations/rules/segments")
+	resp, err := c.doRequest(ctx, http.MethodGet, "/aggregations/rules/segments", nil)
 	if err != nil {
 		return nil, fmt.Errorf("metrics: list segments: %w", err)
 	}
@@ -130,7 +119,7 @@ func (c *Client) CreateSegment(ctx context.Context, s *MetricSegment) (*MetricSe
 		return nil, fmt.Errorf("metrics: create segment: marshal: %w", err)
 	}
 
-	resp, err := c.doMutatingRequest(ctx, http.MethodPost, "/aggregations/rules/segments", bytes.NewReader(data))
+	resp, err := c.doRequest(ctx, http.MethodPost, "/aggregations/rules/segments", bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("metrics: create segment: %w", err)
 	}
@@ -158,7 +147,7 @@ func (c *Client) UpdateSegment(ctx context.Context, id string, s *MetricSegment)
 	}
 
 	path := "/aggregations/rules/segments?segment=" + url.QueryEscape(id)
-	resp, err := c.doMutatingRequest(ctx, http.MethodPut, path, bytes.NewReader(data))
+	resp, err := c.doRequest(ctx, http.MethodPut, path, bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("metrics: update segment: %w", err)
 	}
@@ -180,7 +169,7 @@ func (c *Client) UpdateSegment(ctx context.Context, id string, s *MetricSegment)
 // DeleteSegment deletes a segment by ID. Returns 409 if the segment has dependent data.
 func (c *Client) DeleteSegment(ctx context.Context, id string) error {
 	path := "/aggregations/rules/segments?segment=" + url.QueryEscape(id)
-	resp, err := c.doMutatingRequest(ctx, http.MethodDelete, path, nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return fmt.Errorf("metrics: delete segment: %w", err)
 	}
@@ -210,7 +199,7 @@ func (c *Client) ListExemptions(ctx context.Context, segment string) ([]MetricEx
 		path += "?segment=" + url.QueryEscape(segment)
 	}
 
-	resp, err := c.doRequest(ctx, path)
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("metrics: list exemptions: %w", err)
 	}
@@ -237,7 +226,7 @@ func (c *Client) ListExemptions(ctx context.Context, segment string) ([]MetricEx
 
 // ListSegmentedExemptions returns all exemptions grouped by segment.
 func (c *Client) ListSegmentedExemptions(ctx context.Context) ([]ExemptionsBySegmentEntry, error) {
-	resp, err := c.doRequest(ctx, "/v1/recommendations/segmented_exemptions")
+	resp, err := c.doRequest(ctx, http.MethodGet, "/v1/recommendations/segmented_exemptions", nil)
 	if err != nil {
 		return nil, fmt.Errorf("metrics: list segmented exemptions: %w", err)
 	}
@@ -268,7 +257,7 @@ func (c *Client) GetExemption(ctx context.Context, id, segment string) (*MetricE
 		path += "?segment=" + url.QueryEscape(segment)
 	}
 
-	resp, err := c.doRequest(ctx, path)
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("metrics: get exemption: %w", err)
 	}
@@ -307,7 +296,7 @@ func (c *Client) CreateExemption(ctx context.Context, e *MetricExemption, segmen
 		return nil, fmt.Errorf("metrics: create exemption: marshal: %w", err)
 	}
 
-	resp, err := c.doMutatingRequest(ctx, http.MethodPost, path, bytes.NewReader(data))
+	resp, err := c.doRequest(ctx, http.MethodPost, path, bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("metrics: create exemption: %w", err)
 	}
@@ -344,7 +333,7 @@ func (c *Client) UpdateExemption(ctx context.Context, id string, e *MetricExempt
 		return nil, fmt.Errorf("metrics: update exemption: marshal: %w", err)
 	}
 
-	resp, err := c.doMutatingRequest(ctx, http.MethodPut, path, bytes.NewReader(data))
+	resp, err := c.doRequest(ctx, http.MethodPut, path, bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("metrics: update exemption: %w", err)
 	}
@@ -370,7 +359,7 @@ func (c *Client) DeleteExemption(ctx context.Context, id, segment string) error 
 		path += "?segment=" + url.QueryEscape(segment)
 	}
 
-	resp, err := c.doMutatingRequest(ctx, http.MethodDelete, path, nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return fmt.Errorf("metrics: delete exemption: %w", err)
 	}
@@ -391,7 +380,7 @@ func (c *Client) ListRules(ctx context.Context, segment string) ([]MetricRule, s
 		path += "?segment=" + url.QueryEscape(segment)
 	}
 
-	resp, err := c.doRequest(ctx, path)
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("metrics: list rules: %w", err)
 	}
@@ -421,7 +410,7 @@ func (c *Client) GetRule(ctx context.Context, metric, segment string) (MetricRul
 		path += "?segment=" + url.QueryEscape(segment)
 	}
 
-	resp, err := c.doRequest(ctx, path)
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return MetricRule{}, fmt.Errorf("metrics: get rule: %w", err)
 	}
@@ -644,7 +633,7 @@ func (c *Client) ListRecommendations(ctx context.Context, segment string, action
 		params.Add("action", a)
 	}
 
-	resp, err := c.doRequest(ctx, "/aggregations/recommendations?"+params.Encode())
+	resp, err := c.doRequest(ctx, http.MethodGet, "/aggregations/recommendations?"+params.Encode(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("metrics: list recommendations: %w", err)
 	}
@@ -672,7 +661,7 @@ func (c *Client) ListRecommendedRules(ctx context.Context, segment string) ([]Me
 		params.Set("segment", segment)
 	}
 
-	resp, err := c.doRequest(ctx, "/aggregations/recommendations?"+params.Encode())
+	resp, err := c.doRequest(ctx, http.MethodGet, "/aggregations/recommendations?"+params.Encode(), nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("metrics: list recommended rules: %w", err)
 	}

--- a/internal/providers/metrics/adaptive/client.go
+++ b/internal/providers/metrics/adaptive/client.go
@@ -10,15 +10,24 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/resources/adapter"
 )
 
+// serverError trims trailing whitespace from server response bodies so that
+// error messages don't contain stray newlines in formatted output.
+func serverError(b []byte) string {
+	return strings.TrimRight(string(b), " \t\r\n")
+}
+
 // Sentinel errors for specific HTTP status codes.
 var (
 	ErrRuleNotFound       = fmt.Errorf("rule: %w", adapter.ErrNotFound)
 	ErrPreconditionFailed = errors.New("rule was modified concurrently")
+	ErrSegmentNotFound    = fmt.Errorf("segment: %w", adapter.ErrNotFound)
+	ErrExemptionNotFound  = fmt.Errorf("exemption: %w", adapter.ErrNotFound)
 )
 
 // Client is an HTTP client for the Grafana Adaptive Metrics API.
@@ -54,6 +63,327 @@ func (c *Client) doRequest(ctx context.Context, path string) (*http.Response, er
 	return c.httpClient.Do(req)
 }
 
+// doMutatingRequest builds and executes a POST/PUT/DELETE request with an optional JSON body.
+func (c *Client) doMutatingRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("metrics: create request: %w", err)
+	}
+	req.SetBasicAuth(strconv.Itoa(c.tenantID), c.apiToken)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return c.httpClient.Do(req)
+}
+
+// ---------------------------------------------------------------------------
+// Segments
+// ---------------------------------------------------------------------------
+
+// ListSegments returns all Adaptive Metrics segments.
+func (c *Client) ListSegments(ctx context.Context) ([]MetricSegment, error) {
+	resp, err := c.doRequest(ctx, "/aggregations/rules/segments")
+	if err != nil {
+		return nil, fmt.Errorf("metrics: list segments: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("metrics: list segments: status %d: %s", resp.StatusCode, serverError(b))
+	}
+
+	var segments []MetricSegment
+	if err := json.NewDecoder(resp.Body).Decode(&segments); err != nil {
+		return nil, fmt.Errorf("metrics: list segments: decode: %w", err)
+	}
+
+	if segments == nil {
+		return []MetricSegment{}, nil
+	}
+
+	return segments, nil
+}
+
+// GetSegment returns a single segment by ID (list + filter, no server-side get-by-id).
+// Returns ErrSegmentNotFound if not found.
+func (c *Client) GetSegment(ctx context.Context, id string) (*MetricSegment, error) {
+	segments, err := c.ListSegments(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range segments {
+		if segments[i].ID == id {
+			return &segments[i], nil
+		}
+	}
+
+	return nil, ErrSegmentNotFound
+}
+
+// CreateSegment creates a new Adaptive Metrics segment.
+func (c *Client) CreateSegment(ctx context.Context, s *MetricSegment) (*MetricSegment, error) {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return nil, fmt.Errorf("metrics: create segment: marshal: %w", err)
+	}
+
+	resp, err := c.doMutatingRequest(ctx, http.MethodPost, "/aggregations/rules/segments", bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("metrics: create segment: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("metrics: create segment: status %d: %s", resp.StatusCode, serverError(b))
+	}
+
+	var created MetricSegment
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		return nil, fmt.Errorf("metrics: create segment: decode: %w", err)
+	}
+
+	return &created, nil
+}
+
+// UpdateSegment updates an existing segment. The server returns an empty body on success,
+// so the input segment (with ID set) is returned.
+func (c *Client) UpdateSegment(ctx context.Context, id string, s *MetricSegment) (*MetricSegment, error) {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return nil, fmt.Errorf("metrics: update segment: marshal: %w", err)
+	}
+
+	path := "/aggregations/rules/segments?segment=" + url.QueryEscape(id)
+	resp, err := c.doMutatingRequest(ctx, http.MethodPut, path, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("metrics: update segment: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrSegmentNotFound
+	}
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("metrics: update segment: status %d: %s", resp.StatusCode, serverError(b))
+	}
+
+	result := *s
+	result.ID = id
+	return &result, nil
+}
+
+// DeleteSegment deletes a segment by ID. Returns 409 if the segment has dependent data.
+func (c *Client) DeleteSegment(ctx context.Context, id string) error {
+	path := "/aggregations/rules/segments?segment=" + url.QueryEscape(id)
+	resp, err := c.doMutatingRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return fmt.Errorf("metrics: delete segment: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusConflict {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("metrics: delete segment: segment has dependent rules or exemptions: %s", string(b))
+	}
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("metrics: delete segment: status %d: %s", resp.StatusCode, serverError(b))
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Exemptions
+// ---------------------------------------------------------------------------
+
+// ListExemptions returns all exemptions, optionally scoped to a segment.
+// The API wraps results in {"result": [...]}.
+func (c *Client) ListExemptions(ctx context.Context, segment string) ([]MetricExemption, error) {
+	path := "/v1/recommendations/exemptions"
+	if segment != "" {
+		path += "?segment=" + url.QueryEscape(segment)
+	}
+
+	resp, err := c.doRequest(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("metrics: list exemptions: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("metrics: list exemptions: status %d: %s", resp.StatusCode, serverError(b))
+	}
+
+	var wrapper struct {
+		Result []MetricExemption `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
+		return nil, fmt.Errorf("metrics: list exemptions: decode: %w", err)
+	}
+
+	if wrapper.Result == nil {
+		return []MetricExemption{}, nil
+	}
+
+	return wrapper.Result, nil
+}
+
+// ListSegmentedExemptions returns all exemptions grouped by segment.
+func (c *Client) ListSegmentedExemptions(ctx context.Context) ([]ExemptionsBySegmentEntry, error) {
+	resp, err := c.doRequest(ctx, "/v1/recommendations/segmented_exemptions")
+	if err != nil {
+		return nil, fmt.Errorf("metrics: list segmented exemptions: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("metrics: list segmented exemptions: status %d: %s", resp.StatusCode, serverError(b))
+	}
+
+	var entries []ExemptionsBySegmentEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, fmt.Errorf("metrics: list segmented exemptions: decode: %w", err)
+	}
+
+	if entries == nil {
+		return []ExemptionsBySegmentEntry{}, nil
+	}
+
+	return entries, nil
+}
+
+// GetExemption returns a single exemption by ID, optionally scoped to a segment.
+// Returns ErrExemptionNotFound on 404.
+func (c *Client) GetExemption(ctx context.Context, id, segment string) (*MetricExemption, error) {
+	path := "/v1/recommendations/exemptions/" + url.PathEscape(id)
+	if segment != "" {
+		path += "?segment=" + url.QueryEscape(segment)
+	}
+
+	resp, err := c.doRequest(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("metrics: get exemption: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrExemptionNotFound
+	}
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("metrics: get exemption: status %d: %s", resp.StatusCode, serverError(b))
+	}
+
+	var wrapper struct {
+		Result *MetricExemption `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
+		return nil, fmt.Errorf("metrics: get exemption: decode: %w", err)
+	}
+	if wrapper.Result == nil {
+		return nil, errors.New("metrics: get exemption: empty result")
+	}
+
+	return wrapper.Result, nil
+}
+
+// CreateExemption creates a new exemption, optionally scoped to a segment.
+func (c *Client) CreateExemption(ctx context.Context, e *MetricExemption, segment string) (*MetricExemption, error) {
+	path := "/v1/recommendations/exemptions"
+	if segment != "" {
+		path += "?segment=" + url.QueryEscape(segment)
+	}
+
+	data, err := json.Marshal(e)
+	if err != nil {
+		return nil, fmt.Errorf("metrics: create exemption: marshal: %w", err)
+	}
+
+	resp, err := c.doMutatingRequest(ctx, http.MethodPost, path, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("metrics: create exemption: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("metrics: create exemption: status %d: %s", resp.StatusCode, serverError(b))
+	}
+
+	var wrapper struct {
+		Result *MetricExemption `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
+		return nil, fmt.Errorf("metrics: create exemption: decode: %w", err)
+	}
+	if wrapper.Result == nil {
+		return nil, errors.New("metrics: create exemption: empty result")
+	}
+
+	return wrapper.Result, nil
+}
+
+// UpdateExemption updates an existing exemption. The server returns an empty body on success,
+// so the input exemption (with ID set) is returned.
+func (c *Client) UpdateExemption(ctx context.Context, id string, e *MetricExemption, segment string) (*MetricExemption, error) {
+	path := "/v1/recommendations/exemptions/" + url.PathEscape(id)
+	if segment != "" {
+		path += "?segment=" + url.QueryEscape(segment)
+	}
+
+	data, err := json.Marshal(e)
+	if err != nil {
+		return nil, fmt.Errorf("metrics: update exemption: marshal: %w", err)
+	}
+
+	resp, err := c.doMutatingRequest(ctx, http.MethodPut, path, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("metrics: update exemption: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrExemptionNotFound
+	}
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("metrics: update exemption: status %d: %s", resp.StatusCode, serverError(b))
+	}
+
+	result := *e
+	result.ID = id
+	return &result, nil
+}
+
+// DeleteExemption soft-deletes an exemption, optionally scoped to a segment.
+func (c *Client) DeleteExemption(ctx context.Context, id, segment string) error {
+	path := "/v1/recommendations/exemptions/" + url.PathEscape(id)
+	if segment != "" {
+		path += "?segment=" + url.QueryEscape(segment)
+	}
+
+	resp, err := c.doMutatingRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return fmt.Errorf("metrics: delete exemption: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("metrics: delete exemption: status %d: %s", resp.StatusCode, serverError(b))
+	}
+
+	return nil
+}
+
 // ListRules returns all aggregation rules and the current ETag.
 func (c *Client) ListRules(ctx context.Context, segment string) ([]MetricRule, string, error) {
 	path := "/aggregations/rules"
@@ -69,7 +399,7 @@ func (c *Client) ListRules(ctx context.Context, segment string) ([]MetricRule, s
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, "", fmt.Errorf("metrics: list rules: status %d: %s", resp.StatusCode, string(b))
+		return nil, "", fmt.Errorf("metrics: list rules: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	etag := resp.Header.Get("Etag")
@@ -102,7 +432,7 @@ func (c *Client) GetRule(ctx context.Context, metric, segment string) (MetricRul
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return MetricRule{}, fmt.Errorf("metrics: get rule: status %d: %s", resp.StatusCode, string(b))
+		return MetricRule{}, fmt.Errorf("metrics: get rule: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var rule MetricRule
@@ -148,7 +478,7 @@ func (c *Client) CreateRule(ctx context.Context, rule MetricRule, etag, segment 
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("metrics: create rule: status %d: %s", resp.StatusCode, string(b))
+		return "", fmt.Errorf("metrics: create rule: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	return resp.Header.Get("Etag"), nil
@@ -186,7 +516,7 @@ func (c *Client) UpdateRule(ctx context.Context, rule MetricRule, etag, segment 
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("metrics: update rule: status %d: %s", resp.StatusCode, string(b))
+		return "", fmt.Errorf("metrics: update rule: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	return resp.Header.Get("Etag"), nil
@@ -218,7 +548,7 @@ func (c *Client) DeleteRule(ctx context.Context, metric, etag, segment string) e
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("metrics: delete rule: status %d: %s", resp.StatusCode, string(b))
+		return fmt.Errorf("metrics: delete rule: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	return nil
@@ -256,7 +586,7 @@ func (c *Client) SyncRules(ctx context.Context, rules []MetricRule, etag, segmen
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("metrics: sync rules: status %d: %s", resp.StatusCode, string(b))
+		return fmt.Errorf("metrics: sync rules: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	return nil
@@ -292,7 +622,7 @@ func (c *Client) ValidateRules(ctx context.Context, rules []MetricRule, segment 
 	// Other non-2xx/400 statuses are genuine errors.
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusBadRequest {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: validate rules: status %d: %s", resp.StatusCode, string(b))
+		return nil, fmt.Errorf("metrics: validate rules: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var errs []string
@@ -322,7 +652,7 @@ func (c *Client) ListRecommendations(ctx context.Context, segment string, action
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: list recommendations: status %d: %s", resp.StatusCode, string(b))
+		return nil, fmt.Errorf("metrics: list recommendations: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var recs []MetricRecommendation
@@ -350,7 +680,7 @@ func (c *Client) ListRecommendedRules(ctx context.Context, segment string) ([]Me
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, "", fmt.Errorf("metrics: list recommended rules: status %d: %s", resp.StatusCode, string(b))
+		return nil, "", fmt.Errorf("metrics: list recommended rules: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	rulesVersion := resp.Header.Get("Rules-Version")

--- a/internal/providers/metrics/adaptive/client_test.go
+++ b/internal/providers/metrics/adaptive/client_test.go
@@ -30,6 +30,729 @@ func TestErrRuleNotFound_WrapsAdapterErrNotFound(t *testing.T) {
 		"ErrRuleNotFound must wrap adapter.ErrNotFound so push upsert falls through to Create")
 }
 
+func TestErrSegmentNotFound_WrapsAdapterErrNotFound(t *testing.T) {
+	assert.ErrorIs(t, metrics.ErrSegmentNotFound, adapter.ErrNotFound,
+		"ErrSegmentNotFound must wrap adapter.ErrNotFound so push upsert falls through to Create")
+}
+
+func TestErrExemptionNotFound_WrapsAdapterErrNotFound(t *testing.T) {
+	assert.ErrorIs(t, metrics.ErrExemptionNotFound, adapter.ErrNotFound,
+		"ErrExemptionNotFound must wrap adapter.ErrNotFound so push upsert falls through to Create")
+}
+
+// ---------------------------------------------------------------------------
+// Segments
+// ---------------------------------------------------------------------------
+
+func TestClient_ListSegments(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name: "returns segments",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/aggregations/rules/segments", r.URL.Path)
+				writeJSON(w, []map[string]any{
+					{"id": "seg-1", "name": "production", "selector": `{env="prod"}`},
+					{"id": "seg-2", "name": "staging", "selector": `{env="staging"}`},
+				})
+			},
+			wantLen: 2,
+		},
+		{
+			name: "returns empty list for null response",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("null"))
+			},
+			wantLen: 0,
+		},
+		{
+			name: "returns empty list for empty array",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, []any{})
+			},
+			wantLen: 0,
+		},
+		{
+			name: "propagates 4xx error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte("unauthorized"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "propagates 5xx error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("server error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			segments, err := client.ListSegments(context.Background())
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, segments, tt.wantLen)
+		})
+	}
+}
+
+func TestClient_GetSegment(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		handler    http.HandlerFunc
+		wantName   string
+		wantErr    bool
+		wantErr404 bool
+	}{
+		{
+			name: "returns matching segment",
+			id:   "seg-1",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, []map[string]any{
+					{"id": "seg-1", "name": "production", "selector": `{env="prod"}`},
+					{"id": "seg-2", "name": "staging", "selector": `{env="staging"}`},
+				})
+			},
+			wantName: "production",
+		},
+		{
+			name: "returns ErrSegmentNotFound when ID not in list",
+			id:   "nonexistent",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, []map[string]any{
+					{"id": "seg-1", "name": "production"},
+				})
+			},
+			wantErr404: true,
+		},
+		{
+			name: "returns ErrSegmentNotFound for empty list",
+			id:   "seg-1",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, []any{})
+			},
+			wantErr404: true,
+		},
+		{
+			name: "propagates list error",
+			id:   "seg-1",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			segment, err := client.GetSegment(context.Background(), tt.id)
+
+			if tt.wantErr404 {
+				require.ErrorIs(t, err, metrics.ErrSegmentNotFound)
+				return
+			}
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, segment.Name)
+			assert.Equal(t, tt.id, segment.ID)
+		})
+	}
+}
+
+func TestClient_CreateSegment(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name: "creates segment and returns result",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/aggregations/rules/segments", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+				var seg metrics.MetricSegment
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&seg))
+				assert.Equal(t, "production", seg.Name)
+
+				writeJSON(w, map[string]any{
+					"id":       "seg-new",
+					"name":     "production",
+					"selector": `{env="prod"}`,
+				})
+			},
+		},
+		{
+			name: "propagates error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("invalid selector"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			seg := &metrics.MetricSegment{Name: "production", Selector: `{env="prod"}`}
+			created, err := client.CreateSegment(context.Background(), seg)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, "seg-new", created.ID)
+			assert.Equal(t, "production", created.Name)
+		})
+	}
+}
+
+func TestClient_UpdateSegment(t *testing.T) {
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantErr    bool
+		wantErr404 bool
+	}{
+		{
+			name: "updates segment and returns merged result",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPut, r.Method)
+				assert.Equal(t, "seg-1", r.URL.Query().Get("segment"))
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "returns ErrSegmentNotFound on 404",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			wantErr404: true,
+		},
+		{
+			name: "propagates other errors",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("server error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			seg := &metrics.MetricSegment{Name: "updated"}
+			result, err := client.UpdateSegment(context.Background(), "seg-1", seg)
+
+			if tt.wantErr404 {
+				require.ErrorIs(t, err, metrics.ErrSegmentNotFound)
+				return
+			}
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, "seg-1", result.ID)
+			assert.Equal(t, "updated", result.Name)
+		})
+	}
+}
+
+func TestClient_DeleteSegment(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "deletes segment",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodDelete, r.Method)
+				assert.Equal(t, "seg-1", r.URL.Query().Get("segment"))
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "returns conflict error for dependent data",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte("has rules"))
+			},
+			wantErr: true,
+			errMsg:  "dependent rules or exemptions",
+		},
+		{
+			name: "propagates other errors",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("server error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			err := client.DeleteSegment(context.Background(), "seg-1")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Exemptions
+// ---------------------------------------------------------------------------
+
+func TestClient_ListExemptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		segment string
+		handler http.HandlerFunc
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name: "returns exemptions",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/v1/recommendations/exemptions", r.URL.Path)
+				writeJSON(w, map[string]any{
+					"result": []map[string]any{
+						{"id": "ex-1", "metric": "http_requests_total"},
+						{"id": "ex-2", "metric": "up"},
+					},
+				})
+			},
+			wantLen: 2,
+		},
+		{
+			name:    "passes segment query param",
+			segment: "my-segment",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "my-segment", r.URL.Query().Get("segment"))
+				writeJSON(w, map[string]any{"result": []any{}})
+			},
+			wantLen: 0,
+		},
+		{
+			name: "returns empty list for null result",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, map[string]any{"result": nil})
+			},
+			wantLen: 0,
+		},
+		{
+			name: "propagates error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("server error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			exemptions, err := client.ListExemptions(context.Background(), tt.segment)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, exemptions, tt.wantLen)
+		})
+	}
+}
+
+func TestClient_ListSegmentedExemptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name: "returns grouped exemptions",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/v1/recommendations/segmented_exemptions", r.URL.Path)
+				writeJSON(w, []map[string]any{
+					{
+						"segment":    map[string]any{"id": "seg-1", "name": "prod"},
+						"exemptions": []map[string]any{{"id": "ex-1", "metric": "m1"}},
+					},
+					{
+						"segment":    map[string]any{"id": "seg-2", "name": "staging"},
+						"exemptions": []map[string]any{{"id": "ex-2", "metric": "m2"}, {"id": "ex-3", "metric": "m3"}},
+					},
+				})
+			},
+			wantLen: 2,
+		},
+		{
+			name: "returns empty list for null response",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("null"))
+			},
+			wantLen: 0,
+		},
+		{
+			name: "propagates error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			entries, err := client.ListSegmentedExemptions(context.Background())
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, entries, tt.wantLen)
+		})
+	}
+}
+
+func TestClient_GetExemption(t *testing.T) {
+	tests := []struct {
+		name       string
+		segment    string
+		handler    http.HandlerFunc
+		wantMetric string
+		wantErr    bool
+		wantErr404 bool
+	}{
+		{
+			name: "returns exemption",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/v1/recommendations/exemptions/ex-1", r.URL.Path)
+				writeJSON(w, map[string]any{
+					"result": map[string]any{"id": "ex-1", "metric": "http_requests_total"},
+				})
+			},
+			wantMetric: "http_requests_total",
+		},
+		{
+			name:    "passes segment query param",
+			segment: "my-segment",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "my-segment", r.URL.Query().Get("segment"))
+				writeJSON(w, map[string]any{
+					"result": map[string]any{"id": "ex-1", "metric": "up"},
+				})
+			},
+			wantMetric: "up",
+		},
+		{
+			name: "returns ErrExemptionNotFound on 404",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			wantErr404: true,
+		},
+		{
+			name: "returns error for null result",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, map[string]any{"result": nil})
+			},
+			wantErr: true,
+		},
+		{
+			name: "propagates other errors",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("server error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			exemption, err := client.GetExemption(context.Background(), "ex-1", tt.segment)
+
+			if tt.wantErr404 {
+				require.ErrorIs(t, err, metrics.ErrExemptionNotFound)
+				return
+			}
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMetric, exemption.Metric)
+		})
+	}
+}
+
+func TestClient_CreateExemption(t *testing.T) {
+	tests := []struct {
+		name    string
+		segment string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name: "creates exemption and returns result",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/v1/recommendations/exemptions", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+				var e metrics.MetricExemption
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&e))
+				assert.Equal(t, "http_requests_total", e.Metric)
+
+				writeJSON(w, map[string]any{
+					"result": map[string]any{"id": "ex-new", "metric": "http_requests_total"},
+				})
+			},
+		},
+		{
+			name:    "passes segment query param",
+			segment: "my-segment",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "my-segment", r.URL.Query().Get("segment"))
+				writeJSON(w, map[string]any{
+					"result": map[string]any{"id": "ex-new", "metric": "http_requests_total"},
+				})
+			},
+		},
+		{
+			name: "returns error for null result",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, map[string]any{"result": nil})
+			},
+			wantErr: true,
+		},
+		{
+			name: "propagates error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("invalid"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			e := &metrics.MetricExemption{Metric: "http_requests_total", MatchType: "exact"}
+			created, err := client.CreateExemption(context.Background(), e, tt.segment)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, "ex-new", created.ID)
+		})
+	}
+}
+
+func TestClient_UpdateExemption(t *testing.T) {
+	tests := []struct {
+		name       string
+		segment    string
+		handler    http.HandlerFunc
+		wantErr    bool
+		wantErr404 bool
+	}{
+		{
+			name: "updates exemption and returns merged result",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPut, r.Method)
+				assert.Equal(t, "/v1/recommendations/exemptions/ex-1", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name:    "passes segment query param",
+			segment: "my-segment",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "my-segment", r.URL.Query().Get("segment"))
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "returns ErrExemptionNotFound on 404",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			wantErr404: true,
+		},
+		{
+			name: "propagates other errors",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("server error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			e := &metrics.MetricExemption{Metric: "http_requests_total"}
+			result, err := client.UpdateExemption(context.Background(), "ex-1", e, tt.segment)
+
+			if tt.wantErr404 {
+				require.ErrorIs(t, err, metrics.ErrExemptionNotFound)
+				return
+			}
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, "ex-1", result.ID)
+			assert.Equal(t, "http_requests_total", result.Metric)
+		})
+	}
+}
+
+func TestClient_DeleteExemption(t *testing.T) {
+	tests := []struct {
+		name    string
+		segment string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name: "deletes exemption",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodDelete, r.Method)
+				assert.Equal(t, "/v1/recommendations/exemptions/ex-1", r.URL.Path)
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name:    "passes segment query param",
+			segment: "my-segment",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "my-segment", r.URL.Query().Get("segment"))
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "propagates error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("server error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			err := client.DeleteExemption(context.Background(), "ex-1", tt.segment)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestClient_ListRules(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/providers/metrics/adaptive/commands.go
+++ b/internal/providers/metrics/adaptive/commands.go
@@ -24,6 +24,14 @@ type metricsHelper struct {
 	loader *providers.ConfigLoader
 }
 
+func (h *metricsHelper) newClient(ctx context.Context) (*Client, error) {
+	signalAuth, err := auth.ResolveSignalAuth(ctx, h.loader, "metrics")
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(ctx, signalAuth.BaseURL, signalAuth.TenantID, signalAuth.APIToken, signalAuth.HTTPClient), nil
+}
+
 // Commands returns the Cobra command tree for adaptive metrics management.
 func Commands(loader *providers.ConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
@@ -35,6 +43,8 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 	cmd.AddCommand(
 		h.recommendationsCommand(),
 		h.rulesCommand(),
+		h.segmentsCommand(),
+		h.exemptionsCommand(),
 	)
 
 	return cmd
@@ -662,7 +672,11 @@ func (h *metricsHelper) rulesCreateCommand() *cobra.Command {
 				return err
 			}
 
-			cmdio.Success(cmd.ErrOrStderr(), "Created rule for %s.", opts.Metric)
+			if opts.Segment != "" {
+				cmdio.Success(cmd.ErrOrStderr(), "Created rule for %s in segment %s.", opts.Metric, opts.Segment)
+			} else {
+				cmdio.Success(cmd.ErrOrStderr(), "Created rule for %s.", opts.Metric)
+			}
 			return opts.Encode(cmd.OutOrStdout(), created.Spec)
 		},
 	}
@@ -754,7 +768,11 @@ func (h *metricsHelper) rulesUpdateCommand() *cobra.Command {
 				return err
 			}
 
-			cmdio.Success(cmd.ErrOrStderr(), "Updated rule for %s.", args[0])
+			if opts.Segment != "" {
+				cmdio.Success(cmd.ErrOrStderr(), "Updated rule for %s in segment %s.", args[0], opts.Segment)
+			} else {
+				cmdio.Success(cmd.ErrOrStderr(), "Updated rule for %s.", args[0])
+			}
 			return opts.Encode(cmd.OutOrStdout(), updated.Spec)
 		},
 	}
@@ -808,7 +826,11 @@ func (h *metricsHelper) rulesDeleteCommand() *cobra.Command {
 				return err
 			}
 
-			cmdio.Success(stderr, "Deleted rule for %s.", metric)
+			if opts.Segment != "" {
+				cmdio.Success(stderr, "Deleted rule for %s in segment %s.", metric, opts.Segment)
+			} else {
+				cmdio.Success(stderr, "Deleted rule for %s.", metric)
+			}
 			return nil
 		},
 	}
@@ -847,7 +869,7 @@ func (c *rulesTableCodec) Encode(w io.Writer, v any) error {
 		if c.wide {
 			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%v\t%s\t%s\t%s\n",
 				r.Metric,
-				defaultStr(r.MatchType, "exact"),
+				defaultStr(r.MatchType),
 				strings.Join(r.DropLabels, ","),
 				strings.Join(r.KeepLabels, ","),
 				strings.Join(r.Aggregations, ","),
@@ -859,7 +881,7 @@ func (c *rulesTableCodec) Encode(w io.Writer, v any) error {
 		} else {
 			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
 				r.Metric,
-				defaultStr(r.MatchType, "exact"),
+				defaultStr(r.MatchType),
 				strings.Join(r.DropLabels, ","),
 				strings.Join(r.KeepLabels, ","),
 				strings.Join(r.Aggregations, ","),
@@ -873,9 +895,9 @@ func (c *rulesTableCodec) Decode(_ io.Reader, _ any) error {
 	return errors.New("table format does not support decoding")
 }
 
-func defaultStr(s, fallback string) string {
+func defaultStr(s string) string {
 	if s == "" {
-		return fallback
+		return "exact"
 	}
 	return s
 }
@@ -883,6 +905,19 @@ func defaultStr(s, fallback string) string {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// normalizeExemption fills in server-omitted defaults so that JSON output
+// is complete and subsequent updates don't send empty values the server rejects.
+func normalizeExemption(e *MetricExemption) {
+	if e.MatchType == "" {
+		e.MatchType = "exact"
+	}
+	// The server returns Go zero-time "0001-01-01T00:00:00Z" when there is
+	// no expiration. Replace with empty string so JSON/table output is clean.
+	if strings.HasPrefix(e.ExpiresAt, "0001-01-01") {
+		e.ExpiresAt = ""
+	}
+}
 
 func formatValidationErrors(errs []string) error {
 	var sb strings.Builder
@@ -1031,4 +1066,875 @@ func sortRecommendations(recs []MetricRecommendation, by string, reverse bool) {
 		}
 		return less
 	})
+}
+
+// ---------------------------------------------------------------------------
+// segments
+// ---------------------------------------------------------------------------
+
+func (h *metricsHelper) segmentsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "segments",
+		Short: "Manage Adaptive Metrics segments.",
+	}
+	cmd.AddCommand(
+		h.segmentsListCommand(),
+		h.segmentsGetCommand(),
+		h.segmentsCreateCommand(),
+		h.segmentsUpdateCommand(),
+		h.segmentsDeleteCommand(),
+	)
+	return cmd
+}
+
+// segments list
+
+type segmentsListOpts struct {
+	cmdio.Options
+
+	Limit int
+}
+
+func (o *segmentsListOpts) setup(flags *pflag.FlagSet) {
+	o.DefaultFormat("table")
+	o.RegisterCustomCodec("table", &segmentsTableCodec{wide: false})
+	o.RegisterCustomCodec("wide", &segmentsTableCodec{wide: true})
+	o.BindFlags(flags)
+	flags.IntVar(&o.Limit, "limit", 0, "Maximum number of segments to return (0 for no limit)")
+}
+
+func (h *metricsHelper) segmentsListCommand() *cobra.Command {
+	opts := &segmentsListOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Adaptive Metrics segments.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			segments, err := client.ListSegments(ctx)
+			if err != nil {
+				return err
+			}
+
+			total := len(segments)
+			if opts.Limit > 0 && opts.Limit < total {
+				segments = segments[:opts.Limit]
+			}
+
+			fmt.Fprintf(cmd.ErrOrStderr(), "%d segment(s)\n", total)
+			if len(segments) == 0 {
+				return nil
+			}
+
+			return opts.Encode(cmd.OutOrStdout(), segments)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// segments get
+
+type segmentsGetOpts struct {
+	cmdio.Options
+}
+
+func (o *segmentsGetOpts) setup(flags *pflag.FlagSet) {
+	o.DefaultFormat("json")
+	o.RegisterCustomCodec("table", &segmentsTableCodec{wide: false})
+	o.RegisterCustomCodec("wide", &segmentsTableCodec{wide: true})
+	o.BindFlags(flags)
+}
+
+func (h *metricsHelper) segmentsGetCommand() *cobra.Command {
+	opts := &segmentsGetOpts{}
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get an Adaptive Metrics segment by ID.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			segment, err := client.GetSegment(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			return opts.Encode(cmd.OutOrStdout(), segment)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// segments create
+
+type segmentsCreateOpts struct {
+	cmdio.Options
+
+	Name              string
+	Selector          string
+	FallbackToDefault bool
+	AutoApply         bool
+}
+
+func (o *segmentsCreateOpts) setup(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.Name, "name", "", "Segment name (required)")
+	cmd.Flags().StringVar(&o.Selector, "selector", "", "PromQL label selector (required)")
+	cmd.Flags().BoolVar(&o.FallbackToDefault, "fallback-to-default", false, "Fall back to default segment when no rules match")
+	cmd.Flags().BoolVar(&o.AutoApply, "auto-apply", false, "Automatically apply recommendations")
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("selector")
+	o.DefaultFormat("json")
+	o.BindFlags(cmd.Flags())
+}
+
+func (h *metricsHelper) segmentsCreateCommand() *cobra.Command {
+	opts := &segmentsCreateOpts{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an Adaptive Metrics segment.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			seg := &MetricSegment{
+				Name:              opts.Name,
+				Selector:          opts.Selector,
+				FallbackToDefault: opts.FallbackToDefault,
+				AutoApply:         &AutoApplyConfig{Enabled: opts.AutoApply},
+			}
+
+			created, err := client.CreateSegment(ctx, seg)
+			if err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.ErrOrStderr(), "Created segment %s.", created.ID)
+			return opts.Encode(cmd.OutOrStdout(), created)
+		},
+	}
+	opts.setup(cmd)
+	return cmd
+}
+
+// segments update
+
+type segmentsUpdateOpts struct {
+	cmdio.Options
+
+	Name              string
+	Selector          string
+	FallbackToDefault bool
+	AutoApply         bool
+}
+
+func (o *segmentsUpdateOpts) setup(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.Name, "name", "", "Segment name")
+	cmd.Flags().StringVar(&o.Selector, "selector", "", "PromQL label selector")
+	cmd.Flags().BoolVar(&o.FallbackToDefault, "fallback-to-default", false, "Fall back to default segment when no rules match")
+	cmd.Flags().BoolVar(&o.AutoApply, "auto-apply", false, "Automatically apply recommendations")
+	o.DefaultFormat("json")
+	o.BindFlags(cmd.Flags())
+}
+
+func (h *metricsHelper) segmentsUpdateCommand() *cobra.Command {
+	opts := &segmentsUpdateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update an Adaptive Metrics segment.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			flags := cmd.Flags()
+			if !flags.Changed("name") && !flags.Changed("selector") &&
+				!flags.Changed("fallback-to-default") && !flags.Changed("auto-apply") {
+				return errors.New("specify at least one flag to update")
+			}
+
+			ctx := cmd.Context()
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			id := args[0]
+			existing, err := client.GetSegment(ctx, id)
+			if err != nil {
+				return fmt.Errorf("failed to fetch existing segment for merge: %w", err)
+			}
+
+			if flags.Changed("name") {
+				existing.Name = opts.Name
+			}
+			if flags.Changed("selector") {
+				existing.Selector = opts.Selector
+			}
+			if flags.Changed("fallback-to-default") {
+				existing.FallbackToDefault = opts.FallbackToDefault
+			}
+			if flags.Changed("auto-apply") {
+				if existing.AutoApply == nil {
+					existing.AutoApply = &AutoApplyConfig{}
+				}
+				existing.AutoApply.Enabled = opts.AutoApply
+			}
+
+			updated, err := client.UpdateSegment(ctx, id, existing)
+			if err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.ErrOrStderr(), "Updated segment %s.", id)
+			return opts.Encode(cmd.OutOrStdout(), updated)
+		},
+	}
+	opts.setup(cmd)
+	return cmd
+}
+
+// segments delete
+
+type segmentsDeleteOpts struct {
+	Yes bool
+}
+
+func (o *segmentsDeleteOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.Yes, "yes", false, "Skip confirmation prompt")
+}
+
+func (h *metricsHelper) segmentsDeleteCommand() *cobra.Command {
+	opts := &segmentsDeleteOpts{}
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete an Adaptive Metrics segment.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			stderr := cmd.ErrOrStderr()
+
+			if !opts.Yes {
+				fmt.Fprintf(stderr, "Delete segment %s? [y/N] ", id)
+				reader := bufio.NewReader(cmd.InOrStdin())
+				answer, err := reader.ReadString('\n')
+				if err != nil {
+					return fmt.Errorf("read confirmation: %w", err)
+				}
+				answer = strings.TrimSpace(strings.ToLower(answer))
+				if answer != "y" && answer != "yes" {
+					cmdio.Info(stderr, "Aborted.")
+					return nil
+				}
+			}
+
+			ctx := cmd.Context()
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteSegment(ctx, id); err != nil {
+				return err
+			}
+
+			cmdio.Success(stderr, "Deleted segment %s.", id)
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// segments table codecs
+// ---------------------------------------------------------------------------
+
+type segmentsTableCodec struct {
+	wide bool
+}
+
+func (c *segmentsTableCodec) Format() format.Format {
+	if c.wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *segmentsTableCodec) Encode(w io.Writer, v any) error {
+	segments, ok := v.([]MetricSegment)
+	if !ok {
+		// Also accept *MetricSegment for single-item returns.
+		if s, ok2 := v.(*MetricSegment); ok2 {
+			segments = []MetricSegment{*s}
+		} else {
+			return fmt.Errorf("metrics: segments table codec: expected []MetricSegment, got %T", v)
+		}
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if c.wide {
+		fmt.Fprintln(tw, "ID\tNAME\tSELECTOR\tFALLBACK\tAUTO APPLY\tRECOMMENDATION CONFIG ID")
+	} else {
+		fmt.Fprintln(tw, "ID\tNAME\tSELECTOR\tFALLBACK\tAUTO APPLY")
+	}
+	for _, s := range segments {
+		autoApply := false
+		if s.AutoApply != nil {
+			autoApply = s.AutoApply.Enabled
+		}
+		recConfigID := ""
+		if s.RecommendationConfigurationID != nil {
+			recConfigID = *s.RecommendationConfigurationID
+		}
+		selector := s.Selector
+		if !c.wide && len(selector) > 60 {
+			selector = selector[:57] + "..."
+		}
+		if c.wide {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%v\t%v\t%s\n",
+				s.ID, s.Name, s.Selector, s.FallbackToDefault, autoApply, recConfigID)
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%v\t%v\n",
+				s.ID, s.Name, selector, s.FallbackToDefault, autoApply)
+		}
+	}
+	return tw.Flush()
+}
+
+func (c *segmentsTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// ---------------------------------------------------------------------------
+// exemptions
+// ---------------------------------------------------------------------------
+
+func (h *metricsHelper) exemptionsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "exemptions",
+		Short: "Manage Adaptive Metrics recommendation exemptions.",
+	}
+	cmd.AddCommand(
+		h.exemptionsListCommand(),
+		h.exemptionsGetCommand(),
+		h.exemptionsCreateCommand(),
+		h.exemptionsUpdateCommand(),
+		h.exemptionsDeleteCommand(),
+	)
+	return cmd
+}
+
+// exemptions list
+
+type exemptionsListOpts struct {
+	cmdio.Options
+
+	Segment     string
+	AllSegments bool
+	Limit       int
+}
+
+func (o *exemptionsListOpts) setup(flags *pflag.FlagSet) {
+	o.DefaultFormat("table")
+	o.RegisterCustomCodec("table", &exemptionsTableCodec{wide: false})
+	o.RegisterCustomCodec("wide", &exemptionsTableCodec{wide: true})
+	o.BindFlags(flags)
+	flags.StringVar(&o.Segment, "segment", "", "Segment ID")
+	flags.BoolVar(&o.AllSegments, "all-segments", false, "List exemptions across all segments")
+	flags.IntVar(&o.Limit, "limit", 0, "Maximum number of exemptions to return (0 for no limit)")
+}
+
+func (h *metricsHelper) exemptionsListCommand() *cobra.Command {
+	opts := &exemptionsListOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Adaptive Metrics recommendation exemptions.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			if opts.Segment != "" && opts.AllSegments {
+				return errors.New("--segment and --all-segments are mutually exclusive")
+			}
+
+			ctx := cmd.Context()
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			if opts.AllSegments {
+				entries, err := client.ListSegmentedExemptions(ctx)
+				if err != nil {
+					return err
+				}
+				total := 0
+				for i := range entries {
+					for j := range entries[i].Exemptions {
+						normalizeExemption(&entries[i].Exemptions[j])
+					}
+					total += len(entries[i].Exemptions)
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(), "%d exemption(s) across %d segment(s)\n", total, len(entries))
+				if total == 0 {
+					return nil
+				}
+				return opts.Encode(cmd.OutOrStdout(), entries)
+			}
+
+			exemptions, err := client.ListExemptions(ctx, opts.Segment)
+			if err != nil {
+				return err
+			}
+
+			for i := range exemptions {
+				normalizeExemption(&exemptions[i])
+			}
+
+			total := len(exemptions)
+			if opts.Limit > 0 && opts.Limit < total {
+				exemptions = exemptions[:opts.Limit]
+			}
+
+			fmt.Fprintf(cmd.ErrOrStderr(), "%d exemption(s)\n", total)
+			if len(exemptions) == 0 {
+				return nil
+			}
+
+			return opts.Encode(cmd.OutOrStdout(), exemptions)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// exemptions get
+
+type exemptionsGetOpts struct {
+	cmdio.Options
+
+	Segment string
+}
+
+func (o *exemptionsGetOpts) setup(flags *pflag.FlagSet) {
+	o.DefaultFormat("json")
+	o.RegisterCustomCodec("table", &exemptionsTableCodec{wide: false})
+	o.RegisterCustomCodec("wide", &exemptionsTableCodec{wide: true})
+	o.BindFlags(flags)
+	flags.StringVar(&o.Segment, "segment", "", "Segment ID")
+}
+
+func (h *metricsHelper) exemptionsGetCommand() *cobra.Command {
+	opts := &exemptionsGetOpts{}
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a recommendation exemption by ID.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			exemption, err := client.GetExemption(ctx, args[0], opts.Segment)
+			if err != nil {
+				return err
+			}
+
+			normalizeExemption(exemption)
+			return opts.Encode(cmd.OutOrStdout(), exemption)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// exemptions create
+
+type exemptionsCreateOpts struct {
+	cmdio.Options
+
+	Metric                 string
+	MatchType              string
+	KeepLabels             []string
+	DisableRecommendations bool
+	Reason                 string
+	ManagedBy              string
+	ActiveInterval         string
+	Segment                string
+}
+
+// setupExemptionFlags registers the common flags for exemption create/update.
+func setupExemptionFlags(
+	f *pflag.FlagSet,
+	metric, matchType *string, keepLabels *[]string,
+	disableRecs *bool, reason, managedBy, activeInterval, segment *string,
+	matchTypeDefault, activeIntervalDefault string,
+	opts *cmdio.Options,
+) {
+	f.StringVar(metric, "metric", "", "Metric name or pattern")
+	f.StringVar(matchType, "match-type", matchTypeDefault, "Match type: exact, prefix, or suffix")
+	f.StringSliceVar(keepLabels, "keep-labels", nil, "Labels to keep (comma-separated)")
+	f.BoolVar(disableRecs, "disable-recommendations", false, "Disable all recommendations for matched metrics")
+	f.StringVar(reason, "reason", "", "Reason for the exemption")
+	f.StringVar(managedBy, "managed-by", "", "Manager identifier")
+	f.StringVar(activeInterval, "active-interval", activeIntervalDefault, "Active interval (e.g. 30d, 1h)")
+	f.StringVar(segment, "segment", "", "Segment ID")
+	opts.DefaultFormat("json")
+	opts.BindFlags(f)
+}
+
+func (o *exemptionsCreateOpts) setup(cmd *cobra.Command) {
+	setupExemptionFlags(cmd.Flags(),
+		&o.Metric, &o.MatchType, &o.KeepLabels,
+		&o.DisableRecommendations, &o.Reason, &o.ManagedBy, &o.ActiveInterval, &o.Segment,
+		"exact", "30d", &o.Options,
+	)
+}
+
+func (o *exemptionsCreateOpts) Validate() error {
+	if err := o.Options.Validate(); err != nil {
+		return err
+	}
+	if o.Metric == "" && len(o.KeepLabels) == 0 {
+		return errors.New("either --metric or --keep-labels must be set")
+	}
+	if o.DisableRecommendations && len(o.KeepLabels) > 0 {
+		return errors.New("--disable-recommendations and --keep-labels are mutually exclusive")
+	}
+	return nil
+}
+
+func (h *metricsHelper) exemptionsCreateCommand() *cobra.Command {
+	opts := &exemptionsCreateOpts{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a recommendation exemption.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			e := &MetricExemption{
+				Metric:                 opts.Metric,
+				MatchType:              opts.MatchType,
+				KeepLabels:             opts.KeepLabels,
+				DisableRecommendations: opts.DisableRecommendations,
+				Reason:                 opts.Reason,
+				ManagedBy:              opts.ManagedBy,
+				ActiveInterval:         opts.ActiveInterval,
+			}
+
+			created, err := client.CreateExemption(ctx, e, opts.Segment)
+			if err != nil {
+				return err
+			}
+
+			normalizeExemption(created)
+			if opts.Segment != "" {
+				cmdio.Success(cmd.ErrOrStderr(), "Created exemption %s in segment %s.", created.ID, opts.Segment)
+			} else {
+				cmdio.Success(cmd.ErrOrStderr(), "Created exemption %s.", created.ID)
+			}
+			return opts.Encode(cmd.OutOrStdout(), created)
+		},
+	}
+	opts.setup(cmd)
+	return cmd
+}
+
+// exemptions update
+
+type exemptionsUpdateOpts struct {
+	cmdio.Options
+
+	Metric                 string
+	MatchType              string
+	KeepLabels             []string
+	DisableRecommendations bool
+	Reason                 string
+	ManagedBy              string
+	ActiveInterval         string
+	Segment                string
+}
+
+func (o *exemptionsUpdateOpts) setup(cmd *cobra.Command) {
+	setupExemptionFlags(cmd.Flags(),
+		&o.Metric, &o.MatchType, &o.KeepLabels,
+		&o.DisableRecommendations, &o.Reason, &o.ManagedBy, &o.ActiveInterval, &o.Segment,
+		"", "", &o.Options,
+	)
+}
+
+func (h *metricsHelper) exemptionsUpdateCommand() *cobra.Command {
+	opts := &exemptionsUpdateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a recommendation exemption.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			flags := cmd.Flags()
+			if !flags.Changed("metric") && !flags.Changed("match-type") && !flags.Changed("keep-labels") &&
+				!flags.Changed("disable-recommendations") && !flags.Changed("reason") &&
+				!flags.Changed("managed-by") && !flags.Changed("active-interval") {
+				return errors.New("specify at least one flag to update")
+			}
+
+			ctx := cmd.Context()
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			id := args[0]
+			existing, err := client.GetExemption(ctx, id, opts.Segment)
+			if err != nil {
+				return fmt.Errorf("failed to fetch existing exemption for merge: %w", err)
+			}
+
+			if flags.Changed("metric") {
+				existing.Metric = opts.Metric
+			}
+			if flags.Changed("match-type") {
+				existing.MatchType = opts.MatchType
+			}
+			if flags.Changed("keep-labels") {
+				existing.KeepLabels = opts.KeepLabels
+			}
+			if flags.Changed("disable-recommendations") {
+				existing.DisableRecommendations = opts.DisableRecommendations
+			}
+			if flags.Changed("reason") {
+				existing.Reason = opts.Reason
+			}
+			if flags.Changed("managed-by") {
+				existing.ManagedBy = opts.ManagedBy
+			}
+			if flags.Changed("active-interval") {
+				existing.ActiveInterval = opts.ActiveInterval
+			}
+
+			normalizeExemption(existing)
+			existing.CreatedAt = ""
+			existing.UpdatedAt = ""
+			existing.ExpiresAt = ""
+
+			if _, err := client.UpdateExemption(ctx, id, existing, opts.Segment); err != nil {
+				return err
+			}
+
+			if opts.Segment != "" {
+				cmdio.Success(cmd.ErrOrStderr(), "Updated exemption %s in segment %s.", id, opts.Segment)
+			} else {
+				cmdio.Success(cmd.ErrOrStderr(), "Updated exemption %s.", id)
+			}
+
+			fresh, err := client.GetExemption(ctx, id, opts.Segment)
+			if err != nil {
+				return fmt.Errorf("re-fetch after update: %w", err)
+			}
+			normalizeExemption(fresh)
+			return opts.Encode(cmd.OutOrStdout(), fresh)
+		},
+	}
+	opts.setup(cmd)
+	return cmd
+}
+
+// exemptions delete
+
+type exemptionsDeleteOpts struct {
+	Segment string
+	Yes     bool
+}
+
+func (o *exemptionsDeleteOpts) setup(flags *pflag.FlagSet) {
+	flags.StringVar(&o.Segment, "segment", "", "Segment ID")
+	flags.BoolVar(&o.Yes, "yes", false, "Skip confirmation prompt")
+}
+
+func (h *metricsHelper) exemptionsDeleteCommand() *cobra.Command {
+	opts := &exemptionsDeleteOpts{}
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a recommendation exemption.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			stderr := cmd.ErrOrStderr()
+
+			if !opts.Yes {
+				fmt.Fprintf(stderr, "Delete exemption %s? [y/N] ", id)
+				reader := bufio.NewReader(cmd.InOrStdin())
+				answer, err := reader.ReadString('\n')
+				if err != nil {
+					return fmt.Errorf("read confirmation: %w", err)
+				}
+				answer = strings.TrimSpace(strings.ToLower(answer))
+				if answer != "y" && answer != "yes" {
+					cmdio.Info(stderr, "Aborted.")
+					return nil
+				}
+			}
+
+			ctx := cmd.Context()
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteExemption(ctx, id, opts.Segment); err != nil {
+				return err
+			}
+
+			if opts.Segment != "" {
+				cmdio.Success(stderr, "Deleted exemption %s in segment %s.", id, opts.Segment)
+			} else {
+				cmdio.Success(stderr, "Deleted exemption %s.", id)
+			}
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// exemptions table codecs
+// ---------------------------------------------------------------------------
+
+type exemptionsTableCodec struct {
+	wide bool
+}
+
+func (c *exemptionsTableCodec) Format() format.Format {
+	if c.wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *exemptionsTableCodec) Encode(w io.Writer, v any) error {
+	// Handle []MetricExemption, *MetricExemption (single get), and []ExemptionsBySegmentEntry (--all-segments).
+	switch data := v.(type) {
+	case []MetricExemption:
+		return c.encodeExemptions(w, data)
+	case *MetricExemption:
+		return c.encodeExemptions(w, []MetricExemption{*data})
+	case []ExemptionsBySegmentEntry:
+		return c.encodeSegmentedExemptions(w, data)
+	default:
+		return fmt.Errorf("metrics: exemptions table codec: expected []MetricExemption or []ExemptionsBySegmentEntry, got %T", v)
+	}
+}
+
+func (c *exemptionsTableCodec) encodeExemptions(w io.Writer, exemptions []MetricExemption) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	if c.wide {
+		fmt.Fprintln(tw, "ID\tMETRIC\tMATCH TYPE\tKEEP LABELS\tDISABLE RECS\tREASON\tMANAGED BY\tEXPIRES AT\tACTIVE INTERVAL\tCREATED AT\tUPDATED AT")
+	} else {
+		fmt.Fprintln(tw, "ID\tMETRIC\tMATCH TYPE\tKEEP LABELS\tDISABLE RECS")
+	}
+
+	for _, e := range exemptions {
+		if c.wide {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%v\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				e.ID, e.Metric,
+				defaultStr(e.MatchType),
+				strings.Join(e.KeepLabels, ","),
+				e.DisableRecommendations,
+				e.Reason, e.ManagedBy, e.ExpiresAt, e.ActiveInterval, e.CreatedAt, e.UpdatedAt,
+			)
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%v\n",
+				e.ID, e.Metric,
+				defaultStr(e.MatchType),
+				strings.Join(e.KeepLabels, ","),
+				e.DisableRecommendations,
+			)
+		}
+	}
+	return tw.Flush()
+}
+
+func (c *exemptionsTableCodec) encodeSegmentedExemptions(w io.Writer, entries []ExemptionsBySegmentEntry) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	if c.wide {
+		fmt.Fprintln(tw, "SEGMENT\tID\tMETRIC\tMATCH TYPE\tKEEP LABELS\tDISABLE RECS\tREASON\tMANAGED BY\tEXPIRES AT\tACTIVE INTERVAL\tCREATED AT\tUPDATED AT")
+	} else {
+		fmt.Fprintln(tw, "SEGMENT\tID\tMETRIC\tMATCH TYPE\tKEEP LABELS\tDISABLE RECS")
+	}
+
+	for _, entry := range entries {
+		segName := entry.Segment.Name
+		if segName == "" {
+			segName = "(default)"
+		}
+		for _, e := range entry.Exemptions {
+			if c.wide {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%v\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					segName, e.ID, e.Metric,
+					defaultStr(e.MatchType),
+					strings.Join(e.KeepLabels, ","),
+					e.DisableRecommendations,
+					e.Reason, e.ManagedBy, e.ExpiresAt, e.ActiveInterval, e.CreatedAt, e.UpdatedAt,
+				)
+			} else {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%v\n",
+					segName, e.ID, e.Metric,
+					defaultStr(e.MatchType),
+					strings.Join(e.KeepLabels, ","),
+					e.DisableRecommendations,
+				)
+			}
+		}
+	}
+	return tw.Flush()
+}
+
+func (c *exemptionsTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
 }

--- a/internal/providers/metrics/adaptive/commands.go
+++ b/internal/providers/metrics/adaptive/commands.go
@@ -1127,9 +1127,10 @@ func (h *metricsHelper) segmentsListCommand() *cobra.Command {
 			total := len(segments)
 			if opts.Limit > 0 && opts.Limit < total {
 				segments = segments[:opts.Limit]
+				fmt.Fprintf(cmd.ErrOrStderr(), "%d of %d segment(s)\n", opts.Limit, total)
+			} else {
+				fmt.Fprintf(cmd.ErrOrStderr(), "%d segment(s)\n", total)
 			}
-
-			fmt.Fprintf(cmd.ErrOrStderr(), "%d segment(s)\n", total)
 			if len(segments) == 0 {
 				return nil
 			}
@@ -1482,6 +1483,9 @@ func (h *metricsHelper) exemptionsListCommand() *cobra.Command {
 			if opts.Segment != "" && opts.AllSegments {
 				return errors.New("--segment and --all-segments are mutually exclusive")
 			}
+			if opts.AllSegments && opts.Limit > 0 {
+				return errors.New("--limit is not supported with --all-segments; use --segment to target a specific segment")
+			}
 
 			ctx := cmd.Context()
 			client, err := h.newClient(ctx)
@@ -1520,9 +1524,10 @@ func (h *metricsHelper) exemptionsListCommand() *cobra.Command {
 			total := len(exemptions)
 			if opts.Limit > 0 && opts.Limit < total {
 				exemptions = exemptions[:opts.Limit]
+				fmt.Fprintf(cmd.ErrOrStderr(), "%d of %d exemption(s)\n", opts.Limit, total)
+			} else {
+				fmt.Fprintf(cmd.ErrOrStderr(), "%d exemption(s)\n", total)
 			}
-
-			fmt.Fprintf(cmd.ErrOrStderr(), "%d exemption(s)\n", total)
 			if len(exemptions) == 0 {
 				return nil
 			}

--- a/internal/providers/metrics/adaptive/resource_adapter.go
+++ b/internal/providers/metrics/adaptive/resource_adapter.go
@@ -15,6 +15,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+func init() { //nolint:gochecknoinits // Natural key registration for cross-stack push identity matching.
+	adapter.RegisterNaturalKey(
+		exemptionDescriptorVar.GroupVersionKind(),
+		adapter.SpecFieldKey("metric"),
+	)
+}
+
 const (
 	RuleAPIVersion = "adaptive-metrics.ext.grafana.app/v1alpha1"
 	RuleKind       = "AggregationRule"
@@ -207,6 +214,196 @@ func NewRuleTypedCRUD(ctx context.Context, loader *providers.ConfigLoader, segme
 func NewRuleAdapterFactory(loader *providers.ConfigLoader) adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
 		crud, err := NewRuleTypedCRUD(ctx, loader, "")
+		if err != nil {
+			return nil, err
+		}
+		return crud.AsAdapter(), nil
+	}
+}
+
+// buildMetricsTypedCRUD builds a TypedCRUD for Adaptive Metrics resources.
+func buildMetricsTypedCRUD[T adapter.ResourceNamer](
+	desc resources.Descriptor,
+	list func(context.Context) ([]T, error),
+	get func(context.Context, string) (*T, error),
+	create func(context.Context, *T) (*T, error),
+	update func(context.Context, string, *T) (*T, error),
+	del func(context.Context, string) error,
+) *adapter.TypedCRUD[T] {
+	return &adapter.TypedCRUD[T]{
+		ListFn: func(ctx context.Context, limit int64) ([]T, error) {
+			items, err := list(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return adapter.TruncateSlice(items, limit), nil
+		},
+		GetFn:       get,
+		CreateFn:    create,
+		UpdateFn:    update,
+		DeleteFn:    del,
+		Namespace:   "default",
+		StripFields: []string{"id"},
+		Descriptor:  desc,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Segment resource adapter
+// ---------------------------------------------------------------------------
+
+const (
+	SegmentAPIVersion = "adaptive-metrics.ext.grafana.app/v1alpha1"
+	SegmentKind       = "Segment"
+)
+
+//nolint:gochecknoglobals // Static descriptor used in registration pattern.
+var segmentDescriptorVar = resources.Descriptor{
+	GroupVersion: schema.GroupVersion{
+		Group:   "adaptive-metrics.ext.grafana.app",
+		Version: "v1alpha1",
+	},
+	Kind:     SegmentKind,
+	Singular: "segment",
+	Plural:   "segments",
+}
+
+// SegmentDescriptor returns the resource descriptor for Adaptive Metrics segments.
+func SegmentDescriptor() resources.Descriptor { return segmentDescriptorVar }
+
+// SegmentSchema returns a JSON Schema for the MetricSegment resource type.
+func SegmentSchema() json.RawMessage {
+	return adapter.SchemaFromType[MetricSegment](SegmentDescriptor())
+}
+
+// SegmentExample returns an example MetricSegment manifest as JSON.
+func SegmentExample() json.RawMessage {
+	example := map[string]any{
+		"apiVersion": SegmentAPIVersion,
+		"kind":       SegmentKind,
+		"metadata":   map[string]any{"name": "my-segment"},
+		"spec": map[string]any{
+			"name":                "production",
+			"selector":            `{env="production"}`,
+			"fallback_to_default": false,
+			"auto_apply":          map[string]any{"enabled": false},
+		},
+	}
+	b, err := json.Marshal(example)
+	if err != nil {
+		panic(fmt.Sprintf("adaptive/metrics: failed to marshal segment example: %v", err))
+	}
+	return b
+}
+
+// NewSegmentTypedCRUD creates a TypedCRUD for Adaptive Metrics segments.
+func NewSegmentTypedCRUD(ctx context.Context, loader *providers.ConfigLoader) (*adapter.TypedCRUD[MetricSegment], error) {
+	client, err := newAdaptiveMetricsClient(ctx, loader)
+	if err != nil {
+		return nil, err
+	}
+	crud := buildMetricsTypedCRUD(segmentDescriptorVar,
+		client.ListSegments,
+		client.GetSegment,
+		client.CreateSegment,
+		func(ctx context.Context, id string, s *MetricSegment) (*MetricSegment, error) {
+			return client.UpdateSegment(ctx, id, s)
+		},
+		client.DeleteSegment,
+	)
+	return crud, nil
+}
+
+// NewSegmentAdapterFactory returns an adapter.Factory for Adaptive Metrics segments.
+func NewSegmentAdapterFactory(loader *providers.ConfigLoader) adapter.Factory {
+	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
+		crud, err := NewSegmentTypedCRUD(ctx, loader)
+		if err != nil {
+			return nil, err
+		}
+		return crud.AsAdapter(), nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Exemption resource adapter
+// ---------------------------------------------------------------------------
+
+const (
+	ExemptionAPIVersion = "adaptive-metrics.ext.grafana.app/v1alpha1"
+	ExemptionKind       = "Exemption"
+)
+
+//nolint:gochecknoglobals // Static descriptor used in registration pattern.
+var exemptionDescriptorVar = resources.Descriptor{
+	GroupVersion: schema.GroupVersion{
+		Group:   "adaptive-metrics.ext.grafana.app",
+		Version: "v1alpha1",
+	},
+	Kind:     ExemptionKind,
+	Singular: "exemption",
+	Plural:   "exemptions",
+}
+
+// ExemptionDescriptor returns the resource descriptor for Adaptive Metrics exemptions.
+func ExemptionDescriptor() resources.Descriptor { return exemptionDescriptorVar }
+
+// ExemptionSchema returns a JSON Schema for the MetricExemption resource type.
+func ExemptionSchema() json.RawMessage {
+	return adapter.SchemaFromType[MetricExemption](ExemptionDescriptor())
+}
+
+// ExemptionExample returns an example MetricExemption manifest as JSON.
+func ExemptionExample() json.RawMessage {
+	example := map[string]any{
+		"apiVersion": ExemptionAPIVersion,
+		"kind":       ExemptionKind,
+		"metadata":   map[string]any{"name": "my-exemption"},
+		"spec": map[string]any{
+			"metric":          "my_critical_metric",
+			"match_type":      "exact",
+			"reason":          "Critical metric — exempt from recommendations",
+			"active_interval": "30d",
+		},
+	}
+	b, err := json.Marshal(example)
+	if err != nil {
+		panic(fmt.Sprintf("adaptive/metrics: failed to marshal exemption example: %v", err))
+	}
+	return b
+}
+
+// NewExemptionTypedCRUD creates a TypedCRUD for Adaptive Metrics exemptions (default segment).
+func NewExemptionTypedCRUD(ctx context.Context, loader *providers.ConfigLoader) (*adapter.TypedCRUD[MetricExemption], error) {
+	client, err := newAdaptiveMetricsClient(ctx, loader)
+	if err != nil {
+		return nil, err
+	}
+	const defaultSegment = ""
+	crud := buildMetricsTypedCRUD(exemptionDescriptorVar,
+		func(ctx context.Context) ([]MetricExemption, error) {
+			return client.ListExemptions(ctx, defaultSegment)
+		},
+		func(ctx context.Context, id string) (*MetricExemption, error) {
+			return client.GetExemption(ctx, id, defaultSegment)
+		},
+		func(ctx context.Context, e *MetricExemption) (*MetricExemption, error) {
+			return client.CreateExemption(ctx, e, defaultSegment)
+		},
+		func(ctx context.Context, id string, e *MetricExemption) (*MetricExemption, error) {
+			return client.UpdateExemption(ctx, id, e, defaultSegment)
+		},
+		func(ctx context.Context, id string) error {
+			return client.DeleteExemption(ctx, id, defaultSegment)
+		},
+	)
+	return crud, nil
+}
+
+// NewExemptionAdapterFactory returns an adapter.Factory for Adaptive Metrics exemptions.
+func NewExemptionAdapterFactory(loader *providers.ConfigLoader) adapter.Factory {
+	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
+		crud, err := NewExemptionTypedCRUD(ctx, loader)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/providers/metrics/adaptive/types.go
+++ b/internal/providers/metrics/adaptive/types.go
@@ -2,6 +2,64 @@ package metrics
 
 import "github.com/grafana/gcx/internal/resources/adapter"
 
+// AutoApplyConfig holds the auto-apply configuration for a segment.
+type AutoApplyConfig struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
+}
+
+// MetricSegment represents an Adaptive Metrics segment (a scoped rule grouping).
+//
+//nolint:recvcheck // GetResourceName uses value receiver per ResourceNamer; SetResourceName needs pointer.
+type MetricSegment struct {
+	ID                            string           `json:"id,omitempty" yaml:"id,omitempty"`
+	Name                          string           `json:"name" yaml:"name"`
+	Selector                      string           `json:"selector" yaml:"selector"`
+	FallbackToDefault             bool             `json:"fallback_to_default" yaml:"fallback_to_default"`
+	AutoApply                     *AutoApplyConfig `json:"auto_apply,omitempty" yaml:"auto_apply,omitempty"`
+	RecommendationConfigurationID *string          `json:"recommendation_configuration_id,omitempty" yaml:"recommendation_configuration_id,omitempty"`
+}
+
+// GetResourceName implements adapter.ResourceNamer.
+func (s MetricSegment) GetResourceName() string { return s.ID }
+
+// SetResourceName implements adapter.ResourceIdentity.
+func (s *MetricSegment) SetResourceName(name string) { s.ID = name }
+
+// Compile-time assertion.
+var _ adapter.ResourceIdentity = &MetricSegment{}
+
+// MetricExemption represents an Adaptive Metrics recommendation exemption.
+//
+//nolint:recvcheck // GetResourceName uses value receiver per ResourceNamer; SetResourceName needs pointer.
+type MetricExemption struct {
+	ID                     string   `json:"id,omitempty" yaml:"id,omitempty"`
+	Metric                 string   `json:"metric" yaml:"metric"`
+	MatchType              string   `json:"match_type" yaml:"match_type"`
+	KeepLabels             []string `json:"keep_labels,omitempty" yaml:"keep_labels,omitempty"`
+	DisableRecommendations bool     `json:"disable_recommendations" yaml:"disable_recommendations"`
+	Reason                 string   `json:"reason" yaml:"reason"`
+	ManagedBy              string   `json:"managed_by,omitempty" yaml:"managed_by,omitempty"`
+	ExpiresAt              string   `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
+	ActiveInterval         string   `json:"active_interval" yaml:"active_interval"`
+	CreatedAt              string   `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt              string   `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+}
+
+// GetResourceName implements adapter.ResourceNamer.
+func (e MetricExemption) GetResourceName() string { return e.ID }
+
+// SetResourceName implements adapter.ResourceIdentity.
+func (e *MetricExemption) SetResourceName(name string) { e.ID = name }
+
+// Compile-time assertion.
+var _ adapter.ResourceIdentity = &MetricExemption{}
+
+// ExemptionsBySegmentEntry groups exemptions by their segment (for cross-segment listing).
+type ExemptionsBySegmentEntry struct {
+	Segment    MetricSegment     `json:"segment"`
+	Exemptions []MetricExemption `json:"exemptions"`
+}
+
 // MetricRule represents a metric aggregation rule.
 //
 //nolint:recvcheck // GetResourceName uses value receiver per ResourceNamer; SetResourceName needs pointer.

--- a/internal/providers/metrics/provider.go
+++ b/internal/providers/metrics/provider.go
@@ -116,5 +116,19 @@ func (p *Provider) TypedRegistrations() []adapter.Registration {
 			Schema:     adaptivemetrics.RuleSchema(),
 			Example:    adaptivemetrics.RuleExample(),
 		},
+		{
+			Factory:    adaptivemetrics.NewSegmentAdapterFactory(loader),
+			Descriptor: adaptivemetrics.SegmentDescriptor(),
+			GVK:        adaptivemetrics.SegmentDescriptor().GroupVersionKind(),
+			Schema:     adaptivemetrics.SegmentSchema(),
+			Example:    adaptivemetrics.SegmentExample(),
+		},
+		{
+			Factory:    adaptivemetrics.NewExemptionAdapterFactory(loader),
+			Descriptor: adaptivemetrics.ExemptionDescriptor(),
+			GVK:        adaptivemetrics.ExemptionDescriptor().GroupVersionKind(),
+			Schema:     adaptivemetrics.ExemptionSchema(),
+			Example:    adaptivemetrics.ExemptionExample(),
+		},
 	}
 }


### PR DESCRIPTION
## Summary

- Add full CRUD commands for Adaptive Metrics **segments** (`list`, `get`, `create`, `update`, `delete`) and **exemptions** (`list`, `get`, `create`, `update`, `delete`) under `gcx metrics adaptive`
- Register Segment and Exemption as typed resources with resource adapters, enabling `resources get/push/pull` support
- Add HTTP client methods for the segments (`/aggregations/rules/segments`) and exemptions (`/v1/recommendations/exemptions`) APIs, including cross-segment listing via `--all-segments`
- Unify `doRequest`/`doMutatingRequest` into a single `doRequest(ctx, method, path, body)` matching the adaptive-logs client pattern

## Details

**New leaf commands** (10 total):
- `gcx metrics adaptive segments {list,get,create,update,delete}`
- `gcx metrics adaptive exemptions {list,get,create,update,delete}`

**Features**:
- Table, wide, JSON, YAML output formats with `--json` field discovery/selection
- Merge-update semantics (GET → merge flags → PUT) for both segments and exemptions
- `--all-segments` flag on exemptions list for cross-segment view
- `--limit` flag on segments and exemptions list
- Confirmation prompts on delete with `--yes` to skip
- Agent-mode annotations for all new commands
- Resource adapter registrations with schema, examples, and natural key for exemptions

## Test plan

- [x] Full CRUD lifecycle tested against live dev environment (`cortexdev05`)
- [x] All output formats verified (table, wide, json, yaml, `--json` field selection)
- [x] Error handling / edge cases tested (missing args, conflicting flags, nonexistent IDs, no-op updates)
- [x] Test data cleaned up after testing
- [x] Unit tests for all segment and exemption client methods (34 new table-driven test cases)
- [x] Sentinel error wrapping verified (`ErrSegmentNotFound`, `ErrExemptionNotFound` wrap `adapter.ErrNotFound`)
- [x] CI passes