### PR TITLE
refactor: consolidate inline API path strings into named constants

### DIFF
--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -645,6 +645,54 @@ Unexported fields on domain types would be lost during marshal/unmarshal.
 - `internal/providers/appo11y/overrides/adapter.go`: ToResource preserves annotation
 - ADR: `docs/adrs/appo11y-provider/001-cli-ux-and-resource-adapter-design.md`
 
+### 21. API Path Constants (Adopt)
+
+Every HTTP API path used by a client must be declared as a named constant (or
+format-string constant for paths with dynamic segments) at the top of the file.
+Inline string concatenation of path segments is not recommended.
+
+**Rules:**
+
+1. Static paths → plain `const`:
+   ```go
+   const policiesPath = "/adaptive-traces/api/v1/policies"
+   ```
+2. Paths with a single dynamic segment → format constant + `fmt.Sprintf`:
+   ```go
+   const policyByIDPathFmt = policiesPath + "/%s"
+   // usage:
+   fmt.Sprintf(policyByIDPathFmt, url.PathEscape(id))
+   ```
+3. Paths with multiple dynamic segments or action suffixes → same pattern:
+   ```go
+   const recommendationApplyFmt = recommendationsPath + "/%s/apply"
+   ```
+4. Dynamic segments that represent user-supplied identifiers must be escaped
+   with `url.PathEscape` before interpolation.
+5. Query parameters are appended after the format call, not baked into the
+   constant.
+
+**Rationale:** Centralising path definitions makes API surface auditable at a
+glance, prevents typo drift across call sites, and ensures consistent use of
+`url.PathEscape` for dynamic segments.
+
+**Anti-patterns:**
+```go
+// Bad — inline concatenation
+c.doRequest(ctx, http.MethodGet, basePath+"/"+url.PathEscape(id), nil)
+
+// Bad — format string built ad-hoc
+c.doRequest(ctx, http.MethodPost, fmt.Sprintf("%s/%s/apply", recsPath, id), nil)
+```
+
+**Evidence:**
+- `internal/providers/traces/adaptive/client.go`: `policyByIDPathFmt`, `recommendationApplyFmt`, `recommendationDismissFmt`
+- `internal/providers/logs/adaptive/client.go`: `exemptionByIDFmt`, `dropRuleByIDFmt`
+- `internal/providers/metrics/adaptive/client.go`: `ruleByMetricFmt`, `exemptionByIDFmt`
+- `internal/providers/slo/definitions/client.go`: `sloByUUIDFmt`
+- `internal/providers/kg/client.go`: `ruleByNameFmt`, `suppressionByNameFmt`
+- `internal/providers/aio11y/*/client.go`: `conversationByIDFmt`, `generationByIDFmt`, `ruleByIDFmt`, `templateByIDFmt`, `evaluatorByIDFmt`
+
 ---
 
 ## Contradiction Resolutions

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -16,6 +16,8 @@ import (
 	"github.com/grafana/gcx/internal/retry"
 )
 
+const instancesPath = "/api/instances/"
+
 // StackInfo holds the information about a Grafana Cloud stack as returned by the GCOM API.
 type StackInfo struct {
 	ID         int    `json:"id"`
@@ -120,8 +122,8 @@ func (c *GCOMClient) GetStack(ctx context.Context, slug string) (StackInfo, erro
 		return StackInfo{}, fmt.Errorf("gcom client: parse base URL: %w", err)
 	}
 	endpoint := *base
-	endpoint.Path = base.Path + "/api/instances/" + slug
-	endpoint.RawPath = base.EscapedPath() + "/api/instances/" + url.PathEscape(slug)
+	endpoint.Path = base.Path + instancesPath + slug
+	endpoint.RawPath = base.EscapedPath() + instancesPath + url.PathEscape(slug)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {

--- a/internal/dashboards/renderer.go
+++ b/internal/dashboards/renderer.go
@@ -13,6 +13,11 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	renderSoloPanelPathFmt = "/render/d-solo/%s/"
+	renderDashboardPathFmt = "/render/d/%s/"
+)
+
 // RenderRequest holds parameters for a dashboard render request.
 type RenderRequest struct {
 	// UID is the dashboard UID. Required.
@@ -103,9 +108,9 @@ func (c *Client) Render(ctx context.Context, req RenderRequest) ([]byte, error) 
 func (c *Client) buildRenderURL(req RenderRequest) (string, error) {
 	var path string
 	if req.PanelID != 0 {
-		path = fmt.Sprintf("/render/d-solo/%s/", url.PathEscape(req.UID))
+		path = fmt.Sprintf(renderSoloPanelPathFmt, url.PathEscape(req.UID))
 	} else {
-		path = fmt.Sprintf("/render/d/%s/", url.PathEscape(req.UID))
+		path = fmt.Sprintf(renderDashboardPathFmt, url.PathEscape(req.UID))
 	}
 
 	u, err := url.Parse(c.restConfig.Host + path)

--- a/internal/datasources/client.go
+++ b/internal/datasources/client.go
@@ -12,7 +12,13 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const maxResponseBytes = 10 << 20 // 10 MB
+const (
+	maxResponseBytes = 10 << 20 // 10 MB
+
+	datasourcesPath      = "/api/datasources"
+	datasourceByUIDPath  = "/api/datasources/uid/"
+	datasourceByNamePath = "/api/datasources/name/"
+)
 
 // Datasource holds the fields returned by the legacy Grafana datasource REST API.
 type Datasource struct {
@@ -52,7 +58,7 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 
 // List returns all datasources visible to the authenticated user.
 func (c *Client) List(ctx context.Context) ([]*Datasource, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.host+"/api/datasources", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.host+datasourcesPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -82,12 +88,12 @@ func (c *Client) List(ctx context.Context) ([]*Datasource, error) {
 
 // GetByUID returns the datasource with the given UID.
 func (c *Client) GetByUID(ctx context.Context, uid string) (*Datasource, error) {
-	return c.get(ctx, "/api/datasources/uid/"+url.PathEscape(uid), uid)
+	return c.get(ctx, datasourceByUIDPath+url.PathEscape(uid), uid)
 }
 
 // GetByName returns the datasource with the given display name.
 func (c *Client) GetByName(ctx context.Context, name string) (*Datasource, error) {
-	return c.get(ctx, "/api/datasources/name/"+url.PathEscape(name), name)
+	return c.get(ctx, datasourceByNamePath+url.PathEscape(name), name)
 }
 
 func (c *Client) get(ctx context.Context, path, identifier string) (*Datasource, error) {

--- a/internal/grafana/settings.go
+++ b/internal/grafana/settings.go
@@ -23,6 +23,8 @@ type FrontendSettings struct {
 	BuildInfo BuildInfo `json:"buildInfo"`
 }
 
+const frontendSettingsPath = "/api/frontend/settings"
+
 // FetchAnonymousSettings performs an unauthenticated GET of /api/frontend/settings
 // against baseURL, used for pre-auth target detection. When httpClient is nil it
 // falls back to httputils.NewDefaultClient (so --log-http-payload is honoured).
@@ -31,7 +33,7 @@ type FrontendSettings struct {
 // Errors are returned as-is; callers are responsible for deciding how to classify
 // them (e.g., mapping a non-200 status to TargetUnknown).
 func FetchAnonymousSettings(ctx context.Context, baseURL string, httpClient *http.Client) (*FrontendSettings, error) {
-	settingsURL := strings.TrimSuffix(baseURL, "/") + "/api/frontend/settings"
+	settingsURL := strings.TrimSuffix(baseURL, "/") + frontendSettingsPath
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, settingsURL, nil)
 	if err != nil {
@@ -53,7 +55,7 @@ func FetchAnonymousSettings(ctx context.Context, baseURL string, httpClient *htt
 
 	var settings FrontendSettings
 	if err := json.NewDecoder(resp.Body).Decode(&settings); err != nil {
-		return nil, fmt.Errorf("decoding /api/frontend/settings response: %w", err)
+		return nil, fmt.Errorf("decoding %s response: %w", frontendSettingsPath, err)
 	}
 
 	return &settings, nil

--- a/internal/providers/aio11y/agents/client.go
+++ b/internal/providers/aio11y/agents/client.go
@@ -11,6 +11,12 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
 )
 
+const (
+	agentsPath        = "/query/agents"
+	agentLookupPath   = agentsPath + "/lookup"
+	agentVersionsPath = agentsPath + "/versions"
+)
+
 // Client is an HTTP client for AI Observability agent catalog endpoints.
 type Client struct {
 	base *aio11yhttp.Client
@@ -27,7 +33,7 @@ func (c *Client) List(ctx context.Context, limit int) ([]Agent, error) {
 	if limit > 0 {
 		query.Set("limit", strconv.Itoa(limit))
 	}
-	return aio11yhttp.ListAll[Agent](ctx, c.base, "/query/agents", query, limit)
+	return aio11yhttp.ListAll[Agent](ctx, c.base, agentsPath, query, limit)
 }
 
 // Lookup returns a single agent by name, optionally at a specific version.
@@ -37,7 +43,7 @@ func (c *Client) Lookup(ctx context.Context, name, version string) (*AgentDetail
 		query.Set("version", version)
 	}
 
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, "/query/agents/lookup?"+query.Encode(), nil)
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, agentLookupPath+"?"+query.Encode(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup agent %s: %w", name, err)
 	}
@@ -57,5 +63,5 @@ func (c *Client) Lookup(ctx context.Context, name, version string) (*AgentDetail
 // Versions returns the version history for an agent by name.
 func (c *Client) Versions(ctx context.Context, name string) ([]AgentVersion, error) {
 	query := url.Values{"name": {name}}
-	return aio11yhttp.ListAll[AgentVersion](ctx, c.base, "/query/agents/versions", query)
+	return aio11yhttp.ListAll[AgentVersion](ctx, c.base, agentVersionsPath, query)
 }

--- a/internal/providers/aio11y/conversations/client.go
+++ b/internal/providers/aio11y/conversations/client.go
@@ -11,6 +11,11 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
 )
 
+const (
+	conversationsPath      = "/query/conversations"
+	conversationSearchPath = conversationsPath + "/search"
+)
+
 // Client is an HTTP client for AI Observability conversation endpoints.
 type Client struct {
 	base *aio11yhttp.Client
@@ -23,12 +28,12 @@ func NewClient(base *aio11yhttp.Client) *Client {
 
 // List returns conversations, limited to the given count. Pass 0 for no limit.
 func (c *Client) List(ctx context.Context, limit int) ([]Conversation, error) {
-	return aio11yhttp.ListAll[Conversation](ctx, c.base, "/query/conversations", nil, limit)
+	return aio11yhttp.ListAll[Conversation](ctx, c.base, conversationsPath, nil, limit)
 }
 
 // Get returns a single conversation by ID with all its generations.
 func (c *Client) Get(ctx context.Context, id string) (*ConversationDetail, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, "/query/conversations/"+url.PathEscape(id), nil)
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, conversationsPath+"/"+url.PathEscape(id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get conversation %s: %w", id, err)
 	}
@@ -52,7 +57,7 @@ func (c *Client) Search(ctx context.Context, req SearchRequest) (*SearchResponse
 		return nil, fmt.Errorf("failed to marshal search request: %w", err)
 	}
 
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, "/query/conversations/search", bytes.NewReader(body))
+	resp, err := c.base.DoRequest(ctx, http.MethodPost, conversationSearchPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to search conversations: %w", err)
 	}

--- a/internal/providers/aio11y/conversations/client.go
+++ b/internal/providers/aio11y/conversations/client.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	conversationsPath      = "/query/conversations"
+	conversationByIDFmt    = conversationsPath + "/%s"
 	conversationSearchPath = conversationsPath + "/search"
 )
 
@@ -33,7 +34,7 @@ func (c *Client) List(ctx context.Context, limit int) ([]Conversation, error) {
 
 // Get returns a single conversation by ID with all its generations.
 func (c *Client) Get(ctx context.Context, id string) (*ConversationDetail, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, conversationsPath+"/"+url.PathEscape(id), nil)
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(conversationByIDFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get conversation %s: %w", id, err)
 	}

--- a/internal/providers/aio11y/eval/evaluators/client.go
+++ b/internal/providers/aio11y/eval/evaluators/client.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	basePath     = "/eval/evaluators"
-	evalTestPath = "/eval:test"
+	basePath         = "/eval/evaluators"
+	evaluatorByIDFmt = basePath + "/%s"
+	evalTestPath     = "/eval:test"
 )
 
 // Client is an HTTP client for AI Observability evaluator endpoints.
@@ -34,7 +35,7 @@ func (c *Client) List(ctx context.Context) ([]eval.EvaluatorDefinition, error) {
 
 // Get returns a single evaluator by ID.
 func (c *Client) Get(ctx context.Context, id string) (*eval.EvaluatorDefinition, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, basePath+"/"+url.PathEscape(id), nil)
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(evaluatorByIDFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get evaluator %s: %w", id, err)
 	}
@@ -101,7 +102,7 @@ func (c *Client) RunTest(ctx context.Context, req *eval.EvalTestRequest) (*eval.
 
 // Delete soft-deletes an evaluator by ID.
 func (c *Client) Delete(ctx context.Context, id string) error {
-	resp, err := c.base.DoRequest(ctx, http.MethodDelete, basePath+"/"+url.PathEscape(id), nil)
+	resp, err := c.base.DoRequest(ctx, http.MethodDelete, fmt.Sprintf(evaluatorByIDFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete evaluator %s: %w", id, err)
 	}

--- a/internal/providers/aio11y/eval/evaluators/client.go
+++ b/internal/providers/aio11y/eval/evaluators/client.go
@@ -12,7 +12,10 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/eval"
 )
 
-const basePath = "/eval/evaluators"
+const (
+	basePath     = "/eval/evaluators"
+	evalTestPath = "/eval:test"
+)
 
 // Client is an HTTP client for AI Observability evaluator endpoints.
 type Client struct {
@@ -79,7 +82,7 @@ func (c *Client) RunTest(ctx context.Context, req *eval.EvalTestRequest) (*eval.
 		return nil, fmt.Errorf("failed to marshal test request: %w", err)
 	}
 
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, "/eval:test", bytes.NewReader(body))
+	resp, err := c.base.DoRequest(ctx, http.MethodPost, evalTestPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to run eval test: %w", err)
 	}

--- a/internal/providers/aio11y/eval/judge/client.go
+++ b/internal/providers/aio11y/eval/judge/client.go
@@ -11,6 +11,11 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/eval"
 )
 
+const (
+	judgeProvidersPath = "/eval/judge/providers"
+	judgeModelsPath    = "/eval/judge/models"
+)
+
 // Client is an HTTP client for AI Observability eval judge endpoints.
 type Client struct {
 	base *aio11yhttp.Client
@@ -23,7 +28,7 @@ func NewClient(base *aio11yhttp.Client) *Client {
 
 // ListProviders returns available judge providers.
 func (c *Client) ListProviders(ctx context.Context) ([]eval.JudgeProvider, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, "/eval/judge/providers", nil)
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, judgeProvidersPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list judge providers: %w", err)
 	}
@@ -49,7 +54,7 @@ func (c *Client) ListModels(ctx context.Context, provider string) ([]eval.JudgeM
 		query.Set("provider", provider)
 	}
 
-	path := "/eval/judge/models"
+	path := judgeModelsPath
 	if encoded := query.Encode(); encoded != "" {
 		path += "?" + encoded
 	}

--- a/internal/providers/aio11y/eval/rules/client.go
+++ b/internal/providers/aio11y/eval/rules/client.go
@@ -12,7 +12,10 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/eval"
 )
 
-const basePath = "/eval/rules"
+const (
+	basePath    = "/eval/rules"
+	ruleByIDFmt = basePath + "/%s"
+)
 
 // Client is an HTTP client for AI Observability rule endpoints.
 type Client struct {
@@ -31,7 +34,7 @@ func (c *Client) List(ctx context.Context) ([]eval.RuleDefinition, error) {
 
 // Get returns a single rule by ID.
 func (c *Client) Get(ctx context.Context, id string) (*eval.RuleDefinition, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, basePath+"/"+url.PathEscape(id), nil)
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(ruleByIDFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rule %s: %w", id, err)
 	}
@@ -79,7 +82,7 @@ func (c *Client) Update(ctx context.Context, id string, rule *eval.RuleDefinitio
 		return nil, fmt.Errorf("failed to marshal rule: %w", err)
 	}
 
-	resp, err := c.base.DoRequest(ctx, http.MethodPatch, basePath+"/"+url.PathEscape(id), bytes.NewReader(body))
+	resp, err := c.base.DoRequest(ctx, http.MethodPatch, fmt.Sprintf(ruleByIDFmt, url.PathEscape(id)), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to update rule: %w", err)
 	}
@@ -98,7 +101,7 @@ func (c *Client) Update(ctx context.Context, id string, rule *eval.RuleDefinitio
 
 // Delete deletes a rule by ID.
 func (c *Client) Delete(ctx context.Context, id string) error {
-	resp, err := c.base.DoRequest(ctx, http.MethodDelete, basePath+"/"+url.PathEscape(id), nil)
+	resp, err := c.base.DoRequest(ctx, http.MethodDelete, fmt.Sprintf(ruleByIDFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete rule %s: %w", id, err)
 	}

--- a/internal/providers/aio11y/eval/templates/client.go
+++ b/internal/providers/aio11y/eval/templates/client.go
@@ -11,7 +11,10 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/eval"
 )
 
-const basePath = "/eval/templates"
+const (
+	basePath        = "/eval/templates"
+	versionsPathFmt = basePath + "/%s/versions"
+)
 
 // Client is an HTTP client for AI Observability eval template endpoints.
 type Client struct {
@@ -54,5 +57,5 @@ func (c *Client) Get(ctx context.Context, id string) (*eval.TemplateDetail, erro
 
 // ListVersions returns version history for a template.
 func (c *Client) ListVersions(ctx context.Context, id string) ([]eval.TemplateVersion, error) {
-	return aio11yhttp.ListAll[eval.TemplateVersion](ctx, c.base, basePath+"/"+url.PathEscape(id)+"/versions", nil)
+	return aio11yhttp.ListAll[eval.TemplateVersion](ctx, c.base, fmt.Sprintf(versionsPathFmt, url.PathEscape(id)), nil)
 }

--- a/internal/providers/aio11y/eval/templates/client.go
+++ b/internal/providers/aio11y/eval/templates/client.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	basePath        = "/eval/templates"
+	templateByIDFmt = basePath + "/%s"
 	versionsPathFmt = basePath + "/%s/versions"
 )
 
@@ -38,7 +39,7 @@ func (c *Client) List(ctx context.Context, scope string, maxItems ...int) ([]eva
 
 // Get returns a single template by ID.
 func (c *Client) Get(ctx context.Context, id string) (*eval.TemplateDetail, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, basePath+"/"+url.PathEscape(id), nil)
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(templateByIDFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get template %s: %w", id, err)
 	}

--- a/internal/providers/aio11y/generations/client.go
+++ b/internal/providers/aio11y/generations/client.go
@@ -10,6 +10,8 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
 )
 
+const generationsPath = "/query/generations"
+
 // Client is an HTTP client for AI Observability generation endpoints.
 type Client struct {
 	base *aio11yhttp.Client
@@ -22,7 +24,7 @@ func NewClient(base *aio11yhttp.Client) *Client {
 
 // Get returns a single generation by ID.
 func (c *Client) Get(ctx context.Context, id string) (map[string]any, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, "/query/generations/"+url.PathEscape(id), nil)
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, generationsPath+"/"+url.PathEscape(id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get generation %s: %w", id, err)
 	}

--- a/internal/providers/aio11y/generations/client.go
+++ b/internal/providers/aio11y/generations/client.go
@@ -10,7 +10,10 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
 )
 
-const generationsPath = "/query/generations"
+const (
+	generationsPath   = "/query/generations"
+	generationByIDFmt = generationsPath + "/%s"
+)
 
 // Client is an HTTP client for AI Observability generation endpoints.
 type Client struct {
@@ -24,7 +27,7 @@ func NewClient(base *aio11yhttp.Client) *Client {
 
 // Get returns a single generation by ID.
 func (c *Client) Get(ctx context.Context, id string) (map[string]any, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, generationsPath+"/"+url.PathEscape(id), nil)
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(generationByIDFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get generation %s: %w", id, err)
 	}

--- a/internal/providers/aio11y/scores/client.go
+++ b/internal/providers/aio11y/scores/client.go
@@ -2,11 +2,14 @@ package scores
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 
 	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
 )
+
+const generationScoresPathFmt = "/query/generations/%s/scores"
 
 // Client is an HTTP client for AI Observability generation score endpoints.
 type Client struct {
@@ -24,5 +27,5 @@ func (c *Client) ListByGeneration(ctx context.Context, generationID string, limi
 	if limit > 0 {
 		query.Set("limit", strconv.Itoa(limit))
 	}
-	return aio11yhttp.ListAll[Score](ctx, c.base, "/query/generations/"+url.PathEscape(generationID)+"/scores", query)
+	return aio11yhttp.ListAll[Score](ctx, c.base, fmt.Sprintf(generationScoresPathFmt, url.PathEscape(generationID)), query)
 }

--- a/internal/providers/alert/client.go
+++ b/internal/providers/alert/client.go
@@ -17,7 +17,10 @@ import (
 // ErrNotFound is returned when a requested alert rule or group does not exist.
 var ErrNotFound = errors.New("alert rule not found")
 
-const defaultBasePath = "/api/prometheus/grafana/api/v1/rules"
+const (
+	defaultBasePath       = "/api/prometheus/grafana/api/v1/rules"
+	datasourceBasePathFmt = "/api/prometheus/%s/api/v1/rules"
+)
 
 // Client fetches alert rules and groups from the Prometheus-compatible API.
 type Client struct {
@@ -65,7 +68,7 @@ func (c *Client) List(ctx context.Context, opts ListOptions) (*RulesResponse, er
 
 	path := defaultBasePath
 	if opts.Datasource != "" {
-		path = "/api/prometheus/" + url.PathEscape(opts.Datasource) + "/api/v1/rules"
+		path = fmt.Sprintf(datasourceBasePathFmt, url.PathEscape(opts.Datasource))
 	}
 	if len(params) > 0 {
 		path += "?" + params.Encode()

--- a/internal/providers/faro/client.go
+++ b/internal/providers/faro/client.go
@@ -17,7 +17,10 @@ import (
 )
 
 const (
-	basePath = "/api/plugin-proxy/grafana-kowalski-app/api-proxy/api/v1/app"
+	basePath               = "/api/plugin-proxy/grafana-kowalski-app/api-proxy/api/v1/app"
+	appByIDPathFmt         = basePath + "/%s"
+	sourcemapsPathFmt      = basePath + "/%s/sourcemaps"
+	sourcemapsBatchPathFmt = basePath + "/%s/sourcemaps/batch/%s"
 )
 
 // SourcemapBundle represents a sourcemap bundle from the Faro API.
@@ -79,7 +82,7 @@ func (c *Client) List(ctx context.Context) ([]FaroApp, error) {
 
 // Get retrieves a Faro app by ID.
 func (c *Client) Get(ctx context.Context, id string) (*FaroApp, error) {
-	path := fmt.Sprintf("%s/%s", basePath, url.PathEscape(id))
+	path := fmt.Sprintf(appByIDPathFmt, url.PathEscape(id))
 
 	log := logging.FromContext(ctx)
 	log.Debug("Getting Faro app", "id", id, "path", path)
@@ -178,7 +181,7 @@ func (c *Client) Create(ctx context.Context, app *FaroApp) (*FaroApp, error) {
 // Settings are stripped from the update payload due to Faro API constraints.
 // The ID is included in both URL path and body.
 func (c *Client) Update(ctx context.Context, id string, app *FaroApp) (*FaroApp, error) {
-	path := fmt.Sprintf("%s/%s", basePath, url.PathEscape(id))
+	path := fmt.Sprintf(appByIDPathFmt, url.PathEscape(id))
 
 	log := logging.FromContext(ctx)
 	log.Info("Updating Faro app", "id", id, "name", app.Name)
@@ -211,7 +214,7 @@ func (c *Client) Update(ctx context.Context, id string, app *FaroApp) (*FaroApp,
 func (c *Client) Delete(ctx context.Context, id string) error {
 	log := logging.FromContext(ctx)
 	log.Info("Deleting Faro app", "id", id)
-	path := fmt.Sprintf("%s/%s", basePath, url.PathEscape(id))
+	path := fmt.Sprintf(appByIDPathFmt, url.PathEscape(id))
 
 	_, statusCode, err := c.doRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
@@ -241,7 +244,7 @@ func (c *Client) ListSourcemaps(ctx context.Context, appID string, limit int) ([
 	nextPage := ""
 
 	for {
-		path := fmt.Sprintf("%s/%s/sourcemaps", basePath, url.PathEscape(appID))
+		path := fmt.Sprintf(sourcemapsPathFmt, url.PathEscape(appID))
 
 		q := url.Values{}
 		q.Set("limit", strconv.Itoa(limit))
@@ -279,7 +282,7 @@ func (c *Client) ListSourcemaps(ctx context.Context, appID string, limit int) ([
 
 // DeleteSourcemaps deletes sourcemap bundles for a Faro app.
 func (c *Client) DeleteSourcemaps(ctx context.Context, appID string, bundleIDs []string) error {
-	path := fmt.Sprintf("%s/%s/sourcemaps/batch/%s", basePath, url.PathEscape(appID), strings.Join(bundleIDs, ","))
+	path := fmt.Sprintf(sourcemapsBatchPathFmt, url.PathEscape(appID), strings.Join(bundleIDs, ","))
 
 	log := logging.FromContext(ctx)
 	log.Info("Deleting sourcemap bundles", "app_id", appID, "bundle_count", len(bundleIDs))

--- a/internal/providers/faro/sourcemap_upload.go
+++ b/internal/providers/faro/sourcemap_upload.go
@@ -17,7 +17,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const faroPluginSettingsPath = "/api/plugins/grafana-kowalski-app/settings"
+const (
+	faroPluginSettingsPath = "/api/plugins/grafana-kowalski-app/settings"
+	faroUploadPathFmt      = "%s/api/v1/app/%s/sourcemaps/%s"
+)
 
 // DiscoverFaroAPIURL queries the Grafana Faro plugin settings to discover
 // the direct Faro API endpoint URL (jsonData.api_endpoint).
@@ -69,7 +72,7 @@ func GenerateBundleID() string {
 // UploadSourcemap uploads a sourcemap file to the direct Faro API.
 // Auth uses Bearer {stackId}:{token} format per the faro-bundler-plugins convention.
 func UploadSourcemap(ctx context.Context, faroAPIURL string, stackID int, token string, appID string, bundleID string, reader io.Reader, contentType string) error {
-	endpoint := fmt.Sprintf("%s/api/v1/app/%s/sourcemaps/%s",
+	endpoint := fmt.Sprintf(faroUploadPathFmt,
 		strings.TrimRight(faroAPIURL, "/"), appID, bundleID)
 
 	log := logging.FromContext(ctx)

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -17,7 +17,17 @@ import (
 // not-found and fall through to Create during push upsert.
 var ErrNotFound = fmt.Errorf("incident: %w", adapter.ErrNotFound)
 
-const incidentBasePath = "/api/plugins/grafana-irm-app/resources/api"
+const (
+	incidentBasePath = "/api/plugins/grafana-irm-app/resources/api"
+
+	incGetPath        = incidentBasePath + "/IncidentsService.GetIncident"
+	incCreatePath     = incidentBasePath + "/IncidentsService.CreateIncident"
+	incUpdateStatPath = incidentBasePath + "/IncidentsService.UpdateStatus"
+	incQueryPath      = incidentBasePath + "/IncidentsService.QueryIncidents"
+	actQueryPath      = incidentBasePath + "/ActivityService.QueryActivity"
+	actAddPath        = incidentBasePath + "/ActivityService.AddActivity"
+	sevGetPath        = incidentBasePath + "/SeveritiesService.GetOrgSeverities"
+)
 
 // Client is an HTTP client for the Grafana IRM Incidents API.
 type IncidentClient struct {
@@ -72,7 +82,7 @@ func (c *IncidentClient) Get(ctx context.Context, id string) (*Incident, error) 
 		return nil, fmt.Errorf("incidents: marshal get request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, incidentBasePath+"/IncidentsService.GetIncident", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, incGetPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("incidents: get %s: %w", id, err)
 	}
@@ -122,7 +132,7 @@ func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, 
 		return nil, fmt.Errorf("incidents: marshal create request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, incidentBasePath+"/IncidentsService.CreateIncident", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, incCreatePath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("incidents: create: %w", err)
 	}
@@ -152,7 +162,7 @@ func (c *IncidentClient) UpdateStatus(ctx context.Context, id, status string) (*
 		return nil, fmt.Errorf("incidents: marshal update request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, incidentBasePath+"/IncidentsService.UpdateStatus", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, incUpdateStatPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("incidents: update status %s: %w", id, err)
 	}
@@ -187,7 +197,7 @@ func (c *IncidentClient) QueryActivity(ctx context.Context, incidentID string, l
 		return nil, fmt.Errorf("incidents: marshal activity request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, incidentBasePath+"/ActivityService.QueryActivity", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, actQueryPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("incidents: query activity for %s: %w", incidentID, err)
 	}
@@ -218,7 +228,7 @@ func (c *IncidentClient) AddActivity(ctx context.Context, incidentID, body strin
 		return fmt.Errorf("incidents: marshal add activity request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, incidentBasePath+"/ActivityService.AddActivity", bytes.NewReader(reqBody))
+	resp, err := c.doRequest(ctx, actAddPath, bytes.NewReader(reqBody))
 	if err != nil {
 		return fmt.Errorf("incidents: add activity to %s: %w", incidentID, err)
 	}
@@ -238,7 +248,7 @@ func (c *IncidentClient) GetSeverities(ctx context.Context) ([]Severity, error) 
 		return nil, fmt.Errorf("incidents: marshal severities request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, incidentBasePath+"/SeveritiesService.GetOrgSeverities", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, sevGetPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("incidents: get severities: %w", err)
 	}
@@ -265,7 +275,7 @@ func (c *IncidentClient) queryIncidents(ctx context.Context, query IncidentQuery
 		return nil, fmt.Errorf("incidents: marshal query request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, incidentBasePath+"/IncidentsService.QueryIncidents", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, incQueryPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("incidents: query: %w", err)
 	}

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -19,17 +19,30 @@ import (
 const pluginResourcePath = "/api/plugins/grafana-asserts-app/resources"
 
 const (
-	statusPath       = pluginResourcePath + "/asserts/api-server/v1/stack/status"
-	entitiesPath     = pluginResourcePath + "/asserts/api-server/v1/entity/info"
-	entityTypesPath  = pluginResourcePath + "/asserts/api-server/v1/entity_type"
-	scopesPath       = pluginResourcePath + "/asserts/api-server/v1/entity_scope"
-	assertionsPath   = pluginResourcePath + "/asserts/api-server/v1/assertions"
-	searchPath       = pluginResourcePath + "/asserts/api-server/v1/search"
-	rulesPath        = pluginResourcePath + "/asserts/api-server/v1/config/prom-rules/"
-	suppressionPath  = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alert"
-	suppressionsPath = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alerts"
-	entityLookupPath = pluginResourcePath + "/asserts/api-server/v1/entity"
-	v2ConfigPath     = pluginResourcePath + "/asserts/api-server/v2/config"
+	statusPath          = pluginResourcePath + "/asserts/api-server/v1/stack/status"
+	entitiesPath        = pluginResourcePath + "/asserts/api-server/v1/entity/info"
+	entityTypesPath     = pluginResourcePath + "/asserts/api-server/v1/entity_type"
+	entityCountPath     = entityTypesPath + "/count"
+	scopesPath          = pluginResourcePath + "/asserts/api-server/v1/entity_scope"
+	assertionsPath      = pluginResourcePath + "/asserts/api-server/v1/assertions"
+	assertSummPath      = assertionsPath + "/summary"
+	assertGraphPath     = assertionsPath + "/graph"
+	assertMetricPath    = assertionsPath + "/entity-metric"
+	assertLLMPath       = assertionsPath + "/llm-summary"
+	sourceMetricPath    = pluginResourcePath + "/asserts/api-server/v1/assertion/source-metrics"
+	searchPath          = pluginResourcePath + "/asserts/api-server/v1/search"
+	searchAssertPath    = searchPath + "/assertions"
+	searchSamplePath    = searchPath + "/sample"
+	rulesPath           = pluginResourcePath + "/asserts/api-server/v1/config/prom-rules/"
+	modelRulesPath      = pluginResourcePath + "/asserts/api-server/v1/config/model-rules/"
+	suppressionPath     = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alert"
+	suppressionsPath    = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alerts"
+	entityLookupPath    = pluginResourcePath + "/asserts/api-server/v1/entity"
+	v2ConfigPath        = pluginResourcePath + "/asserts/api-server/v2/config"
+	v2LogConfigPath     = v2ConfigPath + "/log"
+	v2TraceConfigPath   = v2ConfigPath + "/trace"
+	v2ProfileConfigPath = v2ConfigPath + "/profile"
+	v2RelabelRulesPath  = v2ConfigPath + "/relabel-rules/prologue"
 )
 
 // Client is an HTTP client for the Knowledge Graph (Asserts) API.
@@ -208,7 +221,7 @@ func (c *Client) UploadPromRules(ctx context.Context, yamlContent string) error 
 
 // UploadModelRules uploads model rules configuration.
 func (c *Client) UploadModelRules(ctx context.Context, yamlContent string) error {
-	return c.doYAML(ctx, http.MethodPut, pluginResourcePath+"/asserts/api-server/v1/config/model-rules/", yamlContent)
+	return c.doYAML(ctx, http.MethodPut, modelRulesPath, yamlContent)
 }
 
 // Suppression represents a single disabled-alert configuration entry.
@@ -258,7 +271,7 @@ func (c *Client) GetSuppressions(ctx context.Context) (*Suppressions, error) {
 
 // UploadRelabelRules uploads relabel rules configuration.
 func (c *Client) UploadRelabelRules(ctx context.Context, yamlContent string) error {
-	return c.doYAML(ctx, http.MethodPut, pluginResourcePath+"/asserts/api-server/v2/config/relabel-rules/prologue", yamlContent)
+	return c.doYAML(ctx, http.MethodPut, v2RelabelRulesPath, yamlContent)
 }
 
 // ---------------------------------------------------------------------------
@@ -335,7 +348,7 @@ func (c *Client) CountEntityTypes(ctx context.Context) (map[string]int64, error)
 		},
 	}
 	var result map[string]int64
-	if err := c.postJSON(ctx, entityTypesPath+"/count", body, &result); err != nil {
+	if err := c.postJSON(ctx, entityCountPath, body, &result); err != nil {
 		return nil, fmt.Errorf("kg: count entity types: %w", err)
 	}
 	return result, nil
@@ -371,7 +384,7 @@ func (c *Client) QueryAssertions(ctx context.Context, req AssertionsRequest) ([]
 // AssertionsSummary returns a summary of assertions for a given time range and filters.
 func (c *Client) AssertionsSummary(ctx context.Context, req AssertionsRequest) (*AssertionSummary, error) {
 	var result AssertionSummary
-	if err := c.postJSON(ctx, assertionsPath+"/summary", req, &result); err != nil {
+	if err := c.postJSON(ctx, assertSummPath, req, &result); err != nil {
 		return nil, fmt.Errorf("kg: assertions summary: %w", err)
 	}
 	return &result, nil
@@ -380,7 +393,7 @@ func (c *Client) AssertionsSummary(ctx context.Context, req AssertionsRequest) (
 // AssertionsGraph queries assertions with graph topology.
 func (c *Client) AssertionsGraph(ctx context.Context, req AssertionsRequest) (*AssertionsGraphResponse, error) {
 	var result AssertionsGraphResponse
-	if err := c.postJSON(ctx, assertionsPath+"/graph", req, &result); err != nil {
+	if err := c.postJSON(ctx, assertGraphPath, req, &result); err != nil {
 		return nil, fmt.Errorf("kg: assertions graph: %w", err)
 	}
 	return &result, nil
@@ -389,7 +402,7 @@ func (c *Client) AssertionsGraph(ctx context.Context, req AssertionsRequest) (*A
 // AssertionEntityMetric retrieves metric data for a specific assertion on an entity.
 func (c *Client) AssertionEntityMetric(ctx context.Context, req EntityMetricRequest) (*EntityMetricResponse, error) {
 	var result EntityMetricResponse
-	if err := c.postJSON(ctx, assertionsPath+"/entity-metric", req, &result); err != nil {
+	if err := c.postJSON(ctx, assertMetricPath, req, &result); err != nil {
 		return nil, fmt.Errorf("kg: assertion entity metric: %w", err)
 	}
 	return &result, nil
@@ -398,7 +411,7 @@ func (c *Client) AssertionEntityMetric(ctx context.Context, req EntityMetricRequ
 // AssertionSourceMetrics retrieves source metrics for a specific assertion.
 func (c *Client) AssertionSourceMetrics(ctx context.Context, req SourceMetricsRequest) ([]SourceMetricsResponse, error) {
 	var result []SourceMetricsResponse
-	if err := c.postJSON(ctx, pluginResourcePath+"/asserts/api-server/v1/assertion/source-metrics", req, &result); err != nil {
+	if err := c.postJSON(ctx, sourceMetricPath, req, &result); err != nil {
 		return nil, fmt.Errorf("kg: assertion source metrics: %w", err)
 	}
 	return result, nil
@@ -427,7 +440,7 @@ func (c *Client) Search(ctx context.Context, req SearchRequest) ([]SearchResult,
 // SearchAssertions searches for assertion timelines matching the given query.
 func (c *Client) SearchAssertions(ctx context.Context, req SearchRequest) ([]AssertionTimeline, error) {
 	var result []AssertionTimeline
-	if err := c.postJSON(ctx, searchPath+"/assertions", req, &result); err != nil {
+	if err := c.postJSON(ctx, searchAssertPath, req, &result); err != nil {
 		return nil, fmt.Errorf("kg: search assertions: %w", err)
 	}
 	if result == nil {
@@ -441,7 +454,7 @@ func (c *Client) SearchSample(ctx context.Context, req SampleSearchRequest) ([]S
 	var wrapper struct {
 		Entities []SearchResult `json:"entities"`
 	}
-	if err := c.postJSON(ctx, searchPath+"/sample", req, &wrapper); err != nil {
+	if err := c.postJSON(ctx, searchSamplePath, req, &wrapper); err != nil {
 		return nil, fmt.Errorf("kg: search sample: %w", err)
 	}
 	if wrapper.Entities == nil {
@@ -474,7 +487,7 @@ func (c *Client) FetchGraphSchema(ctx context.Context, startMs, endMs int64) (Gr
 // FetchLogConfigs fetches log drilldown configs from the v2 API.
 func (c *Client) FetchLogConfigs(ctx context.Context) (LogConfigsResponse, error) {
 	var resp LogConfigsResponse
-	if err := c.getJSON(ctx, v2ConfigPath+"/log", &resp); err != nil {
+	if err := c.getJSON(ctx, v2LogConfigPath, &resp); err != nil {
 		return LogConfigsResponse{}, fmt.Errorf("kg: fetch log configs: %w", err)
 	}
 	return resp, nil
@@ -483,7 +496,7 @@ func (c *Client) FetchLogConfigs(ctx context.Context) (LogConfigsResponse, error
 // FetchTraceConfigs fetches trace drilldown configs from the v2 API.
 func (c *Client) FetchTraceConfigs(ctx context.Context) (TraceConfigsResponse, error) {
 	var resp TraceConfigsResponse
-	if err := c.getJSON(ctx, v2ConfigPath+"/trace", &resp); err != nil {
+	if err := c.getJSON(ctx, v2TraceConfigPath, &resp); err != nil {
 		return TraceConfigsResponse{}, fmt.Errorf("kg: fetch trace configs: %w", err)
 	}
 	return resp, nil
@@ -492,7 +505,7 @@ func (c *Client) FetchTraceConfigs(ctx context.Context) (TraceConfigsResponse, e
 // FetchProfileConfigs fetches profile drilldown configs from the v2 API.
 func (c *Client) FetchProfileConfigs(ctx context.Context) (ProfileConfigsResponse, error) {
 	var resp ProfileConfigsResponse
-	if err := c.getJSON(ctx, v2ConfigPath+"/profile", &resp); err != nil {
+	if err := c.getJSON(ctx, v2ProfileConfigPath, &resp); err != nil {
 		return ProfileConfigsResponse{}, fmt.Errorf("kg: fetch profile configs: %w", err)
 	}
 	return resp, nil
@@ -501,7 +514,7 @@ func (c *Client) FetchProfileConfigs(ctx context.Context) (ProfileConfigsRespons
 // LLMSummary fetches entity health data from the LLM summary endpoint.
 func (c *Client) LLMSummary(ctx context.Context, req LLMSummaryRequest) (map[string]any, error) {
 	var result map[string]any
-	if err := c.postJSON(ctx, assertionsPath+"/llm-summary", req, &result); err != nil {
+	if err := c.postJSON(ctx, assertLLMPath, req, &result); err != nil {
 		return nil, fmt.Errorf("kg: llm summary: %w", err)
 	}
 	return result, nil

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -19,30 +19,32 @@ import (
 const pluginResourcePath = "/api/plugins/grafana-asserts-app/resources"
 
 const (
-	statusPath          = pluginResourcePath + "/asserts/api-server/v1/stack/status"
-	entitiesPath        = pluginResourcePath + "/asserts/api-server/v1/entity/info"
-	entityTypesPath     = pluginResourcePath + "/asserts/api-server/v1/entity_type"
-	entityCountPath     = entityTypesPath + "/count"
-	scopesPath          = pluginResourcePath + "/asserts/api-server/v1/entity_scope"
-	assertionsPath      = pluginResourcePath + "/asserts/api-server/v1/assertions"
-	assertSummPath      = assertionsPath + "/summary"
-	assertGraphPath     = assertionsPath + "/graph"
-	assertMetricPath    = assertionsPath + "/entity-metric"
-	assertLLMPath       = assertionsPath + "/llm-summary"
-	sourceMetricPath    = pluginResourcePath + "/asserts/api-server/v1/assertion/source-metrics"
-	searchPath          = pluginResourcePath + "/asserts/api-server/v1/search"
-	searchAssertPath    = searchPath + "/assertions"
-	searchSamplePath    = searchPath + "/sample"
-	rulesPath           = pluginResourcePath + "/asserts/api-server/v1/config/prom-rules/"
-	modelRulesPath      = pluginResourcePath + "/asserts/api-server/v1/config/model-rules/"
-	suppressionPath     = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alert"
-	suppressionsPath    = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alerts"
-	entityLookupPath    = pluginResourcePath + "/asserts/api-server/v1/entity"
-	v2ConfigPath        = pluginResourcePath + "/asserts/api-server/v2/config"
-	v2LogConfigPath     = v2ConfigPath + "/log"
-	v2TraceConfigPath   = v2ConfigPath + "/trace"
-	v2ProfileConfigPath = v2ConfigPath + "/profile"
-	v2RelabelRulesPath  = v2ConfigPath + "/relabel-rules/prologue"
+	statusPath           = pluginResourcePath + "/asserts/api-server/v1/stack/status"
+	entitiesPath         = pluginResourcePath + "/asserts/api-server/v1/entity/info"
+	entityTypesPath      = pluginResourcePath + "/asserts/api-server/v1/entity_type"
+	entityCountPath      = entityTypesPath + "/count"
+	scopesPath           = pluginResourcePath + "/asserts/api-server/v1/entity_scope"
+	assertionsPath       = pluginResourcePath + "/asserts/api-server/v1/assertions"
+	assertSummPath       = assertionsPath + "/summary"
+	assertGraphPath      = assertionsPath + "/graph"
+	assertMetricPath     = assertionsPath + "/entity-metric"
+	assertLLMPath        = assertionsPath + "/llm-summary"
+	sourceMetricPath     = pluginResourcePath + "/asserts/api-server/v1/assertion/source-metrics"
+	searchPath           = pluginResourcePath + "/asserts/api-server/v1/search"
+	searchAssertPath     = searchPath + "/assertions"
+	searchSamplePath     = searchPath + "/sample"
+	rulesPath            = pluginResourcePath + "/asserts/api-server/v1/config/prom-rules"
+	ruleByNameFmt        = rulesPath + "/%s"
+	modelRulesPath       = pluginResourcePath + "/asserts/api-server/v1/config/model-rules/"
+	suppressionPath      = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alert"
+	suppressionByNameFmt = suppressionPath + "/%s"
+	suppressionsPath     = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alerts"
+	entityLookupPath     = pluginResourcePath + "/asserts/api-server/v1/entity"
+	v2ConfigPath         = pluginResourcePath + "/asserts/api-server/v2/config"
+	v2LogConfigPath      = v2ConfigPath + "/log"
+	v2TraceConfigPath    = v2ConfigPath + "/trace"
+	v2ProfileConfigPath  = v2ConfigPath + "/profile"
+	v2RelabelRulesPath   = v2ConfigPath + "/relabel-rules/prologue"
 )
 
 // Client is an HTTP client for the Knowledge Graph (Asserts) API.
@@ -245,7 +247,7 @@ func (c *Client) UpsertSuppression(ctx context.Context, s Suppression) error {
 // DeleteSuppression deletes a single suppression by name.
 func (c *Client) DeleteSuppression(ctx context.Context, name string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
-		c.host+suppressionPath+"/"+url.PathEscape(name), nil)
+		c.host+fmt.Sprintf(suppressionByNameFmt, url.PathEscape(name)), nil)
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}
@@ -543,7 +545,7 @@ func (c *Client) GetRule(ctx context.Context, name string) (*Rule, error) {
 	var wrapper struct {
 		Rules []Rule `json:"rules"`
 	}
-	if err := c.getJSON(ctx, rulesPath+name, &wrapper); err != nil {
+	if err := c.getJSON(ctx, fmt.Sprintf(ruleByNameFmt, url.PathEscape(name)), &wrapper); err != nil {
 		return nil, fmt.Errorf("kg: get rule %q: %w", name, err)
 	}
 	if len(wrapper.Rules) == 0 {

--- a/internal/providers/logs/adaptive/client.go
+++ b/internal/providers/logs/adaptive/client.go
@@ -36,10 +36,12 @@ func readDropRulesResponseBody(resp *http.Response) ([]byte, error) {
 
 const (
 	exemptionsPath      = "/adaptive-logs/exemptions"
+	exemptionByIDFmt    = exemptionsPath + "/%s"
 	recommendationsPath = "/adaptive-logs/recommendations"
 	segmentsPath        = "/adaptive-logs/segments"
 	segmentPath         = "/adaptive-logs/segment"
 	dropRulesPath       = "/adaptive-logs/drop-rules"
+	dropRuleByIDFmt     = dropRulesPath + "/%s"
 )
 
 // Client is an HTTP client for the Adaptive Logs API.
@@ -89,7 +91,7 @@ func (c *Client) ListExemptions(ctx context.Context) ([]Exemption, error) {
 
 // GetExemption returns a single exemption by ID.
 func (c *Client) GetExemption(ctx context.Context, id string) (*Exemption, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, exemptionsPath+"/"+url.PathEscape(id), nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf(exemptionByIDFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get exemption %s: %w", id, err)
 	}
@@ -140,7 +142,7 @@ func (c *Client) UpdateExemption(ctx context.Context, id string, e *Exemption) (
 		return nil, fmt.Errorf("failed to marshal exemption: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPut, exemptionsPath+"/"+url.PathEscape(id), bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPut, fmt.Sprintf(exemptionByIDFmt, url.PathEscape(id)), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to update exemption %s: %w", id, err)
 	}
@@ -160,7 +162,7 @@ func (c *Client) UpdateExemption(ctx context.Context, id string, e *Exemption) (
 
 // DeleteExemption deletes a log stream exemption by ID.
 func (c *Client) DeleteExemption(ctx context.Context, id string) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, exemptionsPath+"/"+url.PathEscape(id), nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, fmt.Sprintf(exemptionByIDFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete exemption %s: %w", id, err)
 	}
@@ -354,9 +356,7 @@ func (c *Client) ListDropRules(ctx context.Context, q DropRuleListQuery) ([]Drop
 
 // GetDropRule returns a single drop rule by ID.
 func (c *Client) GetDropRule(ctx context.Context, id string) (*DropRule, error) {
-	pathID := "/" + url.PathEscape(id)
-
-	resp, err := c.doRequest(ctx, http.MethodGet, dropRulesPath+pathID, nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf(dropRuleByIDFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get drop rule %s: %w", id, err)
 	}
@@ -417,9 +417,7 @@ func (c *Client) UpdateDropRule(ctx context.Context, id string, dr *DropRule) (*
 		return nil, fmt.Errorf("failed to marshal drop rule update payload: %w", err)
 	}
 
-	pathID := "/" + url.PathEscape(id)
-
-	resp, err := c.doRequest(ctx, http.MethodPut, dropRulesPath+pathID, bytes.NewReader(payload))
+	resp, err := c.doRequest(ctx, http.MethodPut, fmt.Sprintf(dropRuleByIDFmt, url.PathEscape(id)), bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("failed to update drop rule %s: %w", id, err)
 	}
@@ -444,9 +442,7 @@ func (c *Client) UpdateDropRule(ctx context.Context, id string, dr *DropRule) (*
 
 // DeleteDropRule deletes a drop rule by ID.
 func (c *Client) DeleteDropRule(ctx context.Context, id string) error {
-	pathID := "/" + url.PathEscape(id)
-
-	resp, err := c.doRequest(ctx, http.MethodDelete, dropRulesPath+pathID, nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, fmt.Sprintf(dropRuleByIDFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete drop rule %s: %w", id, err)
 	}

--- a/internal/providers/logs/adaptive/client.go
+++ b/internal/providers/logs/adaptive/client.go
@@ -34,8 +34,13 @@ func readDropRulesResponseBody(resp *http.Response) ([]byte, error) {
 	return body, nil
 }
 
-// dropRulesPath is the log-template-service route for adaptive log drop rules.
-const dropRulesPath = "/adaptive-logs/drop-rules"
+const (
+	exemptionsPath      = "/adaptive-logs/exemptions"
+	recommendationsPath = "/adaptive-logs/recommendations"
+	segmentsPath        = "/adaptive-logs/segments"
+	segmentPath         = "/adaptive-logs/segment"
+	dropRulesPath       = "/adaptive-logs/drop-rules"
+)
 
 // Client is an HTTP client for the Adaptive Logs API.
 type Client struct {
@@ -58,7 +63,7 @@ func NewClient(baseURL string, tenantID int, apiToken string, httpClient *http.C
 // ListExemptions returns all log stream exemptions.
 // The API wraps the result in {"result": [...]}.
 func (c *Client) ListExemptions(ctx context.Context) ([]Exemption, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/adaptive-logs/exemptions", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, exemptionsPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list exemptions: %w", err)
 	}
@@ -84,7 +89,7 @@ func (c *Client) ListExemptions(ctx context.Context) ([]Exemption, error) {
 
 // GetExemption returns a single exemption by ID.
 func (c *Client) GetExemption(ctx context.Context, id string) (*Exemption, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/adaptive-logs/exemptions/"+url.PathEscape(id), nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, exemptionsPath+"/"+url.PathEscape(id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get exemption %s: %w", id, err)
 	}
@@ -109,7 +114,7 @@ func (c *Client) CreateExemption(ctx context.Context, e *Exemption) (*Exemption,
 		return nil, fmt.Errorf("failed to marshal exemption: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, "/adaptive-logs/exemptions", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPost, exemptionsPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create exemption: %w", err)
 	}
@@ -135,7 +140,7 @@ func (c *Client) UpdateExemption(ctx context.Context, id string, e *Exemption) (
 		return nil, fmt.Errorf("failed to marshal exemption: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPut, "/adaptive-logs/exemptions/"+url.PathEscape(id), bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPut, exemptionsPath+"/"+url.PathEscape(id), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to update exemption %s: %w", id, err)
 	}
@@ -155,7 +160,7 @@ func (c *Client) UpdateExemption(ctx context.Context, id string, e *Exemption) (
 
 // DeleteExemption deletes a log stream exemption by ID.
 func (c *Client) DeleteExemption(ctx context.Context, id string) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, "/adaptive-logs/exemptions/"+url.PathEscape(id), nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, exemptionsPath+"/"+url.PathEscape(id), nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete exemption %s: %w", id, err)
 	}
@@ -171,7 +176,7 @@ func (c *Client) DeleteExemption(ctx context.Context, id string) error {
 // ListRecommendations returns all adaptive log pattern recommendations.
 // For each recommendation, the Pattern field is populated using Label() if empty.
 func (c *Client) ListRecommendations(ctx context.Context) ([]LogRecommendation, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/adaptive-logs/recommendations", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, recommendationsPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list recommendations: %w", err)
 	}
@@ -198,7 +203,7 @@ func (c *Client) ListRecommendations(ctx context.Context) ([]LogRecommendation, 
 // ListSegments returns all adaptive log segments.
 // The API returns a bare JSON array (no wrapper).
 func (c *Client) ListSegments(ctx context.Context) ([]LogSegment, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/adaptive-logs/segments", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, segmentsPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list segments: %w", err)
 	}
@@ -223,7 +228,7 @@ func (c *Client) ListSegments(ctx context.Context) ([]LogSegment, error) {
 // GetSegment returns a single segment by ID.
 // The API uses a query parameter: GET /adaptive-logs/segment?segment=<id>.
 func (c *Client) GetSegment(ctx context.Context, id string) (*LogSegment, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/adaptive-logs/segment?segment="+url.QueryEscape(id), nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, segmentPath+"?segment="+url.QueryEscape(id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get segment %s: %w", id, err)
 	}
@@ -248,7 +253,7 @@ func (c *Client) CreateSegment(ctx context.Context, s *LogSegment) (*LogSegment,
 		return nil, fmt.Errorf("failed to marshal segment: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, "/adaptive-logs/segment", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPost, segmentPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create segment: %w", err)
 	}
@@ -274,7 +279,7 @@ func (c *Client) UpdateSegment(ctx context.Context, id string, s *LogSegment) (*
 		return nil, fmt.Errorf("failed to marshal segment: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPut, "/adaptive-logs/segment?segment="+url.QueryEscape(id), bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPut, segmentPath+"?segment="+url.QueryEscape(id), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to update segment %s: %w", id, err)
 	}
@@ -295,7 +300,7 @@ func (c *Client) UpdateSegment(ctx context.Context, id string, s *LogSegment) (*
 // DeleteSegment deletes an adaptive log segment by ID.
 // The API uses a query parameter: DELETE /adaptive-logs/segment?segment=<id>.
 func (c *Client) DeleteSegment(ctx context.Context, id string) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, "/adaptive-logs/segment?segment="+url.QueryEscape(id), nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, segmentPath+"?segment="+url.QueryEscape(id), nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete segment %s: %w", id, err)
 	}

--- a/internal/providers/metrics/adaptive/client.go
+++ b/internal/providers/metrics/adaptive/client.go
@@ -16,6 +16,17 @@ import (
 	"github.com/grafana/gcx/internal/resources/adapter"
 )
 
+const (
+	segmentsPath           = "/aggregations/rules/segments"
+	rulesPath              = "/aggregations/rules"
+	rulePath               = "/aggregations/rule/"
+	checkRulesPath         = "/aggregations/check-rules"
+	recommendationsPath    = "/aggregations/recommendations"
+	exemptionsPath         = "/v1/recommendations/exemptions"
+	exemptionByIDPath      = "/v1/recommendations/exemptions/"
+	segmentedExemptionPath = "/v1/recommendations/segmented_exemptions"
+)
+
 // serverError trims trailing whitespace from server response bodies so that
 // error messages don't contain stray newlines in formatted output.
 func serverError(b []byte) string {
@@ -72,7 +83,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body io.Rea
 
 // ListSegments returns all Adaptive Metrics segments.
 func (c *Client) ListSegments(ctx context.Context) ([]MetricSegment, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/aggregations/rules/segments", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, segmentsPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("adaptive-metrics: list segments: %w", err)
 	}
@@ -119,7 +130,7 @@ func (c *Client) CreateSegment(ctx context.Context, s *MetricSegment) (*MetricSe
 		return nil, fmt.Errorf("adaptive-metrics: create segment: marshal: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, "/aggregations/rules/segments", bytes.NewReader(data))
+	resp, err := c.doRequest(ctx, http.MethodPost, segmentsPath, bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("adaptive-metrics: create segment: %w", err)
 	}
@@ -146,7 +157,7 @@ func (c *Client) UpdateSegment(ctx context.Context, id string, s *MetricSegment)
 		return nil, fmt.Errorf("adaptive-metrics: update segment: marshal: %w", err)
 	}
 
-	path := "/aggregations/rules/segments?segment=" + url.QueryEscape(id)
+	path := segmentsPath + "?segment=" + url.QueryEscape(id)
 	resp, err := c.doRequest(ctx, http.MethodPut, path, bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("adaptive-metrics: update segment: %w", err)
@@ -168,7 +179,7 @@ func (c *Client) UpdateSegment(ctx context.Context, id string, s *MetricSegment)
 
 // DeleteSegment deletes a segment by ID. Returns 409 if the segment has dependent data.
 func (c *Client) DeleteSegment(ctx context.Context, id string) error {
-	path := "/aggregations/rules/segments?segment=" + url.QueryEscape(id)
+	path := segmentsPath + "?segment=" + url.QueryEscape(id)
 	resp, err := c.doRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return fmt.Errorf("adaptive-metrics: delete segment: %w", err)
@@ -194,7 +205,7 @@ func (c *Client) DeleteSegment(ctx context.Context, id string) error {
 // ListExemptions returns all exemptions, optionally scoped to a segment.
 // The API wraps results in {"result": [...]}.
 func (c *Client) ListExemptions(ctx context.Context, segment string) ([]MetricExemption, error) {
-	path := "/v1/recommendations/exemptions"
+	path := exemptionsPath
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -226,7 +237,7 @@ func (c *Client) ListExemptions(ctx context.Context, segment string) ([]MetricEx
 
 // ListSegmentedExemptions returns all exemptions grouped by segment.
 func (c *Client) ListSegmentedExemptions(ctx context.Context) ([]ExemptionsBySegmentEntry, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/v1/recommendations/segmented_exemptions", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, segmentedExemptionPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("adaptive-metrics: list segmented exemptions: %w", err)
 	}
@@ -252,7 +263,7 @@ func (c *Client) ListSegmentedExemptions(ctx context.Context) ([]ExemptionsBySeg
 // GetExemption returns a single exemption by ID, optionally scoped to a segment.
 // Returns ErrExemptionNotFound on 404.
 func (c *Client) GetExemption(ctx context.Context, id, segment string) (*MetricExemption, error) {
-	path := "/v1/recommendations/exemptions/" + url.PathEscape(id)
+	path := exemptionByIDPath + url.PathEscape(id)
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -286,7 +297,7 @@ func (c *Client) GetExemption(ctx context.Context, id, segment string) (*MetricE
 
 // CreateExemption creates a new exemption, optionally scoped to a segment.
 func (c *Client) CreateExemption(ctx context.Context, e *MetricExemption, segment string) (*MetricExemption, error) {
-	path := "/v1/recommendations/exemptions"
+	path := exemptionsPath
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -323,7 +334,7 @@ func (c *Client) CreateExemption(ctx context.Context, e *MetricExemption, segmen
 // UpdateExemption updates an existing exemption. The server returns an empty body on success,
 // so the input exemption (with ID set) is returned.
 func (c *Client) UpdateExemption(ctx context.Context, id string, e *MetricExemption, segment string) (*MetricExemption, error) {
-	path := "/v1/recommendations/exemptions/" + url.PathEscape(id)
+	path := exemptionByIDPath + url.PathEscape(id)
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -354,7 +365,7 @@ func (c *Client) UpdateExemption(ctx context.Context, id string, e *MetricExempt
 
 // DeleteExemption soft-deletes an exemption, optionally scoped to a segment.
 func (c *Client) DeleteExemption(ctx context.Context, id, segment string) error {
-	path := "/v1/recommendations/exemptions/" + url.PathEscape(id)
+	path := exemptionByIDPath + url.PathEscape(id)
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -375,7 +386,7 @@ func (c *Client) DeleteExemption(ctx context.Context, id, segment string) error 
 
 // ListRules returns all aggregation rules and the current ETag.
 func (c *Client) ListRules(ctx context.Context, segment string) ([]MetricRule, string, error) {
-	path := "/aggregations/rules"
+	path := rulesPath
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -405,7 +416,7 @@ func (c *Client) ListRules(ctx context.Context, segment string) ([]MetricRule, s
 // Returns ErrRuleNotFound if the rule does not exist.
 // Note: mutations require the global rules ETag from ListRules, not a per-rule ETag.
 func (c *Client) GetRule(ctx context.Context, metric, segment string) (MetricRule, error) {
-	path := "/aggregations/rule/" + url.PathEscape(metric)
+	path := rulePath + url.PathEscape(metric)
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -436,7 +447,7 @@ func (c *Client) GetRule(ctx context.Context, metric, segment string) (MetricRul
 // The etag should be the current rules ETag from ListRules — the API requires
 // If-Match even for creates against the individual rule endpoint.
 func (c *Client) CreateRule(ctx context.Context, rule MetricRule, etag, segment string) (string, error) {
-	path := "/aggregations/rule/" + url.PathEscape(rule.Metric)
+	path := rulePath + url.PathEscape(rule.Metric)
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -476,7 +487,7 @@ func (c *Client) CreateRule(ctx context.Context, rule MetricRule, etag, segment 
 // UpdateRule updates an existing aggregation rule using the provided ETag.
 // Returns ErrPreconditionFailed on a 412 conflict.
 func (c *Client) UpdateRule(ctx context.Context, rule MetricRule, etag, segment string) (string, error) {
-	path := "/aggregations/rule/" + url.PathEscape(rule.Metric)
+	path := rulePath + url.PathEscape(rule.Metric)
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -514,7 +525,7 @@ func (c *Client) UpdateRule(ctx context.Context, rule MetricRule, etag, segment 
 // DeleteRule deletes an aggregation rule using the provided ETag.
 // Returns ErrPreconditionFailed on a 412 conflict.
 func (c *Client) DeleteRule(ctx context.Context, metric, etag, segment string) error {
-	path := "/aggregations/rule/" + url.PathEscape(metric)
+	path := rulePath + url.PathEscape(metric)
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -545,7 +556,7 @@ func (c *Client) DeleteRule(ctx context.Context, metric, etag, segment string) e
 
 // SyncRules replaces all aggregation rules using the given ETag for optimistic concurrency.
 func (c *Client) SyncRules(ctx context.Context, rules []MetricRule, etag, segment string) error {
-	path := "/aggregations/rules"
+	path := rulesPath
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -584,7 +595,7 @@ func (c *Client) SyncRules(ctx context.Context, rules []MetricRule, etag, segmen
 // ValidateRules validates a set of rules against the API.
 // Returns a list of validation error strings on failure.
 func (c *Client) ValidateRules(ctx context.Context, rules []MetricRule, segment string) ([]string, error) {
-	path := "/aggregations/check-rules"
+	path := checkRulesPath
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -633,7 +644,7 @@ func (c *Client) ListRecommendations(ctx context.Context, segment string, action
 		params.Add("action", a)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodGet, "/aggregations/recommendations?"+params.Encode(), nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, recommendationsPath+"?"+params.Encode(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("adaptive-metrics: list recommendations: %w", err)
 	}
@@ -661,7 +672,7 @@ func (c *Client) ListRecommendedRules(ctx context.Context, segment string) ([]Me
 		params.Set("segment", segment)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodGet, "/aggregations/recommendations?"+params.Encode(), nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, recommendationsPath+"?"+params.Encode(), nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("adaptive-metrics: list recommended rules: %w", err)
 	}

--- a/internal/providers/metrics/adaptive/client.go
+++ b/internal/providers/metrics/adaptive/client.go
@@ -19,11 +19,11 @@ import (
 const (
 	segmentsPath           = "/aggregations/rules/segments"
 	rulesPath              = "/aggregations/rules"
-	rulePath               = "/aggregations/rule/"
+	ruleByMetricFmt        = "/aggregations/rule/%s"
 	checkRulesPath         = "/aggregations/check-rules"
 	recommendationsPath    = "/aggregations/recommendations"
 	exemptionsPath         = "/v1/recommendations/exemptions"
-	exemptionByIDPath      = "/v1/recommendations/exemptions/"
+	exemptionByIDFmt       = exemptionsPath + "/%s"
 	segmentedExemptionPath = "/v1/recommendations/segmented_exemptions"
 )
 
@@ -263,7 +263,7 @@ func (c *Client) ListSegmentedExemptions(ctx context.Context) ([]ExemptionsBySeg
 // GetExemption returns a single exemption by ID, optionally scoped to a segment.
 // Returns ErrExemptionNotFound on 404.
 func (c *Client) GetExemption(ctx context.Context, id, segment string) (*MetricExemption, error) {
-	path := exemptionByIDPath + url.PathEscape(id)
+	path := fmt.Sprintf(exemptionByIDFmt, url.PathEscape(id))
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -334,7 +334,7 @@ func (c *Client) CreateExemption(ctx context.Context, e *MetricExemption, segmen
 // UpdateExemption updates an existing exemption. The server returns an empty body on success,
 // so the input exemption (with ID set) is returned.
 func (c *Client) UpdateExemption(ctx context.Context, id string, e *MetricExemption, segment string) (*MetricExemption, error) {
-	path := exemptionByIDPath + url.PathEscape(id)
+	path := fmt.Sprintf(exemptionByIDFmt, url.PathEscape(id))
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -365,7 +365,7 @@ func (c *Client) UpdateExemption(ctx context.Context, id string, e *MetricExempt
 
 // DeleteExemption soft-deletes an exemption, optionally scoped to a segment.
 func (c *Client) DeleteExemption(ctx context.Context, id, segment string) error {
-	path := exemptionByIDPath + url.PathEscape(id)
+	path := fmt.Sprintf(exemptionByIDFmt, url.PathEscape(id))
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -416,7 +416,7 @@ func (c *Client) ListRules(ctx context.Context, segment string) ([]MetricRule, s
 // Returns ErrRuleNotFound if the rule does not exist.
 // Note: mutations require the global rules ETag from ListRules, not a per-rule ETag.
 func (c *Client) GetRule(ctx context.Context, metric, segment string) (MetricRule, error) {
-	path := rulePath + url.PathEscape(metric)
+	path := fmt.Sprintf(ruleByMetricFmt, url.PathEscape(metric))
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -447,7 +447,7 @@ func (c *Client) GetRule(ctx context.Context, metric, segment string) (MetricRul
 // The etag should be the current rules ETag from ListRules — the API requires
 // If-Match even for creates against the individual rule endpoint.
 func (c *Client) CreateRule(ctx context.Context, rule MetricRule, etag, segment string) (string, error) {
-	path := rulePath + url.PathEscape(rule.Metric)
+	path := fmt.Sprintf(ruleByMetricFmt, url.PathEscape(rule.Metric))
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -487,7 +487,7 @@ func (c *Client) CreateRule(ctx context.Context, rule MetricRule, etag, segment 
 // UpdateRule updates an existing aggregation rule using the provided ETag.
 // Returns ErrPreconditionFailed on a 412 conflict.
 func (c *Client) UpdateRule(ctx context.Context, rule MetricRule, etag, segment string) (string, error) {
-	path := rulePath + url.PathEscape(rule.Metric)
+	path := fmt.Sprintf(ruleByMetricFmt, url.PathEscape(rule.Metric))
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}
@@ -525,7 +525,7 @@ func (c *Client) UpdateRule(ctx context.Context, rule MetricRule, etag, segment 
 // DeleteRule deletes an aggregation rule using the provided ETag.
 // Returns ErrPreconditionFailed on a 412 conflict.
 func (c *Client) DeleteRule(ctx context.Context, metric, etag, segment string) error {
-	path := rulePath + url.PathEscape(metric)
+	path := fmt.Sprintf(ruleByMetricFmt, url.PathEscape(metric))
 	if segment != "" {
 		path += "?segment=" + url.QueryEscape(segment)
 	}

--- a/internal/providers/slo/definitions/client.go
+++ b/internal/providers/slo/definitions/client.go
@@ -16,7 +16,10 @@ import (
 // ErrNotFound is returned when a requested SLO does not exist (HTTP 404).
 var ErrNotFound = errors.New("SLO not found")
 
-const basePath = "/api/plugins/grafana-slo-app/resources/v1/slo"
+const (
+	basePath     = "/api/plugins/grafana-slo-app/resources/v1/slo"
+	sloByUUIDFmt = basePath + "/%s"
+)
 
 // Client is an HTTP client for the Grafana SLO API.
 type Client struct {
@@ -63,7 +66,7 @@ func (c *Client) List(ctx context.Context) ([]Slo, error) {
 
 // Get returns a single SLO definition by UUID.
 func (c *Client) Get(ctx context.Context, uuid string) (*Slo, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, basePath+"/"+uuid, nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf(sloByUUIDFmt, uuid), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get SLO %s: %w", uuid, err)
 	}
@@ -117,7 +120,7 @@ func (c *Client) Update(ctx context.Context, uuid string, slo *Slo) error {
 		return fmt.Errorf("failed to marshal SLO: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPut, basePath+"/"+uuid, bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPut, fmt.Sprintf(sloByUUIDFmt, uuid), bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to update SLO %s: %w", uuid, err)
 	}
@@ -132,7 +135,7 @@ func (c *Client) Update(ctx context.Context, uuid string, slo *Slo) error {
 
 // Delete deletes an SLO definition by UUID.
 func (c *Client) Delete(ctx context.Context, uuid string) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, basePath+"/"+uuid, nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, fmt.Sprintf(sloByUUIDFmt, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete SLO %s: %w", uuid, err)
 	}

--- a/internal/providers/slo/reports/client.go
+++ b/internal/providers/slo/reports/client.go
@@ -16,7 +16,10 @@ import (
 // ErrNotFound is returned when a requested report does not exist (HTTP 404).
 var ErrNotFound = errors.New("report not found")
 
-const basePath = "/api/plugins/grafana-slo-app/resources/v1/report"
+const (
+	basePath        = "/api/plugins/grafana-slo-app/resources/v1/report"
+	reportByUUIDFmt = basePath + "/%s"
+)
 
 // Client is an HTTP client for the Grafana SLO Reports API.
 type Client struct {
@@ -63,7 +66,7 @@ func (c *Client) List(ctx context.Context) ([]Report, error) {
 
 // Get returns a single SLO report by UUID.
 func (c *Client) Get(ctx context.Context, uuid string) (*Report, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, basePath+"/"+uuid, nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf(reportByUUIDFmt, uuid), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get report %s: %w", uuid, err)
 	}
@@ -117,7 +120,7 @@ func (c *Client) Update(ctx context.Context, uuid string, report *Report) error 
 		return fmt.Errorf("failed to marshal report: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPut, basePath+"/"+uuid, bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPut, fmt.Sprintf(reportByUUIDFmt, uuid), bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to update report %s: %w", uuid, err)
 	}
@@ -132,7 +135,7 @@ func (c *Client) Update(ctx context.Context, uuid string, report *Report) error 
 
 // Delete deletes an SLO report by UUID.
 func (c *Client) Delete(ctx context.Context, uuid string) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, basePath+"/"+uuid, nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, fmt.Sprintf(reportByUUIDFmt, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete report %s: %w", uuid, err)
 	}

--- a/internal/providers/synth/checks/client.go
+++ b/internal/providers/synth/checks/client.go
@@ -17,6 +17,16 @@ import (
 // ErrNotFound is returned when a requested check does not exist (HTTP 404).
 var ErrNotFound = errors.New("check not found")
 
+const (
+	checkListPath      = "/check/list"
+	checkAddPath       = "/check/add"
+	checkUpdatePath    = "/check/update"
+	checkByIDPathFmt   = "/check/%d"
+	checkDeletePathFmt = "/check/delete/%d"
+	tenantPath         = "/tenant"
+	probeListPath      = "/probe/list"
+)
+
 // Client is an HTTP client for the Synthetic Monitoring checks API.
 type Client struct {
 	baseURL    string
@@ -36,7 +46,7 @@ func NewClient(ctx context.Context, baseURL, token string) *Client {
 
 // List returns all checks for the authenticated tenant.
 func (c *Client) List(ctx context.Context) ([]Check, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/check/list", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, checkListPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("listing checks: %w", err)
 	}
@@ -60,7 +70,7 @@ func (c *Client) List(ctx context.Context) ([]Check, error) {
 
 // Get returns a single check by ID.
 func (c *Client) Get(ctx context.Context, id int64) (*Check, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/check/%d", id), nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf(checkByIDPathFmt, id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting check %d: %w", id, err)
 	}
@@ -89,7 +99,7 @@ func (c *Client) Create(ctx context.Context, check Check) (*Check, error) {
 		return nil, fmt.Errorf("marshalling check: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, "/check/add", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPost, checkAddPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("creating check: %w", err)
 	}
@@ -114,7 +124,7 @@ func (c *Client) Update(ctx context.Context, check Check) (*Check, error) {
 		return nil, fmt.Errorf("marshalling check: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, "/check/update", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPost, checkUpdatePath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("updating check %d: %w", check.ID, err)
 	}
@@ -134,7 +144,7 @@ func (c *Client) Update(ctx context.Context, check Check) (*Check, error) {
 
 // Delete deletes a check by ID.
 func (c *Client) Delete(ctx context.Context, id int64) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/check/delete/%d", id), nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, fmt.Sprintf(checkDeletePathFmt, id), nil)
 	if err != nil {
 		return fmt.Errorf("deleting check %d: %w", id, err)
 	}
@@ -149,7 +159,7 @@ func (c *Client) Delete(ctx context.Context, id int64) error {
 
 // GetTenant returns the SM tenant info (used to obtain tenantId for push).
 func (c *Client) GetTenant(ctx context.Context) (*Tenant, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/tenant", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, tenantPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting tenant: %w", err)
 	}
@@ -169,7 +179,7 @@ func (c *Client) GetTenant(ctx context.Context) (*Tenant, error) {
 
 // ListProbes returns a minimal list of probes for name/ID resolution.
 func (c *Client) ListProbes(ctx context.Context) ([]ProbeRef, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/probe/list", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, probeListPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("listing probes: %w", err)
 	}

--- a/internal/providers/synth/probes/client.go
+++ b/internal/providers/synth/probes/client.go
@@ -13,6 +13,13 @@ import (
 	"github.com/grafana/gcx/internal/providers/synth/smcfg"
 )
 
+const (
+	probeListPath      = "/probe/list"
+	probeAddPath       = "/probe/add"
+	probeUpdatePath    = "/probe/update"
+	probeDeletePathFmt = "/probe/delete/%d"
+)
+
 // Client is an HTTP client for the Synthetic Monitoring probes API.
 type Client struct {
 	baseURL    string
@@ -44,7 +51,7 @@ type updateResponse struct {
 
 // List returns all probes visible to the authenticated tenant.
 func (c *Client) List(ctx context.Context) ([]Probe, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/probe/list", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, probeListPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("listing probes: %w", err)
 	}
@@ -74,7 +81,7 @@ func (c *Client) Create(ctx context.Context, probe Probe) (*CreateResponse, erro
 		return nil, fmt.Errorf("marshalling probe: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, "/probe/add", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPost, probeAddPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("creating probe: %w", err)
 	}
@@ -130,7 +137,7 @@ func (c *Client) ResetToken(ctx context.Context, probe Probe) (*Probe, error) {
 		return nil, fmt.Errorf("marshalling update request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, "/probe/update", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPost, probeUpdatePath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("resetting probe token %d: %w", probe.ID, err)
 	}
@@ -150,7 +157,7 @@ func (c *Client) ResetToken(ctx context.Context, probe Probe) (*Probe, error) {
 
 // Delete deletes a probe by ID.
 func (c *Client) Delete(ctx context.Context, id int64) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/probe/delete/%d", id), nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, fmt.Sprintf(probeDeletePathFmt, id), nil)
 	if err != nil {
 		return fmt.Errorf("deleting probe %d: %w", id, err)
 	}

--- a/internal/providers/traces/adaptive/client.go
+++ b/internal/providers/traces/adaptive/client.go
@@ -12,6 +12,11 @@ import (
 	"strings"
 )
 
+const (
+	policiesPath        = "/adaptive-traces/api/v1/policies"
+	recommendationsPath = "/adaptive-traces/api/v1/recommendations"
+)
+
 // Client is an HTTP client for the Adaptive Traces API.
 type Client struct {
 	baseURL    string
@@ -32,7 +37,7 @@ func NewClient(baseURL string, tenantID int, apiToken string, httpClient *http.C
 
 // ListPolicies returns all sampling policies.
 func (c *Client) ListPolicies(ctx context.Context) ([]Policy, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/adaptive-traces/api/v1/policies", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, policiesPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("listing policies: %w", err)
 	}
@@ -56,7 +61,7 @@ func (c *Client) ListPolicies(ctx context.Context) ([]Policy, error) {
 
 // GetPolicy returns a single policy by ID.
 func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/adaptive-traces/api/v1/policies/"+url.PathEscape(id), nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, policiesPath+"/"+url.PathEscape(id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting policy %q: %w", id, err)
 	}
@@ -81,7 +86,7 @@ func (c *Client) CreatePolicy(ctx context.Context, p *Policy) (*Policy, error) {
 		return nil, fmt.Errorf("marshalling policy: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, "/adaptive-traces/api/v1/policies", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPost, policiesPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("creating policy: %w", err)
 	}
@@ -106,7 +111,7 @@ func (c *Client) UpdatePolicy(ctx context.Context, id string, p *Policy) (*Polic
 		return nil, fmt.Errorf("marshalling policy: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPut, "/adaptive-traces/api/v1/policies/"+url.PathEscape(id), bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPut, policiesPath+"/"+url.PathEscape(id), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("updating policy %q: %w", id, err)
 	}
@@ -126,7 +131,7 @@ func (c *Client) UpdatePolicy(ctx context.Context, id string, p *Policy) (*Polic
 
 // DeletePolicy deletes a sampling policy by ID.
 func (c *Client) DeletePolicy(ctx context.Context, id string) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, "/adaptive-traces/api/v1/policies/"+url.PathEscape(id), nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, policiesPath+"/"+url.PathEscape(id), nil)
 	if err != nil {
 		return fmt.Errorf("deleting policy %q: %w", id, err)
 	}
@@ -141,7 +146,7 @@ func (c *Client) DeletePolicy(ctx context.Context, id string) error {
 
 // ListRecommendations returns all sampling recommendations.
 func (c *Client) ListRecommendations(ctx context.Context) ([]Recommendation, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, "/adaptive-traces/api/v1/recommendations", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, recommendationsPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("listing recommendations: %w", err)
 	}
@@ -165,7 +170,7 @@ func (c *Client) ListRecommendations(ctx context.Context) ([]Recommendation, err
 
 // ApplyRecommendation applies a recommendation by ID.
 func (c *Client) ApplyRecommendation(ctx context.Context, id string) error {
-	resp, err := c.doRequest(ctx, http.MethodPost, "/adaptive-traces/api/v1/recommendations/"+url.PathEscape(id)+"/apply", nil)
+	resp, err := c.doRequest(ctx, http.MethodPost, recommendationsPath+"/"+url.PathEscape(id)+"/apply", nil)
 	if err != nil {
 		return fmt.Errorf("applying recommendation %q: %w", id, err)
 	}
@@ -180,7 +185,7 @@ func (c *Client) ApplyRecommendation(ctx context.Context, id string) error {
 
 // DismissRecommendation dismisses a recommendation by ID.
 func (c *Client) DismissRecommendation(ctx context.Context, id string) error {
-	resp, err := c.doRequest(ctx, http.MethodPost, "/adaptive-traces/api/v1/recommendations/"+url.PathEscape(id)+"/dismiss", nil)
+	resp, err := c.doRequest(ctx, http.MethodPost, recommendationsPath+"/"+url.PathEscape(id)+"/dismiss", nil)
 	if err != nil {
 		return fmt.Errorf("dismissing recommendation %q: %w", id, err)
 	}

--- a/internal/providers/traces/adaptive/client.go
+++ b/internal/providers/traces/adaptive/client.go
@@ -13,8 +13,11 @@ import (
 )
 
 const (
-	policiesPath        = "/adaptive-traces/api/v1/policies"
-	recommendationsPath = "/adaptive-traces/api/v1/recommendations"
+	policiesPath             = "/adaptive-traces/api/v1/policies"
+	policyByIDPathFmt        = policiesPath + "/%s"
+	recommendationsPath      = "/adaptive-traces/api/v1/recommendations"
+	recommendationApplyFmt   = recommendationsPath + "/%s/apply"
+	recommendationDismissFmt = recommendationsPath + "/%s/dismiss"
 )
 
 // Client is an HTTP client for the Adaptive Traces API.
@@ -61,7 +64,7 @@ func (c *Client) ListPolicies(ctx context.Context) ([]Policy, error) {
 
 // GetPolicy returns a single policy by ID.
 func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, policiesPath+"/"+url.PathEscape(id), nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf(policyByIDPathFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting policy %q: %w", id, err)
 	}
@@ -111,7 +114,7 @@ func (c *Client) UpdatePolicy(ctx context.Context, id string, p *Policy) (*Polic
 		return nil, fmt.Errorf("marshalling policy: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPut, policiesPath+"/"+url.PathEscape(id), bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, http.MethodPut, fmt.Sprintf(policyByIDPathFmt, url.PathEscape(id)), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("updating policy %q: %w", id, err)
 	}
@@ -131,7 +134,7 @@ func (c *Client) UpdatePolicy(ctx context.Context, id string, p *Policy) (*Polic
 
 // DeletePolicy deletes a sampling policy by ID.
 func (c *Client) DeletePolicy(ctx context.Context, id string) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, policiesPath+"/"+url.PathEscape(id), nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, fmt.Sprintf(policyByIDPathFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return fmt.Errorf("deleting policy %q: %w", id, err)
 	}
@@ -170,7 +173,7 @@ func (c *Client) ListRecommendations(ctx context.Context) ([]Recommendation, err
 
 // ApplyRecommendation applies a recommendation by ID.
 func (c *Client) ApplyRecommendation(ctx context.Context, id string) error {
-	resp, err := c.doRequest(ctx, http.MethodPost, recommendationsPath+"/"+url.PathEscape(id)+"/apply", nil)
+	resp, err := c.doRequest(ctx, http.MethodPost, fmt.Sprintf(recommendationApplyFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return fmt.Errorf("applying recommendation %q: %w", id, err)
 	}
@@ -185,7 +188,7 @@ func (c *Client) ApplyRecommendation(ctx context.Context, id string) error {
 
 // DismissRecommendation dismisses a recommendation by ID.
 func (c *Client) DismissRecommendation(ctx context.Context, id string) error {
-	resp, err := c.doRequest(ctx, http.MethodPost, recommendationsPath+"/"+url.PathEscape(id)+"/dismiss", nil)
+	resp, err := c.doRequest(ctx, http.MethodPost, fmt.Sprintf(recommendationDismissFmt, url.PathEscape(id)), nil)
 	if err != nil {
 		return fmt.Errorf("dismissing recommendation %q: %w", id, err)
 	}


### PR DESCRIPTION
## Summary

> Note: Should be a no-op PR!

- Extracts inline API path literals (`"/api/instances/"`, `"/adaptive-traces/api/v1/policies"`, `incidentBasePath+"/IncidentsService.GetIncident"`, etc.) into named `const` blocks at the top of each client file across 21 files
- Every HTTP route is now defined once and referenced by name, eliminating scattered `path + "/extension"` concatenations throughout the codebase
- Covers `internal/cloud`, `internal/datasources`, `internal/grafana`, `internal/dashboards`, and all provider clients (`synth`, `slo`, `alert`, `faro`, `kg`, `logs/adaptive`, `traces/adaptive`, `metrics/adaptive`, `irm`, `aio11y`)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] All 40 affected test suites pass (`go test ./internal/cloud/... ./internal/datasources/... ./internal/grafana/... ./internal/dashboards/... ./internal/providers/synth/... ./internal/providers/slo/... ./internal/providers/alert/... ./internal/providers/faro/... ./internal/providers/kg/... ./internal/providers/logs/... ./internal/providers/traces/... ./internal/providers/metrics/... ./internal/providers/aio11y/... ./internal/providers/irm/...`)
- [x] `gofmt` clean on all touched files
- [x] `mise run lint` passes with 0 issues


Made with [Cursor](https://cursor.com)