### PR TITLE
fix(skills): handle read-only files during skill update

### DIFF
--- a/cmd/gcx/skills/command_test.go
+++ b/cmd/gcx/skills/command_test.go
@@ -229,6 +229,36 @@ func TestUpdateCommand_UpdatesOnlyInstalledSkills(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
+func TestUpdateCommand_UpdatesReadOnlyFiles(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
+	root := filepath.Join(t.TempDir(), ".agents")
+
+	skillPath := filepath.Join(root, "skills", "alpha", "SKILL.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(skillPath), 0o755))
+	require.NoError(t, os.WriteFile(skillPath, []byte("old-content"), 0o600))
+	require.NoError(t, os.Chmod(skillPath, 0o444))
+
+	cmd := newUpdateCommand(testSkillsFS())
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"--dir", root})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "Updated 1 skill(s)")
+
+	data, err := os.ReadFile(skillPath)
+	require.NoError(t, err)
+	require.Equal(t, []byte("alpha-skill"), data)
+
+	info, err := os.Stat(skillPath)
+	require.NoError(t, err)
+	require.Equal(t, fs.FileMode(0o644), info.Mode().Perm())
+}
+
 func TestUpdateCommand_NoInstalledSkillsNoOp(t *testing.T) {
 	t.Setenv("GCX_AGENT_MODE", "false")
 	agent.ResetForTesting()

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -248,6 +248,11 @@ func syncFile(source fs.FS, sourcePath string, targetPath string, force bool, dr
 		if dryRun {
 			return true, true, nil
 		}
+		// handle cases where existing skills files are read-only - WriteFile
+		// doesn't override permissions on existing files.
+		if err := os.Chmod(targetPath, installedFileMode); err != nil {
+			return false, false, err
+		}
 		return true, true, os.WriteFile(targetPath, sourceData, installedFileMode)
 	case errors.Is(err, os.ErrNotExist):
 		if dryRun {


### PR DESCRIPTION
Address permissions issues I saw when running `gcx skills update`

## Summary

- `os.WriteFile` doesn't override permissions on existing files, so updating a skill file that's read-only (e.g. `0o444`) fails with a permission error
- added `os.Chmod` before the write to ensure the file is writable
- added test covering the read-only file update path