### PR TITLE
feat(synth): auto-discover SM URL from plugin settings

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -314,13 +314,13 @@ func convertSMConfigErrors(err error) (*DetailedError, bool) {
 	if strings.Contains(msg, "SM URL not configured") {
 		return &DetailedError{
 			Summary: "SM URL not configured",
-			Details: "The Synthetic Monitoring API URL could not be resolved.\nAuto-discovery requires a Grafana server in the current context.",
+			Details: msg,
 			Parent:  err,
 			Suggestions: []string{
-				"Run gcx setup to auto-discover all provider settings",
 				"Set manually: gcx config set providers.synth.sm-url https://synthetic-monitoring-api-<region>.grafana.net",
 				"Or use env var: export GRAFANA_PROVIDER_SYNTH_SM_URL=<URL>",
-				"Check other contexts: gcx config view",
+				"Auto-discovery requires grafana.server in the current context",
+				"Check config: gcx config view",
 			},
 		}, true
 	}
@@ -328,13 +328,13 @@ func convertSMConfigErrors(err error) (*DetailedError, bool) {
 	if strings.Contains(msg, "SM token not configured") {
 		return &DetailedError{
 			Summary: "SM token not configured",
-			Details: "The SM publisher token could not be resolved.\nAuto-discovery via register/install requires cloud.token and cloud.stack in the current context.",
+			Details: msg,
 			Parent:  err,
 			Suggestions: []string{
-				"Run gcx setup to auto-discover all provider settings",
 				"Set it: gcx config set providers.synth.sm-token <TOKEN>",
 				"Or use env var: export GRAFANA_PROVIDER_SYNTH_SM_TOKEN=<TOKEN>",
-				"Check other contexts: gcx config view",
+				"Auto-discovery requires cloud.token and cloud.stack in the current context",
+				"Check config: gcx config view",
 			},
 		}, true
 	}

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -38,6 +38,7 @@ func ErrorToDetailedError(err error) *DetailedError {
 		convertAPIErrors,          // API-related errors
 		convertVersionErrors,      // Version incompatibility errors
 		convertLinterErrors,       // Linter-related errors
+		convertSMConfigErrors,     // Synthetic Monitoring config errors
 		convertCloudConfigErrors,  // Cloud config / fleet / setup errors
 	}
 
@@ -304,6 +305,40 @@ func convertRequiredFlagErrors(err error) (*DetailedError, bool) {
 			},
 		}, true
 	}
+	return nil, false
+}
+
+func convertSMConfigErrors(err error) (*DetailedError, bool) {
+	msg := err.Error()
+
+	if strings.Contains(msg, "SM URL not configured") {
+		return &DetailedError{
+			Summary: "SM URL not configured",
+			Details: "The Synthetic Monitoring API URL could not be resolved.\nAuto-discovery requires a Grafana server in the current context.",
+			Parent:  err,
+			Suggestions: []string{
+				"Run gcx setup to auto-discover all provider settings",
+				"Set manually: gcx config set providers.synth.sm-url https://synthetic-monitoring-api-<region>.grafana.net",
+				"Or use env var: export GRAFANA_PROVIDER_SYNTH_SM_URL=<URL>",
+				"Check other contexts: gcx config view",
+			},
+		}, true
+	}
+
+	if strings.Contains(msg, "SM token not configured") {
+		return &DetailedError{
+			Summary: "SM token not configured",
+			Details: "The SM publisher token is required but not set in this context.\nTokens cannot be auto-discovered — they must be set manually.",
+			Parent:  err,
+			Suggestions: []string{
+				"Find the token in Grafana: open your SM plugin settings page (/a/grafana-synthetic-monitoring-app)",
+				"Set it: gcx config set providers.synth.sm-token <TOKEN>",
+				"Or use env var: export GRAFANA_PROVIDER_SYNTH_SM_TOKEN=<TOKEN>",
+				"Check other contexts: gcx config view",
+			},
+		}, true
+	}
+
 	return nil, false
 }
 

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -328,10 +328,10 @@ func convertSMConfigErrors(err error) (*DetailedError, bool) {
 	if strings.Contains(msg, "SM token not configured") {
 		return &DetailedError{
 			Summary: "SM token not configured",
-			Details: "The SM publisher token is required but not set in this context.\nTokens cannot be auto-discovered — they must be set manually.",
+			Details: "The SM publisher token could not be resolved.\nAuto-discovery via register/install requires cloud.token and cloud.stack in the current context.",
 			Parent:  err,
 			Suggestions: []string{
-				"Find the token in Grafana: open your SM plugin settings page (/a/grafana-synthetic-monitoring-app)",
+				"Run gcx setup to auto-discover all provider settings",
 				"Set it: gcx config set providers.synth.sm-token <TOKEN>",
 				"Or use env var: export GRAFANA_PROVIDER_SYNTH_SM_TOKEN=<TOKEN>",
 				"Check other contexts: gcx config view",

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -174,32 +174,32 @@ func TestErrorToDetailedError_CobraUnknownCommandError(t *testing.T) {
 
 func TestErrorToDetailedError_SMURLNotConfigured(t *testing.T) {
 	err := fmt.Errorf("failed to load SM config for checks: %w",
-		errors.New("SM URL not configured: auto-discovery from Grafana plugin settings failed or no Grafana server configured"))
+		fmt.Errorf("SM URL not configured: %w", errors.New("no Grafana server configured: grafana config is required")))
 
 	got := fail.ErrorToDetailedError(err)
 
 	require.NotNil(t, got)
 	assert.Equal(t, "SM URL not configured", got.Summary)
-	assert.Contains(t, got.Details, "Auto-discovery requires a Grafana server")
+	assert.Contains(t, got.Details, "SM URL not configured")
 	require.Len(t, got.Suggestions, 4)
-	assert.Contains(t, got.Suggestions[0], "gcx setup")
-	assert.Contains(t, got.Suggestions[1], "gcx config set providers.synth.sm-url")
-	assert.Contains(t, got.Suggestions[2], "GRAFANA_PROVIDER_SYNTH_SM_URL")
+	assert.Contains(t, got.Suggestions[0], "gcx config set providers.synth.sm-url")
+	assert.Contains(t, got.Suggestions[1], "GRAFANA_PROVIDER_SYNTH_SM_URL")
+	assert.Contains(t, got.Suggestions[2], "grafana.server")
 	assert.Contains(t, got.Suggestions[3], "gcx config view")
 }
 
 func TestErrorToDetailedError_SMTokenNotConfigured(t *testing.T) {
 	err := fmt.Errorf("failed to load SM config for checks: %w",
-		errors.New("SM token not configured: auto-discovery via register/install failed or no cloud.token configured"))
+		fmt.Errorf("SM token not configured: %w", errors.New("no cloud config: cloud token is required")))
 
 	got := fail.ErrorToDetailedError(err)
 
 	require.NotNil(t, got)
 	assert.Equal(t, "SM token not configured", got.Summary)
-	assert.Contains(t, got.Details, "register/install requires cloud.token")
+	assert.Contains(t, got.Details, "SM token not configured")
 	require.Len(t, got.Suggestions, 4)
-	assert.Contains(t, got.Suggestions[0], "gcx setup")
-	assert.Contains(t, got.Suggestions[1], "gcx config set providers.synth.sm-token")
-	assert.Contains(t, got.Suggestions[2], "GRAFANA_PROVIDER_SYNTH_SM_TOKEN")
+	assert.Contains(t, got.Suggestions[0], "gcx config set providers.synth.sm-token")
+	assert.Contains(t, got.Suggestions[1], "GRAFANA_PROVIDER_SYNTH_SM_TOKEN")
+	assert.Contains(t, got.Suggestions[2], "cloud.token")
 	assert.Contains(t, got.Suggestions[3], "gcx config view")
 }

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -190,15 +190,15 @@ func TestErrorToDetailedError_SMURLNotConfigured(t *testing.T) {
 
 func TestErrorToDetailedError_SMTokenNotConfigured(t *testing.T) {
 	err := fmt.Errorf("failed to load SM config for checks: %w",
-		errors.New("SM token not configured: set providers.synth.sm-token in config or GRAFANA_PROVIDER_SYNTH_SM_TOKEN env var"))
+		errors.New("SM token not configured: auto-discovery via register/install failed or no cloud.token configured"))
 
 	got := fail.ErrorToDetailedError(err)
 
 	require.NotNil(t, got)
 	assert.Equal(t, "SM token not configured", got.Summary)
-	assert.Contains(t, got.Details, "Tokens cannot be auto-discovered")
+	assert.Contains(t, got.Details, "register/install requires cloud.token")
 	require.Len(t, got.Suggestions, 4)
-	assert.Contains(t, got.Suggestions[0], "SM plugin settings")
+	assert.Contains(t, got.Suggestions[0], "gcx setup")
 	assert.Contains(t, got.Suggestions[1], "gcx config set providers.synth.sm-token")
 	assert.Contains(t, got.Suggestions[2], "GRAFANA_PROVIDER_SYNTH_SM_TOKEN")
 	assert.Contains(t, got.Suggestions[3], "gcx config view")

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -171,3 +171,35 @@ func TestErrorToDetailedError_CobraUnknownCommandError(t *testing.T) {
 	require.Len(t, got.Suggestions, 1)
 	assert.Equal(t, "Run 'gcx kg --help' for full usage and examples", got.Suggestions[0])
 }
+
+func TestErrorToDetailedError_SMURLNotConfigured(t *testing.T) {
+	err := fmt.Errorf("failed to load SM config for checks: %w",
+		errors.New("SM URL not configured: auto-discovery from Grafana plugin settings failed or no Grafana server configured"))
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "SM URL not configured", got.Summary)
+	assert.Contains(t, got.Details, "Auto-discovery requires a Grafana server")
+	require.Len(t, got.Suggestions, 4)
+	assert.Contains(t, got.Suggestions[0], "gcx setup")
+	assert.Contains(t, got.Suggestions[1], "gcx config set providers.synth.sm-url")
+	assert.Contains(t, got.Suggestions[2], "GRAFANA_PROVIDER_SYNTH_SM_URL")
+	assert.Contains(t, got.Suggestions[3], "gcx config view")
+}
+
+func TestErrorToDetailedError_SMTokenNotConfigured(t *testing.T) {
+	err := fmt.Errorf("failed to load SM config for checks: %w",
+		errors.New("SM token not configured: set providers.synth.sm-token in config or GRAFANA_PROVIDER_SYNTH_SM_TOKEN env var"))
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "SM token not configured", got.Summary)
+	assert.Contains(t, got.Details, "Tokens cannot be auto-discovered")
+	require.Len(t, got.Suggestions, 4)
+	assert.Contains(t, got.Suggestions[0], "SM plugin settings")
+	assert.Contains(t, got.Suggestions[1], "gcx config set providers.synth.sm-token")
+	assert.Contains(t, got.Suggestions[2], "GRAFANA_PROVIDER_SYNTH_SM_TOKEN")
+	assert.Contains(t, got.Suggestions[3], "gcx config view")
+}

--- a/internal/providers/synth/configloader_test.go
+++ b/internal/providers/synth/configloader_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers/synth/smcfg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -227,6 +228,35 @@ current-context: default
 	cfg, err := l.LoadConfig(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, wantURL, cfg.GetCurrentContext().Providers["synth"]["sm-url"])
+}
+
+// TestDiscoverSMURL_UsesGrafanaURL verifies that discoverSMURL uses GrafanaURL
+// (the original Grafana server) rather than Host (which may be a proxy endpoint).
+// This prevents a bug where OAuth proxy users hit the wrong endpoint.
+func TestDiscoverSMURL_UsesGrafanaURL(t *testing.T) {
+	const wantURL = "https://synthetic-monitoring-api-eu-west-2.grafana.net"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/plugins/grafana-synthetic-monitoring-app/settings" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonData": map[string]any{"apiHost": wantURL},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	// Simulate OAuth proxy mode: Host points to a proxy, GrafanaURL points to the real server.
+	cfg := config.NamespacedRESTConfig{
+		GrafanaURL: srv.URL,
+	}
+	cfg.Host = "https://proxy.example.com/api/cli/v1/proxy"
+
+	got, err := discoverSMURL(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, wantURL, got)
 }
 
 // TestConfigLoader_LoadSMConfig_AutoDiscoveryFallsBackToError verifies that

--- a/internal/providers/synth/configloader_test.go
+++ b/internal/providers/synth/configloader_test.go
@@ -275,6 +275,119 @@ current-context: default
 	assert.Equal(t, "https://explicit.sm", smURL)
 }
 
+// TestConfigLoader_LoadSMConfig_TokenAutoDiscovery verifies that sm-token is
+// auto-discovered via the SM register/install API when cloud config is available.
+func TestConfigLoader_LoadSMConfig_TokenAutoDiscovery(t *testing.T) {
+	const wantToken = "sm-access-token-abc123"
+
+	// Mock SM API server that handles both plugin settings and register/install.
+	smSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/register/install" && r.Method == http.MethodPost {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"accessToken": wantToken,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer smSrv.Close()
+
+	// Mock GCOM server that returns stack info.
+	gcomSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":                12345,
+			"slug":              "teststack",
+			"regionSlug":        "eu-west-2",
+			"hmInstancePromId":  67890,
+			"hlInstanceId":      11111,
+			"hmInstancePromUrl": "https://prom.example.com",
+			"hlInstanceUrl":     "https://loki.example.com",
+		})
+	}))
+	defer gcomSrv.Close()
+
+	cfgFile := writeConfigFile(t, `
+contexts:
+  default:
+    grafana:
+      server: https://teststack.grafana.net
+      token: test-token
+      stack-id: 12345
+    cloud:
+      token: cloud-token-xyz
+      stack: teststack
+      api-url: `+gcomSrv.URL+`
+    providers:
+      synth:
+        sm-url: `+smSrv.URL+`
+current-context: default
+`)
+
+	l := newTestLoader(t, cfgFile)
+
+	smURL, smToken, _, err := l.LoadSMConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, smSrv.URL, smURL)
+	assert.Equal(t, wantToken, smToken)
+}
+
+// TestConfigLoader_LoadSMConfig_TokenPersistsToConfig verifies that an
+// auto-discovered SM token is saved to the config file for subsequent runs.
+func TestConfigLoader_LoadSMConfig_TokenPersistsToConfig(t *testing.T) {
+	const wantToken = "sm-access-token-persisted"
+
+	smSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/register/install" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"accessToken": wantToken})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer smSrv.Close()
+
+	gcomSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": 12345, "slug": "teststack", "regionSlug": "eu",
+			"hmInstancePromId": 1, "hlInstanceId": 2,
+			"hmInstancePromUrl": "https://prom.example.com",
+			"hlInstanceUrl":     "https://loki.example.com",
+		})
+	}))
+	defer gcomSrv.Close()
+
+	cfgFile := writeConfigFile(t, `
+contexts:
+  default:
+    grafana:
+      server: https://teststack.grafana.net
+      token: test-token
+      stack-id: 12345
+    cloud:
+      token: cloud-token
+      stack: teststack
+      api-url: `+gcomSrv.URL+`
+    providers:
+      synth:
+        sm-url: `+smSrv.URL+`
+current-context: default
+`)
+
+	l := newTestLoader(t, cfgFile)
+
+	_, smToken, _, err := l.LoadSMConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, wantToken, smToken)
+
+	// Verify persisted.
+	cfg, err := l.LoadConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, wantToken, cfg.GetCurrentContext().Providers["synth"]["sm-token"])
+}
+
 // TestConfigLoader_SaveMetricsDatasourceUID_RoundTrip verifies AC-6: saving and
 // reloading sm-metrics-datasource-uid round-trips correctly.
 func TestConfigLoader_SaveMetricsDatasourceUID_RoundTrip(t *testing.T) {

--- a/internal/providers/synth/configloader_test.go
+++ b/internal/providers/synth/configloader_test.go
@@ -2,6 +2,9 @@ package synth //nolint:testpackage // Tests need access to unexported configLoad
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -139,6 +142,137 @@ current-context: default
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "SM token not configured")
 	assert.Empty(t, smURL)
+}
+
+// TestConfigLoader_LoadSMConfig_AutoDiscovery verifies that sm-url is auto-discovered
+// from plugin settings when not explicitly configured and a Grafana server is available.
+func TestConfigLoader_LoadSMConfig_AutoDiscovery(t *testing.T) {
+	const wantURL = "https://synthetic-monitoring-api-eu-west-2.grafana.net"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/plugins/grafana-synthetic-monitoring-app/settings" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonData": map[string]any{
+					"apiHost": wantURL,
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	cfgFile := writeConfigFile(t, `
+contexts:
+  default:
+    grafana:
+      server: `+srv.URL+`
+      token: test-token
+      stack-id: 12345
+    providers:
+      synth:
+        sm-token: tok-test
+current-context: default
+`)
+
+	l := newTestLoader(t, cfgFile)
+
+	smURL, smToken, _, err := l.LoadSMConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, wantURL, smURL)
+	assert.Equal(t, "tok-test", smToken)
+}
+
+// TestConfigLoader_LoadSMConfig_AutoDiscoveryPersistsToConfig verifies that an
+// auto-discovered SM URL is saved to the config file for subsequent runs.
+func TestConfigLoader_LoadSMConfig_AutoDiscoveryPersistsToConfig(t *testing.T) {
+	const wantURL = "https://synthetic-monitoring-api-eu-west-2.grafana.net"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/plugins/grafana-synthetic-monitoring-app/settings" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonData": map[string]any{
+					"apiHost": wantURL,
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	cfgFile := writeConfigFile(t, `
+contexts:
+  default:
+    grafana:
+      server: `+srv.URL+`
+      token: test-token
+      stack-id: 12345
+    providers:
+      synth:
+        sm-token: tok-test
+current-context: default
+`)
+
+	l := newTestLoader(t, cfgFile)
+
+	// First call: auto-discovers and persists.
+	smURL, _, _, err := l.LoadSMConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, wantURL, smURL)
+
+	// Verify persisted: reload config and check the value was saved.
+	cfg, err := l.LoadConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, wantURL, cfg.GetCurrentContext().Providers["synth"]["sm-url"])
+}
+
+// TestConfigLoader_LoadSMConfig_AutoDiscoveryFallsBackToError verifies that
+// when auto-discovery fails (no Grafana server), a clear error is returned.
+func TestConfigLoader_LoadSMConfig_AutoDiscoveryFallsBackToError(t *testing.T) {
+	cfgFile := writeConfigFile(t, `
+contexts:
+  default:
+    providers:
+      synth:
+        sm-token: tok
+current-context: default
+`)
+
+	l := newTestLoader(t, cfgFile)
+
+	_, _, _, err := l.LoadSMConfig(context.Background()) //nolint:dogsled // Only testing error return.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SM URL not configured")
+}
+
+// TestConfigLoader_LoadSMConfig_ExplicitURLSkipsAutoDiscovery verifies that
+// auto-discovery is not attempted when sm-url is already configured.
+func TestConfigLoader_LoadSMConfig_ExplicitURLSkipsAutoDiscovery(t *testing.T) {
+	// Server that would fail if called — proves discovery was skipped.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("auto-discovery should not be attempted when sm-url is configured")
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfgFile := writeConfigFile(t, `
+contexts:
+  default:
+    providers:
+      synth:
+        sm-url: https://explicit.sm
+        sm-token: tok-test
+current-context: default
+`)
+
+	l := newTestLoader(t, cfgFile)
+
+	smURL, _, _, err := l.LoadSMConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "https://explicit.sm", smURL)
 }
 
 // TestConfigLoader_SaveMetricsDatasourceUID_RoundTrip verifies AC-6: saving and

--- a/internal/providers/synth/configloader_test.go
+++ b/internal/providers/synth/configloader_test.go
@@ -230,10 +230,9 @@ current-context: default
 	assert.Equal(t, wantURL, cfg.GetCurrentContext().Providers["synth"]["sm-url"])
 }
 
-// TestDiscoverSMURL_UsesGrafanaURL verifies that discoverSMURL uses GrafanaURL
-// (the original Grafana server) rather than Host (which may be a proxy endpoint).
-// This prevents a bug where OAuth proxy users hit the wrong endpoint.
-func TestDiscoverSMURL_UsesGrafanaURL(t *testing.T) {
+// TestDiscoverSMURL_DirectMode verifies that discoverSMURL uses GrafanaURL
+// in direct (non-proxy) mode.
+func TestDiscoverSMURL_DirectMode(t *testing.T) {
 	const wantURL = "https://synthetic-monitoring-api-eu-west-2.grafana.net"
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -248,13 +247,52 @@ func TestDiscoverSMURL_UsesGrafanaURL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Simulate OAuth proxy mode: Host points to a proxy, GrafanaURL points to the real server.
 	cfg := config.NamespacedRESTConfig{
 		GrafanaURL: srv.URL,
 	}
-	cfg.Host = "https://proxy.example.com/api/cli/v1/proxy"
+	cfg.Host = srv.URL
 
 	got, err := discoverSMURL(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, wantURL, got)
+}
+
+// TestDiscoverSMURL_OAuthProxyMode verifies that discoverSMURL routes through
+// cfg.Host (the proxy) in OAuth proxy mode, not cfg.GrafanaURL (the direct server).
+func TestDiscoverSMURL_OAuthProxyMode(t *testing.T) {
+	const wantURL = "https://synthetic-monitoring-api-us-east-0.grafana.net"
+
+	// This server simulates the proxy. In OAuth proxy mode, cfg.Host is set to
+	// <proxy>/api/cli/v1/proxy, so the full request path becomes
+	// /api/cli/v1/proxy/api/plugins/grafana-synthetic-monitoring-app/settings.
+	const proxyPrefix = "/api/cli/v1/proxy"
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == proxyPrefix+"/api/plugins/grafana-synthetic-monitoring-app/settings" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonData": map[string]any{"apiHost": wantURL},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer proxy.Close()
+
+	// Build a config that looks like OAuth proxy mode.
+	// IsOAuthProxy() returns true when the oauthTransport is set, which happens
+	// via NewNamespacedRESTConfig when proxy-endpoint + oauth-token are present.
+	ctx := config.Context{
+		Name: "test",
+		Grafana: &config.GrafanaConfig{
+			Server:        "https://grafana.example.com",
+			ProxyEndpoint: proxy.URL,
+			OAuthToken:    "gat_test",
+		},
+	}
+	restCfg := config.NewNamespacedRESTConfig(context.Background(), ctx)
+	require.True(t, restCfg.IsOAuthProxy(), "config should be in OAuth proxy mode")
+
+	got, err := discoverSMURL(context.Background(), restCfg)
 	require.NoError(t, err)
 	assert.Equal(t, wantURL, got)
 }

--- a/internal/providers/synth/provider.go
+++ b/internal/providers/synth/provider.go
@@ -192,39 +192,36 @@ func (l *configLoader) LoadSMConfig(ctx context.Context) (string, string, string
 
 	// Tier 2: auto-discover SM URL from plugin settings when not explicitly configured.
 	if smURL == "" {
-		smURL = l.tryDiscoverSMURL(ctx)
-	}
-
-	if smURL == "" {
-		return "", "", "", errors.New(
-			"SM URL not configured: auto-discovery from Grafana plugin settings failed or no Grafana server configured")
+		var discoverErr error
+		smURL, discoverErr = l.tryDiscoverSMURL(ctx)
+		if smURL == "" {
+			return "", "", "", fmt.Errorf("SM URL not configured: %w", discoverErr)
+		}
 	}
 
 	// Tier 2: auto-discover SM token via register/install when not explicitly configured.
 	if smToken == "" {
-		smToken = l.tryDiscoverSMToken(ctx, smURL)
-	}
-
-	if smToken == "" {
-		return "", "", "", errors.New(
-			"SM token not configured: auto-discovery via register/install failed or no cloud.token configured")
+		var discoverErr error
+		smToken, discoverErr = l.tryDiscoverSMToken(ctx, smURL)
+		if smToken == "" {
+			return "", "", "", fmt.Errorf("SM token not configured: %w", discoverErr)
+		}
 	}
 
 	return smURL, smToken, namespace, nil
 }
 
 // tryDiscoverSMURL attempts to auto-discover the SM URL from Grafana plugin settings
-// and persists it to config on success. Returns empty string on failure.
-func (l *configLoader) tryDiscoverSMURL(ctx context.Context) string {
+// and persists it to config on success. Returns empty string and the reason on failure.
+func (l *configLoader) tryDiscoverSMURL(ctx context.Context) (string, error) {
 	restCfg, err := l.LoadGrafanaConfig(ctx)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("no Grafana server configured: %w", err)
 	}
 
 	discovered, err := discoverSMURL(ctx, restCfg)
 	if err != nil {
-		slog.DebugContext(ctx, "SM URL auto-discovery failed", "error", err)
-		return ""
+		return "", fmt.Errorf("plugin settings query failed: %w", err)
 	}
 
 	// Persist to config so subsequent runs skip the API call.
@@ -232,29 +229,27 @@ func (l *configLoader) tryDiscoverSMURL(ctx context.Context) string {
 		slog.DebugContext(ctx, "failed to cache discovered SM URL to config", "error", saveErr)
 	}
 
-	return discovered
+	return discovered, nil
 }
 
 // tryDiscoverSMToken attempts to auto-discover the SM token via the SM register/install
-// API using cloud credentials from GCOM. Persists to config on success. Returns empty string on failure.
-func (l *configLoader) tryDiscoverSMToken(ctx context.Context, smURL string) string {
+// API using cloud credentials from GCOM. Persists to config on success. Returns empty string and the reason on failure.
+func (l *configLoader) tryDiscoverSMToken(ctx context.Context, smURL string) (string, error) {
 	cloudCfg, err := l.LoadCloudConfig(ctx)
 	if err != nil {
-		slog.DebugContext(ctx, "SM token auto-discovery skipped: no cloud config", "error", err)
-		return ""
+		return "", fmt.Errorf("no cloud config: %w", err)
 	}
 
 	token, err := registerSMInstall(ctx, smURL, cloudCfg.Token, cloudCfg.Stack)
 	if err != nil {
-		slog.DebugContext(ctx, "SM token auto-discovery failed", "error", err)
-		return ""
+		return "", fmt.Errorf("register/install API failed: %w", err)
 	}
 
 	if saveErr := l.SaveProviderConfig(ctx, "synth", "sm-token", token); saveErr != nil {
 		slog.DebugContext(ctx, "failed to cache discovered SM token to config", "error", saveErr)
 	}
 
-	return token
+	return token, nil
 }
 
 // registerSMInstall calls the SM register/install endpoint to obtain an access token.

--- a/internal/providers/synth/provider.go
+++ b/internal/providers/synth/provider.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
+	"net/http"
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers"
@@ -12,6 +14,7 @@ import (
 	"github.com/grafana/gcx/internal/providers/synth/probes"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
 )
 
 func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
@@ -112,10 +115,8 @@ func (p *SynthProvider) Commands() []*cobra.Command {
 }
 
 // Validate checks that the given provider configuration is valid.
+// sm-url is not required here because it can be auto-discovered from plugin settings.
 func (p *SynthProvider) Validate(cfg map[string]string) error {
-	if cfg["sm-url"] == "" {
-		return errors.New("sm-url is required for the synth provider")
-	}
 	if cfg["sm-token"] == "" {
 		return errors.New("sm-token is required for the synth provider")
 	}
@@ -165,9 +166,13 @@ type configLoader struct {
 }
 
 // LoadSMConfig loads the SM base URL, token, and K8s namespace from config.
-// Priority (highest first):
-//  1. GRAFANA_PROVIDER_SYNTH_SM_URL / GRAFANA_PROVIDER_SYNTH_SM_TOKEN env vars
-//  2. Config file: providers.synth.sm-url / sm-token
+// SM URL resolution priority (highest first):
+//  1. GRAFANA_PROVIDER_SYNTH_SM_URL env var / providers.synth.sm-url in config
+//  2. Auto-discovery from SM plugin settings (jsonData.apiHost) — requires grafana.server
+//  3. Error with actionable guidance
+//
+// When auto-discovery succeeds the URL is persisted to config so subsequent
+// invocations skip the API call.
 func (l *configLoader) LoadSMConfig(ctx context.Context) (string, string, string, error) {
 	providerCfg, namespace, err := l.LoadProviderConfig(ctx, "synth")
 	if err != nil {
@@ -177,9 +182,14 @@ func (l *configLoader) LoadSMConfig(ctx context.Context) (string, string, string
 	smURL := providerCfg["sm-url"]
 	smToken := providerCfg["sm-token"]
 
+	// Tier 2: auto-discover SM URL from plugin settings when not explicitly configured.
+	if smURL == "" {
+		smURL = l.tryDiscoverSMURL(ctx)
+	}
+
 	if smURL == "" {
 		return "", "", "", errors.New(
-			"SM URL not configured: set providers.synth.sm-url in config or GRAFANA_PROVIDER_SYNTH_SM_URL env var")
+			"SM URL not configured: auto-discovery from Grafana plugin settings failed or no Grafana server configured")
 	}
 	if smToken == "" {
 		return "", "", "", errors.New(
@@ -187,6 +197,70 @@ func (l *configLoader) LoadSMConfig(ctx context.Context) (string, string, string
 	}
 
 	return smURL, smToken, namespace, nil
+}
+
+// tryDiscoverSMURL attempts to auto-discover the SM URL from Grafana plugin settings
+// and persists it to config on success. Returns empty string on failure.
+func (l *configLoader) tryDiscoverSMURL(ctx context.Context) string {
+	restCfg, err := l.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return ""
+	}
+
+	discovered, err := DiscoverSMURL(ctx, restCfg)
+	if err != nil {
+		slog.DebugContext(ctx, "SM URL auto-discovery failed", "error", err)
+		return ""
+	}
+
+	// Persist to config so subsequent runs skip the API call.
+	if saveErr := l.SaveProviderConfig(ctx, "synth", "sm-url", discovered); saveErr != nil {
+		slog.DebugContext(ctx, "failed to cache discovered SM URL to config", "error", saveErr)
+	}
+
+	return discovered
+}
+
+// DiscoverSMURL fetches the SM API URL from the SM plugin settings endpoint.
+// This queries /api/plugins/grafana-synthetic-monitoring-app/settings and reads
+// jsonData.apiHost, which contains the regional SM API base URL.
+func DiscoverSMURL(ctx context.Context, cfg config.NamespacedRESTConfig) (string, error) {
+	httpClient, err := rest.HTTPClientFor(&cfg.Config)
+	if err != nil {
+		return "", fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		cfg.Host+"/api/plugins/grafana-synthetic-monitoring-app/settings", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get SM plugin settings: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("SM plugin settings returned HTTP %d", resp.StatusCode)
+	}
+
+	var settings struct {
+		JSONData struct {
+			APIHost string `json:"apiHost"`
+		} `json:"jsonData"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&settings); err != nil {
+		return "", fmt.Errorf("failed to decode SM plugin settings: %w", err)
+	}
+
+	if settings.JSONData.APIHost == "" {
+		return "", errors.New("apiHost not found in SM plugin settings")
+	}
+
+	return settings.JSONData.APIHost, nil
 }
 
 // LoadConfig loads the full config for datasource UID lookup from context settings.

--- a/internal/providers/synth/provider.go
+++ b/internal/providers/synth/provider.go
@@ -1,14 +1,18 @@
 package synth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
+	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/synth/checks"
 	"github.com/grafana/gcx/internal/providers/synth/probes"
@@ -115,11 +119,9 @@ func (p *SynthProvider) Commands() []*cobra.Command {
 }
 
 // Validate checks that the given provider configuration is valid.
-// sm-url is not required here because it can be auto-discovered from plugin settings.
-func (p *SynthProvider) Validate(cfg map[string]string) error {
-	if cfg["sm-token"] == "" {
-		return errors.New("sm-token is required for the synth provider")
-	}
+// Neither sm-url nor sm-token are required here because both can be auto-discovered:
+// sm-url from plugin settings, sm-token via the SM register/install API.
+func (p *SynthProvider) Validate(_ map[string]string) error {
 	return nil
 }
 
@@ -166,13 +168,19 @@ type configLoader struct {
 }
 
 // LoadSMConfig loads the SM base URL, token, and K8s namespace from config.
+//
 // SM URL resolution priority (highest first):
 //  1. GRAFANA_PROVIDER_SYNTH_SM_URL env var / providers.synth.sm-url in config
 //  2. Auto-discovery from SM plugin settings (jsonData.apiHost) — requires grafana.server
 //  3. Error with actionable guidance
 //
-// When auto-discovery succeeds the URL is persisted to config so subsequent
-// invocations skip the API call.
+// SM token resolution priority (highest first):
+//  1. GRAFANA_PROVIDER_SYNTH_SM_TOKEN env var / providers.synth.sm-token in config
+//  2. Auto-discovery via SM register/install API — requires cloud.token + stack info from GCOM
+//  3. Error with actionable guidance
+//
+// When auto-discovery succeeds, values are persisted to config so subsequent
+// invocations skip the API calls.
 func (l *configLoader) LoadSMConfig(ctx context.Context) (string, string, string, error) {
 	providerCfg, namespace, err := l.LoadProviderConfig(ctx, "synth")
 	if err != nil {
@@ -191,9 +199,15 @@ func (l *configLoader) LoadSMConfig(ctx context.Context) (string, string, string
 		return "", "", "", errors.New(
 			"SM URL not configured: auto-discovery from Grafana plugin settings failed or no Grafana server configured")
 	}
+
+	// Tier 2: auto-discover SM token via register/install when not explicitly configured.
+	if smToken == "" {
+		smToken = l.tryDiscoverSMToken(ctx, smURL)
+	}
+
 	if smToken == "" {
 		return "", "", "", errors.New(
-			"SM token not configured: set providers.synth.sm-token in config or GRAFANA_PROVIDER_SYNTH_SM_TOKEN env var")
+			"SM token not configured: auto-discovery via register/install failed or no cloud.token configured")
 	}
 
 	return smURL, smToken, namespace, nil
@@ -219,6 +233,83 @@ func (l *configLoader) tryDiscoverSMURL(ctx context.Context) string {
 	}
 
 	return discovered
+}
+
+// tryDiscoverSMToken attempts to auto-discover the SM token via the SM register/install
+// API using cloud credentials from GCOM. Persists to config on success. Returns empty string on failure.
+func (l *configLoader) tryDiscoverSMToken(ctx context.Context, smURL string) string {
+	cloudCfg, err := l.LoadCloudConfig(ctx)
+	if err != nil {
+		slog.DebugContext(ctx, "SM token auto-discovery skipped: no cloud config", "error", err)
+		return ""
+	}
+
+	token, err := registerSMInstall(ctx, smURL, cloudCfg.Token, cloudCfg.Stack)
+	if err != nil {
+		slog.DebugContext(ctx, "SM token auto-discovery failed", "error", err)
+		return ""
+	}
+
+	if saveErr := l.SaveProviderConfig(ctx, "synth", "sm-token", token); saveErr != nil {
+		slog.DebugContext(ctx, "failed to cache discovered SM token to config", "error", saveErr)
+	}
+
+	return token
+}
+
+// registerSMInstall calls the SM register/install endpoint to obtain an access token.
+// This uses a Grafana Cloud access policy token and GCOM stack info to register with
+// the SM API, which returns a publisher token for subsequent API calls.
+func registerSMInstall(ctx context.Context, smURL, cloudToken string, stack cloud.StackInfo) (string, error) {
+	reqBody := struct {
+		StackID           int    `json:"stackId"`
+		MetricsInstanceID int    `json:"metricsInstanceId"`
+		LogsInstanceID    int    `json:"logsInstanceId"`
+		PublisherToken    string `json:"publisherToken"`
+		RegionSlug        string `json:"regionSlug"`
+	}{
+		StackID:           stack.ID,
+		MetricsInstanceID: stack.HMInstancePromID,
+		LogsInstanceID:    stack.HLInstanceID,
+		PublisherToken:    cloudToken,
+		RegionSlug:        stack.RegionSlug,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal register/install request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		strings.TrimRight(smURL, "/")+"/api/v1/register/install", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+cloudToken)
+
+	resp, err := httputils.NewDefaultClient(ctx).Do(req)
+	if err != nil {
+		return "", fmt.Errorf("SM register/install request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("SM register/install returned HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		AccessToken string `json:"accessToken"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode register/install response: %w", err)
+	}
+
+	if result.AccessToken == "" {
+		return "", errors.New("SM register/install returned empty access token")
+	}
+
+	return result.AccessToken, nil
 }
 
 // DiscoverSMURL fetches the SM API URL from the SM plugin settings endpoint.

--- a/internal/providers/synth/provider.go
+++ b/internal/providers/synth/provider.go
@@ -221,7 +221,7 @@ func (l *configLoader) tryDiscoverSMURL(ctx context.Context) string {
 		return ""
 	}
 
-	discovered, err := DiscoverSMURL(ctx, restCfg)
+	discovered, err := discoverSMURL(ctx, restCfg)
 	if err != nil {
 		slog.DebugContext(ctx, "SM URL auto-discovery failed", "error", err)
 		return ""
@@ -312,21 +312,20 @@ func registerSMInstall(ctx context.Context, smURL, cloudToken string, stack clou
 	return result.AccessToken, nil
 }
 
-// DiscoverSMURL fetches the SM API URL from the SM plugin settings endpoint.
+// discoverSMURL fetches the SM API URL from the SM plugin settings endpoint.
 // This queries /api/plugins/grafana-synthetic-monitoring-app/settings and reads
 // jsonData.apiHost, which contains the regional SM API base URL.
-func DiscoverSMURL(ctx context.Context, cfg config.NamespacedRESTConfig) (string, error) {
+func discoverSMURL(ctx context.Context, cfg config.NamespacedRESTConfig) (string, error) {
 	httpClient, err := rest.HTTPClientFor(&cfg.Config)
 	if err != nil {
 		return "", fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		cfg.Host+"/api/plugins/grafana-synthetic-monitoring-app/settings", nil)
+		cfg.GrafanaURL+"/api/plugins/grafana-synthetic-monitoring-app/settings", nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/internal/providers/synth/provider.go
+++ b/internal/providers/synth/provider.go
@@ -310,14 +310,25 @@ func registerSMInstall(ctx context.Context, smURL, cloudToken string, stack clou
 // discoverSMURL fetches the SM API URL from the SM plugin settings endpoint.
 // This queries /api/plugins/grafana-synthetic-monitoring-app/settings and reads
 // jsonData.apiHost, which contains the regional SM API base URL.
+//
+// In OAuth proxy mode, requests are routed through cfg.Host (the proxy) which
+// forwards them to the real Grafana server with proper auth. In direct mode,
+// requests go straight to cfg.GrafanaURL with the configured bearer token.
 func discoverSMURL(ctx context.Context, cfg config.NamespacedRESTConfig) (string, error) {
 	httpClient, err := rest.HTTPClientFor(&cfg.Config)
 	if err != nil {
 		return "", fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 
+	// In OAuth proxy mode, cfg.Host routes through the proxy which handles auth.
+	// In direct mode, use GrafanaURL (the real Grafana server).
+	baseURL := cfg.GrafanaURL
+	if cfg.IsOAuthProxy() {
+		baseURL = cfg.Host
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		cfg.GrafanaURL+"/api/plugins/grafana-synthetic-monitoring-app/settings", nil)
+		baseURL+"/api/plugins/grafana-synthetic-monitoring-app/settings", nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/providers/synth/provider_test.go
+++ b/internal/providers/synth/provider_test.go
@@ -42,42 +42,21 @@ func TestSynthProvider_ConfigKeys(t *testing.T) {
 func TestSynthProvider_Validate(t *testing.T) {
 	p := &synth.SynthProvider{}
 
+	// Validate always returns nil because both sm-url and sm-token
+	// can be auto-discovered at runtime.
 	tests := []struct {
-		name    string
-		cfg     map[string]string
-		wantErr bool
+		name string
+		cfg  map[string]string
 	}{
-		{
-			name: "valid config with both keys",
-			cfg: map[string]string{
-				"sm-url":   "https://synthetic-monitoring-api.grafana.net",
-				"sm-token": "my-token",
-			},
-		},
-		{
-			name: "valid config without sm-url (auto-discoverable)",
-			cfg:  map[string]string{"sm-token": "token"},
-		},
-		{
-			name:    "missing sm-token",
-			cfg:     map[string]string{"sm-url": "https://example.com"},
-			wantErr: true,
-		},
-		{
-			name:    "empty config",
-			cfg:     map[string]string{},
-			wantErr: true,
-		},
+		{name: "both keys set", cfg: map[string]string{"sm-url": "https://example.com", "sm-token": "tok"}},
+		{name: "only sm-url", cfg: map[string]string{"sm-url": "https://example.com"}},
+		{name: "only sm-token", cfg: map[string]string{"sm-token": "tok"}},
+		{name: "empty config", cfg: map[string]string{}},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := p.Validate(tc.cfg)
-			if tc.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, p.Validate(tc.cfg))
 		})
 	}
 }

--- a/internal/providers/synth/provider_test.go
+++ b/internal/providers/synth/provider_test.go
@@ -48,16 +48,15 @@ func TestSynthProvider_Validate(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "valid config",
+			name: "valid config with both keys",
 			cfg: map[string]string{
 				"sm-url":   "https://synthetic-monitoring-api.grafana.net",
 				"sm-token": "my-token",
 			},
 		},
 		{
-			name:    "missing sm-url",
-			cfg:     map[string]string{"sm-token": "token"},
-			wantErr: true,
+			name: "valid config without sm-url (auto-discoverable)",
+			cfg:  map[string]string{"sm-token": "token"},
 		},
 		{
 			name:    "missing sm-token",


### PR DESCRIPTION
## Summary

- Add **zero-config SM auto-discovery** — both `sm-url` and `sm-token` are now automatically resolved, eliminating all manual synth provider configuration for Grafana Cloud users
- `sm-url`: discovered from SM plugin settings (`jsonData.apiHost`) via the Grafana API
- `sm-token`: discovered via the SM `register/install` API using cloud credentials from GCOM (same pattern as grafana-cloud-cli)
- Auto-discovered values are **persisted to config** so subsequent runs skip the API calls
- Rich `DetailedError` output for config failures with actionable suggestions

## User Experience

**Before:** Users had to manually find and configure `sm-url` and `sm-token` — the error message didn't tell them how.

**After:** For users with a Grafana Cloud context (`grafana.server` + `cloud.token` + `cloud.stack`):
```
$ gcx synth checks list
# Just works — both URL and token auto-discovered, saved to config
```

## Changes

| File | Change |
|------|--------|
| `internal/providers/synth/provider.go` | Three-tier fallback for both `sm-url` and `sm-token`, `DiscoverSMURL()`, `registerSMInstall()`, `tryDiscoverSMURL()`, `tryDiscoverSMToken()`, config persistence |
| `cmd/gcx/fail/convert.go` | `convertSMConfigErrors()` for styled terminal error output with suggestions |
| `internal/providers/synth/configloader_test.go` | Tests for URL discovery, token discovery, config persistence, fallback-to-error, skip-when-configured |
| `cmd/gcx/fail/convert_test.go` | Tests for SM error conversion |
| `internal/providers/synth/provider_test.go` | Updated Validate tests (both fields now auto-discoverable) |

## Test Plan

- [x] Tests pass locally (`GCX_AGENT_MODE=false make all`)
- [x] New tests cover URL + token auto-discovery, config persistence, fallback, error conversion
- [x] Lints clean
- [x] Race detection passes
- [x] **Live-tested** against 5 contexts: full auto-discovery worked for `ep.amer.cloud.demokit.grafana.com` (zero config → 17 checks listed)

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)