### PR TITLE
ci: add PyPI publishing to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,59 @@ jobs:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
 
+  pypi:
+    needs: release
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gcx/
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+
+      - name: Build wheels
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          COMMIT=$(git rev-parse --short=7 HEAD)
+          DATE=$(git show -s --format=%cI HEAD)
+          # Normalize semver pre-release to PEP 440 (e.g. 1.0.0-rc.1 -> 1.0.0rc1)
+          PEP440_VERSION=$(echo "$VERSION" | sed 's/-alpha\./a/; s/-beta\./b/; s/-rc\./rc/')
+          # TODO: switch to `uvx go-to-wheel` once --package-path is released
+          # (see https://github.com/simonw/go-to-wheel/pull/5)
+          uvx --from "go-to-wheel @ git+https://github.com/nikaro/go-to-wheel@f7939c6868e195204eae1370f899933e555513e3" \
+            go-to-wheel . \
+            --package-path ./cmd/gcx \
+            --name gcx \
+            --version "$PEP440_VERSION" \
+            --description "Grafana Cloud CLI" \
+            --url "https://github.com/grafana/gcx" \
+            --license "Apache-2.0" \
+            --ldflags "-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X main.date=$DATE" \
+            --readme README.md
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
+
   build_docs:
     name: Build documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add a `pypi` job to the release workflow that builds platform wheels via `go-to-wheel` and publishes to PyPI using trusted publishing
- Enables installation via `uvx gcx` and `pipx install gcx`
- Embeds version, commit, and date in the binary via ldflags (matching goreleaser)

## Prerequisites
- [x] PyPI project `gcx` created
- [x] GitHub environment `pypi` created
- [x] Trusted publishing configured on PyPI (publisher: `grafana/gcx`, workflow: `release.yaml`, environment: `pypi`)

## Test plan
- [ ] Merge and tag a release — verify the `pypi` job succeeds
- [ ] Confirm `uvx gcx version` prints the correct version/commit/date
- [ ] Confirm `pipx install gcx && gcx version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)