### PR TITLE
feat(kg): add suppressions list/delete and fix overwrite bug

### DIFF
--- a/docs/reference/cli/gcx_kg.md
+++ b/docs/reference/cli/gcx_kg.md
@@ -33,5 +33,5 @@ Manage Grafana Knowledge Graph rules, entities, and insights
 * [gcx kg rules](gcx_kg_rules.md)	 - Manage Knowledge Graph prom rules.
 * [gcx kg scopes](gcx_kg_scopes.md)	 - Manage Knowledge Graph entity scopes.
 * [gcx kg status](gcx_kg_status.md)	 - Show Knowledge Graph stack status.
-* [gcx kg suppressions](gcx_kg_suppressions.md)	 - Push suppressions to the Knowledge Graph.
+* [gcx kg suppressions](gcx_kg_suppressions.md)	 - Manage alert suppressions in the Knowledge Graph.
 

--- a/docs/reference/cli/gcx_kg_suppressions.md
+++ b/docs/reference/cli/gcx_kg_suppressions.md
@@ -1,6 +1,6 @@
 ## gcx kg suppressions
 
-Push suppressions to the Knowledge Graph.
+Manage alert suppressions in the Knowledge Graph.
 
 ### Options
 
@@ -23,5 +23,7 @@ Push suppressions to the Knowledge Graph.
 ### SEE ALSO
 
 * [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
-* [gcx kg suppressions create](gcx_kg_suppressions_create.md)	 - Upload suppressions from a YAML file.
+* [gcx kg suppressions create](gcx_kg_suppressions_create.md)	 - Upload suppressions from a YAML file or stdin.
+* [gcx kg suppressions delete](gcx_kg_suppressions_delete.md)	 - Delete a suppression by name.
+* [gcx kg suppressions list](gcx_kg_suppressions_list.md)	 - List all alert suppressions.
 

--- a/docs/reference/cli/gcx_kg_suppressions.md
+++ b/docs/reference/cli/gcx_kg_suppressions.md
@@ -23,7 +23,7 @@ Manage alert suppressions in the Knowledge Graph.
 ### SEE ALSO
 
 * [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
-* [gcx kg suppressions create](gcx_kg_suppressions_create.md)	 - Upload suppressions from a YAML file or stdin.
+* [gcx kg suppressions create](gcx_kg_suppressions_create.md)	 - Create or update one or more suppressions from a YAML file or stdin.
 * [gcx kg suppressions delete](gcx_kg_suppressions_delete.md)	 - Delete a suppression by name.
 * [gcx kg suppressions list](gcx_kg_suppressions_list.md)	 - List all alert suppressions.
 

--- a/docs/reference/cli/gcx_kg_suppressions_create.md
+++ b/docs/reference/cli/gcx_kg_suppressions_create.md
@@ -1,15 +1,27 @@
 ## gcx kg suppressions create
 
-Upload suppressions from a YAML file.
+Upload suppressions from a YAML file or stdin.
 
 ```
 gcx kg suppressions create [flags]
 ```
 
+### Examples
+
+```
+  gcx kg suppressions create -f suppressions.yaml
+
+  echo 'disabledAlertConfigs:
+    - name: my-suppression
+      matchLabels:
+        alertname: ErrorRatioBreach
+        job: my-service' | gcx kg suppressions create
+```
+
 ### Options
 
 ```
-  -f, --file string   Input file (YAML)
+  -f, --file string   Input file (YAML), or '-' for stdin. Reads from stdin if omitted.
   -h, --help          help for create
 ```
 
@@ -27,5 +39,5 @@ gcx kg suppressions create [flags]
 
 ### SEE ALSO
 
-* [gcx kg suppressions](gcx_kg_suppressions.md)	 - Push suppressions to the Knowledge Graph.
+* [gcx kg suppressions](gcx_kg_suppressions.md)	 - Manage alert suppressions in the Knowledge Graph.
 

--- a/docs/reference/cli/gcx_kg_suppressions_create.md
+++ b/docs/reference/cli/gcx_kg_suppressions_create.md
@@ -1,6 +1,6 @@
 ## gcx kg suppressions create
 
-Upload suppressions from a YAML file or stdin.
+Create or update one or more suppressions from a YAML file or stdin.
 
 ```
 gcx kg suppressions create [flags]

--- a/docs/reference/cli/gcx_kg_suppressions_delete.md
+++ b/docs/reference/cli/gcx_kg_suppressions_delete.md
@@ -1,0 +1,30 @@
+## gcx kg suppressions delete
+
+Delete a suppression by name.
+
+```
+gcx kg suppressions delete <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx kg suppressions](gcx_kg_suppressions.md)	 - Manage alert suppressions in the Knowledge Graph.
+

--- a/docs/reference/cli/gcx_kg_suppressions_delete.md
+++ b/docs/reference/cli/gcx_kg_suppressions_delete.md
@@ -10,6 +10,7 @@ gcx kg suppressions delete <name> [flags]
 
 ```
   -h, --help   help for delete
+  -y, --yes    Skip confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_suppressions_list.md
+++ b/docs/reference/cli/gcx_kg_suppressions_list.md
@@ -1,0 +1,32 @@
+## gcx kg suppressions list
+
+List all alert suppressions.
+
+```
+gcx kg suppressions list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx kg suppressions](gcx_kg_suppressions.md)	 - Manage alert suppressions in the Knowledge Graph.
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -231,6 +231,8 @@ var commandAnnotations = map[string]annotation{
 	"gcx kg scopes list":             {Cost: "small"},
 	"gcx kg status":                  {Cost: "small"},
 	"gcx kg suppressions create":     {Cost: "small"},
+	"gcx kg suppressions delete":     {Cost: "small"},
+	"gcx kg suppressions list":       {Cost: "small"},
 
 	// -----------------------------------------------------------------------
 	// Logs provider

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -26,6 +26,8 @@ const (
 	assertionsPath   = pluginResourcePath + "/asserts/api-server/v1/assertions"
 	searchPath       = pluginResourcePath + "/asserts/api-server/v1/search"
 	rulesPath        = pluginResourcePath + "/asserts/api-server/v1/config/prom-rules/"
+	suppressionPath  = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alert"
+	suppressionsPath = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alerts"
 	entityLookupPath = pluginResourcePath + "/asserts/api-server/v1/entity"
 	v2ConfigPath     = pluginResourcePath + "/asserts/api-server/v2/config"
 )
@@ -224,13 +226,13 @@ type Suppressions struct {
 // UpsertSuppression creates or updates a single suppression without affecting others.
 // It uses the single-item endpoint so the backend performs a read-modify-write upsert.
 func (c *Client) UpsertSuppression(ctx context.Context, s Suppression) error {
-	return c.postJSON(ctx, pluginResourcePath+"/asserts/api-server/v1/config/disabled-alert", s, nil)
+	return c.postJSON(ctx, suppressionPath, s, nil)
 }
 
 // DeleteSuppression deletes a single suppression by name.
 func (c *Client) DeleteSuppression(ctx context.Context, name string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
-		c.host+pluginResourcePath+"/asserts/api-server/v1/config/disabled-alert/"+url.PathEscape(name), nil)
+		c.host+suppressionPath+"/"+url.PathEscape(name), nil)
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}
@@ -248,7 +250,7 @@ func (c *Client) DeleteSuppression(ctx context.Context, name string) error {
 // GetSuppressions retrieves all disabled-alert configurations for the tenant.
 func (c *Client) GetSuppressions(ctx context.Context) (*Suppressions, error) {
 	var result Suppressions
-	if err := c.getJSON(ctx, pluginResourcePath+"/asserts/api-server/v1/config/disabled-alerts", &result); err != nil {
+	if err := c.getJSON(ctx, suppressionsPath, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -209,9 +209,49 @@ func (c *Client) UploadModelRules(ctx context.Context, yamlContent string) error
 	return c.doYAML(ctx, http.MethodPut, pluginResourcePath+"/asserts/api-server/v1/config/model-rules/", yamlContent)
 }
 
-// UploadSuppressions uploads alert suppression configuration.
-func (c *Client) UploadSuppressions(ctx context.Context, yamlContent string) error {
-	return c.doYAML(ctx, http.MethodPost, pluginResourcePath+"/asserts/api-server/v1/config/disabled-alerts/", yamlContent)
+// Suppression represents a single disabled-alert configuration entry.
+type Suppression struct {
+	Name        string            `json:"name" yaml:"name"`
+	MatchLabels map[string]string `json:"matchLabels,omitempty" yaml:"matchLabels,omitempty"`
+	ManagedBy   string            `json:"managedBy,omitempty" yaml:"managedBy,omitempty"`
+}
+
+// Suppressions is the batch payload shape returned by GET /v1/config/disabled-alerts.
+type Suppressions struct {
+	DisabledAlertConfigs []Suppression `json:"disabledAlertConfigs" yaml:"disabledAlertConfigs"`
+}
+
+// UpsertSuppression creates or updates a single suppression without affecting others.
+// It uses the single-item endpoint so the backend performs a read-modify-write upsert.
+func (c *Client) UpsertSuppression(ctx context.Context, s Suppression) error {
+	return c.postJSON(ctx, pluginResourcePath+"/asserts/api-server/v1/config/disabled-alert", s, nil)
+}
+
+// DeleteSuppression deletes a single suppression by name.
+func (c *Client) DeleteSuppression(ctx context.Context, name string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+		c.host+pluginResourcePath+"/asserts/api-server/v1/config/disabled-alert/"+url.PathEscape(name), nil)
+	if err != nil {
+		return fmt.Errorf("kg: create request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("kg: execute request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return readError(resp)
+	}
+	return nil
+}
+
+// GetSuppressions retrieves all disabled-alert configurations for the tenant.
+func (c *Client) GetSuppressions(ctx context.Context) (*Suppressions, error) {
+	var result Suppressions
+	if err := c.getJSON(ctx, pluginResourcePath+"/asserts/api-server/v1/config/disabled-alerts", &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // UploadRelabelRules uploads relabel rules configuration.

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -642,7 +642,7 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 	var fileFlag string
 	createCmd := &cobra.Command{
 		Use:   "create",
-		Short: "Upload suppressions from a YAML file or stdin.",
+		Short: "Create or update one or more suppressions from a YAML file or stdin.",
 		Example: `  gcx kg suppressions create -f suppressions.yaml
 
   echo 'disabledAlertConfigs:
@@ -670,12 +670,13 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			for _, s := range suppressions.DisabledAlertConfigs {
+			total := len(suppressions.DisabledAlertConfigs)
+			for i, s := range suppressions.DisabledAlertConfigs {
 				if err := client.UpsertSuppression(cmd.Context(), s); err != nil {
-					return fmt.Errorf("failed to upsert suppression %q: %w", s.Name, err)
+					return fmt.Errorf("failed to upsert suppression %q (%d/%d succeeded): %w", s.Name, i, total, err)
 				}
 			}
-			cmdio.Success(cmd.OutOrStdout(), "%d suppression(s) upserted", len(suppressions.DisabledAlertConfigs))
+			cmdio.Success(cmd.OutOrStdout(), "%d suppression(s) upserted", total)
 			return nil
 		},
 	}

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -274,6 +274,13 @@ func readFileOrStdin(cmd *cobra.Command, path string) ([]byte, error) {
 	if path == "-" {
 		return io.ReadAll(cmd.InOrStdin())
 	}
+	if path == "" {
+		fi, err := os.Stdin.Stat()
+		if err != nil || (fi.Mode()&os.ModeCharDevice) != 0 {
+			return nil, fmt.Errorf("no input: use -f <file> or pipe YAML via stdin\n\n  echo 'disabledAlertConfigs:\n    - name: my-suppression\n      matchLabels:\n        alertname: ErrorRatioBreach\n        job: my-service' | gcx kg suppressions create")
+		}
+		return io.ReadAll(cmd.InOrStdin())
+	}
 	return os.ReadFile(path)
 }
 
@@ -599,20 +606,19 @@ func newModelRulesCommand(loader RESTConfigLoader) *cobra.Command {
 	//nolint:dupl
 }
 
-//nolint:dupl
 func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "suppressions",
-		Short: "Push suppressions to the Knowledge Graph.",
+		Short: "Manage alert suppressions in the Knowledge Graph.",
 	}
-	var fileFlag string
-	createCmd := &cobra.Command{
-		Use:   "create",
-		Short: "Upload suppressions from a YAML file.",
+
+	listOpts := &suppressionsListOpts{}
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all alert suppressions.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			data, err := readFileOrStdin(cmd, fileFlag)
-			if err != nil {
-				return fmt.Errorf("failed to read file: %w", err)
+			if err := listOpts.IO.Validate(); err != nil {
+				return err
 			}
 			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
 			if err != nil {
@@ -622,18 +628,111 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := client.UploadSuppressions(cmd.Context(), string(data)); err != nil {
+			suppressions, err := client.GetSuppressions(cmd.Context())
+			if err != nil {
 				return err
 			}
-			cmdio.Success(cmd.OutOrStdout(), "Suppressions uploaded")
+			return listOpts.IO.Encode(cmd.OutOrStdout(), suppressions.DisabledAlertConfigs)
+		},
+	}
+	listOpts.setup(listCmd.Flags())
+
+	var fileFlag string
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Upload suppressions from a YAML file or stdin.",
+		Example: `  gcx kg suppressions create -f suppressions.yaml
+
+  echo 'disabledAlertConfigs:
+    - name: my-suppression
+      matchLabels:
+        alertname: ErrorRatioBreach
+        job: my-service' | gcx kg suppressions create`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			data, err := readFileOrStdin(cmd, fileFlag)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+			var suppressions Suppressions
+			if err := yaml.Unmarshal(data, &suppressions); err != nil {
+				return fmt.Errorf("failed to parse suppressions file: %w", err)
+			}
+			if len(suppressions.DisabledAlertConfigs) == 0 {
+				return fmt.Errorf("no suppressions found in file")
+			}
+			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(cfg)
+			if err != nil {
+				return err
+			}
+			for _, s := range suppressions.DisabledAlertConfigs {
+				if err := client.UpsertSuppression(cmd.Context(), s); err != nil {
+					return fmt.Errorf("failed to upsert suppression %q: %w", s.Name, err)
+				}
+			}
+			cmdio.Success(cmd.OutOrStdout(), "%d suppression(s) upserted", len(suppressions.DisabledAlertConfigs))
 			return nil
 		},
 	}
-	createCmd.Flags().StringVarP(&fileFlag, "file", "f", "", "Input file (YAML)")
-	_ = createCmd.MarkFlagRequired("file")
-	cmd.AddCommand(createCmd)
-	//nolint:dupl
+	createCmd.Flags().StringVarP(&fileFlag, "file", "f", "", "Input file (YAML), or '-' for stdin. Reads from stdin if omitted.")
+
+	deleteCmd := &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete a suppression by name.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(cfg)
+			if err != nil {
+				return err
+			}
+			if err := client.DeleteSuppression(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			cmdio.Success(cmd.OutOrStdout(), "Suppression %q deleted", args[0])
+			return nil
+		},
+	}
+
+	cmd.AddCommand(listCmd, createCmd, deleteCmd)
 	return cmd
+}
+
+type suppressionsListOpts struct {
+	IO cmdio.Options
+}
+
+func (o *suppressionsListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &SuppressionTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+// SuppressionTableCodec renders suppressions as a table.
+type SuppressionTableCodec struct{}
+
+func (c *SuppressionTableCodec) Format() format.Format { return "table" }
+
+func (c *SuppressionTableCodec) Encode(w io.Writer, v any) error {
+	suppressions, ok := v.([]Suppression)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []Suppression")
+	}
+	t := style.NewTable("NAME", "MATCH LABELS")
+	for _, s := range suppressions {
+		t.Row(s.Name, scopeStr(s.MatchLabels))
+	}
+	return t.Render(w)
+}
+
+func (c *SuppressionTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
 }
 
 //nolint:dupl

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1,6 +1,7 @@
 package kg
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/deeplink"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
@@ -679,11 +681,26 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 	}
 	createCmd.Flags().StringVarP(&fileFlag, "file", "f", "", "Input file (YAML), or '-' for stdin. Reads from stdin if omitted.")
 
+	var yes bool
 	deleteCmd := &cobra.Command{
 		Use:   "delete <name>",
 		Short: "Delete a suppression by name.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if !yes {
+				cliOpts, err := config.LoadCLIOptions()
+				if err != nil {
+					return err
+				}
+				if !cliOpts.AutoApprove {
+					fmt.Fprintf(cmd.OutOrStdout(), "Delete suppression %q? [y/N] ", name)
+					scanner := bufio.NewScanner(cmd.InOrStdin())
+					if !scanner.Scan() || !strings.EqualFold(strings.TrimSpace(scanner.Text()), "y") {
+						return nil
+					}
+				}
+			}
 			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
 			if err != nil {
 				return err
@@ -692,13 +709,14 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := client.DeleteSuppression(cmd.Context(), args[0]); err != nil {
+			if err := client.DeleteSuppression(cmd.Context(), name); err != nil {
 				return err
 			}
-			cmdio.Success(cmd.OutOrStdout(), "Suppression %q deleted", args[0])
+			cmdio.Success(cmd.OutOrStdout(), "Suppression %q deleted", name)
 			return nil
 		},
 	}
+	deleteCmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
 
 	cmd.AddCommand(listCmd, createCmd, deleteCmd)
 	return cmd

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -277,7 +277,7 @@ func readFileOrStdin(cmd *cobra.Command, path string) ([]byte, error) {
 	if path == "" {
 		fi, err := os.Stdin.Stat()
 		if err != nil || (fi.Mode()&os.ModeCharDevice) != 0 {
-			return nil, errors.New("no input: use -f <file> or pipe YAML via stdin\n\n  echo 'disabledAlertConfigs:\n    - name: my-suppression\n      matchLabels:\n        alertname: ErrorRatioBreach\n        job: my-service' | gcx kg suppressions create")
+			return nil, errors.New("no input: use -f <file> or pipe YAML via stdin")
 		}
 		return io.ReadAll(cmd.InOrStdin())
 	}
@@ -651,7 +651,7 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			data, err := readFileOrStdin(cmd, fileFlag)
 			if err != nil {
-				return fmt.Errorf("failed to read file: %w", err)
+				return err
 			}
 			var suppressions Suppressions
 			if err := yaml.Unmarshal(data, &suppressions); err != nil {

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -277,7 +277,7 @@ func readFileOrStdin(cmd *cobra.Command, path string) ([]byte, error) {
 	if path == "" {
 		fi, err := os.Stdin.Stat()
 		if err != nil || (fi.Mode()&os.ModeCharDevice) != 0 {
-			return nil, fmt.Errorf("no input: use -f <file> or pipe YAML via stdin\n\n  echo 'disabledAlertConfigs:\n    - name: my-suppression\n      matchLabels:\n        alertname: ErrorRatioBreach\n        job: my-service' | gcx kg suppressions create")
+			return nil, errors.New("no input: use -f <file> or pipe YAML via stdin\n\n  echo 'disabledAlertConfigs:\n    - name: my-suppression\n      matchLabels:\n        alertname: ErrorRatioBreach\n        job: my-service' | gcx kg suppressions create")
 		}
 		return io.ReadAll(cmd.InOrStdin())
 	}
@@ -658,7 +658,7 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 				return fmt.Errorf("failed to parse suppressions file: %w", err)
 			}
 			if len(suppressions.DisabledAlertConfigs) == 0 {
-				return fmt.Errorf("no suppressions found in file")
+				return errors.New("no suppressions found in file")
 			}
 			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
 			if err != nil {


### PR DESCRIPTION
## Summary

- **Bug fix**: `gcx kg suppressions create` was using the batch endpoint (`POST /v1/config/disabled-alerts`) which fully replaces all stored suppressions — silently wiping any not included in the uploaded file. Switched to the single-item endpoint (`POST /v1/config/disabled-alert`) which the backend implements as a read-modify-write upsert, leaving unrelated suppressions untouched.
- **New**: `gcx kg suppressions list` — fetch all current suppressions (table/yaml/json output)
- **New**: `gcx kg suppressions delete <name>` — delete a single suppression by name
- **UX**: `create` now accepts input via stdin (pipe YAML directly, no temp file needed); errors immediately with a helpful example if run interactively without `-f`

## Test plan

- [x] `gcx kg suppressions list` returns existing suppressions without modifying them
- [x] `gcx kg suppressions create -f file.yaml` upserts only the named suppressions, leaves others intact
- [x] `echo '...' | gcx kg suppressions create` works via stdin
- [x] `gcx kg suppressions create` with no input errors immediately (no hang)
- [x] `gcx kg suppressions delete <name>` removes the named suppression, leaves others intact
- [x] All tests pass: `go test -race -count=1 ./...`
- [x] Linter clean: `golangci-lint run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)