### PR TITLE
ci: skip Claude Code Review for bot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,10 @@ jobs:
   claude-review:
     # Run on opened/ready_for_review (if not draft), or on unlabeled only if
     # the removed label is 'claude-reviewed' (manual re-review trigger).
+    # Skip all bot PRs (Dependabot, Renovate, etc.) — user.type is 'Bot' for
+    # GitHub App accounts, 'User' for humans.
     if: |
+      github.event.pull_request.user.type != 'Bot' &&
       github.event.pull_request.draft == false &&
       (github.event.action != 'unlabeled' || github.event.label.name == 'claude-reviewed')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `github.event.pull_request.user.type != 'Bot'` to the Claude Code Review workflow's job condition
- Bot PRs (Dependabot, Renovate, etc.) now **skip** gracefully instead of failing with exit code 1
- Previously, the `claude-code-action` would detect the bot actor and error out: `Workflow initiated by non-human actor: dependabot (type: Bot)`

## Test plan
- [ ] Verify existing bot PRs (e.g. #485) no longer show a failed `claude-review` check
- [ ] Verify human PRs still trigger the Claude Code Review as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)