### PR TITLE
docs(assistant): document service account auth limitation

### DIFF
--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -46,7 +46,10 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "assistant",
 		Short: "Interact with Grafana Assistant",
-		Long:  "Send prompts to Grafana Assistant and receive streaming responses via the A2A protocol.",
+		Long: `Send prompts to Grafana Assistant and receive streaming responses via the A2A protocol.
+
+Requires Grafana Cloud with OAuth authentication (gcx login with browser flow).
+Service account tokens are not supported.`,
 	}
 	// We need a "before each run" hook to block assistant commands on self-hosted
 	// instances. Defining one here replaces the root command's hook (cobra doesn't

--- a/docs/reference/cli/gcx_assistant.md
+++ b/docs/reference/cli/gcx_assistant.md
@@ -6,6 +6,9 @@ Interact with Grafana Assistant
 
 Send prompts to Grafana Assistant and receive streaming responses via the A2A protocol.
 
+Requires Grafana Cloud with OAuth authentication (gcx login with browser flow).
+Service account tokens are not supported.
+
 ### Options
 
 ```

--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -175,7 +175,11 @@ Each entry pairs the error you see with what it means and how to fix it.
     - *Means:* gcx could not reach the server during the validation pipeline — typically a wrong URL, DNS/proxy issue, or TLS mismatch.
     - *Fix:* Verify the server URL is correct and reachable. Check any corporate proxies (`HTTPS_PROXY`) and TLS configuration (`--insecure-skip-verify` for development only).
 
-7. **Flag vs env-var precedence confusion**
+7. **`gcx assistant` commands fail with a service account token**
+    - *Means:* `gcx assistant` commands (prompt, investigations) require OAuth, which is only available when you log in via the browser-based OAuth flow. Service account tokens are not supported.
+    - *Fix:* Re-run `gcx login` and choose the OAuth (browser) option. If your environment cannot open a browser, `gcx assistant` is not available — use the Grafana UI instead.
+
+8. **Flag vs env-var precedence confusion**
     - *Means:* both a CLI flag and an environment variable are set for the same field, and gcx behaves unexpectedly.
     - *Fix:* Flags take precedence over env vars, which take precedence over config-file values. Run `gcx config view` to inspect the resolved config and spot the conflict.
 


### PR DESCRIPTION
## Summary
- Add auth requirement note to `gcx assistant` cobra Long description (visible in `--help` and generated CLI reference)
- Add troubleshooting entry in `docs/reference/login.md` for users who hit this with SA tokens

## Context
`gcx assistant` commands rely on OAuth auth so we have an associated user, which is only available via the browser-based OAuth flow. Service account tokens don't provide this endpoint, so assistant commands fail with a 401. This documents the limitation in the two places users are most likely to look.

## Test plan
- [ ] `gcx assistant --help` shows the auth requirement
- [ ] Login troubleshooting guide renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)