### PR TITLE
feat(kg): validate scope flag values against known KG scopes

### DIFF
--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -87,6 +88,70 @@ func (f *scopeFlags) scopeCriteria() *ScopeCriteria {
 		return nil
 	}
 	return &ScopeCriteria{NameAndValues: vals}
+}
+
+// validateScopes checks that any set scope values exist in the KG scope registry.
+// If a value is not an exact match it fetches known values, finds candidates by
+// substring match, and returns an error with actionable hints so the caller
+// (human or LLM) can retry with the correct value. Validation is best-effort:
+// if the scopes API is unavailable the error is silently ignored.
+func (f *scopeFlags) validateScopes(ctx context.Context, client *Client) error {
+	type check struct{ flag, dim, value string }
+	checks := []check{
+		{"--env", "env", f.env},
+		{"--site", "site", f.site},
+		{"--namespace", "namespace", f.namespace},
+	}
+	var active []check
+	for _, c := range checks {
+		if c.value != "" {
+			active = append(active, c)
+		}
+	}
+	if len(active) == 0 {
+		return nil
+	}
+	scopes, err := client.ListEntityScopes(ctx)
+	if err != nil {
+		return nil // best-effort
+	}
+	var errs []string
+	for _, c := range active {
+		known := scopes[c.dim]
+		if len(known) == 0 {
+			continue
+		}
+		if slices.Contains(known, c.value) {
+			continue
+		}
+		lower := strings.ToLower(c.value)
+		var candidates []string
+		for _, v := range known {
+			if strings.Contains(strings.ToLower(v), lower) {
+				candidates = append(candidates, v)
+			}
+		}
+		sort.Strings(candidates)
+		var msg string
+		if len(candidates) > 0 {
+			msg = fmt.Sprintf("unknown %s value %q — did you mean one of: %s", c.flag, c.value, strings.Join(candidates, ", "))
+		} else {
+			all := append([]string(nil), known...)
+			sort.Strings(all)
+			shown := all
+			suffix := ""
+			if len(shown) > 10 {
+				shown = shown[:10]
+				suffix = fmt.Sprintf(" (and %d more — run gcx kg scopes list)", len(all)-10)
+			}
+			msg = fmt.Sprintf("unknown %s value %q — known %s values: %s%s", c.flag, c.value, c.dim, strings.Join(shown, ", "), suffix)
+		}
+		errs = append(errs, msg)
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "\n"))
+	}
+	return nil
 }
 
 func (f *scopeFlags) scopeMap() map[string]string {
@@ -622,6 +687,9 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 				return err
 			}
 
+			if err := showScope.validateScopes(cmd.Context(), client); err != nil {
+				return err
+			}
 			startMs, endMs, err := showScope.resolveTime()
 			if err != nil {
 				return err
@@ -672,6 +740,9 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 			}
 			client, err := NewClient(cfg)
 			if err != nil {
+				return err
+			}
+			if err := listScope.validateScopes(cmd.Context(), client); err != nil {
 				return err
 			}
 			startMs, endMs, err := listScope.resolveTime()
@@ -903,6 +974,9 @@ func newAssertionsCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if err := activeScope.validateScopes(cmd.Context(), client); err != nil {
+				return err
+			}
 			startMs, endMs, err := activeScope.resolveTime()
 			if err != nil {
 				return err
@@ -960,6 +1034,9 @@ func newAssertionsCommand(loader RESTConfigLoader) *cobra.Command {
 				assertionID, _ := cmd.Flags().GetString("insight-id")
 				if assertionID == "" {
 					return errors.New("--insight-id is required (or use --file)")
+				}
+				if err := entityMetricScope.validateScopes(cmd.Context(), client); err != nil {
+					return err
 				}
 				startMs, endMs, err := entityMetricScope.resolveTime()
 				if err != nil {
@@ -1087,6 +1164,10 @@ func buildAssertionsRequestFromFlags(cmd *cobra.Command, args []string, client *
 	env, _ := cmd.Flags().GetString("env")
 	namespace, _ := cmd.Flags().GetString("namespace")
 	site, _ := cmd.Flags().GetString("site")
+	sf := scopeFlags{env: env, site: site, namespace: namespace}
+	if err := sf.validateScopes(cmd.Context(), client); err != nil {
+		return AssertionsRequest{}, err
+	}
 	startMs, endMs, err := resolveTimeFromFlags(cmd)
 	if err != nil {
 		return AssertionsRequest{}, err
@@ -1172,6 +1253,9 @@ func newSearchCommand(loader RESTConfigLoader) *cobra.Command {
 			} else {
 				entityType, _ := cmd.Flags().GetString("type")
 				entityName, _ := cmd.Flags().GetString("name")
+				if err := searchAssertionsScope.validateScopes(cmd.Context(), client); err != nil {
+					return err
+				}
 				startMs, endMs, err := searchAssertionsScope.resolveTime()
 				if err != nil {
 					return err
@@ -1224,6 +1308,9 @@ func newSearchCommand(loader RESTConfigLoader) *cobra.Command {
 			}
 			client, err := NewClient(cfg)
 			if err != nil {
+				return err
+			}
+			if err := searchSampleScope.validateScopes(cmd.Context(), client); err != nil {
 				return err
 			}
 			startMs, endMs, err := searchSampleScope.resolveTime()
@@ -1281,6 +1368,9 @@ func newInspectCommand(loader RESTConfigLoader) *cobra.Command {
 			}
 			client, err := NewClient(cfg)
 			if err != nil {
+				return err
+			}
+			if err := inspectScope.validateScopes(cmd.Context(), client); err != nil {
 				return err
 			}
 			startMs, endMs, err := inspectScope.resolveTime()
@@ -1369,6 +1459,9 @@ func newHealthCommand(loader RESTConfigLoader) *cobra.Command {
 			}
 			client, err := NewClient(cfg)
 			if err != nil {
+				return err
+			}
+			if err := healthScope.validateScopes(cmd.Context(), client); err != nil {
 				return err
 			}
 			startMs, endMs, err := healthScope.resolveTime()

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -113,7 +113,7 @@ func (f *scopeFlags) validateScopes(ctx context.Context, client *Client) error {
 	}
 	scopes, err := client.ListEntityScopes(ctx)
 	if err != nil {
-		return nil // best-effort
+		return nil //nolint:nilerr // best-effort: scope validation is advisory
 	}
 	var errs []string
 	for _, c := range active {
@@ -883,7 +883,7 @@ func (o *scopesListOpts) setup(flags *pflag.FlagSet) {
 // Insights commands
 // ---------------------------------------------------------------------------
 
-//nolint:maintidx
+//nolint:maintidx,gocyclo
 func newAssertionsCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "insights",

--- a/internal/providers/kg/commands_test.go
+++ b/internal/providers/kg/commands_test.go
@@ -1,0 +1,136 @@
+package kg
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newInternalTestClient(t *testing.T, server *httptest.Server) *Client {
+	t.Helper()
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: server.URL},
+		Namespace: "stack-123",
+	}
+	c, err := NewClient(cfg)
+	require.NoError(t, err)
+	return c
+}
+
+func scopesHandler(scopes map[string][]string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"scopeValues": scopes})
+	}
+}
+
+func TestScopeFlags_ValidateScopes(t *testing.T) {
+	knownScopes := map[string][]string{
+		"env":       {"ops-eu-south-0", "ops-eu-north-1", "prod-us-east-1"},
+		"site":      {"site-a", "site-b"},
+		"namespace": {"default", "monitoring"},
+	}
+
+	tests := []struct {
+		name        string
+		flags       scopeFlags
+		serverScopes map[string][]string
+		serverErr   bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:         "no scope flags set — skips validation",
+			flags:        scopeFlags{},
+			serverScopes: knownScopes,
+		},
+		{
+			name:         "exact match — no error",
+			flags:        scopeFlags{env: "ops-eu-south-0"},
+			serverScopes: knownScopes,
+		},
+		{
+			name:         "exact match multiple flags — no error",
+			flags:        scopeFlags{env: "ops-eu-south-0", namespace: "default"},
+			serverScopes: knownScopes,
+		},
+		{
+			name:         "partial match — error with candidates",
+			flags:        scopeFlags{env: "ops"},
+			serverScopes: knownScopes,
+			wantErr:      true,
+			errContains:  `did you mean one of: ops-eu-north-1, ops-eu-south-0`,
+		},
+		{
+			name:         "no candidates — lists known values",
+			flags:        scopeFlags{env: "totally-unknown"},
+			serverScopes: knownScopes,
+			wantErr:      true,
+			errContains:  `known env values:`,
+		},
+		{
+			name:         "known values truncated at 10 with hint",
+			flags:        scopeFlags{env: "zzz-no-match"},
+			serverScopes: map[string][]string{
+				"env": {"a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10", "a11"},
+			},
+			wantErr:     true,
+			errContains: "and 1 more — run gcx kg scopes list",
+		},
+		{
+			name:         "multiple invalid flags — error lists all",
+			flags:        scopeFlags{env: "bad-env", site: "bad-site"},
+			serverScopes: knownScopes,
+			wantErr:      true,
+			errContains:  "--env",
+		},
+		{
+			name:      "API error — best-effort, no error returned",
+			flags:     scopeFlags{env: "anything"},
+			serverErr: true,
+		},
+		{
+			name:         "empty known values for dimension — skips that dimension",
+			flags:        scopeFlags{env: "whatever"},
+			serverScopes: map[string][]string{"env": {}},
+		},
+		{
+			name:         "case-insensitive substring match",
+			flags:        scopeFlags{env: "OPS"},
+			serverScopes: knownScopes,
+			wantErr:      true,
+			errContains:  "ops-eu",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.serverErr {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				scopesHandler(tt.serverScopes)(w, r)
+			}))
+			defer server.Close()
+
+			client := newInternalTestClient(t, server)
+			err := tt.flags.validateScopes(t.Context(), client)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/providers/kg/commands_test.go
+++ b/internal/providers/kg/commands_test.go
@@ -1,4 +1,4 @@
-package kg
+package kg_test
 
 import (
 	"encoding/json"
@@ -6,22 +6,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/kg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/client-go/rest"
 )
-
-func newInternalTestClient(t *testing.T, server *httptest.Server) *Client {
-	t.Helper()
-	cfg := config.NamespacedRESTConfig{
-		Config:    rest.Config{Host: server.URL},
-		Namespace: "stack-123",
-	}
-	c, err := NewClient(cfg)
-	require.NoError(t, err)
-	return c
-}
 
 func scopesHandler(scopes map[string][]string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -38,45 +26,45 @@ func TestScopeFlags_ValidateScopes(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		flags       scopeFlags
+		name         string
+		flags        kg.ScopeFlags
 		serverScopes map[string][]string
-		serverErr   bool
-		wantErr     bool
-		errContains string
+		serverErr    bool
+		wantErr      bool
+		errContains  string
 	}{
 		{
 			name:         "no scope flags set — skips validation",
-			flags:        scopeFlags{},
+			flags:        kg.NewTestScopeFlags("", "", ""),
 			serverScopes: knownScopes,
 		},
 		{
 			name:         "exact match — no error",
-			flags:        scopeFlags{env: "ops-eu-south-0"},
+			flags:        kg.NewTestScopeFlags("ops-eu-south-0", "", ""),
 			serverScopes: knownScopes,
 		},
 		{
 			name:         "exact match multiple flags — no error",
-			flags:        scopeFlags{env: "ops-eu-south-0", namespace: "default"},
+			flags:        kg.NewTestScopeFlags("ops-eu-south-0", "", "default"),
 			serverScopes: knownScopes,
 		},
 		{
 			name:         "partial match — error with candidates",
-			flags:        scopeFlags{env: "ops"},
+			flags:        kg.NewTestScopeFlags("ops", "", ""),
 			serverScopes: knownScopes,
 			wantErr:      true,
 			errContains:  `did you mean one of: ops-eu-north-1, ops-eu-south-0`,
 		},
 		{
 			name:         "no candidates — lists known values",
-			flags:        scopeFlags{env: "totally-unknown"},
+			flags:        kg.NewTestScopeFlags("totally-unknown", "", ""),
 			serverScopes: knownScopes,
 			wantErr:      true,
 			errContains:  `known env values:`,
 		},
 		{
-			name:         "known values truncated at 10 with hint",
-			flags:        scopeFlags{env: "zzz-no-match"},
+			name:  "known values truncated at 10 with hint",
+			flags: kg.NewTestScopeFlags("zzz-no-match", "", ""),
 			serverScopes: map[string][]string{
 				"env": {"a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10", "a11"},
 			},
@@ -85,24 +73,24 @@ func TestScopeFlags_ValidateScopes(t *testing.T) {
 		},
 		{
 			name:         "multiple invalid flags — error lists all",
-			flags:        scopeFlags{env: "bad-env", site: "bad-site"},
+			flags:        kg.NewTestScopeFlags("bad-env", "bad-site", ""),
 			serverScopes: knownScopes,
 			wantErr:      true,
 			errContains:  "--env",
 		},
 		{
 			name:      "API error — best-effort, no error returned",
-			flags:     scopeFlags{env: "anything"},
+			flags:     kg.NewTestScopeFlags("anything", "", ""),
 			serverErr: true,
 		},
 		{
 			name:         "empty known values for dimension — skips that dimension",
-			flags:        scopeFlags{env: "whatever"},
+			flags:        kg.NewTestScopeFlags("whatever", "", ""),
 			serverScopes: map[string][]string{"env": {}},
 		},
 		{
 			name:         "case-insensitive substring match",
-			flags:        scopeFlags{env: "OPS"},
+			flags:        kg.NewTestScopeFlags("OPS", "", ""),
 			serverScopes: knownScopes,
 			wantErr:      true,
 			errContains:  "ops-eu",
@@ -120,8 +108,8 @@ func TestScopeFlags_ValidateScopes(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := newInternalTestClient(t, server)
-			err := tt.flags.validateScopes(t.Context(), client)
+			client := newTestClient(t, server)
+			err := tt.flags.ValidateScopes(t.Context(), client)
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -1,0 +1,16 @@
+package kg
+
+import "context"
+
+// ScopeFlags is an exported alias for scopeFlags, used only in tests.
+type ScopeFlags = scopeFlags
+
+// NewTestScopeFlags constructs a ScopeFlags for use in tests.
+func NewTestScopeFlags(env, site, namespace string) ScopeFlags {
+	return ScopeFlags{env: env, site: site, namespace: namespace}
+}
+
+// ValidateScopes wraps the unexported validateScopes method for testing.
+func (f ScopeFlags) ValidateScopes(ctx context.Context, c *Client) error {
+	return f.validateScopes(ctx, c)
+}


### PR DESCRIPTION
## Summary

- Adds best-effort scope validation to all `gcx kg` commands that accept `--env`, `--site`, or `--namespace` flags
- When a scope value doesn't match any known value, the command exits with an actionable error listing candidates (via case-insensitive substring match) or up to 10 known values with a hint to run `gcx kg scopes list`
- Validation is skipped silently if `ListEntityScopes` fails (network error, etc.) to avoid blocking on infra issues
- LLM-friendly error format: `unknown --env value "ops" — did you mean one of: ops-eu-south-0, ops-eu-north-1`

## Test plan

- [ ] Run `gcx kg entities list --env nonexistent` — should error with candidates or known values
- [ ] Run `gcx kg entities list --env ops` (with partial match) — should suggest `ops-eu-south-0`, etc.
- [ ] Run `gcx kg entities list` (no scope flags) — should skip validation entirely
- [ ] Verify commands still work normally when scope values are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)