### PR TITLE
feat(kg): replace kg inspect with entities inspect using llm-summary endpoint

### DIFF
--- a/docs/reference/cli/gcx_kg.md
+++ b/docs/reference/cli/gcx_kg.md
@@ -26,7 +26,6 @@ Manage Grafana Knowledge Graph rules, entities, and insights
 * [gcx kg entities](gcx_kg_entities.md)	 - Manage Knowledge Graph entities.
 * [gcx kg health](gcx_kg_health.md)	 - Show a health summary with active insight counts.
 * [gcx kg insights](gcx_kg_insights.md)	 - Query Knowledge Graph insights.
-* [gcx kg inspect](gcx_kg_inspect.md)	 - Inspect an entity: info, insights, and summary.
 * [gcx kg meta](gcx_kg_meta.md)	 - Show Knowledge Graph metadata: entity types, valid env/namespace/site values, and telemetry query configs.
 * [gcx kg model-rules](gcx_kg_model-rules.md)	 - Push model rules to the Knowledge Graph.
 * [gcx kg open](gcx_kg_open.md)	 - Open the Knowledge Graph app in the browser.

--- a/docs/reference/cli/gcx_kg_entities.md
+++ b/docs/reference/cli/gcx_kg_entities.md
@@ -23,5 +23,6 @@ Manage Knowledge Graph entities.
 ### SEE ALSO
 
 * [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
+* [gcx kg entities inspect](gcx_kg_entities_inspect.md)	 - Show detailed info, insights, and summary for a single entity.
 * [gcx kg entities list](gcx_kg_entities_list.md)	 - List Knowledge Graph entities for a given type.
 

--- a/docs/reference/cli/gcx_kg_entities_inspect.md
+++ b/docs/reference/cli/gcx_kg_entities_inspect.md
@@ -1,25 +1,25 @@
-## gcx kg inspect
+## gcx kg entities inspect
 
-Inspect an entity: info, insights, and summary.
+Show detailed info, insights, and summary for a single entity.
 
 ```
-gcx kg inspect [Type--Name] [flags]
+gcx kg entities inspect [Type--Name] [flags]
 ```
 
 ### Options
 
 ```
-      --env string         Environment scope
+      --env string         Environment scope (run 'gcx kg meta scopes' to see valid values)
       --from string        Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help               help for inspect
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string        Entity name
-      --namespace string   Namespace scope
+      --namespace string   Namespace scope (run 'gcx kg meta scopes' to see valid values)
   -o, --output string      Output format. One of: json, yaml (default "json")
       --since string       Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
-      --site string        Site scope
+      --site string        Site scope (run 'gcx kg meta scopes' to see valid values)
       --to string          End time (RFC3339, Unix timestamp, or relative like 'now')
-      --type string        Entity type
+      --type string        Entity type (run 'gcx kg meta schema' to see available types)
 ```
 
 ### Options inherited from parent commands
@@ -36,5 +36,5 @@ gcx kg inspect [Type--Name] [flags]
 
 ### SEE ALSO
 
-* [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
+* [gcx kg entities](gcx_kg_entities.md)	 - Manage Knowledge Graph entities.
 

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -202,7 +202,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx kg insights search":         {Cost: "medium", Hint: "--type <type> --since 1h"},
 	"gcx kg insights source-metrics": {Cost: "medium", Hint: "--insight-id <id> --since 1h"},
 	"gcx kg insights summary":        {Cost: "medium", Hint: "<Type--Name> -o json"},
-	"gcx kg inspect":                 {Cost: "medium", Hint: "<Type--Name> -o json"},
+	"gcx kg entities inspect":        {Cost: "medium", Hint: "--type <EntityType> --name <name> [--env <env>] [--namespace <ns>] | --type is required (run 'gcx kg meta schema' to list valid entity types); scope is auto-discovered if omitted; run 'gcx kg entities list --type <type> --property name=~<name>' first to confirm type and exact name"},
 	"gcx kg meta all":                {Cost: "medium", Hint: "load all sections at once [--since 1h]"},
 	"gcx kg meta logs":               {Cost: "small", Hint: "Loki label mappings for log drilldown"},
 	"gcx kg meta profiles":           {Cost: "small", Hint: "Pyroscope label mappings for profile drilldown"},

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -456,6 +456,15 @@ func (c *Client) FetchProfileConfigs(ctx context.Context) (ProfileConfigsRespons
 	return resp, nil
 }
 
+// LLMSummary fetches entity health data from the LLM summary endpoint.
+func (c *Client) LLMSummary(ctx context.Context, req LLMSummaryRequest) (map[string]any, error) {
+	var result map[string]any
+	if err := c.postJSON(ctx, assertionsPath+"/llm-summary", req, &result); err != nil {
+		return nil, fmt.Errorf("kg: llm summary: %w", err)
+	}
+	return result, nil
+}
+
 // ---------------------------------------------------------------------------
 // Rules operations
 // ---------------------------------------------------------------------------

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net/http"
 	"os"
 	"slices"
 	"sort"
@@ -754,7 +755,7 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 	listOpts.setup(listCmd.Flags())
 	_ = listCmd.MarkFlagRequired("type")
 
-	cmd.AddCommand(listCmd)
+	cmd.AddCommand(listCmd, newEntitiesInspectCommand(loader))
 	return cmd
 }
 
@@ -1254,15 +1255,92 @@ func filterBySeverity(results []SearchResult, sev string) []SearchResult {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// Inspect command
+// Entities describe command
 // ---------------------------------------------------------------------------
 
-func newInspectCommand(loader RESTConfigLoader) *cobra.Command {
+// inspectScopeHint searches for an entity by exact name across all scopes and
+// returns formatted retry suggestions when LLMSummary returns 404. This helps
+// agents and users recover when the scope is incomplete or wrong.
+func inspectScopeHint(ctx context.Context, client *Client, entityType, name string, startMs, endMs int64) string {
+	req := SampleSearchRequest{
+		TimeCriteria: &TimeCriteria{Start: startMs, End: endMs},
+		FilterCriteria: []EntityMatcher{{
+			EntityType:       entityType,
+			PropertyMatchers: []PropertyMatcher{{Name: "name", Op: "=", Value: name}},
+		}},
+		SampleSize: 10,
+	}
+	results, err := client.SearchSample(ctx, req)
+	if err != nil || len(results) == 0 {
+		return ""
+	}
+	var lines []string
+	lines = append(lines, fmt.Sprintf("Found %d matching %s entr%s in other scopes — retry with:", len(results), entityType, map[bool]string{true: "y", false: "ies"}[len(results) == 1]))
+	for _, r := range results {
+		parts := []string{fmt.Sprintf("  gcx kg entities inspect %s--%s", r.Type, r.Name)}
+		for _, dim := range []string{"env", "namespace", "site"} {
+			if v := r.Scope[dim]; v != "" {
+				parts = append(parts, fmt.Sprintf("--%s %s", dim, v))
+			}
+		}
+		lines = append(lines, strings.Join(parts, " "))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// isEmptyLLMResult returns true when llm-summary returns 200 but no real data.
+// The endpoint echoes the requested entity in "summaries" regardless of whether
+// it exists, so summaries being non-empty is not a "found" signal. The only
+// reliable indicator of actual data is a non-empty "graphData".
+func isEmptyLLMResult(result map[string]any) bool {
+	gd, _ := result["graphData"].([]any)
+	return len(gd) == 0
+}
+
+// discoverEntityScope resolves the scope for an entity when the caller didn't
+// provide one. It first tries LookupEntity, then falls back to a name-exact
+// search. Returns nil scope (not an error) when the entity simply isn't found —
+// the caller lets LLMSummary produce the definitive not-found response.
+func discoverEntityScope(cmd *cobra.Command, client *Client, entityType, name string, startMs, endMs int64) (map[string]string, error) {
+	lookup, err := client.LookupEntity(cmd.Context(), entityType, name, nil, startMs, endMs)
+	if err != nil {
+		return nil, err
+	}
+	if lookup != nil {
+		return lookup.Scope, nil
+	}
+	results, err := searchByTypes(cmd.Context(), cmd, client, []string{entityType}, false, nil, startMs, endMs, 0, []PropertyMatcher{{Name: "name", Op: "=", Value: name}})
+	if err != nil {
+		return nil, err
+	}
+	switch len(results) {
+	case 0:
+		return nil, nil //nolint:nilnil // deliberate: no scope found is not an error; caller lets LLMSummary produce the not-found response
+	case 1:
+		return results[0].Scope, nil
+	default:
+		var lines []string
+		lines = append(lines, fmt.Sprintf("found %d entities named %q — re-run with one of:", len(results), name))
+		for _, r := range results {
+			parts := []string{fmt.Sprintf("  gcx kg entities inspect %s--%s", r.Type, r.Name)}
+			for _, dim := range []string{"env", "namespace", "site"} {
+				if v := r.Scope[dim]; v != "" {
+					parts = append(parts, fmt.Sprintf("--%s %s", dim, v))
+				}
+			}
+			lines = append(lines, strings.Join(parts, " "))
+		}
+		return nil, errors.New(strings.Join(lines, "\n"))
+	}
+}
+
+func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 	var inspectScope scopeFlags
 	ioOpts := &inspectOpts{}
 	cmd := &cobra.Command{
 		Use:   "inspect [Type--Name]",
-		Short: "Inspect an entity: info, insights, and summary.",
+		Short: "Show detailed info, insights, and summary for a single entity.",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := ioOpts.IO.Validate(); err != nil {
 				return err
@@ -1276,6 +1354,15 @@ func newInspectCommand(loader RESTConfigLoader) *cobra.Command {
 				return err
 			}
 			if err := inspectScope.validateScopes(cmd.Context(), client); err != nil {
+				name, _ := cmd.Flags().GetString("name")
+				if name == "" && len(args) > 0 {
+					if _, n, parseErr := parseEntityArg(args); parseErr == nil {
+						name = n
+					}
+				}
+				if name != "" {
+					return fmt.Errorf("%w\nRun 'gcx kg entities list --type <type> --property name=~%s' to find matching entities", err, name)
+				}
 				return err
 			}
 			startMs, endMs, err := inspectScope.resolveTime()
@@ -1288,46 +1375,58 @@ func newInspectCommand(loader RESTConfigLoader) *cobra.Command {
 			}
 			scope := inspectScope.scopeMap()
 			if scope == nil {
-				lookup, err := client.LookupEntity(cmd.Context(), entityType, name, nil, startMs, endMs)
+				discovered, err := discoverEntityScope(cmd, client, entityType, name, startMs, endMs)
 				if err != nil {
 					return err
 				}
-				if lookup != nil {
-					scope = lookup.Scope
+				scope = discovered
+			}
+
+			llmReq := LLMSummaryRequest{
+				StartTime: startMs,
+				EndTime:   endMs,
+				EntityKeys: []EntityKey{{
+					Type:  entityType,
+					Name:  name,
+					Scope: toAnyMap(scope),
+				}},
+				SuggestionSrcEntities:                         []EntityKey{},
+				GroupAssertions:                               true,
+				AlertCategories:                               []string{"saturation", "amend", "anomaly", "failure", "error"},
+				HideAssertionsOlderThanNHours:                 48,
+				HideAssertionsPresentMoreThanPercentageOfTime: 90,
+				IncludeSuggestions:                            true,
+				IncludeRcaPatterns:                            false,
+			}
+			result, err := client.LLMSummary(cmd.Context(), llmReq)
+			if err != nil {
+				var apiErr *APIError
+				if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+					if hint := inspectScopeHint(cmd.Context(), client, entityType, name, startMs, endMs); hint != "" {
+						return fmt.Errorf("%w\n\n%s", err, hint)
+					}
 				}
-			}
-
-			entityInfo, err := client.GetEntityInfo(cmd.Context(), entityType, name, scope, startMs, endMs)
-			if err != nil {
 				return err
 			}
-
-			scopeAny := toAnyMap(scope)
-			req := AssertionsRequest{
-				StartTime:  startMs,
-				EndTime:    endMs,
-				EntityKeys: []EntityKey{{Type: entityType, Name: name, Scope: scopeAny}},
-			}
-			assertions, err := client.QueryAssertions(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-			summary, err := client.AssertionsSummary(cmd.Context(), req)
-			if err != nil {
-				return err
-			}
-
-			result := map[string]any{
-				"entity":   entityInfo,
-				"insights": assertions,
-				"summary":  summary,
+			if isEmptyLLMResult(result) {
+				scopeDesc := ""
+				if len(scope) > 0 {
+					scopeDesc = " in " + scopeStr(scope)
+				}
+				if hint := inspectScopeHint(cmd.Context(), client, entityType, name, startMs, endMs); hint != "" {
+					return fmt.Errorf("%s/%s not found%s\n\n%s", entityType, name, scopeDesc, hint)
+				}
+				return fmt.Errorf("%s/%s not found%s\nRun 'gcx kg entities list --type %s --property name=~%s' to find matching entities and their correct scope", entityType, name, scopeDesc, entityType, name)
 			}
 			return ioOpts.IO.Encode(cmd.OutOrStdout(), result)
 		},
 	}
-	cmd.Flags().String("type", "", "Entity type")
+	cmd.Flags().String("type", "", "Entity type (run 'gcx kg meta schema' to see available types)")
 	cmd.Flags().String("name", "", "Entity name")
 	inspectScope.register(cmd)
+	cmd.Flags().Lookup("env").Usage = "Environment scope (run 'gcx kg meta scopes' to see valid values)"
+	cmd.Flags().Lookup("namespace").Usage = "Namespace scope (run 'gcx kg meta scopes' to see valid values)"
+	cmd.Flags().Lookup("site").Usage = "Site scope (run 'gcx kg meta scopes' to see valid values)"
 	ioOpts.setup(cmd.Flags())
 	return cmd
 }

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1354,15 +1354,6 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 				return err
 			}
 			if err := inspectScope.validateScopes(cmd.Context(), client); err != nil {
-				name, _ := cmd.Flags().GetString("name")
-				if name == "" && len(args) > 0 {
-					if _, n, parseErr := parseEntityArg(args); parseErr == nil {
-						name = n
-					}
-				}
-				if name != "" {
-					return fmt.Errorf("%w\nRun 'gcx kg entities list --type <type> --property name=~%s' to find matching entities", err, name)
-				}
 				return err
 			}
 			startMs, endMs, err := inspectScope.resolveTime()

--- a/internal/providers/kg/provider.go
+++ b/internal/providers/kg/provider.go
@@ -52,7 +52,6 @@ func (p *KGProvider) Commands() []*cobra.Command {
 		newAssertionsCommand(loader),
 		newDescribeCommand(loader),
 		// High-level
-		newInspectCommand(loader),
 		newHealthCommand(loader),
 		newOpenCommand(loader),
 	)

--- a/internal/providers/kg/types.go
+++ b/internal/providers/kg/types.go
@@ -369,6 +369,20 @@ type KGSchemaResult struct {
 	Relationships []string           `json:"relationships"`
 }
 
+// LLMSummaryRequest is the request body for POST /v1/assertions/llm-summary.
+type LLMSummaryRequest struct {
+	StartTime                                     int64       `json:"startTime"`
+	EndTime                                       int64       `json:"endTime"`
+	EntityKeys                                    []EntityKey `json:"entityKeys"`
+	SuggestionSrcEntities                         []EntityKey `json:"suggestionSrcEntities"`
+	GroupAssertions                               bool        `json:"groupAssertions"`
+	AlertCategories                               []string    `json:"alertCategories,omitempty"`
+	HideAssertionsOlderThanNHours                 int         `json:"hideAssertionsOlderThanNHours"`
+	HideAssertionsPresentMoreThanPercentageOfTime int         `json:"hideAssertionsPresentMoreThanPercentageOfTime"`
+	IncludeSuggestions                            bool        `json:"includeSuggestions"`
+	IncludeRcaPatterns                            bool        `json:"includeRcaPatterns"`
+}
+
 // KGMetadataOutput is the structured output from gcx kg metadata.
 type KGMetadataOutput struct {
 	Schema   *KGSchemaResult          `json:"schema,omitempty"`


### PR DESCRIPTION
## Summary

- Remove \`gcx kg inspect\` top-level command
- Add \`gcx kg entities inspect [Type--Name]\` under the entities subcommand (also accepts \`--type\`/\`--name\` flags)
- Switch from three separate API calls (\`GetEntityInfo\` + \`QueryAssertions\` + \`AssertionsSummary\`) to the single \`llm-summary\` endpoint, which returns an AI-generated summary with suggestions (RCA patterns disabled)
- Pre-flight scope discovery: when no scope is given and \`LookupEntity\` returns nil, searches by exact name across all scopes to auto-discover scope or surface an actionable multi-match error
- Empty result detection: treats \`graphData\` being empty as "not found" (summaries always echoes the request back so is not a reliable signal)
- Add \`LLMSummaryRequest\` type and \`Client.LLMSummary\` method
- Improve agent annotation to emphasize \`--type\` is required and show flag form explicitly

## Test plan

- [x] `gcx kg entities inspect Service--<name> --env <env> --namespace <namespace>` returns LLM summary
- [x] `gcx kg entities inspect --type Service --name <name> --env <env> --namespace <namespace>` (flag form) returns same result
- [x] `gcx kg entities inspect Service--<name>` where the name matches entities in multiple scopes returns a multi-match error listing retry commands with explicit `--env`/`--namespace`/`--site`
- [x] `gcx kg entities inspect Service--<nonexistent>` (no scope, name not found anywhere) returns "not found" with a `gcx kg entities list` suggestion
- [x] `gcx kg entities inspect Service--<name> --env <wrong-env>` (entity exists but not in that scope) returns "not found in env=<wrong-env>" with a `gcx kg entities list` suggestion
- [x] `gcx kg entities inspect Service--<name> --env <invalid-env>` returns scope validation error with did-you-mean candidates
- [x] `gcx kg inspect` is gone
- [x] Reference docs regenerated and consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)