### PR TITLE
feat(login): engage mTLS on the gcx login path

### DIFF
--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/caarlos0/env/v11"
 	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/config"
@@ -53,21 +52,8 @@ func (opts *Options) LoadConfigTolerant(ctx context.Context, extraOverrides ...c
 
 			curCtx := cfg.Contexts[cfg.CurrentContext]
 
-			if curCtx.Grafana == nil {
-				curCtx.Grafana = &config.GrafanaConfig{}
-			}
-			if curCtx.Grafana.TLS == nil {
-				curCtx.Grafana.TLS = &config.TLS{}
-			}
-
-			if err := env.Parse(curCtx); err != nil {
+			if err := config.ParseEnvIntoContext(curCtx); err != nil {
 				return err
-			}
-
-			// If TLS was only initialized for env parsing and no fields were set,
-			// nil it back out so IsEmpty() and other checks work correctly.
-			if curCtx.Grafana.TLS.IsEmpty() {
-				curCtx.Grafana.TLS = nil
 			}
 
 			// Resolve GRAFANA_PROVIDER_{NAME}_{KEY} environment variables

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -165,6 +165,14 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 		!flags.Yes &&
 		!agent.IsAgentMode()
 
+	// Carry existing TLS settings into the login flow so that mTLS keeps
+	// working on re-auth without requiring the user to re-specify certs.
+	var existingTLS *config.TLS
+	if sourceCtx != nil && sourceCtx.Grafana != nil && sourceCtx.Grafana.TLS != nil &&
+		!sourceCtx.Grafana.TLS.IsEmpty() {
+		existingTLS = sourceCtx.Grafana.TLS
+	}
+
 	opts := login.Options{
 		Inputs: login.Inputs{
 			Server:       flags.Server,
@@ -174,6 +182,7 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 			CloudAPIURL:  flags.CloudAPIURL,
 			Yes:          flags.Yes,
 			Writer:       cmd.ErrOrStderr(),
+			TLS:          existingTLS,
 		},
 		Hooks: login.Hooks{
 			ConfigSource: flags.Config.ConfigSource(),
@@ -337,22 +346,42 @@ func askForInput(e *login.ErrNeedInput, opts *login.Options, sourceCtx *config.C
 //   - Unknown (target still ambiguous): both options are offered, token
 //     first to match the historical default.
 func askGrafanaAuth(opts *login.Options, existingToken string) error {
+	// When TLS client certs are configured, mTLS is a valid standalone auth
+	// method (e.g. Teleport proxy). Offer it as the default choice.
+	hasMTLS := opts.TLS != nil && !opts.TLS.IsEmpty() &&
+		(len(opts.TLS.CertData) > 0 || opts.TLS.CertFile != "")
+	if hasMTLS && opts.Yes {
+		// Non-interactive with certs configured: default to mTLS.
+		return nil // resolveGrafanaAuth will pick up the TLS case.
+	}
+
 	tokenOption := huh.NewOption("Service account token (requires permissions for managing service accounts)", "token")
 	oauthOption := huh.NewOption("OAuth (browser) — recommended for cloud stacks; experimental on some configurations, fall back to a service account token if you hit issues", "oauth")
+	mtlsOption := huh.NewOption("Client certificate (mTLS) — authenticate via TLS client cert (e.g. Teleport)", "mtls")
 
 	var options []huh.Option[string]
 	switch opts.Target {
 	case login.TargetOnPrem:
-		options = []huh.Option[string]{tokenOption}
+		if hasMTLS {
+			options = []huh.Option[string]{mtlsOption, tokenOption}
+		} else {
+			options = []huh.Option[string]{tokenOption}
+		}
 	case login.TargetCloud:
 		options = []huh.Option[string]{oauthOption, tokenOption}
 	default: // TargetUnknown
-		options = []huh.Option[string]{tokenOption, oauthOption}
+		if hasMTLS {
+			options = []huh.Option[string]{mtlsOption, tokenOption, oauthOption}
+		} else {
+			options = []huh.Option[string]{tokenOption, oauthOption}
+		}
 	}
 
 	authMethod := "token"
-	// On-prem has a single option; skip the one-item menu and fall through
-	// to the token-input prompt directly.
+	if hasMTLS {
+		authMethod = "mtls"
+	}
+	// Single option: skip the menu and fall through directly.
 	if len(options) > 1 {
 		methodForm := huh.NewForm(huh.NewGroup(
 			huh.NewSelect[string]().
@@ -366,6 +395,10 @@ func askGrafanaAuth(opts *login.Options, existingToken string) error {
 	}
 	if authMethod == "oauth" {
 		opts.UseOAuth = true
+		return nil
+	}
+	if authMethod == "mtls" {
+		// mTLS needs no additional input — the certs are already in opts.TLS.
 		return nil
 	}
 
@@ -483,7 +516,7 @@ func structuredMissingFieldsError(e *login.ErrNeedInput) error {
 		case "server":
 			suggestions = append(suggestions, "Pass --server <url> or set GRAFANA_SERVER")
 		case "grafana-auth":
-			suggestions = append(suggestions, "Pass --token <token> for a service account token")
+			suggestions = append(suggestions, "Pass --token <token> for a service account token, or configure TLS client certs for mTLS auth")
 		case "cloud-token":
 			suggestions = append(suggestions, "Pass --cloud-token <token> to enable Cloud features, or --yes to skip")
 		default:

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/gcx/internal/format"
 	"github.com/grafana/gcx/internal/login"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/term"
@@ -171,6 +172,17 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 	if sourceCtx != nil && sourceCtx.Grafana != nil && sourceCtx.Grafana.TLS != nil &&
 		!sourceCtx.Grafana.TLS.IsEmpty() {
 		existingTLS = sourceCtx.Grafana.TLS
+		// Advisory: when --allow-server-override re-points the context at a
+		// different server, the existing TLS client cert will be presented to
+		// the new server. This is gated by explicit user opt-in.
+		if flags.AllowServerOverride && flags.Server != "" &&
+			sourceCtx.Grafana != nil && sourceCtx.Grafana.Server != "" &&
+			flags.Server != sourceCtx.Grafana.Server {
+			logging.FromContext(cmd.Context()).Warn("reusing existing TLS client certificate for a different server",
+				"previous_server", sourceCtx.Grafana.Server,
+				"new_server", flags.Server,
+			)
+		}
 	}
 
 	opts := login.Options{
@@ -377,8 +389,10 @@ func askGrafanaAuth(opts *login.Options, existingToken string) error {
 		}
 	}
 
+	// Default to the first option in the menu. For Cloud targets, mTLS is not
+	// offered so we must not default to it even when TLS certs are present.
 	authMethod := "token"
-	if hasMTLS {
+	if hasMTLS && opts.Target != login.TargetCloud {
 		authMethod = "mtls"
 	}
 	// Single option: skip the menu and fall through directly.
@@ -516,7 +530,7 @@ func structuredMissingFieldsError(e *login.ErrNeedInput) error {
 		case "server":
 			suggestions = append(suggestions, "Pass --server <url> or set GRAFANA_SERVER")
 		case "grafana-auth":
-			suggestions = append(suggestions, "Pass --token <token> for a service account token, or configure TLS client certs for mTLS auth")
+			suggestions = append(suggestions, "Pass --token <token> for a service account token, or configure TLS client certs for mTLS auth (GRAFANA_TLS_CERT_FILE / GRAFANA_TLS_KEY_FILE env vars, or gcx config set contexts.<ctx>.grafana.tls.cert-file ...)")
 		case "cloud-token":
 			suggestions = append(suggestions, "Pass --cloud-token <token> to enable Cloud features, or --yes to skip")
 		default:

--- a/docs/architecture/auth-system.md
+++ b/docs/architecture/auth-system.md
@@ -2,18 +2,20 @@
 
 ## Overview
 
-gcx supports three authentication methods — browser-based OAuth (PKCE),
-Grafana service account tokens, and Grafana Cloud Access Policy tokens — and
-each targets a different API surface. The authentication subsystem spans
-package boundaries: OAuth mechanics live in `internal/auth/`, token storage
-lives in `internal/config/` as fields on `GrafanaConfig` and `CloudConfig`,
-and token attachment to HTTP clients happens in `internal/config/rest.go`.
-This document covers all three methods end to end.
+gcx supports four authentication methods — browser-based OAuth (PKCE),
+Grafana service account tokens, mTLS client certificates, and Grafana Cloud
+Access Policy tokens — and each targets a different API surface. The
+authentication subsystem spans package boundaries: OAuth mechanics live in
+`internal/auth/`, token storage lives in `internal/config/` as fields on
+`GrafanaConfig` and `CloudConfig`, TLS certificate settings live in
+`GrafanaConfig.TLS`, and token/cert attachment to HTTP clients happens in
+`internal/config/rest.go`. This document covers all four methods end to end.
 
 ```mermaid
 graph LR
     OAuth[OAuth PKCE<br/>gat_ + gar_ tokens]
     SA[Service account token<br/>glsa_...]
+    mTLS[mTLS client certificate<br/>cert + key files]
     CAP[Cloud Access Policy token<br/>glc_...]
 
     GrafanaAPI[Grafana API<br/>instance-scoped]
@@ -25,6 +27,8 @@ graph LR
     OAuth --> K8sAPI
     SA --> GrafanaAPI
     SA --> K8sAPI
+    mTLS --> GrafanaAPI
+    mTLS --> K8sAPI
     CAP --> GCOM
     CAP --> CloudProd
 ```
@@ -37,6 +41,7 @@ graph LR
 |---|---|---|---|---|---|
 | OAuth PKCE | Grafana API, K8s `/apis` | Browser flow via `gcx login` | `GrafanaConfig.OAuthToken`, `OAuthRefreshToken`, `OAuthTokenExpiresAt`, `OAuthRefreshExpiresAt`, `ProxyEndpoint` | Automatic via `RefreshTransport` | Transparent |
 | Service account token | Grafana API, K8s `/apis` | Grafana UI → Administration → Service accounts | `GrafanaConfig.APIToken` | None (static) | Manual (rotate in Grafana UI) |
+| mTLS client certificate | Grafana API, K8s `/apis` | Identity-aware proxy (e.g. Teleport) | `GrafanaConfig.TLS.CertFile`, `KeyFile`, `CAFile` (or `CertData`, `KeyData`, `CAData`) | External (proxy manages cert lifecycle) | External (e.g. `tsh apps login`) |
 | Cloud Access Policy token | GCOM, Cloud product APIs | Grafana Cloud UI → Security → Access policies | `CloudConfig.Token` | None (static) | Manual (rotate in Cloud UI) |
 
 ---
@@ -54,6 +59,50 @@ sets them as `rest.Config.BearerToken` when no OAuth credentials are present.
 
 Rotation is manual: rotate in the Grafana UI, then update the context with
 `gcx login --context X --token glsa_new_token`.
+
+---
+
+## mTLS client certificates
+
+mTLS (mutual TLS) authentication uses client certificates to authenticate at
+the transport layer. This is the standard method for Grafana instances behind
+identity-aware proxies like [Teleport](https://goteleport.com/), where the
+proxy terminates mTLS and authenticates the user based on the client
+certificate — no Grafana token is needed.
+
+gcx stores the certificate paths in `GrafanaConfig.TLS` (`CertFile`,
+`KeyFile`, optionally `CAFile`), or inline as `CertData`/`KeyData`/`CAData`.
+Environment variables `GRAFANA_TLS_CERT_FILE`, `GRAFANA_TLS_KEY_FILE`, and
+`GRAFANA_TLS_CA_FILE` are supported for CI/CD.
+
+### Configuration
+
+```bash
+# Via gcx config
+gcx config set contexts.myctx.grafana.server https://grafana.teleport.example.com
+gcx config set contexts.myctx.grafana.tls.cert-file "$(tsh apps config grafana -f cert)"
+gcx config set contexts.myctx.grafana.tls.key-file "$(tsh apps config grafana -f key)"
+
+# Login detects mTLS as the auth method
+gcx login --yes
+```
+
+### How it works
+
+The login flow detects mTLS as a standalone auth method when
+`GrafanaConfig.TLS` has a client certificate configured and no token or OAuth
+credentials are provided. The `AuthMethod` is stored as `"mtls"`. TLS
+settings are threaded through the entire login pipeline: target detection,
+connectivity validation, and health checks all use TLS-aware HTTP clients.
+
+On re-auth (`gcx login` against an existing context), the CLI carries
+existing TLS settings forward so the user does not need to re-specify
+certificate paths. `mergeAuthIntoExisting` syncs TLS alongside other auth
+fields.
+
+Certificate lifecycle is managed externally (e.g. `tsh apps login grafana`
+refreshes short-lived certs). gcx reads the files at connection time, so
+refreshed certs take effect on the next command.
 
 ---
 

--- a/docs/architecture/login-system.md
+++ b/docs/architecture/login-system.md
@@ -47,6 +47,7 @@ classDiagram
         CloudToken, CloudAPIURL
         UseOAuth, Yes, Writer
         UseCloudInstanceSelector
+        TLS
     }
     class Hooks {
         ConfigSource
@@ -116,7 +117,7 @@ flowchart TD
     TgtKnown -->|no, --yes or agent| TgtOnPrem[Force TargetOnPrem]
     TgtKnown -->|yes| Auth[Resolve Grafana auth]
     TgtOnPrem --> Auth
-    Auth --> AuthHave{Token or OAuth?}
+    Auth --> AuthHave{Token, mTLS, or OAuth?}
     AuthHave -->|no| AuthSentinel[Return ErrNeedInput&#123;grafana-auth&#125;]
     AuthHave -->|yes| Ctx[Derive context name]
     Ctx --> Cloud[Resolve cloud auth]

--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -34,7 +34,7 @@ contexts:
       oauth-token-expires-at: string
       # OAuthRefreshExpiresAt is the OAuthRefreshToken expiration time in RFC3339 format.
       oauth-refresh-expires-at: string
-      # AuthMethod is the authentication method stored by gcx login: "oauth", "token", or "basic".
+      # AuthMethod is the authentication method stored by gcx login: "oauth", "token", "basic", or "mtls".
       # Empty string is valid for legacy configs; readers should call InferredAuthMethod() in that case.
       auth-method: string
       # OrgID specifies the organization targeted by this config.

--- a/internal/config/envparse.go
+++ b/internal/config/envparse.go
@@ -1,0 +1,38 @@
+package config
+
+import "github.com/caarlos0/env/v11"
+
+// PrepareForEnvParse initializes nested pointer fields on the Context so that
+// env.Parse can populate environment variables like GRAFANA_TLS_CERT_FILE into
+// the nested structs. Without this, env.Parse silently skips nil struct pointers.
+//
+// Call CleanupAfterEnvParse after env.Parse to nil-out any structs that
+// remained empty (preserving IsEmpty semantics).
+func PrepareForEnvParse(ctx *Context) {
+	if ctx.Grafana == nil {
+		ctx.Grafana = &GrafanaConfig{}
+	}
+	if ctx.Grafana.TLS == nil {
+		ctx.Grafana.TLS = &TLS{}
+	}
+}
+
+// CleanupAfterEnvParse nils out nested structs that were only initialized for
+// env.Parse but had no fields actually set. This keeps IsEmpty() and
+// nil-pointer checks working correctly downstream.
+func CleanupAfterEnvParse(ctx *Context) {
+	if ctx.Grafana != nil && ctx.Grafana.TLS != nil && ctx.Grafana.TLS.IsEmpty() {
+		ctx.Grafana.TLS = nil
+	}
+}
+
+// ParseEnvIntoContext is a convenience that combines PrepareForEnvParse,
+// env.Parse, and CleanupAfterEnvParse into a single call.
+func ParseEnvIntoContext(ctx *Context) error {
+	PrepareForEnvParse(ctx)
+	if err := env.Parse(ctx); err != nil {
+		return err
+	}
+	CleanupAfterEnvParse(ctx)
+	return nil
+}

--- a/internal/config/rest_test.go
+++ b/internal/config/rest_test.go
@@ -13,6 +13,84 @@ import (
 	"github.com/grafana/gcx/internal/retry"
 )
 
+func TestNewNamespacedRESTConfig_PropagatesTLSConfig(t *testing.T) {
+	bootdataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bootdataServer.Close()
+
+	certData := []byte("cert-pem-data")
+	keyData := []byte("key-pem-data")
+	caData := []byte("ca-pem-data")
+
+	ctx := config.Context{
+		Grafana: &config.GrafanaConfig{
+			Server:  bootdataServer.URL,
+			StackID: 1,
+			TLS: &config.TLS{
+				CertData:   certData,
+				KeyData:    keyData,
+				CAData:     caData,
+				Insecure:   true,
+				ServerName: "custom-sni.example.com",
+				NextProtos: []string{"http/1.1"},
+			},
+		},
+	}
+
+	restCfg, err := config.NewNamespacedRESTConfig(t.Context(), ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tls := restCfg.TLSClientConfig
+	if string(tls.CertData) != string(certData) {
+		t.Fatalf("CertData not propagated: got %q", tls.CertData)
+	}
+	if string(tls.KeyData) != string(keyData) {
+		t.Fatalf("KeyData not propagated: got %q", tls.KeyData)
+	}
+	if string(tls.CAData) != string(caData) {
+		t.Fatalf("CAData not propagated: got %q", tls.CAData)
+	}
+	if !tls.Insecure {
+		t.Fatal("Insecure not propagated")
+	}
+	if tls.ServerName != "custom-sni.example.com" {
+		t.Fatalf("ServerName not propagated: got %q", tls.ServerName)
+	}
+	if len(tls.NextProtos) != 1 || tls.NextProtos[0] != "http/1.1" {
+		t.Fatalf("NextProtos not propagated: got %v", tls.NextProtos)
+	}
+}
+
+func TestNewNamespacedRESTConfig_NilTLSLeavesDefaults(t *testing.T) {
+	bootdataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bootdataServer.Close()
+
+	ctx := config.Context{
+		Grafana: &config.GrafanaConfig{
+			Server:  bootdataServer.URL,
+			StackID: 1,
+		},
+	}
+
+	restCfg, err := config.NewNamespacedRESTConfig(t.Context(), ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tls := restCfg.TLSClientConfig
+	if len(tls.CertData) != 0 || len(tls.KeyData) != 0 || len(tls.CAData) != 0 {
+		t.Fatal("expected empty TLS data when no TLS config is set")
+	}
+	if tls.Insecure {
+		t.Fatal("expected Insecure to be false by default")
+	}
+}
+
 func TestNewNamespacedRESTConfig_UsesBootdataStack(t *testing.T) {
 	bootdataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{

--- a/internal/config/tls_test.go
+++ b/internal/config/tls_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"os"
 	"path/filepath"
 	"testing"
@@ -161,13 +162,25 @@ func TestTLS_ToStdTLSConfig_WithCertData(t *testing.T) {
 }
 
 func TestTLS_ToStdTLSConfig_HalfConfiguredCertData(t *testing.T) {
-	cfg := &config.TLS{
-		CertData: []byte(testCertPEM),
-	}
+	t.Run("CertData without KeyData", func(t *testing.T) {
+		cfg := &config.TLS{
+			CertData: []byte(testCertPEM),
+		}
 
-	_, err := cfg.ToStdTLSConfig()
-	require.Error(t, err)
-	require.ErrorContains(t, err, "both cert-data and key-data must be provided together")
+		_, err := cfg.ToStdTLSConfig()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "both cert-data and key-data must be provided together")
+	})
+
+	t.Run("KeyData without CertData", func(t *testing.T) {
+		cfg := &config.TLS{
+			KeyData: []byte(testKeyPEM),
+		}
+
+		_, err := cfg.ToStdTLSConfig()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "both cert-data and key-data must be provided together")
+	})
 }
 
 func TestTLS_ToStdTLSConfig_PinsMinVersionTLS12(t *testing.T) {
@@ -186,4 +199,15 @@ func TestTLS_ToStdTLSConfig_CADataAddsToSystemRoots(t *testing.T) {
 	tlsCfg, err := cfg.ToStdTLSConfig()
 	require.NoError(t, err)
 	require.NotNil(t, tlsCfg.RootCAs)
+
+	// Verify the custom CA was added to the system pool, not replacing it.
+	// The pool should contain more subjects than just our single test CA,
+	// proving system roots are preserved.
+	systemPool, sysErr := x509.SystemCertPool()
+	if sysErr == nil && systemPool.Equal(tlsCfg.RootCAs) {
+		// If pools are equal, the custom CA wasn't actually added (unlikely
+		// unless it happens to already be in the system pool). This is a
+		// sanity guard, not a hard failure, since CI environments vary.
+		t.Log("warning: RootCAs equals system pool — custom CA may already be a system root")
+	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -286,7 +286,7 @@ type GrafanaConfig struct {
 	// OAuthRefreshExpiresAt is the OAuthRefreshToken expiration time in RFC3339 format.
 	OAuthRefreshExpiresAt string `json:"oauth-refresh-expires-at,omitempty" yaml:"oauth-refresh-expires-at,omitempty"`
 
-	// AuthMethod is the authentication method stored by gcx login: "oauth", "token", or "basic".
+	// AuthMethod is the authentication method stored by gcx login: "oauth", "token", "basic", or "mtls".
 	// Empty string is valid for legacy configs; readers should call InferredAuthMethod() in that case.
 	AuthMethod string `json:"auth-method,omitempty" yaml:"auth-method,omitempty"`
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -384,7 +384,7 @@ func (grafana GrafanaConfig) IsEmpty() bool {
 // InferredAuthMethod returns the effective authentication method for this config.
 // When AuthMethod is set, it is returned verbatim. Otherwise, the method is inferred
 // from populated credential fields: OAuthToken => "oauth"; APIToken => "token";
-// User or Password => "basic"; no credentials => "unknown".
+// User or Password => "basic"; TLS with client cert => "mtls"; no credentials => "unknown".
 func (grafana GrafanaConfig) InferredAuthMethod() string {
 	if grafana.AuthMethod != "" {
 		return grafana.AuthMethod
@@ -397,6 +397,9 @@ func (grafana GrafanaConfig) InferredAuthMethod() string {
 	}
 	if grafana.User != "" || grafana.Password != "" {
 		return "basic"
+	}
+	if grafana.TLS != nil && (len(grafana.TLS.CertData) > 0 || grafana.TLS.CertFile != "") {
+		return "mtls"
 	}
 	return "unknown"
 }

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+	crypto_tls "crypto/tls"
 	"errors"
 	"fmt"
 	"net/url"
@@ -25,17 +26,24 @@ func (e *VersionIncompatibleError) Error() string {
 	return fmt.Sprintf("grafana version %s is not supported; gcx requires Grafana 12.0.0 or later", e.Version)
 }
 
-func ClientFromContext(ctx *config.Context) (*goapi.GrafanaHTTPAPI, error) {
+// clientResult bundles the goapi client with the resolved *tls.Config so
+// callers like GetVersion can reuse it without calling ToStdTLSConfig twice.
+type clientResult struct {
+	api       *goapi.GrafanaHTTPAPI
+	tlsConfig *crypto_tls.Config // nil when no TLS is configured
+}
+
+func clientFromContextWithTLS(ctx *config.Context) (clientResult, error) {
 	if ctx == nil {
-		return nil, errors.New("no context provided")
+		return clientResult{}, errors.New("no context provided")
 	}
 	if ctx.Grafana == nil {
-		return nil, errors.New("grafana not configured")
+		return clientResult{}, errors.New("grafana not configured")
 	}
 
 	grafanaURL, err := url.Parse(ctx.Grafana.Server)
 	if err != nil {
-		return nil, err
+		return clientResult{}, err
 	}
 
 	cfg := &goapi.TransportConfig{
@@ -47,12 +55,13 @@ func ClientFromContext(ctx *config.Context) (*goapi.GrafanaHTTPAPI, error) {
 		},
 	}
 
+	var stdTLS *crypto_tls.Config
 	if ctx.Grafana.TLS != nil {
-		tlsCfg, err := ctx.Grafana.TLS.ToStdTLSConfig()
+		stdTLS, err = ctx.Grafana.TLS.ToStdTLSConfig()
 		if err != nil {
-			return nil, fmt.Errorf("TLS configuration: %w", err)
+			return clientResult{}, fmt.Errorf("TLS configuration: %w", err)
 		}
-		cfg.TLSConfig = tlsCfg
+		cfg.TLSConfig = stdTLS
 	}
 
 	// Authentication
@@ -66,7 +75,18 @@ func ClientFromContext(ctx *config.Context) (*goapi.GrafanaHTTPAPI, error) {
 		cfg.OrgID = ctx.Grafana.OrgID
 	}
 
-	return goapi.NewHTTPClientWithConfig(strfmt.Default, cfg), nil
+	return clientResult{
+		api:       goapi.NewHTTPClientWithConfig(strfmt.Default, cfg),
+		tlsConfig: stdTLS,
+	}, nil
+}
+
+func ClientFromContext(ctx *config.Context) (*goapi.GrafanaHTTPAPI, error) {
+	res, err := clientFromContextWithTLS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return res.api, nil
 }
 
 // GetVersion returns the Grafana version reported by /api/health.
@@ -84,16 +104,17 @@ func ClientFromContext(ctx *config.Context) (*goapi.GrafanaHTTPAPI, error) {
 //   - err == nil, parsed != nil: fully parseable semver; raw is the
 //     original string.
 func GetVersion(ctx context.Context, cfgCtx *config.Context) (*semver.Version, string, error) {
-	gClient, err := ClientFromContext(cfgCtx)
+	res, err := clientFromContextWithTLS(cfgCtx)
 	if err != nil {
 		return nil, "", err
 	}
-	// Wire the CLI's HTTP client (which carries the --log-http-payload
-	// logging transport when enabled) so `gcx ... --log-http-payload` dumps
-	// the /api/health request/response alongside every other call.
-	// Swapping the HTTP client preserves the auth transport configured above (API key / basic / OrgID);
-	// WithHTTPClient only replaces the underlying transport, not the goapi auth settings.
-	gClient.WithHTTPClient(httputils.NewDefaultClient(ctx))
+	// Wire a CLI HTTP client that carries the --log-http-payload logging
+	// transport when enabled, reusing the TLS config already resolved by
+	// clientFromContextWithTLS to avoid redundant file reads.
+	// WithHTTPClient only replaces the underlying transport, not the
+	// goapi auth settings (API key / basic / OrgID).
+	gClient := res.api
+	gClient.WithHTTPClient(httputils.NewDefaultClientWithTLS(ctx, res.tlsConfig))
 
 	healthResponse, err := gClient.Health.GetHealth()
 	if err != nil {

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -2,7 +2,7 @@ package grafana
 
 import (
 	"context"
-	crypto_tls "crypto/tls"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/url"
@@ -30,7 +30,7 @@ func (e *VersionIncompatibleError) Error() string {
 // callers like GetVersion can reuse it without calling ToStdTLSConfig twice.
 type clientResult struct {
 	api       *goapi.GrafanaHTTPAPI
-	tlsConfig *crypto_tls.Config // nil when no TLS is configured
+	tlsConfig *tls.Config // nil when no TLS is configured
 }
 
 func clientFromContextWithTLS(ctx *config.Context) (clientResult, error) {
@@ -55,7 +55,7 @@ func clientFromContextWithTLS(ctx *config.Context) (clientResult, error) {
 		},
 	}
 
-	var stdTLS *crypto_tls.Config
+	var stdTLS *tls.Config
 	if ctx.Grafana.TLS != nil {
 		stdTLS, err = ctx.Grafana.TLS.ToStdTLSConfig()
 		if err != nil {
@@ -81,12 +81,27 @@ func clientFromContextWithTLS(ctx *config.Context) (clientResult, error) {
 	}, nil
 }
 
+// ClientFromContext returns a goapi client configured from the given context.
+// The returned client's default transport does NOT include TLS configuration;
+// callers that need to wrap the client with middleware via WithHTTPClient
+// should use ClientFromContextWithTLS instead to avoid silently losing mTLS.
 func ClientFromContext(ctx *config.Context) (*goapi.GrafanaHTTPAPI, error) {
 	res, err := clientFromContextWithTLS(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return res.api, nil
+}
+
+// ClientFromContextWithTLS returns both the goapi client and the resolved
+// *tls.Config. Use this when wrapping the client with WithHTTPClient to
+// ensure TLS settings are preserved (see GetVersion for an example).
+func ClientFromContextWithTLS(ctx *config.Context) (*goapi.GrafanaHTTPAPI, *tls.Config, error) {
+	res, err := clientFromContextWithTLS(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return res.api, res.tlsConfig, nil
 }
 
 // GetVersion returns the Grafana version reported by /api/health.

--- a/internal/grafana/settings.go
+++ b/internal/grafana/settings.go
@@ -24,13 +24,13 @@ type FrontendSettings struct {
 }
 
 // FetchAnonymousSettings performs an unauthenticated GET of /api/frontend/settings
-// against baseURL, used for pre-auth target detection. It uses httputils.NewDefaultClient
-// (so --log-http-payload is honoured) and respects the supplied context's deadline
-// and cancellation.
+// against baseURL, used for pre-auth target detection. When httpClient is nil it
+// falls back to httputils.NewDefaultClient (so --log-http-payload is honoured).
+// Respects the supplied context's deadline and cancellation.
 //
 // Errors are returned as-is; callers are responsible for deciding how to classify
 // them (e.g., mapping a non-200 status to TargetUnknown).
-func FetchAnonymousSettings(ctx context.Context, baseURL string) (*FrontendSettings, error) {
+func FetchAnonymousSettings(ctx context.Context, baseURL string, httpClient *http.Client) (*FrontendSettings, error) {
 	settingsURL := strings.TrimSuffix(baseURL, "/") + "/api/frontend/settings"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, settingsURL, nil)
@@ -38,8 +38,10 @@ func FetchAnonymousSettings(ctx context.Context, baseURL string) (*FrontendSetti
 		return nil, fmt.Errorf("building request for %s: %w", settingsURL, err)
 	}
 
-	client := httputils.NewDefaultClient(ctx)
-	resp, err := client.Do(req)
+	if httpClient == nil {
+		httpClient = httputils.NewDefaultClient(ctx)
+	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %w", settingsURL, err)
 	}

--- a/internal/grafana/settings_test.go
+++ b/internal/grafana/settings_test.go
@@ -87,7 +87,7 @@ func TestFetchAnonymousSettings(t *testing.T) {
 				cancel() // cancel immediately before the call
 			}
 
-			got, err := grafana.FetchAnonymousSettings(ctx, srv.URL)
+			got, err := grafana.FetchAnonymousSettings(ctx, srv.URL, nil)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil (settings=%+v)", got)

--- a/internal/httputils/client.go
+++ b/internal/httputils/client.go
@@ -60,12 +60,18 @@ func NewClient(opts ClientOpts) *http.Client {
 //   - PayloadLogging(ctx): when true, adds RequestResponseLoggingMiddleware for full
 //     request/response body dumps (includes headers — may expose tokens).
 func NewDefaultClient(ctx context.Context) *http.Client {
+	return NewDefaultClientWithTLS(ctx, nil)
+}
+
+// NewDefaultClientWithTLS is like NewDefaultClient but accepts an optional
+// *tls.Config for mTLS or custom CA scenarios. When tlsConfig is nil it
+// behaves identically to NewDefaultClient.
+func NewDefaultClientWithTLS(ctx context.Context, tlsConfig *tls.Config) *http.Client {
+	opts := ClientOpts{TLSConfig: tlsConfig}
 	if PayloadLogging(ctx) {
-		return NewClient(ClientOpts{
-			Middlewares: []Middleware{LoggingMiddleware, RequestResponseLoggingMiddleware},
-		})
+		opts.Middlewares = []Middleware{LoggingMiddleware, RequestResponseLoggingMiddleware}
 	}
-	return NewClient(ClientOpts{})
+	return NewClient(opts)
 }
 
 // NewTransport returns an *http.Transport with sensible defaults.

--- a/internal/login/detect.go
+++ b/internal/login/detect.go
@@ -73,13 +73,13 @@ func isLocalHostname(host string) bool {
 // A valid response with no Cloud markers is definitively on-prem (FR-006c).
 // Any error, timeout, or non-200 status yields TargetUnknown.
 //
-// httpClient is accepted for interface compatibility but unused; FetchAnonymousSettings
-// manages its own HTTP client via httputils.NewDefaultClient.
-func probeTarget(ctx context.Context, server string, _ *http.Client) (Target, error) {
+// httpClient is forwarded to FetchAnonymousSettings so that callers can supply
+// a TLS-aware client for mTLS servers. When nil, a default client is used.
+func probeTarget(ctx context.Context, server string, httpClient *http.Client) (Target, error) {
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	settings, err := grafana.FetchAnonymousSettings(probeCtx, server)
+	settings, err := grafana.FetchAnonymousSettings(probeCtx, server, httpClient)
 	if err != nil {
 		// Any error (network failure, timeout, non-200, decode failure) → TargetUnknown.
 		return TargetUnknown, nil

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -133,7 +133,7 @@ type Options struct {
 // render a post-login summary and persist auth-method metadata.
 type Result struct {
 	ContextName    string
-	AuthMethod     string // "oauth", "token", or "basic"
+	AuthMethod     string // "oauth", "token", "basic", or "mtls"
 	IsCloud        bool
 	HasCloudToken  bool
 	GrafanaVersion string
@@ -313,6 +313,11 @@ func Run(ctx context.Context, opts *Options) (Result, error) {
 
 // detectTarget calls DetectFn or falls back to the real DetectTarget.
 // When TLS settings are present, builds a TLS-aware HTTP client for the probe.
+//
+// Cert-load failures (e.g. malformed cert-file path) are returned as hard
+// errors rather than degrading to TargetUnknown. This is intentional: a broken
+// TLS config should fail fast here rather than producing a confusing
+// "auth rejected" error downstream during validation.
 func detectTarget(ctx context.Context, opts Options) (Target, error) {
 	if opts.DetectFn != nil {
 		return opts.DetectFn(ctx, opts.Server)
@@ -368,6 +373,10 @@ func resolveGrafanaAuth(ctx context.Context, opts Options, target Target) (strin
 	case opts.TLS != nil && (len(opts.TLS.CertData) > 0 || opts.TLS.CertFile != ""):
 		// mTLS-only auth: the client certificate authenticates at the transport
 		// layer (e.g. Teleport proxy). No Grafana token or OAuth needed.
+		// Note: we check only for cert presence here, not cert+key pairing.
+		// TLS.ResolveFiles() enforces "both cert-file and key-file must be
+		// provided together" downstream, producing a clear error if the key
+		// is missing.
 		grafanaCfg.AuthMethod = "mtls"
 		method = "mtls"
 

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 
@@ -41,6 +42,13 @@ type Inputs struct {
 	// instance selector
 	UseCloudInstanceSelector bool
 
+	// TLS carries client-side TLS settings (mTLS cert/key, custom CA).
+	// When non-nil, these settings are used for target detection, connectivity
+	// validation, and persisted into the new/updated context.
+	// On re-auth of an existing context, the CLI pre-populates this from the
+	// stored grafana.tls.* block so mTLS keeps working without re-specifying certs.
+	TLS *config.TLS
+
 	// Writer receives human-facing OAuth progress output. When nil, the
 	// internal/login package discards writes (NC-001: the package is UI-free
 	// and never touches os.Stderr on its own). CLI callers should pass
@@ -68,7 +76,8 @@ type Hooks struct {
 	ValidateFn func(ctx context.Context, opts Options, restCfg config.NamespacedRESTConfig) (string, error)
 
 	// DetectFn overrides target detection for testing. When nil,
-	// DetectTarget with httputils.NewDefaultClient(ctx) is used.
+	// DetectTarget is called with a TLS-aware HTTP client (built from
+	// opts.TLS) or a default client when no TLS is configured.
 	DetectFn func(ctx context.Context, server string) (Target, error)
 }
 
@@ -198,7 +207,7 @@ func Run(ctx context.Context, opts *Options) (Result, error) {
 		opts.Server = "https://" + opts.Server
 	}
 
-	// Step 2: detect target
+	// Step 2: detect target (using TLS-aware client when mTLS is configured)
 	target := opts.Target
 	if target == TargetUnknown {
 		detected, err := detectTarget(ctx, *opts)
@@ -303,11 +312,30 @@ func Run(ctx context.Context, opts *Options) (Result, error) {
 }
 
 // detectTarget calls DetectFn or falls back to the real DetectTarget.
+// When TLS settings are present, builds a TLS-aware HTTP client for the probe.
 func detectTarget(ctx context.Context, opts Options) (Target, error) {
 	if opts.DetectFn != nil {
 		return opts.DetectFn(ctx, opts.Server)
 	}
-	return DetectTarget(ctx, opts.Server, httputils.NewDefaultClient(ctx))
+	client, err := tlsAwareClient(ctx, opts.TLS)
+	if err != nil {
+		return TargetUnknown, fmt.Errorf("TLS configuration: %w", err)
+	}
+	return DetectTarget(ctx, opts.Server, client)
+}
+
+// tlsAwareClient returns a TLS-aware *http.Client when tlsCfg is non-nil and
+// non-empty, or a default client otherwise. Used by the login flow for target
+// detection and connectivity validation against mTLS servers.
+func tlsAwareClient(ctx context.Context, tlsCfg *config.TLS) (*http.Client, error) {
+	if tlsCfg == nil || tlsCfg.IsEmpty() {
+		return httputils.NewDefaultClient(ctx), nil
+	}
+	stdTLS, err := tlsCfg.ToStdTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+	return httputils.NewDefaultClientWithTLS(ctx, stdTLS), nil
 }
 
 // resolveGrafanaAuth determines how to authenticate against Grafana (step 4).
@@ -327,6 +355,7 @@ func resolveGrafanaAuth(ctx context.Context, opts Options, target Target) (strin
 
 	grafanaCfg := &config.GrafanaConfig{
 		Server: opts.Server,
+		TLS:    opts.TLS,
 	}
 
 	var method string
@@ -335,6 +364,12 @@ func resolveGrafanaAuth(ctx context.Context, opts Options, target Target) (strin
 		grafanaCfg.APIToken = opts.GrafanaToken
 		grafanaCfg.AuthMethod = "token"
 		method = "token"
+
+	case opts.TLS != nil && (len(opts.TLS.CertData) > 0 || opts.TLS.CertFile != ""):
+		// mTLS-only auth: the client certificate authenticates at the transport
+		// layer (e.g. Teleport proxy). No Grafana token or OAuth needed.
+		grafanaCfg.AuthMethod = "mtls"
+		method = "mtls"
 
 	case opts.UseOAuth:
 		if opts.NewAuthFlow == nil {
@@ -498,6 +533,11 @@ func mergeAuthIntoExisting(existing *config.Context, incoming config.Context) {
 	g.OAuthTokenExpiresAt = src.OAuthTokenExpiresAt
 	g.OAuthRefreshExpiresAt = src.OAuthRefreshExpiresAt
 	g.ProxyEndpoint = src.ProxyEndpoint
+
+	// Sync TLS settings so that re-auth with updated or cleared certs
+	// takes effect. Setting to src.TLS (which may be nil) handles both
+	// the "update certs" and "remove certs" cases.
+	g.TLS = src.TLS
 
 	// Update Cloud config if present in the incoming context.
 	if incoming.Cloud != nil {

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -829,3 +829,190 @@ func TestRun_NormalizesServerScheme(t *testing.T) {
 		t.Errorf("stored server = %q, want https://assistant.grafana-dev.net", got)
 	}
 }
+
+func TestRun_TLSPropagatedToContext(t *testing.T) {
+	dir := t.TempDir()
+
+	tlsCfg := &config.TLS{
+		CertData:   []byte("cert-pem"),
+		KeyData:    []byte("key-pem"),
+		CAData:     []byte("ca-pem"),
+		ServerName: "custom-sni.example.com",
+	}
+
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server:       "https://grafana.example.com",
+			Target:       login.TargetOnPrem,
+			GrafanaToken: "glsa_test",
+			TLS:          tlsCfg,
+		},
+		Hooks: login.Hooks{
+			ConfigSource: configSource(dir),
+			ValidateFn:   noopValidate,
+		},
+	}
+
+	_, err := login.Run(context.Background(), &opts)
+	require.NoError(t, err)
+
+	cfg, err := config.Load(context.Background(), configSource(dir))
+	require.NoError(t, err)
+
+	storedTLS := cfg.Contexts["grafana-example-com"].Grafana.TLS
+	require.NotNil(t, storedTLS, "TLS config must be persisted")
+	assert.Contains(t, string(storedTLS.CertData), "cert-pem")
+	assert.Contains(t, string(storedTLS.KeyData), "key-pem")
+	assert.Contains(t, string(storedTLS.CAData), "ca-pem")
+	assert.Equal(t, "custom-sni.example.com", storedTLS.ServerName)
+}
+
+func TestRun_ReauthPreservesTLS(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed config with TLS settings
+	seed := config.Config{
+		CurrentContext: "grafana-example-com",
+		Contexts: map[string]*config.Context{
+			"grafana-example-com": {
+				Grafana: &config.GrafanaConfig{
+					Server:   "https://grafana.example.com",
+					APIToken: "old-token",
+					OrgID:    42,
+					TLS: &config.TLS{
+						CertData:   []byte("cert-pem"),
+						KeyData:    []byte("key-pem"),
+						ServerName: "custom-sni.example.com",
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, config.Write(context.Background(), configSource(dir), seed))
+
+	// Re-auth with TLS carried through (simulating what the CLI does)
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server:       "https://grafana.example.com",
+			Target:       login.TargetOnPrem,
+			GrafanaToken: "new-token",
+			TLS: &config.TLS{
+				CertData:   []byte("cert-pem"),
+				KeyData:    []byte("key-pem"),
+				ServerName: "custom-sni.example.com",
+			},
+		},
+		Hooks: login.Hooks{
+			ConfigSource: configSource(dir),
+			ValidateFn:   noopValidate,
+		},
+	}
+
+	_, err := login.Run(context.Background(), &opts)
+	require.NoError(t, err)
+
+	cfg, err := config.Load(context.Background(), configSource(dir))
+	require.NoError(t, err)
+
+	grafanaCfg := cfg.Contexts["grafana-example-com"].Grafana
+	assert.Equal(t, "new-token", grafanaCfg.APIToken, "token must be updated")
+	assert.EqualValues(t, 42, grafanaCfg.OrgID, "OrgID must be preserved")
+	require.NotNil(t, grafanaCfg.TLS, "TLS must be preserved on re-auth")
+	assert.Equal(t, "custom-sni.example.com", grafanaCfg.TLS.ServerName)
+}
+
+func TestRun_TLSPassedToDetectFn(t *testing.T) {
+	dir := t.TempDir()
+
+	var detectCalled bool
+	tlsCfg := &config.TLS{
+		CertData: []byte("cert-pem"),
+		KeyData:  []byte("key-pem"),
+	}
+
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server:       "https://grafana.example.com",
+			GrafanaToken: "glsa_test",
+			TLS:          tlsCfg,
+		},
+		Hooks: login.Hooks{
+			ConfigSource: configSource(dir),
+			DetectFn: func(_ context.Context, _ string) (login.Target, error) {
+				detectCalled = true
+				return login.TargetOnPrem, nil
+			},
+			ValidateFn: noopValidate,
+		},
+	}
+
+	_, err := login.Run(context.Background(), &opts)
+	require.NoError(t, err)
+	assert.True(t, detectCalled, "DetectFn must be called")
+}
+
+func TestRun_TLSPassedToValidateFn(t *testing.T) {
+	dir := t.TempDir()
+
+	var validatedTLS *config.TLS
+	tlsCfg := &config.TLS{
+		CertData:   []byte("cert-pem"),
+		KeyData:    []byte("key-pem"),
+		ServerName: "validated-sni",
+	}
+
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server:       "https://grafana.example.com",
+			Target:       login.TargetOnPrem,
+			GrafanaToken: "glsa_test",
+			TLS:          tlsCfg,
+		},
+		Hooks: login.Hooks{
+			ConfigSource: configSource(dir),
+			ValidateFn: func(_ context.Context, o login.Options, _ config.NamespacedRESTConfig) (string, error) {
+				validatedTLS = o.TLS
+				return "12.0.0", nil
+			},
+		},
+	}
+
+	_, err := login.Run(context.Background(), &opts)
+	require.NoError(t, err)
+	require.NotNil(t, validatedTLS, "TLS must be passed to ValidateFn")
+	assert.Equal(t, "validated-sni", validatedTLS.ServerName)
+}
+
+func TestRun_MTLSOnlyAuth(t *testing.T) {
+	dir := t.TempDir()
+
+	tlsCfg := &config.TLS{
+		CertData: []byte("cert-pem"),
+		KeyData:  []byte("key-pem"),
+	}
+
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server: "https://grafana.example.com",
+			Target: login.TargetOnPrem,
+			TLS:    tlsCfg,
+			// No GrafanaToken, no UseOAuth — mTLS is the auth
+		},
+		Hooks: login.Hooks{
+			ConfigSource: configSource(dir),
+			ValidateFn:   noopValidate,
+		},
+	}
+
+	result, err := login.Run(context.Background(), &opts)
+	require.NoError(t, err)
+	assert.Equal(t, "mtls", result.AuthMethod)
+
+	cfg, err := config.Load(context.Background(), configSource(dir))
+	require.NoError(t, err)
+
+	grafanaCfg := cfg.Contexts["grafana-example-com"].Grafana
+	assert.Equal(t, "mtls", grafanaCfg.AuthMethod)
+	require.NotNil(t, grafanaCfg.TLS, "TLS must be persisted")
+	assert.Contains(t, string(grafanaCfg.TLS.CertData), "cert-pem")
+}

--- a/internal/login/validate.go
+++ b/internal/login/validate.go
@@ -113,6 +113,7 @@ func Validate(ctx context.Context, opts Options, restCfg config.NamespacedRESTCo
 		Grafana: &config.GrafanaConfig{
 			Server:   opts.Server,
 			APIToken: opts.GrafanaToken,
+			TLS:      opts.TLS,
 		},
 	}
 

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -93,8 +93,23 @@ func cloudEnvOverride(cfg *config.Config) error {
 	if curCtx.Cloud == nil {
 		curCtx.Cloud = &config.CloudConfig{}
 	}
+	// Initialize nested pointers so env.Parse can populate GRAFANA_TLS_* env vars.
+	if curCtx.Grafana == nil {
+		curCtx.Grafana = &config.GrafanaConfig{}
+	}
+	if curCtx.Grafana.TLS == nil {
+		curCtx.Grafana.TLS = &config.TLS{}
+	}
 
-	return env.Parse(curCtx)
+	if err := env.Parse(curCtx); err != nil {
+		return err
+	}
+
+	// Nil out TLS if no fields were set, so IsEmpty() checks work correctly.
+	if curCtx.Grafana.TLS.IsEmpty() {
+		curCtx.Grafana.TLS = nil
+	}
+	return nil
 }
 
 // contextMustExist is a config.Override that validates the current context exists.
@@ -140,9 +155,19 @@ func envOverride(cfg *config.Config) error {
 	if curCtx.Grafana == nil {
 		curCtx.Grafana = &config.GrafanaConfig{}
 	}
+	// Initialize TLS pointer so env.Parse can populate GRAFANA_TLS_* env vars
+	// into the nested struct (same fix as cmd/gcx/config/command.go).
+	if curCtx.Grafana.TLS == nil {
+		curCtx.Grafana.TLS = &config.TLS{}
+	}
 
 	if err := env.Parse(curCtx); err != nil {
 		return err
+	}
+
+	// Nil out TLS if no fields were set, so IsEmpty() checks work correctly.
+	if curCtx.Grafana.TLS.IsEmpty() {
+		curCtx.Grafana.TLS = nil
 	}
 
 	// Resolve GRAFANA_PROVIDER_{NAME}_{KEY} environment variables.

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/caarlos0/env/v11"
 	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/httputils"
@@ -93,21 +92,8 @@ func cloudEnvOverride(cfg *config.Config) error {
 	if curCtx.Cloud == nil {
 		curCtx.Cloud = &config.CloudConfig{}
 	}
-	// Initialize nested pointers so env.Parse can populate GRAFANA_TLS_* env vars.
-	if curCtx.Grafana == nil {
-		curCtx.Grafana = &config.GrafanaConfig{}
-	}
-	if curCtx.Grafana.TLS == nil {
-		curCtx.Grafana.TLS = &config.TLS{}
-	}
-
-	if err := env.Parse(curCtx); err != nil {
+	if err := config.ParseEnvIntoContext(curCtx); err != nil {
 		return err
-	}
-
-	// Nil out TLS if no fields were set, so IsEmpty() checks work correctly.
-	if curCtx.Grafana.TLS.IsEmpty() {
-		curCtx.Grafana.TLS = nil
 	}
 	return nil
 }
@@ -152,22 +138,8 @@ func envOverride(cfg *config.Config) error {
 	}
 
 	curCtx := cfg.Contexts[cfg.CurrentContext]
-	if curCtx.Grafana == nil {
-		curCtx.Grafana = &config.GrafanaConfig{}
-	}
-	// Initialize TLS pointer so env.Parse can populate GRAFANA_TLS_* env vars
-	// into the nested struct (same fix as cmd/gcx/config/command.go).
-	if curCtx.Grafana.TLS == nil {
-		curCtx.Grafana.TLS = &config.TLS{}
-	}
-
-	if err := env.Parse(curCtx); err != nil {
+	if err := config.ParseEnvIntoContext(curCtx); err != nil {
 		return err
-	}
-
-	// Nil out TLS if no fields were set, so IsEmpty() checks work correctly.
-	if curCtx.Grafana.TLS.IsEmpty() {
-		curCtx.Grafana.TLS = nil
 	}
 
 	// Resolve GRAFANA_PROVIDER_{NAME}_{KEY} environment variables.


### PR DESCRIPTION
  ## Summary

   Thread TLS client certificate configuration through the entire `gcx login` flow so that login
   works against mTLS-protected Grafana servers (e.g. behind a Teleport proxy).

   ### What changed

   **Login flow (`cmd/gcx/login/`, `internal/login/`)**
   - `login.Inputs` carries a `TLS` field populated from the existing context on re-auth (so users
    don't have to re-specify certs)
   - `detectTarget` builds a TLS-aware HTTP client for the server probe
   - `Validate` threads TLS into the health-check context
   - Interactive auth menu offers **"Client certificate (mTLS)"** as a choice when certs are
   configured; defaults to it in non-interactive (`--yes`) mode
   - Re-login preserves existing `grafana.tls.*` settings

   **Grafana client (`internal/grafana/`)**
   - `GetVersion` reuses the TLS config already resolved by `clientFromContextWithTLS`, instead of
    discarding it by replacing the transport with a bare default client
   - `FetchAnonymousSettings` accepts an optional `*http.Client` so callers can supply a TLS-aware
    client for mTLS servers

   **HTTP utils (`internal/httputils/`)**
   - New `NewDefaultClientWithTLS(ctx, *tls.Config)` helper that threads a TLS config into the
   default client pipeline

   **Fix (`internal/providers/configloader.go`)**
   - Fix env-var bug where `GRAFANA_TLS_CERT_FILE` / `GRAFANA_TLS_KEY_FILE` were silently ignored
   because the TLS pointer was not initialized before `env.Parse`

   **Tests**
   - TLS propagation through login flow
   - Re-auth TLS preservation
   - PR #553 suggested test cases: half-configured CertData/KeyData, MinVersion pinning, CAData
   added to system roots, `NewNamespacedRESTConfig` round-trip

   **Docs**
   - Updated `docs/architecture/auth-system.md` with mTLS login flow details

   ### Scope 

   Closes the scope note from #553.

   ## Test plan

   - [x] `go test ./internal/login/...` — TLS propagation and re-auth preservation
   - [x] `go test ./internal/config/...` — REST config round-trip and TLS edge cases
   - [x] `go test ./internal/grafana/...` — settings client signature change
   - [x] Manual: `gcx login --server https://mtls-grafana.example.com` with Teleport certs
   configured
   - [x] Manual: re-auth flow preserves TLS settings without re-prompting