### PR TITLE
feat: notify users about new gcx versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ internal/
 ├── version/     Global version string (Set once from main; provides UserAgent() for HTTP clients)
 ├── secrets/     Redactor for config view
 ├── logs/        slog/klog integration
-├── notifier/    Skills update notifier (XDG state, throttle, message rendering — wired into root PersistentPostRun)
+├── notifier/    Update notifications (skills + gcx version checks; XDG state, throttling, message rendering — wired into root PersistentPostRun)
 ├── skills/      Portable Agent Skills installer primitives (BundledSkillNames, Install, Update — extracted from cmd/gcx/skills)
 └── shared/      Shared utilities (date handling, duration, etc.) to be shared across integrations.
 ```

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/grafana/gcx/internal/providers/traces"   // Provider registrations — blank imports trigger init() self-registration.
 	"github.com/grafana/gcx/internal/style"
 	"github.com/grafana/gcx/internal/terminal"
+	appversion "github.com/grafana/gcx/internal/version"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -204,6 +205,7 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 				return
 			}
 			_ = notifier.MaybeNotifySkills(cmd.ErrOrStderr())
+			_ = notifier.MaybeNotifyVersion(cmd.ErrOrStderr(), appversion.Get())
 		},
 		Annotations: map[string]string{
 			cobra.CommandDisplayNameAnnotation: "gcx",

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -205,7 +205,7 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 				return
 			}
 			_ = notifier.MaybeNotifySkills(cmd.ErrOrStderr())
-			_ = notifier.MaybeNotifyVersion(cmd.ErrOrStderr(), appversion.Get())
+			_ = notifier.MaybeNotifyVersion(cmd.Context(), cmd.ErrOrStderr(), appversion.Get())
 		},
 		Annotations: map[string]string{
 			cobra.CommandDisplayNameAnnotation: "gcx",

--- a/internal/notifier/run.go
+++ b/internal/notifier/run.go
@@ -1,6 +1,7 @@
 package notifier
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -31,9 +32,8 @@ func MaybeNotifySkills(dst io.Writer) error {
 
 // MaybeNotifyVersion runs the default gcx version update check. Network errors
 // are treated as silent misses so notification checks never affect CLI commands.
-func MaybeNotifyVersion(dst io.Writer, currentVersion string) error {
-	client := httpClientWithTimeout()
-	return maybeNotifyVersionAt(dst, StatePath(), currentVersion, time.Now(), client, latestReleaseURL)
+func MaybeNotifyVersion(ctx context.Context, dst io.Writer, currentVersion string) error {
+	return maybeNotifyVersionAt(ctx, dst, StatePath(), currentVersion, time.Now(), http.DefaultClient, latestReleaseURL)
 }
 
 func maybeNotifySkillsAt(source fs.FS, dst io.Writer, statePath, root string, now time.Time) error {
@@ -62,7 +62,7 @@ func maybeNotifySkillsAt(source fs.FS, dst io.Writer, statePath, root string, no
 	return err
 }
 
-func maybeNotifyVersionAt(dst io.Writer, statePath, currentVersion string, now time.Time, client *http.Client, url string) error {
+func maybeNotifyVersionAt(ctx context.Context, dst io.Writer, statePath, currentVersion string, now time.Time, client *http.Client, url string) error {
 	state, err := LoadState(statePath)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func maybeNotifyVersionAt(dst io.Writer, statePath, currentVersion string, now t
 		return nil
 	}
 
-	msg, err := VersionUpdateMessage(client, url, currentVersion)
+	msg, err := VersionUpdateMessage(ctx, client, url, currentVersion)
 	if err != nil {
 		return nil //nolint:nilerr // Version lookup is non-critical UX; do not fail CLI commands.
 	}
@@ -86,8 +86,4 @@ func maybeNotifyVersionAt(dst io.Writer, statePath, currentVersion string, now t
 
 	_, err = fmt.Fprintln(dst, msg)
 	return err
-}
-
-func httpClientWithTimeout() *http.Client {
-	return &http.Client{Timeout: 2 * time.Second}
 }

--- a/internal/notifier/run.go
+++ b/internal/notifier/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"time"
 
 	claudeplugin "github.com/grafana/gcx/claude-plugin"
@@ -12,6 +13,7 @@ import (
 
 const (
 	SkillsCheckKey       = "skills_update_notice"
+	VersionCheckKey      = "gcx_version_notice"
 	DefaultCheckInterval = 24 * time.Hour
 )
 
@@ -25,6 +27,13 @@ func MaybeNotifySkills(dst io.Writer) error {
 	}
 
 	return maybeNotifySkillsAt(claudeplugin.SkillsFS(), dst, StatePath(), root, time.Now())
+}
+
+// MaybeNotifyVersion runs the default gcx version update check. Network errors
+// are treated as silent misses so notification checks never affect CLI commands.
+func MaybeNotifyVersion(dst io.Writer, currentVersion string) error {
+	client := httpClientWithTimeout()
+	return maybeNotifyVersionAt(dst, StatePath(), currentVersion, time.Now(), client, latestReleaseURL)
 }
 
 func maybeNotifySkillsAt(source fs.FS, dst io.Writer, statePath, root string, now time.Time) error {
@@ -51,4 +60,34 @@ func maybeNotifySkillsAt(source fs.FS, dst io.Writer, statePath, root string, no
 
 	_, err = fmt.Fprintln(dst, msg)
 	return err
+}
+
+func maybeNotifyVersionAt(dst io.Writer, statePath, currentVersion string, now time.Time, client *http.Client, url string) error {
+	state, err := LoadState(statePath)
+	if err != nil {
+		return err
+	}
+	if !ShouldRun(state, VersionCheckKey, now, DefaultCheckInterval) {
+		return nil
+	}
+
+	msg, err := VersionUpdateMessage(client, url, currentVersion)
+	if err != nil {
+		return nil //nolint:nilerr // Version lookup is non-critical UX; do not fail CLI commands.
+	}
+
+	MarkRan(&state, VersionCheckKey, now)
+	if err := SaveState(statePath, state); err != nil {
+		return err
+	}
+	if msg == "" {
+		return nil
+	}
+
+	_, err = fmt.Fprintln(dst, msg)
+	return err
+}
+
+func httpClientWithTimeout() *http.Client {
+	return &http.Client{Timeout: 2 * time.Second}
 }

--- a/internal/notifier/run_test.go
+++ b/internal/notifier/run_test.go
@@ -2,6 +2,7 @@ package notifier //nolint:testpackage // Tests exercise the unexported maybeNoti
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -127,7 +128,7 @@ func TestMaybeNotifyVersionAt_WritesMessageAndStateWhenDue(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	var out bytes.Buffer
-	if err := maybeNotifyVersionAt(&out, statePath, "v1.2.3", now, server.Client(), server.URL); err != nil {
+	if err := maybeNotifyVersionAt(context.Background(), &out, statePath, "v1.2.3", now, server.Client(), server.URL); err != nil {
 		t.Fatalf("maybeNotifyVersionAt() error = %v", err)
 	}
 	if !strings.Contains(out.String(), "A new gcx version is available: v1.2.4") {
@@ -163,7 +164,7 @@ func TestMaybeNotifyVersionAt_SkipsWhenNotDue(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	var out bytes.Buffer
-	if err := maybeNotifyVersionAt(&out, statePath, "v1.2.3", now, server.Client(), server.URL); err != nil {
+	if err := maybeNotifyVersionAt(context.Background(), &out, statePath, "v1.2.3", now, server.Client(), server.URL); err != nil {
 		t.Fatalf("maybeNotifyVersionAt() error = %v", err)
 	}
 	if out.Len() != 0 {
@@ -185,7 +186,7 @@ func TestMaybeNotifyVersionAt_FetchErrorIsSilentAndDoesNotMarkState(t *testing.T
 	t.Cleanup(server.Close)
 
 	var out bytes.Buffer
-	if err := maybeNotifyVersionAt(&out, statePath, "v1.2.3", now, server.Client(), server.URL); err != nil {
+	if err := maybeNotifyVersionAt(context.Background(), &out, statePath, "v1.2.3", now, server.Client(), server.URL); err != nil {
 		t.Fatalf("maybeNotifyVersionAt() error = %v", err)
 	}
 	if out.Len() != 0 {

--- a/internal/notifier/run_test.go
+++ b/internal/notifier/run_test.go
@@ -2,9 +2,12 @@ package notifier //nolint:testpackage // Tests exercise the unexported maybeNoti
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -110,5 +113,90 @@ func TestMaybeNotifySkillsAt_NoUpdateNeededMarksStateWithoutOutput(t *testing.T)
 	}
 	if got := state.Checks[SkillsCheckKey].LastCheckedAt; !got.Equal(now) {
 		t.Fatalf("last checked = %v, want %v", got, now)
+	}
+}
+
+func TestMaybeNotifyVersionAt_WritesMessageAndStateWhenDue(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "notifier.yml")
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.4","html_url":"https://github.com/grafana/gcx/releases/tag/v1.2.4"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var out bytes.Buffer
+	if err := maybeNotifyVersionAt(&out, statePath, "v1.2.3", now, server.Client(), server.URL); err != nil {
+		t.Fatalf("maybeNotifyVersionAt() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "A new gcx version is available: v1.2.4") {
+		t.Fatalf("output = %q, want version update notice", out.String())
+	}
+
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if got := state.Checks[VersionCheckKey].LastCheckedAt; !got.Equal(now) {
+		t.Fatalf("last checked = %v, want %v", got, now)
+	}
+}
+
+func TestMaybeNotifyVersionAt_SkipsWhenNotDue(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "notifier.yml")
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	state := State{Checks: map[string]CheckState{
+		VersionCheckKey: {LastCheckedAt: now.Add(-time.Hour)},
+	}}
+	if err := SaveState(statePath, state); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.4"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var out bytes.Buffer
+	if err := maybeNotifyVersionAt(&out, statePath, "v1.2.3", now, server.Client(), server.URL); err != nil {
+		t.Fatalf("maybeNotifyVersionAt() error = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output = %q, want empty", out.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("server calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestMaybeNotifyVersionAt_FetchErrorIsSilentAndDoesNotMarkState(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "notifier.yml")
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	var out bytes.Buffer
+	if err := maybeNotifyVersionAt(&out, statePath, "v1.2.3", now, server.Client(), server.URL); err != nil {
+		t.Fatalf("maybeNotifyVersionAt() error = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("output = %q, want empty", out.String())
+	}
+
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if _, ok := state.Checks[VersionCheckKey]; ok {
+		t.Fatalf("state contains %q after fetch error, want unmarked", VersionCheckKey)
 	}
 }

--- a/internal/notifier/version.go
+++ b/internal/notifier/version.go
@@ -1,0 +1,95 @@
+package notifier
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	appversion "github.com/grafana/gcx/internal/version"
+)
+
+const (
+	latestReleaseURL    = "https://api.github.com/repos/grafana/gcx/releases/latest"
+	releaseTagURLPrefix = "https://github.com/grafana/gcx/releases/tag/"
+)
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+}
+
+// VersionUpdateMessage fetches the latest released gcx version and returns a
+// notification message when it is newer than currentVersion.
+func VersionUpdateMessage(client *http.Client, url, currentVersion string) (string, error) {
+	current, ok := parseNotifyVersion(currentVersion)
+	if !ok {
+		return "", nil
+	}
+
+	release, err := fetchLatestRelease(client, url)
+	if err != nil {
+		return "", err
+	}
+	latest, ok := parseNotifyVersion(release.TagName)
+	if !ok {
+		return "", nil
+	}
+	if !latest.GreaterThan(current) {
+		return "", nil
+	}
+
+	upgradeURL := release.HTMLURL
+	if upgradeURL == "" {
+		upgradeURL = releaseTagURLPrefix + release.TagName
+	}
+
+	return fmt.Sprintf("A new gcx version is available: %s (current: %s)\nUpgrade: %s", release.TagName, currentVersion, upgradeURL), nil
+}
+
+func fetchLatestRelease(client *http.Client, url string) (githubRelease, error) {
+	if client == nil {
+		client = &http.Client{Timeout: 2 * time.Second}
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("create latest release request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", appversion.UserAgent())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("fetch latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return githubRelease{}, fmt.Errorf("fetch latest release: HTTP %d", resp.StatusCode)
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&release); err != nil {
+		return githubRelease{}, fmt.Errorf("decode latest release: %w", err)
+	}
+	return release, nil
+}
+
+func parseNotifyVersion(v string) (*semver.Version, bool) {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	if v == "" || strings.EqualFold(v, "SNAPSHOT") || strings.EqualFold(v, "(devel)") || strings.Contains(v, " ") {
+		return nil, false
+	}
+
+	version, err := semver.NewVersion(v)
+	if err != nil {
+		return nil, false
+	}
+	return version, true
+}

--- a/internal/notifier/version.go
+++ b/internal/notifier/version.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 const (
 	latestReleaseURL    = "https://api.github.com/repos/grafana/gcx/releases/latest"
 	releaseTagURLPrefix = "https://github.com/grafana/gcx/releases/tag/"
+	versionCheckTimeout = 2 * time.Second
 )
 
 type githubRelease struct {
@@ -25,13 +27,17 @@ type githubRelease struct {
 
 // VersionUpdateMessage fetches the latest released gcx version and returns a
 // notification message when it is newer than currentVersion.
-func VersionUpdateMessage(client *http.Client, url, currentVersion string) (string, error) {
+func VersionUpdateMessage(ctx context.Context, client *http.Client, url, currentVersion string) (string, error) {
+	if client == nil {
+		return "", errors.New("version update client is required")
+	}
+
 	current, ok := parseNotifyVersion(currentVersion)
 	if !ok {
 		return "", nil
 	}
 
-	release, err := fetchLatestRelease(client, url)
+	release, err := fetchLatestRelease(ctx, client, url)
 	if err != nil {
 		return "", err
 	}
@@ -51,12 +57,11 @@ func VersionUpdateMessage(client *http.Client, url, currentVersion string) (stri
 	return fmt.Sprintf("A new gcx version is available: %s (current: %s)\nUpgrade: %s", release.TagName, currentVersion, upgradeURL), nil
 }
 
-func fetchLatestRelease(client *http.Client, url string) (githubRelease, error) {
-	if client == nil {
-		client = &http.Client{Timeout: 2 * time.Second}
-	}
+func fetchLatestRelease(ctx context.Context, client *http.Client, url string) (githubRelease, error) {
+	ctx, cancel := context.WithTimeout(ctx, versionCheckTimeout)
+	defer cancel()
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return githubRelease{}, fmt.Errorf("create latest release request: %w", err)
 	}

--- a/internal/notifier/version_test.go
+++ b/internal/notifier/version_test.go
@@ -1,6 +1,7 @@
 package notifier_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,7 +18,7 @@ func TestVersionUpdateMessage_NewerRelease(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	msg, err := notifier.VersionUpdateMessage(server.Client(), server.URL, "v1.2.3")
+	msg, err := notifier.VersionUpdateMessage(context.Background(), server.Client(), server.URL, "v1.2.3")
 	if err != nil {
 		t.Fatalf("VersionUpdateMessage() error = %v", err)
 	}
@@ -38,7 +39,7 @@ func TestVersionUpdateMessage_NoMessageForSameOlderOrInvalidVersions(t *testing.
 		t.Run(current, func(t *testing.T) {
 			t.Parallel()
 
-			msg, err := notifier.VersionUpdateMessage(server.Client(), server.URL, current)
+			msg, err := notifier.VersionUpdateMessage(context.Background(), server.Client(), server.URL, current)
 			if err != nil {
 				t.Fatalf("VersionUpdateMessage() error = %v", err)
 			}
@@ -57,7 +58,15 @@ func TestVersionUpdateMessage_PropagatesFetchError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	if _, err := notifier.VersionUpdateMessage(server.Client(), server.URL, "v1.2.3"); err == nil {
+	if _, err := notifier.VersionUpdateMessage(context.Background(), server.Client(), server.URL, "v1.2.3"); err == nil {
+		t.Fatal("VersionUpdateMessage() error = nil, want error")
+	}
+}
+
+func TestVersionUpdateMessage_RequiresClient(t *testing.T) {
+	t.Parallel()
+
+	if _, err := notifier.VersionUpdateMessage(context.Background(), nil, "http://example.test", "v1.2.3"); err == nil {
 		t.Fatal("VersionUpdateMessage() error = nil, want error")
 	}
 }

--- a/internal/notifier/version_test.go
+++ b/internal/notifier/version_test.go
@@ -1,0 +1,63 @@
+package notifier_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/notifier"
+)
+
+func TestVersionUpdateMessage_NewerRelease(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.4","html_url":"https://github.com/grafana/gcx/releases/tag/v1.2.4"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	msg, err := notifier.VersionUpdateMessage(server.Client(), server.URL, "v1.2.3")
+	if err != nil {
+		t.Fatalf("VersionUpdateMessage() error = %v", err)
+	}
+	if !strings.Contains(msg, "v1.2.4") || !strings.Contains(msg, "v1.2.3") {
+		t.Fatalf("message = %q, want current and latest versions", msg)
+	}
+}
+
+func TestVersionUpdateMessage_NoMessageForSameOlderOrInvalidVersions(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.3","html_url":"https://github.com/grafana/gcx/releases/tag/v1.2.3"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	for _, current := range []string{"v1.2.3", "v1.2.4", "SNAPSHOT", "(devel)", "v1.2.3 built from abc on now"} {
+		t.Run(current, func(t *testing.T) {
+			t.Parallel()
+
+			msg, err := notifier.VersionUpdateMessage(server.Client(), server.URL, current)
+			if err != nil {
+				t.Fatalf("VersionUpdateMessage() error = %v", err)
+			}
+			if msg != "" {
+				t.Fatalf("message = %q, want empty", msg)
+			}
+		})
+	}
+}
+
+func TestVersionUpdateMessage_PropagatesFetchError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	if _, err := notifier.VersionUpdateMessage(server.Client(), server.URL, "v1.2.3"); err == nil {
+		t.Fatal("VersionUpdateMessage() error = nil, want error")
+	}
+}


### PR DESCRIPTION
In a previous pr https://github.com/grafana/gcx/pull/562 we introduced a notification system. This pr uses it to notify the user when a new version of GCX is available. As before this notification (and the check) is done only once per day and users can opt-out
