### PR TITLE
feat(login): step-aware errors for connectivity validation

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/gcx/internal/datasources"
 	"github.com/grafana/gcx/internal/grafana"
 	"github.com/grafana/gcx/internal/linter"
+	"github.com/grafana/gcx/internal/login"
 	"github.com/grafana/gcx/internal/queryerror"
 	"github.com/grafana/gcx/internal/resources"
 	k8sapi "k8s.io/apimachinery/pkg/api/errors"
@@ -35,21 +36,22 @@ func ErrorToDetailedError(err error) *DetailedError {
 	errorConverters := []func(err error) (*DetailedError, bool){
 		convertUsageErrors,
 		convertCobraUnknownCommandErrors,
-		convertContextCanceled,    // Context cancellation (must be first — cancellation can wrap other errors)
-		convertRequiredFlagErrors, // Cobra required-flag errors — must appear before generic checks
-		convertConfigErrors,       // Config-related
-		convertAuthErrors,         // Auth-related (expired tokens)
-		convertQueryErrors,        // Datasource query errors
-		convertDatasourceErrors,   // Grafana datasource REST API errors
-		convertServiceAPIErrors,   // Other structured HTTP API errors
-		convertFSErrors,           // FS-related
-		convertResourcesErrors,    // Resources-related
-		convertNetworkErrors,      // Network-related errors
-		convertAPIErrors,          // API-related errors
-		convertVersionErrors,      // Version incompatibility errors
-		convertLinterErrors,       // Linter-related errors
-		convertSMConfigErrors,     // Synthetic Monitoring config errors
-		convertCloudConfigErrors,  // Cloud config / fleet / setup errors
+		convertContextCanceled,       // Context cancellation (must be first — cancellation can wrap other errors)
+		convertRequiredFlagErrors,    // Cobra required-flag errors — must appear before generic checks
+		convertConfigErrors,          // Config-related
+		convertAuthErrors,            // Auth-related (expired tokens)
+		convertQueryErrors,           // Datasource query errors
+		convertDatasourceErrors,      // Grafana datasource REST API errors
+		convertServiceAPIErrors,      // Other structured HTTP API errors
+		convertFSErrors,              // FS-related
+		convertResourcesErrors,       // Resources-related
+		convertNetworkErrors,         // Network-related errors
+		convertAPIErrors,             // API-related errors
+		convertLoginValidationErrors, // Login connectivity validation (must precede generic version check)
+		convertVersionErrors,         // Version incompatibility errors
+		convertLinterErrors,          // Linter-related errors
+		convertSMConfigErrors,        // Synthetic Monitoring config errors
+		convertCloudConfigErrors,     // Cloud config / fleet / setup errors
 	}
 
 	for _, converter := range errorConverters {
@@ -668,6 +670,120 @@ func convertLinterErrors(err error) (*DetailedError, bool) {
 	}
 
 	return nil, false
+}
+
+func convertLoginValidationErrors(err error) (*DetailedError, bool) {
+	var gcomErr *login.GCOMStackError
+	if errors.As(err, &gcomErr) {
+		return convertGCOMStackError(gcomErr), true
+	}
+
+	var healthErr *login.HealthCheckError
+	if errors.As(err, &healthErr) {
+		return convertHealthCheckError(healthErr), true
+	}
+
+	var k8sErr *login.K8sDiscoveryError
+	if errors.As(err, &k8sErr) {
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Kubernetes-style API unavailable",
+			Details: k8sErr.Cause.Error(),
+			Suggestions: []string{
+				"Confirm the Grafana stack is on version 12 or later",
+				"Confirm the Grafana token has the role required to call /apis (Admin or Editor)",
+				"Check network/proxy access to " + k8sErr.Server,
+			},
+		}, true
+	}
+
+	// Delegate VersionCheckError to convertVersionErrors so ExitCode and copy
+	// stay consistent with VersionIncompatibleError raised from other call sites.
+	var versionErr *login.VersionCheckError
+	if errors.As(err, &versionErr) {
+		if d, ok := convertVersionErrors(versionErr.Cause); ok {
+			d.Parent = err
+			return d, true
+		}
+	}
+
+	return nil, false
+}
+
+func convertGCOMStackError(err *login.GCOMStackError) *DetailedError {
+	switch err.Status {
+	case http.StatusForbidden:
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Grafana Cloud stack lookup denied",
+			Details: fmt.Sprintf("GCOM returned 403 for stack %q.", err.Slug),
+			Suggestions: []string{
+				"Verify the Cloud Access Policy token has the stacks:read scope",
+				"Confirm the access policy is in the same org as the stack",
+				"Regenerate the CAP token if the policy was recently updated",
+			},
+			DocsLink: "https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/",
+			ExitCode: new(ExitAuthFailure),
+		}
+	case http.StatusUnauthorized:
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Grafana Cloud token rejected",
+			Details: fmt.Sprintf("GCOM returned 401 for stack %q.", err.Slug),
+			Suggestions: []string{
+				"Generate a new Cloud Access Policy token at https://grafana.com",
+				"Confirm the token was copied without truncation",
+			},
+			ExitCode: new(ExitAuthFailure),
+		}
+	case http.StatusNotFound:
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Grafana Cloud stack not found",
+			Details: fmt.Sprintf("GCOM has no stack with slug %q.", err.Slug),
+			Suggestions: []string{
+				fmt.Sprintf("Confirm the --server URL points at an existing stack (slug derived: %q)", err.Slug),
+				"List your stacks: gcx providers (or visit grafana.com/orgs/<org>)",
+			},
+		}
+	default:
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Grafana Cloud stack lookup failed",
+			Details: err.Cause.Error(),
+			Suggestions: []string{
+				"Retry — GCOM may be temporarily unavailable",
+				"Check https://status.grafana.com for ongoing incidents",
+			},
+		}
+	}
+}
+
+func convertHealthCheckError(err *login.HealthCheckError) *DetailedError {
+	if err.Status == http.StatusUnauthorized || err.Status == http.StatusForbidden {
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Grafana token rejected",
+			Details: fmt.Sprintf("/api/health returned %d for %s.", err.Status, err.Server),
+			Suggestions: []string{
+				"Confirm the Grafana service-account token belongs to the target stack",
+				"Confirm the token has not expired or been revoked",
+				"Confirm the service-account role grants Admin or Editor as required",
+				reauthSuggestion,
+			},
+			ExitCode: new(ExitAuthFailure),
+		}
+	}
+	return &DetailedError{
+		Parent:  err,
+		Summary: "Grafana server unreachable",
+		Details: err.Cause.Error(),
+		Suggestions: []string{
+			"Confirm --server points at the correct Grafana URL",
+			"Check network/proxy access from this machine",
+			"If using mTLS, verify --tls-cert-file and --tls-key-file paths are correct",
+		},
+	}
 }
 
 func convertVersionErrors(err error) (*DetailedError, bool) {

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -716,7 +716,7 @@ func convertGCOMStackError(err *login.GCOMStackError) *DetailedError {
 		return &DetailedError{
 			Parent:  err,
 			Summary: "Grafana Cloud stack lookup denied",
-			Details: fmt.Sprintf("GCOM returned 403 for stack %q.", err.Slug),
+			Details: fmt.Sprintf("GCOM returned 403 for stack %q", err.Slug),
 			Suggestions: []string{
 				"Verify the Cloud Access Policy token has the stacks:read scope",
 				"Confirm the access policy is in the same org as the stack",
@@ -729,7 +729,7 @@ func convertGCOMStackError(err *login.GCOMStackError) *DetailedError {
 		return &DetailedError{
 			Parent:  err,
 			Summary: "Grafana Cloud token rejected",
-			Details: fmt.Sprintf("GCOM returned 401 for stack %q.", err.Slug),
+			Details: fmt.Sprintf("GCOM returned 401 for stack %q", err.Slug),
 			Suggestions: []string{
 				"Generate a new Cloud Access Policy token at https://grafana.com",
 				"Confirm the token was copied without truncation",
@@ -740,7 +740,7 @@ func convertGCOMStackError(err *login.GCOMStackError) *DetailedError {
 		return &DetailedError{
 			Parent:  err,
 			Summary: "Grafana Cloud stack not found",
-			Details: fmt.Sprintf("GCOM has no stack with slug %q.", err.Slug),
+			Details: fmt.Sprintf("GCOM has no stack with slug %q", err.Slug),
 			Suggestions: []string{
 				fmt.Sprintf("Confirm the --server URL points at an existing stack (slug derived: %q)", err.Slug),
 				"List your stacks: gcx providers (or visit grafana.com/orgs/<org>)",
@@ -764,7 +764,7 @@ func convertHealthCheckError(err *login.HealthCheckError) *DetailedError {
 		return &DetailedError{
 			Parent:  err,
 			Summary: "Grafana token rejected",
-			Details: fmt.Sprintf("/api/health returned %d for %s.", err.Status, err.Server),
+			Details: fmt.Sprintf("/api/health returned %d for %s", err.Status, err.Server),
 			Suggestions: []string{
 				"Confirm the Grafana service-account token belongs to the target stack",
 				"Confirm the token has not expired or been revoked",

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/datasources"
 	"github.com/grafana/gcx/internal/grafana"
+	"github.com/grafana/gcx/internal/login"
 	"github.com/grafana/gcx/internal/queryerror"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -547,6 +550,103 @@ func TestErrorToDetailedError_CloudStackNotConfigured(t *testing.T) {
 	require.Len(t, got.Suggestions, 2)
 	assert.Contains(t, got.Suggestions[0], "gcx config set cloud.stack")
 	assert.Contains(t, got.Suggestions[1], "GRAFANA_CLOUD_STACK")
+}
+
+func TestErrorToDetailedError_LoginGCOMStack403(t *testing.T) {
+	cause := &cloud.GCOMHTTPError{Status: 403, Body: "forbidden"}
+	err := &login.GCOMStackError{Slug: "mystack", Status: 403, Cause: cause}
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Grafana Cloud stack lookup denied", got.Summary)
+	require.NotNil(t, got.ExitCode, "403 should map to ExitAuthFailure")
+	assert.Equal(t, fail.ExitAuthFailure, *got.ExitCode)
+
+	require.NotEmpty(t, got.Suggestions)
+	joined := strings.Join(got.Suggestions, "\n")
+	assert.Contains(t, joined, "stacks:read", "must mention the missing CAP scope")
+}
+
+func TestErrorToDetailedError_LoginGCOMStack401(t *testing.T) {
+	cause := &cloud.GCOMHTTPError{Status: 401, Body: "unauthorized"}
+	err := &login.GCOMStackError{Slug: "mystack", Status: 401, Cause: cause}
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Grafana Cloud token rejected", got.Summary)
+	require.NotNil(t, got.ExitCode)
+	assert.Equal(t, fail.ExitAuthFailure, *got.ExitCode)
+}
+
+func TestErrorToDetailedError_LoginGCOMStack404(t *testing.T) {
+	cause := &cloud.GCOMHTTPError{Status: 404, Body: "not found"}
+	err := &login.GCOMStackError{Slug: "mystack", Status: 404, Cause: cause}
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Grafana Cloud stack not found", got.Summary)
+	require.NotEmpty(t, got.Suggestions)
+	assert.Contains(t, strings.Join(got.Suggestions, "\n"), "mystack")
+}
+
+func TestErrorToDetailedError_LoginHealthCheckAuth(t *testing.T) {
+	for _, status := range []int{401, 403} {
+		t.Run(fmt.Sprintf("status %d", status), func(t *testing.T) {
+			err := &login.HealthCheckError{
+				Server: "https://example.grafana.net",
+				Status: status,
+				Cause:  errors.New("unauthorized"),
+			}
+
+			got := fail.ErrorToDetailedError(err)
+
+			require.NotNil(t, got)
+			assert.Equal(t, "Grafana token rejected", got.Summary)
+			require.NotNil(t, got.ExitCode)
+			assert.Equal(t, fail.ExitAuthFailure, *got.ExitCode)
+		})
+	}
+}
+
+func TestErrorToDetailedError_LoginHealthCheckUnreachable(t *testing.T) {
+	err := &login.HealthCheckError{
+		Server: "https://example.grafana.net",
+		Status: 0,
+		Cause:  errors.New("dial tcp: connection refused"),
+	}
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Grafana server unreachable", got.Summary)
+	assert.Nil(t, got.ExitCode, "transport failures should not map to auth exit code")
+}
+
+func TestErrorToDetailedError_LoginK8sDiscovery(t *testing.T) {
+	err := &login.K8sDiscoveryError{
+		Server: "https://example.grafana.net",
+		Cause:  errors.New("the server could not find the requested resource"),
+	}
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Kubernetes-style API unavailable", got.Summary)
+	require.NotEmpty(t, got.Suggestions)
+}
+
+func TestErrorToDetailedError_LoginVersionCheck(t *testing.T) {
+	v, _ := semver.NewVersion("11.5.0")
+	err := &login.VersionCheckError{Cause: &grafana.VersionIncompatibleError{Version: v}}
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	require.NotNil(t, got.ExitCode)
+	assert.Equal(t, fail.ExitVersionIncompatible, *got.ExitCode)
 }
 
 type fakeServiceAPIError struct {

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,10 @@ require (
 	k8s.io/klog/v2 v2.140.0
 )
 
-require github.com/gofrs/flock v0.13.0
+require (
+	github.com/go-openapi/runtime v0.28.0
+	github.com/gofrs/flock v0.13.0
+)
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
@@ -102,7 +105,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/loads v0.22.0 // indirect
-	github.com/go-openapi/runtime v0.28.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
 	github.com/go-openapi/swag v0.24.1 // indirect
 	github.com/go-openapi/swag/cmdutils v0.24.0 // indirect

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -53,6 +53,19 @@ type StackInfo struct {
 	AMInstanceURL string `json:"amInstanceUrl"`
 }
 
+// GCOMHTTPError is returned by GCOMClient when the GCOM API responds with a
+// non-200 status. Callers can use errors.As to inspect Status and dispatch on
+// 401/403/404 etc. without parsing the error message.
+type GCOMHTTPError struct {
+	Status int
+	Body   string
+}
+
+func (e *GCOMHTTPError) Error() string {
+	return fmt.Sprintf("gcom client: unexpected status %d %s: %s",
+		e.Status, http.StatusText(e.Status), e.Body)
+}
+
 // GCOMClient is an HTTP client for the Grafana Cloud API (GCOM).
 type GCOMClient struct {
 	baseURL string
@@ -130,8 +143,10 @@ func (c *GCOMClient) GetStack(ctx context.Context, slug string) (StackInfo, erro
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return StackInfo{}, fmt.Errorf("gcom client: unexpected status %d %s: %s",
-			resp.StatusCode, http.StatusText(resp.StatusCode), strings.TrimSpace(string(body)))
+		return StackInfo{}, &GCOMHTTPError{
+			Status: resp.StatusCode,
+			Body:   strings.TrimSpace(string(body)),
+		}
 	}
 
 	var info StackInfo

--- a/internal/cloud/gcom_test.go
+++ b/internal/cloud/gcom_test.go
@@ -3,6 +3,7 @@ package cloud_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -123,6 +124,45 @@ func TestGCOMClient_GetStack_NonSuccess(t *testing.T) {
 			if !strings.Contains(errStr, http.StatusText(tt.statusCode)) && !strings.Contains(errStr, "404") &&
 				!strings.Contains(errStr, "401") && !strings.Contains(errStr, "500") {
 				t.Errorf("error %q does not contain status code info", errStr)
+			}
+		})
+	}
+}
+
+func TestGCOMClient_GetStack_TypedHTTPError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"403 forbidden", http.StatusForbidden},
+		{"401 unauthorized", http.StatusUnauthorized},
+		{"404 not found", http.StatusNotFound},
+		{"500 internal", http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(`{"message":"denied"}`))
+			}))
+			defer srv.Close()
+
+			client, err := cloud.NewGCOMClient(srv.URL, "token")
+			if err != nil {
+				t.Fatalf("unexpected error creating client: %v", err)
+			}
+			_, err = client.GetStack(context.Background(), "mystack")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			var httpErr *cloud.GCOMHTTPError
+			if !errors.As(err, &httpErr) {
+				t.Fatalf("expected error to wrap *cloud.GCOMHTTPError, got %T: %v", err, err)
+			}
+			if httpErr.Status != tt.statusCode {
+				t.Errorf("Status: got %d, want %d", httpErr.Status, tt.statusCode)
 			}
 		})
 	}

--- a/internal/login/errors.go
+++ b/internal/login/errors.go
@@ -1,0 +1,59 @@
+package login
+
+import "fmt"
+
+// HealthCheckError is returned when the Grafana /api/health probe fails.
+// Status is the HTTP status code, or 0 for transport-level failures where no
+// HTTP response was received (dial, TLS, timeout).
+type HealthCheckError struct {
+	Server string
+	Status int
+	Cause  error
+}
+
+func (e *HealthCheckError) Error() string {
+	return fmt.Sprintf("connectivity validation: health check failed: %s", e.Cause)
+}
+
+func (e *HealthCheckError) Unwrap() error { return e.Cause }
+
+// K8sDiscoveryError is returned when /apis discovery against the Grafana
+// Kubernetes-compatible API fails.
+type K8sDiscoveryError struct {
+	Server string
+	Cause  error
+}
+
+func (e *K8sDiscoveryError) Error() string {
+	return fmt.Sprintf("connectivity validation: kubernetes API unavailable: %s", e.Cause)
+}
+
+func (e *K8sDiscoveryError) Unwrap() error { return e.Cause }
+
+// VersionCheckError is returned when the Grafana version is below the
+// supported floor. The wrapped Cause is typically a *grafana.VersionIncompatibleError.
+type VersionCheckError struct {
+	Cause error
+}
+
+func (e *VersionCheckError) Error() string {
+	return fmt.Sprintf("connectivity validation: version check failed: %s", e.Cause)
+}
+
+func (e *VersionCheckError) Unwrap() error { return e.Cause }
+
+// GCOMStackError is returned when the GCOM stack lookup fails during Cloud
+// login. Status holds the HTTP status code when the cause wraps a
+// *cloud.GCOMHTTPError (403 typically means the Cloud Access Policy is
+// missing the stacks:read scope).
+type GCOMStackError struct {
+	Slug   string
+	Status int
+	Cause  error
+}
+
+func (e *GCOMStackError) Error() string {
+	return fmt.Sprintf("connectivity validation: GCOM check failed: %s", e.Cause)
+}
+
+func (e *GCOMStackError) Unwrap() error { return e.Cause }

--- a/internal/login/errors_test.go
+++ b/internal/login/errors_test.go
@@ -1,0 +1,68 @@
+package login_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/grafana/gcx/internal/cloud"
+	intgrafana "github.com/grafana/gcx/internal/grafana"
+	"github.com/grafana/gcx/internal/login"
+)
+
+func TestHealthCheckError(t *testing.T) {
+	cause := errors.New("connection refused")
+	e := &login.HealthCheckError{Server: "https://example.grafana.net", Status: 401, Cause: cause}
+
+	if !strings.Contains(e.Error(), "health check failed") {
+		t.Errorf("Error() must contain step name; got %q", e.Error())
+	}
+	if !errors.Is(e, cause) {
+		t.Error("HealthCheckError must unwrap to its cause")
+	}
+}
+
+func TestK8sDiscoveryError(t *testing.T) {
+	cause := errors.New("connection refused")
+	e := &login.K8sDiscoveryError{Server: "https://example.grafana.net", Cause: cause}
+
+	if !strings.Contains(e.Error(), "kubernetes API unavailable") {
+		t.Errorf("Error() must contain step name; got %q", e.Error())
+	}
+	if !errors.Is(e, cause) {
+		t.Error("K8sDiscoveryError must unwrap to its cause")
+	}
+}
+
+func TestVersionCheckError(t *testing.T) {
+	v, _ := semver.NewVersion("11.5.0")
+	cause := &intgrafana.VersionIncompatibleError{Version: v}
+	e := &login.VersionCheckError{Cause: cause}
+
+	if !strings.Contains(e.Error(), "version check failed") {
+		t.Errorf("Error() must contain step name; got %q", e.Error())
+	}
+
+	var vErr *intgrafana.VersionIncompatibleError
+	if !errors.As(e, &vErr) {
+		t.Error("VersionCheckError must allow errors.As to *VersionIncompatibleError")
+	}
+}
+
+func TestGCOMStackError(t *testing.T) {
+	cause := &cloud.GCOMHTTPError{Status: 403, Body: "forbidden"}
+	e := &login.GCOMStackError{Slug: "mystack", Status: 403, Cause: cause}
+
+	if !strings.Contains(e.Error(), "GCOM check failed") {
+		t.Errorf("Error() must contain step name; got %q", e.Error())
+	}
+
+	var httpErr *cloud.GCOMHTTPError
+	if !errors.As(e, &httpErr) {
+		t.Error("GCOMStackError must allow errors.As to *cloud.GCOMHTTPError")
+	}
+	if httpErr.Status != 403 {
+		t.Errorf("Status: got %d, want 403", httpErr.Status)
+	}
+}

--- a/internal/login/validate.go
+++ b/internal/login/validate.go
@@ -2,9 +2,11 @@ package login
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/go-openapi/runtime"
 	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/config"
 	intgrafana "github.com/grafana/gcx/internal/grafana"
@@ -49,19 +51,18 @@ func (v *validator) validate(ctx context.Context, opts Options, restCfg config.N
 	// here as a "health check failed" error.
 	version, rawVersion, err := v.grafana.GetVersion(ctx)
 	if err != nil {
-		return "", fmt.Errorf("connectivity validation: health check failed: %w", err)
+		return "", &HealthCheckError{Server: opts.Server, Status: extractGoAPIStatus(err), Cause: err}
 	}
 
 	// Step 2: K8s API availability via discovery /apis
 	if err := v.discovery(ctx, restCfg); err != nil {
-		return "", fmt.Errorf("connectivity validation: kubernetes API unavailable: %w", err)
+		return "", &K8sDiscoveryError{Server: opts.Server, Cause: err}
 	}
 
 	// Step 3: Grafana version must be >= 12 when we can parse it. Empty or
 	// unparseable versions bypass the check — see function comment.
 	if version != nil && version.Major() < 12 {
-		return "", fmt.Errorf("connectivity validation: version check failed: %w",
-			&intgrafana.VersionIncompatibleError{Version: version})
+		return "", &VersionCheckError{Cause: &intgrafana.VersionIncompatibleError{Version: version}}
 	}
 
 	// Step 4: GCOM stack check when Cloud target has a CAP token and a derivable slug
@@ -69,7 +70,7 @@ func (v *validator) validate(ctx context.Context, opts Options, restCfg config.N
 		slug := resolveStackSlug(opts.Server)
 		if slug != "" {
 			if _, err := v.gcom.GetStack(ctx, slug); err != nil {
-				return "", fmt.Errorf("connectivity validation: GCOM check failed: %w", err)
+				return "", &GCOMStackError{Slug: slug, Status: extractGCOMStatus(err), Cause: err}
 			}
 		}
 	}
@@ -82,6 +83,25 @@ func (v *validator) validate(ctx context.Context, opts Options, restCfg config.N
 	default:
 		return "unknown", nil
 	}
+}
+
+// extractGoAPIStatus returns the HTTP status from a grafana-openapi-client-go
+// runtime.APIError in the chain, or 0 for transport-level failures (dial, TLS,
+// timeout) where no HTTP response was received.
+func extractGoAPIStatus(err error) int {
+	var apiErr *runtime.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Code
+	}
+	return 0
+}
+
+func extractGCOMStatus(err error) int {
+	var httpErr *cloud.GCOMHTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.Status
+	}
+	return 0
 }
 
 // resolveStackSlug derives the Grafana Cloud stack slug from a server URL.

--- a/internal/login/validate_test.go
+++ b/internal/login/validate_test.go
@@ -63,6 +63,7 @@ func TestValidate(t *testing.T) {
 		gcom        gcomClient
 		wantErr     bool
 		wantErrSub  string
+		wantErrAs   any // pointer-to-pointer for errors.As; nil to skip
 		wantGCOMHit bool
 	}{
 		{
@@ -72,6 +73,7 @@ func TestValidate(t *testing.T) {
 			discovery:  okDiscovery,
 			wantErr:    true,
 			wantErrSub: "health check failed",
+			wantErrAs:  new(*HealthCheckError),
 		},
 		{
 			name:       "K8s discovery failure",
@@ -80,6 +82,7 @@ func TestValidate(t *testing.T) {
 			discovery:  failDiscovery,
 			wantErr:    true,
 			wantErrSub: "kubernetes API unavailable",
+			wantErrAs:  new(*K8sDiscoveryError),
 		},
 		{
 			name:       "version below 12 returns named error",
@@ -88,15 +91,17 @@ func TestValidate(t *testing.T) {
 			discovery:  okDiscovery,
 			wantErr:    true,
 			wantErrSub: "version check failed",
+			wantErrAs:  new(*VersionCheckError),
 		},
 		{
 			name:        "GCOM check failure",
 			opts:        Options{Inputs: Inputs{Target: TargetCloud, CloudToken: "cap-token", Server: "https://mystack.grafana.net"}},
 			grafana:     &stubGrafanaClient{version: v12},
 			discovery:   okDiscovery,
-			gcom:        &stubGCOMClient{err: errors.New("unauthorized")},
+			gcom:        &stubGCOMClient{err: &cloud.GCOMHTTPError{Status: 403, Body: "denied"}},
 			wantErr:     true,
 			wantErrSub:  "GCOM check failed",
+			wantErrAs:   new(*GCOMStackError),
 			wantGCOMHit: true,
 		},
 		{
@@ -183,6 +188,9 @@ func TestValidate(t *testing.T) {
 				}
 				if tt.wantErrSub != "" && !strings.Contains(err.Error(), tt.wantErrSub) {
 					t.Fatalf("expected error containing %q, got: %v", tt.wantErrSub, err)
+				}
+				if tt.wantErrAs != nil && !errors.As(err, tt.wantErrAs) {
+					t.Fatalf("expected errors.As to %T to succeed; got %T: %v", tt.wantErrAs, err, err)
 				}
 			} else if err != nil {
 				t.Fatalf("expected nil error, got: %v", err)


### PR DESCRIPTION
## Summary

- Login connectivity validation now returns typed errors per step (health / k8s discovery / version / GCOM stack), each carrying the HTTP status when available.
- A new converter `convertLoginValidationErrors` in `cmd/gcx/fail/convert.go` maps those errors to `DetailedError` with a clear summary, details, and remediation hints. The GCOM 403 case explicitly suggests checking the `stacks:read` scope on the CAP token, which was the trigger for this change.
- `internal/cloud.GCOMClient` now returns a typed `*GCOMHTTPError` instead of a `fmt.Errorf` string so callers can inspect status without parsing.

## Why

A user hit a 403 during `gcx login` with both tokens "set correctly". The actual cause was a Cloud Access Policy missing the `stacks:read` scope. The previous error message — `connectivity validation: GCOM check failed: gcom client: unexpected status 403 Forbidden: ...` — gave no hint about which step or how to fix it. The same opacity applied to the other three steps.

## Error mapping

| Typed error | Status | Summary | Suggestions |
|---|---|---|---|
| `GCOMStackError` | 403 | Grafana Cloud stack lookup denied | **stacks:read scope**, same-org policy, regenerate CAP |
| `GCOMStackError` | 401 | Grafana Cloud token rejected | Regenerate CAP token, check for truncation |
| `GCOMStackError` | 404 | Grafana Cloud stack not found | Confirm `--server` URL, list stacks |
| `HealthCheckError` | 401/403 | Grafana token rejected | Service-account token / role / `gcx login` |
| `HealthCheckError` | other | Grafana server unreachable | URL / network / mTLS paths |
| `K8sDiscoveryError` | — | Kubernetes-style API unavailable | Grafana 12+, role, network |
| `VersionCheckError` | — | Delegates to existing version converter for consistent ExitCode |

## Test plan

- [x] `go test -race -count=1 ./internal/login/... ./internal/cloud/... ./cmd/gcx/fail/...`
- [x] Full suite: `go test -race -count=1 ./...`
- [x] `golangci-lint run ./internal/login/... ./internal/cloud/... ./cmd/gcx/fail/...` clean
- [x] `go build -o bin/gcx ./cmd/gcx/`
- [ ] Manual repro of the 403/CAP scope case against a live stack to confirm the rendered DetailedError matches expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)