### PR TITLE
feat(kg): add RCA Workbench deep link to entities inspect

### DIFF
--- a/docs/reference/cli/gcx_kg_entities.md
+++ b/docs/reference/cli/gcx_kg_entities.md
@@ -23,6 +23,6 @@ Manage Knowledge Graph entities.
 ### SEE ALSO
 
 * [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
-* [gcx kg entities inspect](gcx_kg_entities_inspect.md)	 - Show detailed info, insights, and summary for a single entity, with a link to open it in the RCA Workbench.
+* [gcx kg entities inspect](gcx_kg_entities_inspect.md)	 - Show detailed info, insights, and summary for a single entity, including a link to the RCA Workbench.
 * [gcx kg entities list](gcx_kg_entities_list.md)	 - List Knowledge Graph entities for a given type.
 

--- a/docs/reference/cli/gcx_kg_entities.md
+++ b/docs/reference/cli/gcx_kg_entities.md
@@ -23,6 +23,6 @@ Manage Knowledge Graph entities.
 ### SEE ALSO
 
 * [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
-* [gcx kg entities inspect](gcx_kg_entities_inspect.md)	 - Show detailed info, insights, and summary for a single entity.
+* [gcx kg entities inspect](gcx_kg_entities_inspect.md)	 - Show detailed info, insights, and summary for a single entity, with a link to open it in the RCA Workbench.
 * [gcx kg entities list](gcx_kg_entities_list.md)	 - List Knowledge Graph entities for a given type.
 

--- a/docs/reference/cli/gcx_kg_entities_inspect.md
+++ b/docs/reference/cli/gcx_kg_entities_inspect.md
@@ -15,7 +15,9 @@ gcx kg entities inspect [Type--Name] [flags]
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string        Entity name
       --namespace string   Namespace scope (run 'gcx kg meta scopes' to see valid values)
+      --open               Open the entity in the RCA Workbench in your browser
   -o, --output string      Output format. One of: json, yaml (default "json")
+      --share-link         Print the RCA Workbench URL for this entity to stderr
       --since string       Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
       --site string        Site scope (run 'gcx kg meta scopes' to see valid values)
       --to string          End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_kg_entities_inspect.md
+++ b/docs/reference/cli/gcx_kg_entities_inspect.md
@@ -1,6 +1,6 @@
 ## gcx kg entities inspect
 
-Show detailed info, insights, and summary for a single entity, with a link to open it in the RCA Workbench.
+Show detailed info, insights, and summary for a single entity, including a link to the RCA Workbench.
 
 ```
 gcx kg entities inspect [Type--Name] [flags]

--- a/docs/reference/cli/gcx_kg_entities_inspect.md
+++ b/docs/reference/cli/gcx_kg_entities_inspect.md
@@ -1,6 +1,6 @@
 ## gcx kg entities inspect
 
-Show detailed info, insights, and summary for a single entity.
+Show detailed info, insights, and summary for a single entity, with a link to open it in the RCA Workbench.
 
 ```
 gcx kg entities inspect [Type--Name] [flags]

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1458,7 +1458,7 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 	ioOpts := &inspectOpts{}
 	cmd := &cobra.Command{
 		Use:   "inspect [Type--Name]",
-		Short: "Show detailed info, insights, and summary for a single entity, with a link to open it in the RCA Workbench.",
+		Short: "Show detailed info, insights, and summary for a single entity, including a link to the RCA Workbench.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := ioOpts.IO.Validate(); err != nil {
@@ -1529,7 +1529,7 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 				return fmt.Errorf("%s/%s not found%s\nRun 'gcx kg entities list --type %s --property name=~%s' to find matching entities and their correct scope", entityType, name, scopeDesc, entityType, name)
 			}
 			if u := rcaWorkbenchURL(cfg.GrafanaURL, entityType, name, scope, startMs, endMs, inspectScope.since); u != "" {
-				fmt.Fprintf(cmd.ErrOrStderr(), "link: View in RCA Workbench → %s\n", u)
+				result["rcaWorkbench"] = u
 			}
 			return ioOpts.IO.Encode(cmd.OutOrStdout(), result)
 		},

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1529,7 +1529,15 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 				return fmt.Errorf("%s/%s not found%s\nRun 'gcx kg entities list --type %s --property name=~%s' to find matching entities and their correct scope", entityType, name, scopeDesc, entityType, name)
 			}
 			if u := rcaWorkbenchURL(cfg.GrafanaURL, entityType, name, scope, startMs, endMs, inspectScope.since); u != "" {
-				result["rcaWorkbench"] = u
+				if ioOpts.ShareLink {
+					cmdio.Info(cmd.ErrOrStderr(), "RCA Workbench: %s", u)
+				}
+				if ioOpts.Open {
+					cmdio.Info(cmd.ErrOrStderr(), "Opening RCA Workbench for %s/%s", entityType, name)
+					if err := deeplink.Open(u); err != nil {
+						cmdio.Warning(cmd.ErrOrStderr(), "could not open browser: %v", err)
+					}
+				}
 			}
 			return ioOpts.IO.Encode(cmd.OutOrStdout(), result)
 		},
@@ -1545,12 +1553,16 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 }
 
 type inspectOpts struct {
-	IO cmdio.Options
+	IO        cmdio.Options
+	ShareLink bool
+	Open      bool
 }
 
 func (o *inspectOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("json")
 	o.IO.BindFlags(flags)
+	flags.BoolVar(&o.ShareLink, "share-link", false, "Print the RCA Workbench URL for this entity to stderr")
+	flags.BoolVar(&o.Open, "open", false, "Open the entity in the RCA Workbench in your browser")
 }
 
 // rcaWorkbenchURL builds a deep link to the Asserts RCA Workbench for a single entity.

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"sort"
@@ -1457,7 +1458,7 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 	ioOpts := &inspectOpts{}
 	cmd := &cobra.Command{
 		Use:   "inspect [Type--Name]",
-		Short: "Show detailed info, insights, and summary for a single entity.",
+		Short: "Show detailed info, insights, and summary for a single entity, with a link to open it in the RCA Workbench.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := ioOpts.IO.Validate(); err != nil {
@@ -1527,6 +1528,9 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 				}
 				return fmt.Errorf("%s/%s not found%s\nRun 'gcx kg entities list --type %s --property name=~%s' to find matching entities and their correct scope", entityType, name, scopeDesc, entityType, name)
 			}
+			if u := rcaWorkbenchURL(cfg.GrafanaURL, entityType, name, scope, startMs, endMs, inspectScope.since); u != "" {
+				fmt.Fprintf(cmd.ErrOrStderr(), "link: View in RCA Workbench → %s\n", u)
+			}
 			return ioOpts.IO.Encode(cmd.OutOrStdout(), result)
 		},
 	}
@@ -1547,6 +1551,48 @@ type inspectOpts struct {
 func (o *inspectOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("json")
 	o.IO.BindFlags(flags)
+}
+
+// rcaWorkbenchURL builds a deep link to the Asserts RCA Workbench for a single entity.
+// start/end use the relative expression (e.g. "now-24h"/"now") when since is set,
+// otherwise fall back to millisecond epoch timestamps.
+func rcaWorkbenchURL(host, entityType, name string, scope map[string]string, startMs, endMs int64, since string) string {
+	if host == "" {
+		return ""
+	}
+	start, end := strconv.FormatInt(startMs, 10), strconv.FormatInt(endMs, 10)
+	if since != "" {
+		start, end = "now-"+since, "now"
+	}
+
+	q := url.Values{}
+	q.Set("start", start)
+	q.Set("end", end)
+	if v := scope["env"]; v != "" {
+		q.Set("env[0]", v)
+	}
+	if v := scope["namespace"]; v != "" {
+		q.Set("namespace[0]", v)
+	}
+	if v := scope["site"]; v != "" {
+		q.Set("site[0]", v)
+	}
+	q.Set("we[0][n]", name)
+	q.Set("we[0][tp]", entityType)
+	if v := scope["namespace"]; v != "" {
+		q.Set("we[0][sc][ns]", v)
+	}
+	if v := scope["env"]; v != "" {
+		q.Set("we[0][sc][env]", v)
+	}
+	if v := scope["site"]; v != "" {
+		q.Set("we[0][sc][site]", v)
+	}
+	q.Set("view", "BY_ENTITY")
+
+	// url.Values.Encode percent-encodes brackets; replace them back for readability.
+	encoded := strings.NewReplacer("%5B", "[", "%5D", "]").Replace(q.Encode())
+	return strings.TrimRight(host, "/") + "/a/grafana-asserts-app/assertions?" + encoded
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `--share-link` and `--open` flags to `gcx kg entities inspect`, following the same pattern as the datasource query commands (PR #567):

- **`--share-link`** — prints the RCA Workbench URL for the inspected entity to stderr (opt-in, quiet by default)
- **`--open`** — opens the entity directly in the RCA Workbench in your browser
- The URL encodes entity type, name, scope (env/namespace/site), and time range — relative (`now-24h`/`now`) when `--since` is used, epoch ms timestamps when `--from`/`--to` are used
- No URL injected into JSON output — surfaces only when explicitly requested, consistent with DESIGN.md "quiet by default"

## Test plan

- [x] `--since 24h --share-link` — verify URL on stderr with `start=now-24h&end=now`
- [x] `--from now-24h --to now --share-link` — verify URL uses epoch ms timestamps
- [x] `--open` — verify browser opens to correct entity in RCA Workbench
- [x] `--share-link --open` — verify both work together
- [x] No flags — verify clean JSON output, nothing on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1268" height="549" alt="image" src="https://github.com/user-attachments/assets/fa452ca2-f12d-4965-a4e2-0cbc1d2330a6" />