### PR TITLE
fix(config): resolve bare paths in set/unset against current context

### DIFF
--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -514,13 +514,18 @@ func setCmd(configOpts *Options) *cobra.Command {
 
 PROPERTY_NAME is a dot-delimited reference to the value to set. It can either represent a field or a map entry.
 
+A bare path (e.g. "cloud.token") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context.
+
 PROPERTY_VALUE is the new value to set.`,
 		Example: `
+	# Set the "server" field on the current context to "https://grafana-dev.example"
+	gcx config set grafana.server https://grafana-dev.example
+
 	# Set the "server" field on the "dev-instance" context to "https://grafana-dev.example"
 	gcx config set contexts.dev-instance.grafana.server https://grafana-dev.example
 
-	# Disable the validation of the server's SSL certificate in the "dev-instance" context
-	gcx config set contexts.dev-instance.grafana.insecure-skip-tls-verify true
+	# Disable the validation of the server's SSL certificate in the current context
+	gcx config set grafana.insecure-skip-tls-verify true
 
 	# Set a value in the local config layer
 	gcx config set --file local contexts.prod.cloud.token my-token`,
@@ -535,7 +540,12 @@ PROPERTY_VALUE is the new value to set.`,
 				return err
 			}
 
-			if err := config.SetValue(&cfg, args[0], args[1]); err != nil {
+			path, err := config.ResolveContextPath(cfg, args[0])
+			if err != nil {
+				return err
+			}
+
+			if err := config.SetValue(&cfg, path, args[1]); err != nil {
 				return err
 			}
 
@@ -557,10 +567,15 @@ func unsetCmd(configOpts *Options) *cobra.Command {
 		Short: "Unset a single value in a configuration file",
 		Long: `Unset a single value in a configuration file.
 
-PROPERTY_NAME is a dot-delimited reference to the value to unset. It can either represent a field or a map entry.`,
+PROPERTY_NAME is a dot-delimited reference to the value to unset. It can either represent a field or a map entry.
+
+A bare path (e.g. "cloud.token") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context.`,
 		Example: `
 	# Unset the "foo" context
 	gcx config unset contexts.foo
+
+	# Unset the "insecure-skip-tls-verify" flag in the current context
+	gcx config unset grafana.insecure-skip-tls-verify
 
 	# Unset the "insecure-skip-tls-verify" flag in the "dev-instance" context
 	gcx config unset contexts.dev-instance.grafana.insecure-skip-tls-verify
@@ -578,7 +593,12 @@ PROPERTY_NAME is a dot-delimited reference to the value to unset. It can either 
 				return err
 			}
 
-			if err := config.UnsetValue(&cfg, args[0]); err != nil {
+			path, err := config.ResolveContextPath(cfg, args[0])
+			if err != nil {
+				return err
+			}
+
+			if err := config.UnsetValue(&cfg, path); err != nil {
 				return err
 			}
 

--- a/cmd/gcx/config/command_test.go
+++ b/cmd/gcx/config/command_test.go
@@ -231,6 +231,45 @@ current-context: dev`),
 	viewCmd.Run(t)
 }
 
+func Test_SetCommand_barePathResolvesAgainstCurrentContext(t *testing.T) {
+	cfg := `current-context: dev`
+
+	configFile := testutils.CreateTempFile(t, cfg)
+
+	setCloudToken := testutils.CommandTestCase{
+		Cmd:     config.Command(),
+		Command: []string{"set", "--config", configFile, "cloud.token", "glc_abc123"},
+		Assertions: []testutils.CommandAssertion{
+			testutils.CommandSuccess(),
+		},
+	}
+	setCloudToken.Run(t)
+
+	viewCmd := testutils.CommandTestCase{
+		Cmd:     config.Command(),
+		Command: []string{"view", "--config", configFile, "--minify", "--raw"},
+		Assertions: []testutils.CommandAssertion{
+			testutils.CommandSuccess(),
+			testutils.CommandOutputContains(`cloud:
+      token: glc_abc123`),
+		},
+	}
+	viewCmd.Run(t)
+}
+
+func Test_SetCommand_barePathWithoutCurrentContextErrors(t *testing.T) {
+	configFile := testutils.CreateTempFile(t, `contexts: {}`)
+
+	testCase := testutils.CommandTestCase{
+		Cmd:     config.Command(),
+		Command: []string{"set", "--config", configFile, "cloud.token", "glc_abc123"},
+		Assertions: []testutils.CommandAssertion{
+			testutils.CommandErrorContains("no current context set"),
+		},
+	}
+	testCase.Run(t)
+}
+
 func Test_UnsetCommand(t *testing.T) {
 	cfg := `contexts:
   dev:

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -745,7 +745,7 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 			Details: msg,
 			Parent:  err,
 			Suggestions: []string{
-				"Set cloud.token in your config: gcx config set cloud.token <TOKEN>",
+				"Set cloud.token in your config: gcx config set contexts.<context>.cloud.token <TOKEN>",
 				"Or set GRAFANA_CLOUD_TOKEN environment variable",
 			},
 		}, true
@@ -758,7 +758,7 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 			Details: msg,
 			Parent:  err,
 			Suggestions: []string{
-				"Set cloud.stack in your config: gcx config set cloud.stack <STACK_SLUG>",
+				"Set cloud.stack in your config: gcx config set contexts.<context>.cloud.stack <STACK_SLUG>",
 				"Or set GRAFANA_CLOUD_STACK environment variable",
 			},
 		}, true

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -745,7 +745,7 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 			Details: msg,
 			Parent:  err,
 			Suggestions: []string{
-				"Set cloud.token in your config: gcx config set contexts.<context>.cloud.token <TOKEN>",
+				"Set cloud.token in your config: gcx config set cloud.token <TOKEN>",
 				"Or set GRAFANA_CLOUD_TOKEN environment variable",
 			},
 		}, true
@@ -758,7 +758,7 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 			Details: msg,
 			Parent:  err,
 			Suggestions: []string{
-				"Set cloud.stack in your config: gcx config set contexts.<context>.cloud.stack <STACK_SLUG>",
+				"Set cloud.stack in your config: gcx config set cloud.stack <STACK_SLUG>",
 				"Or set GRAFANA_CLOUD_STACK environment variable",
 			},
 		}, true

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -465,6 +465,30 @@ func TestErrorToDetailedError_SMTokenNotConfigured(t *testing.T) {
 	assert.Contains(t, got.Suggestions[3], "gcx config view")
 }
 
+func TestErrorToDetailedError_CloudTokenNotConfigured(t *testing.T) {
+	err := errors.New("cloud token is required: set cloud.token in config or GRAFANA_CLOUD_TOKEN env var")
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Cloud credentials not configured", got.Summary)
+	require.Len(t, got.Suggestions, 2)
+	assert.Contains(t, got.Suggestions[0], "gcx config set contexts.<context>.cloud.token")
+	assert.Contains(t, got.Suggestions[1], "GRAFANA_CLOUD_TOKEN")
+}
+
+func TestErrorToDetailedError_CloudStackNotConfigured(t *testing.T) {
+	err := errors.New("cloud stack is not configured: set cloud.stack in config or GRAFANA_CLOUD_STACK env var")
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Cloud stack not configured", got.Summary)
+	require.Len(t, got.Suggestions, 2)
+	assert.Contains(t, got.Suggestions[0], "gcx config set contexts.<context>.cloud.stack")
+	assert.Contains(t, got.Suggestions[1], "GRAFANA_CLOUD_STACK")
+}
+
 type fakeServiceAPIError struct {
 	statusCode int
 	service    string

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -473,7 +473,7 @@ func TestErrorToDetailedError_CloudTokenNotConfigured(t *testing.T) {
 	require.NotNil(t, got)
 	assert.Equal(t, "Cloud credentials not configured", got.Summary)
 	require.Len(t, got.Suggestions, 2)
-	assert.Contains(t, got.Suggestions[0], "gcx config set contexts.<context>.cloud.token")
+	assert.Contains(t, got.Suggestions[0], "gcx config set cloud.token")
 	assert.Contains(t, got.Suggestions[1], "GRAFANA_CLOUD_TOKEN")
 }
 
@@ -485,7 +485,7 @@ func TestErrorToDetailedError_CloudStackNotConfigured(t *testing.T) {
 	require.NotNil(t, got)
 	assert.Equal(t, "Cloud stack not configured", got.Summary)
 	require.Len(t, got.Suggestions, 2)
-	assert.Contains(t, got.Suggestions[0], "gcx config set contexts.<context>.cloud.stack")
+	assert.Contains(t, got.Suggestions[0], "gcx config set cloud.stack")
 	assert.Contains(t, got.Suggestions[1], "GRAFANA_CLOUD_STACK")
 }
 

--- a/docs/reference/cli/gcx_config_set.md
+++ b/docs/reference/cli/gcx_config_set.md
@@ -8,6 +8,8 @@ Set a single value in a configuration file.
 
 PROPERTY_NAME is a dot-delimited reference to the value to set. It can either represent a field or a map entry.
 
+A bare path (e.g. "cloud.token") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context.
+
 PROPERTY_VALUE is the new value to set.
 
 ```
@@ -18,11 +20,14 @@ gcx config set PROPERTY_NAME PROPERTY_VALUE [flags]
 
 ```
 
+	# Set the "server" field on the current context to "https://grafana-dev.example"
+	gcx config set grafana.server https://grafana-dev.example
+
 	# Set the "server" field on the "dev-instance" context to "https://grafana-dev.example"
 	gcx config set contexts.dev-instance.grafana.server https://grafana-dev.example
 
-	# Disable the validation of the server's SSL certificate in the "dev-instance" context
-	gcx config set contexts.dev-instance.grafana.insecure-skip-tls-verify true
+	# Disable the validation of the server's SSL certificate in the current context
+	gcx config set grafana.insecure-skip-tls-verify true
 
 	# Set a value in the local config layer
 	gcx config set --file local contexts.prod.cloud.token my-token

--- a/docs/reference/cli/gcx_config_unset.md
+++ b/docs/reference/cli/gcx_config_unset.md
@@ -8,6 +8,8 @@ Unset a single value in a configuration file.
 
 PROPERTY_NAME is a dot-delimited reference to the value to unset. It can either represent a field or a map entry.
 
+A bare path (e.g. "cloud.token") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context.
+
 ```
 gcx config unset PROPERTY_NAME [flags]
 ```
@@ -18,6 +20,9 @@ gcx config unset PROPERTY_NAME [flags]
 
 	# Unset the "foo" context
 	gcx config unset contexts.foo
+
+	# Unset the "insecure-skip-tls-verify" flag in the current context
+	gcx config unset grafana.insecure-skip-tls-verify
 
 	# Unset the "insecure-skip-tls-verify" flag in the "dev-instance" context
 	gcx config unset contexts.dev-instance.grafana.insecure-skip-tls-verify

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ResolveContextPath rewrites a bare config path (e.g. "cloud.token") to a
+// context-qualified path (e.g. "contexts.dev.cloud.token") by prefixing the
+// current context. Paths whose first segment already targets a top-level
+// Config field (see types.go) are returned unchanged.
+//
+// Returns an error if the path is bare but no current context is set.
+func ResolveContextPath(cfg Config, path string) (string, error) {
+	first, _, _ := strings.Cut(path, ".")
+	switch first {
+	case "contexts", "current-context":
+		return path, nil
+	}
+	if cfg.CurrentContext == "" {
+		return "", fmt.Errorf("no current context set; use a fully qualified path (e.g. contexts.<name>.%s) or set one with: gcx config use-context <name>", path)
+	}
+	return "contexts." + cfg.CurrentContext + "." + path, nil
+}

--- a/internal/config/path_test.go
+++ b/internal/config/path_test.go
@@ -1,0 +1,63 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveContextPath(t *testing.T) {
+	testCases := []struct {
+		name    string
+		cfg     config.Config
+		path    string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "bare path resolves under current context",
+			cfg:  config.Config{CurrentContext: "dev"},
+			path: "cloud.token",
+			want: "contexts.dev.cloud.token",
+		},
+		{
+			name: "nested bare path resolves under current context",
+			cfg:  config.Config{CurrentContext: "prod"},
+			path: "grafana.tls.insecure-skip-verify",
+			want: "contexts.prod.grafana.tls.insecure-skip-verify",
+		},
+		{
+			name: "contexts prefix is left alone",
+			cfg:  config.Config{CurrentContext: "dev"},
+			path: "contexts.other.cloud.token",
+			want: "contexts.other.cloud.token",
+		},
+		{
+			name: "current-context is left alone",
+			cfg:  config.Config{CurrentContext: "dev"},
+			path: "current-context",
+			want: "current-context",
+		},
+		{
+			name:    "bare path with no current context errors",
+			cfg:     config.Config{},
+			path:    "cloud.token",
+			wantErr: "no current context set",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := config.ResolveContextPath(tc.cfg, tc.path)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `gcx config set cloud.token <TOKEN>` and similar bare paths now resolve to `contexts.<current-context>.<path>`, matching what error suggestions tell users to run.
- Fully qualified paths and top-level fields (`contexts.*`, `current-context`) are unchanged.
- If no current context is set, the command fails with an actionable message pointing at the fully qualified form and `gcx config use-context`.

## Background

Addresses finding #3 in issue #519: `gcx fleet collectors list` (and other cloud-config errors) suggested `gcx config set cloud.token <TOKEN>`, but running that produced `unable to locate path "cloud" under config.Config` because `cloud.token` lives under each context, not at the top level. The new resolver makes the suggested command work as printed.

## Changes

- `internal/config/path.go`: new `ResolveContextPath` helper.
- `cmd/gcx/config/command.go`: `setCmd` / `unsetCmd` call the resolver before `SetValue` / `UnsetValue`; help text and examples updated to document the bare-path form.
- `cmd/gcx/fail/convert.go`: added tests pinning the `cloud.token` / `cloud.stack` suggestions (they stay bare now that the resolver makes them runnable).
- `docs/reference/cli/gcx_config_set.md`, `gcx_config_unset.md`: regenerated via `make reference`.

## Test Plan

- [x] `go test ./internal/config/...`
- [x] `go test ./cmd/gcx/config/...` (new `Test_SetCommand_barePathResolvesAgainstCurrentContext` + `Test_SetCommand_barePathWithoutCurrentContextErrors`)
- [x] `go test ./cmd/gcx/fail/...`
- [x] `GCX_AGENT_MODE=false make all`
- [x] Manual smoke: `gcx config set cloud.token <v>` against a config with `current-context: dev` writes the token under `contexts.dev.cloud.token`.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)