### PR TITLE
fix: use correct IRM plugin slug in incident URL template

### DIFF
--- a/internal/providers/irm/incidents_adapter.go
+++ b/internal/providers/irm/incidents_adapter.go
@@ -20,7 +20,7 @@ func buildIncidentRegistrations(loader *configLoader) []adapter.Registration {
 			GVK:         desc.GroupVersionKind(),
 			Schema:      IncidentSchema(),
 			Example:     IncidentExample(),
-			URLTemplate: "/a/grafana-incident-app/incidents/{name}",
+			URLTemplate: "/a/grafana-irm-app/incidents/{name}",
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- `gcx irm incidents open` generates URLs with `/a/grafana-incident-app/` but the correct plugin slug is `grafana-irm-app`
- The API client already uses the right path — this fixes the browser deep-link to match
- Verified by comparing `gcx irm incidents open 4` output vs `spec.overviewURL` from the API

## Test plan
- [ ] `gcx irm incidents open <id>` opens the correct URL with `grafana-irm-app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)