### PR TITLE
fix: suggest required scopes on adaptive command auth errors

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -889,35 +889,32 @@ func adaptiveScopeSuggestionFromSignalPrefix(msg string) string {
 	}
 }
 
-type adaptiveMetricsResource struct {
-	keyword   string
-	base      string
-	reads     []string
-	writes    []string
-	deleteKey string
-}
-
-// adaptiveMetricsResources maps error message keywords to scope prefixes.
-// Operation matches are checked in priority order: delete > write > read.
-var adaptiveMetricsResources = []adaptiveMetricsResource{
-	{"rule", "adaptive-metrics-rules",
-		[]string{"list rules", "get rule", "list recommended rules"},
-		[]string{"create rule", "update rule", "sync rules", "validate rules"},
-		"delete rule"},
-	{"recommendation", "adaptive-metrics-recommendations",
-		[]string{"list recommendations"}, nil, ""},
-	{"segment", "adaptive-metrics-segments",
-		[]string{"list segments"},
-		[]string{"create segment", "update segment"},
-		"delete segment"},
-	{"exemption", "adaptive-metrics-exemptions",
-		[]string{"list exemptions", "list segmented exemptions", "get exemption"},
-		[]string{"create exemption", "update exemption"},
-		"delete exemption"},
-}
-
 func adaptiveMetricsScopeFromError(msg string) string {
-	for _, r := range adaptiveMetricsResources {
+	type resource struct {
+		keyword   string
+		base      string
+		reads     []string
+		writes    []string
+		deleteKey string
+	}
+	// Operation matches are checked in priority order: delete > write > read.
+	resources := []resource{
+		{"rule", "adaptive-metrics-rules",
+			[]string{"list rules", "get rule", "list recommended rules"},
+			[]string{"create rule", "update rule", "sync rules", "validate rules"},
+			"delete rule"},
+		{"recommendation", "adaptive-metrics-recommendations",
+			[]string{"list recommendations"}, nil, ""},
+		{"segment", "adaptive-metrics-segments",
+			[]string{"list segments"},
+			[]string{"create segment", "update segment"},
+			"delete segment"},
+		{"exemption", "adaptive-metrics-exemptions",
+			[]string{"list exemptions", "list segmented exemptions", "get exemption"},
+			[]string{"create exemption", "update exemption"},
+			"delete exemption"},
+	}
+	for _, r := range resources {
 		if !strings.Contains(msg, r.keyword) {
 			continue
 		}

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -487,7 +487,7 @@ func convertServiceAPIErrors(err error) (*DetailedError, bool) {
 			Parent:  err,
 			Summary: "Adaptive Logs: permission denied",
 			Suggestions: []string{
-				"Ensure your access policy includes the adaptive-logs:admin scope",
+				"Ensure your Grafana Cloud access policy includes the adaptive-logs:admin scope",
 			},
 			ExitCode: new(ExitAuthFailure),
 		}, true
@@ -807,23 +807,23 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 	}
 
 	// Adaptive Traces scope errors.
-	if strings.Contains(msg, "traces:") && strings.Contains(msg, "invalid scope") {
+	if strings.Contains(msg, "adaptive-traces:") && strings.Contains(msg, "invalid scope") {
 		return &DetailedError{
 			Parent:  err,
 			Summary: "Adaptive Traces: permission denied",
 			Suggestions: []string{
-				"Ensure your access policy includes the adaptive-traces:admin scope",
+				"Ensure your Grafana Cloud access policy includes the adaptive-traces:admin scope",
 			},
 			ExitCode: new(ExitAuthFailure),
 		}, true
 	}
 
 	// Adaptive Metrics scope errors.
-	if strings.Contains(msg, "metrics:") && strings.Contains(msg, "invalid scope") {
+	if strings.Contains(msg, "adaptive-metrics:") && strings.Contains(msg, "invalid scope") {
 		scope := adaptiveMetricsScopeFromError(msg)
-		suggestion := fmt.Sprintf("Ensure your access policy includes the %s scope", scope)
+		suggestion := fmt.Sprintf("Ensure your Grafana Cloud access policy includes the %s scope", scope)
 		if scope == "" {
-			suggestion = "Adaptive Metrics commands require an adaptive-metrics-* scope (the specific scope depends on the subcommand)"
+			suggestion = "Adaptive Metrics commands require an adaptive-metrics-* scope on your Grafana Cloud access policy (the specific scope depends on the subcommand)"
 		}
 		return &DetailedError{
 			Parent:      err,
@@ -850,7 +850,7 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 	// Stack info lookup forbidden — access policy missing stacks:read scope.
 	if strings.Contains(msg, "failed to get stack info for") && strings.Contains(msg, "status 403") {
 		suggestions := []string{
-			"Ensure your access policy includes the stacks:read scope",
+			"Ensure your Grafana Cloud access policy includes the stacks:read scope",
 		}
 		if suggestion := adaptiveScopeSuggestionFromSignalPrefix(msg); suggestion != "" {
 			suggestions = append(suggestions, suggestion)
@@ -880,11 +880,11 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 func adaptiveScopeSuggestionFromSignalPrefix(msg string) string {
 	switch {
 	case strings.Contains(msg, "adaptive-logs:"):
-		return "Ensure your access policy includes the adaptive-logs:admin scope"
+		return "Ensure your Grafana Cloud access policy includes the adaptive-logs:admin scope"
 	case strings.Contains(msg, "adaptive-metrics:"):
-		return "Adaptive Metrics commands also require an adaptive-metrics-* scope (the specific scope depends on the subcommand)"
+		return "Adaptive Metrics commands also require an adaptive-metrics-* scope on your Grafana Cloud access policy (the specific scope depends on the subcommand)"
 	case strings.Contains(msg, "adaptive-traces:"):
-		return "Ensure your access policy includes the adaptive-traces:admin scope"
+		return "Ensure your Grafana Cloud access policy includes the adaptive-traces:admin scope"
 	default:
 		return ""
 	}

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -851,8 +851,8 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 		suggestions := []string{
 			"Ensure your access policy includes the stacks:read scope",
 		}
-		if scope := adaptiveScopeFromSignalPrefix(msg); scope != "" {
-			suggestions = append(suggestions, fmt.Sprintf("Ensure your access policy includes the %s scope", scope))
+		if suggestion := adaptiveScopeSuggestionFromSignalPrefix(msg); suggestion != "" {
+			suggestions = append(suggestions, suggestion)
 		}
 		return &DetailedError{
 			Parent:      err,
@@ -876,16 +876,14 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 	return nil, false
 }
 
-// adaptiveScopeFromSignalPrefix extracts the signal from the "adaptive-<signal>:" error
-// prefix and returns the primary scope needed for that signal's commands.
-func adaptiveScopeFromSignalPrefix(msg string) string {
+func adaptiveScopeSuggestionFromSignalPrefix(msg string) string {
 	switch {
 	case strings.Contains(msg, "adaptive-logs:"):
-		return "adaptive-logs:admin"
+		return "Ensure your access policy includes the adaptive-logs:admin scope"
 	case strings.Contains(msg, "adaptive-metrics:"):
-		return "adaptive-metrics-rules:read"
+		return "Adaptive Metrics commands also require an adaptive-metrics-* scope (the specific scope depends on the subcommand)"
 	case strings.Contains(msg, "adaptive-traces:"):
-		return "adaptive-traces:admin"
+		return "Ensure your access policy includes the adaptive-traces:admin scope"
 	default:
 		return ""
 	}

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -826,10 +826,10 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 			suggestion = "Adaptive Metrics commands require an adaptive-metrics-* scope (the specific scope depends on the subcommand)"
 		}
 		return &DetailedError{
-			Parent:  err,
-			Summary: "Adaptive Metrics: permission denied",
+			Parent:      err,
+			Summary:     "Adaptive Metrics: permission denied",
 			Suggestions: []string{suggestion},
-			ExitCode: new(ExitAuthFailure),
+			ExitCode:    new(ExitAuthFailure),
 		}, true
 	}
 

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -477,7 +477,9 @@ func convertServiceAPIErrors(err error) (*DetailedError, bool) {
 		return nil, false
 	}
 
-	// Adaptive Logs scope errors — consistent format with traces/metrics handlers in convertCloudConfigErrors.
+	// Adaptive Logs scope errors — handled here (not in convertCloudConfigErrors with
+	// traces/metrics) because the logs client returns a typed APIError that this converter
+	// catches before convertCloudConfigErrors runs.
 	if apiErr.APIServiceName() == "Adaptive Logs" &&
 		strings.Contains(apiErr.APIUserMessage(), "invalid scope") &&
 		(apiErr.HTTPStatusCode() == http.StatusUnauthorized || apiErr.HTTPStatusCode() == http.StatusForbidden) {

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -794,6 +794,20 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 		}, true
 	}
 
+	// Adaptive Metrics scope errors.
+	if strings.Contains(msg, "metrics:") && strings.Contains(msg, "invalid scope") {
+		if scope := adaptiveMetricsScopeFromError(msg); scope != "" {
+			return &DetailedError{
+				Parent:  err,
+				Summary: "Adaptive Metrics: permission denied",
+				Suggestions: []string{
+					fmt.Sprintf("Ensure your access policy includes the %s scope", scope),
+				},
+				ExitCode: new(ExitAuthFailure),
+			}, true
+		}
+	}
+
 	// Fleet management not available.
 	if strings.Contains(msg, "fleet management endpoint is not available") ||
 		strings.Contains(msg, "fleet management instance ID is not available") {
@@ -810,13 +824,17 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 
 	// Stack info lookup forbidden — access policy missing stacks:read scope.
 	if strings.Contains(msg, "failed to get stack info for") && strings.Contains(msg, "status 403") {
+		suggestions := []string{
+			"Ensure your access policy includes the stacks:read scope",
+		}
+		if scope := adaptiveScopeFromSignalPrefix(msg); scope != "" {
+			suggestions = append(suggestions, fmt.Sprintf("Ensure your access policy includes the %s scope", scope))
+		}
 		return &DetailedError{
-			Parent:  err,
-			Summary: "Cloud stack lookup: permission denied",
-			Suggestions: []string{
-				"Ensure your access policy includes the stacks:read scope",
-			},
-			ExitCode: new(ExitAuthFailure),
+			Parent:      err,
+			Summary:     "Cloud stack lookup: permission denied",
+			Suggestions: suggestions,
+			ExitCode:    new(ExitAuthFailure),
 		}, true
 	}
 
@@ -832,6 +850,70 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 	}
 
 	return nil, false
+}
+
+// adaptiveScopeFromSignalPrefix extracts the signal from the "adaptive-<signal>:" error
+// prefix and returns the primary scope needed for that signal's commands.
+func adaptiveScopeFromSignalPrefix(msg string) string {
+	switch {
+	case strings.Contains(msg, "adaptive-logs:"):
+		return "adaptive-logs:admin"
+	case strings.Contains(msg, "adaptive-metrics:"):
+		return "adaptive-metrics-rules:read"
+	case strings.Contains(msg, "adaptive-traces:"):
+		return "adaptive-traces:admin"
+	default:
+		return ""
+	}
+}
+
+type adaptiveMetricsResource struct {
+	keyword   string
+	base      string
+	reads     []string
+	writes    []string
+	deleteKey string
+}
+
+// adaptiveMetricsResources maps error message keywords to scope prefixes.
+// Operation matches are checked in priority order: delete > write > read.
+var adaptiveMetricsResources = []adaptiveMetricsResource{
+	{"rule", "adaptive-metrics-rules",
+		[]string{"list rules", "get rule", "list recommended rules"},
+		[]string{"create rule", "update rule", "sync rules", "validate rules"},
+		"delete rule"},
+	{"recommendation", "adaptive-metrics-recommendations",
+		[]string{"list recommendations"}, nil, ""},
+	{"segment", "adaptive-metrics-segments",
+		[]string{"list segments"},
+		[]string{"create segment", "update segment"},
+		"delete segment"},
+	{"exemption", "adaptive-metrics-exemptions",
+		[]string{"list exemptions", "list segmented exemptions", "get exemption"},
+		[]string{"create exemption", "update exemption"},
+		"delete exemption"},
+}
+
+func adaptiveMetricsScopeFromError(msg string) string {
+	for _, r := range adaptiveMetricsResources {
+		if !strings.Contains(msg, r.keyword) {
+			continue
+		}
+		if r.deleteKey != "" && strings.Contains(msg, r.deleteKey) {
+			return r.base + ":delete"
+		}
+		for _, v := range r.writes {
+			if strings.Contains(msg, v) {
+				return r.base + ":write"
+			}
+		}
+		for _, v := range r.reads {
+			if strings.Contains(msg, v) {
+				return r.base + ":read"
+			}
+		}
+	}
+	return ""
 }
 
 func fallbackDetailedError(err error) *DetailedError {

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -477,6 +477,20 @@ func convertServiceAPIErrors(err error) (*DetailedError, bool) {
 		return nil, false
 	}
 
+	// Adaptive Logs scope errors — consistent format with traces/metrics handlers in convertCloudConfigErrors.
+	if apiErr.APIServiceName() == "Adaptive Logs" &&
+		strings.Contains(apiErr.APIUserMessage(), "invalid scope") &&
+		(apiErr.HTTPStatusCode() == http.StatusUnauthorized || apiErr.HTTPStatusCode() == http.StatusForbidden) {
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Adaptive Logs: permission denied",
+			Suggestions: []string{
+				"Ensure your access policy includes the adaptive-logs:admin scope",
+			},
+			ExitCode: new(ExitAuthFailure),
+		}, true
+	}
+
 	detailedErr := &DetailedError{
 		Summary:     serviceAPIErrorSummary(apiErr),
 		Details:     joinErrorDetails(wrappedTypedErrorContext(err, apiErr), strings.TrimSpace(apiErr.APIUserMessage())),
@@ -511,14 +525,10 @@ func serviceAPIErrorSummary(apiErr serviceAPIError) string {
 func serviceAPIErrorSuggestions(apiErr serviceAPIError) []string {
 	switch apiErr.HTTPStatusCode() {
 	case http.StatusUnauthorized, http.StatusForbidden:
-		suggestions := []string{
+		return []string{
 			"Review your Grafana credentials: gcx config view",
 			"Re-authenticate if needed: gcx auth login",
 		}
-		if apiErr.APIServiceName() == "Adaptive Logs" && strings.Contains(apiErr.APIUserMessage(), "invalid scope") {
-			suggestions = append(suggestions, "Ensure your access policy includes the adaptive-logs:admin scope")
-		}
-		return suggestions
 	default:
 		return nil
 	}

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -820,16 +820,17 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 
 	// Adaptive Metrics scope errors.
 	if strings.Contains(msg, "metrics:") && strings.Contains(msg, "invalid scope") {
-		if scope := adaptiveMetricsScopeFromError(msg); scope != "" {
-			return &DetailedError{
-				Parent:  err,
-				Summary: "Adaptive Metrics: permission denied",
-				Suggestions: []string{
-					fmt.Sprintf("Ensure your access policy includes the %s scope", scope),
-				},
-				ExitCode: new(ExitAuthFailure),
-			}, true
+		scope := adaptiveMetricsScopeFromError(msg)
+		suggestion := fmt.Sprintf("Ensure your access policy includes the %s scope", scope)
+		if scope == "" {
+			suggestion = "Adaptive Metrics commands require an adaptive-metrics-* scope (the specific scope depends on the subcommand)"
 		}
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Adaptive Metrics: permission denied",
+			Suggestions: []string{suggestion},
+			ExitCode: new(ExitAuthFailure),
+		}, true
 	}
 
 	// Fleet management not available.

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -794,6 +794,18 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 		}, true
 	}
 
+	// Adaptive Traces scope errors.
+	if strings.Contains(msg, "traces:") && strings.Contains(msg, "invalid scope") {
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Adaptive Traces: permission denied",
+			Suggestions: []string{
+				"Ensure your access policy includes the adaptive-traces:admin scope",
+			},
+			ExitCode: new(ExitAuthFailure),
+		}, true
+	}
+
 	// Adaptive Metrics scope errors.
 	if strings.Contains(msg, "metrics:") && strings.Contains(msg, "invalid scope") {
 		if scope := adaptiveMetricsScopeFromError(msg); scope != "" {

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -511,10 +511,14 @@ func serviceAPIErrorSummary(apiErr serviceAPIError) string {
 func serviceAPIErrorSuggestions(apiErr serviceAPIError) []string {
 	switch apiErr.HTTPStatusCode() {
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return []string{
+		suggestions := []string{
 			"Review your Grafana credentials: gcx config view",
 			"Re-authenticate if needed: gcx auth login",
 		}
+		if apiErr.APIServiceName() == "Adaptive Logs" && strings.Contains(apiErr.APIUserMessage(), "invalid scope") {
+			suggestions = append(suggestions, "Ensure your access policy includes the adaptive-logs:admin scope")
+		}
+		return suggestions
 	default:
 		return nil
 	}

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -488,23 +488,23 @@ func TestErrorToDetailedError_AdaptiveMetricsScopeError(t *testing.T) {
 		err       error
 		wantScope string
 	}{
-		{"list rules", errors.New(`metrics: list rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:read"},
-		{"get rule", errors.New(`metrics: get rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:read"},
-		{"list recommended rules", errors.New(`metrics: list recommended rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:read"},
-		{"create rule", errors.New(`metrics: create rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
-		{"update rule", errors.New(`metrics: update rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
-		{"sync rules", errors.New(`metrics: sync rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
-		{"validate rules", errors.New(`metrics: validate rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
-		{"delete rule", errors.New(`metrics: delete rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:delete"},
-		{"list recommendations", errors.New(`metrics: list recommendations: status 401: authentication error: invalid scope requested`), "adaptive-metrics-recommendations:read"},
-		{"list segments", errors.New(`metrics: list segments: status 401: authentication error: invalid scope requested`), "adaptive-metrics-segments:read"},
-		{"create segment", errors.New(`metrics: create segment: status 401: authentication error: invalid scope requested`), "adaptive-metrics-segments:write"},
-		{"delete segment", errors.New(`metrics: delete segment: status 401: authentication error: invalid scope requested`), "adaptive-metrics-segments:delete"},
-		{"list exemptions", errors.New(`metrics: list exemptions: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:read"},
-		{"list segmented exemptions", errors.New(`metrics: list segmented exemptions: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:read"},
-		{"get exemption", errors.New(`metrics: get exemption: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:read"},
-		{"create exemption", errors.New(`metrics: create exemption: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:write"},
-		{"delete exemption", errors.New(`metrics: delete exemption: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:delete"},
+		{"list rules", errors.New(`adaptive-metrics: list rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:read"},
+		{"get rule", errors.New(`adaptive-metrics: get rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:read"},
+		{"list recommended rules", errors.New(`adaptive-metrics: list recommended rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:read"},
+		{"create rule", errors.New(`adaptive-metrics: create rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
+		{"update rule", errors.New(`adaptive-metrics: update rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
+		{"sync rules", errors.New(`adaptive-metrics: sync rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
+		{"validate rules", errors.New(`adaptive-metrics: validate rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
+		{"delete rule", errors.New(`adaptive-metrics: delete rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:delete"},
+		{"list recommendations", errors.New(`adaptive-metrics: list recommendations: status 401: authentication error: invalid scope requested`), "adaptive-metrics-recommendations:read"},
+		{"list segments", errors.New(`adaptive-metrics: list segments: status 401: authentication error: invalid scope requested`), "adaptive-metrics-segments:read"},
+		{"create segment", errors.New(`adaptive-metrics: create segment: status 401: authentication error: invalid scope requested`), "adaptive-metrics-segments:write"},
+		{"delete segment", errors.New(`adaptive-metrics: delete segment: status 401: authentication error: invalid scope requested`), "adaptive-metrics-segments:delete"},
+		{"list exemptions", errors.New(`adaptive-metrics: list exemptions: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:read"},
+		{"list segmented exemptions", errors.New(`adaptive-metrics: list segmented exemptions: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:read"},
+		{"get exemption", errors.New(`adaptive-metrics: get exemption: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:read"},
+		{"create exemption", errors.New(`adaptive-metrics: create exemption: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:write"},
+		{"delete exemption", errors.New(`adaptive-metrics: delete exemption: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:delete"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -523,14 +523,14 @@ func TestErrorToDetailedError_AdaptiveTracesScopeError(t *testing.T) {
 		name string
 		err  error
 	}{
-		{"list policies", errors.New(`traces: list policies: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
-		{"get policy", errors.New(`traces: get policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
-		{"create policy", errors.New(`traces: create policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
-		{"update policy", errors.New(`traces: update policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
-		{"delete policy", errors.New(`traces: delete policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
-		{"list recommendations", errors.New(`traces: list recommendations: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
-		{"apply recommendation", errors.New(`traces: apply recommendation: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
-		{"dismiss recommendation", errors.New(`traces: dismiss recommendation: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"list policies", errors.New(`adaptive-traces: list policies: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"get policy", errors.New(`adaptive-traces: get policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"create policy", errors.New(`adaptive-traces: create policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"update policy", errors.New(`adaptive-traces: update policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"delete policy", errors.New(`adaptive-traces: delete policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"list recommendations", errors.New(`adaptive-traces: list recommendations: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"apply recommendation", errors.New(`adaptive-traces: apply recommendation: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"dismiss recommendation", errors.New(`adaptive-traces: dismiss recommendation: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -450,24 +450,24 @@ func TestErrorToDetailedError_FleetScopeError(t *testing.T) {
 
 func TestErrorToDetailedError_StacksReadAdaptiveContext(t *testing.T) {
 	tests := []struct {
-		name      string
-		err       error
-		wantScope string
+		name           string
+		err            error
+		wantSuggestion string
 	}{
 		{
-			name:      "logs signal suggests adaptive-logs:admin",
-			err:       errors.New(`adaptive-logs: failed to load cloud config for token: failed to get stack info for "mystack": gcom client: unexpected status 403 Forbidden`),
-			wantScope: "adaptive-logs:admin",
+			name:           "logs signal suggests adaptive-logs:admin",
+			err:            errors.New(`adaptive-logs: failed to load cloud config for token: failed to get stack info for "mystack": gcom client: unexpected status 403 Forbidden`),
+			wantSuggestion: "adaptive-logs:admin",
 		},
 		{
-			name:      "metrics signal suggests adaptive-metrics-rules:read",
-			err:       errors.New(`adaptive-metrics: failed to load cloud config for token: failed to get stack info for "mystack": gcom client: unexpected status 403 Forbidden`),
-			wantScope: "adaptive-metrics-rules:read",
+			name:           "metrics signal mentions adaptive-metrics-* scope",
+			err:            errors.New(`adaptive-metrics: failed to load cloud config for token: failed to get stack info for "mystack": gcom client: unexpected status 403 Forbidden`),
+			wantSuggestion: "adaptive-metrics-*",
 		},
 		{
-			name:      "traces signal suggests adaptive-traces:admin",
-			err:       errors.New(`adaptive-traces: failed to load cloud config for token: failed to get stack info for "mystack": gcom client: unexpected status 403 Forbidden`),
-			wantScope: "adaptive-traces:admin",
+			name:           "traces signal suggests adaptive-traces:admin",
+			err:            errors.New(`adaptive-traces: failed to load cloud config for token: failed to get stack info for "mystack": gcom client: unexpected status 403 Forbidden`),
+			wantSuggestion: "adaptive-traces:admin",
 		},
 	}
 	for _, tc := range tests {
@@ -477,7 +477,7 @@ func TestErrorToDetailedError_StacksReadAdaptiveContext(t *testing.T) {
 			assert.Equal(t, "Cloud stack lookup: permission denied", got.Summary)
 			require.Len(t, got.Suggestions, 2)
 			assert.Contains(t, got.Suggestions[0], "stacks:read")
-			assert.Contains(t, got.Suggestions[1], tc.wantScope)
+			assert.Contains(t, got.Suggestions[1], tc.wantSuggestion)
 		})
 	}
 }

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -446,6 +446,76 @@ func TestErrorToDetailedError_FleetScopeError(t *testing.T) {
 	}
 }
 
+func TestErrorToDetailedError_StacksReadAdaptiveContext(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantScope string
+	}{
+		{
+			name:      "logs signal suggests adaptive-logs:admin",
+			err:       errors.New(`adaptive-logs: failed to load cloud config for token: failed to get stack info for "mystack": gcom client: unexpected status 403 Forbidden`),
+			wantScope: "adaptive-logs:admin",
+		},
+		{
+			name:      "metrics signal suggests adaptive-metrics-rules:read",
+			err:       errors.New(`adaptive-metrics: failed to load cloud config for token: failed to get stack info for "mystack": gcom client: unexpected status 403 Forbidden`),
+			wantScope: "adaptive-metrics-rules:read",
+		},
+		{
+			name:      "traces signal suggests adaptive-traces:admin",
+			err:       errors.New(`adaptive-traces: failed to load cloud config for token: failed to get stack info for "mystack": gcom client: unexpected status 403 Forbidden`),
+			wantScope: "adaptive-traces:admin",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fail.ErrorToDetailedError(tc.err)
+			require.NotNil(t, got)
+			assert.Equal(t, "Cloud stack lookup: permission denied", got.Summary)
+			require.Len(t, got.Suggestions, 2)
+			assert.Contains(t, got.Suggestions[0], "stacks:read")
+			assert.Contains(t, got.Suggestions[1], tc.wantScope)
+		})
+	}
+}
+
+func TestErrorToDetailedError_AdaptiveMetricsScopeError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantScope string
+	}{
+		{"list rules", errors.New(`metrics: list rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:read"},
+		{"get rule", errors.New(`metrics: get rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:read"},
+		{"list recommended rules", errors.New(`metrics: list recommended rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:read"},
+		{"create rule", errors.New(`metrics: create rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
+		{"update rule", errors.New(`metrics: update rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
+		{"sync rules", errors.New(`metrics: sync rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
+		{"validate rules", errors.New(`metrics: validate rules: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:write"},
+		{"delete rule", errors.New(`metrics: delete rule: status 401: authentication error: invalid scope requested`), "adaptive-metrics-rules:delete"},
+		{"list recommendations", errors.New(`metrics: list recommendations: status 401: authentication error: invalid scope requested`), "adaptive-metrics-recommendations:read"},
+		{"list segments", errors.New(`metrics: list segments: status 401: authentication error: invalid scope requested`), "adaptive-metrics-segments:read"},
+		{"create segment", errors.New(`metrics: create segment: status 401: authentication error: invalid scope requested`), "adaptive-metrics-segments:write"},
+		{"delete segment", errors.New(`metrics: delete segment: status 401: authentication error: invalid scope requested`), "adaptive-metrics-segments:delete"},
+		{"list exemptions", errors.New(`metrics: list exemptions: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:read"},
+		{"list segmented exemptions", errors.New(`metrics: list segmented exemptions: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:read"},
+		{"get exemption", errors.New(`metrics: get exemption: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:read"},
+		{"create exemption", errors.New(`metrics: create exemption: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:write"},
+		{"delete exemption", errors.New(`metrics: delete exemption: status 401: authentication error: invalid scope requested`), "adaptive-metrics-exemptions:delete"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fail.ErrorToDetailedError(tc.err)
+			assert.Equal(t, "Adaptive Metrics: permission denied", got.Summary)
+			require.NotNil(t, got.ExitCode)
+			assert.Equal(t, fail.ExitAuthFailure, *got.ExitCode)
+			require.Len(t, got.Suggestions, 1)
+			assert.Contains(t, got.Suggestions[0], tc.wantScope)
+		})
+	}
+}
+
 func TestErrorToDetailedError_SMURLNotConfigured(t *testing.T) {
 	err := fmt.Errorf("failed to load SM config for checks: %w",
 		fmt.Errorf("SM URL not configured: %w", errors.New("no Grafana server configured: grafana config is required")))

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -516,6 +516,32 @@ func TestErrorToDetailedError_AdaptiveMetricsScopeError(t *testing.T) {
 	}
 }
 
+func TestErrorToDetailedError_AdaptiveTracesScopeError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"list policies", errors.New(`traces: list policies: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"get policy", errors.New(`traces: get policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"create policy", errors.New(`traces: create policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"update policy", errors.New(`traces: update policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"delete policy", errors.New(`traces: delete policy: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"list recommendations", errors.New(`traces: list recommendations: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"apply recommendation", errors.New(`traces: apply recommendation: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+		{"dismiss recommendation", errors.New(`traces: dismiss recommendation: unexpected status 401: {"status":"error","error":"authentication error: invalid scope requested"}`)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fail.ErrorToDetailedError(tc.err)
+			assert.Equal(t, "Adaptive Traces: permission denied", got.Summary)
+			require.NotNil(t, got.ExitCode)
+			assert.Equal(t, fail.ExitAuthFailure, *got.ExitCode)
+			require.Len(t, got.Suggestions, 1)
+			assert.Contains(t, got.Suggestions[0], "adaptive-traces:admin")
+		})
+	}
+}
+
 func TestErrorToDetailedError_SMURLNotConfigured(t *testing.T) {
 	err := fmt.Errorf("failed to load SM config for checks: %w",
 		fmt.Errorf("SM URL not configured: %w", errors.New("no Grafana server configured: grafana config is required")))

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -239,6 +239,19 @@ func TestErrorToDetailedError_GenericServiceAPIAuthFailure(t *testing.T) {
 	assert.Equal(t, fail.ExitAuthFailure, *got.ExitCode)
 }
 
+func TestErrorToDetailedError_AdaptiveLogsScopeSuggestion(t *testing.T) {
+	got := fail.ErrorToDetailedError(fakeServiceAPIError{
+		statusCode: 401,
+		service:    "Adaptive Logs",
+		message:    "authentication error: invalid scope requested",
+	})
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Authentication failed querying Adaptive Logs", got.Summary)
+	require.Len(t, got.Suggestions, 3)
+	assert.Contains(t, got.Suggestions[2], "adaptive-logs:admin")
+}
+
 func TestErrorToDetailedError_WrappedServiceAPIErrorPreservesOuterContext(t *testing.T) {
 	err := fmt.Errorf("kg: get rule %q: %w", "prod-errors", fakeServiceAPIError{
 		statusCode: 404,

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -247,9 +247,11 @@ func TestErrorToDetailedError_AdaptiveLogsScopeSuggestion(t *testing.T) {
 	})
 
 	require.NotNil(t, got)
-	assert.Equal(t, "Authentication failed querying Adaptive Logs", got.Summary)
-	require.Len(t, got.Suggestions, 3)
-	assert.Contains(t, got.Suggestions[2], "adaptive-logs:admin")
+	assert.Equal(t, "Adaptive Logs: permission denied", got.Summary)
+	require.NotNil(t, got.ExitCode)
+	assert.Equal(t, fail.ExitAuthFailure, *got.ExitCode)
+	require.Len(t, got.Suggestions, 1)
+	assert.Contains(t, got.Suggestions[0], "adaptive-logs:admin")
 }
 
 func TestErrorToDetailedError_WrappedServiceAPIErrorPreservesOuterContext(t *testing.T) {

--- a/internal/auth/adaptive/auth.go
+++ b/internal/auth/adaptive/auth.go
@@ -49,12 +49,12 @@ func getCachedSignalAuth(ctx context.Context, loader *providers.ConfigLoader, si
 
 	cloudCfg, cloudErr := loader.LoadCloudConfig(ctx)
 	if cloudErr != nil {
-		return SignalAuth{}, false, fmt.Errorf("adaptive: failed to load cloud config for token: %w", cloudErr)
+		return SignalAuth{}, false, fmt.Errorf("adaptive-%s: failed to load cloud config for token: %w", signal, cloudErr)
 	}
 
 	httpClient, httpErr := cloudCfg.HTTPClient(ctx)
 	if httpErr != nil {
-		return SignalAuth{}, false, fmt.Errorf("adaptive: failed to create HTTP client: %w", httpErr)
+		return SignalAuth{}, false, fmt.Errorf("adaptive-%s: failed to create HTTP client: %w", signal, httpErr)
 	}
 
 	return SignalAuth{
@@ -81,7 +81,7 @@ func ResolveSignalAuth(ctx context.Context, loader *providers.ConfigLoader, sign
 	// Cache miss — resolve via GCOM.
 	cloudCfg, err := loader.LoadCloudConfig(ctx)
 	if err != nil {
-		return SignalAuth{}, fmt.Errorf("adaptive: failed to load cloud config: %w", err)
+		return SignalAuth{}, fmt.Errorf("adaptive-%s: failed to load cloud config: %w", signal, err)
 	}
 
 	baseURL, tenantID, err := ExtractSignalInfo(cloudCfg.Stack, signal)
@@ -91,7 +91,7 @@ func ResolveSignalAuth(ctx context.Context, loader *providers.ConfigLoader, sign
 
 	httpClient, err := cloudCfg.HTTPClient(ctx)
 	if err != nil {
-		return SignalAuth{}, fmt.Errorf("adaptive: failed to create HTTP client: %w", err)
+		return SignalAuth{}, fmt.Errorf("adaptive-%s: failed to create HTTP client: %w", signal, err)
 	}
 
 	// Cache resolved values for subsequent calls.

--- a/internal/providers/metrics/adaptive/client.go
+++ b/internal/providers/metrics/adaptive/client.go
@@ -56,7 +56,7 @@ func NewClient(ctx context.Context, baseURL string, tenantID int, apiToken strin
 func (c *Client) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: create request: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: create request: %w", err)
 	}
 	req.SetBasicAuth(strconv.Itoa(c.tenantID), c.apiToken)
 	if body != nil {
@@ -74,18 +74,18 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body io.Rea
 func (c *Client) ListSegments(ctx context.Context) ([]MetricSegment, error) {
 	resp, err := c.doRequest(ctx, http.MethodGet, "/aggregations/rules/segments", nil)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: list segments: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: list segments: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: list segments: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, fmt.Errorf("adaptive-metrics: list segments: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var segments []MetricSegment
 	if err := json.NewDecoder(resp.Body).Decode(&segments); err != nil {
-		return nil, fmt.Errorf("metrics: list segments: decode: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: list segments: decode: %w", err)
 	}
 
 	if segments == nil {
@@ -116,23 +116,23 @@ func (c *Client) GetSegment(ctx context.Context, id string) (*MetricSegment, err
 func (c *Client) CreateSegment(ctx context.Context, s *MetricSegment) (*MetricSegment, error) {
 	data, err := json.Marshal(s)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: create segment: marshal: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: create segment: marshal: %w", err)
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPost, "/aggregations/rules/segments", bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("metrics: create segment: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: create segment: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: create segment: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, fmt.Errorf("adaptive-metrics: create segment: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var created MetricSegment
 	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
-		return nil, fmt.Errorf("metrics: create segment: decode: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: create segment: decode: %w", err)
 	}
 
 	return &created, nil
@@ -143,13 +143,13 @@ func (c *Client) CreateSegment(ctx context.Context, s *MetricSegment) (*MetricSe
 func (c *Client) UpdateSegment(ctx context.Context, id string, s *MetricSegment) (*MetricSegment, error) {
 	data, err := json.Marshal(s)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: update segment: marshal: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: update segment: marshal: %w", err)
 	}
 
 	path := "/aggregations/rules/segments?segment=" + url.QueryEscape(id)
 	resp, err := c.doRequest(ctx, http.MethodPut, path, bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("metrics: update segment: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: update segment: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -158,7 +158,7 @@ func (c *Client) UpdateSegment(ctx context.Context, id string, s *MetricSegment)
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: update segment: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, fmt.Errorf("adaptive-metrics: update segment: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	result := *s
@@ -171,17 +171,17 @@ func (c *Client) DeleteSegment(ctx context.Context, id string) error {
 	path := "/aggregations/rules/segments?segment=" + url.QueryEscape(id)
 	resp, err := c.doRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
-		return fmt.Errorf("metrics: delete segment: %w", err)
+		return fmt.Errorf("adaptive-metrics: delete segment: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusConflict {
 		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("metrics: delete segment: segment has dependent rules or exemptions: %s", string(b))
+		return fmt.Errorf("adaptive-metrics: delete segment: segment has dependent rules or exemptions: %s", string(b))
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("metrics: delete segment: status %d: %s", resp.StatusCode, serverError(b))
+		return fmt.Errorf("adaptive-metrics: delete segment: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	return nil
@@ -201,20 +201,20 @@ func (c *Client) ListExemptions(ctx context.Context, segment string) ([]MetricEx
 
 	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: list exemptions: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: list exemptions: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: list exemptions: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, fmt.Errorf("adaptive-metrics: list exemptions: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var wrapper struct {
 		Result []MetricExemption `json:"result"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
-		return nil, fmt.Errorf("metrics: list exemptions: decode: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: list exemptions: decode: %w", err)
 	}
 
 	if wrapper.Result == nil {
@@ -228,18 +228,18 @@ func (c *Client) ListExemptions(ctx context.Context, segment string) ([]MetricEx
 func (c *Client) ListSegmentedExemptions(ctx context.Context) ([]ExemptionsBySegmentEntry, error) {
 	resp, err := c.doRequest(ctx, http.MethodGet, "/v1/recommendations/segmented_exemptions", nil)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: list segmented exemptions: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: list segmented exemptions: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: list segmented exemptions: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, fmt.Errorf("adaptive-metrics: list segmented exemptions: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var entries []ExemptionsBySegmentEntry
 	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
-		return nil, fmt.Errorf("metrics: list segmented exemptions: decode: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: list segmented exemptions: decode: %w", err)
 	}
 
 	if entries == nil {
@@ -259,7 +259,7 @@ func (c *Client) GetExemption(ctx context.Context, id, segment string) (*MetricE
 
 	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: get exemption: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: get exemption: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -268,17 +268,17 @@ func (c *Client) GetExemption(ctx context.Context, id, segment string) (*MetricE
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: get exemption: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, fmt.Errorf("adaptive-metrics: get exemption: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var wrapper struct {
 		Result *MetricExemption `json:"result"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
-		return nil, fmt.Errorf("metrics: get exemption: decode: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: get exemption: decode: %w", err)
 	}
 	if wrapper.Result == nil {
-		return nil, errors.New("metrics: get exemption: empty result")
+		return nil, errors.New("adaptive-metrics: get exemption: empty result")
 	}
 
 	return wrapper.Result, nil
@@ -293,28 +293,28 @@ func (c *Client) CreateExemption(ctx context.Context, e *MetricExemption, segmen
 
 	data, err := json.Marshal(e)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: create exemption: marshal: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: create exemption: marshal: %w", err)
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPost, path, bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("metrics: create exemption: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: create exemption: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: create exemption: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, fmt.Errorf("adaptive-metrics: create exemption: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var wrapper struct {
 		Result *MetricExemption `json:"result"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
-		return nil, fmt.Errorf("metrics: create exemption: decode: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: create exemption: decode: %w", err)
 	}
 	if wrapper.Result == nil {
-		return nil, errors.New("metrics: create exemption: empty result")
+		return nil, errors.New("adaptive-metrics: create exemption: empty result")
 	}
 
 	return wrapper.Result, nil
@@ -330,12 +330,12 @@ func (c *Client) UpdateExemption(ctx context.Context, id string, e *MetricExempt
 
 	data, err := json.Marshal(e)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: update exemption: marshal: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: update exemption: marshal: %w", err)
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPut, path, bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("metrics: update exemption: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: update exemption: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -344,7 +344,7 @@ func (c *Client) UpdateExemption(ctx context.Context, id string, e *MetricExempt
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: update exemption: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, fmt.Errorf("adaptive-metrics: update exemption: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	result := *e
@@ -361,13 +361,13 @@ func (c *Client) DeleteExemption(ctx context.Context, id, segment string) error 
 
 	resp, err := c.doRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
-		return fmt.Errorf("metrics: delete exemption: %w", err)
+		return fmt.Errorf("adaptive-metrics: delete exemption: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("metrics: delete exemption: status %d: %s", resp.StatusCode, serverError(b))
+		return fmt.Errorf("adaptive-metrics: delete exemption: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	return nil
@@ -382,20 +382,20 @@ func (c *Client) ListRules(ctx context.Context, segment string) ([]MetricRule, s
 
 	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return nil, "", fmt.Errorf("metrics: list rules: %w", err)
+		return nil, "", fmt.Errorf("adaptive-metrics: list rules: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, "", fmt.Errorf("metrics: list rules: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, "", fmt.Errorf("adaptive-metrics: list rules: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	etag := resp.Header.Get("Etag")
 
 	var rules []MetricRule
 	if err := json.NewDecoder(resp.Body).Decode(&rules); err != nil {
-		return nil, "", fmt.Errorf("metrics: list rules: decode: %w", err)
+		return nil, "", fmt.Errorf("adaptive-metrics: list rules: decode: %w", err)
 	}
 
 	return rules, etag, nil
@@ -412,7 +412,7 @@ func (c *Client) GetRule(ctx context.Context, metric, segment string) (MetricRul
 
 	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return MetricRule{}, fmt.Errorf("metrics: get rule: %w", err)
+		return MetricRule{}, fmt.Errorf("adaptive-metrics: get rule: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -421,12 +421,12 @@ func (c *Client) GetRule(ctx context.Context, metric, segment string) (MetricRul
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return MetricRule{}, fmt.Errorf("metrics: get rule: status %d: %s", resp.StatusCode, serverError(b))
+		return MetricRule{}, fmt.Errorf("adaptive-metrics: get rule: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var rule MetricRule
 	if err := json.NewDecoder(resp.Body).Decode(&rule); err != nil {
-		return MetricRule{}, fmt.Errorf("metrics: get rule: decode: %w", err)
+		return MetricRule{}, fmt.Errorf("adaptive-metrics: get rule: decode: %w", err)
 	}
 
 	return rule, nil
@@ -443,12 +443,12 @@ func (c *Client) CreateRule(ctx context.Context, rule MetricRule, etag, segment 
 
 	data, err := json.Marshal(rule)
 	if err != nil {
-		return "", fmt.Errorf("metrics: create rule: marshal: %w", err)
+		return "", fmt.Errorf("adaptive-metrics: create rule: marshal: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(data))
 	if err != nil {
-		return "", fmt.Errorf("metrics: create rule: create request: %w", err)
+		return "", fmt.Errorf("adaptive-metrics: create rule: create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if etag != "" {
@@ -458,7 +458,7 @@ func (c *Client) CreateRule(ctx context.Context, rule MetricRule, etag, segment 
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("metrics: create rule: %w", err)
+		return "", fmt.Errorf("adaptive-metrics: create rule: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -467,7 +467,7 @@ func (c *Client) CreateRule(ctx context.Context, rule MetricRule, etag, segment 
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("metrics: create rule: status %d: %s", resp.StatusCode, serverError(b))
+		return "", fmt.Errorf("adaptive-metrics: create rule: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	return resp.Header.Get("Etag"), nil
@@ -483,12 +483,12 @@ func (c *Client) UpdateRule(ctx context.Context, rule MetricRule, etag, segment 
 
 	data, err := json.Marshal(rule)
 	if err != nil {
-		return "", fmt.Errorf("metrics: update rule: marshal: %w", err)
+		return "", fmt.Errorf("adaptive-metrics: update rule: marshal: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+path, bytes.NewReader(data))
 	if err != nil {
-		return "", fmt.Errorf("metrics: update rule: create request: %w", err)
+		return "", fmt.Errorf("adaptive-metrics: update rule: create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("If-Match", etag)
@@ -496,7 +496,7 @@ func (c *Client) UpdateRule(ctx context.Context, rule MetricRule, etag, segment 
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("metrics: update rule: %w", err)
+		return "", fmt.Errorf("adaptive-metrics: update rule: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -505,7 +505,7 @@ func (c *Client) UpdateRule(ctx context.Context, rule MetricRule, etag, segment 
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("metrics: update rule: status %d: %s", resp.StatusCode, serverError(b))
+		return "", fmt.Errorf("adaptive-metrics: update rule: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	return resp.Header.Get("Etag"), nil
@@ -521,14 +521,14 @@ func (c *Client) DeleteRule(ctx context.Context, metric, etag, segment string) e
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+path, nil)
 	if err != nil {
-		return fmt.Errorf("metrics: delete rule: create request: %w", err)
+		return fmt.Errorf("adaptive-metrics: delete rule: create request: %w", err)
 	}
 	req.Header.Set("If-Match", etag)
 	req.SetBasicAuth(strconv.Itoa(c.tenantID), c.apiToken)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("metrics: delete rule: %w", err)
+		return fmt.Errorf("adaptive-metrics: delete rule: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -537,7 +537,7 @@ func (c *Client) DeleteRule(ctx context.Context, metric, etag, segment string) e
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("metrics: delete rule: status %d: %s", resp.StatusCode, serverError(b))
+		return fmt.Errorf("adaptive-metrics: delete rule: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	return nil
@@ -552,12 +552,12 @@ func (c *Client) SyncRules(ctx context.Context, rules []MetricRule, etag, segmen
 
 	data, err := json.Marshal(rules)
 	if err != nil {
-		return fmt.Errorf("metrics: sync rules: marshal: %w", err)
+		return fmt.Errorf("adaptive-metrics: sync rules: marshal: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("metrics: sync rules: create request: %w", err)
+		return fmt.Errorf("adaptive-metrics: sync rules: create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -566,7 +566,7 @@ func (c *Client) SyncRules(ctx context.Context, rules []MetricRule, etag, segmen
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("metrics: sync rules: %w", err)
+		return fmt.Errorf("adaptive-metrics: sync rules: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -575,7 +575,7 @@ func (c *Client) SyncRules(ctx context.Context, rules []MetricRule, etag, segmen
 	}
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("metrics: sync rules: status %d: %s", resp.StatusCode, serverError(b))
+		return fmt.Errorf("adaptive-metrics: sync rules: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	return nil
@@ -591,19 +591,19 @@ func (c *Client) ValidateRules(ctx context.Context, rules []MetricRule, segment 
 
 	data, err := json.Marshal(rules)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: validate rules: marshal: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: validate rules: marshal: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("metrics: validate rules: create request: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: validate rules: create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth(strconv.Itoa(c.tenantID), c.apiToken)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: validate rules: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: validate rules: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -611,12 +611,12 @@ func (c *Client) ValidateRules(ctx context.Context, rules []MetricRule, segment 
 	// Other non-2xx/400 statuses are genuine errors.
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusBadRequest {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: validate rules: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, fmt.Errorf("adaptive-metrics: validate rules: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var errs []string
 	if err := json.NewDecoder(resp.Body).Decode(&errs); err != nil {
-		return nil, fmt.Errorf("metrics: validate rules: decode: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: validate rules: decode: %w", err)
 	}
 
 	return errs, nil
@@ -635,18 +635,18 @@ func (c *Client) ListRecommendations(ctx context.Context, segment string, action
 
 	resp, err := c.doRequest(ctx, http.MethodGet, "/aggregations/recommendations?"+params.Encode(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("metrics: list recommendations: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: list recommendations: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("metrics: list recommendations: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, fmt.Errorf("adaptive-metrics: list recommendations: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	var recs []MetricRecommendation
 	if err := json.NewDecoder(resp.Body).Decode(&recs); err != nil {
-		return nil, fmt.Errorf("metrics: list recommendations: decode: %w", err)
+		return nil, fmt.Errorf("adaptive-metrics: list recommendations: decode: %w", err)
 	}
 
 	return recs, nil
@@ -663,20 +663,20 @@ func (c *Client) ListRecommendedRules(ctx context.Context, segment string) ([]Me
 
 	resp, err := c.doRequest(ctx, http.MethodGet, "/aggregations/recommendations?"+params.Encode(), nil)
 	if err != nil {
-		return nil, "", fmt.Errorf("metrics: list recommended rules: %w", err)
+		return nil, "", fmt.Errorf("adaptive-metrics: list recommended rules: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return nil, "", fmt.Errorf("metrics: list recommended rules: status %d: %s", resp.StatusCode, serverError(b))
+		return nil, "", fmt.Errorf("adaptive-metrics: list recommended rules: status %d: %s", resp.StatusCode, serverError(b))
 	}
 
 	rulesVersion := resp.Header.Get("Rules-Version")
 
 	var rules []MetricRule
 	if err := json.NewDecoder(resp.Body).Decode(&rules); err != nil {
-		return nil, "", fmt.Errorf("metrics: list recommended rules: decode: %w", err)
+		return nil, "", fmt.Errorf("adaptive-metrics: list recommended rules: decode: %w", err)
 	}
 
 	return rules, rulesVersion, nil

--- a/internal/providers/metrics/adaptive/commands.go
+++ b/internal/providers/metrics/adaptive/commands.go
@@ -856,7 +856,7 @@ func (c *rulesTableCodec) Format() format.Format {
 func (c *rulesTableCodec) Encode(w io.Writer, v any) error {
 	rules, ok := v.([]MetricRule)
 	if !ok {
-		return fmt.Errorf("metrics: rules table codec: expected []MetricRule, got %T", v)
+		return fmt.Errorf("adaptive-metrics: rules table codec: expected []MetricRule, got %T", v)
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
@@ -947,7 +947,7 @@ func (c *recommendationsTableCodec) Format() format.Format {
 func (c *recommendationsTableCodec) Encode(w io.Writer, v any) error {
 	recs, ok := v.([]MetricRecommendation)
 	if !ok {
-		return fmt.Errorf("metrics: recommendations table codec: expected []MetricRecommendation, got %T", v)
+		return fmt.Errorf("adaptive-metrics: recommendations table codec: expected []MetricRecommendation, got %T", v)
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
@@ -996,7 +996,7 @@ func (c *recommendationsDiffTableCodec) Format() format.Format { return "table" 
 func (c *recommendationsDiffTableCodec) Encode(w io.Writer, v any) error {
 	entries, ok := v.([]diffEntry)
 	if !ok {
-		return fmt.Errorf("metrics: diff table codec: expected []diffEntry, got %T", v)
+		return fmt.Errorf("adaptive-metrics: diff table codec: expected []diffEntry, got %T", v)
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
@@ -1394,7 +1394,7 @@ func (c *segmentsTableCodec) Encode(w io.Writer, v any) error {
 		if s, ok2 := v.(*MetricSegment); ok2 {
 			segments = []MetricSegment{*s}
 		} else {
-			return fmt.Errorf("metrics: segments table codec: expected []MetricSegment, got %T", v)
+			return fmt.Errorf("adaptive-metrics: segments table codec: expected []MetricSegment, got %T", v)
 		}
 	}
 
@@ -1870,7 +1870,7 @@ func (c *exemptionsTableCodec) Encode(w io.Writer, v any) error {
 	case []ExemptionsBySegmentEntry:
 		return c.encodeSegmentedExemptions(w, data)
 	default:
-		return fmt.Errorf("metrics: exemptions table codec: expected []MetricExemption or []ExemptionsBySegmentEntry, got %T", v)
+		return fmt.Errorf("adaptive-metrics: exemptions table codec: expected []MetricExemption or []ExemptionsBySegmentEntry, got %T", v)
 	}
 }
 

--- a/internal/providers/traces/adaptive/client.go
+++ b/internal/providers/traces/adaptive/client.go
@@ -39,7 +39,7 @@ func (c *Client) ListPolicies(ctx context.Context) ([]Policy, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, handleErrorResponse(resp)
+		return nil, fmt.Errorf("traces: list policies: %w", handleErrorResponse(resp))
 	}
 
 	var policies []Policy
@@ -63,7 +63,7 @@ func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, handleErrorResponse(resp)
+		return nil, fmt.Errorf("traces: get policy: %w", handleErrorResponse(resp))
 	}
 
 	var policy Policy
@@ -88,7 +88,7 @@ func (c *Client) CreatePolicy(ctx context.Context, p *Policy) (*Policy, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, handleErrorResponse(resp)
+		return nil, fmt.Errorf("traces: create policy: %w", handleErrorResponse(resp))
 	}
 
 	var created Policy
@@ -113,7 +113,7 @@ func (c *Client) UpdatePolicy(ctx context.Context, id string, p *Policy) (*Polic
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, handleErrorResponse(resp)
+		return nil, fmt.Errorf("traces: update policy: %w", handleErrorResponse(resp))
 	}
 
 	var updated Policy
@@ -133,7 +133,7 @@ func (c *Client) DeletePolicy(ctx context.Context, id string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return handleErrorResponse(resp)
+		return fmt.Errorf("traces: delete policy: %w", handleErrorResponse(resp))
 	}
 
 	return nil
@@ -148,7 +148,7 @@ func (c *Client) ListRecommendations(ctx context.Context) ([]Recommendation, err
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, handleErrorResponse(resp)
+		return nil, fmt.Errorf("traces: list recommendations: %w", handleErrorResponse(resp))
 	}
 
 	var recs []Recommendation
@@ -172,7 +172,7 @@ func (c *Client) ApplyRecommendation(ctx context.Context, id string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return handleErrorResponse(resp)
+		return fmt.Errorf("traces: apply recommendation: %w", handleErrorResponse(resp))
 	}
 
 	return nil
@@ -187,7 +187,7 @@ func (c *Client) DismissRecommendation(ctx context.Context, id string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return handleErrorResponse(resp)
+		return fmt.Errorf("traces: dismiss recommendation: %w", handleErrorResponse(resp))
 	}
 
 	return nil

--- a/internal/providers/traces/adaptive/client.go
+++ b/internal/providers/traces/adaptive/client.go
@@ -39,7 +39,7 @@ func (c *Client) ListPolicies(ctx context.Context) ([]Policy, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("traces: list policies: %w", handleErrorResponse(resp))
+		return nil, fmt.Errorf("adaptive-traces: list policies: %w", handleErrorResponse(resp))
 	}
 
 	var policies []Policy
@@ -63,7 +63,7 @@ func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("traces: get policy: %w", handleErrorResponse(resp))
+		return nil, fmt.Errorf("adaptive-traces: get policy: %w", handleErrorResponse(resp))
 	}
 
 	var policy Policy
@@ -88,7 +88,7 @@ func (c *Client) CreatePolicy(ctx context.Context, p *Policy) (*Policy, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("traces: create policy: %w", handleErrorResponse(resp))
+		return nil, fmt.Errorf("adaptive-traces: create policy: %w", handleErrorResponse(resp))
 	}
 
 	var created Policy
@@ -113,7 +113,7 @@ func (c *Client) UpdatePolicy(ctx context.Context, id string, p *Policy) (*Polic
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("traces: update policy: %w", handleErrorResponse(resp))
+		return nil, fmt.Errorf("adaptive-traces: update policy: %w", handleErrorResponse(resp))
 	}
 
 	var updated Policy
@@ -133,7 +133,7 @@ func (c *Client) DeletePolicy(ctx context.Context, id string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("traces: delete policy: %w", handleErrorResponse(resp))
+		return fmt.Errorf("adaptive-traces: delete policy: %w", handleErrorResponse(resp))
 	}
 
 	return nil
@@ -148,7 +148,7 @@ func (c *Client) ListRecommendations(ctx context.Context) ([]Recommendation, err
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("traces: list recommendations: %w", handleErrorResponse(resp))
+		return nil, fmt.Errorf("adaptive-traces: list recommendations: %w", handleErrorResponse(resp))
 	}
 
 	var recs []Recommendation
@@ -172,7 +172,7 @@ func (c *Client) ApplyRecommendation(ctx context.Context, id string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("traces: apply recommendation: %w", handleErrorResponse(resp))
+		return fmt.Errorf("adaptive-traces: apply recommendation: %w", handleErrorResponse(resp))
 	}
 
 	return nil
@@ -187,7 +187,7 @@ func (c *Client) DismissRecommendation(ctx context.Context, id string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("traces: dismiss recommendation: %w", handleErrorResponse(resp))
+		return fmt.Errorf("adaptive-traces: dismiss recommendation: %w", handleErrorResponse(resp))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

When adaptive commands fail with scope-related auth errors, the error messages now tell the user exactly which access policy scope they need to add. Previously users had to guess or look up documentation.

## What changed

### Scope suggestions on "invalid scope" errors

Each adaptive provider now suggests the specific scope(s) needed:

- **Adaptive Logs** → `adaptive-logs:admin`
- **Adaptive Traces** → `adaptive-traces:admin`
- **Adaptive Metrics** → the specific scope for the subcommand (e.g. `adaptive-metrics-rules:read`, `adaptive-metrics-segments:write`, `adaptive-metrics-exemptions:delete`)

Examples:
```
# no stacks:read scope
gcx metrics adaptive exemptions list
Error: Cloud stack lookup: permission denied
│
├─ Details:
│
│ adaptive-metrics: failed to load cloud config for token: failed to get stack info for "dafyddt": gcom client: unexpected status 403 Forbidden: {
│   "code": "Forbidden",
│   "message": "You do not have permission to perform the requested action.",
│   "requestId": "fd9b090d-93a1-49fd-a513-c643a19fdc32"
│ }
│
├─ Suggestions:
│
│ • Ensure your access policy includes the stacks:read scope
│ • Adaptive Metrics commands also require an adaptive-metrics-* scope (the specific scope depends on the subcommand)
│
└─


# with stacks:read, missing adaptive-logs:admin
./bin/gcx logs adaptive patterns show
Error: Adaptive Logs: permission denied
│
├─ Details:
│
│ API request failed (HTTP 401): authentication error: invalid scope requested
│
├─ Suggestions:
│
│ • Ensure your access policy includes the adaptive-logs:admin scope
│
└─

# adaptive metrics writes require the write scope
./bin/gcx metrics adaptive rules create  --metric hello
Error: Adaptive Metrics: permission denied
│
├─ Details:
│
│ metrics: create rule: status 401: {"status":"error","error":"authentication error: invalid scope requested"}
│
├─ Suggestions:
│
│ • Ensure your access policy includes the adaptive-metrics-rules:write scope
│
└─
```


### Supporting changes

- **`internal/auth/adaptive/auth.go`**: Error prefix changed from `adaptive:` to `adaptive-<signal>:` (e.g. `adaptive-logs:`, `adaptive-metrics:`) so the fail converter can identify which product's scope to suggest.
- **`internal/providers/traces/adaptive/client.go`**: Wrapped `handleErrorResponse` calls with a `traces:` prefix so the fail converter can identify traces errors (previously returned bare "unexpected status" errors with no provider context).

