### PR TITLE
chore(release): v0.2.8 changelog

### DIFF
--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,19 +1,20 @@
-
-
-- Consolidate OnCall + Incidents under unified `irm` provider
-- Add adaptive metrics segments and exemptions commands
-- Adopt server-side pagination for list commands
-- Auto-discover Synthetic Monitoring URL from plugin settings
-- Improve skills list output, add installed status, single-skill install
-- Fix adaptive telemetry auth when using OAuth for Grafana
-- Suggest `stacks:read` scope on cloud stack lookup 403
-- Update OAuth coverage warning to remove incidents/oncall
-- Align assistant SSE HTTP client timeout with `--timeout` flag
-- Fix `gcx dev serve` not exiting on Ctrl+C
-- Fix watcher error channel handling
-- Trim Knowledge Graph CLI surface and typed resources
-- Add marketing bento-box slide with verified CLI commands
-- Upgrade ASCII logo to ANSI Shadow font
-- Use "k6" instead of "K6" in UI text
-- Restructure README for better narrative flow
-- Dependency updates (Go modules, GitHub Actions)
+- Fix OAuth refresh lockout when running multiple gcx invocations concurrently
+- Improve typed API error handling for datasource queries
+- Rename OnCall/Incidents references to IRM across docs and CLI
+- Default SLO definitions list limit to all results
+- Add Homebrew installation support with docs
+- Allow login through grafana.com/launch
+- Unified CLI UX consistency pass across commands
+- Reorganise and clean up README
+- Add DatasourceProvider interface and plugin system for datasources
+- Add billing subtree and generic series leaf to metrics
+- Add --from/--to time range flags to all kg commands
+- Validate kg --scope flag values against known scopes
+- Remove redundant kg search entities command
+- Filter incidents by tags and from/to time range
+- Add fleet auth error scopes suggestion
+- Add sigil skill to claude-plugin
+- Guide agents to use Grafana Assistant for reasoning tasks
+- Recognise OPENCODE as an agent mode
+- Bump Kubernetes dependencies to v0.35.4 and Docker deps
+- Update anthropics/claude-code-action workflow digest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## v0.2.8 (2026-04-20)
+
+- Fix OAuth refresh lockout when running multiple gcx invocations concurrently
+- Improve typed API error handling for datasource queries
+- Rename OnCall/Incidents references to IRM across docs and CLI
+- Default SLO definitions list limit to all results
+- Add Homebrew installation support with docs
+- Allow login through grafana.com/launch
+- Unified CLI UX consistency pass across commands
+- Reorganise and clean up README
+- Add DatasourceProvider interface and plugin system for datasources
+- Add billing subtree and generic series leaf to metrics
+- Add --from/--to time range flags to all kg commands
+- Validate kg --scope flag values against known scopes
+- Remove redundant kg search entities command
+- Filter incidents by tags and from/to time range
+- Add fleet auth error scopes suggestion
+- Add sigil skill to claude-plugin
+- Guide agents to use Grafana Assistant for reasoning tasks
+- Recognise OPENCODE as an agent mode
+- Bump Kubernetes dependencies to v0.35.4 and Docker deps
+- Update anthropics/claude-code-action workflow digest
+
+
 ## v0.2.7 (2026-04-15)
 
 


### PR DESCRIPTION
## Summary

Changelog entry for v0.2.8 patch release. Merge this PR, then tag the merge commit on `main` with `v0.2.8` to trigger the GoReleaser workflow.

## Release notes (v0.2.8)

- Consolidate OnCall + Incidents under unified `irm` provider
- Add adaptive metrics segments and exemptions commands
- Adopt server-side pagination for list commands
- Auto-discover Synthetic Monitoring URL from plugin settings
- Improve skills list output, add installed status, single-skill install
- Fix adaptive telemetry auth when using OAuth for Grafana
- Suggest `stacks:read` scope on cloud stack lookup 403
- Update OAuth coverage warning to remove incidents/oncall
- Align assistant SSE HTTP client timeout with `--timeout` flag
- Fix `gcx dev serve` not exiting on Ctrl+C
- Fix watcher error channel handling
- Trim Knowledge Graph CLI surface and typed resources
- Add marketing bento-box slide with verified CLI commands
- Upgrade ASCII logo to ANSI Shadow font
- Use "k6" instead of "K6" in UI text
- Restructure README for better narrative flow
- Dependency updates (Go modules, GitHub Actions)

## Test plan

- [ ] CI passes on the branch
- [ ] After merge, tag the merge commit: `git checkout main && git pull && git tag v0.2.8 && git push origin v0.2.8`
- [ ] GoReleaser workflow publishes the release