### PR TITLE
feat(serve): sync dashboard variable params to URL and restore on refresh

### DIFF
--- a/internal/server/embed/assets/iframe.js
+++ b/internal/server/embed/assets/iframe.js
@@ -1,0 +1,51 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const iframe = document.querySelector("iframe");
+
+  iframe.addEventListener("load", () => {
+    try {
+      patchIframeHistory(iframe, handleParamsChange);
+    } catch (e) {
+      console.warn("[gcx] could not patch iframe history to sync params:", e);
+    }
+  });
+});
+
+// Listen to changes in the iframe's URL search params and sync them to the parent window's search params.
+// This allows for dashboard variables to persist across refreshes
+function handleParamsChange(newSearch, oldSearch, iframe) {
+  const url = new URL(window.location.href);
+  url.search = newSearch;
+  history.replaceState(null, "", url); // replaceState avoids adding a new entry in the browser history for each variable change
+}
+
+// Patches the iframe's history methods to detect changes in the URL search parameters.
+function patchIframeHistory(iframe, onParamsChange) {
+  const iframeWindow = iframe.contentWindow;
+  let lastSearch = iframeWindow.location.search;
+
+  function onURLChange() {
+    const search = iframeWindow.location.search;
+    if (search !== lastSearch) {
+      onParamsChange(search, lastSearch, iframe);
+      lastSearch = search;
+    }
+  }
+
+  const origPushState = iframeWindow.history.pushState.bind(
+    iframeWindow.history,
+  );
+  iframeWindow.history.pushState = function (state, title, url) {
+    origPushState(state, title, url);
+    onURLChange();
+  };
+
+  const origReplaceState = iframeWindow.history.replaceState.bind(
+    iframeWindow.history,
+  );
+  iframeWindow.history.replaceState = function (state, title, url) {
+    origReplaceState(state, title, url);
+    onURLChange();
+  };
+
+  iframeWindow.addEventListener("popstate", onURLChange);
+}

--- a/internal/server/embed/templates/proxy/iframe.html.tmpl
+++ b/internal/server/embed/templates/proxy/iframe.html.tmpl
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="/gcx/assets/style.css"/>
     <link rel="icon" type="image/png" href="/gcx/assets/fav32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/gcx/assets/apple-touch-icon.png" />
+    <script src="/gcx/assets/iframe.js" type="module"></script>
 </head>
 <body>
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -281,8 +281,15 @@ func (s *Server) iframeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	iframeURL := s.subpath + handler.ProxyURL(name)
+
+	// Sync URL params for dashboard variables down to the iframe URL
+	if r.URL.RawQuery != "" {
+		iframeURL += "?" + r.URL.RawQuery
+	}
+
 	templateVars := map[string]any{
-		"IframeURL":      s.subpath + handler.ProxyURL(name),
+		"IframeURL":      iframeURL,
 		"CurrentContext": s.context,
 		"Port":           s.config.Port,
 	}


### PR DESCRIPTION
## Summary

When using `gcx dev serve`, changing dashboard variables (e.g. environment, time range, datasource) now persists in the browser URL. Refreshing the page restores the dashboard to the same state — the variables are no longer reset on every load.

This is implemented with two complementary changes:
- **Go (`server.go`)**: the iframe `src` is initialised with the parent page's query string, so variable state is restored server-side on load with no JS required
- **JS (`iframe.js`)**: `pushState`/`replaceState` on the iframe's `contentWindow` are patched to mirror variable changes back to the parent URL via `history.replaceState` — no polling

## Test plan

- [ ] Start `gcx dev serve` against a local dashboard
- [ ] Change a dashboard variable — confirm the parent URL updates in the address bar without a page reload
- [ ] Refresh — confirm the dashboard reopens with the same variable values
- [ ] Copy the URL and open it in a new tab — confirm variables are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)