### PR TITLE
fix(assistant): align SSE HTTP client timeout with --timeout

### DIFF
--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"sync"
 	"time"
@@ -152,15 +153,13 @@ func runPrompt(cmd *cobra.Command, message string, opts *promptOpts, configOpts 
 		contextID = lastContextID
 	}
 
-	// Load config and build client
-	clientOpts, err := resolveClientOptions(ctx, configOpts)
+	clientOpts, err := resolveAssistantClientOptions(ctx, configOpts, opts.timeout)
 	if err != nil {
 		if opts.jsonOut {
 			return jsonError(err)
 		}
 		return err
 	}
-
 	c := assistant.New(clientOpts)
 
 	// Validate context ID if provided
@@ -314,8 +313,10 @@ func handlePromptResult(cmd *cobra.Command, result assistant.StreamResult, opts 
 	return err
 }
 
-// resolveClientOptions loads the gcx config and builds assistant.ClientOptions.
-func resolveClientOptions(ctx context.Context, configOpts *cmdconfig.Options) (assistant.ClientOptions, error) {
+// resolveAssistantClientOptions loads the gcx config and returns assistant
+// ClientOptions for assistant prompt, including an HTTP client whose Timeout
+// matches streamTimeoutSeconds (see --timeout and SSE body reads).
+func resolveAssistantClientOptions(ctx context.Context, configOpts *cmdconfig.Options, streamTimeoutSeconds int) (assistant.ClientOptions, error) {
 	cfg, err := configOpts.LoadConfig(ctx)
 	if err != nil {
 		return assistant.ClientOptions{}, err
@@ -331,6 +332,8 @@ func resolveClientOptions(ctx context.Context, configOpts *cmdconfig.Options) (a
 		return assistant.ClientOptions{}, fmt.Errorf("no grafana config in context %q", cfg.CurrentContext)
 	}
 
+	httpClient := newAssistantStreamingHTTPClient(ctx, streamTimeoutSeconds)
+
 	switch {
 	case grafana.ProxyEndpoint != "" && grafana.OAuthToken != "":
 		// OAuth path: direct API via ProxyEndpoint
@@ -340,7 +343,7 @@ func resolveClientOptions(ctx context.Context, configOpts *cmdconfig.Options) (a
 			Token:          grafana.OAuthToken,
 			APIEndpoint:    grafana.ProxyEndpoint,
 			TokenRefresher: refresher,
-			HTTPClient:     httputils.NewDefaultClient(ctx),
+			HTTPClient:     httpClient,
 		}, nil
 
 	case grafana.APIToken != "":
@@ -348,12 +351,32 @@ func resolveClientOptions(ctx context.Context, configOpts *cmdconfig.Options) (a
 		return assistant.ClientOptions{
 			GrafanaURL: grafana.Server,
 			Token:      grafana.APIToken,
-			HTTPClient: httputils.NewDefaultClient(ctx),
+			HTTPClient: httpClient,
 		}, nil
 
 	default:
 		return assistant.ClientOptions{}, errors.New("no authentication configured; run 'gcx auth login' or set grafana.token in config")
 	}
+}
+
+// newAssistantStreamingHTTPClient returns an HTTP client suitable for assistant
+// A2A streaming: Timeout spans the full response body read and must align with
+// internal/assistant StreamOptions.Timeout (see --timeout on assistant prompt).
+func newAssistantStreamingHTTPClient(ctx context.Context, streamTimeoutSeconds int) *http.Client {
+	if streamTimeoutSeconds <= 0 {
+		streamTimeoutSeconds = 300
+	}
+	d := time.Duration(streamTimeoutSeconds) * time.Second
+	if httputils.PayloadLogging(ctx) {
+		return httputils.NewClient(httputils.ClientOpts{
+			Timeout: d,
+			Middlewares: []httputils.Middleware{
+				httputils.LoggingMiddleware,
+				httputils.RequestResponseLoggingMiddleware,
+			},
+		})
+	}
+	return httputils.NewClient(httputils.ClientOpts{Timeout: d})
 }
 
 const refreshThreshold = 5 * time.Minute

--- a/cmd/gcx/assistant/export_test.go
+++ b/cmd/gcx/assistant/export_test.go
@@ -1,0 +1,6 @@
+package assistant
+
+// Exported aliases for black-box tests.
+//
+//nolint:gochecknoglobals // Test-only exports for black-box test package.
+var NewAssistantStreamingHTTPClient = newAssistantStreamingHTTPClient

--- a/cmd/gcx/assistant/streaming_http_client_test.go
+++ b/cmd/gcx/assistant/streaming_http_client_test.go
@@ -1,21 +1,27 @@
-package assistant
+package assistant_test
 
 import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/grafana/gcx/cmd/gcx/assistant"
 )
 
-func TestNewAssistantStreamingHTTPClient_TimeoutMatchesStreamSeconds(t *testing.T) {
-	c := newAssistantStreamingHTTPClient(context.Background(), 420)
-	if c.Timeout != 420*time.Second {
-		t.Fatalf("Timeout: got %v, want %v", c.Timeout, 420*time.Second)
-	}
-}
-
-func TestNewAssistantStreamingHTTPClient_DefaultsWhenNonPositive(t *testing.T) {
-	c := newAssistantStreamingHTTPClient(context.Background(), 0)
-	if c.Timeout != 300*time.Second {
-		t.Fatalf("Timeout: got %v, want default 300s", c.Timeout)
+func TestNewAssistantStreamingHTTPClient(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input int
+		want  time.Duration
+	}{
+		{"positive value", 420, 420 * time.Second},
+		{"non-positive defaults to 300s", 0, 300 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := assistant.NewAssistantStreamingHTTPClient(context.Background(), tc.input)
+			if c.Timeout != tc.want {
+				t.Fatalf("Timeout: got %v, want %v", c.Timeout, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/gcx/assistant/streaming_http_client_test.go
+++ b/cmd/gcx/assistant/streaming_http_client_test.go
@@ -1,0 +1,21 @@
+package assistant
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewAssistantStreamingHTTPClient_TimeoutMatchesStreamSeconds(t *testing.T) {
+	c := newAssistantStreamingHTTPClient(context.Background(), 420)
+	if c.Timeout != 420*time.Second {
+		t.Fatalf("Timeout: got %v, want %v", c.Timeout, 420*time.Second)
+	}
+}
+
+func TestNewAssistantStreamingHTTPClient_DefaultsWhenNonPositive(t *testing.T) {
+	c := newAssistantStreamingHTTPClient(context.Background(), 0)
+	if c.Timeout != 300*time.Second {
+		t.Fatalf("Timeout: got %v, want default 300s", c.Timeout)
+	}
+}


### PR DESCRIPTION
`gcx assistant prompt` was timing out too quickly because the http client used for streaming was using the base HTTP client with a 60s timeout.

resolveAssistantClientOptions builds an HTTP client whose Timeout matches assistant prompt --timeout so long A2A streams are not cut off by the default 60s client. Keeps newAssistantStreamingHTTPClient for tests and payload-logging parity with NewDefaultClient.

Made-with: Cursor