### PR TITLE
chore(release): v0.2.9 changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "gcx",
       "source": "./claude-plugin",
       "description": "Debug, explore, and instrument with Grafana using gcx CLI",
-      "version": "0.1.0"
+      "version": "0.2.9"
     }
   ]
 }

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,21 +1,7 @@
-- Rename `gcx sigil` command and provider to `gcx aio11y` (AI Observability)
-- Fix OAuth refresh lockout when running multiple gcx invocations concurrently
-- Improve typed API error handling for datasource queries
-- Rename OnCall/Incidents references to IRM across docs and CLI
-- Default SLO definitions list limit to all results
-- Add Homebrew installation support with docs
-- Allow login through grafana.com/launch
-- Unified CLI UX consistency pass across commands
-- Reorganise and clean up README
-- Add DatasourceProvider interface and plugin system for datasources
-- Add billing subtree and generic series leaf to metrics
-- Add --from/--to time range flags to all kg commands
-- Validate kg --scope flag values against known scopes
-- Remove redundant kg search entities command
-- Filter incidents by tags and from/to time range
-- Add fleet auth error scopes suggestion
-- Add sigil skill to claude-plugin
-- Guide agents to use Grafana Assistant for reasoning tasks
-- Recognise OPENCODE as an agent mode
-- Bump Kubernetes dependencies to v0.35.4 and Docker deps
-- Update anthropics/claude-code-action workflow digest
+- Consolidated `gcx auth` and `gcx config` into a unified `gcx login` command
+- Renamed `gcx sigil` command and provider to `gcx aio11y` (AI Observability)
+- Fixed `gcx irm` to pass `--max-age` filter through to the OnCall backend
+- Added PyPI publishing to the release workflow
+- Bumped Claude plugin version automatically on release
+- Added Grafana Cloud API tiers architectural overview to the docs
+- Added compatibility matrix to the README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.2.9 (2026-04-23)
+
+- Consolidated `gcx auth` and `gcx config` into a unified `gcx login` command
+- Renamed `gcx sigil` command and provider to `gcx aio11y` (AI Observability)
+- Fixed `gcx irm` to pass `--max-age` filter through to the OnCall backend
+- Added PyPI publishing to the release workflow
+- Bumped Claude plugin version automatically on release
+- Added Grafana Cloud API tiers architectural overview to the docs
+- Added compatibility matrix to the README
+
+
 ## v0.2.8 (2026-04-20)
 
 - Rename `gcx sigil` command and provider to `gcx aio11y` (AI Observability)

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcx",
-  "version": "0.1.0",
+  "version": "0.2.9",
   "description": "Debug, explore, and instrument with Grafana using gcx CLI",
   "keywords": ["grafana", "observability", "monitoring", "prometheus", "loki", "dashboards"],
   "author": {


### PR DESCRIPTION
## Summary
- Bumps version to v0.2.9
- Generates CHANGELOG.md entry and .release-notes.md
- Bumps Claude plugin version to 0.2.9

## Test plan
- [x] `make tag BUMP=patch` (DRY_RUN) generated entries cleanly
- [ ] CI passes
- [ ] After merge, tag v0.2.9 on main to trigger GoReleaser

🤖 Generated with [Claude Code](https://claude.com/claude-code)