### PR TITLE
fix(assistant): gracefully block `assistant` commands for self-hosted Grafana instances

### DIFF
--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -48,8 +48,10 @@ func Command() *cobra.Command {
 		Short: "Interact with Grafana Assistant",
 		Long:  "Send prompts to Grafana Assistant and receive streaming responses via the A2A protocol.",
 	}
-	// Defining PersistentPreRunE here shadows the root command's PersistentPreRun,
-	// so we call it manually. The root != cmd guard avoids self-recursion in tests.
+	// We need a "before each run" hook to block assistant commands on self-hosted
+	// instances. Defining one here replaces the root command's hook (cobra doesn't
+	// stack them), so we call the root's hook manually first. The root != cmd
+	// guard avoids self-recursion when there's no parent (in tests).
 	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 		if root := c.Root(); root != cmd {
 			if root.PersistentPreRunE != nil {

--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -48,11 +48,8 @@ func Command() *cobra.Command {
 		Short: "Interact with Grafana Assistant",
 		Long:  "Send prompts to Grafana Assistant and receive streaming responses via the A2A protocol.",
 	}
-	// Cobra doesn't chain PersistentPreRun hooks automatically — a child's hook
-	// shadows all ancestors. We manually call the root's hook (logging, terminal
-	// detection, --json tracking) then gate on Grafana Cloud before any subcommand
-	// runs. The root != cmd guard prevents self-recursion when the assistant
-	// command is the root (e.g. in tests).
+	// Defining PersistentPreRunE here shadows the root command's PersistentPreRun,
+	// so we call it manually. The root != cmd guard avoids self-recursion in tests.
 	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 		if root := c.Root(); root != cmd {
 			if root.PersistentPreRunE != nil {

--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -48,6 +48,11 @@ func Command() *cobra.Command {
 		Short: "Interact with Grafana Assistant",
 		Long:  "Send prompts to Grafana Assistant and receive streaming responses via the A2A protocol.",
 	}
+	// Cobra doesn't chain PersistentPreRun hooks automatically — a child's hook
+	// shadows all ancestors. We manually call the root's hook (logging, terminal
+	// detection, --json tracking) then gate on Grafana Cloud before any subcommand
+	// runs. The root != cmd guard prevents self-recursion when the assistant
+	// command is the root (e.g. in tests).
 	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 		if root := c.Root(); root != cmd {
 			if root.PersistentPreRunE != nil {
@@ -76,6 +81,8 @@ func Command() *cobra.Command {
 	// the loader picks up flag values resolved at execution time.
 	invLoader := &providers.ConfigLoader{}
 	invCmd := investigations.Commands(invLoader)
+	// Chain to the parent assistant command's PersistentPreRunE (root hook +
+	// cloud guard), then wire resolved --config/--context flags to the loader.
 	invCmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 		if err := cmd.PersistentPreRunE(c, args); err != nil {
 			return err

--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -80,8 +80,8 @@ func Command() *cobra.Command {
 	// the loader picks up flag values resolved at execution time.
 	invLoader := &providers.ConfigLoader{}
 	invCmd := investigations.Commands(invLoader)
-	// Chain to the parent assistant command's PersistentPreRunE (root hook +
-	// cloud guard), then wire resolved --config/--context flags to the loader.
+	// Run the parent's hook (root setup + cloud guard), then wire the
+	// resolved --config/--context flag values into the investigations loader.
 	invCmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 		if err := cmd.PersistentPreRunE(c, args); err != nil {
 			return err

--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/assistant"
 	"github.com/grafana/gcx/internal/assistant/investigations"
@@ -24,6 +25,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func requireGrafanaCloud(ctx *config.Context) error {
+	if ctx.Grafana == nil || ctx.Grafana.Server == "" {
+		return nil
+	}
+	if ctx.ResolveStackSlug() == "" {
+		return fail.DetailedError{
+			Summary: "Unsupported command",
+			Details: "Due to technical limitations of how gcx interacts with Grafana Assistant, " +
+				"`gcx assistant` commands do not currently work with self-hosted Grafana instances.",
+		}
+	}
+	return nil
+}
+
 // Command returns the assistant command group.
 func Command() *cobra.Command {
 	configOpts := &cmdconfig.Options{}
@@ -32,19 +47,32 @@ func Command() *cobra.Command {
 		Use:   "assistant",
 		Short: "Interact with Grafana Assistant",
 		Long:  "Send prompts to Grafana Assistant and receive streaming responses via the A2A protocol.",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if root := cmd.Root(); root.PersistentPreRun != nil {
+				root.PersistentPreRun(cmd, args)
+			}
+			cfg, err := configOpts.LoadConfigTolerant(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if curCtx := cfg.Contexts[cfg.CurrentContext]; curCtx != nil {
+				return requireGrafanaCloud(curCtx)
+			}
+			return nil
+		},
 	}
 
 	configOpts.BindFlags(cmd.PersistentFlags())
 	cmd.AddCommand(promptCommand(configOpts))
 
 	// Create a ConfigLoader for investigations that shares the same --config/--context
-	// flags already bound by configOpts. Wire the values via PersistentPreRun so that
+	// flags already bound by configOpts. Wire the values via PersistentPreRunE so that
 	// the loader picks up flag values resolved at execution time.
 	invLoader := &providers.ConfigLoader{}
 	invCmd := investigations.Commands(invLoader)
-	invCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-		if root := cmd.Root(); root.PersistentPreRun != nil {
-			root.PersistentPreRun(cmd, args)
+	invCmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		if err := cmd.PersistentPreRunE(c, args); err != nil {
+			return err
 		}
 		if configOpts.ConfigFile != "" {
 			invLoader.SetConfigFile(configOpts.ConfigFile)
@@ -52,6 +80,7 @@ func Command() *cobra.Command {
 		if configOpts.Context != "" {
 			invLoader.SetContextName(configOpts.Context)
 		}
+		return nil
 	}
 	cmd.AddCommand(invCmd)
 	return cmd

--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -47,19 +47,25 @@ func Command() *cobra.Command {
 		Use:   "assistant",
 		Short: "Interact with Grafana Assistant",
 		Long:  "Send prompts to Grafana Assistant and receive streaming responses via the A2A protocol.",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if root := cmd.Root(); root.PersistentPreRun != nil {
-				root.PersistentPreRun(cmd, args)
+	}
+	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		if root := c.Root(); root != cmd {
+			if root.PersistentPreRunE != nil {
+				if err := root.PersistentPreRunE(c, args); err != nil {
+					return err
+				}
+			} else if root.PersistentPreRun != nil {
+				root.PersistentPreRun(c, args)
 			}
-			cfg, err := configOpts.LoadConfigTolerant(cmd.Context())
-			if err != nil {
-				return err
-			}
-			if curCtx := cfg.Contexts[cfg.CurrentContext]; curCtx != nil {
-				return requireGrafanaCloud(curCtx)
-			}
-			return nil
-		},
+		}
+		cfg, err := configOpts.LoadConfigTolerant(c.Context())
+		if err != nil {
+			return err
+		}
+		if curCtx := cfg.Contexts[cfg.CurrentContext]; curCtx != nil {
+			return requireGrafanaCloud(curCtx)
+		}
+		return nil
 	}
 
 	configOpts.BindFlags(cmd.PersistentFlags())

--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -80,7 +80,7 @@ func Command() *cobra.Command {
 	// the loader picks up flag values resolved at execution time.
 	invLoader := &providers.ConfigLoader{}
 	invCmd := investigations.Commands(invLoader)
-	// Run the parent's hook (root setup + cloud guard), then wire the
+	// Run the parent's hook to get the self-hosted guard, then wire the
 	// resolved --config/--context flag values into the investigations loader.
 	invCmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 		if err := cmd.PersistentPreRunE(c, args); err != nil {

--- a/cmd/gcx/assistant/command_test.go
+++ b/cmd/gcx/assistant/command_test.go
@@ -2,11 +2,13 @@ package assistant_test
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/assistant"
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -149,6 +151,10 @@ func TestRequireGrafanaCloud(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
+				}
+				var de fail.DetailedError
+				if !errors.As(err, &de) {
+					t.Fatalf("expected fail.DetailedError, got %T", err)
 				}
 			} else if err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/cmd/gcx/assistant/command_test.go
+++ b/cmd/gcx/assistant/command_test.go
@@ -2,9 +2,12 @@ package assistant_test
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/assistant"
+	"github.com/grafana/gcx/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -62,8 +65,18 @@ func TestConventions_ValidateExported(t *testing.T) {
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 
-	// Set mutually exclusive flags — Validate should reject this.
-	cmd.SetArgs([]string{"prompt", "test", "--context-id", "abc", "--continue"})
+	// Write a minimal cloud config so PersistentPreRunE's cloud check passes,
+	// letting us exercise the flag validation logic.
+	cfgPath := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(cfgPath, []byte(`current-context: test
+contexts:
+  test:
+    grafana:
+      server: https://test.grafana.net
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd.SetArgs([]string{"prompt", "test", "--config", cfgPath, "--context-id", "abc", "--continue"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -92,5 +105,54 @@ func TestConventions_PromptAnnotations(t *testing.T) {
 
 	if _, ok := promptCmd.Annotations["agent.token_cost"]; !ok {
 		t.Fatal("expected prompt command to have agent.token_cost annotation")
+	}
+}
+
+func TestRequireGrafanaCloud(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctx     *config.Context
+		wantErr bool
+	}{
+		{
+			name: "cloud instance via server URL",
+			ctx: &config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana.net"},
+			},
+		},
+		{
+			name: "cloud instance via explicit stack slug",
+			ctx: &config.Context{
+				Cloud:   &config.CloudConfig{Stack: "mystack"},
+				Grafana: &config.GrafanaConfig{Server: "https://custom.example.com"},
+			},
+		},
+		{
+			name: "self-hosted instance",
+			ctx: &config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://grafana.example.com"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no grafana config skips check",
+			ctx:  &config.Context{},
+		},
+		{
+			name: "empty server skips check",
+			ctx:  &config.Context{Grafana: &config.GrafanaConfig{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := assistant.RequireGrafanaCloud(tt.ctx)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }

--- a/cmd/gcx/assistant/export_test.go
+++ b/cmd/gcx/assistant/export_test.go
@@ -3,4 +3,7 @@ package assistant
 // Exported aliases for black-box tests.
 //
 //nolint:gochecknoglobals // Test-only exports for black-box test package.
-var NewAssistantStreamingHTTPClient = newAssistantStreamingHTTPClient
+var (
+	NewAssistantStreamingHTTPClient = newAssistantStreamingHTTPClient
+	RequireGrafanaCloud             = requireGrafanaCloud
+)


### PR DESCRIPTION
## Summary

We can't support `gcx assistant` commands for self-hosted grafana instances at the moment, because of the fact that the `gcs assistant` commands go to our Assistant infrastructure, and we cannot access the self-hosted grafana instance APIs from there. 

- adds a `PersistentPreRunE` guard on the `assistant` command group that checks `ResolveStackSlug()` to determine whether the current context is Grafana Cloud
- self-hosted instances get a structured `DetailedError` instead of confusing API failures
- both `prompt` and `investigations` subcommands go through the same check (investigations chains to the parent's hook explicitly)

### Before

```
$ gcx assistant prompt "help"
🛈 Sending message (timeout: 300s)...
⚠ HTTP 401: invalid user

✘ Request failed: HTTP 401: invalid user

Error: Request failed
│
│ HTTP 401: invalid user
│
└─
```

### After

```
$ gcx assistant prompt "help"
Error: Unsupported command
│
│ Due to technical limitations of how gcx interacts with Grafana Assistant,
│ `gcx assistant` commands do not currently work with self-hosted Grafana instances.
│
└─
```