### PR TITLE
fix: re-enable grafana-com instance selector

### DIFF
--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -263,12 +263,16 @@ func askForInput(e *login.ErrNeedInput, opts *login.Options, sourceCtx *config.C
 	for _, field := range e.Fields {
 		switch field {
 		case "server":
+			description := "e.g. https://my-stack.grafana.net"
+			if opts.GrafanaToken == "" {
+				description += "\nLeave empty to select your Grafana Cloud instance interactively"
+			}
 			form := huh.NewForm(huh.NewGroup(
 				huh.NewInput().
 					Title("Grafana server URL").
-					Description("e.g. https://my-stack.grafana.net").
+					Description(description).
 					Validate(func(s string) error {
-						if s == "" {
+						if opts.GrafanaToken != "" && s == "" {
 							return errors.New("server URL is required")
 						}
 						return nil
@@ -277,6 +281,10 @@ func askForInput(e *login.ErrNeedInput, opts *login.Options, sourceCtx *config.C
 			))
 			if err := form.Run(); err != nil {
 				return err
+			}
+			if opts.Server == "" {
+				opts.UseCloudInstanceSelector = true
+				return nil
 			}
 
 		case "grafana-auth":

--- a/docs/architecture/login-system.md
+++ b/docs/architecture/login-system.md
@@ -46,6 +46,7 @@ classDiagram
         Target, GrafanaToken
         CloudToken, CloudAPIURL
         UseOAuth, Yes, Writer
+        UseCloudInstanceSelector
     }
     class Hooks {
         ConfigSource
@@ -109,8 +110,7 @@ flowchart TD
     Start([Run entry]) --> Server{Server set?}
     Server -->|no| SrvSentinel[Return ErrNeedInput&#123;server&#125;]
     Server -->|yes| Scheme[Normalize scheme:<br/>default https]
-    Scheme --> Ctx[Derive context name]
-    Ctx --> Detect[Detect target]
+    Scheme --> Detect[Detect target]
     Detect --> TgtKnown{Target resolved?}
     TgtKnown -->|no, interactive| TgtSentinel[Return ErrNeedClarification&#123;target&#125;]
     TgtKnown -->|no, --yes or agent| TgtOnPrem[Force TargetOnPrem]
@@ -118,7 +118,8 @@ flowchart TD
     TgtOnPrem --> Auth
     Auth --> AuthHave{Token or OAuth?}
     AuthHave -->|no| AuthSentinel[Return ErrNeedInput&#123;grafana-auth&#125;]
-    AuthHave -->|yes| Cloud[Resolve cloud auth]
+    AuthHave -->|yes| Ctx[Derive context name]
+    Ctx --> Cloud[Resolve cloud auth]
     Cloud --> CloudNeeded{Cloud target<br/>+ no token?}
     CloudNeeded -->|yes, interactive| CloudSentinel[Return ErrNeedInput&#123;cloud-token&#125;<br/>Optional=true]
     CloudNeeded -->|no or skip| Validate[Validation pipeline]
@@ -135,25 +136,25 @@ The pipeline reads top-to-bottom in `Run()` (login.go:180). Each step returns
 early on failure; sentinel branches unwind to the CLI for interactive
 resolution and re-entry:
 
-1. **Server check** (login.go:182). Missing server → `ErrNeedInput{server}`.
-2. **Scheme normalization** (login.go:188). A bare hostname is rewritten to
+1. **Server check** (login.go:184). Missing server → `ErrNeedInput{server}`.
+2. **Scheme normalization** (login.go:191). A bare hostname is rewritten to
    `https://<host>`. Callers that need `http://` must pass it explicitly.
-3. **Context-name derivation** (login.go:193). Falls back to
-   `config.ContextNameFromServerURL`, which returns the stack slug for known
-   Grafana Cloud URLs and a hyphenated hostname otherwise.
-4. **Target detection** (login.go:199). Delegates to `detectTarget`; see the
+3. **Target detection** (login.go:194). Delegates to `detectTarget`; see the
    next section. An unresolved target with `--yes` or agent mode falls
    through to `TargetOnPrem`; otherwise it yields
    `ErrNeedClarification{target}`.
-5. **Grafana auth resolution** (`resolveGrafanaAuth`, login.go:304). Picks
+4. **Grafana auth resolution** (`resolveGrafanaAuth`, login.go:223). Picks
    between explicit token and OAuth based on input flags. Missing auth
    yields `ErrNeedInput{grafana-auth}`.
-6. **Cloud auth resolution** (`resolveCloudAuth`, login.go:373). Only runs
+5. **Context-name derivation** (login.go:234). Falls back to
+   `config.ContextNameFromServerURL`, which returns the stack slug for known
+   Grafana Cloud URLs and a hyphenated hostname otherwise.
+6. **Cloud auth resolution** (`resolveCloudAuth`, login.go:383). Only runs
    for `TargetCloud`; a missing token yields an optional
    `ErrNeedInput{cloud-token}` that the CLI may skip.
-7. **Validation** (login.go:246). Delegated to `Validate` (see below); the
+7. **Validation** (login.go:245). Delegated to `Validate` (see below); the
    CLI offers an escape hatch for interactive users when validation fails.
-8. **Persistence** (`persistContext`, login.go:400). Writes only after all
+8. **Persistence** (`persistContext`, login.go:414). Writes only after all
    checks pass; may raise `ErrNeedClarification{allow-override}` when the
    context already targets a different server.
 

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -224,15 +224,16 @@ func (f *Flow) startCallbackServer(ctx context.Context, bindAddress string, port
 			}
 
 			instanceEndpoint := r.URL.Query().Get("instanceEndpoint")
-			if instanceEndpoint != "" {
-				// only check if explicitly specified
-				// a missing value is not critical if the user has manually specified the grafana url
-				_, err = url.Parse(instanceEndpoint)
-				if err != nil {
-					errCh <- fmt.Errorf("invalid endpoint url: %w", err)
-					renderErrorPage(w, "Invalid instance endpoint passed")
-					return
-				}
+			instanceEndpointUrl, err := url.Parse(instanceEndpoint)
+			if err != nil {
+				errCh <- fmt.Errorf("invalid endpoint url: %w", err)
+				renderErrorPage(w, "Invalid instance endpoint passed")
+				return
+			}
+			if instanceEndpointUrl.Scheme != "https" {
+				errCh <- fmt.Errorf("invalid endpoint scheme: expected 'https', got '%s'", instanceEndpointUrl.Scheme)
+				renderErrorPage(w, "Invalid instance endpoint: needs to be an HTTPS URL")
+				return
 			}
 
 			result := &Result{

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -36,6 +36,10 @@ type Inputs struct {
 	CloudAPIURL  string
 	UseOAuth     bool
 	Yes          bool
+	// UseCloudInstanceSelector is only used internally to mark the case in which
+	// a user explicitly left the server empty to be directed to the cloud
+	// instance selector
+	UseCloudInstanceSelector bool
 
 	// Writer receives human-facing OAuth progress output. When nil, the
 	// internal/login package discards writes (NC-001: the package is UI-free
@@ -166,9 +170,9 @@ type AuthFlow interface {
 // Run orchestrates the full login lifecycle:
 //
 //  1. Validate server is set
-//  2. Derive context name
-//  3. Detect target (Cloud vs OnPrem)
-//  4. Resolve Grafana auth (token or OAuth)
+//  2. Detect target (Cloud vs OnPrem)
+//  3. Resolve Grafana auth (token or OAuth)
+//  4. Derive context name
 //  5. Resolve Cloud API token (Cloud targets only)
 //  6. Build REST config and run connectivity validation
 //  7. Persist context to config
@@ -179,24 +183,22 @@ type AuthFlow interface {
 // the CLI sentinel-retry flow. Callers that retry after ErrNeedInput /
 // ErrNeedClarification should reuse the same Options value.
 func Run(ctx context.Context, opts *Options) (Result, error) {
-	// Step 1: server must be set
-	if opts.Server == "" {
+	// Step 1: check if the server is set
+	if opts.Server == "" && !opts.UseCloudInstanceSelector {
 		return Result{}, &ErrNeedInput{Fields: []string{"server"}}
+	}
+	if opts.UseCloudInstanceSelector {
+		opts.UseOAuth = true
+		opts.Target = TargetCloud
 	}
 
 	// Normalize: missing scheme → default to https. Users who meant http://
 	// must pass the full URL explicitly; defaulting to https is safer.
-	if !strings.HasPrefix(opts.Server, "http://") && !strings.HasPrefix(opts.Server, "https://") {
+	if opts.Server != "" && !strings.HasPrefix(opts.Server, "http://") && !strings.HasPrefix(opts.Server, "https://") {
 		opts.Server = "https://" + opts.Server
 	}
 
-	// Step 2: derive context name
-	contextName := opts.ContextName
-	if contextName == "" {
-		contextName = config.ContextNameFromServerURL(opts.Server)
-	}
-
-	// Step 3: detect target
+	// Step 2: detect target
 	target := opts.Target
 	if target == TargetUnknown {
 		detected, err := detectTarget(ctx, *opts)
@@ -224,10 +226,21 @@ func Run(ctx context.Context, opts *Options) (Result, error) {
 	// layer can branch on target (e.g. drop the OAuth option for on-prem).
 	opts.Target = target
 
-	// Step 4: Grafana auth
+	// Step 3: Grafana auth
 	authMethod, grafanaCfg, err := resolveGrafanaAuth(ctx, *opts, target)
 	if err != nil {
 		return Result{}, err
+	}
+
+	// set the server if the user used the interactive instance selector
+	if opts.Server == "" {
+		opts.Server = grafanaCfg.Server
+	}
+
+	// Step 4: derive context name
+	contextName := opts.ContextName
+	if contextName == "" {
+		contextName = config.ContextNameFromServerURL(opts.Server)
 	}
 
 	// Step 5: Cloud API token (Cloud targets only)
@@ -340,6 +353,9 @@ func resolveGrafanaAuth(ctx context.Context, opts Options, target Target) (strin
 		result, err := flow.Run(ctx)
 		if err != nil {
 			return "", nil, fmt.Errorf("OAuth flow failed: %w", err)
+		}
+		if grafanaCfg.Server == "" {
+			grafanaCfg.Server = result.InstanceEndpoint
 		}
 		grafanaCfg.OAuthToken = result.Token
 		grafanaCfg.OAuthRefreshToken = result.RefreshToken

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -51,6 +51,7 @@ func TestRun(t *testing.T) { //nolint:maintidx // 8 table-driven cases; complexi
 		ExpiresAt:        "2030-01-01T00:00:00Z",
 		RefreshExpiresAt: "2030-06-01T00:00:00Z",
 		APIEndpoint:      "https://mystack.grafana.net/api",
+		InstanceEndpoint: "https://mystack.grafana.net",
 	}
 
 	tests := []struct {
@@ -319,6 +320,33 @@ func TestRun(t *testing.T) { //nolint:maintidx // 8 table-driven cases; complexi
 				assert.Equal(t, "rotated-token", ctx.Grafana.APIToken)
 				assert.Equal(t, "token", ctx.Grafana.AuthMethod)
 				assert.EqualValues(t, 42, ctx.Grafana.OrgID, "OrgID must be preserved in re-auth")
+			},
+		},
+		{
+			// AC-013: Redirect to grafana.com on empty server selection
+			name: "redirect_grafana_com_empty_server",
+			opts: func(dir string) login.Options {
+				return login.Options{
+					Inputs: login.Inputs{
+						UseCloudInstanceSelector: true,
+						Yes:                      true,
+					},
+					Hooks: login.Hooks{
+						ConfigSource: configSource(dir),
+						ValidateFn:   noopValidate,
+						NewAuthFlow: func(_ string, _ auth.Options) login.AuthFlow {
+							return &stubAuthFlow{result: oauthResult}
+						},
+					},
+				}
+			},
+			checkConfig: func(t *testing.T, cfg config.Config) {
+				t.Helper()
+				ctx := cfg.Contexts["mystack"]
+				require.NotNil(t, ctx)
+				assert.Equal(t, oauthResult.InstanceEndpoint, ctx.Grafana.Server)
+				assert.Equal(t, "gat_test", ctx.Grafana.OAuthToken)
+				assert.Equal(t, "oauth", ctx.Grafana.AuthMethod)
 			},
 		},
 	}


### PR DESCRIPTION
#529 removed functionality introduced in #481

This PR adds back this functionality by launching the interactive instance selector when no server is provided