### PR TITLE
Guide agents to use Grafana Assistant for reasoning tasks

### DIFF
--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -147,6 +147,44 @@ The `gcx datasources` group provides typed query interfaces:
 
 Use `gcx datasources <type> --help` to discover type-specific flags.
 
+## Grafana Assistant
+
+gcx provides direct access to the Grafana Assistant — use it for **reasoning
+and exploration**, not data retrieval. Deterministic commands are faster and
+cheaper for known queries; the Assistant adds value when you need intelligence.
+
+| Situation | Use | Example |
+|-----------|-----|---------|
+| You know the exact query | Deterministic command | `gcx metrics query 'rate(http_requests_total[5m])'` |
+| You don't know which metrics/labels exist | `gcx assistant prompt` | `"What metrics exist for the checkout service?"` |
+| You need cross-signal root cause analysis | `gcx assistant investigations` | Multi-agent parallel exploration across metrics, logs, traces, profiles |
+| You need a precise, repeatable data point | Deterministic command | `gcx slo definitions status`, `gcx alert instances list --state firing` |
+| You need to understand service dependencies | `gcx assistant prompt` | `"How are services in namespace X connected?"` — Assistant Memories know your stack topology |
+
+### Commands
+
+```bash
+# Ask a question (Assistant uses Infrastructure Memories for context)
+gcx assistant prompt "What services are unhealthy in namespace checkout?"
+
+# Follow up on the previous conversation
+gcx assistant prompt "Dig into the database connection issue" --continue
+
+# Launch a deep investigation (multi-agent, parallel signal exploration)
+gcx assistant investigations create --title="Checkout latency spike"
+
+# Monitor and read results
+gcx assistant investigations timeline <id>
+gcx assistant investigations report <id>
+```
+
+### Recommended Workflow: Interleave Both
+
+1. **Detect** with deterministic commands — `gcx alert instances list --state firing`
+2. **Understand** with the Assistant — `gcx assistant prompt "Why is checkout-latency firing?"`
+3. **Investigate** if needed — `gcx assistant investigations create --title="..."`
+4. **Verify fix** with deterministic commands — `gcx slo definitions status <uuid>`
+
 ## Provider Commands
 
 Product-specific providers register their own top-level command groups.

--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -110,7 +110,7 @@ the A2A (Agent-to-Agent) protocol over Server-Sent Events.`,
 		Example: "  gcx assistant prompt \"What alerts are firing?\"\n  gcx assistant prompt \"Show CPU usage\" --json\n  gcx assistant prompt \"Follow up\" --continue",
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "large",
-			agent.AnnotationLLMHint:   "\"What alerts are firing?\" --json",
+			agent.AnnotationLLMHint:   "Prefer deterministic gcx commands (gcx metrics query, gcx slo definitions status, gcx alert instances list) for precise data retrieval. Use assistant prompt for reasoning: root cause analysis, holistic health questions, or when you don't know which metrics/labels exist — the Assistant's Infrastructure Memories know your stack topology. Example: \"Why is checkout-latency spiking?\" --json",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -30,7 +30,7 @@ var commandAnnotations = map[string]annotation{
 	// assistant
 	"gcx assistant investigations approvals": {Cost: "medium", Hint: "<id> -o json"},
 	"gcx assistant investigations cancel":    {Cost: "small"},
-	"gcx assistant investigations create":    {Cost: "small"},
+	"gcx assistant investigations create":    {Cost: "small", Hint: "Use for deep cross-signal root cause analysis. Dispatches specialist agents for metrics, logs, traces, and profiles in parallel — more efficient than chaining individual gcx query commands. Example: --title=\"Checkout latency spike after deploy\""},
 	"gcx assistant investigations document":  {Cost: "medium", Hint: "<investigation-id> <document-id> -o json"},
 	"gcx assistant investigations get":       {Cost: "medium", Hint: "<id> -o json"},
 	"gcx assistant investigations list":      {Cost: "small"},


### PR DESCRIPTION
## Summary

- Adds a "Grafana Assistant" section to the gcx agent skill (`claude-plugin/skills/gcx/SKILL.md`)
- Teaches coding agents **when** to use the Assistant vs deterministic commands: data retrieval → deterministic, reasoning/exploration → Assistant
- Includes a decision table, command examples, and the recommended detect→understand→investigate→verify workflow

This ensures agents leverage the Assistant where it provides the most value (Infrastructure Memories, multi-agent Investigations, cross-signal reasoning) rather than brute-forcing exploration with sequential CLI queries.

## Test plan

- [ ] Read the updated SKILL.md and verify it parses correctly as a Claude Code skill
- [ ] Verify the decision table covers the key routing scenarios
- [ ] Confirm command examples match current `gcx assistant` CLI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)