### PR TITLE
fix(dev): register v1 converters for Folder and Dashboard import

### DIFF
--- a/cmd/gcx/dev/import.go
+++ b/cmd/gcx/dev/import.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana-foundation-sdk/go/cog/plugins"
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
 	"github.com/grafana/grafana-foundation-sdk/go/dashboardv2beta1"
+	"github.com/grafana/grafana-foundation-sdk/go/folderv1beta1"
 	"github.com/huandu/xstrings"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -24,8 +25,10 @@ import (
 //nolint:gochecknoglobals
 var convertersMap = map[string]resourceConverter{
 	"Dashboard.dashboard.grafana.app/v0alpha1": dashboardv1Converter,
+	"Dashboard.dashboard.grafana.app/v1":       dashboardv1Converter,
 	"Dashboard.dashboard.grafana.app/v1beta1":  dashboardv1Converter,
 	"Dashboard.dashboard.grafana.app/v2beta1":  dashboardv2Converter,
+	"Folder.folder.grafana.app/v1":             folderConverter,
 }
 
 type importOpts struct {
@@ -189,4 +192,23 @@ func dashboardv2Converter(resource *model.Resource) (string, string, error) {
 	}
 
 	return dashboardv2beta1.DashboardConverter(object), "dashboardv2beta1", nil
+}
+
+func folderConverter(resource *model.Resource) (string, string, error) {
+	spec, err := resource.Spec()
+	if err != nil {
+		return "", "", err
+	}
+
+	marshalled, err := json.Marshal(spec)
+	if err != nil {
+		return "", "", err
+	}
+
+	object := folderv1beta1.Folder{}
+	if err = json.Unmarshal(marshalled, &object); err != nil {
+		return "", "", err
+	}
+
+	return folderv1beta1.FolderConverter(object), "folderv1beta1", nil
 }

--- a/cmd/gcx/dev/import_test.go
+++ b/cmd/gcx/dev/import_test.go
@@ -1,0 +1,84 @@
+//nolint:testpackage // tests need access to internal converters and the registry map
+package dev
+
+import (
+	"testing"
+
+	model "github.com/grafana/gcx/internal/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestConvertersMapCoversReportedGVKs(t *testing.T) {
+	required := []string{
+		"Dashboard.dashboard.grafana.app/v0alpha1",
+		"Dashboard.dashboard.grafana.app/v1",
+		"Dashboard.dashboard.grafana.app/v1beta1",
+		"Dashboard.dashboard.grafana.app/v2beta1",
+		"Folder.folder.grafana.app/v1",
+	}
+
+	for _, key := range required {
+		t.Run(key, func(t *testing.T) {
+			_, ok := convertersMap[key]
+			assert.True(t, ok, "convertersMap missing entry for %s", key)
+		})
+	}
+}
+
+func TestConverters(t *testing.T) {
+	tests := []struct {
+		name           string
+		object         map[string]any
+		wantSDKPackage string
+		wantContains   string
+	}{
+		{
+			name: "dashboard v1",
+			object: map[string]any{
+				"apiVersion": "dashboard.grafana.app/v1",
+				"kind":       "Dashboard",
+				"metadata":   map[string]any{"name": "my-dashboard"},
+				"spec": map[string]any{
+					"title":         "My Dashboard",
+					"schemaVersion": float64(36),
+				},
+			},
+			wantSDKPackage: "dashboard",
+			wantContains:   "NewDashboardBuilder",
+		},
+		{
+			name: "folder v1",
+			object: map[string]any{
+				"apiVersion": "folder.grafana.app/v1",
+				"kind":       "Folder",
+				"metadata":   map[string]any{"name": "my-folder"},
+				"spec": map[string]any{
+					"title":       "My Folder",
+					"description": "a folder",
+				},
+			},
+			wantSDKPackage: "folderv1beta1",
+			wantContains:   "NewFolderBuilder",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := model.FromUnstructured(&unstructured.Unstructured{Object: tt.object})
+			require.NoError(t, err)
+
+			gvk := res.GroupVersionKind()
+			key := gvk.Kind + "." + gvk.GroupVersion().String()
+
+			converter, ok := convertersMap[key]
+			require.True(t, ok, "no converter registered for %s", key)
+
+			code, sdkPkg, err := converter(res)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSDKPackage, sdkPkg)
+			assert.Contains(t, code, tt.wantContains)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `gcx dev import` skipped `folder.grafana.app/v1` and `dashboard.grafana.app/v1` resources with `no converter found`.
- The converter registry in `cmd/gcx/dev/import.go` only covered `v0alpha1`, `v1beta1`, and `v2beta1` for Dashboard, and had no entry for Folder at all.

## Changes
- `cmd/gcx/dev/import.go`: register `Dashboard.dashboard.grafana.app/v1` (reusing `dashboardv1Converter` — same schema as v1beta1) and `Folder.folder.grafana.app/v1` with a new `folderConverter` that delegates to the foundation-sdk `folderv1beta1` package.
- `cmd/gcx/dev/import_test.go`: table-driven tests asserting the registry covers the reported GVKs and that each converter produces the expected SDK package + builder call for a representative unstructured fixture.

## Test Plan
- [x] `go test ./cmd/gcx/dev/...` passes
- [x] `go test -race -count=1 ./...` passes
- [x] `go build -buildvcs=false -o bin/gcx ./cmd/gcx/` succeeds
- [x] `make lint` only reports pre-existing gosec warnings unrelated to this change

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)