### PR TITLE
chore: remove pypi publishing job from release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,59 +54,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
 
-  pypi:
-    needs: release
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    environment:
-      name: pypi
-      url: https://pypi.org/p/gcx/
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: false
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: false
-
-      - name: Build wheels
-        run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          COMMIT=$(git rev-parse --short=7 HEAD)
-          DATE=$(git show -s --format=%cI HEAD)
-          # Normalize semver pre-release to PEP 440 (e.g. 1.0.0-rc.1 -> 1.0.0rc1)
-          PEP440_VERSION=$(echo "$VERSION" | sed 's/-alpha\./a/; s/-beta\./b/; s/-rc\./rc/')
-          # TODO: switch to `uvx go-to-wheel` once --package-path is released
-          # (see https://github.com/simonw/go-to-wheel/pull/5)
-          uvx --from "go-to-wheel @ git+https://github.com/nikaro/go-to-wheel@f7939c6868e195204eae1370f899933e555513e3" \
-            go-to-wheel . \
-            --package-path ./cmd/gcx \
-            --name gcx \
-            --version "$PEP440_VERSION" \
-            --description "Grafana Cloud CLI" \
-            --url "https://github.com/grafana/gcx" \
-            --license "Apache-2.0" \
-            --ldflags "-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X main.date=$DATE" \
-            --readme README.md
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          skip-existing: true
-
   publish_homebrew_formula:
     name: Publish Homebrew formula
     needs: release


### PR DESCRIPTION
The built binaries are too big to fit in a wheel, and I don't want to abuse PyPI
any more by asking for a limit increase, so just remove this installation method.

It's not documented anywhere, and Homebrew is working fine now, so it's not a huge
deal IMO.
