### PR TITLE
chore: add .DS_Store to gitignore and update AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /.devbox
 /.venv
 /.worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,18 @@ Run this checklist **before every commit** (not only before PR/push):
    git status
    ```
 
+## GitHub Issues
+
+When creating or commenting on GitHub issues, **always anonymize system-specific details**. Replace real values with placeholders:
+
+- Stack names / context names → `<my-context>`, `<stack>`
+- URLs with stack or region identifiers → `https://example-<region>.grafana.net`
+- Hosted IDs, stack IDs, org IDs → `12345`, `99999`
+- Datasource names with stack slugs → `grafanacloud-<stack>-prom`
+- API tokens, credentials → never include, even partially
+
+This applies to issue bodies, comments, and code snippets embedded in issues.
+
 ## Beads Issue Tracker (optional)
 
 This project can use **bd (beads)** for issue tracking. Run `bd prime` for full command reference.


### PR DESCRIPTION
## Summary
- Add `.DS_Store` to `.gitignore` to prevent macOS metadata files from being tracked
- Update `AGENTS.md` with guidelines for anonymizing system-specific details in GitHub issues

## Test plan
- [x] No code changes — documentation and gitignore only

🤖 Generated with [Claude Code](https://claude.com/claude-code)