### PR TITLE
Bump Claude plugin version on release

### DIFF
--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -10,27 +10,27 @@ BUMP="${1:-}"
 # ── validate args ─────────────────────────────────────────────────────────────
 
 if [[ -z "$BUMP" ]]; then
-  echo "Usage: make tag BUMP=<major|minor|patch>" >&2
-  exit 1
+	echo "Usage: make tag BUMP=<major|minor|patch>" >&2
+	exit 1
 fi
 
 case "$BUMP" in
-  major|minor|patch) ;;
-  *)
-    echo "Error: invalid BUMP value '${BUMP}'. Must be major, minor, or patch." >&2
-    exit 1
-    ;;
+major | minor | patch) ;;
+*)
+	echo "Error: invalid BUMP value '${BUMP}'. Must be major, minor, or patch." >&2
+	exit 1
+	;;
 esac
 
 # ── check dependencies ────────────────────────────────────────────────────────
 
 for cmd in claude svu; do
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "Error: '${cmd}' is required but not found." >&2
-    [[ "$cmd" == "claude" ]] && echo "Install from https://claude.ai/download" >&2
-    [[ "$cmd" == "svu" ]] && echo "Install with: go install github.com/caarlos0/svu/v3@latest" >&2
-    exit 1
-  fi
+	if ! command -v "$cmd" >/dev/null 2>&1; then
+		echo "Error: '${cmd}' is required but not found." >&2
+		[[ "$cmd" == "claude" ]] && echo "Install from https://claude.ai/download" >&2
+		[[ "$cmd" == "svu" ]] && echo "Install with: go install github.com/caarlos0/svu/v3@latest" >&2
+		exit 1
+	fi
 done
 
 # ── get latest tag ────────────────────────────────────────────────────────────
@@ -40,22 +40,22 @@ LAST_TAG=$(svu current 2>/dev/null || echo "v0.0.0")
 # ── check for new commits since last tag ─────────────────────────────────────
 
 if [[ "$LAST_TAG" == "v0.0.0" ]]; then
-  COMMIT_COUNT=$(git rev-list --count HEAD 2>/dev/null || echo "0")
+	COMMIT_COUNT=$(git rev-list --count HEAD 2>/dev/null || echo "0")
 else
-  COMMIT_COUNT=$(git rev-list --count "${LAST_TAG}..HEAD" 2>/dev/null || echo "0")
+	COMMIT_COUNT=$(git rev-list --count "${LAST_TAG}..HEAD" 2>/dev/null || echo "0")
 fi
 
 if [[ "$COMMIT_COUNT" -eq 0 ]]; then
-  echo "Error: no new commits since ${LAST_TAG}. Nothing to release." >&2
-  exit 1
+	echo "Error: no new commits since ${LAST_TAG}. Nothing to release." >&2
+	exit 1
 fi
 
 # ── bump version ──────────────────────────────────────────────────────────────
 
 case "$BUMP" in
-  major) NEW_TAG=$(svu major) ;;
-  minor) NEW_TAG=$(svu minor) ;;
-  patch) NEW_TAG=$(svu patch) ;;
+major) NEW_TAG=$(svu major) ;;
+minor) NEW_TAG=$(svu minor) ;;
+patch) NEW_TAG=$(svu patch) ;;
 esac
 
 TODAY=$(date -u +%Y-%m-%d)
@@ -67,20 +67,20 @@ echo "Bumping ${LAST_TAG} → ${NEW_TAG}"
 # Prints the "## vX.Y.Z (date)\n\n<bullets>\n" block, or nothing if no commits.
 
 generate_entry() {
-  local from_ref="$1" to_ref="$2" display_tag="$3" entry_date="$4"
-  local commits diffstat
+	local from_ref="$1" to_ref="$2" display_tag="$3" entry_date="$4"
+	local commits diffstat
 
-  if [[ "$from_ref" == "v0.0.0" ]]; then
-    commits=$(git log --oneline "$to_ref" 2>/dev/null || echo "")
-    diffstat=$(git diff --stat "$(git rev-list --max-parents=0 HEAD)" "$to_ref" 2>/dev/null || echo "")
-  else
-    commits=$(git log --oneline "${from_ref}..${to_ref}" 2>/dev/null || echo "")
-    diffstat=$(git diff --stat "${from_ref}" "${to_ref}" 2>/dev/null || echo "")
-  fi
+	if [[ "$from_ref" == "v0.0.0" ]]; then
+		commits=$(git log --oneline "$to_ref" 2>/dev/null || echo "")
+		diffstat=$(git diff --stat "$(git rev-list --max-parents=0 HEAD)" "$to_ref" 2>/dev/null || echo "")
+	else
+		commits=$(git log --oneline "${from_ref}..${to_ref}" 2>/dev/null || echo "")
+		diffstat=$(git diff --stat "${from_ref}" "${to_ref}" 2>/dev/null || echo "")
+	fi
 
-  [[ -z "$commits" ]] && return 0
+	[[ -z "$commits" ]] && return 0
 
-  local prompt="You are writing a CHANGELOG entry for a CLI tool called gcx (Grafana Cloud resource manager).
+	local prompt="You are writing a CHANGELOG entry for a CLI tool called gcx (Grafana Cloud resource manager).
 
 Summarize the following commits into a concise bullet-point list for version ${display_tag}.
 Group related changes. Use plain English. Keep each bullet under 80 chars.
@@ -92,36 +92,36 @@ ${commits}
 Diffstat:
 ${diffstat}"
 
-  local summary
-  echo "Generating changelog entry for ${display_tag} with Claude..." >&2
-  summary=$(echo "$prompt" | env -u CLAUDECODE claude -p 2>/dev/null)
+	local summary
+	echo "Generating changelog entry for ${display_tag} with Claude..." >&2
+	summary=$(echo "$prompt" | env -u CLAUDECODE claude -p 2>/dev/null)
 
-  printf '## %s (%s)\n\n%s\n' "$display_tag" "$entry_date" "$summary"
+	printf '## %s (%s)\n\n%s\n' "$display_tag" "$entry_date" "$summary"
 }
 
 # ── detect last documented version in CHANGELOG.md ───────────────────────────
 
 CHANGELOG="CHANGELOG.md"
-LAST_CHANGELOG_VERSION=$(grep -m1 '^## v' "$CHANGELOG" 2>/dev/null \
-  | sed 's/^## \(v[^ )]*\).*/\1/' || echo "v0.0.0")
+LAST_CHANGELOG_VERSION=$(grep -m1 '^## v' "$CHANGELOG" 2>/dev/null |
+	sed 's/^## \(v[^ )]*\).*/\1/' || echo "v0.0.0")
 
 # ── backfill any tags not yet documented ─────────────────────────────────────
 
 NEW_CONTENT=""
 
 if [[ "$LAST_CHANGELOG_VERSION" != "$LAST_TAG" ]]; then
-  PREV="$LAST_CHANGELOG_VERSION"
-  while IFS= read -r GAP_TAG; do
-    GAP_DATE=$(git log -1 --format="%as" "$GAP_TAG")
-    entry=$(generate_entry "$PREV" "$GAP_TAG" "$GAP_TAG" "$GAP_DATE")
-    if [[ -n "$entry" ]]; then
-      NEW_CONTENT="${NEW_CONTENT}${entry}
+	PREV="$LAST_CHANGELOG_VERSION"
+	while IFS= read -r GAP_TAG; do
+		GAP_DATE=$(git log -1 --format="%as" "$GAP_TAG")
+		entry=$(generate_entry "$PREV" "$GAP_TAG" "$GAP_TAG" "$GAP_DATE")
+		if [[ -n "$entry" ]]; then
+			NEW_CONTENT="${NEW_CONTENT}${entry}
 
 "
-    fi
-    PREV="$GAP_TAG"
-  done < <(git tag --sort=version:refname | awk -v start="$LAST_CHANGELOG_VERSION" \
-    '$0 == start { found=1; next } found { print }')
+		fi
+		PREV="$GAP_TAG"
+	done < <(git tag --sort=version:refname | awk -v start="$LAST_CHANGELOG_VERSION" \
+		'$0 == start { found=1; next } found { print }')
 fi
 
 # ── generate the new version entry ───────────────────────────────────────────
@@ -134,10 +134,10 @@ ${NEW_CONTENT}"
 # ── write changelog ───────────────────────────────────────────────────────────
 
 if [[ -f "$CHANGELOG" ]]; then
-  EXISTING=$(cat "$CHANGELOG")
-  printf '%s\n%s\n' "$NEW_CONTENT" "$EXISTING" > "$CHANGELOG"
+	EXISTING=$(cat "$CHANGELOG")
+	printf '%s\n%s\n' "$NEW_CONTENT" "$EXISTING" >"$CHANGELOG"
 else
-  printf '%s\n' "$NEW_CONTENT" > "$CHANGELOG"
+	printf '%s\n' "$NEW_CONTENT" >"$CHANGELOG"
 fi
 
 echo "Updated ${CHANGELOG}"
@@ -145,19 +145,34 @@ echo "Updated ${CHANGELOG}"
 # ── write release notes (used by GoReleaser for GitHub release body) ──────────
 # Strip the "## vX.Y.Z (date)" header line and the blank line after it.
 
-printf '%s\n' "$NEW_ENTRY" | tail -n +3 > .release-notes.md
+printf '%s\n' "$NEW_ENTRY" | tail -n +3 >.release-notes.md
 echo "Updated .release-notes.md"
+
+# ── bump Claude plugin version ──────────────────────────────────────────────
+
+SEMVER="${NEW_TAG#v}"
+PLUGIN_JSON="claude-plugin/.claude-plugin/plugin.json"
+MARKETPLACE_JSON=".claude-plugin/marketplace.json"
+
+for f in "$PLUGIN_JSON" "$MARKETPLACE_JSON"; do
+	if [[ -f "$f" ]]; then
+		sed -i.bak 's/"version": "[^"]*"/"version": "'"${SEMVER}"'"/' "$f" && rm -f "${f}.bak"
+		echo "Updated plugin version in ${f} → ${SEMVER}"
+	fi
+done
 
 # ── dry-run exits here ────────────────────────────────────────────────────────
 
 if [[ "${DRY_RUN:-0}" == "1" ]]; then
-  echo "[DRY_RUN] Would commit, tag ${NEW_TAG}, and push."
-  exit 0
+	echo "[DRY_RUN] Would commit, tag ${NEW_TAG}, and push."
+	exit 0
 fi
 
 # ── commit, tag, push ─────────────────────────────────────────────────────────
 
 git add "$CHANGELOG" .release-notes.md
+[[ -f "$PLUGIN_JSON" ]] && git add "$PLUGIN_JSON"
+[[ -f "$MARKETPLACE_JSON" ]] && git add "$MARKETPLACE_JSON"
 git commit -m "chore(release): ${NEW_TAG} changelog"
 git tag "$NEW_TAG"
 

--- a/scripts/tag_test.sh
+++ b/scripts/tag_test.sh
@@ -11,43 +11,49 @@ FAIL=0
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 green() { printf '\033[0;32m✓ %s\033[0m\n' "$*"; }
-red()   { printf '\033[0;31m✗ %s\033[0m\n' "$*"; }
+red() { printf '\033[0;31m✗ %s\033[0m\n' "$*"; }
 
-pass() { green "$1"; PASS=$((PASS + 1)); }
-fail() { red   "$1"; FAIL=$((FAIL + 1)); }
+pass() {
+	green "$1"
+	PASS=$((PASS + 1))
+}
+fail() {
+	red "$1"
+	FAIL=$((FAIL + 1))
+}
 
 # Create a temp git repo with some commits and optional tag.
 make_repo() {
-  local dir
-  dir=$(mktemp -d)
-  git -C "$dir" init -q
-  git -C "$dir" config user.email "test@test.com"
-  git -C "$dir" config user.name "Test"
-  echo "# repo" > "$dir/README.md"
-  git -C "$dir" add .
-  git -C "$dir" commit -q -m "chore: initial commit"
-  echo "$dir"
+	local dir
+	dir=$(mktemp -d)
+	git -C "$dir" init -q
+	git -C "$dir" config user.email "test@test.com"
+	git -C "$dir" config user.name "Test"
+	echo "# repo" >"$dir/README.md"
+	git -C "$dir" add .
+	git -C "$dir" commit -q -m "chore: initial commit"
+	echo "$dir"
 }
 
 add_commit() {
-  local dir=$1 msg=$2
-  echo "$RANDOM" >> "$dir/README.md"
-  git -C "$dir" add .
-  git -C "$dir" commit -q -m "$msg"
+	local dir=$1 msg=$2
+	echo "$RANDOM" >>"$dir/README.md"
+	git -C "$dir" add .
+	git -C "$dir" commit -q -m "$msg"
 }
 
 add_tag() {
-  local dir=$1 tag=$2
-  git -C "$dir" tag "$tag"
+	local dir=$1 tag=$2
+	git -C "$dir" tag "$tag"
 }
 
 mock_tools() {
-  local dir
-  dir=$(mktemp -d)
-  printf '#!/bin/sh\necho "- mocked entry"\n' > "$dir/claude"
-  chmod +x "$dir/claude"
-  # svu mock that delegates to real svu behavior via git tags
-  cat > "$dir/svu" <<'SVUSCRIPT'
+	local dir
+	dir=$(mktemp -d)
+	printf '#!/bin/sh\necho "- mocked entry"\n' >"$dir/claude"
+	chmod +x "$dir/claude"
+	# svu mock that delegates to real svu behavior via git tags
+	cat >"$dir/svu" <<'SVUSCRIPT'
 #!/bin/sh
 case "$1" in
   current) git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0" ;;
@@ -71,263 +77,330 @@ EOF
     echo "v${M}.${m}.$((p + 1))" ;;
 esac
 SVUSCRIPT
-  chmod +x "$dir/svu"
-  echo "$dir"
+	chmod +x "$dir/svu"
+	echo "$dir"
 }
 
 # ── version bumping tests ────────────────────────────────────────────────────
 
 test_bump_patch() {
-  local dir mock
-  dir=$(make_repo)
-  add_tag "$dir" "v0.5.5"
-  add_commit "$dir" "fix: some fix"
-  mock=$(mock_tools)
+	local dir mock
+	dir=$(make_repo)
+	add_tag "$dir" "v0.5.5"
+	add_commit "$dir" "fix: some fix"
+	mock=$(mock_tools)
 
-  local out
-  out=$(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1)
-  if echo "$out" | grep -q "v0.5.6"; then
-    pass "patch bump: v0.5.5 → v0.5.6"
-  else
-    fail "patch bump: v0.5.5 → v0.5.6 (got: $out)"
-  fi
-  rm -rf "$dir" "$mock"
+	local out
+	out=$(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1)
+	if echo "$out" | grep -q "v0.5.6"; then
+		pass "patch bump: v0.5.5 → v0.5.6"
+	else
+		fail "patch bump: v0.5.5 → v0.5.6 (got: $out)"
+	fi
+	rm -rf "$dir" "$mock"
 }
 
 test_bump_minor() {
-  local dir mock
-  dir=$(make_repo)
-  add_tag "$dir" "v0.5.5"
-  add_commit "$dir" "feat: new feature"
-  mock=$(mock_tools)
+	local dir mock
+	dir=$(make_repo)
+	add_tag "$dir" "v0.5.5"
+	add_commit "$dir" "feat: new feature"
+	mock=$(mock_tools)
 
-  local out
-  out=$(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" minor 2>&1)
-  if echo "$out" | grep -q "v0.6.0"; then
-    pass "minor bump: v0.5.5 → v0.6.0"
-  else
-    fail "minor bump: v0.5.5 → v0.6.0 (got: $out)"
-  fi
-  rm -rf "$dir" "$mock"
+	local out
+	out=$(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" minor 2>&1)
+	if echo "$out" | grep -q "v0.6.0"; then
+		pass "minor bump: v0.5.5 → v0.6.0"
+	else
+		fail "minor bump: v0.5.5 → v0.6.0 (got: $out)"
+	fi
+	rm -rf "$dir" "$mock"
 }
 
 test_bump_major() {
-  local dir mock
-  dir=$(make_repo)
-  add_tag "$dir" "v0.5.5"
-  add_commit "$dir" "feat!: breaking change"
-  mock=$(mock_tools)
+	local dir mock
+	dir=$(make_repo)
+	add_tag "$dir" "v0.5.5"
+	add_commit "$dir" "feat!: breaking change"
+	mock=$(mock_tools)
 
-  local out
-  out=$(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" major 2>&1)
-  if echo "$out" | grep -q "v1.0.0"; then
-    pass "major bump: v0.5.5 → v1.0.0"
-  else
-    fail "major bump: v0.5.5 → v1.0.0 (got: $out)"
-  fi
-  rm -rf "$dir" "$mock"
+	local out
+	out=$(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" major 2>&1)
+	if echo "$out" | grep -q "v1.0.0"; then
+		pass "major bump: v0.5.5 → v1.0.0"
+	else
+		fail "major bump: v0.5.5 → v1.0.0 (got: $out)"
+	fi
+	rm -rf "$dir" "$mock"
 }
 
 test_fallback_no_tags() {
-  local dir mock
-  dir=$(make_repo)
-  add_commit "$dir" "feat: first feature"
-  mock=$(mock_tools)
+	local dir mock
+	dir=$(make_repo)
+	add_commit "$dir" "feat: first feature"
+	mock=$(mock_tools)
 
-  local out
-  out=$(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1)
-  if echo "$out" | grep -q "v0.0.1"; then
-    pass "no tags fallback: v0.0.0 → v0.0.1"
-  else
-    fail "no tags fallback: v0.0.0 → v0.0.1 (got: $out)"
-  fi
-  rm -rf "$dir" "$mock"
+	local out
+	out=$(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1)
+	if echo "$out" | grep -q "v0.0.1"; then
+		pass "no tags fallback: v0.0.0 → v0.0.1"
+	else
+		fail "no tags fallback: v0.0.0 → v0.0.1 (got: $out)"
+	fi
+	rm -rf "$dir" "$mock"
 }
 
 # ── error handling tests ──────────────────────────────────────────────────────
 
 test_no_bump_arg() {
-  local dir
-  dir=$(make_repo)
-  local rc=0 out
-  out=$(cd "$dir" && bash "$SCRIPT" 2>&1) || rc=$?
-  if [[ $rc -ne 0 ]] && echo "$out" | grep -qi "usage\|bump\|major\|minor\|patch"; then
-    pass "no BUMP arg → usage error"
-  else
-    fail "no BUMP arg → usage error (rc=$rc, got: $out)"
-  fi
-  rm -rf "$dir"
+	local dir
+	dir=$(make_repo)
+	local rc=0 out
+	out=$(cd "$dir" && bash "$SCRIPT" 2>&1) || rc=$?
+	if [[ $rc -ne 0 ]] && echo "$out" | grep -qi "usage\|bump\|major\|minor\|patch"; then
+		pass "no BUMP arg → usage error"
+	else
+		fail "no BUMP arg → usage error (rc=$rc, got: $out)"
+	fi
+	rm -rf "$dir"
 }
 
 test_invalid_bump() {
-  local dir
-  dir=$(make_repo)
-  local rc=0 out
-  out=$(cd "$dir" && bash "$SCRIPT" bogus 2>&1) || rc=$?
-  if [[ $rc -ne 0 ]] && echo "$out" | grep -qi "invalid\|bogus\|major\|minor\|patch"; then
-    pass "invalid BUMP → error"
-  else
-    fail "invalid BUMP → error (rc=$rc, got: $out)"
-  fi
-  rm -rf "$dir"
+	local dir
+	dir=$(make_repo)
+	local rc=0 out
+	out=$(cd "$dir" && bash "$SCRIPT" bogus 2>&1) || rc=$?
+	if [[ $rc -ne 0 ]] && echo "$out" | grep -qi "invalid\|bogus\|major\|minor\|patch"; then
+		pass "invalid BUMP → error"
+	else
+		fail "invalid BUMP → error (rc=$rc, got: $out)"
+	fi
+	rm -rf "$dir"
 }
 
 test_claude_not_installed() {
-  local dir
-  dir=$(make_repo)
-  add_commit "$dir" "feat: something"
-  add_tag "$dir" "v0.1.0"
-  add_commit "$dir" "feat: another thing"
+	local dir
+	dir=$(make_repo)
+	add_commit "$dir" "feat: something"
+	add_tag "$dir" "v0.1.0"
+	add_commit "$dir" "feat: another thing"
 
-  local empty_path
-  empty_path=$(mktemp -d)
+	local empty_path
+	empty_path=$(mktemp -d)
 
-  local rc=0 out
-  out=$(cd "$dir" && PATH="$empty_path" "$(command -v bash)" "$SCRIPT" patch 2>&1) || rc=$?
-  if [[ $rc -ne 0 ]] && echo "$out" | grep -qi "claude"; then
-    pass "claude not installed → clear error"
-  else
-    fail "claude not installed → clear error (rc=$rc, got: $out)"
-  fi
-  rm -rf "$dir" "$empty_path"
+	local rc=0 out
+	out=$(cd "$dir" && PATH="$empty_path" "$(command -v bash)" "$SCRIPT" patch 2>&1) || rc=$?
+	if [[ $rc -ne 0 ]] && echo "$out" | grep -qi "claude"; then
+		pass "claude not installed → clear error"
+	else
+		fail "claude not installed → clear error (rc=$rc, got: $out)"
+	fi
+	rm -rf "$dir" "$empty_path"
 }
 
 test_no_new_commits() {
-  local dir mock
-  dir=$(make_repo)
-  add_tag "$dir" "v0.1.0"
-  mock=$(mock_tools)
+	local dir mock
+	dir=$(make_repo)
+	add_tag "$dir" "v0.1.0"
+	mock=$(mock_tools)
 
-  local rc=0 out
-  out=$(cd "$dir" && PATH="$mock:$PATH" bash "$SCRIPT" patch 2>&1) || rc=$?
-  if [[ $rc -ne 0 ]] && echo "$out" | grep -qi "no new commits\|nothing to release\|no commits"; then
-    pass "no new commits → error"
-  else
-    fail "no new commits → error (rc=$rc, got: $out)"
-  fi
-  rm -rf "$dir" "$mock"
+	local rc=0 out
+	out=$(cd "$dir" && PATH="$mock:$PATH" bash "$SCRIPT" patch 2>&1) || rc=$?
+	if [[ $rc -ne 0 ]] && echo "$out" | grep -qi "no new commits\|nothing to release\|no commits"; then
+		pass "no new commits → error"
+	else
+		fail "no new commits → error (rc=$rc, got: $out)"
+	fi
+	rm -rf "$dir" "$mock"
 }
 
 # ── changelog tests ───────────────────────────────────────────────────────────
 
 test_changelog_created_if_missing() {
-  local dir mock
-  dir=$(make_repo)
-  add_tag "$dir" "v0.2.0"
-  add_commit "$dir" "feat: add thing"
-  mock=$(mock_tools)
+	local dir mock
+	dir=$(make_repo)
+	add_tag "$dir" "v0.2.0"
+	add_commit "$dir" "feat: add thing"
+	mock=$(mock_tools)
 
-  (cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1) || true
+	(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1) || true
 
-  if [[ -f "$dir/CHANGELOG.md" ]]; then
-    pass "CHANGELOG.md created when missing"
-  else
-    fail "CHANGELOG.md created when missing"
-  fi
-  rm -rf "$dir" "$mock"
+	if [[ -f "$dir/CHANGELOG.md" ]]; then
+		pass "CHANGELOG.md created when missing"
+	else
+		fail "CHANGELOG.md created when missing"
+	fi
+	rm -rf "$dir" "$mock"
 }
 
 test_changelog_prepended_if_exists() {
-  local dir mock
-  dir=$(make_repo)
-  add_tag "$dir" "v0.2.0"
-  add_commit "$dir" "feat: new thing"
+	local dir mock
+	dir=$(make_repo)
+	add_tag "$dir" "v0.2.0"
+	add_commit "$dir" "feat: new thing"
 
-  echo "## v0.2.0 (2025-01-01)" > "$dir/CHANGELOG.md"
-  echo "- old entry" >> "$dir/CHANGELOG.md"
+	echo "## v0.2.0 (2025-01-01)" >"$dir/CHANGELOG.md"
+	echo "- old entry" >>"$dir/CHANGELOG.md"
 
-  mock=$(mock_tools)
+	mock=$(mock_tools)
 
-  (cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1) || true
+	(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1) || true
 
-  local first_line
-  first_line=$(head -1 "$dir/CHANGELOG.md")
-  if echo "$first_line" | grep -q "v0.2.1"; then
-    pass "CHANGELOG.md prepended (new version first)"
-  else
-    fail "CHANGELOG.md prepended (got first line: $first_line)"
-  fi
-  rm -rf "$dir" "$mock"
+	local first_line
+	first_line=$(head -1 "$dir/CHANGELOG.md")
+	if echo "$first_line" | grep -q "v0.2.1"; then
+		pass "CHANGELOG.md prepended (new version first)"
+	else
+		fail "CHANGELOG.md prepended (got first line: $first_line)"
+	fi
+	rm -rf "$dir" "$mock"
 }
 
 test_changelog_header_format() {
-  local dir mock
-  dir=$(make_repo)
-  add_tag "$dir" "v1.2.3"
-  add_commit "$dir" "fix: something"
-  mock=$(mock_tools)
+	local dir mock
+	dir=$(make_repo)
+	add_tag "$dir" "v1.2.3"
+	add_commit "$dir" "fix: something"
+	mock=$(mock_tools)
 
-  (cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1) || true
+	(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1) || true
 
-  if grep -q "## v1.2.4" "$dir/CHANGELOG.md" 2>/dev/null; then
-    pass "CHANGELOG.md header format: ## vX.Y.Z (date)"
-  else
-    fail "CHANGELOG.md header format (content: $(cat "$dir/CHANGELOG.md" 2>/dev/null || echo 'missing'))"
-  fi
-  rm -rf "$dir" "$mock"
+	if grep -q "## v1.2.4" "$dir/CHANGELOG.md" 2>/dev/null; then
+		pass "CHANGELOG.md header format: ## vX.Y.Z (date)"
+	else
+		fail "CHANGELOG.md header format (content: $(cat "$dir/CHANGELOG.md" 2>/dev/null || echo 'missing'))"
+	fi
+	rm -rf "$dir" "$mock"
 }
 
 # ── release notes test ───────────────────────────────────────────────────────
 
 test_release_notes_written() {
-  local dir mock
-  dir=$(make_repo)
-  add_tag "$dir" "v0.3.0"
-  add_commit "$dir" "feat: something great"
-  mock=$(mock_tools)
+	local dir mock
+	dir=$(make_repo)
+	add_tag "$dir" "v0.3.0"
+	add_commit "$dir" "feat: something great"
+	mock=$(mock_tools)
 
-  (cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1) || true
+	(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1) || true
 
-  if [[ -f "$dir/.release-notes.md" ]]; then
-    local has_bullet has_header
-    grep -q "mocked entry" "$dir/.release-notes.md" && has_bullet=1 || has_bullet=0
-    grep -q "^## " "$dir/.release-notes.md" && has_header=1 || has_header=0
-    if [[ $has_bullet -eq 1 && $has_header -eq 0 ]]; then
-      pass ".release-notes.md has bullets, no header"
-    else
-      fail ".release-notes.md content wrong (bullet=$has_bullet, header=$has_header): $(cat "$dir/.release-notes.md")"
-    fi
-  else
-    fail ".release-notes.md not created"
-  fi
-  rm -rf "$dir" "$mock"
+	if [[ -f "$dir/.release-notes.md" ]]; then
+		local has_bullet has_header
+		grep -q "mocked entry" "$dir/.release-notes.md" && has_bullet=1 || has_bullet=0
+		grep -q "^## " "$dir/.release-notes.md" && has_header=1 || has_header=0
+		if [[ $has_bullet -eq 1 && $has_header -eq 0 ]]; then
+			pass ".release-notes.md has bullets, no header"
+		else
+			fail ".release-notes.md content wrong (bullet=$has_bullet, header=$has_header): $(cat "$dir/.release-notes.md")"
+		fi
+	else
+		fail ".release-notes.md not created"
+	fi
+	rm -rf "$dir" "$mock"
 }
 
 # ── backfill gap test ─────────────────────────────────────────────────────────
 
 test_backfill_gap() {
-  local dir mock
-  dir=$(make_repo)
+	local dir mock
+	dir=$(make_repo)
 
-  add_commit "$dir" "feat: initial feature"
-  add_tag "$dir" "v0.1.0"
-  printf '## v0.1.0 (2025-01-01)\n\n- initial feature\n' > "$dir/CHANGELOG.md"
+	add_commit "$dir" "feat: initial feature"
+	add_tag "$dir" "v0.1.0"
+	printf '## v0.1.0 (2025-01-01)\n\n- initial feature\n' >"$dir/CHANGELOG.md"
 
-  add_commit "$dir" "feat: gap feature"
-  add_tag "$dir" "v0.2.0"
+	add_commit "$dir" "feat: gap feature"
+	add_tag "$dir" "v0.2.0"
 
-  add_commit "$dir" "fix: new fix"
-  mock=$(mock_tools)
+	add_commit "$dir" "fix: new fix"
+	mock=$(mock_tools)
 
-  (cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1) || true
+	(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1) || true
 
-  local has_gap has_new
-  grep -q "## v0.2.0" "$dir/CHANGELOG.md" 2>/dev/null && has_gap=1 || has_gap=0
-  grep -q "## v0.2.1" "$dir/CHANGELOG.md" 2>/dev/null && has_new=1 || has_new=0
+	local has_gap has_new
+	grep -q "## v0.2.0" "$dir/CHANGELOG.md" 2>/dev/null && has_gap=1 || has_gap=0
+	grep -q "## v0.2.1" "$dir/CHANGELOG.md" 2>/dev/null && has_new=1 || has_new=0
 
-  if [[ $has_gap -eq 1 && $has_new -eq 1 ]]; then
-    local line_gap line_new
-    line_gap=$(grep -n "## v0.2.0" "$dir/CHANGELOG.md" | head -1 | cut -d: -f1)
-    line_new=$(grep -n "## v0.2.1" "$dir/CHANGELOG.md" | head -1 | cut -d: -f1)
-    if [[ $line_new -lt $line_gap ]]; then
-      pass "backfill gap: v0.2.0 backfilled and v0.2.1 prepended in correct order"
-    else
-      fail "backfill gap: entries out of order (v0.2.1 line=$line_new, v0.2.0 line=$line_gap)"
-    fi
-  else
-    fail "backfill gap: missing entries (v0.2.0 present=$has_gap, v0.2.1 present=$has_new)"
-  fi
-  rm -rf "$dir" "$mock"
+	if [[ $has_gap -eq 1 && $has_new -eq 1 ]]; then
+		local line_gap line_new
+		line_gap=$(grep -n "## v0.2.0" "$dir/CHANGELOG.md" | head -1 | cut -d: -f1)
+		line_new=$(grep -n "## v0.2.1" "$dir/CHANGELOG.md" | head -1 | cut -d: -f1)
+		if [[ $line_new -lt $line_gap ]]; then
+			pass "backfill gap: v0.2.0 backfilled and v0.2.1 prepended in correct order"
+		else
+			fail "backfill gap: entries out of order (v0.2.1 line=$line_new, v0.2.0 line=$line_gap)"
+		fi
+	else
+		fail "backfill gap: missing entries (v0.2.0 present=$has_gap, v0.2.1 present=$has_new)"
+	fi
+	rm -rf "$dir" "$mock"
+}
+
+# ── plugin version bump tests ────────────────────────────────────────────────
+
+add_plugin_manifests() {
+	local dir=$1 version=${2:-0.1.0}
+	mkdir -p "$dir/.claude-plugin"
+	cat >"$dir/.claude-plugin/marketplace.json" <<EOF
+{
+  "name": "gcx-marketplace",
+  "plugins": [
+    {
+      "name": "gcx",
+      "source": "./claude-plugin",
+      "version": "${version}"
+    }
+  ]
+}
+EOF
+	mkdir -p "$dir/claude-plugin/.claude-plugin"
+	cat >"$dir/claude-plugin/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "gcx",
+  "version": "${version}"
+}
+EOF
+	git -C "$dir" add .
+	git -C "$dir" commit -q -m "chore: add plugin manifests"
+}
+
+test_plugin_version_bumped() {
+	local dir mock
+	dir=$(make_repo)
+	add_tag "$dir" "v0.5.0"
+	add_plugin_manifests "$dir" "0.5.0"
+	add_commit "$dir" "feat: new skill"
+	mock=$(mock_tools)
+
+	(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1) || true
+
+	local marketplace_ver plugin_ver
+	marketplace_ver=$(grep '"version"' "$dir/.claude-plugin/marketplace.json" | head -1 | sed 's/.*"\([0-9][^"]*\)".*/\1/')
+	plugin_ver=$(grep '"version"' "$dir/claude-plugin/.claude-plugin/plugin.json" | head -1 | sed 's/.*"\([0-9][^"]*\)".*/\1/')
+
+	if [[ "$marketplace_ver" == "0.5.1" && "$plugin_ver" == "0.5.1" ]]; then
+		pass "plugin version bumped: 0.5.0 → 0.5.1 in both files"
+	else
+		fail "plugin version bumped: expected 0.5.1, got marketplace=${marketplace_ver} plugin=${plugin_ver}"
+	fi
+	rm -rf "$dir" "$mock"
+}
+
+test_plugin_version_no_files() {
+	local dir mock
+	dir=$(make_repo)
+	add_tag "$dir" "v0.3.0"
+	add_commit "$dir" "fix: something"
+	mock=$(mock_tools)
+
+	local out
+	out=$(cd "$dir" && PATH="$mock:$PATH" DRY_RUN=1 bash "$SCRIPT" patch 2>&1)
+	if echo "$out" | grep -q "v0.3.1"; then
+		pass "no plugin files → tag script still succeeds"
+	else
+		fail "no plugin files → tag script still succeeds (got: $out)"
+	fi
+	rm -rf "$dir" "$mock"
 }
 
 # ── run all ───────────────────────────────────────────────────────────────────
@@ -348,6 +421,8 @@ test_changelog_prepended_if_exists
 test_changelog_header_format
 test_release_notes_written
 test_backfill_gap
+test_plugin_version_bumped
+test_plugin_version_no_files
 
 echo
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

- The `make tag` release script now automatically updates the version in `.claude-plugin/marketplace.json` and `claude-plugin/.claude-plugin/plugin.json` to match the release tag
- Plugin JSON files are included in the release commit alongside CHANGELOG.md
- Gracefully skipped when plugin files are absent

This enables Claude Code's auto-updater to detect new versions, so plugin subscribers get fresh skills without reinstalling.

## Test plan

- [x] `test_plugin_version_bumped` — verifies both JSON files get the new semver after a patch bump
- [x] `test_plugin_version_no_files` — verifies the tag script succeeds when plugin files don't exist
- [x] All 15 tests pass (`bash scripts/tag_test.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)