### PR TITLE
feat: adopt server-side pagination for list commands

### DIFF
--- a/docs/reference/cli/gcx_assistant_investigations_list.md
+++ b/docs/reference/cli/gcx_assistant_investigations_list.md
@@ -16,6 +16,7 @@ gcx assistant investigations list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of investigations to return (default 50)
+      --offset int      Number of investigations to skip (for pagination)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
       --state string    Filter by investigation state (e.g. running, completed, cancelled)
 ```

--- a/internal/assistant/investigations/client.go
+++ b/internal/assistant/investigations/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/grafana/gcx/internal/assistant/assistanthttp"
 )
@@ -21,11 +22,28 @@ func NewClient(base *assistanthttp.Client) *Client {
 	return &Client{base: base}
 }
 
+// ListOptions holds optional parameters for listing investigations.
+type ListOptions struct {
+	State  string
+	Limit  int
+	Offset int
+}
+
 // List returns investigation summaries.
-func (c *Client) List(ctx context.Context, state string) ([]InvestigationSummary, error) {
+func (c *Client) List(ctx context.Context, opts ListOptions) ([]InvestigationSummary, error) {
+	params := url.Values{}
+	if opts.State != "" {
+		params.Set("state", opts.State)
+	}
+	if opts.Limit > 0 {
+		params.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.Offset > 0 {
+		params.Set("offset", strconv.Itoa(opts.Offset))
+	}
 	path := "/investigations/summary"
-	if state != "" {
-		path += "?" + url.Values{"state": {state}}.Encode()
+	if len(params) > 0 {
+		path += "?" + params.Encode()
 	}
 
 	resp, err := c.base.DoRequest(ctx, http.MethodGet, path, nil)

--- a/internal/assistant/investigations/client_test.go
+++ b/internal/assistant/investigations/client_test.go
@@ -40,14 +40,13 @@ func writeJSON(w http.ResponseWriter, v any) {
 func TestList(t *testing.T) {
 	tests := []struct {
 		name      string
-		state     string
+		opts      investigations.ListOptions
 		handler   http.HandlerFunc
 		wantCount int
 		wantErr   bool
 	}{
 		{
-			name:  "success",
-			state: "",
+			name: "success",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodGet, r.Method)
 				assert.Contains(t, r.URL.Path, "/investigations/summary")
@@ -63,8 +62,8 @@ func TestList(t *testing.T) {
 			wantCount: 2,
 		},
 		{
-			name:  "filter by state",
-			state: "completed",
+			name: "filter by state",
+			opts: investigations.ListOptions{State: "completed"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "completed", r.URL.Query().Get("state"))
 				writeJSON(w, map[string]any{
@@ -78,8 +77,23 @@ func TestList(t *testing.T) {
 			wantCount: 1,
 		},
 		{
-			name:  "empty list",
-			state: "",
+			name: "pagination params",
+			opts: investigations.ListOptions{Limit: 10, Offset: 20},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "10", r.URL.Query().Get("limit"))
+				assert.Equal(t, "20", r.URL.Query().Get("offset"))
+				writeJSON(w, map[string]any{
+					"data": map[string]any{
+						"investigations": []investigations.InvestigationSummary{
+							{ID: "inv-3", Title: "Test 3", State: "running"},
+						},
+					},
+				})
+			},
+			wantCount: 1,
+		},
+		{
+			name: "empty list",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				writeJSON(w, map[string]any{
 					"data": map[string]any{
@@ -90,8 +104,7 @@ func TestList(t *testing.T) {
 			wantCount: 0,
 		},
 		{
-			name:  "server error",
-			state: "",
+			name: "server error",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte("internal error"))
@@ -103,7 +116,7 @@ func TestList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := newTestClient(t, tt.handler)
-			summaries, err := client.List(t.Context(), tt.state)
+			summaries, err := client.List(t.Context(), tt.opts)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -448,7 +461,7 @@ func TestList_InvalidJSON(t *testing.T) {
 		_, _ = w.Write([]byte("{invalid"))
 	}))
 
-	_, err := client.List(t.Context(), "")
+	_, err := client.List(t.Context(), investigations.ListOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to decode")
 }
@@ -462,7 +475,7 @@ func TestList_NullResponse(t *testing.T) {
 		})
 	}))
 
-	summaries, err := client.List(t.Context(), "")
+	summaries, err := client.List(t.Context(), investigations.ListOptions{})
 	require.NoError(t, err)
 	assert.Empty(t, summaries)
 }

--- a/internal/assistant/investigations/commands.go
+++ b/internal/assistant/investigations/commands.go
@@ -51,9 +51,10 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 // --- list ---
 
 type listOpts struct {
-	IO    cmdio.Options
-	State string
-	Limit int
+	IO     cmdio.Options
+	State  string
+	Limit  int
+	Offset int
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet) {
@@ -63,6 +64,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 	flags.StringVar(&o.State, "state", "", "Filter by investigation state (e.g. running, completed, cancelled)")
 	flags.IntVar(&o.Limit, "limit", 50, "Maximum number of investigations to return")
+	flags.IntVar(&o.Offset, "offset", 0, "Number of investigations to skip (for pagination)")
 }
 
 func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
@@ -79,12 +81,13 @@ func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			summaries, err := client.List(cmd.Context(), opts.State)
+			summaries, err := client.List(cmd.Context(), ListOptions{
+				State:  opts.State,
+				Limit:  opts.Limit,
+				Offset: opts.Offset,
+			})
 			if err != nil {
 				return err
-			}
-			if opts.Limit > 0 && len(summaries) > opts.Limit {
-				summaries = summaries[:opts.Limit]
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), summaries)
 		},

--- a/internal/providers/k6/client.go
+++ b/internal/providers/k6/client.go
@@ -289,11 +289,6 @@ func (c *Client) GetProjectByName(ctx context.Context, name string) (*Project, e
 // Load Tests
 // ---------------------------------------------------------------------------
 
-// ListAllLoadTests retrieves all load tests across all projects.
-func (c *Client) ListAllLoadTests(ctx context.Context) ([]LoadTest, error) {
-	return c.listLoadTests(ctx, loadTestsPath, 0)
-}
-
 // ListLoadTestsByProject retrieves load tests filtered by project ID.
 // Uses the server-side project_id query parameter to avoid fetching all tests.
 func (c *Client) ListLoadTestsByProject(ctx context.Context, projectID int) ([]LoadTest, error) {
@@ -319,11 +314,10 @@ func (c *Client) listLoadTests(ctx context.Context, path string, limit int) ([]L
 	const defaultPageSize = 100
 	var all []LoadTest
 
-	for offset := 0; ; offset += defaultPageSize {
+	for {
 		pageSize := defaultPageSize
 		if limit > 0 {
-			remaining := limit - len(all)
-			if remaining < pageSize {
+			if remaining := limit - len(all); remaining < pageSize {
 				pageSize = remaining
 			}
 		}
@@ -332,7 +326,7 @@ func (c *Client) listLoadTests(ctx context.Context, path string, limit int) ([]L
 		if strings.Contains(path, "?") {
 			sep = "&"
 		}
-		pagePath := fmt.Sprintf("%s%s$skip=%d&$top=%d", path, sep, offset, pageSize)
+		pagePath := fmt.Sprintf("%s%s$skip=%d&$top=%d", path, sep, len(all), pageSize)
 
 		resp, err := c.doJSON(ctx, http.MethodGet, pagePath, nil)
 		if err != nil {

--- a/internal/providers/k6/client.go
+++ b/internal/providers/k6/client.go
@@ -290,30 +290,44 @@ func (c *Client) GetProjectByName(ctx context.Context, name string) (*Project, e
 // ---------------------------------------------------------------------------
 
 // ListAllLoadTests retrieves all load tests across all projects.
-// This is an alias for ListLoadTests for clarity when both variants are used.
 func (c *Client) ListAllLoadTests(ctx context.Context) ([]LoadTest, error) {
-	return c.ListLoadTests(ctx)
+	return c.listLoadTests(ctx, loadTestsPath, 0)
 }
 
 // ListLoadTestsByProject retrieves load tests filtered by project ID.
 // Uses the server-side project_id query parameter to avoid fetching all tests.
 func (c *Client) ListLoadTestsByProject(ctx context.Context, projectID int) ([]LoadTest, error) {
 	path := fmt.Sprintf(loadTestsPath+"?project_id=%d", projectID)
-	return c.listLoadTests(ctx, path)
+	return c.listLoadTests(ctx, path, 0)
 }
 
 // ListLoadTests retrieves all load tests across all projects, handling pagination.
 func (c *Client) ListLoadTests(ctx context.Context) ([]LoadTest, error) {
-	return c.listLoadTests(ctx, loadTestsPath)
+	return c.listLoadTests(ctx, loadTestsPath, 0)
+}
+
+// ListLoadTestsWithLimit retrieves load tests with a server-side limit on the
+// number of results. Pass 0 for no limit (fetches all).
+func (c *Client) ListLoadTestsWithLimit(ctx context.Context, limit int) ([]LoadTest, error) {
+	return c.listLoadTests(ctx, loadTestsPath, limit)
 }
 
 // listLoadTests fetches load tests from the given path, paginating through all pages.
 // The k6 v6 API uses OData-style pagination with $skip/$top parameters and @count.
-func (c *Client) listLoadTests(ctx context.Context, path string) ([]LoadTest, error) {
-	const pageSize = 100
+// If limit > 0, at most limit items are fetched by setting $top accordingly.
+func (c *Client) listLoadTests(ctx context.Context, path string, limit int) ([]LoadTest, error) {
+	const defaultPageSize = 100
 	var all []LoadTest
 
-	for offset := 0; ; offset += pageSize {
+	for offset := 0; ; offset += defaultPageSize {
+		pageSize := defaultPageSize
+		if limit > 0 {
+			remaining := limit - len(all)
+			if remaining < pageSize {
+				pageSize = remaining
+			}
+		}
+
 		sep := "?"
 		if strings.Contains(path, "?") {
 			sep = "&"
@@ -338,6 +352,12 @@ func (c *Client) listLoadTests(ctx context.Context, path string) ([]LoadTest, er
 		}
 
 		all = append(all, result.Value...)
+
+		// Stop if limit reached.
+		if limit > 0 && len(all) >= limit {
+			all = all[:limit]
+			break
+		}
 
 		// Stop if we got fewer results than page size or have fetched all (per @count).
 		if len(result.Value) < pageSize || (result.Count > 0 && len(all) >= result.Count) {

--- a/internal/providers/k6/client_test.go
+++ b/internal/providers/k6/client_test.go
@@ -243,6 +243,27 @@ func TestClient_ListLoadTests(t *testing.T) {
 	assert.Equal(t, "My Test", tests[0].Name)
 }
 
+func TestClient_ListLoadTests_WithLimit(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		// When limit=5 is passed, $top should be 5 instead of the default 100
+		assert.Equal(t, "5", r.URL.Query().Get("$top"))
+		assert.Equal(t, "0", r.URL.Query().Get("$skip"))
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(t, w, map[string]any{
+			"value": []map[string]any{
+				{"id": 1, "name": "Test 1", "project_id": 1},
+				{"id": 2, "name": "Test 2", "project_id": 1},
+			},
+		})
+	})
+
+	client := newAuthenticatedClient(t, handler)
+	tests, err := client.ListLoadTestsWithLimit(t.Context(), 5)
+	require.NoError(t, err)
+	assert.Len(t, tests, 2)
+}
+
 func TestClient_GetLoadTest(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)

--- a/internal/providers/k6/commands.go
+++ b/internal/providers/k6/commands.go
@@ -53,7 +53,7 @@ func resolveLoadTest(cmd *cobra.Command, client *Client, idFlag, projectID int, 
 		return client.GetLoadTestByName(ctx, projectID, nameArg)
 	}
 	// No project-id: scan all tests.
-	all, err := client.ListAllLoadTests(ctx)
+	all, err := client.ListLoadTests(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/k6/commands.go
+++ b/internal/providers/k6/commands.go
@@ -552,18 +552,20 @@ func newTestsListCommand(loader CloudConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			tests, err := client.ListLoadTestsWithLimit(ctx, int(opts.Limit))
-			if err != nil {
-				return err
-			}
+			var tests []LoadTest
 			if opts.ProjectID != 0 {
-				var filtered []LoadTest
-				for _, t := range tests {
-					if t.ProjectID == opts.ProjectID {
-						filtered = append(filtered, t)
-					}
+				tests, err = client.ListLoadTestsByProject(ctx, opts.ProjectID)
+				if err != nil {
+					return err
 				}
-				tests = filtered
+				if l := int(opts.Limit); l > 0 && len(tests) > l {
+					tests = tests[:l]
+				}
+			} else {
+				tests, err = client.ListLoadTestsWithLimit(ctx, int(opts.Limit))
+				if err != nil {
+					return err
+				}
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), tests)
 		},

--- a/internal/providers/k6/commands.go
+++ b/internal/providers/k6/commands.go
@@ -552,7 +552,7 @@ func newTestsListCommand(loader CloudConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			tests, err := client.ListLoadTests(ctx)
+			tests, err := client.ListLoadTestsWithLimit(ctx, int(opts.Limit))
 			if err != nil {
 				return err
 			}
@@ -565,7 +565,6 @@ func newTestsListCommand(loader CloudConfigLoader) *cobra.Command {
 				}
 				tests = filtered
 			}
-			tests = adapter.TruncateSlice(tests, opts.Limit)
 			return opts.IO.Encode(cmd.OutOrStdout(), tests)
 		},
 	}

--- a/internal/providers/k6/resource_adapter.go
+++ b/internal/providers/k6/resource_adapter.go
@@ -525,7 +525,7 @@ func NewTypedCRUDLoadTest(ctx context.Context, loader CloudConfigLoader) (*adapt
 		return nil, "", err
 	}
 	crud := &adapter.TypedCRUD[LoadTest]{
-		ListFn: adapter.LimitedListFn(client.ListAllLoadTests),
+		ListFn: adapter.LimitedListFn(client.ListLoadTests),
 		GetFn: func(ctx context.Context, name string) (*LoadTest, error) {
 			id, err := strconv.Atoi(name)
 			if err != nil {

--- a/internal/providers/oncall/client.go
+++ b/internal/providers/oncall/client.go
@@ -507,18 +507,10 @@ func applyListOpts(opts []ListOption) listConfig {
 }
 
 // ListAlertGroups returns all alert groups, optionally filtered.
-func (c *Client) ListAlertGroups(ctx context.Context, filters ...any) ([]AlertGroup, error) {
+func (c *Client) ListAlertGroups(ctx context.Context, filter AlertGroupFilter, opts ...ListOption) ([]AlertGroup, error) {
 	params := url.Values{}
-	var opts []ListOption
-	for _, f := range filters {
-		switch v := f.(type) {
-		case AlertGroupFilter:
-			if v.StartedAt != "" {
-				params.Set("started_at", v.StartedAt)
-			}
-		case ListOption:
-			opts = append(opts, v)
-		}
+	if filter.StartedAt != "" {
+		params.Set("started_at", filter.StartedAt)
 	}
 	cfg := applyListOpts(opts)
 	return collectN(iterResources[AlertGroup](c, ctx, pathWithParams(AlertGroupsPath, params), "alert group"), cfg.limit)

--- a/internal/providers/oncall/client.go
+++ b/internal/providers/oncall/client.go
@@ -211,12 +211,20 @@ func iterResources[T any](c *Client, ctx context.Context, path, resourceType str
 
 // collectAll collects all items from an iterator into a slice.
 func collectAll[T any](it iter.Seq2[T, error]) ([]T, error) {
+	return collectN(it, 0)
+}
+
+// collectN collects up to n items from an iterator. If n <= 0, all items are collected.
+func collectN[T any](it iter.Seq2[T, error], n int) ([]T, error) {
 	var items []T
 	for item, err := range it {
 		if err != nil {
 			return nil, err
 		}
 		items = append(items, item)
+		if n > 0 && len(items) >= n {
+			break
+		}
 	}
 	return items, nil
 }
@@ -478,13 +486,42 @@ type AlertGroupFilter struct {
 	StartedAt string
 }
 
-// ListAlertGroups returns all alert groups, optionally filtered.
-func (c *Client) ListAlertGroups(ctx context.Context, filters ...AlertGroupFilter) ([]AlertGroup, error) {
-	params := url.Values{}
-	if len(filters) > 0 && filters[0].StartedAt != "" {
-		params.Set("started_at", filters[0].StartedAt)
+// ListOption configures list behaviour (e.g. early termination).
+type ListOption func(*listConfig)
+
+type listConfig struct {
+	limit int
+}
+
+// WithLimit stops collecting after n items (0 = no limit).
+func WithLimit(n int) ListOption {
+	return func(c *listConfig) { c.limit = n }
+}
+
+func applyListOpts(opts []ListOption) listConfig {
+	var cfg listConfig
+	for _, o := range opts {
+		o(&cfg)
 	}
-	return collectAll(iterResources[AlertGroup](c, ctx, pathWithParams(AlertGroupsPath, params), "alert group"))
+	return cfg
+}
+
+// ListAlertGroups returns all alert groups, optionally filtered.
+func (c *Client) ListAlertGroups(ctx context.Context, filters ...any) ([]AlertGroup, error) {
+	params := url.Values{}
+	var opts []ListOption
+	for _, f := range filters {
+		switch v := f.(type) {
+		case AlertGroupFilter:
+			if v.StartedAt != "" {
+				params.Set("started_at", v.StartedAt)
+			}
+		case ListOption:
+			opts = append(opts, v)
+		}
+	}
+	cfg := applyListOpts(opts)
+	return collectN(iterResources[AlertGroup](c, ctx, pathWithParams(AlertGroupsPath, params), "alert group"), cfg.limit)
 }
 
 // GetAlertGroup retrieves an alert group by ID.
@@ -628,12 +665,13 @@ func (c *Client) DeletePersonalNotificationRule(ctx context.Context, id string) 
 // --- Alerts ---
 
 // ListAlerts returns all alerts, optionally filtered by alert group.
-func (c *Client) ListAlerts(ctx context.Context, alertGroupID string) ([]Alert, error) {
+func (c *Client) ListAlerts(ctx context.Context, alertGroupID string, opts ...ListOption) ([]Alert, error) {
 	params := url.Values{}
 	if alertGroupID != "" {
 		params.Set("alert_group_id", alertGroupID)
 	}
-	return collectAll(iterResources[Alert](c, ctx, pathWithParams("/api/v1/alerts/", params), "alert"))
+	cfg := applyListOpts(opts)
+	return collectN(iterResources[Alert](c, ctx, pathWithParams("/api/v1/alerts/", params), "alert"), cfg.limit)
 }
 
 // GetAlert retrieves an alert by ID.

--- a/internal/providers/oncall/client_test.go
+++ b/internal/providers/oncall/client_test.go
@@ -197,6 +197,55 @@ func TestListAlertGroups(t *testing.T) {
 	}
 }
 
+func TestListAlertGroups_StopsEarlyWithLimit(t *testing.T) {
+	t.Parallel()
+
+	var srvURL string
+	pageHits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		pageHits++
+		w.Header().Set("Content-Type", "application/json")
+		switch pageHits {
+		case 1:
+			nextURL := srvURL + "/api/v1/alert_groups/?page=2"
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"results": []map[string]any{
+					{"id": "ag1", "title": "Alert 1", "state": "firing", "alerts_count": 1},
+					{"id": "ag2", "title": "Alert 2", "state": "firing", "alerts_count": 2},
+				},
+				"next": nextURL,
+			})
+		default:
+			// This page should never be fetched when limit=1
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"results": []map[string]any{
+					{"id": "ag3", "title": "Alert 3", "state": "resolved", "alerts_count": 1},
+				},
+				"next": nil,
+			})
+		}
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	client := newTestClient(t, srv)
+	items, err := client.ListAlertGroups(context.Background(), oncall.WithLimit(1))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(items) != 1 {
+		t.Fatalf("expected 1 alert group with limit=1, got %d", len(items))
+	}
+	if items[0].ID != "ag1" {
+		t.Errorf("expected first alert group, got %s", items[0].ID)
+	}
+	// Should not have fetched page 2
+	if pageHits > 1 {
+		t.Errorf("expected only 1 page fetch with limit=1, but fetched %d pages", pageHits)
+	}
+}
+
 func TestGetIntegration_NotFound(t *testing.T) {
 	t.Parallel()
 

--- a/internal/providers/oncall/client_test.go
+++ b/internal/providers/oncall/client_test.go
@@ -184,7 +184,7 @@ func TestListAlertGroups(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestClient(t, srv)
-	items, err := client.ListAlertGroups(context.Background())
+	items, err := client.ListAlertGroups(context.Background(), oncall.AlertGroupFilter{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestListAlertGroups_StopsEarlyWithLimit(t *testing.T) {
 	srvURL = srv.URL
 
 	client := newTestClient(t, srv)
-	items, err := client.ListAlertGroups(context.Background(), oncall.WithLimit(1))
+	items, err := client.ListAlertGroups(context.Background(), oncall.AlertGroupFilter{}, oncall.WithLimit(1))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/providers/oncall/commands_extra.go
+++ b/internal/providers/oncall/commands_extra.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/gcx/internal/deeplink"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
-	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -52,11 +51,10 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 				filter.StartedAt = startedAt
 			}
 
-			items, err := client.ListAlertGroups(cmd.Context(), filter)
+			items, err := client.ListAlertGroups(cmd.Context(), filter, WithLimit(int(opts.Limit)))
 			if err != nil {
 				return err
 			}
-			items = adapter.TruncateSlice(items, opts.Limit)
 
 			objs, err := itemsToUnstructured(items, "AlertGroup", "id", namespace)
 			if err != nil {
@@ -115,11 +113,10 @@ func newAlertGroupListAlertsCommand(loader OnCallConfigLoader) *cobra.Command {
 				return err
 			}
 
-			items, err := client.ListAlerts(cmd.Context(), args[0])
+			items, err := client.ListAlerts(cmd.Context(), args[0], WithLimit(int(opts.Limit)))
 			if err != nil {
 				return err
 			}
-			items = adapter.TruncateSlice(items, opts.Limit)
 
 			objs, err := itemsToUnstructured(items, "Alert", "id", namespace)
 			if err != nil {

--- a/internal/providers/oncall/resource_adapter.go
+++ b/internal/providers/oncall/resource_adapter.go
@@ -294,7 +294,9 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 	meta.Schema = adapter.SchemaFromType[AlertGroup](meta.Descriptor)
 	meta.URLTemplate = "/a/grafana-oncall-app/alert-groups/{name}"
 	regs = append(regs, buildOnCallRegistration(loader, meta,
-		func(ctx context.Context, c *Client) ([]AlertGroup, error) { return c.ListAlertGroups(ctx) }, // no filter
+		func(ctx context.Context, c *Client) ([]AlertGroup, error) {
+			return c.ListAlertGroups(ctx, AlertGroupFilter{})
+		},
 		func(ctx context.Context, c *Client, name string) (*AlertGroup, error) {
 			return c.GetAlertGroup(ctx, name)
 		},

--- a/internal/providers/sigil/eval/templates/client.go
+++ b/internal/providers/sigil/eval/templates/client.go
@@ -24,12 +24,13 @@ func NewClient(base *sigilhttp.Client) *Client {
 }
 
 // List returns templates, optionally filtered by scope.
-func (c *Client) List(ctx context.Context, scope string) ([]eval.TemplateDefinition, error) {
+// An optional maxItems argument limits how many items are fetched (0 = no limit).
+func (c *Client) List(ctx context.Context, scope string, maxItems ...int) ([]eval.TemplateDefinition, error) {
 	query := url.Values{}
 	if scope != "" {
 		query.Set("scope", scope)
 	}
-	return sigilhttp.ListAll[eval.TemplateDefinition](ctx, c.base, basePath, query)
+	return sigilhttp.ListAll[eval.TemplateDefinition](ctx, c.base, basePath, query, maxItems...)
 }
 
 // Get returns a single template by ID.

--- a/internal/providers/sigil/eval/templates/client_test.go
+++ b/internal/providers/sigil/eval/templates/client_test.go
@@ -90,6 +90,24 @@ func TestClient_Get(t *testing.T) {
 	assert.Equal(t, "llm_judge", (*detail)["kind"])
 }
 
+func TestClient_List_WithLimit(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"items": []eval.TemplateDefinition{
+				{TemplateID: "tpl-1", Scope: "global", Kind: "llm_judge"},
+				{TemplateID: "tpl-2", Scope: "tenant", Kind: "regex"},
+				{TemplateID: "tpl-3", Scope: "global", Kind: "llm_judge"},
+			},
+		})
+	}))
+
+	items, err := client.List(context.Background(), "", 2)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, "tpl-1", items[0].TemplateID)
+	assert.Equal(t, "tpl-2", items[1].TemplateID)
+}
+
 func TestClient_ListVersions(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)

--- a/internal/providers/sigil/eval/templates/commands.go
+++ b/internal/providers/sigil/eval/templates/commands.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/sigil/eval"
 	"github.com/grafana/gcx/internal/providers/sigil/sigilhttp"
-	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -72,11 +71,10 @@ func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			templates, err := client.List(cmd.Context(), opts.Scope)
+			templates, err := client.List(cmd.Context(), opts.Scope, int(opts.Limit))
 			if err != nil {
 				return err
 			}
-			templates = adapter.TruncateSlice(templates, opts.Limit)
 			return opts.IO.Encode(cmd.OutOrStdout(), templates)
 		},
 	}


### PR DESCRIPTION
## Summary

- **investigations**: pass `limit`/`offset` query params to server, add `--offset` CLI flag, remove client-side truncation
- **sigil templates**: wire `opts.Limit` through to `ListAll`'s existing `maxItems` early-termination support
- **oncall alert-groups/alerts**: add `collectN` for early iterator termination via `WithLimit` option, stop fetching pages once limit is reached
- **k6 load-tests**: pass user's `--limit` as `$top` instead of hardcoded 100

## Test plan

- [x] New test: `TestClient_List_WithLimit` (sigil) — server returns 3, limit=2 → 2 returned
- [x] New test: `TestListAlertGroups_StopsEarlyWithLimit` (oncall) — 2-page server, limit=1 → 1 returned, only 1 page fetched
- [x] New test: `TestClient_ListLoadTests_WithLimit` (k6) — asserts `$top=5` sent when limit=5
- [x] New test: `TestList` pagination params (investigations) — asserts `limit=10&offset=20` sent as query params
- [x] Lint passes (`make lint` — 0 issues)
- [x] All changed package tests pass
- [x] Live-tested `investigations list --limit=2 --offset=N` against ep.amer.cloud.demokit.grafana.com

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)