### PR TITLE
feat(adaptive-traces): add config get/update commands

### DIFF
--- a/docs/reference/cli/gcx_traces_adaptive_config.md
+++ b/docs/reference/cli/gcx_traces_adaptive_config.md
@@ -1,11 +1,11 @@
-## gcx traces adaptive
+## gcx traces adaptive config
 
-Manage Adaptive Traces resources
+Manage Adaptive Traces tenant configuration.
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+  -h, --help   help for config
 ```
 
 ### Options inherited from parent commands
@@ -22,8 +22,7 @@ Manage Adaptive Traces resources
 
 ### SEE ALSO
 
-* [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces
-* [gcx traces adaptive config](gcx_traces_adaptive_config.md)	 - Manage Adaptive Traces tenant configuration.
-* [gcx traces adaptive policies](gcx_traces_adaptive_policies.md)	 - Manage Adaptive Traces sampling policies.
-* [gcx traces adaptive recommendations](gcx_traces_adaptive_recommendations.md)	 - Manage Adaptive Traces recommendations.
+* [gcx traces adaptive](gcx_traces_adaptive.md)	 - Manage Adaptive Traces resources
+* [gcx traces adaptive config get](gcx_traces_adaptive_config_get.md)	 - Get Adaptive Traces tenant configuration.
+* [gcx traces adaptive config update](gcx_traces_adaptive_config_update.md)	 - Update Adaptive Traces tenant configuration.
 

--- a/docs/reference/cli/gcx_traces_adaptive_config_get.md
+++ b/docs/reference/cli/gcx_traces_adaptive_config_get.md
@@ -1,11 +1,17 @@
-## gcx traces adaptive
+## gcx traces adaptive config get
 
-Manage Adaptive Traces resources
+Get Adaptive Traces tenant configuration.
+
+```
+gcx traces adaptive config get [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands
@@ -22,8 +28,5 @@ Manage Adaptive Traces resources
 
 ### SEE ALSO
 
-* [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces
 * [gcx traces adaptive config](gcx_traces_adaptive_config.md)	 - Manage Adaptive Traces tenant configuration.
-* [gcx traces adaptive policies](gcx_traces_adaptive_policies.md)	 - Manage Adaptive Traces sampling policies.
-* [gcx traces adaptive recommendations](gcx_traces_adaptive_recommendations.md)	 - Manage Adaptive Traces recommendations.
 

--- a/docs/reference/cli/gcx_traces_adaptive_config_update.md
+++ b/docs/reference/cli/gcx_traces_adaptive_config_update.md
@@ -2,6 +2,10 @@
 
 Update Adaptive Traces tenant configuration.
 
+### Synopsis
+
+Replace the Adaptive Traces tenant configuration. The API does not support partial updates — all fields must be present in the input file. Use 'gcx traces adaptive config get' to fetch the current configuration, edit the desired fields, then pass the full file to this command.
+
 ```
 gcx traces adaptive config update [flags]
 ```

--- a/docs/reference/cli/gcx_traces_adaptive_config_update.md
+++ b/docs/reference/cli/gcx_traces_adaptive_config_update.md
@@ -1,11 +1,18 @@
-## gcx traces adaptive
+## gcx traces adaptive config update
 
-Manage Adaptive Traces resources
+Update Adaptive Traces tenant configuration.
+
+```
+gcx traces adaptive config update [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+  -f, --filename string   File containing the config definition (use - for stdin)
+  -h, --help              help for update
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands
@@ -22,8 +29,5 @@ Manage Adaptive Traces resources
 
 ### SEE ALSO
 
-* [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces
 * [gcx traces adaptive config](gcx_traces_adaptive_config.md)	 - Manage Adaptive Traces tenant configuration.
-* [gcx traces adaptive policies](gcx_traces_adaptive_policies.md)	 - Manage Adaptive Traces sampling policies.
-* [gcx traces adaptive recommendations](gcx_traces_adaptive_recommendations.md)	 - Manage Adaptive Traces recommendations.
 

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -397,6 +397,8 @@ var commandAnnotations = map[string]annotation{
 	"gcx traces query":   {Cost: "large", Hint: "'{ span.http.status_code >= 500 }' --since 1h --limit 20 -o json"},
 
 	// Traces adaptive
+	"gcx traces adaptive config get":              {Cost: "small"},
+	"gcx traces adaptive config update":           {Cost: "small"},
 	"gcx traces adaptive policies create":         {Cost: "small"},
 	"gcx traces adaptive policies delete":         {Cost: "small"},
 	"gcx traces adaptive policies get":            {Cost: "small"},

--- a/internal/providers/traces/adaptive/client.go
+++ b/internal/providers/traces/adaptive/client.go
@@ -213,7 +213,9 @@ func (c *Client) GetConfig(ctx context.Context) (*ReadonlyTenantConfig, error) {
 	return &cfg, nil
 }
 
-// UpdateConfig updates the tenant configuration.
+// UpdateConfig replaces the entire tenant configuration. The API does not
+// support partial updates — all fields must be set in cfg. Callers should
+// first call GetConfig, modify the desired fields, and pass the full object.
 func (c *Client) UpdateConfig(ctx context.Context, cfg *TenantConfig) (*TenantConfig, error) {
 	body, err := json.Marshal(cfg)
 	if err != nil {

--- a/internal/providers/traces/adaptive/client.go
+++ b/internal/providers/traces/adaptive/client.go
@@ -193,6 +193,51 @@ func (c *Client) DismissRecommendation(ctx context.Context, id string) error {
 	return nil
 }
 
+// GetConfig returns the tenant configuration.
+func (c *Client) GetConfig(ctx context.Context) (*ReadonlyTenantConfig, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, "/adaptive-traces/api/v1/config", nil)
+	if err != nil {
+		return nil, fmt.Errorf("getting config: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, handleErrorResponse(resp)
+	}
+
+	var cfg ReadonlyTenantConfig
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("decoding config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// UpdateConfig updates the tenant configuration.
+func (c *Client) UpdateConfig(ctx context.Context, cfg *TenantConfig) (*TenantConfig, error) {
+	body, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling config: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, http.MethodPut, "/adaptive-traces/api/v1/config", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("updating config: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, handleErrorResponse(resp)
+	}
+
+	var updated TenantConfig
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		return nil, fmt.Errorf("decoding updated config: %w", err)
+	}
+
+	return &updated, nil
+}
+
 func (c *Client) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
 	if err != nil {

--- a/internal/providers/traces/adaptive/client_test.go
+++ b/internal/providers/traces/adaptive/client_test.go
@@ -389,7 +389,7 @@ func TestClient_UpdateConfig(t *testing.T) {
 				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
 				var cfg traces.TenantConfig
-				require.NoError(t, json.NewDecoder(r.Body).Decode(&cfg))
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&cfg))
 				assert.True(t, cfg.DisableAnomalyPolicies)
 				assert.True(t, cfg.SpanNameSemconvTransformEnabled)
 				assert.Equal(t, "v1.3.0", cfg.SpanNameSemconvVersion)

--- a/internal/providers/traces/adaptive/client_test.go
+++ b/internal/providers/traces/adaptive/client_test.go
@@ -300,6 +300,137 @@ func TestClient_DeletePolicy(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// GetConfig
+// ---------------------------------------------------------------------------
+
+func TestClient_GetConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    *traces.ReadonlyTenantConfig
+		wantErr bool
+	}{
+		{
+			name: "success",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/adaptive-traces/api/v1/config", r.URL.Path)
+				assert.Equal(t, "Basic NDI6dGVzdC10b2tlbg==", r.Header.Get("Authorization"))
+				writeJSON(w, traces.ReadonlyTenantConfig{
+					DisableAnomalyPolicies:          true,
+					SpanNameSemconvTransformEnabled: false,
+					SpanNameSemconvVersion:          "v1.2.0",
+					AnomalyRateLimitBytesPerSec:     1024.5,
+				})
+			},
+			want: &traces.ReadonlyTenantConfig{
+				DisableAnomalyPolicies:          true,
+				SpanNameSemconvTransformEnabled: false,
+				SpanNameSemconvVersion:          "v1.2.0",
+				AnomalyRateLimitBytesPerSec:     1024.5,
+			},
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				writeJSON(w, map[string]string{"error": "internal server error"})
+			},
+			wantErr: true,
+		},
+		{
+			name: "not found",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			client := newTestClient(srv)
+			got, err := client.GetConfig(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateConfig
+// ---------------------------------------------------------------------------
+
+func TestClient_UpdateConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *traces.TenantConfig
+		handler http.HandlerFunc
+		want    *traces.TenantConfig
+		wantErr bool
+	}{
+		{
+			name: "success",
+			cfg: &traces.TenantConfig{
+				DisableAnomalyPolicies:          true,
+				SpanNameSemconvTransformEnabled: true,
+				SpanNameSemconvVersion:          "v1.3.0",
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPut, r.Method)
+				assert.Equal(t, "/adaptive-traces/api/v1/config", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+				var cfg traces.TenantConfig
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&cfg))
+				assert.True(t, cfg.DisableAnomalyPolicies)
+				assert.True(t, cfg.SpanNameSemconvTransformEnabled)
+				assert.Equal(t, "v1.3.0", cfg.SpanNameSemconvVersion)
+
+				writeJSON(w, cfg)
+			},
+			want: &traces.TenantConfig{
+				DisableAnomalyPolicies:          true,
+				SpanNameSemconvTransformEnabled: true,
+				SpanNameSemconvVersion:          "v1.3.0",
+			},
+		},
+		{
+			name: "server error",
+			cfg:  &traces.TenantConfig{},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				writeJSON(w, map[string]string{"error": "bad request"})
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			client := newTestClient(srv)
+			got, err := client.UpdateConfig(context.Background(), tc.cfg)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // ListRecommendations
 // ---------------------------------------------------------------------------
 

--- a/internal/providers/traces/adaptive/commands.go
+++ b/internal/providers/traces/adaptive/commands.go
@@ -28,6 +28,7 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "Manage Adaptive Traces resources.",
 	}
 	h := &tracesHelper{loader: loader}
+	cmd.AddCommand(h.configCommand())
 	cmd.AddCommand(h.policiesCommand())
 	cmd.AddCommand(h.recommendationsCommand())
 	return cmd
@@ -48,6 +49,183 @@ func (h *tracesHelper) newClient(ctx context.Context) (*Client, error) {
 func (h *tracesHelper) newPolicyCRUD(ctx context.Context) (*adapter.TypedCRUD[Policy], error) {
 	crud, _, err := NewPolicyTypedCRUD(ctx, h.loader)
 	return crud, err
+}
+
+// ===========================================================================
+// config
+// ===========================================================================
+
+func (h *tracesHelper) configCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage Adaptive Traces tenant configuration.",
+	}
+	cmd.AddCommand(
+		h.configGetCommand(),
+		h.configUpdateCommand(),
+	)
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// config get
+// ---------------------------------------------------------------------------
+
+type configGetOpts struct {
+	IO cmdio.Options
+}
+
+func (o *configGetOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &configTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func (h *tracesHelper) configGetCommand() *cobra.Command {
+	opts := &configGetOpts{}
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get Adaptive Traces tenant configuration.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			cfg, err := client.GetConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), cfg)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// NewConfigTableCodec creates a table codec for config. Exported for testing.
+func NewConfigTableCodec() *configTableCodec {
+	return &configTableCodec{}
+}
+
+type configTableCodec struct{}
+
+func (c *configTableCodec) Format() format.Format { return "table" }
+
+func (c *configTableCodec) Encode(w io.Writer, v any) error {
+	cfg, ok := v.(*ReadonlyTenantConfig)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected *ReadonlyTenantConfig")
+	}
+
+	t := style.NewTable("SETTING", "VALUE")
+	t.Row("disable_anomaly_policies", strconv.FormatBool(cfg.DisableAnomalyPolicies))
+	t.Row("span_name_semconv_transform_enabled", strconv.FormatBool(cfg.SpanNameSemconvTransformEnabled))
+	t.Row("span_name_semconv_version", cfg.SpanNameSemconvVersion)
+	if cfg.AnomalyRateLimitBytesPerSec > 0 {
+		t.Row("anomaly_rate_limit_bytes_per_sec", strconv.FormatFloat(cfg.AnomalyRateLimitBytesPerSec, 'f', -1, 64))
+	}
+
+	return t.Render(w)
+}
+
+func (c *configTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// ---------------------------------------------------------------------------
+// config update
+// ---------------------------------------------------------------------------
+
+type configUpdateOpts struct {
+	IO   cmdio.Options
+	File string
+}
+
+func (o *configUpdateOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("yaml")
+	o.IO.BindFlags(flags)
+	flags.StringVarP(&o.File, "filename", "f", "", "File containing the config definition (use - for stdin)")
+}
+
+func (o *configUpdateOpts) Validate() error {
+	if o.File == "" {
+		return errors.New("--filename/-f is required")
+	}
+	return nil
+}
+
+func (h *tracesHelper) configUpdateCommand() *cobra.Command {
+	opts := &configUpdateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update Adaptive Traces tenant configuration.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			cfg, err := readConfigFromFile(opts.File, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			updated, err := client.UpdateConfig(ctx, cfg)
+			if err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.ErrOrStderr(), "Updated tenant configuration")
+			return opts.IO.Encode(cmd.OutOrStdout(), updated)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// readConfigFromFile reads and decodes a TenantConfig from a file path or stdin ("-").
+func readConfigFromFile(filePath string, stdin io.Reader) (*TenantConfig, error) {
+	var reader io.Reader
+	if filePath == "-" {
+		reader = stdin
+	} else {
+		f, err := os.Open(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("opening file %s: %w", filePath, err)
+		}
+		defer f.Close()
+		reader = f
+	}
+
+	data, err := io.ReadAll(io.LimitReader(reader, maxPolicyFileSize))
+	if err != nil {
+		return nil, fmt.Errorf("reading input: %w", err)
+	}
+
+	var cfg TenantConfig
+	yamlCodec := format.NewYAMLCodec()
+	if err := yamlCodec.Decode(strings.NewReader(string(data)), &cfg); err != nil {
+		return nil, fmt.Errorf("decoding input: %w", err)
+	}
+
+	return &cfg, nil
 }
 
 func (h *tracesHelper) recommendationsCommand() *cobra.Command {

--- a/internal/providers/traces/adaptive/commands.go
+++ b/internal/providers/traces/adaptive/commands.go
@@ -167,6 +167,7 @@ func (h *tracesHelper) configUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update Adaptive Traces tenant configuration.",
+		Long:  "Replace the Adaptive Traces tenant configuration. The API does not support partial updates — all fields must be present in the input file. Use 'gcx traces adaptive config get' to fetch the current configuration, edit the desired fields, then pass the full file to this command.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/providers/traces/adaptive/commands_test.go
+++ b/internal/providers/traces/adaptive/commands_test.go
@@ -14,6 +14,60 @@ import (
 )
 
 // ---------------------------------------------------------------------------
+// configTableCodec
+// ---------------------------------------------------------------------------
+
+func TestConfigTableCodec(t *testing.T) {
+	t.Run("renders all fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		codec := traces.NewConfigTableCodec()
+		err := codec.Encode(&buf, &traces.ReadonlyTenantConfig{
+			DisableAnomalyPolicies:          true,
+			SpanNameSemconvTransformEnabled: false,
+			SpanNameSemconvVersion:          "v1.2.0",
+			AnomalyRateLimitBytesPerSec:     1024.5,
+		})
+		require.NoError(t, err)
+
+		output := buf.String()
+		assert.Contains(t, output, "SETTING")
+		assert.Contains(t, output, "VALUE")
+		assert.Contains(t, output, "disable_anomaly_policies")
+		assert.Contains(t, output, "true")
+		assert.Contains(t, output, "span_name_semconv_transform_enabled")
+		assert.Contains(t, output, "false")
+		assert.Contains(t, output, "span_name_semconv_version")
+		assert.Contains(t, output, "v1.2.0")
+		assert.Contains(t, output, "anomaly_rate_limit_bytes_per_sec")
+		assert.Contains(t, output, "1024.5")
+	})
+
+	t.Run("omits zero anomaly rate", func(t *testing.T) {
+		var buf bytes.Buffer
+		codec := traces.NewConfigTableCodec()
+		err := codec.Encode(&buf, &traces.ReadonlyTenantConfig{})
+		require.NoError(t, err)
+
+		output := buf.String()
+		assert.NotContains(t, output, "anomaly_rate_limit_bytes_per_sec")
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		var buf bytes.Buffer
+		codec := traces.NewConfigTableCodec()
+		err := codec.Encode(&buf, "not a config")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected *ReadonlyTenantConfig")
+	})
+
+	t.Run("decode unsupported", func(t *testing.T) {
+		codec := traces.NewConfigTableCodec()
+		err := codec.Decode(nil, nil)
+		require.Error(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
 // policyTableCodec
 // ---------------------------------------------------------------------------
 

--- a/internal/providers/traces/adaptive/types.go
+++ b/internal/providers/traces/adaptive/types.go
@@ -34,6 +34,8 @@ func (p *Policy) SetResourceName(name string) { p.ID = name }
 var _ adapter.ResourceIdentity = &Policy{}
 
 // TenantConfig represents the writable configuration for an adaptive traces tenant.
+// The API does not support partial updates — all fields must be provided on
+// every update. Omitted fields will be reset to their zero values.
 type TenantConfig struct {
 	DisableAnomalyPolicies          bool   `json:"disable_anomaly_policies" yaml:"disable_anomaly_policies"`
 	SpanNameSemconvTransformEnabled bool   `json:"span_name_semconv_transform_enabled" yaml:"span_name_semconv_transform_enabled"`

--- a/internal/providers/traces/adaptive/types.go
+++ b/internal/providers/traces/adaptive/types.go
@@ -33,6 +33,23 @@ func (p *Policy) SetResourceName(name string) { p.ID = name }
 // Compile-time assertion that *Policy satisfies ResourceIdentity.
 var _ adapter.ResourceIdentity = &Policy{}
 
+// TenantConfig represents the writable configuration for an adaptive traces tenant.
+type TenantConfig struct {
+	DisableAnomalyPolicies          bool   `json:"disable_anomaly_policies" yaml:"disable_anomaly_policies"`
+	SpanNameSemconvTransformEnabled bool   `json:"span_name_semconv_transform_enabled" yaml:"span_name_semconv_transform_enabled"`
+	SpanNameSemconvVersion          string `json:"span_name_semconv_version" yaml:"span_name_semconv_version"`
+}
+
+// ReadonlyTenantConfig is the response model for GET /api/v1/config.
+// It is a superset of TenantConfig, including computed fields like the
+// anomaly rate limit that are set by the forecaster.
+type ReadonlyTenantConfig struct {
+	AnomalyRateLimitBytesPerSec     float64 `json:"anomaly_rate_limit_bytes_per_sec,omitempty" yaml:"anomaly_rate_limit_bytes_per_sec,omitempty"`
+	DisableAnomalyPolicies          bool    `json:"disable_anomaly_policies" yaml:"disable_anomaly_policies"`
+	SpanNameSemconvTransformEnabled bool    `json:"span_name_semconv_transform_enabled" yaml:"span_name_semconv_transform_enabled"`
+	SpanNameSemconvVersion          string  `json:"span_name_semconv_version" yaml:"span_name_semconv_version"`
+}
+
 // PolicySeed represents the policy configuration embedded in a recommendation action.
 type PolicySeed struct {
 	ID               string `json:"id"`


### PR DESCRIPTION
## Summary
- Add `gcx traces adaptive config get` and `gcx traces adaptive config update` commands
- Add `GetConfig` and `UpdateConfig` client methods for `GET/PUT /adaptive-traces/api/v1/config`
- Add `TenantConfig` and `ReadonlyTenantConfig` types
- Add table codec for config display and tests for all new code

## Test plan
- [x] Unit tests for `GetConfig` and `UpdateConfig` client methods pass
- [x] Unit tests for `configTableCodec` pass
- [x] All existing adaptive traces tests still pass
- [x] Manual test with a real Grafana Cloud stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)