### PR TITLE
feat(alert): add provisioning CRUD for contact-points, mute-timings, notification-policies, templates

### DIFF
--- a/docs/reference/cli/gcx_aio11y_collections.md
+++ b/docs/reference/cli/gcx_aio11y_collections.md
@@ -13,7 +13,7 @@ Manage named groups of saved conversations.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_collections_conversations.md
+++ b/docs/reference/cli/gcx_aio11y_collections_conversations.md
@@ -13,7 +13,7 @@ Manage saved conversations belonging to a collection.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_collections_conversations_add.md
+++ b/docs/reference/cli/gcx_aio11y_collections_conversations_add.md
@@ -17,7 +17,7 @@ gcx aio11y collections conversations add <collection-id> <saved-id>... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_collections_conversations_list.md
+++ b/docs/reference/cli/gcx_aio11y_collections_conversations_list.md
@@ -20,7 +20,7 @@ gcx aio11y collections conversations list <collection-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_collections_conversations_remove.md
+++ b/docs/reference/cli/gcx_aio11y_collections_conversations_remove.md
@@ -17,7 +17,7 @@ gcx aio11y collections conversations remove <collection-id> <saved-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_collections_create.md
+++ b/docs/reference/cli/gcx_aio11y_collections_create.md
@@ -32,7 +32,7 @@ gcx aio11y collections create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_collections_delete.md
+++ b/docs/reference/cli/gcx_aio11y_collections_delete.md
@@ -18,7 +18,7 @@ gcx aio11y collections delete COLLECTION-ID... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_collections_get.md
+++ b/docs/reference/cli/gcx_aio11y_collections_get.md
@@ -19,7 +19,7 @@ gcx aio11y collections get <collection-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_collections_list.md
+++ b/docs/reference/cli/gcx_aio11y_collections_list.md
@@ -20,7 +20,7 @@ gcx aio11y collections list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_collections_update.md
+++ b/docs/reference/cli/gcx_aio11y_collections_update.md
@@ -21,7 +21,7 @@ gcx aio11y collections update <collection-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_saved-conversations.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations.md
@@ -13,7 +13,7 @@ Bookmark live conversations as fixed inputs for evaluation runs.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_collections.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_collections.md
@@ -19,7 +19,7 @@ gcx aio11y saved-conversations collections <saved-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_delete.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_delete.md
@@ -18,7 +18,7 @@ gcx aio11y saved-conversations delete SAVED-ID... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_get.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_get.md
@@ -19,7 +19,7 @@ gcx aio11y saved-conversations get <saved-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_list.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_list.md
@@ -21,7 +21,7 @@ gcx aio11y saved-conversations list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_save.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_save.md
@@ -38,7 +38,7 @@ gcx aio11y saved-conversations save <conversation-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert.md
+++ b/docs/reference/cli/gcx_alert.md
@@ -23,7 +23,11 @@ Manage Grafana alert rules and alert groups
 ### SEE ALSO
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx alert contact-points](gcx_alert_contact-points.md)	 - Manage Grafana alerting contact points.
 * [gcx alert groups](gcx_alert_groups.md)	 - Manage alert rule groups.
 * [gcx alert instances](gcx_alert_instances.md)	 - Manage alert instances.
+* [gcx alert mute-timings](gcx_alert_mute-timings.md)	 - Manage Grafana alerting mute timings.
+* [gcx alert notification-policies](gcx_alert_notification-policies.md)	 - Manage the Grafana alerting notification policy tree.
 * [gcx alert rules](gcx_alert_rules.md)	 - Manage alert rules.
+* [gcx alert templates](gcx_alert_templates.md)	 - Manage Grafana alerting notification templates.
 

--- a/docs/reference/cli/gcx_alert_contact-points.md
+++ b/docs/reference/cli/gcx_alert_contact-points.md
@@ -1,0 +1,32 @@
+## gcx alert contact-points
+
+Manage Grafana alerting contact points.
+
+### Options
+
+```
+  -h, --help   help for contact-points
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert](gcx_alert.md)	 - Manage Grafana alert rules and alert groups
+* [gcx alert contact-points create](gcx_alert_contact-points_create.md)	 - Create a new contact point.
+* [gcx alert contact-points delete](gcx_alert_contact-points_delete.md)	 - Delete a contact point by UID.
+* [gcx alert contact-points export](gcx_alert_contact-points_export.md)	 - Export all contact points in provisioning format.
+* [gcx alert contact-points get](gcx_alert_contact-points_get.md)	 - Get a single contact point by UID.
+* [gcx alert contact-points list](gcx_alert_contact-points_list.md)	 - List alerting contact points.
+* [gcx alert contact-points update](gcx_alert_contact-points_update.md)	 - Update an existing contact point by UID.
+

--- a/docs/reference/cli/gcx_alert_contact-points.md
+++ b/docs/reference/cli/gcx_alert_contact-points.md
@@ -13,7 +13,7 @@ Manage Grafana alerting contact points.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_contact-points_create.md
+++ b/docs/reference/cli/gcx_alert_contact-points_create.md
@@ -1,0 +1,33 @@
+## gcx alert contact-points create
+
+Create a new contact point.
+
+```
+gcx alert contact-points create [flags]
+```
+
+### Options
+
+```
+  -f, --filename string   File containing the contact point definition (JSON/YAML, use - for stdin)
+  -h, --help              help for create
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert contact-points](gcx_alert_contact-points.md)	 - Manage Grafana alerting contact points.
+

--- a/docs/reference/cli/gcx_alert_contact-points_create.md
+++ b/docs/reference/cli/gcx_alert_contact-points_create.md
@@ -20,7 +20,7 @@ gcx alert contact-points create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_contact-points_delete.md
+++ b/docs/reference/cli/gcx_alert_contact-points_delete.md
@@ -1,0 +1,30 @@
+## gcx alert contact-points delete
+
+Delete a contact point by UID.
+
+```
+gcx alert contact-points delete UID [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert contact-points](gcx_alert_contact-points.md)	 - Manage Grafana alerting contact points.
+

--- a/docs/reference/cli/gcx_alert_contact-points_delete.md
+++ b/docs/reference/cli/gcx_alert_contact-points_delete.md
@@ -9,7 +9,8 @@ gcx alert contact-points delete UID [flags]
 ### Options
 
 ```
-  -h, --help   help for delete
+      --force   Skip confirmation prompt
+  -h, --help    help for delete
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_contact-points_delete.md
+++ b/docs/reference/cli/gcx_alert_contact-points_delete.md
@@ -18,7 +18,7 @@ gcx alert contact-points delete UID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_contact-points_export.md
+++ b/docs/reference/cli/gcx_alert_contact-points_export.md
@@ -1,0 +1,31 @@
+## gcx alert contact-points export
+
+Export all contact points in provisioning format.
+
+```
+gcx alert contact-points export [flags]
+```
+
+### Options
+
+```
+      --format string   Export format: yaml, json, or hcl (default "yaml")
+  -h, --help            help for export
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert contact-points](gcx_alert_contact-points.md)	 - Manage Grafana alerting contact points.
+

--- a/docs/reference/cli/gcx_alert_contact-points_export.md
+++ b/docs/reference/cli/gcx_alert_contact-points_export.md
@@ -18,7 +18,7 @@ gcx alert contact-points export [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_contact-points_get.md
+++ b/docs/reference/cli/gcx_alert_contact-points_get.md
@@ -1,0 +1,32 @@
+## gcx alert contact-points get
+
+Get a single contact point by UID.
+
+```
+gcx alert contact-points get UID [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert contact-points](gcx_alert_contact-points.md)	 - Manage Grafana alerting contact points.
+

--- a/docs/reference/cli/gcx_alert_contact-points_get.md
+++ b/docs/reference/cli/gcx_alert_contact-points_get.md
@@ -19,7 +19,7 @@ gcx alert contact-points get UID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_contact-points_list.md
+++ b/docs/reference/cli/gcx_alert_contact-points_list.md
@@ -1,0 +1,33 @@
+## gcx alert contact-points list
+
+List alerting contact points.
+
+```
+gcx alert contact-points list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for unlimited) (default 50)
+  -o, --output string   Output format. One of: json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert contact-points](gcx_alert_contact-points.md)	 - Manage Grafana alerting contact points.
+

--- a/docs/reference/cli/gcx_alert_contact-points_list.md
+++ b/docs/reference/cli/gcx_alert_contact-points_list.md
@@ -20,7 +20,7 @@ gcx alert contact-points list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_contact-points_update.md
+++ b/docs/reference/cli/gcx_alert_contact-points_update.md
@@ -1,0 +1,33 @@
+## gcx alert contact-points update
+
+Update an existing contact point by UID.
+
+```
+gcx alert contact-points update UID [flags]
+```
+
+### Options
+
+```
+  -f, --filename string   File containing the contact point definition (JSON/YAML, use - for stdin)
+  -h, --help              help for update
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert contact-points](gcx_alert_contact-points.md)	 - Manage Grafana alerting contact points.
+

--- a/docs/reference/cli/gcx_alert_contact-points_update.md
+++ b/docs/reference/cli/gcx_alert_contact-points_update.md
@@ -20,7 +20,7 @@ gcx alert contact-points update UID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_mute-timings.md
+++ b/docs/reference/cli/gcx_alert_mute-timings.md
@@ -1,0 +1,32 @@
+## gcx alert mute-timings
+
+Manage Grafana alerting mute timings.
+
+### Options
+
+```
+  -h, --help   help for mute-timings
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert](gcx_alert.md)	 - Manage Grafana alert rules and alert groups
+* [gcx alert mute-timings create](gcx_alert_mute-timings_create.md)	 - Create a new mute timing.
+* [gcx alert mute-timings delete](gcx_alert_mute-timings_delete.md)	 - Delete a mute timing by name.
+* [gcx alert mute-timings export](gcx_alert_mute-timings_export.md)	 - Export mute timings in provisioning format.
+* [gcx alert mute-timings get](gcx_alert_mute-timings_get.md)	 - Get a mute timing by name.
+* [gcx alert mute-timings list](gcx_alert_mute-timings_list.md)	 - List mute timings.
+* [gcx alert mute-timings update](gcx_alert_mute-timings_update.md)	 - Update an existing mute timing by name.
+

--- a/docs/reference/cli/gcx_alert_mute-timings.md
+++ b/docs/reference/cli/gcx_alert_mute-timings.md
@@ -13,7 +13,7 @@ Manage Grafana alerting mute timings.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_mute-timings_create.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_create.md
@@ -1,0 +1,33 @@
+## gcx alert mute-timings create
+
+Create a new mute timing.
+
+```
+gcx alert mute-timings create [flags]
+```
+
+### Options
+
+```
+  -f, --filename string   File containing the mute timing definition (JSON/YAML, use - for stdin)
+  -h, --help              help for create
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert mute-timings](gcx_alert_mute-timings.md)	 - Manage Grafana alerting mute timings.
+

--- a/docs/reference/cli/gcx_alert_mute-timings_create.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_create.md
@@ -20,7 +20,7 @@ gcx alert mute-timings create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_mute-timings_delete.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_delete.md
@@ -1,0 +1,30 @@
+## gcx alert mute-timings delete
+
+Delete a mute timing by name.
+
+```
+gcx alert mute-timings delete NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert mute-timings](gcx_alert_mute-timings.md)	 - Manage Grafana alerting mute timings.
+

--- a/docs/reference/cli/gcx_alert_mute-timings_delete.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_delete.md
@@ -9,7 +9,8 @@ gcx alert mute-timings delete NAME [flags]
 ### Options
 
 ```
-  -h, --help   help for delete
+      --force   Skip confirmation prompt
+  -h, --help    help for delete
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_mute-timings_delete.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_delete.md
@@ -18,7 +18,7 @@ gcx alert mute-timings delete NAME [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_mute-timings_export.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_export.md
@@ -1,0 +1,32 @@
+## gcx alert mute-timings export
+
+Export mute timings in provisioning format.
+
+```
+gcx alert mute-timings export [flags]
+```
+
+### Options
+
+```
+      --format string   Export format: yaml, json, or hcl (default "yaml")
+  -h, --help            help for export
+      --name string     Export a single mute timing by name (default: all)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert mute-timings](gcx_alert_mute-timings.md)	 - Manage Grafana alerting mute timings.
+

--- a/docs/reference/cli/gcx_alert_mute-timings_export.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_export.md
@@ -19,7 +19,7 @@ gcx alert mute-timings export [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_mute-timings_get.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_get.md
@@ -1,0 +1,32 @@
+## gcx alert mute-timings get
+
+Get a mute timing by name.
+
+```
+gcx alert mute-timings get NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert mute-timings](gcx_alert_mute-timings.md)	 - Manage Grafana alerting mute timings.
+

--- a/docs/reference/cli/gcx_alert_mute-timings_get.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_get.md
@@ -19,7 +19,7 @@ gcx alert mute-timings get NAME [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_mute-timings_list.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_list.md
@@ -1,0 +1,33 @@
+## gcx alert mute-timings list
+
+List mute timings.
+
+```
+gcx alert mute-timings list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for unlimited) (default 50)
+  -o, --output string   Output format. One of: json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert mute-timings](gcx_alert_mute-timings.md)	 - Manage Grafana alerting mute timings.
+

--- a/docs/reference/cli/gcx_alert_mute-timings_list.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_list.md
@@ -20,7 +20,7 @@ gcx alert mute-timings list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_mute-timings_update.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_update.md
@@ -1,0 +1,33 @@
+## gcx alert mute-timings update
+
+Update an existing mute timing by name.
+
+```
+gcx alert mute-timings update NAME [flags]
+```
+
+### Options
+
+```
+  -f, --filename string   File containing the mute timing definition (JSON/YAML, use - for stdin)
+  -h, --help              help for update
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert mute-timings](gcx_alert_mute-timings.md)	 - Manage Grafana alerting mute timings.
+

--- a/docs/reference/cli/gcx_alert_mute-timings_update.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_update.md
@@ -20,7 +20,7 @@ gcx alert mute-timings update NAME [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_notification-policies.md
+++ b/docs/reference/cli/gcx_alert_notification-policies.md
@@ -1,0 +1,30 @@
+## gcx alert notification-policies
+
+Manage the Grafana alerting notification policy tree.
+
+### Options
+
+```
+  -h, --help   help for notification-policies
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert](gcx_alert.md)	 - Manage Grafana alert rules and alert groups
+* [gcx alert notification-policies export](gcx_alert_notification-policies_export.md)	 - Export the notification policy tree in provisioning format.
+* [gcx alert notification-policies get](gcx_alert_notification-policies_get.md)	 - Get the notification policy tree.
+* [gcx alert notification-policies reset](gcx_alert_notification-policies_reset.md)	 - Reset the notification policy tree to its default.
+* [gcx alert notification-policies set](gcx_alert_notification-policies_set.md)	 - Replace the entire notification policy tree.
+

--- a/docs/reference/cli/gcx_alert_notification-policies.md
+++ b/docs/reference/cli/gcx_alert_notification-policies.md
@@ -13,7 +13,7 @@ Manage the Grafana alerting notification policy tree.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_notification-policies_export.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_export.md
@@ -1,0 +1,31 @@
+## gcx alert notification-policies export
+
+Export the notification policy tree in provisioning format.
+
+```
+gcx alert notification-policies export [flags]
+```
+
+### Options
+
+```
+      --format string   Export format: yaml, json, or hcl (default "yaml")
+  -h, --help            help for export
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert notification-policies](gcx_alert_notification-policies.md)	 - Manage the Grafana alerting notification policy tree.
+

--- a/docs/reference/cli/gcx_alert_notification-policies_export.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_export.md
@@ -18,7 +18,7 @@ gcx alert notification-policies export [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_notification-policies_get.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_get.md
@@ -1,0 +1,32 @@
+## gcx alert notification-policies get
+
+Get the notification policy tree.
+
+```
+gcx alert notification-policies get [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert notification-policies](gcx_alert_notification-policies.md)	 - Manage the Grafana alerting notification policy tree.
+

--- a/docs/reference/cli/gcx_alert_notification-policies_get.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_get.md
@@ -19,7 +19,7 @@ gcx alert notification-policies get [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_notification-policies_reset.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_reset.md
@@ -1,0 +1,30 @@
+## gcx alert notification-policies reset
+
+Reset the notification policy tree to its default.
+
+```
+gcx alert notification-policies reset [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for reset
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert notification-policies](gcx_alert_notification-policies.md)	 - Manage the Grafana alerting notification policy tree.
+

--- a/docs/reference/cli/gcx_alert_notification-policies_reset.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_reset.md
@@ -9,7 +9,8 @@ gcx alert notification-policies reset [flags]
 ### Options
 
 ```
-  -h, --help   help for reset
+      --force   Skip confirmation prompt
+  -h, --help    help for reset
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_notification-policies_reset.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_reset.md
@@ -18,7 +18,7 @@ gcx alert notification-policies reset [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_notification-policies_set.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_set.md
@@ -1,0 +1,31 @@
+## gcx alert notification-policies set
+
+Replace the entire notification policy tree.
+
+```
+gcx alert notification-policies set [flags]
+```
+
+### Options
+
+```
+  -f, --filename string   File containing the policy tree (JSON/YAML, use - for stdin)
+  -h, --help              help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert notification-policies](gcx_alert_notification-policies.md)	 - Manage the Grafana alerting notification policy tree.
+

--- a/docs/reference/cli/gcx_alert_notification-policies_set.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_set.md
@@ -19,7 +19,7 @@ gcx alert notification-policies set [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_notification-policies_set.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_set.md
@@ -10,6 +10,7 @@ gcx alert notification-policies set [flags]
 
 ```
   -f, --filename string   File containing the policy tree (JSON/YAML, use - for stdin)
+      --force             Skip confirmation prompt
   -h, --help              help for set
 ```
 

--- a/docs/reference/cli/gcx_alert_templates.md
+++ b/docs/reference/cli/gcx_alert_templates.md
@@ -1,0 +1,30 @@
+## gcx alert templates
+
+Manage Grafana alerting notification templates.
+
+### Options
+
+```
+  -h, --help   help for templates
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert](gcx_alert.md)	 - Manage Grafana alert rules and alert groups
+* [gcx alert templates delete](gcx_alert_templates_delete.md)	 - Delete a notification template by name.
+* [gcx alert templates get](gcx_alert_templates_get.md)	 - Get a notification template by name.
+* [gcx alert templates list](gcx_alert_templates_list.md)	 - List notification templates.
+* [gcx alert templates upsert](gcx_alert_templates_upsert.md)	 - Create or update a notification template.
+

--- a/docs/reference/cli/gcx_alert_templates.md
+++ b/docs/reference/cli/gcx_alert_templates.md
@@ -13,7 +13,7 @@ Manage Grafana alerting notification templates.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_templates_delete.md
+++ b/docs/reference/cli/gcx_alert_templates_delete.md
@@ -9,7 +9,8 @@ gcx alert templates delete NAME [flags]
 ### Options
 
 ```
-  -h, --help   help for delete
+      --force   Skip confirmation prompt
+  -h, --help    help for delete
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_templates_delete.md
+++ b/docs/reference/cli/gcx_alert_templates_delete.md
@@ -1,0 +1,30 @@
+## gcx alert templates delete
+
+Delete a notification template by name.
+
+```
+gcx alert templates delete NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert templates](gcx_alert_templates.md)	 - Manage Grafana alerting notification templates.
+

--- a/docs/reference/cli/gcx_alert_templates_delete.md
+++ b/docs/reference/cli/gcx_alert_templates_delete.md
@@ -18,7 +18,7 @@ gcx alert templates delete NAME [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_templates_get.md
+++ b/docs/reference/cli/gcx_alert_templates_get.md
@@ -1,0 +1,32 @@
+## gcx alert templates get
+
+Get a notification template by name.
+
+```
+gcx alert templates get NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert templates](gcx_alert_templates.md)	 - Manage Grafana alerting notification templates.
+

--- a/docs/reference/cli/gcx_alert_templates_get.md
+++ b/docs/reference/cli/gcx_alert_templates_get.md
@@ -19,7 +19,7 @@ gcx alert templates get NAME [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_templates_list.md
+++ b/docs/reference/cli/gcx_alert_templates_list.md
@@ -1,0 +1,33 @@
+## gcx alert templates list
+
+List notification templates.
+
+```
+gcx alert templates list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for unlimited) (default 50)
+  -o, --output string   Output format. One of: json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert templates](gcx_alert_templates.md)	 - Manage Grafana alerting notification templates.
+

--- a/docs/reference/cli/gcx_alert_templates_list.md
+++ b/docs/reference/cli/gcx_alert_templates_list.md
@@ -20,7 +20,7 @@ gcx alert templates list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_templates_upsert.md
+++ b/docs/reference/cli/gcx_alert_templates_upsert.md
@@ -1,0 +1,40 @@
+## gcx alert templates upsert
+
+Create or update a notification template.
+
+### Synopsis
+
+Create or update a notification template.
+
+The provisioning API uses a single PUT endpoint keyed by template name,
+so the same command handles both create and update.
+
+```
+gcx alert templates upsert [flags]
+```
+
+### Options
+
+```
+  -f, --filename string   File containing the template definition (JSON/YAML, use - for stdin)
+  -h, --help              help for upsert
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert templates](gcx_alert_templates.md)	 - Manage Grafana alerting notification templates.
+

--- a/docs/reference/cli/gcx_alert_templates_upsert.md
+++ b/docs/reference/cli/gcx_alert_templates_upsert.md
@@ -27,7 +27,7 @@ gcx alert templates upsert [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -98,12 +98,32 @@ var commandAnnotations = map[string]annotation{
 	// -----------------------------------------------------------------------
 	// Alert provider
 	// -----------------------------------------------------------------------
-	"gcx alert groups get":     {Cost: "small"},
-	"gcx alert groups list":    {Cost: "small"},
-	"gcx alert groups status":  {Cost: "medium", Hint: "<name> -o json"},
-	"gcx alert instances list": {Cost: "large", Hint: "--state firing --group <name> -o json"},
-	"gcx alert rules get":      {Cost: "small"},
-	"gcx alert rules list":     {Cost: "medium", Hint: "--folder <uid> --group <name> -o json"},
+	"gcx alert groups get":                   {Cost: "small"},
+	"gcx alert groups list":                  {Cost: "small"},
+	"gcx alert groups status":                {Cost: "medium", Hint: "<name> -o json"},
+	"gcx alert instances list":               {Cost: "large", Hint: "--state firing --group <name> -o json"},
+	"gcx alert rules get":                    {Cost: "small"},
+	"gcx alert rules list":                   {Cost: "medium", Hint: "--folder <uid> --group <name> -o json"},
+	"gcx alert contact-points list":          {Cost: "small"},
+	"gcx alert contact-points get":           {Cost: "small"},
+	"gcx alert contact-points create":        {Cost: "small"},
+	"gcx alert contact-points update":        {Cost: "small"},
+	"gcx alert contact-points delete":        {Cost: "small"},
+	"gcx alert contact-points export":        {Cost: "medium", Hint: "--format yaml"},
+	"gcx alert mute-timings list":            {Cost: "small"},
+	"gcx alert mute-timings get":             {Cost: "small"},
+	"gcx alert mute-timings create":          {Cost: "small"},
+	"gcx alert mute-timings update":          {Cost: "small"},
+	"gcx alert mute-timings delete":          {Cost: "small"},
+	"gcx alert mute-timings export":          {Cost: "medium", Hint: "--format yaml [--name <mute-timing>]"},
+	"gcx alert notification-policies get":    {Cost: "small"},
+	"gcx alert notification-policies set":    {Cost: "small"},
+	"gcx alert notification-policies reset":  {Cost: "small"},
+	"gcx alert notification-policies export": {Cost: "medium", Hint: "--format yaml"},
+	"gcx alert templates list":               {Cost: "small"},
+	"gcx alert templates get":                {Cost: "small"},
+	"gcx alert templates upsert":             {Cost: "small"},
+	"gcx alert templates delete":             {Cost: "small"},
 
 	// -----------------------------------------------------------------------
 	// App Observability provider

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -111,12 +111,32 @@ var commandAnnotations = map[string]annotation{
 	// -----------------------------------------------------------------------
 	// Alert provider
 	// -----------------------------------------------------------------------
-	"gcx alert groups get":     {Cost: "small"},
-	"gcx alert groups list":    {Cost: "small"},
-	"gcx alert groups status":  {Cost: "medium", Hint: "<name> -o json"},
-	"gcx alert instances list": {Cost: "large", Hint: "--state firing --group <name> -o json"},
-	"gcx alert rules get":      {Cost: "small"},
-	"gcx alert rules list":     {Cost: "medium", Hint: "--folder <uid> --group <name> -o json"},
+	"gcx alert groups get":                   {Cost: "small"},
+	"gcx alert groups list":                  {Cost: "small"},
+	"gcx alert groups status":                {Cost: "medium", Hint: "<name> -o json"},
+	"gcx alert instances list":               {Cost: "large", Hint: "--state firing --group <name> -o json"},
+	"gcx alert rules get":                    {Cost: "small"},
+	"gcx alert rules list":                   {Cost: "medium", Hint: "--folder <uid> --group <name> -o json"},
+	"gcx alert contact-points list":          {Cost: "small"},
+	"gcx alert contact-points get":           {Cost: "small"},
+	"gcx alert contact-points create":        {Cost: "small"},
+	"gcx alert contact-points update":        {Cost: "small"},
+	"gcx alert contact-points delete":        {Cost: "small"},
+	"gcx alert contact-points export":        {Cost: "medium", Hint: "--format yaml"},
+	"gcx alert mute-timings list":            {Cost: "small"},
+	"gcx alert mute-timings get":             {Cost: "small"},
+	"gcx alert mute-timings create":          {Cost: "small"},
+	"gcx alert mute-timings update":          {Cost: "small"},
+	"gcx alert mute-timings delete":          {Cost: "small"},
+	"gcx alert mute-timings export":          {Cost: "medium", Hint: "--format yaml [--name <mute-timing>]"},
+	"gcx alert notification-policies get":    {Cost: "small"},
+	"gcx alert notification-policies set":    {Cost: "small"},
+	"gcx alert notification-policies reset":  {Cost: "small"},
+	"gcx alert notification-policies export": {Cost: "medium", Hint: "--format yaml"},
+	"gcx alert templates list":               {Cost: "small"},
+	"gcx alert templates get":                {Cost: "small"},
+	"gcx alert templates upsert":             {Cost: "small"},
+	"gcx alert templates delete":             {Cost: "small"},
 
 	// -----------------------------------------------------------------------
 	// App Observability provider

--- a/internal/providers/alert/contact_points_commands.go
+++ b/internal/providers/alert/contact_points_commands.go
@@ -1,0 +1,272 @@
+package alert
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// contactPointsCommands returns the contact-points command group.
+func contactPointsCommands(loader GrafanaConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "contact-points",
+		Short:   "Manage Grafana alerting contact points.",
+		Aliases: []string{"contact-point"},
+	}
+	cmd.AddCommand(
+		newContactPointsListCommand(loader),
+		newContactPointsGetCommand(loader),
+		newContactPointsCreateCommand(loader),
+		newContactPointsUpdateCommand(loader),
+		newContactPointsDeleteCommand(loader),
+		newContactPointsExportCommand(loader),
+	)
+	return cmd
+}
+
+type contactPointsListOpts struct {
+	IO    cmdio.Options
+	Limit int64
+}
+
+func (o *contactPointsListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ContactPointsTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for unlimited)")
+}
+
+func newContactPointsListCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &contactPointsListOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List alerting contact points.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			points, err := client.ListContactPoints(ctx)
+			if err != nil {
+				return err
+			}
+			points = adapter.TruncateSlice(points, opts.Limit)
+			return opts.IO.Encode(cmd.OutOrStdout(), points)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ContactPointsTableCodec renders contact points as a tabular table.
+type ContactPointsTableCodec struct{}
+
+func (c *ContactPointsTableCodec) Format() format.Format { return "table" }
+
+func (c *ContactPointsTableCodec) Encode(w io.Writer, v any) error {
+	points, ok := v.([]ContactPoint)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []ContactPoint")
+	}
+	t := style.NewTable("UID", "NAME", "TYPE", "PROVENANCE")
+	for _, p := range points {
+		t.Row(p.UID, p.Name, p.Type, p.Provenance)
+	}
+	return t.Render(w)
+}
+
+func (c *ContactPointsTableCodec) Decode(io.Reader, any) error {
+	return errors.New("table format does not support decoding")
+}
+
+type contactPointsGetOpts struct {
+	IO cmdio.Options
+}
+
+func (o *contactPointsGetOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+}
+
+func newContactPointsGetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &contactPointsGetOpts{}
+	cmd := &cobra.Command{
+		Use:   "get UID",
+		Short: "Get a single contact point by UID.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			cp, err := client.GetContactPoint(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), cp)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type contactPointsMutateOpts struct {
+	IO   cmdio.Options
+	File string
+}
+
+func (o *contactPointsMutateOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+	flags.StringVarP(&o.File, "filename", "f", "", "File containing the contact point definition (JSON/YAML, use - for stdin)")
+}
+
+//nolint:dupl // Similar structure to mute-timings create command is intentional
+func newContactPointsCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &contactPointsMutateOpts{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new contact point.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			var cp ContactPoint
+			if err := readProvisioningInput(opts.File, cmd.InOrStdin(), &cp); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			created, err := client.CreateContactPoint(ctx, cp)
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), created)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func newContactPointsUpdateCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &contactPointsMutateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update UID",
+		Short: "Update an existing contact point by UID.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			var cp ContactPoint
+			if err := readProvisioningInput(opts.File, cmd.InOrStdin(), &cp); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			updated, err := client.UpdateContactPoint(ctx, args[0], cp)
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), updated)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func newContactPointsDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete UID",
+		Short: "Delete a contact point by UID.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			if err := client.DeleteContactPoint(ctx, args[0]); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted contact point %s\n", args[0])
+			return nil
+		},
+	}
+	return cmd
+}
+
+type contactPointsExportOpts struct {
+	Format string
+}
+
+func newContactPointsExportCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &contactPointsExportOpts{}
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export all contact points in provisioning format.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateExportFormat(opts.Format); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			data, err := client.ExportContactPoints(ctx, opts.Format)
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(data)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&opts.Format, "format", "yaml", "Export format: yaml, json, or hcl")
+	return cmd
+}

--- a/internal/providers/alert/contact_points_commands.go
+++ b/internal/providers/alert/contact_points_commands.go
@@ -2,7 +2,6 @@ package alert
 
 import (
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/grafana/gcx/internal/format"
@@ -144,7 +143,6 @@ func (o *contactPointsMutateOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.File, "filename", "f", "", "File containing the contact point definition (JSON/YAML, use - for stdin)")
 }
 
-//nolint:dupl // Similar structure to mute-timings create command is intentional
 func newContactPointsCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &contactPointsMutateOpts{}
 	cmd := &cobra.Command{
@@ -212,13 +210,31 @@ func newContactPointsUpdateCommand(loader GrafanaConfigLoader) *cobra.Command {
 	return cmd
 }
 
+type contactPointsDeleteOpts struct {
+	Force bool
+}
+
+func (o *contactPointsDeleteOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
+}
+
+//nolint:dupl // Similar structure to mute-timings and templates delete commands is intentional
 func newContactPointsDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &contactPointsDeleteOpts{}
 	cmd := &cobra.Command{
 		Use:   "delete UID",
 		Short: "Delete a contact point by UID.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ok, err := confirmDestructive(cmd.InOrStdin(), cmd.OutOrStdout(), opts.Force,
+				"Delete contact point "+args[0]+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
 			restCfg, err := loader.LoadGrafanaConfig(ctx)
 			if err != nil {
 				return err
@@ -230,10 +246,11 @@ func newContactPointsDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
 			if err := client.DeleteContactPoint(ctx, args[0]); err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Deleted contact point %s\n", args[0])
+			cmdio.Success(cmd.OutOrStdout(), "Deleted contact point %s", args[0])
 			return nil
 		},
 	}
+	opts.setup(cmd.Flags())
 	return cmd
 }
 

--- a/internal/providers/alert/mute_timings_commands.go
+++ b/internal/providers/alert/mute_timings_commands.go
@@ -2,7 +2,6 @@ package alert
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -158,7 +157,6 @@ func (o *muteTimingsMutateOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.File, "filename", "f", "", "File containing the mute timing definition (JSON/YAML, use - for stdin)")
 }
 
-//nolint:dupl // Similar structure to contact-points create command is intentional
 func newMuteTimingsCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &muteTimingsMutateOpts{}
 	cmd := &cobra.Command{
@@ -226,13 +224,31 @@ func newMuteTimingsUpdateCommand(loader GrafanaConfigLoader) *cobra.Command {
 	return cmd
 }
 
+type muteTimingsDeleteOpts struct {
+	Force bool
+}
+
+func (o *muteTimingsDeleteOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
+}
+
+//nolint:dupl // Similar structure to contact-points and templates delete commands is intentional
 func newMuteTimingsDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &muteTimingsDeleteOpts{}
 	cmd := &cobra.Command{
 		Use:   "delete NAME",
 		Short: "Delete a mute timing by name.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ok, err := confirmDestructive(cmd.InOrStdin(), cmd.OutOrStdout(), opts.Force,
+				"Delete mute timing "+args[0]+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
 			restCfg, err := loader.LoadGrafanaConfig(ctx)
 			if err != nil {
 				return err
@@ -244,10 +260,11 @@ func newMuteTimingsDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
 			if err := client.DeleteMuteTiming(ctx, args[0]); err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Deleted mute timing %s\n", args[0])
+			cmdio.Success(cmd.OutOrStdout(), "Deleted mute timing %s", args[0])
 			return nil
 		},
 	}
+	opts.setup(cmd.Flags())
 	return cmd
 }
 

--- a/internal/providers/alert/mute_timings_commands.go
+++ b/internal/providers/alert/mute_timings_commands.go
@@ -1,0 +1,296 @@
+package alert
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// muteTimingsCommands returns the mute-timings command group.
+func muteTimingsCommands(loader GrafanaConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "mute-timings",
+		Short:   "Manage Grafana alerting mute timings.",
+		Aliases: []string{"mute-timing"},
+	}
+	cmd.AddCommand(
+		newMuteTimingsListCommand(loader),
+		newMuteTimingsGetCommand(loader),
+		newMuteTimingsCreateCommand(loader),
+		newMuteTimingsUpdateCommand(loader),
+		newMuteTimingsDeleteCommand(loader),
+		newMuteTimingsExportCommand(loader),
+	)
+	return cmd
+}
+
+type muteTimingsListOpts struct {
+	IO    cmdio.Options
+	Limit int64
+}
+
+func (o *muteTimingsListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &MuteTimingsTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for unlimited)")
+}
+
+func newMuteTimingsListCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &muteTimingsListOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List mute timings.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			timings, err := client.ListMuteTimings(ctx)
+			if err != nil {
+				return err
+			}
+			timings = adapter.TruncateSlice(timings, opts.Limit)
+			return opts.IO.Encode(cmd.OutOrStdout(), timings)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// MuteTimingsTableCodec renders mute timings as a tabular table.
+type MuteTimingsTableCodec struct{}
+
+func (c *MuteTimingsTableCodec) Format() format.Format { return "table" }
+
+func (c *MuteTimingsTableCodec) Encode(w io.Writer, v any) error {
+	timings, ok := v.([]MuteTiming)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []MuteTiming")
+	}
+	t := style.NewTable("NAME", "INTERVALS", "SUMMARY")
+	for _, mt := range timings {
+		t.Row(mt.Name, strconv.Itoa(len(mt.TimeIntervals)), summarizeIntervals(mt.TimeIntervals))
+	}
+	return t.Render(w)
+}
+
+func (c *MuteTimingsTableCodec) Decode(io.Reader, any) error {
+	return errors.New("table format does not support decoding")
+}
+
+func summarizeIntervals(intervals []TimeInterval) string {
+	if len(intervals) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(intervals[0].Weekdays)+len(intervals[0].Times))
+	parts = append(parts, intervals[0].Weekdays...)
+	for _, t := range intervals[0].Times {
+		parts = append(parts, t.Start+"-"+t.End)
+	}
+	return strings.Join(parts, ",")
+}
+
+type muteTimingsGetOpts struct {
+	IO cmdio.Options
+}
+
+func (o *muteTimingsGetOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+}
+
+func newMuteTimingsGetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &muteTimingsGetOpts{}
+	cmd := &cobra.Command{
+		Use:   "get NAME",
+		Short: "Get a mute timing by name.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			mt, err := client.GetMuteTiming(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), mt)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type muteTimingsMutateOpts struct {
+	IO   cmdio.Options
+	File string
+}
+
+func (o *muteTimingsMutateOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+	flags.StringVarP(&o.File, "filename", "f", "", "File containing the mute timing definition (JSON/YAML, use - for stdin)")
+}
+
+//nolint:dupl // Similar structure to contact-points create command is intentional
+func newMuteTimingsCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &muteTimingsMutateOpts{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new mute timing.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			var mt MuteTiming
+			if err := readProvisioningInput(opts.File, cmd.InOrStdin(), &mt); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			created, err := client.CreateMuteTiming(ctx, mt)
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), created)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func newMuteTimingsUpdateCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &muteTimingsMutateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update NAME",
+		Short: "Update an existing mute timing by name.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			var mt MuteTiming
+			if err := readProvisioningInput(opts.File, cmd.InOrStdin(), &mt); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			updated, err := client.UpdateMuteTiming(ctx, args[0], mt)
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), updated)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func newMuteTimingsDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete NAME",
+		Short: "Delete a mute timing by name.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			if err := client.DeleteMuteTiming(ctx, args[0]); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted mute timing %s\n", args[0])
+			return nil
+		},
+	}
+	return cmd
+}
+
+type muteTimingsExportOpts struct {
+	Format string
+	Name   string
+}
+
+func newMuteTimingsExportCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &muteTimingsExportOpts{}
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export mute timings in provisioning format.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateExportFormat(opts.Format); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			var (
+				data   []byte
+				expErr error
+			)
+			if opts.Name != "" {
+				data, expErr = client.ExportMuteTiming(ctx, opts.Name, opts.Format)
+			} else {
+				data, expErr = client.ExportMuteTimings(ctx, opts.Format)
+			}
+			if expErr != nil {
+				return expErr
+			}
+			_, err = cmd.OutOrStdout().Write(data)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&opts.Format, "format", "yaml", "Export format: yaml, json, or hcl")
+	cmd.Flags().StringVar(&opts.Name, "name", "", "Export a single mute timing by name (default: all)")
+	return cmd
+}

--- a/internal/providers/alert/notification_policies_commands.go
+++ b/internal/providers/alert/notification_policies_commands.go
@@ -1,0 +1,155 @@
+package alert
+
+import (
+	"fmt"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// notificationPoliciesCommands returns the notification-policies command group.
+func notificationPoliciesCommands(loader GrafanaConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "notification-policies",
+		Short:   "Manage the Grafana alerting notification policy tree.",
+		Aliases: []string{"notification-policy", "policies"},
+	}
+	cmd.AddCommand(
+		newNotificationPoliciesGetCommand(loader),
+		newNotificationPoliciesSetCommand(loader),
+		newNotificationPoliciesResetCommand(loader),
+		newNotificationPoliciesExportCommand(loader),
+	)
+	return cmd
+}
+
+type notificationPoliciesGetOpts struct {
+	IO cmdio.Options
+}
+
+func (o *notificationPoliciesGetOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+}
+
+func newNotificationPoliciesGetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &notificationPoliciesGetOpts{}
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get the notification policy tree.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			policy, err := client.GetNotificationPolicy(ctx)
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), policy)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type notificationPoliciesSetOpts struct {
+	File string
+}
+
+func newNotificationPoliciesSetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &notificationPoliciesSetOpts{}
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Replace the entire notification policy tree.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var policy NotificationPolicy
+			if err := readProvisioningInput(opts.File, cmd.InOrStdin(), &policy); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			if err := client.SetNotificationPolicy(ctx, policy); err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Notification policy updated")
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&opts.File, "filename", "f", "", "File containing the policy tree (JSON/YAML, use - for stdin)")
+	return cmd
+}
+
+func newNotificationPoliciesResetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset the notification policy tree to its default.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			if err := client.ResetNotificationPolicy(ctx); err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Notification policy reset to default")
+			return nil
+		},
+	}
+	return cmd
+}
+
+type notificationPoliciesExportOpts struct {
+	Format string
+}
+
+func newNotificationPoliciesExportCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &notificationPoliciesExportOpts{}
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export the notification policy tree in provisioning format.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateExportFormat(opts.Format); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			data, err := client.ExportNotificationPolicy(ctx, opts.Format)
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(data)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&opts.Format, "format", "yaml", "Export format: yaml, json, or hcl")
+	return cmd
+}

--- a/internal/providers/alert/notification_policies_commands.go
+++ b/internal/providers/alert/notification_policies_commands.go
@@ -1,8 +1,6 @@
 package alert
 
 import (
-	"fmt"
-
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -88,7 +86,7 @@ func newNotificationPoliciesSetCommand(loader GrafanaConfigLoader) *cobra.Comman
 			if err := client.SetNotificationPolicy(ctx, policy); err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "Notification policy updated")
+			cmdio.Success(cmd.OutOrStdout(), "Notification policy updated")
 			return nil
 		},
 	}
@@ -96,12 +94,29 @@ func newNotificationPoliciesSetCommand(loader GrafanaConfigLoader) *cobra.Comman
 	return cmd
 }
 
+type notificationPoliciesResetOpts struct {
+	Force bool
+}
+
+func (o *notificationPoliciesResetOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
+}
+
 func newNotificationPoliciesResetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &notificationPoliciesResetOpts{}
 	cmd := &cobra.Command{
 		Use:   "reset",
 		Short: "Reset the notification policy tree to its default.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ok, err := confirmDestructive(cmd.InOrStdin(), cmd.OutOrStdout(), opts.Force,
+				"Reset notification policy tree to default? This replaces the entire tree.")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
 			restCfg, err := loader.LoadGrafanaConfig(ctx)
 			if err != nil {
 				return err
@@ -113,10 +128,11 @@ func newNotificationPoliciesResetCommand(loader GrafanaConfigLoader) *cobra.Comm
 			if err := client.ResetNotificationPolicy(ctx); err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "Notification policy reset to default")
+			cmdio.Success(cmd.OutOrStdout(), "Notification policy reset to default")
 			return nil
 		},
 	}
+	opts.setup(cmd.Flags())
 	return cmd
 }
 

--- a/internal/providers/alert/notification_policies_commands.go
+++ b/internal/providers/alert/notification_policies_commands.go
@@ -61,7 +61,13 @@ func newNotificationPoliciesGetCommand(loader GrafanaConfigLoader) *cobra.Comman
 }
 
 type notificationPoliciesSetOpts struct {
-	File string
+	File  string
+	Force bool
+}
+
+func (o *notificationPoliciesSetOpts) setup(flags *pflag.FlagSet) {
+	flags.StringVarP(&o.File, "filename", "f", "", "File containing the policy tree (JSON/YAML, use - for stdin)")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 }
 
 func newNotificationPoliciesSetCommand(loader GrafanaConfigLoader) *cobra.Command {
@@ -73,6 +79,14 @@ func newNotificationPoliciesSetCommand(loader GrafanaConfigLoader) *cobra.Comman
 			var policy NotificationPolicy
 			if err := readProvisioningInput(opts.File, cmd.InOrStdin(), &policy); err != nil {
 				return err
+			}
+			ok, err := confirmDestructive(cmd.InOrStdin(), cmd.OutOrStdout(), opts.Force,
+				"Replace notification policy tree? This overwrites the entire existing tree.")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
 			}
 			ctx := cmd.Context()
 			restCfg, err := loader.LoadGrafanaConfig(ctx)
@@ -90,7 +104,7 @@ func newNotificationPoliciesSetCommand(loader GrafanaConfigLoader) *cobra.Comman
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&opts.File, "filename", "f", "", "File containing the policy tree (JSON/YAML, use - for stdin)")
+	opts.setup(cmd.Flags())
 	return cmd
 }
 

--- a/internal/providers/alert/provider.go
+++ b/internal/providers/alert/provider.go
@@ -40,6 +40,10 @@ func (p *AlertProvider) Commands() []*cobra.Command {
 	alertCmd.AddCommand(rulesCommands(loader))
 	alertCmd.AddCommand(groupsCommands(loader))
 	alertCmd.AddCommand(instancesCommands(loader))
+	alertCmd.AddCommand(contactPointsCommands(loader))
+	alertCmd.AddCommand(muteTimingsCommands(loader))
+	alertCmd.AddCommand(notificationPoliciesCommands(loader))
+	alertCmd.AddCommand(templatesCommands(loader))
 
 	return []*cobra.Command{alertCmd}
 }

--- a/internal/providers/alert/provisioning_client.go
+++ b/internal/providers/alert/provisioning_client.go
@@ -1,0 +1,291 @@
+package alert
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const (
+	contactPointsPath = "/api/v1/provisioning/contact-points"
+	muteTimingsPath   = "/api/v1/provisioning/mute-timings"
+	policiesPath      = "/api/v1/provisioning/policies"
+	templatesPath     = "/api/v1/provisioning/templates"
+)
+
+// ErrProvisioningNotFound is returned when a provisioning resource does not exist.
+var ErrProvisioningNotFound = errors.New("provisioning resource not found")
+
+// doJSON performs an HTTP request with an optional JSON body and optionally
+// decodes a JSON response. Returns ErrProvisioningNotFound for 404 responses.
+// A 202 Accepted with an empty body is treated as success.
+func (c *Client) doJSON(ctx context.Context, method, path string, in, out any) error {
+	var body io.Reader
+	if in != nil {
+		data, err := json.Marshal(in)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		body = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.host+path, body)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	if in != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		return fmt.Errorf("%s %s: %w", method, path, ErrProvisioningNotFound)
+	case resp.StatusCode >= 400:
+		return handleErrorResponse(resp)
+	}
+
+	if out == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+	return nil
+}
+
+// doRaw performs an HTTP GET and returns the raw response body bytes.
+func (c *Client) doRaw(ctx context.Context, path string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.host+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("GET %s: %w", path, ErrProvisioningNotFound)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, handleErrorResponse(resp)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+// ---------------------------------------------------------------------------
+// Contact points
+// ---------------------------------------------------------------------------
+
+// ListContactPoints returns all contact points.
+func (c *Client) ListContactPoints(ctx context.Context) ([]ContactPoint, error) {
+	var out []ContactPoint
+	if err := c.doJSON(ctx, http.MethodGet, contactPointsPath, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetContactPoint returns a contact point by UID. The API has no get-by-UID
+// endpoint so this filters the list.
+func (c *Client) GetContactPoint(ctx context.Context, uid string) (*ContactPoint, error) {
+	list, err := c.ListContactPoints(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range list {
+		if list[i].UID == uid {
+			return &list[i], nil
+		}
+	}
+	return nil, fmt.Errorf("contact point %q: %w", uid, ErrProvisioningNotFound)
+}
+
+// CreateContactPoint creates a new contact point.
+func (c *Client) CreateContactPoint(ctx context.Context, cp ContactPoint) (*ContactPoint, error) {
+	var created ContactPoint
+	if err := c.doJSON(ctx, http.MethodPost, contactPointsPath, cp, &created); err != nil {
+		return nil, err
+	}
+	return &created, nil
+}
+
+// UpdateContactPoint updates an existing contact point. The PUT endpoint
+// returns 202 Accepted with no body; the caller gets back the input with
+// its UID preserved.
+func (c *Client) UpdateContactPoint(ctx context.Context, uid string, cp ContactPoint) (*ContactPoint, error) {
+	path := contactPointsPath + "/" + url.PathEscape(uid)
+	if err := c.doJSON(ctx, http.MethodPut, path, cp, nil); err != nil {
+		return nil, err
+	}
+	cp.UID = uid
+	return &cp, nil
+}
+
+// DeleteContactPoint deletes a contact point by UID.
+func (c *Client) DeleteContactPoint(ctx context.Context, uid string) error {
+	path := contactPointsPath + "/" + url.PathEscape(uid)
+	return c.doJSON(ctx, http.MethodDelete, path, nil, nil)
+}
+
+// ExportContactPoints returns all contact points in the provisioning export
+// format (yaml, json, or hcl).
+func (c *Client) ExportContactPoints(ctx context.Context, format string) ([]byte, error) {
+	return c.doRaw(ctx, contactPointsPath+"/export?format="+url.QueryEscape(format))
+}
+
+// ---------------------------------------------------------------------------
+// Mute timings
+// ---------------------------------------------------------------------------
+
+// ListMuteTimings returns all mute timings.
+func (c *Client) ListMuteTimings(ctx context.Context) ([]MuteTiming, error) {
+	var out []MuteTiming
+	if err := c.doJSON(ctx, http.MethodGet, muteTimingsPath, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetMuteTiming returns a mute timing by name.
+func (c *Client) GetMuteTiming(ctx context.Context, name string) (*MuteTiming, error) {
+	var out MuteTiming
+	path := muteTimingsPath + "/" + url.PathEscape(name)
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CreateMuteTiming creates a new mute timing.
+func (c *Client) CreateMuteTiming(ctx context.Context, mt MuteTiming) (*MuteTiming, error) {
+	var created MuteTiming
+	if err := c.doJSON(ctx, http.MethodPost, muteTimingsPath, mt, &created); err != nil {
+		return nil, err
+	}
+	return &created, nil
+}
+
+// UpdateMuteTiming updates a mute timing. The PUT endpoint returns 202 with
+// no body; the caller gets back the input with its name preserved.
+func (c *Client) UpdateMuteTiming(ctx context.Context, name string, mt MuteTiming) (*MuteTiming, error) {
+	path := muteTimingsPath + "/" + url.PathEscape(name)
+	if err := c.doJSON(ctx, http.MethodPut, path, mt, nil); err != nil {
+		return nil, err
+	}
+	mt.Name = name
+	return &mt, nil
+}
+
+// DeleteMuteTiming deletes a mute timing by name.
+func (c *Client) DeleteMuteTiming(ctx context.Context, name string) error {
+	path := muteTimingsPath + "/" + url.PathEscape(name)
+	return c.doJSON(ctx, http.MethodDelete, path, nil, nil)
+}
+
+// ExportMuteTimings exports all mute timings in the given provisioning format.
+func (c *Client) ExportMuteTimings(ctx context.Context, format string) ([]byte, error) {
+	return c.doRaw(ctx, muteTimingsPath+"/export?format="+url.QueryEscape(format))
+}
+
+// ExportMuteTiming exports a single mute timing by name in the given format.
+func (c *Client) ExportMuteTiming(ctx context.Context, name, format string) ([]byte, error) {
+	path := fmt.Sprintf("%s/%s/export?format=%s", muteTimingsPath, url.PathEscape(name), url.QueryEscape(format))
+	return c.doRaw(ctx, path)
+}
+
+// ---------------------------------------------------------------------------
+// Notification policies
+// ---------------------------------------------------------------------------
+
+// GetNotificationPolicy returns the (singleton) notification policy tree.
+func (c *Client) GetNotificationPolicy(ctx context.Context) (*NotificationPolicy, error) {
+	var out NotificationPolicy
+	if err := c.doJSON(ctx, http.MethodGet, policiesPath, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// SetNotificationPolicy replaces the entire notification policy tree.
+func (c *Client) SetNotificationPolicy(ctx context.Context, p NotificationPolicy) error {
+	return c.doJSON(ctx, http.MethodPut, policiesPath, p, nil)
+}
+
+// ResetNotificationPolicy restores the default notification policy.
+func (c *Client) ResetNotificationPolicy(ctx context.Context) error {
+	return c.doJSON(ctx, http.MethodDelete, policiesPath, nil, nil)
+}
+
+// ExportNotificationPolicy exports the notification policy tree.
+func (c *Client) ExportNotificationPolicy(ctx context.Context, format string) ([]byte, error) {
+	return c.doRaw(ctx, policiesPath+"/export?format="+url.QueryEscape(format))
+}
+
+// ---------------------------------------------------------------------------
+// Notification templates
+// ---------------------------------------------------------------------------
+
+// ListTemplates returns all notification templates.
+func (c *Client) ListTemplates(ctx context.Context) ([]NotificationTemplate, error) {
+	var out []NotificationTemplate
+	if err := c.doJSON(ctx, http.MethodGet, templatesPath, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetTemplate returns a template by name.
+func (c *Client) GetTemplate(ctx context.Context, name string) (*NotificationTemplate, error) {
+	var out NotificationTemplate
+	path := templatesPath + "/" + url.PathEscape(name)
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpsertTemplate creates or updates a template by name. The provisioning API
+// uses the same PUT endpoint for both create and update.
+func (c *Client) UpsertTemplate(ctx context.Context, t NotificationTemplate) (*NotificationTemplate, error) {
+	var out NotificationTemplate
+	path := templatesPath + "/" + url.PathEscape(t.Name)
+	if err := c.doJSON(ctx, http.MethodPut, path, t, &out); err != nil {
+		return nil, err
+	}
+	if out.Name == "" {
+		// Some versions return 202 with empty body; echo the input back.
+		return &t, nil
+	}
+	return &out, nil
+}
+
+// DeleteTemplate deletes a template by name.
+func (c *Client) DeleteTemplate(ctx context.Context, name string) error {
+	path := templatesPath + "/" + url.PathEscape(name)
+	return c.doJSON(ctx, http.MethodDelete, path, nil, nil)
+}

--- a/internal/providers/alert/provisioning_client_test.go
+++ b/internal/providers/alert/provisioning_client_test.go
@@ -1,0 +1,194 @@
+package alert_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/alert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ListContactPoints(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "returns contact points",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/api/v1/provisioning/contact-points", r.URL.Path)
+				writeJSON(w, []alert.ContactPoint{
+					{UID: "u1", Name: "Primary", Type: "webhook"},
+					{UID: "u2", Name: "Secondary", Type: "email"},
+				})
+			},
+			want: 2,
+		},
+		{
+			name: "server error surfaces",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			points, err := client.ListContactPoints(context.Background())
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, points, tt.want)
+		})
+	}
+}
+
+func TestClient_GetContactPoint_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, []alert.ContactPoint{{UID: "u1", Name: "Primary"}})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	_, err := client.GetContactPoint(context.Background(), "missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, alert.ErrProvisioningNotFound)
+}
+
+func TestClient_MuteTimings_CRUD(t *testing.T) {
+	var lastMethod, lastPath string
+	var lastBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastMethod = r.Method
+		lastPath = r.URL.Path
+		lastBody, _ = io.ReadAll(r.Body)
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, alert.MuteTiming{Name: "weekends"})
+		case http.MethodPost:
+			writeJSON(w, alert.MuteTiming{Name: "weekends"})
+		case http.MethodPut:
+			w.WriteHeader(http.StatusAccepted) // 202, no body
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	ctx := context.Background()
+
+	got, err := client.GetMuteTiming(ctx, "weekends")
+	require.NoError(t, err)
+	assert.Equal(t, "weekends", got.Name)
+	assert.Equal(t, "/api/v1/provisioning/mute-timings/weekends", lastPath)
+
+	created, err := client.CreateMuteTiming(ctx, alert.MuteTiming{Name: "weekends"})
+	require.NoError(t, err)
+	assert.Equal(t, "weekends", created.Name)
+	assert.Equal(t, http.MethodPost, lastMethod)
+
+	updated, err := client.UpdateMuteTiming(ctx, "weekends", alert.MuteTiming{Name: "weekends"})
+	require.NoError(t, err)
+	assert.Equal(t, "weekends", updated.Name) // PUT returns 202 with no body; the input is echoed back.
+	assert.NotEmpty(t, lastBody)
+
+	require.NoError(t, client.DeleteMuteTiming(ctx, "weekends"))
+	assert.Equal(t, http.MethodDelete, lastMethod)
+}
+
+func TestClient_NotificationPolicy_RoundTrip(t *testing.T) {
+	var putBody alert.NotificationPolicy
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, alert.NotificationPolicy{
+				Receiver: "default",
+				Routes: []alert.NotificationRoute{{
+					Receiver: "team-a",
+					Matchers: []alert.Matcher{{Label: "severity", Match: "=", Value: "info"}},
+				}},
+			})
+		case http.MethodPut:
+			if err := json.NewDecoder(r.Body).Decode(&putBody); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	ctx := context.Background()
+
+	policy, err := client.GetNotificationPolicy(ctx)
+	require.NoError(t, err)
+	require.Len(t, policy.Routes, 1)
+	assert.Equal(t, "severity", policy.Routes[0].Matchers[0].Label)
+
+	require.NoError(t, client.SetNotificationPolicy(ctx, *policy))
+	// Matchers must round-trip as the 3-element array wire format.
+	require.Len(t, putBody.Routes, 1)
+	assert.Equal(t, "info", putBody.Routes[0].Matchers[0].Value)
+
+	require.NoError(t, client.ResetNotificationPolicy(ctx))
+}
+
+func TestClient_Templates_UpsertHandles202EmptyBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/provisioning/templates/welcome", r.URL.Path)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	saved, err := client.UpsertTemplate(context.Background(), alert.NotificationTemplate{Name: "welcome", Template: "{{ .Alerts }}"})
+	require.NoError(t, err)
+	assert.Equal(t, "welcome", saved.Name)
+}
+
+func TestClient_Export_ReturnsRawBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/provisioning/contact-points/export", r.URL.Path)
+		assert.Equal(t, "yaml", r.URL.Query().Get("format"))
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write([]byte("apiVersion: 1\ncontactPoints: []\n"))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	data, err := client.ExportContactPoints(context.Background(), "yaml")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "apiVersion: 1")
+}
+
+func TestClient_doJSON_NotFoundWrapsSentinelError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	_, err := client.GetMuteTiming(context.Background(), "missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, alert.ErrProvisioningNotFound)
+}

--- a/internal/providers/alert/provisioning_commands.go
+++ b/internal/providers/alert/provisioning_commands.go
@@ -1,0 +1,58 @@
+package alert
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// readProvisioningInput decodes a plain JSON/YAML object from a file path or
+// stdin (when file == "-") into the provided target. Unlike the K8s-envelope
+// readers used elsewhere, provisioning resources are posted as bare objects
+// and therefore have no apiVersion/kind/spec wrapper.
+func readProvisioningInput(file string, stdin io.Reader, out any) error {
+	if file == "" {
+		return errors.New("--filename is required (use - to read from stdin)")
+	}
+
+	var reader io.Reader
+	if file == "-" {
+		reader = stdin
+	} else {
+		f, err := os.Open(file)
+		if err != nil {
+			return fmt.Errorf("failed to open file %s: %w", file, err)
+		}
+		defer f.Close()
+		reader = f
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return errors.New("input is empty")
+	}
+
+	// sigs.k8s.io/yaml decodes both JSON and YAML into JSON, then unmarshals.
+	if err := yaml.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("failed to parse input: %w", err)
+	}
+	return nil
+}
+
+// validateExportFormat rejects unknown export formats early with a helpful
+// error. Grafana's provisioning export endpoint supports yaml, json and hcl.
+func validateExportFormat(format string) error {
+	switch format {
+	case "yaml", "json", "hcl":
+		return nil
+	default:
+		return fmt.Errorf("invalid export format %q: must be yaml, json, or hcl", format)
+	}
+}

--- a/internal/providers/alert/provisioning_commands.go
+++ b/internal/providers/alert/provisioning_commands.go
@@ -1,12 +1,15 @@
 package alert
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/grafana/gcx/internal/config"
+	cmdio "github.com/grafana/gcx/internal/output"
 	"sigs.k8s.io/yaml"
 )
 
@@ -44,6 +47,34 @@ func readProvisioningInput(file string, stdin io.Reader, out any) error {
 		return fmt.Errorf("failed to parse input: %w", err)
 	}
 	return nil
+}
+
+// confirmDestructive prompts the user to confirm a destructive operation,
+// honoring the --force flag and the GCX_AUTO_APPROVE env var. Returns true if
+// the caller should proceed, false if the user declined.
+func confirmDestructive(in io.Reader, out io.Writer, force bool, prompt string) (bool, error) {
+	if force {
+		return true, nil
+	}
+	cliOpts, err := config.LoadCLIOptions()
+	if err != nil {
+		return false, err
+	}
+	if cliOpts.AutoApprove {
+		return true, nil
+	}
+
+	fmt.Fprintf(out, "%s [y/N] ", prompt)
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("failed to read confirmation: %w", err)
+	}
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "y" && answer != "yes" {
+		cmdio.Info(out, "Aborted.")
+		return false, nil
+	}
+	return true, nil
 }
 
 // validateExportFormat rejects unknown export formats early with a helpful

--- a/internal/providers/alert/provisioning_types.go
+++ b/internal/providers/alert/provisioning_types.go
@@ -1,0 +1,127 @@
+package alert
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// JSONModel wraps json.RawMessage to support YAML string round-tripping.
+// When loading from YAML, the model is a JSON string. When serializing to
+// JSON it emits raw bytes. Used for contact-point settings.
+type JSONModel json.RawMessage
+
+// MarshalJSON outputs the raw JSON bytes.
+func (m JSONModel) MarshalJSON() ([]byte, error) {
+	if len(m) == 0 {
+		return []byte("null"), nil
+	}
+	return m, nil
+}
+
+// UnmarshalJSON stores the raw bytes.
+func (m *JSONModel) UnmarshalJSON(data []byte) error {
+	*m = append((*m)[:0], data...)
+	return nil
+}
+
+// ContactPoint represents a Grafana alerting contact point (notifier).
+type ContactPoint struct {
+	UID                   string    `json:"uid,omitempty"`
+	Name                  string    `json:"name"`
+	Type                  string    `json:"type"`
+	Settings              JSONModel `json:"settings"`
+	DisableResolveMessage bool      `json:"disableResolveMessage,omitempty"`
+	Provenance            string    `json:"provenance,omitempty"`
+}
+
+// GetResourceName returns the contact point UID.
+func (cp ContactPoint) GetResourceName() string { return cp.UID }
+
+// MuteTiming represents a named set of time intervals during which
+// notifications are suppressed.
+type MuteTiming struct {
+	Name          string         `json:"name"`
+	TimeIntervals []TimeInterval `json:"time_intervals"`
+}
+
+// GetResourceName returns the mute timing name.
+func (m MuteTiming) GetResourceName() string { return m.Name }
+
+// TimeInterval is a single entry inside a MuteTiming.
+type TimeInterval struct {
+	Times       []TimeRangeHHMM `json:"times,omitempty"`
+	Weekdays    []string        `json:"weekdays,omitempty"`
+	DaysOfMonth []string        `json:"days_of_month,omitempty"`
+	Months      []string        `json:"months,omitempty"`
+	Years       []string        `json:"years,omitempty"`
+	Location    string          `json:"location,omitempty"`
+}
+
+// TimeRangeHHMM represents a start/end clock time in HH:MM.
+type TimeRangeHHMM struct {
+	Start string `json:"start_time"`
+	End   string `json:"end_time"`
+}
+
+// Matcher selects alerts for a notification route.
+// Wire format is a 3-element array: ["label", "operator", "value"].
+type Matcher struct {
+	Label string
+	Match string // "=", "!=", "=~", "!~"
+	Value string
+}
+
+// MarshalJSON emits the API-expected 3-element array form.
+func (m Matcher) MarshalJSON() ([]byte, error) {
+	return json.Marshal([]string{m.Label, m.Match, m.Value})
+}
+
+// UnmarshalJSON decodes the 3-element array form.
+func (m *Matcher) UnmarshalJSON(data []byte) error {
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return err
+	}
+	if len(arr) != 3 {
+		return fmt.Errorf("expected 3-element array for matcher, got %d", len(arr))
+	}
+	m.Label = arr[0]
+	m.Match = arr[1]
+	m.Value = arr[2]
+	return nil
+}
+
+// NotificationPolicy is the root of the notification policy tree.
+type NotificationPolicy struct {
+	Receiver          string              `json:"receiver"`
+	GroupBy           []string            `json:"group_by,omitempty"`
+	GroupWait         string              `json:"group_wait,omitempty"`
+	GroupInterval     string              `json:"group_interval,omitempty"`
+	RepeatInterval    string              `json:"repeat_interval,omitempty"`
+	Routes            []NotificationRoute `json:"routes,omitempty"`
+	MuteTimeIntervals []string            `json:"mute_time_intervals,omitempty"`
+	Provenance        string              `json:"provenance,omitempty"`
+}
+
+// NotificationRoute is a nested route in the notification policy tree.
+type NotificationRoute struct {
+	Receiver          string              `json:"receiver,omitempty"`
+	GroupBy           []string            `json:"group_by,omitempty"`
+	GroupWait         string              `json:"group_wait,omitempty"`
+	GroupInterval     string              `json:"group_interval,omitempty"`
+	RepeatInterval    string              `json:"repeat_interval,omitempty"`
+	Matchers          []Matcher           `json:"object_matchers,omitempty"`
+	Continue          bool                `json:"continue,omitempty"`
+	Routes            []NotificationRoute `json:"routes,omitempty"`
+	MuteTimeIntervals []string            `json:"mute_time_intervals,omitempty"`
+}
+
+// NotificationTemplate is a named Go template used to render alert messages.
+type NotificationTemplate struct {
+	Name       string `json:"name"`
+	Template   string `json:"template"`
+	Provenance string `json:"provenance,omitempty"`
+}
+
+// GetResourceName returns the template name.
+func (t NotificationTemplate) GetResourceName() string { return t.Name }

--- a/internal/providers/alert/templates_commands.go
+++ b/internal/providers/alert/templates_commands.go
@@ -2,7 +2,6 @@ package alert
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"strconv"
 
@@ -184,13 +183,31 @@ so the same command handles both create and update.`,
 	return cmd
 }
 
+type templatesDeleteOpts struct {
+	Force bool
+}
+
+func (o *templatesDeleteOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
+}
+
+//nolint:dupl // Similar structure to contact-points and mute-timings delete commands is intentional
 func newTemplatesDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &templatesDeleteOpts{}
 	cmd := &cobra.Command{
 		Use:   "delete NAME",
 		Short: "Delete a notification template by name.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			ok, err := confirmDestructive(cmd.InOrStdin(), cmd.OutOrStdout(), opts.Force,
+				"Delete notification template "+args[0]+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
 			restCfg, err := loader.LoadGrafanaConfig(ctx)
 			if err != nil {
 				return err
@@ -202,9 +219,10 @@ func newTemplatesDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
 			if err := client.DeleteTemplate(ctx, args[0]); err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Deleted template %s\n", args[0])
+			cmdio.Success(cmd.OutOrStdout(), "Deleted template %s", args[0])
 			return nil
 		},
 	}
+	opts.setup(cmd.Flags())
 	return cmd
 }

--- a/internal/providers/alert/templates_commands.go
+++ b/internal/providers/alert/templates_commands.go
@@ -1,0 +1,210 @@
+package alert
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// templatesCommands returns the templates command group.
+func templatesCommands(loader GrafanaConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "templates",
+		Short:   "Manage Grafana alerting notification templates.",
+		Aliases: []string{"template"},
+	}
+	cmd.AddCommand(
+		newTemplatesListCommand(loader),
+		newTemplatesGetCommand(loader),
+		newTemplatesUpsertCommand(loader),
+		newTemplatesDeleteCommand(loader),
+	)
+	return cmd
+}
+
+type templatesListOpts struct {
+	IO    cmdio.Options
+	Limit int64
+}
+
+func (o *templatesListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &TemplatesTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for unlimited)")
+}
+
+func newTemplatesListCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &templatesListOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List notification templates.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			templates, err := client.ListTemplates(ctx)
+			if err != nil {
+				return err
+			}
+			templates = adapter.TruncateSlice(templates, opts.Limit)
+			return opts.IO.Encode(cmd.OutOrStdout(), templates)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// TemplatesTableCodec renders notification templates as a tabular table.
+type TemplatesTableCodec struct{}
+
+func (c *TemplatesTableCodec) Format() format.Format { return "table" }
+
+func (c *TemplatesTableCodec) Encode(w io.Writer, v any) error {
+	templates, ok := v.([]NotificationTemplate)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []NotificationTemplate")
+	}
+	t := style.NewTable("NAME", "PROVENANCE", "LENGTH")
+	for _, tmpl := range templates {
+		t.Row(tmpl.Name, tmpl.Provenance, strconv.Itoa(len(tmpl.Template)))
+	}
+	return t.Render(w)
+}
+
+func (c *TemplatesTableCodec) Decode(io.Reader, any) error {
+	return errors.New("table format does not support decoding")
+}
+
+type templatesGetOpts struct {
+	IO cmdio.Options
+}
+
+func (o *templatesGetOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+}
+
+func newTemplatesGetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &templatesGetOpts{}
+	cmd := &cobra.Command{
+		Use:   "get NAME",
+		Short: "Get a notification template by name.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			tmpl, err := client.GetTemplate(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), tmpl)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type templatesUpsertOpts struct {
+	IO   cmdio.Options
+	File string
+}
+
+func (o *templatesUpsertOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+	flags.StringVarP(&o.File, "filename", "f", "", "File containing the template definition (JSON/YAML, use - for stdin)")
+}
+
+func newTemplatesUpsertCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &templatesUpsertOpts{}
+	cmd := &cobra.Command{
+		Use:   "upsert",
+		Short: "Create or update a notification template.",
+		Long: `Create or update a notification template.
+
+The provisioning API uses a single PUT endpoint keyed by template name,
+so the same command handles both create and update.`,
+		Aliases: []string{"create", "update", "apply"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			var t NotificationTemplate
+			if err := readProvisioningInput(opts.File, cmd.InOrStdin(), &t); err != nil {
+				return err
+			}
+			if t.Name == "" {
+				return errors.New("template name is required in the input payload")
+			}
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			saved, err := client.UpsertTemplate(ctx, t)
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), saved)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func newTemplatesDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete NAME",
+		Short: "Delete a notification template by name.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+			if err := client.DeleteTemplate(ctx, args[0]); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted template %s\n", args[0])
+			return nil
+		},
+	}
+	return cmd
+}


### PR DESCRIPTION
## Summary

Closes a P1 gap from the [migration gap analysis](docs/reference/migration-gap-analysis.md) by wiring the four most-used alerting provisioning resources into the existing `gcx alert` provider:

- **`gcx alert contact-points`** — list, get, create, update, delete, export
- **`gcx alert mute-timings`** — list, get, create, update, delete, export (bulk or `--name`)
- **`gcx alert notification-policies`** — get, set, reset, export (singleton tree)
- **`gcx alert templates`** — list, get, upsert, delete

All four map to `/api/v1/provisioning/*` and reuse the alert provider's existing HTTP client and `GrafanaConfigLoader`.

## Implementation notes

- **`provisioning_client.go`** — generic `doJSON` / `doRaw` helpers alongside the existing `doRequest`. They handle 404 → `ErrProvisioningNotFound`, 202 Accepted with empty body (the PUT contract), and JSON body (un)marshalling.
- **`provisioning_types.go`** — types for `ContactPoint`, `MuteTiming`, `NotificationPolicy` / `Route` / `Matcher` (with 3-element wire-array JSON), `NotificationTemplate`, and `JSONModel`.
- **`provisioning_commands.go`** — shared file-input reader (plain JSON/YAML, no K8s envelope) and export-format validator.
- **Annotations** — 24 new entries in `internal/agent/command_annotations.go` (token_cost + llm_hint, enforced by `consistency_test.go`).
- **Tests** — table-driven unit tests in `provisioning_client_test.go` covering list, get-404, CRUD round-trip, notification-policy matcher wire format, template PUT-202 handling, export raw body.
- **Reference docs** — regenerated via `GCX_AGENT_MODE=false make reference`.

No new K8s adapters registered; no changes to the provider interface.

## Test plan

- [x] `go test ./...` — green
- [x] `make lint` — 0 issues
- [x] `GCX_AGENT_MODE=false make reference` — no drift
- [x] Live-tested against a real stack: `list`, `get`, `export`, 404-path, invalid `--format`
- [ ] Reviewer: verify PR checks pass (CI)

## Live-test output (real stack)

```
$ gcx alert contact-points list -o table
UID             NAME                      TYPE     PROVENANCE
afc082f2iqt4wa  Commerce GMA              oncall   api
ffc082fz1x79ca  Frontend GMA              oncall   api
...

$ gcx alert notification-policies get -o yaml
receiver: Telescope Department GMA
group_by:
  - alertname
group_wait: 45s
...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)