### PR TITLE
feat(datasources): add explore share links for queries

### DIFF
--- a/docs/reference/cli/gcx_datasources_loki_metrics.md
+++ b/docs/reference/cli/gcx_datasources_loki_metrics.md
@@ -14,6 +14,8 @@ time-series data with proper table, graph, and JSON formatters.
 
 Instant vs range is deduced from time flags: no time flags = instant query,
 --since or --from/--to = range query.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.
 
 ```
 gcx datasources loki metrics [EXPR] [flags]
@@ -28,6 +30,9 @@ gcx datasources loki metrics [EXPR] [flags]
 
   # Count of error logs
   gcx datasources loki metrics 'count_over_time({job="varlogs"} |= "error" [5m])' --since 1h
+
+  # Print a Grafana Explore share link for the query
+  gcx datasources loki metrics 'rate({job="varlogs"}[5m])' --share-link
 
   # Line chart output
   gcx datasources loki metrics -d loki-001 'rate({job="varlogs"}[5m])' --since 1h -o graph
@@ -44,7 +49,9 @@ gcx datasources loki metrics [EXPR] [flags]
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for metrics
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_loki_query.md
+++ b/docs/reference/cli/gcx_datasources_loki_query.md
@@ -13,6 +13,8 @@ Default table output is optimized for humans. Use -o raw for original line
 bodies or -o json for the full structured response.
 
 Default --limit is 50; use --limit 0 for no cap.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.
 
 ```
 gcx datasources loki query [EXPR] [flags]
@@ -27,6 +29,9 @@ gcx datasources loki query [EXPR] [flags]
 
   # Query with explicit datasource UID
   gcx datasources loki query -d UID '{job="varlogs"} |= "error"'
+
+  # Print a Grafana Explore share link for the query
+  gcx datasources loki query '{job="varlogs"}' --share-link
 
   # Raw line bodies only
   gcx datasources loki query -d UID '{job="varlogs"}' -o raw
@@ -44,7 +49,9 @@ gcx datasources loki query [EXPR] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of log lines to return (0 means no limit) (default 50)
+      --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: json, raw, table, wide, yaml (default "table")
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_prometheus_query.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_query.md
@@ -9,6 +9,8 @@ Execute a PromQL query against a Prometheus datasource.
 EXPR is the PromQL expression to evaluate, passed as a positional argument or
 via --expr (familiar to promtool users).
 Datasource is resolved from -d flag or datasources.prometheus in your context.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.
 
 ```
 gcx datasources prometheus query [EXPR] [flags]
@@ -27,6 +29,9 @@ gcx datasources prometheus query [EXPR] [flags]
   # Query the last hour
   gcx datasources prometheus query 'up' --since 1h
 
+  # Print a Grafana Explore share link for the executed query
+  gcx datasources prometheus query 'up' --share-link
+
   # Output as JSON
   gcx datasources prometheus query -d UID 'up' -o json
 ```
@@ -39,7 +44,9 @@ gcx datasources prometheus query [EXPR] [flags]
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_tempo_get.md
+++ b/docs/reference/cli/gcx_datasources_tempo_get.md
@@ -8,6 +8,9 @@ Retrieve a single trace by its trace ID from a Tempo datasource.
 
 TRACE_ID is the hex-encoded trace identifier to retrieve.
 Datasource is resolved from -d flag or datasources.tempo in your context.
+Use --share-link to print a Grafana Explore URL for the trace, or --open to
+open it in your browser after retrieval succeeds. Share links require an
+explicit time range via --since or --from/--to.
 
 ```
 gcx datasources tempo get TRACE_ID [flags]
@@ -22,6 +25,9 @@ gcx datasources tempo get TRACE_ID [flags]
 
   # Get a trace with explicit datasource UID
   gcx datasources tempo get -d tempo-001 abc123def456
+
+  # Print a Grafana Explore share link for the trace
+  gcx datasources tempo get abc123def456 --share-link
 
   # Get LLM-friendly output
   gcx datasources tempo get abc123def456 --llm
@@ -38,7 +44,9 @@ gcx datasources tempo get TRACE_ID [flags]
   -h, --help                help for get
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --llm                 Request LLM-friendly trace format
+      --open                Open the retrieved trace in Grafana Explore
   -o, --output string       Output format. One of: json, yaml (default "json")
+      --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_datasources_tempo_metrics.md
+++ b/docs/reference/cli/gcx_datasources_tempo_metrics.md
@@ -13,6 +13,8 @@ Instant vs range is deduced from time flags: no time flags = instant query,
 --since or --from/--to = range query. Use --instant to force an instant query
 even when a time range is provided. If no time flags are set, gcx queries the
 last hour by default.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.
 
 ```
 gcx datasources tempo metrics [TRACEQL] [flags]
@@ -27,6 +29,9 @@ gcx datasources tempo metrics [TRACEQL] [flags]
 
   # Range query with relative window
   gcx datasources tempo metrics -d tempo-001 '{ } | rate()' --since 1h
+
+  # Print a Grafana Explore share link for the query
+  gcx datasources tempo metrics '{ } | rate()' --share-link
 
   # Instant query with explicit time range
   gcx datasources tempo metrics '{ } | rate()' --instant --since 1h
@@ -47,7 +52,9 @@ gcx datasources tempo metrics [TRACEQL] [flags]
   -h, --help                help for metrics
       --instant             Run an instant query over the selected time range instead of a range query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_tempo_query.md
+++ b/docs/reference/cli/gcx_datasources_tempo_query.md
@@ -8,6 +8,9 @@ Search for traces using a TraceQL query against a Tempo datasource.
 
 TRACEQL is the TraceQL expression to evaluate.
 Datasource is resolved from -d flag or datasources.tempo in your context.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds. Share links require an
+explicit time range via --since or --from/--to.
 
 ```
 gcx datasources tempo query [TRACEQL] [flags]
@@ -22,6 +25,9 @@ gcx datasources tempo query [TRACEQL] [flags]
 
   # Search with explicit datasource UID and time range
   gcx datasources tempo query -d UID '{ span.http.status_code >= 500 }' --since 1h
+
+  # Print a Grafana Explore share link for the query
+  gcx datasources tempo query '{ span.http.status_code >= 500 }' --share-link
 
   # With custom limit
   gcx datasources tempo query -d UID '{ span.http.status_code >= 500 }' --since 1h --limit 50
@@ -39,7 +45,9 @@ gcx datasources tempo query [TRACEQL] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of traces to return (0 means no limit) (default 20)
+      --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: json, table, wide, yaml (default "table")
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_logs_metrics.md
+++ b/docs/reference/cli/gcx_logs_metrics.md
@@ -14,6 +14,8 @@ time-series data with proper table, graph, and JSON formatters.
 
 Instant vs range is deduced from time flags: no time flags = instant query,
 --since or --from/--to = range query.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.
 
 ```
 gcx logs metrics [EXPR] [flags]
@@ -25,6 +27,9 @@ gcx logs metrics [EXPR] [flags]
 
   # Run a metric query over logs
   gcx logs metrics -d UID 'rate({job="grafana"}[5m])' --since 1h
+
+  # Print a Grafana Explore share link for the query
+  gcx logs metrics 'rate({job="grafana"}[5m])' --share-link
 
   # Output as JSON
   gcx logs metrics -d UID 'rate({job="grafana"}[5m])' --since 1h -o json
@@ -38,7 +43,9 @@ gcx logs metrics [EXPR] [flags]
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for metrics
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_logs_query.md
+++ b/docs/reference/cli/gcx_logs_query.md
@@ -13,6 +13,8 @@ Default table output is optimized for humans. Use -o raw for original line
 bodies or -o json for the full structured response.
 
 Default --limit is 50; use --limit 0 for no cap.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.
 
 ```
 gcx logs query [EXPR] [flags]
@@ -27,6 +29,9 @@ gcx logs query [EXPR] [flags]
 
   # Query with explicit datasource UID
   gcx logs query -d abc123 '{job="varlogs"} |= "error"'
+
+  # Print a Grafana Explore share link for the query
+  gcx logs query '{job="varlogs"}' --share-link
 
   # Raw line bodies only
   gcx logs query -d abc123 '{job="varlogs"}' -o raw
@@ -44,7 +49,9 @@ gcx logs query [EXPR] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of log lines to return (0 means no limit) (default 50)
+      --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: json, raw, table, wide, yaml (default "table")
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_metrics_billing_query.md
+++ b/docs/reference/cli/gcx_metrics_billing_query.md
@@ -9,6 +9,8 @@ Execute a PromQL query against a Prometheus datasource.
 EXPR is the PromQL expression to evaluate, passed as a positional argument or
 via --expr (familiar to promtool users).
 Datasource is resolved from -d flag or datasources.prometheus in your context.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.
 
 ```
 gcx metrics billing query [EXPR] [flags]
@@ -24,6 +26,9 @@ gcx metrics billing query [EXPR] [flags]
   # Active series over the last hour
   gcx metrics billing query 'grafanacloud_instance_active_series' --since 1h --step 1m
 
+  # Print a Grafana Explore share link for the executed query
+  gcx metrics billing query 'grafanacloud_instance_active_series' --share-link
+
   # Output as JSON
   gcx metrics billing query 'grafanacloud_instance_active_series' -o json
 ```
@@ -36,7 +41,9 @@ gcx metrics billing query [EXPR] [flags]
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_metrics_query.md
+++ b/docs/reference/cli/gcx_metrics_query.md
@@ -9,6 +9,8 @@ Execute a PromQL query against a Prometheus datasource.
 EXPR is the PromQL expression to evaluate, passed as a positional argument or
 via --expr (familiar to promtool users).
 Datasource is resolved from -d flag or datasources.prometheus in your context.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.
 
 ```
 gcx metrics query [EXPR] [flags]
@@ -27,6 +29,9 @@ gcx metrics query [EXPR] [flags]
   # Query the last hour
   gcx metrics query 'up' --since 1h
 
+  # Print a Grafana Explore share link for the executed query
+  gcx metrics query 'up' --share-link
+
   # Output as JSON
   gcx metrics query -d abc123 'up' -o json
 ```
@@ -39,7 +44,9 @@ gcx metrics query [EXPR] [flags]
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_traces_get.md
+++ b/docs/reference/cli/gcx_traces_get.md
@@ -8,6 +8,9 @@ Retrieve a single trace by its trace ID from a Tempo datasource.
 
 TRACE_ID is the hex-encoded trace identifier to retrieve.
 Datasource is resolved from -d flag or datasources.tempo in your context.
+Use --share-link to print a Grafana Explore URL for the trace, or --open to
+open it in your browser after retrieval succeeds. Share links require an
+explicit time range via --since or --from/--to.
 
 ```
 gcx traces get TRACE_ID [flags]
@@ -19,6 +22,9 @@ gcx traces get TRACE_ID [flags]
 
   # Fetch a trace by ID
   gcx traces get -d UID <trace-id>
+
+  # Print a Grafana Explore share link for the trace
+  gcx traces get -d UID <trace-id> --share-link
 
   # Output as JSON
   gcx traces get -d UID <trace-id> -o json
@@ -32,7 +38,9 @@ gcx traces get TRACE_ID [flags]
   -h, --help                help for get
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --llm                 Request LLM-friendly trace format
+      --open                Open the retrieved trace in Grafana Explore
   -o, --output string       Output format. One of: json, yaml (default "json")
+      --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_traces_metrics.md
+++ b/docs/reference/cli/gcx_traces_metrics.md
@@ -13,6 +13,8 @@ Instant vs range is deduced from time flags: no time flags = instant query,
 --since or --from/--to = range query. Use --instant to force an instant query
 even when a time range is provided. If no time flags are set, gcx queries the
 last hour by default.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.
 
 ```
 gcx traces metrics [TRACEQL] [flags]
@@ -24,6 +26,9 @@ gcx traces metrics [TRACEQL] [flags]
 
   # Run a TraceQL metrics query
   gcx traces metrics -d UID '{ } | rate()' --since 1h
+
+  # Print a Grafana Explore share link for the query
+  gcx traces metrics '{ } | rate()' --share-link
 
   # Output as JSON
   gcx traces metrics -d UID '{ } | rate()' --since 1h -o json
@@ -38,7 +43,9 @@ gcx traces metrics [TRACEQL] [flags]
   -h, --help                help for metrics
       --instant             Run an instant query over the selected time range instead of a range query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_traces_query.md
+++ b/docs/reference/cli/gcx_traces_query.md
@@ -8,6 +8,9 @@ Search for traces using a TraceQL query against a Tempo datasource.
 
 TRACEQL is the TraceQL expression to evaluate.
 Datasource is resolved from -d flag or datasources.tempo in your context.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds. Share links require an
+explicit time range via --since or --from/--to.
 
 ```
 gcx traces query [TRACEQL] [flags]
@@ -19,6 +22,9 @@ gcx traces query [TRACEQL] [flags]
 
   # Run a TraceQL query
   gcx traces query -d UID '{ span.http.status_code >= 500 }'
+
+  # Print a Grafana Explore share link for the query
+  gcx traces query '{ span.http.status_code >= 500 }' --share-link
 
   # Output as JSON
   gcx traces query -d UID '{ span.http.status_code >= 500 }' -o json
@@ -33,7 +39,9 @@ gcx traces query [TRACEQL] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of traces to return (0 means no limit) (default 20)
+      --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: json, table, wide, yaml (default "table")
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/internal/datasources/loki/explore.go
+++ b/internal/datasources/loki/explore.go
@@ -1,0 +1,58 @@
+package loki
+
+import (
+	"strings"
+
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+)
+
+// LogsExploreURL builds a Grafana Explore URL for a Loki log-lines query.
+func LogsExploreURL(host string, query dsquery.ExploreQuery) string {
+	if strings.TrimSpace(host) == "" || query.DatasourceUID == "" || strings.TrimSpace(query.Expr) == "" {
+		return ""
+	}
+
+	from, to := dsquery.ShortExploreRange(query.From, query.To)
+
+	queries := []any{map[string]any{
+		"refId":      "A",
+		"expr":       query.Expr,
+		"queryType":  "range",
+		"editorMode": "code",
+		"direction":  "backward",
+		"datasource": dsquery.ExploreDatasource(query.DatasourceType, query.DatasourceUID),
+	}}
+
+	return dsquery.BuildExploreURL(host, query.OrgID, dsquery.SinglePane(query.DatasourceUID, queries, from, to, map[string]any{
+		"panelsState": map[string]any{
+			"logs": map[string]any{
+				"sortOrder": "Descending",
+			},
+		},
+		"compact": false,
+	}), nil)
+}
+
+// MetricsExploreURL builds a Grafana Explore URL for a Loki metric LogQL query.
+func MetricsExploreURL(host string, query dsquery.ExploreQuery) string {
+	if strings.TrimSpace(host) == "" || query.DatasourceUID == "" || strings.TrimSpace(query.Expr) == "" {
+		return ""
+	}
+
+	from, to := dsquery.ShortExploreRange(query.From, query.To)
+
+	queries := []any{map[string]any{
+		"refId":      "A",
+		"expr":       query.Expr,
+		"queryType":  "range",
+		"instant":    query.Instant,
+		"range":      !query.Instant,
+		"editorMode": "code",
+		"direction":  "backward",
+		"datasource": dsquery.ExploreDatasource(query.DatasourceType, query.DatasourceUID),
+	}}
+
+	return dsquery.BuildExploreURL(host, query.OrgID, dsquery.SinglePane(query.DatasourceUID, queries, from, to, map[string]any{
+		"compact": false,
+	}), nil)
+}

--- a/internal/datasources/loki/explore.go
+++ b/internal/datasources/loki/explore.go
@@ -41,7 +41,7 @@ func MetricsExploreURL(host string, query dsquery.ExploreQuery) string {
 
 	from, to := dsquery.ShortExploreRange(query.From, query.To)
 
-	queries := []any{map[string]any{
+	q := map[string]any{
 		"refId":      "A",
 		"expr":       query.Expr,
 		"queryType":  "range",
@@ -50,9 +50,12 @@ func MetricsExploreURL(host string, query dsquery.ExploreQuery) string {
 		"editorMode": "code",
 		"direction":  "backward",
 		"datasource": dsquery.ExploreDatasource(query.DatasourceType, query.DatasourceUID),
-	}}
+	}
+	if query.Step > 0 {
+		q["intervalMs"] = query.Step.Milliseconds()
+	}
 
-	return dsquery.BuildExploreURL(host, query.OrgID, dsquery.SinglePane(query.DatasourceUID, queries, from, to, map[string]any{
+	return dsquery.BuildExploreURL(host, query.OrgID, dsquery.SinglePane(query.DatasourceUID, []any{q}, from, to, map[string]any{
 		"compact": false,
 	}), nil)
 }

--- a/internal/datasources/loki/explore_test.go
+++ b/internal/datasources/loki/explore_test.go
@@ -1,0 +1,93 @@
+package loki_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/grafana/gcx/internal/datasources/loki"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogsExploreURL(t *testing.T) {
+	t.Run("builds logs explore link", func(t *testing.T) {
+		got := loki.LogsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
+			DatasourceUID:  "grafanacloud-logs",
+			DatasourceType: "loki",
+			Expr:           `{name="ingress-nginx-controller"}`,
+			OrgID:          1,
+		})
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Equal(t, "1", params.Get("schemaVersion"))
+		assert.Equal(t, "1", params.Get("orgId"))
+		assert.Contains(t, params.Get("panes"), `"datasource":"grafanacloud-logs"`)
+		assert.Contains(t, params.Get("panes"), `"expr":"{name=\"ingress-nginx-controller\"}"`)
+		assert.Contains(t, params.Get("panes"), `"queryType":"range"`)
+		assert.Contains(t, params.Get("panes"), `"direction":"backward"`)
+		assert.Contains(t, params.Get("panes"), `"sortOrder":"Descending"`)
+		assert.Contains(t, params.Get("panes"), `"compact":false`)
+		assert.Contains(t, params.Get("panes"), `"from":"now-1m"`)
+		assert.Contains(t, params.Get("panes"), `"to":"now"`)
+	})
+
+	t.Run("returns empty for missing required fields", func(t *testing.T) {
+		assert.Empty(t, loki.LogsExploreURL("", dsquery.ExploreQuery{DatasourceUID: "loki-uid", Expr: "{}"}))
+		assert.Empty(t, loki.LogsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{Expr: "{}"}))
+		assert.Empty(t, loki.LogsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{DatasourceUID: "loki-uid"}))
+	})
+}
+
+func TestMetricsExploreURL(t *testing.T) {
+	t.Run("builds metric logql explore link", func(t *testing.T) {
+		got := loki.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
+			DatasourceUID:  "grafanacloud-logs",
+			DatasourceType: "loki",
+			Expr:           `rate({name="ingress-nginx-controller"}[$__auto])`,
+			Instant:        false,
+		})
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Equal(t, "1", params.Get("schemaVersion"))
+		assert.Contains(t, params.Get("panes"), `"datasource":"grafanacloud-logs"`)
+		assert.Contains(t, params.Get("panes"), `"expr":"rate({name=\"ingress-nginx-controller\"}[$__auto])"`)
+		assert.Contains(t, params.Get("panes"), `"queryType":"range"`)
+		assert.Contains(t, params.Get("panes"), `"instant":false`)
+		assert.Contains(t, params.Get("panes"), `"range":true`)
+		assert.Contains(t, params.Get("panes"), `"direction":"backward"`)
+		assert.Contains(t, params.Get("panes"), `"compact":false`)
+		assert.Contains(t, params.Get("panes"), `"from":"now-1m"`)
+		assert.Contains(t, params.Get("panes"), `"to":"now"`)
+		assert.NotContains(t, params.Get("panes"), `"panelsState"`)
+	})
+
+	t.Run("builds instant metric logql explore link", func(t *testing.T) {
+		got := loki.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
+			DatasourceUID:  "grafanacloud-logs",
+			DatasourceType: "loki",
+			Expr:           `rate({name="ingress-nginx-controller"}[$__auto])`,
+			Instant:        true,
+		})
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Contains(t, params.Get("panes"), `"instant":true`)
+		assert.Contains(t, params.Get("panes"), `"range":false`)
+	})
+
+	t.Run("returns empty for missing required fields", func(t *testing.T) {
+		assert.Empty(t, loki.MetricsExploreURL("", dsquery.ExploreQuery{DatasourceUID: "loki-uid", Expr: "rate({}[5m])"}))
+		assert.Empty(t, loki.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{Expr: "rate({}[5m])"}))
+		assert.Empty(t, loki.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{DatasourceUID: "loki-uid"}))
+	})
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}

--- a/internal/datasources/loki/explore_test.go
+++ b/internal/datasources/loki/explore_test.go
@@ -3,6 +3,7 @@ package loki_test
 import (
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/grafana/gcx/internal/datasources/loki"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
@@ -76,6 +77,44 @@ func TestMetricsExploreURL(t *testing.T) {
 		params := mustParseURL(t, got).Query()
 		assert.Contains(t, params.Get("panes"), `"instant":true`)
 		assert.Contains(t, params.Get("panes"), `"range":false`)
+	})
+
+	t.Run("includes orgId when present", func(t *testing.T) {
+		got := loki.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
+			DatasourceUID:  "grafanacloud-logs",
+			DatasourceType: "loki",
+			Expr:           `rate({name="ingress-nginx-controller"}[$__auto])`,
+			OrgID:          7,
+		})
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Equal(t, "7", params.Get("orgId"))
+	})
+
+	t.Run("includes intervalMs when step is set", func(t *testing.T) {
+		got := loki.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
+			DatasourceUID:  "grafanacloud-logs",
+			DatasourceType: "loki",
+			Expr:           `rate({name="ingress-nginx-controller"}[$__auto])`,
+			Step:           time.Minute,
+		})
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Contains(t, params.Get("panes"), `"intervalMs":60000`)
+	})
+
+	t.Run("omits intervalMs when step is zero", func(t *testing.T) {
+		got := loki.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
+			DatasourceUID:  "grafanacloud-logs",
+			DatasourceType: "loki",
+			Expr:           `rate({name="ingress-nginx-controller"}[$__auto])`,
+		})
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.NotContains(t, params.Get("panes"), `"intervalMs"`)
 	})
 
 	t.Run("returns empty for missing required fields", func(t *testing.T) {

--- a/internal/datasources/loki/metrics.go
+++ b/internal/datasources/loki/metrics.go
@@ -17,6 +17,7 @@ import (
 // MetricsCmd returns the `metrics` subcommand for metric LogQL queries.
 func MetricsCmd(loader *providers.ConfigLoader) *cobra.Command {
 	shared := &dsquery.SharedOpts{}
+	share := &dsquery.ExploreLinkOpts{}
 	var datasource string
 
 	cmd := &cobra.Command{
@@ -31,13 +32,18 @@ Unlike 'logs query' which returns log lines, 'logs metrics' returns
 time-series data with proper table, graph, and JSON formatters.
 
 Instant vs range is deduced from time flags: no time flags = instant query,
---since or --from/--to = range query.`,
+--since or --from/--to = range query.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.`,
 		Example: `
   # Rate of log lines over 5 minutes
   gcx datasources loki metrics 'rate({job="varlogs"}[5m])' --since 1h -o table
 
   # Count of error logs
   gcx datasources loki metrics 'count_over_time({job="varlogs"} |= "error" [5m])' --since 1h
+
+  # Print a Grafana Explore share link for the query
+  gcx datasources loki metrics 'rate({job="varlogs"}[5m])' --share-link
 
   # Line chart output
   gcx datasources loki metrics -d loki-001 'rate({job="varlogs"}[5m])' --since 1h -o graph
@@ -107,7 +113,24 @@ Instant vs range is deduced from time flags: no time flags = instant query,
 				return fmt.Errorf("metric query failed: %w", err)
 			}
 
-			return shared.IO.Encode(cmd.OutOrStdout(), resp)
+			exploreURL := MetricsExploreURL(cfg.GrafanaURL, dsquery.ExploreQuery{
+				DatasourceUID:  datasourceUID,
+				DatasourceType: dsType,
+				Expr:           expr,
+				From:           shared.From,
+				To:             shared.To,
+				Instant:        !req.IsRange(),
+				OrgID:          dsquery.OrgID(cfgCtx),
+			})
+			unavailableMsg, failedOpenMsg := dsquery.ExploreMessages("metric query")
+
+			return dsquery.EncodeAndHandleExplore(cmd, func() error {
+				return shared.IO.Encode(cmd.OutOrStdout(), resp)
+			}, *share, dsquery.ExploreLink{
+				URL:            exploreURL,
+				UnavailableMsg: unavailableMsg,
+				FailedOpenMsg:  failedOpenMsg,
+			})
 		},
 	}
 
@@ -118,6 +141,7 @@ Instant vs range is deduced from time flags: no time flags = instant query,
 
 	shared.Setup(cmd.Flags(), true)
 	cmd.Flags().StringVarP(&datasource, "datasource", "d", "", "Datasource UID (required unless datasources.loki is configured)")
+	share.Setup(cmd.Flags(), "executed query")
 
 	return cmd
 }

--- a/internal/datasources/loki/metrics.go
+++ b/internal/datasources/loki/metrics.go
@@ -120,6 +120,7 @@ open it in your browser after the query succeeds.`,
 				From:           shared.From,
 				To:             shared.To,
 				Instant:        !req.IsRange(),
+				Step:           step,
 				OrgID:          dsquery.OrgID(cfgCtx),
 			})
 			unavailableMsg, failedOpenMsg := dsquery.ExploreMessages("metric query")

--- a/internal/datasources/loki/query.go
+++ b/internal/datasources/loki/query.go
@@ -17,6 +17,7 @@ import (
 // QueryCmd returns the `query` subcommand for a Loki datasource parent.
 func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
 	shared := &dsquery.SharedOpts{}
+	share := &dsquery.ExploreLinkOpts{}
 	var limit int
 	var datasource string
 
@@ -31,13 +32,18 @@ Datasource is resolved from -d flag or datasources.loki in your context.
 Default table output is optimized for humans. Use -o raw for original line
 bodies or -o json for the full structured response.
 
-Default --limit is 50; use --limit 0 for no cap.`,
+Default --limit is 50; use --limit 0 for no cap.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.`,
 		Example: `
   # Query logs using configured default datasource
   gcx datasources loki query '{job="varlogs"}'
 
   # Query with explicit datasource UID
   gcx datasources loki query -d UID '{job="varlogs"} |= "error"'
+
+  # Print a Grafana Explore share link for the query
+  gcx datasources loki query '{job="varlogs"}' --share-link
 
   # Raw line bodies only
   gcx datasources loki query -d UID '{job="varlogs"}' -o raw
@@ -108,7 +114,23 @@ Default --limit is 50; use --limit 0 for no cap.`,
 				return fmt.Errorf("query failed: %w", err)
 			}
 
-			return shared.IO.Encode(cmd.OutOrStdout(), resp)
+			exploreURL := LogsExploreURL(cfg.GrafanaURL, dsquery.ExploreQuery{
+				DatasourceUID:  datasourceUID,
+				DatasourceType: dsType,
+				Expr:           expr,
+				From:           shared.From,
+				To:             shared.To,
+				OrgID:          dsquery.OrgID(cfgCtx),
+			})
+			unavailableMsg, failedOpenMsg := dsquery.ExploreMessages("query")
+
+			return dsquery.EncodeAndHandleExplore(cmd, func() error {
+				return shared.IO.Encode(cmd.OutOrStdout(), resp)
+			}, *share, dsquery.ExploreLink{
+				URL:            exploreURL,
+				UnavailableMsg: unavailableMsg,
+				FailedOpenMsg:  failedOpenMsg,
+			})
 		},
 	}
 
@@ -125,6 +147,7 @@ Default --limit is 50; use --limit 0 for no cap.`,
 	shared.SetupExprFlag(cmd.Flags())
 	cmd.Flags().StringVarP(&datasource, "datasource", "d", "", "Datasource UID (required unless datasources.loki is configured)")
 	cmd.Flags().IntVar(&limit, "limit", dsquery.DefaultLokiLimit, "Maximum number of log lines to return (0 means no limit)")
+	share.Setup(cmd.Flags(), "executed query")
 
 	return cmd
 }

--- a/internal/datasources/prometheus/explore.go
+++ b/internal/datasources/prometheus/explore.go
@@ -1,0 +1,30 @@
+package prometheus
+
+import (
+	"strings"
+
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+)
+
+// ExploreURL builds a Grafana Explore URL for a Prometheus query.
+func ExploreURL(host string, query dsquery.ExploreQuery) string {
+	if strings.TrimSpace(host) == "" || query.DatasourceUID == "" || strings.TrimSpace(query.Expr) == "" {
+		return ""
+	}
+
+	from, to := dsquery.ExploreRange(query.From, query.To, query.Instant)
+
+	q := map[string]any{
+		"refId":      "A",
+		"expr":       query.Expr,
+		"editorMode": "code",
+		"instant":    query.Instant,
+		"range":      !query.Instant,
+		"datasource": dsquery.ExploreDatasource(query.DatasourceType, query.DatasourceUID),
+	}
+	if query.Step > 0 {
+		q["intervalMs"] = query.Step.Milliseconds()
+	}
+
+	return dsquery.BuildExploreURL(host, query.OrgID, dsquery.SinglePane(query.DatasourceUID, []any{q}, from, to, nil), nil)
+}

--- a/internal/datasources/prometheus/explore.go
+++ b/internal/datasources/prometheus/explore.go
@@ -6,8 +6,8 @@ import (
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 )
 
-// ExploreURL builds a Grafana Explore URL for a Prometheus query.
-func ExploreURL(host string, query dsquery.ExploreQuery) string {
+// QueryExploreURL builds a Grafana Explore URL for a Prometheus query.
+func QueryExploreURL(host string, query dsquery.ExploreQuery) string {
 	if strings.TrimSpace(host) == "" || query.DatasourceUID == "" || strings.TrimSpace(query.Expr) == "" {
 		return ""
 	}

--- a/internal/datasources/prometheus/explore_test.go
+++ b/internal/datasources/prometheus/explore_test.go
@@ -1,0 +1,68 @@
+package prometheus_test
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/datasources/prometheus"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExploreURL(t *testing.T) {
+	t.Run("builds instant explore link", func(t *testing.T) {
+		got := prometheus.ExploreURL("https://mystack.grafana.net/", dsquery.ExploreQuery{
+			DatasourceUID:  "prom-uid",
+			DatasourceType: "prometheus",
+			Expr:           `up{job="grafana/server"}`,
+			Instant:        true,
+			OrgID:          7,
+		})
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Equal(t, "1", params.Get("schemaVersion"))
+		assert.Equal(t, "7", params.Get("orgId"))
+		assert.Contains(t, params.Get("panes"), `"expr":"up{job=\"grafana/server\"}"`)
+		assert.Contains(t, params.Get("panes"), `"uid":"prom-uid"`)
+		assert.Contains(t, params.Get("panes"), `"instant":true`)
+		assert.Contains(t, params.Get("panes"), `"range":false`)
+		assert.Contains(t, params.Get("panes"), `"from":"now-1m"`)
+		assert.Contains(t, params.Get("panes"), `"to":"now"`)
+	})
+
+	t.Run("builds range explore link with explicit time bounds", func(t *testing.T) {
+		got := prometheus.ExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{
+			DatasourceUID:  "prom-uid",
+			DatasourceType: "prometheus",
+			Expr:           "rate(http_requests_total[5m])",
+			From:           "2026-04-24T10:00:00Z",
+			To:             "2026-04-24T11:00:00Z",
+			Step:           time.Minute,
+		})
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Contains(t, params.Get("panes"), `"expr":"rate(http_requests_total[5m])"`)
+		assert.Contains(t, params.Get("panes"), `"instant":false`)
+		assert.Contains(t, params.Get("panes"), `"range":true`)
+		assert.Contains(t, params.Get("panes"), `"from":"2026-04-24T10:00:00Z"`)
+		assert.Contains(t, params.Get("panes"), `"to":"2026-04-24T11:00:00Z"`)
+		assert.Contains(t, params.Get("panes"), `"intervalMs":60000`)
+	})
+
+	t.Run("returns empty for missing host or required query fields", func(t *testing.T) {
+		assert.Empty(t, prometheus.ExploreURL("", dsquery.ExploreQuery{DatasourceUID: "prom-uid", Expr: "up"}))
+		assert.Empty(t, prometheus.ExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{Expr: "up"}))
+		assert.Empty(t, prometheus.ExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{DatasourceUID: "prom-uid"}))
+	})
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}

--- a/internal/datasources/prometheus/explore_test.go
+++ b/internal/datasources/prometheus/explore_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExploreURL(t *testing.T) {
+func TestQueryExploreURL(t *testing.T) {
 	t.Run("builds instant explore link", func(t *testing.T) {
-		got := prometheus.ExploreURL("https://mystack.grafana.net/", dsquery.ExploreQuery{
+		got := prometheus.QueryExploreURL("https://mystack.grafana.net/", dsquery.ExploreQuery{
 			DatasourceUID:  "prom-uid",
 			DatasourceType: "prometheus",
 			Expr:           `up{job="grafana/server"}`,
@@ -34,7 +34,7 @@ func TestExploreURL(t *testing.T) {
 	})
 
 	t.Run("builds range explore link with explicit time bounds", func(t *testing.T) {
-		got := prometheus.ExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{
+		got := prometheus.QueryExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{
 			DatasourceUID:  "prom-uid",
 			DatasourceType: "prometheus",
 			Expr:           "rate(http_requests_total[5m])",
@@ -54,9 +54,9 @@ func TestExploreURL(t *testing.T) {
 	})
 
 	t.Run("returns empty for missing host or required query fields", func(t *testing.T) {
-		assert.Empty(t, prometheus.ExploreURL("", dsquery.ExploreQuery{DatasourceUID: "prom-uid", Expr: "up"}))
-		assert.Empty(t, prometheus.ExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{Expr: "up"}))
-		assert.Empty(t, prometheus.ExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{DatasourceUID: "prom-uid"}))
+		assert.Empty(t, prometheus.QueryExploreURL("", dsquery.ExploreQuery{DatasourceUID: "prom-uid", Expr: "up"}))
+		assert.Empty(t, prometheus.QueryExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{Expr: "up"}))
+		assert.Empty(t, prometheus.QueryExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{DatasourceUID: "prom-uid"}))
 	})
 }
 

--- a/internal/datasources/prometheus/query.go
+++ b/internal/datasources/prometheus/query.go
@@ -23,6 +23,7 @@ func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
 // UID used when --datasource is not provided. Pass "" for no default.
 func QueryCmdWithDefault(loader *providers.ConfigLoader, defaultDS string) *cobra.Command {
 	shared := &dsquery.SharedOpts{}
+	share := &dsquery.ExploreLinkOpts{}
 	var datasource string
 
 	cmd := &cobra.Command{
@@ -32,7 +33,9 @@ func QueryCmdWithDefault(loader *providers.ConfigLoader, defaultDS string) *cobr
 
 EXPR is the PromQL expression to evaluate, passed as a positional argument or
 via --expr (familiar to promtool users).
-Datasource is resolved from -d flag or datasources.prometheus in your context.`,
+Datasource is resolved from -d flag or datasources.prometheus in your context.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.`,
 		Example: `
   # Instant query using configured default datasource
   gcx datasources prometheus query 'up{job="grafana"}'
@@ -42,6 +45,9 @@ Datasource is resolved from -d flag or datasources.prometheus in your context.`,
 
   # Query the last hour
   gcx datasources prometheus query 'up' --since 1h
+
+  # Print a Grafana Explore share link for the executed query
+  gcx datasources prometheus query 'up' --share-link
 
   # Output as JSON
   gcx datasources prometheus query -d UID 'up' -o json`,
@@ -113,7 +119,25 @@ Datasource is resolved from -d flag or datasources.prometheus in your context.`,
 				return fmt.Errorf("query failed: %w", err)
 			}
 
-			return shared.IO.Encode(cmd.OutOrStdout(), resp)
+			exploreURL := ExploreURL(cfg.GrafanaURL, dsquery.ExploreQuery{
+				DatasourceUID:  datasourceUID,
+				DatasourceType: dsType,
+				Expr:           expr,
+				From:           shared.From,
+				To:             shared.To,
+				Instant:        !req.IsRange(),
+				Step:           step,
+				OrgID:          dsquery.OrgID(cfgCtx),
+			})
+			unavailableMsg, failedOpenMsg := dsquery.ExploreMessages("query")
+
+			return dsquery.EncodeAndHandleExplore(cmd, func() error {
+				return shared.IO.Encode(cmd.OutOrStdout(), resp)
+			}, *share, dsquery.ExploreLink{
+				URL:            exploreURL,
+				UnavailableMsg: unavailableMsg,
+				FailedOpenMsg:  failedOpenMsg,
+			})
 		},
 	}
 
@@ -124,6 +148,7 @@ Datasource is resolved from -d flag or datasources.prometheus in your context.`,
 
 	shared.Setup(cmd.Flags(), true)
 	cmd.Flags().StringVarP(&datasource, "datasource", "d", "", "Datasource UID (required unless datasources.prometheus is configured)")
+	share.Setup(cmd.Flags(), "executed query")
 
 	return cmd
 }

--- a/internal/datasources/prometheus/query.go
+++ b/internal/datasources/prometheus/query.go
@@ -119,7 +119,7 @@ open it in your browser after the query succeeds.`,
 				return fmt.Errorf("query failed: %w", err)
 			}
 
-			exploreURL := ExploreURL(cfg.GrafanaURL, dsquery.ExploreQuery{
+			exploreURL := QueryExploreURL(cfg.GrafanaURL, dsquery.ExploreQuery{
 				DatasourceUID:  datasourceUID,
 				DatasourceType: dsType,
 				Expr:           expr,

--- a/internal/datasources/query/explore.go
+++ b/internal/datasources/query/explore.go
@@ -1,0 +1,105 @@
+package query
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const DefaultExplorePaneID = "gcx"
+
+// ExploreQuery describes the query state encoded into a Grafana Explore URL.
+type ExploreQuery struct {
+	DatasourceUID  string
+	DatasourceType string
+	Expr           string
+	From           string
+	To             string
+	Instant        bool
+	Step           time.Duration
+	OrgID          int64
+}
+
+// ExploreRange normalizes the visible Explore time range.
+func ExploreRange(from, to string, instant bool) (string, string) {
+	from = strings.TrimSpace(from)
+	to = strings.TrimSpace(to)
+	if to == "" {
+		to = "now"
+	}
+	if from == "" {
+		if instant {
+			from = "now-1m"
+		} else {
+			from = "now-1h"
+		}
+	}
+	return from, to
+}
+
+// ShortExploreRange normalizes the visible Explore time range using a short
+// default lookback window when no explicit range was provided.
+func ShortExploreRange(from, to string) (string, string) {
+	from, to = ExploreRange(from, to, false)
+	if strings.TrimSpace(from) == "now-1h" {
+		from = "now-1m"
+	}
+	return from, to
+}
+
+// ExploreDatasource renders the datasource reference block expected by Explore.
+func ExploreDatasource(dsType, uid string) map[string]any {
+	return map[string]any{
+		"type": dsType,
+		"uid":  uid,
+	}
+}
+
+// SinglePane renders a single Explore pane payload under the default pane ID.
+func SinglePane(datasourceUID string, queries []any, from, to string, extra map[string]any) map[string]any {
+	pane := map[string]any{
+		"datasource": datasourceUID,
+		"queries":    queries,
+		"range": map[string]any{
+			"from": from,
+			"to":   to,
+		},
+	}
+	for key, value := range extra {
+		pane[key] = value
+	}
+	return map[string]any{DefaultExplorePaneID: pane}
+}
+
+// BuildExploreURL renders the final Grafana Explore URL.
+func BuildExploreURL(host string, orgID int64, panes map[string]any, extra map[string]string) string {
+	host = strings.TrimRight(strings.TrimSpace(host), "/")
+	if host == "" {
+		return ""
+	}
+
+	panesJSON, err := json.Marshal(panes)
+	if err != nil {
+		return ""
+	}
+
+	u, err := url.Parse(host + "/explore")
+	if err != nil {
+		return ""
+	}
+
+	params := u.Query()
+	params.Set("schemaVersion", "1")
+	params.Set("panes", string(panesJSON))
+	if orgID > 0 {
+		params.Set("orgId", strconv.FormatInt(orgID, 10))
+	}
+	for key, value := range extra {
+		params.Set(key, value)
+	}
+	u.RawQuery = params.Encode()
+
+	return u.String()
+}

--- a/internal/datasources/query/explore.go
+++ b/internal/datasources/query/explore.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"encoding/json"
+	"maps"
 	"net/url"
 	"strconv"
 	"strings"
@@ -42,8 +43,12 @@ func ExploreRange(from, to string, instant bool) (string, string) {
 // ShortExploreRange normalizes the visible Explore time range using a short
 // default lookback window when no explicit range was provided.
 func ShortExploreRange(from, to string) (string, string) {
-	from, to = ExploreRange(from, to, false)
-	if strings.TrimSpace(from) == "now-1h" {
+	from = strings.TrimSpace(from)
+	to = strings.TrimSpace(to)
+	if to == "" {
+		to = "now"
+	}
+	if from == "" {
 		from = "now-1m"
 	}
 	return from, to
@@ -67,9 +72,7 @@ func SinglePane(datasourceUID string, queries []any, from, to string, extra map[
 			"to":   to,
 		},
 	}
-	for key, value := range extra {
-		pane[key] = value
-	}
+	maps.Copy(pane, extra)
 	return map[string]any{DefaultExplorePaneID: pane}
 }
 
@@ -77,6 +80,9 @@ func SinglePane(datasourceUID string, queries []any, from, to string, extra map[
 func BuildExploreURL(host string, orgID int64, panes map[string]any, extra map[string]string) string {
 	host = strings.TrimRight(strings.TrimSpace(host), "/")
 	if host == "" {
+		return ""
+	}
+	if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
 		return ""
 	}
 

--- a/internal/datasources/query/explore_test.go
+++ b/internal/datasources/query/explore_test.go
@@ -1,0 +1,84 @@
+package query_test
+
+import (
+	"testing"
+
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShortExploreRange(t *testing.T) {
+	tests := []struct {
+		name     string
+		from     string
+		to       string
+		wantFrom string
+		wantTo   string
+	}{
+		{
+			name:     "defaults to short window when neither provided",
+			wantFrom: "now-1m",
+			wantTo:   "now",
+		},
+		{
+			name:     "preserves explicit relative from",
+			from:     "now-1h",
+			wantFrom: "now-1h",
+			wantTo:   "now",
+		},
+		{
+			name:     "preserves explicit absolute timestamps",
+			from:     "2026-04-24T10:00:00Z",
+			to:       "2026-04-24T11:00:00Z",
+			wantFrom: "2026-04-24T10:00:00Z",
+			wantTo:   "2026-04-24T11:00:00Z",
+		},
+		{
+			name:     "trims whitespace from inputs",
+			from:     "  now-15m  ",
+			to:       "  now  ",
+			wantFrom: "now-15m",
+			wantTo:   "now",
+		},
+		{
+			name:     "applies short default when only to is provided",
+			to:       "now",
+			wantFrom: "now-1m",
+			wantTo:   "now",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFrom, gotTo := dsquery.ShortExploreRange(tt.from, tt.to)
+			assert.Equal(t, tt.wantFrom, gotFrom)
+			assert.Equal(t, tt.wantTo, gotTo)
+		})
+	}
+}
+
+func TestBuildExploreURL_RejectsNonHTTPSchemes(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+	}{
+		{name: "javascript", host: "javascript:alert(1)"},
+		{name: "data", host: "data:text/html,<script>alert(1)</script>"},
+		{name: "file", host: "file:///etc/passwd"},
+		{name: "no scheme", host: "example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dsquery.BuildExploreURL(tt.host, 0, map[string]any{"k": "v"}, nil)
+			assert.Empty(t, got)
+		})
+	}
+}
+
+func TestBuildExploreURL_AcceptsHTTPAndHTTPS(t *testing.T) {
+	for _, host := range []string{"http://localhost:3000", "https://example.grafana.net"} {
+		got := dsquery.BuildExploreURL(host, 0, map[string]any{"k": "v"}, nil)
+		assert.NotEmpty(t, got, host)
+	}
+}

--- a/internal/datasources/query/sharelink.go
+++ b/internal/datasources/query/sharelink.go
@@ -1,0 +1,78 @@
+package query
+
+import (
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/deeplink"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// ExploreLinkOpts controls optional Grafana Explore link output for query-like commands.
+type ExploreLinkOpts struct {
+	ShareLink bool
+	Open      bool
+}
+
+// Setup registers the standard share/open flags for query-like commands.
+func (opts *ExploreLinkOpts) Setup(flags *pflag.FlagSet, subject string) {
+	flags.BoolVar(&opts.ShareLink, "share-link", false, "Print the Grafana Explore URL for the "+subject+" to stderr")
+	flags.BoolVar(&opts.Open, "open", false, "Open the "+subject+" in Grafana Explore")
+}
+
+// Enabled reports whether either share/open behavior was requested.
+func (opts ExploreLinkOpts) Enabled() bool {
+	return opts.ShareLink || opts.Open
+}
+
+// ExploreLink describes optional Grafana Explore link handling after a command succeeds.
+type ExploreLink struct {
+	URL            string
+	UnavailableMsg string
+	FailedOpenMsg  string
+}
+
+// ExploreMessages returns the standard unavailable/open-failed messages for a
+// successfully completed command subject.
+func ExploreMessages(subject string) (string, string) {
+	return subject + " succeeded, but no Grafana Explore URL could be built",
+		subject + " succeeded, but could not open browser"
+}
+
+// OrgID returns the Grafana org ID for Explore link generation.
+func OrgID(cfgCtx *config.Context) int64 {
+	if cfgCtx != nil && cfgCtx.Grafana != nil {
+		return cfgCtx.Grafana.OrgID
+	}
+	return 0
+}
+
+// EncodeAndHandleExplore writes command output and then handles the optional
+// Explore link side effects.
+func EncodeAndHandleExplore(cmd *cobra.Command, encode func() error, opts ExploreLinkOpts, link ExploreLink) error {
+	if err := encode(); err != nil {
+		return err
+	}
+	return HandleExploreLink(cmd, opts, link.URL, link.UnavailableMsg, link.FailedOpenMsg)
+}
+
+// HandleExploreLink prints and/or opens a Grafana Explore URL.
+// Missing URLs are warned about but do not fail the command after successful data retrieval.
+func HandleExploreLink(cmd *cobra.Command, opts ExploreLinkOpts, url string, unavailableMsg, failedOpenMsg string) error {
+	if !opts.Enabled() {
+		return nil
+	}
+	if url == "" {
+		cmdio.Warning(cmd.ErrOrStderr(), "%s", unavailableMsg)
+		return nil
+	}
+	if opts.ShareLink {
+		cmdio.Info(cmd.ErrOrStderr(), "Explore link: %s", url)
+	}
+	if opts.Open {
+		if err := deeplink.Open(url); err != nil {
+			cmdio.Warning(cmd.ErrOrStderr(), "%s: %v", failedOpenMsg, err)
+		}
+	}
+	return nil
+}

--- a/internal/datasources/query/sharelink.go
+++ b/internal/datasources/query/sharelink.go
@@ -21,7 +21,7 @@ func (opts *ExploreLinkOpts) Setup(flags *pflag.FlagSet, subject string) {
 }
 
 // Enabled reports whether either share/open behavior was requested.
-func (opts ExploreLinkOpts) Enabled() bool {
+func (opts *ExploreLinkOpts) Enabled() bool {
 	return opts.ShareLink || opts.Open
 }
 

--- a/internal/datasources/query/sharelink_test.go
+++ b/internal/datasources/query/sharelink_test.go
@@ -1,0 +1,61 @@
+package query
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrgID(t *testing.T) {
+	assert.Zero(t, OrgID(nil))
+	assert.Zero(t, OrgID(&config.Context{}))
+	assert.Equal(t, int64(42), OrgID(&config.Context{Grafana: &config.GrafanaConfig{OrgID: 42}}))
+}
+
+func TestExploreMessages(t *testing.T) {
+	unavailable, failedOpen := ExploreMessages("query")
+	assert.Equal(t, "query succeeded, but no Grafana Explore URL could be built", unavailable)
+	assert.Equal(t, "query succeeded, but could not open browser", failedOpen)
+}
+
+func TestEncodeAndHandleExplore(t *testing.T) {
+	t.Run("encodes output then prints share link", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stderr)
+
+		called := false
+		err := EncodeAndHandleExplore(cmd, func() error {
+			called = true
+			_, writeErr := stdout.WriteString("ok\n")
+			return writeErr
+		}, ExploreLinkOpts{ShareLink: true}, ExploreLink{
+			URL:            "https://example.grafana.net/explore?x=1",
+			UnavailableMsg: "unavailable",
+			FailedOpenMsg:  "failed",
+		})
+		require.NoError(t, err)
+		assert.True(t, called)
+		assert.Equal(t, "ok\n", stdout.String())
+		assert.Contains(t, stderr.String(), "Explore link: https://example.grafana.net/explore?x=1")
+	})
+
+	t.Run("warns when no explore url is available", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		var stderr bytes.Buffer
+		cmd.SetErr(&stderr)
+
+		err := EncodeAndHandleExplore(cmd, func() error { return nil }, ExploreLinkOpts{ShareLink: true}, ExploreLink{
+			UnavailableMsg: "no url",
+			FailedOpenMsg:  "failed",
+		})
+		require.NoError(t, err)
+		assert.Contains(t, stderr.String(), "no url")
+	})
+}

--- a/internal/datasources/query/sharelink_test.go
+++ b/internal/datasources/query/sharelink_test.go
@@ -1,23 +1,24 @@
-package query
+package query_test
 
 import (
 	"bytes"
 	"testing"
 
 	"github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestOrgID(t *testing.T) {
-	assert.Zero(t, OrgID(nil))
-	assert.Zero(t, OrgID(&config.Context{}))
-	assert.Equal(t, int64(42), OrgID(&config.Context{Grafana: &config.GrafanaConfig{OrgID: 42}}))
+	assert.Zero(t, dsquery.OrgID(nil))
+	assert.Zero(t, dsquery.OrgID(&config.Context{}))
+	assert.Equal(t, int64(42), dsquery.OrgID(&config.Context{Grafana: &config.GrafanaConfig{OrgID: 42}}))
 }
 
 func TestExploreMessages(t *testing.T) {
-	unavailable, failedOpen := ExploreMessages("query")
+	unavailable, failedOpen := dsquery.ExploreMessages("query")
 	assert.Equal(t, "query succeeded, but no Grafana Explore URL could be built", unavailable)
 	assert.Equal(t, "query succeeded, but could not open browser", failedOpen)
 }
@@ -31,11 +32,11 @@ func TestEncodeAndHandleExplore(t *testing.T) {
 		cmd.SetErr(&stderr)
 
 		called := false
-		err := EncodeAndHandleExplore(cmd, func() error {
+		err := dsquery.EncodeAndHandleExplore(cmd, func() error {
 			called = true
 			_, writeErr := stdout.WriteString("ok\n")
 			return writeErr
-		}, ExploreLinkOpts{ShareLink: true}, ExploreLink{
+		}, dsquery.ExploreLinkOpts{ShareLink: true}, dsquery.ExploreLink{
 			URL:            "https://example.grafana.net/explore?x=1",
 			UnavailableMsg: "unavailable",
 			FailedOpenMsg:  "failed",
@@ -51,7 +52,7 @@ func TestEncodeAndHandleExplore(t *testing.T) {
 		var stderr bytes.Buffer
 		cmd.SetErr(&stderr)
 
-		err := EncodeAndHandleExplore(cmd, func() error { return nil }, ExploreLinkOpts{ShareLink: true}, ExploreLink{
+		err := dsquery.EncodeAndHandleExplore(cmd, func() error { return nil }, dsquery.ExploreLinkOpts{ShareLink: true}, dsquery.ExploreLink{
 			UnavailableMsg: "no url",
 			FailedOpenMsg:  "failed",
 		})

--- a/internal/datasources/tempo/explore.go
+++ b/internal/datasources/tempo/explore.go
@@ -1,0 +1,75 @@
+package tempo
+
+import (
+	"strings"
+
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+)
+
+// SearchExploreURL builds a Grafana Explore URL for a Tempo TraceQL search query.
+func SearchExploreURL(host string, query dsquery.ExploreQuery, limit int) string {
+	return buildTraceQLExploreURL(host, query, limit, "range")
+}
+
+// MetricsExploreURL builds a Grafana Explore URL for a Tempo TraceQL metrics query.
+func MetricsExploreURL(host string, query dsquery.ExploreQuery, limit int) string {
+	metricsQueryType := "range"
+	if query.Instant {
+		metricsQueryType = "instant"
+	}
+	return buildTraceQLExploreURL(host, query, limit, metricsQueryType)
+}
+
+func buildTraceQLExploreURL(host string, query dsquery.ExploreQuery, limit int, metricsQueryType string) string {
+	if strings.TrimSpace(host) == "" || query.DatasourceUID == "" || strings.TrimSpace(query.Expr) == "" {
+		return ""
+	}
+	if limit == 0 {
+		return ""
+	}
+	if limit < 0 {
+		limit = 20
+	}
+
+	from, to := dsquery.ShortExploreRange(query.From, query.To)
+
+	queries := []any{map[string]any{
+		"refId":                         "A",
+		"datasource":                    dsquery.ExploreDatasource(query.DatasourceType, query.DatasourceUID),
+		"queryType":                     "traceql",
+		"limit":                         limit,
+		"tableType":                     "traces",
+		"metricsQueryType":              metricsQueryType,
+		"serviceMapUseNativeHistograms": false,
+		"query":                         query.Expr,
+	}}
+
+	return dsquery.BuildExploreURL(host, query.OrgID, dsquery.SinglePane(query.DatasourceUID, queries, from, to, map[string]any{
+		"compact": false,
+	}), nil)
+}
+
+// TraceExploreURL builds a Grafana Explore URL for a Tempo trace ID lookup.
+func TraceExploreURL(host string, query dsquery.ExploreQuery, traceID string) string {
+	traceID = strings.TrimSpace(traceID)
+	if strings.TrimSpace(host) == "" || query.DatasourceUID == "" || traceID == "" {
+		return ""
+	}
+
+	from, to := dsquery.ShortExploreRange(query.From, query.To)
+
+	queries := []any{map[string]any{
+		"refId":                         "A",
+		"datasource":                    dsquery.ExploreDatasource(query.DatasourceType, query.DatasourceUID),
+		"queryType":                     "traceql",
+		"limit":                         20,
+		"tableType":                     "traces",
+		"metricsQueryType":              "range",
+		"serviceMapUseNativeHistograms": false,
+		"query":                         traceID,
+	}}
+
+	return dsquery.BuildExploreURL(host, query.OrgID, dsquery.SinglePane(query.DatasourceUID, queries, from, to, map[string]any{
+		"compact": false,
+	}), map[string]string{"traceId": traceID})
+}

--- a/internal/datasources/tempo/explore_test.go
+++ b/internal/datasources/tempo/explore_test.go
@@ -1,0 +1,133 @@
+package tempo_test
+
+import (
+	"net/url"
+	"testing"
+
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/datasources/tempo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchExploreURL(t *testing.T) {
+	t.Run("builds traceql search explore link", func(t *testing.T) {
+		got := tempo.SearchExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
+			DatasourceUID:  "grafanacloud-traces",
+			DatasourceType: "tempo",
+			Expr:           `{name != nil}`,
+		}, 20)
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Equal(t, "1", params.Get("schemaVersion"))
+		assert.Contains(t, params.Get("panes"), `"datasource":"grafanacloud-traces"`)
+		assert.Contains(t, params.Get("panes"), `"queryType":"traceql"`)
+		assert.Contains(t, params.Get("panes"), `"limit":20`)
+		assert.Contains(t, params.Get("panes"), `"tableType":"traces"`)
+		assert.Contains(t, params.Get("panes"), `"metricsQueryType":"range"`)
+		assert.Contains(t, params.Get("panes"), `"serviceMapUseNativeHistograms":false`)
+		assert.Contains(t, params.Get("panes"), `"query":"{name != nil}"`)
+		assert.Contains(t, params.Get("panes"), `"from":"now-1m"`)
+		assert.Contains(t, params.Get("panes"), `"to":"now"`)
+		assert.Contains(t, params.Get("panes"), `"compact":false`)
+	})
+
+	t.Run("returns empty for missing required fields", func(t *testing.T) {
+		assert.Empty(t, tempo.SearchExploreURL("", dsquery.ExploreQuery{DatasourceUID: "tempo-uid", Expr: "{}"}, 20))
+		assert.Empty(t, tempo.SearchExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{Expr: "{}"}, 20))
+		assert.Empty(t, tempo.SearchExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{DatasourceUID: "tempo-uid"}, 20))
+	})
+
+	t.Run("returns empty for unlimited result searches", func(t *testing.T) {
+		assert.Empty(t, tempo.SearchExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
+			DatasourceUID:  "grafanacloud-traces",
+			DatasourceType: "tempo",
+			Expr:           `{name != nil}`,
+		}, 0))
+	})
+}
+
+func TestMetricsExploreURL(t *testing.T) {
+	t.Run("builds traceql metrics explore link", func(t *testing.T) {
+		got := tempo.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
+			DatasourceUID:  "grafanacloud-traces",
+			DatasourceType: "tempo",
+			Expr:           `{name != nil} | rate()`,
+		}, 20)
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Equal(t, "1", params.Get("schemaVersion"))
+		assert.Contains(t, params.Get("panes"), `"datasource":"grafanacloud-traces"`)
+		assert.Contains(t, params.Get("panes"), `"queryType":"traceql"`)
+		assert.Contains(t, params.Get("panes"), `"limit":20`)
+		assert.Contains(t, params.Get("panes"), `"tableType":"traces"`)
+		assert.Contains(t, params.Get("panes"), `"metricsQueryType":"range"`)
+		assert.Contains(t, params.Get("panes"), `"serviceMapUseNativeHistograms":false`)
+		assert.Contains(t, params.Get("panes"), `"query":"{name != nil} | rate()"`)
+		assert.Contains(t, params.Get("panes"), `"from":"now-1m"`)
+		assert.Contains(t, params.Get("panes"), `"to":"now"`)
+		assert.Contains(t, params.Get("panes"), `"compact":false`)
+	})
+
+	t.Run("uses instant metrics query type for instant queries", func(t *testing.T) {
+		got := tempo.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
+			DatasourceUID:  "grafanacloud-traces",
+			DatasourceType: "tempo",
+			Expr:           `{name != nil} | rate()`,
+			Instant:        true,
+		}, 20)
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Contains(t, params.Get("panes"), `"metricsQueryType":"instant"`)
+	})
+
+	t.Run("returns empty for missing required fields", func(t *testing.T) {
+		assert.Empty(t, tempo.MetricsExploreURL("", dsquery.ExploreQuery{DatasourceUID: "tempo-uid", Expr: "{ } | rate()"}, 20))
+		assert.Empty(t, tempo.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{Expr: "{ } | rate()"}, 20))
+		assert.Empty(t, tempo.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{DatasourceUID: "tempo-uid"}, 20))
+	})
+}
+
+func TestTraceExploreURL(t *testing.T) {
+	t.Run("builds trace explore link", func(t *testing.T) {
+		got := tempo.TraceExploreURL("https://mystack.grafana.net/", dsquery.ExploreQuery{
+			DatasourceUID:  "tempo-uid",
+			DatasourceType: "tempo",
+			From:           "2026-04-24T10:00:00Z",
+			To:             "2026-04-24T11:00:00Z",
+			OrgID:          9,
+		}, "287e20fb791cf30")
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Equal(t, "1", params.Get("schemaVersion"))
+		assert.Equal(t, "9", params.Get("orgId"))
+		assert.Equal(t, "287e20fb791cf30", params.Get("traceId"))
+		assert.Contains(t, params.Get("panes"), `"datasource":"tempo-uid"`)
+		assert.Contains(t, params.Get("panes"), `"queryType":"traceql"`)
+		assert.Contains(t, params.Get("panes"), `"limit":20`)
+		assert.Contains(t, params.Get("panes"), `"tableType":"traces"`)
+		assert.Contains(t, params.Get("panes"), `"metricsQueryType":"range"`)
+		assert.Contains(t, params.Get("panes"), `"serviceMapUseNativeHistograms":false`)
+		assert.Contains(t, params.Get("panes"), `"query":"287e20fb791cf30"`)
+		assert.Contains(t, params.Get("panes"), `"from":"2026-04-24T10:00:00Z"`)
+		assert.Contains(t, params.Get("panes"), `"to":"2026-04-24T11:00:00Z"`)
+		assert.Contains(t, params.Get("panes"), `"compact":false`)
+	})
+
+	t.Run("returns empty for missing required fields", func(t *testing.T) {
+		assert.Empty(t, tempo.TraceExploreURL("", dsquery.ExploreQuery{DatasourceUID: "tempo-uid"}, "abc"))
+		assert.Empty(t, tempo.TraceExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{}, "abc"))
+		assert.Empty(t, tempo.TraceExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{DatasourceUID: "tempo-uid"}, ""))
+	})
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}

--- a/internal/datasources/tempo/explore_test.go
+++ b/internal/datasources/tempo/explore_test.go
@@ -10,119 +10,305 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSearchExploreURL(t *testing.T) {
-	t.Run("builds traceql search explore link", func(t *testing.T) {
-		got := tempo.SearchExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
-			DatasourceUID:  "grafanacloud-traces",
-			DatasourceType: "tempo",
-			Expr:           `{name != nil}`,
-		}, 20)
+// traceQLBuilder identifies which TraceQL URL builder a table case targets.
+type traceQLBuilder int
 
-		require.NotEmpty(t, got)
-		params := mustParseURL(t, got).Query()
-		assert.Equal(t, "1", params.Get("schemaVersion"))
-		assert.Contains(t, params.Get("panes"), `"datasource":"grafanacloud-traces"`)
-		assert.Contains(t, params.Get("panes"), `"queryType":"traceql"`)
-		assert.Contains(t, params.Get("panes"), `"limit":20`)
-		assert.Contains(t, params.Get("panes"), `"tableType":"traces"`)
-		assert.Contains(t, params.Get("panes"), `"metricsQueryType":"range"`)
-		assert.Contains(t, params.Get("panes"), `"serviceMapUseNativeHistograms":false`)
-		assert.Contains(t, params.Get("panes"), `"query":"{name != nil}"`)
-		assert.Contains(t, params.Get("panes"), `"from":"now-1m"`)
-		assert.Contains(t, params.Get("panes"), `"to":"now"`)
-		assert.Contains(t, params.Get("panes"), `"compact":false`)
-	})
+const (
+	builderSearch traceQLBuilder = iota
+	builderMetrics
+)
 
-	t.Run("returns empty for missing required fields", func(t *testing.T) {
-		assert.Empty(t, tempo.SearchExploreURL("", dsquery.ExploreQuery{DatasourceUID: "tempo-uid", Expr: "{}"}, 20))
-		assert.Empty(t, tempo.SearchExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{Expr: "{}"}, 20))
-		assert.Empty(t, tempo.SearchExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{DatasourceUID: "tempo-uid"}, 20))
-	})
+func TestTraceQLExploreURLs(t *testing.T) {
+	tests := []struct {
+		name         string
+		builder      traceQLBuilder
+		host         string
+		query        dsquery.ExploreQuery
+		limit        int
+		wantEmpty    bool
+		wantContains []string
+	}{
+		{
+			name:    "search builds traceql search explore link",
+			builder: builderSearch,
+			host:    "https://ops.grafana-ops.net",
+			query: dsquery.ExploreQuery{
+				DatasourceUID:  "grafanacloud-traces",
+				DatasourceType: "tempo",
+				Expr:           `{name != nil}`,
+			},
+			limit: 20,
+			wantContains: []string{
+				`"datasource":"grafanacloud-traces"`,
+				`"queryType":"traceql"`,
+				`"limit":20`,
+				`"tableType":"traces"`,
+				`"metricsQueryType":"range"`,
+				`"serviceMapUseNativeHistograms":false`,
+				`"query":"{name != nil}"`,
+				`"from":"now-1m"`,
+				`"to":"now"`,
+				`"compact":false`,
+			},
+		},
+		{
+			name:    "search preserves explicit relative from",
+			builder: builderSearch,
+			host:    "https://ops.grafana-ops.net",
+			query: dsquery.ExploreQuery{
+				DatasourceUID:  "grafanacloud-traces",
+				DatasourceType: "tempo",
+				Expr:           `{name != nil}`,
+				From:           "now-1h",
+			},
+			limit: 20,
+			wantContains: []string{
+				`"from":"now-1h"`,
+				`"to":"now"`,
+			},
+		},
+		{
+			name:      "search returns empty when host missing",
+			builder:   builderSearch,
+			host:      "",
+			query:     dsquery.ExploreQuery{DatasourceUID: "tempo-uid", Expr: "{}"},
+			limit:     20,
+			wantEmpty: true,
+		},
+		{
+			name:      "search returns empty when datasource UID missing",
+			builder:   builderSearch,
+			host:      "https://ops.grafana-ops.net",
+			query:     dsquery.ExploreQuery{Expr: "{}"},
+			limit:     20,
+			wantEmpty: true,
+		},
+		{
+			name:      "search returns empty when expr missing",
+			builder:   builderSearch,
+			host:      "https://ops.grafana-ops.net",
+			query:     dsquery.ExploreQuery{DatasourceUID: "tempo-uid"},
+			limit:     20,
+			wantEmpty: true,
+		},
+		{
+			name:    "search returns empty when limit is zero",
+			builder: builderSearch,
+			host:    "https://ops.grafana-ops.net",
+			query: dsquery.ExploreQuery{
+				DatasourceUID:  "grafanacloud-traces",
+				DatasourceType: "tempo",
+				Expr:           `{name != nil}`,
+			},
+			limit:     0,
+			wantEmpty: true,
+		},
+		{
+			name:    "metrics builds traceql metrics explore link",
+			builder: builderMetrics,
+			host:    "https://ops.grafana-ops.net",
+			query: dsquery.ExploreQuery{
+				DatasourceUID:  "grafanacloud-traces",
+				DatasourceType: "tempo",
+				Expr:           `{name != nil} | rate()`,
+			},
+			limit: 20,
+			wantContains: []string{
+				`"datasource":"grafanacloud-traces"`,
+				`"queryType":"traceql"`,
+				`"limit":20`,
+				`"tableType":"traces"`,
+				`"metricsQueryType":"range"`,
+				`"serviceMapUseNativeHistograms":false`,
+				`"query":"{name != nil} | rate()"`,
+				`"from":"now-1m"`,
+				`"to":"now"`,
+				`"compact":false`,
+			},
+		},
+		{
+			name:    "metrics preserves explicit relative from",
+			builder: builderMetrics,
+			host:    "https://ops.grafana-ops.net",
+			query: dsquery.ExploreQuery{
+				DatasourceUID:  "grafanacloud-traces",
+				DatasourceType: "tempo",
+				Expr:           `{name != nil} | rate()`,
+				From:           "now-1h",
+			},
+			limit: 20,
+			wantContains: []string{
+				`"from":"now-1h"`,
+				`"to":"now"`,
+			},
+		},
+		{
+			name:    "metrics uses instant query type for instant queries",
+			builder: builderMetrics,
+			host:    "https://ops.grafana-ops.net",
+			query: dsquery.ExploreQuery{
+				DatasourceUID:  "grafanacloud-traces",
+				DatasourceType: "tempo",
+				Expr:           `{name != nil} | rate()`,
+				Instant:        true,
+			},
+			limit: 20,
+			wantContains: []string{
+				`"metricsQueryType":"instant"`,
+			},
+		},
+		{
+			name:      "metrics returns empty when host missing",
+			builder:   builderMetrics,
+			host:      "",
+			query:     dsquery.ExploreQuery{DatasourceUID: "tempo-uid", Expr: "{ } | rate()"},
+			limit:     20,
+			wantEmpty: true,
+		},
+		{
+			name:      "metrics returns empty when datasource UID missing",
+			builder:   builderMetrics,
+			host:      "https://ops.grafana-ops.net",
+			query:     dsquery.ExploreQuery{Expr: "{ } | rate()"},
+			limit:     20,
+			wantEmpty: true,
+		},
+		{
+			name:      "metrics returns empty when expr missing",
+			builder:   builderMetrics,
+			host:      "https://ops.grafana-ops.net",
+			query:     dsquery.ExploreQuery{DatasourceUID: "tempo-uid"},
+			limit:     20,
+			wantEmpty: true,
+		},
+	}
 
-	t.Run("returns empty for unlimited result searches", func(t *testing.T) {
-		assert.Empty(t, tempo.SearchExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
-			DatasourceUID:  "grafanacloud-traces",
-			DatasourceType: "tempo",
-			Expr:           `{name != nil}`,
-		}, 0))
-	})
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			switch tt.builder {
+			case builderSearch:
+				got = tempo.SearchExploreURL(tt.host, tt.query, tt.limit)
+			case builderMetrics:
+				got = tempo.MetricsExploreURL(tt.host, tt.query, tt.limit)
+			default:
+				t.Fatalf("unknown builder: %v", tt.builder)
+			}
 
-func TestMetricsExploreURL(t *testing.T) {
-	t.Run("builds traceql metrics explore link", func(t *testing.T) {
-		got := tempo.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
-			DatasourceUID:  "grafanacloud-traces",
-			DatasourceType: "tempo",
-			Expr:           `{name != nil} | rate()`,
-		}, 20)
+			if tt.wantEmpty {
+				assert.Empty(t, got)
+				return
+			}
 
-		require.NotEmpty(t, got)
-		params := mustParseURL(t, got).Query()
-		assert.Equal(t, "1", params.Get("schemaVersion"))
-		assert.Contains(t, params.Get("panes"), `"datasource":"grafanacloud-traces"`)
-		assert.Contains(t, params.Get("panes"), `"queryType":"traceql"`)
-		assert.Contains(t, params.Get("panes"), `"limit":20`)
-		assert.Contains(t, params.Get("panes"), `"tableType":"traces"`)
-		assert.Contains(t, params.Get("panes"), `"metricsQueryType":"range"`)
-		assert.Contains(t, params.Get("panes"), `"serviceMapUseNativeHistograms":false`)
-		assert.Contains(t, params.Get("panes"), `"query":"{name != nil} | rate()"`)
-		assert.Contains(t, params.Get("panes"), `"from":"now-1m"`)
-		assert.Contains(t, params.Get("panes"), `"to":"now"`)
-		assert.Contains(t, params.Get("panes"), `"compact":false`)
-	})
-
-	t.Run("uses instant metrics query type for instant queries", func(t *testing.T) {
-		got := tempo.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{
-			DatasourceUID:  "grafanacloud-traces",
-			DatasourceType: "tempo",
-			Expr:           `{name != nil} | rate()`,
-			Instant:        true,
-		}, 20)
-
-		require.NotEmpty(t, got)
-		params := mustParseURL(t, got).Query()
-		assert.Contains(t, params.Get("panes"), `"metricsQueryType":"instant"`)
-	})
-
-	t.Run("returns empty for missing required fields", func(t *testing.T) {
-		assert.Empty(t, tempo.MetricsExploreURL("", dsquery.ExploreQuery{DatasourceUID: "tempo-uid", Expr: "{ } | rate()"}, 20))
-		assert.Empty(t, tempo.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{Expr: "{ } | rate()"}, 20))
-		assert.Empty(t, tempo.MetricsExploreURL("https://ops.grafana-ops.net", dsquery.ExploreQuery{DatasourceUID: "tempo-uid"}, 20))
-	})
+			require.NotEmpty(t, got)
+			params := mustParseURL(t, got).Query()
+			assert.Equal(t, "1", params.Get("schemaVersion"))
+			panes := params.Get("panes")
+			for _, want := range tt.wantContains {
+				assert.Contains(t, panes, want)
+			}
+		})
+	}
 }
 
 func TestTraceExploreURL(t *testing.T) {
-	t.Run("builds trace explore link", func(t *testing.T) {
-		got := tempo.TraceExploreURL("https://mystack.grafana.net/", dsquery.ExploreQuery{
-			DatasourceUID:  "tempo-uid",
-			DatasourceType: "tempo",
-			From:           "2026-04-24T10:00:00Z",
-			To:             "2026-04-24T11:00:00Z",
-			OrgID:          9,
-		}, "287e20fb791cf30")
+	tests := []struct {
+		name         string
+		host         string
+		query        dsquery.ExploreQuery
+		traceID      string
+		wantEmpty    bool
+		wantOrgID    string
+		wantTraceID  string
+		wantContains []string
+	}{
+		{
+			name: "builds trace explore link",
+			host: "https://mystack.grafana.net/",
+			query: dsquery.ExploreQuery{
+				DatasourceUID:  "tempo-uid",
+				DatasourceType: "tempo",
+				From:           "2026-04-24T10:00:00Z",
+				To:             "2026-04-24T11:00:00Z",
+				OrgID:          9,
+			},
+			traceID:     "287e20fb791cf30",
+			wantOrgID:   "9",
+			wantTraceID: "287e20fb791cf30",
+			wantContains: []string{
+				`"datasource":"tempo-uid"`,
+				`"queryType":"traceql"`,
+				`"limit":20`,
+				`"tableType":"traces"`,
+				`"metricsQueryType":"range"`,
+				`"serviceMapUseNativeHistograms":false`,
+				`"query":"287e20fb791cf30"`,
+				`"from":"2026-04-24T10:00:00Z"`,
+				`"to":"2026-04-24T11:00:00Z"`,
+				`"compact":false`,
+			},
+		},
+		{
+			name: "preserves explicit relative from",
+			host: "https://mystack.grafana.net",
+			query: dsquery.ExploreQuery{
+				DatasourceUID:  "tempo-uid",
+				DatasourceType: "tempo",
+				From:           "now-1h",
+			},
+			traceID:     "287e20fb791cf30",
+			wantTraceID: "287e20fb791cf30",
+			wantContains: []string{
+				`"from":"now-1h"`,
+				`"to":"now"`,
+			},
+		},
+		{
+			name:      "returns empty when host missing",
+			host:      "",
+			query:     dsquery.ExploreQuery{DatasourceUID: "tempo-uid"},
+			traceID:   "abc",
+			wantEmpty: true,
+		},
+		{
+			name:      "returns empty when datasource UID missing",
+			host:      "https://mystack.grafana.net",
+			query:     dsquery.ExploreQuery{},
+			traceID:   "abc",
+			wantEmpty: true,
+		},
+		{
+			name:      "returns empty when trace ID missing",
+			host:      "https://mystack.grafana.net",
+			query:     dsquery.ExploreQuery{DatasourceUID: "tempo-uid"},
+			traceID:   "",
+			wantEmpty: true,
+		},
+	}
 
-		require.NotEmpty(t, got)
-		params := mustParseURL(t, got).Query()
-		assert.Equal(t, "1", params.Get("schemaVersion"))
-		assert.Equal(t, "9", params.Get("orgId"))
-		assert.Equal(t, "287e20fb791cf30", params.Get("traceId"))
-		assert.Contains(t, params.Get("panes"), `"datasource":"tempo-uid"`)
-		assert.Contains(t, params.Get("panes"), `"queryType":"traceql"`)
-		assert.Contains(t, params.Get("panes"), `"limit":20`)
-		assert.Contains(t, params.Get("panes"), `"tableType":"traces"`)
-		assert.Contains(t, params.Get("panes"), `"metricsQueryType":"range"`)
-		assert.Contains(t, params.Get("panes"), `"serviceMapUseNativeHistograms":false`)
-		assert.Contains(t, params.Get("panes"), `"query":"287e20fb791cf30"`)
-		assert.Contains(t, params.Get("panes"), `"from":"2026-04-24T10:00:00Z"`)
-		assert.Contains(t, params.Get("panes"), `"to":"2026-04-24T11:00:00Z"`)
-		assert.Contains(t, params.Get("panes"), `"compact":false`)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tempo.TraceExploreURL(tt.host, tt.query, tt.traceID)
+			if tt.wantEmpty {
+				assert.Empty(t, got)
+				return
+			}
 
-	t.Run("returns empty for missing required fields", func(t *testing.T) {
-		assert.Empty(t, tempo.TraceExploreURL("", dsquery.ExploreQuery{DatasourceUID: "tempo-uid"}, "abc"))
-		assert.Empty(t, tempo.TraceExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{}, "abc"))
-		assert.Empty(t, tempo.TraceExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{DatasourceUID: "tempo-uid"}, ""))
-	})
+			require.NotEmpty(t, got)
+			params := mustParseURL(t, got).Query()
+			assert.Equal(t, "1", params.Get("schemaVersion"))
+			if tt.wantOrgID != "" {
+				assert.Equal(t, tt.wantOrgID, params.Get("orgId"))
+			}
+			if tt.wantTraceID != "" {
+				assert.Equal(t, tt.wantTraceID, params.Get("traceId"))
+			}
+			panes := params.Get("panes")
+			for _, want := range tt.wantContains {
+				assert.Contains(t, panes, want)
+			}
+		})
+	}
 }
 
 func mustParseURL(t *testing.T, raw string) *url.URL {

--- a/internal/datasources/tempo/get.go
+++ b/internal/datasources/tempo/get.go
@@ -20,6 +20,7 @@ type getOpts struct {
 	dsquery.TimeRangeOpts
 
 	IO         cmdio.Options
+	Share      dsquery.ExploreLinkOpts
 	Datasource string
 	LLM        bool
 }
@@ -30,6 +31,7 @@ func (opts *getOpts) setup(flags *pflag.FlagSet) {
 
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.tempo is configured)")
 	flags.BoolVar(&opts.LLM, "llm", false, "Request LLM-friendly trace format")
+	opts.Share.Setup(flags, "retrieved trace")
 	opts.SetupTimeFlags(flags)
 }
 
@@ -49,13 +51,19 @@ func GetCmd(loader *providers.ConfigLoader) *cobra.Command {
 		Long: `Retrieve a single trace by its trace ID from a Tempo datasource.
 
 TRACE_ID is the hex-encoded trace identifier to retrieve.
-Datasource is resolved from -d flag or datasources.tempo in your context.`,
+Datasource is resolved from -d flag or datasources.tempo in your context.
+Use --share-link to print a Grafana Explore URL for the trace, or --open to
+open it in your browser after retrieval succeeds. Share links require an
+explicit time range via --since or --from/--to.`,
 		Example: `
   # Get a trace using configured default datasource
   gcx datasources tempo get abc123def456
 
   # Get a trace with explicit datasource UID
   gcx datasources tempo get -d tempo-001 abc123def456
+
+  # Print a Grafana Explore share link for the trace
+  gcx datasources tempo get abc123def456 --share-link
 
   # Get LLM-friendly output
   gcx datasources tempo get abc123def456 --llm
@@ -114,7 +122,27 @@ Datasource is resolved from -d flag or datasources.tempo in your context.`,
 				return fmt.Errorf("get trace failed: %w", err)
 			}
 
-			return opts.IO.Encode(cmd.OutOrStdout(), resp)
+			exploreURL := ""
+			unavailableMsg, failedOpenMsg := dsquery.ExploreMessages("trace retrieval")
+			if opts.IsRange() {
+				exploreURL = TraceExploreURL(cfg.GrafanaURL, dsquery.ExploreQuery{
+					DatasourceUID:  datasourceUID,
+					DatasourceType: "tempo",
+					From:           opts.From,
+					To:             opts.To,
+					OrgID:          dsquery.OrgID(cfgCtx),
+				}, traceID)
+			} else if opts.Share.Enabled() {
+				unavailableMsg = "trace retrieval succeeded, but Grafana Explore links require --since or --from/--to for Tempo trace retrieval"
+			}
+
+			return dsquery.EncodeAndHandleExplore(cmd, func() error {
+				return opts.IO.Encode(cmd.OutOrStdout(), resp)
+			}, opts.Share, dsquery.ExploreLink{
+				URL:            exploreURL,
+				UnavailableMsg: unavailableMsg,
+				FailedOpenMsg:  failedOpenMsg,
+			})
 		},
 	}
 

--- a/internal/datasources/tempo/get_test.go
+++ b/internal/datasources/tempo/get_test.go
@@ -1,0 +1,86 @@
+package tempo
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCmd_DoesNotLookupDatasourceTypeWithoutShareFlags(t *testing.T) {
+	t.Helper()
+
+	var traceCalls int
+	var metadataCalls int
+	var bootdataCalls int
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/bootdata":
+			bootdataCalls++
+			http.Error(w, `{"message":"not a cloud stack"}`, http.StatusNotFound)
+		case "/api/datasources/proxy/uid/tempo-uid/api/v2/traces/trace-123":
+			traceCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{"trace":{"traceID":"trace-123"}}`))
+			require.NoError(t, err)
+		case "/api/datasources/uid/tempo-uid":
+			metadataCalls++
+			http.Error(w, `{"message":"unexpected datasource lookup"}`, http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfgFile := writeTempoTestConfig(t, `
+contexts:
+  default:
+    grafana:
+      server: "`+srv.URL+`"
+      token: "test-token"
+      org-id: 1
+      tls:
+        insecure-skip-verify: true
+    datasources:
+      tempo: tempo-uid
+current-context: default
+`)
+
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(cfgFile)
+
+	cmd := GetCmd(loader)
+	root := &cobra.Command{Use: "test"}
+	root.AddCommand(cmd)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"get", "trace-123"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.Equal(t, 1, traceCalls)
+	assert.Equal(t, 1, bootdataCalls)
+	assert.Zero(t, metadataCalls)
+	assert.Contains(t, stdout.String(), `"traceID": "trace-123"`)
+	assert.Empty(t, stderr.String())
+}
+
+func writeTempoTestConfig(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "gcx-tempo-config-*.yaml")
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}

--- a/internal/datasources/tempo/get_test.go
+++ b/internal/datasources/tempo/get_test.go
@@ -1,4 +1,4 @@
-package tempo
+package tempo_test
 
 import (
 	"bytes"
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/grafana/gcx/internal/datasources/tempo"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -14,8 +15,6 @@ import (
 )
 
 func TestGetCmd_DoesNotLookupDatasourceTypeWithoutShareFlags(t *testing.T) {
-	t.Helper()
-
 	var traceCalls int
 	var metadataCalls int
 	var bootdataCalls int
@@ -29,7 +28,7 @@ func TestGetCmd_DoesNotLookupDatasourceTypeWithoutShareFlags(t *testing.T) {
 			traceCalls++
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(`{"trace":{"traceID":"trace-123"}}`))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		case "/api/datasources/uid/tempo-uid":
 			metadataCalls++
 			http.Error(w, `{"message":"unexpected datasource lookup"}`, http.StatusInternalServerError)
@@ -56,7 +55,7 @@ current-context: default
 	loader := &providers.ConfigLoader{}
 	loader.SetConfigFile(cfgFile)
 
-	cmd := GetCmd(loader)
+	cmd := tempo.GetCmd(loader)
 	root := &cobra.Command{Use: "test"}
 	root.AddCommand(cmd)
 

--- a/internal/datasources/tempo/metrics.go
+++ b/internal/datasources/tempo/metrics.go
@@ -20,6 +20,7 @@ const defaultTraceMetricsWindow = time.Hour
 // MetricsCmd returns the `metrics` subcommand for TraceQL metrics queries.
 func MetricsCmd(loader *providers.ConfigLoader) *cobra.Command {
 	shared := &dsquery.SharedOpts{}
+	share := &dsquery.ExploreLinkOpts{}
 	var datasource string
 	var instant bool
 
@@ -34,13 +35,18 @@ Datasource is resolved from -d flag or datasources.tempo in your context.
 Instant vs range is deduced from time flags: no time flags = instant query,
 --since or --from/--to = range query. Use --instant to force an instant query
 even when a time range is provided. If no time flags are set, gcx queries the
-last hour by default.`,
+last hour by default.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.`,
 		Example: `
   # Instant query over the last hour (default, no time flags)
   gcx datasources tempo metrics '{ } | rate()'
 
   # Range query with relative window
   gcx datasources tempo metrics -d tempo-001 '{ } | rate()' --since 1h
+
+  # Print a Grafana Explore share link for the query
+  gcx datasources tempo metrics '{ } | rate()' --share-link
 
   # Instant query with explicit time range
   gcx datasources tempo metrics '{ } | rate()' --instant --since 1h
@@ -111,7 +117,32 @@ last hour by default.`,
 				return fmt.Errorf("metrics query failed: %w", err)
 			}
 
-			return shared.IO.Encode(cmd.OutOrStdout(), resp)
+			from := shared.From
+			to := shared.To
+			if from == "" && !req.Start.IsZero() {
+				from = req.Start.Format(time.RFC3339)
+			}
+			if to == "" && !req.End.IsZero() {
+				to = req.End.Format(time.RFC3339)
+			}
+			exploreURL := MetricsExploreURL(cfg.GrafanaURL, dsquery.ExploreQuery{
+				DatasourceUID:  datasourceUID,
+				DatasourceType: dsType,
+				Expr:           expr,
+				From:           from,
+				To:             to,
+				Instant:        req.Instant,
+				OrgID:          dsquery.OrgID(cfgCtx),
+			}, 20)
+			unavailableMsg, failedOpenMsg := dsquery.ExploreMessages("metrics query")
+
+			return dsquery.EncodeAndHandleExplore(cmd, func() error {
+				return shared.IO.Encode(cmd.OutOrStdout(), resp)
+			}, *share, dsquery.ExploreLink{
+				URL:            exploreURL,
+				UnavailableMsg: unavailableMsg,
+				FailedOpenMsg:  failedOpenMsg,
+			})
 		},
 	}
 
@@ -123,6 +154,7 @@ last hour by default.`,
 	shared.Setup(cmd.Flags(), true)
 	cmd.Flags().StringVarP(&datasource, "datasource", "d", "", "Datasource UID (required unless datasources.tempo is configured)")
 	cmd.Flags().BoolVar(&instant, "instant", false, "Run an instant query over the selected time range instead of a range query")
+	share.Setup(cmd.Flags(), "executed query")
 
 	return cmd
 }

--- a/internal/datasources/tempo/search.go
+++ b/internal/datasources/tempo/search.go
@@ -18,6 +18,7 @@ import (
 // It also registers `search` as a non-deprecated alias.
 func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
 	shared := &dsquery.SharedOpts{}
+	share := &dsquery.ExploreLinkOpts{}
 	var limit int
 	var datasource string
 
@@ -28,13 +29,19 @@ func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
 		Long: `Search for traces using a TraceQL query against a Tempo datasource.
 
 TRACEQL is the TraceQL expression to evaluate.
-Datasource is resolved from -d flag or datasources.tempo in your context.`,
+Datasource is resolved from -d flag or datasources.tempo in your context.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds. Share links require an
+explicit time range via --since or --from/--to.`,
 		Example: `
   # Search traces using configured default datasource
   gcx datasources tempo query '{ span.http.status_code >= 500 }'
 
   # Search with explicit datasource UID and time range
   gcx datasources tempo query -d UID '{ span.http.status_code >= 500 }' --since 1h
+
+  # Print a Grafana Explore share link for the query
+  gcx datasources tempo query '{ span.http.status_code >= 500 }' --share-link
 
   # With custom limit
   gcx datasources tempo query -d UID '{ span.http.status_code >= 500 }' --since 1h --limit 50
@@ -73,14 +80,6 @@ Datasource is resolved from -d flag or datasources.tempo in your context.`,
 				return err
 			}
 
-			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			if err := dsquery.ValidateDatasourceType(dsType, "tempo"); err != nil {
-				return err
-			}
-
 			now := time.Now()
 			start, end, _, err := shared.ParseTimes(now)
 			if err != nil {
@@ -104,7 +103,31 @@ Datasource is resolved from -d flag or datasources.tempo in your context.`,
 				return fmt.Errorf("search failed: %w", err)
 			}
 
-			return shared.IO.Encode(cmd.OutOrStdout(), resp)
+			exploreURL := ""
+			unavailableMsg, failedOpenMsg := dsquery.ExploreMessages("search")
+			switch {
+			case !shared.IsRange() && share.Enabled():
+				unavailableMsg = "search succeeded, but Grafana Explore links require --since or --from/--to for Tempo trace searches"
+			case limit == 0 && share.Enabled():
+				unavailableMsg = "search succeeded, but Grafana Explore links do not support --limit 0 for Tempo trace searches"
+			case shared.IsRange():
+				exploreURL = SearchExploreURL(cfg.GrafanaURL, dsquery.ExploreQuery{
+					DatasourceUID:  datasourceUID,
+					DatasourceType: "tempo",
+					Expr:           expr,
+					From:           shared.From,
+					To:             shared.To,
+					OrgID:          dsquery.OrgID(cfgCtx),
+				}, limit)
+			}
+
+			return dsquery.EncodeAndHandleExplore(cmd, func() error {
+				return shared.IO.Encode(cmd.OutOrStdout(), resp)
+			}, *share, dsquery.ExploreLink{
+				URL:            exploreURL,
+				UnavailableMsg: unavailableMsg,
+				FailedOpenMsg:  failedOpenMsg,
+			})
 		},
 	}
 
@@ -116,6 +139,7 @@ Datasource is resolved from -d flag or datasources.tempo in your context.`,
 	shared.Setup(cmd.Flags(), false)
 	cmd.Flags().StringVarP(&datasource, "datasource", "d", "", "Datasource UID (required unless datasources.tempo is configured)")
 	cmd.Flags().IntVar(&limit, "limit", 20, "Maximum number of traces to return (0 means no limit)")
+	share.Setup(cmd.Flags(), "executed query")
 
 	return cmd
 }

--- a/internal/datasources/tempo/sharelink_test.go
+++ b/internal/datasources/tempo/sharelink_test.go
@@ -1,0 +1,165 @@
+package tempo
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCmd_ShareLinkRequiresExplicitTimeRange(t *testing.T) {
+	var traceCalls int
+	var metadataCalls int
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/bootdata":
+			http.Error(w, `{"message":"not a cloud stack"}`, http.StatusNotFound)
+		case "/api/datasources/proxy/uid/tempo-uid/api/v2/traces/trace-123":
+			traceCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{"trace":{"traceID":"trace-123"}}`))
+			require.NoError(t, err)
+		case "/api/datasources/uid/tempo-uid":
+			metadataCalls++
+			http.Error(w, `{"message":"unexpected datasource lookup"}`, http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(writeTempoTestConfig(t, `
+contexts:
+  default:
+    grafana:
+      server: "`+srv.URL+`"
+      token: "test-token"
+      org-id: 1
+      tls:
+        insecure-skip-verify: true
+    datasources:
+      tempo: tempo-uid
+current-context: default
+`))
+
+	stdout, stderr, err := execTempoCmd(GetCmd(loader), []string{"get", "trace-123", "--share-link"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, traceCalls)
+	assert.Zero(t, metadataCalls)
+	assert.Contains(t, stdout, `"traceID": "trace-123"`)
+	assert.Contains(t, stderr, "Grafana Explore links require --since or --from/--to")
+	assert.NotContains(t, stderr, "Explore link:")
+}
+
+func TestSearchCmd_ShareLinkRequiresExplicitTimeRange(t *testing.T) {
+	var searchCalls int
+	var metadataCalls int
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/bootdata":
+			http.Error(w, `{"message":"not a cloud stack"}`, http.StatusNotFound)
+		case "/api/datasources/proxy/uid/tempo-uid/api/search":
+			searchCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{"traces":[{"traceID":"trace-123","rootServiceName":"svc","rootTraceName":"op","startTimeUnixNano":"1","durationMs":10}]}`))
+			require.NoError(t, err)
+		case "/api/datasources/uid/tempo-uid":
+			metadataCalls++
+			http.Error(w, `{"message":"unexpected datasource lookup"}`, http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(writeTempoTestConfig(t, `
+contexts:
+  default:
+    grafana:
+      server: "`+srv.URL+`"
+      token: "test-token"
+      org-id: 1
+      tls:
+        insecure-skip-verify: true
+    datasources:
+      tempo: tempo-uid
+current-context: default
+`))
+
+	stdout, stderr, err := execTempoCmd(QueryCmd(loader), []string{"query", "--share-link", "-o", "json", `{ span.http.status_code >= 500 }`})
+	require.NoError(t, err)
+	assert.Equal(t, 1, searchCalls)
+	assert.Zero(t, metadataCalls)
+	assert.Contains(t, stdout, `"traceID": "trace-123"`)
+	assert.Contains(t, stderr, "Grafana Explore links require --since or --from/--to")
+	assert.NotContains(t, stderr, "Explore link:")
+}
+
+func TestSearchCmd_ShareLinkRejectsUnlimitedResultLinks(t *testing.T) {
+	var searchCalls int
+	var metadataCalls int
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/bootdata":
+			http.Error(w, `{"message":"not a cloud stack"}`, http.StatusNotFound)
+		case "/api/datasources/proxy/uid/tempo-uid/api/search":
+			searchCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{"traces":[{"traceID":"trace-123","rootServiceName":"svc","rootTraceName":"op","startTimeUnixNano":"1","durationMs":10}]}`))
+			require.NoError(t, err)
+		case "/api/datasources/uid/tempo-uid":
+			metadataCalls++
+			http.Error(w, `{"message":"unexpected datasource lookup"}`, http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(writeTempoTestConfig(t, `
+contexts:
+  default:
+    grafana:
+      server: "`+srv.URL+`"
+      token: "test-token"
+      org-id: 1
+      tls:
+        insecure-skip-verify: true
+    datasources:
+      tempo: tempo-uid
+current-context: default
+`))
+
+	stdout, stderr, err := execTempoCmd(QueryCmd(loader), []string{"query", "--share-link", "--since", "1h", "--limit", "0", "-o", "json", `{ span.http.status_code >= 500 }`})
+	require.NoError(t, err)
+	assert.Equal(t, 1, searchCalls)
+	assert.Zero(t, metadataCalls)
+	assert.Contains(t, stdout, `"traceID": "trace-123"`)
+	assert.Contains(t, stderr, "Grafana Explore links do not support --limit 0")
+	assert.NotContains(t, stderr, "Explore link:")
+}
+
+func execTempoCmd(cmd *cobra.Command, args []string) (string, string, error) {
+	root := &cobra.Command{Use: "test"}
+	root.AddCommand(cmd)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs(args)
+
+	err := root.Execute()
+	return stdout.String(), stderr.String(), err
+}

--- a/internal/datasources/tempo/sharelink_test.go
+++ b/internal/datasources/tempo/sharelink_test.go
@@ -1,4 +1,4 @@
-package tempo
+package tempo_test
 
 import (
 	"bytes"
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/grafana/gcx/internal/datasources/tempo"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ func TestGetCmd_ShareLinkRequiresExplicitTimeRange(t *testing.T) {
 			traceCalls++
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(`{"trace":{"traceID":"trace-123"}}`))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		case "/api/datasources/uid/tempo-uid":
 			metadataCalls++
 			http.Error(w, `{"message":"unexpected datasource lookup"}`, http.StatusInternalServerError)
@@ -49,7 +50,7 @@ contexts:
 current-context: default
 `))
 
-	stdout, stderr, err := execTempoCmd(GetCmd(loader), []string{"get", "trace-123", "--share-link"})
+	stdout, stderr, err := execTempoCmd(tempo.GetCmd(loader), []string{"get", "trace-123", "--share-link"})
 	require.NoError(t, err)
 	assert.Equal(t, 1, traceCalls)
 	assert.Zero(t, metadataCalls)
@@ -70,7 +71,7 @@ func TestSearchCmd_ShareLinkRequiresExplicitTimeRange(t *testing.T) {
 			searchCalls++
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(`{"traces":[{"traceID":"trace-123","rootServiceName":"svc","rootTraceName":"op","startTimeUnixNano":"1","durationMs":10}]}`))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		case "/api/datasources/uid/tempo-uid":
 			metadataCalls++
 			http.Error(w, `{"message":"unexpected datasource lookup"}`, http.StatusInternalServerError)
@@ -95,7 +96,7 @@ contexts:
 current-context: default
 `))
 
-	stdout, stderr, err := execTempoCmd(QueryCmd(loader), []string{"query", "--share-link", "-o", "json", `{ span.http.status_code >= 500 }`})
+	stdout, stderr, err := execTempoCmd(tempo.QueryCmd(loader), []string{"query", "--share-link", "-o", "json", `{ span.http.status_code >= 500 }`})
 	require.NoError(t, err)
 	assert.Equal(t, 1, searchCalls)
 	assert.Zero(t, metadataCalls)
@@ -116,7 +117,7 @@ func TestSearchCmd_ShareLinkRejectsUnlimitedResultLinks(t *testing.T) {
 			searchCalls++
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(`{"traces":[{"traceID":"trace-123","rootServiceName":"svc","rootTraceName":"op","startTimeUnixNano":"1","durationMs":10}]}`))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		case "/api/datasources/uid/tempo-uid":
 			metadataCalls++
 			http.Error(w, `{"message":"unexpected datasource lookup"}`, http.StatusInternalServerError)
@@ -141,7 +142,7 @@ contexts:
 current-context: default
 `))
 
-	stdout, stderr, err := execTempoCmd(QueryCmd(loader), []string{"query", "--share-link", "--since", "1h", "--limit", "0", "-o", "json", `{ span.http.status_code >= 500 }`})
+	stdout, stderr, err := execTempoCmd(tempo.QueryCmd(loader), []string{"query", "--share-link", "--since", "1h", "--limit", "0", "-o", "json", `{ span.http.status_code >= 500 }`})
 	require.NoError(t, err)
 	assert.Equal(t, 1, searchCalls)
 	assert.Zero(t, metadataCalls)

--- a/internal/providers/logs/provider.go
+++ b/internal/providers/logs/provider.go
@@ -51,6 +51,9 @@ func (p *Provider) Commands() []*cobra.Command {
   # Query with explicit datasource UID
   gcx logs query -d abc123 '{job="varlogs"} |= "error"'
 
+  # Print a Grafana Explore share link for the query
+  gcx logs query '{job="varlogs"}' --share-link
+
   # Raw line bodies only
   gcx logs query -d abc123 '{job="varlogs"}' -o raw
 
@@ -66,6 +69,9 @@ func (p *Provider) Commands() []*cobra.Command {
 	mqCmd.Example = `
   # Run a metric query over logs
   gcx logs metrics -d UID 'rate({job="grafana"}[5m])' --since 1h
+
+  # Print a Grafana Explore share link for the query
+  gcx logs metrics 'rate({job="grafana"}[5m])' --share-link
 
   # Output as JSON
   gcx logs metrics -d UID 'rate({job="grafana"}[5m])' --since 1h -o json`

--- a/internal/providers/metrics/billing.go
+++ b/internal/providers/metrics/billing.go
@@ -40,6 +40,9 @@ func billingQueryCmd(loader *providers.ConfigLoader) *cobra.Command {
   # Active series over the last hour
   gcx metrics billing query 'grafanacloud_instance_active_series' --since 1h --step 1m
 
+  # Print a Grafana Explore share link for the executed query
+  gcx metrics billing query 'grafanacloud_instance_active_series' --share-link
+
   # Output as JSON
   gcx metrics billing query 'grafanacloud_instance_active_series' -o json`
 	c.Annotations = map[string]string{

--- a/internal/providers/metrics/provider.go
+++ b/internal/providers/metrics/provider.go
@@ -54,6 +54,9 @@ func (p *Provider) Commands() []*cobra.Command {
   # Query the last hour
   gcx metrics query 'up' --since 1h
 
+  # Print a Grafana Explore share link for the executed query
+  gcx metrics query 'up' --share-link
+
   # Output as JSON
   gcx metrics query -d abc123 'up' -o json`
 	cmd.AddCommand(qCmd)

--- a/internal/providers/traces/provider.go
+++ b/internal/providers/traces/provider.go
@@ -48,6 +48,9 @@ func (p *Provider) Commands() []*cobra.Command {
   # Run a TraceQL query
   gcx traces query -d UID '{ span.http.status_code >= 500 }'
 
+  # Print a Grafana Explore share link for the query
+  gcx traces query '{ span.http.status_code >= 500 }' --share-link
+
   # Output as JSON
   gcx traces query -d UID '{ span.http.status_code >= 500 }' -o json`
 	cmd.AddCommand(qCmd)
@@ -60,6 +63,9 @@ func (p *Provider) Commands() []*cobra.Command {
 	gCmd.Example = `
   # Fetch a trace by ID
   gcx traces get -d UID <trace-id>
+
+  # Print a Grafana Explore share link for the trace
+  gcx traces get -d UID <trace-id> --share-link
 
   # Output as JSON
   gcx traces get -d UID <trace-id> -o json`
@@ -86,6 +92,9 @@ func (p *Provider) Commands() []*cobra.Command {
 	mCmd.Example = `
   # Run a TraceQL metrics query
   gcx traces metrics -d UID '{ } | rate()' --since 1h
+
+  # Print a Grafana Explore share link for the query
+  gcx traces metrics '{ } | rate()' --share-link
 
   # Output as JSON
   gcx traces metrics -d UID '{ } | rate()' --since 1h -o json`


### PR DESCRIPTION
## What

Adds `--share-link` and `--open` flags to the Loki (`query`, `metrics`), Prometheus (`query`), and Tempo (`query`, `metrics`, `get`) datasource subcommands. With `--share-link`, the equivalent Grafana Explore URL is printed to stderr after the command succeeds. With `--open`, the URL is also opened in the user's default browser.

Introduces a shared helper layer for assembling Explore-pane payloads and per-datasource URL builders. Reuses the existing `deeplink.Open` primitive for the browser handoff.

## Why

The CLI is fast for query iteration and automation, but visualization, drill-down, and ad-hoc exploration are easier in Grafana Explore. Without a deep link, users have to paste expressions and time ranges manually. The new flags close that gap and enable mixed CLI-then-UI workflows for both humans and agents.

Both flags are off by default, so non-interactive and agent-mode output is unaffected. The link is written to stderr, keeping stdout reserved for resource data.

## How it was tested

- [x] `make build` passed
- [x] `make lint` passed (0 issues)
- [x] `make tests` passed under `TZ=UTC`
- [x] `go test ./internal/datasources/...` passed including new table-driven explore-URL tests with a `now-1h` regression case and a `javascript:`-scheme rejection case
- [x] CI green on the latest push: Linters, Tests, Documentation, Socket Security, TruffleHog, zizmor
- [x] `gcx datasources loki query '{job="varlogs"}' --from now-1h --share-link` produced an Explore URL whose panes payload contained `"from":"now-1h"` (not `now-1m`)
- [x] `gcx datasources loki metrics 'rate({job="varlogs"}[5m])' --step 30s --share-link` produced an Explore URL whose panes payload contained `"intervalMs":30000`

<img width="1482" height="587" alt="Screenshot 2026-04-24 at 17 08 19" src="https://github.com/user-attachments/assets/37f65541-c20c-4152-a6a8-fdadd7188e17" />

---
**Generated by Claude Code**
