### PR TITLE
fix(synth): surface required scopes when SM register/install fails

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -720,6 +720,22 @@ func convertSMConfigErrors(err error) (*DetailedError, bool) {
 		}, true
 	}
 
+	if strings.Contains(msg, "SM token not configured") && strings.Contains(msg, "register/install") &&
+		(strings.Contains(msg, "status 401") || strings.Contains(msg, "status 403") ||
+			(strings.Contains(msg, "status 400") && strings.Contains(msg, "permission"))) {
+		return &DetailedError{
+			Parent:  err,
+			Summary: "SM token auto-discovery: permission denied",
+			Details: msg,
+			Suggestions: []string{
+				"Ensure your cloud.token access policy includes these scopes: stacks:read, metrics:write, logs:write, traces:write",
+				"Or set the SM token directly: gcx config set providers.synth.sm-token <TOKEN>",
+				"Or use env var: export GRAFANA_PROVIDER_SYNTH_SM_TOKEN=<TOKEN>",
+			},
+			ExitCode: new(ExitAuthFailure),
+		}, true
+	}
+
 	if strings.Contains(msg, "SM token not configured") {
 		return &DetailedError{
 			Summary: "SM token not configured",

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -465,6 +465,66 @@ func TestErrorToDetailedError_SMTokenNotConfigured(t *testing.T) {
 	assert.Contains(t, got.Suggestions[3], "gcx config view")
 }
 
+func TestErrorToDetailedError_SMTokenRegisterInstallPermissionDenied(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "HTTP 400 from register/install",
+			err: fmt.Errorf("failed to load SM config for checks: %w",
+				fmt.Errorf("SM token not configured: %w",
+					fmt.Errorf("register/install API failed: %w",
+						errors.New("SM register/install: request failed with status 400: insufficient permissions")))),
+		},
+		{
+			name: "HTTP 403 from register/install",
+			err: fmt.Errorf("failed to load SM config for checks: %w",
+				fmt.Errorf("SM token not configured: %w",
+					fmt.Errorf("register/install API failed: %w",
+						errors.New("SM register/install: request failed with status 403: forbidden")))),
+		},
+		{
+			name: "HTTP 401 from register/install",
+			err: fmt.Errorf("failed to load SM config for checks: %w",
+				fmt.Errorf("SM token not configured: %w",
+					fmt.Errorf("register/install API failed: %w",
+						errors.New("SM register/install: request failed with status 401: unauthorized")))),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fail.ErrorToDetailedError(tc.err)
+
+			require.NotNil(t, got)
+			assert.Equal(t, "SM token auto-discovery: permission denied", got.Summary)
+			assert.Contains(t, got.Details, "SM token not configured")
+			assert.Contains(t, got.Details, "register/install")
+			require.NotNil(t, got.ExitCode)
+			assert.Equal(t, fail.ExitAuthFailure, *got.ExitCode)
+			require.Len(t, got.Suggestions, 3)
+			assert.Contains(t, got.Suggestions[0], "stacks:read")
+			assert.Contains(t, got.Suggestions[0], "metrics:write")
+			assert.Contains(t, got.Suggestions[0], "logs:write")
+			assert.Contains(t, got.Suggestions[0], "traces:write")
+			assert.Contains(t, got.Suggestions[1], "gcx config set providers.synth.sm-token")
+		})
+	}
+}
+
+func TestErrorToDetailedError_SMTokenRegisterInstallGeneric400FallsThrough(t *testing.T) {
+	err := fmt.Errorf("failed to load SM config for checks: %w",
+		fmt.Errorf("SM token not configured: %w",
+			fmt.Errorf("register/install API failed: %w",
+				errors.New("SM register/install: request failed with status 400: bad request"))))
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "SM token not configured", got.Summary)
+}
+
 func TestErrorToDetailedError_CloudTokenNotConfigured(t *testing.T) {
 	err := errors.New("cloud token is required: set cloud.token in config or GRAFANA_CLOUD_TOKEN env var")
 

--- a/internal/providers/synth/configloader_test.go
+++ b/internal/providers/synth/configloader_test.go
@@ -456,6 +456,58 @@ current-context: default
 	assert.Equal(t, wantToken, cfg.GetCurrentContext().Providers["synth"]["sm-token"])
 }
 
+func TestConfigLoader_LoadSMConfig_TokenAutoDiscoveryPermissionError(t *testing.T) {
+	smSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/register/install" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": "insufficient permissions",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer smSrv.Close()
+
+	gcomSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": 12345, "slug": "teststack", "regionSlug": "eu",
+			"hmInstancePromId": 1, "hlInstanceId": 2,
+			"hmInstancePromUrl": "https://prom.example.com",
+			"hlInstanceUrl":     "https://loki.example.com",
+		})
+	}))
+	defer gcomSrv.Close()
+
+	cfgFile := writeConfigFile(t, `
+contexts:
+  default:
+    grafana:
+      server: https://teststack.grafana.net
+      token: test-token
+      stack-id: 12345
+    cloud:
+      token: cloud-token
+      stack: teststack
+      api-url: `+gcomSrv.URL+`
+    providers:
+      synth:
+        sm-url: `+smSrv.URL+`
+current-context: default
+`)
+
+	l := newTestLoader(t, cfgFile)
+
+	_, smToken, _, err := l.LoadSMConfig(context.Background())
+	require.Error(t, err)
+	assert.Empty(t, smToken)
+	assert.Contains(t, err.Error(), "SM token not configured")
+	assert.Contains(t, err.Error(), "insufficient permissions")
+	assert.Contains(t, err.Error(), "status 400")
+}
+
 // TestConfigLoader_SaveMetricsDatasourceUID_RoundTrip verifies AC-6: saving and
 // reloading sm-metrics-datasource-uid round-trips correctly.
 func TestConfigLoader_SaveMetricsDatasourceUID_RoundTrip(t *testing.T) {

--- a/internal/providers/synth/provider.go
+++ b/internal/providers/synth/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/synth/checks"
 	"github.com/grafana/gcx/internal/providers/synth/probes"
+	"github.com/grafana/gcx/internal/providers/synth/smcfg"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
@@ -290,7 +291,7 @@ func registerSMInstall(ctx context.Context, smURL, cloudToken string, stack clou
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("SM register/install returned HTTP %d", resp.StatusCode)
+		return "", fmt.Errorf("SM register/install: %w", smcfg.HandleErrorResponse(resp))
 	}
 
 	var result struct {


### PR DESCRIPTION
## Summary

Provide some useful suggestions for when the sm-token generation fails in gcx.

- Read the SM API response body on non-200 errors (via `smcfg.HandleErrorResponse`) instead of only reporting the HTTP status code
- Add a scope-specific error branch when the register/install endpoint returns 400 (with permission message), 401, or 403
- Suggest the four required Cloud Access Policy scopes: `stacks:read`, `metrics:write`, `logs:write`, `traces:write`

### Before

```
Error: SM token not configured
│
│ failed to load SM config for checks: SM token not configured: register/install API failed: SM register/install returned HTTP 400
│
├─ Suggestions:
│
│ • Set it: gcx config set providers.synth.sm-token <TOKEN>
│ • Or use env var: export GRAFANA_PROVIDER_SYNTH_SM_TOKEN=<TOKEN>
│ • Auto-discovery requires cloud.token and cloud.stack in the current context
│ • Check config: gcx config view
│
└─
```

### After

```
./bin/gcx synth checks list
Error: SM token auto-discovery: permission denied
│
│ failed to load SM config for checks: SM token not configured: register/install API failed: SM register/install: request failed with status 400: publisher token missing required scopes - stacks:read, metrics:write, logs:write, traces:write
│
├─ Suggestions:
│
│ • Ensure your cloud.token access policy includes these scopes: stacks:read, metrics:write, logs:write, traces:write
│ • Or set the SM token directly: gcx config set providers.synth.sm-token <TOKEN>
│ • Or use env var: export GRAFANA_PROVIDER_SYNTH_SM_TOKEN=<TOKEN>
│
└─
```

## Test plan

- [x] `go test ./internal/providers/synth/... ./cmd/gcx/fail/...` — all pass
- [x] `make lint` — 0 issues
- [x] New test: register/install returns 400/401/403 → scope-specific suggestions shown
- [x] New test: generic 400 (no "permission" in body) falls through to generic handler
- [x] New test: mock SM server returning 400 with error body → body surfaced in error message
- [x] Existing SM token tests still pass (no regression)