### PR TITLE
Fix worktree vendor sync by warming module cache

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "go mod download"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 .claude/*
 !.claude/skills/
 !.claude/CLAUDE.md
+!.claude/settings.json
 .claude/settings.local.json
 
 # Integration testing artifacts


### PR DESCRIPTION
## Summary
- Worktrees don't get a `vendor/` directory (it's gitignored), which can cause build confusion
- Go automatically falls back to the shared module cache when vendor is absent — builds already work, but the cache needs to be warm
- Adds a `PostToolUse` hook on `EnterWorktree` that runs `go mod download` to ensure the module cache is populated before any build/test commands

## Changes
- **`.claude/settings.json`** (new): project-level hook that runs `go mod download` after entering a worktree
- **`.gitignore`**: un-ignore `.claude/settings.json` so the hook is shared with all contributors

## Test plan
- [x] Created a worktree, confirmed no `vendor/` directory present
- [x] `go build ./cmd/gcx/` succeeds using module cache
- [x] `go test ./internal/config/...` passes without vendor

🤖 Generated with [Claude Code](https://claude.com/claude-code)