### PR TITLE
fix(irm): pass --max-age filter to OnCall backend

### DIFF
--- a/internal/providers/irm/oncall_client.go
+++ b/internal/providers/irm/oncall_client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers/irm/oncalltypes"
@@ -492,7 +493,14 @@ func (c *OnCallClient) DeleteWebhook(ctx context.Context, id string) error {
 
 func (c *OnCallClient) ListAlertGroups(ctx context.Context, opts ...oncalltypes.ListOption) ([]AlertGroup, error) {
 	cfg := oncalltypes.ApplyListOpts(opts)
-	return collectN(iterResources[AlertGroup](ctx, c, alertGroupsPath, "alert group"), cfg.Limit)
+	params := url.Values{}
+	if cfg.StartedAfter != nil {
+		const layout = "2006-01-02T15:04:05"
+		start := cfg.StartedAfter.UTC().Format(layout)
+		end := time.Now().UTC().Format(layout)
+		params.Set("started_at", start+"_"+end)
+	}
+	return collectN(iterResources[AlertGroup](ctx, c, pathWithParams(alertGroupsPath, params), "alert group"), cfg.Limit)
 }
 
 func (c *OnCallClient) GetAlertGroup(ctx context.Context, id string) (*AlertGroup, error) {

--- a/internal/providers/irm/oncall_client_test.go
+++ b/internal/providers/irm/oncall_client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/gcx/internal/providers/irm"
 	"github.com/grafana/gcx/internal/providers/irm/oncalltypes"
@@ -228,6 +229,55 @@ func TestListAlertGroups_StopsEarlyWithLimit(t *testing.T) {
 	}
 	if pageHits > 1 {
 		t.Errorf("expected only 1 page fetch with limit=1, but fetched %d pages", pageHits)
+	}
+}
+
+func TestListAlertGroups_WithStartedAfter(t *testing.T) {
+	t.Parallel()
+
+	var gotStartedAt string
+	client := newTestOnCallClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotStartedAt = r.URL.Query().Get("started_at")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"results": []map[string]any{
+				{"pk": "ag1", "started_at": "2025-01-15T10:00:00Z"},
+			},
+		})
+	}))
+
+	cutoff := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+	items, err := client.ListAlertGroups(context.Background(), oncalltypes.WithStartedAfter(cutoff))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+
+	if !strings.HasPrefix(gotStartedAt, "2025-01-15T00:00:00_") {
+		t.Errorf("started_at = %q, want prefix %q", gotStartedAt, "2025-01-15T00:00:00_")
+	}
+}
+
+func TestListAlertGroups_NoStartedAfterByDefault(t *testing.T) {
+	t.Parallel()
+
+	var gotRawQuery string
+	client := newTestOnCallClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRawQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"results": []map[string]any{{"pk": "ag1"}},
+		})
+	}))
+
+	_, err := client.ListAlertGroups(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotRawQuery != "" {
+		t.Errorf("expected no query params, got %q", gotRawQuery)
 	}
 }
 

--- a/internal/providers/irm/oncall_commands_extra.go
+++ b/internal/providers/irm/oncall_commands_extra.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/irm/oncalltypes"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -84,19 +85,19 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 				return err
 			}
 
-			// The internal API uses cursor-based pagination; started_at filter
-			// may or may not be supported the same way. For now, fetch all and
-			// filter client-side if --max-age is set.
-			items, err := client.ListAlertGroups(cmd.Context())
-			if err != nil {
-				return err
+			var listOpts []oncalltypes.ListOption
+			if opts.MaxAge != "" {
+				dur, err := parseDuration(opts.MaxAge)
+				if err != nil {
+					return fmt.Errorf("invalid --max-age value %q: %w", opts.MaxAge, err)
+				}
+				cutoff := time.Now().UTC().Add(-dur)
+				listOpts = append(listOpts, oncalltypes.WithStartedAfter(cutoff))
 			}
 
-			if opts.MaxAge != "" {
-				items, err = filterAlertGroupsByMaxAge(items, opts.MaxAge)
-				if err != nil {
-					return err
-				}
+			items, err := client.ListAlertGroups(cmd.Context(), listOpts...)
+			if err != nil {
+				return err
 			}
 
 			objs, err := itemsToUnstructured(items, "AlertGroup", "pk", namespace)
@@ -109,31 +110,6 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 	}
 	opts.setup(cmd.Flags())
 	return cmd
-}
-
-func filterAlertGroupsByMaxAge(items []AlertGroup, maxAge string) ([]AlertGroup, error) {
-	dur, err := parseDuration(maxAge)
-	if err != nil {
-		return nil, fmt.Errorf("invalid --max-age value %q: %w", maxAge, err)
-	}
-	cutoff := time.Now().UTC().Add(-dur)
-	var filtered []AlertGroup
-	for _, ag := range items {
-		if ag.StartedAt == "" {
-			continue
-		}
-		t, err := time.Parse(time.RFC3339, ag.StartedAt)
-		if err != nil {
-			t, err = time.Parse("2006-01-02T15:04:05", ag.StartedAt)
-			if err != nil {
-				continue
-			}
-		}
-		if t.After(cutoff) {
-			filtered = append(filtered, ag)
-		}
-	}
-	return filtered, nil
 }
 
 func parseDuration(s string) (time.Duration, error) {

--- a/internal/providers/irm/oncallpublic/client.go
+++ b/internal/providers/irm/oncallpublic/client.go
@@ -625,7 +625,14 @@ func (c *Client) DeleteWebhook(ctx context.Context, id string) error {
 
 func (c *Client) ListAlertGroups(ctx context.Context, opts ...oncalltypes.ListOption) ([]oncalltypes.AlertGroup, error) {
 	cfg := oncalltypes.ApplyListOpts(opts)
-	items, err := collectN(iterResources[alertGroup](ctx, c, alertGroupsPath, "alert group"), cfg.Limit)
+	params := url.Values{}
+	if cfg.StartedAfter != nil {
+		const layout = "2006-01-02T15:04:05"
+		start := cfg.StartedAfter.UTC().Format(layout)
+		end := time.Now().UTC().Format(layout)
+		params.Set("started_at", start+"_"+end)
+	}
+	items, err := collectN(iterResources[alertGroup](ctx, c, pathWithParams(alertGroupsPath, params), "alert group"), cfg.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/irm/oncalltypes/api.go
+++ b/internal/providers/irm/oncalltypes/api.go
@@ -1,18 +1,27 @@
 package oncalltypes
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // ListOption configures list behaviour (e.g. early termination).
 type ListOption func(*ListConfig)
 
 // ListConfig holds resolved list options.
 type ListConfig struct {
-	Limit int
+	Limit        int
+	StartedAfter *time.Time
 }
 
 // WithLimit stops collecting after n items (0 = no limit).
 func WithLimit(n int) ListOption {
 	return func(c *ListConfig) { c.Limit = n }
+}
+
+// WithStartedAfter restricts results to items started at or after t.
+func WithStartedAfter(t time.Time) ListOption {
+	return func(c *ListConfig) { c.StartedAfter = &t }
 }
 
 // ApplyListOpts resolves a slice of ListOption into a ListConfig.

--- a/internal/providers/irm/oncalltypes/api_test.go
+++ b/internal/providers/irm/oncalltypes/api_test.go
@@ -1,0 +1,27 @@
+package oncalltypes_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/providers/irm/oncalltypes"
+)
+
+func TestWithStartedAfter(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	cfg := oncalltypes.ApplyListOpts([]oncalltypes.ListOption{oncalltypes.WithStartedAfter(ts)})
+	if cfg.StartedAfter == nil || !cfg.StartedAfter.Equal(ts) {
+		t.Errorf("expected StartedAfter=%v, got %v", ts, cfg.StartedAfter)
+	}
+}
+
+func TestWithStartedAfter_NotSetByDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := oncalltypes.ApplyListOpts(nil)
+	if cfg.StartedAfter != nil {
+		t.Errorf("expected StartedAfter=nil, got %v", cfg.StartedAfter)
+	}
+}


### PR DESCRIPTION
## Summary

- The `gcx irm oncall alert-groups list --max-age` flag was fetching **all** alert groups and filtering client-side. Now the duration is converted to a `started_after` ISO8601 timestamp and sent as a query parameter, letting the backend handle the filtering.
- Extends `ListConfig`/`ListOption` with `WithStartedAfter(time.Time)` — both the internal API client and the public API client forward the parameter.
- Removes the `filterAlertGroupsByMaxAge` client-side filter function.

## Test plan

- [x] New unit tests verify the query param is sent when `WithStartedAfter` is provided
- [x] New unit tests verify no query param is sent by default (backward-compat)
- [x] Existing pagination and limit tests pass unchanged
- [x] Full test suite passes (`go test ./...`)
- [x] Lint clean (`make lint` — 0 issues)
- [ ] Manual: `gcx irm oncall alert-groups list --max-age 24h` against a live stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)