### PR TITLE
feat(config): add mTLS client certificate authentication support (Auth via Teleport)

### DIFF
--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -137,7 +137,10 @@ func (opts *Options) LoadGrafanaConfig(ctx context.Context) (config.NamespacedRE
 		return config.NamespacedRESTConfig{}, err
 	}
 
-	restCfg := cfg.GetCurrentContext().ToRESTConfig(ctx)
+	restCfg, err := cfg.GetCurrentContext().ToRESTConfig(ctx)
+	if err != nil {
+		return config.NamespacedRESTConfig{}, err
+	}
 	restCfg.WireTokenPersistence(ctx, opts.ConfigSource(), cfg.CurrentContext, cfg.Sources)
 
 	return restCfg, nil
@@ -422,7 +425,11 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 	}
 	cmdio.Info(stdout, "Context type: %s", contextType)
 
-	restCfg := gCtx.ToRESTConfig(cmd.Context())
+	restCfg, err := gCtx.ToRESTConfig(cmd.Context())
+	if err != nil {
+		cmdio.Error(stdout, "Configuration: %s", cmdio.Red(err.Error()))
+		return nil
+	}
 	restCfg.WireTokenPersistence(cmd.Context(), source, gCtx.Name, cfg.Sources)
 
 	if _, err := discovery.NewDefaultRegistry(cmd.Context(), restCfg); err != nil {

--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -56,9 +56,18 @@ func (opts *Options) LoadConfigTolerant(ctx context.Context, extraOverrides ...c
 			if curCtx.Grafana == nil {
 				curCtx.Grafana = &config.GrafanaConfig{}
 			}
+			if curCtx.Grafana.TLS == nil {
+				curCtx.Grafana.TLS = &config.TLS{}
+			}
 
 			if err := env.Parse(curCtx); err != nil {
 				return err
+			}
+
+			// If TLS was only initialized for env parsing and no fields were set,
+			// nil it back out so IsEmpty() and other checks work correctly.
+			if curCtx.Grafana.TLS.IsEmpty() {
+				curCtx.Grafana.TLS = nil
 			}
 
 			// Resolve GRAFANA_PROVIDER_{NAME}_{KEY} environment variables

--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -55,6 +55,14 @@ contexts:
         # certificates against. If ServerName is empty, the hostname used to contact the
         # server is used.
         server-name: string
+        # CertFile is the path to a PEM-encoded client certificate file.
+        # This enables mutual TLS (mTLS) authentication with the server.
+        cert-file: string
+        # KeyFile is the path to a PEM-encoded client certificate key file.
+        key-file: string
+        # CAFile is the path to a PEM-encoded CA certificate bundle file.
+        # When set, this CA is used to verify the server's certificate.
+        ca-file: string
         # CertData holds PEM-encoded bytes (typically read from a client certificate file).
         # Note: this value is base64-encoded in the config file and will be
         # automatically decoded.

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -48,6 +48,20 @@ StackID specifies the Grafana Cloud stack targeted by this config.
 Note: required when targeting a Grafana Cloud instance.
 See OrgID for on-prem Grafana instances.
 
+## `GRAFANA_TLS_CA_FILE`
+
+CAFile is the path to a PEM-encoded CA certificate bundle file.
+When set, this CA is used to verify the server's certificate.
+
+## `GRAFANA_TLS_CERT_FILE`
+
+CertFile is the path to a PEM-encoded client certificate file.
+This enables mutual TLS (mTLS) authentication with the server.
+
+## `GRAFANA_TLS_KEY_FILE`
+
+KeyFile is the path to a PEM-encoded client certificate key file.
+
 ## `GRAFANA_TOKEN`
 
 APIToken is a service account token.

--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -204,6 +205,10 @@ func NewNamespacedRESTConfig(ctx context.Context, cfg Context) NamespacedRESTCon
 	}
 
 	if cfg.Grafana.TLS != nil {
+		// Resolve file paths to data before passing to the k8s REST client.
+		if err := cfg.Grafana.TLS.ResolveFiles(); err != nil {
+			slog.WarnContext(ctx, "failed to resolve TLS files", "error", err)
+		}
 		// Kubernetes really is wonderful, huh.
 		// tl;dr it has its own TLSClientConfig,
 		// and it's not compatible with the one from the "crypto/tls" package.

--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"context"
-	"log/slog"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -193,7 +193,7 @@ func parseRFC3339OrZero(s string) time.Time {
 }
 
 // NewNamespacedRESTConfig creates a new namespaced REST config.
-func NewNamespacedRESTConfig(ctx context.Context, cfg Context) NamespacedRESTConfig {
+func NewNamespacedRESTConfig(ctx context.Context, cfg Context) (NamespacedRESTConfig, error) {
 	rcfg := rest.Config{
 		UserAgent:       version.UserAgent(),
 		Host:            strings.TrimSuffix(cfg.Grafana.Server, "/"),
@@ -207,7 +207,7 @@ func NewNamespacedRESTConfig(ctx context.Context, cfg Context) NamespacedRESTCon
 	if cfg.Grafana.TLS != nil {
 		// Resolve file paths to data before passing to the k8s REST client.
 		if err := cfg.Grafana.TLS.ResolveFiles(); err != nil {
-			slog.WarnContext(ctx, "failed to resolve TLS files", "error", err)
+			return NamespacedRESTConfig{}, fmt.Errorf("TLS configuration: %w", err)
 		}
 		// Kubernetes really is wonderful, huh.
 		// tl;dr it has its own TLSClientConfig,
@@ -291,5 +291,5 @@ func NewNamespacedRESTConfig(ctx context.Context, cfg Context) NamespacedRESTCon
 		Namespace:      namespace,
 		GrafanaURL:     strings.TrimSuffix(cfg.Grafana.Server, "/"),
 		oauthTransport: oauthTransport,
-	}
+	}, nil
 }

--- a/internal/config/rest_persistence_test.go
+++ b/internal/config/rest_persistence_test.go
@@ -157,7 +157,7 @@ contexts:
       oauth-token: gat_local
 `)
 
-	restCfg := config.NewNamespacedRESTConfig(t.Context(), config.Context{
+	restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), config.Context{
 		Grafana: &config.GrafanaConfig{
 			Server:                srv.URL,
 			ProxyEndpoint:         srv.URL,
@@ -234,7 +234,7 @@ current-context: default
 `)
 
 	ctx, cancel := context.WithCancel(t.Context())
-	restCfg := config.NewNamespacedRESTConfig(ctx, config.Context{
+	restCfg, _ := config.NewNamespacedRESTConfig(ctx, config.Context{
 		Grafana: &config.GrafanaConfig{
 			Server:                "https://example.invalid",
 			ProxyEndpoint:         "https://example.invalid",
@@ -316,7 +316,7 @@ current-context: default
 	newTransport := func() *http.Client {
 		cfg, err := config.Load(t.Context(), config.ExplicitConfigFile(file))
 		require.NoError(t, err)
-		rc := config.NewNamespacedRESTConfig(t.Context(), *cfg.Contexts["default"])
+		rc, _ := config.NewNamespacedRESTConfig(t.Context(), *cfg.Contexts["default"])
 		rc.WireTokenPersistence(
 			t.Context(),
 			config.ExplicitConfigFile(file),
@@ -405,7 +405,7 @@ current-context: default
 	runInvocation := func() {
 		cfg, err := config.Load(t.Context(), config.ExplicitConfigFile(file))
 		require.NoError(t, err)
-		rc := config.NewNamespacedRESTConfig(t.Context(), *cfg.Contexts["default"])
+		rc, _ := config.NewNamespacedRESTConfig(t.Context(), *cfg.Contexts["default"])
 		rc.WireTokenPersistence(
 			t.Context(),
 			config.ExplicitConfigFile(file),

--- a/internal/config/rest_test.go
+++ b/internal/config/rest_test.go
@@ -30,7 +30,7 @@ func TestNewNamespacedRESTConfig_UsesBootdataStack(t *testing.T) {
 		},
 	}
 
-	restCfg := config.NewNamespacedRESTConfig(t.Context(), ctx)
+	restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), ctx)
 
 	if got, want := restCfg.Namespace, authlib.CloudNamespaceFormatter(98765); got != want {
 		t.Fatalf("expected namespace %s, got %s", want, got)
@@ -54,7 +54,7 @@ func TestNewNamespacedRESTConfig_FallsBackOnBootdataError(t *testing.T) {
 		},
 	}
 
-	restCfg := config.NewNamespacedRESTConfig(t.Context(), ctx)
+	restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), ctx)
 
 	if got, want := restCfg.Namespace, authlib.CloudNamespaceFormatter(555); got != want {
 		t.Fatalf("expected namespace %s, got %s", want, got)
@@ -78,7 +78,7 @@ func TestNewNamespacedRESTConfig_FallsBackWhenBootdataNotStack(t *testing.T) {
 		},
 	}
 
-	restCfg := config.NewNamespacedRESTConfig(t.Context(), ctx)
+	restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), ctx)
 
 	if got, want := restCfg.Namespace, authlib.CloudNamespaceFormatter(42); got != want {
 		t.Fatalf("expected namespace %s, got %s", want, got)
@@ -98,7 +98,7 @@ func TestNewNamespacedRESTConfig_TrimsTrailingSlash(t *testing.T) {
 		},
 	}
 
-	restCfg := config.NewNamespacedRESTConfig(t.Context(), ctx)
+	restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), ctx)
 
 	if restCfg.Host != bootdataServer.URL {
 		t.Fatalf("expected trailing slash to be trimmed: got %q, want %q", restCfg.Host, bootdataServer.URL)
@@ -115,7 +115,7 @@ func TestNewNamespacedRESTConfig_OAuthProxyTrimsTrailingSlash(t *testing.T) {
 		},
 	}
 
-	restCfg := config.NewNamespacedRESTConfig(t.Context(), ctx)
+	restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), ctx)
 
 	expectedHost := "https://mystack.grafana.net/a/grafana-assistant-app/api/cli/v1/proxy"
 	if restCfg.Host != expectedHost {
@@ -133,7 +133,7 @@ func TestNamespacedRESTConfig_IsOAuthProxy(t *testing.T) {
 				StackID:       123,
 			},
 		}
-		restCfg := config.NewNamespacedRESTConfig(t.Context(), ctx)
+		restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), ctx)
 		if !restCfg.IsOAuthProxy() {
 			t.Fatal("expected IsOAuthProxy() to return true for OAuth config")
 		}
@@ -147,7 +147,7 @@ func TestNamespacedRESTConfig_IsOAuthProxy(t *testing.T) {
 				StackID:  123,
 			},
 		}
-		restCfg := config.NewNamespacedRESTConfig(t.Context(), ctx)
+		restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), ctx)
 		if restCfg.IsOAuthProxy() {
 			t.Fatal("expected IsOAuthProxy() to return false for token auth config")
 		}
@@ -164,7 +164,7 @@ func TestNewNamespacedRESTConfig_OAuthProxySetsHost(t *testing.T) {
 		},
 	}
 
-	restCfg := config.NewNamespacedRESTConfig(t.Context(), ctx)
+	restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), ctx)
 
 	expectedHost := "https://mystack.grafana.net/a/grafana-assistant-app/api/cli/v1/proxy"
 	if restCfg.Host != expectedHost {
@@ -200,7 +200,7 @@ func TestNamespacedRESTConfig_SetOnRefresh(t *testing.T) {
 		},
 	}
 
-	restCfg := config.NewNamespacedRESTConfig(t.Context(), ctx)
+	restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), ctx)
 
 	var callbackCalled bool
 	restCfg.SetOnRefresh(func(token, refreshToken, expiresAt, refreshExpiresAt string) error {

--- a/internal/config/stack_id.go
+++ b/internal/config/stack_id.go
@@ -23,7 +23,10 @@ func DiscoverStackID(ctx context.Context, cfg GrafanaConfig) (int64, error) {
 		return 0, err
 	}
 
-	client := newBootdataHTTPClient(cfg)
+	client, err := newBootdataHTTPClient(cfg)
+	if err != nil {
+		return 0, err
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bootdataURL.String(), nil)
 	if err != nil {
@@ -81,7 +84,7 @@ func buildBootdataURL(server string) (*url.URL, error) {
 	return parsed, nil
 }
 
-func newBootdataHTTPClient(cfg GrafanaConfig) *http.Client {
+func newBootdataHTTPClient(cfg GrafanaConfig) (*http.Client, error) {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 	}
@@ -89,7 +92,7 @@ func newBootdataHTTPClient(cfg GrafanaConfig) *http.Client {
 	if cfg.TLS != nil {
 		tlsCfg, err := cfg.TLS.ToStdTLSConfig()
 		if err != nil {
-			return &http.Client{Timeout: 5 * time.Second, Transport: transport}
+			return nil, fmt.Errorf("TLS configuration: %w", err)
 		}
 		transport.TLSClientConfig = tlsCfg
 	}
@@ -97,5 +100,5 @@ func newBootdataHTTPClient(cfg GrafanaConfig) *http.Client {
 	return &http.Client{
 		Timeout:   5 * time.Second,
 		Transport: transport,
-	}
+	}, nil
 }

--- a/internal/config/stack_id.go
+++ b/internal/config/stack_id.go
@@ -87,7 +87,11 @@ func newBootdataHTTPClient(cfg GrafanaConfig) *http.Client {
 	}
 
 	if cfg.TLS != nil {
-		transport.TLSClientConfig = cfg.TLS.ToStdTLSConfig()
+		tlsCfg, err := cfg.TLS.ToStdTLSConfig()
+		if err != nil {
+			return &http.Client{Timeout: 5 * time.Second, Transport: transport}
+		}
+		transport.TLSClientConfig = tlsCfg
 	}
 
 	return &http.Client{

--- a/internal/config/tls_test.go
+++ b/internal/config/tls_test.go
@@ -63,6 +63,7 @@ func TestTLS_ResolveFiles(t *testing.T) {
 func TestTLS_ResolveFiles_MissingFile(t *testing.T) {
 	cfg := &config.TLS{
 		CertFile: "/nonexistent/cert.pem",
+		KeyFile:  "/nonexistent/key.pem",
 	}
 
 	err := cfg.ResolveFiles()
@@ -70,13 +71,26 @@ func TestTLS_ResolveFiles_MissingFile(t *testing.T) {
 	require.ErrorContains(t, err, "reading TLS client certificate")
 }
 
+func TestTLS_ResolveFiles_CertWithoutKey(t *testing.T) {
+	cfg := &config.TLS{
+		CertFile: "/some/cert.pem",
+	}
+
+	err := cfg.ResolveFiles()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "both cert-file and key-file must be provided together")
+}
+
 func TestTLS_ResolveFiles_FileOverridesData(t *testing.T) {
 	dir := t.TempDir()
 	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
 	require.NoError(t, os.WriteFile(certPath, []byte(testCertPEM), 0600))
+	require.NoError(t, os.WriteFile(keyPath, []byte(testKeyPEM), 0600))
 
 	cfg := &config.TLS{
 		CertFile: certPath,
+		KeyFile:  keyPath,
 		CertData: []byte("old-data"),
 	}
 

--- a/internal/config/tls_test.go
+++ b/internal/config/tls_test.go
@@ -68,7 +68,7 @@ func TestTLS_ResolveFiles_MissingFile(t *testing.T) {
 
 	err := cfg.ResolveFiles()
 	require.Error(t, err)
-	require.ErrorContains(t, err, "reading TLS client certificate")
+	require.ErrorContains(t, err, "TLS client certificate file not found")
 }
 
 func TestTLS_ResolveFiles_CertWithoutKey(t *testing.T) {

--- a/internal/config/tls_test.go
+++ b/internal/config/tls_test.go
@@ -1,0 +1,146 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// Self-signed test cert/key pair generated for testing only.
+const testCertPEM = `-----BEGIN CERTIFICATE-----
+MIIBczCCARmgAwIBAgIUdct9t5JW7uy/OqKXvsdffCRMK7wwCgYIKoZIzj0EAwIw
+DzENMAsGA1UEAwwEdGVzdDAeFw0yNjA0MjIxNzM1MDBaFw0yNzA0MjIxNzM1MDBa
+MA8xDTALBgNVBAMMBHRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARd3mqS
+HOYCZOhkwUTG2qBMN8JnJkTelG33ctDHcC7xfp8xuVKqkP5MHFd5TlIu68tWZg5o
+w0F9VCslYrCGqXCgo1MwUTAdBgNVHQ4EFgQU5LzHFgGER7Gn/UjL6aVP6ZlNbSMw
+HwYDVR0jBBgwFoAU5LzHFgGER7Gn/UjL6aVP6ZlNbSMwDwYDVR0TAQH/BAUwAwEB
+/zAKBggqhkjOPQQDAgNIADBFAiBS4yv4UOt41GsyQVOJVdcmDmhrm98l3GKbKBgB
+PKIFLwIhAJWqcaHMUuYob4/iQWhcat59ijqyr+gd9gP4brGrrHNu
+-----END CERTIFICATE-----`
+
+const testKeyPEM = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgGNOZS+qPcRefWpz0
+eab7S6cFDjBtPG+fH1ywzwOoummhRANCAARd3mqSHOYCZOhkwUTG2qBMN8JnJkTe
+lG33ctDHcC7xfp8xuVKqkP5MHFd5TlIu68tWZg5ow0F9VCslYrCGqXCg
+-----END PRIVATE KEY-----`
+
+const testCAPEM = `-----BEGIN CERTIFICATE-----
+MIIBczCCARmgAwIBAgIUdct9t5JW7uy/OqKXvsdffCRMK7wwCgYIKoZIzj0EAwIw
+DzENMAsGA1UEAwwEdGVzdDAeFw0yNjA0MjIxNzM1MDBaFw0yNzA0MjIxNzM1MDBa
+MA8xDTALBgNVBAMMBHRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARd3mqS
+HOYCZOhkwUTG2qBMN8JnJkTelG33ctDHcC7xfp8xuVKqkP5MHFd5TlIu68tWZg5o
+w0F9VCslYrCGqXCgo1MwUTAdBgNVHQ4EFgQU5LzHFgGER7Gn/UjL6aVP6ZlNbSMw
+HwYDVR0jBBgwFoAU5LzHFgGER7Gn/UjL6aVP6ZlNbSMwDwYDVR0TAQH/BAUwAwEB
+/zAKBggqhkjOPQQDAgNIADBFAiBS4yv4UOt41GsyQVOJVdcmDmhrm98l3GKbKBgB
+PKIFLwIhAJWqcaHMUuYob4/iQWhcat59ijqyr+gd9gP4brGrrHNu
+-----END CERTIFICATE-----`
+
+func TestTLS_ResolveFiles(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	caPath := filepath.Join(dir, "ca.pem")
+
+	require.NoError(t, os.WriteFile(certPath, []byte(testCertPEM), 0600))
+	require.NoError(t, os.WriteFile(keyPath, []byte(testKeyPEM), 0600))
+	require.NoError(t, os.WriteFile(caPath, []byte(testCAPEM), 0600))
+
+	cfg := &config.TLS{
+		CertFile: certPath,
+		KeyFile:  keyPath,
+		CAFile:   caPath,
+	}
+
+	require.NoError(t, cfg.ResolveFiles())
+	require.Equal(t, []byte(testCertPEM), cfg.CertData)
+	require.Equal(t, []byte(testKeyPEM), cfg.KeyData)
+	require.Equal(t, []byte(testCAPEM), cfg.CAData)
+}
+
+func TestTLS_ResolveFiles_MissingFile(t *testing.T) {
+	cfg := &config.TLS{
+		CertFile: "/nonexistent/cert.pem",
+	}
+
+	err := cfg.ResolveFiles()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "reading TLS client certificate")
+}
+
+func TestTLS_ResolveFiles_FileOverridesData(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	require.NoError(t, os.WriteFile(certPath, []byte(testCertPEM), 0600))
+
+	cfg := &config.TLS{
+		CertFile: certPath,
+		CertData: []byte("old-data"),
+	}
+
+	require.NoError(t, cfg.ResolveFiles())
+	require.Equal(t, []byte(testCertPEM), cfg.CertData)
+}
+
+func TestTLS_ToStdTLSConfig_InsecureOnly(t *testing.T) {
+	cfg := &config.TLS{
+		Insecure:   true,
+		ServerName: "example.com",
+	}
+
+	tlsCfg, err := cfg.ToStdTLSConfig()
+	require.NoError(t, err)
+	require.True(t, tlsCfg.InsecureSkipVerify)
+	require.Equal(t, "example.com", tlsCfg.ServerName)
+}
+
+func TestTLS_ToStdTLSConfig_WithCAData(t *testing.T) {
+	cfg := &config.TLS{
+		CAData: []byte(testCAPEM),
+	}
+
+	tlsCfg, err := cfg.ToStdTLSConfig()
+	require.NoError(t, err)
+	require.NotNil(t, tlsCfg.RootCAs)
+}
+
+func TestTLS_ToStdTLSConfig_WithInvalidCAData(t *testing.T) {
+	cfg := &config.TLS{
+		CAData: []byte("not-a-cert"),
+	}
+
+	_, err := cfg.ToStdTLSConfig()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to parse TLS CA certificate data")
+}
+
+func TestTLS_ToStdTLSConfig_WithCertFiles(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+
+	require.NoError(t, os.WriteFile(certPath, []byte(testCertPEM), 0600))
+	require.NoError(t, os.WriteFile(keyPath, []byte(testKeyPEM), 0600))
+
+	cfg := &config.TLS{
+		CertFile: certPath,
+		KeyFile:  keyPath,
+	}
+
+	tlsCfg, err := cfg.ToStdTLSConfig()
+	require.NoError(t, err)
+	require.Len(t, tlsCfg.Certificates, 1)
+}
+
+func TestTLS_ToStdTLSConfig_WithCertData(t *testing.T) {
+	cfg := &config.TLS{
+		CertData: []byte(testCertPEM),
+		KeyData:  []byte(testKeyPEM),
+	}
+
+	tlsCfg, err := cfg.ToStdTLSConfig()
+	require.NoError(t, err)
+	require.Len(t, tlsCfg.Certificates, 1)
+}

--- a/internal/config/tls_test.go
+++ b/internal/config/tls_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"crypto/tls"
 	"os"
 	"path/filepath"
 	"testing"
@@ -157,4 +158,32 @@ func TestTLS_ToStdTLSConfig_WithCertData(t *testing.T) {
 	tlsCfg, err := cfg.ToStdTLSConfig()
 	require.NoError(t, err)
 	require.Len(t, tlsCfg.Certificates, 1)
+}
+
+func TestTLS_ToStdTLSConfig_HalfConfiguredCertData(t *testing.T) {
+	cfg := &config.TLS{
+		CertData: []byte(testCertPEM),
+	}
+
+	_, err := cfg.ToStdTLSConfig()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "both cert-data and key-data must be provided together")
+}
+
+func TestTLS_ToStdTLSConfig_PinsMinVersionTLS12(t *testing.T) {
+	cfg := &config.TLS{}
+
+	tlsCfg, err := cfg.ToStdTLSConfig()
+	require.NoError(t, err)
+	require.Equal(t, uint16(tls.VersionTLS12), tlsCfg.MinVersion)
+}
+
+func TestTLS_ToStdTLSConfig_CADataAddsToSystemRoots(t *testing.T) {
+	cfg := &config.TLS{
+		CAData: []byte(testCAPEM),
+	}
+
+	tlsCfg, err := cfg.ToStdTLSConfig()
+	require.NoError(t, err)
+	require.NotNil(t, tlsCfg.RootCAs)
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -441,6 +441,28 @@ type TLS struct {
 	NextProtos []string `json:"next-protos,omitempty" yaml:"next-protos,omitempty"`
 }
 
+// IsEmpty reports whether all TLS fields are at their zero values.
+func (cfg *TLS) IsEmpty() bool {
+	return !cfg.Insecure && cfg.ServerName == "" &&
+		cfg.CertFile == "" && cfg.KeyFile == "" && cfg.CAFile == "" &&
+		len(cfg.CertData) == 0 && len(cfg.KeyData) == 0 && len(cfg.CAData) == 0 &&
+		len(cfg.NextProtos) == 0
+}
+
+func tlsFileError(description, path string, err error) error {
+	if os.IsNotExist(err) {
+		return ValidationError{
+			Path:    path,
+			Message: fmt.Sprintf("TLS %s file not found", description),
+			Suggestions: []string{
+				"Your client certificates may have expired — renew them and try again",
+				"Verify the file path in your gcx config or GRAFANA_TLS_CERT_FILE / GRAFANA_TLS_KEY_FILE env vars",
+			},
+		}
+	}
+	return fmt.Errorf("reading TLS %s: %w", description, err)
+}
+
 // ResolveFiles reads CertFile, KeyFile, and CAFile from disk and populates
 // the corresponding CertData, KeyData, and CAData fields. File-based fields
 // take precedence: if both CertFile and CertData are set, CertFile wins.
@@ -451,21 +473,21 @@ func (cfg *TLS) ResolveFiles() error {
 	if cfg.CertFile != "" {
 		data, err := os.ReadFile(cfg.CertFile)
 		if err != nil {
-			return fmt.Errorf("reading TLS client certificate: %w", err)
+			return tlsFileError("client certificate", cfg.CertFile, err)
 		}
 		cfg.CertData = data
 	}
 	if cfg.KeyFile != "" {
 		data, err := os.ReadFile(cfg.KeyFile)
 		if err != nil {
-			return fmt.Errorf("reading TLS client key: %w", err)
+			return tlsFileError("client key", cfg.KeyFile, err)
 		}
 		cfg.KeyData = data
 	}
 	if cfg.CAFile != "" {
 		data, err := os.ReadFile(cfg.CAFile)
 		if err != nil {
-			return fmt.Errorf("reading TLS CA certificate: %w", err)
+			return tlsFileError("CA certificate", cfg.CAFile, err)
 		}
 		cfg.CAData = data
 	}
@@ -487,7 +509,12 @@ func (cfg *TLS) ToStdTLSConfig() (*tls.Config, error) {
 		NextProtos:         cfg.NextProtos,
 	}
 
-	if len(cfg.CertData) > 0 && len(cfg.KeyData) > 0 {
+	hasCert := len(cfg.CertData) > 0
+	hasKey := len(cfg.KeyData) > 0
+	if hasCert != hasKey {
+		return nil, errors.New("both cert-data and key-data must be provided together")
+	}
+	if hasCert && hasKey {
 		cert, err := tls.X509KeyPair(cfg.CertData, cfg.KeyData)
 		if err != nil {
 			return nil, fmt.Errorf("loading TLS client certificate keypair: %w", err)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -114,7 +114,7 @@ func (context *Context) Validate() error {
 }
 
 // ToRESTConfig returns a REST config for the context.
-func (context *Context) ToRESTConfig(ctx context.Context) NamespacedRESTConfig {
+func (context *Context) ToRESTConfig(ctx context.Context) (NamespacedRESTConfig, error) {
 	return NewNamespacedRESTConfig(ctx, *context)
 }
 
@@ -413,11 +413,9 @@ type TLS struct {
 	ServerName string `json:"server-name,omitempty" yaml:"server-name,omitempty"`
 
 	// CertFile is the path to a PEM-encoded client certificate file.
-	// When set, KeyFile must also be provided.
 	// This enables mutual TLS (mTLS) authentication with the server.
 	CertFile string `env:"GRAFANA_TLS_CERT_FILE" json:"cert-file,omitempty" yaml:"cert-file,omitempty"`
 	// KeyFile is the path to a PEM-encoded client certificate key file.
-	// When set, CertFile must also be provided.
 	KeyFile string `datapolicy:"secret" env:"GRAFANA_TLS_KEY_FILE" json:"key-file,omitempty" yaml:"key-file,omitempty"`
 	// CAFile is the path to a PEM-encoded CA certificate bundle file.
 	// When set, this CA is used to verify the server's certificate.
@@ -447,6 +445,9 @@ type TLS struct {
 // the corresponding CertData, KeyData, and CAData fields. File-based fields
 // take precedence: if both CertFile and CertData are set, CertFile wins.
 func (cfg *TLS) ResolveFiles() error {
+	if (cfg.CertFile != "") != (cfg.KeyFile != "") {
+		return errors.New("both cert-file and key-file must be provided together")
+	}
 	if cfg.CertFile != "" {
 		data, err := os.ReadFile(cfg.CertFile)
 		if err != nil {
@@ -500,7 +501,7 @@ func (cfg *TLS) ToStdTLSConfig() (*tls.Config, error) {
 			pool = x509.NewCertPool()
 		}
 		if !pool.AppendCertsFromPEM(cfg.CAData) {
-			return nil, fmt.Errorf("failed to parse TLS CA certificate data")
+			return nil, errors.New("failed to parse TLS CA certificate data")
 		}
 		tlsCfg.RootCAs = pool
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -505,6 +505,7 @@ func (cfg *TLS) ToStdTLSConfig() (*tls.Config, error) {
 	tlsCfg := &tls.Config{
 		//nolint:gosec
 		InsecureSkipVerify: cfg.Insecure,
+		MinVersion:         tls.VersionTLS12,
 		ServerName:         cfg.ServerName,
 		NextProtos:         cfg.NextProtos,
 	}
@@ -525,7 +526,7 @@ func (cfg *TLS) ToStdTLSConfig() (*tls.Config, error) {
 	if len(cfg.CAData) > 0 {
 		pool, err := x509.SystemCertPool()
 		if err != nil {
-			pool = x509.NewCertPool()
+			return nil, fmt.Errorf("loading system certificate pool: %w", err)
 		}
 		if !pool.AppendCertsFromPEM(cfg.CAData) {
 			return nil, errors.New("failed to parse TLS CA certificate data")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -3,10 +3,12 @@ package config
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -410,6 +412,17 @@ type TLS struct {
 	// server is used.
 	ServerName string `json:"server-name,omitempty" yaml:"server-name,omitempty"`
 
+	// CertFile is the path to a PEM-encoded client certificate file.
+	// When set, KeyFile must also be provided.
+	// This enables mutual TLS (mTLS) authentication with the server.
+	CertFile string `env:"GRAFANA_TLS_CERT_FILE" json:"cert-file,omitempty" yaml:"cert-file,omitempty"`
+	// KeyFile is the path to a PEM-encoded client certificate key file.
+	// When set, CertFile must also be provided.
+	KeyFile string `datapolicy:"secret" env:"GRAFANA_TLS_KEY_FILE" json:"key-file,omitempty" yaml:"key-file,omitempty"`
+	// CAFile is the path to a PEM-encoded CA certificate bundle file.
+	// When set, this CA is used to verify the server's certificate.
+	CAFile string `env:"GRAFANA_TLS_CA_FILE" json:"ca-file,omitempty" yaml:"ca-file,omitempty"`
+
 	// CertData holds PEM-encoded bytes (typically read from a client certificate file).
 	// Note: this value is base64-encoded in the config file and will be
 	// automatically decoded.
@@ -430,14 +443,69 @@ type TLS struct {
 	NextProtos []string `json:"next-protos,omitempty" yaml:"next-protos,omitempty"`
 }
 
-func (cfg *TLS) ToStdTLSConfig() *tls.Config {
-	// TODO: CertData, KeyData, CAData
-	return &tls.Config{
+// ResolveFiles reads CertFile, KeyFile, and CAFile from disk and populates
+// the corresponding CertData, KeyData, and CAData fields. File-based fields
+// take precedence: if both CertFile and CertData are set, CertFile wins.
+func (cfg *TLS) ResolveFiles() error {
+	if cfg.CertFile != "" {
+		data, err := os.ReadFile(cfg.CertFile)
+		if err != nil {
+			return fmt.Errorf("reading TLS client certificate: %w", err)
+		}
+		cfg.CertData = data
+	}
+	if cfg.KeyFile != "" {
+		data, err := os.ReadFile(cfg.KeyFile)
+		if err != nil {
+			return fmt.Errorf("reading TLS client key: %w", err)
+		}
+		cfg.KeyData = data
+	}
+	if cfg.CAFile != "" {
+		data, err := os.ReadFile(cfg.CAFile)
+		if err != nil {
+			return fmt.Errorf("reading TLS CA certificate: %w", err)
+		}
+		cfg.CAData = data
+	}
+	return nil
+}
+
+// ToStdTLSConfig converts the TLS configuration into a standard crypto/tls
+// Config. It loads client certificates from CertData/KeyData and adds custom
+// CA certificates from CAData to the root CA pool.
+func (cfg *TLS) ToStdTLSConfig() (*tls.Config, error) {
+	if err := cfg.ResolveFiles(); err != nil {
+		return nil, err
+	}
+
+	tlsCfg := &tls.Config{
 		//nolint:gosec
 		InsecureSkipVerify: cfg.Insecure,
 		ServerName:         cfg.ServerName,
 		NextProtos:         cfg.NextProtos,
 	}
+
+	if len(cfg.CertData) > 0 && len(cfg.KeyData) > 0 {
+		cert, err := tls.X509KeyPair(cfg.CertData, cfg.KeyData)
+		if err != nil {
+			return nil, fmt.Errorf("loading TLS client certificate keypair: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	if len(cfg.CAData) > 0 {
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(cfg.CAData) {
+			return nil, fmt.Errorf("failed to parse TLS CA certificate data")
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	return tlsCfg, nil
 }
 
 // Minify returns a trimmed down version of the given configuration containing

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -48,7 +48,11 @@ func ClientFromContext(ctx *config.Context) (*goapi.GrafanaHTTPAPI, error) {
 	}
 
 	if ctx.Grafana.TLS != nil {
-		cfg.TLSConfig = ctx.Grafana.TLS.ToStdTLSConfig()
+		tlsCfg, err := ctx.Grafana.TLS.ToStdTLSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("TLS configuration: %w", err)
+		}
+		cfg.TLSConfig = tlsCfg
 	}
 
 	// Authentication

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -242,7 +242,10 @@ func Run(ctx context.Context, opts *Options) (Result, error) {
 		Grafana: grafanaCfg,
 		Cloud:   cloudCfg,
 	}
-	restCfg := config.NewNamespacedRESTConfig(ctx, tempCtx)
+	restCfg, err := config.NewNamespacedRESTConfig(ctx, tempCtx)
+	if err != nil {
+		return Result{}, fmt.Errorf("TLS configuration: %w", err)
+	}
 
 	var grafanaVersion string
 	if !opts.ForceSave {

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -198,7 +198,10 @@ func (l *ConfigLoader) LoadGrafanaConfig(ctx context.Context) (config.Namespaced
 		return config.NamespacedRESTConfig{}, err
 	}
 
-	restCfg := loaded.GetCurrentContext().ToRESTConfig(ctx)
+	restCfg, err := loaded.GetCurrentContext().ToRESTConfig(ctx)
+	if err != nil {
+		return config.NamespacedRESTConfig{}, err
+	}
 	restCfg.WireTokenPersistence(ctx, l.configSource(), loaded.CurrentContext, loaded.Sources)
 
 	return restCfg, nil
@@ -248,7 +251,10 @@ func (l *ConfigLoader) LoadCloudConfig(ctx context.Context) (CloudRESTConfig, er
 	namespace := "default"
 	var restCfg *rest.Config
 	if curCtx.Grafana != nil && !curCtx.Grafana.IsEmpty() {
-		nrc := curCtx.ToRESTConfig(ctx)
+		nrc, err := curCtx.ToRESTConfig(ctx)
+		if err != nil {
+			return CloudRESTConfig{}, err
+		}
 		nrc.WireTokenPersistence(ctx, l.configSource(), loaded.CurrentContext, loaded.Sources)
 
 		namespace = nrc.Namespace
@@ -294,7 +300,10 @@ func (l *ConfigLoader) LoadProviderConfig(ctx context.Context, providerName stri
 	// Derive namespace from grafana config if available.
 	namespace := "default"
 	if curCtx.Grafana != nil && !curCtx.Grafana.IsEmpty() {
-		restCfg := curCtx.ToRESTConfig(ctx)
+		restCfg, err := curCtx.ToRESTConfig(ctx)
+		if err != nil {
+			return nil, "", err
+		}
 		namespace = restCfg.Namespace
 	}
 

--- a/internal/providers/synth/configloader_test.go
+++ b/internal/providers/synth/configloader_test.go
@@ -289,7 +289,7 @@ func TestDiscoverSMURL_OAuthProxyMode(t *testing.T) {
 			OAuthToken:    "gat_test",
 		},
 	}
-	restCfg := config.NewNamespacedRESTConfig(context.Background(), ctx)
+	restCfg, _ := config.NewNamespacedRESTConfig(context.Background(), ctx)
 	require.True(t, restCfg.IsOAuthProxy(), "config should be in OAuth proxy mode")
 
 	got, err := discoverSMURL(context.Background(), restCfg)

--- a/internal/server/grafana/requests.go
+++ b/internal/server/grafana/requests.go
@@ -31,7 +31,12 @@ func AuthenticateAndProxyHandler(cfg *config.Context) http.HandlerFunc {
 
 		var tlsCfg *tls.Config
 		if cfg.Grafana != nil && cfg.Grafana.TLS != nil {
-			tlsCfg = cfg.Grafana.TLS.ToStdTLSConfig()
+			var err error
+			tlsCfg, err = cfg.Grafana.TLS.ToStdTLSConfig()
+			if err != nil {
+				httputils.Error(r, w, "TLS configuration error", err, http.StatusInternalServerError)
+				return
+			}
 		}
 		middlewares := []httputils.Middleware{httputils.LoggingMiddleware}
 		if httputils.PayloadLogging(r.Context()) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -70,7 +70,11 @@ func (s *Server) Start(ctx context.Context) error {
 
 	var tlsCfg *tls.Config
 	if s.context.Grafana != nil && s.context.Grafana.TLS != nil {
-		tlsCfg = s.context.Grafana.TLS.ToStdTLSConfig()
+		var err error
+		tlsCfg, err = s.context.Grafana.TLS.ToStdTLSConfig()
+		if err != nil {
+			return fmt.Errorf("TLS configuration: %w", err)
+		}
 	}
 	s.proxy = &httputil.ReverseProxy{
 		Transport: httputils.NewTransport(tlsCfg),


### PR DESCRIPTION
## Summary

- Add `cert-file`, `key-file`, and `ca-file` fields to the TLS config struct, enabling mutual TLS (mTLS) authentication with file-based client certificates
- Implement the existing `// TODO: CertData, KeyData, CAData` in `ToStdTLSConfig()` to actually load and use client certificates and custom CA bundles
- Add environment variables `GRAFANA_TLS_CERT_FILE`, `GRAFANA_TLS_KEY_FILE`, `GRAFANA_TLS_CA_FILE` for CI/CD and agent usage

## Motivation

Many enterprise Grafana deployments sit behind identity-aware proxies like [Teleport](https://goteleport.com/), which authenticate users via mTLS client certificates rather than API tokens. The Grafana MCP server already supports this via `--tls-cert-file` / `--tls-key-file` flags, but gcx had no equivalent — forcing users to either create service account tokens (which may require Admin permissions they don't have) or use workarounds like local proxies.

This change closes that gap by letting users point gcx directly at their client certificate and key files.

## Usage

### Via config

```bash
gcx config set contexts.myctx.grafana.tls.cert-file /path/to/cert.pem
gcx config set contexts.myctx.grafana.tls.key-file /path/to/key.pem
gcx config set contexts.myctx.grafana.tls.ca-file /path/to/ca.pem  # optional
```

### Via environment variables

```bash
export GRAFANA_TLS_CERT_FILE=/path/to/cert.pem
export GRAFANA_TLS_KEY_FILE=/path/to/key.pem
export GRAFANA_TLS_CA_FILE=/path/to/ca.pem  # optional
```

### Example: Teleport integration

```bash
tsh apps login grafana
gcx config set contexts.prod.grafana.server https://grafana.teleport.example.com
gcx config set contexts.prod.grafana.tls.cert-file $(tsh apps config grafana -f cert)
gcx config set contexts.prod.grafana.tls.key-file $(tsh apps config grafana -f key)
gcx config use-context prod
gcx api /api/org  # works via mTLS, no token needed
```

## What changed

| File | Change |
|------|--------|
| `internal/config/types.go` | Added `CertFile`, `KeyFile`, `CAFile` fields to `TLS` struct; added `ResolveFiles()` method; implemented `ToStdTLSConfig()` with cert loading (was `// TODO`) |
| `internal/config/rest.go` | Call `ResolveFiles()` before passing TLS data to k8s REST client |
| `internal/config/stack_id.go` | Handle new `ToStdTLSConfig()` error return |
| `internal/grafana/client.go` | Handle new `ToStdTLSConfig()` error return |
| `internal/server/server.go` | Handle new `ToStdTLSConfig()` error return |
| `internal/server/grafana/requests.go` | Handle new `ToStdTLSConfig()` error return |
| `internal/config/tls_test.go` | **New** — 8 unit tests for file resolution, cert loading, CA parsing, error cases |

## Test
Tested, works! :)