### PR TITLE
feat(logs): add patterns detection command for Loki datasources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 require (
 	github.com/go-openapi/runtime v0.28.0
 	github.com/gofrs/flock v0.13.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -293,5 +294,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/internal/datasources/loki/patterns.go
+++ b/internal/datasources/loki/patterns.go
@@ -1,0 +1,197 @@
+package loki
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"time"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/loki"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type lokiPatternsOpts struct {
+	dsquery.TimeRangeOpts
+
+	IO         cmdio.Options
+	Datasource string
+	Step       string
+	Expr       string
+}
+
+func (opts *lokiPatternsOpts) setup(flags *pflag.FlagSet) {
+	opts.IO.RegisterCustomCodec("table", &lokiPatternsTableCodec{})
+	opts.IO.DefaultFormat("table")
+	opts.IO.BindFlags(flags)
+
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.loki is configured)")
+	flags.StringVar(&opts.Expr, "expr", "", "LogQL stream selector (alternative to positional argument)")
+	opts.SetupTimeFlags(flags)
+	flags.StringVar(&opts.Step, "step", "", "Step between pattern samples (e.g., '15s', '1m')")
+}
+
+func (opts *lokiPatternsOpts) Validate() error {
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	return opts.ValidateTimeRange()
+}
+
+func (opts *lokiPatternsOpts) resolveExpr(args []string) (string, error) {
+	haveFlag := opts.Expr != ""
+	haveArg := len(args) > 0
+
+	if haveFlag && haveArg {
+		return "", errors.New("provide the expression as a positional argument or via --expr, not both")
+	}
+	if !haveFlag && !haveArg {
+		return "", errors.New("expression is required: provide a LogQL stream selector as a positional argument or via --expr")
+	}
+	if haveFlag {
+		return opts.Expr, nil
+	}
+	return args[0], nil
+}
+
+// PatternsCmd returns the `patterns` subcommand for a Loki datasource parent.
+func PatternsCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &lokiPatternsOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "patterns [EXPR]",
+		Short: "Detect log patterns from a Loki datasource",
+		Long: `Detect log patterns from a Loki datasource.
+
+EXPR is a LogQL stream selector (e.g., {job="varlogs"}).
+The result shows detected patterns aggregated across matching streams,
+sorted by total occurrence count.
+
+Requires pattern_ingester to be enabled on the Loki instance.
+A time range is required; defaults to --since 1h if not specified.`,
+		Example: `
+  # Detect patterns over the last hour
+  gcx datasources loki patterns '{job="varlogs"}'
+
+  # Patterns with explicit time range
+  gcx datasources loki patterns '{job="varlogs"}' --from 2024-01-01T00:00:00Z --to 2024-01-01T01:00:00Z
+
+  # Output as JSON (includes per-timestamp samples)
+  gcx datasources loki patterns '{job="varlogs"}' --since 1h -o json`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			expr, err := opts.resolveExpr(args)
+			if err != nil {
+				return err
+			}
+
+			// Default to --since 1h when no time range is specified.
+			if !opts.IsRange() && opts.Since == "" {
+				opts.Since = "1h"
+				if err := opts.ValidateTimeRange(); err != nil {
+					return err
+				}
+			}
+
+			ctx := cmd.Context()
+
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "loki")
+			if err != nil {
+				return err
+			}
+
+			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
+			if err != nil {
+				return err
+			}
+			if err := dsquery.ValidateDatasourceType(dsType, "loki"); err != nil {
+				return err
+			}
+
+			now := time.Now()
+			start, end, err := opts.ParseTimeRange(now)
+			if err != nil {
+				return err
+			}
+
+			var step time.Duration
+			if opts.Step != "" {
+				step, err = dsquery.ParseDuration(opts.Step)
+				if err != nil {
+					return fmt.Errorf("invalid --step duration: %w", err)
+				}
+			}
+
+			client, err := loki.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			req := loki.PatternsRequest{
+				Query: expr,
+				Start: start,
+				End:   end,
+				Step:  step,
+			}
+
+			resp, err := client.Patterns(ctx, datasourceUID, req)
+			if err != nil {
+				return fmt.Errorf("patterns query failed: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), resp)
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "medium",
+		agent.AnnotationLLMHint:   `gcx datasources loki patterns -d UID '{job="grafana"}' --since 1h -o json`,
+	}
+
+	opts.setup(cmd.Flags())
+
+	return cmd
+}
+
+type lokiPatternsTableCodec struct{}
+
+func (c *lokiPatternsTableCodec) Format() format.Format {
+	return "table"
+}
+
+func (c *lokiPatternsTableCodec) Encode(w io.Writer, data any) error {
+	resp, ok := data.(*loki.PatternsResponse)
+	if !ok {
+		return errors.New("invalid data type for loki patterns table codec")
+	}
+	return loki.FormatPatternsTable(w, resp)
+}
+
+func (c *lokiPatternsTableCodec) Decode(io.Reader, any) error {
+	return errors.New("loki patterns table codec does not support decoding")
+}

--- a/internal/providers/logs/provider.go
+++ b/internal/providers/logs/provider.go
@@ -109,6 +109,22 @@ func (p *Provider) Commands() []*cobra.Command {
   gcx logs series -d UID --match '{job="varlogs"}' -o json`
 	cmd.AddCommand(sCmd)
 
+	pCmd := dsloki.PatternsCmd(loader)
+	pCmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "medium",
+		agent.AnnotationLLMHint:   `gcx logs patterns -d abc123 '{job="grafana"}' --since 1h -o json`,
+	}
+	pCmd.Example = `
+  # Detect patterns in logs over the last hour
+  gcx logs patterns '{job="varlogs"}'
+
+  # Patterns with explicit time range
+  gcx logs patterns '{job="varlogs"}' --from 2024-01-01T00:00:00Z --to 2024-01-01T01:00:00Z
+
+  # Output as JSON (includes per-timestamp sample counts)
+  gcx logs patterns '{job="varlogs"}' --since 1h -o json`
+	cmd.AddCommand(pCmd)
+
 	// Adaptive Logs subcommands — rename Use from "logs" to "adaptive".
 	adaptiveCmd := adaptivelogs.Commands(loader)
 	adaptiveCmd.Use = "adaptive"

--- a/internal/query/loki/client.go
+++ b/internal/query/loki/client.go
@@ -335,6 +335,46 @@ func (c *Client) Series(ctx context.Context, datasourceUID string, matchers []st
 	return &result, nil
 }
 
+func (c *Client) Patterns(ctx context.Context, datasourceUID string, req PatternsRequest) (*PatternsResponse, error) {
+	apiPath := c.buildPatternsPath(datasourceUID)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.restConfig.Host+apiPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	q := httpReq.URL.Query()
+	q.Set("query", req.Query)
+	q.Set("start", strconv.FormatInt(req.Start.Unix(), 10))
+	q.Set("end", strconv.FormatInt(req.End.Unix(), 10))
+	if req.Step > 0 {
+		q.Set("step", strconv.FormatInt(int64(req.Step.Seconds()), 10))
+	}
+	httpReq.URL.RawQuery = q.Encode()
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get patterns: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, queryerror.FromBody("loki", "patterns query", resp.StatusCode, respBody)
+	}
+
+	var result PatternsResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
 func (c *Client) buildQueryPath() string {
 	return fmt.Sprintf("/apis/query.grafana.app/v0alpha1/namespaces/%s/query",
 		c.restConfig.Namespace)
@@ -351,6 +391,10 @@ func (c *Client) buildLabelValuesPath(datasourceUID, labelName string) string {
 
 func (c *Client) buildSeriesPath(datasourceUID string) string {
 	return fmt.Sprintf("/api/datasources/uid/%s/resources/series", url.PathEscape(datasourceUID))
+}
+
+func (c *Client) buildPatternsPath(datasourceUID string) string {
+	return fmt.Sprintf("/api/datasources/uid/%s/resources/patterns", url.PathEscape(datasourceUID))
 }
 
 func convertGrafanaResponse(grafanaResp *GrafanaQueryResponse) *QueryResponse {

--- a/internal/query/loki/client_test.go
+++ b/internal/query/loki/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/query/loki"
@@ -28,6 +29,7 @@ func TestBuildPathsEscapeDatasourceUID(t *testing.T) {
 		{"labels", c.BuildLabelsPath(uid)},
 		{"labelValues", c.BuildLabelValuesPath(uid, "job")},
 		{"series", c.BuildSeriesPath(uid)},
+		{"patterns", c.BuildPatternsPath(uid)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -39,6 +41,62 @@ func TestBuildPathsEscapeDatasourceUID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPatterns_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/api/datasources/uid/loki-uid/resources/patterns")
+		assert.Equal(t, `{job="varlogs"}`, r.URL.Query().Get("query"))
+		assert.NotEmpty(t, r.URL.Query().Get("start"))
+		assert.NotEmpty(t, r.URL.Query().Get("end"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":[{"pattern":"<_> level=info <_>","samples":[[1711839260,105],[1711839270,222]]}]}`))
+	}))
+	defer server.Close()
+
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: server.URL},
+		Namespace: "default",
+	}
+	client, err := loki.NewClient(cfg)
+	require.NoError(t, err)
+
+	now := time.Now()
+	resp, err := client.Patterns(context.Background(), "loki-uid", loki.PatternsRequest{
+		Query: `{job="varlogs"}`,
+		Start: now.Add(-1 * time.Hour),
+		End:   now,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "success", resp.Status)
+	require.Len(t, resp.Data, 1)
+	assert.Equal(t, "<_> level=info <_>", resp.Data[0].Pattern)
+	assert.Len(t, resp.Data[0].Samples, 2)
+}
+
+func TestPatterns_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"status":"error","error":"parse error"}`))
+	}))
+	defer server.Close()
+
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: server.URL},
+		Namespace: "default",
+	}
+	client, err := loki.NewClient(cfg)
+	require.NoError(t, err)
+
+	now := time.Now()
+	_, err = client.Patterns(context.Background(), "loki-uid", loki.PatternsRequest{
+		Query: `{job="bad"}`,
+		Start: now.Add(-1 * time.Hour),
+		End:   now,
+	})
+	require.Error(t, err)
 }
 
 func TestQuery_ReturnsTypedAPIErrorForGrafanaEnvelope(t *testing.T) {

--- a/internal/query/loki/export_test.go
+++ b/internal/query/loki/export_test.go
@@ -14,6 +14,10 @@ func (c *Client) BuildSeriesPath(datasourceUID string) string {
 	return c.buildSeriesPath(datasourceUID)
 }
 
+func (c *Client) BuildPatternsPath(datasourceUID string) string {
+	return c.buildPatternsPath(datasourceUID)
+}
+
 // ConvertGrafanaResponse exposes convertGrafanaResponse for testing.
 func ConvertGrafanaResponse(resp *GrafanaQueryResponse) *QueryResponse {
 	return convertGrafanaResponse(resp)

--- a/internal/query/loki/formatter.go
+++ b/internal/query/loki/formatter.go
@@ -175,6 +175,31 @@ func FormatLabelsTable(w io.Writer, resp *LabelsResponse) error {
 	return t.Render(w)
 }
 
+// FormatPatternsTable formats a PatternsResponse as a table sorted by total count descending.
+func FormatPatternsTable(w io.Writer, resp *PatternsResponse) error {
+	if len(resp.Data) == 0 {
+		fmt.Fprintln(w, "No patterns found")
+		return nil
+	}
+
+	type ranked struct {
+		pattern string
+		count   int64
+	}
+
+	rows := make([]ranked, 0, len(resp.Data))
+	for _, entry := range resp.Data {
+		rows = append(rows, ranked{pattern: entry.Pattern, count: entry.TotalCount()})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].count > rows[j].count })
+
+	t := style.NewTable("PATTERN", "COUNT")
+	for _, r := range rows {
+		t.Row(r.pattern, strconv.FormatInt(r.count, 10))
+	}
+	return t.Render(w)
+}
+
 func FormatSeriesTable(w io.Writer, resp *SeriesResponse) error {
 	if len(resp.Data) == 0 {
 		fmt.Fprintln(w, "No series found")

--- a/internal/query/loki/formatter_test.go
+++ b/internal/query/loki/formatter_test.go
@@ -182,3 +182,75 @@ func TestFormatQueryRaw_EmptyIsSilent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, buf.String())
 }
+
+func TestFormatPatternsTable_SortedByCountDescending(t *testing.T) {
+	resp := &loki.PatternsResponse{
+		Status: "success",
+		Data: []loki.PatternEntry{
+			{
+				Pattern: "<_> level=error <_>",
+				Samples: [][]int64{{1711839260, 3}, {1711839270, 1}},
+			},
+			{
+				Pattern: "<_> level=info <_>",
+				Samples: [][]int64{{1711839260, 105}, {1711839270, 222}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := loki.FormatPatternsTable(&buf, resp)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "PATTERN")
+	assert.Contains(t, out, "COUNT")
+	assert.Contains(t, out, "<_> level=info <_>")
+	assert.Contains(t, out, "327")
+	assert.Contains(t, out, "<_> level=error <_>")
+	assert.Contains(t, out, "4")
+
+	// info (327) should appear before error (4)
+	infoIdx := strings.Index(out, "<_> level=info <_>")
+	errorIdx := strings.Index(out, "<_> level=error <_>")
+	assert.Less(t, infoIdx, errorIdx, "higher-count pattern should appear first")
+}
+
+func TestFormatPatternsTable_Empty(t *testing.T) {
+	resp := &loki.PatternsResponse{Status: "success", Data: []loki.PatternEntry{}}
+
+	var buf bytes.Buffer
+	err := loki.FormatPatternsTable(&buf, resp)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "No patterns found")
+}
+
+func TestPatternEntry_TotalCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		entry   loki.PatternEntry
+		want    int64
+	}{
+		{
+			name:  "multiple samples",
+			entry: loki.PatternEntry{Samples: [][]int64{{1, 10}, {2, 20}, {3, 30}}},
+			want:  60,
+		},
+		{
+			name:  "empty samples",
+			entry: loki.PatternEntry{Samples: [][]int64{}},
+			want:  0,
+		},
+		{
+			name:  "single sample",
+			entry: loki.PatternEntry{Samples: [][]int64{{1, 42}}},
+			want:  42,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.entry.TotalCount())
+		})
+	}
+}

--- a/internal/query/loki/types.go
+++ b/internal/query/loki/types.go
@@ -86,6 +86,37 @@ type MetricQuerySample struct {
 	Values [][]any           `json:"values,omitempty"` // [[timestamp, value], ...] for range queries
 }
 
+// PatternsRequest represents a request to the Loki patterns detection endpoint.
+type PatternsRequest struct {
+	Query string
+	Start time.Time
+	End   time.Time
+	Step  time.Duration
+}
+
+// PatternsResponse represents the response from the Loki patterns API.
+type PatternsResponse struct {
+	Status string         `json:"status"`
+	Data   []PatternEntry `json:"data"`
+}
+
+// PatternEntry represents a single detected log pattern with sample counts.
+type PatternEntry struct {
+	Pattern string    `json:"pattern"`
+	Samples [][]int64 `json:"samples"` // [[timestamp_sec, count], ...]
+}
+
+// TotalCount returns the sum of all sample counts for this pattern.
+func (p PatternEntry) TotalCount() int64 {
+	var total int64
+	for _, s := range p.Samples {
+		if len(s) >= 2 {
+			total += s[1]
+		}
+	}
+	return total
+}
+
 // GrafanaQueryResponse represents the response from Grafana's datasource query API.
 type GrafanaQueryResponse struct {
 	Results map[string]GrafanaResult `json:"results"`


### PR DESCRIPTION
## Summary

- Adds `gcx logs patterns` and `gcx datasources loki patterns` commands that expose the Loki `/patterns` API for detecting recurring log patterns across matching streams
- Implements the full stack: `PatternsRequest`/`PatternsResponse` types, `Client.Patterns()` method, `FormatPatternsTable` formatter with count-descending sort, table codec, and CLI command with standard `--datasource`, time range, and output flags
- Includes unit tests for the client (success + HTTP error), formatter (sort order, empty response), and `TotalCount()` helper

## Test plan

- [ ] `go test ./internal/query/loki/...` passes (client, formatter, types tests)
- [ ] `go test ./internal/datasources/loki/...` compiles (patterns command)
- [ ] `go test ./internal/providers/logs/...` compiles (provider registration)
- [ ] Manual: `gcx logs patterns '{job="grafana"}' --since 1h` returns detected patterns
- [ ] Manual: `-o json` outputs full PatternsResponse with per-timestamp samples