### PR TITLE
add a scopes suggestion for fleet auth errors

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -384,6 +384,19 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 		}, true
 	}
 
+	// Fleet API scope error on write operations.
+	if strings.Contains(msg, "fleet:") && strings.Contains(msg, "invalid scope") &&
+		(strings.Contains(msg, "create ") || strings.Contains(msg, "update ")) {
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Fleet Management: permission denied",
+			Suggestions: []string{
+				"Ensure your cloud.token access policy includes the fleet-management:write scope",
+			},
+			ExitCode: new(ExitAuthFailure),
+		}, true
+	}
+
 	// Fleet management not available.
 	if strings.Contains(msg, "fleet management endpoint is not available") ||
 		strings.Contains(msg, "fleet management instance ID is not available") {

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -371,6 +371,19 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 		}, true
 	}
 
+	// Fleet API scope error on read operations.
+	if strings.Contains(msg, "fleet:") && strings.Contains(msg, "invalid scope") &&
+		(strings.Contains(msg, "list ") || strings.Contains(msg, "get ")) {
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Fleet Management: permission denied",
+			Suggestions: []string{
+				"Ensure your cloud.token access policy includes the fleet-management:read scope",
+			},
+			ExitCode: new(ExitAuthFailure),
+		}, true
+	}
+
 	// Fleet management not available.
 	if strings.Contains(msg, "fleet management endpoint is not available") ||
 		strings.Contains(msg, "fleet management instance ID is not available") {

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -386,7 +386,7 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 
 	// Fleet API scope error on write operations.
 	if strings.Contains(msg, "fleet:") && strings.Contains(msg, "invalid scope") &&
-		(strings.Contains(msg, "create ") || strings.Contains(msg, "update ")) {
+		(strings.Contains(msg, "create ") || strings.Contains(msg, "update ") || strings.Contains(msg, "delete ")) {
 		return &DetailedError{
 			Parent:  err,
 			Summary: "Fleet Management: permission denied",

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -225,37 +225,46 @@ func TestErrorToDetailedError_FleetScopeError(t *testing.T) {
 	tests := []struct {
 		name      string
 		err       error
-		wantMatch bool
+		wantScope string
 	}{
 		{
 			name:      "list pipelines invalid scope suggests fleet-management:read",
 			err:       errors.New(`fleet: list pipelines: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantMatch: true,
+			wantScope: "fleet-management:read",
 		},
 		{
 			name:      "list collectors invalid scope suggests fleet-management:read",
 			err:       errors.New(`fleet: list collectors: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantMatch: true,
+			wantScope: "fleet-management:read",
 		},
 		{
 			name:      "get pipeline invalid scope suggests fleet-management:read",
 			err:       errors.New(`fleet: get pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantMatch: true,
+			wantScope: "fleet-management:read",
 		},
 		{
-			name:      "create pipeline invalid scope is not matched",
+			name:      "create pipeline invalid scope suggests fleet-management:write",
 			err:       errors.New(`fleet: create pipeline: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantMatch: false,
+			wantScope: "fleet-management:write",
 		},
 		{
-			name:      "update pipeline invalid scope is not matched",
+			name:      "update pipeline invalid scope suggests fleet-management:write",
 			err:       errors.New(`fleet: update pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantMatch: false,
+			wantScope: "fleet-management:write",
 		},
 		{
-			name:      "delete pipeline invalid scope is not matched",
-			err:       errors.New(`fleet: delete pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantMatch: false,
+			name:      "create collector invalid scope suggests fleet-management:write",
+			err:       errors.New(`fleet: create collector: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
+			wantScope: "fleet-management:write",
+		},
+		{
+			name:      "update collector invalid scope suggests fleet-management:write",
+			err:       errors.New(`fleet: update collector abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
+			wantScope: "fleet-management:write",
+		},
+		{
+			name: "delete pipeline invalid scope is not matched",
+			err:  errors.New(`fleet: delete pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
 		},
 	}
 
@@ -263,7 +272,7 @@ func TestErrorToDetailedError_FleetScopeError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := fail.ErrorToDetailedError(tc.err)
 
-			if !tc.wantMatch {
+			if tc.wantScope == "" {
 				assert.Equal(t, "Unexpected error", got.Summary)
 				return
 			}
@@ -272,7 +281,7 @@ func TestErrorToDetailedError_FleetScopeError(t *testing.T) {
 			require.NotNil(t, got.ExitCode)
 			assert.Equal(t, fail.ExitAuthFailure, *got.ExitCode)
 			require.Len(t, got.Suggestions, 1)
-			assert.Contains(t, got.Suggestions[0], "fleet-management:read")
+			assert.Contains(t, got.Suggestions[0], tc.wantScope)
 		})
 	}
 }

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -263,8 +263,9 @@ func TestErrorToDetailedError_FleetScopeError(t *testing.T) {
 			wantScope: "fleet-management:write",
 		},
 		{
-			name: "delete pipeline invalid scope is not matched",
-			err:  errors.New(`fleet: delete pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
+			name:      "delete pipeline invalid scope suggests fleet-management:write",
+			err:       errors.New(`fleet: delete pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
+			wantScope: "fleet-management:write",
 		},
 	}
 

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -221,6 +221,62 @@ func TestErrorToDetailedError_CloudStackLookupForbidden(t *testing.T) {
 	}
 }
 
+func TestErrorToDetailedError_FleetScopeError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantMatch bool
+	}{
+		{
+			name:      "list pipelines invalid scope suggests fleet-management:read",
+			err:       errors.New(`fleet: list pipelines: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
+			wantMatch: true,
+		},
+		{
+			name:      "list collectors invalid scope suggests fleet-management:read",
+			err:       errors.New(`fleet: list collectors: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
+			wantMatch: true,
+		},
+		{
+			name:      "get pipeline invalid scope suggests fleet-management:read",
+			err:       errors.New(`fleet: get pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
+			wantMatch: true,
+		},
+		{
+			name:      "create pipeline invalid scope is not matched",
+			err:       errors.New(`fleet: create pipeline: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
+			wantMatch: false,
+		},
+		{
+			name:      "update pipeline invalid scope is not matched",
+			err:       errors.New(`fleet: update pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
+			wantMatch: false,
+		},
+		{
+			name:      "delete pipeline invalid scope is not matched",
+			err:       errors.New(`fleet: delete pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fail.ErrorToDetailedError(tc.err)
+
+			if !tc.wantMatch {
+				assert.Equal(t, "Unexpected error", got.Summary)
+				return
+			}
+
+			assert.Equal(t, "Fleet Management: permission denied", got.Summary)
+			require.NotNil(t, got.ExitCode)
+			assert.Equal(t, fail.ExitAuthFailure, *got.ExitCode)
+			require.Len(t, got.Suggestions, 1)
+			assert.Contains(t, got.Suggestions[0], "fleet-management:read")
+		})
+	}
+}
+
 func TestErrorToDetailedError_SMURLNotConfigured(t *testing.T) {
 	err := fmt.Errorf("failed to load SM config for checks: %w",
 		fmt.Errorf("SM URL not configured: %w", errors.New("no Grafana server configured: grafana config is required")))


### PR DESCRIPTION
closes https://github.com/grafana/gcx/issues/436

Add a suggestion for `fleet-management:read` if we see `list|get` on the fleet command

```
gcx --context ops fleet collectors list
Error: Fleet Management: permission denied
│
├─ Details:
│
│ fleet: list collectors: status 401: {"status":"error","error":"authentication error: invalid scope requested"}
│
├─ Suggestions:
│
│ • Ensure your cloud.token access policy includes the fleet-management:read scope
│
└─
````