### PR TITLE
feat(kg): add suppressions dry-run diff

### DIFF
--- a/docs/reference/cli/gcx_kg_suppressions_create.md
+++ b/docs/reference/cli/gcx_kg_suppressions_create.md
@@ -9,6 +9,7 @@ gcx kg suppressions create [flags]
 ### Options
 
 ```
+      --dry-run       Validate and show a diff without uploading
   -f, --file string   Input file (YAML)
   -h, --help          help for create
 ```

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/open-policy-agent/opa v1.15.2
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/prometheus v0.55.0 // pinned: loki v3.4.2 depends on v0.55.0 package layout (tsdb/errors, otlptranslator); upgrade requires loki upgrade first
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -202,7 +203,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pires/go-proxyproto v0.7.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -215,7 +215,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx kg search insights":         {Cost: "medium", Hint: "--type <type> --since 1h"},
 	"gcx kg search sample":           {Cost: "small"},
 	"gcx kg status":                  {Cost: "small"},
-	"gcx kg suppressions create":     {Cost: "small"},
+	"gcx kg suppressions create":     {Cost: "small", Hint: "-f suppressions.yaml --dry-run"},
 
 	// -----------------------------------------------------------------------
 	// Logs provider

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -26,6 +26,7 @@ const (
 	assertionsPath   = pluginResourcePath + "/asserts/api-server/v1/assertions"
 	searchPath       = pluginResourcePath + "/asserts/api-server/v1/search"
 	rulesPath        = pluginResourcePath + "/asserts/api-server/v1/config/prom-rules/"
+	suppressionsPath = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alerts/"
 	entityLookupPath = pluginResourcePath + "/asserts/api-server/v1/entity"
 )
 
@@ -61,6 +62,30 @@ func (c *Client) getJSON(ctx context.Context, path string, v any) error {
 		return readError(resp)
 	}
 	return json.NewDecoder(resp.Body).Decode(v)
+}
+
+// getRaw performs a GET request and returns the raw response body.
+func (c *Client) getRaw(ctx context.Context, path string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.host+path, nil)
+	if err != nil {
+		return "", fmt.Errorf("kg: create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/x-yaml, application/yaml, text/yaml, application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("kg: execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return "", readError(resp)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("kg: read response body: %w", err)
+	}
+	return string(body), nil
 }
 
 // postJSON performs a POST request with a JSON body and decodes the response into v.
@@ -208,9 +233,14 @@ func (c *Client) UploadModelRules(ctx context.Context, yamlContent string) error
 	return c.doYAML(ctx, http.MethodPut, pluginResourcePath+"/asserts/api-server/v1/config/model-rules/", yamlContent)
 }
 
+// GetSuppressions retrieves the current alert suppression configuration.
+func (c *Client) GetSuppressions(ctx context.Context) (string, error) {
+	return c.getRaw(ctx, suppressionsPath)
+}
+
 // UploadSuppressions uploads alert suppression configuration.
 func (c *Client) UploadSuppressions(ctx context.Context, yamlContent string) error {
-	return c.doYAML(ctx, http.MethodPost, pluginResourcePath+"/asserts/api-server/v1/config/disabled-alerts/", yamlContent)
+	return c.doYAML(ctx, http.MethodPost, suppressionsPath, yamlContent)
 }
 
 // UploadRelabelRules uploads relabel rules configuration.

--- a/internal/providers/kg/client_test.go
+++ b/internal/providers/kg/client_test.go
@@ -200,6 +200,36 @@ func TestClient_UploadPromRules(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestClient_GetSuppressions(t *testing.T) {
+	const body = "disabledAlerts:\n- name: remote\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "config/disabled-alerts")
+		assert.Contains(t, r.Header.Get("Accept"), "application/x-yaml")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	got, err := client.GetSuppressions(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
+}
+
+func TestClient_UploadSuppressions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "config/disabled-alerts")
+		assert.Equal(t, "application/x-yaml", r.Header.Get("Content-Type"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	err := client.UploadSuppressions(t.Context(), "disabledAlerts:\n- name: test\n")
+	require.NoError(t, err)
+}
+
 func TestClient_Search(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -667,14 +667,14 @@ func runSuppressionsDryRun(cmd *cobra.Command, client *Client, localData []byte)
 		return err
 	}
 	if remote == local {
-		cmdio.Info(cmd.OutOrStdout(), "[dry-run] Suppressions YAML is valid; no changes")
+		cmdio.Info(cmd.ErrOrStderr(), "[dry-run] Suppressions YAML is valid; no changes")
 		return nil
 	}
 	diff, err := unifiedYAMLDiff(remote, local)
 	if err != nil {
 		return fmt.Errorf("render suppressions diff: %w", err)
 	}
-	cmdio.Info(cmd.OutOrStdout(), "[dry-run] Suppressions YAML is valid; showing diff (remote -> local)")
+	cmdio.Info(cmd.ErrOrStderr(), "[dry-run] Suppressions YAML is valid; showing diff (remote -> local)")
 	_, err = fmt.Fprint(cmd.OutOrStdout(), diff)
 	return err
 }

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -116,7 +116,7 @@ func (f *scopeFlags) validateScopes(ctx context.Context, client *Client) error {
 	if err != nil {
 		return nil //nolint:nilerr // best-effort: scope validation is advisory
 	}
-	var errs []string
+	errs := make([]string, 0, len(active))
 	for _, c := range active {
 		known := scopes[c.dim]
 		if len(known) == 0 {
@@ -605,7 +605,6 @@ func newModelRulesCommand(loader RESTConfigLoader) *cobra.Command {
 	//nolint:dupl
 }
 
-//nolint:dupl
 func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "suppressions",
@@ -641,7 +640,6 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 	opts.setup(createCmd.Flags())
 	_ = createCmd.MarkFlagRequired("file")
 	cmd.AddCommand(createCmd)
-	//nolint:dupl
 	return cmd
 }
 

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/shared"
 	"github.com/grafana/gcx/internal/style"
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
@@ -256,6 +257,31 @@ func readFileOrStdin(cmd *cobra.Command, path string) ([]byte, error) {
 		return io.ReadAll(cmd.InOrStdin())
 	}
 	return os.ReadFile(path)
+}
+
+func normalizeYAMLForDiff(name string, data []byte) (string, error) {
+	if strings.TrimSpace(string(data)) == "" {
+		return "", nil
+	}
+	var value any
+	if err := yaml.Unmarshal(data, &value); err != nil {
+		return "", fmt.Errorf("invalid %s YAML: %w", name, err)
+	}
+	normalized, err := yaml.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("normalize %s YAML: %w", name, err)
+	}
+	return string(normalized), nil
+}
+
+func unifiedYAMLDiff(remote, local string) (string, error) {
+	return difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(remote),
+		B:        difflib.SplitLines(local),
+		FromFile: "remote",
+		ToFile:   "local",
+		Context:  3,
+	})
 }
 
 // searchByTypes fans out Search across multiple entity types and merges results.
@@ -585,12 +611,12 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 		Use:   "suppressions",
 		Short: "Push suppressions to the Knowledge Graph.",
 	}
-	var fileFlag string
+	opts := &suppressionsCreateOpts{}
 	createCmd := &cobra.Command{
 		Use:   "create",
 		Short: "Upload suppressions from a YAML file.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			data, err := readFileOrStdin(cmd, fileFlag)
+			data, err := readFileOrStdin(cmd, opts.File)
 			if err != nil {
 				return fmt.Errorf("failed to read file: %w", err)
 			}
@@ -602,6 +628,9 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if opts.DryRun {
+				return runSuppressionsDryRun(cmd, client, data)
+			}
 			if err := client.UploadSuppressions(cmd.Context(), string(data)); err != nil {
 				return err
 			}
@@ -609,11 +638,47 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 			return nil
 		},
 	}
-	createCmd.Flags().StringVarP(&fileFlag, "file", "f", "", "Input file (YAML)")
+	opts.setup(createCmd.Flags())
 	_ = createCmd.MarkFlagRequired("file")
 	cmd.AddCommand(createCmd)
 	//nolint:dupl
 	return cmd
+}
+
+type suppressionsCreateOpts struct {
+	File   string
+	DryRun bool
+}
+
+func (o *suppressionsCreateOpts) setup(flags *pflag.FlagSet) {
+	flags.StringVarP(&o.File, "file", "f", "", "Input file (YAML)")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Validate and show a diff without uploading")
+}
+
+func runSuppressionsDryRun(cmd *cobra.Command, client *Client, localData []byte) error {
+	local, err := normalizeYAMLForDiff("local suppressions", localData)
+	if err != nil {
+		return err
+	}
+	remoteData, err := client.GetSuppressions(cmd.Context())
+	if err != nil {
+		return err
+	}
+	remote, err := normalizeYAMLForDiff("remote suppressions", []byte(remoteData))
+	if err != nil {
+		return err
+	}
+	if remote == local {
+		cmdio.Info(cmd.OutOrStdout(), "[dry-run] Suppressions YAML is valid; no changes")
+		return nil
+	}
+	diff, err := unifiedYAMLDiff(remote, local)
+	if err != nil {
+		return fmt.Errorf("render suppressions diff: %w", err)
+	}
+	cmdio.Info(cmd.OutOrStdout(), "[dry-run] Suppressions YAML is valid; showing diff (remote -> local)")
+	_, err = fmt.Fprint(cmd.OutOrStdout(), diff)
+	return err
 }
 
 //nolint:dupl

--- a/internal/providers/kg/commands_test.go
+++ b/internal/providers/kg/commands_test.go
@@ -59,12 +59,15 @@ func TestSuppressionsCreate_DryRunShowsDiffWithoutUploading(t *testing.T) {
 		cfg: config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}},
 	})
 	var out bytes.Buffer
+	var errOut bytes.Buffer
 	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
 	cmd.SetArgs([]string{"create", "-f", file, "--dry-run"})
 
 	require.NoError(t, cmd.Execute())
 	assert.False(t, postCalled.Load())
-	assert.Contains(t, out.String(), "[dry-run] Suppressions YAML is valid")
+	assert.Contains(t, errOut.String(), "[dry-run] Suppressions YAML is valid")
+	assert.NotContains(t, out.String(), "[dry-run] Suppressions YAML is valid")
 	assert.Contains(t, out.String(), "--- remote")
 	assert.Contains(t, out.String(), "+++ local")
 	assert.Contains(t, out.String(), "-      name: remote")
@@ -86,13 +89,15 @@ func TestSuppressionsCreate_DryRunNoChanges(t *testing.T) {
 		cfg: config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}},
 	})
 	var out bytes.Buffer
+	var errOut bytes.Buffer
 	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
 	cmd.SetArgs([]string{"create", "-f", file, "--dry-run"})
 
 	require.NoError(t, cmd.Execute())
 	assert.False(t, postCalled.Load())
-	assert.Contains(t, out.String(), "no changes")
-	assert.NotContains(t, out.String(), "--- remote")
+	assert.Empty(t, out.String())
+	assert.Contains(t, errOut.String(), "no changes")
 }
 
 func TestSuppressionsCreate_DryRunRejectsInvalidYAML(t *testing.T) {

--- a/internal/providers/kg/commands_test.go
+++ b/internal/providers/kg/commands_test.go
@@ -1,21 +1,123 @@
 package kg_test
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers/kg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
+
+type testRESTConfigLoader struct {
+	cfg config.NamespacedRESTConfig
+}
+
+func (l testRESTConfigLoader) LoadGrafanaConfig(_ context.Context) (config.NamespacedRESTConfig, error) {
+	return l.cfg, nil
+}
 
 func scopesHandler(scopes map[string][]string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"scopeValues": scopes})
 	}
+}
+
+func TestSuppressionsCreate_DryRunShowsDiffWithoutUploading(t *testing.T) {
+	var postCalled atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "config/disabled-alerts")
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, map[string]any{
+				"disabledAlertConfigs": []map[string]any{{
+					"name":        "remote",
+					"matchLabels": map[string]string{"env": "prod"},
+				}},
+			})
+		case http.MethodPost:
+			postCalled.Store(true)
+			t.Fatalf("dry-run must not upload suppressions")
+		default:
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	file := writeTempYAML(t, "disabledAlertConfigs:\n- name: local\n  matchLabels:\n    env: prod\n")
+	cmd := kg.NewTestSuppressionsCommand(testRESTConfigLoader{
+		cfg: config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}},
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"create", "-f", file, "--dry-run"})
+
+	require.NoError(t, cmd.Execute())
+	assert.False(t, postCalled.Load())
+	assert.Contains(t, out.String(), "[dry-run] Suppressions YAML is valid")
+	assert.Contains(t, out.String(), "--- remote")
+	assert.Contains(t, out.String(), "+++ local")
+	assert.Contains(t, out.String(), "-      name: remote")
+	assert.Contains(t, out.String(), "+      name: local")
+}
+
+func TestSuppressionsCreate_DryRunNoChanges(t *testing.T) {
+	const configYAML = "disabledAlertConfigs:\n- name: same\n  matchLabels:\n    env: prod\n"
+	var postCalled atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "config/disabled-alerts")
+		_, _ = w.Write([]byte(configYAML))
+	}))
+	defer server.Close()
+
+	file := writeTempYAML(t, configYAML)
+	cmd := kg.NewTestSuppressionsCommand(testRESTConfigLoader{
+		cfg: config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}},
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"create", "-f", file, "--dry-run"})
+
+	require.NoError(t, cmd.Execute())
+	assert.False(t, postCalled.Load())
+	assert.Contains(t, out.String(), "no changes")
+	assert.NotContains(t, out.String(), "--- remote")
+}
+
+func TestSuppressionsCreate_DryRunRejectsInvalidYAML(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("invalid YAML should fail before remote suppressions are fetched")
+	}))
+	defer server.Close()
+
+	file := writeTempYAML(t, "disabledAlerts:\n- name: [unterminated\n")
+	cmd := kg.NewTestSuppressionsCommand(testRESTConfigLoader{
+		cfg: config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}},
+	})
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"create", "-f", file, "--dry-run"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid local suppressions YAML")
+}
+
+func writeTempYAML(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "suppressions.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
 }
 
 func TestScopeFlags_ValidateScopes(t *testing.T) {

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -1,6 +1,10 @@
 package kg
 
-import "context"
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
 
 // ScopeFlags is an exported alias for scopeFlags, used only in tests.
 type ScopeFlags = scopeFlags
@@ -13,4 +17,9 @@ func NewTestScopeFlags(env, site, namespace string) ScopeFlags {
 // ValidateScopes wraps the unexported validateScopes method for testing.
 func (f ScopeFlags) ValidateScopes(ctx context.Context, c *Client) error {
 	return f.validateScopes(ctx, c)
+}
+
+// NewTestSuppressionsCommand exposes the suppressions command for black-box command tests.
+func NewTestSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
+	return newSuppressionsCommand(loader)
 }


### PR DESCRIPTION
Add --dry-run to gcx kg suppressions create so users can validate YAML and preview the remote-to-local diff without uploading. The remote read path uses `GET /api/plugins/grafana-asserts-app/resources/asserts/api-server/v1/config/disabled-alerts/`, which was tested against the configured stack and returned disabledAlertConfigs.

Tested with `go test ./internal/providers/kg/... ./internal/agent/...`

Fixes https://github.com/grafana/gcx/issues/577

Made-with: Cursor