### PR TITLE
chore(release): v0.2.7 changelog

### DIFF
--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,16 +1,19 @@
 
 
-- Add `--limit` flag with default pagination (50) to all list commands
-- Add retry transport for rate limiting and transient HTTP errors
-- Unified HTTP client construction with debug logging
-- Set consistent User-Agent header on all HTTP clients
-- Add `alert instances list` with server-side state filtering
-- Route OnCall requests through OAuth proxy
-- Add `skills install` command for .agents-compatible harnesses
-- Add `--expr` flag alias for datasource query commands
-- Add curl-pipe installer script with shell-specific PATH instructions
-- Fix config context selection before env overrides in provider loaders
-- Fix SLO definitions commands not inheriting parent config loader
-- Restore shell tab-completion
-- Add Fish shell completion docs
-- Update Go and Docker dependencies
+- Consolidate OnCall + Incidents under unified `irm` provider
+- Add adaptive metrics segments and exemptions commands
+- Adopt server-side pagination for list commands
+- Auto-discover Synthetic Monitoring URL from plugin settings
+- Improve skills list output, add installed status, single-skill install
+- Fix adaptive telemetry auth when using OAuth for Grafana
+- Suggest `stacks:read` scope on cloud stack lookup 403
+- Update OAuth coverage warning to remove incidents/oncall
+- Align assistant SSE HTTP client timeout with `--timeout` flag
+- Fix `gcx dev serve` not exiting on Ctrl+C
+- Fix watcher error channel handling
+- Trim Knowledge Graph CLI surface and typed resources
+- Add marketing bento-box slide with verified CLI commands
+- Upgrade ASCII logo to ANSI Shadow font
+- Use "k6" instead of "K6" in UI text
+- Restructure README for better narrative flow
+- Dependency updates (Go modules, GitHub Actions)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## v0.2.7 (2026-04-15)
+
+
+
+- Consolidate OnCall + Incidents under unified `irm` provider
+- Add adaptive metrics segments and exemptions commands
+- Adopt server-side pagination for list commands
+- Auto-discover Synthetic Monitoring URL from plugin settings
+- Improve skills list output, add installed status, single-skill install
+- Fix adaptive telemetry auth when using OAuth for Grafana
+- Suggest `stacks:read` scope on cloud stack lookup 403
+- Update OAuth coverage warning to remove incidents/oncall
+- Align assistant SSE HTTP client timeout with `--timeout` flag
+- Fix `gcx dev serve` not exiting on Ctrl+C
+- Fix watcher error channel handling
+- Trim Knowledge Graph CLI surface and typed resources
+- Add marketing bento-box slide with verified CLI commands
+- Upgrade ASCII logo to ANSI Shadow font
+- Use "k6" instead of "K6" in UI text
+- Restructure README for better narrative flow
+- Dependency updates (Go modules, GitHub Actions)
+
+
 ## v0.2.6 (2026-04-13)
 
 


### PR DESCRIPTION
## Summary
- Release changelog for v0.2.7

## Release Notes
- Consolidate OnCall + Incidents under unified `irm` provider
- Add adaptive metrics segments and exemptions commands
- Adopt server-side pagination for list commands
- Auto-discover Synthetic Monitoring URL from plugin settings
- Improve skills list output, add installed status, single-skill install
- Fix adaptive telemetry auth when using OAuth for Grafana
- Suggest `stacks:read` scope on cloud stack lookup 403
- Update OAuth coverage warning to remove incidents/oncall
- Align assistant SSE HTTP client timeout with `--timeout` flag
- Fix `gcx dev serve` not exiting on Ctrl+C
- Fix watcher error channel handling
- Trim Knowledge Graph CLI surface and typed resources
- Add marketing bento-box slide with verified CLI commands
- Upgrade ASCII logo to ANSI Shadow font
- Use "k6" instead of "K6" in UI text
- Restructure README for better narrative flow
- Dependency updates (Go modules, GitHub Actions)

## Post-merge steps
After merging, tag the merge commit on main and push the tag:
```bash
git checkout main && git pull
git tag v0.2.7
git push origin v0.2.7
```