### PR TITLE
fix(auth): bind OAuth callback port before opening browser

### DIFF
--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -105,29 +105,30 @@ func NewFlow(endpoint string, opts Options) *Flow {
 
 // Run executes the authentication flow.
 func (f *Flow) Run(ctx context.Context) (*Result, error) {
-	port := f.opts.Port
-	if port == 0 {
-		var err error
-		port, err = findAvailablePort(ctx, f.opts.BindAddress)
-		if err != nil {
+	listener, port, err := listenOnCallbackPort(ctx, f.opts.BindAddress, f.opts.Port)
+	if err != nil {
+		if f.opts.Port == 0 {
 			return nil, fmt.Errorf("no available port: %w", err)
 		}
+		return nil, err
 	}
 
 	state, err := generateState()
 	if err != nil {
+		_ = listener.Close()
 		return nil, fmt.Errorf("failed to generate state: %w", err)
 	}
 
 	codeVerifier, err := generateCodeVerifier()
 	if err != nil {
+		_ = listener.Close()
 		return nil, fmt.Errorf("failed to generate PKCE code verifier: %w", err)
 	}
 	codeChallenge := generateCodeChallenge(codeVerifier)
 
 	resultCh := make(chan *Result, 1)
 	errCh := make(chan error, 1)
-	server := f.startCallbackServer(ctx, f.opts.BindAddress, port, state, codeVerifier, resultCh, errCh)
+	server := f.startCallbackServer(ctx, listener, state, codeVerifier, resultCh, errCh)
 
 	defer func() { //nolint:contextcheck // intentionally use Background for graceful shutdown after ctx cancellation
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -174,7 +175,7 @@ func (f *Flow) Run(ctx context.Context) (*Result, error) {
 	}
 }
 
-func (f *Flow) startCallbackServer(ctx context.Context, bindAddress string, port int, expectedState, codeVerifier string, resultCh chan<- *Result, errCh chan<- error) *http.Server {
+func (f *Flow) startCallbackServer(ctx context.Context, listener net.Listener, expectedState, codeVerifier string, resultCh chan<- *Result, errCh chan<- error) *http.Server {
 	var once sync.Once
 
 	mux := http.NewServeMux()
@@ -256,13 +257,13 @@ func (f *Flow) startCallbackServer(ctx context.Context, bindAddress string, port
 	})
 
 	server := &http.Server{
-		Addr:              fmt.Sprintf("%s:%d", bindAddress, port),
+		Addr:              listener.Addr().String(),
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {
-		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- fmt.Errorf("callback server error: %w", err)
 		}
 	}()
@@ -382,16 +383,23 @@ func exchangeCodeForToken(ctx context.Context, endpoint, code, codeVerifier stri
 	return &result, nil
 }
 
-func findAvailablePort(ctx context.Context, bindAddress string) (int, error) {
+func listenOnCallbackPort(ctx context.Context, bindAddress string, fixedPort int) (net.Listener, int, error) {
 	var lc net.ListenConfig
+	if fixedPort != 0 {
+		listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf("%s:%d", bindAddress, fixedPort))
+		if err != nil {
+			return nil, 0, fmt.Errorf("callback port %d unavailable: %w", fixedPort, err)
+		}
+		return listener, fixedPort, nil
+	}
+
 	for port := 54321; port < 54400; port++ {
 		listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf("%s:%d", bindAddress, port))
 		if err == nil {
-			_ = listener.Close()
-			return port, nil
+			return listener, port, nil
 		}
 	}
-	return 0, errors.New("no available port in range 54321-54399")
+	return nil, 0, errors.New("no available port in range 54321-54399")
 }
 
 func generateState() (string, error) {

--- a/internal/auth/flow_test.go
+++ b/internal/auth/flow_test.go
@@ -1,7 +1,13 @@
 package auth_test
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/gcx/internal/auth"
 )
@@ -42,5 +48,39 @@ func TestValidateEndpointURL_RejectsUntrustedDomains(t *testing.T) {
 				t.Fatalf("expected %q to be rejected", tt.endpoint)
 			}
 		})
+	}
+}
+
+func TestFlowRun_FailsBeforeBrowserOutputWhenFixedPortUnavailable(t *testing.T) {
+	var lc net.ListenConfig
+	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve callback port: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatal("expected *net.TCPAddr from listener")
+	}
+	port := tcpAddr.Port
+	var writer bytes.Buffer
+	flow := auth.NewFlow("https://mystack.grafana.net", auth.Options{
+		Port:   port,
+		Writer: &writer,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err = flow.Run(ctx)
+	if err == nil {
+		t.Fatal("expected fixed callback port conflict to fail")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("callback port %d unavailable", port)) {
+		t.Fatalf("expected unavailable port error for %d, got %v", port, err)
+	}
+	if writer.Len() != 0 {
+		t.Fatalf("expected no browser instructions before bind failure, got %q", writer.String())
 	}
 }


### PR DESCRIPTION
## Summary
- Bind the OAuth callback listener synchronously before printing browser instructions or opening the auth URL.
- Reuse the already-bound listener for the callback server, avoiding the auto-pick probe/rebind race.
- Add regression coverage for occupied fixed callback ports failing before browser output.

Follow up of https://github.com/grafana/gcx/pull/612

## Test plan
- [x] `GOFLAGS=-mod=readonly go test ./internal/auth/...`


Made with [Cursor](https://cursor.com)