### PR TITLE
feat(aio11y): add saved-conversations and collections commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ internal/
 │   ├── metrics/    Metrics signal provider (Prometheus queries + Adaptive Metrics commands)
 │   ├── appo11y/    App Observability provider (overrides, settings — singleton resources)
 │   ├── profiles/   Profiles signal provider (Pyroscope queries + adaptive stub)
-│   ├── aio11y/     AI Observability provider (conversations, agents, generations, evaluators, rules, templates, scores, judge — via grafana-sigil-app plugin API)
+│   ├── aio11y/     AI Observability provider (conversations, agents, generations, evaluators, rules, templates, scores, judge, saved-conversations, collections — via grafana-sigil-app plugin API)
 │   ├── slo/        SLO provider (definitions, reports)
 │   ├── synth/      Synthetic Monitoring provider (checks, probes)
 │   └── traces/     Traces signal provider (Tempo queries + Adaptive Traces commands)

--- a/docs/reference/cli/gcx_aio11y.md
+++ b/docs/reference/cli/gcx_aio11y.md
@@ -24,11 +24,13 @@ Manage Grafana AI Observability resources
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx aio11y agents](gcx_aio11y_agents.md)	 - Query AI Observability agent catalog.
+* [gcx aio11y collections](gcx_aio11y_collections.md)	 - Manage named groups of saved conversations.
 * [gcx aio11y conversations](gcx_aio11y_conversations.md)	 - Query AI Observability conversations.
 * [gcx aio11y evaluators](gcx_aio11y_evaluators.md)	 - Manage evaluator definitions (LLM judge, regex, heuristic).
 * [gcx aio11y generations](gcx_aio11y_generations.md)	 - Inspect individual LLM generations.
 * [gcx aio11y judge](gcx_aio11y_judge.md)	 - List LLM providers and models available for LLM-judge evaluators.
 * [gcx aio11y rules](gcx_aio11y_rules.md)	 - Manage rules that route generations to evaluators.
+* [gcx aio11y saved-conversations](gcx_aio11y_saved-conversations.md)	 - Bookmark live conversations as fixed inputs for evaluation runs.
 * [gcx aio11y scores](gcx_aio11y_scores.md)	 - View evaluation scores for generations.
 * [gcx aio11y templates](gcx_aio11y_templates.md)	 - Browse reusable evaluator blueprints (global and tenant-scoped).
 

--- a/docs/reference/cli/gcx_aio11y_collections.md
+++ b/docs/reference/cli/gcx_aio11y_collections.md
@@ -1,0 +1,32 @@
+## gcx aio11y collections
+
+Manage named groups of saved conversations.
+
+### Options
+
+```
+  -h, --help   help for collections
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y](gcx_aio11y.md)	 - Manage Grafana AI Observability resources
+* [gcx aio11y collections conversations](gcx_aio11y_collections_conversations.md)	 - Manage saved conversations belonging to a collection.
+* [gcx aio11y collections create](gcx_aio11y_collections_create.md)	 - Create a new collection.
+* [gcx aio11y collections delete](gcx_aio11y_collections_delete.md)	 - Delete collections.
+* [gcx aio11y collections get](gcx_aio11y_collections_get.md)	 - Get a single collection.
+* [gcx aio11y collections list](gcx_aio11y_collections_list.md)	 - List collections.
+* [gcx aio11y collections update](gcx_aio11y_collections_update.md)	 - Patch a collection's name and/or description.
+

--- a/docs/reference/cli/gcx_aio11y_collections_conversations.md
+++ b/docs/reference/cli/gcx_aio11y_collections_conversations.md
@@ -1,0 +1,29 @@
+## gcx aio11y collections conversations
+
+Manage saved conversations belonging to a collection.
+
+### Options
+
+```
+  -h, --help   help for conversations
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y collections](gcx_aio11y_collections.md)	 - Manage named groups of saved conversations.
+* [gcx aio11y collections conversations add](gcx_aio11y_collections_conversations_add.md)	 - Add one or more saved conversations to a collection.
+* [gcx aio11y collections conversations list](gcx_aio11y_collections_conversations_list.md)	 - List saved conversations belonging to a collection.
+* [gcx aio11y collections conversations remove](gcx_aio11y_collections_conversations_remove.md)	 - Remove a single saved conversation from a collection.
+

--- a/docs/reference/cli/gcx_aio11y_collections_conversations_add.md
+++ b/docs/reference/cli/gcx_aio11y_collections_conversations_add.md
@@ -1,0 +1,30 @@
+## gcx aio11y collections conversations add
+
+Add one or more saved conversations to a collection.
+
+```
+gcx aio11y collections conversations add <collection-id> <saved-id>... [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for add
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y collections conversations](gcx_aio11y_collections_conversations.md)	 - Manage saved conversations belonging to a collection.
+

--- a/docs/reference/cli/gcx_aio11y_collections_conversations_list.md
+++ b/docs/reference/cli/gcx_aio11y_collections_conversations_list.md
@@ -1,0 +1,33 @@
+## gcx aio11y collections conversations list
+
+List saved conversations belonging to a collection.
+
+```
+gcx aio11y collections conversations list <collection-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of saved conversations to return (0 for no limit) (default 50)
+  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y collections conversations](gcx_aio11y_collections_conversations.md)	 - Manage saved conversations belonging to a collection.
+

--- a/docs/reference/cli/gcx_aio11y_collections_conversations_remove.md
+++ b/docs/reference/cli/gcx_aio11y_collections_conversations_remove.md
@@ -1,0 +1,30 @@
+## gcx aio11y collections conversations remove
+
+Remove a single saved conversation from a collection.
+
+```
+gcx aio11y collections conversations remove <collection-id> <saved-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y collections conversations](gcx_aio11y_collections_conversations.md)	 - Manage saved conversations belonging to a collection.
+

--- a/docs/reference/cli/gcx_aio11y_collections_create.md
+++ b/docs/reference/cli/gcx_aio11y_collections_create.md
@@ -1,0 +1,45 @@
+## gcx aio11y collections create
+
+Create a new collection.
+
+```
+gcx aio11y collections create [flags]
+```
+
+### Examples
+
+```
+  # Create with inline flags.
+  gcx aio11y collections create --name "Regression suite" --description "Nightly regression"
+
+  # Create from a YAML file (either raw {name,description} or a typed resource envelope).
+  gcx aio11y collections create -f collection.yaml
+```
+
+### Options
+
+```
+      --description string   Collection description
+  -f, --filename string      File containing the collection create payload (use - for stdin)
+  -h, --help                 help for create
+      --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --name string          Collection name (required if --filename is not given)
+  -o, --output string        Output format. One of: json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y collections](gcx_aio11y_collections.md)	 - Manage named groups of saved conversations.
+

--- a/docs/reference/cli/gcx_aio11y_collections_delete.md
+++ b/docs/reference/cli/gcx_aio11y_collections_delete.md
@@ -1,0 +1,31 @@
+## gcx aio11y collections delete
+
+Delete collections.
+
+```
+gcx aio11y collections delete COLLECTION-ID... [flags]
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y collections](gcx_aio11y_collections.md)	 - Manage named groups of saved conversations.
+

--- a/docs/reference/cli/gcx_aio11y_collections_get.md
+++ b/docs/reference/cli/gcx_aio11y_collections_get.md
@@ -1,0 +1,32 @@
+## gcx aio11y collections get
+
+Get a single collection.
+
+```
+gcx aio11y collections get <collection-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, yaml (default "yaml")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y collections](gcx_aio11y_collections.md)	 - Manage named groups of saved conversations.
+

--- a/docs/reference/cli/gcx_aio11y_collections_list.md
+++ b/docs/reference/cli/gcx_aio11y_collections_list.md
@@ -1,0 +1,33 @@
+## gcx aio11y collections list
+
+List collections.
+
+```
+gcx aio11y collections list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of collections to return (0 for no limit) (default 50)
+  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y collections](gcx_aio11y_collections.md)	 - Manage named groups of saved conversations.
+

--- a/docs/reference/cli/gcx_aio11y_collections_update.md
+++ b/docs/reference/cli/gcx_aio11y_collections_update.md
@@ -1,0 +1,34 @@
+## gcx aio11y collections update
+
+Patch a collection's name and/or description.
+
+```
+gcx aio11y collections update <collection-id> [flags]
+```
+
+### Options
+
+```
+      --description string   New collection description
+  -h, --help                 help for update
+      --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --name string          New collection name
+  -o, --output string        Output format. One of: json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y collections](gcx_aio11y_collections.md)	 - Manage named groups of saved conversations.
+

--- a/docs/reference/cli/gcx_aio11y_saved-conversations.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations.md
@@ -1,0 +1,31 @@
+## gcx aio11y saved-conversations
+
+Bookmark live conversations as fixed inputs for evaluation runs.
+
+### Options
+
+```
+  -h, --help   help for saved-conversations
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y](gcx_aio11y.md)	 - Manage Grafana AI Observability resources
+* [gcx aio11y saved-conversations collections](gcx_aio11y_saved-conversations_collections.md)	 - List collections that contain a saved conversation.
+* [gcx aio11y saved-conversations delete](gcx_aio11y_saved-conversations_delete.md)	 - Delete saved conversations.
+* [gcx aio11y saved-conversations get](gcx_aio11y_saved-conversations_get.md)	 - Get a single saved conversation.
+* [gcx aio11y saved-conversations list](gcx_aio11y_saved-conversations_list.md)	 - List saved conversations.
+* [gcx aio11y saved-conversations save](gcx_aio11y_saved-conversations_save.md)	 - Bookmark an existing live conversation as a saved conversation.
+

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_collections.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_collections.md
@@ -1,0 +1,32 @@
+## gcx aio11y saved-conversations collections
+
+List collections that contain a saved conversation.
+
+```
+gcx aio11y saved-conversations collections <saved-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for collections
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y saved-conversations](gcx_aio11y_saved-conversations.md)	 - Bookmark live conversations as fixed inputs for evaluation runs.
+

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_delete.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_delete.md
@@ -1,0 +1,31 @@
+## gcx aio11y saved-conversations delete
+
+Delete saved conversations.
+
+```
+gcx aio11y saved-conversations delete SAVED-ID... [flags]
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y saved-conversations](gcx_aio11y_saved-conversations.md)	 - Bookmark live conversations as fixed inputs for evaluation runs.
+

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_get.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_get.md
@@ -1,0 +1,32 @@
+## gcx aio11y saved-conversations get
+
+Get a single saved conversation.
+
+```
+gcx aio11y saved-conversations get <saved-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, yaml (default "yaml")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y saved-conversations](gcx_aio11y_saved-conversations.md)	 - Bookmark live conversations as fixed inputs for evaluation runs.
+

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_list.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_list.md
@@ -1,0 +1,34 @@
+## gcx aio11y saved-conversations list
+
+List saved conversations.
+
+```
+gcx aio11y saved-conversations list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of saved conversations to return (0 for no limit) (default 50)
+  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+      --source string   Filter by source (telemetry or manual)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y saved-conversations](gcx_aio11y_saved-conversations.md)	 - Bookmark live conversations as fixed inputs for evaluation runs.
+

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_save.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_save.md
@@ -1,0 +1,51 @@
+## gcx aio11y saved-conversations save
+
+Bookmark an existing live conversation as a saved conversation.
+
+### Synopsis
+
+Bookmark a live conversation surfaced by gcx aio11y conversations.
+By default the bookmark ID is derived as saved-<conversation-id>, matching the
+plugin UI; pass --saved-id to override.
+
+```
+gcx aio11y saved-conversations save <conversation-id> [flags]
+```
+
+### Examples
+
+```
+  # Bookmark with the default saved ID.
+  gcx aio11y saved-conversations save conv-123 --name "Regression seed"
+
+  # Bookmark with tags.
+  gcx aio11y saved-conversations save conv-123 --name "Regression seed" --tag suite=checkout --tag priority=high
+```
+
+### Options
+
+```
+  -h, --help              help for save
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --name string       Human-readable name for the bookmark (required)
+  -o, --output string     Output format. One of: json, yaml (default "json")
+      --saved-id string   Bookmark ID; defaults to saved-<conversation-id>
+      --tag stringArray   Tag in key=value form (repeatable)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y saved-conversations](gcx_aio11y_saved-conversations.md)	 - Bookmark live conversations as fixed inputs for evaluation runs.
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -372,6 +372,21 @@ var commandAnnotations = map[string]annotation{
 	"gcx aio11y templates list":     {Cost: "small"},
 	"gcx aio11y templates versions": {Cost: "small"},
 
+	"gcx aio11y saved-conversations list":        {Cost: "small"},
+	"gcx aio11y saved-conversations get":         {Cost: "medium", Hint: "<saved-id> -o json"},
+	"gcx aio11y saved-conversations save":        {Cost: "small"},
+	"gcx aio11y saved-conversations delete":      {Cost: "small"},
+	"gcx aio11y saved-conversations collections": {Cost: "small"},
+
+	"gcx aio11y collections list":                 {Cost: "small"},
+	"gcx aio11y collections get":                  {Cost: "small"},
+	"gcx aio11y collections create":               {Cost: "small"},
+	"gcx aio11y collections update":               {Cost: "small"},
+	"gcx aio11y collections delete":               {Cost: "small"},
+	"gcx aio11y collections conversations list":   {Cost: "small"},
+	"gcx aio11y collections conversations add":    {Cost: "small"},
+	"gcx aio11y collections conversations remove": {Cost: "small"},
+
 	// -----------------------------------------------------------------------
 	// SLO provider
 	// -----------------------------------------------------------------------

--- a/internal/providers/aio11y/eval/collections/client.go
+++ b/internal/providers/aio11y/eval/collections/client.go
@@ -1,0 +1,164 @@
+package collections
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/savedconversations"
+)
+
+const basePath = "/eval/collections"
+
+// ErrNotFound is returned by Get when the server responds with 404.
+var ErrNotFound = errors.New("collection not found")
+
+type Client struct {
+	base *aio11yhttp.Client
+}
+
+// NewClient creates a new collection client.
+func NewClient(base *aio11yhttp.Client) *Client {
+	return &Client{base: base}
+}
+
+// List returns collections, paginated. Pass 0 for no limit.
+func (c *Client) List(ctx context.Context, limit int) ([]Collection, error) {
+	return aio11yhttp.ListAll[Collection](ctx, c.base, basePath, nil, limit)
+}
+
+// Get returns a single collection by ID. Returns ErrNotFound on HTTP 404 so
+// callers (and the resource adapter) can distinguish missing resources from
+// other API errors.
+func (c *Client) Get(ctx context.Context, id string) (*Collection, error) {
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, basePath+"/"+url.PathEscape(id), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get collection %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%s: %w", id, ErrNotFound)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, aio11yhttp.HandleErrorResponse(resp)
+	}
+
+	var col Collection
+	if err := json.NewDecoder(resp.Body).Decode(&col); err != nil {
+		return nil, fmt.Errorf("failed to decode collection response: %w", err)
+	}
+	return &col, nil
+}
+
+// Create creates a new collection. Server-managed fields on the input are
+// dropped on the wire by the `omitempty` / `omitzero` JSON tags.
+func (c *Client) Create(ctx context.Context, col *Collection) (*Collection, error) {
+	body, err := json.Marshal(col)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal create request: %w", err)
+	}
+
+	resp, err := c.base.DoRequest(ctx, http.MethodPost, basePath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create collection: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, aio11yhttp.HandleErrorResponse(resp)
+	}
+
+	var created Collection
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		return nil, fmt.Errorf("failed to decode collection response: %w", err)
+	}
+	return &created, nil
+}
+
+// Update patches a collection's name and/or description. The collections API
+// is not an upsert — Update must be called against an existing collection.
+func (c *Client) Update(ctx context.Context, id string, req *UpdateRequest) (*Collection, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal update request: %w", err)
+	}
+
+	resp, err := c.base.DoRequest(ctx, http.MethodPatch, basePath+"/"+url.PathEscape(id), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to update collection %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, aio11yhttp.HandleErrorResponse(resp)
+	}
+
+	var col Collection
+	if err := json.NewDecoder(resp.Body).Decode(&col); err != nil {
+		return nil, fmt.Errorf("failed to decode collection response: %w", err)
+	}
+	return &col, nil
+}
+
+// Delete removes a collection by ID.
+func (c *Client) Delete(ctx context.Context, id string) error {
+	resp, err := c.base.DoRequest(ctx, http.MethodDelete, basePath+"/"+url.PathEscape(id), nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete collection %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return aio11yhttp.HandleErrorResponse(resp)
+	}
+	return nil
+}
+
+// ListMembers returns the saved conversations belonging to a collection.
+// The CLI surface calls these "conversations", but the HTTP path remains
+// `/members` upstream.
+func (c *Client) ListMembers(ctx context.Context, id string, limit int) ([]savedconversations.SavedConversation, error) {
+	path := basePath + "/" + url.PathEscape(id) + "/members"
+	return aio11yhttp.ListAll[savedconversations.SavedConversation](ctx, c.base, path, nil, limit)
+}
+
+// AddMembers adds one or more saved conversations to a collection.
+func (c *Client) AddMembers(ctx context.Context, id string, savedIDs []string) error {
+	body, err := json.Marshal(&AddMembersRequest{SavedIDs: savedIDs})
+	if err != nil {
+		return fmt.Errorf("failed to marshal add-members request: %w", err)
+	}
+
+	path := basePath + "/" + url.PathEscape(id) + "/members"
+	resp, err := c.base.DoRequest(ctx, http.MethodPost, path, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to add members to collection %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
+		return aio11yhttp.HandleErrorResponse(resp)
+	}
+	return nil
+}
+
+// RemoveMember removes a single saved conversation from a collection.
+func (c *Client) RemoveMember(ctx context.Context, id, savedID string) error {
+	path := basePath + "/" + url.PathEscape(id) + "/members/" + url.PathEscape(savedID)
+	resp, err := c.base.DoRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to remove member %s from collection %s: %w", savedID, id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return aio11yhttp.HandleErrorResponse(resp)
+	}
+	return nil
+}

--- a/internal/providers/aio11y/eval/collections/client_test.go
+++ b/internal/providers/aio11y/eval/collections/client_test.go
@@ -1,0 +1,255 @@
+package collections_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/collections"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/savedconversations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func writeJSON(w http.ResponseWriter, v any) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func newTestClient(t *testing.T, handler http.Handler) *collections.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: srv.URL},
+		Namespace: "default",
+	}
+	base, err := aio11yhttp.NewClient(cfg)
+	require.NoError(t, err)
+	return collections.NewClient(base)
+}
+
+func TestClient_List(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/collections")
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{
+			"items": []collections.Collection{
+				{CollectionID: "c-1", Name: "Regression"},
+				{CollectionID: "c-2", Name: "Smoke"},
+			},
+		})
+	}))
+
+	items, err := client.List(context.Background(), 0)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, "c-1", items[0].CollectionID)
+}
+
+func TestClient_Get(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/collections/c-1")
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, collections.Collection{
+			CollectionID: "c-1",
+			Name:         "Regression",
+			Description:  "Nightly run",
+			MemberCount:  2,
+			CreatedAt:    time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		})
+	}))
+
+	col, err := client.Get(context.Background(), "c-1")
+	require.NoError(t, err)
+	assert.Equal(t, "c-1", col.CollectionID)
+	assert.Equal(t, "Nightly run", col.Description)
+	assert.Equal(t, 2, col.MemberCount)
+}
+
+func TestClient_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+
+	_, err := client.Get(context.Background(), "missing")
+	require.Error(t, err)
+	require.ErrorIs(t, err, collections.ErrNotFound)
+}
+
+func TestClient_Create(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/collections", r.URL.Path)
+
+		body, _ := io.ReadAll(r.Body)
+		var raw map[string]any
+		assert.NoError(t, json.Unmarshal(body, &raw))
+		assert.Equal(t, "Regression", raw["name"])
+
+		w.WriteHeader(http.StatusOK)
+		writeJSON(w, collections.Collection{
+			CollectionID: "c-99",
+			Name:         "Regression",
+			Description:  "Nightly",
+		})
+	}))
+
+	col, err := client.Create(context.Background(), &collections.Collection{
+		Name:        "Regression",
+		Description: "Nightly",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "c-99", col.CollectionID)
+}
+
+func TestClient_Update_PATCH(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/collections/c-1")
+
+		body, _ := io.ReadAll(r.Body)
+		var raw map[string]any
+		assert.NoError(t, json.Unmarshal(body, &raw))
+		assert.Equal(t, "renamed", raw["name"])
+		_, hasDescription := raw["description"]
+		assert.False(t, hasDescription, "description must be omitted when not set")
+		_, hasUpdatedBy := raw["updated_by"]
+		assert.False(t, hasUpdatedBy, "updated_by must not be sent by gcx")
+
+		w.WriteHeader(http.StatusOK)
+		writeJSON(w, collections.Collection{CollectionID: "c-1", Name: "renamed"})
+	}))
+
+	name := "renamed"
+	col, err := client.Update(context.Background(), "c-1", &collections.UpdateRequest{Name: &name})
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", col.Name)
+}
+
+func TestClient_Delete(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/collections/c-1")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	require.NoError(t, client.Delete(context.Background(), "c-1"))
+}
+
+func TestClient_ListMembers(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/collections/c-1/members")
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{
+			"items": []savedconversations.SavedConversation{
+				{SavedID: "saved-1", Name: "first", ConversationID: "conv-1", Source: "telemetry"},
+				{SavedID: "saved-2", Name: "second", ConversationID: "conv-2", Source: "manual"},
+			},
+		})
+	}))
+
+	items, err := client.ListMembers(context.Background(), "c-1", 0)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, "saved-1", items[0].SavedID)
+}
+
+func TestClient_AddMembers(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/collections/c-1/members")
+
+		body, _ := io.ReadAll(r.Body)
+		var raw map[string]any
+		assert.NoError(t, json.Unmarshal(body, &raw))
+
+		ids, ok := raw["saved_ids"].([]any)
+		assert.True(t, ok)
+		if ok {
+			assert.Equal(t, "saved-1", ids[0])
+			assert.Equal(t, "saved-2", ids[1])
+		}
+
+		_, hasAddedBy := raw["added_by"]
+		assert.False(t, hasAddedBy, "added_by must not be sent by gcx")
+
+		w.WriteHeader(http.StatusOK)
+		writeJSON(w, map[string]string{"status": "ok"})
+	}))
+
+	require.NoError(t, client.AddMembers(context.Background(), "c-1", []string{"saved-1", "saved-2"}))
+}
+
+func TestClient_RemoveMember(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/collections/c-1/members/saved-1")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	require.NoError(t, client.RemoveMember(context.Background(), "c-1", "saved-1"))
+}
+
+func TestStaticDescriptor(t *testing.T) {
+	d := collections.StaticDescriptor()
+	assert.Equal(t, "sigil.ext.grafana.app", d.GroupVersion.Group)
+	assert.Equal(t, "v1alpha1", d.GroupVersion.Version)
+	assert.Equal(t, "Collection", d.Kind)
+	assert.Equal(t, "collections", d.Plural)
+}
+
+func TestCollectionSchema_NotEmpty(t *testing.T) {
+	schema := collections.CollectionSchema()
+	require.NotEmpty(t, schema)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(schema, &raw))
+}
+
+func TestSpecToUnstructured_StripsServerFields(t *testing.T) {
+	col := collections.Collection{
+		CollectionID: "c-1",
+		TenantID:     "tenant-1",
+		Name:         "Regression",
+		Description:  "Nightly run",
+		CreatedBy:    "alice",
+		UpdatedBy:    "bob",
+		MemberCount:  5,
+		CreatedAt:    time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:    time.Date(2026, 4, 2, 10, 0, 0, 0, time.UTC),
+	}
+
+	u, err := collections.SpecToUnstructured(col, "default")
+	require.NoError(t, err)
+
+	meta, ok := u.Object["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "c-1", meta["name"])
+	assert.Equal(t, "default", meta["namespace"])
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Regression", spec["name"])
+	assert.Equal(t, "Nightly run", spec["description"])
+
+	for _, f := range []string{"collection_id", "tenant_id", "created_by", "updated_by", "created_at", "updated_at", "member_count"} {
+		_, has := spec[f]
+		assert.False(t, has, "spec must not contain server-managed field %q", f)
+	}
+}

--- a/internal/providers/aio11y/eval/collections/commands.go
+++ b/internal/providers/aio11y/eval/collections/commands.go
@@ -1,0 +1,517 @@
+package collections
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/savedconversations"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func newClient(cmd *cobra.Command, loader *providers.ConfigLoader) (*Client, error) {
+	base, err := aio11yhttp.NewClientFromCommand(cmd, loader)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(base), nil
+}
+
+// Commands returns the collections command group.
+func Commands(loader *providers.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "collections",
+		Short: "Manage named groups of saved conversations.",
+	}
+	cmd.AddCommand(
+		newListCommand(),
+		newGetCommand(),
+		newCreateCommand(),
+		newUpdateCommand(loader),
+		newDeleteCommand(),
+		newConversationsCommand(loader),
+	)
+	return cmd
+}
+
+// --- list ---
+
+type listOpts struct {
+	IO    cmdio.Options
+	Limit int64
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &TableCodec{})
+	o.IO.RegisterCustomCodec("wide", &TableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of collections to return (0 for no limit)")
+}
+
+func newListCommand() *cobra.Command {
+	opts := &listOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List collections.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx)
+			if err != nil {
+				return err
+			}
+
+			typedObjs, err := crud.List(ctx, opts.Limit)
+			if err != nil {
+				return err
+			}
+
+			specs := make([]Collection, len(typedObjs))
+			for i := range typedObjs {
+				specs[i] = typedObjs[i].Spec
+			}
+
+			if opts.IO.OutputFormat == "table" || opts.IO.OutputFormat == "wide" {
+				return opts.IO.Encode(cmd.OutOrStdout(), specs)
+			}
+
+			objs := make([]unstructured.Unstructured, 0, len(specs))
+			for _, spec := range specs {
+				u, err := crud.ToUnstructured(spec)
+				if err != nil {
+					return err
+				}
+				objs = append(objs, u)
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), objs)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- get ---
+
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("yaml")
+	o.IO.BindFlags(flags)
+}
+
+func newGetCommand() *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:   "get <collection-id>",
+		Short: "Get a single collection.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx)
+			if err != nil {
+				return err
+			}
+
+			typedObj, err := crud.Get(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			u, err := crud.ToUnstructured(typedObj.Spec)
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), &u)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- create ---
+
+type createOpts struct {
+	IO          cmdio.Options
+	File        string
+	Name        string
+	Description string
+}
+
+func (o *createOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+	flags.StringVarP(&o.File, "filename", "f", "", "File containing the collection create payload (use - for stdin)")
+	flags.StringVar(&o.Name, "name", "", "Collection name (required if --filename is not given)")
+	flags.StringVar(&o.Description, "description", "", "Collection description")
+}
+
+func (o *createOpts) Validate() error {
+	if o.File == "" && strings.TrimSpace(o.Name) == "" {
+		return errors.New("either --filename/-f or --name is required")
+	}
+	if o.File != "" && (o.Name != "" || o.Description != "") {
+		return errors.New("--filename/-f is mutually exclusive with --name and --description")
+	}
+	return o.IO.Validate()
+}
+
+// readCollectionFile reads a Collection from a JSON or YAML file. For
+// envelope-shaped YAMLs use `gcx resources push`.
+func readCollectionFile(path string, stdin io.Reader) (*Collection, error) {
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var col Collection
+	if err := json.Unmarshal(data, &col); err != nil {
+		var yamlCol Collection
+		if yamlErr := yaml.Unmarshal(data, &yamlCol); yamlErr != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, yamlErr)
+		}
+		col = yamlCol
+	}
+	if strings.TrimSpace(col.Name) == "" {
+		return nil, fmt.Errorf("parsing %s: name is required", path)
+	}
+	return &col, nil
+}
+
+func newCreateCommand() *cobra.Command {
+	opts := &createOpts{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new collection.",
+		Example: `  # Create with inline flags.
+  gcx aio11y collections create --name "Regression suite" --description "Nightly regression"
+
+  # Create from a YAML file (either raw {name,description} or a typed resource envelope).
+  gcx aio11y collections create -f collection.yaml`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			var spec Collection
+			if opts.File != "" {
+				col, err := readCollectionFile(opts.File, cmd.InOrStdin())
+				if err != nil {
+					return err
+				}
+				spec = *col
+			} else {
+				spec = Collection{Name: opts.Name, Description: opts.Description}
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx)
+			if err != nil {
+				return err
+			}
+
+			created, err := crud.Create(ctx, &adapter.TypedObject[Collection]{Spec: spec})
+			if err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.ErrOrStderr(), "Collection %s created", created.Spec.CollectionID)
+			return opts.IO.Encode(cmd.OutOrStdout(), created.Spec)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- update ---
+
+type updateOpts struct {
+	IO          cmdio.Options
+	Name        string
+	Description string
+}
+
+func (o *updateOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Name, "name", "", "New collection name")
+	flags.StringVar(&o.Description, "description", "", "New collection description")
+}
+
+// newUpdateCommand sends a true partial PATCH; TypedCRUD's full-spec UpdateFn
+// cannot express field-presence semantics, so the request goes through the
+// underlying Client. The response is rendered via TypedCRUD.ToUnstructured so
+// JSON/YAML output matches `gcx resources get`.
+func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &updateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update <collection-id>",
+		Short: "Patch a collection's name and/or description.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			req := &UpdateRequest{}
+			if cmd.Flags().Changed("name") {
+				name := opts.Name
+				req.Name = &name
+			}
+			if cmd.Flags().Changed("description") {
+				desc := opts.Description
+				req.Description = &desc
+			}
+			if req.Name == nil && req.Description == nil {
+				return errors.New("at least one of --name or --description is required")
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx)
+			if err != nil {
+				return err
+			}
+
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			updated, err := client.Update(ctx, args[0], req)
+			if err != nil {
+				return err
+			}
+			cmdio.Success(cmd.ErrOrStderr(), "Collection %s updated", updated.CollectionID)
+
+			u, err := crud.ToUnstructured(*updated)
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), &u)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- delete ---
+
+type deleteOpts struct {
+	Force bool
+}
+
+func (o *deleteOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
+}
+
+func newDeleteCommand() *cobra.Command {
+	opts := &deleteOpts{}
+	cmd := &cobra.Command{
+		Use:   "delete COLLECTION-ID...",
+		Short: "Delete collections.",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !opts.Force {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Delete %d collection(s)? [y/N] ", len(args))
+				reader := bufio.NewReader(cmd.InOrStdin())
+				answer, err := reader.ReadString('\n')
+				if err != nil {
+					return fmt.Errorf("reading confirmation: %w", err)
+				}
+				answer = strings.TrimSpace(strings.ToLower(answer))
+				if answer != "y" && answer != "yes" {
+					cmdio.Info(cmd.ErrOrStderr(), "Aborted.")
+					return nil
+				}
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx)
+			if err != nil {
+				return err
+			}
+
+			for _, id := range args {
+				if err := crud.Delete(ctx, id); err != nil {
+					return fmt.Errorf("deleting collection %s: %w", id, err)
+				}
+				cmdio.Success(cmd.ErrOrStderr(), "Deleted collection %s", id)
+			}
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- conversations subgroup ---
+
+func newConversationsCommand(loader *providers.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "conversations",
+		Short: "Manage saved conversations belonging to a collection.",
+	}
+	cmd.AddCommand(
+		newConversationsListCommand(loader),
+		newConversationsAddCommand(loader),
+		newConversationsRemoveCommand(loader),
+	)
+	return cmd
+}
+
+type membersListOpts struct {
+	IO    cmdio.Options
+	Limit int64
+}
+
+func (o *membersListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &savedconversations.TableCodec{})
+	o.IO.RegisterCustomCodec("wide", &savedconversations.TableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of saved conversations to return (0 for no limit)")
+}
+
+func newConversationsListCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &membersListOpts{}
+	cmd := &cobra.Command{
+		Use:   "list <collection-id>",
+		Short: "List saved conversations belonging to a collection.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			items, err := client.ListMembers(cmd.Context(), args[0], int(opts.Limit))
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), items)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func newConversationsAddCommand(loader *providers.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add <collection-id> <saved-id>...",
+		Short: "Add one or more saved conversations to a collection.",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			collectionID := args[0]
+			savedIDs := args[1:]
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			if err := client.AddMembers(cmd.Context(), collectionID, savedIDs); err != nil {
+				return err
+			}
+			cmdio.Success(cmd.ErrOrStderr(), "Added %d conversation(s) to collection %s", len(savedIDs), collectionID)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newConversationsRemoveCommand(loader *providers.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <collection-id> <saved-id>",
+		Short: "Remove a single saved conversation from a collection.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			collectionID := args[0]
+			savedID := args[1]
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			if err := client.RemoveMember(cmd.Context(), collectionID, savedID); err != nil {
+				return err
+			}
+			cmdio.Success(cmd.ErrOrStderr(), "Removed %s from collection %s", savedID, collectionID)
+			return nil
+		},
+	}
+	return cmd
+}
+
+// --- table codecs ---
+
+// TableCodec renders []Collection rows.
+type TableCodec struct {
+	Wide bool
+}
+
+func (c *TableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *TableCodec) Encode(w io.Writer, v any) error {
+	items, ok := v.([]Collection)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []Collection")
+	}
+
+	var t *style.TableBuilder
+	if c.Wide {
+		t = style.NewTable("ID", "NAME", "MEMBERS", "DESCRIPTION", "CREATED BY", "CREATED AT", "UPDATED AT")
+	} else {
+		t = style.NewTable("ID", "NAME", "MEMBERS", "DESCRIPTION")
+	}
+
+	for _, col := range items {
+		desc := aio11yhttp.Truncate(col.Description, 40)
+		members := strconv.Itoa(col.MemberCount)
+		if c.Wide {
+			createdBy := col.CreatedBy
+			if createdBy == "" {
+				createdBy = "-"
+			}
+			t.Row(col.CollectionID, col.Name, members, desc, createdBy, aio11yhttp.FormatTime(col.CreatedAt), aio11yhttp.FormatTime(col.UpdatedAt))
+		} else {
+			t.Row(col.CollectionID, col.Name, members, desc)
+		}
+	}
+	return t.Render(w)
+}
+
+func (c *TableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}

--- a/internal/providers/aio11y/eval/collections/commands_test.go
+++ b/internal/providers/aio11y/eval/collections/commands_test.go
@@ -1,0 +1,147 @@
+package collections_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/collections"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableCodec_Encode(t *testing.T) {
+	items := []collections.Collection{
+		{
+			CollectionID: "c-1", Name: "Regression", Description: "Nightly", MemberCount: 4,
+			CreatedBy: "alice", CreatedAt: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		},
+		{CollectionID: "c-2", Name: "Smoke"},
+	}
+
+	tests := []struct {
+		name string
+		wide bool
+		want []string
+	}{
+		{
+			name: "table format",
+			wide: false,
+			want: []string{"ID", "NAME", "MEMBERS", "DESCRIPTION", "c-1", "Regression"},
+		},
+		{
+			name: "wide adds CREATED BY",
+			wide: true,
+			want: []string{"CREATED BY", "alice", "2026-04-01 10:00"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			codec := &collections.TableCodec{Wide: tc.wide}
+			var buf bytes.Buffer
+			require.NoError(t, codec.Encode(&buf, items))
+			out := buf.String()
+			for _, s := range tc.want {
+				assert.Contains(t, out, s)
+			}
+		})
+	}
+}
+
+func TestTableCodec_WrongType(t *testing.T) {
+	codec := &collections.TableCodec{}
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, "not-a-slice")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected []Collection")
+}
+
+func TestTableCodec_Format(t *testing.T) {
+	assert.Equal(t, "table", string((&collections.TableCodec{}).Format()))
+	assert.Equal(t, "wide", string((&collections.TableCodec{Wide: true}).Format()))
+}
+
+func TestCommands_HasNestedConversations(t *testing.T) {
+	cmd := collections.Commands(nil)
+	convCmd, _, err := cmd.Find([]string{"conversations"})
+	require.NoError(t, err)
+	require.NotNil(t, convCmd)
+	require.Equal(t, "conversations", convCmd.Name())
+
+	for _, sub := range []string{"list", "add", "remove"} {
+		c, _, err := cmd.Find([]string{"conversations", sub})
+		require.NoError(t, err, "subcommand %q must exist", sub)
+		require.NotNil(t, c)
+	}
+}
+
+func TestCreateCommand_RejectsConflictingFlags(t *testing.T) {
+	cmd := collections.Commands(nil)
+	cmd.SetArgs([]string{"create", "-f", "x.yaml", "--name", "x"})
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestCreateCommand_RequiresInput(t *testing.T) {
+	cmd := collections.Commands(nil)
+	cmd.SetArgs([]string{"create"})
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--filename/-f or --name is required")
+}
+
+func TestUpdateCommand_RequiresAtLeastOneFlag(t *testing.T) {
+	cmd := collections.Commands(nil)
+	cmd.SetArgs([]string{"update", "c-1"})
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one of --name or --description")
+}
+
+func TestConversationsAddCommand_NeedsTwoArgs(t *testing.T) {
+	cmd := collections.Commands(nil)
+	cmd.SetArgs([]string{"conversations", "add", "c-1"})
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires at least 2 arg")
+}
+
+func TestDeleteCommand_AbortsWithoutForce(t *testing.T) {
+	cmd := collections.Commands(nil)
+	cmd.SetArgs([]string{"delete", "c-1"})
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetIn(strings.NewReader("n\n"))
+
+	err := cmd.Execute()
+	if err != nil {
+		assert.Contains(t, err.Error(), "use --force")
+	} else {
+		assert.Contains(t, stderr.String(), "Aborted")
+	}
+}

--- a/internal/providers/aio11y/eval/collections/export_test.go
+++ b/internal/providers/aio11y/eval/collections/export_test.go
@@ -1,0 +1,18 @@
+package collections
+
+import (
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// SpecToUnstructured renders a Collection through the typed CRUD's strip
+// pipeline. Exposed for tests that assert server-managed fields are removed
+// from spec output.
+func SpecToUnstructured(item Collection, namespace string) (unstructured.Unstructured, error) {
+	crud := &adapter.TypedCRUD[Collection]{
+		Namespace:   namespace,
+		StripFields: stripFields(),
+		Descriptor:  StaticDescriptor(),
+	}
+	return crud.ToUnstructured(item)
+}

--- a/internal/providers/aio11y/eval/collections/resource_adapter.go
+++ b/internal/providers/aio11y/eval/collections/resource_adapter.go
@@ -1,0 +1,111 @@
+package collections
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	internalconfig "github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
+	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// StaticDescriptor returns the resource descriptor for AI Observability collections.
+func StaticDescriptor() resources.Descriptor {
+	return resources.Descriptor{
+		GroupVersion: schema.GroupVersion{
+			Group:   "sigil.ext.grafana.app",
+			Version: "v1alpha1",
+		},
+		Kind:     "Collection",
+		Singular: "collection",
+		Plural:   "collections",
+	}
+}
+
+// CollectionSchema returns a JSON Schema for the Collection resource type.
+func CollectionSchema() json.RawMessage {
+	return adapter.SchemaFromType[Collection](StaticDescriptor())
+}
+
+// stripFields lists server-managed fields that must not appear in the YAML
+// representation. These are restored on read by the GET endpoint.
+func stripFields() []string {
+	return []string{
+		"collection_id",
+		"tenant_id",
+		"created_by",
+		"updated_by",
+		"created_at",
+		"updated_at",
+		"member_count",
+	}
+}
+
+// NewTypedCRUD creates a TypedCRUD for AI Observability collections.
+//
+// The collections API is *not* an upsert (unlike evaluators), so CreateFn and
+// UpdateFn dispatch to different HTTP endpoints (POST vs PATCH).
+//
+// UpdateFn only sends the description when it is non-empty so that an absent
+// description in the pulled YAML — Collection.Description has `omitempty`, so
+// it round-trips as zero — does not clear the server-side value. To explicitly
+// clear a description, use `gcx aio11y collections update <id> --description ""`.
+func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[Collection], string, error) {
+	var loader providers.ConfigLoader
+	loader.SetContextName(internalconfig.ContextNameFromCtx(ctx))
+
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to load REST config for AI Observability collections: %w", err)
+	}
+
+	base, err := aio11yhttp.NewClient(cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create AI Observability HTTP client: %w", err)
+	}
+	client := NewClient(base)
+
+	crud := &adapter.TypedCRUD[Collection]{
+		ListFn: func(ctx context.Context, limit int64) ([]Collection, error) {
+			return client.List(ctx, int(limit))
+		},
+		GetFn: func(ctx context.Context, name string) (*Collection, error) {
+			item, err := client.Get(ctx, name)
+			if errors.Is(err, ErrNotFound) {
+				return nil, fmt.Errorf("collection %s: %w", name, adapter.ErrNotFound)
+			}
+			return item, err
+		},
+		CreateFn: func(ctx context.Context, item *Collection) (*Collection, error) {
+			return client.Create(ctx, item)
+		},
+		UpdateFn: func(ctx context.Context, name string, item *Collection) (*Collection, error) {
+			update := &UpdateRequest{Name: &item.Name}
+			if item.Description != "" {
+				update.Description = &item.Description
+			}
+			return client.Update(ctx, name, update)
+		},
+		DeleteFn:    client.Delete,
+		Namespace:   cfg.Namespace,
+		StripFields: stripFields(),
+		Descriptor:  StaticDescriptor(),
+	}
+	return crud, cfg.Namespace, nil
+}
+
+// NewLazyFactory returns an adapter.Factory for AI Observability collections.
+func NewLazyFactory() adapter.Factory {
+	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
+		crud, _, err := NewTypedCRUD(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return crud.AsAdapter(), nil
+	}
+}

--- a/internal/providers/aio11y/eval/collections/types.go
+++ b/internal/providers/aio11y/eval/collections/types.go
@@ -1,0 +1,36 @@
+package collections
+
+import "time"
+
+//nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
+type Collection struct {
+	// User-provided fields (spec).
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+
+	// Server-managed fields (stripped from spec on push).
+	CollectionID string    `json:"collection_id,omitempty"`
+	TenantID     string    `json:"tenant_id,omitempty"`
+	CreatedBy    string    `json:"created_by,omitempty"`
+	UpdatedBy    string    `json:"updated_by,omitempty"`
+	CreatedAt    time.Time `json:"created_at,omitzero"`
+	UpdatedAt    time.Time `json:"updated_at,omitzero"`
+	MemberCount  int       `json:"member_count,omitempty"`
+}
+
+// GetResourceName implements adapter.ResourceNamer.
+func (c Collection) GetResourceName() string { return c.CollectionID }
+
+// SetResourceName implements adapter.ResourceIdentity.
+func (c *Collection) SetResourceName(name string) { c.CollectionID = name }
+
+// UpdateRequest is the partial-PATCH body for the update endpoint. Pointer
+// fields let callers send only the fields they want to change.
+type UpdateRequest struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
+type AddMembersRequest struct {
+	SavedIDs []string `json:"saved_ids"`
+}

--- a/internal/providers/aio11y/eval/savedconversations/client.go
+++ b/internal/providers/aio11y/eval/savedconversations/client.go
@@ -1,0 +1,118 @@
+package savedconversations
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
+)
+
+const basePath = "/eval/saved-conversations"
+
+type Client struct {
+	base *aio11yhttp.Client
+}
+
+func NewClient(base *aio11yhttp.Client) *Client {
+	return &Client{base: base}
+}
+
+// List returns saved conversations, optionally filtered by source
+// (`telemetry` or `manual`). Pass empty source for no filter, and 0 for
+// no limit.
+func (c *Client) List(ctx context.Context, source string, limit int) ([]SavedConversation, error) {
+	var query url.Values
+	if source != "" {
+		query = url.Values{}
+		query.Set("source", source)
+	}
+	return aio11yhttp.ListAll[SavedConversation](ctx, c.base, basePath, query, limit)
+}
+
+// Get returns a single saved conversation by saved ID.
+func (c *Client) Get(ctx context.Context, savedID string) (*SavedConversation, error) {
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, basePath+"/"+url.PathEscape(savedID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get saved conversation %s: %w", savedID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, aio11yhttp.HandleErrorResponse(resp)
+	}
+
+	var sc SavedConversation
+	if err := json.NewDecoder(resp.Body).Decode(&sc); err != nil {
+		return nil, fmt.Errorf("failed to decode saved conversation response: %w", err)
+	}
+	return &sc, nil
+}
+
+// Save bookmarks an existing live conversation.
+func (c *Client) Save(ctx context.Context, req *SaveRequest) (*SavedConversation, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal save request: %w", err)
+	}
+
+	resp, err := c.base.DoRequest(ctx, http.MethodPost, basePath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to save conversation: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, aio11yhttp.HandleErrorResponse(resp)
+	}
+
+	var sc SavedConversation
+	if err := json.NewDecoder(resp.Body).Decode(&sc); err != nil {
+		return nil, fmt.Errorf("failed to decode save response: %w", err)
+	}
+	return &sc, nil
+}
+
+// Delete removes a saved conversation by saved ID.
+func (c *Client) Delete(ctx context.Context, savedID string) error {
+	resp, err := c.base.DoRequest(ctx, http.MethodDelete, basePath+"/"+url.PathEscape(savedID), nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete saved conversation %s: %w", savedID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return aio11yhttp.HandleErrorResponse(resp)
+	}
+	return nil
+}
+
+// ListCollections returns all collections that contain the given saved
+// conversation. The endpoint is not cursor-paginated — it returns the full
+// set in one response.
+func (c *Client) ListCollections(ctx context.Context, savedID string) ([]CollectionRef, error) {
+	path := basePath + "/" + url.PathEscape(savedID) + "/collections"
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list collections for saved conversation %s: %w", savedID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, aio11yhttp.HandleErrorResponse(resp)
+	}
+
+	var page struct {
+		Items []CollectionRef `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		return nil, fmt.Errorf("failed to decode collections response: %w", err)
+	}
+	if page.Items == nil {
+		return []CollectionRef{}, nil
+	}
+	return page.Items, nil
+}

--- a/internal/providers/aio11y/eval/savedconversations/client_test.go
+++ b/internal/providers/aio11y/eval/savedconversations/client_test.go
@@ -1,0 +1,188 @@
+package savedconversations_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/savedconversations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func writeJSON(w http.ResponseWriter, v any) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func newTestClient(t *testing.T, handler http.Handler) *savedconversations.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: srv.URL},
+		Namespace: "default",
+	}
+	base, err := aio11yhttp.NewClient(cfg)
+	require.NoError(t, err)
+	return savedconversations.NewClient(base)
+}
+
+func TestClient_List(t *testing.T) {
+	var capturedSource string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/saved-conversations")
+		capturedSource = r.URL.Query().Get("source")
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{
+			"items": []savedconversations.SavedConversation{
+				{SavedID: "saved-1", Name: "first", ConversationID: "conv-1", Source: "telemetry"},
+				{SavedID: "saved-2", Name: "second", ConversationID: "conv-2", Source: "telemetry"},
+			},
+		})
+	}))
+
+	items, err := client.List(context.Background(), "telemetry", 10)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, "saved-1", items[0].SavedID)
+	assert.Equal(t, "telemetry", capturedSource)
+}
+
+func TestClient_List_NoSource(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.URL.Query().Get("source"))
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{"items": []savedconversations.SavedConversation{}})
+	}))
+
+	items, err := client.List(context.Background(), "", 0)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+func TestClient_Get(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/saved-conversations/saved-1")
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, savedconversations.SavedConversation{
+			SavedID:        "saved-1",
+			ConversationID: "conv-1",
+			Name:           "Regression seed",
+			Source:         "telemetry",
+		})
+	}))
+
+	sc, err := client.Get(context.Background(), "saved-1")
+	require.NoError(t, err)
+	assert.Equal(t, "saved-1", sc.SavedID)
+	assert.Equal(t, "conv-1", sc.ConversationID)
+}
+
+func TestClient_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+
+	_, err := client.Get(context.Background(), "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestClient_Save(t *testing.T) {
+	var captured savedconversations.SaveRequest
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/saved-conversations")
+		body, _ := io.ReadAll(r.Body)
+		assert.NoError(t, json.Unmarshal(body, &captured))
+
+		w.WriteHeader(http.StatusOK)
+		writeJSON(w, savedconversations.SavedConversation{
+			SavedID:        captured.SavedID,
+			ConversationID: captured.ConversationID,
+			Name:           captured.Name,
+			Tags:           captured.Tags,
+			Source:         "telemetry",
+			SavedBy:        "user",
+			CreatedAt:      time.Now().UTC(),
+		})
+	}))
+
+	sc, err := client.Save(context.Background(), &savedconversations.SaveRequest{
+		SavedID:        "saved-conv-123",
+		ConversationID: "conv-123",
+		Name:           "Regression seed",
+		Tags:           map[string]string{"suite": "checkout", "priority": "high"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "saved-conv-123", sc.SavedID)
+	assert.Equal(t, "conv-123", captured.ConversationID)
+	assert.Equal(t, "Regression seed", captured.Name)
+	assert.Equal(t, "checkout", captured.Tags["suite"])
+	assert.Equal(t, "high", captured.Tags["priority"])
+}
+
+func TestClient_Delete(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/saved-conversations/saved-1")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	require.NoError(t, client.Delete(context.Background(), "saved-1"))
+}
+
+func TestClient_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+
+	err := client.Delete(context.Background(), "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestClient_ListCollections(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/saved-conversations/saved-1/collections")
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{
+			"items": []savedconversations.CollectionRef{
+				{CollectionID: "c-1", Name: "Regression suite", MemberCount: 3},
+				{CollectionID: "c-2", Name: "Smoke", MemberCount: 1},
+			},
+		})
+	}))
+
+	cols, err := client.ListCollections(context.Background(), "saved-1")
+	require.NoError(t, err)
+	require.Len(t, cols, 2)
+	assert.Equal(t, "c-1", cols[0].CollectionID)
+	assert.Equal(t, "Regression suite", cols[0].Name)
+}
+
+func TestClient_ListCollections_NotFound(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+
+	_, err := client.ListCollections(context.Background(), "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}

--- a/internal/providers/aio11y/eval/savedconversations/commands.go
+++ b/internal/providers/aio11y/eval/savedconversations/commands.go
@@ -1,0 +1,392 @@
+package savedconversations
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func newClient(cmd *cobra.Command, loader *providers.ConfigLoader) (*Client, error) {
+	base, err := aio11yhttp.NewClientFromCommand(cmd, loader)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(base), nil
+}
+
+// Commands returns the saved-conversations command group.
+func Commands(loader *providers.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "saved-conversations",
+		Short: "Bookmark live conversations as fixed inputs for evaluation runs.",
+	}
+	cmd.AddCommand(
+		newListCommand(loader),
+		newGetCommand(loader),
+		newSaveCommand(loader),
+		newDeleteCommand(loader),
+		newCollectionsCommand(loader),
+	)
+	return cmd
+}
+
+// --- list ---
+
+type listOpts struct {
+	IO     cmdio.Options
+	Source string
+	Limit  int64
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &TableCodec{})
+	o.IO.RegisterCustomCodec("wide", &TableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Source, "source", "", "Filter by source (telemetry or manual)")
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of saved conversations to return (0 for no limit)")
+}
+
+func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List saved conversations.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			items, err := client.List(cmd.Context(), opts.Source, int(opts.Limit))
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), items)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- get ---
+
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("yaml")
+	o.IO.BindFlags(flags)
+}
+
+func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:   "get <saved-id>",
+		Short: "Get a single saved conversation.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			sc, err := client.Get(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), sc)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- save ---
+
+type saveOpts struct {
+	IO      cmdio.Options
+	SavedID string
+	Name    string
+	Tags    []string
+}
+
+func (o *saveOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.SavedID, "saved-id", "", "Bookmark ID; defaults to saved-<conversation-id>")
+	flags.StringVar(&o.Name, "name", "", "Human-readable name for the bookmark (required)")
+	flags.StringArrayVar(&o.Tags, "tag", nil, "Tag in key=value form (repeatable)")
+}
+
+func (o *saveOpts) Validate() error {
+	if strings.TrimSpace(o.Name) == "" {
+		return errors.New("--name is required")
+	}
+	return o.IO.Validate()
+}
+
+func parseTags(raw []string) (map[string]string, error) {
+	tags := make(map[string]string, len(raw))
+	for _, t := range raw {
+		k, v, ok := strings.Cut(t, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid --tag %q: expected key=value", t)
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k == "" {
+			return nil, fmt.Errorf("invalid --tag %q: empty key", t)
+		}
+		tags[k] = v
+	}
+	return tags, nil
+}
+
+func newSaveCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &saveOpts{}
+	cmd := &cobra.Command{
+		Use:   "save <conversation-id>",
+		Short: "Bookmark an existing live conversation as a saved conversation.",
+		Long: `Bookmark a live conversation surfaced by gcx aio11y conversations.
+By default the bookmark ID is derived as saved-<conversation-id>, matching the
+plugin UI; pass --saved-id to override.`,
+		Example: `  # Bookmark with the default saved ID.
+  gcx aio11y saved-conversations save conv-123 --name "Regression seed"
+
+  # Bookmark with tags.
+  gcx aio11y saved-conversations save conv-123 --name "Regression seed" --tag suite=checkout --tag priority=high`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			tags, err := parseTags(opts.Tags)
+			if err != nil {
+				return err
+			}
+			conversationID := args[0]
+			savedID := opts.SavedID
+			if savedID == "" {
+				savedID = "saved-" + conversationID
+			}
+
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			sc, err := client.Save(cmd.Context(), &SaveRequest{
+				SavedID:        savedID,
+				ConversationID: conversationID,
+				Name:           opts.Name,
+				Tags:           tags,
+			})
+			if err != nil {
+				return err
+			}
+			cmdio.Success(cmd.ErrOrStderr(), "Saved conversation %s", sc.SavedID)
+			return opts.IO.Encode(cmd.OutOrStdout(), sc)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- delete ---
+
+type deleteOpts struct {
+	Force bool
+}
+
+func (o *deleteOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
+}
+
+func newDeleteCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &deleteOpts{}
+	cmd := &cobra.Command{
+		Use:   "delete SAVED-ID...",
+		Short: "Delete saved conversations.",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !opts.Force {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Delete %d saved conversation(s)? [y/N] ", len(args))
+				reader := bufio.NewReader(cmd.InOrStdin())
+				answer, err := reader.ReadString('\n')
+				if err != nil {
+					return fmt.Errorf("reading confirmation: %w", err)
+				}
+				answer = strings.TrimSpace(strings.ToLower(answer))
+				if answer != "y" && answer != "yes" {
+					cmdio.Info(cmd.ErrOrStderr(), "Aborted.")
+					return nil
+				}
+			}
+
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			for _, id := range args {
+				if err := client.Delete(cmd.Context(), id); err != nil {
+					return fmt.Errorf("deleting saved conversation %s: %w", id, err)
+				}
+				cmdio.Success(cmd.ErrOrStderr(), "Deleted saved conversation %s", id)
+			}
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- collections (reverse lookup) ---
+
+type collectionsOpts struct {
+	IO cmdio.Options
+}
+
+func (o *collectionsOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &CollectionsTableCodec{})
+	o.IO.RegisterCustomCodec("wide", &CollectionsTableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newCollectionsCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &collectionsOpts{}
+	cmd := &cobra.Command{
+		Use:   "collections <saved-id>",
+		Short: "List collections that contain a saved conversation.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			items, err := client.ListCollections(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), items)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- table codecs ---
+
+// TableCodec renders []SavedConversation rows.
+type TableCodec struct {
+	Wide bool
+}
+
+func (c *TableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *TableCodec) Encode(w io.Writer, v any) error {
+	items, ok := v.([]SavedConversation)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []SavedConversation")
+	}
+
+	var t *style.TableBuilder
+	if c.Wide {
+		t = style.NewTable("SAVED ID", "NAME", "CONVERSATION", "SOURCE", "GENS", "SAVED BY", "CREATED AT")
+	} else {
+		t = style.NewTable("SAVED ID", "NAME", "CONVERSATION", "SOURCE", "GENS")
+	}
+
+	for _, sc := range items {
+		name := aio11yhttp.Truncate(sc.Name, 40)
+		source := sc.Source
+		if source == "" {
+			source = "-"
+		}
+		gens := strconv.Itoa(sc.GenerationCount)
+		if c.Wide {
+			savedBy := sc.SavedBy
+			if savedBy == "" {
+				savedBy = "-"
+			}
+			t.Row(sc.SavedID, name, sc.ConversationID, source, gens, savedBy, aio11yhttp.FormatTime(sc.CreatedAt))
+		} else {
+			t.Row(sc.SavedID, name, sc.ConversationID, source, gens)
+		}
+	}
+	return t.Render(w)
+}
+
+func (c *TableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// CollectionsTableCodec renders []CollectionRef rows for the reverse-lookup
+// `saved-conversations collections <saved-id>` command.
+type CollectionsTableCodec struct {
+	Wide bool
+}
+
+func (c *CollectionsTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *CollectionsTableCodec) Encode(w io.Writer, v any) error {
+	items, ok := v.([]CollectionRef)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []CollectionRef")
+	}
+
+	var t *style.TableBuilder
+	if c.Wide {
+		t = style.NewTable("COLLECTION ID", "NAME", "MEMBERS", "DESCRIPTION", "CREATED BY", "CREATED AT")
+	} else {
+		t = style.NewTable("COLLECTION ID", "NAME", "MEMBERS")
+	}
+
+	for _, cref := range items {
+		members := strconv.Itoa(cref.MemberCount)
+		if c.Wide {
+			desc := aio11yhttp.Truncate(cref.Description, 40)
+			createdBy := cref.CreatedBy
+			if createdBy == "" {
+				createdBy = "-"
+			}
+			t.Row(cref.CollectionID, cref.Name, members, desc, createdBy, aio11yhttp.FormatTime(cref.CreatedAt))
+		} else {
+			t.Row(cref.CollectionID, cref.Name, members)
+		}
+	}
+	return t.Render(w)
+}
+
+func (c *CollectionsTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}

--- a/internal/providers/aio11y/eval/savedconversations/commands_test.go
+++ b/internal/providers/aio11y/eval/savedconversations/commands_test.go
@@ -1,0 +1,154 @@
+package savedconversations_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/savedconversations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableCodec_Encode(t *testing.T) {
+	items := []savedconversations.SavedConversation{
+		{
+			SavedID: "saved-1", Name: "Regression seed", ConversationID: "conv-1",
+			Source: "telemetry", GenerationCount: 4, SavedBy: "alice",
+			CreatedAt: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		},
+		{SavedID: "saved-2", Name: "Manual", ConversationID: "conv-manual-2", Source: "manual"},
+	}
+
+	tests := []struct {
+		name string
+		wide bool
+		want []string
+	}{
+		{
+			name: "table format",
+			wide: false,
+			want: []string{"SAVED ID", "NAME", "CONVERSATION", "SOURCE", "GENS", "saved-1", "Regression seed", "telemetry"},
+		},
+		{
+			name: "wide adds saved-by and created-at",
+			wide: true,
+			want: []string{"SAVED BY", "CREATED AT", "alice", "2026-04-01 10:00"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			codec := &savedconversations.TableCodec{Wide: tc.wide}
+			var buf bytes.Buffer
+			require.NoError(t, codec.Encode(&buf, items))
+
+			out := buf.String()
+			for _, s := range tc.want {
+				assert.Contains(t, out, s)
+			}
+		})
+	}
+}
+
+func TestTableCodec_WrongType(t *testing.T) {
+	codec := &savedconversations.TableCodec{}
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, "not-a-slice")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected []SavedConversation")
+}
+
+func TestTableCodec_Format(t *testing.T) {
+	assert.Equal(t, "table", string((&savedconversations.TableCodec{}).Format()))
+	assert.Equal(t, "wide", string((&savedconversations.TableCodec{Wide: true}).Format()))
+}
+
+func TestCollectionsTableCodec_Encode(t *testing.T) {
+	items := []savedconversations.CollectionRef{
+		{CollectionID: "c-1", Name: "Regression suite", MemberCount: 3, Description: "Used for nightly regression"},
+	}
+	codec := &savedconversations.CollectionsTableCodec{Wide: true}
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, items))
+
+	out := buf.String()
+	for _, s := range []string{"COLLECTION ID", "NAME", "MEMBERS", "DESCRIPTION", "c-1", "Regression suite", "3", "Used for nightly regression"} {
+		assert.Contains(t, out, s)
+	}
+}
+
+func TestCollectionsTableCodec_WrongType(t *testing.T) {
+	codec := &savedconversations.CollectionsTableCodec{}
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, []string{"x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected []CollectionRef")
+}
+
+func TestSaveCommand_RequiresName(t *testing.T) {
+	cmd := savedconversations.Commands(nil)
+	cmd.SetArgs([]string{"save", "conv-1"})
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name is required")
+}
+
+func TestSaveCommand_ParseTags_Invalid(t *testing.T) {
+	cmd := savedconversations.Commands(nil)
+	cmd.SetArgs([]string{"save", "conv-1", "--name", "x", "--tag", "no-equals"})
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --tag")
+}
+
+func TestDeleteCommand_AbortsWithoutForce(t *testing.T) {
+	// Without --force, with stdin piped (not a terminal) it should error out.
+	cmd := savedconversations.Commands(nil)
+	cmd.SetArgs([]string{"delete", "saved-1"})
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetIn(strings.NewReader("n\n"))
+
+	err := cmd.Execute()
+	// Either a piped-stdin error OR aborted: both prove the prompt was consulted.
+	if err != nil {
+		// Piped-stdin path.
+		assert.Contains(t, err.Error(), "use --force")
+	} else {
+		assert.Contains(t, stderr.String(), "Aborted")
+	}
+}
+
+func TestListCommand_RegistersSourceFlag(t *testing.T) {
+	cmd := savedconversations.Commands(nil)
+	listCmd, _, err := cmd.Find([]string{"list"})
+	require.NoError(t, err)
+	require.NotNil(t, listCmd.Flag("source"))
+	require.NotNil(t, listCmd.Flag("limit"))
+}
+
+func TestSaveCommand_DefaultsSavedID(t *testing.T) {
+	// We can't run the full save (no server), but we can confirm flags exist
+	// and that the default saved-id value is empty (derived at runtime).
+	cmd := savedconversations.Commands(nil)
+	saveCmd, _, err := cmd.Find([]string{"save"})
+	require.NoError(t, err)
+
+	savedIDFlag := saveCmd.Flag("saved-id")
+	require.NotNil(t, savedIDFlag)
+	assert.Empty(t, savedIDFlag.DefValue, "--saved-id default must be empty; runtime derives saved-<conversation-id>")
+}

--- a/internal/providers/aio11y/eval/savedconversations/types.go
+++ b/internal/providers/aio11y/eval/savedconversations/types.go
@@ -1,0 +1,42 @@
+package savedconversations
+
+import "time"
+
+// SavedConversation is the bookmark record for a live conversation.
+type SavedConversation struct {
+	TenantID       string            `json:"tenant_id,omitempty"`
+	SavedID        string            `json:"saved_id"`
+	ConversationID string            `json:"conversation_id"`
+	Name           string            `json:"name"`
+	Source         string            `json:"source,omitempty"`
+	Tags           map[string]string `json:"tags,omitempty"`
+	SavedBy        string            `json:"saved_by,omitempty"`
+	CreatedAt      time.Time         `json:"created_at,omitzero"`
+	UpdatedAt      time.Time         `json:"updated_at,omitzero"`
+
+	// Enrichment fields populated by the server when listing.
+	GenerationCount int               `json:"generation_count,omitempty"`
+	TotalTokens     int64             `json:"total_tokens,omitempty"`
+	AgentNames      []string          `json:"agent_names,omitempty"`
+	Models          []string          `json:"models,omitempty"`
+	ModelProviders  map[string]string `json:"model_providers,omitempty"`
+}
+
+type SaveRequest struct {
+	SavedID        string            `json:"saved_id"`
+	ConversationID string            `json:"conversation_id"`
+	Name           string            `json:"name"`
+	Tags           map[string]string `json:"tags,omitempty"`
+}
+
+// CollectionRef is a slim view of a collection returned by the reverse-lookup
+// endpoint, with just the columns the table codec renders.
+type CollectionRef struct {
+	CollectionID string    `json:"collection_id"`
+	Name         string    `json:"name"`
+	Description  string    `json:"description,omitempty"`
+	MemberCount  int       `json:"member_count,omitempty"`
+	CreatedBy    string    `json:"created_by,omitempty"`
+	CreatedAt    time.Time `json:"created_at,omitzero"`
+	UpdatedAt    time.Time `json:"updated_at,omitzero"`
+}

--- a/internal/providers/aio11y/provider.go
+++ b/internal/providers/aio11y/provider.go
@@ -5,9 +5,11 @@ import (
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/aio11y/agents"
 	"github.com/grafana/gcx/internal/providers/aio11y/conversations"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/collections"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/evaluators"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/judge"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/rules"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/savedconversations"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/templates"
 	"github.com/grafana/gcx/internal/providers/aio11y/generations"
 	"github.com/grafana/gcx/internal/providers/aio11y/scores"
@@ -94,7 +96,19 @@ func (p *AIO11yProvider) Commands() []*cobra.Command {
 		agent.AnnotationLLMHint:   `gcx aio11y judge providers -o json; gcx aio11y judge models --provider openai -o json`,
 	}
 
-	aio11yCmd.AddCommand(convsCmd, agentsCmd, evaluatorsCmd, rulesCmd, templatesCmd, generationsCmd, scoresCmd, judgeCmd)
+	savedConvsCmd := savedconversations.Commands(loader)
+	savedConvsCmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "medium",
+		agent.AnnotationLLMHint:   `gcx aio11y saved-conversations list -o json; gcx aio11y saved-conversations get <id> -o yaml; gcx aio11y saved-conversations save <conv-id> --name '...' -o json; gcx aio11y saved-conversations collections <saved-id> -o json`,
+	}
+
+	collectionsCmd := collections.Commands(loader)
+	collectionsCmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "low",
+		agent.AnnotationLLMHint:   `gcx aio11y collections list -o json; gcx aio11y collections get <id> -o yaml; gcx aio11y collections create --name '...' -o json; gcx aio11y collections update <id> --name '...' -o json; gcx aio11y collections delete <id> --force; gcx aio11y collections conversations list <id> -o json; gcx aio11y collections conversations add <id> <saved-id>; gcx aio11y collections conversations remove <id> <saved-id>`,
+	}
+
+	aio11yCmd.AddCommand(convsCmd, agentsCmd, evaluatorsCmd, rulesCmd, templatesCmd, generationsCmd, scoresCmd, judgeCmd, savedConvsCmd, collectionsCmd)
 
 	return []*cobra.Command{aio11yCmd}
 }
@@ -114,9 +128,14 @@ func (p *AIO11yProvider) ConfigKeys() []providers.ConfigKey {
 }
 
 // TypedRegistrations returns adapter registrations for AI Observability resource types.
+//
+// Saved-conversations are intentionally absent: `save` bookmarks a specific
+// live conversation (not an idempotent upsert) and the resource is shaped
+// like an event record rather than declarative config.
 func (p *AIO11yProvider) TypedRegistrations() []adapter.Registration {
 	evalDesc := evaluators.StaticDescriptor()
 	ruleDesc := rules.StaticDescriptor()
+	collectionDesc := collections.StaticDescriptor()
 
 	return []adapter.Registration{
 		{
@@ -132,6 +151,13 @@ func (p *AIO11yProvider) TypedRegistrations() []adapter.Registration {
 			GVK:         ruleDesc.GroupVersionKind(),
 			Schema:      rules.RuleSchema(),
 			URLTemplate: "/a/grafana-sigil-app/rules/{name}",
+		},
+		{
+			Factory:     collections.NewLazyFactory(),
+			Descriptor:  collectionDesc,
+			GVK:         collectionDesc.GroupVersionKind(),
+			Schema:      collections.CollectionSchema(),
+			URLTemplate: "/a/grafana-sigil-app/collections/{name}",
 		},
 	}
 }

--- a/internal/resources/adapter/typed.go
+++ b/internal/resources/adapter/typed.go
@@ -230,8 +230,9 @@ func (c *TypedCRUD[T]) AsAdapter() ResourceAdapter {
 	return &typedAdapter[T]{crud: c}
 }
 
-// toUnstructured converts a domain object T into an unstructured Kubernetes envelope.
-func (c *TypedCRUD[T]) toUnstructured(item T) (unstructured.Unstructured, error) {
+// ToUnstructured converts a domain object T into an unstructured Kubernetes envelope,
+// stripping the fields listed in StripFields and applying any MetadataFn.
+func (c *TypedCRUD[T]) ToUnstructured(item T) (unstructured.Unstructured, error) {
 	// T -> JSON -> map[string]any (this becomes the spec)
 	data, err := json.Marshal(item)
 	if err != nil {
@@ -339,7 +340,7 @@ func (a *typedAdapter[T]) List(ctx context.Context, opts metav1.ListOptions) (*u
 
 	result := &unstructured.UnstructuredList{}
 	for _, item := range items {
-		u, err := a.crud.toUnstructured(item)
+		u, err := a.crud.ToUnstructured(item)
 		if err != nil {
 			return nil, err
 		}
@@ -363,7 +364,7 @@ func (a *typedAdapter[T]) Get(ctx context.Context, name string, _ metav1.GetOpti
 		return nil, err
 	}
 
-	u, err := a.crud.toUnstructured(obj.Spec)
+	u, err := a.crud.ToUnstructured(obj.Spec)
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +391,7 @@ func (a *typedAdapter[T]) Create(ctx context.Context, obj *unstructured.Unstruct
 		return nil, err
 	}
 
-	u, err := a.crud.toUnstructured(*created)
+	u, err := a.crud.ToUnstructured(*created)
 	if err != nil {
 		return nil, err
 	}
@@ -417,7 +418,7 @@ func (a *typedAdapter[T]) Update(ctx context.Context, obj *unstructured.Unstruct
 		return nil, err
 	}
 
-	u, err := a.crud.toUnstructured(*updated)
+	u, err := a.crud.ToUnstructured(*updated)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +442,7 @@ func (a *typedAdapter[T]) dryRunValidate(ctx context.Context, item *T) (*unstruc
 			return nil, err
 		}
 	}
-	u, err := a.crud.toUnstructured(*item)
+	u, err := a.crud.ToUnstructured(*item)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds two new command groups under `gcx aio11y`: `saved-conversations` and `collections`.

`gcx aio11y saved-conversations` saves conversation so it stays available as a fixed input for eval runs.

- `list`, `get`, `save`, `delete`
- `collections <saved-id>` — reverse lookup: which collections contain this bookmark

`gcx aio11y collections` named groups of saved conversations.

- `list`, `get`, `create`, `update`, `delete`
- `conversations {list,add,remove}` — manage membership