### PR TITLE
docs: add manifest examples to `gcx irm incidents create`

### DIFF
--- a/docs/reference/cli/gcx_irm_incidents_create.md
+++ b/docs/reference/cli/gcx_irm_incidents_create.md
@@ -8,30 +8,28 @@ gcx irm incidents create [flags]
 
 ### Examples
 
-Create an incident from a YAML manifest:
+```
+  # Create an incident from a YAML manifest:
+  cat <<EOF | gcx irm incidents create -f -
+  apiVersion: incident.ext.grafana.app/v1alpha1
+  kind: Incident
+  metadata:
+    name: my-incident
+  spec:
+    title: "Service degradation in production"
+    status: active
+    isDrill: false
+    incidentType: internal
+    labels:
+      - key: team
+        label: platform
+      - key: env
+        label: production
+  EOF
 
-    cat <<EOF | gcx irm incidents create -f -
-    apiVersion: incident.ext.grafana.app/v1alpha1
-    kind: Incident
-    metadata:
-      name: my-incident
-    spec:
-      title: "Service degradation in production"
-      status: active
-      isDrill: false
-      incidentType: internal
-      labels:
-        - key: team
-          label: platform
-        - key: env
-          label: production
-    EOF
-
-Create from a file:
-
-    gcx irm incidents create -f incident.yaml
-
-Required fields: `apiVersion`, `kind`, `metadata.name`, `spec.title`, `spec.status`.
+  # Create from a file:
+  gcx irm incidents create -f incident.yaml
+```
 
 ### Options
 

--- a/docs/reference/cli/gcx_irm_incidents_create.md
+++ b/docs/reference/cli/gcx_irm_incidents_create.md
@@ -6,6 +6,33 @@ Create a new incident from a file.
 gcx irm incidents create [flags]
 ```
 
+### Examples
+
+Create an incident from a YAML manifest:
+
+    cat <<EOF | gcx irm incidents create -f -
+    apiVersion: incident.ext.grafana.app/v1alpha1
+    kind: Incident
+    metadata:
+      name: my-incident
+    spec:
+      title: "Service degradation in production"
+      status: active
+      isDrill: false
+      incidentType: internal
+      labels:
+        - key: team
+          label: platform
+        - key: env
+          label: production
+    EOF
+
+Create from a file:
+
+    gcx irm incidents create -f incident.yaml
+
+Required fields: `apiVersion`, `kind`, `metadata.name`, `spec.title`, `spec.status`.
+
 ### Options
 
 ```

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -281,6 +281,26 @@ func NewCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new incident from a file.",
+		Example: `  # Create an incident from a YAML manifest:
+  cat <<EOF | gcx irm incidents create -f -
+  apiVersion: incident.ext.grafana.app/v1alpha1
+  kind: Incident
+  metadata:
+    name: my-incident
+  spec:
+    title: "Service degradation in production"
+    status: active
+    isDrill: false
+    incidentType: internal
+    labels:
+      - key: team
+        label: platform
+      - key: env
+        label: production
+  EOF
+
+  # Create from a file:
+  gcx irm incidents create -f incident.yaml`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err


### PR DESCRIPTION
## Summary
- `gcx irm incidents create -f` accepts a Kubernetes-style manifest but the expected format is not documented
- Added a complete YAML example showing all supported fields, plus a file-based usage example
- Manifest format derived from `IncidentExample()` and `IncidentSchema()` in source, verified against a live stack

## Test plan
- [ ] Verify the example manifest creates an incident successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)