### PR TITLE
feat: setup framework — interfaces, stubs, and orchestration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ internal/
 ├── cloud/       GCOM HTTP client for Grafana Cloud stack discovery
 ├── fleet/       Shared fleet base client (HTTP, auth, config — used by fleet provider and setup/instrumentation)
 ├── setup/
+│   ├── framework/        Setup framework: StatusDetectable/Setupable interfaces, AggregateStatus, Run orchestrator, prompt widgets, testhelpers
 │   └── instrumentation/  Manifest types, instrumentation client, optimistic lock comparison
 ├── resources/
 │   ├── *.go     Core types: Resource, Selector, Filter, Descriptor, Resources collection

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -177,6 +177,7 @@ Multiple auth mechanisms for different tiers.
 | [013](docs/adrs/appo11y-provider/001-cli-ux-and-resource-adapter-design.md) | App O11y provider: singleton TypedCRUD, ETag-as-annotation, verb naming | accepted |
 | [014](docs/adrs/instrumentation/001-instrumentation-provider-design.md) | Declarative Instrumentation Setup under `gcx setup` | proposed |
 | [015](docs/adrs/faro-provider/001-faro-provider-design.md) | Faro provider: CLI UX, TypedCRUD adapter, sourcemaps as sub-resource verbs | proposed |
+| [016](docs/adrs/setup-framework/001-setup-framework-interfaces-and-orchestration.md) | Setup Framework: StatusDetectable/Setupable interfaces, AggregateStatus, gcx setup run orchestration | accepted |
 
 See [docs/adrs/](docs/adrs/) for all ADRs.
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -81,6 +81,12 @@ agent mode detection, behavior changes, and opt-out mechanisms.
 - **STDOUT is the result, STDERR is the diagnostic.** Summary tables and
   resource data go to stdout. Failure details and progress feedback go to
   stderr. Both use structured formats (tables or JSON), not unstructured prose.
+- **Interactive wizard commands are exempt from the STDOUT=data rule.** Commands
+  that are TTY-guarded (refuse when stdin is not a terminal), agent-mode-blocked
+  (refuse with exit code 2 when `agent.IsAgentMode()` is true), and have no
+  machine-readable output surface may write prompts, previews, and interactive
+  prose to stdout. `gcx setup run` is the canonical example. These commands must
+  be listed in `docs/design/agent-mode.md § 6.4 Exempt Commands`.
 
 ## Push/Pull Philosophy
 
@@ -139,6 +145,12 @@ agent mode detection, behavior changes, and opt-out mechanisms.
 - No circular dependencies between packages.
 - Provider implementations (`internal/providers/*/`) may import core resource types but not
   other providers.
+- **`internal/providers` (top-level package) MUST NOT import `internal/setup/framework`.**
+  Individual provider packages (`internal/providers/*/`) may import `internal/setup/framework`
+  to implement `StatusDetectable` and `Setupable`. The top-level `internal/providers` package
+  (containing the registry) must not import `framework` — this would create a cycle since
+  `framework` imports `internal/providers` for discovery. Enforce via code review;
+  consider adding a `depguard` rule to `.golangci.yaml` when the project upgrades the linter config.
 - Query clients (`internal/query/*/`) bypass the k8s dynamic client — they call datasource
   HTTP APIs directly.
 - PromQL construction uses `github.com/grafana/promql-builder/go/promql`, not string formatting.

--- a/cmd/gcx/setup/command.go
+++ b/cmd/gcx/setup/command.go
@@ -1,13 +1,15 @@
 package setup
 
 import (
-	"fmt"
+	"errors"
 	"io"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/grafana/gcx/cmd/gcx/setup/instrumentation"
-	fleetbase "github.com/grafana/gcx/internal/fleet"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
-	instrum "github.com/grafana/gcx/internal/setup/instrumentation"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -31,28 +33,28 @@ func Command() *cobra.Command {
 	loader.BindFlags(cmd.PersistentFlags())
 
 	cmd.AddCommand(instrumentation.Command(loader))
-	cmd.AddCommand(newStatusCommand(loader))
+	cmd.AddCommand(NewStatusCommand())
 
 	return cmd
 }
 
 type setupStatusOpts struct {
-	IO setupStatusIO
+	IO cmdio.Options
 }
 
 func (o *setupStatusOpts) setup(flags *pflag.FlagSet) {
-	_ = flags // no flags yet — placeholder for future --output support
+	o.IO.RegisterCustomCodec("text", &statusTextCodec{})
+	o.IO.RegisterCustomCodec("wide", &statusTextCodec{})
+	o.IO.DefaultFormat("text")
+	o.IO.BindFlags(flags)
 }
 
 func (o *setupStatusOpts) Validate() error {
-	return nil
+	return o.IO.Validate()
 }
 
-// setupStatusIO is a minimal output interface for the aggregated status table.
-// Kept separate from output.Options since aggregated status has a fixed table format.
-type setupStatusIO struct{}
-
-func newStatusCommand(loader *providers.ConfigLoader) *cobra.Command {
+// NewStatusCommand returns the `setup status` subcommand. Exported for testing.
+func NewStatusCommand() *cobra.Command {
 	opts := &setupStatusOpts{}
 	cmd := &cobra.Command{
 		Use:   "status",
@@ -61,47 +63,51 @@ func newStatusCommand(loader *providers.ConfigLoader) *cobra.Command {
 			if err := opts.Validate(); err != nil {
 				return err
 			}
-
-			ctx := cmd.Context()
-
-			r, err := fleetbase.LoadClientWithStack(ctx, loader)
-			if err != nil {
-				return fmt.Errorf("setup: %w", err)
-			}
-			client := instrum.NewClient(r.Client)
-			promHdrs := instrum.PromHeadersFromStack(r.Stack)
-
-			monResp, err := client.RunK8sMonitoring(ctx, promHdrs)
-			if err != nil {
-				return fmt.Errorf("setup: %w", err)
-			}
-
-			enabled := "no"
-			if len(monResp.Clusters) > 0 {
-				enabled = "yes"
-			}
-			details := fmt.Sprintf("%d clusters", len(monResp.Clusters))
-
-			return writeSetupStatusTable(cmd.OutOrStdout(), []setupProductRow{
-				{Product: "instrumentation", Enabled: enabled, Health: "healthy", Details: details},
-			})
+			statuses := framework.AggregateStatus(cmd.Context(), 0)
+			return opts.IO.Encode(cmd.OutOrStdout(), statuses)
 		},
 	}
 	opts.setup(cmd.Flags())
 	return cmd
 }
 
-type setupProductRow struct {
-	Product string
-	Enabled string
-	Health  string
-	Details string
+type statusTextCodec struct{}
+
+func (c *statusTextCodec) Format() format.Format {
+	return "text"
 }
 
-func writeSetupStatusTable(w io.Writer, rows []setupProductRow) error {
-	t := style.NewTable("PRODUCT", "ENABLED", "HEALTH", "DETAILS")
-	for _, r := range rows {
-		t.Row(r.Product, r.Enabled, r.Health, r.Details)
+func (c *statusTextCodec) Encode(w io.Writer, data any) error {
+	statuses, ok := data.([]framework.ProductStatus)
+	if !ok {
+		return errors.New("statusTextCodec: expected []framework.ProductStatus")
+	}
+	t := style.NewTable("PRODUCT", "STATE", "DETAILS", "HINT")
+	for _, s := range statuses {
+		stateStr := string(s.State)
+		if style.IsStylingEnabled() {
+			stateStr = colorState(s.State)
+		}
+		t.Row(s.Product, stateStr, s.Details, s.SetupHint)
 	}
 	return t.Render(w)
+}
+
+func (c *statusTextCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("text codec does not support decoding")
+}
+
+func colorState(state framework.ProductState) string {
+	var color lipgloss.Color
+	switch state {
+	case framework.StateActive:
+		color = lipgloss.Color("#7EB26D")
+	case framework.StateConfigured:
+		color = lipgloss.Color("#EAB839")
+	case framework.StateError:
+		color = lipgloss.Color("#F2495C")
+	default:
+		color = style.ColorMuted
+	}
+	return lipgloss.NewStyle().Foreground(color).Render(string(state))
 }

--- a/cmd/gcx/setup/command.go
+++ b/cmd/gcx/setup/command.go
@@ -34,6 +34,7 @@ func Command() *cobra.Command {
 
 	cmd.AddCommand(instrumentation.Command(loader))
 	cmd.AddCommand(NewStatusCommand())
+	cmd.AddCommand(NewRunCommand(loader))
 
 	return cmd
 }

--- a/cmd/gcx/setup/command.go
+++ b/cmd/gcx/setup/command.go
@@ -64,7 +64,7 @@ func NewStatusCommand() *cobra.Command {
 			if err := opts.Validate(); err != nil {
 				return err
 			}
-			statuses := framework.AggregateStatus(cmd.Context(), 0)
+			statuses := framework.AggregateStatus(cmd.Context())
 			return opts.IO.Encode(cmd.OutOrStdout(), statuses)
 		},
 	}

--- a/cmd/gcx/setup/command_test.go
+++ b/cmd/gcx/setup/command_test.go
@@ -1,0 +1,292 @@
+package setup_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/setup"
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/grafana/gcx/internal/setup/framework/testhelpers"
+	"github.com/spf13/cobra"
+)
+
+// stubProvider implements providers.Provider with no-op methods.
+type stubProvider struct{ name string }
+
+func (s *stubProvider) Name() string                               { return s.name }
+func (s *stubProvider) ShortDesc() string                          { return "" }
+func (s *stubProvider) Commands() []*cobra.Command                 { return nil }
+func (s *stubProvider) Validate(_ map[string]string) error         { return nil }
+func (s *stubProvider) ConfigKeys() []providers.ConfigKey          { return nil }
+func (s *stubProvider) TypedRegistrations() []adapter.Registration { return nil }
+
+// statusProvider is a stubProvider that also implements framework.StatusDetectable.
+type statusProvider struct {
+	stubProvider
+
+	status_ *framework.ProductStatus
+	err     error
+}
+
+func (p *statusProvider) ProductName() string { return p.name }
+func (p *statusProvider) Status(_ context.Context) (*framework.ProductStatus, error) {
+	return p.status_, p.err
+}
+
+func runStatusCmd(t *testing.T, args []string) (string, error) {
+	t.Helper()
+	cmd := setup.NewStatusCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs(args)
+	err := cmd.ExecuteContext(context.Background())
+	return buf.String(), err
+}
+
+func TestStatusCommand_TextOutput(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(agent.ResetForTesting)
+
+	ps := []providers.Provider{
+		&statusProvider{
+			stubProvider: stubProvider{name: "slo"},
+			status_:      &framework.ProductStatus{Product: "slo", State: framework.StateActive, Details: "3 SLOs", SetupHint: ""},
+		},
+		&statusProvider{
+			stubProvider: stubProvider{name: "metrics"},
+			status_:      &framework.ProductStatus{Product: "metrics", State: framework.StateConfigured},
+		},
+		&statusProvider{
+			stubProvider: stubProvider{name: "alerts"},
+			status_:      &framework.ProductStatus{Product: "alerts", State: framework.StateNotConfigured, SetupHint: "run gcx alerts setup"},
+		},
+		// Plain provider (no StatusDetectable) — must not appear in output.
+		&stubProvider{name: "invisible"},
+	}
+	testhelpers.SetupTestRegistry(t, ps)
+
+	out, err := runStatusCmd(t, []string{"-o", "text"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Headers present
+	if !strings.Contains(out, "PRODUCT") {
+		t.Error("output missing PRODUCT header")
+	}
+	if !strings.Contains(out, "STATE") {
+		t.Error("output missing STATE header")
+	}
+
+	// All three status providers appear.
+	for _, name := range []string{"slo", "metrics", "alerts"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("output missing provider %q", name)
+		}
+	}
+
+	// State values present.
+	if !strings.Contains(out, "active") {
+		t.Error("output missing 'active' state")
+	}
+	if !strings.Contains(out, "not_configured") {
+		t.Error("output missing 'not_configured' state")
+	}
+
+	// Details present.
+	if !strings.Contains(out, "3 SLOs") {
+		t.Error("output missing details '3 SLOs'")
+	}
+
+	// Hint present.
+	if !strings.Contains(out, "run gcx alerts setup") {
+		t.Error("output missing setup hint")
+	}
+
+	// Alphabetical: alerts < metrics < slo
+	alertsIdx := strings.Index(out, "alerts")
+	metricsIdx := strings.Index(out, "metrics")
+	sloIdx := strings.Index(out, "slo")
+	if alertsIdx > metricsIdx || metricsIdx > sloIdx {
+		t.Errorf("output not in alphabetical order: alerts=%d metrics=%d slo=%d", alertsIdx, metricsIdx, sloIdx)
+	}
+
+	// Non-StatusDetectable provider must not appear.
+	if strings.Contains(out, "invisible") {
+		t.Error("output must not contain 'invisible' (not a StatusDetectable provider)")
+	}
+}
+
+func TestStatusCommand_JSONOutput(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(agent.ResetForTesting)
+	ps := []providers.Provider{
+		&statusProvider{
+			stubProvider: stubProvider{name: "synth"},
+			status_:      &framework.ProductStatus{Product: "synth", State: framework.StateActive, Details: "5 checks"},
+		},
+	}
+	testhelpers.SetupTestRegistry(t, ps)
+
+	out, err := runStatusCmd(t, []string{"-o", "json"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, `"product"`) {
+		t.Error("JSON output missing 'product' key")
+	}
+	if !strings.Contains(out, `"synth"`) {
+		t.Error("JSON output missing 'synth'")
+	}
+	if !strings.Contains(out, `"state"`) {
+		t.Error("JSON output missing 'state' key")
+	}
+	if !strings.Contains(out, `"active"`) {
+		t.Error("JSON output missing 'active'")
+	}
+	if !strings.Contains(out, `"5 checks"`) {
+		t.Error("JSON output missing details")
+	}
+}
+
+func TestStatusCommand_YAMLOutput(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(agent.ResetForTesting)
+	ps := []providers.Provider{
+		&statusProvider{
+			stubProvider: stubProvider{name: "slo"},
+			status_:      &framework.ProductStatus{Product: "slo", State: framework.StateConfigured},
+		},
+	}
+	testhelpers.SetupTestRegistry(t, ps)
+
+	out, err := runStatusCmd(t, []string{"-o", "yaml"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "product:") {
+		t.Error("YAML output missing 'product:' key")
+	}
+	if !strings.Contains(out, "slo") {
+		t.Error("YAML output missing 'slo'")
+	}
+	if !strings.Contains(out, "state:") {
+		t.Error("YAML output missing 'state:' key")
+	}
+	if !strings.Contains(out, "configured") {
+		t.Error("YAML output missing 'configured'")
+	}
+
+	// No ANSI color escape sequences in YAML output.
+	if strings.Contains(out, "\x1b[") {
+		t.Error("YAML output must not contain ANSI escape sequences")
+	}
+}
+
+func TestStatusCommand_AgentModeDefaultsToJSON(t *testing.T) {
+	agent.SetFlag(true)
+	t.Cleanup(func() { agent.SetFlag(false) })
+
+	ps := []providers.Provider{
+		&statusProvider{
+			stubProvider: stubProvider{name: "fleet"},
+			status_:      &framework.ProductStatus{Product: "fleet", State: framework.StateActive},
+		},
+	}
+	testhelpers.SetupTestRegistry(t, ps)
+
+	// No -o flag: agent mode must default to JSON.
+	out, err := runStatusCmd(t, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, `"product"`) {
+		t.Errorf("agent mode: expected JSON output, got: %s", out)
+	}
+	if !strings.Contains(out, `"fleet"`) {
+		t.Error("agent mode: expected fleet in JSON output")
+	}
+}
+
+func TestStatusCommand_ErrorProviderRendersAsStateError(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(agent.ResetForTesting)
+	ps := []providers.Provider{
+		&statusProvider{
+			stubProvider: stubProvider{name: "broken"},
+			err:          errors.New("connection refused"),
+		},
+		&statusProvider{
+			stubProvider: stubProvider{name: "healthy"},
+			status_:      &framework.ProductStatus{Product: "healthy", State: framework.StateActive},
+		},
+	}
+	testhelpers.SetupTestRegistry(t, ps)
+
+	out, err := runStatusCmd(t, []string{"-o", "text"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "broken") {
+		t.Error("output missing 'broken' provider")
+	}
+	if !strings.Contains(out, "error") {
+		t.Error("output missing 'error' state for broken provider")
+	}
+	if !strings.Contains(out, "connection refused") {
+		t.Error("output missing error details 'connection refused'")
+	}
+	if !strings.Contains(out, "healthy") {
+		t.Error("output missing 'healthy' provider — error must not cancel siblings")
+	}
+}
+
+func TestStatusCommand_EmptyRegistry(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(agent.ResetForTesting)
+	testhelpers.SetupTestRegistry(t, []providers.Provider{})
+
+	out, err := runStatusCmd(t, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No data rows, but command should succeed.
+	_ = out
+}
+
+func TestStatusCommand_WideOutputEqualsText(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(agent.ResetForTesting)
+	ps := []providers.Provider{
+		&statusProvider{
+			stubProvider: stubProvider{name: "oncall"},
+			status_:      &framework.ProductStatus{Product: "oncall", State: framework.StateActive, Details: "configured"},
+		},
+	}
+	testhelpers.SetupTestRegistry(t, ps)
+
+	outWide, err := runStatusCmd(t, []string{"-o", "wide"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(outWide, "oncall") {
+		t.Error("wide output missing 'oncall'")
+	}
+	if !strings.Contains(outWide, "active") {
+		t.Error("wide output missing 'active' state")
+	}
+}

--- a/cmd/gcx/setup/run.go
+++ b/cmd/gcx/setup/run.go
@@ -1,0 +1,83 @@
+package setup
+
+import (
+	"os"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// isInteractiveFn is a package-level hook that overrides terminal TTY detection for the run command.
+// When nil, framework.Run uses terminal.StdinIsTerminal. Only set in tests.
+var isInteractiveFn func() bool //nolint:gochecknoglobals
+
+// SetIsInteractiveForTest overrides the TTY check used by NewRunCommand for testing.
+// Call with nil to restore the default.
+func SetIsInteractiveForTest(fn func() bool) {
+	isInteractiveFn = fn
+}
+
+type runOpts struct {
+	loader *providers.ConfigLoader
+}
+
+func (o *runOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *runOpts) Validate() error { return nil }
+
+// NewRunCommand returns the `setup run` subcommand. Exported for testing.
+func NewRunCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &runOpts{loader: loader}
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Interactive orchestrator for product setup.",
+		Long: `Run the interactive setup flow to onboard and configure Grafana Cloud products.
+
+This command is interactive and requires a terminal (stdin must be a TTY).
+In agent mode or non-interactive environments, use the per-product setup commands instead:
+  gcx <product> setup
+
+For example:
+  gcx slo setup
+  gcx synth setup`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			if agent.IsAgentMode() {
+				cmd.PrintErrln("gcx setup run is not available in agent mode.")
+				cmd.PrintErrln("Use per-product setup commands instead: gcx <product> setup")
+				ec := fail.ExitUsageError
+				return &fail.DetailedError{
+					Summary:  "setup run is not available in agent mode",
+					ExitCode: &ec,
+				}
+			}
+
+			fopts := framework.Options{
+				In:            cmd.InOrStdin(),
+				StdinFile:     os.Stdin,
+				Out:           cmd.OutOrStdout(),
+				Err:           cmd.ErrOrStderr(),
+				IsInteractive: isInteractiveFn,
+			}
+			summary, err := framework.Run(cmd.Context(), fopts)
+			if err != nil {
+				ec := fail.ExitUsageError
+				return &fail.DetailedError{
+					Summary:  err.Error(),
+					ExitCode: &ec,
+				}
+			}
+			_ = summary
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/cmd/gcx/setup/run.go
+++ b/cmd/gcx/setup/run.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/grafana/gcx/cmd/gcx/fail"
@@ -44,6 +45,7 @@ In agent mode or non-interactive environments, use the per-product setup command
 For example:
   gcx slo setup
   gcx synth setup`,
+		Annotations: map[string]string{agent.AnnotationTokenCost: "small"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.Validate(); err != nil {
 				return err
@@ -74,7 +76,20 @@ For example:
 					ExitCode: &ec,
 				}
 			}
-			_ = summary
+
+			if len(summary.Cancelled) > 0 || cmd.Context().Err() != nil {
+				ec := fail.ExitCancelled
+				return &fail.DetailedError{
+					Summary:  "setup cancelled",
+					ExitCode: &ec,
+				}
+			}
+
+			statuses := framework.AggregateStatus(cmd.Context(), 0)
+			if encErr := (&statusTextCodec{}).Encode(cmd.OutOrStdout(), statuses); encErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not render status: %v\n", encErr)
+			}
+
 			return nil
 		},
 	}

--- a/cmd/gcx/setup/run.go
+++ b/cmd/gcx/setup/run.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/agent"
+	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
@@ -23,16 +24,23 @@ func SetIsInteractiveForTest(fn func() bool) {
 }
 
 type runOpts struct {
-	loader *providers.ConfigLoader
+	IO cmdio.Options
 }
 
-func (o *runOpts) setup(_ *pflag.FlagSet) {}
+func (o *runOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("text", &statusTextCodec{})
+	o.IO.RegisterCustomCodec("wide", &statusTextCodec{})
+	o.IO.DefaultFormat("text")
+	o.IO.BindFlags(flags)
+}
 
-func (o *runOpts) Validate() error { return nil }
+func (o *runOpts) Validate() error {
+	return o.IO.Validate()
+}
 
 // NewRunCommand returns the `setup run` subcommand. Exported for testing.
 func NewRunCommand(loader *providers.ConfigLoader) *cobra.Command {
-	opts := &runOpts{loader: loader}
+	opts := &runOpts{}
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Interactive orchestrator for product setup.",
@@ -85,8 +93,16 @@ For example:
 				}
 			}
 
-			statuses := framework.AggregateStatus(cmd.Context(), 0)
-			if encErr := (&statusTextCodec{}).Encode(cmd.OutOrStdout(), statuses); encErr != nil {
+			if len(summary.Failed) > 0 {
+				ec := fail.ExitPartialFailure
+				return &fail.DetailedError{
+					Summary:  "one or more setup operations failed",
+					ExitCode: &ec,
+				}
+			}
+
+			statuses := framework.AggregateStatus(cmd.Context())
+			if encErr := opts.IO.Encode(cmd.OutOrStdout(), statuses); encErr != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not render status: %v\n", encErr)
 			}
 

--- a/cmd/gcx/setup/run_test.go
+++ b/cmd/gcx/setup/run_test.go
@@ -1,0 +1,120 @@
+package setup_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/cmd/gcx/setup"
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/grafana/gcx/internal/setup/framework/testhelpers"
+)
+
+// setupProvider implements both providers.Provider and framework.Setupable for run tests.
+type setupProvider struct {
+	stubProvider
+	categories []framework.InfraCategory
+}
+
+func (p *setupProvider) ProductName() string { return p.name }
+func (p *setupProvider) Status(_ context.Context) (*framework.ProductStatus, error) {
+	return &framework.ProductStatus{Product: p.name, State: framework.StateNotConfigured}, nil
+}
+func (p *setupProvider) InfraCategories() []framework.InfraCategory { return p.categories }
+func (p *setupProvider) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+func (p *setupProvider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
+func (p *setupProvider) Setup(_ context.Context, _ map[string]string) error         { return nil }
+
+func TestRunCommand_AgentModeRefusal(t *testing.T) {
+	agent.SetFlag(true)
+	t.Cleanup(agent.ResetForTesting)
+
+	cmd := setup.NewRunCommand(nil)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error for agent mode, got nil")
+	}
+
+	var detailedErr *fail.DetailedError
+	if !errors.As(err, &detailedErr) {
+		t.Fatalf("expected *fail.DetailedError, got %T: %v", err, err)
+	}
+	if detailedErr.ExitCode == nil || *detailedErr.ExitCode != fail.ExitUsageError {
+		t.Errorf("expected exit code %d, got %v", fail.ExitUsageError, detailedErr.ExitCode)
+	}
+	if !strings.Contains(stderr.String(), "not available in agent mode") {
+		t.Errorf("expected stderr to contain 'not available in agent mode', got: %q", stderr.String())
+	}
+}
+
+func TestRunCommand_ZeroCategories(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(agent.ResetForTesting)
+
+	setup.SetIsInteractiveForTest(func() bool { return true })
+	t.Cleanup(func() { setup.SetIsInteractiveForTest(nil) })
+
+	ps := []providers.Provider{
+		&setupProvider{
+			stubProvider: stubProvider{name: "nocat"},
+			categories:   nil,
+		},
+	}
+	testhelpers.SetupTestRegistry(t, ps)
+
+	cmd := setup.NewRunCommand(nil)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.ExecuteContext(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "No interactive setup flows available") {
+		t.Errorf("expected stdout to contain 'No interactive setup flows available', got: %q", stdout.String())
+	}
+}
+
+func TestRunCommand_NonTTY(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(agent.ResetForTesting)
+
+	// Ensure no TTY override from other tests.
+	setup.SetIsInteractiveForTest(nil)
+
+	cmd := setup.NewRunCommand(nil)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error for non-TTY stdin, got nil")
+	}
+
+	var detailedErr *fail.DetailedError
+	if !errors.As(err, &detailedErr) {
+		t.Fatalf("expected *fail.DetailedError, got %T: %v", err, err)
+	}
+	if detailedErr.ExitCode == nil || *detailedErr.ExitCode != fail.ExitUsageError {
+		t.Errorf("expected exit code %d, got %v", fail.ExitUsageError, detailedErr.ExitCode)
+	}
+}

--- a/cmd/gcx/setup/run_test.go
+++ b/cmd/gcx/setup/run_test.go
@@ -20,6 +20,7 @@ type setupProvider struct {
 	stubProvider
 
 	categories []framework.InfraCategory
+	setupErr   error // returned by Setup(); nil means success
 }
 
 func (p *setupProvider) ProductName() string { return p.name }
@@ -31,7 +32,7 @@ func (p *setupProvider) ResolveChoices(_ context.Context, _ string) ([]string, e
 	return nil, nil
 }
 func (p *setupProvider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
-func (p *setupProvider) Setup(_ context.Context, _ map[string]string) error         { return nil }
+func (p *setupProvider) Setup(_ context.Context, _ map[string]string) error         { return p.setupErr }
 
 func TestRunCommand_AgentModeRefusal(t *testing.T) {
 	agent.SetFlag(true)
@@ -163,5 +164,52 @@ func TestRunCommand_CancelledSummary(t *testing.T) {
 	}
 	if detailedErr.ExitCode == nil || *detailedErr.ExitCode != fail.ExitCancelled {
 		t.Errorf("expected exit code %d, got %v", fail.ExitCancelled, detailedErr.ExitCode)
+	}
+}
+
+func TestRunCommand_FailedExitCode(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(agent.ResetForTesting)
+
+	setup.SetIsInteractiveForTest(func() bool { return true })
+	t.Cleanup(func() { setup.SetIsInteractiveForTest(nil) })
+
+	ps := []providers.Provider{
+		&setupProvider{
+			stubProvider: stubProvider{name: "svc"},
+			setupErr:     errors.New("boom"),
+			categories: []framework.InfraCategory{
+				{
+					ID:    "infra",
+					Label: "Infrastructure",
+					Params: []framework.SetupParam{
+						{Name: "endpoint", Prompt: "Endpoint", Kind: framework.ParamKindText, Required: true},
+					},
+				},
+			},
+		},
+	}
+	testhelpers.SetupTestRegistry(t, ps)
+
+	cmd := setup.NewRunCommand(nil)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	// Enter (select all categories) + param value + "y" (confirm preview → triggers Setup())
+	cmd.SetIn(strings.NewReader("\nval\ny\n"))
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error when setup operation fails, got nil")
+	}
+
+	var detailedErr *fail.DetailedError
+	if !errors.As(err, &detailedErr) {
+		t.Fatalf("expected *fail.DetailedError, got %T: %v", err, err)
+	}
+	if detailedErr.ExitCode == nil || *detailedErr.ExitCode != fail.ExitPartialFailure {
+		t.Errorf("expected exit code %d (ExitPartialFailure), got %v", fail.ExitPartialFailure, detailedErr.ExitCode)
 	}
 }

--- a/cmd/gcx/setup/run_test.go
+++ b/cmd/gcx/setup/run_test.go
@@ -18,6 +18,7 @@ import (
 // setupProvider implements both providers.Provider and framework.Setupable for run tests.
 type setupProvider struct {
 	stubProvider
+
 	categories []framework.InfraCategory
 }
 
@@ -86,8 +87,8 @@ func TestRunCommand_ZeroCategories(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(stdout.String(), "No interactive setup flows available") {
-		t.Errorf("expected stdout to contain 'No interactive setup flows available', got: %q", stdout.String())
+	if !strings.Contains(stderr.String(), "No interactive setup flows available") {
+		t.Errorf("expected stderr to contain 'No interactive setup flows available', got: %q", stderr.String())
 	}
 }
 
@@ -116,5 +117,51 @@ func TestRunCommand_NonTTY(t *testing.T) {
 	}
 	if detailedErr.ExitCode == nil || *detailedErr.ExitCode != fail.ExitUsageError {
 		t.Errorf("expected exit code %d, got %v", fail.ExitUsageError, detailedErr.ExitCode)
+	}
+}
+
+func TestRunCommand_CancelledSummary(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(agent.ResetForTesting)
+
+	setup.SetIsInteractiveForTest(func() bool { return true })
+	t.Cleanup(func() { setup.SetIsInteractiveForTest(nil) })
+
+	ps := []providers.Provider{
+		&setupProvider{
+			stubProvider: stubProvider{name: "svc"},
+			categories: []framework.InfraCategory{
+				{
+					ID:    "infra",
+					Label: "Infrastructure",
+					Params: []framework.SetupParam{
+						{Name: "endpoint", Prompt: "Endpoint", Kind: framework.ParamKindText, Required: true},
+					},
+				},
+			},
+		},
+	}
+	testhelpers.SetupTestRegistry(t, ps)
+
+	cmd := setup.NewRunCommand(nil)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	// Enter (select all categories) + param value + "n" (decline preview)
+	cmd.SetIn(strings.NewReader("\nval\nn\n"))
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error for cancelled setup, got nil")
+	}
+
+	var detailedErr *fail.DetailedError
+	if !errors.As(err, &detailedErr) {
+		t.Fatalf("expected *fail.DetailedError, got %T: %v", err, err)
+	}
+	if detailedErr.ExitCode == nil || *detailedErr.ExitCode != fail.ExitCancelled {
+		t.Errorf("expected exit code %d, got %v", fail.ExitCancelled, detailedErr.ExitCode)
 	}
 }

--- a/docs/adrs/setup-framework/001-setup-framework-interfaces-and-orchestration.md
+++ b/docs/adrs/setup-framework/001-setup-framework-interfaces-and-orchestration.md
@@ -1,0 +1,436 @@
+# Setup Framework: Interfaces and Orchestration
+
+**Created**: 2026-04-16
+**Status**: proposed
+**Bead**: TBD
+**Supersedes**: none
+
+<!-- Status lifecycle: proposed -> accepted -> deprecated | superseded -->
+
+## Context
+
+gcx has 16+ providers but no unified way to answer "what's configured,
+what's broken, and what should I do next?" The current `gcx setup status`
+is hardcoded to show only instrumentation. Each provider's onboarding is
+independent, with no orchestrated path from "just logged in" to "products
+working."
+
+The [UX consistency design](docs/plans/2026-04-14-ux-consistency-design.md)
+(Area 2) specifies a setup framework with three entry points:
+
+- **`gcx setup status`** — aggregated product status dashboard.
+- **`gcx setup run`** — interactive multi-select onboarding orchestrator;
+  re-runnable, skips already-configured products.
+- **`gcx <provider> setup`** — per-provider non-interactive setup commands.
+
+This ADR decides the interfaces, contracts, and orchestration model.
+Detailed implementation (timeouts, package layout, error-message
+conventions, codec wiring) belongs in the spec that follows this ADR.
+
+**Key constraint** ([CONSTITUTION.md](CONSTITUTION.md)): providers are
+self-registering plugins. The framework must discover setup capabilities
+through the existing `providers.All()` registry, not hard-coded lists.
+
+**Scope**: framework interfaces, orchestration model, and stub
+implementations on all existing providers so `gcx setup status` shows
+every provider from day one. Rich per-provider setup logic (synth auto-
+discovery, Faro app creation, etc.) remains Area 7.
+
+**Related**: #287 (unified setup framework), #319 (setup status dashboard),
+[docs/adrs/instrumentation/001-instrumentation-provider-design.md](docs/adrs/instrumentation/001-instrumentation-provider-design.md)
+
+## Decision
+
+### 1. Two Optional Interfaces: `StatusDetectable` and `Setupable`
+
+The framework defines two optional interfaces discovered via Go type
+assertion on `providers.All()`. `Setupable` embeds `StatusDetectable`,
+enforcing at compile time that anything in the run flow also appears in
+the status table.
+
+```go
+// StatusDetectable is the minimum contract to appear in `gcx setup status`.
+// Status-only providers (e.g. signal providers with no setup flow) implement
+// just this.
+type StatusDetectable interface {
+    // ProductName returns the human-readable product name
+    // (e.g., "Synthetic Monitoring").
+    ProductName() string
+
+    // Status reports the provider's current configuration state.
+    // Must respect ctx deadline. "Not configured" is a valid state,
+    // not an error.
+    Status(ctx context.Context) (*ProductStatus, error)
+}
+
+// Setupable is the full contract for providers that participate in
+// `gcx setup run`. Setupable embeds StatusDetectable — you cannot set
+// up something you cannot describe.
+type Setupable interface {
+    StatusDetectable
+
+    // ValidateSetup validates params without side effects. Called by
+    // the orchestrator before Setup and by the CLI setup command during
+    // preflight. Returns nil if params are acceptable. Errors are
+    // user-facing and should guide correction.
+    ValidateSetup(ctx context.Context, params map[string]string) error
+
+    // Setup runs the provider's setup flow. Called by both the CLI
+    // setup command and the `gcx setup run` orchestrator. Providers
+    // without a real setup flow are not Setupable — they implement
+    // StatusDetectable only.
+    Setup(ctx context.Context, params map[string]string) error
+
+    // InfraCategories returns the infrastructure categories this
+    // provider handles for `gcx setup run`. Returns nil if the provider
+    // does not participate in guided run (but still has a CLI
+    // `gcx <provider> setup` command).
+    InfraCategories() []InfraCategory
+
+    // ResolveChoices returns dynamic choices for a parameter whose
+    // SetupParam has Kind=choice/multi_choice and empty static Choices.
+    // Returns nil, nil if the provider has no dynamic choices.
+    ResolveChoices(ctx context.Context, paramName string) ([]string, error)
+}
+```
+
+Providers that don't implement either interface remain fully functional
+as regular providers but are invisible to the setup framework.
+
+### 2. `ProductStatus` and `ProductState`
+
+```go
+type ProductState string
+
+const (
+    StateNotConfigured ProductState = "not_configured"
+    StateConfigured    ProductState = "configured"
+    StateActive        ProductState = "active"
+    StateError         ProductState = "error"
+)
+
+type ProductStatus struct {
+    Product   string       // same as ProductName()
+    State     ProductState
+    Details   string       // human-readable summary; may be empty
+    SetupHint string       // CLI command to configure; empty when active
+}
+```
+
+Providers determine state using whatever criteria makes sense for them.
+A typical detection combines the provider's existing `ConfigKeys()`
+(absent = `not_configured`) with an API probe (unreachable = `error`,
+empty resources = `configured`, resources present = `active`). The
+framework does not prescribe a waterfall — providers own their state
+semantics.
+
+### 3. `gcx setup status` — Aggregation Contract
+
+The status command iterates `providers.All()`, type-asserts
+`StatusDetectable`, and calls `Status()` on each in parallel. Per-provider
+failures must not block the aggregate:
+
+- Each `Status()` call runs under an enforced per-provider timeout.
+- An error from `Status()` is surfaced as a `StateError` row with the
+  error message in `Details` — it never cancels other providers' calls.
+- Rows are rendered in a deterministic order (alphabetical by product
+  name) regardless of call completion order.
+
+The table uses the standard gcx codec system (`text|json|yaml|wide`),
+not a bespoke format. Human mode color-codes state
+(gray/yellow/green/red). Agent mode suppresses color and truncation.
+
+### 4. `InfraCategory` and `SetupParam`
+
+```go
+type InfraCategoryID string
+
+type InfraCategory struct {
+    ID     InfraCategoryID
+    Label  string        // multi-select label; first provider's label wins
+    Params []SetupParam
+}
+
+type ParamKind string
+
+const (
+    ParamKindText        ParamKind = "text"
+    ParamKindBool        ParamKind = "bool"
+    ParamKindChoice      ParamKind = "choice"       // single select
+    ParamKindMultiChoice ParamKind = "multi_choice" // multi-select
+)
+
+type SetupParam struct {
+    Name     string
+    Prompt   string
+    Kind     ParamKind
+    Required bool
+    Default  string
+
+    // Secret indicates the value is sensitive. The orchestrator masks
+    // input during prompting and renders "***" in the preview.
+    Secret bool
+
+    // Choices is used only when Kind is choice/multi_choice. If empty
+    // and Kind requires choices, the orchestrator calls ResolveChoices.
+    Choices []string
+}
+```
+
+`SetupParam` drives three things:
+- Interactive prompt widget and input masking during `setup run`.
+- Flag registration on the CLI `gcx <provider> setup` command.
+- Preview rendering before confirmation.
+
+### 5. Provider Setup Command Contract
+
+Every provider that implements `Setupable` must expose
+`gcx <provider-area> setup` as a Cobra subcommand. The Cobra command
+is a thin wrapper around `Setupable.Setup()` — one implementation,
+two entry points.
+
+| Requirement | Contract |
+|-------------|----------|
+| Location | `gcx <provider-area> setup` |
+| Interaction | Non-interactive; flags only. No stdin prompts. |
+| Structure | Standard opts pattern (opts struct + setup(flags) + Validate + constructor). |
+| Idempotency | Safe to re-run. Detects existing configuration and skips or updates. |
+| Output | Success: structured mutation summary via codec system. Failure: error to stderr, non-zero exit. |
+| Agent-friendly | Must work in agent mode (JSON output, no prompts). |
+
+The CLI command collects flag values, builds the params map (same shape
+the orchestrator uses), calls `ValidateSetup`, then `Setup`. Agents invoke
+this command directly rather than `gcx setup run`.
+
+### 6. `gcx setup run` — Orchestration Model
+
+The run command is interactive, re-runnable, and idempotent. Subsequent
+invocations skip already-configured products and fill in gaps.
+
+Orchestration flow:
+
+1. **Discovery** — collect `InfraCategories()` from every `Setupable`.
+   Multiple providers may register the same category ID; the first
+   encountered label wins.
+
+2. **Category selection** — present a multi-select of infrastructure
+   categories. User picks what they have.
+
+3. **Provider resolution** — map selected categories to the providers
+   that handle them. Providers are processed sequentially in
+   alphabetical order.
+
+4. **Per-provider loop**:
+   - **Skip check** — call `Status()`. If `configured` or `active`,
+     print "already configured, skipping" and continue.
+   - **Parameter collection** — for each `SetupParam`:
+     - If `Kind` is choice/multi_choice and `Choices` is empty, call
+       `ResolveChoices` to populate options.
+     - Render the input widget matching `Kind` (text / bool / select /
+       multi-select). Mask input when `Secret` is set.
+     - Collect the value into the params map.
+   - **Validation** — call `ValidateSetup`. On failure, print the error
+     and re-run parameter collection with previously-collected values as
+     defaults. Loop until validation passes or the user cancels.
+
+5. **Preview and confirmation** — before any mutation, display the
+   configuration summary:
+
+   ```
+   About to configure:
+
+     Synthetic Monitoring
+       url:        https://example.com
+       frequency:  60s
+       probes:     Atlanta, London, Tokyo
+
+     Frontend Observability
+       name:       my-app
+       sourcemaps: enabled
+
+     OnCall
+
+   Continue? [Y/n]
+   ```
+
+   Providers with no parameters show the name only. Secret values render
+   as `***`.
+
+6. **Execution** — for each confirmed provider, sequentially:
+   - Call `Setup(ctx, params)`. Stream progress to stderr.
+   - On error, log and continue to the next provider. Partial completion
+     is valid state; re-running `setup run` retries failed providers
+     because they will not reach `configured` state.
+
+7. **Summary** — render the status table showing post-run state.
+
+Ctrl-C at any point prints a summary of what completed and what remains,
+then exits. Completed setups are not rolled back.
+
+**Agent mode**: `gcx setup run` refuses in agent mode and points to
+individual provider setup commands. The orchestrator is inherently
+interactive; agents already know the exact flags and should invoke
+`gcx <provider> setup` directly.
+
+**Validation retry targeting**: on validation failure, the orchestrator
+re-prompts all fields for that provider with previously-collected values
+pre-filled as defaults. The user presses Enter to accept fields that
+were correct and corrects the offending one. This avoids parsing
+validator error messages to target specific fields — a deliberate
+simplicity trade-off (see rejected alternatives).
+
+**Concurrency**: `Status()` calls in section 3 are parallel. `Setup()`
+calls here are sequential. The two operations have different
+trade-offs: `Status()` is read-only, fast, and its output is a single
+aggregated table rendered at the end — parallelism is pure win.
+`Setup()` has side effects, streams progress to the user, may have
+cross-provider ordering concerns (instrumentation → metrics/logs flow),
+and is typically invoked for a small N (1–5 providers). Sequential
+execution keeps output legible, error attribution clear, and the door
+open to future dependency-aware ordering.
+
+### 7. Stub Implementations on Existing Providers
+
+To validate the interfaces and populate the status table from day one,
+every existing provider gets a minimal implementation:
+
+- **Signal and data providers without real setup flows** (metrics, logs,
+  traces, profiles, etc.) implement `StatusDetectable` only. `Status()`
+  returns a basic config-key-presence check using the provider's
+  existing `ConfigKeys()`. No API probing in the stub.
+- **Providers that will eventually support setup** (synth, frontend,
+  appo11y, etc.) implement `Setupable` with `Setup()` returning
+  `ErrSetupNotSupported` and `InfraCategories()` returning `nil`. They
+  show up in the status table but not yet in `setup run`.
+
+Area 7 then progressively replaces stubs with rich implementations —
+real API probing in `Status()`, working `Setup()` flows, populated
+`InfraCategories()` — one provider at a time, without framework changes.
+
+## Rejected Alternatives
+
+- **Single combined interface** (`SetupProvider` with all 6 methods):
+  initially chosen when the interface had 4 methods, reconsidered once
+  `ValidateSetup` and `ResolveChoices` were added. Status-only providers
+  would carry four nil-returning stubs out of six. The embedded-interface
+  split keeps the status-only case clean while preserving the invariant
+  that setupable implies detectable.
+
+- **Generic `SetupProvider[T]`** with typed `Setup(ctx, opts T)`:
+  type-erased iteration (`providers.All()`) cannot discover generic
+  interfaces. Same wall that led `TypedCRUD[T]` to pair with
+  `AsAdapter()` — typed inside a provider, untyped at the framework
+  boundary. Providers get type safety via internal opts structs; the
+  `map[string]string` is the plugin-uniform envelope.
+
+- **`map[string]any` params**: `any` forces type assertions at every
+  call site without adding safety. Setup input originates as strings
+  (argv flags, stdin prompts) — `strconv.Atoi` / `time.ParseDuration`
+  in the provider's param parser is the right place for typing.
+  Matches the existing `Provider.Validate(cfg map[string]string)`
+  pattern.
+
+- **Three-way interface split** (StatusDetectable → Setupable →
+  WizardCapable): tempting symmetry, but providers almost never have
+  a non-wizard setup flow. The two-way split covers the real cases;
+  `InfraCategories() == nil` already expresses "setupable but not in
+  the guided run."
+
+- **Descriptor-based approach** (provider returns a `SetupDescriptor`
+  struct; framework executes probing and command generation): more
+  uniform but requires `ProbeFunc` escape hatches for providers with
+  unusual detection logic (synth auto-discovery, fleet multi-cluster),
+  eroding the uniformity benefit. Method-based interfaces give each
+  provider full flexibility while the framework controls orchestration.
+
+- **Extending the `Provider` interface** with setup methods: conflates
+  "registered provider" with "setup-capable provider" and forces every
+  existing provider to implement setup stubs as part of core `Provider`.
+  Optional interfaces via type assertion keep the concerns separate.
+
+- **Subprocess invocation** from the run orchestrator
+  (`exec "gcx" "synth" "setup" ...`): adds cold-start overhead, loses
+  in-process context and logging, and introduces PATH/binary-location
+  fragility. Direct `Setup()` method calls are the right primitive; the
+  Cobra command is a thin wrapper around it.
+
+- **Concurrent `Setup()` execution**: small N, cross-provider ordering
+  concerns (instrumentation → metrics/logs), progress streaming
+  interleaving, and harder error attribution. Sequential execution is
+  strictly better for v1. If we later find a real opportunity (two
+  provably independent providers each taking 30+ seconds), we add
+  `ConcurrencySafe() bool` or a `--parallel` flag — not v1.
+
+- **CLI-command preview** (showing `gcx synth setup --url ...` commands
+  before confirmation): power-user feature; default preview shows
+  selected products and collected values. Can be surfaced later behind
+  `--dry-run` or `--show-commands`.
+
+- **Field-level validation error targeting** (re-prompt only the bad
+  field): requires a structured error protocol between
+  `ValidateSetup` and the orchestrator. Deferred in favor of
+  full-param re-prompting with previous values as defaults. Good
+  enough for v1; revisit if providers demand it.
+
+- **Rich choice metadata** (`[]Choice{Value, Description}` from
+  `ResolveChoices`): `[]string` is sufficient for v1. Evolve when a
+  provider genuinely needs descriptions alongside values.
+
+- **Dependency-aware provider ordering** (e.g., instrumentation before
+  metrics): alphabetical is sufficient initially. If ordering needs
+  emerge, add a `Dependencies() []string` method or priority field
+  on `InfraCategory` — not v1.
+
+## Consequences
+
+### Positive
+
+- **Self-registering**: adding setup to a new provider requires only
+  implementing the interface on its existing type.
+- **Incremental adoption**: stubs ship on day one; rich implementations
+  land provider-by-provider in Area 7 without framework changes.
+- **Status-only path is cheap**: providers that don't need setup flows
+  implement 2 methods total via `StatusDetectable`.
+- **Embedding enforces invariants**: `Setupable` embeds
+  `StatusDetectable` at compile time. Can't be setupable without being
+  detectable.
+- **Agent-friendly**: `Setup()` is directly callable from in-process
+  orchestration; `gcx setup status --output json` gives agents a
+  structured view; `gcx <provider> setup` is the non-interactive
+  entry point agents already want.
+- **Error isolation**: one broken provider's `Status()` can't block
+  the table or other providers' setup.
+
+### Negative
+
+- **Consistency risk**: each provider owns its `Status()`, `Setup()`,
+  and `ValidateSetup()` logic. Without guidelines, semantics may
+  drift across providers. Mitigated by code review and the stub-first
+  rollout (stubs establish a minimum bar before rich implementations
+  land).
+- **Two interfaces to understand**: modest learning overhead. Offset
+  by the standard Go embedding idiom (`io.ReadWriter` embeds
+  `io.Reader` and `io.Writer`).
+- **`Setup()` surface area**: `params map[string]string` is a loose
+  contract. Providers must document expected keys; the CLI command's
+  flags serve as the canonical documentation and the `SetupParam`
+  declarations serve as the declarative schema.
+
+### Follow-up Work
+
+- **Spec** for framework implementation (timeouts, package layout,
+  error-message conventions, codec wiring) — the concrete plan that
+  turns this ADR into code.
+- **Area 7**: progressively replace stubs with rich `Status()` probes,
+  working `Setup()` flows, populated `InfraCategories()`, and
+  `ResolveChoices()` for dynamic wizards.
+- **Future**: field-level validation error targeting if providers
+  demand it.
+- **Future**: `ConcurrencySafe()` or `--parallel` flag if real
+  independent-setup opportunities emerge.
+- **Future**: `gcx setup doctor` — deeper health checks beyond what
+  status shows (token expiry, API version compatibility).
+- **Future**: dependency-aware provider ordering if cross-provider
+  dependencies become common.
+- **Future**: `--dry-run` / `--show-commands` on `setup run` for
+  power users who want the equivalent CLI commands.

--- a/docs/design/agent-mode.md
+++ b/docs/design/agent-mode.md
@@ -60,4 +60,10 @@ Commands that produce non-data output are exempt from format switching:
 - `serve` — starts a long-running server
 - `push`, `pull` — output is status messages, not data
 
+**Interactive wizard commands** (TTY-guarded + agent-mode-blocked) are additionally
+exempt from the STDOUT=data rule. Their prompts, previews, and prose may go to stdout:
+- `gcx setup run` — interactive product setup orchestrator; refuses agent mode with
+  exit code 2 and refuses non-TTY stdin. Equivalent machine-readable output is
+  available via `gcx setup status` and per-product `gcx <product> setup` commands.
+
 See [environment-variables.md § Agent Mode Variables](environment-variables.md#agent-mode-variables) for the full variable reference.

--- a/docs/reference/cli/gcx_appo11y.md
+++ b/docs/reference/cli/gcx_appo11y.md
@@ -25,4 +25,5 @@ Manage Grafana App Observability settings
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx appo11y overrides](gcx_appo11y_overrides.md)	 - Manage App Observability metrics generator overrides.
 * [gcx appo11y settings](gcx_appo11y_settings.md)	 - Manage App Observability plugin settings.
+* [gcx appo11y setup](gcx_appo11y_setup.md)	 - Set up appo11y (not yet implemented).
 

--- a/docs/reference/cli/gcx_appo11y_setup.md
+++ b/docs/reference/cli/gcx_appo11y_setup.md
@@ -1,17 +1,15 @@
-## gcx setup status
+## gcx appo11y setup
 
-Show aggregated setup status across all products.
+Set up appo11y (not yet implemented).
 
 ```
-gcx setup status [flags]
+gcx appo11y setup [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -h, --help   help for setup
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ gcx setup status [flags]
 
 ### SEE ALSO
 
-* [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
+* [gcx appo11y](gcx_appo11y.md)	 - Manage Grafana App Observability settings
 

--- a/docs/reference/cli/gcx_fleet.md
+++ b/docs/reference/cli/gcx_fleet.md
@@ -25,5 +25,6 @@ Manage Grafana Fleet Management pipelines and collectors
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx fleet collectors](gcx_fleet_collectors.md)	 - Manage Fleet Management collectors.
 * [gcx fleet pipelines](gcx_fleet_pipelines.md)	 - Manage Fleet Management pipelines.
+* [gcx fleet setup](gcx_fleet_setup.md)	 - Set up fleet (not yet implemented).
 * [gcx fleet tenant](gcx_fleet_tenant.md)	 - Manage Fleet Management tenant settings.
 

--- a/docs/reference/cli/gcx_fleet_setup.md
+++ b/docs/reference/cli/gcx_fleet_setup.md
@@ -1,17 +1,15 @@
-## gcx setup status
+## gcx fleet setup
 
-Show aggregated setup status across all products.
+Set up fleet (not yet implemented).
 
 ```
-gcx setup status [flags]
+gcx fleet setup [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -h, --help   help for setup
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ gcx setup status [flags]
 
 ### SEE ALSO
 
-* [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
+* [gcx fleet](gcx_fleet.md)	 - Manage Grafana Fleet Management pipelines and collectors
 

--- a/docs/reference/cli/gcx_frontend.md
+++ b/docs/reference/cli/gcx_frontend.md
@@ -24,5 +24,5 @@ Manage Grafana Frontend Observability resources
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx frontend apps](gcx_frontend_apps.md)	 - Manage Frontend Observability apps.
-* [gcx frontend setup](gcx_frontend_setup.md)	 - Set up faro (not yet implemented).
+* [gcx frontend setup](gcx_frontend_setup.md)	 - Set up Frontend Observability (not yet implemented).
 

--- a/docs/reference/cli/gcx_frontend.md
+++ b/docs/reference/cli/gcx_frontend.md
@@ -24,4 +24,5 @@ Manage Grafana Frontend Observability resources
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx frontend apps](gcx_frontend_apps.md)	 - Manage Frontend Observability apps.
+* [gcx frontend setup](gcx_frontend_setup.md)	 - Set up faro (not yet implemented).
 

--- a/docs/reference/cli/gcx_frontend_setup.md
+++ b/docs/reference/cli/gcx_frontend_setup.md
@@ -1,6 +1,6 @@
 ## gcx frontend setup
 
-Set up faro (not yet implemented).
+Set up Frontend Observability (not yet implemented).
 
 ```
 gcx frontend setup [flags]

--- a/docs/reference/cli/gcx_frontend_setup.md
+++ b/docs/reference/cli/gcx_frontend_setup.md
@@ -1,17 +1,15 @@
-## gcx setup status
+## gcx frontend setup
 
-Show aggregated setup status across all products.
+Set up faro (not yet implemented).
 
 ```
-gcx setup status [flags]
+gcx frontend setup [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -h, --help   help for setup
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ gcx setup status [flags]
 
 ### SEE ALSO
 
-* [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
+* [gcx frontend](gcx_frontend.md)	 - Manage Grafana Frontend Observability resources
 

--- a/docs/reference/cli/gcx_irm.md
+++ b/docs/reference/cli/gcx_irm.md
@@ -25,4 +25,5 @@ Manage Grafana IRM (OnCall + Incidents)
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx irm incidents](gcx_irm_incidents.md)	 - Manage incidents.
 * [gcx irm oncall](gcx_irm_oncall.md)	 - Manage Grafana OnCall resources.
+* [gcx irm setup](gcx_irm_setup.md)	 - Set up irm (not yet implemented).
 

--- a/docs/reference/cli/gcx_irm_setup.md
+++ b/docs/reference/cli/gcx_irm_setup.md
@@ -1,17 +1,15 @@
-## gcx setup status
+## gcx irm setup
 
-Show aggregated setup status across all products.
+Set up irm (not yet implemented).
 
 ```
-gcx setup status [flags]
+gcx irm setup [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -h, --help   help for setup
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ gcx setup status [flags]
 
 ### SEE ALSO
 
-* [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
+* [gcx irm](gcx_irm.md)	 - Manage Grafana IRM (OnCall + Incidents)
 

--- a/docs/reference/cli/gcx_k6.md
+++ b/docs/reference/cli/gcx_k6.md
@@ -30,5 +30,6 @@ Manage Grafana k6 Cloud projects, load tests, and schedules
 * [gcx k6 projects](gcx_k6_projects.md)	 - Manage k6 Cloud projects.
 * [gcx k6 runs](gcx_k6_runs.md)	 - Manage k6 test runs.
 * [gcx k6 schedules](gcx_k6_schedules.md)	 - Manage k6 Cloud schedules.
+* [gcx k6 setup](gcx_k6_setup.md)	 - Set up k6 (not yet implemented).
 * [gcx k6 test-run](gcx_k6_test-run.md)	 - Manage k6 TestRun CRD manifests.
 

--- a/docs/reference/cli/gcx_k6_setup.md
+++ b/docs/reference/cli/gcx_k6_setup.md
@@ -1,17 +1,15 @@
-## gcx setup status
+## gcx k6 setup
 
-Show aggregated setup status across all products.
+Set up k6 (not yet implemented).
 
 ```
-gcx setup status [flags]
+gcx k6 setup [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -h, --help   help for setup
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ gcx setup status [flags]
 
 ### SEE ALSO
 
-* [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
+* [gcx k6](gcx_k6.md)	 - Manage Grafana k6 Cloud projects, load tests, and schedules
 

--- a/docs/reference/cli/gcx_kg.md
+++ b/docs/reference/cli/gcx_kg.md
@@ -33,6 +33,7 @@ Manage Grafana Knowledge Graph rules, entities, and insights
 * [gcx kg rules](gcx_kg_rules.md)	 - Manage Knowledge Graph prom rules.
 * [gcx kg scopes](gcx_kg_scopes.md)	 - Manage Knowledge Graph entity scopes.
 * [gcx kg search](gcx_kg_search.md)	 - Search Knowledge Graph entities or insights.
+* [gcx kg setup](gcx_kg_setup.md)	 - Set up kg (not yet implemented).
 * [gcx kg status](gcx_kg_status.md)	 - Show Knowledge Graph stack status.
 * [gcx kg suppressions](gcx_kg_suppressions.md)	 - Push suppressions to the Knowledge Graph.
 

--- a/docs/reference/cli/gcx_kg_setup.md
+++ b/docs/reference/cli/gcx_kg_setup.md
@@ -1,17 +1,15 @@
-## gcx setup status
+## gcx kg setup
 
-Show aggregated setup status across all products.
+Set up kg (not yet implemented).
 
 ```
-gcx setup status [flags]
+gcx kg setup [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -h, --help   help for setup
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ gcx setup status [flags]
 
 ### SEE ALSO
 
-* [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
+* [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
 

--- a/docs/reference/cli/gcx_setup.md
+++ b/docs/reference/cli/gcx_setup.md
@@ -24,5 +24,6 @@ Onboard and configure Grafana Cloud products.
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx setup instrumentation](gcx_setup_instrumentation.md)	 - Manage observability instrumentation for Kubernetes clusters.
+* [gcx setup run](gcx_setup_run.md)	 - Interactive orchestrator for product setup.
 * [gcx setup status](gcx_setup_status.md)	 - Show aggregated setup status across all products.
 

--- a/docs/reference/cli/gcx_setup_run.md
+++ b/docs/reference/cli/gcx_setup_run.md
@@ -21,7 +21,9 @@ gcx setup run [flags]
 ### Options
 
 ```
-  -h, --help   help for run
+  -h, --help            help for run
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_setup_run.md
+++ b/docs/reference/cli/gcx_setup_run.md
@@ -1,17 +1,27 @@
-## gcx setup status
+## gcx setup run
 
-Show aggregated setup status across all products.
+Interactive orchestrator for product setup.
+
+### Synopsis
+
+Run the interactive setup flow to onboard and configure Grafana Cloud products.
+
+This command is interactive and requires a terminal (stdin must be a TTY).
+In agent mode or non-interactive environments, use the per-product setup commands instead:
+  gcx <product> setup
+
+For example:
+  gcx slo setup
+  gcx synth setup
 
 ```
-gcx setup status [flags]
+gcx setup run [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -h, --help   help for run
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_sigil.md
+++ b/docs/reference/cli/gcx_sigil.md
@@ -30,5 +30,6 @@ Manage Sigil AI observability resources
 * [gcx sigil judge](gcx_sigil_judge.md)	 - List LLM providers and models available for LLM-judge evaluators.
 * [gcx sigil rules](gcx_sigil_rules.md)	 - Manage rules that route generations to evaluators.
 * [gcx sigil scores](gcx_sigil_scores.md)	 - View evaluation scores for generations.
+* [gcx sigil setup](gcx_sigil_setup.md)	 - Set up sigil (not yet implemented).
 * [gcx sigil templates](gcx_sigil_templates.md)	 - Browse reusable evaluator blueprints (global and tenant-scoped).
 

--- a/docs/reference/cli/gcx_sigil_setup.md
+++ b/docs/reference/cli/gcx_sigil_setup.md
@@ -1,17 +1,15 @@
-## gcx setup status
+## gcx sigil setup
 
-Show aggregated setup status across all products.
+Set up sigil (not yet implemented).
 
 ```
-gcx setup status [flags]
+gcx sigil setup [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -h, --help   help for setup
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ gcx setup status [flags]
 
 ### SEE ALSO
 
-* [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
+* [gcx sigil](gcx_sigil.md)	 - Manage Sigil AI observability resources
 

--- a/docs/reference/cli/gcx_slo.md
+++ b/docs/reference/cli/gcx_slo.md
@@ -25,4 +25,5 @@ Manage Grafana SLO definitions and reports
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx slo definitions](gcx_slo_definitions.md)	 - Manage SLO definitions.
 * [gcx slo reports](gcx_slo_reports.md)	 - Manage SLO reports.
+* [gcx slo setup](gcx_slo_setup.md)	 - Set up slo (not yet implemented).
 

--- a/docs/reference/cli/gcx_slo_setup.md
+++ b/docs/reference/cli/gcx_slo_setup.md
@@ -1,17 +1,15 @@
-## gcx setup status
+## gcx slo setup
 
-Show aggregated setup status across all products.
+Set up slo (not yet implemented).
 
 ```
-gcx setup status [flags]
+gcx slo setup [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -h, --help   help for setup
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ gcx setup status [flags]
 
 ### SEE ALSO
 
-* [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
+* [gcx slo](gcx_slo.md)	 - Manage Grafana SLO definitions and reports
 

--- a/docs/reference/cli/gcx_synth.md
+++ b/docs/reference/cli/gcx_synth.md
@@ -25,4 +25,5 @@ Manage Grafana Synthetic Monitoring checks and probes
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx synth checks](gcx_synth_checks.md)	 - Manage Synthetic Monitoring checks.
 * [gcx synth probes](gcx_synth_probes.md)	 - Manage Synthetic Monitoring probes.
+* [gcx synth setup](gcx_synth_setup.md)	 - Set up synth (not yet implemented).
 

--- a/docs/reference/cli/gcx_synth_setup.md
+++ b/docs/reference/cli/gcx_synth_setup.md
@@ -1,17 +1,15 @@
-## gcx setup status
+## gcx synth setup
 
-Show aggregated setup status across all products.
+Set up synth (not yet implemented).
 
 ```
-gcx setup status [flags]
+gcx synth setup [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -h, --help   help for setup
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ gcx setup status [flags]
 
 ### SEE ALSO
 
-* [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
+* [gcx synth](gcx_synth.md)	 - Manage Grafana Synthetic Monitoring checks and probes
 

--- a/docs/specs/feature-setup-framework/plan.md
+++ b/docs/specs/feature-setup-framework/plan.md
@@ -1,0 +1,196 @@
+---
+type: feature-plan
+title: "Setup Framework: Interfaces, Stubs, and Orchestration"
+status: approved
+spec: docs/specs/feature-setup-framework/spec.md
+created: 2026-04-17
+---
+
+# Architecture and Design Decisions
+
+## Pipeline Architecture
+
+The setup framework sits between the global provider registry and the CLI layer. It defines the interfaces that providers opt into, a discovery helper that filters `providers.All()` by interface assertion, and two orchestrating commands that consume discovery results. Per-provider `setup` subcommands reuse the exact same `Setup()` method the orchestrator calls, so there is one implementation behind two entry points.
+
+```
+providers.All()  (internal/providers.Registry)
+        │
+        ▼
+internal/setup/framework/                              (NEW)
+    ├─ interfaces.go      StatusDetectable / Setupable
+    │                     ProductStatus / ProductState / ParamKind
+    │                     InfraCategory / InfraCategoryID / SetupParam
+    │                     ErrSetupNotSupported
+    ├─ discovery.go       DiscoverStatusDetectable() / DiscoverSetupable()
+    │                     (type assertions over providers.All())
+    ├─ aggregate.go       AggregateStatus(ctx, timeout)
+    │                     errgroup (bounded=10) + per-provider
+    │                     context.WithTimeout(5s) + error isolation
+    │                     + alphabetical sort by ProductName()
+    ├─ stub.go            ConfigKeysStatus(p providers.Provider)
+    │                     shared helper: not_configured / configured
+    │                     based on ConfigKeys() presence in current ctx
+    ├─ orchestrator.go    Run(ctx, Options)
+    │                     discovery → category select → skip-if-configured
+    │                     → param collect → ValidateSetup (retry loop)
+    │                     → preview (masked) → sequential Setup
+    │                     → summary; signal.NotifyContext(os.Interrupt)
+    └─ prompt/            Text / Bool / Choice / MultiChoice / Secret
+                          widgets (bufio + golang.org/x/term)
+        │                                  ▲
+        ▼                                  │
+CLI layer (cmd/gcx/setup/)                 │
+    ├─ command.go   `gcx setup status`     │
+    │               → framework.Aggregate  │
+    │               → internal/output      │
+    │                   (text/json/yaml/   │
+    │                    wide) + style     │
+    │                    TableBuilder      │
+    │                                      │
+    ├─ run.go       `gcx setup run`        │
+    │   (NEW)       → agent.IsAgentMode()  │
+    │               → framework.Run        │
+    │                   └─ uses prompt/ ───┘
+    │
+    └─ instrumentation/  (UNCHANGED subtree — coexists)
+        └─ gcx setup instrumentation {status|show|apply|discover|export}
+
+Per-provider entry points (also wired through the same Setup()):
+    internal/providers/<area>/setup.go  (NEW for 9 setup-capable)
+        → registered via provider.Commands()
+        → `gcx <provider-area> setup`    (thin Cobra wrapper over
+                                          Setupable.Setup())
+
+Provider stubs (14 files touched):
+    Signal providers (StatusDetectable only):
+        alert, logs, metrics, profiles, traces
+            └─ Status() delegates to framework.ConfigKeysStatus()
+    Setup-capable providers (Setupable, stubs):
+        appo11y, faro, fleet, incidents, k6, kg, sigil, slo, synth
+            ├─ Status() delegates to framework.ConfigKeysStatus()
+            ├─ InfraCategories(), ResolveChoices(), ValidateSetup() stubs
+            └─ Setup() returns ErrSetupNotSupported
+```
+
+Key flow properties:
+
+- `gcx setup status` and every per-provider `setup` subcommand share a single downstream function per concern (`AggregateStatus`, `Setup`). Adding a new provider that implements the interfaces automatically surfaces in status output and the run orchestrator — no CLI wiring required beyond the per-provider command.
+- Framework is imported by providers; providers are never imported by framework (one-way dependency, cycle-free).
+- `cmd/gcx/setup/instrumentation/` is untouched — the legacy subtree keeps working verbatim.
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Framework package lives at `internal/setup/framework/` (new package) | Keeps framework logic out of `internal/providers` to avoid import cycles; mirrors the existing `internal/setup/instrumentation/` naming. An alternative `internal/providers/setup/` was rejected because providers must import the interface definitions — a framework package that providers depend on (one-way) is cleaner. Traces to FR-001..FR-010. |
+| `Setupable` embeds `StatusDetectable` at the interface level | Compile-time invariant that every setup-capable provider also exposes status; prevents drift where `setup run` offers a product that has no `status` entry. Traces to FR-002. |
+| `ProductState` is a typed string enum (`not_configured`, `configured`, `active`, `error`) | Human-readable in text codec, round-trips cleanly through JSON/YAML codecs without a custom marshaller, stable API surface for agent consumers. Traces to FR-003, FR-004. |
+| Status aggregation uses `errgroup.Group` with bounded parallelism = 10 and per-provider `context.WithTimeout(5s)` | Matches the codebase-wide concurrency standard (CLAUDE.md). 5s default answers the spec's [NEEDS CLARIFICATION] open question — Status() probes are expected to be fast (single HTTP call or cached lookup), and 5s matches typical provider HTTP timeouts in gcx. Overridable via a status command flag in a later iteration. Traces to FR-012, FR-013. |
+| Error isolation: a `Status()` error is wrapped into `ProductStatus{State: error, Details: err.Error()}` and rendered inline | One slow/broken provider must not collapse the whole table. Users see which providers failed and why, alphabetical ordering is preserved. Traces to FR-014, FR-015. |
+| Alphabetical ordering via `slices.SortFunc` on `ProductName()` after aggregation, before render | Deterministic output for snapshot tests and agent consumers; simpler than maintaining sort order in the aggregator goroutine channel. Traces to FR-016. |
+| Codec wiring reuses `internal/output.Options`, registering a custom text codec via `RegisterCustomCodec` for the status table | Matches Pattern 13 (format-agnostic fetching) — aggregation does not care about output format; codecs control rendering only. JSON/YAML codecs map `[]ProductStatus` directly through the default encoders. Traces to FR-017, FR-019, FR-020. |
+| Text-codec table rendering uses `internal/style.TableBuilder` and the Grafana Neon Dark palette for state colouring | Consistency with the rest of gcx; color is only applied when stdout is a TTY (existing `internal/terminal.Detect` gating). Traces to FR-018. |
+| Agent-mode default flip to JSON on `gcx setup status` reuses `agent.IsAgentMode()` inside the output options default resolver | Same mechanism every other gcx command uses; no new detection path. Traces to FR-019, FR-020. |
+| `gcx setup run` refuses in agent mode via an early `agent.IsAgentMode()` check in `RunE` returning a usage error with exit code 2 | Interactive orchestration cannot function in agent mode; failing fast with an actionable error preserves the agent-safety contract from CONSTITUTION/DESIGN. Traces to FR-036. |
+| `InfraCategory` conflicts: first write wins, keyed by `InfraCategoryID` in a `map[InfraCategoryID]InfraCategory` seeded in alphabetical-provider order | Deterministic merge, cheap to compute, and the alphabetical seeding means the category owner is predictable from the provider order. Future spec can elevate this to an explicit precedence registry if conflicts emerge in practice. Traces to FR-021. |
+| Skip-if-configured check runs *before* param collection, not before preview | Avoids prompting for params the user will not need if the provider reports `configured` or `active`. Traces to FR-027. |
+| Validation retry loop: on `ValidateSetup` error, re-prompt every param for the current provider with previously-collected values as defaults; loop until validation succeeds or the user cancels | Conforms to DESIGN's "fail fast with actionable errors" while letting users correct typos without aborting the whole flow; avoids parsing validator error strings to target specific fields. Traces to FR-029. |
+| Preview step masks every param where `Secret=true` using `***` before display | Prevents accidental token disclosure in terminal scrollback and screen-shares. Traces to FR-023, FR-030. |
+| Sequential `Setup()` invocation (not parallel) in the orchestrator | Order matters for cross-provider dependencies (e.g. instrumentation depends on infra category choices); sequential is also easier to reason about for a first version. Traces to FR-032, FR-037. |
+| Ctrl-C handling via `signal.NotifyContext(ctx, os.Interrupt)` wrapping the run loop; the orchestrator catches `ctx.Err() == context.Canceled` and renders the summary of completed/skipped/failed products | Clean shutdown without orphaned prompts; summary preserves audit trail. Traces to FR-034. |
+| Per-provider `gcx <provider-area> setup` command is a thin Cobra wrapper that calls the same `Setupable.Setup()` the orchestrator uses | One implementation, two entry points; the wrapper uses the opts pattern (opts struct + `setup(flags)` + `Validate()` + constructor) and is flag-only (no prompts) so it is scriptable and agent-friendly. Traces to FR-039, FR-040, FR-041, FR-043, FR-044, FR-045. |
+| Stub implementation strategy: a shared `framework.ConfigKeysStatus(p providers.Provider) ProductStatus` helper inspects `p.ConfigKeys()` in the current context — returns `configured` if all required keys have non-empty values, else `not_configured` | Lets all 14 providers ship a working `Status()` today without implementing product-specific probes; product-specific `active` detection lands per-provider later. Traces to FR-046, FR-047. |
+| Setup-capable stubs implement `InfraCategories() []InfraCategory` returning `nil`, `ResolveChoices(...)` returning `(nil, nil)`, `ValidateSetup(...)` returning `nil`, and `Setup(...)` returning `ErrSetupNotSupported` | Framework code treats `ErrSetupNotSupported` as a non-failure sentinel in the orchestrator summary (marked "not yet implemented") but as a hard error when invoked directly via the per-provider command (non-zero exit). Traces to FR-048..FR-053. |
+| Interactive prompt widgets are an in-repo minimal implementation using `bufio.Reader` + `golang.org/x/term` (`term.MakeRaw` for raw input, `term.ReadPassword` for secret masking) | `x/term` is already transitively available via Cobra's dependency graph, keeping the dependency surface small. Avoids heavy TUI libraries (bubbletea, survey/v2) whose scope far exceeds what the orchestrator needs. Traces to FR-023, FR-028. |
+| Prompt widgets preserve defaults: pressing Enter on a prompt with `Default` accepts it; `Required` params without `Default` re-prompt | Keeps happy-path short; explicit `Required` semantics are enforced at the widget level, not deferred to `ValidateSetup`. Traces to FR-028. |
+| Test strategy: interface-level table-driven tests using fake providers (implementing `StatusDetectable`/`Setupable`) live in an internal test package; integration tests at the command level use a registry override helper (`SetupTestRegistry`) that swaps `providers.All()`'s backing slice | Decouples framework tests from the real provider set; keeps test runs deterministic and network-free. Traces to spec Test Strategy. |
+| Backward-compat guard: `cmd/gcx/setup/instrumentation/` subtree is not touched — only `cmd/gcx/setup/command.go`'s `status` command body is rewritten to call `framework.AggregateStatus` | Keeps the Instrumentation migration path stable; the legacy `status_test.go` must continue to pass unchanged as a regression guard. Traces to FR-054. |
+
+## Compatibility
+
+**What continues working unchanged:**
+
+- `gcx setup instrumentation` subtree in full: `status`, `show`, `apply`, `discover`, `export`. None of those files are edited.
+- All existing provider `Commands()` return values — adding stub interfaces does not remove or rename any existing subcommand.
+- The base `providers.Provider` interface contract (Name, ShortDesc, Commands, Validate, ConfigKeys, TypedRegistrations).
+- Agent-mode auto-detection (`internal/agent`) and every codec in `internal/output`.
+- `cmd/gcx/setup/instrumentation/status_test.go` passes without modification (regression guard).
+
+**What is deprecated:**
+
+- The old hardcoded shape of `gcx setup status` output. Previously this command rendered an instrumentation-only table; it now renders an aggregated all-providers table. Callers parsing the old shape must migrate by either:
+  1. Switching to `--output json` and consuming structured `ProductStatus` records, or
+  2. Calling `gcx setup instrumentation status` for the narrower instrumentation-only view.
+
+No config keys, env vars, or flags are removed. The command name itself is unchanged.
+
+**What is newly available:**
+
+- Public Go types in `internal/setup/framework`: `StatusDetectable`, `Setupable`, `ProductStatus`, `ProductState`, `InfraCategory`, `InfraCategoryID`, `SetupParam`, `ParamKind`, `ErrSetupNotSupported`.
+- New CLI commands: `gcx setup run` (interactive orchestrator) and `gcx <provider-area> setup` for each of the 9 setup-capable providers (appo11y, faro, fleet, incidents, k6, kg, sigil, slo, synth). All 9 per-provider commands currently return `ErrSetupNotSupported`; Area 7 of the roadmap will replace the stubs with real implementations.
+- New `gcx setup status` rendering across all 14 providers with codec support (text / json / yaml / wide) and agent-mode JSON default.
+
+## Package Layout
+
+New and touched paths:
+
+- `internal/setup/framework/` **(new package)**
+  - `interfaces.go` — `StatusDetectable`, `Setupable`, `InfraCategory`, `InfraCategoryID`, `SetupParam`, `ProductStatus`, `ProductState`, `ParamKind`, `ErrSetupNotSupported`, `ValidationError`.
+  - `discovery.go` — `DiscoverStatusDetectable()`, `DiscoverSetupable()` — type-assertion helpers over `providers.All()`.
+  - `aggregate.go` — `AggregateStatus(ctx context.Context, timeout time.Duration) []ProductStatus` — parallel aggregation (errgroup, bounded=10), per-provider `context.WithTimeout`, error isolation via `ProductStatus{State: error}` synthesis, alphabetical sort.
+  - `orchestrator.go` — `Run(ctx context.Context, opts Options) (Summary, error)` — full run flow: discovery, category selection, skip-if-configured, param collection, validation retry, masked preview, sequential `Setup()`, summary. Owns the `signal.NotifyContext(ctx, os.Interrupt)` wrapper.
+  - `stub.go` — `ConfigKeysStatus(p providers.Provider) ProductStatus` — shared helper returning `configured` or `not_configured` based on `ConfigKeys()` presence in the current context.
+  - `prompt/` — minimal interactive widgets:
+    - `prompt.go` — `Text`, `Bool`, `Choice`, `MultiChoice`, `Secret` (uses `golang.org/x/term`).
+    - `prompt_test.go`.
+  - `*_test.go` — table-driven unit tests using fake providers.
+  - `fakes_test.go` (or `internal/fakes`) — reusable `FakeStatusDetectable` / `FakeSetupable` test doubles.
+
+- `cmd/gcx/setup/command.go` **(modified)** — the `status` subcommand body is rewritten to call `framework.AggregateStatus` and render via `internal/output.Options`; the `run` subcommand is added (delegating to `cmd/gcx/setup/run.go`).
+- `cmd/gcx/setup/run.go` **(new)** — Cobra constructor for `gcx setup run` using the opts pattern (opts struct + `setup(flags)` + `Validate()` + constructor); early agent-mode refusal; delegation to `framework.Run`.
+- `cmd/gcx/setup/command_test.go` **(new or extended)** — integration tests using `framework.SetupTestRegistry`.
+
+- `internal/providers/<area>/provider.go` **(modified — 14 files)** — add `Status()` method to signal providers (5); add `Status()`, `InfraCategories()`, `ResolveChoices()`, `ValidateSetup()`, `Setup()` stubs to setup-capable providers (9).
+  - Signal providers (StatusDetectable only): `alert`, `logs`, `metrics`, `profiles`, `traces`.
+  - Setup-capable providers (Setupable stub): `appo11y`, `faro`, `fleet`, `incidents`, `k6`, `kg`, `sigil`, `slo`, `synth`.
+- `internal/providers/<area>/setup.go` **(new — 9 files)** — per-provider Cobra `setup` subcommand; registered via `provider.Commands()`; calls `Setupable.Setup()` which returns `ErrSetupNotSupported` until Area 7 replaces the stubs. Help text marks the command "not yet implemented".
+- `internal/providers/<area>/provider_test.go` **(modified — 14 files)** — assert stub method presence and `Setup()` returns `ErrSetupNotSupported` where applicable.
+
+## Implementation Sequence
+
+Ordered workstreams suitable for downstream task decomposition:
+
+1. Scaffold `internal/setup/framework/` with `interfaces.go`, `discovery.go`, `stub.go`, and their table-driven unit tests. Establish the fake-provider test doubles used by later workstreams.
+2. Implement `framework.AggregateStatus` (parallel via errgroup with bounded=10, per-provider `context.WithTimeout(5s)`, error isolation, alphabetical sort) with fake-provider table-driven tests covering: happy path, timeout, provider panic, ordering, mixed states.
+3. Rewrite `gcx setup status` in `cmd/gcx/setup/command.go` to call `AggregateStatus`; wire `internal/output.Options` with a registered text codec using `internal/style.TableBuilder` and Neon Dark colour mapping. Add integration tests with `framework.SetupTestRegistry`. Verify `cmd/gcx/setup/instrumentation/status_test.go` continues to pass untouched.
+4. Implement minimal prompt widgets in `internal/setup/framework/prompt/` (text, bool, choice, multi_choice, secret) with tests asserting masking behaviour and default-preservation on empty input. Use `golang.org/x/term` for secret masking.
+5. Implement `framework.Orchestrator` (`Run`) covering: discovery, category select, skip-if-configured (via pre-run `Status()`), param collection, validation retry loop, preview with secret masking, sequential `Setup()` invocation, summary rendering, `signal.NotifyContext` Ctrl-C handling. Fake-provider tests exercise each path including interrupt and validation retry.
+6. Add `gcx setup run` command in `cmd/gcx/setup/run.go` using the opts pattern; early agent-mode refusal returning usage-error exit code; delegate to `framework.Run`. Integration tests via `SetupTestRegistry` cover agent-mode refusal and a full interactive flow against a fake provider.
+7. Add StatusDetectable-only stubs to the 5 signal providers (`alert`, `logs`, `metrics`, `profiles`, `traces`) by delegating `Status()` to `framework.ConfigKeysStatus`. Per-provider tests assert stub method presence and config-keys-driven state resolution.
+8. Add `Setupable` stubs plus `<provider-area> setup` Cobra commands to the 9 setup-capable providers (`appo11y`, `faro`, `fleet`, `incidents`, `k6`, `kg`, `sigil`, `slo`, `synth`). Each stub `Setup()` returns `ErrSetupNotSupported`; the Cobra command surfaces a "not yet implemented" help string and exits non-zero when invoked. Per-provider tests assert command existence, exit behaviour, and error sentinel identity.
+9. Regenerate reference docs (`GCX_AGENT_MODE=false make reference`) and run `GCX_AGENT_MODE=false make all`.
+
+## Testing Strategy
+
+- **Unit tests** — table-driven for every file under `internal/setup/framework/*.go` and `internal/setup/framework/prompt/*.go`. No network calls; all provider interactions go through fake doubles.
+- **Fake providers** — `FakeStatusDetectable` and `FakeSetupable` implemented in the framework test package. Cover configurable state, configurable errors, configurable latencies for timeout tests, and configurable panic for error-isolation tests.
+- **Integration tests** — at the command level for `gcx setup status` and `gcx setup run` using a `framework.SetupTestRegistry(providers []providers.Provider) (restore func())` helper that swaps the backing slice of `providers.All()` inside a test (with cleanup restoring the real registry). Runs against Cobra's in-memory `rootCmd.SetOut/SetErr` so stdout is captured.
+- **Regression guard** — `cmd/gcx/setup/instrumentation/status_test.go` must continue to pass unmodified.
+- **Agent-mode tests** — cover both the default JSON flip on `gcx setup status` and the refusal on `gcx setup run` (exit code 2, usage error message).
+- **Codec tests** — assert JSON and YAML outputs round-trip `ProductStatus` records; assert text codec produces a `TableBuilder`-rendered table with deterministic column ordering.
+- **Ordering tests** — assert alphabetical-by-ProductName across a mixed set of providers including error rows.
+- **Stub tests** — per-provider assertions that signal providers implement `StatusDetectable` and setup-capable providers implement `Setupable`; `Setup()` returns `ErrSetupNotSupported` identity (`errors.Is`).
+- **No network calls** in any unit or integration test. Provider HTTP clients are not invoked — all state flows through fakes or `ConfigKeysStatus` which reads in-memory config.
+
+## Risks and Mitigations (Plan-level)
+
+Spec-level risks are enumerated in `spec.md`. The following are plan-specific additions:
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Import cycle between `internal/setup/framework` and `internal/providers` if the framework needs to call back into provider types. | Build breaks; framework cannot be imported. | Strict one-way dependency: providers import framework (for interface types), framework imports only the base `providers.Provider` contract via a small read-only accessor if needed. Early Task 1 scaffolding includes a build-time cycle check. |
+| Test harness complexity when overriding `providers.All()` for integration tests (global registry is hostile to parallel tests). | Flaky or serialized integration tests; difficult to add new fakes. | Ship `framework.SetupTestRegistry(providers)` returning a `restore func()`. Guard with `t.Cleanup`; document in a `doc.go` that integration tests using it must run with `t.Parallel()` off unless each subtest scopes its own registry. |
+| `--output` flag collision with the legacy `gcx setup status` command's existing flag set (if any non-codec flags are present). | Invocation ambiguity, surprising behaviour for scripted callers. | Adopt the standard `internal/output.Options` registration which is the same pattern every other gcx command uses. Inventory existing flags on the `status` command during Task 3 and migrate any conflicting ones before wiring the codec. |
+| Prompt widget portability across terminal emulators (raw-mode, non-TTY stdin). | Orchestrator hangs or misrenders on CI/non-TTY stdin despite agent-mode refusal. | Detect non-TTY via `internal/terminal.IsPiped` at the start of `Run`; refuse with an actionable error when stdin is not a TTY. Add a dedicated non-TTY test using a `bytes.Buffer` stdin. |
+| Per-provider `setup` command discoverability in the global help tree. | Users unaware that `gcx <provider-area> setup` exists. | Ensure each per-provider command contributes a `setup` entry to `cmd/gcx/helptree/`; update the agent metadata catalog in `cmd/gcx/commands/` as part of Task 8. |
+| Ctrl-C during a secret prompt leaves the terminal in raw mode. | Broken user terminal post-abort. | `prompt.Secret` registers a `defer term.Restore(fd, state)` immediately after `term.MakeRaw`; unit-test the restore path by forcing a panic inside the read call. |

--- a/docs/specs/feature-setup-framework/plan.md
+++ b/docs/specs/feature-setup-framework/plan.md
@@ -66,7 +66,7 @@ Provider stubs (14 files touched):
         alert, logs, metrics, profiles, traces
             └─ Status() delegates to framework.ConfigKeysStatus()
     Setup-capable providers (Setupable, stubs):
-        appo11y, faro, fleet, incidents, k6, kg, sigil, slo, synth
+        appo11y, faro, fleet, irm, k6, kg, sigil, slo, synth
             ├─ Status() delegates to framework.ConfigKeysStatus()
             ├─ InfraCategories(), ResolveChoices(), ValidateSetup() stubs
             └─ Setup() returns ErrSetupNotSupported
@@ -127,7 +127,7 @@ No config keys, env vars, or flags are removed. The command name itself is uncha
 **What is newly available:**
 
 - Public Go types in `internal/setup/framework`: `StatusDetectable`, `Setupable`, `ProductStatus`, `ProductState`, `InfraCategory`, `InfraCategoryID`, `SetupParam`, `ParamKind`, `ErrSetupNotSupported`.
-- New CLI commands: `gcx setup run` (interactive orchestrator) and `gcx <provider-area> setup` for each of the 9 setup-capable providers (appo11y, faro, fleet, incidents, k6, kg, sigil, slo, synth). All 9 per-provider commands currently return `ErrSetupNotSupported`; Area 7 of the roadmap will replace the stubs with real implementations.
+- New CLI commands: `gcx setup run` (interactive orchestrator) and `gcx <provider-area> setup` for each of the 9 setup-capable providers (appo11y, faro, fleet, irm, k6, kg, sigil, slo, synth). All 9 per-provider commands currently return `ErrSetupNotSupported`; Area 7 of the roadmap will replace the stubs with real implementations.
 - New `gcx setup status` rendering across all 14 providers with codec support (text / json / yaml / wide) and agent-mode JSON default.
 
 ## Package Layout
@@ -152,7 +152,7 @@ New and touched paths:
 
 - `internal/providers/<area>/provider.go` **(modified — 14 files)** — add `Status()` method to signal providers (5); add `Status()`, `InfraCategories()`, `ResolveChoices()`, `ValidateSetup()`, `Setup()` stubs to setup-capable providers (9).
   - Signal providers (StatusDetectable only): `alert`, `logs`, `metrics`, `profiles`, `traces`.
-  - Setup-capable providers (Setupable stub): `appo11y`, `faro`, `fleet`, `incidents`, `k6`, `kg`, `sigil`, `slo`, `synth`.
+  - Setup-capable providers (Setupable stub): `appo11y`, `faro`, `fleet`, `irm`, `k6`, `kg`, `sigil`, `slo`, `synth`.
 - `internal/providers/<area>/setup.go` **(new — 9 files)** — per-provider Cobra `setup` subcommand; registered via `provider.Commands()`; calls `Setupable.Setup()` which returns `ErrSetupNotSupported` until Area 7 replaces the stubs. Help text marks the command "not yet implemented".
 - `internal/providers/<area>/provider_test.go` **(modified — 14 files)** — assert stub method presence and `Setup()` returns `ErrSetupNotSupported` where applicable.
 
@@ -167,7 +167,7 @@ Ordered workstreams suitable for downstream task decomposition:
 5. Implement `framework.Orchestrator` (`Run`) covering: discovery, category select, skip-if-configured (via pre-run `Status()`), param collection, validation retry loop, preview with secret masking, sequential `Setup()` invocation, summary rendering, `signal.NotifyContext` Ctrl-C handling. Fake-provider tests exercise each path including interrupt and validation retry.
 6. Add `gcx setup run` command in `cmd/gcx/setup/run.go` using the opts pattern; early agent-mode refusal returning usage-error exit code; delegate to `framework.Run`. Integration tests via `SetupTestRegistry` cover agent-mode refusal and a full interactive flow against a fake provider.
 7. Add StatusDetectable-only stubs to the 5 signal providers (`alert`, `logs`, `metrics`, `profiles`, `traces`) by delegating `Status()` to `framework.ConfigKeysStatus`. Per-provider tests assert stub method presence and config-keys-driven state resolution.
-8. Add `Setupable` stubs plus `<provider-area> setup` Cobra commands to the 9 setup-capable providers (`appo11y`, `faro`, `fleet`, `incidents`, `k6`, `kg`, `sigil`, `slo`, `synth`). Each stub `Setup()` returns `ErrSetupNotSupported`; the Cobra command surfaces a "not yet implemented" help string and exits non-zero when invoked. Per-provider tests assert command existence, exit behaviour, and error sentinel identity.
+8. Add `Setupable` stubs plus `<provider-area> setup` Cobra commands to the 9 setup-capable providers (`appo11y`, `faro`, `fleet`, `irm`, `k6`, `kg`, `sigil`, `slo`, `synth`). Each stub `Setup()` returns `ErrSetupNotSupported`; the Cobra command surfaces a "not yet implemented" help string and exits non-zero when invoked. Per-provider tests assert command existence, exit behaviour, and error sentinel identity.
 9. Regenerate reference docs (`GCX_AGENT_MODE=false make reference`) and run `GCX_AGENT_MODE=false make all`.
 
 ## Testing Strategy

--- a/docs/specs/feature-setup-framework/spec.md
+++ b/docs/specs/feature-setup-framework/spec.md
@@ -1,0 +1,292 @@
+---
+type: feature-spec
+title: "Setup Framework: Interfaces, Stubs, and Orchestration"
+status: approved
+adr: docs/adrs/setup-framework/001-setup-framework-interfaces-and-orchestration.md
+created: 2026-04-17
+---
+
+# Setup Framework: Interfaces, Stubs, and Orchestration
+
+## Problem Statement
+
+gcx today ships 14 providers plus the instrumentation subsystem (15 setup-capable participants in total) but has no unified way to answer "what is configured, what is broken, and what should I do next?" Each provider's onboarding path is independent — there is no orchestrated flow from "just authenticated" to "products working."
+
+The current `gcx setup status` (cmd/gcx/setup/command.go:55-92) is hardcoded to instrumentation: it calls `instrum.NewClient(r.Client).RunK8sMonitoring` and renders a fixed PRODUCT|ENABLED|HEALTH|DETAILS table. It cannot surface state for any other provider. There is no `gcx setup run` command today, and there is no contract for a per-provider `gcx <provider-area> setup` command either.
+
+Users (and agents) who just logged in must discover, enable, and validate products one at a time by reading per-provider docs and inventing their own sequencing. This is a growing onboarding gap as the provider count increases. The approved ADR (docs/adrs/setup-framework/001-setup-framework-interfaces-and-orchestration.md) locks in a three-entry-point model that closes this gap:
+
+- `gcx setup status` — aggregated product status dashboard across every provider.
+- `gcx setup run` — interactive, re-runnable orchestrator that skips already-configured products.
+- `gcx <provider-area> setup` — non-interactive per-provider setup commands, agent-friendly.
+
+This spec turns the ADR into an executable plan: the interfaces, types, orchestration rules, stub coverage, and tests that must exist for the framework to ship. Rich per-provider logic (real API probes in `Status()`, working `Setup()` flows, populated `InfraCategories()`) is deliberately deferred to Area 7 and is out of scope here.
+
+## Scope
+
+### In Scope
+
+- Two optional interfaces: `StatusDetectable` and `Setupable`, with `Setupable` embedding `StatusDetectable`.
+- Supporting types: `ProductStatus`, `ProductState` (enum), `InfraCategory`, `InfraCategoryID`, `SetupParam`, `ParamKind`.
+- A sentinel error `ErrSetupNotSupported` for setup-capable providers whose stub `Setup()` is not yet implemented.
+- Capability discovery via Go type assertion on `providers.All()` — no hard-coded provider lists anywhere.
+- `gcx setup status` rewritten to aggregate every `StatusDetectable` provider (parallel calls with per-provider timeout, deterministic alphabetical rendering, error isolation).
+- `gcx setup status` rendered via the standard codec system (`text`, `json`, `yaml`, `wide`) with human color-coding and agent-mode color suppression.
+- `gcx setup run` command implementing the ADR §6 flow: discovery → category multi-select → provider resolution → per-provider loop (skip-if-configured → parameter collection → validation retry) → preview → sequential `Setup()` execution → post-run status summary.
+- Ctrl-C handling in `gcx setup run`: print summary of completed vs remaining providers, exit with code 5 (cancelled). No rollback.
+- Agent-mode refusal of `gcx setup run` (exit code 2 usage error) with a message pointing to per-provider setup commands.
+- Per-provider `gcx <provider-area> setup` Cobra command contract: opts pattern, flag-only, idempotent, agent-friendly, codec-rendered mutation summary on success, non-zero exit on failure.
+- Orchestrator invocation of `Setupable.Setup()` in-process only — never subprocess.
+- Stub coverage across all 14 existing providers:
+  - **Signal/data providers** (alert, logs, metrics, profiles, traces) implement `StatusDetectable` only. `Status()` uses a `ConfigKeys()` presence heuristic; no API probing.
+  - **Setup-capable providers** (appo11y, faro, fleet, incidents, k6, kg, sigil, slo, synth) implement `Setupable`. `Setup()` returns `ErrSetupNotSupported`. `InfraCategories()` returns `nil`. `ValidateSetup()` returns `nil` (no-op). `ResolveChoices()` returns `(nil, nil)`.
+- Interactive prompt widgets for `text`, `bool`, `choice` (single select), `multi_choice` (multi-select), and secret (masked input). Minimal implementation, no heavy UI dependency.
+- Preview rendering with secret masking (`***` for any `SetupParam` where `Secret == true`).
+- Validation retry flow: on `ValidateSetup` error, re-prompt all fields for that provider with previously-collected values as defaults; loop until validation passes or the user cancels.
+- Backward compatibility: the existing `gcx setup instrumentation {status|show|apply|discover|export}` subtree continues to work unchanged.
+- Test coverage: table-driven unit tests for status aggregation, ordering, error isolation, codec rendering, stub behavior, per-provider setup command idempotency, validation retry, agent-mode refusal.
+
+### Out of Scope
+
+- **Rich per-provider `Status()` probes** (real API calls, resource counting, token-expiry checks). Deferred to Area 7 — this spec ships stubs.
+- **Real `Setup()` flows** for the 9 setup-capable providers. All stubs return `ErrSetupNotSupported`. Area 7 replaces them one provider at a time.
+- **Populated `InfraCategories()`** on any provider. All stubs return `nil`. Area 7 adds them per provider.
+- **`ConcurrencySafe()` method or `--parallel` flag** on `gcx setup run`. `Setup()` execution is sequential in v1 (ADR §6, rejected alternative "Concurrent `Setup()` execution").
+- **Dependency-aware provider ordering** (e.g., instrumentation before metrics). Alphabetical only in v1.
+- **Field-level validation error targeting.** Validation failure re-prompts all fields for the provider; no structured error protocol between `ValidateSetup` and the orchestrator.
+- **`--dry-run` / `--show-commands` preview modes** on `gcx setup run`. Deferred.
+- **Rich choice metadata** (`[]Choice{Value, Description}`). `ResolveChoices` returns `[]string` only.
+- **`gcx setup doctor`** deep health checks (token expiry, API version compatibility). Future work listed in ADR §Follow-up.
+- **Changes to the base `Provider` interface** in internal/providers/provider.go. The new interfaces are additive and optional.
+- **Subprocess-based orchestration.** Never.
+- **Rollback of completed `Setup()` calls** on error or cancellation. Partial completion is a valid state.
+
+## Key Decisions
+
+| Decision | Chosen | Rationale | Source |
+|----------|--------|-----------|--------|
+| Interface shape | Two optional interfaces: `StatusDetectable` (2 methods) and `Setupable` embedding `StatusDetectable` (+4 methods) | Status-only providers stay minimal; embedding enforces at compile time that anything in `setup run` is also in the status table | ADR-001 §1 |
+| Status payload | `ProductStatus{Product, State, Details, SetupHint}` with `ProductState` enum (`not_configured`, `configured`, `active`, `error`) | Flat, codec-friendly shape; enum values are machine-readable and color-map cleanly in human mode | ADR-001 §2 |
+| Status aggregation contract | Parallel `Status()` calls with per-provider timeout; errors surfaced as `StateError` rows; deterministic alphabetical ordering; standard codec system | Error isolation prevents one slow/broken provider from blocking the table; alphabetical ordering makes output diffable and stable | ADR-001 §3 |
+| Category + param model | `InfraCategory{ID, Label, Params}` multi-select (first label wins on ID collision); `SetupParam{Name, Prompt, Kind, Required, Default, Secret, Choices}` with `ParamKind` enum | Declarative schema drives prompt widget, flag registration, and preview rendering from one source | ADR-001 §4 |
+| Per-provider setup command contract | Every `Setupable` exposes `gcx <provider-area> setup` as a Cobra subcommand using the opts pattern; non-interactive, flag-only, idempotent, agent-friendly, codec-rendered output | Matches existing gcx UX rules; agents get a stable non-interactive entry; one implementation (`Setupable.Setup()`) powers both CLI and orchestrator | ADR-001 §5 |
+| Orchestration model | `gcx setup run` discovers categories, multi-selects, resolves providers alphabetically, skips already-configured, collects params, validates with full-param retry, previews with secret masking, executes sequentially with stderr progress, renders status summary; Ctrl-C prints summary and exits | Sequential `Setup()` keeps progress legible, error attribution clear, preserves instrumentation→signal ordering, matches small-N reality | ADR-001 §6 |
+| Stub coverage | All 14 existing providers get stubs on day one: signals implement only `StatusDetectable` (config-key presence heuristic); setup-capable providers implement `Setupable` with `Setup()` returning `ErrSetupNotSupported` and `InfraCategories()` returning `nil` | Validates the interfaces end-to-end, populates the status table from day one, lets Area 7 land rich implementations provider-by-provider without framework churn | ADR-001 §7 |
+
+## Functional Requirements
+
+**Interfaces and types**
+
+- FR-001: The system MUST define a `StatusDetectable` interface with two methods: `ProductName() string` and `Status(ctx context.Context) (*ProductStatus, error)`.
+- FR-002: The system MUST define a `Setupable` interface that embeds `StatusDetectable` and adds `ValidateSetup(ctx, params map[string]string) error`, `Setup(ctx, params map[string]string) error`, `InfraCategories() []InfraCategory`, and `ResolveChoices(ctx, paramName string) ([]string, error)`.
+- FR-003: The system MUST define a `ProductState` string enum with exactly four values: `not_configured`, `configured`, `active`, `error`.
+- FR-004: The system MUST define a `ProductStatus` struct with fields `Product string`, `State ProductState`, `Details string`, `SetupHint string`.
+- FR-005: The system MUST define an `InfraCategory` struct with fields `ID InfraCategoryID`, `Label string`, `Params []SetupParam`, and an `InfraCategoryID` string alias.
+- FR-006: The system MUST define a `ParamKind` string enum with exactly four values: `text`, `bool`, `choice`, `multi_choice`.
+- FR-007: The system MUST define a `SetupParam` struct with fields `Name`, `Prompt`, `Kind`, `Required`, `Default`, `Secret`, `Choices`.
+- FR-008: The system MUST export a sentinel error `ErrSetupNotSupported` that setup-capable stubs return from `Setup()` to signal the flow is not yet implemented.
+- FR-009: The system MUST NOT extend the base `Provider` interface (internal/providers/provider.go) — the new interfaces are strictly additive and optional.
+
+**Discovery**
+
+- FR-010: The system MUST discover setup capabilities by iterating `providers.All()` and applying Go type assertions for `StatusDetectable` and `Setupable`. It MUST NOT reference provider package names, provider lists, or any registry outside of `providers.All()`.
+- FR-011: Providers that implement neither interface MUST remain fully functional as regular providers and MUST be invisible to the setup framework.
+
+**`gcx setup status` aggregation**
+
+- FR-012: The `gcx setup status` command MUST call `Status()` on every `StatusDetectable` provider in parallel using `errgroup` with bounded parallelism (default 10, matching the codebase standard).
+- FR-013: Each `Status()` call MUST run under a per-provider timeout enforced by the orchestrator via `context.WithTimeout`. The default timeout MUST be 5 seconds (matching the typical HTTP call budget in gcx; see plan.md Design Decisions).
+- FR-014: An error returned by `Status()` MUST be rendered as a row with `State = error` (StateError) and the error message placed in `Details`. The error MUST NOT cancel sibling `Status()` calls.
+- FR-015: A `Status()` call that exceeds its timeout MUST be treated as an error per FR-014 (row with `State = error`, message indicating timeout), not a hang, not a cancellation of other providers.
+- FR-016: Status rows MUST be rendered in alphabetical order by `ProductName()`, independent of call completion order.
+- FR-017: Status output MUST be rendered through the standard codec system (internal/output) supporting at least `text`, `json`, `yaml`, and `wide` formats. The command MUST NOT print bespoke formats or bypass the codec registry.
+- FR-018: In human mode, the `text` codec MUST color-code `State` (gray=not_configured, yellow=configured, green=active, red=error) using internal/style.
+- FR-019: In agent mode (`agent.IsAgentMode() == true`), the status command MUST default `--output` to `json`, suppress color, and suppress truncation.
+- FR-020: `gcx setup status` MUST work in agent mode.
+
+**`InfraCategory` and `SetupParam` semantics**
+
+- FR-021: When multiple providers register the same `InfraCategoryID`, the orchestrator MUST use the label of the first provider encountered (in alphabetical order of `ProductName()`) and ignore subsequent labels for that ID.
+- FR-022: `SetupParam` with `Kind ∈ {choice, multi_choice}` MUST populate options from `Choices` when non-empty. When `Choices` is empty, the orchestrator MUST call `ResolveChoices(ctx, param.Name)` to obtain options.
+- FR-023: `SetupParam.Secret == true` MUST cause the interactive prompt to mask input and MUST cause the preview step to render the value as `***`.
+
+**`gcx setup run` orchestration**
+
+- FR-024: `gcx setup run` MUST discover categories by iterating `providers.All()`, type-asserting `Setupable`, and collecting every non-nil `InfraCategories()` result.
+- FR-025: `gcx setup run` MUST present a multi-select of discovered category labels and allow the user to pick zero or more.
+- FR-026: After category selection, `gcx setup run` MUST resolve the set of providers whose `InfraCategories()` contains any selected ID and process them sequentially in alphabetical order of `ProductName()`.
+- FR-027: Before collecting parameters for a provider, the orchestrator MUST call `Status(ctx)`. If the result is `StateConfigured` or `StateActive`, the orchestrator MUST print "already configured, skipping" to stderr and continue to the next provider.
+- FR-028: For each `SetupParam`, the orchestrator MUST render the prompt widget matching `Kind`: plain text input for `text`, yes/no for `bool`, single-select list for `choice`, multi-select list for `multi_choice`. `Secret == true` MUST mask the text input.
+- FR-029: After parameter collection for a provider, the orchestrator MUST call `ValidateSetup(ctx, params)`. On error, it MUST print the error to stderr and re-run parameter collection for that provider with previously-collected values pre-filled as defaults. The loop MUST continue until validation succeeds or the user cancels.
+- FR-030: Before any `Setup()` call, the orchestrator MUST render a preview block listing each selected provider and its parameters. Providers with no parameters MUST render with their name only. Parameters where `Secret == true` MUST render as `***`.
+- FR-031: The orchestrator MUST prompt for confirmation (`Continue? [Y/n]`) after the preview. A negative answer MUST exit without invoking any `Setup()` and MUST use exit code 5 (cancelled).
+- FR-032: After confirmation, the orchestrator MUST call `Setup(ctx, params)` for each confirmed provider sequentially in alphabetical order of `ProductName()`, streaming per-provider progress to stderr.
+- FR-033: If `Setup()` returns an error, the orchestrator MUST log the error to stderr and continue to the next provider. It MUST NOT abort the run and MUST NOT roll back any prior successful `Setup()` call.
+- FR-034: On Ctrl-C (SIGINT) at any point during the run, the orchestrator MUST print a summary to stderr listing completed providers and remaining providers, then exit with code 5 (cancelled). It MUST NOT attempt rollback.
+- FR-035: After the execution phase, the orchestrator MUST render the post-run status table using the same aggregator as `gcx setup status`.
+- FR-036: In agent mode (`agent.IsAgentMode() == true`), `gcx setup run` MUST refuse to execute, MUST print a message to stderr directing the user to per-provider `gcx <provider-area> setup` commands, and MUST exit with code 2 (usage error).
+- FR-037: `gcx setup run` MUST NOT call `Setup()` concurrently. All `Setup()` invocations in the run orchestrator are sequential.
+- FR-038: The orchestrator MUST invoke `Setupable.Setup()` as a direct in-process method call. It MUST NOT invoke `gcx <provider-area> setup` as a subprocess.
+
+**Per-provider `gcx <provider-area> setup` command**
+
+- FR-039: Every provider that implements `Setupable` MUST expose a Cobra subcommand `gcx <provider-area> setup` that is a thin wrapper over `Setupable.Setup()`.
+- FR-040: The per-provider setup command MUST follow the codebase opts pattern: `opts struct` + `setup(flags *pflag.FlagSet)` + `Validate() error` + constructor returning `*cobra.Command`.
+- FR-041: The per-provider setup command MUST be non-interactive: flags only, no stdin prompts. It MUST work with `stdin` closed.
+- FR-042: The per-provider setup command MUST be idempotent: re-running it against an already-configured product MUST NOT produce a duplicate configuration or a spurious error; it either no-ops or updates in place.
+- FR-043: On success, the per-provider setup command MUST emit a structured mutation summary through the standard codec system (`text|json|yaml|wide`) and exit with code 0.
+- FR-044: On failure, the per-provider setup command MUST write a diagnostic to stderr, MUST NOT emit a partial data payload to stdout, and MUST exit with a non-zero exit code per DESIGN.md (1 general, 2 usage, 3 auth, 6 version-incompatible as appropriate).
+- FR-045: The per-provider setup command MUST work in agent mode with no prompts and JSON output by default.
+
+**Stub implementations**
+
+- FR-046: Every existing signal provider (alert, logs, metrics, profiles, traces) MUST implement `StatusDetectable` and MUST NOT implement `Setupable`.
+- FR-047: Every existing signal provider stub `Status()` MUST determine state from `ConfigKeys()` presence: when every non-secret required config key has a value, return `StateConfigured`; otherwise return `StateNotConfigured`. The stub MUST NOT perform any API probe.
+- FR-048: Every existing setup-capable provider (appo11y, faro, fleet, incidents, k6, kg, sigil, slo, synth) MUST implement `Setupable`.
+- FR-049: Every existing setup-capable provider stub `Setup()` MUST return `ErrSetupNotSupported`.
+- FR-050: Every existing setup-capable provider stub `InfraCategories()` MUST return `nil`.
+- FR-051: Every existing setup-capable provider stub `ValidateSetup()` MUST return `nil` (no-op validation).
+- FR-052: Every existing setup-capable provider stub `ResolveChoices()` MUST return `(nil, nil)`.
+- FR-053: Every `Setupable` stub MUST still expose a `gcx <provider-area> setup` Cobra command per FR-039. The command body MAY surface `ErrSetupNotSupported` via non-zero exit until Area 7 replaces the stub.
+
+**Backward compatibility**
+
+- FR-054: The existing subcommand tree `gcx setup instrumentation {status, show, apply, discover, export}` (cmd/gcx/setup/instrumentation/) MUST continue to function identically — command paths, flags, output shapes, exit codes unchanged.
+- FR-055: `gcx setup status` output semantics CHANGE: it now aggregates every `StatusDetectable` provider instead of the hardcoded instrumentation-only table. This is the intended behavior and MUST be documented in release notes.
+
+## Acceptance Criteria
+
+**Status aggregation**
+
+- GIVEN the provider registry contains providers A, B, C where A and C implement `StatusDetectable` and B does not
+  WHEN the user runs `gcx setup status`
+  THEN the rendered table contains rows for A and C only, in alphabetical order, and does not contain a row for B
+
+- GIVEN three `StatusDetectable` providers where provider "Logs" returns `StateActive`, provider "Metrics" returns `StateConfigured`, and provider "Traces" returns `StateNotConfigured`
+  WHEN the user runs `gcx setup status --output text`
+  THEN the output renders three rows in alphabetical order (Logs, Metrics, Traces) with colorized states (green, yellow, gray respectively)
+
+- GIVEN three `StatusDetectable` providers where provider "Faro" returns an error from `Status()`
+  WHEN the user runs `gcx setup status`
+  THEN the row for "Faro" renders with `State = error` and the error message in `Details`, the other two provider rows render their real state, and the sibling `Status()` calls are not cancelled
+
+- GIVEN a `StatusDetectable` provider whose `Status()` sleeps past the per-provider timeout
+  WHEN the user runs `gcx setup status`
+  THEN the row for that provider renders with `State = error` and a timeout message in `Details`, and the command returns within a bounded time proportional to the timeout (not to the sleep)
+
+- GIVEN `Status()` calls complete in the order C, A, B
+  WHEN the status table is rendered
+  THEN rows appear in alphabetical order A, B, C
+
+**Codec output shapes**
+
+- GIVEN a `gcx setup status --output json` invocation with two `StatusDetectable` providers
+  WHEN the command writes to stdout
+  THEN stdout contains a JSON array of two objects, each with keys `product`, `state`, `details`, `setup_hint`, and stderr contains no data payload
+
+- GIVEN a `gcx setup status --output yaml` invocation
+  WHEN the command writes to stdout
+  THEN stdout contains a YAML list with the same fields as the JSON variant and no ANSI color codes
+
+- GIVEN `gcx setup status` invoked while `agent.IsAgentMode()` returns true
+  WHEN no `--output` flag is passed
+  THEN the command defaults to JSON output, suppresses color, and suppresses truncation
+
+**`gcx setup run` happy path**
+
+- GIVEN three `Setupable` providers registered to the same category "kubernetes" with different parameters, and `Status()` returns `StateNotConfigured` for all three
+  WHEN the user runs `gcx setup run`, selects the "kubernetes" category, provides valid parameters for each, and confirms the preview
+  THEN `Setup()` is called sequentially in alphabetical order for all three providers with the collected params, and the command exits with code 0 and renders a final status table showing the post-run state
+
+- GIVEN a `Setupable` provider whose `Status()` returns `StateActive`
+  WHEN the orchestrator reaches that provider during the per-provider loop
+  THEN the orchestrator prints "already configured, skipping" to stderr, does not prompt for parameters, and does not call `Setup()` for that provider
+
+- GIVEN a `Setupable` provider whose first `ValidateSetup(params)` call returns a non-nil error
+  WHEN the orchestrator receives the validation error
+  THEN it prints the error to stderr and re-prompts every parameter for that provider with the previously-collected values as the default value for each field, and loops until `ValidateSetup` returns nil
+
+- GIVEN a `Setupable` provider with a `SetupParam` where `Secret == true` and the user entered the value "supersecret"
+  WHEN the orchestrator renders the preview block
+  THEN the parameter's value is rendered as `***` and the raw value "supersecret" does not appear anywhere in stdout or stderr
+
+- GIVEN `gcx setup run` has completed `Setup()` for two providers and the user sends SIGINT before the third provider completes
+  WHEN the signal is received
+  THEN stderr contains a summary listing the two completed providers and the remaining provider(s), the command exits with code 5, and no rollback of completed providers is attempted
+
+- GIVEN `gcx setup run` is invoked while `agent.IsAgentMode()` returns true
+  WHEN the command starts
+  THEN it writes a message to stderr pointing the user to per-provider `gcx <provider-area> setup` commands, does not prompt, and exits with code 2
+
+**Per-provider setup command**
+
+- GIVEN a `Setupable` provider "foo" has been configured successfully once
+  WHEN the user re-runs `gcx foo setup` with the same flags
+  THEN the command detects existing configuration, either no-ops or updates idempotently, emits a structured mutation summary through the codec system, and exits with code 0
+
+- GIVEN `gcx foo setup --output json` is invoked with valid flags in agent mode
+  WHEN the command succeeds
+  THEN stdout contains only JSON, stderr contains progress/diagnostic text only, and the exit code is 0
+
+- GIVEN `gcx foo setup` is invoked with an invalid flag value
+  WHEN the command validates flags via `opts.Validate()`
+  THEN the command writes a usage-style diagnostic to stderr, exits with code 2, and does not call `Setup()`
+
+**Stub behavior**
+
+- GIVEN the signal provider "metrics" is `StatusDetectable` only and its required config keys are all present in the active context
+  WHEN `gcx setup status` evaluates its row
+  THEN the row shows `State = configured` (from `ConfigKeys()` presence heuristic) and `Details` indicates config-key presence only — no API probe has been performed
+
+- GIVEN a setup-capable provider stub "synth" whose `Setup()` returns `ErrSetupNotSupported`
+  WHEN the user runs `gcx synth setup --...`
+  THEN the command exits with a non-zero code and stderr contains a clear "setup not yet implemented" message
+
+- GIVEN every setup-capable provider stub returns `nil` from `InfraCategories()`
+  WHEN the user runs `gcx setup run`
+  THEN the category multi-select presents zero categories, the command prints a message indicating no interactive setup flows are available, and exits with code 0
+
+**Backward compatibility**
+
+- GIVEN the framework is shipped
+  WHEN the user runs `gcx setup instrumentation status`, `gcx setup instrumentation show`, `gcx setup instrumentation apply`, `gcx setup instrumentation discover`, or `gcx setup instrumentation export`
+  THEN each command behaves identically to its pre-framework behavior (flags, output shape, exit codes), and cmd/gcx/setup/instrumentation/status_test.go continues to pass
+
+## Negative Constraints
+
+- NEVER hard-code a list of providers anywhere in the setup framework. Discovery is exclusively via `providers.All()` + type assertion.
+- NEVER extend the base `Provider` interface (internal/providers/provider.go) as part of this feature. New interfaces are additive and optional.
+- NEVER require a provider to implement `Setupable`. `StatusDetectable`-only is a first-class case.
+- NEVER run `Setup()` concurrently in the `gcx setup run` orchestrator. v1 is strictly sequential.
+- NEVER cancel sibling `Status()` calls when one provider's `Status()` errors or times out. Error isolation is mandatory.
+- NEVER roll back completed `Setup()` calls on cancellation, Ctrl-C, or a later provider's error. Partial completion is a valid state.
+- NEVER execute `gcx setup run` in agent mode. The command MUST refuse with exit code 2 and a message directing to per-provider setup commands.
+- NEVER invoke a provider's `Setup()` through a subprocess (`exec "gcx" ...`) from the orchestrator. Direct in-process method call only.
+- NEVER output result data via printf/fmt or bespoke renderers — every data payload goes through the codec system.
+- NEVER mix data and diagnostics on stdout. STDOUT is data, STDERR is progress and diagnostics.
+- NEVER emit a secret parameter's raw value to stdout or stderr anywhere in the preview, progress, or summary. Secret values render as `***`.
+- NEVER parse `ValidateSetup` error strings to target specific fields. Re-prompt all fields for the provider.
+- NEVER break the `gcx setup instrumentation {status|show|apply|discover|export}` subtree. It is compatibility-locked.
+- DO NOT introduce a heavy interactive UI library for v1 prompt widgets. Keep widgets minimal and self-contained.
+- DO NOT render a status table via a bespoke format. Always via the codec system.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Consistency drift across provider `Status()` and `Setup()` implementations (each provider owns its semantics) | Divergent user experience; inconsistent color/state meanings across products | Ship stub templates (documented pattern) for both `StatusDetectable`-only and `Setupable` providers; enforce via code review; Area 7 replaces stubs incrementally with a documented minimum bar established first |
+| Breaking change to `gcx setup status` output shape (instrumentation-only → all-providers aggregated) | CI/automation parsing the old fixed PRODUCT/ENABLED/HEALTH/DETAILS table will break silently | Release notes documenting the change; agent-mode JSON contract is stable and preferred for automation; `gcx setup instrumentation status` remains for the narrower query |
+| Interactive prompt library choice adds dependency weight or conflicts with gcx style system | Slower binary, larger surface, or clashes with internal/style theming | Implement minimal widgets in-repo (text/bool/choice/multi_choice/secret) using bufio + termios-style input masking; keep the door open to adopt a small, vetted library later without changing the orchestration contract |
+| Partial-completion state in `gcx setup run` confuses users (some providers succeed, some fail, some skipped, some cancelled) | Users re-run and are unsure of resulting state; perceived unreliability | Render a clear post-run summary: per-provider outcome (completed / failed / skipped / cancelled) + explicit "re-run `gcx setup run` to retry un-configured providers" message; post-run status table confirms ground truth |
+| Stub `Status()` using only `ConfigKeys()` presence can misreport a provider as `configured` when the upstream API is unreachable | Users see a green-ish row while the product is actually broken | Document the stub heuristic explicitly in the status `Details` column (e.g., "config keys present; no API probe performed"); Area 7 replaces stubs with real probes and the `Details` copy flips automatically |
+| Per-provider setup commands that must exist but have no real implementation (stubs) are discoverable in `--help` and may mislead users | Users run `gcx synth setup` and get `ErrSetupNotSupported` | Stub command help text explicitly marks the flow as "not yet implemented"; non-zero exit code + stderr message on invocation; tracking issue per provider for Area 7 replacement |
+
+## Open Questions
+
+- [RESOLVED]: What is the default per-provider timeout for `Status()` aggregation? — 5 seconds (locked in plan.md Design Decisions; matches typical gcx HTTP call budget). Flag-based override is deferred to a later iteration.
+- [DEFERRED]: Field-level validation error targeting (structured error protocol between `ValidateSetup` and the orchestrator to re-prompt only the bad field). v1 re-prompts all fields with previous values as defaults. Revisit if providers demand it (ADR §Rejected Alternatives).
+- [DEFERRED]: `ConcurrencySafe() bool` method or `--parallel` flag on `gcx setup run`. v1 is strictly sequential `Setup()` execution. Revisit if two provably independent long-running setup flows emerge (ADR §Rejected Alternatives).
+- [DEFERRED]: Rich choice metadata (`[]Choice{Value, Description}` from `ResolveChoices`). v1 uses `[]string`. Evolve when a provider needs descriptions alongside values (ADR §Rejected Alternatives).
+- [DEFERRED]: Dependency-aware provider ordering (e.g., instrumentation before metrics/logs). v1 uses alphabetical ordering. Revisit by adding `Dependencies() []string` or a priority field on `InfraCategory` if needs emerge (ADR §Rejected Alternatives).
+- [DEFERRED]: `--dry-run` / `--show-commands` preview modes on `gcx setup run` that render equivalent `gcx <provider-area> setup` commands instead of executing. Power-user feature, not v1 (ADR §Rejected Alternatives).
+- [DEFERRED]: `gcx setup doctor` deeper health checks (token expiry, API version compatibility). Future follow-up listed in ADR §Follow-up Work.

--- a/docs/specs/feature-setup-framework/spec.md
+++ b/docs/specs/feature-setup-framework/spec.md
@@ -39,7 +39,7 @@ This spec turns the ADR into an executable plan: the interfaces, types, orchestr
 - Orchestrator invocation of `Setupable.Setup()` in-process only — never subprocess.
 - Stub coverage across all 14 existing providers:
   - **Signal/data providers** (alert, logs, metrics, profiles, traces) implement `StatusDetectable` only. `Status()` uses a `ConfigKeys()` presence heuristic; no API probing.
-  - **Setup-capable providers** (appo11y, faro, fleet, incidents, k6, kg, sigil, slo, synth) implement `Setupable`. `Setup()` returns `ErrSetupNotSupported`. `InfraCategories()` returns `nil`. `ValidateSetup()` returns `nil` (no-op). `ResolveChoices()` returns `(nil, nil)`.
+  - **Setup-capable providers** (appo11y, faro, fleet, irm, k6, kg, sigil, slo, synth) implement `Setupable`. `Setup()` returns `ErrSetupNotSupported`. `InfraCategories()` returns `nil`. `ValidateSetup()` returns `nil` (no-op). `ResolveChoices()` returns `(nil, nil)`.
 - Interactive prompt widgets for `text`, `bool`, `choice` (single select), `multi_choice` (multi-select), and secret (masked input). Minimal implementation, no heavy UI dependency.
 - Preview rendering with secret masking (`***` for any `SetupParam` where `Secret == true`).
 - Validation retry flow: on `ValidateSetup` error, re-prompt all fields for that provider with previously-collected values as defaults; loop until validation passes or the user cancels.
@@ -142,7 +142,7 @@ This spec turns the ADR into an executable plan: the interfaces, types, orchestr
 
 - FR-046: Every existing signal provider (alert, logs, metrics, profiles, traces) MUST implement `StatusDetectable` and MUST NOT implement `Setupable`.
 - FR-047: Every existing signal provider stub `Status()` MUST determine state from `ConfigKeys()` presence: when every non-secret required config key has a value, return `StateConfigured`; otherwise return `StateNotConfigured`. The stub MUST NOT perform any API probe.
-- FR-048: Every existing setup-capable provider (appo11y, faro, fleet, incidents, k6, kg, sigil, slo, synth) MUST implement `Setupable`.
+- FR-048: Every existing setup-capable provider (appo11y, faro, fleet, irm, k6, kg, sigil, slo, synth) MUST implement `Setupable`.
 - FR-049: Every existing setup-capable provider stub `Setup()` MUST return `ErrSetupNotSupported`.
 - FR-050: Every existing setup-capable provider stub `InfraCategories()` MUST return `nil`.
 - FR-051: Every existing setup-capable provider stub `ValidateSetup()` MUST return `nil` (no-op validation).

--- a/docs/specs/feature-setup-framework/spec.md
+++ b/docs/specs/feature-setup-framework/spec.md
@@ -1,7 +1,7 @@
 ---
 type: feature-spec
 title: "Setup Framework: Interfaces, Stubs, and Orchestration"
-status: approved
+status: done
 adr: docs/adrs/setup-framework/001-setup-framework-interfaces-and-orchestration.md
 created: 2026-04-17
 ---

--- a/docs/specs/feature-setup-framework/tasks.md
+++ b/docs/specs/feature-setup-framework/tasks.md
@@ -1,0 +1,774 @@
+---
+type: feature-tasks
+title: "Setup Framework: Interfaces, Stubs, and Orchestration"
+status: approved
+spec: docs/specs/feature-setup-framework/spec.md
+plan: docs/specs/feature-setup-framework/plan.md
+generated: 2026-04-20
+---
+
+# Implementation Tasks
+
+Derived from `plan.md` §Implementation Sequence. Waves computed from inter-task
+dependencies so independent tasks run in parallel.
+
+> **Provider naming note:** spec.md §Stub Implementations lists providers by
+> conceptual name ("incidents"). The actual Go package and `Name()` value for the
+> Incidents provider is `irm` (see `internal/providers/irm/` — `IRMProvider.Name()`
+> returns `"irm"`). All tasks below MUST use directory and provider names as they
+> exist in the repo. The 14 providers are: `alert`, `appo11y`, `faro`, `fleet`,
+> `irm`, `k6`, `kg`, `logs`, `metrics`, `profiles`, `sigil`, `slo`, `synth`,
+> `traces`.
+
+## Dependency Graph
+
+```
+T1 (framework scaffold)
+ ├──→ T2 (AggregateStatus)     ──┐
+ │                               │
+ ├──→ T4 (prompt widgets)     ──┐│
+ │                              ││
+ ├──→ T7 (signal stubs, 5p)     ││
+ │                              ││
+ └──→ T8 (setup-cap stubs, 9p)  ││
+                                ▼▼
+                    T3 (`gcx setup status` CLI)     (needs T2)
+                         │
+                         │
+                    T5 (Orchestrator.Run)          (needs T2, T4)
+                         │
+                         ▼
+                    T6 (`gcx setup run` CLI)       (needs T5)
+                         │
+                         ▼
+                    T9 (docs regen + make all)     (needs T3, T6, T7, T8)
+```
+
+**Waves** (topological order, tasks in the same wave run in parallel):
+
+- **Wave 1**: T1
+- **Wave 2**: T2, T4, T7, T8
+- **Wave 3**: T3, T5
+- **Wave 4**: T6
+- **Wave 5**: T9
+
+---
+
+## Wave 1: Framework Scaffold
+
+### T1: Scaffold `internal/setup/framework/` package
+
+**Priority**: P0
+**Effort**: Medium-Large
+**Depends on**: none
+**Type**: task
+
+Create the new `internal/setup/framework/` package with interface definitions,
+discovery helpers, the `ConfigKeysStatus` stub helper, and the fake-provider
+test doubles that every downstream wave will reuse. This is the foundation —
+no CLI wiring, no aggregation, no orchestrator yet.
+
+**Deliverables:**
+
+- `internal/setup/framework/interfaces.go`
+  - `StatusDetectable` interface: `ProductName() string`, `Status(ctx) (*ProductStatus, error)`.
+  - `Setupable` interface: embeds `StatusDetectable`, adds `ValidateSetup(ctx, params) error`,
+    `Setup(ctx, params) error`, `InfraCategories() []InfraCategory`,
+    `ResolveChoices(ctx, paramName) ([]string, error)`.
+  - `ProductState` string enum with exactly four values: `not_configured`,
+    `configured`, `active`, `error` (as named constants
+    `StateNotConfigured`, `StateConfigured`, `StateActive`, `StateError`).
+  - `ProductStatus` struct: `Product`, `State`, `Details`, `SetupHint`.
+  - `InfraCategoryID` string alias.
+  - `InfraCategory` struct: `ID`, `Label`, `Params`.
+  - `ParamKind` string enum with exactly four values: `text`, `bool`, `choice`,
+    `multi_choice` (as named constants).
+  - `SetupParam` struct: `Name`, `Prompt`, `Kind`, `Required`, `Default`,
+    `Secret`, `Choices`.
+  - `ErrSetupNotSupported` sentinel error exported as a package-level `var`.
+
+- `internal/setup/framework/discovery.go`
+  - `DiscoverStatusDetectable() []StatusDetectable` — iterates `providers.All()`,
+    filters via type assertion, returns in arbitrary order.
+  - `DiscoverSetupable() []Setupable` — same pattern for `Setupable`.
+
+- `internal/setup/framework/stub.go`
+  - `ConfigKeysStatus(p providers.Provider) ProductStatus` — returns
+    `StateConfigured` when every non-secret required key in `p.ConfigKeys()`
+    has a non-empty value in the active config context; otherwise
+    `StateNotConfigured`. `Details` indicates "config keys present; no API probe
+    performed" (or similar clarifying copy). MUST NOT perform any API probe.
+
+- `internal/setup/framework/fakes_test.go` (or `internal/setup/framework/testhelpers/`):
+  - `FakeStatusDetectable` and `FakeSetupable` test doubles with configurable
+    state, errors, latency, and panic behavior. These doubles will be reused
+    by T2, T3, T5, T6.
+
+- `internal/setup/framework/registry_test.go` (or similar):
+  - `SetupTestRegistry(t *testing.T, providers []providers.Provider)` helper
+    that swaps the backing slice of `providers.All()` for the duration of a
+    test, restoring via `t.Cleanup`. Guard against concurrent test runs by
+    documenting that integration users must disable parallelism or scope
+    per-subtest.
+
+- `internal/setup/framework/interfaces_test.go`, `discovery_test.go`,
+  `stub_test.go` — table-driven unit tests covering:
+  - `StatusDetectable` and `Setupable` compile-time assertions against the
+    fake doubles.
+  - Discovery returns exactly the providers that implement each interface.
+  - `ConfigKeysStatus` returns `StateConfigured` iff every non-secret required
+    key has a value; `StateNotConfigured` otherwise.
+  - Secret keys are ignored by the heuristic.
+
+**Acceptance criteria:**
+
+- GIVEN the provider registry contains providers A (StatusDetectable),
+  B (plain Provider), C (Setupable)
+  WHEN `DiscoverStatusDetectable()` is called
+  THEN it returns both A and C (since `Setupable` embeds `StatusDetectable`),
+  and does NOT return B.
+
+- GIVEN the provider registry contains providers A (StatusDetectable) and
+  C (Setupable)
+  WHEN `DiscoverSetupable()` is called
+  THEN it returns only C.
+
+- GIVEN a provider with `ConfigKeys() = [{Name: "url", Secret: false},
+  {Name: "token", Secret: true}]` and the active context has a value for "url"
+  WHEN `ConfigKeysStatus(p)` is called
+  THEN it returns `ProductStatus{Product: p.Name(), State: StateConfigured,
+  Details: "…"}`.
+
+- GIVEN the same provider but the active context has NO value for "url"
+  WHEN `ConfigKeysStatus(p)` is called
+  THEN it returns `ProductStatus{Product: p.Name(), State: StateNotConfigured,
+  Details: "…"}`.
+
+- GIVEN `ErrSetupNotSupported`
+  WHEN an external caller tests with `errors.Is(err, framework.ErrSetupNotSupported)`
+  THEN identity is preserved across wrap/unwrap.
+
+- `go vet ./internal/setup/framework/...` passes; `go test ./internal/setup/framework/...`
+  passes with `-race`; no import cycle between `internal/setup/framework` and
+  `internal/providers`.
+
+**Implementation notes:**
+
+- `internal/setup/framework` imports `internal/providers` for the base
+  `Provider` interface and `providers.All()`. `internal/providers` MUST NOT
+  import `internal/setup/framework`. Enforce with a build-time cycle check.
+- No changes to `internal/providers/provider.go` — the base interface is
+  untouched (FR-009).
+- The `SetupTestRegistry` helper must avoid mutating `providers.All()` if the
+  registry type is opaque. If needed, expose a test-only setter via a
+  `go:linkname`-free mechanism (e.g., a test hook registered from
+  `internal/providers`).
+
+---
+
+## Wave 2: Aggregation, Prompts, and Stubs (parallel)
+
+### T2: Implement `framework.AggregateStatus`
+
+**Priority**: P0
+**Effort**: Medium
+**Depends on**: T1
+**Type**: task
+
+Implement the parallel, error-isolated status aggregator that every downstream
+consumer (CLI `setup status`, orchestrator pre-run check, post-run summary)
+calls.
+
+**Deliverables:**
+
+- `internal/setup/framework/aggregate.go`
+  - `AggregateStatus(ctx context.Context, timeout time.Duration) []ProductStatus`
+  - Uses `golang.org/x/sync/errgroup` with `SetLimit(10)` for bounded parallelism.
+  - Each `Status()` call runs under its own `context.WithTimeout(ctx, timeout)`.
+  - `Status()` errors are converted into `ProductStatus{State: StateError,
+    Details: err.Error()}` (error isolation — sibling calls are not cancelled).
+  - Timeouts are rendered as `StateError` with a timeout message.
+  - Panics in `Status()` are recovered and rendered as `StateError` with a
+    panic message (never crash the command).
+  - Returned slice is sorted alphabetically by `ProductName()` before return.
+  - `timeout <= 0` falls back to 5 seconds (the spec-declared default).
+
+- `internal/setup/framework/aggregate_test.go` — table-driven tests covering:
+  - Happy path: three providers with distinct states, alphabetical rendering,
+    completion-order independence.
+  - Error isolation: one provider errors, others succeed.
+  - Timeout: one provider exceeds its timeout, others complete under it.
+  - Panic: one provider panics, others succeed.
+  - Mixed: errors + timeouts + successes in the same call.
+  - Ordering: call-completion order C, A, B → rendered order A, B, C.
+
+**Acceptance criteria:**
+
+- GIVEN three `StatusDetectable` fakes returning `StateActive`, `StateConfigured`,
+  `StateNotConfigured` (in completion-time order C, A, B)
+  WHEN `AggregateStatus(ctx, 5s)` returns
+  THEN the result is alphabetically ordered by ProductName.
+
+- GIVEN three providers, one of which returns a non-nil error from `Status()`
+  WHEN `AggregateStatus` returns
+  THEN the erroring provider appears as `StateError` with the error message in
+  `Details` and the other two provider rows reflect their real state (no sibling
+  cancellation).
+
+- GIVEN a provider whose `Status()` sleeps for 10s with a 5s per-provider timeout
+  WHEN `AggregateStatus(ctx, 5s)` is called
+  THEN the provider's row is `StateError` with a timeout-indicating `Details`,
+  AND the call returns in ≤ ~6s (bounded by the timeout, not the sleep).
+
+- GIVEN a provider whose `Status()` panics with a runtime error
+  WHEN `AggregateStatus` runs
+  THEN the provider's row is `StateError` with a panic-indicating `Details`,
+  AND other providers return their real state.
+
+- GIVEN ten `StatusDetectable` fakes
+  WHEN `AggregateStatus` is called
+  THEN the bounded parallelism is respected (no more than 10 in-flight calls;
+  verify via counter in the fake).
+
+**Implementation notes:**
+
+- Use `context.WithTimeout` inside the errgroup closure, not outside, so each
+  provider gets its own deadline independent of siblings.
+- `errgroup.Group.Wait()` is called without returning its error — the aggregator
+  does not propagate individual provider errors upward; they are folded into the
+  result slice.
+
+---
+
+### T4: Implement prompt widgets
+
+**Priority**: P0
+**Effort**: Medium
+**Depends on**: T1
+**Type**: task
+
+Implement the minimal interactive prompt widgets used by the orchestrator.
+Must work over a `bufio.Reader` input and `io.Writer` output, with optional
+raw-mode masking for secret input via `golang.org/x/term`.
+
+**Deliverables:**
+
+- `internal/setup/framework/prompt/prompt.go`
+  - `Text(in io.Reader, out io.Writer, prompt, def string) (string, error)` —
+    line-edited text input with default. Empty input returns `def`.
+  - `Bool(in, out, prompt string, def bool) (bool, error)` — `[Y/n]` or `[y/N]`
+    depending on `def`; yes/no parsing tolerates `y`, `Y`, `yes`, `n`, `N`, `no`.
+  - `Choice(in, out, prompt string, options []string, def string) (string, error)` —
+    numbered menu, Enter accepts `def` if non-empty, arrow-key nav NOT required
+    (number-entry sufficient for v1).
+  - `MultiChoice(in, out, prompt string, options []string, defs []string) ([]string, error)` —
+    numbered menu with comma-separated selection input ("1,3,5"), Enter accepts
+    the defaults.
+  - `Secret(in *os.File, out io.Writer, prompt string) (string, error)` —
+    uses `term.MakeRaw` + `term.ReadPassword` for masked input. MUST `defer
+    term.Restore(fd, state)` to guarantee terminal state is restored on panic.
+
+- `internal/setup/framework/prompt/prompt_test.go` — tests cover:
+  - Text widget: default returned on empty input; entered value returned otherwise.
+  - Bool widget: Y/N/y/n/yes/no all parsed; empty returns default.
+  - Choice widget: out-of-range index re-prompts; Enter accepts default.
+  - MultiChoice widget: comma-separated selection; invalid index re-prompts;
+    Enter accepts defaults.
+  - Secret widget: raw-mode terminal state is restored even if the read panics.
+  - Required-with-no-default: empty input re-prompts.
+
+**Acceptance criteria:**
+
+- GIVEN a `Text` prompt with default "foo" and empty user input
+  WHEN the prompt returns
+  THEN the returned value is "foo".
+
+- GIVEN a `Secret` prompt that panics mid-read
+  WHEN the panic is recovered in the test
+  THEN the terminal's raw-mode state has been restored.
+
+- GIVEN a `Choice` prompt with options `[a, b, c]` and default `b`
+  WHEN the user presses Enter without typing
+  THEN the prompt returns `b`.
+
+- GIVEN a `MultiChoice` prompt with options `[a, b, c, d]` and defaults `[]`
+  WHEN the user types `1,3`
+  THEN the prompt returns `[a, c]`.
+
+- `go test ./internal/setup/framework/prompt/...` passes with `-race`.
+
+**Implementation notes:**
+
+- Do NOT adopt `bubbletea`, `survey/v2`, or any heavy TUI library. Widget
+  implementations are in-repo with `bufio` + `x/term`.
+- Non-TTY input detection is the orchestrator's concern (T5), not the widget's.
+  Widgets accept arbitrary `io.Reader`/`io.Writer` so tests can drive them
+  with `bytes.Buffer`.
+
+---
+
+### T7: Add `StatusDetectable` stubs to signal providers
+
+**Priority**: P1
+**Effort**: Medium
+**Depends on**: T1
+**Type**: task
+
+Add `ProductName()` and `Status()` methods to the 5 signal providers. Each
+`Status()` delegates to `framework.ConfigKeysStatus`. No API probing.
+
+**Providers**: `alert`, `logs`, `metrics`, `profiles`, `traces`.
+(Dirs: `internal/providers/{alert,logs,metrics,profiles,traces}/`.)
+
+**Deliverables:**
+
+- `internal/providers/<area>/provider.go` (modified × 5)
+  - Add methods to the existing provider struct:
+    - `ProductName() string` — returns the provider's display name
+      (same as `Name()` for v1; future work may differentiate).
+    - `Status(ctx context.Context) (*framework.ProductStatus, error)` — calls
+      `framework.ConfigKeysStatus(p)` and returns it.
+
+- `internal/providers/<area>/provider_test.go` (modified × 5)
+  - Assert the provider implements `framework.StatusDetectable`
+    (via compile-time type assertion or runtime check).
+  - Assert it does NOT implement `framework.Setupable`
+    (runtime `_, ok := p.(framework.Setupable); !ok`).
+  - Assert `ProductName()` matches `Name()`.
+  - Exercise `Status(ctx)` with a provider whose config keys are fully set → `StateConfigured`.
+  - Exercise `Status(ctx)` with missing config keys → `StateNotConfigured`.
+
+**Acceptance criteria:**
+
+- GIVEN the metrics provider whose required config keys are all present
+  WHEN `provider.Status(ctx)` is called
+  THEN it returns `ProductStatus{State: StateConfigured, ...}`.
+
+- GIVEN the logs provider with missing required config keys
+  WHEN `provider.Status(ctx)` is called
+  THEN it returns `ProductStatus{State: StateNotConfigured, ...}`.
+
+- `go vet ./internal/providers/{alert,logs,metrics,profiles,traces}/...` passes.
+- `go test ./internal/providers/{alert,logs,metrics,profiles,traces}/...` passes.
+- Compile-time assertion that signal providers implement `StatusDetectable` but
+  NOT `Setupable`.
+
+---
+
+### T8: Add `Setupable` stubs + per-provider setup commands
+
+**Priority**: P1
+**Effort**: Large
+**Depends on**: T1
+**Type**: task
+
+Add the full `Setupable` stub plus a per-provider `setup` Cobra subcommand
+to the 9 setup-capable providers. All stubs return `ErrSetupNotSupported`
+from `Setup()`; the Cobra commands surface that sentinel with a "not yet
+implemented" diagnostic and a non-zero exit.
+
+**Providers**: `appo11y`, `faro`, `fleet`, `irm`, `k6`, `kg`, `sigil`, `slo`,
+`synth`.
+(Directories: `internal/providers/{appo11y,faro,fleet,irm,k6,kg,sigil,slo,synth}/`.)
+
+> **Naming note**: spec FR-048 says "incidents" for the Incidents provider;
+> the actual directory and `Name()` value is `irm`. Use `irm` everywhere in
+> this task.
+
+**Deliverables:**
+
+- `internal/providers/<area>/provider.go` (modified × 9)
+  - Add to the existing provider struct:
+    - `ProductName() string` — typically returns `Name()`.
+    - `Status(ctx) (*framework.ProductStatus, error)` → calls
+      `framework.ConfigKeysStatus(p)`.
+    - `InfraCategories() []framework.InfraCategory` → returns `nil`.
+    - `ResolveChoices(ctx, paramName string) ([]string, error)` → returns
+      `(nil, nil)`.
+    - `ValidateSetup(ctx, params map[string]string) error` → returns `nil`.
+    - `Setup(ctx, params map[string]string) error` → returns
+      `framework.ErrSetupNotSupported`.
+
+- `internal/providers/<area>/setup.go` **(new × 9)**
+  - Thin Cobra subcommand `setup` using the codebase opts pattern:
+    `opts` struct + `setup(flags *pflag.FlagSet)` + `Validate()` + constructor
+    returning `*cobra.Command`.
+  - Flag-only, non-interactive, idempotent, agent-friendly.
+  - `Use: "setup"`, `Short: "Set up <product> (not yet implemented)."`.
+  - RunE calls the provider's `Setup(ctx, params)` directly (in-process).
+  - On `errors.Is(err, framework.ErrSetupNotSupported)`: stderr message "setup
+    not yet implemented for <product>"; exit with non-zero code (exit code 1,
+    general). Wire through `cmd/gcx/fail` if that's the codebase convention.
+  - Register the command via `provider.Commands()`.
+
+- `internal/providers/<area>/provider_test.go` (modified × 9)
+  - Compile-time assertion: the provider implements `framework.Setupable`.
+  - `Setup()` returns an error satisfying `errors.Is(err, framework.ErrSetupNotSupported)`.
+  - `InfraCategories()` returns `nil`.
+  - `ResolveChoices(ctx, "any")` returns `(nil, nil)`.
+  - `ValidateSetup(ctx, any)` returns `nil`.
+  - Cobra command exists: `provider.Commands()` contains a child named `setup`.
+  - Running the `setup` subcommand with `--help` works; running it without
+    `--help` exits non-zero and writes the "not yet implemented" diagnostic to
+    stderr.
+
+- `internal/providers/<area>/setup_test.go` **(new × 9)** OR fold into
+  `provider_test.go` — integration-style test that invokes the Cobra command
+  with `cmd.SetArgs([])` + `cmd.SetErr(&buf)` and asserts the stderr message
+  and exit behavior.
+
+**Acceptance criteria:**
+
+- GIVEN the `synth` provider
+  WHEN `errors.Is(synth.Setup(ctx, nil), framework.ErrSetupNotSupported)`
+  THEN it returns `true`.
+
+- GIVEN any of the 9 setup-capable providers
+  WHEN `_, ok := p.(framework.Setupable)`
+  THEN `ok` is `true`.
+
+- GIVEN `gcx synth setup` is invoked without special flags
+  WHEN the command runs
+  THEN stderr contains "not yet implemented" (or a substring asserting
+  ErrSetupNotSupported messaging) AND the exit code is non-zero.
+
+- GIVEN `gcx synth setup --help` is invoked
+  WHEN the help text renders
+  THEN it includes a "not yet implemented" marker.
+
+- `go test ./internal/providers/{appo11y,faro,fleet,irm,k6,kg,sigil,slo,synth}/...`
+  passes.
+
+**Implementation notes:**
+
+- DO NOT create a framework-level helper that auto-registers the setup command
+  for every provider. Each provider registers its own `setup` command for
+  v1, matching the existing pattern for Commands().
+- The help-tree entry for `gcx <provider-area> setup` will be picked up
+  automatically when the Cobra command is added (cmd/gcx/helptree/ scans the
+  tree dynamically). Verify at T9 during docs regen.
+- If a provider already has a `setup` subcommand (it shouldn't — do a
+  preflight check), that's a blocker: open a discussion before overwriting.
+
+---
+
+## Wave 3: CLI Wiring and Orchestrator (parallel)
+
+### T3: Rewrite `gcx setup status` over `AggregateStatus`
+
+**Priority**: P0
+**Effort**: Medium
+**Depends on**: T2
+**Type**: task
+
+Replace the hardcoded instrumentation-only `setup status` body with a call to
+`framework.AggregateStatus`, and wire `internal/output.Options` for
+`text|json|yaml|wide` codec support. Adds agent-mode JSON default.
+
+**Deliverables:**
+
+- `cmd/gcx/setup/command.go` (modified)
+  - Replace the existing `newStatusCommand(loader)` body:
+    - Accept `internal/output.Options` — register a custom `text` codec that
+      uses `internal/style.TableBuilder` (columns: PRODUCT, STATE, DETAILS,
+      HINT) with state-color mapping (gray = not_configured, yellow = configured,
+      green = active, red = error). Color only when stdout is a TTY.
+    - JSON / YAML codecs use `[]ProductStatus` directly via the default
+      encoders.
+    - Agent-mode: when `agent.IsAgentMode()` returns true, default `--output`
+      to `json`, suppress color, suppress truncation.
+    - Call `framework.AggregateStatus(ctx, 5*time.Second)` and feed the result
+      through the registered codec.
+    - Preserve the existing `loader.BindFlags` for context-loading flags.
+  - Remove `setupProductRow` and `writeSetupStatusTable` (replaced by codec).
+
+- `cmd/gcx/setup/command_test.go` **(new — integration tests)**
+  - Use `framework.SetupTestRegistry` to inject two `StatusDetectable` fakes.
+  - Assert `text` output contains expected rows and column ordering.
+  - Assert `json` output is a valid JSON array with keys
+    `product`, `state`, `details`, `setup_hint`.
+  - Assert `yaml` output matches the JSON variant structure.
+  - Assert agent-mode defaults to JSON.
+  - Assert an errored provider renders as `StateError` in text/json/yaml.
+
+- Regression verification: `cmd/gcx/setup/instrumentation/status_test.go` must
+  continue to pass UNCHANGED. This is a hard gate.
+
+**Acceptance criteria:**
+
+- GIVEN the registry contains providers A (StatusDetectable),
+  B (plain Provider), C (StatusDetectable)
+  WHEN `gcx setup status --output text` runs
+  THEN the output contains rows for A and C in alphabetical order and NO row for B.
+
+- GIVEN three providers `Logs` (active), `Metrics` (configured), `Traces` (not_configured)
+  WHEN `gcx setup status --output text` runs on a TTY
+  THEN the rows appear alphabetically (Logs, Metrics, Traces) with
+  colored state cells (green / yellow / gray).
+
+- GIVEN the same three providers
+  WHEN `gcx setup status --output json` runs
+  THEN stdout is a JSON array with three objects, each with keys
+  `product`, `state`, `details`, `setup_hint`; no ANSI escape codes anywhere.
+
+- GIVEN `gcx setup status` is run with `agent.IsAgentMode()` returning true
+  WHEN no `--output` flag is passed
+  THEN the command defaults to JSON output, suppresses color, suppresses
+  truncation.
+
+- `cmd/gcx/setup/instrumentation/status_test.go` passes WITHOUT modification.
+
+**Implementation notes:**
+
+- The custom text codec registration pattern is documented in
+  `docs/architecture/patterns.md` (Pattern 13: format-agnostic fetching).
+- Column naming: prefer `PRODUCT | STATE | DETAILS | HINT` over the legacy
+  `PRODUCT | ENABLED | HEALTH | DETAILS` — state replaces enabled/health.
+- Handle the "no StatusDetectable providers registered" edge case: render an
+  empty table with headers and a helpful `Details` note if none discovered,
+  OR exit 0 with a stderr note — prefer the empty table (matches gcx UX).
+
+---
+
+### T5: Implement `framework.Orchestrator` (Run)
+
+**Priority**: P0
+**Effort**: Large
+**Depends on**: T2, T4
+**Type**: task
+
+Implement the full `gcx setup run` flow inside the framework. The CLI layer
+(T6) is a thin wrapper that calls this. Owns Ctrl-C handling, validation retry,
+preview masking, sequential `Setup()`, and the post-run summary.
+
+**Deliverables:**
+
+- `internal/setup/framework/orchestrator.go`
+  - `type Options struct { In io.Reader; Out, Err io.Writer; StatusTimeout time.Duration; … }`
+  - `type Summary struct { Completed, Failed, Skipped, Cancelled []string; … }`
+  - `func Run(ctx context.Context, opts Options) (Summary, error)`
+  - Flow per spec §`gcx setup run` orchestration (FR-024..FR-038):
+    1. Discover `Setupable` providers via `DiscoverSetupable()`.
+    2. Collect all `InfraCategories()` — dedupe by `InfraCategoryID` with
+       "first label wins" in alphabetical-ProductName order.
+    3. If zero categories → write "no interactive setup flows available" to
+       stderr, exit with code 0.
+    4. Present a `MultiChoice` of category labels; user picks 0..N.
+    5. Resolve providers whose categories intersect the selection; process
+       alphabetically by `ProductName()`.
+    6. For each provider:
+       a. Call `Status(ctx)`. If `StateConfigured` or `StateActive`, stderr
+          "already configured, skipping"; add to Summary.Skipped; continue.
+       b. For each `InfraCategory` of the selected set, for each `SetupParam`:
+          - Render the widget matching `Kind` (text/bool/choice/multi_choice).
+          - `Secret=true` masks input via `prompt.Secret`.
+          - If `Choices` empty and `Kind ∈ {choice, multi_choice}`, call
+            `ResolveChoices(ctx, param.Name)` to populate options.
+       c. Call `ValidateSetup(ctx, params)`. On error: stderr the message,
+          re-prompt every param for this provider with previously-collected
+          values as defaults. Loop until `ValidateSetup` returns nil OR
+          user cancels.
+    7. Render preview: for each confirmed provider, list params with
+       secret-masked values (`***` where `Secret=true`).
+    8. Confirmation prompt `Continue? [Y/n]`. Negative → exit code 5,
+       summary includes remaining as Cancelled.
+    9. Sequentially invoke `provider.Setup(ctx, params)` for each confirmed
+       provider; stream progress to stderr. `Setup()` errors → stderr; add
+       to Summary.Failed; continue to next provider.
+    10. Post-run: call `AggregateStatus(ctx, timeout)` and render via the
+        same mechanism as `gcx setup status`.
+  - SIGINT handling via `signal.NotifyContext(ctx, os.Interrupt)`: on
+    cancellation, stop param collection / next `Setup()` at the next
+    checkpoint, print the summary, return exit code 5.
+  - Non-TTY stdin detection at Run entry (via `internal/terminal.IsPiped`):
+    if stdin is not a TTY, return a usage error with an actionable message.
+
+- `internal/setup/framework/orchestrator_test.go` — fake-provider tests
+  covering:
+  - Zero categories available → stderr message + exit 0.
+  - Skip-if-configured: provider returning `StateActive` is skipped; no
+    param prompts; no `Setup()` call.
+  - Validation retry: first `ValidateSetup` fails, second succeeds; param
+    defaults re-populate previous values.
+  - Preview masking: `Secret=true` param value never appears in stdout/stderr
+    in the preview block.
+  - Sequential execution: `Setup()` call order is alphabetical by ProductName.
+  - `Setup()` error isolation: one provider's error does not prevent
+    subsequent providers' `Setup()` from running; Summary reflects it.
+  - Ctrl-C: simulated cancellation → summary + exit code 5; no rollback
+    attempted.
+  - Non-TTY stdin refusal.
+
+**Acceptance criteria:**
+
+- GIVEN three `Setupable` fakes in category "kubernetes" all `StateNotConfigured`
+  WHEN `Run` is driven with category "kubernetes" selected, valid params for
+  each, and confirmed preview
+  THEN `Setup()` is invoked alphabetically for all three, Summary.Completed
+  lists all three, and the returned error is nil.
+
+- GIVEN a provider returning `StateActive` from `Status()`
+  WHEN `Run` reaches the per-provider loop
+  THEN stderr contains "already configured, skipping"; `Setup()` is NOT called
+  for it; Summary.Skipped includes it.
+
+- GIVEN a provider whose first `ValidateSetup` returns an error
+  WHEN the orchestrator receives the error
+  THEN stderr prints the error; params are re-prompted with previous values
+  as defaults; loop continues until `ValidateSetup` returns nil.
+
+- GIVEN a `SetupParam{Secret: true}` with user value "supersecret"
+  WHEN the preview block renders
+  THEN the preview prints `***` for that param; "supersecret" does NOT appear
+  anywhere in stdout/stderr captured by the test.
+
+- GIVEN two providers have completed `Setup()` and a third is mid-way when
+  SIGINT fires
+  WHEN the signal is observed
+  THEN the summary lists two completed and one remaining, return value indicates
+  cancellation, and no rollback was attempted on the completed providers.
+
+- GIVEN stdin is piped (non-TTY)
+  WHEN `Run` is called
+  THEN it returns a usage error pointing to per-provider `gcx <area> setup`
+  without prompting.
+
+**Implementation notes:**
+
+- `signal.NotifyContext` must be scoped to the Run call, not global, to avoid
+  leaking handlers across tests.
+- Widget calls feed through `opts.In`/`opts.Out` so tests can drive with
+  buffers instead of an actual TTY.
+- DO NOT short-circuit the post-run status render on Ctrl-C. The summary (not
+  the status table) is what ships on cancellation per spec.
+- Non-TTY detection for stdin uses `internal/terminal.IsPiped` — assumes a
+  facility exists for stdin; if the existing util is stdout-only, add a
+  stdin variant here.
+
+---
+
+## Wave 4: `gcx setup run` CLI
+
+### T6: Add `gcx setup run` command
+
+**Priority**: P0
+**Effort**: Small-Medium
+**Depends on**: T5
+**Type**: task
+
+Add the Cobra command `gcx setup run` as a thin wrapper over
+`framework.Run`, with early agent-mode refusal and the opts pattern.
+
+**Deliverables:**
+
+- `cmd/gcx/setup/run.go` **(new)**
+  - `type runOpts struct { loader *providers.ConfigLoader; … }`
+  - `(o *runOpts) setup(flags *pflag.FlagSet)` — register flags (if any;
+    likely none for v1).
+  - `(o *runOpts) Validate() error`.
+  - `newRunCommand(loader *providers.ConfigLoader) *cobra.Command` returning
+    a Cobra command:
+    - `Use: "run"`, `Short: "Interactive orchestrator for product setup."`.
+    - RunE:
+      1. If `agent.IsAgentMode()` → write to stderr "interactive setup is
+         not available in agent mode; run 'gcx <area> setup' for each
+         product" → return a usage error with exit code 2 (via
+         `cmd/gcx/fail` if that's the convention).
+      2. Call `framework.Run(ctx, Options{In: cmd.InOrStdin(), Out:
+         cmd.OutOrStdout(), Err: cmd.ErrOrStderr(), ...})`.
+      3. On cancellation, exit with code 5.
+
+- `cmd/gcx/setup/command.go` (modified)
+  - Register `newRunCommand(loader)` alongside the existing commands:
+    `cmd.AddCommand(newRunCommand(loader))`.
+
+- `cmd/gcx/setup/run_test.go` **(new — integration tests)**
+  - Agent-mode refusal: set `agent.IsAgentMode()` → true; assert stderr
+    contains the redirect message; assert exit code 2.
+  - Full orchestrated flow against `framework.SetupTestRegistry`-injected
+    fakes + `bytes.Buffer` stdin/stdout: verify that a happy-path run
+    exits 0 with the post-run status table.
+  - Zero categories → exit 0 with stderr note.
+
+**Acceptance criteria:**
+
+- GIVEN `agent.IsAgentMode()` returns true
+  WHEN `gcx setup run` is invoked
+  THEN stderr contains a redirect message to per-provider `gcx <area> setup`
+  AND the exit code is 2 AND NO prompts are issued.
+
+- GIVEN a fake registry with one `Setupable` category and a valid preview
+  confirmation
+  WHEN `gcx setup run` is invoked in non-agent mode
+  THEN exit code is 0 and the post-run status table is rendered.
+
+- GIVEN no `Setupable` providers register any categories
+  WHEN `gcx setup run` is invoked
+  THEN stderr contains "no interactive setup flows available" AND exit code is 0.
+
+**Implementation notes:**
+
+- Reuse `providers.ConfigLoader` so `run` picks up the same context flags as
+  `status` (context / namespace / kubeconfig equivalents).
+- Exit-code convention: 0 success, 2 usage (agent-mode refusal, flag error),
+  5 cancelled (Ctrl-C or preview-no). Map any cancellation error from the
+  framework to exit 5; map agent-mode refusal to exit 2.
+
+---
+
+## Wave 5: Docs + Verification
+
+### T9: Regenerate reference docs and run full verification
+
+**Priority**: P0
+**Effort**: Small
+**Depends on**: T3, T6, T7, T8
+**Type**: chore
+
+Regenerate CLI reference docs, env-var reference, config reference, and
+linter-rules reference after all command additions. Run full lint/test/build
+with agent-mode forced off.
+
+**Deliverables:**
+
+- Regenerated artifacts (auto-updated by `make reference`):
+  - `docs/reference/cli/` (new subcommands: `gcx setup run`,
+    `gcx <provider-area> setup` × 9).
+  - `docs/reference/` env-var / config / linter-rules snapshots if touched.
+- Any additional doc-maintenance updates flagged in
+  `docs/reference/doc-maintenance.md` (package map in CLAUDE.md if
+  `internal/setup/framework/` needs to be listed; ARCHITECTURE.md ADR index
+  should already reference ADR-001).
+- A release-note line for `CHANGELOG.md` or `.release-notes.md` capturing
+  "gcx setup status: output shape now aggregates every StatusDetectable
+  provider; instrumentation-only table moved to `gcx setup instrumentation
+  status`."
+
+**Verification commands:**
+
+- `GCX_AGENT_MODE=false make reference` (regen CLI docs, must not drift
+  after commit).
+- `GCX_AGENT_MODE=false make lint`.
+- `GCX_AGENT_MODE=false make tests` (full suite, race enabled).
+- `GCX_AGENT_MODE=false make docs` (build MkDocs site).
+- `GCX_AGENT_MODE=false make all` (umbrella: lint + tests + build + docs).
+
+**Acceptance criteria:**
+
+- `make reference-drift` passes (the regen step produced no uncommitted
+  changes).
+- `make lint` exits 0.
+- `make tests` exits 0.
+- `make docs` builds successfully.
+- `make all` exits 0.
+- `cmd/gcx/setup/instrumentation/status_test.go` still passes unmodified.
+- `CLAUDE.md`'s package-map section lists `internal/setup/framework/` (if
+  gate #4 from `docs/reference/doc-maintenance.md` requires it).
+
+**Implementation notes:**
+
+- If `make reference` produces a diff, commit the regenerated files on the
+  integration branch (small commit distinct from the implementation task
+  commits).
+- If a previously passing test now fails because the cmd help tree changed,
+  fix the test to match the new help output (don't mute the failure).

--- a/internal/providers/alert/provider.go
+++ b/internal/providers/alert/provider.go
@@ -66,6 +66,7 @@ func (p *AlertProvider) ProductName() string { return p.Name() }
 // context; a missing or unreadable config is treated as StateNotConfigured.
 func (p *AlertProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	loader := &providers.ConfigLoader{}
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	s := framework.ConfigKeysStatus(p, cfg)
 	return &s, nil

--- a/internal/providers/alert/provider.go
+++ b/internal/providers/alert/provider.go
@@ -1,12 +1,16 @@
 package alert
 
 import (
+	"context"
+
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 )
 
 var _ providers.Provider = &AlertProvider{}
+var _ framework.StatusDetectable = &AlertProvider{}
 
 func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
 	providers.Register(&AlertProvider{})
@@ -52,6 +56,19 @@ func (p *AlertProvider) Validate(cfg map[string]string) error {
 // ConfigKeys returns the configuration keys used by this provider.
 func (p *AlertProvider) ConfigKeys() []providers.ConfigKey {
 	return nil
+}
+
+// ProductName returns the human-readable product name.
+func (p *AlertProvider) ProductName() string { return p.Name() }
+
+// Status returns the current configuration state based on config key presence.
+// This is a v1 stub: it never probes any API. Config is loaded from the active
+// context; a missing or unreadable config is treated as StateNotConfigured.
+func (p *AlertProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	loader := &providers.ConfigLoader{}
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	s := framework.ConfigKeysStatus(p, cfg)
+	return &s, nil
 }
 
 // TypedRegistrations returns adapter registrations for Alert resource types.

--- a/internal/providers/alert/provider_test.go
+++ b/internal/providers/alert/provider_test.go
@@ -1,13 +1,18 @@
 package alert_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/alert"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Compile-time assertion: AlertProvider satisfies StatusDetectable.
+var _ framework.StatusDetectable = (*alert.AlertProvider)(nil)
 
 func TestAlertProvider_Interface(t *testing.T) {
 	p := &alert.AlertProvider{}
@@ -16,6 +21,34 @@ func TestAlertProvider_Interface(t *testing.T) {
 	assert.NotEmpty(t, p.ShortDesc())
 	require.NoError(t, p.Validate(nil))
 	assert.Nil(t, p.ConfigKeys())
+}
+
+func TestAlertProvider_StatusDetectable(t *testing.T) {
+	p := &alert.AlertProvider{}
+
+	t.Run("NotSetupable", func(t *testing.T) {
+		_, ok := any(p).(framework.Setupable)
+		assert.False(t, ok, "alert provider must not implement Setupable")
+	})
+
+	t.Run("ProductName", func(t *testing.T) {
+		assert.Equal(t, p.Name(), p.ProductName())
+	})
+
+	t.Run("Status", func(t *testing.T) {
+		// Alert has no ConfigKeys → ConfigKeysStatus returns StateActive.
+		status, err := p.Status(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		assert.NotEmpty(t, string(status.State))
+		validStates := map[framework.ProductState]bool{
+			framework.StateNotConfigured: true,
+			framework.StateConfigured:    true,
+			framework.StateActive:        true,
+			framework.StateError:         true,
+		}
+		assert.True(t, validStates[status.State], "unexpected state: %q", status.State)
+	})
 }
 
 func TestAlertProvider_Commands(t *testing.T) {

--- a/internal/providers/appo11y/provider.go
+++ b/internal/providers/appo11y/provider.go
@@ -40,6 +40,7 @@ func (p *AppO11yProvider) ProductName() string { return p.Name() }
 // Status implements framework.StatusDetectable using a config-key heuristic.
 func (p *AppO11yProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	var loader providers.ConfigLoader
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	status := framework.ConfigKeysStatus(p, cfg)
 	return &status, nil

--- a/internal/providers/appo11y/provider.go
+++ b/internal/providers/appo11y/provider.go
@@ -1,10 +1,13 @@
 package appo11y
 
 import (
+	"context"
+
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/appo11y/overrides"
 	"github.com/grafana/gcx/internal/providers/appo11y/settings"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +34,33 @@ func (p *AppO11yProvider) ConfigKeys() []providers.ConfigKey { return nil }
 // App Observability requires no provider-specific configuration.
 func (p *AppO11yProvider) Validate(_ map[string]string) error { return nil }
 
+// ProductName implements framework.StatusDetectable.
+func (p *AppO11yProvider) ProductName() string { return p.Name() }
+
+// Status implements framework.StatusDetectable using a config-key heuristic.
+func (p *AppO11yProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	var loader providers.ConfigLoader
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	status := framework.ConfigKeysStatus(p, cfg)
+	return &status, nil
+}
+
+// InfraCategories implements framework.Setupable.
+func (p *AppO11yProvider) InfraCategories() []framework.InfraCategory { return nil }
+
+// ResolveChoices implements framework.Setupable.
+func (p *AppO11yProvider) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+// ValidateSetup implements framework.Setupable.
+func (p *AppO11yProvider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
+
+// Setup implements framework.Setupable.
+func (p *AppO11yProvider) Setup(_ context.Context, _ map[string]string) error {
+	return framework.ErrSetupNotSupported
+}
+
 // Commands returns the Cobra commands contributed by this provider.
 func (p *AppO11yProvider) Commands() []*cobra.Command {
 	loader := &providers.ConfigLoader{}
@@ -50,6 +80,7 @@ func (p *AppO11yProvider) Commands() []*cobra.Command {
 
 	cmd.AddCommand(overrides.Commands())
 	cmd.AddCommand(settings.Commands())
+	cmd.AddCommand(newSetupCommand(p))
 	return []*cobra.Command{cmd}
 }
 

--- a/internal/providers/appo11y/provider_test.go
+++ b/internal/providers/appo11y/provider_test.go
@@ -3,7 +3,6 @@ package appo11y_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers"
@@ -118,7 +117,7 @@ func TestAppO11yProvider_ValidateSetup(t *testing.T) {
 func TestAppO11yProvider_Setup(t *testing.T) {
 	p := &appo11y.AppO11yProvider{}
 	err := p.Setup(context.Background(), nil)
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	assert.ErrorIs(t, err, framework.ErrSetupNotSupported)
 }
 
 func TestAppO11yProvider_SetupCommand(t *testing.T) {
@@ -139,6 +138,6 @@ func TestAppO11yProvider_SetupCommand(t *testing.T) {
 	setupCmd.SetErr(stderr)
 	err := setupCmd.RunE(setupCmd, nil)
 
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported), "expected ErrSetupNotSupported, got %v", err)
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported, "expected ErrSetupNotSupported, got %v", err)
 	assert.NotEmpty(t, stderr.String(), "expected message written to stderr")
 }

--- a/internal/providers/appo11y/provider_test.go
+++ b/internal/providers/appo11y/provider_test.go
@@ -1,13 +1,21 @@
 package appo11y_test
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers"
-	_ "github.com/grafana/gcx/internal/providers/appo11y" // triggers init() self-registration
+	appo11y "github.com/grafana/gcx/internal/providers/appo11y"
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Compile-time assertion: AppO11yProvider implements framework.Setupable.
+var _ framework.Setupable = (*appo11y.AppO11yProvider)(nil)
 
 func TestAppO11yProvider_RegisteredInRegistry(t *testing.T) {
 	all := providers.All()
@@ -72,4 +80,65 @@ func TestAppO11yProvider_Commands(t *testing.T) {
 	}
 	assert.True(t, subNames["overrides"], "expected 'overrides' subcommand")
 	assert.True(t, subNames["settings"], "expected 'settings' subcommand")
+	assert.True(t, subNames["setup"], "expected 'setup' subcommand")
+}
+
+func TestAppO11yProvider_ProductName(t *testing.T) {
+	p := &appo11y.AppO11yProvider{}
+	assert.Equal(t, "appo11y", p.ProductName())
+}
+
+func TestAppO11yProvider_Status(t *testing.T) {
+	p := &appo11y.AppO11yProvider{}
+	status, err := p.Status(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, "appo11y", status.Product)
+	// No config keys → StateActive.
+	assert.Equal(t, framework.StateActive, status.State)
+}
+
+func TestAppO11yProvider_InfraCategories(t *testing.T) {
+	p := &appo11y.AppO11yProvider{}
+	assert.Nil(t, p.InfraCategories())
+}
+
+func TestAppO11yProvider_ResolveChoices(t *testing.T) {
+	p := &appo11y.AppO11yProvider{}
+	choices, err := p.ResolveChoices(context.Background(), "any")
+	require.NoError(t, err)
+	assert.Nil(t, choices)
+}
+
+func TestAppO11yProvider_ValidateSetup(t *testing.T) {
+	p := &appo11y.AppO11yProvider{}
+	assert.NoError(t, p.ValidateSetup(context.Background(), nil))
+}
+
+func TestAppO11yProvider_Setup(t *testing.T) {
+	p := &appo11y.AppO11yProvider{}
+	err := p.Setup(context.Background(), nil)
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+}
+
+func TestAppO11yProvider_SetupCommand(t *testing.T) {
+	p := &appo11y.AppO11yProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+
+	var setupCmd *cobra.Command
+	for _, sub := range cmds[0].Commands() {
+		if sub.Name() == "setup" {
+			setupCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, setupCmd, "expected 'setup' subcommand")
+
+	stderr := &bytes.Buffer{}
+	setupCmd.SetErr(stderr)
+	err := setupCmd.RunE(setupCmd, nil)
+
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported), "expected ErrSetupNotSupported, got %v", err)
+	assert.NotEmpty(t, stderr.String(), "expected message written to stderr")
 }

--- a/internal/providers/appo11y/setup.go
+++ b/internal/providers/appo11y/setup.go
@@ -1,0 +1,43 @@
+package appo11y
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type setupOpts struct{}
+
+func (o *setupOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *setupOpts) Validate() error { return nil }
+
+func newSetupCommand(p *AppO11yProvider) *cobra.Command {
+	opts := &setupOpts{}
+	cmd := &cobra.Command{
+		Use:           "setup",
+		Short:         "Set up appo11y (not yet implemented).",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			err := p.Setup(ctx, nil)
+			if errors.Is(err, framework.ErrSetupNotSupported) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "setup not yet implemented for %s\n", p.Name())
+			}
+			return err
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/appo11y/setup.go
+++ b/internal/providers/appo11y/setup.go
@@ -22,6 +22,7 @@ func newSetupCommand(p *AppO11yProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "setup",
 		Short:         "Set up appo11y (not yet implemented).",
+		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},

--- a/internal/providers/appo11y/setup.go
+++ b/internal/providers/appo11y/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -23,6 +24,7 @@ func newSetupCommand(p *AppO11yProvider) *cobra.Command {
 		Short:         "Set up appo11y (not yet implemented).",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/providers/faro/provider.go
+++ b/internal/providers/faro/provider.go
@@ -41,6 +41,7 @@ func (p *FaroProvider) ProductName() string { return p.Name() }
 // Status implements framework.StatusDetectable using a config-key heuristic.
 func (p *FaroProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	var loader providers.ConfigLoader
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	status := framework.ConfigKeysStatus(p, cfg)
 	return &status, nil

--- a/internal/providers/faro/provider.go
+++ b/internal/providers/faro/provider.go
@@ -1,8 +1,11 @@
 package faro
 
 import (
+	"context"
+
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +33,33 @@ func (p *FaroProvider) ConfigKeys() []providers.ConfigKey {
 	return []providers.ConfigKey{
 		{Name: "faro-api-url", Secret: false},
 	}
+}
+
+// ProductName implements framework.StatusDetectable.
+func (p *FaroProvider) ProductName() string { return p.Name() }
+
+// Status implements framework.StatusDetectable using a config-key heuristic.
+func (p *FaroProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	var loader providers.ConfigLoader
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	status := framework.ConfigKeysStatus(p, cfg)
+	return &status, nil
+}
+
+// InfraCategories implements framework.Setupable.
+func (p *FaroProvider) InfraCategories() []framework.InfraCategory { return nil }
+
+// ResolveChoices implements framework.Setupable.
+func (p *FaroProvider) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+// ValidateSetup implements framework.Setupable.
+func (p *FaroProvider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
+
+// Setup implements framework.Setupable.
+func (p *FaroProvider) Setup(_ context.Context, _ map[string]string) error {
+	return framework.ErrSetupNotSupported
 }
 
 // Validate checks that the given provider configuration is valid.
@@ -63,6 +93,7 @@ func (p *FaroProvider) Commands() []*cobra.Command {
 	)
 
 	faroCmd.AddCommand(appsCmd)
+	faroCmd.AddCommand(newSetupCommand(p))
 	return []*cobra.Command{faroCmd}
 }
 

--- a/internal/providers/faro/provider_test.go
+++ b/internal/providers/faro/provider_test.go
@@ -3,7 +3,6 @@ package faro_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/faro"
@@ -50,7 +49,7 @@ func TestFaroProvider_ValidateSetup(t *testing.T) {
 func TestFaroProvider_Setup(t *testing.T) {
 	p := &faro.FaroProvider{}
 	err := p.Setup(context.Background(), nil)
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 }
 
 func TestFaroProvider_SetupCommand(t *testing.T) {
@@ -71,6 +70,6 @@ func TestFaroProvider_SetupCommand(t *testing.T) {
 	setupCmd.SetErr(stderr)
 	err := setupCmd.RunE(setupCmd, nil)
 
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/faro/provider_test.go
+++ b/internal/providers/faro/provider_test.go
@@ -1,0 +1,76 @@
+package faro_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/faro"
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time assertion: FaroProvider implements framework.Setupable.
+var _ framework.Setupable = (*faro.FaroProvider)(nil)
+
+func TestFaroProvider_ProductName(t *testing.T) {
+	p := &faro.FaroProvider{}
+	assert.Equal(t, "faro", p.ProductName())
+}
+
+func TestFaroProvider_Status(t *testing.T) {
+	p := &faro.FaroProvider{}
+	status, err := p.Status(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, "faro", status.Product)
+	assert.NotEmpty(t, string(status.State))
+}
+
+func TestFaroProvider_InfraCategories(t *testing.T) {
+	p := &faro.FaroProvider{}
+	assert.Nil(t, p.InfraCategories())
+}
+
+func TestFaroProvider_ResolveChoices(t *testing.T) {
+	p := &faro.FaroProvider{}
+	choices, err := p.ResolveChoices(context.Background(), "any")
+	require.NoError(t, err)
+	assert.Nil(t, choices)
+}
+
+func TestFaroProvider_ValidateSetup(t *testing.T) {
+	p := &faro.FaroProvider{}
+	assert.NoError(t, p.ValidateSetup(context.Background(), nil))
+}
+
+func TestFaroProvider_Setup(t *testing.T) {
+	p := &faro.FaroProvider{}
+	err := p.Setup(context.Background(), nil)
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+}
+
+func TestFaroProvider_SetupCommand(t *testing.T) {
+	p := &faro.FaroProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+
+	var setupCmd *cobra.Command
+	for _, sub := range cmds[0].Commands() {
+		if sub.Name() == "setup" {
+			setupCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, setupCmd, "expected 'setup' subcommand")
+
+	stderr := &bytes.Buffer{}
+	setupCmd.SetErr(stderr)
+	err := setupCmd.RunE(setupCmd, nil)
+
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	assert.NotEmpty(t, stderr.String())
+}

--- a/internal/providers/faro/setup.go
+++ b/internal/providers/faro/setup.go
@@ -1,0 +1,43 @@
+package faro
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type setupOpts struct{}
+
+func (o *setupOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *setupOpts) Validate() error { return nil }
+
+func newSetupCommand(p *FaroProvider) *cobra.Command {
+	opts := &setupOpts{}
+	cmd := &cobra.Command{
+		Use:           "setup",
+		Short:         "Set up faro (not yet implemented).",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			err := p.Setup(ctx, nil)
+			if errors.Is(err, framework.ErrSetupNotSupported) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "setup not yet implemented for %s\n", p.Name())
+			}
+			return err
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/faro/setup.go
+++ b/internal/providers/faro/setup.go
@@ -21,7 +21,8 @@ func newSetupCommand(p *FaroProvider) *cobra.Command {
 	opts := &setupOpts{}
 	cmd := &cobra.Command{
 		Use:           "setup",
-		Short:         "Set up faro (not yet implemented).",
+		Short:         "Set up Frontend Observability (not yet implemented).",
+		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},
@@ -35,7 +36,7 @@ func newSetupCommand(p *FaroProvider) *cobra.Command {
 			}
 			err := p.Setup(ctx, nil)
 			if errors.Is(err, framework.ErrSetupNotSupported) {
-				fmt.Fprintf(cmd.ErrOrStderr(), "setup not yet implemented for %s\n", p.Name())
+				fmt.Fprintf(cmd.ErrOrStderr(), "setup not yet implemented for %s\n", p.ProductName())
 			}
 			return err
 		},

--- a/internal/providers/faro/setup.go
+++ b/internal/providers/faro/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -23,6 +24,7 @@ func newSetupCommand(p *FaroProvider) *cobra.Command {
 		Short:         "Set up faro (not yet implemented).",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/providers/fleet/provider.go
+++ b/internal/providers/fleet/provider.go
@@ -135,6 +135,7 @@ func (p *FleetProvider) ProductName() string { return p.Name() }
 // Status implements framework.StatusDetectable using a config-key heuristic.
 func (p *FleetProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	var loader providers.ConfigLoader
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	status := framework.ConfigKeysStatus(p, cfg)
 	return &status, nil

--- a/internal/providers/fleet/provider.go
+++ b/internal/providers/fleet/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -122,9 +123,37 @@ func (p *FleetProvider) Commands() []*cobra.Command {
 		helper.pipelinesCommand(),
 		helper.collectorsCommand(),
 		helper.tenantCommand(),
+		newSetupCommand(p),
 	)
 
 	return []*cobra.Command{fleetCmd}
+}
+
+// ProductName implements framework.StatusDetectable.
+func (p *FleetProvider) ProductName() string { return p.Name() }
+
+// Status implements framework.StatusDetectable using a config-key heuristic.
+func (p *FleetProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	var loader providers.ConfigLoader
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	status := framework.ConfigKeysStatus(p, cfg)
+	return &status, nil
+}
+
+// InfraCategories implements framework.Setupable.
+func (p *FleetProvider) InfraCategories() []framework.InfraCategory { return nil }
+
+// ResolveChoices implements framework.Setupable.
+func (p *FleetProvider) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+// ValidateSetup implements framework.Setupable.
+func (p *FleetProvider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
+
+// Setup implements framework.Setupable.
+func (p *FleetProvider) Setup(_ context.Context, _ map[string]string) error {
+	return framework.ErrSetupNotSupported
 }
 
 // Validate checks that the given provider configuration is valid.

--- a/internal/providers/fleet/provider_test.go
+++ b/internal/providers/fleet/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,9 +13,14 @@ import (
 	"time"
 
 	"github.com/grafana/gcx/internal/providers/fleet"
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Compile-time assertion: FleetProvider implements framework.Setupable.
+var _ framework.Setupable = (*fleet.FleetProvider)(nil)
 
 // ---------------------------------------------------------------------------
 // Pipeline round-trip tests
@@ -356,4 +362,68 @@ func TestPipelineProtectionGuard(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Setupable interface tests
+// ---------------------------------------------------------------------------
+
+func TestFleetProvider_ProductName(t *testing.T) {
+	p := &fleet.FleetProvider{}
+	assert.Equal(t, "fleet", p.ProductName())
+}
+
+func TestFleetProvider_Status(t *testing.T) {
+	p := &fleet.FleetProvider{}
+	status, err := p.Status(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, "fleet", status.Product)
+	// No config keys → StateActive.
+	assert.Equal(t, framework.StateActive, status.State)
+}
+
+func TestFleetProvider_InfraCategories(t *testing.T) {
+	p := &fleet.FleetProvider{}
+	assert.Nil(t, p.InfraCategories())
+}
+
+func TestFleetProvider_ResolveChoices(t *testing.T) {
+	p := &fleet.FleetProvider{}
+	choices, err := p.ResolveChoices(context.Background(), "any")
+	require.NoError(t, err)
+	assert.Nil(t, choices)
+}
+
+func TestFleetProvider_ValidateSetup(t *testing.T) {
+	p := &fleet.FleetProvider{}
+	assert.NoError(t, p.ValidateSetup(context.Background(), nil))
+}
+
+func TestFleetProvider_Setup(t *testing.T) {
+	p := &fleet.FleetProvider{}
+	err := p.Setup(context.Background(), nil)
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+}
+
+func TestFleetProvider_SetupCommand(t *testing.T) {
+	p := &fleet.FleetProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+
+	var setupCmd *cobra.Command
+	for _, sub := range cmds[0].Commands() {
+		if sub.Name() == "setup" {
+			setupCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, setupCmd, "expected 'setup' subcommand")
+
+	stderr := &bytes.Buffer{}
+	setupCmd.SetErr(stderr)
+	err := setupCmd.RunE(setupCmd, nil)
+
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/fleet/provider_test.go
+++ b/internal/providers/fleet/provider_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -403,7 +402,7 @@ func TestFleetProvider_ValidateSetup(t *testing.T) {
 func TestFleetProvider_Setup(t *testing.T) {
 	p := &fleet.FleetProvider{}
 	err := p.Setup(context.Background(), nil)
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 }
 
 func TestFleetProvider_SetupCommand(t *testing.T) {
@@ -424,6 +423,6 @@ func TestFleetProvider_SetupCommand(t *testing.T) {
 	setupCmd.SetErr(stderr)
 	err := setupCmd.RunE(setupCmd, nil)
 
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/fleet/setup.go
+++ b/internal/providers/fleet/setup.go
@@ -1,0 +1,43 @@
+package fleet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type setupOpts struct{}
+
+func (o *setupOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *setupOpts) Validate() error { return nil }
+
+func newSetupCommand(p *FleetProvider) *cobra.Command {
+	opts := &setupOpts{}
+	cmd := &cobra.Command{
+		Use:           "setup",
+		Short:         "Set up fleet (not yet implemented).",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			err := p.Setup(ctx, nil)
+			if errors.Is(err, framework.ErrSetupNotSupported) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "setup not yet implemented for %s\n", p.Name())
+			}
+			return err
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/fleet/setup.go
+++ b/internal/providers/fleet/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -23,6 +24,7 @@ func newSetupCommand(p *FleetProvider) *cobra.Command {
 		Short:         "Set up fleet (not yet implemented).",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/providers/fleet/setup.go
+++ b/internal/providers/fleet/setup.go
@@ -22,6 +22,7 @@ func newSetupCommand(p *FleetProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "setup",
 		Short:         "Set up fleet (not yet implemented).",
+		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},

--- a/internal/providers/irm/provider.go
+++ b/internal/providers/irm/provider.go
@@ -1,8 +1,11 @@
 package irm
 
 import (
+	"context"
+
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +20,33 @@ type IRMProvider struct{}
 
 func (p *IRMProvider) Name() string      { return "irm" }
 func (p *IRMProvider) ShortDesc() string { return "Manage Grafana IRM (OnCall + Incidents)" }
+
+// ProductName implements framework.StatusDetectable.
+func (p *IRMProvider) ProductName() string { return p.Name() }
+
+// Status implements framework.StatusDetectable using a config-key heuristic.
+func (p *IRMProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	var loader providers.ConfigLoader
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	status := framework.ConfigKeysStatus(p, cfg)
+	return &status, nil
+}
+
+// InfraCategories implements framework.Setupable.
+func (p *IRMProvider) InfraCategories() []framework.InfraCategory { return nil }
+
+// ResolveChoices implements framework.Setupable.
+func (p *IRMProvider) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+// ValidateSetup implements framework.Setupable.
+func (p *IRMProvider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
+
+// Setup implements framework.Setupable.
+func (p *IRMProvider) Setup(_ context.Context, _ map[string]string) error {
+	return framework.ErrSetupNotSupported
+}
 
 func (p *IRMProvider) Commands() []*cobra.Command {
 	loader := &configLoader{}
@@ -56,6 +86,7 @@ func (p *IRMProvider) Commands() []*cobra.Command {
 
 	irmCmd.AddCommand(oncallCmd)
 	irmCmd.AddCommand(newIncidentsCmd(loader))
+	irmCmd.AddCommand(newSetupCommand(p))
 
 	return []*cobra.Command{irmCmd}
 }

--- a/internal/providers/irm/provider.go
+++ b/internal/providers/irm/provider.go
@@ -27,6 +27,7 @@ func (p *IRMProvider) ProductName() string { return p.Name() }
 // Status implements framework.StatusDetectable using a config-key heuristic.
 func (p *IRMProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	var loader providers.ConfigLoader
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	status := framework.ConfigKeysStatus(p, cfg)
 	return &status, nil

--- a/internal/providers/irm/provider_test.go
+++ b/internal/providers/irm/provider_test.go
@@ -1,0 +1,76 @@
+package irm_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/irm"
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time assertion: IRMProvider implements framework.Setupable.
+var _ framework.Setupable = (*irm.IRMProvider)(nil)
+
+func TestIRMProvider_ProductName(t *testing.T) {
+	p := &irm.IRMProvider{}
+	assert.Equal(t, "irm", p.ProductName())
+}
+
+func TestIRMProvider_Status(t *testing.T) {
+	p := &irm.IRMProvider{}
+	status, err := p.Status(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, "irm", status.Product)
+	assert.NotEmpty(t, string(status.State))
+}
+
+func TestIRMProvider_InfraCategories(t *testing.T) {
+	p := &irm.IRMProvider{}
+	assert.Nil(t, p.InfraCategories())
+}
+
+func TestIRMProvider_ResolveChoices(t *testing.T) {
+	p := &irm.IRMProvider{}
+	choices, err := p.ResolveChoices(context.Background(), "any")
+	require.NoError(t, err)
+	assert.Nil(t, choices)
+}
+
+func TestIRMProvider_ValidateSetup(t *testing.T) {
+	p := &irm.IRMProvider{}
+	assert.NoError(t, p.ValidateSetup(context.Background(), nil))
+}
+
+func TestIRMProvider_Setup(t *testing.T) {
+	p := &irm.IRMProvider{}
+	err := p.Setup(context.Background(), nil)
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+}
+
+func TestIRMProvider_SetupCommand(t *testing.T) {
+	p := &irm.IRMProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+
+	var setupCmd *cobra.Command
+	for _, sub := range cmds[0].Commands() {
+		if sub.Name() == "setup" {
+			setupCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, setupCmd, "expected 'setup' subcommand")
+
+	stderr := &bytes.Buffer{}
+	setupCmd.SetErr(stderr)
+	err := setupCmd.RunE(setupCmd, nil)
+
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	assert.NotEmpty(t, stderr.String())
+}

--- a/internal/providers/irm/provider_test.go
+++ b/internal/providers/irm/provider_test.go
@@ -3,7 +3,6 @@ package irm_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/irm"
@@ -50,7 +49,7 @@ func TestIRMProvider_ValidateSetup(t *testing.T) {
 func TestIRMProvider_Setup(t *testing.T) {
 	p := &irm.IRMProvider{}
 	err := p.Setup(context.Background(), nil)
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 }
 
 func TestIRMProvider_SetupCommand(t *testing.T) {
@@ -71,6 +70,6 @@ func TestIRMProvider_SetupCommand(t *testing.T) {
 	setupCmd.SetErr(stderr)
 	err := setupCmd.RunE(setupCmd, nil)
 
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/irm/setup.go
+++ b/internal/providers/irm/setup.go
@@ -22,6 +22,7 @@ func newSetupCommand(p *IRMProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "setup",
 		Short:         "Set up irm (not yet implemented).",
+		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},

--- a/internal/providers/irm/setup.go
+++ b/internal/providers/irm/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -23,6 +24,7 @@ func newSetupCommand(p *IRMProvider) *cobra.Command {
 		Short:         "Set up irm (not yet implemented).",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/providers/irm/setup.go
+++ b/internal/providers/irm/setup.go
@@ -1,0 +1,43 @@
+package irm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type setupOpts struct{}
+
+func (o *setupOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *setupOpts) Validate() error { return nil }
+
+func newSetupCommand(p *IRMProvider) *cobra.Command {
+	opts := &setupOpts{}
+	cmd := &cobra.Command{
+		Use:           "setup",
+		Short:         "Set up irm (not yet implemented).",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			err := p.Setup(ctx, nil)
+			if errors.Is(err, framework.ErrSetupNotSupported) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "setup not yet implemented for %s\n", p.Name())
+			}
+			return err
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/k6/provider.go
+++ b/internal/providers/k6/provider.go
@@ -1,9 +1,12 @@
 package k6
 
 import (
+	"context"
+
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -45,9 +48,37 @@ func (p *K6Provider) Commands() []*cobra.Command {
 		newLoadZonesCommand(loader),
 		newTestrunCommand(loader),
 		newAuthCommand(loader),
+		newSetupCommand(p),
 	)
 
 	return []*cobra.Command{k6Cmd}
+}
+
+// ProductName implements framework.StatusDetectable.
+func (p *K6Provider) ProductName() string { return p.Name() }
+
+// Status implements framework.StatusDetectable using a config-key heuristic.
+func (p *K6Provider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	var loader providers.ConfigLoader
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	status := framework.ConfigKeysStatus(p, cfg)
+	return &status, nil
+}
+
+// InfraCategories implements framework.Setupable.
+func (p *K6Provider) InfraCategories() []framework.InfraCategory { return nil }
+
+// ResolveChoices implements framework.Setupable.
+func (p *K6Provider) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+// ValidateSetup implements framework.Setupable.
+func (p *K6Provider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
+
+// Setup implements framework.Setupable.
+func (p *K6Provider) Setup(_ context.Context, _ map[string]string) error {
+	return framework.ErrSetupNotSupported
 }
 
 // Validate checks that the given provider configuration is valid.

--- a/internal/providers/k6/provider.go
+++ b/internal/providers/k6/provider.go
@@ -60,6 +60,7 @@ func (p *K6Provider) ProductName() string { return p.Name() }
 // Status implements framework.StatusDetectable using a config-key heuristic.
 func (p *K6Provider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	var loader providers.ConfigLoader
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	status := framework.ConfigKeysStatus(p, cfg)
 	return &status, nil
@@ -82,7 +83,7 @@ func (p *K6Provider) Setup(_ context.Context, _ map[string]string) error {
 }
 
 // Validate checks that the given provider configuration is valid.
-func (p *K6Provider) Validate(cfg map[string]string) error {
+func (p *K6Provider) Validate(_ map[string]string) error {
 	return nil
 }
 

--- a/internal/providers/k6/provider_test.go
+++ b/internal/providers/k6/provider_test.go
@@ -3,7 +3,6 @@ package k6_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/k6"
@@ -50,7 +49,7 @@ func TestK6Provider_ValidateSetup(t *testing.T) {
 func TestK6Provider_Setup(t *testing.T) {
 	p := &k6.K6Provider{}
 	err := p.Setup(context.Background(), nil)
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 }
 
 func TestK6Provider_SetupCommand(t *testing.T) {
@@ -71,6 +70,6 @@ func TestK6Provider_SetupCommand(t *testing.T) {
 	setupCmd.SetErr(stderr)
 	err := setupCmd.RunE(setupCmd, nil)
 
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/k6/provider_test.go
+++ b/internal/providers/k6/provider_test.go
@@ -1,0 +1,76 @@
+package k6_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/k6"
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time assertion: K6Provider implements framework.Setupable.
+var _ framework.Setupable = (*k6.K6Provider)(nil)
+
+func TestK6Provider_ProductName(t *testing.T) {
+	p := &k6.K6Provider{}
+	assert.Equal(t, "k6", p.ProductName())
+}
+
+func TestK6Provider_Status(t *testing.T) {
+	p := &k6.K6Provider{}
+	status, err := p.Status(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, "k6", status.Product)
+	assert.NotEmpty(t, string(status.State))
+}
+
+func TestK6Provider_InfraCategories(t *testing.T) {
+	p := &k6.K6Provider{}
+	assert.Nil(t, p.InfraCategories())
+}
+
+func TestK6Provider_ResolveChoices(t *testing.T) {
+	p := &k6.K6Provider{}
+	choices, err := p.ResolveChoices(context.Background(), "any")
+	require.NoError(t, err)
+	assert.Nil(t, choices)
+}
+
+func TestK6Provider_ValidateSetup(t *testing.T) {
+	p := &k6.K6Provider{}
+	assert.NoError(t, p.ValidateSetup(context.Background(), nil))
+}
+
+func TestK6Provider_Setup(t *testing.T) {
+	p := &k6.K6Provider{}
+	err := p.Setup(context.Background(), nil)
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+}
+
+func TestK6Provider_SetupCommand(t *testing.T) {
+	p := &k6.K6Provider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+
+	var setupCmd *cobra.Command
+	for _, sub := range cmds[0].Commands() {
+		if sub.Name() == "setup" {
+			setupCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, setupCmd, "expected 'setup' subcommand")
+
+	stderr := &bytes.Buffer{}
+	setupCmd.SetErr(stderr)
+	err := setupCmd.RunE(setupCmd, nil)
+
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	assert.NotEmpty(t, stderr.String())
+}

--- a/internal/providers/k6/setup.go
+++ b/internal/providers/k6/setup.go
@@ -1,0 +1,43 @@
+package k6
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type setupOpts struct{}
+
+func (o *setupOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *setupOpts) Validate() error { return nil }
+
+func newSetupCommand(p *K6Provider) *cobra.Command {
+	opts := &setupOpts{}
+	cmd := &cobra.Command{
+		Use:           "setup",
+		Short:         "Set up k6 (not yet implemented).",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			err := p.Setup(ctx, nil)
+			if errors.Is(err, framework.ErrSetupNotSupported) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "setup not yet implemented for %s\n", p.Name())
+			}
+			return err
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/k6/setup.go
+++ b/internal/providers/k6/setup.go
@@ -22,6 +22,7 @@ func newSetupCommand(p *K6Provider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "setup",
 		Short:         "Set up k6 (not yet implemented).",
+		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},

--- a/internal/providers/k6/setup.go
+++ b/internal/providers/k6/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -23,6 +24,7 @@ func newSetupCommand(p *K6Provider) *cobra.Command {
 		Short:         "Set up k6 (not yet implemented).",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/providers/kg/provider.go
+++ b/internal/providers/kg/provider.go
@@ -1,8 +1,11 @@
 package kg
 
 import (
+	"context"
+
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 )
 
@@ -56,9 +59,37 @@ func (p *KGProvider) Commands() []*cobra.Command {
 		newInspectCommand(loader),
 		newHealthCommand(loader),
 		newOpenCommand(loader),
+		newSetupCommand(p),
 	)
 
 	return []*cobra.Command{kgCmd}
+}
+
+// ProductName implements framework.StatusDetectable.
+func (p *KGProvider) ProductName() string { return p.Name() }
+
+// Status implements framework.StatusDetectable using a config-key heuristic.
+func (p *KGProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	var loader providers.ConfigLoader
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	status := framework.ConfigKeysStatus(p, cfg)
+	return &status, nil
+}
+
+// InfraCategories implements framework.Setupable.
+func (p *KGProvider) InfraCategories() []framework.InfraCategory { return nil }
+
+// ResolveChoices implements framework.Setupable.
+func (p *KGProvider) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+// ValidateSetup implements framework.Setupable.
+func (p *KGProvider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
+
+// Setup implements framework.Setupable.
+func (p *KGProvider) Setup(_ context.Context, _ map[string]string) error {
+	return framework.ErrSetupNotSupported
 }
 
 // Validate checks that the given provider configuration is valid.

--- a/internal/providers/kg/provider.go
+++ b/internal/providers/kg/provider.go
@@ -71,6 +71,7 @@ func (p *KGProvider) ProductName() string { return p.Name() }
 // Status implements framework.StatusDetectable using a config-key heuristic.
 func (p *KGProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	var loader providers.ConfigLoader
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	status := framework.ConfigKeysStatus(p, cfg)
 	return &status, nil

--- a/internal/providers/kg/provider_test.go
+++ b/internal/providers/kg/provider_test.go
@@ -3,7 +3,6 @@ package kg_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/kg"
@@ -51,7 +50,7 @@ func TestKGProvider_ValidateSetup(t *testing.T) {
 func TestKGProvider_Setup(t *testing.T) {
 	p := &kg.KGProvider{}
 	err := p.Setup(context.Background(), nil)
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 }
 
 func TestKGProvider_SetupCommand(t *testing.T) {
@@ -72,6 +71,6 @@ func TestKGProvider_SetupCommand(t *testing.T) {
 	setupCmd.SetErr(stderr)
 	err := setupCmd.RunE(setupCmd, nil)
 
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/kg/provider_test.go
+++ b/internal/providers/kg/provider_test.go
@@ -1,0 +1,77 @@
+package kg_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/kg"
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time assertion: KGProvider implements framework.Setupable.
+var _ framework.Setupable = (*kg.KGProvider)(nil)
+
+func TestKGProvider_ProductName(t *testing.T) {
+	p := &kg.KGProvider{}
+	assert.Equal(t, "kg", p.ProductName())
+}
+
+func TestKGProvider_Status(t *testing.T) {
+	p := &kg.KGProvider{}
+	status, err := p.Status(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, "kg", status.Product)
+	// No config keys → StateActive.
+	assert.Equal(t, framework.StateActive, status.State)
+}
+
+func TestKGProvider_InfraCategories(t *testing.T) {
+	p := &kg.KGProvider{}
+	assert.Nil(t, p.InfraCategories())
+}
+
+func TestKGProvider_ResolveChoices(t *testing.T) {
+	p := &kg.KGProvider{}
+	choices, err := p.ResolveChoices(context.Background(), "any")
+	require.NoError(t, err)
+	assert.Nil(t, choices)
+}
+
+func TestKGProvider_ValidateSetup(t *testing.T) {
+	p := &kg.KGProvider{}
+	assert.NoError(t, p.ValidateSetup(context.Background(), nil))
+}
+
+func TestKGProvider_Setup(t *testing.T) {
+	p := &kg.KGProvider{}
+	err := p.Setup(context.Background(), nil)
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+}
+
+func TestKGProvider_SetupCommand(t *testing.T) {
+	p := &kg.KGProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+
+	var setupCmd *cobra.Command
+	for _, sub := range cmds[0].Commands() {
+		if sub.Name() == "setup" {
+			setupCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, setupCmd, "expected 'setup' subcommand")
+
+	stderr := &bytes.Buffer{}
+	setupCmd.SetErr(stderr)
+	err := setupCmd.RunE(setupCmd, nil)
+
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	assert.NotEmpty(t, stderr.String())
+}

--- a/internal/providers/kg/setup.go
+++ b/internal/providers/kg/setup.go
@@ -1,0 +1,43 @@
+package kg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type setupOpts struct{}
+
+func (o *setupOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *setupOpts) Validate() error { return nil }
+
+func newSetupCommand(p *KGProvider) *cobra.Command {
+	opts := &setupOpts{}
+	cmd := &cobra.Command{
+		Use:           "setup",
+		Short:         "Set up kg (not yet implemented).",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			err := p.Setup(ctx, nil)
+			if errors.Is(err, framework.ErrSetupNotSupported) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "setup not yet implemented for %s\n", p.Name())
+			}
+			return err
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/kg/setup.go
+++ b/internal/providers/kg/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -23,6 +24,7 @@ func newSetupCommand(p *KGProvider) *cobra.Command {
 		Short:         "Set up kg (not yet implemented).",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/providers/kg/setup.go
+++ b/internal/providers/kg/setup.go
@@ -22,6 +22,7 @@ func newSetupCommand(p *KGProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "setup",
 		Short:         "Set up kg (not yet implemented).",
+		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},

--- a/internal/providers/logs/provider.go
+++ b/internal/providers/logs/provider.go
@@ -131,6 +131,7 @@ func (p *Provider) ProductName() string { return p.Name() }
 // context; a missing or unreadable config is treated as StateNotConfigured.
 func (p *Provider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	loader := &providers.ConfigLoader{}
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	s := framework.ConfigKeysStatus(p, cfg)
 	return &s, nil

--- a/internal/providers/logs/provider.go
+++ b/internal/providers/logs/provider.go
@@ -1,13 +1,18 @@
 package logs
 
 import (
+	"context"
+
 	"github.com/grafana/gcx/internal/agent"
 	dsloki "github.com/grafana/gcx/internal/datasources/loki"
 	"github.com/grafana/gcx/internal/providers"
 	adaptivelogs "github.com/grafana/gcx/internal/providers/logs/adaptive"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 )
+
+var _ framework.StatusDetectable = &Provider{}
 
 func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
 	providers.Register(&Provider{})
@@ -117,6 +122,19 @@ func queryCmd(loader *providers.ConfigLoader) *cobra.Command   { return dsloki.Q
 func metricsCmd(loader *providers.ConfigLoader) *cobra.Command { return dsloki.MetricsCmd(loader) }
 
 func (p *Provider) Validate(_ map[string]string) error { return nil }
+
+// ProductName returns the human-readable product name.
+func (p *Provider) ProductName() string { return p.Name() }
+
+// Status returns the current configuration state based on config key presence.
+// This is a v1 stub: it never probes any API. Config is loaded from the active
+// context; a missing or unreadable config is treated as StateNotConfigured.
+func (p *Provider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	loader := &providers.ConfigLoader{}
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	s := framework.ConfigKeysStatus(p, cfg)
+	return &s, nil
+}
 
 func (p *Provider) ConfigKeys() []providers.ConfigKey {
 	return []providers.ConfigKey{

--- a/internal/providers/logs/provider_test.go
+++ b/internal/providers/logs/provider_test.go
@@ -1,13 +1,18 @@
 package logs_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/logs"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Compile-time assertion: Provider satisfies StatusDetectable.
+var _ framework.StatusDetectable = (*logs.Provider)(nil)
 
 func TestProviderRegistration(t *testing.T) {
 	p := &logs.Provider{}
@@ -68,5 +73,31 @@ func TestProviderRegistration(t *testing.T) {
 			}
 		}
 		assert.True(t, found, "logs provider not found in providers.All()")
+	})
+}
+
+func TestProvider_StatusDetectable(t *testing.T) {
+	p := &logs.Provider{}
+
+	t.Run("NotSetupable", func(t *testing.T) {
+		_, ok := any(p).(framework.Setupable)
+		assert.False(t, ok, "logs provider must not implement Setupable")
+	})
+
+	t.Run("ProductName", func(t *testing.T) {
+		assert.Equal(t, p.Name(), p.ProductName())
+	})
+
+	t.Run("Status", func(t *testing.T) {
+		status, err := p.Status(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		validStates := map[framework.ProductState]bool{
+			framework.StateNotConfigured: true,
+			framework.StateConfigured:    true,
+			framework.StateActive:        true,
+			framework.StateError:         true,
+		}
+		assert.True(t, validStates[status.State], "unexpected state: %q", status.State)
 	})
 }

--- a/internal/providers/metrics/provider.go
+++ b/internal/providers/metrics/provider.go
@@ -126,6 +126,7 @@ func (p *Provider) ProductName() string { return p.Name() }
 // context; a missing or unreadable config is treated as StateNotConfigured.
 func (p *Provider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	loader := &providers.ConfigLoader{}
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	s := framework.ConfigKeysStatus(p, cfg)
 	return &s, nil

--- a/internal/providers/metrics/provider.go
+++ b/internal/providers/metrics/provider.go
@@ -1,13 +1,18 @@
 package metrics
 
 import (
+	"context"
+
 	"github.com/grafana/gcx/internal/agent"
 	dsprometheus "github.com/grafana/gcx/internal/datasources/prometheus"
 	"github.com/grafana/gcx/internal/providers"
 	adaptivemetrics "github.com/grafana/gcx/internal/providers/metrics/adaptive"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 )
+
+var _ framework.StatusDetectable = &Provider{}
 
 func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
 	providers.Register(&Provider{})
@@ -112,6 +117,19 @@ func (p *Provider) Commands() []*cobra.Command {
 func queryCmd(loader *providers.ConfigLoader) *cobra.Command { return dsprometheus.QueryCmd(loader) }
 
 func (p *Provider) Validate(_ map[string]string) error { return nil }
+
+// ProductName returns the human-readable product name.
+func (p *Provider) ProductName() string { return p.Name() }
+
+// Status returns the current configuration state based on config key presence.
+// This is a v1 stub: it never probes any API. Config is loaded from the active
+// context; a missing or unreadable config is treated as StateNotConfigured.
+func (p *Provider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	loader := &providers.ConfigLoader{}
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	s := framework.ConfigKeysStatus(p, cfg)
+	return &s, nil
+}
 
 func (p *Provider) ConfigKeys() []providers.ConfigKey {
 	return []providers.ConfigKey{

--- a/internal/providers/metrics/provider_test.go
+++ b/internal/providers/metrics/provider_test.go
@@ -1,13 +1,18 @@
 package metrics_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/metrics"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Compile-time assertion: Provider satisfies StatusDetectable.
+var _ framework.StatusDetectable = (*metrics.Provider)(nil)
 
 func TestProviderRegistration(t *testing.T) {
 	p := &metrics.Provider{}
@@ -68,5 +73,31 @@ func TestProviderRegistration(t *testing.T) {
 			}
 		}
 		assert.True(t, found, "metrics provider not found in providers.All()")
+	})
+}
+
+func TestProvider_StatusDetectable(t *testing.T) {
+	p := &metrics.Provider{}
+
+	t.Run("NotSetupable", func(t *testing.T) {
+		_, ok := any(p).(framework.Setupable)
+		assert.False(t, ok, "metrics provider must not implement Setupable")
+	})
+
+	t.Run("ProductName", func(t *testing.T) {
+		assert.Equal(t, p.Name(), p.ProductName())
+	})
+
+	t.Run("Status", func(t *testing.T) {
+		status, err := p.Status(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		validStates := map[framework.ProductState]bool{
+			framework.StateNotConfigured: true,
+			framework.StateConfigured:    true,
+			framework.StateActive:        true,
+			framework.StateError:         true,
+		}
+		assert.True(t, validStates[status.State], "unexpected state: %q", status.State)
 	})
 }

--- a/internal/providers/profiles/provider.go
+++ b/internal/providers/profiles/provider.go
@@ -142,6 +142,7 @@ func (p *Provider) ProductName() string { return p.Name() }
 // context; a missing or unreadable config is treated as StateNotConfigured.
 func (p *Provider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	loader := &providers.ConfigLoader{}
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	s := framework.ConfigKeysStatus(p, cfg)
 	return &s, nil

--- a/internal/providers/profiles/provider.go
+++ b/internal/providers/profiles/provider.go
@@ -1,14 +1,18 @@
 package profiles
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/grafana/gcx/internal/agent"
 	dspyroscope "github.com/grafana/gcx/internal/datasources/pyroscope"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 )
+
+var _ framework.StatusDetectable = &Provider{}
 
 func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
 	providers.Register(&Provider{})
@@ -129,6 +133,19 @@ func queryCmd(loader *providers.ConfigLoader) *cobra.Command   { return dspyrosc
 func metricsCmd(loader *providers.ConfigLoader) *cobra.Command { return dspyroscope.MetricsCmd(loader) }
 
 func (p *Provider) Validate(_ map[string]string) error { return nil }
+
+// ProductName returns the human-readable product name.
+func (p *Provider) ProductName() string { return p.Name() }
+
+// Status returns the current configuration state based on config key presence.
+// This is a v1 stub: it never probes any API. Config is loaded from the active
+// context; a missing or unreadable config is treated as StateNotConfigured.
+func (p *Provider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	loader := &providers.ConfigLoader{}
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	s := framework.ConfigKeysStatus(p, cfg)
+	return &s, nil
+}
 
 func (p *Provider) ConfigKeys() []providers.ConfigKey {
 	return []providers.ConfigKey{

--- a/internal/providers/profiles/provider_test.go
+++ b/internal/providers/profiles/provider_test.go
@@ -1,13 +1,18 @@
 package profiles_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/profiles"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Compile-time assertion: Provider satisfies StatusDetectable.
+var _ framework.StatusDetectable = (*profiles.Provider)(nil)
 
 func TestProviderRegistration(t *testing.T) {
 	p := &profiles.Provider{}
@@ -68,5 +73,31 @@ func TestProviderRegistration(t *testing.T) {
 			}
 		}
 		assert.True(t, found, "profiles provider not found in providers.All()")
+	})
+}
+
+func TestProvider_StatusDetectable(t *testing.T) {
+	p := &profiles.Provider{}
+
+	t.Run("NotSetupable", func(t *testing.T) {
+		_, ok := any(p).(framework.Setupable)
+		assert.False(t, ok, "profiles provider must not implement Setupable")
+	})
+
+	t.Run("ProductName", func(t *testing.T) {
+		assert.Equal(t, p.Name(), p.ProductName())
+	})
+
+	t.Run("Status", func(t *testing.T) {
+		status, err := p.Status(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		validStates := map[framework.ProductState]bool{
+			framework.StateNotConfigured: true,
+			framework.StateConfigured:    true,
+			framework.StateActive:        true,
+			framework.StateError:         true,
+		}
+		assert.True(t, validStates[status.State], "unexpected state: %q", status.State)
 	})
 }

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -30,3 +30,12 @@ func All() []Provider {
 	}
 	return registry
 }
+
+// SetRegistryForTest replaces the global registry with ps for the duration of
+// a test and returns a restore function that reverts to the previous state.
+// Use testhelpers.SetupTestRegistry for automatic cleanup via t.Cleanup.
+func SetRegistryForTest(ps []Provider) func() {
+	prev := registry
+	registry = ps
+	return func() { registry = prev }
+}

--- a/internal/providers/sigil/provider.go
+++ b/internal/providers/sigil/provider.go
@@ -1,6 +1,8 @@
 package sigil
 
 import (
+	"context"
+
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/sigil/agents"
@@ -12,6 +14,7 @@ import (
 	"github.com/grafana/gcx/internal/providers/sigil/generations"
 	"github.com/grafana/gcx/internal/providers/sigil/scores"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 )
 
@@ -94,8 +97,36 @@ func (p *SigilProvider) Commands() []*cobra.Command {
 	}
 
 	sigilCmd.AddCommand(convsCmd, agentsCmd, evaluatorsCmd, rulesCmd, templatesCmd, generationsCmd, scoresCmd, judgeCmd)
+	sigilCmd.AddCommand(newSetupCommand(p))
 
 	return []*cobra.Command{sigilCmd}
+}
+
+// ProductName implements framework.StatusDetectable.
+func (p *SigilProvider) ProductName() string { return p.Name() }
+
+// Status implements framework.StatusDetectable using a config-key heuristic.
+func (p *SigilProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	var loader providers.ConfigLoader
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	status := framework.ConfigKeysStatus(p, cfg)
+	return &status, nil
+}
+
+// InfraCategories implements framework.Setupable.
+func (p *SigilProvider) InfraCategories() []framework.InfraCategory { return nil }
+
+// ResolveChoices implements framework.Setupable.
+func (p *SigilProvider) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+// ValidateSetup implements framework.Setupable.
+func (p *SigilProvider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
+
+// Setup implements framework.Setupable.
+func (p *SigilProvider) Setup(_ context.Context, _ map[string]string) error {
+	return framework.ErrSetupNotSupported
 }
 
 // Validate checks that the given provider configuration is valid.

--- a/internal/providers/sigil/provider.go
+++ b/internal/providers/sigil/provider.go
@@ -108,6 +108,7 @@ func (p *SigilProvider) ProductName() string { return p.Name() }
 // Status implements framework.StatusDetectable using a config-key heuristic.
 func (p *SigilProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	var loader providers.ConfigLoader
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	status := framework.ConfigKeysStatus(p, cfg)
 	return &status, nil
@@ -132,7 +133,7 @@ func (p *SigilProvider) Setup(_ context.Context, _ map[string]string) error {
 // Validate checks that the given provider configuration is valid.
 // The Sigil provider uses Grafana's built-in authentication via the plugin API,
 // so no extra keys are required.
-func (p *SigilProvider) Validate(cfg map[string]string) error {
+func (p *SigilProvider) Validate(_ map[string]string) error {
 	return nil
 }
 

--- a/internal/providers/sigil/provider_test.go
+++ b/internal/providers/sigil/provider_test.go
@@ -1,13 +1,20 @@
 package sigil_test
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/sigil"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Compile-time assertion: SigilProvider implements framework.Setupable.
+var _ framework.Setupable = (*sigil.SigilProvider)(nil)
 
 func TestSigilProvider_Interface(t *testing.T) {
 	p := &sigil.SigilProvider{}
@@ -56,4 +63,58 @@ func findSubcommand(parent *cobra.Command, name string) *cobra.Command {
 		}
 	}
 	return nil
+}
+
+func TestSigilProvider_ProductName(t *testing.T) {
+	p := &sigil.SigilProvider{}
+	assert.Equal(t, "sigil", p.ProductName())
+}
+
+func TestSigilProvider_Status(t *testing.T) {
+	p := &sigil.SigilProvider{}
+	status, err := p.Status(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, "sigil", status.Product)
+	// No config keys → StateActive.
+	assert.Equal(t, framework.StateActive, status.State)
+}
+
+func TestSigilProvider_InfraCategories(t *testing.T) {
+	p := &sigil.SigilProvider{}
+	assert.Nil(t, p.InfraCategories())
+}
+
+func TestSigilProvider_ResolveChoices(t *testing.T) {
+	p := &sigil.SigilProvider{}
+	choices, err := p.ResolveChoices(context.Background(), "any")
+	require.NoError(t, err)
+	assert.Nil(t, choices)
+}
+
+func TestSigilProvider_ValidateSetup(t *testing.T) {
+	p := &sigil.SigilProvider{}
+	assert.NoError(t, p.ValidateSetup(context.Background(), nil))
+}
+
+func TestSigilProvider_Setup(t *testing.T) {
+	p := &sigil.SigilProvider{}
+	err := p.Setup(context.Background(), nil)
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+}
+
+func TestSigilProvider_SetupCommand(t *testing.T) {
+	p := &sigil.SigilProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+
+	setupCmd := findSubcommand(cmds[0], "setup")
+	require.NotNil(t, setupCmd, "expected 'setup' subcommand")
+
+	stderr := &bytes.Buffer{}
+	setupCmd.SetErr(stderr)
+	err := setupCmd.RunE(setupCmd, nil)
+
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/sigil/provider_test.go
+++ b/internal/providers/sigil/provider_test.go
@@ -3,7 +3,6 @@ package sigil_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/sigil"
@@ -100,7 +99,7 @@ func TestSigilProvider_ValidateSetup(t *testing.T) {
 func TestSigilProvider_Setup(t *testing.T) {
 	p := &sigil.SigilProvider{}
 	err := p.Setup(context.Background(), nil)
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 }
 
 func TestSigilProvider_SetupCommand(t *testing.T) {
@@ -115,6 +114,6 @@ func TestSigilProvider_SetupCommand(t *testing.T) {
 	setupCmd.SetErr(stderr)
 	err := setupCmd.RunE(setupCmd, nil)
 
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/sigil/setup.go
+++ b/internal/providers/sigil/setup.go
@@ -1,0 +1,43 @@
+package sigil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type setupOpts struct{}
+
+func (o *setupOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *setupOpts) Validate() error { return nil }
+
+func newSetupCommand(p *SigilProvider) *cobra.Command {
+	opts := &setupOpts{}
+	cmd := &cobra.Command{
+		Use:           "setup",
+		Short:         "Set up sigil (not yet implemented).",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			err := p.Setup(ctx, nil)
+			if errors.Is(err, framework.ErrSetupNotSupported) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "setup not yet implemented for %s\n", p.Name())
+			}
+			return err
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/sigil/setup.go
+++ b/internal/providers/sigil/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -23,6 +24,7 @@ func newSetupCommand(p *SigilProvider) *cobra.Command {
 		Short:         "Set up sigil (not yet implemented).",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/providers/sigil/setup.go
+++ b/internal/providers/sigil/setup.go
@@ -22,6 +22,7 @@ func newSetupCommand(p *SigilProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "setup",
 		Short:         "Set up sigil (not yet implemented).",
+		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},

--- a/internal/providers/slo/provider.go
+++ b/internal/providers/slo/provider.go
@@ -1,10 +1,13 @@
 package slo
 
 import (
+	"context"
+
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/slo/definitions"
 	"github.com/grafana/gcx/internal/providers/slo/reports"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 )
 
@@ -40,8 +43,36 @@ func (p *SLOProvider) Commands() []*cobra.Command {
 
 	sloCmd.AddCommand(definitions.Commands(loader))
 	sloCmd.AddCommand(reports.Commands(loader))
+	sloCmd.AddCommand(newSetupCommand(p))
 
 	return []*cobra.Command{sloCmd}
+}
+
+// ProductName implements framework.StatusDetectable.
+func (p *SLOProvider) ProductName() string { return p.Name() }
+
+// Status implements framework.StatusDetectable using a config-key heuristic.
+func (p *SLOProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	var loader providers.ConfigLoader
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	status := framework.ConfigKeysStatus(p, cfg)
+	return &status, nil
+}
+
+// InfraCategories implements framework.Setupable.
+func (p *SLOProvider) InfraCategories() []framework.InfraCategory { return nil }
+
+// ResolveChoices implements framework.Setupable.
+func (p *SLOProvider) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+// ValidateSetup implements framework.Setupable.
+func (p *SLOProvider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
+
+// Setup implements framework.Setupable.
+func (p *SLOProvider) Setup(_ context.Context, _ map[string]string) error {
+	return framework.ErrSetupNotSupported
 }
 
 // Validate checks that the given provider configuration is valid.

--- a/internal/providers/slo/provider.go
+++ b/internal/providers/slo/provider.go
@@ -54,6 +54,7 @@ func (p *SLOProvider) ProductName() string { return p.Name() }
 // Status implements framework.StatusDetectable using a config-key heuristic.
 func (p *SLOProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	var loader providers.ConfigLoader
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	status := framework.ConfigKeysStatus(p, cfg)
 	return &status, nil
@@ -78,7 +79,7 @@ func (p *SLOProvider) Setup(_ context.Context, _ map[string]string) error {
 // Validate checks that the given provider configuration is valid.
 // The SLO provider uses Grafana's built-in authentication, so no extra keys
 // are required.
-func (p *SLOProvider) Validate(cfg map[string]string) error {
+func (p *SLOProvider) Validate(_ map[string]string) error {
 	return nil
 }
 

--- a/internal/providers/slo/provider_test.go
+++ b/internal/providers/slo/provider_test.go
@@ -1,13 +1,20 @@
 package slo_test
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/slo"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Compile-time assertion: SLOProvider implements framework.Setupable.
+var _ framework.Setupable = (*slo.SLOProvider)(nil)
 
 func TestSLOProvider_Interface(t *testing.T) {
 	p := &slo.SLOProvider{}
@@ -80,4 +87,64 @@ func TestSLOProvider_Commands(t *testing.T) {
 	assert.Contains(t, reportSubNames, "push")
 	assert.Contains(t, reportSubNames, "pull")
 	assert.Contains(t, reportSubNames, "delete")
+}
+
+func TestSLOProvider_ProductName(t *testing.T) {
+	p := &slo.SLOProvider{}
+	assert.Equal(t, "slo", p.ProductName())
+}
+
+func TestSLOProvider_Status(t *testing.T) {
+	p := &slo.SLOProvider{}
+	status, err := p.Status(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, "slo", status.Product)
+	// No config keys → StateActive.
+	assert.Equal(t, framework.StateActive, status.State)
+}
+
+func TestSLOProvider_InfraCategories(t *testing.T) {
+	p := &slo.SLOProvider{}
+	assert.Nil(t, p.InfraCategories())
+}
+
+func TestSLOProvider_ResolveChoices(t *testing.T) {
+	p := &slo.SLOProvider{}
+	choices, err := p.ResolveChoices(context.Background(), "any")
+	require.NoError(t, err)
+	assert.Nil(t, choices)
+}
+
+func TestSLOProvider_ValidateSetup(t *testing.T) {
+	p := &slo.SLOProvider{}
+	assert.NoError(t, p.ValidateSetup(context.Background(), nil))
+}
+
+func TestSLOProvider_Setup(t *testing.T) {
+	p := &slo.SLOProvider{}
+	err := p.Setup(context.Background(), nil)
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+}
+
+func TestSLOProvider_SetupCommand(t *testing.T) {
+	p := &slo.SLOProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+
+	var setupCmd *cobra.Command
+	for _, sub := range cmds[0].Commands() {
+		if sub.Name() == "setup" {
+			setupCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, setupCmd, "expected 'setup' subcommand")
+
+	stderr := &bytes.Buffer{}
+	setupCmd.SetErr(stderr)
+	err := setupCmd.RunE(setupCmd, nil)
+
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/slo/provider_test.go
+++ b/internal/providers/slo/provider_test.go
@@ -3,7 +3,6 @@ package slo_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/slo"
@@ -124,7 +123,7 @@ func TestSLOProvider_ValidateSetup(t *testing.T) {
 func TestSLOProvider_Setup(t *testing.T) {
 	p := &slo.SLOProvider{}
 	err := p.Setup(context.Background(), nil)
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 }
 
 func TestSLOProvider_SetupCommand(t *testing.T) {
@@ -145,6 +144,6 @@ func TestSLOProvider_SetupCommand(t *testing.T) {
 	setupCmd.SetErr(stderr)
 	err := setupCmd.RunE(setupCmd, nil)
 
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/slo/setup.go
+++ b/internal/providers/slo/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -23,6 +24,7 @@ func newSetupCommand(p *SLOProvider) *cobra.Command {
 		Short:         "Set up slo (not yet implemented).",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/providers/slo/setup.go
+++ b/internal/providers/slo/setup.go
@@ -1,0 +1,43 @@
+package slo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type setupOpts struct{}
+
+func (o *setupOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *setupOpts) Validate() error { return nil }
+
+func newSetupCommand(p *SLOProvider) *cobra.Command {
+	opts := &setupOpts{}
+	cmd := &cobra.Command{
+		Use:           "setup",
+		Short:         "Set up slo (not yet implemented).",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			err := p.Setup(ctx, nil)
+			if errors.Is(err, framework.ErrSetupNotSupported) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "setup not yet implemented for %s\n", p.Name())
+			}
+			return err
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/slo/setup.go
+++ b/internal/providers/slo/setup.go
@@ -22,6 +22,7 @@ func newSetupCommand(p *SLOProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "setup",
 		Short:         "Set up slo (not yet implemented).",
+		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},

--- a/internal/providers/synth/provider.go
+++ b/internal/providers/synth/provider.go
@@ -126,6 +126,7 @@ func (p *SynthProvider) ProductName() string { return p.Name() }
 // Status implements framework.StatusDetectable using a config-key heuristic.
 func (p *SynthProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	var loader providers.ConfigLoader
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	status := framework.ConfigKeysStatus(p, cfg)
 	return &status, nil

--- a/internal/providers/synth/provider.go
+++ b/internal/providers/synth/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/gcx/internal/providers/synth/checks"
 	"github.com/grafana/gcx/internal/providers/synth/probes"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 )
@@ -114,8 +115,36 @@ func (p *SynthProvider) Commands() []*cobra.Command {
 
 	synthCmd.AddCommand(checks.Commands(loader))
 	synthCmd.AddCommand(probes.Commands(loader))
+	synthCmd.AddCommand(newSetupCommand(p))
 
 	return []*cobra.Command{synthCmd}
+}
+
+// ProductName implements framework.StatusDetectable.
+func (p *SynthProvider) ProductName() string { return p.Name() }
+
+// Status implements framework.StatusDetectable using a config-key heuristic.
+func (p *SynthProvider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	var loader providers.ConfigLoader
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	status := framework.ConfigKeysStatus(p, cfg)
+	return &status, nil
+}
+
+// InfraCategories implements framework.Setupable.
+func (p *SynthProvider) InfraCategories() []framework.InfraCategory { return nil }
+
+// ResolveChoices implements framework.Setupable.
+func (p *SynthProvider) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+// ValidateSetup implements framework.Setupable.
+func (p *SynthProvider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
+
+// Setup implements framework.Setupable.
+func (p *SynthProvider) Setup(_ context.Context, _ map[string]string) error {
+	return framework.ErrSetupNotSupported
 }
 
 // Validate checks that the given provider configuration is valid.

--- a/internal/providers/synth/provider_test.go
+++ b/internal/providers/synth/provider_test.go
@@ -1,13 +1,21 @@
 package synth_test
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/synth"
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Compile-time assertion: SynthProvider implements framework.Setupable.
+var _ framework.Setupable = (*synth.SynthProvider)(nil)
 
 func TestSynthProvider_Interface(t *testing.T) {
 	var p providers.Provider = &synth.SynthProvider{}
@@ -59,4 +67,63 @@ func TestSynthProvider_Validate(t *testing.T) {
 			require.NoError(t, p.Validate(tc.cfg))
 		})
 	}
+}
+
+func TestSynthProvider_ProductName(t *testing.T) {
+	p := &synth.SynthProvider{}
+	assert.Equal(t, "synth", p.ProductName())
+}
+
+func TestSynthProvider_Status(t *testing.T) {
+	p := &synth.SynthProvider{}
+	status, err := p.Status(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, "synth", status.Product)
+	assert.NotEmpty(t, string(status.State))
+}
+
+func TestSynthProvider_InfraCategories(t *testing.T) {
+	p := &synth.SynthProvider{}
+	assert.Nil(t, p.InfraCategories())
+}
+
+func TestSynthProvider_ResolveChoices(t *testing.T) {
+	p := &synth.SynthProvider{}
+	choices, err := p.ResolveChoices(context.Background(), "any")
+	require.NoError(t, err)
+	assert.Nil(t, choices)
+}
+
+func TestSynthProvider_ValidateSetup(t *testing.T) {
+	p := &synth.SynthProvider{}
+	assert.NoError(t, p.ValidateSetup(context.Background(), nil))
+}
+
+func TestSynthProvider_Setup(t *testing.T) {
+	p := &synth.SynthProvider{}
+	err := p.Setup(context.Background(), nil)
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+}
+
+func TestSynthProvider_SetupCommand(t *testing.T) {
+	p := &synth.SynthProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+
+	var setupCmd *cobra.Command
+	for _, sub := range cmds[0].Commands() {
+		if sub.Name() == "setup" {
+			setupCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, setupCmd, "expected 'setup' subcommand")
+
+	stderr := &bytes.Buffer{}
+	setupCmd.SetErr(stderr)
+	err := setupCmd.RunE(setupCmd, nil)
+
+	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/synth/provider_test.go
+++ b/internal/providers/synth/provider_test.go
@@ -3,7 +3,6 @@ package synth_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers"
@@ -103,7 +102,7 @@ func TestSynthProvider_ValidateSetup(t *testing.T) {
 func TestSynthProvider_Setup(t *testing.T) {
 	p := &synth.SynthProvider{}
 	err := p.Setup(context.Background(), nil)
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 }
 
 func TestSynthProvider_SetupCommand(t *testing.T) {
@@ -124,6 +123,6 @@ func TestSynthProvider_SetupCommand(t *testing.T) {
 	setupCmd.SetErr(stderr)
 	err := setupCmd.RunE(setupCmd, nil)
 
-	assert.True(t, errors.Is(err, framework.ErrSetupNotSupported))
+	require.ErrorIs(t, err, framework.ErrSetupNotSupported)
 	assert.NotEmpty(t, stderr.String())
 }

--- a/internal/providers/synth/setup.go
+++ b/internal/providers/synth/setup.go
@@ -22,6 +22,7 @@ func newSetupCommand(p *SynthProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "setup",
 		Short:         "Set up synth (not yet implemented).",
+		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},

--- a/internal/providers/synth/setup.go
+++ b/internal/providers/synth/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -23,6 +24,7 @@ func newSetupCommand(p *SynthProvider) *cobra.Command {
 		Short:         "Set up synth (not yet implemented).",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Annotations:   map[string]string{agent.AnnotationTokenCost: "small"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/providers/synth/setup.go
+++ b/internal/providers/synth/setup.go
@@ -1,0 +1,43 @@
+package synth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type setupOpts struct{}
+
+func (o *setupOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *setupOpts) Validate() error { return nil }
+
+func newSetupCommand(p *SynthProvider) *cobra.Command {
+	opts := &setupOpts{}
+	cmd := &cobra.Command{
+		Use:           "setup",
+		Short:         "Set up synth (not yet implemented).",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			err := p.Setup(ctx, nil)
+			if errors.Is(err, framework.ErrSetupNotSupported) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "setup not yet implemented for %s\n", p.Name())
+			}
+			return err
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/traces/provider.go
+++ b/internal/providers/traces/provider.go
@@ -1,13 +1,18 @@
 package traces
 
 import (
+	"context"
+
 	"github.com/grafana/gcx/internal/agent"
 	dstempo "github.com/grafana/gcx/internal/datasources/tempo"
 	"github.com/grafana/gcx/internal/providers"
 	adaptivetraces "github.com/grafana/gcx/internal/providers/traces/adaptive"
 	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/spf13/cobra"
 )
+
+var _ framework.StatusDetectable = &Provider{}
 
 func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
 	providers.Register(&Provider{})
@@ -105,6 +110,19 @@ func queryCmd(loader *providers.ConfigLoader) *cobra.Command   { return dstempo.
 func metricsCmd(loader *providers.ConfigLoader) *cobra.Command { return dstempo.MetricsCmd(loader) }
 
 func (p *Provider) Validate(_ map[string]string) error { return nil }
+
+// ProductName returns the human-readable product name.
+func (p *Provider) ProductName() string { return p.Name() }
+
+// Status returns the current configuration state based on config key presence.
+// This is a v1 stub: it never probes any API. Config is loaded from the active
+// context; a missing or unreadable config is treated as StateNotConfigured.
+func (p *Provider) Status(ctx context.Context) (*framework.ProductStatus, error) {
+	loader := &providers.ConfigLoader{}
+	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
+	s := framework.ConfigKeysStatus(p, cfg)
+	return &s, nil
+}
 
 func (p *Provider) ConfigKeys() []providers.ConfigKey {
 	return []providers.ConfigKey{

--- a/internal/providers/traces/provider.go
+++ b/internal/providers/traces/provider.go
@@ -119,6 +119,7 @@ func (p *Provider) ProductName() string { return p.Name() }
 // context; a missing or unreadable config is treated as StateNotConfigured.
 func (p *Provider) Status(ctx context.Context) (*framework.ProductStatus, error) {
 	loader := &providers.ConfigLoader{}
+	// TODO: add proper error handling once provider setup is implemented
 	cfg, _, _ := loader.LoadProviderConfig(ctx, p.Name())
 	s := framework.ConfigKeysStatus(p, cfg)
 	return &s, nil

--- a/internal/providers/traces/provider_test.go
+++ b/internal/providers/traces/provider_test.go
@@ -1,13 +1,18 @@
 package traces_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/traces"
+	"github.com/grafana/gcx/internal/setup/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Compile-time assertion: Provider satisfies StatusDetectable.
+var _ framework.StatusDetectable = (*traces.Provider)(nil)
 
 func TestProviderRegistration(t *testing.T) {
 	p := &traces.Provider{}
@@ -68,5 +73,31 @@ func TestProviderRegistration(t *testing.T) {
 			}
 		}
 		assert.True(t, found, "traces provider not found in providers.All()")
+	})
+}
+
+func TestProvider_StatusDetectable(t *testing.T) {
+	p := &traces.Provider{}
+
+	t.Run("NotSetupable", func(t *testing.T) {
+		_, ok := any(p).(framework.Setupable)
+		assert.False(t, ok, "traces provider must not implement Setupable")
+	})
+
+	t.Run("ProductName", func(t *testing.T) {
+		assert.Equal(t, p.Name(), p.ProductName())
+	})
+
+	t.Run("Status", func(t *testing.T) {
+		status, err := p.Status(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		validStates := map[framework.ProductState]bool{
+			framework.StateNotConfigured: true,
+			framework.StateConfigured:    true,
+			framework.StateActive:        true,
+			framework.StateError:         true,
+		}
+		assert.True(t, validStates[status.State], "unexpected state: %q", status.State)
 	})
 }

--- a/internal/setup/framework/aggregate.go
+++ b/internal/setup/framework/aggregate.go
@@ -32,7 +32,6 @@ func AggregateStatusFrom(ctx context.Context, timeout time.Duration, providers [
 	g.SetLimit(10)
 
 	for i, sd := range providers {
-		i, sd := i, sd
 		g.Go(func() error {
 			cctx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()

--- a/internal/setup/framework/aggregate.go
+++ b/internal/setup/framework/aggregate.go
@@ -1,0 +1,96 @@
+package framework
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+const defaultAggregateTimeout = 5 * time.Second
+
+// AggregateStatus calls Status() on every StatusDetectable provider in parallel.
+// timeout <= 0 defaults to 5 seconds.
+// Returns []ProductStatus sorted alphabetically by ProductName().
+func AggregateStatus(ctx context.Context, timeout time.Duration) []ProductStatus {
+	return AggregateStatusFrom(ctx, timeout, DiscoverStatusDetectable())
+}
+
+// AggregateStatusFrom is like AggregateStatus but operates on an explicit
+// provider list instead of the global registry. Useful for testing.
+func AggregateStatusFrom(ctx context.Context, timeout time.Duration, providers []StatusDetectable) []ProductStatus {
+	if timeout <= 0 {
+		timeout = defaultAggregateTimeout
+	}
+
+	results := make([]ProductStatus, len(providers))
+
+	g := new(errgroup.Group)
+	g.SetLimit(10)
+
+	for i, sd := range providers {
+		i, sd := i, sd
+		g.Go(func() error {
+			cctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			results[i] = collectStatus(cctx, sd, timeout)
+			return nil
+		})
+	}
+
+	_ = g.Wait()
+
+	slices.SortFunc(results, func(a, b ProductStatus) int {
+		return cmp.Compare(a.Product, b.Product)
+	})
+
+	return results
+}
+
+// collectStatus calls sd.Status in an isolated goroutine, recovering panics and
+// enforcing the per-provider deadline via a select on cctx.Done().
+// It always sets result.Product = sd.ProductName().
+func collectStatus(cctx context.Context, sd StatusDetectable, timeout time.Duration) ProductStatus {
+	name := sd.ProductName()
+	done := make(chan ProductStatus, 1)
+
+	go func() {
+		var ps ProductStatus
+		defer func() {
+			if r := recover(); r != nil {
+				ps = ProductStatus{
+					Product: name,
+					State:   StateError,
+					Details: fmt.Sprintf("panic: %v", r),
+				}
+			}
+			done <- ps
+		}()
+
+		status, err := sd.Status(cctx)
+		if err != nil {
+			ps = ProductStatus{Product: name, State: StateError, Details: err.Error()}
+			return
+		}
+		if status == nil {
+			ps = ProductStatus{Product: name, State: StateError, Details: "nil status returned"}
+			return
+		}
+		ps = *status
+		ps.Product = name
+	}()
+
+	select {
+	case s := <-done:
+		return s
+	case <-cctx.Done():
+		return ProductStatus{
+			Product: name,
+			State:   StateError,
+			Details: fmt.Sprintf("status check timed out after %v", timeout),
+		}
+	}
+}

--- a/internal/setup/framework/aggregate.go
+++ b/internal/setup/framework/aggregate.go
@@ -5,27 +5,20 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"time"
 
 	"golang.org/x/sync/errgroup"
 )
 
-const defaultAggregateTimeout = 5 * time.Second
-
 // AggregateStatus calls Status() on every StatusDetectable provider in parallel.
-// timeout <= 0 defaults to 5 seconds.
 // Returns []ProductStatus sorted alphabetically by ProductName().
-func AggregateStatus(ctx context.Context, timeout time.Duration) []ProductStatus {
-	return AggregateStatusFrom(ctx, timeout, DiscoverStatusDetectable())
+// Deadline management is the caller's responsibility via ctx.
+func AggregateStatus(ctx context.Context) []ProductStatus {
+	return AggregateStatusFrom(ctx, DiscoverStatusDetectable())
 }
 
 // AggregateStatusFrom is like AggregateStatus but operates on an explicit
 // provider list instead of the global registry. Useful for testing.
-func AggregateStatusFrom(ctx context.Context, timeout time.Duration, providers []StatusDetectable) []ProductStatus {
-	if timeout <= 0 {
-		timeout = defaultAggregateTimeout
-	}
-
+func AggregateStatusFrom(ctx context.Context, providers []StatusDetectable) []ProductStatus {
 	results := make([]ProductStatus, len(providers))
 
 	g := new(errgroup.Group)
@@ -33,14 +26,12 @@ func AggregateStatusFrom(ctx context.Context, timeout time.Duration, providers [
 
 	for i, sd := range providers {
 		g.Go(func() error {
-			cctx, cancel := context.WithTimeout(ctx, timeout)
-			defer cancel()
-			results[i] = collectStatus(cctx, sd, timeout)
+			results[i] = collectStatus(ctx, sd)
 			return nil
 		})
 	}
 
-	_ = g.Wait()
+	_ = g.Wait() // goroutines always return nil; errors are collected in collectStatus
 
 	slices.SortFunc(results, func(a, b ProductStatus) int {
 		return cmp.Compare(a.Product, b.Product)
@@ -50,9 +41,11 @@ func AggregateStatusFrom(ctx context.Context, timeout time.Duration, providers [
 }
 
 // collectStatus calls sd.Status in an isolated goroutine, recovering panics and
-// enforcing the per-provider deadline via a select on cctx.Done().
+// propagating context cancellation via a select on ctx.Done().
 // It always sets result.Product = sd.ProductName().
-func collectStatus(cctx context.Context, sd StatusDetectable, timeout time.Duration) ProductStatus {
+// The buffered done channel (size 1) prevents the goroutine from blocking if ctx
+// is cancelled before the goroutine writes its result.
+func collectStatus(ctx context.Context, sd StatusDetectable) ProductStatus {
 	name := sd.ProductName()
 	done := make(chan ProductStatus, 1)
 
@@ -69,7 +62,7 @@ func collectStatus(cctx context.Context, sd StatusDetectable, timeout time.Durat
 			done <- ps
 		}()
 
-		status, err := sd.Status(cctx)
+		status, err := sd.Status(ctx)
 		if err != nil {
 			ps = ProductStatus{Product: name, State: StateError, Details: err.Error()}
 			return
@@ -85,11 +78,11 @@ func collectStatus(cctx context.Context, sd StatusDetectable, timeout time.Durat
 	select {
 	case s := <-done:
 		return s
-	case <-cctx.Done():
+	case <-ctx.Done():
 		return ProductStatus{
 			Product: name,
 			State:   StateError,
-			Details: fmt.Sprintf("status check timed out after %v", timeout),
+			Details: "status check cancelled",
 		}
 	}
 }

--- a/internal/setup/framework/aggregate_test.go
+++ b/internal/setup/framework/aggregate_test.go
@@ -1,0 +1,221 @@
+package framework_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/grafana/gcx/internal/setup/framework/testhelpers"
+)
+
+func TestAggregateStatusFrom(t *testing.T) {
+	active := func(name string) *framework.ProductStatus {
+		return &framework.ProductStatus{Product: name, State: framework.StateActive}
+	}
+	configured := func(name string) *framework.ProductStatus {
+		return &framework.ProductStatus{Product: name, State: framework.StateConfigured}
+	}
+	notConfigured := func(name string) *framework.ProductStatus {
+		return &framework.ProductStatus{Product: name, State: framework.StateNotConfigured}
+	}
+
+	t.Run("happy path: mixed states returned in alphabetical order", func(t *testing.T) {
+		providers := []framework.StatusDetectable{
+			&testhelpers.FakeStatusDetectable{ProductName_: "C-provider", Status_: active("C-provider")},
+			&testhelpers.FakeStatusDetectable{ProductName_: "A-provider", Status_: configured("A-provider")},
+			&testhelpers.FakeStatusDetectable{ProductName_: "B-provider", Status_: notConfigured("B-provider")},
+		}
+
+		got := aggregateFrom(t, providers, time.Second)
+
+		requireLen(t, got, 3)
+		requireProduct(t, got[0], "A-provider", framework.StateConfigured)
+		requireProduct(t, got[1], "B-provider", framework.StateNotConfigured)
+		requireProduct(t, got[2], "C-provider", framework.StateActive)
+	})
+
+	t.Run("error isolation: one error does not affect siblings", func(t *testing.T) {
+		errMsg := "connection refused"
+		providers := []framework.StatusDetectable{
+			&testhelpers.FakeStatusDetectable{ProductName_: "A-ok", Status_: active("A-ok")},
+			&testhelpers.FakeStatusDetectable{ProductName_: "B-err", Err: errorf(errMsg)},
+			&testhelpers.FakeStatusDetectable{ProductName_: "C-ok", Status_: active("C-ok")},
+		}
+
+		got := aggregateFrom(t, providers, time.Second)
+
+		requireLen(t, got, 3)
+		requireProduct(t, got[0], "A-ok", framework.StateActive)
+		requireProduct(t, got[1], "B-err", framework.StateError)
+		if got[1].Details != errMsg {
+			t.Errorf("error details: want %q, got %q", errMsg, got[1].Details)
+		}
+		requireProduct(t, got[2], "C-ok", framework.StateActive)
+	})
+
+	t.Run("timeout: slow provider returns StateError within bounded time", func(t *testing.T) {
+		providers := []framework.StatusDetectable{
+			&testhelpers.FakeStatusDetectable{ProductName_: "A-fast", Status_: active("A-fast")},
+			// sleeps 10s but timeout is 500ms
+			&testhelpers.FakeStatusDetectable{ProductName_: "B-slow", Latency: 10 * time.Second, Status_: active("B-slow")},
+			&testhelpers.FakeStatusDetectable{ProductName_: "C-fast", Status_: active("C-fast")},
+		}
+
+		perProvider := 500 * time.Millisecond
+		start := time.Now()
+		got := aggregateFrom(t, providers, perProvider)
+		elapsed := time.Since(start)
+
+		// Must complete well within 10s (slow provider's sleep).
+		if elapsed > 3*time.Second {
+			t.Errorf("AggregateStatus took %v, expected < 3s", elapsed)
+		}
+
+		requireLen(t, got, 3)
+		requireProduct(t, got[0], "A-fast", framework.StateActive)
+		requireProduct(t, got[1], "B-slow", framework.StateError)
+		requireProduct(t, got[2], "C-fast", framework.StateActive)
+	})
+
+	t.Run("panic: panicking provider is StateError; siblings succeed", func(t *testing.T) {
+		providers := []framework.StatusDetectable{
+			&testhelpers.FakeStatusDetectable{ProductName_: "A-ok", Status_: active("A-ok")},
+			&testhelpers.FakeStatusDetectable{ProductName_: "B-panic", ShouldPanic: true},
+			&testhelpers.FakeStatusDetectable{ProductName_: "C-ok", Status_: active("C-ok")},
+		}
+
+		got := aggregateFrom(t, providers, time.Second)
+
+		requireLen(t, got, 3)
+		requireProduct(t, got[0], "A-ok", framework.StateActive)
+		requireProduct(t, got[1], "B-panic", framework.StateError)
+		requireProduct(t, got[2], "C-ok", framework.StateActive)
+	})
+
+	t.Run("ordering: completion order C,A,B → result order A,B,C", func(t *testing.T) {
+		// C completes first (no latency), A second (small latency), B last (larger latency)
+		// but results should still be alphabetical.
+		providers := []framework.StatusDetectable{
+			&testhelpers.FakeStatusDetectable{ProductName_: "C-third-alpha", Status_: active("C-third-alpha")},
+			&testhelpers.FakeStatusDetectable{ProductName_: "A-first-alpha", Latency: 10 * time.Millisecond, Status_: active("A-first-alpha")},
+			&testhelpers.FakeStatusDetectable{ProductName_: "B-second-alpha", Latency: 20 * time.Millisecond, Status_: active("B-second-alpha")},
+		}
+
+		got := aggregateFrom(t, providers, time.Second)
+
+		requireLen(t, got, 3)
+		requireProduct(t, got[0], "A-first-alpha", framework.StateActive)
+		requireProduct(t, got[1], "B-second-alpha", framework.StateActive)
+		requireProduct(t, got[2], "C-third-alpha", framework.StateActive)
+	})
+
+	t.Run("bounded parallelism: max concurrency <= 10", func(t *testing.T) {
+		var current atomic.Int64
+		var maxSeen atomic.Int64
+
+		makeProvider := func(name string) framework.StatusDetectable {
+			return &concurrencyProbeProvider{
+				name:    name,
+				current: &current,
+				maxSeen: &maxSeen,
+			}
+		}
+
+		providers := make([]framework.StatusDetectable, 20)
+		for i := range providers {
+			providers[i] = makeProvider(providerName(i))
+		}
+
+		got := aggregateFrom(t, providers, 5*time.Second)
+		requireLen(t, got, 20)
+
+		if maxSeen.Load() > 10 {
+			t.Errorf("max concurrency %d exceeds limit of 10", maxSeen.Load())
+		}
+	})
+
+	t.Run("default timeout applied when timeout<=0", func(t *testing.T) {
+		// Just verify it doesn't panic and returns results.
+		providers := []framework.StatusDetectable{
+			&testhelpers.FakeStatusDetectable{ProductName_: "A", Status_: active("A")},
+		}
+		// timeout=0 triggers default; use the exported aggregateStatusFrom via integration path
+		got := aggregateFrom(t, providers, 0)
+		requireLen(t, got, 1)
+		requireProduct(t, got[0], "A", framework.StateActive)
+	})
+}
+
+// helpers
+
+func aggregateFrom(t *testing.T, providers []framework.StatusDetectable, timeout time.Duration) []framework.ProductStatus {
+	t.Helper()
+	// Access the package-internal aggregateStatusFrom via the exported AggregateStatus
+	// by using testhelpers.SetupTestRegistry to populate the global registry.
+	// However, since aggregateStatusFrom is unexported, we use the exported path
+	// through the global registry for integration coverage.
+	// For isolation, use a test registry.
+	return framework.AggregateStatusFrom(context.Background(), timeout, providers)
+}
+
+func requireLen(t *testing.T, got []framework.ProductStatus, want int) {
+	t.Helper()
+	if len(got) != want {
+		t.Fatalf("len(results) = %d, want %d", len(got), want)
+	}
+}
+
+func requireProduct(t *testing.T, ps framework.ProductStatus, wantProduct string, wantState framework.ProductState) {
+	t.Helper()
+	if ps.Product != wantProduct {
+		t.Errorf("Product = %q, want %q", ps.Product, wantProduct)
+	}
+	if ps.State != wantState {
+		t.Errorf("[%s] State = %q, want %q", ps.Product, ps.State, wantState)
+	}
+}
+
+func errorf(msg string) error {
+	return &simpleError{msg}
+}
+
+type simpleError struct{ msg string }
+
+func (e *simpleError) Error() string { return e.msg }
+
+func providerName(i int) string {
+	return fmt.Sprintf("provider-%02d", i)
+}
+
+// concurrencyProbeProvider tracks concurrent invocations.
+type concurrencyProbeProvider struct {
+	name    string
+	current *atomic.Int64
+	maxSeen *atomic.Int64
+}
+
+func (p *concurrencyProbeProvider) ProductName() string { return p.name }
+
+func (p *concurrencyProbeProvider) Status(_ context.Context) (*framework.ProductStatus, error) {
+	cur := p.current.Add(1)
+	defer p.current.Add(-1)
+
+	// update maxSeen
+	for {
+		old := p.maxSeen.Load()
+		if cur <= old {
+			break
+		}
+		if p.maxSeen.CompareAndSwap(old, cur) {
+			break
+		}
+	}
+
+	// small sleep to allow concurrent goroutines to overlap
+	time.Sleep(5 * time.Millisecond)
+
+	return &framework.ProductStatus{Product: p.name, State: framework.StateActive}, nil
+}

--- a/internal/setup/framework/aggregate_test.go
+++ b/internal/setup/framework/aggregate_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/grafana/gcx/internal/setup/framework/testhelpers"
 )
 
+// Deadline/timeout enforcement is the caller's responsibility via context.
+// Pass a context.WithTimeout or context.WithDeadline to AggregateStatus /
+// AggregateStatusFrom when bounded execution time is required.
+
 func TestAggregateStatusFrom(t *testing.T) {
 	active := func(name string) *framework.ProductStatus {
 		return &framework.ProductStatus{Product: name, State: framework.StateActive}
@@ -29,7 +33,7 @@ func TestAggregateStatusFrom(t *testing.T) {
 			&testhelpers.FakeStatusDetectable{ProductName_: "B-provider", Status_: notConfigured("B-provider")},
 		}
 
-		got := aggregateFrom(t, providers, time.Second)
+		got := aggregateFrom(t, providers)
 
 		requireLen(t, got, 3)
 		requireProduct(t, got[0], "A-provider", framework.StateConfigured)
@@ -45,7 +49,7 @@ func TestAggregateStatusFrom(t *testing.T) {
 			&testhelpers.FakeStatusDetectable{ProductName_: "C-ok", Status_: active("C-ok")},
 		}
 
-		got := aggregateFrom(t, providers, time.Second)
+		got := aggregateFrom(t, providers)
 
 		requireLen(t, got, 3)
 		requireProduct(t, got[0], "A-ok", framework.StateActive)
@@ -56,29 +60,8 @@ func TestAggregateStatusFrom(t *testing.T) {
 		requireProduct(t, got[2], "C-ok", framework.StateActive)
 	})
 
-	t.Run("timeout: slow provider returns StateError within bounded time", func(t *testing.T) {
-		providers := []framework.StatusDetectable{
-			&testhelpers.FakeStatusDetectable{ProductName_: "A-fast", Status_: active("A-fast")},
-			// sleeps 10s but timeout is 500ms
-			&testhelpers.FakeStatusDetectable{ProductName_: "B-slow", Latency: 10 * time.Second, Status_: active("B-slow")},
-			&testhelpers.FakeStatusDetectable{ProductName_: "C-fast", Status_: active("C-fast")},
-		}
-
-		perProvider := 500 * time.Millisecond
-		start := time.Now()
-		got := aggregateFrom(t, providers, perProvider)
-		elapsed := time.Since(start)
-
-		// Must complete well within 10s (slow provider's sleep).
-		if elapsed > 3*time.Second {
-			t.Errorf("AggregateStatus took %v, expected < 3s", elapsed)
-		}
-
-		requireLen(t, got, 3)
-		requireProduct(t, got[0], "A-fast", framework.StateActive)
-		requireProduct(t, got[1], "B-slow", framework.StateError)
-		requireProduct(t, got[2], "C-fast", framework.StateActive)
-	})
+	// Timeout/deadline enforcement is the caller's responsibility via context.
+	// Pass context.WithTimeout to AggregateStatusFrom when bounded execution is needed.
 
 	t.Run("panic: panicking provider is StateError; siblings succeed", func(t *testing.T) {
 		providers := []framework.StatusDetectable{
@@ -87,7 +70,7 @@ func TestAggregateStatusFrom(t *testing.T) {
 			&testhelpers.FakeStatusDetectable{ProductName_: "C-ok", Status_: active("C-ok")},
 		}
 
-		got := aggregateFrom(t, providers, time.Second)
+		got := aggregateFrom(t, providers)
 
 		requireLen(t, got, 3)
 		requireProduct(t, got[0], "A-ok", framework.StateActive)
@@ -104,7 +87,7 @@ func TestAggregateStatusFrom(t *testing.T) {
 			&testhelpers.FakeStatusDetectable{ProductName_: "B-second-alpha", Latency: 20 * time.Millisecond, Status_: active("B-second-alpha")},
 		}
 
-		got := aggregateFrom(t, providers, time.Second)
+		got := aggregateFrom(t, providers)
 
 		requireLen(t, got, 3)
 		requireProduct(t, got[0], "A-first-alpha", framework.StateActive)
@@ -129,36 +112,20 @@ func TestAggregateStatusFrom(t *testing.T) {
 			providers[i] = makeProvider(providerName(i))
 		}
 
-		got := aggregateFrom(t, providers, 5*time.Second)
+		got := aggregateFrom(t, providers)
 		requireLen(t, got, 20)
 
 		if maxSeen.Load() > 10 {
 			t.Errorf("max concurrency %d exceeds limit of 10", maxSeen.Load())
 		}
 	})
-
-	t.Run("default timeout applied when timeout<=0", func(t *testing.T) {
-		// Just verify it doesn't panic and returns results.
-		providers := []framework.StatusDetectable{
-			&testhelpers.FakeStatusDetectable{ProductName_: "A", Status_: active("A")},
-		}
-		// timeout=0 triggers default; use the exported aggregateStatusFrom via integration path
-		got := aggregateFrom(t, providers, 0)
-		requireLen(t, got, 1)
-		requireProduct(t, got[0], "A", framework.StateActive)
-	})
 }
 
 // helpers
 
-func aggregateFrom(t *testing.T, providers []framework.StatusDetectable, timeout time.Duration) []framework.ProductStatus {
+func aggregateFrom(t *testing.T, providers []framework.StatusDetectable) []framework.ProductStatus {
 	t.Helper()
-	// Access the package-internal aggregateStatusFrom via the exported AggregateStatus
-	// by using testhelpers.SetupTestRegistry to populate the global registry.
-	// However, since aggregateStatusFrom is unexported, we use the exported path
-	// through the global registry for integration coverage.
-	// For isolation, use a test registry.
-	return framework.AggregateStatusFrom(context.Background(), timeout, providers)
+	return framework.AggregateStatusFrom(context.Background(), providers)
 }
 
 func requireLen(t *testing.T, got []framework.ProductStatus, want int) {

--- a/internal/setup/framework/discovery.go
+++ b/internal/setup/framework/discovery.go
@@ -1,0 +1,35 @@
+package framework
+
+import "github.com/grafana/gcx/internal/providers"
+
+// DiscoverStatusDetectableFrom returns all providers in ps that implement StatusDetectable.
+func DiscoverStatusDetectableFrom(ps []providers.Provider) []StatusDetectable {
+	var out []StatusDetectable
+	for _, p := range ps {
+		if sd, ok := p.(StatusDetectable); ok {
+			out = append(out, sd)
+		}
+	}
+	return out
+}
+
+// DiscoverStatusDetectable returns all globally registered providers that implement StatusDetectable.
+func DiscoverStatusDetectable() []StatusDetectable {
+	return DiscoverStatusDetectableFrom(providers.All())
+}
+
+// DiscoverSetupableFrom returns all providers in ps that implement Setupable.
+func DiscoverSetupableFrom(ps []providers.Provider) []Setupable {
+	var out []Setupable
+	for _, p := range ps {
+		if s, ok := p.(Setupable); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// DiscoverSetupable returns all globally registered providers that implement Setupable.
+func DiscoverSetupable() []Setupable {
+	return DiscoverSetupableFrom(providers.All())
+}

--- a/internal/setup/framework/discovery_test.go
+++ b/internal/setup/framework/discovery_test.go
@@ -1,0 +1,159 @@
+package framework_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/spf13/cobra"
+)
+
+// stubProvider is a minimal providers.Provider implementation for tests.
+type stubProvider struct{ name string }
+
+func (s *stubProvider) Name() string                               { return s.name }
+func (s *stubProvider) ShortDesc() string                          { return "" }
+func (s *stubProvider) Commands() []*cobra.Command                 { return nil }
+func (s *stubProvider) Validate(_ map[string]string) error         { return nil }
+func (s *stubProvider) ConfigKeys() []providers.ConfigKey          { return nil }
+func (s *stubProvider) TypedRegistrations() []adapter.Registration { return nil }
+
+// detectableProvider is a stubProvider that also implements StatusDetectable.
+type detectableProvider struct {
+	stubProvider
+
+	state framework.ProductState
+}
+
+func (d *detectableProvider) ProductName() string { return d.name }
+func (d *detectableProvider) Status(_ context.Context) (*framework.ProductStatus, error) {
+	return &framework.ProductStatus{Product: d.name, State: d.state}, nil
+}
+
+// setupableProvider is a stubProvider that also implements Setupable.
+type setupableProvider struct {
+	stubProvider
+}
+
+func (s *setupableProvider) ProductName() string { return s.name }
+func (s *setupableProvider) Status(_ context.Context) (*framework.ProductStatus, error) {
+	return &framework.ProductStatus{Product: s.name, State: framework.StateActive}, nil
+}
+func (s *setupableProvider) InfraCategories() []framework.InfraCategory { return nil }
+func (s *setupableProvider) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+func (s *setupableProvider) ValidateSetup(_ context.Context, _ map[string]string) error { return nil }
+func (s *setupableProvider) Setup(_ context.Context, _ map[string]string) error         { return nil }
+
+func TestDiscoverStatusDetectableFrom(t *testing.T) {
+	cases := []struct {
+		name      string
+		providers []providers.Provider
+		wantNames []string
+	}{
+		{
+			name:      "empty slice returns empty",
+			providers: []providers.Provider{},
+			wantNames: nil,
+		},
+		{
+			name: "non-detectable provider excluded",
+			providers: []providers.Provider{
+				&stubProvider{name: "plain"},
+			},
+			wantNames: nil,
+		},
+		{
+			name: "detectable provider included",
+			providers: []providers.Provider{
+				&detectableProvider{stubProvider: stubProvider{name: "slo"}, state: framework.StateActive},
+			},
+			wantNames: []string{"slo"},
+		},
+		{
+			name: "mixed: only detectable included",
+			providers: []providers.Provider{
+				&stubProvider{name: "plain"},
+				&detectableProvider{stubProvider: stubProvider{name: "slo"}, state: framework.StateActive},
+				&detectableProvider{stubProvider: stubProvider{name: "metrics"}, state: framework.StateConfigured},
+			},
+			wantNames: []string{"slo", "metrics"},
+		},
+		{
+			name: "setupable satisfies detectable",
+			providers: []providers.Provider{
+				&setupableProvider{stubProvider: stubProvider{name: "synth"}},
+			},
+			wantNames: []string{"synth"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := framework.DiscoverStatusDetectableFrom(tc.providers)
+			if len(got) != len(tc.wantNames) {
+				t.Fatalf("got %d results, want %d", len(got), len(tc.wantNames))
+			}
+			for i, sd := range got {
+				if sd.ProductName() != tc.wantNames[i] {
+					t.Errorf("result[%d].ProductName() = %q, want %q", i, sd.ProductName(), tc.wantNames[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDiscoverSetupableFrom(t *testing.T) {
+	cases := []struct {
+		name      string
+		providers []providers.Provider
+		wantNames []string
+	}{
+		{
+			name:      "empty slice returns empty",
+			providers: []providers.Provider{},
+			wantNames: nil,
+		},
+		{
+			name: "detectable-only excluded",
+			providers: []providers.Provider{
+				&detectableProvider{stubProvider: stubProvider{name: "slo"}},
+			},
+			wantNames: nil,
+		},
+		{
+			name: "setupable included",
+			providers: []providers.Provider{
+				&setupableProvider{stubProvider: stubProvider{name: "synth"}},
+			},
+			wantNames: []string{"synth"},
+		},
+		{
+			name: "mixed: only setupable included",
+			providers: []providers.Provider{
+				&stubProvider{name: "plain"},
+				&detectableProvider{stubProvider: stubProvider{name: "slo"}},
+				&setupableProvider{stubProvider: stubProvider{name: "synth"}},
+				&setupableProvider{stubProvider: stubProvider{name: "k6"}},
+			},
+			wantNames: []string{"synth", "k6"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := framework.DiscoverSetupableFrom(tc.providers)
+			if len(got) != len(tc.wantNames) {
+				t.Fatalf("got %d results, want %d", len(got), len(tc.wantNames))
+			}
+			for i, s := range got {
+				if s.ProductName() != tc.wantNames[i] {
+					t.Errorf("result[%d].ProductName() = %q, want %q", i, s.ProductName(), tc.wantNames[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/setup/framework/interfaces.go
+++ b/internal/setup/framework/interfaces.go
@@ -1,0 +1,85 @@
+package framework
+
+import (
+	"context"
+	"errors"
+)
+
+// ProductState represents the configuration/activation state of a product.
+type ProductState string
+
+const (
+	StateNotConfigured ProductState = "not_configured"
+	StateConfigured    ProductState = "configured"
+	StateActive        ProductState = "active"
+	StateError         ProductState = "error"
+)
+
+// ProductStatus is the status snapshot returned by StatusDetectable.Status().
+type ProductStatus struct {
+	Product   string       `json:"product"    yaml:"product"`
+	State     ProductState `json:"state"      yaml:"state"`
+	Details   string       `json:"details"    yaml:"details"`
+	SetupHint string       `json:"setup_hint" yaml:"setup_hint"`
+}
+
+// InfraCategoryID is the identifier for an infrastructure category.
+type InfraCategoryID string
+
+// InfraCategory groups related setup parameters under a named category.
+type InfraCategory struct {
+	ID     InfraCategoryID
+	Label  string
+	Params []SetupParam
+}
+
+// ParamKind describes the type of input a SetupParam expects.
+type ParamKind string
+
+const (
+	ParamKindText        ParamKind = "text"
+	ParamKindBool        ParamKind = "bool"
+	ParamKindChoice      ParamKind = "choice"
+	ParamKindMultiChoice ParamKind = "multi_choice"
+)
+
+// SetupParam describes a single configurable parameter for a setup flow.
+type SetupParam struct {
+	Name     string
+	Prompt   string
+	Default  string
+	Kind     ParamKind
+	Required bool
+	Secret   bool
+	Choices  []string
+}
+
+// StatusDetectable is implemented by providers that can report their
+// configuration/activation state without performing a full setup.
+type StatusDetectable interface {
+	ProductName() string
+	Status(ctx context.Context) (*ProductStatus, error)
+}
+
+// Setupable is implemented by providers that support guided setup flows.
+// It extends StatusDetectable with setup orchestration methods.
+type Setupable interface {
+	StatusDetectable
+
+	// InfraCategories returns the categories of infrastructure parameters
+	// required to set up this product.
+	InfraCategories() []InfraCategory
+
+	// ResolveChoices returns the available options for a choice-type parameter.
+	ResolveChoices(ctx context.Context, paramName string) ([]string, error)
+
+	// ValidateSetup validates setup parameters without applying them.
+	ValidateSetup(ctx context.Context, params map[string]string) error
+
+	// Setup applies the provided parameters to configure the product.
+	Setup(ctx context.Context, params map[string]string) error
+}
+
+// ErrSetupNotSupported is returned by Setupable implementations that have
+// not yet implemented their setup flow.
+var ErrSetupNotSupported = errors.New("setup not yet implemented for this provider")

--- a/internal/setup/framework/interfaces.go
+++ b/internal/setup/framework/interfaces.go
@@ -58,6 +58,9 @@ type SetupParam struct {
 // configuration/activation state without performing a full setup.
 type StatusDetectable interface {
 	ProductName() string
+	// Status returns the current configuration state of this product.
+	// Implementations MUST return promptly when ctx is cancelled — the caller
+	// may cancel ctx to enforce a deadline. Do not ignore ctx.Done().
 	Status(ctx context.Context) (*ProductStatus, error)
 }
 
@@ -74,9 +77,13 @@ type Setupable interface {
 	ResolveChoices(ctx context.Context, paramName string) ([]string, error)
 
 	// ValidateSetup validates setup parameters without applying them.
+	// IMPORTANT: Error messages MUST NOT include raw secret parameter values.
+	// The orchestrator prints ValidateSetup errors to stderr verbatim.
 	ValidateSetup(ctx context.Context, params map[string]string) error
 
 	// Setup applies the provided parameters to configure the product.
+	// IMPORTANT: Error messages MUST NOT include raw secret parameter values.
+	// The orchestrator prints Setup errors to stderr verbatim.
 	Setup(ctx context.Context, params map[string]string) error
 }
 

--- a/internal/setup/framework/interfaces_test.go
+++ b/internal/setup/framework/interfaces_test.go
@@ -1,0 +1,34 @@
+package framework_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+)
+
+func TestErrSetupNotSupported(t *testing.T) {
+	if framework.ErrSetupNotSupported == nil {
+		t.Fatal("ErrSetupNotSupported must not be nil")
+	}
+	if !errors.Is(framework.ErrSetupNotSupported, framework.ErrSetupNotSupported) {
+		t.Fatal("errors.Is identity check failed")
+	}
+}
+
+func TestProductStateConstants(t *testing.T) {
+	cases := []struct {
+		state framework.ProductState
+		want  string
+	}{
+		{framework.StateNotConfigured, "not_configured"},
+		{framework.StateConfigured, "configured"},
+		{framework.StateActive, "active"},
+		{framework.StateError, "error"},
+	}
+	for _, tc := range cases {
+		if string(tc.state) != tc.want {
+			t.Errorf("ProductState %q: got %q, want %q", tc.state, string(tc.state), tc.want)
+		}
+	}
+}

--- a/internal/setup/framework/orchestrator.go
+++ b/internal/setup/framework/orchestrator.go
@@ -1,0 +1,390 @@
+package framework
+
+import (
+	"bufio"
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"slices"
+	"time"
+
+	"github.com/grafana/gcx/internal/setup/framework/prompt"
+	"github.com/grafana/gcx/internal/terminal"
+)
+
+// Summary is the structured result returned by Run.
+type Summary struct {
+	Completed      []string // providers whose Setup() succeeded
+	Failed         []string // providers whose Setup() returned a non-stub error
+	NotImplemented []string // providers whose Setup() returned ErrSetupNotSupported
+	Skipped        []string // providers skipped because already configured/active
+	Cancelled      []string // providers not reached due to Ctrl-C or user refusal
+}
+
+// Options configures a Run invocation.
+type Options struct {
+	In            io.Reader
+	StdinFile     *os.File  // needed for secret prompts; may be nil (disables Secret kind)
+	Out           io.Writer // informational output
+	Err           io.Writer // error/warning output
+	StatusTimeout time.Duration
+	Providers     []Setupable // if nil, DiscoverSetupable() is used
+	// IsInteractive overrides the default TTY check (terminal.StdinIsTerminal).
+	// Useful for tests that inject a bytes.Buffer as stdin.
+	IsInteractive func() bool
+	// SecretFn overrides the default prompt.Secret call.
+	// Signature: func(label string) (string, error).
+	// When nil and StdinFile is set, prompt.Secret is used.
+	SecretFn func(label string) (string, error)
+}
+
+// Run is the interactive setup orchestrator.
+// It discovers Setupable providers, presents a category multi-select,
+// collects parameters per provider, shows a preview, confirms, then calls
+// Setup() sequentially for each confirmed provider.
+//
+// Returns a non-nil error only for unrecoverable failures (e.g., I/O errors).
+// Per-provider Setup() failures are recorded in Summary.Failed; Run continues.
+// Context cancellation (Ctrl-C) is handled internally and returns (summary, nil).
+func Run(ctx context.Context, opts Options) (Summary, error) {
+	var summary Summary
+
+	isInteractive := terminal.StdinIsTerminal
+	if opts.IsInteractive != nil {
+		isInteractive = opts.IsInteractive
+	}
+	if !isInteractive() {
+		return summary, fmt.Errorf("gcx setup run requires an interactive terminal (stdin is not a TTY)")
+	}
+
+	// Wrap ctx with signal handling so Ctrl-C cancels the run cleanly.
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
+	defer stop()
+
+	out := opts.Out
+	if out == nil {
+		out = os.Stdout
+	}
+	errOut := opts.Err
+	if errOut == nil {
+		errOut = os.Stderr
+	}
+
+	// Use a single bufio.Reader for all interactive prompt input.
+	var in *bufio.Reader
+	if opts.In != nil {
+		if br, ok := opts.In.(*bufio.Reader); ok {
+			in = br
+		} else {
+			in = bufio.NewReader(opts.In)
+		}
+	} else {
+		in = bufio.NewReader(os.Stdin)
+	}
+
+	providers := opts.Providers
+	if providers == nil {
+		providers = DiscoverSetupable()
+	}
+
+	// Sort providers alphabetically so iteration order is deterministic.
+	slices.SortFunc(providers, func(a, b Setupable) int {
+		return cmp.Compare(a.ProductName(), b.ProductName())
+	})
+
+	// Build the category map (first-label-wins for duplicate IDs).
+	type catEntry struct {
+		id    InfraCategoryID
+		label string
+	}
+	seen := make(map[InfraCategoryID]bool)
+	var catOrder []catEntry
+	for _, p := range providers {
+		for _, c := range p.InfraCategories() {
+			if !seen[c.ID] {
+				seen[c.ID] = true
+				catOrder = append(catOrder, catEntry{id: c.ID, label: c.Label})
+			}
+		}
+	}
+
+	if len(catOrder) == 0 {
+		fmt.Fprintln(out, "No interactive setup flows available.")
+		return summary, nil
+	}
+
+	// Build label list and reverse-map for user selection.
+	catLabels := make([]string, len(catOrder))
+	labelToID := make(map[string]InfraCategoryID, len(catOrder))
+	for i, c := range catOrder {
+		catLabels[i] = c.label
+		labelToID[c.label] = c.id
+	}
+
+	selected, err := prompt.MultiChoice(in, out, "Select infrastructure categories to set up:", catLabels, catLabels)
+	if err != nil {
+		return summary, fmt.Errorf("category selection: %w", err)
+	}
+	if len(selected) == 0 {
+		fmt.Fprintln(out, "No categories selected. Nothing to do.")
+		return summary, nil
+	}
+
+	selectedIDs := make(map[InfraCategoryID]bool, len(selected))
+	for _, label := range selected {
+		selectedIDs[labelToID[label]] = true
+	}
+
+	// Filter providers to those with at least one selected category.
+	var selectedProviders []Setupable
+	for _, p := range providers {
+		for _, c := range p.InfraCategories() {
+			if selectedIDs[c.ID] {
+				selectedProviders = append(selectedProviders, p)
+				break
+			}
+		}
+	}
+
+	secretFn := opts.SecretFn
+	if secretFn == nil && opts.StdinFile != nil {
+		f := opts.StdinFile
+		secretFn = func(label string) (string, error) {
+			return prompt.Secret(f, errOut, label)
+		}
+	}
+
+	// Per-provider parameter collection.
+	type providerParams struct {
+		provider Setupable
+		params   map[string]string
+	}
+	confirmed := make([]providerParams, 0, len(selectedProviders))
+
+	for _, p := range selectedProviders {
+		if ctx.Err() != nil {
+			summary.Cancelled = append(summary.Cancelled, p.ProductName())
+			continue
+		}
+
+		status, err := p.Status(ctx)
+		if err == nil && status != nil {
+			if status.State == StateConfigured || status.State == StateActive {
+				fmt.Fprintf(errOut, "%s: already configured, skipping\n", p.ProductName())
+				summary.Skipped = append(summary.Skipped, p.ProductName())
+				continue
+			}
+		}
+
+		var collectedParams map[string]string
+		for {
+			if ctx.Err() != nil {
+				break
+			}
+			params, err := collectProviderParams(ctx, p, selectedIDs, in, out, collectedParams, secretFn)
+			if err != nil {
+				return summary, fmt.Errorf("collecting params for %s: %w", p.ProductName(), err)
+			}
+			collectedParams = params
+
+			if validateErr := p.ValidateSetup(ctx, params); validateErr != nil {
+				fmt.Fprintf(errOut, "Validation error for %s: %v\n", p.ProductName(), validateErr)
+				continue
+			}
+			break
+		}
+
+		if ctx.Err() != nil {
+			summary.Cancelled = append(summary.Cancelled, p.ProductName())
+			continue
+		}
+
+		confirmed = append(confirmed, providerParams{provider: p, params: collectedParams})
+	}
+
+	if len(confirmed) == 0 {
+		printSummary(errOut, &summary)
+		return summary, nil
+	}
+
+	// Preview block.
+	fmt.Fprintln(out, "\n=== Setup Preview ===")
+	for _, pp := range confirmed {
+		fmt.Fprintf(out, "\n%s:\n", pp.provider.ProductName())
+		if len(pp.params) == 0 {
+			fmt.Fprintln(out, "  (no parameters)")
+		} else {
+			for _, cat := range pp.provider.InfraCategories() {
+				for _, param := range cat.Params {
+					val := pp.params[param.Name]
+					if param.Secret {
+						val = "***"
+					}
+					fmt.Fprintf(out, "  %s: %s\n", param.Name, val)
+				}
+			}
+		}
+	}
+	fmt.Fprintln(out, "")
+
+	ok, err := prompt.Bool(in, out, "Continue?", true)
+	if err != nil {
+		return summary, fmt.Errorf("confirmation prompt: %w", err)
+	}
+	if !ok {
+		for _, pp := range confirmed {
+			summary.Cancelled = append(summary.Cancelled, pp.provider.ProductName())
+		}
+		printSummary(errOut, &summary)
+		return summary, nil
+	}
+
+	// Sequential Setup invocations.
+	for _, pp := range confirmed {
+		if ctx.Err() != nil {
+			summary.Cancelled = append(summary.Cancelled, pp.provider.ProductName())
+			continue
+		}
+		fmt.Fprintf(errOut, "Setting up %s...\n", pp.provider.ProductName())
+		if err := pp.provider.Setup(ctx, pp.params); err != nil {
+			if errors.Is(err, ErrSetupNotSupported) {
+				fmt.Fprintf(errOut, "%s: setup not yet implemented\n", pp.provider.ProductName())
+				summary.NotImplemented = append(summary.NotImplemented, pp.provider.ProductName())
+			} else {
+				fmt.Fprintf(errOut, "%s: setup failed: %v\n", pp.provider.ProductName(), err)
+				summary.Failed = append(summary.Failed, pp.provider.ProductName())
+			}
+			continue
+		}
+		summary.Completed = append(summary.Completed, pp.provider.ProductName())
+	}
+
+	// Post-run status table.
+	timeout := opts.StatusTimeout
+	if timeout <= 0 {
+		timeout = defaultAggregateTimeout
+	}
+	allSD := setupableToStatusDetectable(selectedProviders)
+	statuses := AggregateStatusFrom(ctx, timeout, allSD)
+	fmt.Fprintln(out, "\n=== Post-Run Status ===")
+	for _, s := range statuses {
+		fmt.Fprintf(out, "  %-20s %s\n", s.Product, s.State)
+	}
+
+	printSummary(errOut, &summary)
+	return summary, nil
+}
+
+// collectProviderParams collects all parameters for a single provider from
+// the user. prev contains previously-collected values used as defaults on retry.
+func collectProviderParams(
+	ctx context.Context,
+	p Setupable,
+	selectedIDs map[InfraCategoryID]bool,
+	in *bufio.Reader,
+	out io.Writer,
+	prev map[string]string,
+	secretFn func(string) (string, error),
+) (map[string]string, error) {
+	params := make(map[string]string)
+
+	for _, cat := range p.InfraCategories() {
+		if !selectedIDs[cat.ID] {
+			continue
+		}
+		for _, param := range cat.Params {
+			if ctx.Err() != nil {
+				return params, nil
+			}
+
+			def := param.Default
+			if v, ok := prev[param.Name]; ok && v != "" {
+				def = v
+			}
+
+			var val string
+			var err error
+
+			switch param.Kind {
+			case ParamKindBool:
+				defBool := def == "true"
+				b, bErr := prompt.Bool(in, out, param.Prompt, defBool)
+				if bErr != nil {
+					return nil, bErr
+				}
+				if b {
+					val = "true"
+				} else {
+					val = "false"
+				}
+			case ParamKindChoice:
+				val, err = prompt.Choice(in, out, param.Prompt, param.Choices, def)
+				if err != nil {
+					return nil, err
+				}
+			case ParamKindMultiChoice:
+				var defs []string
+				if def != "" {
+					defs = []string{def}
+				}
+				vals, mErr := prompt.MultiChoice(in, out, param.Prompt, param.Choices, defs)
+				if mErr != nil {
+					return nil, mErr
+				}
+				// Encode multi-choice as comma-separated.
+				for i, v := range vals {
+					if i > 0 {
+						val += ","
+					}
+					val += v
+				}
+			default: // ParamKindText and Secret
+				if param.Secret && secretFn != nil {
+					val, err = secretFn(param.Prompt)
+					if err != nil {
+						return nil, err
+					}
+				} else {
+					val, err = prompt.Text(in, out, param.Prompt, def, param.Required)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+
+			params[param.Name] = val
+		}
+	}
+	return params, nil
+}
+
+// setupableToStatusDetectable upcasts a []Setupable to []StatusDetectable.
+func setupableToStatusDetectable(ps []Setupable) []StatusDetectable {
+	out := make([]StatusDetectable, len(ps))
+	for i, p := range ps {
+		out[i] = p
+	}
+	return out
+}
+
+func printSummary(w io.Writer, s *Summary) {
+	if len(s.Completed) > 0 {
+		fmt.Fprintf(w, "\nCompleted: %v\n", s.Completed)
+	}
+	if len(s.Failed) > 0 {
+		fmt.Fprintf(w, "Failed: %v\n", s.Failed)
+	}
+	if len(s.NotImplemented) > 0 {
+		fmt.Fprintf(w, "Not implemented: %v\n", s.NotImplemented)
+	}
+	if len(s.Skipped) > 0 {
+		fmt.Fprintf(w, "Skipped: %v\n", s.Skipped)
+	}
+	if len(s.Cancelled) > 0 {
+		fmt.Fprintf(w, "Cancelled: %v\n", s.Cancelled)
+	}
+}

--- a/internal/setup/framework/orchestrator.go
+++ b/internal/setup/framework/orchestrator.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"slices"
-	"time"
+	"strings"
 
 	"github.com/grafana/gcx/internal/setup/framework/prompt"
 	"github.com/grafana/gcx/internal/terminal"
@@ -27,12 +27,11 @@ type Summary struct {
 
 // Options configures a Run invocation.
 type Options struct {
-	In            io.Reader
-	StdinFile     *os.File  // needed for secret prompts; may be nil (disables Secret kind)
-	Out           io.Writer // informational output
-	Err           io.Writer // error/warning output
-	StatusTimeout time.Duration
-	Providers     []Setupable // if nil, DiscoverSetupable() is used
+	In        io.Reader
+	StdinFile *os.File    // needed for secret prompts; may be nil (disables Secret kind)
+	Out       io.Writer   // informational output
+	Err       io.Writer   // error/warning output
+	Providers []Setupable // if nil, DiscoverSetupable() is used
 	// IsInteractive overrides the default TTY check (terminal.StdinIsTerminal).
 	// Useful for tests that inject a bytes.Buffer as stdin.
 	IsInteractive func() bool
@@ -50,6 +49,8 @@ type Options struct {
 // Returns a non-nil error only for unrecoverable failures (e.g., I/O errors).
 // Per-provider Setup() failures are recorded in Summary.Failed; Run continues.
 // Context cancellation (Ctrl-C) is handled internally and returns (summary, nil).
+//
+//nolint:gocyclo,maintidx
 func Run(ctx context.Context, opts Options) (Summary, error) {
 	var summary Summary
 
@@ -58,7 +59,7 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 		isInteractive = opts.IsInteractive
 	}
 	if !isInteractive() {
-		return summary, fmt.Errorf("gcx setup run requires an interactive terminal (stdin is not a TTY)")
+		return summary, errors.New("gcx setup run requires an interactive terminal (stdin is not a TTY)")
 	}
 
 	// Wrap ctx with signal handling so Ctrl-C cancels the run cleanly.
@@ -113,7 +114,7 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 	}
 
 	if len(catOrder) == 0 {
-		fmt.Fprintln(out, "No interactive setup flows available.")
+		fmt.Fprintln(errOut, "No interactive setup flows available.")
 		return summary, nil
 	}
 
@@ -130,7 +131,7 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 		return summary, fmt.Errorf("category selection: %w", err)
 	}
 	if len(selected) == 0 {
-		fmt.Fprintln(out, "No categories selected. Nothing to do.")
+		fmt.Fprintln(errOut, "No categories selected. Nothing to do.")
 		return summary, nil
 	}
 
@@ -181,12 +182,12 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 		}
 
 		var collectedParams map[string]string
-		for {
-			if ctx.Err() != nil {
-				break
-			}
-			params, err := collectProviderParams(ctx, p, selectedIDs, in, out, collectedParams, secretFn)
+		for ctx.Err() == nil {
+			params, err := collectProviderParams(ctx, p, selectedIDs, in, out, errOut, collectedParams, secretFn)
 			if err != nil {
+				if ctx.Err() != nil {
+					break
+				}
 				return summary, fmt.Errorf("collecting params for %s: %w", p.ProductName(), err)
 			}
 			collectedParams = params
@@ -263,18 +264,6 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 		summary.Completed = append(summary.Completed, pp.provider.ProductName())
 	}
 
-	// Post-run status table.
-	timeout := opts.StatusTimeout
-	if timeout <= 0 {
-		timeout = defaultAggregateTimeout
-	}
-	allSD := setupableToStatusDetectable(selectedProviders)
-	statuses := AggregateStatusFrom(ctx, timeout, allSD)
-	fmt.Fprintln(out, "\n=== Post-Run Status ===")
-	for _, s := range statuses {
-		fmt.Fprintf(out, "  %-20s %s\n", s.Product, s.State)
-	}
-
 	printSummary(errOut, &summary)
 	return summary, nil
 }
@@ -287,6 +276,7 @@ func collectProviderParams(
 	selectedIDs map[InfraCategoryID]bool,
 	in *bufio.Reader,
 	out io.Writer,
+	errOut io.Writer,
 	prev map[string]string,
 	secretFn func(string) (string, error),
 ) (map[string]string, error) {
@@ -298,7 +288,7 @@ func collectProviderParams(
 		}
 		for _, param := range cat.Params {
 			if ctx.Err() != nil {
-				return params, nil
+				return params, ctx.Err()
 			}
 
 			def := param.Default
@@ -322,26 +312,38 @@ func collectProviderParams(
 					val = "false"
 				}
 			case ParamKindChoice:
-				val, err = prompt.Choice(in, out, param.Prompt, param.Choices, def)
+				choices := param.Choices
+				if len(choices) == 0 {
+					resolved, rErr := p.ResolveChoices(ctx, param.Name)
+					if rErr != nil {
+						fmt.Fprintf(errOut, "warning: could not resolve choices for %s: %v\n", param.Name, rErr)
+					} else {
+						choices = resolved
+					}
+				}
+				val, err = prompt.Choice(in, out, param.Prompt, choices, def)
 				if err != nil {
 					return nil, err
 				}
 			case ParamKindMultiChoice:
+				choices := param.Choices
+				if len(choices) == 0 {
+					resolved, rErr := p.ResolveChoices(ctx, param.Name)
+					if rErr != nil {
+						fmt.Fprintf(errOut, "warning: could not resolve choices for %s: %v\n", param.Name, rErr)
+					} else {
+						choices = resolved
+					}
+				}
 				var defs []string
 				if def != "" {
 					defs = []string{def}
 				}
-				vals, mErr := prompt.MultiChoice(in, out, param.Prompt, param.Choices, defs)
+				vals, mErr := prompt.MultiChoice(in, out, param.Prompt, choices, defs)
 				if mErr != nil {
 					return nil, mErr
 				}
-				// Encode multi-choice as comma-separated.
-				for i, v := range vals {
-					if i > 0 {
-						val += ","
-					}
-					val += v
-				}
+				val = strings.Join(vals, ",")
 			default: // ParamKindText and Secret
 				if param.Secret && secretFn != nil {
 					val, err = secretFn(param.Prompt)
@@ -360,15 +362,6 @@ func collectProviderParams(
 		}
 	}
 	return params, nil
-}
-
-// setupableToStatusDetectable upcasts a []Setupable to []StatusDetectable.
-func setupableToStatusDetectable(ps []Setupable) []StatusDetectable {
-	out := make([]StatusDetectable, len(ps))
-	for i, p := range ps {
-		out[i] = p
-	}
-	return out
 }
 
 func printSummary(w io.Writer, s *Summary) {

--- a/internal/setup/framework/orchestrator.go
+++ b/internal/setup/framework/orchestrator.go
@@ -41,6 +41,12 @@ type Options struct {
 	SecretFn func(label string) (string, error)
 }
 
+// providerParams holds a provider and its collected parameter values.
+type providerParams struct {
+	provider Setupable
+	params   map[string]string
+}
+
 // Run is the interactive setup orchestrator.
 // It discovers Setupable providers, presents a category multi-select,
 // collects parameters per provider, shows a preview, confirms, then calls
@@ -49,8 +55,6 @@ type Options struct {
 // Returns a non-nil error only for unrecoverable failures (e.g., I/O errors).
 // Per-provider Setup() failures are recorded in Summary.Failed; Run continues.
 // Context cancellation (Ctrl-C) is handled internally and returns (summary, nil).
-//
-//nolint:gocyclo,maintidx
 func Run(ctx context.Context, opts Options) (Summary, error) {
 	var summary Summary
 
@@ -97,6 +101,67 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 		return cmp.Compare(a.ProductName(), b.ProductName())
 	})
 
+	secretFn := opts.SecretFn
+	if secretFn == nil && opts.StdinFile != nil {
+		f := opts.StdinFile
+		secretFn = func(label string) (string, error) {
+			return prompt.Secret(f, errOut, label)
+		}
+	}
+
+	selectedProviders, selectedIDs, err := selectCategories(ctx, in, out, errOut, providers)
+	if err != nil {
+		return summary, err
+	}
+	if selectedProviders == nil {
+		return summary, nil
+	}
+
+	confirmed, collectionSummary, err := collectAllParams(ctx, in, out, errOut, selectedProviders, selectedIDs, secretFn)
+	if err != nil {
+		return summary, err
+	}
+	// Merge partial summary state (Skipped, Cancelled) from collection phase.
+	summary.Skipped = append(summary.Skipped, collectionSummary.Skipped...)
+	summary.Cancelled = append(summary.Cancelled, collectionSummary.Cancelled...)
+
+	if len(confirmed) == 0 {
+		printSummary(errOut, &summary)
+		return summary, nil
+	}
+
+	ok, err := previewAndConfirm(ctx, in, out, errOut, confirmed)
+	if err != nil {
+		return summary, err
+	}
+	if !ok {
+		for _, pp := range confirmed {
+			summary.Cancelled = append(summary.Cancelled, pp.provider.ProductName())
+		}
+		printSummary(errOut, &summary)
+		return summary, nil
+	}
+
+	setupSummary := executeSetups(ctx, errOut, confirmed)
+	summary.Completed = append(summary.Completed, setupSummary.Completed...)
+	summary.Failed = append(summary.Failed, setupSummary.Failed...)
+	summary.NotImplemented = append(summary.NotImplemented, setupSummary.NotImplemented...)
+	summary.Cancelled = append(summary.Cancelled, setupSummary.Cancelled...)
+
+	printSummary(errOut, &summary)
+	return summary, nil
+}
+
+// selectCategories builds the category selection UI, prompts the user, and
+// returns the filtered list of providers plus the set of selected category IDs.
+// Returns (nil, nil, nil) when there is nothing to do (no categories or nothing selected).
+func selectCategories(
+	_ context.Context,
+	in *bufio.Reader,
+	out io.Writer,
+	errOut io.Writer,
+	providers []Setupable,
+) ([]Setupable, map[InfraCategoryID]bool, error) {
 	// Build the category map (first-label-wins for duplicate IDs).
 	type catEntry struct {
 		id    InfraCategoryID
@@ -115,7 +180,7 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 
 	if len(catOrder) == 0 {
 		fmt.Fprintln(errOut, "No interactive setup flows available.")
-		return summary, nil
+		return nil, nil, nil
 	}
 
 	// Build label list and reverse-map for user selection.
@@ -128,11 +193,11 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 
 	selected, err := prompt.MultiChoice(in, out, "Select infrastructure categories to set up:", catLabels, catLabels)
 	if err != nil {
-		return summary, fmt.Errorf("category selection: %w", err)
+		return nil, nil, fmt.Errorf("category selection: %w", err)
 	}
 	if len(selected) == 0 {
 		fmt.Fprintln(errOut, "No categories selected. Nothing to do.")
-		return summary, nil
+		return nil, nil, nil
 	}
 
 	selectedIDs := make(map[InfraCategoryID]bool, len(selected))
@@ -151,34 +216,40 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 		}
 	}
 
-	secretFn := opts.SecretFn
-	if secretFn == nil && opts.StdinFile != nil {
-		f := opts.StdinFile
-		secretFn = func(label string) (string, error) {
-			return prompt.Secret(f, errOut, label)
-		}
-	}
+	return selectedProviders, selectedIDs, nil
+}
 
-	// Per-provider parameter collection.
-	type providerParams struct {
-		provider Setupable
-		params   map[string]string
-	}
-	confirmed := make([]providerParams, 0, len(selectedProviders))
+// collectAllParams collects parameters for each provider, handling status checks,
+// validation retries, and context cancellation. Returns confirmed provider+param
+// pairs and a partial Summary capturing Skipped and Cancelled providers.
+func collectAllParams(
+	ctx context.Context,
+	in *bufio.Reader,
+	out io.Writer,
+	errOut io.Writer,
+	providers []Setupable,
+	selectedIDs map[InfraCategoryID]bool,
+	secretFn func(string) (string, error),
+) ([]providerParams, Summary, error) {
+	var summary Summary
+	confirmed := make([]providerParams, 0, len(providers))
 
-	for _, p := range selectedProviders {
+	for _, p := range providers {
 		if ctx.Err() != nil {
 			summary.Cancelled = append(summary.Cancelled, p.ProductName())
 			continue
 		}
 
 		status, err := p.Status(ctx)
-		if err == nil && status != nil {
-			if status.State == StateConfigured || status.State == StateActive {
-				fmt.Fprintf(errOut, "%s: already configured, skipping\n", p.ProductName())
-				summary.Skipped = append(summary.Skipped, p.ProductName())
-				continue
-			}
+		if err != nil {
+			fmt.Fprintf(errOut, "warning: could not determine status for %s: %v\n", p.ProductName(), err)
+			summary.Skipped = append(summary.Skipped, p.ProductName())
+			continue
+		}
+		if status != nil && (status.State == StateConfigured || status.State == StateActive) {
+			fmt.Fprintf(errOut, "%s: already configured, skipping\n", p.ProductName())
+			summary.Skipped = append(summary.Skipped, p.ProductName())
+			continue
 		}
 
 		var collectedParams map[string]string
@@ -188,7 +259,7 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 				if ctx.Err() != nil {
 					break
 				}
-				return summary, fmt.Errorf("collecting params for %s: %w", p.ProductName(), err)
+				return confirmed, summary, fmt.Errorf("collecting params for %s: %w", p.ProductName(), err)
 			}
 			collectedParams = params
 
@@ -207,12 +278,18 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 		confirmed = append(confirmed, providerParams{provider: p, params: collectedParams})
 	}
 
-	if len(confirmed) == 0 {
-		printSummary(errOut, &summary)
-		return summary, nil
-	}
+	return confirmed, summary, nil
+}
 
-	// Preview block.
+// previewAndConfirm displays the setup preview block and asks the user to confirm.
+// Returns (false, nil) when the user declines.
+func previewAndConfirm(
+	_ context.Context,
+	in *bufio.Reader,
+	out io.Writer,
+	_ io.Writer,
+	confirmed []providerParams,
+) (bool, error) {
 	fmt.Fprintln(out, "\n=== Setup Preview ===")
 	for _, pp := range confirmed {
 		fmt.Fprintf(out, "\n%s:\n", pp.provider.ProductName())
@@ -234,17 +311,15 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 
 	ok, err := prompt.Bool(in, out, "Continue?", true)
 	if err != nil {
-		return summary, fmt.Errorf("confirmation prompt: %w", err)
+		return false, fmt.Errorf("confirmation prompt: %w", err)
 	}
-	if !ok {
-		for _, pp := range confirmed {
-			summary.Cancelled = append(summary.Cancelled, pp.provider.ProductName())
-		}
-		printSummary(errOut, &summary)
-		return summary, nil
-	}
+	return ok, nil
+}
 
-	// Sequential Setup invocations.
+// executeSetups calls Setup() sequentially for each confirmed provider and
+// returns a Summary capturing the outcomes.
+func executeSetups(ctx context.Context, errOut io.Writer, confirmed []providerParams) Summary {
+	var summary Summary
 	for _, pp := range confirmed {
 		if ctx.Err() != nil {
 			summary.Cancelled = append(summary.Cancelled, pp.provider.ProductName())
@@ -263,9 +338,7 @@ func Run(ctx context.Context, opts Options) (Summary, error) {
 		}
 		summary.Completed = append(summary.Completed, pp.provider.ProductName())
 	}
-
-	printSummary(errOut, &summary)
-	return summary, nil
+	return summary
 }
 
 // collectProviderParams collects all parameters for a single provider from
@@ -292,8 +365,14 @@ func collectProviderParams(
 			}
 
 			def := param.Default
-			if v, ok := prev[param.Name]; ok && v != "" {
-				def = v
+			if !param.Secret {
+				if v, ok := prev[param.Name]; ok && v != "" {
+					def = v
+				}
+			}
+
+			if param.Secret && param.Kind != ParamKindText && param.Kind != "" {
+				return nil, fmt.Errorf("param %q has Secret=true but Kind=%q: Secret is only valid for ParamKindText", param.Name, param.Kind)
 			}
 
 			var val string
@@ -344,8 +423,11 @@ func collectProviderParams(
 					return nil, mErr
 				}
 				val = strings.Join(vals, ",")
-			default: // ParamKindText and Secret
-				if param.Secret && secretFn != nil {
+			default: // ParamKindText
+				if param.Secret {
+					if secretFn == nil {
+						return nil, fmt.Errorf("cannot collect secret param %q: no StdinFile provided", param.Name)
+					}
 					val, err = secretFn(param.Prompt)
 					if err != nil {
 						return nil, err

--- a/internal/setup/framework/orchestrator_test.go
+++ b/internal/setup/framework/orchestrator_test.go
@@ -313,6 +313,46 @@ func TestRun_UserRefusal(t *testing.T) {
 	}
 }
 
+// TestRun_StatusErrorSkipsProvider verifies that a provider whose Status() returns an error
+// is skipped (not prompted for params), appears in summary.Skipped, and emits a warning.
+func TestRun_StatusErrorSkipsProvider(t *testing.T) {
+	statusErr := errors.New("connection refused")
+	p := &testhelpers.FakeSetupable{
+		ProductName_: "alpha",
+		StatusErr:    statusErr,
+		Categories_:  []framework.InfraCategory{infraCat},
+	}
+	var errBuf bytes.Buffer
+	opts := framework.Options{
+		In:            strings.NewReader("\n"), // Enter for category selection; no further input needed
+		Out:           &bytes.Buffer{},
+		Err:           &errBuf,
+		Providers:     []framework.Setupable{p},
+		IsInteractive: func() bool { return true },
+		SecretFn:      func(label string) (string, error) { return "secret-value", nil },
+	}
+	summary, err := framework.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Skipped) != 1 || summary.Skipped[0] != "alpha" {
+		t.Errorf("expected alpha in Skipped, got %+v", summary)
+	}
+	if p.SetupCalled {
+		t.Error("Setup should not have been called for provider with Status() error")
+	}
+	if p.LastParams != nil {
+		t.Error("params should not have been collected for provider with Status() error")
+	}
+	warnMsg := errBuf.String()
+	if !strings.Contains(warnMsg, "warning: could not determine status") {
+		t.Errorf("expected warning on stderr, got: %q", warnMsg)
+	}
+	if !strings.Contains(warnMsg, "alpha") {
+		t.Errorf("expected provider name in warning, got: %q", warnMsg)
+	}
+}
+
 // TestRun_ResolveChoices verifies that ResolveChoices is called when param.Choices is empty.
 func TestRun_ResolveChoices(t *testing.T) {
 	dynamicChoicesCat := framework.InfraCategory{

--- a/internal/setup/framework/orchestrator_test.go
+++ b/internal/setup/framework/orchestrator_test.go
@@ -1,0 +1,312 @@
+package framework_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+	"github.com/grafana/gcx/internal/setup/framework/testhelpers"
+)
+
+func makeOpts(in string, providers []framework.Setupable) framework.Options {
+	return framework.Options{
+		In:            strings.NewReader(in),
+		Out:           &bytes.Buffer{},
+		Err:           &bytes.Buffer{},
+		Providers:     providers,
+		IsInteractive: func() bool { return true },
+		SecretFn:      func(label string) (string, error) { return "secret-value", nil },
+	}
+}
+
+var infraCat = framework.InfraCategory{
+	ID:    "infra",
+	Label: "Infrastructure",
+	Params: []framework.SetupParam{
+		{Name: "endpoint", Prompt: "Endpoint", Kind: framework.ParamKindText, Required: true},
+	},
+}
+
+var secretInfraCat = framework.InfraCategory{
+	ID:    "infra",
+	Label: "Infrastructure",
+	Params: []framework.SetupParam{
+		{Name: "token", Prompt: "API Token", Kind: framework.ParamKindText, Secret: true},
+	},
+}
+
+func notConfiguredStatus(name string) *framework.ProductStatus {
+	return &framework.ProductStatus{Product: name, State: framework.StateNotConfigured}
+}
+
+func configuredStatus(name string) *framework.ProductStatus {
+	return &framework.ProductStatus{Product: name, State: framework.StateConfigured}
+}
+
+// TestRun_ZeroCategories verifies early exit when no providers have categories.
+func TestRun_ZeroCategories(t *testing.T) {
+	p := &testhelpers.FakeSetupable{
+		ProductName_: "alpha",
+		Status_:      notConfiguredStatus("alpha"),
+		// No categories
+	}
+	opts := makeOpts("", []framework.Setupable{p})
+	summary, err := framework.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Completed) != 0 || len(summary.Failed) != 0 {
+		t.Errorf("expected empty summary, got %+v", summary)
+	}
+}
+
+// TestRun_SkipIfConfigured verifies that providers already configured are skipped.
+func TestRun_SkipIfConfigured(t *testing.T) {
+	p := &testhelpers.FakeSetupable{
+		ProductName_: "alpha",
+		Status_:      configuredStatus("alpha"),
+		Categories_:  []framework.InfraCategory{infraCat},
+	}
+	// Select "Infrastructure" by pressing Enter (default = all selected)
+	// then hit Enter to accept defaults
+	opts := makeOpts("\n\n", []framework.Setupable{p})
+	summary, err := framework.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Skipped) != 1 || summary.Skipped[0] != "alpha" {
+		t.Errorf("expected alpha skipped, got %+v", summary)
+	}
+	if p.SetupCalled {
+		t.Error("Setup should not have been called for already-configured provider")
+	}
+}
+
+// TestRun_ValidationRetry verifies that validation errors cause re-prompting.
+func TestRun_ValidationRetry(t *testing.T) {
+	validationErr := errors.New("invalid endpoint")
+	p := &testhelpers.FakeSetupable{
+		ProductName_: "beta",
+		Status_:      notConfiguredStatus("beta"),
+		Categories_:  []framework.InfraCategory{infraCat},
+		ValidateSetupErrs: []error{
+			validationErr, // first attempt fails
+			nil,           // second attempt succeeds
+		},
+	}
+	// Input: Enter (default categories) + "bad\n" + "good\n" (two param prompts) + Enter (confirm)
+	opts := makeOpts("\nbad\ngood\n\n", []framework.Setupable{p})
+	opts.Out = &bytes.Buffer{}
+	opts.Err = &bytes.Buffer{}
+	summary, err := framework.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Completed) != 1 || summary.Completed[0] != "beta" {
+		t.Errorf("expected beta completed, got %+v", summary)
+	}
+	if p.LastParams["endpoint"] != "good" {
+		t.Errorf("expected last params to have endpoint=good, got %v", p.LastParams)
+	}
+}
+
+// TestRun_SecretMasking verifies that secret params use SecretFn and preview masks values.
+func TestRun_SecretMasking(t *testing.T) {
+	p := &testhelpers.FakeSetupable{
+		ProductName_: "gamma",
+		Status_:      notConfiguredStatus("gamma"),
+		Categories_:  []framework.InfraCategory{secretInfraCat},
+	}
+	var outBuf bytes.Buffer
+	secretCalled := false
+	opts := framework.Options{
+		In:            strings.NewReader("\n\n"), // Enter for category, Enter for confirm
+		Out:           &outBuf,
+		Err:           &bytes.Buffer{},
+		Providers:     []framework.Setupable{p},
+		IsInteractive: func() bool { return true },
+		SecretFn: func(label string) (string, error) {
+			secretCalled = true
+			return "super-secret", nil
+		},
+	}
+	summary, err := framework.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !secretCalled {
+		t.Error("SecretFn was not called")
+	}
+	// Preview must show *** not the actual value.
+	outStr := outBuf.String()
+	if strings.Contains(outStr, "super-secret") {
+		t.Errorf("preview should not contain the secret value, got:\n%s", outStr)
+	}
+	if !strings.Contains(outStr, "***") {
+		t.Errorf("preview should contain *** for secret, got:\n%s", outStr)
+	}
+	if len(summary.Completed) != 1 || summary.Completed[0] != "gamma" {
+		t.Errorf("expected gamma completed, got %+v", summary)
+	}
+	if p.LastParams["token"] != "super-secret" {
+		t.Errorf("Setup should receive actual secret, got %v", p.LastParams)
+	}
+}
+
+// TestRun_AlphabeticalOrder verifies providers are set up in alphabetical order.
+func TestRun_AlphabeticalOrder(t *testing.T) {
+	var order []string
+	mkProvider := func(name string) *testhelpers.FakeSetupable {
+		return &testhelpers.FakeSetupable{
+			ProductName_:       name,
+			Status_:            notConfiguredStatus(name),
+			Categories_:        []framework.InfraCategory{infraCat},
+			SetupOrderRecorder: &order,
+		}
+	}
+	// Add in reverse alphabetical order to test sorting.
+	providers := []framework.Setupable{
+		mkProvider("zeta"),
+		mkProvider("alpha"),
+		mkProvider("mu"),
+	}
+	// Input: Enter (select all categories) + 3x "val\n" for 3 param prompts + Enter (confirm)
+	opts := makeOpts("\nval\nval\nval\n\n", providers)
+	summary, err := framework.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Completed) != 3 {
+		t.Fatalf("expected 3 completed, got %+v", summary)
+	}
+	if order[0] != "alpha" || order[1] != "mu" || order[2] != "zeta" {
+		t.Errorf("expected alphabetical order [alpha mu zeta], got %v", order)
+	}
+}
+
+// TestRun_SetupErrorIsolation verifies that a Setup failure doesn't abort the run.
+func TestRun_SetupErrorIsolation(t *testing.T) {
+	setupErr := errors.New("setup failed")
+	alpha := &testhelpers.FakeSetupable{
+		ProductName_: "alpha",
+		Status_:      notConfiguredStatus("alpha"),
+		Categories_:  []framework.InfraCategory{infraCat},
+		SetupErr:     setupErr,
+	}
+	beta := &testhelpers.FakeSetupable{
+		ProductName_: "beta",
+		Status_:      notConfiguredStatus("beta"),
+		Categories_:  []framework.InfraCategory{infraCat},
+	}
+	// Input: Enter (categories) + "v1\n" + "v2\n" (two params) + Enter (confirm)
+	opts := makeOpts("\nv1\nv2\n\n", []framework.Setupable{alpha, beta})
+	summary, err := framework.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Failed) != 1 || summary.Failed[0] != "alpha" {
+		t.Errorf("expected alpha in Failed, got %+v", summary)
+	}
+	if len(summary.Completed) != 1 || summary.Completed[0] != "beta" {
+		t.Errorf("expected beta in Completed, got %+v", summary)
+	}
+}
+
+// TestRun_CtrlCSimulation verifies that context cancellation during Setup is handled gracefully.
+func TestRun_CtrlCSimulation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var order []string
+	alpha := &testhelpers.FakeSetupable{
+		ProductName_:       "alpha",
+		Status_:            notConfiguredStatus("alpha"),
+		Categories_:        []framework.InfraCategory{infraCat},
+		SetupOrderRecorder: &order,
+		OnSetup:            cancel, // cancels context on first Setup call
+	}
+	beta := &testhelpers.FakeSetupable{
+		ProductName_:       "beta",
+		Status_:            notConfiguredStatus("beta"),
+		Categories_:        []framework.InfraCategory{infraCat},
+		SetupOrderRecorder: &order,
+	}
+
+	// Input: Enter (categories) + "v1\n" + "v2\n" + Enter (confirm)
+	opts := makeOpts("\nv1\nv2\n\n", []framework.Setupable{alpha, beta})
+	opts.Out = &bytes.Buffer{}
+	opts.Err = &bytes.Buffer{}
+	summary, err := framework.Run(ctx, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// alpha should have been called (it cancelled the context), beta should be in Cancelled.
+	if len(order) != 1 || order[0] != "alpha" {
+		t.Errorf("expected only alpha Setup called, got %v", order)
+	}
+	if len(summary.Cancelled) == 0 {
+		t.Errorf("expected beta in Cancelled, got %+v", summary)
+	}
+}
+
+// TestRun_NonInteractiveRefusal verifies that a non-TTY stdin is rejected.
+func TestRun_NonInteractiveRefusal(t *testing.T) {
+	opts := framework.Options{
+		In:            strings.NewReader(""),
+		Out:           &bytes.Buffer{},
+		Err:           &bytes.Buffer{},
+		Providers:     nil,
+		IsInteractive: func() bool { return false },
+	}
+	_, err := framework.Run(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error for non-interactive terminal")
+	}
+	if !strings.Contains(err.Error(), "interactive terminal") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestRun_NotImplementedSentinel verifies that ErrSetupNotSupported routes to NotImplemented, not Failed.
+func TestRun_NotImplementedSentinel(t *testing.T) {
+	p := &testhelpers.FakeSetupable{
+		ProductName_: "stub",
+		Status_:      notConfiguredStatus("stub"),
+		Categories_:  []framework.InfraCategory{infraCat},
+		SetupErr:     framework.ErrSetupNotSupported,
+	}
+	opts := makeOpts("\nval\n\n", []framework.Setupable{p})
+	summary, err := framework.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Failed) != 0 {
+		t.Errorf("ErrSetupNotSupported should not be in Failed, got %v", summary.Failed)
+	}
+	if len(summary.NotImplemented) != 1 || summary.NotImplemented[0] != "stub" {
+		t.Errorf("expected stub in NotImplemented, got %+v", summary)
+	}
+}
+
+// TestRun_UserRefusal verifies that declining the preview causes all providers to be Cancelled.
+func TestRun_UserRefusal(t *testing.T) {
+	p := &testhelpers.FakeSetupable{
+		ProductName_: "alpha",
+		Status_:      notConfiguredStatus("alpha"),
+		Categories_:  []framework.InfraCategory{infraCat},
+	}
+	// Input: Enter (categories) + "val\n" (param) + "n\n" (decline)
+	opts := makeOpts("\nval\nn\n", []framework.Setupable{p})
+	summary, err := framework.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.SetupCalled {
+		t.Error("Setup should not be called when user declines")
+	}
+	if len(summary.Cancelled) == 0 {
+		t.Errorf("expected alpha in Cancelled, got %+v", summary)
+	}
+}

--- a/internal/setup/framework/orchestrator_test.go
+++ b/internal/setup/framework/orchestrator_test.go
@@ -22,6 +22,7 @@ func makeOpts(in string, providers []framework.Setupable) framework.Options {
 	}
 }
 
+//nolint:gochecknoglobals // test-only constant-like data
 var infraCat = framework.InfraCategory{
 	ID:    "infra",
 	Label: "Infrastructure",
@@ -30,6 +31,7 @@ var infraCat = framework.InfraCategory{
 	},
 }
 
+//nolint:gochecknoglobals // test-only constant-like data
 var secretInfraCat = framework.InfraCategory{
 	ID:    "infra",
 	Label: "Infrastructure",
@@ -173,8 +175,8 @@ func TestRun_AlphabeticalOrder(t *testing.T) {
 		mkProvider("alpha"),
 		mkProvider("mu"),
 	}
-	// Input: Enter (select all categories) + 3x "val\n" for 3 param prompts + Enter (confirm)
-	opts := makeOpts("\nval\nval\nval\n\n", providers)
+	// Input: Enter (select all categories) + 3x distinct values for 3 param prompts + Enter (confirm)
+	opts := makeOpts("\nv1\nv2\nv3\n\n", providers)
 	summary, err := framework.Run(context.Background(), opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -308,5 +310,36 @@ func TestRun_UserRefusal(t *testing.T) {
 	}
 	if len(summary.Cancelled) == 0 {
 		t.Errorf("expected alpha in Cancelled, got %+v", summary)
+	}
+}
+
+// TestRun_ResolveChoices verifies that ResolveChoices is called when param.Choices is empty.
+func TestRun_ResolveChoices(t *testing.T) {
+	dynamicChoicesCat := framework.InfraCategory{
+		ID:    "infra",
+		Label: "Infrastructure",
+		Params: []framework.SetupParam{
+			{Name: "region", Prompt: "Region", Kind: framework.ParamKindChoice},
+		},
+	}
+	p := &testhelpers.FakeSetupable{
+		ProductName_: "alpha",
+		Status_:      notConfiguredStatus("alpha"),
+		Categories_:  []framework.InfraCategory{dynamicChoicesCat},
+		ResolveChoicesResult: map[string][]string{
+			"region": {"us-east", "eu-west", "ap-south"},
+		},
+	}
+	// Input: Enter (categories) + "1\n" (select first choice) + Enter (confirm)
+	opts := makeOpts("\n1\n\n", []framework.Setupable{p})
+	summary, err := framework.Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Completed) != 1 || summary.Completed[0] != "alpha" {
+		t.Errorf("expected alpha completed, got %+v", summary)
+	}
+	if p.LastParams["region"] != "us-east" {
+		t.Errorf("expected region=us-east, got %v", p.LastParams)
 	}
 }

--- a/internal/setup/framework/prompt/prompt.go
+++ b/internal/setup/framework/prompt/prompt.go
@@ -101,11 +101,14 @@ func Choice(in io.Reader, out io.Writer, prompt string, options []string, def st
 		line = strings.TrimSpace(line)
 
 		if line == "" {
+			if err != nil {
+				if def != "" {
+					return def, err
+				}
+				return "", err
+			}
 			if def != "" {
 				return def, nil
-			}
-			if err != nil {
-				return "", err
 			}
 			fmt.Fprintln(out, "Please enter a number.")
 			continue
@@ -114,7 +117,7 @@ func Choice(in io.Reader, out io.Writer, prompt string, options []string, def st
 		n, parseErr := strconv.Atoi(line)
 		if parseErr != nil || n < 1 || n > len(options) {
 			if err != nil {
-				return "", fmt.Errorf("prompt: invalid selection %q", line)
+				return "", err
 			}
 			fmt.Fprintf(out, "Please enter a number between 1 and %d.\n", len(options))
 			continue
@@ -126,6 +129,8 @@ func Choice(in io.Reader, out io.Writer, prompt string, options []string, def st
 
 // MultiChoice presents a numbered menu allowing comma-separated selection (e.g. "1,3").
 // defs contains the initially-selected options. Pressing Enter with no input returns defs.
+// If defs is nil/empty and the user presses Enter, returns (nil, nil) — callers that
+// require at least one selection must check the returned slice length.
 // Returns an error after maxRetries failed attempts.
 func MultiChoice(in io.Reader, out io.Writer, prompt string, options []string, defs []string) ([]string, error) {
 	defSet := make(map[string]bool, len(defs))
@@ -149,7 +154,7 @@ func MultiChoice(in io.Reader, out io.Writer, prompt string, options []string, d
 		line = strings.TrimSpace(line)
 
 		if line == "" {
-			return defs, nil
+			return defs, err
 		}
 
 		parts := strings.Split(line, ",")
@@ -167,7 +172,7 @@ func MultiChoice(in io.Reader, out io.Writer, prompt string, options []string, d
 
 		if !valid {
 			if err != nil {
-				return nil, fmt.Errorf("prompt: invalid selection %q", line)
+				return nil, err
 			}
 			fmt.Fprintf(out, "Please enter valid numbers between 1 and %d.\n", len(options))
 			continue
@@ -187,5 +192,9 @@ func Secret(f *os.File, out io.Writer, prompt string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(b), nil
+	s := string(b)
+	for i := range b {
+		b[i] = 0
+	}
+	return s, nil
 }

--- a/internal/setup/framework/prompt/prompt.go
+++ b/internal/setup/framework/prompt/prompt.go
@@ -1,0 +1,191 @@
+package prompt
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+const maxRetries = 3
+
+// Text prompts the user for a line of text. Returns def if input is empty.
+// If required is true and def is empty and input is empty, re-prompts up to maxRetries times.
+func Text(in io.Reader, out io.Writer, prompt, def string, required bool) (string, error) {
+	r := bufio.NewReader(in)
+	for range maxRetries {
+		if def != "" {
+			fmt.Fprintf(out, "%s [%s]: ", prompt, def)
+		} else {
+			fmt.Fprintf(out, "%s: ", prompt)
+		}
+
+		line, err := r.ReadString('\n')
+		line = strings.TrimRight(line, "\r\n")
+
+		if line != "" {
+			return line, nil
+		}
+		if err != nil {
+			if def != "" {
+				return def, nil
+			}
+			if !required {
+				return "", nil
+			}
+			return "", err
+		}
+		if def != "" {
+			return def, nil
+		}
+		if !required {
+			return "", nil
+		}
+		fmt.Fprintln(out, "This field is required.")
+	}
+	return "", fmt.Errorf("prompt: no valid input after %d attempts", maxRetries)
+}
+
+// Bool prompts yes/no. def=true means [Y/n], def=false means [y/N].
+// Accepts: y/Y/yes/YES → true; n/N/no/NO → false; empty → def.
+func Bool(in io.Reader, out io.Writer, prompt string, def bool) (bool, error) {
+	hint := "[y/N]"
+	if def {
+		hint = "[Y/n]"
+	}
+	r := bufio.NewReader(in)
+	for range maxRetries {
+		fmt.Fprintf(out, "%s %s: ", prompt, hint)
+		line, err := r.ReadString('\n')
+		line = strings.TrimRight(line, "\r\n")
+
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "y", "yes":
+			return true, nil
+		case "n", "no":
+			return false, nil
+		case "":
+			return def, nil
+		default:
+			if err != nil {
+				return def, nil
+			}
+			fmt.Fprintln(out, "Please enter y or n.")
+		}
+	}
+	return def, fmt.Errorf("prompt: no valid input after %d attempts", maxRetries)
+}
+
+// Choice presents a numbered menu. Returns the selected option string.
+// If def is non-empty, pressing Enter selects it. Out-of-range index re-prompts.
+// Returns an error after maxRetries failed attempts.
+func Choice(in io.Reader, out io.Writer, prompt string, options []string, def string) (string, error) {
+	r := bufio.NewReader(in)
+	for range maxRetries {
+		fmt.Fprintln(out, prompt)
+		for i, opt := range options {
+			fmt.Fprintf(out, "  [%d] %s\n", i+1, opt)
+		}
+		if def != "" {
+			fmt.Fprintf(out, "Enter number (default: %s): ", def)
+		} else {
+			fmt.Fprint(out, "Enter number: ")
+		}
+
+		line, err := r.ReadString('\n')
+		line = strings.TrimRight(line, "\r\n")
+		line = strings.TrimSpace(line)
+
+		if line == "" {
+			if def != "" {
+				return def, nil
+			}
+			if err != nil {
+				return "", err
+			}
+			fmt.Fprintln(out, "Please enter a number.")
+			continue
+		}
+
+		n, parseErr := strconv.Atoi(line)
+		if parseErr != nil || n < 1 || n > len(options) {
+			if err != nil {
+				return "", fmt.Errorf("prompt: invalid selection %q", line)
+			}
+			fmt.Fprintf(out, "Please enter a number between 1 and %d.\n", len(options))
+			continue
+		}
+		return options[n-1], nil
+	}
+	return "", fmt.Errorf("prompt: no valid selection after %d attempts", maxRetries)
+}
+
+// MultiChoice presents a numbered menu allowing comma-separated selection (e.g. "1,3").
+// defs contains the initially-selected options. Pressing Enter with no input returns defs.
+// Returns an error after maxRetries failed attempts.
+func MultiChoice(in io.Reader, out io.Writer, prompt string, options []string, defs []string) ([]string, error) {
+	defSet := make(map[string]bool, len(defs))
+	for _, d := range defs {
+		defSet[d] = true
+	}
+	r := bufio.NewReader(in)
+	for range maxRetries {
+		fmt.Fprintln(out, prompt)
+		for i, opt := range options {
+			if defSet[opt] {
+				fmt.Fprintf(out, "  [%d]* %s\n", i+1, opt)
+			} else {
+				fmt.Fprintf(out, "  [%d]  %s\n", i+1, opt)
+			}
+		}
+		fmt.Fprint(out, "Enter numbers (comma-separated, Enter for defaults): ")
+
+		line, err := r.ReadString('\n')
+		line = strings.TrimRight(line, "\r\n")
+		line = strings.TrimSpace(line)
+
+		if line == "" {
+			return defs, nil
+		}
+
+		parts := strings.Split(line, ",")
+		result := make([]string, 0, len(parts))
+		valid := true
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			n, parseErr := strconv.Atoi(p)
+			if parseErr != nil || n < 1 || n > len(options) {
+				valid = false
+				break
+			}
+			result = append(result, options[n-1])
+		}
+
+		if !valid {
+			if err != nil {
+				return nil, fmt.Errorf("prompt: invalid selection %q", line)
+			}
+			fmt.Fprintf(out, "Please enter valid numbers between 1 and %d.\n", len(options))
+			continue
+		}
+		return result, nil
+	}
+	return nil, fmt.Errorf("prompt: no valid selection after %d attempts", maxRetries)
+}
+
+// Secret reads a masked password from f (must be a real TTY file).
+// Uses term.ReadPassword which handles raw-mode entry and terminal restore internally,
+// ensuring the terminal is restored even if a panic occurs during the read.
+func Secret(f *os.File, out io.Writer, prompt string) (string, error) {
+	fmt.Fprintf(out, "%s: ", prompt)
+	b, err := term.ReadPassword(int(f.Fd()))
+	fmt.Fprintln(out)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/internal/setup/framework/prompt/prompt.go
+++ b/internal/setup/framework/prompt/prompt.go
@@ -72,7 +72,7 @@ func Bool(in io.Reader, out io.Writer, prompt string, def bool) (bool, error) {
 			return def, nil
 		default:
 			if err != nil {
-				return def, nil
+				return def, err
 			}
 			fmt.Fprintln(out, "Please enter y or n.")
 		}

--- a/internal/setup/framework/prompt/prompt_test.go
+++ b/internal/setup/framework/prompt/prompt_test.go
@@ -1,0 +1,186 @@
+package prompt_test
+
+import (
+	"bytes"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/setup/framework/prompt"
+)
+
+func TestText(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		def      string
+		required bool
+		want     string
+		wantErr  bool
+	}{
+		{name: "empty returns default", input: "\n", def: "foo", want: "foo"},
+		{name: "typed input returned", input: "hello\n", want: "hello"},
+		{name: "required re-prompts once then succeeds", input: "\nhello\n", required: true, want: "hello"},
+		{name: "newline only equals empty uses default", input: "\n", def: "bar", want: "bar"},
+		{name: "not required empty no default returns empty", input: "\n", want: ""},
+		{name: "eof with default returns default", input: "", def: "fallback", want: "fallback"},
+		{name: "required eof returns error", input: "", required: true, wantErr: true},
+		{name: "typed input over default", input: "custom\n", def: "def", want: "custom"},
+		{name: "crlf trimmed", input: "hello\r\n", want: "hello"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := strings.NewReader(tc.input)
+			var out bytes.Buffer
+			got, err := prompt.Text(in, &out, "Enter value", tc.def, tc.required)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBool(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		def     bool
+		want    bool
+		wantErr bool
+	}{
+		{name: "Y returns true", input: "Y\n", def: false, want: true},
+		{name: "y returns true", input: "y\n", def: false, want: true},
+		{name: "yes returns true", input: "yes\n", def: false, want: true},
+		{name: "YES returns true", input: "YES\n", def: false, want: true},
+		{name: "N returns false", input: "N\n", def: true, want: false},
+		{name: "n returns false", input: "n\n", def: true, want: false},
+		{name: "no returns false", input: "no\n", def: true, want: false},
+		{name: "NO returns false", input: "NO\n", def: true, want: false},
+		{name: "empty def true returns true", input: "\n", def: true, want: true},
+		{name: "empty def false returns false", input: "\n", def: false, want: false},
+		{name: "unrecognized re-prompts then succeeds", input: "maybe\ny\n", def: false, want: true},
+		{name: "eof returns default", input: "", def: true, want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := strings.NewReader(tc.input)
+			var out bytes.Buffer
+			got, err := prompt.Bool(in, &out, "Continue?", tc.def)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChoice(t *testing.T) {
+	options := []string{"a", "b", "c"}
+	cases := []struct {
+		name    string
+		input   string
+		def     string
+		want    string
+		wantErr bool
+	}{
+		{name: "valid index returns option", input: "2\n", def: "a", want: "b"},
+		{name: "index 1 returns first", input: "1\n", want: "a"},
+		{name: "index 3 returns last", input: "3\n", want: "c"},
+		{name: "enter returns def", input: "\n", def: "b", want: "b"},
+		{name: "out-of-range re-prompts then succeeds", input: "5\n1\n", want: "a"},
+		{name: "non-numeric re-prompts then succeeds", input: "x\n3\n", want: "c"},
+		{name: "eof no def returns error", input: "", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := strings.NewReader(tc.input)
+			var out bytes.Buffer
+			got, err := prompt.Choice(in, &out, "Pick one:", options, tc.def)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMultiChoice(t *testing.T) {
+	options := []string{"a", "b", "c", "d"}
+	cases := []struct {
+		name    string
+		input   string
+		defs    []string
+		want    []string
+		wantErr bool
+	}{
+		{name: "1,3 selects a and c", input: "1,3\n", defs: nil, want: []string{"a", "c"}},
+		{name: "empty input returns defs", input: "\n", defs: []string{"b"}, want: []string{"b"}},
+		{name: "invalid re-prompts then succeeds", input: "x\n1\n", defs: nil, want: []string{"a"}},
+		{name: "out-of-range re-prompts then succeeds", input: "5\n2\n", defs: nil, want: []string{"b"}},
+		{name: "empty defs empty input returns nil", input: "\n", defs: nil, want: nil},
+		{name: "spaces around numbers", input: " 1 , 3 \n", defs: nil, want: []string{"a", "c"}},
+		{name: "single selection", input: "4\n", defs: nil, want: []string{"d"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := strings.NewReader(tc.input)
+			var out bytes.Buffer
+			got, err := prompt.MultiChoice(in, &out, "Pick many:", options, tc.defs)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSecret(t *testing.T) {
+	t.Run("non-TTY returns error", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("os.Pipe: %v", err)
+		}
+		defer r.Close()
+		defer w.Close()
+
+		var out bytes.Buffer
+		_, err = prompt.Secret(r, &out, "Password")
+		if err == nil {
+			t.Fatal("expected error for non-TTY input, got nil")
+		}
+	})
+}

--- a/internal/setup/framework/prompt/prompt_test.go
+++ b/internal/setup/framework/prompt/prompt_test.go
@@ -108,6 +108,7 @@ func TestChoice(t *testing.T) {
 		{name: "out-of-range re-prompts then succeeds", input: "5\n1\n", want: "a"},
 		{name: "non-numeric re-prompts then succeeds", input: "x\n3\n", want: "c"},
 		{name: "eof no def returns error", input: "", wantErr: true},
+		{name: "eof with def returns def and error", input: "", def: "b", want: "b", wantErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -117,6 +118,9 @@ func TestChoice(t *testing.T) {
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got %q", got)
+				}
+				if tc.want != "" && got != tc.want {
+					t.Errorf("got %q, want %q", got, tc.want)
 				}
 				return
 			}
@@ -146,6 +150,8 @@ func TestMultiChoice(t *testing.T) {
 		{name: "empty defs empty input returns nil", input: "\n", defs: nil, want: nil},
 		{name: "spaces around numbers", input: " 1 , 3 \n", defs: nil, want: []string{"a", "c"}},
 		{name: "single selection", input: "4\n", defs: nil, want: []string{"d"}},
+		{name: "eof with defs returns defs and error", input: "", defs: []string{"b"}, want: []string{"b"}, wantErr: true},
+		{name: "eof no defs returns nil and error", input: "", defs: nil, wantErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -155,6 +161,9 @@ func TestMultiChoice(t *testing.T) {
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got %v", got)
+				}
+				if tc.want != nil && !reflect.DeepEqual(got, tc.want) {
+					t.Errorf("got %v, want %v", got, tc.want)
 				}
 				return
 			}

--- a/internal/setup/framework/stub.go
+++ b/internal/setup/framework/stub.go
@@ -1,0 +1,59 @@
+package framework
+
+import (
+	"strings"
+
+	"github.com/grafana/gcx/internal/providers"
+)
+
+// ConfigKeysStatus returns a ProductStatus for p based solely on whether
+// the non-secret config keys reported by p.ConfigKeys() are present in cfg.
+//
+// This is a heuristic stub: it never probes any API. A provider with no
+// config keys is always reported as StateActive (no configuration required).
+// A provider with non-secret keys is reported as StateConfigured when all
+// such keys are present and non-empty, or StateNotConfigured otherwise.
+//
+// cfg should be the provider-specific config map returned by
+// providers.ConfigLoader.LoadProviderConfig for the named provider.
+func ConfigKeysStatus(p providers.Provider, cfg map[string]string) ProductStatus {
+	keys := p.ConfigKeys()
+
+	// Collect non-secret keys — these are the ones a user must supply.
+	var required []string
+	for _, k := range keys {
+		if !k.Secret {
+			required = append(required, k.Name)
+		}
+	}
+
+	if len(required) == 0 {
+		return ProductStatus{
+			Product: p.Name(),
+			State:   StateActive,
+			Details: "no configuration required",
+		}
+	}
+
+	var missing []string
+	for _, name := range required {
+		if cfg[name] == "" {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) == 0 {
+		return ProductStatus{
+			Product: p.Name(),
+			State:   StateConfigured,
+			Details: "all required config keys are present",
+		}
+	}
+
+	return ProductStatus{
+		Product:   p.Name(),
+		State:     StateNotConfigured,
+		Details:   "missing config keys: " + strings.Join(missing, ", "),
+		SetupHint: "run 'gcx config set' to configure the missing keys",
+	}
+}

--- a/internal/setup/framework/stub_test.go
+++ b/internal/setup/framework/stub_test.go
@@ -1,0 +1,117 @@
+package framework_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/setup/framework"
+)
+
+func TestConfigKeysStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		configKeys []providers.ConfigKey
+		cfg        map[string]string
+		wantState  framework.ProductState
+	}{
+		{
+			name:       "no config keys → active",
+			configKeys: nil,
+			cfg:        map[string]string{},
+			wantState:  framework.StateActive,
+		},
+		{
+			name: "all non-secret keys present → configured",
+			configKeys: []providers.ConfigKey{
+				{Name: "tenant-id", Secret: false},
+				{Name: "tenant-url", Secret: false},
+			},
+			cfg: map[string]string{
+				"tenant-id":  "123",
+				"tenant-url": "https://example.com",
+			},
+			wantState: framework.StateConfigured,
+		},
+		{
+			name: "one non-secret key missing → not configured",
+			configKeys: []providers.ConfigKey{
+				{Name: "tenant-id", Secret: false},
+				{Name: "tenant-url", Secret: false},
+			},
+			cfg: map[string]string{
+				"tenant-id": "123",
+			},
+			wantState: framework.StateNotConfigured,
+		},
+		{
+			name: "all non-secret keys missing → not configured",
+			configKeys: []providers.ConfigKey{
+				{Name: "tenant-id", Secret: false},
+				{Name: "tenant-url", Secret: false},
+			},
+			cfg:       map[string]string{},
+			wantState: framework.StateNotConfigured,
+		},
+		{
+			name: "only secret keys, all absent → active (no non-secret required)",
+			configKeys: []providers.ConfigKey{
+				{Name: "api-token", Secret: true},
+			},
+			cfg:       map[string]string{},
+			wantState: framework.StateActive,
+		},
+		{
+			name: "mix of secret and non-secret; non-secret present → configured",
+			configKeys: []providers.ConfigKey{
+				{Name: "tenant-id", Secret: false},
+				{Name: "api-token", Secret: true},
+			},
+			cfg: map[string]string{
+				"tenant-id": "123",
+			},
+			wantState: framework.StateConfigured,
+		},
+		{
+			name: "mix of secret and non-secret; non-secret absent → not configured",
+			configKeys: []providers.ConfigKey{
+				{Name: "tenant-id", Secret: false},
+				{Name: "api-token", Secret: true},
+			},
+			cfg: map[string]string{
+				"api-token": "tok",
+			},
+			wantState: framework.StateNotConfigured,
+		},
+		{
+			name:       "nil cfg with required keys → not configured",
+			configKeys: []providers.ConfigKey{{Name: "tenant-id", Secret: false}},
+			cfg:        nil,
+			wantState:  framework.StateNotConfigured,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &stubProvider{name: "test"}
+			// We need a provider whose ConfigKeys() returns tc.configKeys.
+			sp := &configKeyProvider{stubProvider: *p, keys: tc.configKeys}
+			got := framework.ConfigKeysStatus(sp, tc.cfg)
+
+			if got.State != tc.wantState {
+				t.Errorf("State = %q, want %q (details: %q)", got.State, tc.wantState, got.Details)
+			}
+			if got.Product != "test" {
+				t.Errorf("Product = %q, want %q", got.Product, "test")
+			}
+		})
+	}
+}
+
+// configKeyProvider overrides ConfigKeys() on stubProvider.
+type configKeyProvider struct {
+	stubProvider
+
+	keys []providers.ConfigKey
+}
+
+func (c *configKeyProvider) ConfigKeys() []providers.ConfigKey { return c.keys }

--- a/internal/setup/framework/testhelpers/fakes.go
+++ b/internal/setup/framework/testhelpers/fakes.go
@@ -42,9 +42,16 @@ type FakeSetupable struct {
 	ShouldPanic      bool
 	Categories_      []framework.InfraCategory
 	ValidateSetupErr error
-	SetupErr         error
-	SetupCalled      bool
-	LastParams       map[string]string
+	// ValidateSetupErrs is consumed one per call; if exhausted, ValidateSetupErr is used.
+	ValidateSetupErrs []error
+	validateCallCount int
+	SetupErr          error
+	SetupCalled       bool
+	LastParams        map[string]string
+	// OnSetup is called at the start of Setup, before recording or returning errors.
+	OnSetup func()
+	// SetupOrderRecorder, when non-nil, gets ProductName_ appended on each Setup call.
+	SetupOrderRecorder *[]string
 }
 
 var _ framework.Setupable = (*FakeSetupable)(nil)
@@ -71,11 +78,22 @@ func (f *FakeSetupable) ResolveChoices(_ context.Context, _ string) ([]string, e
 
 func (f *FakeSetupable) ValidateSetup(_ context.Context, params map[string]string) error {
 	f.LastParams = params
+	idx := f.validateCallCount
+	f.validateCallCount++
+	if idx < len(f.ValidateSetupErrs) {
+		return f.ValidateSetupErrs[idx]
+	}
 	return f.ValidateSetupErr
 }
 
 func (f *FakeSetupable) Setup(_ context.Context, params map[string]string) error {
+	if f.OnSetup != nil {
+		f.OnSetup()
+	}
 	f.SetupCalled = true
 	f.LastParams = params
+	if f.SetupOrderRecorder != nil {
+		*f.SetupOrderRecorder = append(*f.SetupOrderRecorder, f.ProductName_)
+	}
 	return f.SetupErr
 }

--- a/internal/setup/framework/testhelpers/fakes.go
+++ b/internal/setup/framework/testhelpers/fakes.go
@@ -35,13 +35,15 @@ func (f *FakeStatusDetectable) Status(_ context.Context) (*framework.ProductStat
 
 // FakeSetupable is a test double that implements framework.Setupable.
 type FakeSetupable struct {
-	ProductName_     string
-	Status_          *framework.ProductStatus
-	StatusErr        error
-	Latency          time.Duration
-	ShouldPanic      bool
-	Categories_      []framework.InfraCategory
-	ValidateSetupErr error
+	ProductName_ string
+	Status_      *framework.ProductStatus
+	StatusErr    error
+	Latency      time.Duration
+	ShouldPanic  bool
+	Categories_  []framework.InfraCategory
+	// ResolveChoicesResult maps param names to dynamic choices returned by ResolveChoices.
+	ResolveChoicesResult map[string][]string
+	ValidateSetupErr     error
 	// ValidateSetupErrs is consumed one per call; if exhausted, ValidateSetupErr is used.
 	ValidateSetupErrs []error
 	validateCallCount int
@@ -72,7 +74,12 @@ func (f *FakeSetupable) InfraCategories() []framework.InfraCategory {
 	return f.Categories_
 }
 
-func (f *FakeSetupable) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+func (f *FakeSetupable) ResolveChoices(_ context.Context, paramName string) ([]string, error) {
+	if f.ResolveChoicesResult != nil {
+		if result, ok := f.ResolveChoicesResult[paramName]; ok {
+			return result, nil
+		}
+	}
 	return nil, nil
 }
 

--- a/internal/setup/framework/testhelpers/fakes.go
+++ b/internal/setup/framework/testhelpers/fakes.go
@@ -1,0 +1,81 @@
+// Package testhelpers provides reusable test doubles for the setup framework.
+// It is a regular (non-test) package so that downstream packages (T2–T6) can
+// import it in their own test files.
+package testhelpers
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/gcx/internal/setup/framework"
+)
+
+// FakeStatusDetectable is a test double that implements framework.StatusDetectable.
+type FakeStatusDetectable struct {
+	ProductName_ string
+	Status_      *framework.ProductStatus
+	Err          error
+	Latency      time.Duration
+	ShouldPanic  bool
+}
+
+var _ framework.StatusDetectable = (*FakeStatusDetectable)(nil)
+
+func (f *FakeStatusDetectable) ProductName() string { return f.ProductName_ }
+
+func (f *FakeStatusDetectable) Status(_ context.Context) (*framework.ProductStatus, error) {
+	if f.ShouldPanic {
+		panic("FakeStatusDetectable: ShouldPanic is true")
+	}
+	if f.Latency > 0 {
+		time.Sleep(f.Latency)
+	}
+	return f.Status_, f.Err
+}
+
+// FakeSetupable is a test double that implements framework.Setupable.
+type FakeSetupable struct {
+	ProductName_     string
+	Status_          *framework.ProductStatus
+	StatusErr        error
+	Latency          time.Duration
+	ShouldPanic      bool
+	Categories_      []framework.InfraCategory
+	ValidateSetupErr error
+	SetupErr         error
+	SetupCalled      bool
+	LastParams       map[string]string
+}
+
+var _ framework.Setupable = (*FakeSetupable)(nil)
+
+func (f *FakeSetupable) ProductName() string { return f.ProductName_ }
+
+func (f *FakeSetupable) Status(_ context.Context) (*framework.ProductStatus, error) {
+	if f.ShouldPanic {
+		panic("FakeSetupable: ShouldPanic is true")
+	}
+	if f.Latency > 0 {
+		time.Sleep(f.Latency)
+	}
+	return f.Status_, f.StatusErr
+}
+
+func (f *FakeSetupable) InfraCategories() []framework.InfraCategory {
+	return f.Categories_
+}
+
+func (f *FakeSetupable) ResolveChoices(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (f *FakeSetupable) ValidateSetup(_ context.Context, params map[string]string) error {
+	f.LastParams = params
+	return f.ValidateSetupErr
+}
+
+func (f *FakeSetupable) Setup(_ context.Context, params map[string]string) error {
+	f.SetupCalled = true
+	f.LastParams = params
+	return f.SetupErr
+}

--- a/internal/setup/framework/testhelpers/registry.go
+++ b/internal/setup/framework/testhelpers/registry.go
@@ -1,0 +1,19 @@
+package testhelpers
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers"
+)
+
+// SetupTestRegistry replaces the global provider registry with ps for the
+// duration of t and automatically restores it via t.Cleanup. It returns the
+// slice passed in, allowing inline construction patterns such as:
+//
+//	ps := testhelpers.SetupTestRegistry(t, []providers.Provider{fake1, fake2})
+func SetupTestRegistry(t *testing.T, ps []providers.Provider) []providers.Provider {
+	t.Helper()
+	restore := providers.SetRegistryForTest(ps)
+	t.Cleanup(restore)
+	return ps
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -34,6 +34,11 @@ func StdoutIsTerminal() bool {
 	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
+// StdinIsTerminal reports whether stdin is connected to a real terminal.
+func StdinIsTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
 // StdoutWidth returns the current stdout terminal width, or 0 when unknown.
 func StdoutWidth() int {
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))


### PR DESCRIPTION
## Summary

Implements [setup framework spec](docs/specs/feature-setup-framework/spec.md) from ADR-001.

- New `internal/setup/framework/` package: `StatusDetectable`/`Setupable` interfaces, `ProductStatus`/`ProductState` types, `AggregateStatus` (parallel, error-isolated, alphabetical), `ConfigKeysStatus` stub helper, `Run` orchestrator, and minimal prompt widgets.
- `gcx setup status` rewritten to aggregate all 14 providers via codec system (text/json/yaml/wide, agent-mode JSON default, color-coded states).
- `gcx setup run` interactive orchestrator: category multi-select, skip-if-configured, validation retry, secret-masked preview, sequential `Setup()`, Ctrl-C with summary, post-run status table.
- `StatusDetectable` stubs on 5 signal providers (alert, logs, metrics, profiles, traces).
- `Setupable` stubs + `gcx <area> setup` commands on 9 setup-capable providers (appo11y, faro, fleet, irm, k6, kg, sigil, slo, synth); all `Setup()` return `ErrSetupNotSupported` until Area 7.

## Test Plan

- [ ] `go test -race ./...` passes (CI will verify)
- [ ] `make lint` passes — 0 issues
- [ ] `go test ./cmd/gcx/setup/instrumentation/...` passes (backward-compat regression guard)
- [ ] `TestConsistency_AllLeafCommandsHaveTokenCost` passes for all 10 new commands
- [ ] Review acceptance criteria coverage in spec.md §Acceptance Criteria
- [ ] Manually run `gcx setup status` after auth to verify aggregated table renders

## Release Notes

**Breaking change (output shape):** `gcx setup status` now aggregates _all_ `StatusDetectable` providers instead of the hardcoded instrumentation-only table. Callers parsing the old shape should migrate to `--output json` or use `gcx setup instrumentation status` for the narrower view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)