### PR TITLE
chore(release): v0.2.11

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "gcx",
       "source": "./claude-plugin",
       "description": "Debug, explore, and instrument with Grafana using gcx CLI",
-      "version": "0.2.9"
+      "version": "0.2.11"
     }
   ]
 }

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,7 +1,11 @@
-- Consolidated `gcx auth` and `gcx config` into a unified `gcx login` command
-- Renamed `gcx sigil` command and provider to `gcx aio11y` (AI Observability)
-- Fixed `gcx irm` to pass `--max-age` filter through to the OnCall backend
-- Added PyPI publishing to the release workflow
-- Bumped Claude plugin version automatically on release
-- Added Grafana Cloud API tiers architectural overview to the docs
-- Added compatibility matrix to the README
+- Add mTLS client certificate authentication for config and login (Teleport)
+- Add `kg describe` command for schema, scopes, and telemetry configs
+- Add `skills update` command to update existing installed skills
+- Fix metrics default view to be usable out of the box
+- Fix synthetic monitoring to surface required scopes on register/install failure
+- Fix grafana-com instance selector regression
+- Fix `config set/unset` to resolve bare paths against the current context
+- Fix front matter in the debug-with-grafana skill
+- Update README with sigil/aio11y rename and restored Compatibility section
+- Update Go dependencies, GitHub Actions, and MySQL Docker tag to v9.7
+- Remove PyPI publishing job from release CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## v0.2.11 (2026-04-29)
+
+- Add mTLS client certificate authentication for config and login (Teleport)
+- Add `kg describe` command for schema, scopes, and telemetry configs
+- Add `skills update` command to update existing installed skills
+- Fix metrics default view to be usable out of the box
+- Fix synthetic monitoring to surface required scopes on register/install failure
+- Fix grafana-com instance selector regression
+- Fix `config set/unset` to resolve bare paths against the current context
+- Fix front matter in the debug-with-grafana skill
+- Update README with sigil/aio11y rename and restored Compatibility section
+- Update Go dependencies, GitHub Actions, and MySQL Docker tag to v9.7
+- Remove PyPI publishing job from release CI
+
+## v0.2.10 (2026-04-23)
+
+- Replace Homebrew binary cask with source formula for Gatekeeper-free macOS installs
+- Add automated workflow to publish Homebrew formula on release
+- Update installation docs and README with new Homebrew instructions
+
+
 ## v0.2.9 (2026-04-23)
 
 - Consolidated `gcx auth` and `gcx config` into a unified `gcx login` command

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcx",
-  "version": "0.2.9",
+  "version": "0.2.11",
   "description": "Debug, explore, and instrument with Grafana using gcx CLI",
   "keywords": ["grafana", "observability", "monitoring", "prometheus", "loki", "dashboards"],
   "author": {


### PR DESCRIPTION
Release v0.2.11.

Auto-generated changelog and version bumps via `make tag BUMP=patch`.

After merge, the release tag will be created on the merge commit on main.