### PR TITLE
fix(providers): honor --context across all CRUD adapters

### DIFF
--- a/cmd/gcx/root/command_test.go
+++ b/cmd/gcx/root/command_test.go
@@ -12,6 +12,7 @@ import (
 	claudeplugin "github.com/grafana/gcx/claude-plugin"
 	"github.com/grafana/gcx/cmd/gcx/root"
 	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/spf13/cobra"
@@ -231,4 +232,114 @@ func executeRootCommandForTest(args ...string) (string, string, error) {
 	cmd.SetArgs(args)
 	err := cmd.Execute()
 	return stdout.String(), stderr.String(), err
+}
+
+// buildContextFlagFixture wires a provider that mirrors the aio11y/appo11y
+// shape: a parent group that binds the standard provider config flags via
+// providers.ConfigLoader, plus a leaf subcommand that captures the resolved
+// context name from cmd.Context() through internalconfig.ContextNameFromCtx.
+//
+// The captured value is what the four buggy CRUD adapters
+// (aio11y rules, aio11y evaluators, appo11y settings, appo11y overrides)
+// rely on to resolve the active context. If a duplicate provider-level
+// `--context` flag silently swallows the root-level value, the captured
+// context name will be empty and these tests will fail.
+func buildContextFlagFixture(t *testing.T, captured *string) *cobra.Command {
+	t.Helper()
+
+	loader := &providers.ConfigLoader{}
+	leafCmd := &cobra.Command{
+		Use:   "list",
+		Short: "leaf",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			*captured = internalconfig.ContextNameFromCtx(cmd.Context())
+			return nil
+		},
+	}
+	rulesCmd := &cobra.Command{Use: "rules", Short: "rules group"}
+	rulesCmd.AddCommand(leafCmd)
+
+	parentCmd := &cobra.Command{
+		Use:   "aio11y",
+		Short: "aio11y group",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if r := cmd.Root(); r.PersistentPreRun != nil {
+				r.PersistentPreRun(cmd, args)
+			}
+		},
+	}
+	loader.BindFlags(parentCmd.PersistentFlags())
+	parentCmd.AddCommand(rulesCmd)
+
+	rootCmd := root.NewCommandForTest("v0.0.0-test", []providers.Provider{
+		&mockProvider{name: "aio11y", commands: []*cobra.Command{parentCmd}},
+	})
+	rootCmd.SilenceErrors = true
+	rootCmd.SilenceUsage = true
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	return rootCmd
+}
+
+// TestContextFlag_PropagatesAtAllPositions is a regression test for the bug
+// where a duplicate provider-level `--context` flag binding silently shadowed
+// the root-level flag. When the duplicate exists, the child's pflag binding
+// wins regardless of position on the command line, so root's `contextName`
+// stays empty and `ContextNameFromCtx` returns "". Removing the duplicate
+// (the fix) makes root's binding the single source of truth.
+func TestContextFlag_PropagatesAtAllPositions(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "before provider",
+			args: []string{"--context", "default", "aio11y", "rules", "list"},
+		},
+		{
+			name: "after provider",
+			args: []string{"aio11y", "--context", "default", "rules", "list"},
+		},
+		{
+			name: "after leaf",
+			args: []string{"aio11y", "rules", "list", "--context", "default"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured string
+			rootCmd := buildContextFlagFixture(t, &captured)
+			rootCmd.SetArgs(tc.args)
+			require.NoError(t, rootCmd.Execute())
+			assert.Equal(t, "default", captured,
+				"expected --context to propagate to leaf command's context.Context")
+		})
+	}
+}
+
+// TestContextFlag_ProviderDoesNotBindContextFlag verifies that when a provider
+// uses the standard providers.ConfigLoader.BindFlags pattern, the resulting
+// parent command does not register a provider-local `--context` flag. The flag
+// must remain root-only so its value flows through root's PersistentPreRun
+// into the Go context, where adapter factories pick it up.
+func TestContextFlag_ProviderDoesNotBindContextFlag(t *testing.T) {
+	loader := &providers.ConfigLoader{}
+	parentCmd := &cobra.Command{Use: "aio11y", Short: "aio11y group"}
+	loader.BindFlags(parentCmd.PersistentFlags())
+
+	assert.NotNil(t, parentCmd.PersistentFlags().Lookup("config"),
+		"provider parent must still bind --config")
+	assert.Nil(t, parentCmd.PersistentFlags().Lookup("context"),
+		"provider parent must NOT bind --context (root binds it as a global flag)")
+}
+
+// TestContextFlag_RootBindsContextAsPersistentGlobalFlag verifies the
+// help-output requirement: `--context` is a root-level persistent flag, so
+// `gcx <provider> --help` lists it under "Global Flags" and not under the
+// provider's local "Flags" section.
+func TestContextFlag_RootBindsContextAsPersistentGlobalFlag(t *testing.T) {
+	rootCmd := root.NewCommandForTest("v0.0.0-test", nil)
+	require.NotNil(t, rootCmd.PersistentFlags().Lookup("context"),
+		"root must bind --context as a persistent (global) flag")
 }

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -661,7 +661,7 @@ Files most important for understanding the codebase. Organized by architectural 
 | `internal/providers/registry.go` | `All()` — compile-time provider registry |
 | `internal/providers/redact.go` | `RedactSecrets()` — secure-by-default secret redaction |
 | `cmd/gcx/providers/command.go` | `providers` command (list registered providers) |
-| `internal/providers/configloader.go` | Shared `ConfigLoader` — binds `--config`/`--context` flags and loads REST config for all providers |
+| `internal/providers/configloader.go` | Shared `ConfigLoader` — binds the `--config` flag and loads REST config for all providers (`--context` is owned by the root command and threaded via `context.Context`) |
 
 ### Signal Providers (Metrics, Logs, Traces, Profiles)
 

--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -93,7 +93,7 @@ gcx (root)
 │
 ├── setup                    [cmd/gcx/setup/command.go]
 │   ├── --config             [persistent: inherited from providers.ConfigLoader]
-│   ├── --context            [persistent: inherited from providers.ConfigLoader]
+│   ├── --context            [persistent: inherited from root command]
 │   ├── status               Aggregated setup status across all products
 │   └── instrumentation      [cmd/gcx/setup/instrumentation/command.go]
 │       ├── status           Per-cluster instrumentation state + Beyla errors
@@ -163,7 +163,7 @@ operations plus optional product-specific commands.
 ```
 gcx {provider}           [contributed by Provider.Commands()]
 ├── --config                    [persistent: inherited via providers.ConfigLoader]
-├── --context                   [persistent: inherited via providers.ConfigLoader]
+├── --context                   [persistent: inherited from root command]
 │
 ├── {resource-type}             [one group per resource type]
 │   ├── list                    [always: list all resources]
@@ -212,13 +212,15 @@ gcx synthetic-monitoring [internal/providers/synth/provider.go]
 ### Config loading pattern
 
 Provider commands cannot import `cmd/gcx/config` (import cycle). Instead,
-they use a shared, exported `providers.ConfigLoader` that binds `--config` and `--context` flags
-independently. See `internal/providers/configloader.go` for the reference implementation.
+they use a shared, exported `providers.ConfigLoader` that binds the `--config`
+flag. The `--context` flag is owned by the root command and threaded into
+provider commands via `context.Context`. See `internal/providers/configloader.go`
+for the reference implementation.
 
 ```go
 // Shared across all providers — defined in internal/providers/configloader.go
 loader := &providers.ConfigLoader{}
-loader.BindFlags(sloCmd.PersistentFlags())  // --config, --context flags
+loader.BindFlags(sloCmd.PersistentFlags())  // --config flag (root owns --context)
 
 func (l *ConfigLoader) LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error) {
     // Applies env vars (GRAFANA_TOKEN, GRAFANA_PROVIDER_*), context flag,

--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -478,8 +478,10 @@ the issue for architectural discussion.
 
 ### Provider ConfigLoader
 
-All provider commands must use `providers.ConfigLoader` for flag binding
-(`--config`, `--context`) and config resolution (YAML + env var precedence).
+All provider commands must use `providers.ConfigLoader` for `--config` flag
+binding and config resolution (YAML + env var precedence). The `--context`
+flag is owned by the root command and threaded to providers via
+`context.Context` (see "Context threading" below).
 
 | Method | Purpose | Used by |
 |--------|---------|---------|
@@ -491,7 +493,7 @@ All provider commands must use `providers.ConfigLoader` for flag binding
 
 Do not:
 - Import `cmd/gcx/config` from provider code (import cycle)
-- Roll custom flag binding for `--config`/`--context`
+- Roll custom flag binding for `--config` (or re-bind `--context` — root owns it)
 - Construct HTTP clients or load credentials outside ConfigLoader
 - Hardcode env var names — ConfigLoader handles `GRAFANA_PROVIDER_*` resolution
 - Use `os.Getenv` for provider-specific env vars — use `LoadProviderConfig`

--- a/docs/reference/cli/gcx_aio11y.md
+++ b/docs/reference/cli/gcx_aio11y.md
@@ -5,15 +5,15 @@ Manage Grafana AI Observability resources
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for aio11y
+      --config string   Path to the configuration file to use
+  -h, --help            help for aio11y
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_agents.md
+++ b/docs/reference/cli/gcx_aio11y_agents.md
@@ -13,7 +13,7 @@ Query AI Observability agent catalog.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_agents_get.md
+++ b/docs/reference/cli/gcx_aio11y_agents_get.md
@@ -24,7 +24,7 @@ gcx aio11y agents get <agent-name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_agents_list.md
+++ b/docs/reference/cli/gcx_aio11y_agents_list.md
@@ -20,7 +20,7 @@ gcx aio11y agents list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_agents_versions.md
+++ b/docs/reference/cli/gcx_aio11y_agents_versions.md
@@ -19,7 +19,7 @@ gcx aio11y agents versions <agent-name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_conversations.md
+++ b/docs/reference/cli/gcx_aio11y_conversations.md
@@ -13,7 +13,7 @@ Query AI Observability conversations.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_conversations_get.md
+++ b/docs/reference/cli/gcx_aio11y_conversations_get.md
@@ -19,7 +19,7 @@ gcx aio11y conversations get <conversation-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_conversations_list.md
+++ b/docs/reference/cli/gcx_aio11y_conversations_list.md
@@ -20,7 +20,7 @@ gcx aio11y conversations list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_conversations_search.md
+++ b/docs/reference/cli/gcx_aio11y_conversations_search.md
@@ -47,7 +47,7 @@ gcx aio11y conversations search [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_evaluators.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators.md
@@ -13,7 +13,7 @@ Manage evaluator definitions (LLM judge, regex, heuristic).
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_evaluators_create.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_create.md
@@ -34,7 +34,7 @@ gcx aio11y evaluators create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_evaluators_delete.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_delete.md
@@ -18,7 +18,7 @@ gcx aio11y evaluators delete ID... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_evaluators_get.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_get.md
@@ -19,7 +19,7 @@ gcx aio11y evaluators get <evaluator-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_evaluators_list.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_list.md
@@ -20,7 +20,7 @@ gcx aio11y evaluators list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_evaluators_test.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_test.md
@@ -36,7 +36,7 @@ gcx aio11y evaluators test [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_generations.md
+++ b/docs/reference/cli/gcx_aio11y_generations.md
@@ -13,7 +13,7 @@ Inspect individual LLM generations.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_generations_get.md
+++ b/docs/reference/cli/gcx_aio11y_generations_get.md
@@ -23,7 +23,7 @@ gcx aio11y generations get <generation-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_judge.md
+++ b/docs/reference/cli/gcx_aio11y_judge.md
@@ -19,7 +19,7 @@ Use these values in the 'provider' and 'model' fields of an llm_judge evaluator 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_judge_models.md
+++ b/docs/reference/cli/gcx_aio11y_judge_models.md
@@ -20,7 +20,7 @@ gcx aio11y judge models --provider <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_judge_providers.md
+++ b/docs/reference/cli/gcx_aio11y_judge_providers.md
@@ -19,7 +19,7 @@ gcx aio11y judge providers [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_rules.md
+++ b/docs/reference/cli/gcx_aio11y_rules.md
@@ -13,7 +13,7 @@ Manage rules that route generations to evaluators.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_rules_create.md
+++ b/docs/reference/cli/gcx_aio11y_rules_create.md
@@ -33,7 +33,7 @@ gcx aio11y rules create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_rules_delete.md
+++ b/docs/reference/cli/gcx_aio11y_rules_delete.md
@@ -18,7 +18,7 @@ gcx aio11y rules delete ID... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_rules_get.md
+++ b/docs/reference/cli/gcx_aio11y_rules_get.md
@@ -19,7 +19,7 @@ gcx aio11y rules get <rule-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_rules_list.md
+++ b/docs/reference/cli/gcx_aio11y_rules_list.md
@@ -20,7 +20,7 @@ gcx aio11y rules list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_rules_update.md
+++ b/docs/reference/cli/gcx_aio11y_rules_update.md
@@ -27,7 +27,7 @@ gcx aio11y rules update <rule-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_scores.md
+++ b/docs/reference/cli/gcx_aio11y_scores.md
@@ -13,7 +13,7 @@ View evaluation scores for generations.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_scores_list.md
+++ b/docs/reference/cli/gcx_aio11y_scores_list.md
@@ -24,7 +24,7 @@ gcx aio11y scores list <generation-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_templates.md
+++ b/docs/reference/cli/gcx_aio11y_templates.md
@@ -13,7 +13,7 @@ Browse reusable evaluator blueprints (global and tenant-scoped).
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_templates_get.md
+++ b/docs/reference/cli/gcx_aio11y_templates_get.md
@@ -34,7 +34,7 @@ gcx aio11y templates get <template-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_templates_list.md
+++ b/docs/reference/cli/gcx_aio11y_templates_list.md
@@ -31,7 +31,7 @@ gcx aio11y templates list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_aio11y_templates_versions.md
+++ b/docs/reference/cli/gcx_aio11y_templates_versions.md
@@ -19,7 +19,7 @@ gcx aio11y templates versions <template-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert.md
+++ b/docs/reference/cli/gcx_alert.md
@@ -5,15 +5,15 @@ Manage Grafana alert rules and alert groups
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for alert
+      --config string   Path to the configuration file to use
+  -h, --help            help for alert
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_groups.md
+++ b/docs/reference/cli/gcx_alert_groups.md
@@ -13,7 +13,7 @@ Manage alert rule groups.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_groups_get.md
+++ b/docs/reference/cli/gcx_alert_groups_get.md
@@ -19,7 +19,7 @@ gcx alert groups get NAME [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_groups_list.md
+++ b/docs/reference/cli/gcx_alert_groups_list.md
@@ -20,7 +20,7 @@ gcx alert groups list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_groups_status.md
+++ b/docs/reference/cli/gcx_alert_groups_status.md
@@ -19,7 +19,7 @@ gcx alert groups status [NAME] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_instances.md
+++ b/docs/reference/cli/gcx_alert_instances.md
@@ -13,7 +13,7 @@ Manage alert instances.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_instances_list.md
+++ b/docs/reference/cli/gcx_alert_instances_list.md
@@ -25,7 +25,7 @@ gcx alert instances list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_rules.md
+++ b/docs/reference/cli/gcx_alert_rules.md
@@ -13,7 +13,7 @@ Manage alert rules.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_rules_get.md
+++ b/docs/reference/cli/gcx_alert_rules_get.md
@@ -19,7 +19,7 @@ gcx alert rules get UID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_alert_rules_list.md
+++ b/docs/reference/cli/gcx_alert_rules_list.md
@@ -23,7 +23,7 @@ gcx alert rules list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_appo11y.md
+++ b/docs/reference/cli/gcx_appo11y.md
@@ -5,15 +5,15 @@ Manage Grafana App Observability settings
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for appo11y
+      --config string   Path to the configuration file to use
+  -h, --help            help for appo11y
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_appo11y_overrides.md
+++ b/docs/reference/cli/gcx_appo11y_overrides.md
@@ -13,7 +13,7 @@ Manage App Observability metrics generator overrides.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_appo11y_overrides_get.md
+++ b/docs/reference/cli/gcx_appo11y_overrides_get.md
@@ -19,7 +19,7 @@ gcx appo11y overrides get [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_appo11y_overrides_update.md
+++ b/docs/reference/cli/gcx_appo11y_overrides_update.md
@@ -18,7 +18,7 @@ gcx appo11y overrides update [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_appo11y_settings.md
+++ b/docs/reference/cli/gcx_appo11y_settings.md
@@ -13,7 +13,7 @@ Manage App Observability plugin settings.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_appo11y_settings_get.md
+++ b/docs/reference/cli/gcx_appo11y_settings_get.md
@@ -19,7 +19,7 @@ gcx appo11y settings get [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_appo11y_settings_update.md
+++ b/docs/reference/cli/gcx_appo11y_settings_update.md
@@ -18,7 +18,7 @@ gcx appo11y settings update [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_dashboards.md
+++ b/docs/reference/cli/gcx_dashboards.md
@@ -9,15 +9,15 @@ Create, read, update, delete, and search Grafana dashboards via the Kubernetes-c
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for dashboards
+      --config string   Path to the configuration file to use
+  -h, --help            help for dashboards
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_dashboards_create.md
+++ b/docs/reference/cli/gcx_dashboards_create.md
@@ -19,7 +19,7 @@ gcx dashboards create -f <file> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_dashboards_delete.md
+++ b/docs/reference/cli/gcx_dashboards_delete.md
@@ -19,7 +19,7 @@ gcx dashboards delete <name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_dashboards_get.md
+++ b/docs/reference/cli/gcx_dashboards_get.md
@@ -26,7 +26,7 @@ gcx dashboards get <name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_dashboards_list.md
+++ b/docs/reference/cli/gcx_dashboards_list.md
@@ -20,7 +20,7 @@ gcx dashboards list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_dashboards_search.md
+++ b/docs/reference/cli/gcx_dashboards_search.md
@@ -51,7 +51,7 @@ gcx dashboards search [query] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_dashboards_snapshot.md
+++ b/docs/reference/cli/gcx_dashboards_snapshot.md
@@ -56,7 +56,7 @@ gcx dashboards snapshot <name> [name...] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_dashboards_update.md
+++ b/docs/reference/cli/gcx_dashboards_update.md
@@ -34,7 +34,7 @@ gcx dashboards update <name> -f <file> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_dashboards_versions.md
+++ b/docs/reference/cli/gcx_dashboards_versions.md
@@ -13,7 +13,7 @@ Manage dashboard version history
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_dashboards_versions_list.md
+++ b/docs/reference/cli/gcx_dashboards_versions_list.md
@@ -21,7 +21,7 @@ gcx dashboards versions list <name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_dashboards_versions_restore.md
+++ b/docs/reference/cli/gcx_dashboards_versions_restore.md
@@ -20,7 +20,7 @@ gcx dashboards versions restore <name> <version> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_loki.md
+++ b/docs/reference/cli/gcx_datasources_loki.md
@@ -5,15 +5,15 @@ Query Loki datasources
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for loki
+      --config string   Path to the configuration file to use
+  -h, --help            help for loki
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_loki_labels.md
+++ b/docs/reference/cli/gcx_datasources_loki_labels.md
@@ -39,7 +39,7 @@ gcx datasources loki labels [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_loki_metrics.md
+++ b/docs/reference/cli/gcx_datasources_loki_metrics.md
@@ -62,7 +62,7 @@ gcx datasources loki metrics [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_loki_query.md
+++ b/docs/reference/cli/gcx_datasources_loki_query.md
@@ -62,7 +62,7 @@ gcx datasources loki query [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_loki_series.md
+++ b/docs/reference/cli/gcx_datasources_loki_series.md
@@ -42,7 +42,7 @@ gcx datasources loki series [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_prometheus.md
+++ b/docs/reference/cli/gcx_datasources_prometheus.md
@@ -5,15 +5,15 @@ Query Prometheus datasources
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for prometheus
+      --config string   Path to the configuration file to use
+  -h, --help            help for prometheus
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_prometheus_labels.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_labels.md
@@ -39,7 +39,7 @@ gcx datasources prometheus labels [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_prometheus_metadata.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_metadata.md
@@ -39,7 +39,7 @@ gcx datasources prometheus metadata [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_prometheus_query.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_query.md
@@ -57,7 +57,7 @@ gcx datasources prometheus query [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_pyroscope.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope.md
@@ -5,15 +5,15 @@ Query Pyroscope datasources
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for pyroscope
+      --config string   Path to the configuration file to use
+  -h, --help            help for pyroscope
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_pyroscope_exemplars.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_exemplars.md
@@ -21,7 +21,7 @@ span" (span exemplars).
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_pyroscope_exemplars_profile.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_exemplars_profile.md
@@ -49,7 +49,7 @@ gcx datasources pyroscope exemplars profile [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_pyroscope_exemplars_span.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_exemplars_span.md
@@ -49,7 +49,7 @@ gcx datasources pyroscope exemplars span [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_pyroscope_labels.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_labels.md
@@ -39,7 +39,7 @@ gcx datasources pyroscope labels [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_pyroscope_metrics.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_metrics.md
@@ -69,7 +69,7 @@ gcx datasources pyroscope metrics [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_pyroscope_profile-types.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_profile-types.md
@@ -35,7 +35,7 @@ gcx datasources pyroscope profile-types [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -51,7 +51,7 @@ gcx datasources pyroscope query [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_tempo.md
+++ b/docs/reference/cli/gcx_datasources_tempo.md
@@ -5,15 +5,15 @@ Query Tempo datasources
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for tempo
+      --config string   Path to the configuration file to use
+  -h, --help            help for tempo
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_tempo_get.md
+++ b/docs/reference/cli/gcx_datasources_tempo_get.md
@@ -56,7 +56,7 @@ gcx datasources tempo get TRACE_ID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_tempo_labels.md
+++ b/docs/reference/cli/gcx_datasources_tempo_labels.md
@@ -55,7 +55,7 @@ gcx datasources tempo labels [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_tempo_metrics.md
+++ b/docs/reference/cli/gcx_datasources_tempo_metrics.md
@@ -65,7 +65,7 @@ gcx datasources tempo metrics [TRACEQL] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_datasources_tempo_query.md
+++ b/docs/reference/cli/gcx_datasources_tempo_query.md
@@ -58,7 +58,7 @@ gcx datasources tempo query [TRACEQL] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet.md
+++ b/docs/reference/cli/gcx_fleet.md
@@ -5,15 +5,15 @@ Manage Grafana Fleet Management pipelines and collectors
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for fleet
+      --config string   Path to the configuration file to use
+  -h, --help            help for fleet
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_collectors.md
+++ b/docs/reference/cli/gcx_fleet_collectors.md
@@ -13,7 +13,7 @@ Manage Fleet Management collectors.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_collectors_create.md
+++ b/docs/reference/cli/gcx_fleet_collectors_create.md
@@ -18,7 +18,7 @@ gcx fleet collectors create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_collectors_delete.md
+++ b/docs/reference/cli/gcx_fleet_collectors_delete.md
@@ -17,7 +17,7 @@ gcx fleet collectors delete <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_collectors_get.md
+++ b/docs/reference/cli/gcx_fleet_collectors_get.md
@@ -19,7 +19,7 @@ gcx fleet collectors get <id|name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_collectors_list.md
+++ b/docs/reference/cli/gcx_fleet_collectors_list.md
@@ -20,7 +20,7 @@ gcx fleet collectors list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_collectors_update.md
+++ b/docs/reference/cli/gcx_fleet_collectors_update.md
@@ -18,7 +18,7 @@ gcx fleet collectors update <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_pipelines.md
+++ b/docs/reference/cli/gcx_fleet_pipelines.md
@@ -13,7 +13,7 @@ Manage Fleet Management pipelines.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_pipelines_create.md
+++ b/docs/reference/cli/gcx_fleet_pipelines_create.md
@@ -19,7 +19,7 @@ gcx fleet pipelines create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_pipelines_delete.md
+++ b/docs/reference/cli/gcx_fleet_pipelines_delete.md
@@ -18,7 +18,7 @@ gcx fleet pipelines delete <name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_pipelines_get.md
+++ b/docs/reference/cli/gcx_fleet_pipelines_get.md
@@ -19,7 +19,7 @@ gcx fleet pipelines get <id|name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_pipelines_list.md
+++ b/docs/reference/cli/gcx_fleet_pipelines_list.md
@@ -20,7 +20,7 @@ gcx fleet pipelines list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_pipelines_update.md
+++ b/docs/reference/cli/gcx_fleet_pipelines_update.md
@@ -19,7 +19,7 @@ gcx fleet pipelines update <name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_tenant.md
+++ b/docs/reference/cli/gcx_fleet_tenant.md
@@ -13,7 +13,7 @@ Manage Fleet Management tenant settings.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_fleet_tenant_limits.md
+++ b/docs/reference/cli/gcx_fleet_tenant_limits.md
@@ -19,7 +19,7 @@ gcx fleet tenant limits [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_frontend.md
+++ b/docs/reference/cli/gcx_frontend.md
@@ -5,15 +5,15 @@ Manage Grafana Frontend Observability resources
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for frontend
+      --config string   Path to the configuration file to use
+  -h, --help            help for frontend
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_frontend_apps.md
+++ b/docs/reference/cli/gcx_frontend_apps.md
@@ -13,7 +13,7 @@ Manage Frontend Observability apps.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_frontend_apps_apply-sourcemap.md
+++ b/docs/reference/cli/gcx_frontend_apps_apply-sourcemap.md
@@ -26,7 +26,7 @@ gcx frontend apps apply-sourcemap <app-name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_frontend_apps_create.md
+++ b/docs/reference/cli/gcx_frontend_apps_create.md
@@ -28,7 +28,7 @@ gcx frontend apps create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_frontend_apps_delete.md
+++ b/docs/reference/cli/gcx_frontend_apps_delete.md
@@ -17,7 +17,7 @@ gcx frontend apps delete <name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_frontend_apps_get.md
+++ b/docs/reference/cli/gcx_frontend_apps_get.md
@@ -30,7 +30,7 @@ gcx frontend apps get [slug-id] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_frontend_apps_list.md
+++ b/docs/reference/cli/gcx_frontend_apps_list.md
@@ -20,7 +20,7 @@ gcx frontend apps list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_frontend_apps_remove-sourcemap.md
+++ b/docs/reference/cli/gcx_frontend_apps_remove-sourcemap.md
@@ -27,7 +27,7 @@ gcx frontend apps remove-sourcemap <app-name> <bundle-id> [bundle-id...] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_frontend_apps_show-sourcemaps.md
+++ b/docs/reference/cli/gcx_frontend_apps_show-sourcemaps.md
@@ -33,7 +33,7 @@ gcx frontend apps show-sourcemaps <app-name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_frontend_apps_update.md
+++ b/docs/reference/cli/gcx_frontend_apps_update.md
@@ -25,7 +25,7 @@ gcx frontend apps update <name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm.md
+++ b/docs/reference/cli/gcx_irm.md
@@ -5,15 +5,15 @@ Manage Grafana IRM (OnCall + Incidents)
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for irm
+      --config string   Path to the configuration file to use
+  -h, --help            help for irm
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_incidents.md
+++ b/docs/reference/cli/gcx_irm_incidents.md
@@ -13,7 +13,7 @@ Manage incidents.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_incidents_activity.md
+++ b/docs/reference/cli/gcx_irm_incidents_activity.md
@@ -13,7 +13,7 @@ Manage incident activity timeline.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_incidents_activity_add.md
+++ b/docs/reference/cli/gcx_irm_incidents_activity_add.md
@@ -18,7 +18,7 @@ gcx irm incidents activity add <incident-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_incidents_activity_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_activity_list.md
@@ -20,7 +20,7 @@ gcx irm incidents activity list <incident-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_incidents_close.md
+++ b/docs/reference/cli/gcx_irm_incidents_close.md
@@ -17,7 +17,7 @@ gcx irm incidents close <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_incidents_create.md
+++ b/docs/reference/cli/gcx_irm_incidents_create.md
@@ -20,7 +20,7 @@ gcx irm incidents create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_incidents_get.md
+++ b/docs/reference/cli/gcx_irm_incidents_get.md
@@ -19,7 +19,7 @@ gcx irm incidents get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_incidents_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_list.md
@@ -23,7 +23,7 @@ gcx irm incidents list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_incidents_open.md
+++ b/docs/reference/cli/gcx_irm_incidents_open.md
@@ -17,7 +17,7 @@ gcx irm incidents open <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_incidents_severities.md
+++ b/docs/reference/cli/gcx_irm_incidents_severities.md
@@ -13,7 +13,7 @@ Manage incident severity levels.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_incidents_severities_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_severities_list.md
@@ -19,7 +19,7 @@ gcx irm incidents severities list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall.md
+++ b/docs/reference/cli/gcx_irm_oncall.md
@@ -13,7 +13,7 @@ Manage Grafana OnCall resources.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups.md
@@ -13,7 +13,7 @@ Manage alert groups.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
@@ -19,7 +19,7 @@ gcx irm oncall alert-groups acknowledge <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
@@ -19,7 +19,7 @@ gcx irm oncall alert-groups delete <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_get.md
@@ -19,7 +19,7 @@ gcx irm oncall alert-groups get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_list-alerts.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_list-alerts.md
@@ -19,7 +19,7 @@ gcx irm oncall alert-groups list-alerts <alert-group-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_list.md
@@ -20,7 +20,7 @@ gcx irm oncall alert-groups list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
@@ -19,7 +19,7 @@ gcx irm oncall alert-groups resolve <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
@@ -20,7 +20,7 @@ gcx irm oncall alert-groups silence <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
@@ -19,7 +19,7 @@ gcx irm oncall alert-groups unacknowledge <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
@@ -19,7 +19,7 @@ gcx irm oncall alert-groups unresolve <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
@@ -19,7 +19,7 @@ gcx irm oncall alert-groups unsilence <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alerts.md
+++ b/docs/reference/cli/gcx_irm_oncall_alerts.md
@@ -13,7 +13,7 @@ View individual alerts.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_alerts_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_alerts_get.md
@@ -19,7 +19,7 @@ gcx irm oncall alerts get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_escalate.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalate.md
@@ -24,7 +24,7 @@ gcx irm oncall escalate [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_escalation-chains.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-chains.md
@@ -13,7 +13,7 @@ Manage escalation chains.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_escalation-chains_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-chains_get.md
@@ -19,7 +19,7 @@ gcx irm oncall escalation-chains get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_escalation-chains_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-chains_list.md
@@ -19,7 +19,7 @@ gcx irm oncall escalation-chains list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_escalation-policies.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-policies.md
@@ -13,7 +13,7 @@ Manage escalation policies.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_escalation-policies_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-policies_get.md
@@ -19,7 +19,7 @@ gcx irm oncall escalation-policies get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_escalation-policies_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-policies_list.md
@@ -19,7 +19,7 @@ gcx irm oncall escalation-policies list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_integrations.md
+++ b/docs/reference/cli/gcx_irm_oncall_integrations.md
@@ -13,7 +13,7 @@ Manage OnCall integrations.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_integrations_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_integrations_get.md
@@ -19,7 +19,7 @@ gcx irm oncall integrations get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_integrations_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_integrations_list.md
@@ -19,7 +19,7 @@ gcx irm oncall integrations list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_organizations.md
+++ b/docs/reference/cli/gcx_irm_oncall_organizations.md
@@ -13,7 +13,7 @@ View organization info.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_organizations_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_organizations_get.md
@@ -19,7 +19,7 @@ gcx irm oncall organizations get [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_resolution-notes.md
+++ b/docs/reference/cli/gcx_irm_oncall_resolution-notes.md
@@ -13,7 +13,7 @@ Manage resolution notes.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_resolution-notes_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_resolution-notes_get.md
@@ -19,7 +19,7 @@ gcx irm oncall resolution-notes get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_resolution-notes_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_resolution-notes_list.md
@@ -19,7 +19,7 @@ gcx irm oncall resolution-notes list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_routes.md
+++ b/docs/reference/cli/gcx_irm_oncall_routes.md
@@ -13,7 +13,7 @@ Manage OnCall routes.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_routes_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_routes_get.md
@@ -19,7 +19,7 @@ gcx irm oncall routes get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_routes_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_routes_list.md
@@ -19,7 +19,7 @@ gcx irm oncall routes list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_schedules.md
+++ b/docs/reference/cli/gcx_irm_oncall_schedules.md
@@ -13,7 +13,7 @@ Manage OnCall schedules.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_schedules_final-shifts.md
+++ b/docs/reference/cli/gcx_irm_oncall_schedules_final-shifts.md
@@ -21,7 +21,7 @@ gcx irm oncall schedules final-shifts <schedule-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_schedules_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_schedules_get.md
@@ -19,7 +19,7 @@ gcx irm oncall schedules get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_schedules_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_schedules_list.md
@@ -19,7 +19,7 @@ gcx irm oncall schedules list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_shift-swaps.md
+++ b/docs/reference/cli/gcx_irm_oncall_shift-swaps.md
@@ -13,7 +13,7 @@ Manage shift swaps.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_shift-swaps_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_shift-swaps_get.md
@@ -19,7 +19,7 @@ gcx irm oncall shift-swaps get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_shift-swaps_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_shift-swaps_list.md
@@ -19,7 +19,7 @@ gcx irm oncall shift-swaps list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_shifts.md
+++ b/docs/reference/cli/gcx_irm_oncall_shifts.md
@@ -13,7 +13,7 @@ Manage OnCall shifts.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_shifts_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_shifts_get.md
@@ -19,7 +19,7 @@ gcx irm oncall shifts get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_shifts_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_shifts_list.md
@@ -19,7 +19,7 @@ gcx irm oncall shifts list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_slack-channels.md
+++ b/docs/reference/cli/gcx_irm_oncall_slack-channels.md
@@ -13,7 +13,7 @@ List Slack channels.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_slack-channels_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_slack-channels_list.md
@@ -19,7 +19,7 @@ gcx irm oncall slack-channels list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_teams.md
+++ b/docs/reference/cli/gcx_irm_oncall_teams.md
@@ -13,7 +13,7 @@ Manage OnCall teams.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_teams_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_teams_get.md
@@ -19,7 +19,7 @@ gcx irm oncall teams get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_teams_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_teams_list.md
@@ -19,7 +19,7 @@ gcx irm oncall teams list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_user-groups.md
+++ b/docs/reference/cli/gcx_irm_oncall_user-groups.md
@@ -13,7 +13,7 @@ List user groups.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_user-groups_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_user-groups_list.md
@@ -19,7 +19,7 @@ gcx irm oncall user-groups list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_users.md
+++ b/docs/reference/cli/gcx_irm_oncall_users.md
@@ -13,7 +13,7 @@ Manage OnCall users.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_users_current.md
+++ b/docs/reference/cli/gcx_irm_oncall_users_current.md
@@ -19,7 +19,7 @@ gcx irm oncall users current [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_users_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_users_get.md
@@ -19,7 +19,7 @@ gcx irm oncall users get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_users_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_users_list.md
@@ -19,7 +19,7 @@ gcx irm oncall users list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_webhooks.md
+++ b/docs/reference/cli/gcx_irm_oncall_webhooks.md
@@ -13,7 +13,7 @@ Manage outgoing webhooks.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_webhooks_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_webhooks_get.md
@@ -19,7 +19,7 @@ gcx irm oncall webhooks get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_irm_oncall_webhooks_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_webhooks_list.md
@@ -19,7 +19,7 @@ gcx irm oncall webhooks list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6.md
+++ b/docs/reference/cli/gcx_k6.md
@@ -5,15 +5,15 @@ Manage Grafana k6 Cloud projects, load tests, and schedules
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for k6
+      --config string   Path to the configuration file to use
+  -h, --help            help for k6
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_auth.md
+++ b/docs/reference/cli/gcx_k6_auth.md
@@ -13,7 +13,7 @@ k6 authentication commands.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_auth_token.md
+++ b/docs/reference/cli/gcx_k6_auth_token.md
@@ -17,7 +17,7 @@ gcx k6 auth token [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_env-vars.md
+++ b/docs/reference/cli/gcx_k6_env-vars.md
@@ -13,7 +13,7 @@ Manage k6 Cloud environment variables.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_env-vars_create.md
+++ b/docs/reference/cli/gcx_k6_env-vars_create.md
@@ -18,7 +18,7 @@ gcx k6 env-vars create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_env-vars_delete.md
+++ b/docs/reference/cli/gcx_k6_env-vars_delete.md
@@ -17,7 +17,7 @@ gcx k6 env-vars delete <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_env-vars_list.md
+++ b/docs/reference/cli/gcx_k6_env-vars_list.md
@@ -20,7 +20,7 @@ gcx k6 env-vars list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_env-vars_update.md
+++ b/docs/reference/cli/gcx_k6_env-vars_update.md
@@ -18,7 +18,7 @@ gcx k6 env-vars update <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-tests.md
+++ b/docs/reference/cli/gcx_k6_load-tests.md
@@ -13,7 +13,7 @@ Manage k6 Cloud load tests.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-tests_create.md
+++ b/docs/reference/cli/gcx_k6_load-tests_create.md
@@ -23,7 +23,7 @@ gcx k6 load-tests create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-tests_delete.md
+++ b/docs/reference/cli/gcx_k6_load-tests_delete.md
@@ -17,7 +17,7 @@ gcx k6 load-tests delete <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-tests_get.md
+++ b/docs/reference/cli/gcx_k6_load-tests_get.md
@@ -20,7 +20,7 @@ gcx k6 load-tests get <id-or-name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-tests_list.md
+++ b/docs/reference/cli/gcx_k6_load-tests_list.md
@@ -21,7 +21,7 @@ gcx k6 load-tests list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-tests_update-script.md
+++ b/docs/reference/cli/gcx_k6_load-tests_update-script.md
@@ -18,7 +18,7 @@ gcx k6 load-tests update-script <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-tests_update.md
+++ b/docs/reference/cli/gcx_k6_load-tests_update.md
@@ -18,7 +18,7 @@ gcx k6 load-tests update <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-zones.md
+++ b/docs/reference/cli/gcx_k6_load-zones.md
@@ -13,7 +13,7 @@ Manage k6 private load zones.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones.md
@@ -13,7 +13,7 @@ Manage load zones allowed for a project.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones_list.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones_list.md
@@ -19,7 +19,7 @@ gcx k6 load-zones allowed-load-zones list <project-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones_update.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones_update.md
@@ -18,7 +18,7 @@ gcx k6 load-zones allowed-load-zones update <project-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-projects.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-projects.md
@@ -13,7 +13,7 @@ Manage projects allowed to use a load zone.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-projects_list.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-projects_list.md
@@ -19,7 +19,7 @@ gcx k6 load-zones allowed-projects list <load-zone-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-projects_update.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-projects_update.md
@@ -18,7 +18,7 @@ gcx k6 load-zones allowed-projects update <load-zone-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-zones_create.md
+++ b/docs/reference/cli/gcx_k6_load-zones_create.md
@@ -22,7 +22,7 @@ gcx k6 load-zones create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-zones_delete.md
+++ b/docs/reference/cli/gcx_k6_load-zones_delete.md
@@ -17,7 +17,7 @@ gcx k6 load-zones delete <name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_load-zones_list.md
+++ b/docs/reference/cli/gcx_k6_load-zones_list.md
@@ -20,7 +20,7 @@ gcx k6 load-zones list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_projects.md
+++ b/docs/reference/cli/gcx_k6_projects.md
@@ -13,7 +13,7 @@ Manage k6 Cloud projects.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_projects_create.md
+++ b/docs/reference/cli/gcx_k6_projects_create.md
@@ -20,7 +20,7 @@ gcx k6 projects create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_projects_delete.md
+++ b/docs/reference/cli/gcx_k6_projects_delete.md
@@ -17,7 +17,7 @@ gcx k6 projects delete <id-or-name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_projects_get.md
+++ b/docs/reference/cli/gcx_k6_projects_get.md
@@ -19,7 +19,7 @@ gcx k6 projects get <id-or-name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_projects_list.md
+++ b/docs/reference/cli/gcx_k6_projects_list.md
@@ -20,7 +20,7 @@ gcx k6 projects list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_projects_update.md
+++ b/docs/reference/cli/gcx_k6_projects_update.md
@@ -18,7 +18,7 @@ gcx k6 projects update <id-or-name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_runs.md
+++ b/docs/reference/cli/gcx_k6_runs.md
@@ -13,7 +13,7 @@ Manage k6 test runs.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_runs_list.md
+++ b/docs/reference/cli/gcx_k6_runs_list.md
@@ -22,7 +22,7 @@ gcx k6 runs list [id-or-name] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_schedules.md
+++ b/docs/reference/cli/gcx_k6_schedules.md
@@ -13,7 +13,7 @@ Manage k6 Cloud schedules.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_schedules_create.md
+++ b/docs/reference/cli/gcx_k6_schedules_create.md
@@ -19,7 +19,7 @@ gcx k6 schedules create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_schedules_delete.md
+++ b/docs/reference/cli/gcx_k6_schedules_delete.md
@@ -17,7 +17,7 @@ gcx k6 schedules delete <load-test-id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_schedules_get.md
+++ b/docs/reference/cli/gcx_k6_schedules_get.md
@@ -19,7 +19,7 @@ gcx k6 schedules get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_schedules_list.md
+++ b/docs/reference/cli/gcx_k6_schedules_list.md
@@ -20,7 +20,7 @@ gcx k6 schedules list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_schedules_update.md
+++ b/docs/reference/cli/gcx_k6_schedules_update.md
@@ -18,7 +18,7 @@ gcx k6 schedules update <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_test-run.md
+++ b/docs/reference/cli/gcx_k6_test-run.md
@@ -13,7 +13,7 @@ Manage k6 TestRun CRD manifests.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_test-run_emit.md
+++ b/docs/reference/cli/gcx_k6_test-run_emit.md
@@ -24,7 +24,7 @@ gcx k6 test-run emit [test-name] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_test-run_runs.md
+++ b/docs/reference/cli/gcx_k6_test-run_runs.md
@@ -13,7 +13,7 @@ Query k6 Cloud test run history.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_test-run_runs_list.md
+++ b/docs/reference/cli/gcx_k6_test-run_runs_list.md
@@ -22,7 +22,7 @@ gcx k6 test-run runs list [test-name] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_k6_test-run_status.md
+++ b/docs/reference/cli/gcx_k6_test-run_status.md
@@ -19,7 +19,7 @@ gcx k6 test-run status [test-name] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg.md
+++ b/docs/reference/cli/gcx_kg.md
@@ -5,15 +5,15 @@ Manage Grafana Knowledge Graph rules, entities, and insights
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for kg
+      --config string   Path to the configuration file to use
+  -h, --help            help for kg
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_cypher.md
+++ b/docs/reference/cli/gcx_kg_cypher.md
@@ -32,7 +32,7 @@ gcx kg cypher <query> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_entities.md
+++ b/docs/reference/cli/gcx_kg_entities.md
@@ -13,7 +13,7 @@ Manage Knowledge Graph entities.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_entities_inspect.md
+++ b/docs/reference/cli/gcx_kg_entities_inspect.md
@@ -27,7 +27,7 @@ gcx kg entities inspect [Type--Name] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_entities_list.md
+++ b/docs/reference/cli/gcx_kg_entities_list.md
@@ -39,7 +39,7 @@ gcx kg entities list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_health.md
+++ b/docs/reference/cli/gcx_kg_health.md
@@ -26,7 +26,7 @@ gcx kg health [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_insights.md
+++ b/docs/reference/cli/gcx_kg_insights.md
@@ -13,7 +13,7 @@ Query Knowledge Graph insights.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_insights_active.md
+++ b/docs/reference/cli/gcx_kg_insights_active.md
@@ -28,7 +28,7 @@ gcx kg insights active [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_insights_entity-metric.md
+++ b/docs/reference/cli/gcx_kg_insights_entity-metric.md
@@ -27,7 +27,7 @@ gcx kg insights entity-metric [Type--Name] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_insights_example.md
+++ b/docs/reference/cli/gcx_kg_insights_example.md
@@ -17,7 +17,7 @@ gcx kg insights example [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_insights_graph.md
+++ b/docs/reference/cli/gcx_kg_insights_graph.md
@@ -26,7 +26,7 @@ gcx kg insights graph [Type--Name] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_insights_query.md
+++ b/docs/reference/cli/gcx_kg_insights_query.md
@@ -26,7 +26,7 @@ gcx kg insights query [Type--Name] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_insights_search.md
+++ b/docs/reference/cli/gcx_kg_insights_search.md
@@ -26,7 +26,7 @@ gcx kg insights search [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_insights_source-metrics.md
+++ b/docs/reference/cli/gcx_kg_insights_source-metrics.md
@@ -22,7 +22,7 @@ gcx kg insights source-metrics [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_insights_summary.md
+++ b/docs/reference/cli/gcx_kg_insights_summary.md
@@ -26,7 +26,7 @@ gcx kg insights summary [Type--Name] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_meta.md
+++ b/docs/reference/cli/gcx_kg_meta.md
@@ -13,7 +13,7 @@ Show Knowledge Graph metadata: entity types, valid env/namespace/site values, an
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_meta_all.md
+++ b/docs/reference/cli/gcx_kg_meta_all.md
@@ -22,7 +22,7 @@ gcx kg meta all [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_meta_logs.md
+++ b/docs/reference/cli/gcx_kg_meta_logs.md
@@ -19,7 +19,7 @@ gcx kg meta logs [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_meta_profiles.md
+++ b/docs/reference/cli/gcx_kg_meta_profiles.md
@@ -19,7 +19,7 @@ gcx kg meta profiles [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_meta_schema.md
+++ b/docs/reference/cli/gcx_kg_meta_schema.md
@@ -22,7 +22,7 @@ gcx kg meta schema [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_meta_scopes.md
+++ b/docs/reference/cli/gcx_kg_meta_scopes.md
@@ -19,7 +19,7 @@ gcx kg meta scopes [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_meta_traces.md
+++ b/docs/reference/cli/gcx_kg_meta_traces.md
@@ -19,7 +19,7 @@ gcx kg meta traces [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_model-rules.md
+++ b/docs/reference/cli/gcx_kg_model-rules.md
@@ -13,7 +13,7 @@ Push model rules to the Knowledge Graph.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_model-rules_create.md
+++ b/docs/reference/cli/gcx_kg_model-rules_create.md
@@ -18,7 +18,7 @@ gcx kg model-rules create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_open.md
+++ b/docs/reference/cli/gcx_kg_open.md
@@ -17,7 +17,7 @@ gcx kg open [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_relabel-rules.md
+++ b/docs/reference/cli/gcx_kg_relabel-rules.md
@@ -13,7 +13,7 @@ Push relabel rules to the Knowledge Graph.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_relabel-rules_create.md
+++ b/docs/reference/cli/gcx_kg_relabel-rules_create.md
@@ -18,7 +18,7 @@ gcx kg relabel-rules create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_rules.md
+++ b/docs/reference/cli/gcx_kg_rules.md
@@ -13,7 +13,7 @@ Manage Knowledge Graph prom rules.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_rules_create.md
+++ b/docs/reference/cli/gcx_kg_rules_create.md
@@ -18,7 +18,7 @@ gcx kg rules create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_rules_delete.md
+++ b/docs/reference/cli/gcx_kg_rules_delete.md
@@ -17,7 +17,7 @@ gcx kg rules delete [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_rules_get.md
+++ b/docs/reference/cli/gcx_kg_rules_get.md
@@ -19,7 +19,7 @@ gcx kg rules get <name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_rules_list.md
+++ b/docs/reference/cli/gcx_kg_rules_list.md
@@ -20,7 +20,7 @@ gcx kg rules list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_scopes.md
+++ b/docs/reference/cli/gcx_kg_scopes.md
@@ -13,7 +13,7 @@ Manage Knowledge Graph entity scopes.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_scopes_list.md
+++ b/docs/reference/cli/gcx_kg_scopes_list.md
@@ -20,7 +20,7 @@ gcx kg scopes list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_status.md
+++ b/docs/reference/cli/gcx_kg_status.md
@@ -19,7 +19,7 @@ gcx kg status [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_suppressions.md
+++ b/docs/reference/cli/gcx_kg_suppressions.md
@@ -13,7 +13,7 @@ Manage alert suppressions in the Knowledge Graph.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_suppressions_create.md
+++ b/docs/reference/cli/gcx_kg_suppressions_create.md
@@ -30,7 +30,7 @@ gcx kg suppressions create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_suppressions_delete.md
+++ b/docs/reference/cli/gcx_kg_suppressions_delete.md
@@ -18,7 +18,7 @@ gcx kg suppressions delete <name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_kg_suppressions_list.md
+++ b/docs/reference/cli/gcx_kg_suppressions_list.md
@@ -19,7 +19,7 @@ gcx kg suppressions list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs.md
+++ b/docs/reference/cli/gcx_logs.md
@@ -5,15 +5,15 @@ Query Loki datasources and manage Adaptive Logs
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for logs
+      --config string   Path to the configuration file to use
+  -h, --help            help for logs
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive.md
+++ b/docs/reference/cli/gcx_logs_adaptive.md
@@ -13,7 +13,7 @@ Manage Adaptive Logs resources
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules.md
@@ -21,7 +21,7 @@ Create and update load a rule from a file (`--filename` / `-f`). The file's top-
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_create.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_create.md
@@ -26,7 +26,7 @@ gcx logs adaptive drop-rules create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_delete.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_delete.md
@@ -17,7 +17,7 @@ gcx logs adaptive drop-rules delete ID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_get.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_get.md
@@ -25,7 +25,7 @@ gcx logs adaptive drop-rules get ID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_list.md
@@ -21,7 +21,7 @@ gcx logs adaptive drop-rules list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_update.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_update.md
@@ -26,7 +26,7 @@ gcx logs adaptive drop-rules update ID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions.md
@@ -13,7 +13,7 @@ Manage adaptive log exemptions.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions_create.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions_create.md
@@ -21,7 +21,7 @@ gcx logs adaptive exemptions create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions_delete.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions_delete.md
@@ -17,7 +17,7 @@ gcx logs adaptive exemptions delete ID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions_list.md
@@ -20,7 +20,7 @@ gcx logs adaptive exemptions list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions_update.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions_update.md
@@ -21,7 +21,7 @@ gcx logs adaptive exemptions update ID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_patterns.md
+++ b/docs/reference/cli/gcx_logs_adaptive_patterns.md
@@ -13,7 +13,7 @@ Manage adaptive log patterns.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_patterns_show.md
+++ b/docs/reference/cli/gcx_logs_adaptive_patterns_show.md
@@ -21,7 +21,7 @@ gcx logs adaptive patterns show [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_patterns_stats.md
+++ b/docs/reference/cli/gcx_logs_adaptive_patterns_stats.md
@@ -19,7 +19,7 @@ gcx logs adaptive patterns stats [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_segments.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments.md
@@ -13,7 +13,7 @@ Manage adaptive log segments.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_segments_create.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments_create.md
@@ -22,7 +22,7 @@ gcx logs adaptive segments create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_segments_delete.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments_delete.md
@@ -17,7 +17,7 @@ gcx logs adaptive segments delete ID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_segments_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments_list.md
@@ -20,7 +20,7 @@ gcx logs adaptive segments list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_adaptive_segments_update.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments_update.md
@@ -22,7 +22,7 @@ gcx logs adaptive segments update ID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_labels.md
+++ b/docs/reference/cli/gcx_logs_labels.md
@@ -39,7 +39,7 @@ gcx logs labels [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_metrics.md
+++ b/docs/reference/cli/gcx_logs_metrics.md
@@ -56,7 +56,7 @@ gcx logs metrics [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_query.md
+++ b/docs/reference/cli/gcx_logs_query.md
@@ -62,7 +62,7 @@ gcx logs query [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_logs_series.md
+++ b/docs/reference/cli/gcx_logs_series.md
@@ -39,7 +39,7 @@ gcx logs series [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics.md
+++ b/docs/reference/cli/gcx_metrics.md
@@ -5,15 +5,15 @@ Query Prometheus datasources and manage Adaptive Metrics
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for metrics
+      --config string   Path to the configuration file to use
+  -h, --help            help for metrics
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive.md
+++ b/docs/reference/cli/gcx_metrics_adaptive.md
@@ -13,7 +13,7 @@ Manage Adaptive Metrics resources
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions.md
@@ -13,7 +13,7 @@ Manage Adaptive Metrics recommendation exemptions.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_create.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_create.md
@@ -27,7 +27,7 @@ gcx metrics adaptive exemptions create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_delete.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_delete.md
@@ -19,7 +19,7 @@ gcx metrics adaptive exemptions delete <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_get.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_get.md
@@ -20,7 +20,7 @@ gcx metrics adaptive exemptions get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_list.md
@@ -22,7 +22,7 @@ gcx metrics adaptive exemptions list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_update.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_update.md
@@ -27,7 +27,7 @@ gcx metrics adaptive exemptions update <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_recommendations.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_recommendations.md
@@ -13,7 +13,7 @@ Manage metric recommendations.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_recommendations_apply.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_recommendations_apply.md
@@ -21,7 +21,7 @@ gcx metrics adaptive recommendations apply [<metric>...|--all] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_recommendations_diff.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_recommendations_diff.md
@@ -20,7 +20,7 @@ gcx metrics adaptive recommendations diff <metric>... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_recommendations_show.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_recommendations_show.md
@@ -24,7 +24,7 @@ gcx metrics adaptive recommendations show [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_rules.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules.md
@@ -13,7 +13,7 @@ Manage aggregation rules.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_create.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_create.md
@@ -28,7 +28,7 @@ gcx metrics adaptive rules create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_delete.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_delete.md
@@ -19,7 +19,7 @@ gcx metrics adaptive rules delete <metric> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_get.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_get.md
@@ -20,7 +20,7 @@ gcx metrics adaptive rules get <metric> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_list.md
@@ -21,7 +21,7 @@ gcx metrics adaptive rules list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_update.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_update.md
@@ -27,7 +27,7 @@ gcx metrics adaptive rules update <metric> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_segments.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments.md
@@ -13,7 +13,7 @@ Manage Adaptive Metrics segments.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_create.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_create.md
@@ -23,7 +23,7 @@ gcx metrics adaptive segments create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_delete.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_delete.md
@@ -18,7 +18,7 @@ gcx metrics adaptive segments delete <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_get.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_get.md
@@ -19,7 +19,7 @@ gcx metrics adaptive segments get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_list.md
@@ -20,7 +20,7 @@ gcx metrics adaptive segments list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_update.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_update.md
@@ -23,7 +23,7 @@ gcx metrics adaptive segments update <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_billing.md
+++ b/docs/reference/cli/gcx_metrics_billing.md
@@ -21,7 +21,7 @@ the --datasource flag defaults to "grafanacloud-usage" but can be overridden.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_billing_labels.md
+++ b/docs/reference/cli/gcx_metrics_billing_labels.md
@@ -39,7 +39,7 @@ gcx metrics billing labels [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_billing_query.md
+++ b/docs/reference/cli/gcx_metrics_billing_query.md
@@ -54,7 +54,7 @@ gcx metrics billing query [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_billing_series.md
+++ b/docs/reference/cli/gcx_metrics_billing_series.md
@@ -45,7 +45,7 @@ gcx metrics billing series [SELECTOR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_labels.md
+++ b/docs/reference/cli/gcx_metrics_labels.md
@@ -39,7 +39,7 @@ gcx metrics labels [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_metadata.md
+++ b/docs/reference/cli/gcx_metrics_metadata.md
@@ -39,7 +39,7 @@ gcx metrics metadata [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_query.md
+++ b/docs/reference/cli/gcx_metrics_query.md
@@ -57,7 +57,7 @@ gcx metrics query [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_metrics_series.md
+++ b/docs/reference/cli/gcx_metrics_series.md
@@ -45,7 +45,7 @@ gcx metrics series [SELECTOR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_profiles.md
+++ b/docs/reference/cli/gcx_profiles.md
@@ -5,15 +5,15 @@ Query Pyroscope datasources and manage continuous profiling
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for profiles
+      --config string   Path to the configuration file to use
+  -h, --help            help for profiles
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_profiles_adaptive.md
+++ b/docs/reference/cli/gcx_profiles_adaptive.md
@@ -17,7 +17,7 @@ gcx profiles adaptive [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_profiles_exemplars.md
+++ b/docs/reference/cli/gcx_profiles_exemplars.md
@@ -37,7 +37,7 @@ span" (span exemplars).
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_profiles_exemplars_profile.md
+++ b/docs/reference/cli/gcx_profiles_exemplars_profile.md
@@ -49,7 +49,7 @@ gcx profiles exemplars profile [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_profiles_exemplars_span.md
+++ b/docs/reference/cli/gcx_profiles_exemplars_span.md
@@ -49,7 +49,7 @@ gcx profiles exemplars span [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_profiles_labels.md
+++ b/docs/reference/cli/gcx_profiles_labels.md
@@ -39,7 +39,7 @@ gcx profiles labels [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_profiles_metrics.md
+++ b/docs/reference/cli/gcx_profiles_metrics.md
@@ -61,7 +61,7 @@ gcx profiles metrics [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_profiles_profile-types.md
+++ b/docs/reference/cli/gcx_profiles_profile-types.md
@@ -35,7 +35,7 @@ gcx profiles profile-types [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -51,7 +51,7 @@ gcx profiles query [EXPR] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_setup.md
+++ b/docs/reference/cli/gcx_setup.md
@@ -5,15 +5,15 @@ Onboard and configure Grafana Cloud products.
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for setup
+      --config string   Path to the configuration file to use
+  -h, --help            help for setup
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_setup_instrumentation.md
+++ b/docs/reference/cli/gcx_setup_instrumentation.md
@@ -13,7 +13,7 @@ Manage observability instrumentation for Kubernetes clusters.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_setup_instrumentation_apply.md
+++ b/docs/reference/cli/gcx_setup_instrumentation_apply.md
@@ -19,7 +19,7 @@ gcx setup instrumentation apply [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_setup_instrumentation_discover.md
+++ b/docs/reference/cli/gcx_setup_instrumentation_discover.md
@@ -20,7 +20,7 @@ gcx setup instrumentation discover [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_setup_instrumentation_show.md
+++ b/docs/reference/cli/gcx_setup_instrumentation_show.md
@@ -19,7 +19,7 @@ gcx setup instrumentation show <cluster> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_setup_instrumentation_status.md
+++ b/docs/reference/cli/gcx_setup_instrumentation_status.md
@@ -20,7 +20,7 @@ gcx setup instrumentation status [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_setup_status.md
+++ b/docs/reference/cli/gcx_setup_status.md
@@ -17,7 +17,7 @@ gcx setup status [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo.md
+++ b/docs/reference/cli/gcx_slo.md
@@ -5,15 +5,15 @@ Manage Grafana SLO definitions and reports
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for slo
+      --config string   Path to the configuration file to use
+  -h, --help            help for slo
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_definitions.md
+++ b/docs/reference/cli/gcx_slo_definitions.md
@@ -13,7 +13,7 @@ Manage SLO definitions.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_definitions_delete.md
+++ b/docs/reference/cli/gcx_slo_definitions_delete.md
@@ -18,7 +18,7 @@ gcx slo definitions delete UUID... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_definitions_get.md
+++ b/docs/reference/cli/gcx_slo_definitions_get.md
@@ -19,7 +19,7 @@ gcx slo definitions get UUID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_definitions_list.md
+++ b/docs/reference/cli/gcx_slo_definitions_list.md
@@ -20,7 +20,7 @@ gcx slo definitions list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_definitions_pull.md
+++ b/docs/reference/cli/gcx_slo_definitions_pull.md
@@ -18,7 +18,7 @@ gcx slo definitions pull [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_definitions_push.md
+++ b/docs/reference/cli/gcx_slo_definitions_push.md
@@ -18,7 +18,7 @@ gcx slo definitions push FILE... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_definitions_status.md
+++ b/docs/reference/cli/gcx_slo_definitions_status.md
@@ -46,7 +46,7 @@ gcx slo definitions status [UUID] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_definitions_timeline.md
+++ b/docs/reference/cli/gcx_slo_definitions_timeline.md
@@ -50,7 +50,7 @@ gcx slo definitions timeline [UUID] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_reports.md
+++ b/docs/reference/cli/gcx_slo_reports.md
@@ -13,7 +13,7 @@ Manage SLO reports.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_reports_delete.md
+++ b/docs/reference/cli/gcx_slo_reports_delete.md
@@ -18,7 +18,7 @@ gcx slo reports delete UUID... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_reports_get.md
+++ b/docs/reference/cli/gcx_slo_reports_get.md
@@ -19,7 +19,7 @@ gcx slo reports get UUID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_reports_list.md
+++ b/docs/reference/cli/gcx_slo_reports_list.md
@@ -20,7 +20,7 @@ gcx slo reports list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_reports_pull.md
+++ b/docs/reference/cli/gcx_slo_reports_pull.md
@@ -18,7 +18,7 @@ gcx slo reports pull [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_reports_push.md
+++ b/docs/reference/cli/gcx_slo_reports_push.md
@@ -18,7 +18,7 @@ gcx slo reports push FILE... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_reports_status.md
+++ b/docs/reference/cli/gcx_slo_reports_status.md
@@ -45,7 +45,7 @@ gcx slo reports status [UUID] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_slo_reports_timeline.md
+++ b/docs/reference/cli/gcx_slo_reports_timeline.md
@@ -51,7 +51,7 @@ gcx slo reports timeline [UUID] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring.md
@@ -5,15 +5,15 @@ Manage Grafana Synthetic Monitoring checks and probes
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for synthetic-monitoring
+      --config string   Path to the configuration file to use
+  -h, --help            help for synthetic-monitoring
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks.md
@@ -13,7 +13,7 @@ Manage Synthetic Monitoring checks.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_create.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_create.md
@@ -33,7 +33,7 @@ gcx synthetic-monitoring checks create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_delete.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_delete.md
@@ -18,7 +18,7 @@ gcx synthetic-monitoring checks delete NAME... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_get.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_get.md
@@ -33,7 +33,7 @@ gcx synthetic-monitoring checks get NAME [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_list.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_list.md
@@ -35,7 +35,7 @@ gcx synthetic-monitoring checks list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_status.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_status.md
@@ -53,7 +53,7 @@ gcx synthetic-monitoring checks status [ID] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_timeline.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_timeline.md
@@ -50,7 +50,7 @@ gcx synthetic-monitoring checks timeline ID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_update.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_update.md
@@ -30,7 +30,7 @@ gcx synthetic-monitoring checks update <name> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_probes.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_probes.md
@@ -13,7 +13,7 @@ Manage Synthetic Monitoring probes.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_probes_create.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_probes_create.md
@@ -32,7 +32,7 @@ gcx synthetic-monitoring probes create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_probes_delete.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_probes_delete.md
@@ -18,7 +18,7 @@ gcx synthetic-monitoring probes delete ID... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_probes_deploy.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_probes_deploy.md
@@ -32,7 +32,7 @@ gcx synthetic-monitoring probes deploy [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_probes_list.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_probes_list.md
@@ -20,7 +20,7 @@ gcx synthetic-monitoring probes list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_synthetic-monitoring_probes_token-reset.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_probes_token-reset.md
@@ -17,7 +17,7 @@ gcx synthetic-monitoring probes token-reset ID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces.md
+++ b/docs/reference/cli/gcx_traces.md
@@ -5,15 +5,15 @@ Query Tempo datasources and manage Adaptive Traces
 ### Options
 
 ```
-      --config string    Path to the configuration file to use
-      --context string   Name of the context to use
-  -h, --help             help for traces
+      --config string   Path to the configuration file to use
+  -h, --help            help for traces
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_adaptive.md
+++ b/docs/reference/cli/gcx_traces_adaptive.md
@@ -13,7 +13,7 @@ Manage Adaptive Traces resources
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_adaptive_policies.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies.md
@@ -13,7 +13,7 @@ Manage Adaptive Traces sampling policies.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_adaptive_policies_create.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_create.md
@@ -20,7 +20,7 @@ gcx traces adaptive policies create [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_adaptive_policies_delete.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_delete.md
@@ -18,7 +18,7 @@ gcx traces adaptive policies delete <id>... [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_adaptive_policies_get.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_get.md
@@ -19,7 +19,7 @@ gcx traces adaptive policies get <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_adaptive_policies_list.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_list.md
@@ -20,7 +20,7 @@ gcx traces adaptive policies list [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_adaptive_policies_update.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_update.md
@@ -20,7 +20,7 @@ gcx traces adaptive policies update <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_adaptive_recommendations.md
+++ b/docs/reference/cli/gcx_traces_adaptive_recommendations.md
@@ -13,7 +13,7 @@ Manage Adaptive Traces recommendations.
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_adaptive_recommendations_apply.md
+++ b/docs/reference/cli/gcx_traces_adaptive_recommendations_apply.md
@@ -18,7 +18,7 @@ gcx traces adaptive recommendations apply <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_adaptive_recommendations_dismiss.md
+++ b/docs/reference/cli/gcx_traces_adaptive_recommendations_dismiss.md
@@ -18,7 +18,7 @@ gcx traces adaptive recommendations dismiss <id> [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_adaptive_recommendations_show.md
+++ b/docs/reference/cli/gcx_traces_adaptive_recommendations_show.md
@@ -19,7 +19,7 @@ gcx traces adaptive recommendations show [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_get.md
+++ b/docs/reference/cli/gcx_traces_get.md
@@ -50,7 +50,7 @@ gcx traces get TRACE_ID [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_labels.md
+++ b/docs/reference/cli/gcx_traces_labels.md
@@ -43,7 +43,7 @@ gcx traces labels [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_metrics.md
+++ b/docs/reference/cli/gcx_traces_metrics.md
@@ -56,7 +56,7 @@ gcx traces metrics [TRACEQL] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/docs/reference/cli/gcx_traces_query.md
+++ b/docs/reference/cli/gcx_traces_query.md
@@ -52,7 +52,7 @@ gcx traces query [TRACEQL] [flags]
 ```
       --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
       --config string      Path to the configuration file to use
-      --context string     Name of the context to use
+      --context string     Name of the context to use (overrides current-context in config)
       --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
       --no-color           Disable color output
       --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)

--- a/internal/providers/aio11y/eval/evaluators/resource_adapter.go
+++ b/internal/providers/aio11y/eval/evaluators/resource_adapter.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	internalconfig "github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval"
@@ -44,7 +43,6 @@ func evalStripFields() []string {
 // NewTypedCRUD creates a TypedCRUD for AI Observability evaluators.
 func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.EvaluatorDefinition], string, error) {
 	var loader providers.ConfigLoader
-	loader.SetContextName(internalconfig.ContextNameFromCtx(ctx))
 
 	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {

--- a/internal/providers/aio11y/eval/rules/resource_adapter.go
+++ b/internal/providers/aio11y/eval/rules/resource_adapter.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	internalconfig "github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval"
@@ -43,7 +42,6 @@ func ruleStripFields() []string {
 // NewTypedCRUD creates a TypedCRUD for AI Observability evaluation rules.
 func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.RuleDefinition], string, error) {
 	var loader providers.ConfigLoader
-	loader.SetContextName(internalconfig.ContextNameFromCtx(ctx))
 
 	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {

--- a/internal/providers/appo11y/overrides/resource_adapter.go
+++ b/internal/providers/appo11y/overrides/resource_adapter.go
@@ -76,7 +76,6 @@ func OverridesExample() json.RawMessage {
 // ListFn, CreateFn, and DeleteFn are nil (singleton, no collection endpoint).
 func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[MetricsGeneratorConfig], internalconfig.NamespacedRESTConfig, error) {
 	var loader providers.ConfigLoader
-	loader.SetContextName(internalconfig.ContextNameFromCtx(ctx))
 
 	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {

--- a/internal/providers/appo11y/settings/resource_adapter.go
+++ b/internal/providers/appo11y/settings/resource_adapter.go
@@ -148,7 +148,6 @@ func checkSettingsStatus(resp *http.Response) error {
 // It loads config via ConfigLoader (same pattern as the adapter factory).
 func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[PluginSettings], internalconfig.NamespacedRESTConfig, error) {
 	var loader providers.ConfigLoader
-	loader.SetContextName(internalconfig.ContextNameFromCtx(ctx))
 
 	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -106,10 +106,14 @@ func contextMustExist(cfg *config.Config) error {
 	return nil
 }
 
-// BindFlags registers --config and --context flags on the given flag set.
+// BindFlags registers the --config flag on the given flag set.
+//
+// --context is intentionally NOT bound here: it is owned by the root command
+// as a persistent global flag and threaded into context.Context via
+// PersistentPreRun. Re-binding it here would silently shadow the root binding,
+// causing --context to be ignored on subcommands depending on its position.
 func (l *ConfigLoader) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&l.configFile, "config", "", "Path to the configuration file to use")
-	flags.StringVar(&l.ctxName, "context", "", "Name of the context to use")
 }
 
 // SetContextName sets the config context name to use when loading config.

--- a/internal/providers/configloader_test.go
+++ b/internal/providers/configloader_test.go
@@ -14,9 +14,24 @@ import (
 	"github.com/grafana/gcx/internal/cloud"
 	internalconfig "github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestConfigLoader_BindFlags_OnlyBindsConfig is a regression test for the
+// duplicate `--context` flag binding that silently overrode the root command's
+// `--context` value at the provider level. BindFlags must register only
+// `--config`; `--context` is owned by the root command and threaded into
+// context.Context via PersistentPreRun.
+func TestConfigLoader_BindFlags_OnlyBindsConfig(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	loader := &providers.ConfigLoader{}
+	loader.BindFlags(flags)
+
+	require.NotNil(t, flags.Lookup("config"), "BindFlags must bind --config")
+	assert.Nil(t, flags.Lookup("context"), "BindFlags must NOT bind --context (it is a root-level global flag)")
+}
 
 // newMockGCOMServer returns an httptest.Server that responds to any request
 // with the given StackInfo encoded as JSON.

--- a/internal/providers/slo/definitions/resource_adapter.go
+++ b/internal/providers/slo/definitions/resource_adapter.go
@@ -125,7 +125,6 @@ func NewTypedCRUD(ctx context.Context, loader GrafanaConfigLoader) (*adapter.Typ
 func NewLazyFactory() adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
 		var loader providers.ConfigLoader
-		loader.SetContextName(internalconfig.ContextNameFromCtx(ctx))
 		crud, _, err := NewTypedCRUD(ctx, &loader)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
`--context` was silently ignored on multiple providers (aio11y, apo11y, k6, faro, fleet, irm, slo, synth, etc). These adapters always ran against the active context regardless of what the user passed.

The provider `ConfigLoader.BindFlags` re-bound `--context` as a persistent flag on each provider's parent command, shadowing root's binding. When parent and child register the same persistent flag, pflag picks the child's value, so root's `PersistentPreRun` (which threads the value into `context.Context`) saw an empty string.

This PR drops the duplicate binding. Root now owns `--context` exclusively and the adapters already read it via `ContextNameFromCtx(ctx)` and pick up the threaded value with no code change.

#### How to test manually

With at least two contexts:

```bash
gcx config list-contexts
gcx config use-context stackA

# Each of these must return stackB's resources, not stackA's:
gcx aio11y rules list --context=stackB
gcx --context=stackB aio11y rules list
```

Before the fix, they returned `stackA`'s data.
