### PR TITLE
docs(readme): add macOS Gatekeeper guidance for manual installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ tar xzf gcx_*.tar.gz
 chmod +x gcx && sudo mv gcx /usr/local/bin/
 ```
 
+> [!NOTE]
+> **macOS Gatekeeper**: gcx release binaries are not yet Apple-notarized, so
+> macOS may block the binary with *"Apple could not verify…"* or *"killed: 9"*.
+> The `curl | sh` installer above handles this automatically. For manual
+> downloads, remove the quarantine attribute and ad-hoc sign the binary:
+>
+> ```sh
+> xattr -d com.apple.quarantine /usr/local/bin/gcx 2>/dev/null || true
+> codesign --sign - --force /usr/local/bin/gcx   # needed on Apple Silicon
+> ```
+
 **Go install:**
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a note under the **Pre-built binary** install section explaining the macOS Gatekeeper warnings users hit with un-notarized release binaries (*"Apple could not verify…"*, *"killed: 9"* on Apple Silicon).
- Points users at the `curl | sh` installer (which already strips `com.apple.quarantine`) and documents the manual workaround: `xattr -d com.apple.quarantine` + `codesign --sign - --force` for Apple Silicon.

## Test plan
- [ ] Render README on GitHub and confirm the `[!NOTE]` callout appears correctly under the pre-built binary section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)