### PR TITLE
Suggest stacks:read scope on cloud stack lookup 403

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -385,6 +385,18 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 		}, true
 	}
 
+	// Stack info lookup forbidden — access policy missing stacks:read scope.
+	if strings.Contains(msg, "failed to get stack info for") && strings.Contains(msg, "status 403") {
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Cloud stack lookup: permission denied",
+			Suggestions: []string{
+				"Ensure your access policy includes the stacks:read scope",
+			},
+			ExitCode: new(ExitAuthFailure),
+		}, true
+	}
+
 	// Setup/instrumentation prefixed errors — surface them directly instead of "Unexpected error".
 	if strings.HasPrefix(msg, "setup/instrumentation:") || strings.Contains(msg, "setup/instrumentation:") {
 		// Extract the message after the prefix for the summary.

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -172,6 +172,55 @@ func TestErrorToDetailedError_CobraUnknownCommandError(t *testing.T) {
 	assert.Equal(t, "Run 'gcx kg --help' for full usage and examples", got.Suggestions[0])
 }
 
+func TestErrorToDetailedError_CloudStackLookupForbidden(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantMatch   bool
+		wantSummary string
+	}{
+		{
+			name:        "k6 stack info 403 suggests stacks:read scope",
+			err:         errors.New("k6: load cloud config: failed to get stack info for \"mystack\": status 403: forbidden"),
+			wantMatch:   true,
+			wantSummary: "Cloud stack lookup: permission denied",
+		},
+		{
+			name:        "faro stack info 403 also matches",
+			err:         errors.New("cloud config required for sourcemap upload: failed to get stack info for \"mystack\": status 403: forbidden"),
+			wantMatch:   true,
+			wantSummary: "Cloud stack lookup: permission denied",
+		},
+		{
+			name:      "stack info 404 is not matched",
+			err:       errors.New("k6: load cloud config: failed to get stack info for \"mystack\": status 404: not found"),
+			wantMatch: false,
+		},
+		{
+			name:      "403 without stack info is not matched",
+			err:       errors.New("k6: list projects: status 403: forbidden"),
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fail.ErrorToDetailedError(tc.err)
+
+			if !tc.wantMatch {
+				assert.Equal(t, "Unexpected error", got.Summary)
+				return
+			}
+
+			assert.Equal(t, tc.wantSummary, got.Summary)
+			require.NotNil(t, got.ExitCode)
+			assert.Equal(t, fail.ExitAuthFailure, *got.ExitCode)
+			require.Len(t, got.Suggestions, 1)
+			assert.Contains(t, got.Suggestions[0], "stacks:read")
+		})
+	}
+}
+
 func TestErrorToDetailedError_SMURLNotConfigured(t *testing.T) {
 	err := fmt.Errorf("failed to load SM config for checks: %w",
 		fmt.Errorf("SM URL not configured: %w", errors.New("no Grafana server configured: grafana config is required")))


### PR DESCRIPTION
closes https://github.com/grafana/gcx/issues/405

hints at the correct scope to add to the grafana.com access policy to add when we see this particular k6s auth error.

## Summary
- When a cloud provider fails to look up stack info with a 403 Forbidden, the error converter now suggests that the access policy needs the `stacks:read` scope
- Applies to all cloud-tier providers (k6, faro, fleet, synth, etc.) since the error originates from the shared `ConfigLoader.LoadCloudConfig()` path
- This was originally designed for the k6 failure mode, since it was not clear what scopes are missing from the AP

Now we see:
```
gcx k6 projects list
Error: Cloud stack lookup: permission denied
│
├─ Details:
│
│ k6: load cloud config: failed to get stack info for "dev": gcom client: unexpected status 403 Forbidden: {
│   "code": "Forbidden",
│   "message": "You do not have permission to perform the requested action.",
│   "requestId": "45788493-b900-439a-a3d9-5c7c0a79cc72"
│ }
│
├─ Suggestions:
│
│ • Ensure your access policy includes the stacks:read scope
│
└─
```