### PR TITLE
feat(alert): add --datasource and --name flags to instances list

### DIFF
--- a/docs/reference/cli/gcx_alert_instances_list.md
+++ b/docs/reference/cli/gcx_alert_instances_list.md
@@ -9,13 +9,15 @@ gcx alert instances list [flags]
 ### Options
 
 ```
-      --folder string   Filter by folder UID
-      --group string    Filter by group name
-  -h, --help            help for list
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
-      --rule string     Filter by rule UID
-      --state string    Filter by alert instance state (firing, pending, inactive)
+      --datasource string   Datasource UID to query (default: Grafana-managed rules)
+      --folder string       Filter by folder UID
+      --group string        Filter by group name
+  -h, --help                help for list
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --name string         Filter by rule name (regex, e.g. 'Tempo.*')
+  -o, --output string       Output format. One of: json, table, wide, yaml (default "table")
+      --rule string         Filter by rule UID
+      --state string        Filter by alert instance state (firing, pending, inactive)
 ```
 
 ### Options inherited from parent commands

--- a/internal/providers/alert/client.go
+++ b/internal/providers/alert/client.go
@@ -17,7 +17,7 @@ import (
 // ErrNotFound is returned when a requested alert rule or group does not exist.
 var ErrNotFound = errors.New("alert rule not found")
 
-const basePath = "/api/prometheus/grafana/api/v1/rules"
+const defaultBasePath = "/api/prometheus/grafana/api/v1/rules"
 
 // Client fetches alert rules and groups from the Prometheus-compatible API.
 type Client struct {
@@ -41,6 +41,7 @@ type ListOptions struct {
 	FolderUID  string
 	State      string
 	GroupLimit int
+	Datasource string
 }
 
 // List returns rules matching the given options.
@@ -62,7 +63,10 @@ func (c *Client) List(ctx context.Context, opts ListOptions) (*RulesResponse, er
 		params.Set("group_limit", strconv.Itoa(opts.GroupLimit))
 	}
 
-	path := basePath
+	path := defaultBasePath
+	if opts.Datasource != "" {
+		path = "/api/prometheus/" + opts.Datasource + "/api/v1/rules"
+	}
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}

--- a/internal/providers/alert/client.go
+++ b/internal/providers/alert/client.go
@@ -65,7 +65,7 @@ func (c *Client) List(ctx context.Context, opts ListOptions) (*RulesResponse, er
 
 	path := defaultBasePath
 	if opts.Datasource != "" {
-		path = "/api/prometheus/" + opts.Datasource + "/api/v1/rules"
+		path = "/api/prometheus/" + url.PathEscape(opts.Datasource) + "/api/v1/rules"
 	}
 	if len(params) > 0 {
 		path += "?" + params.Encode()

--- a/internal/providers/alert/instances_commands.go
+++ b/internal/providers/alert/instances_commands.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -38,11 +39,13 @@ func instancesCommands(loader GrafanaConfigLoader) *cobra.Command {
 }
 
 type instancesListOpts struct {
-	IO        cmdio.Options
-	RuleUID   string
-	GroupName string
-	FolderUID string
-	State     string
+	IO         cmdio.Options
+	RuleUID    string
+	GroupName  string
+	FolderUID  string
+	State      string
+	Datasource string
+	Name       string
 }
 
 func (o *instancesListOpts) Validate() error {
@@ -61,6 +64,8 @@ func (o *instancesListOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVar(&o.GroupName, "group", "", "Filter by group name")
 	flags.StringVar(&o.FolderUID, "folder", "", "Filter by folder UID")
 	flags.StringVar(&o.State, "state", "", "Filter by alert instance state (firing, pending, inactive)")
+	flags.StringVar(&o.Datasource, "datasource", "", "Datasource UID to query (default: Grafana-managed rules)")
+	flags.StringVar(&o.Name, "name", "", "Filter by rule name (regex, e.g. 'Tempo.*')")
 }
 
 func newInstancesListCommand(loader GrafanaConfigLoader) *cobra.Command {
@@ -85,16 +90,26 @@ func newInstancesListCommand(loader GrafanaConfigLoader) *cobra.Command {
 			}
 
 			resp, err := client.List(ctx, ListOptions{
-				RuleUID:   opts.RuleUID,
-				GroupName: opts.GroupName,
-				FolderUID: opts.FolderUID,
-				State:     opts.State,
+				RuleUID:    opts.RuleUID,
+				GroupName:  opts.GroupName,
+				FolderUID:  opts.FolderUID,
+				State:      opts.State,
+				Datasource: opts.Datasource,
 			})
 			if err != nil {
 				return err
 			}
 
 			instances := collectAlertInstances(resp.Data.Groups)
+
+			if opts.Name != "" {
+				re, err := regexp.Compile("(?i)" + opts.Name)
+				if err != nil {
+					return fmt.Errorf("invalid --name regex %q: %w", opts.Name, err)
+				}
+				instances = filterInstancesByName(instances, re)
+			}
+
 			return opts.IO.Encode(cmd.OutOrStdout(), instances)
 		},
 	}
@@ -144,6 +159,16 @@ func (c *InstancesTableCodec) Encode(w io.Writer, v any) error {
 
 func (c *InstancesTableCodec) Decode(r io.Reader, v any) error {
 	return errors.New("table format does not support decoding")
+}
+
+func filterInstancesByName(instances []AlertInstanceRecord, re *regexp.Regexp) []AlertInstanceRecord {
+	filtered := make([]AlertInstanceRecord, 0, len(instances))
+	for _, inst := range instances {
+		if re.MatchString(inst.RuleName) {
+			filtered = append(filtered, inst)
+		}
+	}
+	return filtered
 }
 
 func collectAlertInstances(groups []RuleGroup) []AlertInstanceRecord {


### PR DESCRIPTION
## Summary

- **`--datasource <uid>`**: queries alert rules from a Prometheus datasource's ruler API instead of only Grafana-managed rules. This makes Mimir ruler alerts (Tempo, Mimir, Loki, Pyroscope) visible to `gcx alert instances list`.
- **`--name <regex>`**: case-insensitive regex filter on rule name (e.g. `--name Tempo` to show only Tempo alerts).

Example:
```
gcx alert instances list --datasource grafanacloud-prom --state firing --name Tempo
```

## Motivation

Product team alerts are evaluated by the Mimir ruler and served through Prometheus datasources at `/api/prometheus/{uid}/api/v1/rules`. The command previously only queried `/api/prometheus/grafana/api/v1/rules` (Grafana-managed rules), making the majority of infrastructure alerts invisible.

## Test plan

- [x] `go build ./cmd/gcx/` compiles cleanly
- [x] `go test ./internal/providers/alert/...` passes
- [x] Verified default behavior (no `--datasource`) still works against Grafana-managed rules
- [x] Verified `--datasource grafanacloud-prom --state firing --name Tempo` returns Tempo Mimir ruler alerts
- [x] Verified `--name` regex is case-insensitive and filters correctly