### PR TITLE
fix(login): persist cloud.stack slug when logging in without a CAP token

### DIFF
--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -562,7 +562,9 @@ func mergeAuthIntoExisting(existing *config.Context, incoming config.Context) {
 		if existing.Cloud == nil {
 			existing.Cloud = &config.CloudConfig{}
 		}
-		existing.Cloud.Token = incoming.Cloud.Token
+		if incoming.Cloud.Token != "" {
+			existing.Cloud.Token = incoming.Cloud.Token
+		}
 		if incoming.Cloud.APIUrl != "" {
 			existing.Cloud.APIUrl = incoming.Cloud.APIUrl
 		}

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -454,8 +454,13 @@ func resolveCloudAuth(opts Options, target Target) (*config.CloudConfig, error) 
 		return cc, nil
 	}
 
-	// Cloud target with no token: skip if Yes or agent mode (D9, D10)
+	// Cloud target with no token: skip if Yes or agent mode (D9, D10).
+	// Still persist the stack slug when derivable so datasource auto-discovery
+	// works on stacks with multiple signal datasources.
 	if opts.Yes || agent.IsAgentMode() {
+		if slug := resolveStackSlug(opts.Server); slug != "" {
+			return &config.CloudConfig{Stack: slug}, nil
+		}
 		return nil, nil //nolint:nilnil // nil CloudConfig means "Cloud auth skipped"; valid non-error state.
 	}
 
@@ -560,6 +565,9 @@ func mergeAuthIntoExisting(existing *config.Context, incoming config.Context) {
 		existing.Cloud.Token = incoming.Cloud.Token
 		if incoming.Cloud.APIUrl != "" {
 			existing.Cloud.APIUrl = incoming.Cloud.APIUrl
+		}
+		if incoming.Cloud.Stack != "" {
+			existing.Cloud.Stack = incoming.Cloud.Stack
 		}
 	}
 }

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -127,6 +127,58 @@ func TestRun(t *testing.T) { //nolint:maintidx // 8 table-driven cases; complexi
 				assert.True(t, r.IsCloud)
 				assert.False(t, r.HasCloudToken)
 			},
+			checkConfig: func(t *testing.T, cfg config.Config) {
+				t.Helper()
+				ctx := cfg.Contexts["mystack"]
+				require.NotNil(t, ctx)
+				require.NotNil(t, ctx.Cloud)
+				assert.Equal(t, "mystack", ctx.Cloud.Stack, "stack slug must be persisted even without a CAP token")
+				assert.Empty(t, ctx.Cloud.Token, "no token was provided")
+			},
+		},
+		{
+			// AC-002b: Re-auth of existing Cloud context without CAP updates stack slug
+			name: "cloud_oauth_skip_cap_reauth_updates_stack",
+			opts: func(dir string) login.Options {
+				src := configSource(dir)
+				path, _ := src()
+				seed := config.Config{
+					CurrentContext: "mystack",
+					Contexts: map[string]*config.Context{
+						"mystack": {
+							Grafana: &config.GrafanaConfig{
+								Server:     "https://mystack.grafana.net",
+								OAuthToken: "old-token",
+								AuthMethod: "oauth",
+							},
+							Cloud: &config.CloudConfig{}, // no Stack set
+						},
+					},
+				}
+				require.NoError(t, config.Write(context.Background(), config.ExplicitConfigFile(path), seed))
+				return login.Options{
+					Inputs: login.Inputs{
+						Server:   "https://mystack.grafana.net",
+						Target:   login.TargetCloud,
+						UseOAuth: true,
+						Yes:      true,
+					},
+					Hooks: login.Hooks{
+						ConfigSource: src,
+						NewAuthFlow: func(_ string, _ auth.Options) login.AuthFlow {
+							return &stubAuthFlow{result: oauthResult}
+						},
+						ValidateFn: noopValidate,
+					},
+				}
+			},
+			checkConfig: func(t *testing.T, cfg config.Config) {
+				t.Helper()
+				ctx := cfg.Contexts["mystack"]
+				require.NotNil(t, ctx)
+				require.NotNil(t, ctx.Cloud)
+				assert.Equal(t, "mystack", ctx.Cloud.Stack, "re-auth must update stack slug")
+			},
 		},
 		{
 			// AC-003: On-prem with SA token; OAuth not attempted

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -181,6 +181,50 @@ func TestRun(t *testing.T) { //nolint:maintidx // 8 table-driven cases; complexi
 			},
 		},
 		{
+			// AC-002c: Re-auth via OAuth-only must not wipe a previously stored CAP token
+			name: "cloud_oauth_skip_cap_preserves_existing_token",
+			opts: func(dir string) login.Options {
+				src := configSource(dir)
+				path, _ := src()
+				seed := config.Config{
+					CurrentContext: "mystack",
+					Contexts: map[string]*config.Context{
+						"mystack": {
+							Grafana: &config.GrafanaConfig{
+								Server:     "https://mystack.grafana.net",
+								OAuthToken: "old-token",
+								AuthMethod: "oauth",
+							},
+							Cloud: &config.CloudConfig{Token: "existing-cap-token"},
+						},
+					},
+				}
+				require.NoError(t, config.Write(context.Background(), config.ExplicitConfigFile(path), seed))
+				return login.Options{
+					Inputs: login.Inputs{
+						Server:   "https://mystack.grafana.net",
+						Target:   login.TargetCloud,
+						UseOAuth: true,
+						Yes:      true,
+					},
+					Hooks: login.Hooks{
+						ConfigSource: src,
+						NewAuthFlow: func(_ string, _ auth.Options) login.AuthFlow {
+							return &stubAuthFlow{result: oauthResult}
+						},
+						ValidateFn: noopValidate,
+					},
+				}
+			},
+			checkConfig: func(t *testing.T, cfg config.Config) {
+				t.Helper()
+				ctx := cfg.Contexts["mystack"]
+				require.NotNil(t, ctx)
+				require.NotNil(t, ctx.Cloud)
+				assert.Equal(t, "existing-cap-token", ctx.Cloud.Token, "OAuth-only re-auth must not wipe a stored CAP token")
+			},
+		},
+		{
 			// AC-003: On-prem with SA token; OAuth not attempted
 			name: "onprem_sa_token",
 			opts: func(dir string) login.Options {


### PR DESCRIPTION
## Summary

- `resolveCloudAuth()` returned `nil` for `CloudConfig` on Cloud OAuth logins without a CAP token, so `cloud.stack` was never written to config
- This caused `gcx metrics query`, `gcx logs query`, etc. to fail with *"multiple datasources found"* on stacks with more than one signal datasource
- `mergeAuthIntoExisting()` also never updated `Cloud.Stack` on re-auth, so existing contexts couldn't self-heal on next login

## Changes

- `internal/login/login.go` — `resolveCloudAuth()`: when `Yes || agent.IsAgentMode()` and a slug is derivable from the server URL, return `&config.CloudConfig{Stack: slug}` instead of `nil`
- `internal/login/login.go` — `mergeAuthIntoExisting()`: also update `Cloud.Stack` when the incoming context carries a non-empty slug
- `internal/login/login_test.go` — two new test cases covering both paths

## Test Plan

- [x] New tests `cloud_oauth_skip_cap` (with `checkConfig`) and `cloud_oauth_skip_cap_reauth_updates_stack` pass
- [x] Full test suite passes with race detection (`go test -race -count=1 ./...`)
- [x] Reference docs regenerated, no drift
- [x] Lint clean (verified in main worktree)

Closes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)