### PR TITLE
feat(metrics): add billing subtree and generic series leaf

### DIFF
--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -67,6 +67,11 @@ gcx (root)
 │   ├── query                [DATASOURCE_UID] EXPR   [--from] [--to] [--step] [--since] [-o]
 │   ├── labels               [--datasource/-d UID] [--label/-l NAME]
 │   ├── metadata             [--datasource/-d UID] [--metric/-m NAME]
+│   ├── series               [SELECTOR] [--datasource/-d UID] [--match SELECTOR]... [--from] [--to] [--since]
+│   ├── billing              Query grafanacloud_* billing metrics via pre-provisioned grafanacloud-usage datasource
+│   │   ├── query            EXPR   [--from] [--to] [--step] [--since] [-o]
+│   │   ├── labels           [--label/-l NAME]
+│   │   └── series           [SELECTOR] [--match SELECTOR]... [--from] [--to] [--since]
 │   └── adaptive             Adaptive Metrics (rules show/sync, recommendations show/apply)
 │
 ├── logs                     [internal/providers/logs/provider.go] (registered via providers.Register)

--- a/docs/reference/cli/gcx_metrics.md
+++ b/docs/reference/cli/gcx_metrics.md
@@ -24,7 +24,9 @@ Query Prometheus datasources and manage Adaptive Metrics
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx metrics adaptive](gcx_metrics_adaptive.md)	 - Manage Adaptive Metrics resources
+* [gcx metrics billing](gcx_metrics_billing.md)	 - Query Grafana Cloud billing metrics (grafanacloud_*)
 * [gcx metrics labels](gcx_metrics_labels.md)	 - List labels or label values
 * [gcx metrics metadata](gcx_metrics_metadata.md)	 - Get metric metadata
 * [gcx metrics query](gcx_metrics_query.md)	 - Execute a PromQL query against a Prometheus datasource
+* [gcx metrics series](gcx_metrics_series.md)	 - List time series matching one or more selectors
 

--- a/docs/reference/cli/gcx_metrics_billing.md
+++ b/docs/reference/cli/gcx_metrics_billing.md
@@ -1,0 +1,37 @@
+## gcx metrics billing
+
+Query Grafana Cloud billing metrics (grafanacloud_*)
+
+### Synopsis
+
+Query Grafana Cloud billing metrics via the grafanacloud-usage datasource
+that ships pre-provisioned on every Grafana Cloud stack.
+
+These commands are thin conveniences over the generic metrics subcommands;
+the --datasource flag defaults to "grafanacloud-usage" but can be overridden.
+
+### Options
+
+```
+  -h, --help   help for billing
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
+* [gcx metrics billing labels](gcx_metrics_billing_labels.md)	 - List label names available on billing metrics
+* [gcx metrics billing query](gcx_metrics_billing_query.md)	 - Execute a PromQL query against billing metrics
+* [gcx metrics billing series](gcx_metrics_billing_series.md)	 - List billing time series matching a selector
+

--- a/docs/reference/cli/gcx_metrics_billing_labels.md
+++ b/docs/reference/cli/gcx_metrics_billing_labels.md
@@ -1,0 +1,52 @@
+## gcx metrics billing labels
+
+List label names available on billing metrics
+
+### Synopsis
+
+List all labels or get values for a specific label from a Prometheus datasource.
+
+```
+gcx metrics billing labels [flags]
+```
+
+### Examples
+
+```
+
+  # All billing label names
+  gcx metrics billing labels
+
+  # Values for a single label
+  gcx metrics billing labels --label product
+
+  # Output as JSON
+  gcx metrics billing labels -o json
+```
+
+### Options
+
+```
+  -d, --datasource string   Datasource UID (required unless default-prometheus-datasource is configured)
+  -h, --help                help for labels
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -l, --label string        Get values for this label (omit to list all labels)
+  -o, --output string       Output format. One of: json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics billing](gcx_metrics_billing.md)	 - Query Grafana Cloud billing metrics (grafanacloud_*)
+

--- a/docs/reference/cli/gcx_metrics_billing_query.md
+++ b/docs/reference/cli/gcx_metrics_billing_query.md
@@ -1,0 +1,60 @@
+## gcx metrics billing query
+
+Execute a PromQL query against billing metrics
+
+### Synopsis
+
+Execute a PromQL query against a Prometheus datasource.
+
+EXPR is the PromQL expression to evaluate, passed as a positional argument or
+via --expr (familiar to promtool users).
+Datasource is resolved from -d flag or datasources.prometheus in your context.
+
+```
+gcx metrics billing query [EXPR] [flags]
+```
+
+### Examples
+
+```
+
+  # Active series right now
+  gcx metrics billing query 'grafanacloud_instance_active_series'
+
+  # Active series over the last hour
+  gcx metrics billing query 'grafanacloud_instance_active_series' --since 1h --step 1m
+
+  # Output as JSON
+  gcx metrics billing query 'grafanacloud_instance_active_series' -o json
+```
+
+### Options
+
+```
+  -d, --datasource string   Datasource UID (required unless datasources.prometheus is configured)
+      --expr string         Query expression (alternative to positional argument)
+      --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
+  -h, --help                help for query
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --step string         Query step (e.g., '15s', '1m')
+      --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics billing](gcx_metrics_billing.md)	 - Query Grafana Cloud billing metrics (grafanacloud_*)
+

--- a/docs/reference/cli/gcx_metrics_billing_series.md
+++ b/docs/reference/cli/gcx_metrics_billing_series.md
@@ -30,11 +30,11 @@ gcx metrics billing series [SELECTOR] [flags]
 ### Options
 
 ```
-  -d, --datasource string   Datasource UID (required unless default-prometheus-datasource is configured)
+  -d, --datasource string   Datasource UID (required unless datasources.prometheus is configured)
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for series
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --match strings       Additional series selector(s); repeatable
+      --match stringArray   Additional series selector(s); repeatable
   -o, --output string       Output format. One of: json, table, yaml (default "table")
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_metrics_billing_series.md
+++ b/docs/reference/cli/gcx_metrics_billing_series.md
@@ -1,0 +1,58 @@
+## gcx metrics billing series
+
+List billing time series matching a selector
+
+### Synopsis
+
+List time series matching one or more selectors via the Prometheus /api/v1/series endpoint.
+
+A selector can be passed as a positional argument and/or via --match (repeatable).
+Time range defaults to unbounded; pass --since, or --from/--to, to scope.
+
+```
+gcx metrics billing series [SELECTOR] [flags]
+```
+
+### Examples
+
+```
+
+  # All billing series
+  gcx metrics billing series '{__name__=~"grafanacloud_.*"}' --since 1h
+
+  # Filter to a specific product
+  gcx metrics billing series '{__name__=~"grafanacloud_.*",product="metrics"}' --since 1h
+
+  # Output as JSON
+  gcx metrics billing series '{__name__=~"grafanacloud_.*"}' --since 1h -o json
+```
+
+### Options
+
+```
+  -d, --datasource string   Datasource UID (required unless default-prometheus-datasource is configured)
+      --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
+  -h, --help                help for series
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --match strings       Additional series selector(s); repeatable
+  -o, --output string       Output format. One of: json, table, yaml (default "table")
+      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics billing](gcx_metrics_billing.md)	 - Query Grafana Cloud billing metrics (grafanacloud_*)
+

--- a/docs/reference/cli/gcx_metrics_series.md
+++ b/docs/reference/cli/gcx_metrics_series.md
@@ -30,11 +30,11 @@ gcx metrics series [SELECTOR] [flags]
 ### Options
 
 ```
-  -d, --datasource string   Datasource UID (required unless default-prometheus-datasource is configured)
+  -d, --datasource string   Datasource UID (required unless datasources.prometheus is configured)
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for series
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --match strings       Additional series selector(s); repeatable
+      --match stringArray   Additional series selector(s); repeatable
   -o, --output string       Output format. One of: json, table, yaml (default "table")
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_metrics_series.md
+++ b/docs/reference/cli/gcx_metrics_series.md
@@ -1,0 +1,58 @@
+## gcx metrics series
+
+List time series matching one or more selectors
+
+### Synopsis
+
+List time series matching one or more selectors via the Prometheus /api/v1/series endpoint.
+
+A selector can be passed as a positional argument and/or via --match (repeatable).
+Time range defaults to unbounded; pass --since, or --from/--to, to scope.
+
+```
+gcx metrics series [SELECTOR] [flags]
+```
+
+### Examples
+
+```
+
+  # Match a single metric family
+  gcx metrics series -d <datasource-uid> '{__name__="up"}'
+
+  # Match multiple selectors scoped to the last hour
+  gcx metrics series -d <datasource-uid> --match '{job="grafana"}' --match '{job="loki"}' --since 1h
+
+  # Output as JSON
+  gcx metrics series -d <datasource-uid> '{__name__=~"grafanacloud_.*"}' -o json
+```
+
+### Options
+
+```
+  -d, --datasource string   Datasource UID (required unless default-prometheus-datasource is configured)
+      --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
+  -h, --help                help for series
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --match strings       Additional series selector(s); repeatable
+  -o, --output string       Output format. One of: json, table, yaml (default "table")
+      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
+

--- a/internal/datasources/prometheus/labels.go
+++ b/internal/datasources/prometheus/labels.go
@@ -38,6 +38,12 @@ func (opts *labelsOpts) Validate() error {
 }
 
 func LabelsCmd(loader *providers.ConfigLoader) *cobra.Command {
+	return LabelsCmdWithDefault(loader, "")
+}
+
+// LabelsCmdWithDefault returns the labels command with a fallback datasource
+// UID used when --datasource is not provided. Pass "" for no default.
+func LabelsCmdWithDefault(loader *providers.ConfigLoader, defaultDS string) *cobra.Command {
 	opts := &labelsOpts{}
 
 	cmd := &cobra.Command{
@@ -73,7 +79,12 @@ func LabelsCmd(loader *providers.ConfigLoader) *cobra.Command {
 				cfgCtx = fullCfg.GetCurrentContext()
 			}
 
-			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "prometheus")
+			effectiveDS := opts.Datasource
+			if effectiveDS == "" {
+				effectiveDS = defaultDS
+			}
+
+			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, effectiveDS, cfgCtx, cfg, "prometheus")
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/prometheus/query.go
+++ b/internal/datasources/prometheus/query.go
@@ -16,6 +16,12 @@ import (
 
 // QueryCmd returns the `query` subcommand for a Prometheus datasource parent.
 func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
+	return QueryCmdWithDefault(loader, "")
+}
+
+// QueryCmdWithDefault returns the query command with a fallback datasource
+// UID used when --datasource is not provided. Pass "" for no default.
+func QueryCmdWithDefault(loader *providers.ConfigLoader, defaultDS string) *cobra.Command {
 	shared := &dsquery.SharedOpts{}
 	var datasource string
 
@@ -66,7 +72,12 @@ Datasource is resolved from -d flag or datasources.prometheus in your context.`,
 				return err
 			}
 
-			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, datasource, cfgCtx, cfg, "prometheus")
+			effectiveDS := datasource
+			if effectiveDS == "" {
+				effectiveDS = defaultDS
+			}
+
+			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, effectiveDS, cfgCtx, cfg, "prometheus")
 			if err != nil {
 				return err
 			}

--- a/internal/providers/metrics/billing.go
+++ b/internal/providers/metrics/billing.go
@@ -1,0 +1,87 @@
+package metrics
+
+import (
+	"github.com/grafana/gcx/internal/agent"
+	dsprometheus "github.com/grafana/gcx/internal/datasources/prometheus"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+)
+
+// BillingDatasourceUID is the name of the billing-metrics Prometheus datasource
+// auto-provisioned on every Grafana Cloud stack.
+const BillingDatasourceUID = "grafanacloud-usage"
+
+// BillingCommands returns the `billing` subcommand group that exposes Grafana
+// Cloud billing (grafanacloud_*) metrics via the pre-provisioned
+// grafanacloud-usage datasource.
+func BillingCommands(loader *providers.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "billing",
+		Short: "Query Grafana Cloud billing metrics (grafanacloud_*)",
+		Long: `Query Grafana Cloud billing metrics via the grafanacloud-usage datasource
+that ships pre-provisioned on every Grafana Cloud stack.
+
+These commands are thin conveniences over the generic metrics subcommands;
+the --datasource flag defaults to "grafanacloud-usage" but can be overridden.`,
+	}
+
+	cmd.AddCommand(billingQueryCmd(loader), billingLabelsCmd(loader), billingSeriesCmd(loader))
+
+	return cmd
+}
+
+func billingQueryCmd(loader *providers.ConfigLoader) *cobra.Command {
+	c := dsprometheus.QueryCmdWithDefault(loader, BillingDatasourceUID)
+	c.Short = "Execute a PromQL query against billing metrics"
+	c.Example = `
+  # Active series right now
+  gcx metrics billing query 'grafanacloud_instance_active_series'
+
+  # Active series over the last hour
+  gcx metrics billing query 'grafanacloud_instance_active_series' --since 1h --step 1m
+
+  # Output as JSON
+  gcx metrics billing query 'grafanacloud_instance_active_series' -o json`
+	c.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "medium",
+		agent.AnnotationLLMHint:   `gcx metrics billing query 'grafanacloud_instance_active_series' --since 1h -o json`,
+	}
+	return c
+}
+
+func billingLabelsCmd(loader *providers.ConfigLoader) *cobra.Command {
+	c := dsprometheus.LabelsCmdWithDefault(loader, BillingDatasourceUID)
+	c.Short = "List label names available on billing metrics"
+	c.Example = `
+  # All billing label names
+  gcx metrics billing labels
+
+  # Values for a single label
+  gcx metrics billing labels --label product
+
+  # Output as JSON
+  gcx metrics billing labels -o json`
+	c.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+	}
+	return c
+}
+
+func billingSeriesCmd(loader *providers.ConfigLoader) *cobra.Command {
+	c := newSeriesCmd(loader, BillingDatasourceUID)
+	c.Short = "List billing time series matching a selector"
+	c.Example = `
+  # All billing series
+  gcx metrics billing series '{__name__=~"grafanacloud_.*"}' --since 1h
+
+  # Filter to a specific product
+  gcx metrics billing series '{__name__=~"grafanacloud_.*",product="metrics"}' --since 1h
+
+  # Output as JSON
+  gcx metrics billing series '{__name__=~"grafanacloud_.*"}' --since 1h -o json`
+	c.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "medium",
+		agent.AnnotationLLMHint:   `gcx metrics billing series '{__name__=~"grafanacloud_.*"}' --since 1h -o json`,
+	}
+	return c
+}

--- a/internal/providers/metrics/provider.go
+++ b/internal/providers/metrics/provider.go
@@ -90,6 +90,15 @@ func (p *Provider) Commands() []*cobra.Command {
   gcx metrics metadata -d UID -o json`
 	cmd.AddCommand(mCmd)
 
+	sCmd := seriesCmd(loader)
+	sCmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "medium",
+		agent.AnnotationLLMHint:   `gcx metrics series -d abc123 '{__name__="up"}' --since 1h -o json`,
+	}
+	cmd.AddCommand(sCmd)
+
+	cmd.AddCommand(BillingCommands(loader))
+
 	// Adaptive Metrics subcommands — rename Use from "metrics" to "adaptive".
 	adaptiveCmd := adaptivemetrics.Commands(loader)
 	adaptiveCmd.Use = "adaptive"

--- a/internal/providers/metrics/provider_test.go
+++ b/internal/providers/metrics/provider_test.go
@@ -32,7 +32,7 @@ func TestProviderRegistration(t *testing.T) {
 			subNames = append(subNames, sub.Name())
 		}
 
-		for _, expected := range []string{"query", "labels", "metadata", "adaptive"} {
+		for _, expected := range []string{"query", "labels", "metadata", "series", "billing", "adaptive"} {
 			assert.Contains(t, subNames, expected, "missing subcommand %q", expected)
 		}
 	})

--- a/internal/providers/metrics/series.go
+++ b/internal/providers/metrics/series.go
@@ -1,0 +1,157 @@
+package metrics
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"time"
+
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type seriesOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	TimeRange  dsquery.TimeRangeOpts
+	Match      []string
+}
+
+func (opts *seriesOpts) setup(flags *pflag.FlagSet) {
+	opts.IO.RegisterCustomCodec("table", &seriesTableCodec{})
+	opts.IO.DefaultFormat("table")
+	opts.IO.BindFlags(flags)
+
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless default-prometheus-datasource is configured)")
+	flags.StringSliceVar(&opts.Match, "match", nil, "Additional series selector(s); repeatable")
+	opts.TimeRange.SetupTimeFlags(flags)
+}
+
+func (opts *seriesOpts) Validate() error {
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	return opts.TimeRange.ValidateTimeRange()
+}
+
+// runSeries executes a Prometheus /api/v1/series lookup against datasourceUID.
+// It is extracted so the billing subcommands can reuse the same flow with a
+// pre-selected datasource.
+func runSeries(cmd *cobra.Command, loader *providers.ConfigLoader, opts *seriesOpts, positional []string, datasourceDefault string) error {
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	selectors := append([]string{}, opts.Match...)
+	selectors = append(selectors, positional...)
+	if len(selectors) == 0 {
+		return errors.New("at least one selector is required (positional arg or --match)")
+	}
+
+	ctx := cmd.Context()
+
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	var cfgCtx *internalconfig.Context
+	fullCfg, err := loader.LoadFullConfig(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+	} else {
+		cfgCtx = fullCfg.GetCurrentContext()
+	}
+
+	datasource := opts.Datasource
+	if datasource == "" {
+		datasource = datasourceDefault
+	}
+
+	datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, datasource, cfgCtx, cfg, "prometheus")
+	if err != nil {
+		return err
+	}
+
+	start, end, err := opts.TimeRange.ParseTimeRange(time.Now())
+	if err != nil {
+		return err
+	}
+
+	client, err := prometheus.NewClient(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resp, err := client.Series(ctx, datasourceUID, selectors, start, end)
+	if err != nil {
+		return fmt.Errorf("failed to list series: %w", err)
+	}
+
+	if opts.IO.OutputFormat == "table" {
+		return prometheus.FormatSeriesTable(cmd.OutOrStdout(), resp)
+	}
+
+	return opts.IO.Encode(cmd.OutOrStdout(), resp)
+}
+
+func seriesCmd(loader *providers.ConfigLoader) *cobra.Command {
+	return newSeriesCmd(loader, "")
+}
+
+func newSeriesCmd(loader *providers.ConfigLoader, defaultDS string) *cobra.Command {
+	opts := &seriesOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "series [SELECTOR]",
+		Short: "List time series matching one or more selectors",
+		Long: `List time series matching one or more selectors via the Prometheus /api/v1/series endpoint.
+
+A selector can be passed as a positional argument and/or via --match (repeatable).
+Time range defaults to unbounded; pass --since, or --from/--to, to scope.`,
+		Example: `
+  # Match a single metric family
+  gcx metrics series -d <datasource-uid> '{__name__="up"}'
+
+  # Match multiple selectors scoped to the last hour
+  gcx metrics series -d <datasource-uid> --match '{job="grafana"}' --match '{job="loki"}' --since 1h
+
+  # Output as JSON
+  gcx metrics series -d <datasource-uid> '{__name__=~"grafanacloud_.*"}' -o json`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSeries(cmd, loader, opts, args, defaultDS)
+		},
+	}
+
+	opts.setup(cmd.Flags())
+
+	return cmd
+}
+
+type seriesTableCodec struct{}
+
+func (c *seriesTableCodec) Format() format.Format {
+	return "table"
+}
+
+func (c *seriesTableCodec) Encode(w io.Writer, data any) error {
+	resp, ok := data.(*prometheus.SeriesResponse)
+	if !ok {
+		return errors.New("invalid data type for series table codec")
+	}
+
+	return prometheus.FormatSeriesTable(w, resp)
+}
+
+func (c *seriesTableCodec) Decode(io.Reader, any) error {
+	return errors.New("series table codec does not support decoding")
+}

--- a/internal/providers/metrics/series.go
+++ b/internal/providers/metrics/series.go
@@ -30,8 +30,8 @@ func (opts *seriesOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.DefaultFormat("table")
 	opts.IO.BindFlags(flags)
 
-	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless default-prometheus-datasource is configured)")
-	flags.StringSliceVar(&opts.Match, "match", nil, "Additional series selector(s); repeatable")
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.prometheus is configured)")
+	flags.StringArrayVar(&opts.Match, "match", nil, "Additional series selector(s); repeatable")
 	opts.TimeRange.SetupTimeFlags(flags)
 }
 
@@ -94,10 +94,6 @@ func runSeries(cmd *cobra.Command, loader *providers.ConfigLoader, opts *seriesO
 	resp, err := client.Series(ctx, datasourceUID, selectors, start, end)
 	if err != nil {
 		return fmt.Errorf("failed to list series: %w", err)
-	}
-
-	if opts.IO.OutputFormat == "table" {
-		return prometheus.FormatSeriesTable(cmd.OutOrStdout(), resp)
 	}
 
 	return opts.IO.Encode(cmd.OutOrStdout(), resp)

--- a/internal/query/prometheus/export_test.go
+++ b/internal/query/prometheus/export_test.go
@@ -13,3 +13,7 @@ func (c *Client) BuildLabelValuesPath(datasourceUID, labelName string) string {
 func (c *Client) BuildMetadataPath(datasourceUID string) string {
 	return c.buildMetadataPath(datasourceUID)
 }
+
+func (c *Client) BuildSeriesPath(datasourceUID string) string {
+	return c.buildSeriesPath(datasourceUID)
+}

--- a/internal/query/prometheus/formatter.go
+++ b/internal/query/prometheus/formatter.go
@@ -154,6 +154,41 @@ func FormatLabelsTable(w io.Writer, resp *LabelsResponse) error {
 	return t.Render(w)
 }
 
+// FormatSeriesTable formats a SeriesResponse as a table. Each row is a single
+// series rendered in Prometheus selector syntax ({k="v",k2="v2"}) with labels
+// sorted for stability.
+func FormatSeriesTable(w io.Writer, resp *SeriesResponse) error {
+	t := style.NewTable("SERIES")
+	for _, series := range resp.Data {
+		t.Row(formatSeriesSelector(series))
+	}
+	return t.Render(w)
+}
+
+func formatSeriesSelector(labels map[string]string) string {
+	if len(labels) == 0 {
+		return "{}"
+	}
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(strconv.Quote(labels[k]))
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
 // FormatMetadataTable formats a MetadataResponse as a table.
 func FormatMetadataTable(w io.Writer, resp *MetadataResponse) error {
 	t := style.NewTable("METRIC", "TYPE", "HELP")

--- a/internal/query/prometheus/series.go
+++ b/internal/query/prometheus/series.go
@@ -1,0 +1,67 @@
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// SeriesResponse represents the response from a /api/v1/series query.
+type SeriesResponse struct {
+	Status string              `json:"status"`
+	Data   []map[string]string `json:"data"`
+}
+
+// Series returns time series matching the given selectors. A zero start or end
+// omits that bound from the request.
+func (c *Client) Series(ctx context.Context, datasourceUID string, match []string, start, end time.Time) (*SeriesResponse, error) {
+	apiPath := c.buildSeriesPath(datasourceUID)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.restConfig.Host+apiPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	q := httpReq.URL.Query()
+	for _, m := range match {
+		q.Add("match[]", m)
+	}
+	if !start.IsZero() {
+		q.Set("start", strconv.FormatInt(start.Unix(), 10))
+	}
+	if !end.IsZero() {
+		q.Set("end", strconv.FormatInt(end.Unix(), 10))
+	}
+	httpReq.URL.RawQuery = q.Encode()
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get series: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("series query failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result SeriesResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func (c *Client) buildSeriesPath(datasourceUID string) string {
+	return fmt.Sprintf("/api/datasources/uid/%s/resources/api/v1/series", url.PathEscape(datasourceUID))
+}

--- a/internal/query/prometheus/series_test.go
+++ b/internal/query/prometheus/series_test.go
@@ -1,0 +1,127 @@
+package prometheus_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newTestClient(t *testing.T, srvURL string) *prometheus.Client {
+	t.Helper()
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: srvURL, BearerToken: "test-token"},
+		Namespace: "default",
+	}
+	client, err := prometheus.NewClient(cfg)
+	require.NoError(t, err)
+	return client
+}
+
+func TestClient_Series(t *testing.T) {
+	var (
+		capturedPath  string
+		capturedQuery url.Values
+		capturedAuth  string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.Query()
+		capturedAuth = r.Header.Get("Authorization")
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(prometheus.SeriesResponse{
+			Status: "success",
+			Data: []map[string]string{
+				{"__name__": "up", "job": "prometheus"},
+				{"__name__": "up", "job": "node"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	start := time.Unix(1700000000, 0)
+	end := time.Unix(1700003600, 0)
+	resp, err := client.Series(
+		context.Background(),
+		"grafanacloud-usage",
+		[]string{`{__name__="up"}`, `{job="node"}`},
+		start, end,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/datasources/uid/grafanacloud-usage/resources/api/v1/series", capturedPath)
+	assert.Equal(t, []string{`{__name__="up"}`, `{job="node"}`}, capturedQuery["match[]"])
+	assert.Equal(t, "1700000000", capturedQuery.Get("start"))
+	assert.Equal(t, "1700003600", capturedQuery.Get("end"))
+	assert.Equal(t, "Bearer test-token", capturedAuth)
+
+	require.NotNil(t, resp)
+	assert.Equal(t, "success", resp.Status)
+	require.Len(t, resp.Data, 2)
+	assert.Equal(t, "up", resp.Data[0]["__name__"])
+	assert.Equal(t, "prometheus", resp.Data[0]["job"])
+}
+
+func TestClient_Series_NoTimeRange(t *testing.T) {
+	var capturedQuery url.Values
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(prometheus.SeriesResponse{Status: "success"})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	_, err := client.Series(
+		context.Background(),
+		"test",
+		[]string{`{a="b"}`},
+		time.Time{}, time.Time{},
+	)
+	require.NoError(t, err)
+
+	assert.Empty(t, capturedQuery.Get("start"))
+	assert.Empty(t, capturedQuery.Get("end"))
+	assert.Equal(t, []string{`{a="b"}`}, capturedQuery["match[]"])
+}
+
+func TestClient_Series_NonOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	_, err := client.Series(
+		context.Background(),
+		"test",
+		[]string{`{a="b"}`},
+		time.Time{}, time.Time{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestClient_BuildSeriesPathEscapesUID(t *testing.T) {
+	c := &prometheus.Client{}
+	path := c.BuildSeriesPath("uid/../admin")
+	assert.Contains(t, path, "uid%2F..%2Fadmin")
+	assert.NotContains(t, path, "uid/../admin")
+}


### PR DESCRIPTION
## Summary

Ports `billing metrics` from grafana-cloud-cli (migration doc §6, [line 216](../blob/main/docs/reference/migration-gap-analysis.md#L216)) as a thin convenience shell under the existing `metrics` provider, plus a generic `metrics series` leaf.

**Key discovery:** every Grafana Cloud stack ships a pre-provisioned Prometheus datasource named `grafanacloud-usage` that proxies `https://billing.grafana.net/api/prom`. Verified live against a real stack — the existing OAuth-proxy path in `internal/query/prometheus/client.go` queries it with no code changes, so the port needs **no new HTTP client, no AP token, no org-ID Basic-auth**. It collapses from ~400 LOC to ~200.

### New commands
- `gcx metrics billing query <promql>` — instant or range query, `-d` defaults to `grafanacloud-usage`
- `gcx metrics billing labels` — label name listing
- `gcx metrics billing series <selector>` — series lookup
- `gcx metrics series <selector>` — generic series leaf for any Prom datasource (previously missing)

Each leaf has `token_cost` + `llm_hint` annotations and passes `cmd/gcx/root/consistency_test.go`.

### Implementation notes
- `query.go` / `labels.go` / `series.go` gained a private `newXCmd(loader, defaultDS)` helper so billing can reuse the same command body with a pre-selected datasource — no code duplication.
- New `SeriesResponse` + `Client.Series` + `FormatSeriesTable` added to `internal/query/prometheus/`.
- `billing.go` lives in the same package as `metrics` (not a sub-package) to avoid an import cycle.

## Test plan

- [x] `go test ./internal/query/prometheus/...` — new httptest coverage for Series (path, match[] params, unix-second timestamps, Bearer-auth forwarding, 4xx handling, UID escaping)
- [x] `go test ./internal/providers/metrics/...` — provider-level subcommand registration check extended
- [x] `go test ./cmd/gcx/root/...` — consistency_test green (annotations present)
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./...` — clean
- [x] `make reference` — new CLI reference docs generated, no drift on existing ones
- [x] Live smoke against a real Grafana Cloud stack (OAuth token only): `billing labels`, `billing query 'grafanacloud_instance_active_series'`, `billing series '{__name__=~"grafanacloud_.*"}' --since 1h` — all return real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)