### PR TITLE
feat(login): support custom oauth callback port

### DIFF
--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -47,6 +47,7 @@ type loginOpts struct {
 	Cloud               bool
 	Yes                 bool
 	AllowServerOverride bool
+	OAuthCallbackPort   int
 }
 
 func (opts *loginOpts) setup(flags *pflag.FlagSet) {
@@ -65,6 +66,7 @@ func (opts *loginOpts) setup(flags *pflag.FlagSet) {
 	flags.BoolVar(&opts.Cloud, "cloud", false, "Force Grafana Cloud target (skip auto-detection)")
 	flags.BoolVar(&opts.Yes, "yes", false, "Non-interactive: skip optional prompts and use defaults")
 	flags.BoolVar(&opts.AllowServerOverride, "allow-server-override", false, "Allow re-pointing an existing context at a different server URL")
+	flags.IntVar(&opts.OAuthCallbackPort, "oauth-callback-port", 0, "Fixed local port for the OAuth callback server (default: auto-pick from 54321-54399). Useful when only specific ports are forwarded between a remote host and your browser")
 }
 
 // Validate checks opts and args for internal consistency before runLogin executes.
@@ -86,6 +88,12 @@ func (opts *loginOpts) Validate(args []string) error {
 	}
 	if err := opts.IO.Validate(); err != nil {
 		return err
+	}
+	if opts.OAuthCallbackPort < 0 || opts.OAuthCallbackPort > 65535 {
+		return fail.DetailedError{
+			Summary: "invalid --oauth-callback-port",
+			Details: fmt.Sprintf("Port must be between 1 and 65535 (or 0 to auto-pick); got %d.", opts.OAuthCallbackPort),
+		}
 	}
 	return nil
 }
@@ -187,14 +195,15 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 
 	opts := login.Options{
 		Inputs: login.Inputs{
-			Server:       flags.Server,
-			ContextName:  contextName,
-			GrafanaToken: flags.Token,
-			CloudToken:   flags.CloudToken,
-			CloudAPIURL:  flags.CloudAPIURL,
-			Yes:          flags.Yes,
-			Writer:       cmd.ErrOrStderr(),
-			TLS:          existingTLS,
+			Server:            flags.Server,
+			ContextName:       contextName,
+			GrafanaToken:      flags.Token,
+			CloudToken:        flags.CloudToken,
+			CloudAPIURL:       flags.CloudAPIURL,
+			OAuthCallbackPort: flags.OAuthCallbackPort,
+			Yes:               flags.Yes,
+			Writer:            cmd.ErrOrStderr(),
+			TLS:               existingTLS,
 		},
 		Hooks: login.Hooks{
 			ConfigSource: flags.Config.ConfigSource(),

--- a/docs/reference/cli/gcx_login.md
+++ b/docs/reference/cli/gcx_login.md
@@ -31,18 +31,19 @@ gcx login [CONTEXT_NAME] [flags]
 ### Options
 
 ```
-      --allow-server-override   Allow re-pointing an existing context at a different server URL
-      --cloud                   Force Grafana Cloud target (skip auto-detection)
-      --cloud-api-url string    Override Grafana Cloud API URL
-      --cloud-token string      Grafana Cloud API token (enables Cloud management features)
-      --config string           Path to the configuration file to use
-      --context string          Name of the context to use
-  -h, --help                    help for login
-      --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string           Output format. One of: json, text, yaml (default "text")
-      --server string           Grafana server URL (e.g. https://my-stack.grafana.net)
-      --token string            Grafana service account token
-      --yes                     Non-interactive: skip optional prompts and use defaults
+      --allow-server-override     Allow re-pointing an existing context at a different server URL
+      --cloud                     Force Grafana Cloud target (skip auto-detection)
+      --cloud-api-url string      Override Grafana Cloud API URL
+      --cloud-token string        Grafana Cloud API token (enables Cloud management features)
+      --config string             Path to the configuration file to use
+      --context string            Name of the context to use
+  -h, --help                      help for login
+      --json string               Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --oauth-callback-port int   Fixed local port for the OAuth callback server (default: auto-pick from 54321-54399). Useful when only specific ports are forwarded between a remote host and your browser
+  -o, --output string             Output format. One of: json, text, yaml (default "text")
+      --server string             Grafana server URL (e.g. https://my-stack.grafana.net)
+      --token string              Grafana service account token
+      --yes                       Non-interactive: skip optional prompts and use defaults
 ```
 
 ### Options inherited from parent commands

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -36,7 +36,11 @@ type Inputs struct {
 	CloudToken   string
 	CloudAPIURL  string
 	UseOAuth     bool
-	Yes          bool
+	// OAuthCallbackPort fixes the local port for the OAuth callback server.
+	// Zero means auto-pick from the default range. Useful when only specific
+	// ports are forwarded between a remote dev host and the user's browser.
+	OAuthCallbackPort int
+	Yes               bool
 	// UseCloudInstanceSelector is only used internally to mark the case in which
 	// a user explicitly left the server empty to be directed to the cloud
 	// instance selector
@@ -393,7 +397,7 @@ func resolveGrafanaAuth(ctx context.Context, opts Options, target Target) (strin
 		if w == nil {
 			w = io.Discard
 		}
-		flow := opts.NewAuthFlow(opts.Server, auth.Options{Writer: w})
+		flow := opts.NewAuthFlow(opts.Server, auth.Options{Writer: w, Port: opts.OAuthCallbackPort})
 		result, err := flow.Run(ctx)
 		if err != nil {
 			return "", nil, fmt.Errorf("OAuth flow failed: %w", err)


### PR DESCRIPTION
closes https://github.com/grafana/gcx/issues/611

Adds a `--oauth-callback-port` flag to `gcx login` so users can pin the OAuth callback server to a fixed local port instead of the auto-pick range (54321–54399).

**Before:** `gcx login` always probes 54321–54399 for a free port, requiring whichever it lands on to be reachable from the browser. **After:** `gcx login --oauth-callback-port 8250` binds the callback to the user-specified port.

When developers run `gcx login` on a remote dev host, the OAuth flow only works if the callback port is forwarded back to the machine running the browser. Many organizations port-forward a fixed set of ports between local and remote dev machines; today that means adding all of 54321–54399 to the forwarding list (or hoping the right one is free). `auth.Options.Port` already supports a fixed port internally — this just exposes it as a CLI flag.

- `internal/login/login.go` — new `Inputs.OAuthCallbackPort int` field, threaded into `auth.Options.Port` when constructing the OAuth flow
- `cmd/gcx/login/command.go` — new `--oauth-callback-port` flag with range validation (1–65535, or 0 to auto-pick) wired into `login.Inputs`
- `docs/reference/cli/gcx_login.md` — regenerated

The flag is purely additive; default of 0 preserves today's auto-pick behavior.

- [x] `go test ./internal/login/... ./internal/auth/... ./cmd/gcx/login/...` passes
- [x] `go vet` on touched packages passes
- [x] `gcx login --help` shows the new flag with a clear description
- [x] `gcx login --oauth-callback-port 99999` returns the structured "Port must be between 1 and 65535" validation error
- [x] Manual e2e on a remote dev host: confirm callback binds to the user-specified port and OAuth completes through the forwarded port