### PR TITLE
fix(auth): skip OAuth bearer injection when Authorization header already set

### DIFF
--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -39,6 +39,12 @@ type RefreshTransport struct {
 }
 
 func (t *RefreshTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// If the caller already set an Authorization header (e.g. Basic auth for
+	// adaptive metrics), respect it and skip OAuth bearer injection.
+	if req.Header.Get("Authorization") != "" {
+		return t.base().RoundTrip(req)
+	}
+
 	if err := t.maybeRefresh(req); err != nil {
 		return nil, fmt.Errorf("token refresh failed: %w", err)
 	}

--- a/internal/auth/transport_test.go
+++ b/internal/auth/transport_test.go
@@ -210,6 +210,46 @@ func TestRefreshTransport_ReturnsErrRefreshTokenExpired_On401(t *testing.T) {
 	}
 }
 
+func TestRefreshTransport_PreservesExistingAuthorizationHeader(t *testing.T) {
+	var gotHeader string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	transport := &auth.RefreshTransport{
+		Base:          http.DefaultTransport,
+		ProxyEndpoint: backend.URL,
+		Token:         "gat_test-token",
+		ExpiresAt:     time.Now().Add(1 * time.Hour),
+	}
+
+	client := &http.Client{Transport: transport}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, backend.URL+"/api/test", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req.SetBasicAuth("12345", "glc_secret")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotHeader == "Bearer gat_test-token" {
+		t.Fatal("RefreshTransport overwrote existing Authorization header with bearer token")
+	}
+	if gotHeader == "" {
+		t.Fatal("Authorization header was not forwarded")
+	}
+	// Verify it's still the Basic auth header.
+	if want := "Basic MTIzNDU6Z2xjX3NlY3JldA=="; gotHeader != want {
+		t.Fatalf("expected Authorization header %q, got %q", want, gotHeader)
+	}
+}
+
 func TestRefreshTransport_RejectsExpiredRefreshToken(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary
- `RefreshTransport.RoundTrip` unconditionally overwrote the `Authorization` header with its OAuth bearer token, breaking code paths that set their own auth (e.g. Basic auth for adaptive metrics API calls)
- Added an early return that skips bearer injection when the request already carries an `Authorization` header, matching the k8s `bearerAuthRoundTripper` pattern
- Verified live: `gcx metrics adaptive rules list` against the ep context now succeeds (was returning 401)

## Changes
- `internal/auth/transport.go` — guard `RoundTrip` to pass through requests with existing `Authorization` header
- `internal/auth/transport_test.go` — add `TestRefreshTransport_PreservesExistingAuthorizationHeader`

## Test Plan
- [x] New test verifies Basic auth header is preserved through the transport
- [x] All existing transport tests still pass
- [x] Full test suite passes with race detection (`go test -race -count=1 ./...`)
- [x] Lint clean (`make lint` — 0 issues)
- [x] Live-verified against ep context: `gcx metrics adaptive rules list` returns `0 rule(s)` instead of 401
- [x] OAuth-authenticated commands (`gcx resources get folders`) still work

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)