### PR TITLE
feat(stacks): add Grafana Cloud stack management commands

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/grafana/gcx/internal/auth"
+	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/datasources"
 	"github.com/grafana/gcx/internal/grafana"
@@ -52,6 +53,7 @@ func ErrorToDetailedError(err error) *DetailedError {
 		convertLinterErrors,          // Linter-related errors
 		convertSMConfigErrors,        // Synthetic Monitoring config errors
 		convertCloudConfigErrors,     // Cloud config / fleet / setup errors
+		convertStacksErrors,          // Stacks management GCOM errors
 	}
 
 	for _, converter := range errorConverters {
@@ -1155,6 +1157,75 @@ func humanizeSummary(summary string) string {
 	}
 
 	return summary
+}
+
+func convertStacksErrors(err error) (*DetailedError, bool) {
+	msg := err.Error()
+
+	// Only match stacks-related errors (from stacks provider commands).
+	if !strings.Contains(msg, "failed to list stacks") &&
+		!strings.Contains(msg, "failed to create stack") &&
+		!strings.Contains(msg, "failed to update stack") &&
+		!strings.Contains(msg, "failed to delete stack") &&
+		!strings.Contains(msg, "failed to get stack") &&
+		!strings.Contains(msg, "failed to list regions") {
+		return nil, false
+	}
+
+	var httpErr *cloud.GCOMHTTPError
+	if !errors.As(err, &httpErr) {
+		return nil, false
+	}
+
+	switch httpErr.Status {
+	case http.StatusConflict:
+		if strings.Contains(msg, "delete") {
+			return &DetailedError{
+				Summary: "Stack has delete protection enabled",
+				Details: msg,
+				Parent:  err,
+				Suggestions: []string{
+					"Disable delete protection first: gcx stacks update <slug> --no-delete-protection",
+					"Then retry: gcx stacks delete <slug>",
+				},
+			}, true
+		}
+		return &DetailedError{
+			Summary: "Stack slug already taken",
+			Details: msg,
+			Parent:  err,
+			Suggestions: []string{
+				"Choose a different slug with --slug",
+				"List existing stacks: gcx stacks list --org <org-slug>",
+			},
+		}, true
+	case http.StatusForbidden:
+		return &DetailedError{
+			Summary:  "Stacks: permission denied",
+			Details:  msg,
+			Parent:   err,
+			ExitCode: new(ExitAuthFailure),
+			Suggestions: []string{
+				"Ensure your Cloud Access Policy includes the required stacks scopes:",
+				"  stacks:read   — for list, get, regions",
+				"  stacks:write  — for create, update",
+				"  stacks:delete — for delete",
+			},
+		}, true
+	case http.StatusUnauthorized:
+		return &DetailedError{
+			Summary:  "Stacks: authentication failed",
+			Details:  msg,
+			Parent:   err,
+			ExitCode: new(ExitAuthFailure),
+			Suggestions: []string{
+				"Check your cloud.token is valid and not expired",
+				reauthSuggestion,
+			},
+		}, true
+	}
+
+	return nil, false
 }
 
 func convertContextCanceled(err error) (*DetailedError, bool) {

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -1179,7 +1179,7 @@ func convertStacksErrors(err error) (*DetailedError, bool) {
 
 	switch httpErr.Status {
 	case http.StatusConflict:
-		if strings.Contains(msg, "delete") {
+		if strings.Contains(msg, "failed to delete stack") {
 			return &DetailedError{
 				Summary: "Stack has delete protection enabled",
 				Details: msg,

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -41,9 +41,9 @@ import (
 	_ "github.com/grafana/gcx/internal/providers/metrics"    // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/profiles"   // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/slo"        // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/stacks"    // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/synth"     // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/traces"    // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/stacks"     // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/synth"      // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/traces"     // Provider registrations — blank imports trigger init() self-registration.
 	"github.com/grafana/gcx/internal/style"
 	"github.com/grafana/gcx/internal/terminal"
 	appversion "github.com/grafana/gcx/internal/version"

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -41,8 +41,9 @@ import (
 	_ "github.com/grafana/gcx/internal/providers/metrics"    // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/profiles"   // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/slo"        // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/synth"      // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/traces"     // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/stacks"    // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/synth"     // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/traces"    // Provider registrations — blank imports trigger init() self-registration.
 	"github.com/grafana/gcx/internal/style"
 	"github.com/grafana/gcx/internal/terminal"
 	appversion "github.com/grafana/gcx/internal/version"

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -46,6 +46,7 @@ gcx is a unified CLI for managing Grafana resources, dashboards, datasources, al
 * [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
 * [gcx skills](gcx_skills.md)	 - Manage portable gcx Agent Skills
 * [gcx slo](gcx_slo.md)	 - Manage Grafana SLO definitions and reports
+* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
 * [gcx synthetic-monitoring](gcx_synthetic-monitoring.md)	 - Manage Grafana Synthetic Monitoring checks and probes
 * [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces
 

--- a/docs/reference/cli/gcx_stacks.md
+++ b/docs/reference/cli/gcx_stacks.md
@@ -1,0 +1,32 @@
+## gcx stacks
+
+Manage Grafana Cloud stacks (list, create, update, delete)
+
+### Options
+
+```
+      --config string    Path to the configuration file to use
+      --context string   Name of the context to use
+  -h, --help             help for stacks
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx stacks create](gcx_stacks_create.md)	 - Create a new Grafana Cloud stack.
+* [gcx stacks delete](gcx_stacks_delete.md)	 - Delete a Grafana Cloud stack.
+* [gcx stacks get](gcx_stacks_get.md)	 - Get details of a single stack.
+* [gcx stacks list](gcx_stacks_list.md)	 - List stacks in an organisation.
+* [gcx stacks regions](gcx_stacks_regions.md)	 - List available regions for stack creation.
+* [gcx stacks update](gcx_stacks_update.md)	 - Update a Grafana Cloud stack.
+

--- a/docs/reference/cli/gcx_stacks.md
+++ b/docs/reference/cli/gcx_stacks.md
@@ -5,15 +5,15 @@ Manage Grafana Cloud stacks (list, create, update, delete)
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for stacks
+      --config string   Path to the configuration file to use
+  -h, --help            help for stacks
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_stacks_create.md
+++ b/docs/reference/cli/gcx_stacks_create.md
@@ -1,0 +1,48 @@
+## gcx stacks create
+
+Create a new Grafana Cloud stack.
+
+### Synopsis
+
+Create a new Grafana Cloud stack.
+
+This command creates a new Grafana Cloud stack, which provisions infrastructure
+and may incur costs. Always confirm the stack name, slug, and region with the
+user before executing. Prefer --dry-run first.
+
+```
+gcx stacks create [flags]
+```
+
+### Options
+
+```
+      --delete-protection    Enable delete protection
+      --description string   Short description
+      --dry-run              Preview the request without executing it
+  -h, --help                 help for create
+      --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --labels strings       Labels in key=value format (may be repeated)
+      --name string          Stack name (required)
+  -o, --output string        Output format. One of: json, table, yaml (default "table")
+      --region string        Region slug (e.g. us, eu). Use 'gcx stacks regions' to list.
+      --slug string          Stack slug / subdomain (required)
+      --url string           Custom domain URL
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+

--- a/docs/reference/cli/gcx_stacks_create.md
+++ b/docs/reference/cli/gcx_stacks_create.md
@@ -35,7 +35,7 @@ gcx stacks create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_stacks_delete.md
+++ b/docs/reference/cli/gcx_stacks_delete.md
@@ -1,0 +1,41 @@
+## gcx stacks delete
+
+Delete a Grafana Cloud stack.
+
+### Synopsis
+
+Delete a Grafana Cloud stack.
+
+This command permanently deletes a Grafana Cloud stack and ALL its data
+(dashboards, alerts, datasources, metrics, logs, traces). This action is
+IRREVERSIBLE. Always confirm with the user by name before executing. Prefer
+--dry-run first. Never run this command without explicit user confirmation.
+
+```
+gcx stacks delete <stack-slug> [flags]
+```
+
+### Options
+
+```
+      --dry-run   Preview the operation without executing it
+      --force     Skip interactive confirmation
+  -h, --help      help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+

--- a/docs/reference/cli/gcx_stacks_delete.md
+++ b/docs/reference/cli/gcx_stacks_delete.md
@@ -28,7 +28,7 @@ gcx stacks delete <stack-slug> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_stacks_delete.md
+++ b/docs/reference/cli/gcx_stacks_delete.md
@@ -19,8 +19,8 @@ gcx stacks delete <stack-slug> [flags]
 
 ```
       --dry-run   Preview the operation without executing it
-      --force     Skip interactive confirmation
   -h, --help      help for delete
+  -y, --yes       Skip confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_stacks_get.md
+++ b/docs/reference/cli/gcx_stacks_get.md
@@ -1,0 +1,32 @@
+## gcx stacks get
+
+Get details of a single stack.
+
+```
+gcx stacks get <stack-slug> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+

--- a/docs/reference/cli/gcx_stacks_get.md
+++ b/docs/reference/cli/gcx_stacks_get.md
@@ -19,7 +19,7 @@ gcx stacks get <stack-slug> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_stacks_get.md
+++ b/docs/reference/cli/gcx_stacks_get.md
@@ -11,7 +11,7 @@ gcx stacks get <stack-slug> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_stacks_list.md
+++ b/docs/reference/cli/gcx_stacks_list.md
@@ -20,7 +20,7 @@ gcx stacks list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_stacks_list.md
+++ b/docs/reference/cli/gcx_stacks_list.md
@@ -1,0 +1,33 @@
+## gcx stacks list
+
+List stacks in an organisation.
+
+```
+gcx stacks list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --org string      Organisation slug (required)
+  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+

--- a/docs/reference/cli/gcx_stacks_regions.md
+++ b/docs/reference/cli/gcx_stacks_regions.md
@@ -1,0 +1,32 @@
+## gcx stacks regions
+
+List available regions for stack creation.
+
+```
+gcx stacks regions [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for regions
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+

--- a/docs/reference/cli/gcx_stacks_regions.md
+++ b/docs/reference/cli/gcx_stacks_regions.md
@@ -19,7 +19,7 @@ gcx stacks regions [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_stacks_update.md
+++ b/docs/reference/cli/gcx_stacks_update.md
@@ -1,0 +1,46 @@
+## gcx stacks update
+
+Update a Grafana Cloud stack.
+
+### Synopsis
+
+Update a Grafana Cloud stack.
+
+This command modifies a live Grafana Cloud stack. Changing the name or disabling
+delete protection can have downstream effects. Always confirm the intended
+changes with the user and prefer --dry-run first.
+
+```
+gcx stacks update <stack-slug> [flags]
+```
+
+### Options
+
+```
+      --delete-protection      Enable delete protection
+      --description string     New description
+      --dry-run                Preview the request without executing it
+  -h, --help                   help for update
+      --json string            Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --labels strings         Labels in key=value format (replaces all labels)
+      --name string            New stack name
+      --no-delete-protection   Disable delete protection
+  -o, --output string          Output format. One of: json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+

--- a/docs/reference/cli/gcx_stacks_update.md
+++ b/docs/reference/cli/gcx_stacks_update.md
@@ -33,7 +33,7 @@ gcx stacks update <stack-slug> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/migration-gap-analysis.md
+++ b/docs/reference/migration-gap-analysis.md
@@ -221,7 +221,7 @@ We are migrating from the old `grafana-cloud-cli` to the new `gcx` codebase. Thi
 
 | Old Command | Description | Status in gcx |
 |-------------|-------------|---------------|
-| `gcx stacks list/get/create/update/delete/pause/resume` | Stack management | **Missing** |
+| `gcx stacks list/get/create/update/delete/pause/resume` | Stack management | **Exists** (`gcx stacks list\|get\|create\|update\|delete\|regions`; pause/resume not yet implemented) |
 | `gcx access-policies` CRUD | Cloud access policy management | **Missing** |
 | `gcx credentials` | Bootstrap telemetry credentials | **Missing** |
 | `gcx invites` CRUD | Org invite management | **Missing** |
@@ -234,7 +234,7 @@ We are migrating from the old `grafana-cloud-cli` to the new `gcx` codebase. Thi
 | `gcx scim` | SCIM resource CRUD | **Missing** |
 | `gcx securevalues` | Unified Storage secure values | **K8s tier** (SecureValue, Keeper resources: `gcx resources get securevalues\|keepers`) |
 | `gcx cloud-migrations` | Cloud migration CRUD | **Missing** |
-| `gcx stack-regions` | List available regions | **Missing** |
+| `gcx stack-regions` | List available regions | **Exists** (`gcx stacks regions`) |
 | `gcx labels` | GOPS labels CRUD | **Missing** |
 | `gcx assistant tunnel/auth/prompt/credentials/agents/rotate` | Assistant/AI management | **Partially exists** (`gcx assistant prompt` with streaming A2A; tunnel/auth/credentials/agents/rotate **missing**) |
 
@@ -490,7 +490,7 @@ Old CLI annotates every command with structured metadata:
 1. **`init` bootstrap flow** -- Users can't onboard without this
 2. **Global `--output` / `-o`** -- Consistent output formatting everywhere
 3. **`--dry-run --diff`** -- Essential for safe operations
-4. **`stacks` management** -- Can't manage stacks at all
+4. ~~**`stacks` management**~~ -- **DONE** (`gcx stacks list|get|create|update|delete|regions`; pause/resume pending)
 5. **`access-policies`** -- Can't manage IAM
 
 ### P1 -- High Priority (frequent user workflows)

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -2,6 +2,7 @@
 package cloud
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -29,6 +30,20 @@ type StackInfo struct {
 	Status     string `json:"status"`
 	RegionSlug string `json:"regionSlug"`
 
+	// Stack metadata (returned by list/create/update/get).
+	Type             string            `json:"type,omitempty"`
+	Description      string            `json:"description,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	DeleteProtection bool              `json:"deleteProtection,omitempty"`
+	Plan             string            `json:"plan,omitempty"`
+	PlanName         string            `json:"planName,omitempty"`
+	ClusterSlug      string            `json:"clusterSlug,omitempty"`
+	RunningVersion   string            `json:"runningVersion,omitempty"`
+	CreatedAt        string            `json:"createdAt,omitempty"`
+	CreatedBy        string            `json:"createdBy,omitempty"`
+	UpdatedAt        string            `json:"updatedAt,omitempty"`
+	UpdatedBy        string            `json:"updatedBy,omitempty"`
+
 	// Prometheus (Hosted Metrics)
 	HMInstancePromID        int    `json:"hmInstancePromId"`
 	HMInstancePromURL       string `json:"hmInstancePromUrl"`
@@ -53,6 +68,37 @@ type StackInfo struct {
 	// Alertmanager
 	AMInstanceID  int    `json:"amInstanceId"`
 	AMInstanceURL string `json:"amInstanceUrl"`
+}
+
+// Region describes a Grafana Cloud stack region as returned by the GCOM API.
+type Region struct {
+	ID          int    `json:"id"`
+	Status      string `json:"status"`
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Provider    string `json:"provider"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+	UpdatedAt   string `json:"updatedAt,omitempty"`
+}
+
+// CreateStackRequest is the request body for creating a new Grafana Cloud stack.
+type CreateStackRequest struct {
+	Name             string            `json:"name"`
+	Slug             string            `json:"slug"`
+	URL              string            `json:"url,omitempty"`
+	Region           string            `json:"region,omitempty"`
+	Description      string            `json:"description,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	DeleteProtection *bool             `json:"deleteProtection,omitempty"`
+}
+
+// UpdateStackRequest is the request body for updating a Grafana Cloud stack.
+type UpdateStackRequest struct {
+	Name             string            `json:"name,omitempty"`
+	Description      *string           `json:"description,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	DeleteProtection *bool             `json:"deleteProtection,omitempty"`
 }
 
 // GCOMHTTPError is returned by GCOMClient when the GCOM API responds with a
@@ -114,24 +160,16 @@ func NewGCOMClient(baseURL, token string) (*GCOMClient, error) {
 // GetStack calls GET /api/instances/{slug} on the GCOM API and returns the
 // corresponding StackInfo. It returns an error if the response status is not 200.
 func (c *GCOMClient) GetStack(ctx context.Context, slug string) (StackInfo, error) {
-	// Build the endpoint URL, preserving percent-encoding of the slug by setting
-	// both Path (decoded) and RawPath (encoded) so that url.URL.String() uses
-	// the raw path and does not re-encode or normalise percent-encoded sequences.
-	base, err := url.Parse(c.baseURL)
+	endpoint, err := c.buildURL("/api/instances/" + url.PathEscape(slug))
 	if err != nil {
-		return StackInfo{}, fmt.Errorf("gcom client: parse base URL: %w", err)
+		return StackInfo{}, err
 	}
-	endpoint := *base
-	endpoint.Path = base.Path + instancesPath + slug
-	endpoint.RawPath = base.EscapedPath() + instancesPath + url.PathEscape(slug)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return StackInfo{}, fmt.Errorf("gcom client: create request: %w", err)
 	}
-
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Accept", "application/json")
+	c.setHeaders(req)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -157,6 +195,220 @@ func (c *GCOMClient) GetStack(ctx context.Context, slug string) (StackInfo, erro
 	}
 
 	return info, nil
+}
+
+// ListStacks calls GET /api/orgs/{orgSlug}/instances on the GCOM API and
+// returns the stacks belonging to the given organisation.
+func (c *GCOMClient) ListStacks(ctx context.Context, orgSlug string) ([]StackInfo, error) {
+	endpoint, err := c.buildURL("/api/orgs/" + url.PathEscape(orgSlug) + "/instances")
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("gcom client: create request: %w", err)
+	}
+	c.setHeaders(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gcom client: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("gcom client: read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &GCOMHTTPError{Status: resp.StatusCode, Body: strings.TrimSpace(string(body))}
+	}
+
+	var envelope struct {
+		Items []StackInfo `json:"items"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("gcom client: decode response: %w", err)
+	}
+	return envelope.Items, nil
+}
+
+// CreateStack calls POST /api/instances on the GCOM API to create a new stack.
+func (c *GCOMClient) CreateStack(ctx context.Context, r CreateStackRequest) (StackInfo, error) {
+	payload, err := json.Marshal(r)
+	if err != nil {
+		return StackInfo{}, fmt.Errorf("gcom client: marshal request: %w", err)
+	}
+
+	endpoint, err := c.buildURL("/api/instances")
+	if err != nil {
+		return StackInfo{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return StackInfo{}, fmt.Errorf("gcom client: create request: %w", err)
+	}
+	c.setHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return StackInfo{}, fmt.Errorf("gcom client: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return StackInfo{}, fmt.Errorf("gcom client: read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return StackInfo{}, &GCOMHTTPError{Status: resp.StatusCode, Body: strings.TrimSpace(string(body))}
+	}
+
+	var info StackInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return StackInfo{}, fmt.Errorf("gcom client: decode response: %w", err)
+	}
+	return info, nil
+}
+
+// UpdateStack calls POST /api/instances/{slug} on the GCOM API to update a stack.
+func (c *GCOMClient) UpdateStack(ctx context.Context, slug string, r UpdateStackRequest) (StackInfo, error) {
+	payload, err := json.Marshal(r)
+	if err != nil {
+		return StackInfo{}, fmt.Errorf("gcom client: marshal request: %w", err)
+	}
+
+	endpoint, err := c.buildURL("/api/instances/" + url.PathEscape(slug))
+	if err != nil {
+		return StackInfo{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return StackInfo{}, fmt.Errorf("gcom client: create request: %w", err)
+	}
+	c.setHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return StackInfo{}, fmt.Errorf("gcom client: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return StackInfo{}, fmt.Errorf("gcom client: read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return StackInfo{}, &GCOMHTTPError{Status: resp.StatusCode, Body: strings.TrimSpace(string(body))}
+	}
+
+	var info StackInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return StackInfo{}, fmt.Errorf("gcom client: decode response: %w", err)
+	}
+	return info, nil
+}
+
+// DeleteStack calls DELETE /api/instances/{slug} on the GCOM API.
+// Returns a GCOMHTTPError with Status 409 when delete protection is enabled.
+func (c *GCOMClient) DeleteStack(ctx context.Context, slug string) error {
+	endpoint, err := c.buildURL("/api/instances/" + url.PathEscape(slug))
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("gcom client: create request: %w", err)
+	}
+	c.setHeaders(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("gcom client: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("gcom client: read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return &GCOMHTTPError{Status: resp.StatusCode, Body: strings.TrimSpace(string(body))}
+	}
+	return nil
+}
+
+// ListRegions calls GET /api/stack-regions on the GCOM API and returns
+// the available regions for stack creation.
+func (c *GCOMClient) ListRegions(ctx context.Context) ([]Region, error) {
+	endpoint, err := c.buildURL("/api/stack-regions")
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("gcom client: create request: %w", err)
+	}
+	c.setHeaders(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gcom client: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("gcom client: read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &GCOMHTTPError{Status: resp.StatusCode, Body: strings.TrimSpace(string(body))}
+	}
+
+	var envelope struct {
+		Items []Region `json:"items"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("gcom client: decode response: %w", err)
+	}
+	return envelope.Items, nil
+}
+
+// buildURL constructs a full URL from the base and the given raw path.
+// The rawPath must already be percent-encoded where necessary.
+// Both Path (decoded) and RawPath (encoded) are set so url.URL.String()
+// preserves the encoded form rather than re-encoding.
+func (c *GCOMClient) buildURL(rawPath string) (string, error) {
+	base, err := url.Parse(c.baseURL)
+	if err != nil {
+		return "", fmt.Errorf("gcom client: parse base URL: %w", err)
+	}
+	endpoint := *base
+	endpoint.RawPath = base.EscapedPath() + rawPath
+	decoded, err := url.PathUnescape(rawPath)
+	if err != nil {
+		decoded = rawPath
+	}
+	endpoint.Path = base.Path + decoded
+	return endpoint.String(), nil
+}
+
+// setHeaders sets the standard Authorization and Accept headers on a request.
+func (c *GCOMClient) setHeaders(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
 }
 
 // isLoopbackHost reports whether host refers to the loopback interface.

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -17,6 +17,12 @@ import (
 	"github.com/grafana/gcx/internal/retry"
 )
 
+const (
+	instancesPath    = "/api/instances/"
+	stackRegionsPath = "/api/stack-regions"
+	orgsPath         = "/api/orgs/"
+)
+
 // StackInfo holds the information about a Grafana Cloud stack as returned by the GCOM API.
 type StackInfo struct {
 	ID         int    `json:"id"`
@@ -158,7 +164,7 @@ func NewGCOMClient(baseURL, token string) (*GCOMClient, error) {
 // GetStack calls GET /api/instances/{slug} on the GCOM API and returns the
 // corresponding StackInfo. It returns an error if the response status is not 200.
 func (c *GCOMClient) GetStack(ctx context.Context, slug string) (StackInfo, error) {
-	endpoint, err := c.buildURL("/api/instances/" + url.PathEscape(slug))
+	endpoint, err := c.buildURL(instancesPath + url.PathEscape(slug))
 	if err != nil {
 		return StackInfo{}, err
 	}
@@ -198,7 +204,7 @@ func (c *GCOMClient) GetStack(ctx context.Context, slug string) (StackInfo, erro
 // ListStacks calls GET /api/orgs/{orgSlug}/instances on the GCOM API and
 // returns the stacks belonging to the given organisation.
 func (c *GCOMClient) ListStacks(ctx context.Context, orgSlug string) ([]StackInfo, error) {
-	endpoint, err := c.buildURL("/api/orgs/" + url.PathEscape(orgSlug) + "/instances")
+	endpoint, err := c.buildURL(orgsPath + url.PathEscape(orgSlug) + "/instances")
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +246,7 @@ func (c *GCOMClient) CreateStack(ctx context.Context, r CreateStackRequest) (Sta
 		return StackInfo{}, fmt.Errorf("gcom client: marshal request: %w", err)
 	}
 
-	endpoint, err := c.buildURL("/api/instances")
+	endpoint, err := c.buildURL(instancesPath)
 	if err != nil {
 		return StackInfo{}, err
 	}
@@ -281,7 +287,7 @@ func (c *GCOMClient) UpdateStack(ctx context.Context, slug string, r UpdateStack
 		return StackInfo{}, fmt.Errorf("gcom client: marshal request: %w", err)
 	}
 
-	endpoint, err := c.buildURL("/api/instances/" + url.PathEscape(slug))
+	endpoint, err := c.buildURL(instancesPath + url.PathEscape(slug))
 	if err != nil {
 		return StackInfo{}, err
 	}
@@ -318,7 +324,7 @@ func (c *GCOMClient) UpdateStack(ctx context.Context, slug string, r UpdateStack
 // DeleteStack calls DELETE /api/instances/{slug} on the GCOM API.
 // Returns a GCOMHTTPError with Status 409 when delete protection is enabled.
 func (c *GCOMClient) DeleteStack(ctx context.Context, slug string) error {
-	endpoint, err := c.buildURL("/api/instances/" + url.PathEscape(slug))
+	endpoint, err := c.buildURL(instancesPath + url.PathEscape(slug))
 	if err != nil {
 		return err
 	}
@@ -349,7 +355,7 @@ func (c *GCOMClient) DeleteStack(ctx context.Context, slug string) error {
 // ListRegions calls GET /api/stack-regions on the GCOM API and returns
 // the available regions for stack creation.
 func (c *GCOMClient) ListRegions(ctx context.Context) ([]Region, error) {
-	endpoint, err := c.buildURL("/api/stack-regions")
+	endpoint, err := c.buildURL(stackRegionsPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -17,8 +17,6 @@ import (
 	"github.com/grafana/gcx/internal/retry"
 )
 
-const instancesPath = "/api/instances/"
-
 // StackInfo holds the information about a Grafana Cloud stack as returned by the GCOM API.
 type StackInfo struct {
 	ID         int    `json:"id"`

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -246,7 +246,7 @@ func (c *GCOMClient) CreateStack(ctx context.Context, r CreateStackRequest) (Sta
 		return StackInfo{}, fmt.Errorf("gcom client: marshal request: %w", err)
 	}
 
-	endpoint, err := c.buildURL(instancesPath)
+	endpoint, err := c.buildURL(strings.TrimRight(instancesPath, "/"))
 	if err != nil {
 		return StackInfo{}, err
 	}

--- a/internal/cloud/gcom_test.go
+++ b/internal/cloud/gcom_test.go
@@ -274,6 +274,252 @@ func TestNewGCOMClient_SchemeValidation(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// ListStacks
+// ---------------------------------------------------------------------------
+
+func TestGCOMClient_ListStacks_Success(t *testing.T) {
+	want := []cloud.StackInfo{
+		{ID: 1, Slug: "stack-a", Name: "Stack A", Status: "active", OrgSlug: "myorg"},
+		{ID: 2, Slug: "stack-b", Name: "Stack B", Status: "active", OrgSlug: "myorg"},
+	}
+
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": want})
+	}))
+	defer srv.Close()
+
+	client, err := cloud.NewGCOMClient(srv.URL, "test-token")
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	got, err := client.ListStacks(context.Background(), "myorg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedPath != "/api/orgs/myorg/instances" {
+		t.Errorf("expected path /api/orgs/myorg/instances, got %q", capturedPath)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 stacks, got %d", len(got))
+	}
+	if got[0].Slug != "stack-a" {
+		t.Errorf("Slug[0]: got %q, want %q", got[0].Slug, "stack-a")
+	}
+}
+
+func TestGCOMClient_ListStacks_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+	}))
+	defer srv.Close()
+
+	client, err := cloud.NewGCOMClient(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	_, err = client.ListStacks(context.Background(), "myorg")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var httpErr *cloud.GCOMHTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *GCOMHTTPError, got %T", err)
+	}
+	if httpErr.Status != http.StatusForbidden {
+		t.Errorf("Status: got %d, want %d", httpErr.Status, http.StatusForbidden)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateStack
+// ---------------------------------------------------------------------------
+
+func TestGCOMClient_CreateStack_Success(t *testing.T) {
+	var capturedBody map[string]any
+	var capturedMethod string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(cloud.StackInfo{
+			ID: 42, Slug: "newstack", Name: "newstack", Status: "active", RegionSlug: "us",
+		})
+	}))
+	defer srv.Close()
+
+	client, err := cloud.NewGCOMClient(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	got, err := client.CreateStack(context.Background(), cloud.CreateStackRequest{
+		Name:   "newstack",
+		Slug:   "newstack",
+		Region: "us",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedMethod != http.MethodPost {
+		t.Errorf("expected POST, got %q", capturedMethod)
+	}
+	if got.Slug != "newstack" {
+		t.Errorf("Slug: got %q, want %q", got.Slug, "newstack")
+	}
+	if capturedBody["slug"] != "newstack" {
+		t.Errorf("request body slug: got %v", capturedBody["slug"])
+	}
+}
+
+func TestGCOMClient_CreateStack_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"message":"slug already taken"}`))
+	}))
+	defer srv.Close()
+
+	client, err := cloud.NewGCOMClient(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	_, err = client.CreateStack(context.Background(), cloud.CreateStackRequest{
+		Name: "dup", Slug: "dup",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var httpErr *cloud.GCOMHTTPError
+	if !errors.As(err, &httpErr) || httpErr.Status != http.StatusConflict {
+		t.Errorf("expected 409 GCOMHTTPError, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateStack
+// ---------------------------------------------------------------------------
+
+func TestGCOMClient_UpdateStack_Success(t *testing.T) {
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(cloud.StackInfo{
+			ID: 42, Slug: "mystack", Description: "updated",
+		})
+	}))
+	defer srv.Close()
+
+	client, err := cloud.NewGCOMClient(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	desc := "updated"
+	got, err := client.UpdateStack(context.Background(), "mystack", cloud.UpdateStackRequest{
+		Description: &desc,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedPath != "/api/instances/mystack" {
+		t.Errorf("expected path /api/instances/mystack, got %q", capturedPath)
+	}
+	if got.Description != "updated" {
+		t.Errorf("Description: got %q, want %q", got.Description, "updated")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeleteStack
+// ---------------------------------------------------------------------------
+
+func TestGCOMClient_DeleteStack_Success(t *testing.T) {
+	var capturedMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client, err := cloud.NewGCOMClient(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	err = client.DeleteStack(context.Background(), "mystack")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedMethod != http.MethodDelete {
+		t.Errorf("expected DELETE, got %q", capturedMethod)
+	}
+}
+
+func TestGCOMClient_DeleteStack_DeleteProtection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"message":"delete protection is enabled"}`))
+	}))
+	defer srv.Close()
+
+	client, err := cloud.NewGCOMClient(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	err = client.DeleteStack(context.Background(), "mystack")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var httpErr *cloud.GCOMHTTPError
+	if !errors.As(err, &httpErr) || httpErr.Status != http.StatusConflict {
+		t.Errorf("expected 409 GCOMHTTPError, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListRegions
+// ---------------------------------------------------------------------------
+
+func TestGCOMClient_ListRegions_Success(t *testing.T) {
+	want := []cloud.Region{
+		{ID: 1, Slug: "us", Name: "GCP US Central", Description: "United States", Provider: "gcp", Status: "active"},
+		{ID: 2, Slug: "eu", Name: "GCP Belgium", Description: "Europe", Provider: "gcp", Status: "active"},
+	}
+
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": want})
+	}))
+	defer srv.Close()
+
+	client, err := cloud.NewGCOMClient(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	got, err := client.ListRegions(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedPath != "/api/stack-regions" {
+		t.Errorf("expected path /api/stack-regions, got %q", capturedPath)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 regions, got %d", len(got))
+	}
+	if got[0].Slug != "us" {
+		t.Errorf("Slug[0]: got %q, want %q", got[0].Slug, "us")
+	}
+	if got[1].Provider != "gcp" {
+		t.Errorf("Provider[1]: got %q, want %q", got[1].Provider, "gcp")
+	}
+}
+
 func TestGCOMClient_GetStack_NoRedirectToDifferentDomain(t *testing.T) {
 	// This server redirects to a different domain
 	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -208,65 +208,107 @@ func (l *ConfigLoader) LoadGrafanaConfig(ctx context.Context) (config.Namespaced
 	return restCfg, nil
 }
 
-// LoadCloudConfig loads Grafana Cloud configuration, applying env var overrides.
-// Unlike LoadGrafanaConfig it does not require grafana.server to be set.
-// It validates that cloud.token is present, resolves the stack slug and GCOM URL,
-// calls the GCOM API to discover stack info, and returns a CloudRESTConfig.
-func (l *ConfigLoader) LoadCloudConfig(ctx context.Context) (CloudRESTConfig, error) {
+// cloudBase holds the common pieces resolved by loadCloudBase.
+type cloudBase struct {
+	token  string
+	client *cloud.GCOMClient
+	loaded config.Config
+	curCtx *config.Context
+}
+
+// loadCloudBase loads config, validates cloud.token, resolves the GCOM URL,
+// and creates a GCOMClient. It is the shared preamble for both
+// LoadCloudConfig (which additionally needs a stack slug) and
+// LoadCloudTokenConfig (which does not).
+func (l *ConfigLoader) loadCloudBase(ctx context.Context) (cloudBase, error) {
 	ctxName := l.resolvedContextName(ctx)
 	overrides := []config.Override{contextSelectionOverride(ctxName), cloudEnvOverride}
 
 	loaded, err := config.LoadLayered(ctx, l.configFile, overrides...)
 	if err != nil {
-		return CloudRESTConfig{}, err
+		return cloudBase{}, err
 	}
 
 	curCtx := loaded.GetCurrentContext()
 
-	// Validate cloud token.
 	if curCtx.Cloud == nil || curCtx.Cloud.Token == "" {
-		return CloudRESTConfig{}, errors.New("cloud token is required: set cloud.token in config or GRAFANA_CLOUD_TOKEN env var")
+		return cloudBase{}, errors.New("cloud token is required: set cloud.token in config or GRAFANA_CLOUD_TOKEN env var")
 	}
 
 	token := curCtx.Cloud.Token
+	gcomURL := curCtx.ResolveGCOMURL()
+	client, err := cloud.NewGCOMClient(gcomURL, token)
+	if err != nil {
+		return cloudBase{}, fmt.Errorf("failed to create GCOM client: %w", err)
+	}
 
-	// Resolve stack slug.
-	slug := curCtx.ResolveStackSlug()
+	return cloudBase{
+		token:  token,
+		client: client,
+		loaded: loaded,
+		curCtx: curCtx,
+	}, nil
+}
+
+// CloudTokenConfig holds the minimal cloud credentials needed for
+// org-level GCOM operations that do not target a specific stack.
+type CloudTokenConfig struct {
+	Token  string
+	Client *cloud.GCOMClient
+}
+
+// LoadCloudTokenConfig loads Grafana Cloud configuration requiring only
+// cloud.token (or GRAFANA_CLOUD_TOKEN). Unlike LoadCloudConfig it does not
+// require a stack slug and does not call GetStack.
+func (l *ConfigLoader) LoadCloudTokenConfig(ctx context.Context) (CloudTokenConfig, error) {
+	base, err := l.loadCloudBase(ctx)
+	if err != nil {
+		return CloudTokenConfig{}, err
+	}
+	return CloudTokenConfig{
+		Token:  base.token,
+		Client: base.client,
+	}, nil
+}
+
+// LoadCloudConfig loads Grafana Cloud configuration, applying env var overrides.
+// Unlike LoadGrafanaConfig it does not require grafana.server to be set.
+// It validates that cloud.token is present, resolves the stack slug and GCOM URL,
+// calls the GCOM API to discover stack info, and returns a CloudRESTConfig.
+func (l *ConfigLoader) LoadCloudConfig(ctx context.Context) (CloudRESTConfig, error) {
+	base, err := l.loadCloudBase(ctx)
+	if err != nil {
+		return CloudRESTConfig{}, err
+	}
+
+	slug := base.curCtx.ResolveStackSlug()
 	if slug == "" {
 		return CloudRESTConfig{}, errors.New("cloud stack is not configured: set cloud.stack in config or GRAFANA_CLOUD_STACK env var")
 	}
 
-	// Resolve GCOM URL and fetch stack info.
-	gcomURL := curCtx.ResolveGCOMURL()
-	client, err := cloud.NewGCOMClient(gcomURL, token)
-	if err != nil {
-		return CloudRESTConfig{}, fmt.Errorf("failed to create GCOM client: %w", err)
-	}
-
-	stack, err := client.GetStack(ctx, slug)
+	stack, err := base.client.GetStack(ctx, slug)
 	if err != nil {
 		return CloudRESTConfig{}, fmt.Errorf("failed to get stack info for %q: %w", slug, err)
 	}
 
-	// Derive namespace and REST config from grafana config if available.
 	namespace := "default"
 	var restCfg *rest.Config
-	if curCtx.Grafana != nil && !curCtx.Grafana.IsEmpty() {
-		nrc, err := curCtx.ToRESTConfig(ctx)
+	if base.curCtx.Grafana != nil && !base.curCtx.Grafana.IsEmpty() {
+		nrc, err := base.curCtx.ToRESTConfig(ctx)
 		if err != nil {
 			return CloudRESTConfig{}, err
 		}
-		nrc.WireTokenPersistence(ctx, l.configSource(), loaded.CurrentContext, loaded.Sources)
+		nrc.WireTokenPersistence(ctx, l.configSource(), base.loaded.CurrentContext, base.loaded.Sources)
 
 		namespace = nrc.Namespace
 		restCfg = &nrc.Config
 	}
 
 	return CloudRESTConfig{
-		Token:           token,
+		Token:           base.token,
 		Stack:           stack,
 		Namespace:       namespace,
-		ProviderConfigs: curCtx.Providers,
+		ProviderConfigs: base.curCtx.Providers,
 		RESTConfig:      restCfg,
 	}, nil
 }

--- a/internal/providers/stacks/commands.go
+++ b/internal/providers/stacks/commands.go
@@ -2,6 +2,7 @@ package stacks
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -41,7 +42,7 @@ func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.Org == "" {
-				return fmt.Errorf("--org is required")
+				return errors.New("--org is required")
 			}
 			if err := opts.IO.Validate(); err != nil {
 				return err
@@ -154,11 +155,11 @@ and may incur costs. Always confirm the stack name, slug, and region with the
 user before executing. Prefer --dry-run first.`,
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:write",
-			agent.AnnotationLLMHint:      "This command creates a new Grafana Cloud stack, which provisions infrastructure and may incur costs. Always confirm the stack name, slug, and region with the user before executing. Prefer --dry-run first.",
+			agent.AnnotationLLMHint:       "This command creates a new Grafana Cloud stack, which provisions infrastructure and may incur costs. Always confirm the stack name, slug, and region with the user before executing. Prefer --dry-run first.",
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.Name == "" || opts.Slug == "" {
-				return fmt.Errorf("--name and --slug are required")
+				return errors.New("--name and --slug are required")
 			}
 			if err := opts.IO.Validate(); err != nil {
 				return err
@@ -246,14 +247,14 @@ changes with the user and prefer --dry-run first.`,
 		Args: cobra.ExactArgs(1),
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:write",
-			agent.AnnotationLLMHint:      "This command modifies a live Grafana Cloud stack. Changing the name or disabling delete protection can have downstream effects. Always confirm the intended changes with the user and prefer --dry-run first.",
+			agent.AnnotationLLMHint:       "This command modifies a live Grafana Cloud stack. Changing the name or disabling delete protection can have downstream effects. Always confirm the intended changes with the user and prefer --dry-run first.",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err
 			}
 			if opts.DeleteProtection && opts.NoDeleteProtection {
-				return fmt.Errorf("--delete-protection and --no-delete-protection are mutually exclusive")
+				return errors.New("--delete-protection and --no-delete-protection are mutually exclusive")
 			}
 
 			labels, err := labelsFromFlag(opts.Labels)
@@ -325,7 +326,7 @@ IRREVERSIBLE. Always confirm with the user by name before executing. Prefer
 		Args: cobra.ExactArgs(1),
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:delete",
-			agent.AnnotationLLMHint:      "This command permanently deletes a Grafana Cloud stack and all its data (dashboards, alerts, datasources, metrics, logs, traces). This action is irreversible. Always confirm with the user by name before executing. Prefer --dry-run first. Never run this command without explicit user confirmation.",
+			agent.AnnotationLLMHint:       "This command permanently deletes a Grafana Cloud stack and all its data (dashboards, alerts, datasources, metrics, logs, traces). This action is irreversible. Always confirm with the user by name before executing. Prefer --dry-run first. Never run this command without explicit user confirmation.",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			slug := args[0]

--- a/internal/providers/stacks/commands.go
+++ b/internal/providers/stacks/commands.go
@@ -16,6 +16,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const instancesPath = "/api/instances"
+
 // ---------------------------------------------------------------------------
 // list
 // ---------------------------------------------------------------------------
@@ -190,7 +192,7 @@ user before executing. Prefer --dry-run first.`,
 			}
 
 			if opts.DryRun {
-				dryRunSummary(cmd.OutOrStdout(), http.MethodPost, "/api/instances", req)
+				dryRunSummary(cmd.OutOrStdout(), http.MethodPost, instancesPath, req)
 				return nil
 			}
 
@@ -288,7 +290,7 @@ changes with the user and prefer --dry-run first.`,
 			slug := args[0]
 
 			if opts.DryRun {
-				dryRunSummary(cmd.OutOrStdout(), http.MethodPost, "/api/instances/"+slug, req)
+				dryRunSummary(cmd.OutOrStdout(), http.MethodPost, instancesPath+"/"+slug, req)
 				return nil
 			}
 
@@ -345,7 +347,7 @@ IRREVERSIBLE. Always confirm with the user by name before executing. Prefer
 			slug := args[0]
 
 			if opts.DryRun {
-				fmt.Fprintf(cmd.OutOrStdout(), "Dry run: DELETE /api/instances/%s\n", slug)
+				fmt.Fprintf(cmd.OutOrStdout(), "Dry run: DELETE %s/%s\n", instancesPath, slug)
 				fmt.Fprintf(cmd.OutOrStdout(), "\nStack %q would be permanently deleted. No changes were made.\n", slug)
 				return nil
 			}

--- a/internal/providers/stacks/commands.go
+++ b/internal/providers/stacks/commands.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/cloud"
+	"github.com/grafana/gcx/internal/config"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/spf13/cobra"
@@ -79,6 +80,7 @@ type getOpts struct {
 
 func (o *getOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &stackTableCodec{})
+	o.IO.RegisterCustomCodec("wide", &stackTableCodec{Wide: true})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
 }
@@ -313,8 +315,13 @@ changes with the user and prefer --dry-run first.`,
 // ---------------------------------------------------------------------------
 
 type deleteOpts struct {
-	Force  bool
+	Yes    bool
 	DryRun bool
+}
+
+func (o *deleteOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVarP(&o.Yes, "yes", "y", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview the operation without executing it")
 }
 
 func newDeleteCommand(loader *providers.ConfigLoader) *cobra.Command {
@@ -343,8 +350,13 @@ IRREVERSIBLE. Always confirm with the user by name before executing. Prefer
 				return nil
 			}
 
-			if !opts.Force {
-				fmt.Fprintf(cmd.ErrOrStderr(),
+			cliOpts, err := config.LoadCLIOptions()
+			if err != nil {
+				return err
+			}
+
+			if !opts.Yes && !cliOpts.AutoApprove {
+				fmt.Fprintf(cmd.OutOrStdout(),
 					"WARNING: This will permanently delete stack %q and ALL its data.\n"+
 						"Type the stack slug to confirm: ", slug)
 
@@ -366,12 +378,11 @@ IRREVERSIBLE. Always confirm with the user by name before executing. Prefer
 				return fmt.Errorf("failed to delete stack: %w", err)
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Stack %q deleted successfully.\n", slug)
+			cmdio.Success(cmd.OutOrStdout(), "Stack %q deleted successfully.", slug)
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&opts.Force, "force", false, "Skip interactive confirmation")
-	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Preview the operation without executing it")
+	opts.setup(cmd.Flags())
 	return cmd
 }
 

--- a/internal/providers/stacks/commands.go
+++ b/internal/providers/stacks/commands.go
@@ -40,6 +40,7 @@ func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:read",
 			agent.AnnotationTokenCost:     "large",
+			agent.AnnotationLLMHint:       "List all stacks in the organisation. Use get to view details of a single stack.",
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.Org == "" {

--- a/internal/providers/stacks/commands.go
+++ b/internal/providers/stacks/commands.go
@@ -1,0 +1,414 @@
+package stacks
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/cloud"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+type listOpts struct {
+	IO  cmdio.Options
+	Org string
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &stackTableCodec{})
+	o.IO.RegisterCustomCodec("wide", &stackTableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Org, "org", "", "Organisation slug (required)")
+}
+
+func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List stacks in an organisation.",
+		Annotations: map[string]string{
+			agent.AnnotationRequiredScope: "stacks:read",
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if opts.Org == "" {
+				return fmt.Errorf("--org is required")
+			}
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			cfg, err := loader.LoadCloudTokenConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			stacks, err := cfg.Client.ListStacks(ctx, opts.Org)
+			if err != nil {
+				return fmt.Errorf("failed to list stacks: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), stacks)
+		},
+	}
+	opts.setup(cmd.Flags())
+	_ = cmd.MarkFlagRequired("org")
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// get
+// ---------------------------------------------------------------------------
+
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &stackTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:   "get <stack-slug>",
+		Short: "Get details of a single stack.",
+		Args:  cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			agent.AnnotationRequiredScope: "stacks:read",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			cfg, err := loader.LoadCloudTokenConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			stack, err := cfg.Client.GetStack(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to get stack: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), stack)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+
+type createOpts struct {
+	IO               cmdio.Options
+	Name             string
+	Slug             string
+	Region           string
+	Description      string
+	Labels           []string
+	URL              string
+	DeleteProtection bool
+	DryRun           bool
+}
+
+func (o *createOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &stackTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Name, "name", "", "Stack name (required)")
+	flags.StringVar(&o.Slug, "slug", "", "Stack slug / subdomain (required)")
+	flags.StringVar(&o.Region, "region", "", "Region slug (e.g. us, eu). Use 'gcx stacks regions' to list.")
+	flags.StringVar(&o.Description, "description", "", "Short description")
+	flags.StringSliceVar(&o.Labels, "labels", nil, "Labels in key=value format (may be repeated)")
+	flags.StringVar(&o.URL, "url", "", "Custom domain URL")
+	flags.BoolVar(&o.DeleteProtection, "delete-protection", false, "Enable delete protection")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview the request without executing it")
+}
+
+func newCreateCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &createOpts{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new Grafana Cloud stack.",
+		Long: `Create a new Grafana Cloud stack.
+
+This command creates a new Grafana Cloud stack, which provisions infrastructure
+and may incur costs. Always confirm the stack name, slug, and region with the
+user before executing. Prefer --dry-run first.`,
+		Annotations: map[string]string{
+			agent.AnnotationRequiredScope: "stacks:write",
+			agent.AnnotationLLMHint:      "This command creates a new Grafana Cloud stack, which provisions infrastructure and may incur costs. Always confirm the stack name, slug, and region with the user before executing. Prefer --dry-run first.",
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if opts.Name == "" || opts.Slug == "" {
+				return fmt.Errorf("--name and --slug are required")
+			}
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			labels, err := labelsFromFlag(opts.Labels)
+			if err != nil {
+				return err
+			}
+
+			req := cloud.CreateStackRequest{
+				Name:        opts.Name,
+				Slug:        opts.Slug,
+				Region:      opts.Region,
+				Description: opts.Description,
+				Labels:      labels,
+				URL:         opts.URL,
+			}
+			if opts.DeleteProtection {
+				dp := true
+				req.DeleteProtection = &dp
+			}
+
+			if opts.DryRun {
+				dryRunSummary(cmd.OutOrStdout(), http.MethodPost, "/api/instances", req)
+				return nil
+			}
+
+			ctx := cmd.Context()
+			cfg, err := loader.LoadCloudTokenConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			stack, err := cfg.Client.CreateStack(ctx, req)
+			if err != nil {
+				return fmt.Errorf("failed to create stack: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), stack)
+		},
+	}
+	opts.setup(cmd.Flags())
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("slug")
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// update
+// ---------------------------------------------------------------------------
+
+type updateOpts struct {
+	IO                 cmdio.Options
+	Name               string
+	Description        string
+	Labels             []string
+	DeleteProtection   bool
+	NoDeleteProtection bool
+	DryRun             bool
+}
+
+func (o *updateOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &stackTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Name, "name", "", "New stack name")
+	flags.StringVar(&o.Description, "description", "", "New description")
+	flags.StringSliceVar(&o.Labels, "labels", nil, "Labels in key=value format (replaces all labels)")
+	flags.BoolVar(&o.DeleteProtection, "delete-protection", false, "Enable delete protection")
+	flags.BoolVar(&o.NoDeleteProtection, "no-delete-protection", false, "Disable delete protection")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview the request without executing it")
+}
+
+func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &updateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update <stack-slug>",
+		Short: "Update a Grafana Cloud stack.",
+		Long: `Update a Grafana Cloud stack.
+
+This command modifies a live Grafana Cloud stack. Changing the name or disabling
+delete protection can have downstream effects. Always confirm the intended
+changes with the user and prefer --dry-run first.`,
+		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			agent.AnnotationRequiredScope: "stacks:write",
+			agent.AnnotationLLMHint:      "This command modifies a live Grafana Cloud stack. Changing the name or disabling delete protection can have downstream effects. Always confirm the intended changes with the user and prefer --dry-run first.",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			if opts.DeleteProtection && opts.NoDeleteProtection {
+				return fmt.Errorf("--delete-protection and --no-delete-protection are mutually exclusive")
+			}
+
+			labels, err := labelsFromFlag(opts.Labels)
+			if err != nil {
+				return err
+			}
+
+			req := cloud.UpdateStackRequest{
+				Name:   opts.Name,
+				Labels: labels,
+			}
+			if cmd.Flags().Changed("description") {
+				req.Description = &opts.Description
+			}
+			if opts.DeleteProtection {
+				dp := true
+				req.DeleteProtection = &dp
+			}
+			if opts.NoDeleteProtection {
+				dp := false
+				req.DeleteProtection = &dp
+			}
+
+			slug := args[0]
+
+			if opts.DryRun {
+				dryRunSummary(cmd.OutOrStdout(), http.MethodPost, "/api/instances/"+slug, req)
+				return nil
+			}
+
+			ctx := cmd.Context()
+			cfg, err := loader.LoadCloudTokenConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			stack, err := cfg.Client.UpdateStack(ctx, slug, req)
+			if err != nil {
+				return fmt.Errorf("failed to update stack: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), stack)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// delete
+// ---------------------------------------------------------------------------
+
+type deleteOpts struct {
+	Force  bool
+	DryRun bool
+}
+
+func newDeleteCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &deleteOpts{}
+	cmd := &cobra.Command{
+		Use:   "delete <stack-slug>",
+		Short: "Delete a Grafana Cloud stack.",
+		Long: `Delete a Grafana Cloud stack.
+
+This command permanently deletes a Grafana Cloud stack and ALL its data
+(dashboards, alerts, datasources, metrics, logs, traces). This action is
+IRREVERSIBLE. Always confirm with the user by name before executing. Prefer
+--dry-run first. Never run this command without explicit user confirmation.`,
+		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			agent.AnnotationRequiredScope: "stacks:delete",
+			agent.AnnotationLLMHint:      "This command permanently deletes a Grafana Cloud stack and all its data (dashboards, alerts, datasources, metrics, logs, traces). This action is irreversible. Always confirm with the user by name before executing. Prefer --dry-run first. Never run this command without explicit user confirmation.",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slug := args[0]
+
+			if opts.DryRun {
+				fmt.Fprintf(cmd.OutOrStdout(), "Dry run: DELETE /api/instances/%s\n", slug)
+				fmt.Fprintf(cmd.OutOrStdout(), "\nStack %q would be permanently deleted. No changes were made.\n", slug)
+				return nil
+			}
+
+			if !opts.Force {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"WARNING: This will permanently delete stack %q and ALL its data.\n"+
+						"Type the stack slug to confirm: ", slug)
+
+				scanner := bufio.NewScanner(cmd.InOrStdin())
+				scanner.Scan()
+				confirmation := strings.TrimSpace(scanner.Text())
+				if confirmation != slug {
+					return fmt.Errorf("confirmation did not match: expected %q, got %q", slug, confirmation)
+				}
+			}
+
+			ctx := cmd.Context()
+			cfg, err := loader.LoadCloudTokenConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			if err := cfg.Client.DeleteStack(ctx, slug); err != nil {
+				return fmt.Errorf("failed to delete stack: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Stack %q deleted successfully.\n", slug)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Skip interactive confirmation")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Preview the operation without executing it")
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// regions
+// ---------------------------------------------------------------------------
+
+type regionsOpts struct {
+	IO cmdio.Options
+}
+
+func (o *regionsOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &regionTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newRegionsCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &regionsOpts{}
+	cmd := &cobra.Command{
+		Use:   "regions",
+		Short: "List available regions for stack creation.",
+		Annotations: map[string]string{
+			agent.AnnotationRequiredScope: "stacks:read",
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			cfg, err := loader.LoadCloudTokenConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			regions, err := cfg.Client.ListRegions(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to list regions: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), regions)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/stacks/commands.go
+++ b/internal/providers/stacks/commands.go
@@ -39,6 +39,7 @@ func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "List stacks in an organisation.",
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:read",
+			agent.AnnotationTokenCost:     "large",
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.Org == "" {
@@ -89,6 +90,7 @@ func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:read",
+			agent.AnnotationTokenCost:     "small",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.IO.Validate(); err != nil {
@@ -155,6 +157,7 @@ and may incur costs. Always confirm the stack name, slug, and region with the
 user before executing. Prefer --dry-run first.`,
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:write",
+			agent.AnnotationTokenCost:     "small",
 			agent.AnnotationLLMHint:       "This command creates a new Grafana Cloud stack, which provisions infrastructure and may incur costs. Always confirm the stack name, slug, and region with the user before executing. Prefer --dry-run first.",
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -247,6 +250,7 @@ changes with the user and prefer --dry-run first.`,
 		Args: cobra.ExactArgs(1),
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:write",
+			agent.AnnotationTokenCost:     "small",
 			agent.AnnotationLLMHint:       "This command modifies a live Grafana Cloud stack. Changing the name or disabling delete protection can have downstream effects. Always confirm the intended changes with the user and prefer --dry-run first.",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -326,6 +330,7 @@ IRREVERSIBLE. Always confirm with the user by name before executing. Prefer
 		Args: cobra.ExactArgs(1),
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:delete",
+			agent.AnnotationTokenCost:     "small",
 			agent.AnnotationLLMHint:       "This command permanently deletes a Grafana Cloud stack and all its data (dashboards, alerts, datasources, metrics, logs, traces). This action is irreversible. Always confirm with the user by name before executing. Prefer --dry-run first. Never run this command without explicit user confirmation.",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -390,6 +395,7 @@ func newRegionsCommand(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "List available regions for stack creation.",
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:read",
+			agent.AnnotationTokenCost:     "small",
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {

--- a/internal/providers/stacks/commands_test.go
+++ b/internal/providers/stacks/commands_test.go
@@ -1,0 +1,301 @@
+package stacks_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/stacks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runCmd builds a parent command with SilenceUsage/SilenceErrors, adds the
+// given child, sets args and optional stdin, then executes.
+func runCmd(t *testing.T, child *cobra.Command, args []string, stdin string) (string, string, error) {
+	t.Helper()
+
+	parent := &cobra.Command{
+		Use:           "test",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	parent.AddCommand(child)
+
+	var outBuf, errBuf bytes.Buffer
+	parent.SetOut(&outBuf)
+	parent.SetErr(&errBuf)
+	parent.SetIn(strings.NewReader(stdin))
+	parent.SetArgs(args)
+
+	err := parent.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// parseDryRunOutput splits dry-run output into the header line and the JSON
+// body payload. Returns the header (e.g. "Dry run: POST /api/instances") and
+// the decoded JSON as a map.
+func parseDryRunOutput(t *testing.T, out string) (header string, body map[string]any) {
+	t.Helper()
+	parts := strings.SplitN(out, "\n\n", 2)
+	require.Len(t, parts, 2, "dry-run output should have header + blank line + JSON body")
+
+	header = strings.TrimSpace(parts[0])
+	err := json.Unmarshal([]byte(parts[1]), &body)
+	require.NoError(t, err, "dry-run body should be valid JSON")
+	return header, body
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+func TestListCommand_OrgRequired(t *testing.T) {
+	_, _, err := runCmd(t, stacks.NewTestListCommand(), []string{"list"}, "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "org")
+}
+
+// ---------------------------------------------------------------------------
+// create — validation
+// ---------------------------------------------------------------------------
+
+func TestCreateCommand_NameAndSlugRequired(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"missing both", []string{"create"}, "required flag"},
+		{"missing slug", []string{"create", "--name", "foo"}, "required flag"},
+		{"missing name", []string{"create", "--slug", "foo"}, "required flag"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := runCmd(t, stacks.NewTestCreateCommand(), tt.args, "")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// create — dry-run
+// ---------------------------------------------------------------------------
+
+func TestCreateCommand_DryRun(t *testing.T) {
+	out, _, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
+		"create", "--name", "My Stack", "--slug", "mystack", "--region", "us",
+		"--dry-run", "-o", "table",
+	}, "")
+
+	require.NoError(t, err)
+
+	header, body := parseDryRunOutput(t, out)
+	assert.Equal(t, "Dry run: POST /api/instances", header)
+	assert.Equal(t, "My Stack", body["name"])
+	assert.Equal(t, "mystack", body["slug"])
+	assert.Equal(t, "us", body["region"])
+}
+
+func TestCreateCommand_DryRun_WithLabels(t *testing.T) {
+	out, _, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
+		"create", "--name", "My Stack", "--slug", "mystack",
+		"--labels", "env=prod", "--labels", "team=platform",
+		"--dry-run", "-o", "table",
+	}, "")
+
+	require.NoError(t, err)
+
+	_, body := parseDryRunOutput(t, out)
+	labels, ok := body["labels"].(map[string]any)
+	require.True(t, ok, "labels should be a JSON object")
+	assert.Equal(t, "prod", labels["env"])
+	assert.Equal(t, "platform", labels["team"])
+}
+
+func TestCreateCommand_DryRun_DeleteProtectionFlag(t *testing.T) {
+	out, _, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
+		"create", "--name", "My Stack", "--slug", "mystack",
+		"--delete-protection",
+		"--dry-run", "-o", "table",
+	}, "")
+
+	require.NoError(t, err)
+
+	_, body := parseDryRunOutput(t, out)
+	assert.Equal(t, true, body["deleteProtection"], "deleteProtection should be true in the request body")
+}
+
+func TestCreateCommand_DryRun_InvalidLabels(t *testing.T) {
+	_, _, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
+		"create", "--name", "My Stack", "--slug", "mystack",
+		"--labels", "noequalssign",
+		"--dry-run", "-o", "table",
+	}, "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid label "noequalssign"`)
+}
+
+func TestCreateCommand_DryRun_DoesNotCallAPI(t *testing.T) {
+	// Dry-run should return before reaching the config loader. If it tried
+	// to load config, it would error because there's no config context set up.
+	_, _, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
+		"create", "--name", "X", "--slug", "x", "--dry-run", "-o", "table",
+	}, "")
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// update — validation
+// ---------------------------------------------------------------------------
+
+func TestUpdateCommand_MutualExclusion(t *testing.T) {
+	_, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
+		"update", "mystack",
+		"--delete-protection", "--no-delete-protection",
+		"--dry-run", "-o", "table",
+	}, "")
+
+	require.Error(t, err)
+	assert.Equal(t, "--delete-protection and --no-delete-protection are mutually exclusive", err.Error())
+}
+
+func TestUpdateCommand_RequiresArg(t *testing.T) {
+	_, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{"update"}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 1 arg")
+}
+
+// ---------------------------------------------------------------------------
+// update — dry-run
+// ---------------------------------------------------------------------------
+
+func TestUpdateCommand_DryRun(t *testing.T) {
+	out, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
+		"update", "mystack", "--name", "New Name", "--dry-run", "-o", "table",
+	}, "")
+
+	require.NoError(t, err)
+
+	header, body := parseDryRunOutput(t, out)
+	assert.Equal(t, "Dry run: POST /api/instances/mystack", header)
+	assert.Equal(t, "New Name", body["name"])
+}
+
+func TestUpdateCommand_DryRun_EnableDeleteProtection(t *testing.T) {
+	out, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
+		"update", "mystack", "--delete-protection", "--dry-run", "-o", "table",
+	}, "")
+
+	require.NoError(t, err)
+
+	_, body := parseDryRunOutput(t, out)
+	assert.Equal(t, true, body["deleteProtection"])
+}
+
+func TestUpdateCommand_DryRun_DisableDeleteProtection(t *testing.T) {
+	out, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
+		"update", "mystack", "--no-delete-protection", "--dry-run", "-o", "table",
+	}, "")
+
+	require.NoError(t, err)
+
+	_, body := parseDryRunOutput(t, out)
+	assert.Equal(t, false, body["deleteProtection"])
+}
+
+func TestUpdateCommand_DryRun_DoesNotCallAPI(t *testing.T) {
+	_, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
+		"update", "mystack", "--name", "X", "--dry-run", "-o", "table",
+	}, "")
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// delete — dry-run
+// ---------------------------------------------------------------------------
+
+func TestDeleteCommand_DryRun(t *testing.T) {
+	out, _, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{
+		"delete", "mystack", "--dry-run",
+	}, "")
+
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.Len(t, lines, 3, "dry-run delete should produce 3 lines (header, blank, summary)")
+	assert.Equal(t, "Dry run: DELETE /api/instances/mystack", lines[0])
+	assert.Equal(t, "", lines[1])
+	assert.Equal(t, `Stack "mystack" would be permanently deleted. No changes were made.`, lines[2])
+}
+
+func TestDeleteCommand_DryRun_DoesNotCallAPI(t *testing.T) {
+	_, _, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{
+		"delete", "mystack", "--dry-run",
+	}, "")
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// delete — confirmation
+// ---------------------------------------------------------------------------
+
+func TestDeleteCommand_ConfirmationMismatch(t *testing.T) {
+	_, _, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{"delete", "mystack"}, "wrong-slug\n")
+
+	require.Error(t, err)
+	assert.Equal(t, `confirmation did not match: expected "mystack", got "wrong-slug"`, err.Error())
+}
+
+func TestDeleteCommand_ConfirmationPrompt(t *testing.T) {
+	_, stderr, _ := runCmd(t, stacks.NewTestDeleteCommand(), []string{"delete", "mystack"}, "wrong\n")
+
+	assert.Contains(t, stderr, "WARNING")
+	assert.Contains(t, stderr, `permanently delete stack "mystack"`)
+	assert.Contains(t, stderr, "Type the stack slug to confirm")
+}
+
+func TestDeleteCommand_RequiresArg(t *testing.T) {
+	_, _, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{"delete"}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 1 arg")
+}
+
+// ---------------------------------------------------------------------------
+// get — validation
+// ---------------------------------------------------------------------------
+
+func TestGetCommand_RequiresArg(t *testing.T) {
+	_, _, err := runCmd(t, stacks.NewTestGetCommand(), []string{"get"}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 1 arg")
+}
+
+// ---------------------------------------------------------------------------
+// provider registration
+// ---------------------------------------------------------------------------
+
+func TestStacksProvider_Commands(t *testing.T) {
+	p := &stacks.StacksProvider{}
+
+	assert.Equal(t, "stacks", p.Name())
+	assert.NotEmpty(t, p.ShortDesc())
+
+	cmds := p.Commands()
+	require.Len(t, cmds, 1, "should return one top-level 'stacks' command")
+
+	stacksCmd := cmds[0]
+	assert.Equal(t, "stacks", stacksCmd.Use)
+
+	subNames := make([]string, 0, len(stacksCmd.Commands()))
+	for _, sub := range stacksCmd.Commands() {
+		subNames = append(subNames, sub.Name())
+	}
+	assert.ElementsMatch(t, []string{"list", "get", "create", "update", "delete", "regions"}, subNames)
+}

--- a/internal/providers/stacks/commands_test.go
+++ b/internal/providers/stacks/commands_test.go
@@ -14,7 +14,7 @@ import (
 
 // runCmd builds a parent command with SilenceUsage/SilenceErrors, adds the
 // given child, sets args and optional stdin, then executes.
-func runCmd(t *testing.T, child *cobra.Command, args []string, stdin string) (string, string, error) {
+func runCmd(t *testing.T, child *cobra.Command, args []string, stdin string) (string, error) {
 	t.Helper()
 
 	parent := &cobra.Command{
@@ -24,25 +24,26 @@ func runCmd(t *testing.T, child *cobra.Command, args []string, stdin string) (st
 	}
 	parent.AddCommand(child)
 
-	var outBuf, errBuf bytes.Buffer
+	var outBuf bytes.Buffer
 	parent.SetOut(&outBuf)
-	parent.SetErr(&errBuf)
+	parent.SetErr(&outBuf)
 	parent.SetIn(strings.NewReader(stdin))
 	parent.SetArgs(args)
 
 	err := parent.Execute()
-	return outBuf.String(), errBuf.String(), err
+	return outBuf.String(), err
 }
 
 // parseDryRunOutput splits dry-run output into the header line and the JSON
 // body payload. Returns the header (e.g. "Dry run: POST /api/instances") and
 // the decoded JSON as a map.
-func parseDryRunOutput(t *testing.T, out string) (header string, body map[string]any) {
+func parseDryRunOutput(t *testing.T, out string) (string, map[string]any) {
 	t.Helper()
 	parts := strings.SplitN(out, "\n\n", 2)
 	require.Len(t, parts, 2, "dry-run output should have header + blank line + JSON body")
 
-	header = strings.TrimSpace(parts[0])
+	header := strings.TrimSpace(parts[0])
+	var body map[string]any
 	err := json.Unmarshal([]byte(parts[1]), &body)
 	require.NoError(t, err, "dry-run body should be valid JSON")
 	return header, body
@@ -53,7 +54,7 @@ func parseDryRunOutput(t *testing.T, out string) (header string, body map[string
 // ---------------------------------------------------------------------------
 
 func TestListCommand_OrgRequired(t *testing.T) {
-	_, _, err := runCmd(t, stacks.NewTestListCommand(), []string{"list"}, "")
+	_, err := runCmd(t, stacks.NewTestListCommand(), []string{"list"}, "")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "org")
@@ -76,7 +77,7 @@ func TestCreateCommand_NameAndSlugRequired(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := runCmd(t, stacks.NewTestCreateCommand(), tt.args, "")
+			_, err := runCmd(t, stacks.NewTestCreateCommand(), tt.args, "")
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
@@ -88,7 +89,7 @@ func TestCreateCommand_NameAndSlugRequired(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCreateCommand_DryRun(t *testing.T) {
-	out, _, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
+	out, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
 		"create", "--name", "My Stack", "--slug", "mystack", "--region", "us",
 		"--dry-run", "-o", "table",
 	}, "")
@@ -103,7 +104,7 @@ func TestCreateCommand_DryRun(t *testing.T) {
 }
 
 func TestCreateCommand_DryRun_WithLabels(t *testing.T) {
-	out, _, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
+	out, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
 		"create", "--name", "My Stack", "--slug", "mystack",
 		"--labels", "env=prod", "--labels", "team=platform",
 		"--dry-run", "-o", "table",
@@ -119,7 +120,7 @@ func TestCreateCommand_DryRun_WithLabels(t *testing.T) {
 }
 
 func TestCreateCommand_DryRun_DeleteProtectionFlag(t *testing.T) {
-	out, _, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
+	out, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
 		"create", "--name", "My Stack", "--slug", "mystack",
 		"--delete-protection",
 		"--dry-run", "-o", "table",
@@ -132,7 +133,7 @@ func TestCreateCommand_DryRun_DeleteProtectionFlag(t *testing.T) {
 }
 
 func TestCreateCommand_DryRun_InvalidLabels(t *testing.T) {
-	_, _, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
+	_, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
 		"create", "--name", "My Stack", "--slug", "mystack",
 		"--labels", "noequalssign",
 		"--dry-run", "-o", "table",
@@ -145,7 +146,7 @@ func TestCreateCommand_DryRun_InvalidLabels(t *testing.T) {
 func TestCreateCommand_DryRun_DoesNotCallAPI(t *testing.T) {
 	// Dry-run should return before reaching the config loader. If it tried
 	// to load config, it would error because there's no config context set up.
-	_, _, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
+	_, err := runCmd(t, stacks.NewTestCreateCommand(), []string{
 		"create", "--name", "X", "--slug", "x", "--dry-run", "-o", "table",
 	}, "")
 	require.NoError(t, err)
@@ -156,7 +157,7 @@ func TestCreateCommand_DryRun_DoesNotCallAPI(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestUpdateCommand_MutualExclusion(t *testing.T) {
-	_, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
+	_, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
 		"update", "mystack",
 		"--delete-protection", "--no-delete-protection",
 		"--dry-run", "-o", "table",
@@ -167,7 +168,7 @@ func TestUpdateCommand_MutualExclusion(t *testing.T) {
 }
 
 func TestUpdateCommand_RequiresArg(t *testing.T) {
-	_, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{"update"}, "")
+	_, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{"update"}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "accepts 1 arg")
 }
@@ -177,7 +178,7 @@ func TestUpdateCommand_RequiresArg(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestUpdateCommand_DryRun(t *testing.T) {
-	out, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
+	out, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
 		"update", "mystack", "--name", "New Name", "--dry-run", "-o", "table",
 	}, "")
 
@@ -189,7 +190,7 @@ func TestUpdateCommand_DryRun(t *testing.T) {
 }
 
 func TestUpdateCommand_DryRun_EnableDeleteProtection(t *testing.T) {
-	out, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
+	out, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
 		"update", "mystack", "--delete-protection", "--dry-run", "-o", "table",
 	}, "")
 
@@ -200,7 +201,7 @@ func TestUpdateCommand_DryRun_EnableDeleteProtection(t *testing.T) {
 }
 
 func TestUpdateCommand_DryRun_DisableDeleteProtection(t *testing.T) {
-	out, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
+	out, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
 		"update", "mystack", "--no-delete-protection", "--dry-run", "-o", "table",
 	}, "")
 
@@ -211,7 +212,7 @@ func TestUpdateCommand_DryRun_DisableDeleteProtection(t *testing.T) {
 }
 
 func TestUpdateCommand_DryRun_DoesNotCallAPI(t *testing.T) {
-	_, _, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
+	_, err := runCmd(t, stacks.NewTestUpdateCommand(), []string{
 		"update", "mystack", "--name", "X", "--dry-run", "-o", "table",
 	}, "")
 	require.NoError(t, err)
@@ -222,7 +223,7 @@ func TestUpdateCommand_DryRun_DoesNotCallAPI(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDeleteCommand_DryRun(t *testing.T) {
-	out, _, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{
+	out, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{
 		"delete", "mystack", "--dry-run",
 	}, "")
 
@@ -231,12 +232,12 @@ func TestDeleteCommand_DryRun(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 	require.Len(t, lines, 3, "dry-run delete should produce 3 lines (header, blank, summary)")
 	assert.Equal(t, "Dry run: DELETE /api/instances/mystack", lines[0])
-	assert.Equal(t, "", lines[1])
+	assert.Empty(t, lines[1])
 	assert.Equal(t, `Stack "mystack" would be permanently deleted. No changes were made.`, lines[2])
 }
 
 func TestDeleteCommand_DryRun_DoesNotCallAPI(t *testing.T) {
-	_, _, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{
+	_, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{
 		"delete", "mystack", "--dry-run",
 	}, "")
 	require.NoError(t, err)
@@ -247,22 +248,22 @@ func TestDeleteCommand_DryRun_DoesNotCallAPI(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDeleteCommand_ConfirmationMismatch(t *testing.T) {
-	_, _, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{"delete", "mystack"}, "wrong-slug\n")
+	_, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{"delete", "mystack"}, "wrong-slug\n")
 
 	require.Error(t, err)
 	assert.Equal(t, `confirmation did not match: expected "mystack", got "wrong-slug"`, err.Error())
 }
 
 func TestDeleteCommand_ConfirmationPrompt(t *testing.T) {
-	_, stderr, _ := runCmd(t, stacks.NewTestDeleteCommand(), []string{"delete", "mystack"}, "wrong\n")
+	stdout, _ := runCmd(t, stacks.NewTestDeleteCommand(), []string{"delete", "mystack"}, "wrong\n")
 
-	assert.Contains(t, stderr, "WARNING")
-	assert.Contains(t, stderr, `permanently delete stack "mystack"`)
-	assert.Contains(t, stderr, "Type the stack slug to confirm")
+	assert.Contains(t, stdout, "WARNING")
+	assert.Contains(t, stdout, `permanently delete stack "mystack"`)
+	assert.Contains(t, stdout, "Type the stack slug to confirm")
 }
 
 func TestDeleteCommand_RequiresArg(t *testing.T) {
-	_, _, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{"delete"}, "")
+	_, err := runCmd(t, stacks.NewTestDeleteCommand(), []string{"delete"}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "accepts 1 arg")
 }
@@ -272,7 +273,7 @@ func TestDeleteCommand_RequiresArg(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestGetCommand_RequiresArg(t *testing.T) {
-	_, _, err := runCmd(t, stacks.NewTestGetCommand(), []string{"get"}, "")
+	_, err := runCmd(t, stacks.NewTestGetCommand(), []string{"get"}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "accepts 1 arg")
 }

--- a/internal/providers/stacks/export_test.go
+++ b/internal/providers/stacks/export_test.go
@@ -1,0 +1,68 @@
+package stacks
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/grafana/gcx/internal/cloud"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+)
+
+// NewTestListCommand creates a list command for external tests.
+func NewTestListCommand() *cobra.Command { return newListCommand(&providers.ConfigLoader{}) }
+
+// NewTestGetCommand creates a get command for external tests.
+func NewTestGetCommand() *cobra.Command { return newGetCommand(&providers.ConfigLoader{}) }
+
+// NewTestCreateCommand creates a create command for external tests.
+func NewTestCreateCommand() *cobra.Command { return newCreateCommand(&providers.ConfigLoader{}) }
+
+// NewTestUpdateCommand creates an update command for external tests.
+func NewTestUpdateCommand() *cobra.Command { return newUpdateCommand(&providers.ConfigLoader{}) }
+
+// NewTestDeleteCommand creates a delete command for external tests.
+func NewTestDeleteCommand() *cobra.Command { return newDeleteCommand(&providers.ConfigLoader{}) }
+
+// ExportLabelsFromFlag exposes labelsFromFlag for external tests.
+func ExportLabelsFromFlag(labels []string) (map[string]string, error) { return labelsFromFlag(labels) }
+
+// ExportDryRunSummary exposes dryRunSummary for external tests.
+func ExportDryRunSummary(w io.Writer, method, endpoint string, body any) {
+	dryRunSummary(w, method, endpoint, body)
+}
+
+// ExportStackTableCodec returns a stackTableCodec for external tests.
+func ExportStackTableCodec(wide bool) interface {
+	Encode(io.Writer, any) error
+} {
+	return &stackTableCodec{Wide: wide}
+}
+
+// ExportRegionTableCodec returns a regionTableCodec for external tests.
+func ExportRegionTableCodec() interface {
+	Encode(io.Writer, any) error
+} {
+	return &regionTableCodec{}
+}
+
+// ExportEncodeStackTable encodes stacks using the table codec and returns the output.
+func ExportEncodeStackTable(stacks []cloud.StackInfo, wide bool) (string, error) {
+	var buf bytes.Buffer
+	err := (&stackTableCodec{Wide: wide}).Encode(&buf, stacks)
+	return buf.String(), err
+}
+
+// ExportEncodeStackTableSingle encodes a single stack using the table codec.
+func ExportEncodeStackTableSingle(stack cloud.StackInfo) (string, error) {
+	var buf bytes.Buffer
+	err := (&stackTableCodec{}).Encode(&buf, stack)
+	return buf.String(), err
+}
+
+// ExportEncodeRegionTable encodes regions using the table codec and returns the output.
+func ExportEncodeRegionTable(regions []cloud.Region) (string, error) {
+	var buf bytes.Buffer
+	err := (&regionTableCodec{}).Encode(&buf, regions)
+	return buf.String(), err
+}

--- a/internal/providers/stacks/export_test.go
+++ b/internal/providers/stacks/export_test.go
@@ -34,14 +34,14 @@ func ExportDryRunSummary(w io.Writer, method, endpoint string, body any) {
 
 // ExportStackTableCodec returns a stackTableCodec for external tests.
 func ExportStackTableCodec(wide bool) interface {
-	Encode(io.Writer, any) error
+	Encode(w io.Writer, v any) error
 } {
 	return &stackTableCodec{Wide: wide}
 }
 
 // ExportRegionTableCodec returns a regionTableCodec for external tests.
 func ExportRegionTableCodec() interface {
-	Encode(io.Writer, any) error
+	Encode(w io.Writer, v any) error
 } {
 	return &regionTableCodec{}
 }

--- a/internal/providers/stacks/format.go
+++ b/internal/providers/stacks/format.go
@@ -98,7 +98,7 @@ func dryRunSummary(w io.Writer, method, endpoint string, body any) {
 // labelsFromFlag parses a slice of "key=value" strings into a map.
 func labelsFromFlag(labels []string) (map[string]string, error) {
 	if len(labels) == 0 {
-		return nil, nil
+		return nil, nil //nolint:nilnil // nil signals "no labels specified" so omitempty omits the field.
 	}
 	m := make(map[string]string, len(labels))
 	for _, l := range labels {

--- a/internal/providers/stacks/format.go
+++ b/internal/providers/stacks/format.go
@@ -1,0 +1,112 @@
+package stacks
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/grafana/gcx/internal/cloud"
+	"github.com/grafana/gcx/internal/format"
+	"github.com/grafana/gcx/internal/style"
+)
+
+// stackTableCodec renders []cloud.StackInfo as a table.
+type stackTableCodec struct {
+	Wide bool
+}
+
+func (c *stackTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *stackTableCodec) Encode(w io.Writer, v any) error {
+	stacks, ok := v.([]cloud.StackInfo)
+	if !ok {
+		if s, ok := v.(cloud.StackInfo); ok {
+			stacks = []cloud.StackInfo{s}
+		} else {
+			return errors.New("invalid data type for table codec: expected []cloud.StackInfo or cloud.StackInfo")
+		}
+	}
+
+	var tbl *style.TableBuilder
+	if c.Wide {
+		tbl = style.NewTable("SLUG", "NAME", "STATUS", "REGION", "URL", "PLAN", "DELETE-PROTECTION", "CREATED")
+	} else {
+		tbl = style.NewTable("SLUG", "NAME", "STATUS", "REGION", "URL")
+	}
+
+	for _, s := range stacks {
+		if c.Wide {
+			dp := "false"
+			if s.DeleteProtection {
+				dp = "true"
+			}
+			created := s.CreatedAt
+			if len(created) > 10 {
+				created = created[:10]
+			}
+			tbl.Row(s.Slug, s.Name, s.Status, s.RegionSlug, s.URL, s.PlanName, dp, created)
+		} else {
+			tbl.Row(s.Slug, s.Name, s.Status, s.RegionSlug, s.URL)
+		}
+	}
+
+	return tbl.Render(w)
+}
+
+func (c *stackTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// regionTableCodec renders []cloud.Region as a table.
+type regionTableCodec struct{}
+
+func (c *regionTableCodec) Format() format.Format { return "table" }
+
+func (c *regionTableCodec) Encode(w io.Writer, v any) error {
+	regions, ok := v.([]cloud.Region)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []cloud.Region")
+	}
+
+	tbl := style.NewTable("SLUG", "NAME", "DESCRIPTION", "PROVIDER", "STATUS")
+	for _, r := range regions {
+		tbl.Row(r.Slug, r.Name, r.Description, r.Provider, r.Status)
+	}
+	return tbl.Render(w)
+}
+
+func (c *regionTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// dryRunSummary prints a human-readable dry-run preview.
+func dryRunSummary(w io.Writer, method, endpoint string, body any) {
+	fmt.Fprintf(w, "Dry run: %s %s\n", method, endpoint)
+	if body != nil {
+		fmt.Fprintln(w)
+		codec := format.NewJSONCodec()
+		_ = codec.Encode(w, body)
+	}
+}
+
+// labelsFromFlag parses a slice of "key=value" strings into a map.
+func labelsFromFlag(labels []string) (map[string]string, error) {
+	if len(labels) == 0 {
+		return nil, nil
+	}
+	m := make(map[string]string, len(labels))
+	for _, l := range labels {
+		k, v, ok := strings.Cut(l, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid label %q: must be in key=value format", l)
+		}
+		m[k] = v
+	}
+	return m, nil
+}

--- a/internal/providers/stacks/format_test.go
+++ b/internal/providers/stacks/format_test.go
@@ -1,0 +1,135 @@
+package stacks_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/grafana/gcx/internal/cloud"
+	"github.com/grafana/gcx/internal/providers/stacks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackTableCodec_Encode_Slice(t *testing.T) {
+	out, err := stacks.ExportEncodeStackTable([]cloud.StackInfo{
+		{Slug: "prod", Name: "Production", Status: "active", RegionSlug: "us", URL: "https://prod.grafana.net"},
+		{Slug: "dev", Name: "Development", Status: "active", RegionSlug: "eu", URL: "https://dev.grafana.net"},
+	}, false)
+
+	require.NoError(t, err)
+	assert.Contains(t, out, "SLUG")
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "STATUS")
+	assert.Contains(t, out, "REGION")
+	assert.Contains(t, out, "URL")
+	assert.Contains(t, out, "prod")
+	assert.Contains(t, out, "dev")
+	assert.NotContains(t, out, "PLAN", "narrow table should not include PLAN column")
+}
+
+func TestStackTableCodec_Encode_Wide(t *testing.T) {
+	out, err := stacks.ExportEncodeStackTable([]cloud.StackInfo{
+		{
+			Slug: "prod", Name: "Production", Status: "active", RegionSlug: "us",
+			URL: "https://prod.grafana.net", PlanName: "Pro", DeleteProtection: true,
+			CreatedAt: "2024-01-15T10:30:00Z",
+		},
+	}, true)
+
+	require.NoError(t, err)
+	assert.Contains(t, out, "PLAN")
+	assert.Contains(t, out, "DELETE-PROTECTION")
+	assert.Contains(t, out, "CREATED")
+	assert.Contains(t, out, "Pro")
+	assert.Contains(t, out, "true")
+	assert.Contains(t, out, "2024-01-15", "CreatedAt should be truncated to date")
+}
+
+func TestStackTableCodec_Encode_SingleStack(t *testing.T) {
+	out, err := stacks.ExportEncodeStackTableSingle(cloud.StackInfo{
+		Slug: "mystack", Name: "My Stack", Status: "active", RegionSlug: "us",
+		URL: "https://mystack.grafana.net",
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, out, "mystack")
+	assert.Contains(t, out, "My Stack")
+}
+
+func TestStackTableCodec_Encode_InvalidType(t *testing.T) {
+	var buf bytes.Buffer
+	err := stacks.ExportStackTableCodec(false).Encode(&buf, "not a stack")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid data type")
+}
+
+func TestRegionTableCodec_Encode(t *testing.T) {
+	out, err := stacks.ExportEncodeRegionTable([]cloud.Region{
+		{Slug: "us", Name: "US Central", Description: "United States", Provider: "gcp", Status: "active"},
+		{Slug: "eu", Name: "Belgium", Description: "Europe", Provider: "gcp", Status: "active"},
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, out, "SLUG")
+	assert.Contains(t, out, "PROVIDER")
+	assert.Contains(t, out, "us")
+	assert.Contains(t, out, "eu")
+	assert.Contains(t, out, "gcp")
+}
+
+func TestRegionTableCodec_Encode_InvalidType(t *testing.T) {
+	var buf bytes.Buffer
+	err := stacks.ExportRegionTableCodec().Encode(&buf, "not regions")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid data type")
+}
+
+func TestDryRunSummary(t *testing.T) {
+	var buf bytes.Buffer
+	stacks.ExportDryRunSummary(&buf, "POST", "/api/instances", map[string]string{"name": "test"})
+
+	out := buf.String()
+	assert.Contains(t, out, "Dry run: POST /api/instances")
+	assert.Contains(t, out, `"name"`)
+	assert.Contains(t, out, `"test"`)
+}
+
+func TestDryRunSummary_NilBody(t *testing.T) {
+	var buf bytes.Buffer
+	stacks.ExportDryRunSummary(&buf, "DELETE", "/api/instances/mystack", nil)
+
+	out := buf.String()
+	assert.Contains(t, out, "Dry run: DELETE /api/instances/mystack")
+	assert.NotContains(t, out, "{", "nil body should not produce JSON output")
+}
+
+func TestLabelsFromFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		want    map[string]string
+		wantErr string
+	}{
+		{name: "nil input", input: nil, want: nil},
+		{name: "empty input", input: []string{}, want: nil},
+		{name: "single label", input: []string{"env=prod"}, want: map[string]string{"env": "prod"}},
+		{name: "multiple labels", input: []string{"env=prod", "team=platform"}, want: map[string]string{"env": "prod", "team": "platform"}},
+		{name: "value with equals sign", input: []string{"config=key=value"}, want: map[string]string{"config": "key=value"}},
+		{name: "empty value", input: []string{"flag="}, want: map[string]string{"flag": ""}},
+		{name: "missing equals", input: []string{"noequalssign"}, wantErr: "invalid label"},
+		{name: "empty key", input: []string{"=value"}, wantErr: "invalid label"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := stacks.ExportLabelsFromFlag(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/providers/stacks/provider.go
+++ b/internal/providers/stacks/provider.go
@@ -1,0 +1,50 @@
+package stacks
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/spf13/cobra"
+)
+
+var _ providers.Provider = &StacksProvider{}
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	providers.Register(&StacksProvider{})
+}
+
+// StacksProvider manages Grafana Cloud stack lifecycle via the GCOM API.
+type StacksProvider struct{}
+
+func (p *StacksProvider) Name() string { return "stacks" }
+
+func (p *StacksProvider) ShortDesc() string {
+	return "Manage Grafana Cloud stacks (list, create, update, delete)"
+}
+
+func (p *StacksProvider) Commands() []*cobra.Command {
+	loader := &providers.ConfigLoader{}
+
+	stacksCmd := &cobra.Command{
+		Use:   "stacks",
+		Short: p.ShortDesc(),
+	}
+
+	loader.BindFlags(stacksCmd.PersistentFlags())
+
+	stacksCmd.AddCommand(
+		newListCommand(loader),
+		newGetCommand(loader),
+		newCreateCommand(loader),
+		newUpdateCommand(loader),
+		newDeleteCommand(loader),
+		newRegionsCommand(loader),
+	)
+
+	return []*cobra.Command{stacksCmd}
+}
+
+func (p *StacksProvider) Validate(_ map[string]string) error { return nil }
+
+func (p *StacksProvider) ConfigKeys() []providers.ConfigKey { return nil }
+
+func (p *StacksProvider) TypedRegistrations() []adapter.Registration { return nil }


### PR DESCRIPTION
## Summary

Adds a new `stacks` provider to `gcx` for managing Grafana Cloud stack lifecycle via the GCOM API. This closes the P0 gap identified in the migration gap analysis.

### Commands

| Command | Description |
|---------|-------------|
| `gcx stacks list --org <slug>` | List all stacks in an org |
| `gcx stacks get <slug>` | Get details for a single stack |
| `gcx stacks create --name <n> --slug <s> --region <r>` | Create a new stack |
| `gcx stacks update <slug> [flags]` | Update stack settings |
| `gcx stacks delete <slug>` | Delete a stack (with confirmation) |
| `gcx stacks regions` | List available cloud regions |

### Key design decisions

- **`--org` is required** for `list` — no inference from the configured stack to keep it explicit.
- **`--dry-run`** on all mutating commands (`create`, `update`, `delete`) previews operations without executing.
- **LLM safety hints** via `agent.AnnotationLLMHint` on destructive commands to prevent agents from running them without explicit user confirmation.
- **Extended `StackInfo`** with additional GCOM fields rather than introducing a new type — backwards-compatible.
- **New `LoadCloudTokenConfig`** for providers needing only a cloud token (no stack slug), with shared logic refactored into `loadCloudBase`.
- **Stacks-specific error conversion** for GCOM 409/403/401 with actionable suggestions.

### Test coverage

**GCOM client (`internal/cloud/gcom_test.go`)** — httptest-based tests for all new API methods:
- `ListStacks`, `CreateStack`, `UpdateStack`, `DeleteStack`, `ListRegions` (success + error paths including 409 conflict, 403 forbidden, delete protection)

**Command layer (`internal/providers/stacks/commands_test.go`)** — 21 tests via Cobra `Execute()`:
- Flag validation: `--org` required on list, `--name`/`--slug` required on create, arg count enforcement on get/update/delete
- Dry-run for create/update/delete: parses JSON body and asserts on exact field values (name, slug, region, labels, deleteProtection)
- Mutual exclusion of `--delete-protection` / `--no-delete-protection`
- Delete confirmation prompt text and mismatch error with exact message matching
- Dry-run short-circuits before config loader (DoesNotCallAPI tests)
- Provider registration and subcommand tree

**Format layer (`internal/providers/stacks/format_test.go`)** — 12 tests:
- `stackTableCodec`: narrow, wide, single item, invalid type
- `regionTableCodec`: valid encoding, invalid type
- `dryRunSummary`: with body (JSON output), nil body (no JSON)
- `labelsFromFlag`: valid pairs, empty value, value containing `=`, missing `=`, empty key

### Commits

1. `feat(cloud)` — Extend GCOM client with stack lifecycle and regions API methods + tests
2. `refactor(providers)` — Extract `loadCloudBase` helper, add `LoadCloudTokenConfig`
3. `feat(stacks)` — Stacks provider with all commands, format codecs, registration, error hints
4. `docs` — Update migration gap analysis
5. `fix` — Resolve lint issues (gci, perfsprint, nilnil)
6. `fix` — Add token cost annotations and regenerate CLI reference docs
7. `test(stacks)` — Add command and format tests for stacks provider