### PR TITLE
fix(slo): default definitions list limit to all; satisfy prealloc lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 
+- Default `gcx slo definitions list --limit` to 0 (print all SLOs); raise agent `token_cost` to medium with hint to use `--limit` when narrowing output
 - Consolidate OnCall + Incidents under unified `irm` provider
 - Add adaptive metrics segments and exemptions commands
 - Adopt server-side pagination for list commands

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ gcx resources get folders                       # list all folders
 gcx alert rules list                            # list alert rules
 
 # Grafana Cloud products
-gcx slo definitions list                        # list SLOs
+gcx slo definitions list                        # list all SLO definitions
 gcx synth checks list                           # list synthetic monitoring checks
 gcx oncall schedules list                       # list on-call schedules
 gcx k6 load-tests list                          # list k6 load tests

--- a/cmd/gcx/commands/command_test.go
+++ b/cmd/gcx/commands/command_test.go
@@ -248,7 +248,7 @@ func TestCollectResourceTypes(t *testing.T) {
 			Aliases: []string{"slo", "slos"},
 			GVK:     schema.GroupVersionKind{Group: "slo.grafana.app", Version: "v1", Kind: "SLODefinition"},
 			Operations: map[string]agent.OperationHint{
-				"get": {TokenCost: "medium", LLMHint: "gcx slo definitions list"},
+				"get": {TokenCost: "medium", LLMHint: "gcx slo definitions list --limit 50 -o json"},
 			},
 		},
 	}

--- a/docs/design/help-text.md
+++ b/docs/design/help-text.md
@@ -32,11 +32,14 @@ Examples are prefixed with a comment explaining intent. Show 3-5 examples per
 command, progressing from simple to complex:
 
 ```go
-Example: `  # List all SLOs
+Example: `  # List all SLOs (default: no row cap; API returns the full list)
   gcx slo definitions list
 
   # List SLOs with JSON output
   gcx slo definitions list -o json
+
+  # Trim printed rows after fetch (optional; same API payload either way)
+  gcx slo definitions list --limit 50
 
   # List SLOs from a specific context
   gcx slo definitions list --context=prod`,

--- a/docs/reference/cli/gcx_slo_definitions_list.md
+++ b/docs/reference/cli/gcx_slo_definitions_list.md
@@ -11,7 +11,7 @@ gcx slo definitions list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int       Maximum number of items to return (0 for all) (default 50)
+      --limit int       Maximum number of items to return after fetch (0 for all; use a positive value to trim output only)
   -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -359,7 +359,7 @@ var commandAnnotations = map[string]annotation{
 	// -----------------------------------------------------------------------
 	"gcx slo definitions delete":   {Cost: "small"},
 	"gcx slo definitions get":      {Cost: "small"},
-	"gcx slo definitions list":     {Cost: "small"},
+	"gcx slo definitions list":     {Cost: "medium", Hint: "--limit 50 -o json"},
 	"gcx slo definitions pull":     {Cost: "medium", Hint: "-d ./slo-definitions"},
 	"gcx slo definitions push":     {Cost: "medium", Hint: "./definitions.yaml --dry-run"},
 	"gcx slo definitions status":   {Cost: "medium", Hint: "<uuid> -o json"},

--- a/internal/graph/chart.go
+++ b/internal/graph/chart.go
@@ -374,7 +374,7 @@ func renderLegend(series []Series) string {
 		return ""
 	}
 
-	var legendParts []string
+	legendParts := make([]string, 0, len(series))
 	for i, s := range series {
 		// Use the series-specific Color if set; otherwise fall back to ColorForIndex.
 		color := s.Color
@@ -398,7 +398,7 @@ func renderBarLegend(series []Series) string {
 		return ""
 	}
 
-	var legendParts []string
+	legendParts := make([]string, 0, len(series))
 	for i, s := range series {
 		if len(s.Points) == 0 {
 			continue

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -172,12 +172,13 @@ func New(opts ...Option) (*Linter, error) {
 }
 
 func (linter *Linter) Rules(ctx context.Context) ([]Rule, error) {
-	var rules []Rule
-
 	preparedQuery, err := linter.prepare(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	mods := preparedQuery.Modules()
+	rules := make([]Rule, 0, len(mods))
 
 	updateFromAnnotations := func(r *Rule, annotations []*ast.Annotations) {
 		if len(annotations) == 0 {
@@ -201,7 +202,7 @@ func (linter *Linter) Rules(ctx context.Context) ([]Rule, error) {
 	}
 
 	// Builtin rules
-	for _, module := range preparedQuery.Modules() {
+	for _, module := range mods {
 		parts := unquotedPath(module.Package.Path)
 
 		// 0   1     2        3        4
@@ -229,7 +230,7 @@ func (linter *Linter) Rules(ctx context.Context) ([]Rule, error) {
 	}
 
 	// custom rules
-	for _, module := range preparedQuery.Modules() {
+	for _, module := range mods {
 		parts := unquotedPath(module.Package.Path)
 
 		// 0      1   2     3        4        5

--- a/internal/providers/irm/oncall_client.go
+++ b/internal/providers/irm/oncall_client.go
@@ -201,7 +201,7 @@ func collectAll[T any](it iter.Seq2[T, error]) ([]T, error) {
 
 // collectN collects up to n items from an iterator. If n <= 0, all items are collected.
 func collectN[T any](it iter.Seq2[T, error], n int) ([]T, error) {
-	var items []T
+	items := make([]T, 0, max(0, n))
 	for item, err := range it {
 		if err != nil {
 			return nil, err

--- a/internal/providers/irm/oncall_commands_extra.go
+++ b/internal/providers/irm/oncall_commands_extra.go
@@ -472,7 +472,7 @@ func newEscalateCommand(loader OnCallConfigLoader) *cobra.Command {
 // ---------------------------------------------------------------------------
 
 func itemsToUnstructured[T any](items []T, kind, idField, namespace string) ([]unstructured.Unstructured, error) {
-	var objs []unstructured.Unstructured
+	objs := make([]unstructured.Unstructured, 0, len(items))
 	for _, item := range items {
 		data, err := json.Marshal(item)
 		if err != nil {

--- a/internal/providers/irm/oncallpublic/client.go
+++ b/internal/providers/irm/oncallpublic/client.go
@@ -203,7 +203,7 @@ func collectAll[T any](it iter.Seq2[T, error]) ([]T, error) {
 }
 
 func collectN[T any](it iter.Seq2[T, error], n int) ([]T, error) {
-	var items []T
+	items := make([]T, 0, max(0, n))
 	for item, err := range it {
 		if err != nil {
 			return nil, err
@@ -485,7 +485,7 @@ func (c *Client) ListFilterEvents(ctx context.Context, scheduleID, userTZ, start
 	if err != nil {
 		return nil, err
 	}
-	var events []oncalltypes.FinalShiftEvent
+	events := make([]oncalltypes.FinalShiftEvent, 0, len(items))
 	for _, fs := range items {
 		events = append(events, oncalltypes.FinalShiftEvent{
 			Start: fs.ShiftStart,

--- a/internal/providers/logs/adaptive/segment_stats.go
+++ b/internal/providers/logs/adaptive/segment_stats.go
@@ -26,7 +26,7 @@ func filterPatternsBySegment(recs []LogRecommendation, segmentRef string, catalo
 		}
 	}
 	seen := make(map[string]bool)
-	var keys []string
+	keys := make([]string, 0, len(matchKeys))
 	for _, k := range matchKeys {
 		if k == "" || seen[k] {
 			continue

--- a/internal/providers/metrics/adaptive/commands.go
+++ b/internal/providers/metrics/adaptive/commands.go
@@ -368,7 +368,7 @@ func applySelectiveRecommendations(cmd *cobra.Command, client *Client, opts *rec
 		recsByMetric[r.Metric] = r
 	}
 
-	var items []applyItem
+	items := make([]applyItem, 0, len(metrics))
 	for _, m := range metrics {
 		rec, ok := recsByMetric[m]
 		if !ok {

--- a/internal/providers/slo/definitions/commands.go
+++ b/internal/providers/slo/definitions/commands.go
@@ -60,7 +60,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
 
-	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
+	flags.Int64Var(&o.Limit, "limit", 0, "Maximum number of items to return after fetch (0 for all; use a positive value to trim output only)")
 }
 
 func newListCommand(loader GrafanaConfigLoader) *cobra.Command {

--- a/internal/providers/slo/provider_test.go
+++ b/internal/providers/slo/provider_test.go
@@ -48,6 +48,18 @@ func TestSLOProvider_Commands(t *testing.T) {
 	assert.Contains(t, subNames, "pull")
 	assert.Contains(t, subNames, "delete")
 
+	var listCmd *cobra.Command
+	for _, sub := range defsCmd.Commands() {
+		if sub.Name() == "list" {
+			listCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, listCmd)
+	limitFlag := listCmd.Flags().Lookup("limit")
+	require.NotNil(t, limitFlag)
+	assert.Equal(t, "0", limitFlag.DefValue, "list --limit should default to 0 (all SLOs); API returns the full list either way")
+
 	// Find reports subcommand
 	var reportsCmd *cobra.Command
 	for _, sub := range sloCmd.Commands() {

--- a/internal/style/banner.go
+++ b/internal/style/banner.go
@@ -24,7 +24,7 @@ func RenderLogo() string {
 		return ""
 	}
 
-	var lines []string
+	lines := make([]string, 0, len(asciiLogo))
 	for _, line := range asciiLogo {
 		lines = append(lines, Gradient(line, GradientAccentFrom, GradientBrandTo))
 	}


### PR DESCRIPTION
- Default `gcx slo definitions list --limit` to 0; document trim behavior and set agent token_cost to medium with a scoped llm_hint.
- Pre-allocate slices flagged by golangci-lint prealloc (graph, linter, IRM OnCall clients, logs/metrics adaptive, banner) and use max(0, n) in collectN for iterator helpers. These changes unfortunately got mixed with the real changes in this PR, but the following changes are all lint related
	- internal/graph/chart.go internal/linter/linter.go
	- internal/providers/irm/oncall_commands_extra.go
	- internal/providers/irm/oncallpublic/client.go
	- internal/providers/logs/adaptive/segment_stats.go
	- internal/providers/metrics/adaptive/commands.go
	- internal/providers/slo/definitions/commands.go
	- internal/providers/slo/provider_test.go
	- internal/style/banner.go


Made-with: Cursor