### PR TITLE
Guide agents to prefer dedicated commands over gcx api

### DIFF
--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -67,6 +67,17 @@ right group:
 If no command exists for the requested operation, say so and propose the nearest
 supported flow.
 
+### Avoid Raw API Passthrough
+
+**Do not use `gcx api`** when a dedicated command exists. `gcx api` is a low-level
+fallback for endpoints not yet covered by dedicated commands. Dedicated commands
+provide proper output formatting, pagination, error handling, and token-efficient
+output. Check the intent-to-group table above first.
+
+Similarly, prefer `gcx metrics query` over `gcx datasources query <prometheus-uid>`
+for PromQL queries — the signal-specific command handles datasource resolution
+automatically.
+
 ## Verify Context First
 
 Before any operation, confirm which environment is targeted:

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -25,7 +25,7 @@ var commandAnnotations = map[string]annotation{
 	// Core CLI commands (cmd/gcx/)
 	// -----------------------------------------------------------------------
 
-	"gcx api": {Cost: "large", Hint: "GET /api/datasources -o json"},
+	"gcx api": {Cost: "large", Hint: "Run gcx help-tree --depth 1 to discover dedicated commands. Prefer gcx slo, gcx metrics query, gcx logs query, gcx alert, etc. Reserve gcx api for endpoints without a dedicated command. Example: GET /api/health -o json"},
 
 	// assistant
 	"gcx assistant investigations approvals": {Cost: "medium", Hint: "<id> -o json"},
@@ -58,7 +58,7 @@ var commandAnnotations = map[string]annotation{
 	// datasources
 	"gcx datasources get":   {Cost: "medium", Hint: "<uid> -o json"},
 	"gcx datasources list":  {Cost: "small"},
-	"gcx datasources query": {Cost: "large", Hint: "<datasource-uid> 'up' --since 1h -o json"},
+	"gcx datasources query": {Cost: "large", Hint: "Run gcx help-tree metrics (or logs, traces, profiles) to discover signal commands. Prefer gcx metrics query for PromQL, gcx logs query for LogQL, gcx traces query for TraceQL, gcx profiles query for profiling. Example: <datasource-uid> 'up' --since 1h -o json"},
 
 	// dev
 	"gcx dev generate":   {Cost: "small"},


### PR DESCRIPTION
## Summary
- Update `llm_hint` annotations on `gcx api` and `gcx datasources query` to direct agents toward dedicated provider commands and teach them to discover the command surface via `gcx help-tree`
- Add "Avoid Raw API Passthrough" section to the portable `gcx` skill (`claude-plugin/skills/gcx/SKILL.md`)

## Motivation
AI agents tend to reach for `gcx api /api/...` (raw HTTP passthrough) instead of using dedicated provider commands like `gcx slo definitions list`, `gcx metrics query`, etc. The existing `token_cost: large` annotation wasn't enough to steer agents away. By enriching the `llm_hint` with discovery guidance and explicit preference, agents now see the right path in both `gcx help-tree` output and the `gcx commands` catalog.

## Test plan
- [x] `go test ./cmd/gcx/root/...` — consistency tests pass (hint strings valid)
- [x] `go test ./cmd/gcx/helptree/...` — help-tree rendering unaffected
- [ ] Verify `gcx help-tree` shows updated hints for `api` and `datasources query`
- [ ] Smoke test: agent session uses dedicated commands instead of `gcx api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)