### PR TITLE
Update gcx skills to remove common errors

### DIFF
--- a/claude-plugin/skills/debug-with-grafana/SKILL.md
+++ b/claude-plugin/skills/debug-with-grafana/SKILL.md
@@ -254,6 +254,55 @@ Look for:
 - Stack traces or panic messages that identify the root cause
 - Upstream service names in error messages (database, external APIs)
 
+### Step 5b: Correlate Traces (if Tempo is available)
+
+If a Tempo datasource exists, search for traces matching the incident window.
+Traces show individual request paths and identify slow or failing spans.
+
+```bash
+# Check for Tempo datasources
+gcx datasources list -t tempo -o json
+
+# Search for error traces in the incident window
+gcx traces query -d <tempo-uid> '{ status = error }' --from now-1h --to now
+
+# Search by service name
+gcx traces query -d <tempo-uid> '{ resource.service.name = "<service-name>" }' --from now-1h --to now
+
+# Search for slow traces (duration > 1s)
+gcx traces query -d <tempo-uid> \
+  '{ resource.service.name = "<service-name>" && duration > 1s }' \
+  --from now-1h --to now
+
+# Fetch a specific trace by ID (from search results or log trace IDs)
+gcx traces get -d <tempo-uid> <trace-id>
+
+# LLM-friendly trace output for analysis
+gcx traces get -d <tempo-uid> <trace-id> --llm
+```
+
+**TraceQL attribute scoping**: Tempo requires scoped attribute names. Use
+`resource.` for resource-level attributes and `span.` for span-level:
+- `resource.service.name` (not `service.name`)
+- `span.http.status_code` (not `http.status_code`)
+
+Use `name` (unscoped) for the span name, `duration` for span duration,
+and `status` for span status. Use `trace:rootService` and `trace:rootName`
+for root span attributes (not `rootServiceName` or `rootTraceName`).
+
+Discover available labels:
+```bash
+gcx traces labels -d <tempo-uid>
+gcx traces labels -d <tempo-uid> -l resource.service.name
+```
+
+> **Common mistake**: `gcx traces labels -l service.name` will fail — Tempo
+> parses the dot as an identifier boundary. Always fully qualify:
+> `-l resource.service.name`, not `-l service.name`.
+
+See [`references/traceql-patterns.md`](references/traceql-patterns.md) for full
+TraceQL syntax reference.
+
 ### Step 6: Check Related Dashboards and Resources
 
 Check whether relevant dashboards exist that give broader context, and inspect
@@ -560,3 +609,7 @@ gcx alert rules list -o json | jq '.[] | .rules[]? | select(.state == "firing")'
   query patterns for Prometheus and Loki datasources, including time range
   formats, aggregation patterns, Loki stream operators, and output format
   reference.
+
+- [`references/traceql-patterns.md`](references/traceql-patterns.md) — TraceQL
+  query patterns for Tempo trace search, attribute scoping rules, and the
+  distinction between `traces query` and `traces get`.

--- a/claude-plugin/skills/debug-with-grafana/SKILL.md
+++ b/claude-plugin/skills/debug-with-grafana/SKILL.md
@@ -80,7 +80,7 @@ gcx logs labels -d <loki-uid> -l job -o json
 gcx logs series -d <loki-uid> -M '{job="<service-name>"}' -o json
 
 # Spot-check: confirm uptime metrics are present for the service
-gcx metrics query <prom-uid> 'up{job="<service-name>"}' -o json
+gcx metrics query -d <prom-uid> 'up{job="<service-name>"}' -o json
 ```
 
 **Expected output shape:**
@@ -107,22 +107,22 @@ whether an error spike exists and when it began.
 
 ```bash
 # HTTP 5xx error rate (range query for trend)
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'rate(http_requests_total{job="<service-name>",status=~"5.."}[5m])' \
   --from now-1h --to now --step 1m -o json
 
 # Visualize the trend
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'rate(http_requests_total{job="<service-name>",status=~"5.."}[5m])' \
   --from now-1h --to now --step 1m -o graph
 
 # Error ratio (errors / total)
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'rate(http_requests_total{job="<service-name>",status=~"5.."}[5m]) / rate(http_requests_total{job="<service-name>"}[5m])' \
   --from now-1h --to now --step 1m -o json
 
 # Break down by status code to identify 500 vs 503 vs 504
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'sum by(status) (rate(http_requests_total{job="<service-name>"}[5m]))' \
   --from now-1h --to now --step 1m -o json
 ```
@@ -153,22 +153,22 @@ or failing fast (error issue). High latency often precedes error spikes.
 
 ```bash
 # P50/P95/P99 latency from histogram
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="<service-name>"}[5m]))' \
   --from now-1h --to now --step 1m -o json
 
 # Visualize P95 latency trend
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="<service-name>"}[5m]))' \
   --from now-1h --to now --step 1m -o graph
 
 # Average latency as a simpler signal if histograms are unavailable
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'rate(http_request_duration_seconds_sum{job="<service-name>"}[5m]) / rate(http_request_duration_seconds_count{job="<service-name>"}[5m])' \
   --from now-1h --to now --step 1m -o json
 
 # Latency by endpoint (if label available)
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'histogram_quantile(0.95, sum by(le, handler) (rate(http_request_duration_seconds_bucket{job="<service-name>"}[5m])))' \
   --from now-1h --to now --step 1m -o json
 ```
@@ -200,22 +200,22 @@ metrics cannot.
 
 ```bash
 # Error logs for the service in the incident window
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   '{job="<service-name>"} |= "error"' \
   --from now-1h --to now -o json
 
 # JSON-parsed logs with level filter (if structured logging)
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   '{job="<service-name>"} | json | level="error"' \
   --from now-1h --to now -o json
 
 # Error rate from logs (count over time)
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   'count_over_time({job="<service-name>"} |= "error" [5m])' \
   --from now-1h --to now --step 1m -o json
 
 # Grep for specific error patterns
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   '{job="<service-name>"} |~ "timeout|connection refused|OOM|panic"' \
   --from now-1h --to now -o json
 ```
@@ -353,25 +353,25 @@ gcx datasources list -t prometheus -o json
 gcx datasources list -t loki -o json
 
 # Step 2: Confirm service is being scraped
-gcx metrics query <prom-uid> 'up{job="api"}' -o json
+gcx metrics query -d <prom-uid> 'up{job="api"}' -o json
 
 # Step 3: Observe error rate over last 2 hours (wider window to see the spike start)
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'rate(http_requests_total{job="api",status=~"5.."}[5m])' \
   --from now-2h --to now --step 1m -o graph
 
 # Identify which status codes are elevated
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'sum by(status) (rate(http_requests_total{job="api"}[5m]))' \
   --from now-2h --to now --step 1m -o json
 
 # Step 4: Check if latency rose at the same time
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="api"}[5m]))' \
   --from now-2h --to now --step 1m -o graph
 
 # Step 5: Get error logs in the spike window
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   '{job="api"} |= "error"' \
   --from now-2h --to now -o json
 
@@ -411,30 +411,30 @@ increasing from baseline. Match this to log timestamps in Step 5.
 gcx datasources list -t prometheus -o json
 
 # Step 2: Confirm service health (latency without errors suggests slow dependency)
-gcx metrics query <prom-uid> 'up{job="api"}' -o json
+gcx metrics query -d <prom-uid> 'up{job="api"}' -o json
 
 # Step 3: Error rate (confirm it's not elevated yet)
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'rate(http_requests_total{job="api",status=~"5.."}[5m])' \
   --from now-1h --to now --step 1m -o json
 
 # Step 4: P95 latency is the primary signal — visualize trend
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="api"}[5m]))' \
   --from now-2h --to now --step 1m -o graph
 
 # Break down by endpoint to isolate which routes are slow
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'histogram_quantile(0.95, sum by(le, handler) (rate(http_request_duration_seconds_bucket{job="api"}[5m])))' \
   --from now-1h --to now --step 1m -o json
 
 # Step 5: Check for timeout log patterns suggesting upstream dependency issue
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   '{job="api"} |~ "timeout|slow|waiting"' \
   --from now-2h --to now -o json
 
 # Check database or downstream service latency if metrics available
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'rate(db_query_duration_seconds_sum{job="api"}[5m]) / rate(db_query_duration_seconds_count{job="api"}[5m])' \
   --from now-2h --to now --step 1m -o json
 ```
@@ -475,28 +475,28 @@ gcx datasources list -o json
 gcx metrics query -d <prom-uid> 'up{job="api"}' -o json
 
 # Confirm up metric — value "0" means scrape failure, absent means not scraped
-gcx metrics query <prom-uid> 'up{job="api"}' -o json
+gcx metrics query -d <prom-uid> 'up{job="api"}' -o json
 
 # Check if the job label exists at all (absence = service was never registered)
 gcx metrics labels -d <prom-uid> -l job -o json
 
 # Step 3: Without error rate data, check for recent data gaps
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'absent(up{job="api"})' \
   --from now-1h --to now --step 1m -o json
 
 # Step 4: Query latency from any recent data before the outage
-gcx metrics query <prom-uid> \
+gcx metrics query -d <prom-uid> \
   'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="api"}[5m]))' \
   --from now-3h --to now --step 5m -o graph
 
 # Step 5: Check Loki for last known logs before data disappeared
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   '{job="api"}' \
   --from now-3h --to now -o json
 
 # Crash or OOM signals in logs
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   '{job="api"} |~ "panic|OOM|killed|crashed|SIGTERM"' \
   --from now-3h --to now -o json
 

--- a/claude-plugin/skills/debug-with-grafana/SKILL.md
+++ b/claude-plugin/skills/debug-with-grafana/SKILL.md
@@ -248,6 +248,10 @@ gcx logs query -d <loki-uid> \
 }
 ```
 
+> **LogQL pitfall**: Loki requires at least one non-empty label matcher in the
+> stream selector. `{}` and `{} |~ "pattern"` will be rejected. Always include
+> at least one label, e.g., `{job=~".+"}` as a catch-all.
+
 Look for:
 - Repeated error messages pointing to a specific code path or dependency
 - Timestamps of first error matching the metric spike time from Step 3

--- a/claude-plugin/skills/debug-with-grafana/SKILL.md
+++ b/claude-plugin/skills/debug-with-grafana/SKILL.md
@@ -45,8 +45,10 @@ gcx datasources list -t prometheus -o json
 gcx datasources list -t loki -o json
 
 # Capture UIDs for use in subsequent steps
-PROM_UID=$(gcx datasources list -t prometheus -o json | jq -r '.datasources[0].uid')
-LOKI_UID=$(gcx datasources list -t loki -o json | jq -r '.datasources[0].uid')
+PROM_UID=$(gcx datasources list -t prometheus -o json 2>/dev/null | \
+  python3 -c "import json,sys; print(json.load(sys.stdin)['datasources'][0]['uid'])")
+LOKI_UID=$(gcx datasources list -t loki -o json 2>/dev/null | \
+  python3 -c "import json,sys; print(json.load(sys.stdin)['datasources'][0]['uid'])")
 ```
 
 **Expected output shape:**
@@ -62,6 +64,16 @@ LOKI_UID=$(gcx datasources list -t loki -o json | jq -r '.datasources[0].uid')
 If no datasources appear, confirm the context is pointing at the correct
 Grafana instance. See `references/error-recovery.md` for auth and
 datasource-not-found recovery patterns.
+
+> **JSON output piping**: When piping gcx output through external tools, never
+> use `2>&1` — gcx writes hints to stderr that break JSON parsers. Use
+> `2>/dev/null` to suppress stderr, or use `--json field1,field2` to select
+> fields directly without piping:
+> ```bash
+> gcx datasources list -t prometheus --json uid
+> gcx metrics query -d <prom-uid> 'up' --json metric,value
+> ```
+> Use `--json list` to discover available fields for any command.
 
 ### Step 2: Confirm Data Availability
 

--- a/claude-plugin/skills/debug-with-grafana/references/error-recovery.md
+++ b/claude-plugin/skills/debug-with-grafana/references/error-recovery.md
@@ -289,6 +289,39 @@ Error: bad_data: invalid parameter "query": <details>
 
 ---
 
+## Failure Mode 6: "Accepts between 0 and 1 arg(s), received 2"
+
+### Error Message Pattern
+
+```
+Error: Accepts between 0 and 1 arg(s), received 2
+```
+
+### Likely Cause
+
+The datasource UID was passed as a positional argument instead of using the
+`-d` flag. Query commands accept at most one positional argument (the
+expression). The datasource must be specified with `-d <uid>`.
+
+### Corrective Action
+
+Move the datasource UID from a positional argument to the `-d` flag:
+
+```bash
+# Wrong — two positional args (UID + expression):
+gcx metrics query prometheus 'rate(http_requests_total[5m])' --from now-1h --to now
+
+# Correct — UID via -d flag:
+gcx metrics query -d prometheus 'rate(http_requests_total[5m])' --from now-1h --to now
+
+# Also correct — omit -d if a default datasource is configured:
+gcx metrics query 'rate(http_requests_total[5m])' --from now-1h --to now
+```
+
+The same pattern applies to `gcx logs query` and `gcx traces query`.
+
+---
+
 ## Quick Reference: Recovery Command Cheatsheet
 
 | Failure | First Diagnostic Command |
@@ -300,3 +333,4 @@ Error: bad_data: invalid parameter "query": <details>
 | Query timeout | Increase `--step`, reduce time range |
 | PromQL parse error | Check braces, quotes, and range windows |
 | Loki parse error | Check stream selector syntax and double-quoted labels |
+| "Accepts between 0 and 1 arg(s)" | Move datasource UID to `-d <uid>` flag |

--- a/claude-plugin/skills/debug-with-grafana/references/error-recovery.md
+++ b/claude-plugin/skills/debug-with-grafana/references/error-recovery.md
@@ -100,7 +100,7 @@ Error: failed to query datasource: 404 Not Found
 4. Retry the query using the correct UID from the listing output:
 
    ```bash
-   gcx metrics query <correct-uid> '<expr>' --from now-1h --to now --step 1m -o json
+   gcx metrics query -d <correct-uid> '<expr>' --from now-1h --to now --step 1m -o json
    ```
 
 ---
@@ -153,7 +153,7 @@ Or for a range query:
 4. Broaden the time range to confirm whether data exists at all:
 
    ```bash
-   gcx metrics query <uid> '<metric>' --from now-24h --to now --step 5m -o json
+   gcx metrics query -d <uid> '<metric>' --from now-24h --to now --step 5m -o json
    ```
 
 5. Simplify the query to remove label filters and verify the base metric returns data:
@@ -161,7 +161,7 @@ Or for a range query:
    ```bash
    # Before: http_requests_total{job="api",code="500"}
    # After (simplified):
-   gcx metrics query <uid> 'http_requests_total' --from now-1h --to now --step 1m -o json
+   gcx metrics query -d <uid> 'http_requests_total' --from now-1h --to now --step 1m -o json
    ```
 
 ---
@@ -189,13 +189,13 @@ Error: failed to execute query: upstream timeout
 1. Reduce the time range to limit the number of data points:
 
    ```bash
-   gcx metrics query <uid> '<expr>' --from now-30m --to now --step 1m -o json
+   gcx metrics query -d <uid> '<expr>' --from now-30m --to now --step 1m -o json
    ```
 
 2. Increase the step interval to reduce the resolution and query load:
 
    ```bash
-   gcx metrics query <uid> '<expr>' --from now-1h --to now --step 5m -o json
+   gcx metrics query -d <uid> '<expr>' --from now-1h --to now --step 5m -o json
    ```
 
 3. Add label filters to reduce cardinality:
@@ -203,7 +203,7 @@ Error: failed to execute query: upstream timeout
    ```bash
    # Before: rate(http_requests_total[5m])
    # After (scoped):
-   gcx metrics query <uid> 'rate(http_requests_total{job="api"}[5m])' --from now-1h --to now --step 5m -o json
+   gcx metrics query -d <uid> 'rate(http_requests_total{job="api"}[5m])' --from now-1h --to now --step 5m -o json
    ```
 
 4. Check Prometheus scrape targets to confirm the datasource is healthy:
@@ -252,7 +252,7 @@ Error: bad_data: invalid parameter "query": <details>
    ```bash
    # Broken: rate(http_requests_total{job="api"[5m])
    # Fixed:
-   gcx metrics query <uid> 'rate(http_requests_total{job="api"}[5m])' --from now-1h --to now --step 1m -o json
+   gcx metrics query -d <uid> 'rate(http_requests_total{job="api"}[5m])' --from now-1h --to now --step 1m -o json
    ```
 
 2. Confirm the datasource type matches the query language. List datasources and check the `type` field:
@@ -269,7 +269,7 @@ Error: bad_data: invalid parameter "query": <details>
    # Wrong: {job='api'}
    # Wrong: {job=api}
    # Correct:
-   gcx logs query <uid> '{job="api"} |= "error"' --from now-1h --to now -o json
+   gcx logs query -d <uid> '{job="api"} |= "error"' --from now-1h --to now -o json
    ```
 
 4. For rate and increase functions, always specify the range window:
@@ -277,7 +277,7 @@ Error: bad_data: invalid parameter "query": <details>
    ```bash
    # Wrong: rate(http_requests_total{code="500"})
    # Correct:
-   gcx metrics query <uid> 'rate(http_requests_total{code="500"}[5m])' --from now-1h --to now --step 1m -o json
+   gcx metrics query -d <uid> 'rate(http_requests_total{code="500"}[5m])' --from now-1h --to now --step 1m -o json
    ```
 
 5. Use the Prometheus labels command to confirm label names and valid values before building complex queries:

--- a/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
@@ -44,13 +44,13 @@ Query current values:
 
 ```bash
 # Current uptime for all targets
-gcx metrics query <uid> 'up'
+gcx metrics query -d <uid> 'up'
 
 # CPU usage by job
-gcx metrics query <uid> 'avg by(job) (rate(cpu_usage_seconds[5m]))'
+gcx metrics query -d <uid> 'avg by(job) (rate(cpu_usage_seconds[5m]))'
 
 # Memory usage with threshold
-gcx metrics query <uid> 'node_memory_MemAvailable_bytes < 1000000000'
+gcx metrics query -d <uid> 'node_memory_MemAvailable_bytes < 1000000000'
 ```
 
 ### Range Queries
@@ -59,15 +59,15 @@ Query over time periods:
 
 ```bash
 # HTTP request rate over last hour
-gcx metrics query <uid> 'rate(http_requests_total[5m])' \
+gcx metrics query -d <uid> 'rate(http_requests_total[5m])' \
   --from now-1h --to now --step 1m
 
 # CPU usage for specific time period
-gcx metrics query <uid> 'avg(cpu_usage)' \
+gcx metrics query -d <uid> 'avg(cpu_usage)' \
   --from 2026-03-01T00:00:00Z --to 2026-03-01T12:00:00Z --step 5m
 
 # Disk usage over last 24 hours
-gcx metrics query <uid> 'disk_used_percent' \
+gcx metrics query -d <uid> 'disk_used_percent' \
   --from now-24h --to now --step 15m
 ```
 
@@ -94,15 +94,15 @@ Choose step based on time range:
 
 ```bash
 # Short ranges: 1-5 second steps
-gcx metrics query <uid> 'rate(requests[1m])' \
+gcx metrics query -d <uid> 'rate(requests[1m])' \
   --from now-5m --to now --step 1s
 
 # Medium ranges: 1-5 minute steps
-gcx metrics query <uid> 'rate(requests[5m])' \
+gcx metrics query -d <uid> 'rate(requests[5m])' \
   --from now-6h --to now --step 1m
 
 # Long ranges: 15-60 minute steps
-gcx metrics query <uid> 'rate(requests[1h])' \
+gcx metrics query -d <uid> 'rate(requests[1h])' \
   --from now-7d --to now --step 1h
 ```
 
@@ -112,30 +112,30 @@ gcx metrics query <uid> 'rate(requests[1h])' \
 
 ```bash
 # Sum across all instances
-gcx metrics query <uid> 'sum(http_requests_total)'
+gcx metrics query -d <uid> 'sum(http_requests_total)'
 
 # Average by label
-gcx metrics query <uid> 'avg by(job) (cpu_usage)'
+gcx metrics query -d <uid> 'avg by(job) (cpu_usage)'
 
 # Top 5 by value
-gcx metrics query <uid> 'topk(5, http_requests_total)'
+gcx metrics query -d <uid> 'topk(5, http_requests_total)'
 
 # 95th percentile
-gcx metrics query <uid> 'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))'
+gcx metrics query -d <uid> 'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))'
 ```
 
 ### Combining with Graph
 
 ```bash
 # Line chart (default) — pass -o graph directly to the query command
-gcx metrics query <uid> 'rate(http_requests_total[5m])' \
+gcx metrics query -d <uid> 'rate(http_requests_total[5m])' \
   --from now-1h --to now --step 1m -o graph
 
 # Instant query as graph
-gcx metrics query <uid> 'up' -o graph
+gcx metrics query -d <uid> 'up' -o graph
 
 # Range query as graph
-gcx metrics query <uid> 'cpu_usage' --from now-6h --to now --step 5m -o graph
+gcx metrics query -d <uid> 'cpu_usage' --from now-6h --to now --step 5m -o graph
 ```
 
 ## Loki Query Patterns
@@ -146,32 +146,32 @@ Basic log filtering:
 
 ```bash
 # All logs from a job
-gcx logs query <loki-uid> '{job="varlogs"}'
+gcx logs query -d <loki-uid> '{job="varlogs"}'
 
 # Multiple labels (AND)
-gcx logs query <loki-uid> '{job="varlogs",level="error"}'
+gcx logs query -d <loki-uid> '{job="varlogs",level="error"}'
 
 # Regex matching
-gcx logs query <loki-uid> '{job=~"mysql.*",level!="debug"}'
+gcx logs query -d <loki-uid> '{job=~"mysql.*",level!="debug"}'
 
 # Exclude specific values
-gcx logs query <loki-uid> '{namespace="production",pod!~"test.*"}'
+gcx logs query -d <loki-uid> '{namespace="production",pod!~"test.*"}'
 ```
 
 ### Log Stream Operators
 
 ```bash
 # Contains text
-gcx logs query <loki-uid> '{job="varlogs"} |= "error"'
+gcx logs query -d <loki-uid> '{job="varlogs"} |= "error"'
 
 # Doesn't contain text
-gcx logs query <loki-uid> '{job="varlogs"} != "debug"'
+gcx logs query -d <loki-uid> '{job="varlogs"} != "debug"'
 
 # Regex match in log line
-gcx logs query <loki-uid> '{job="varlogs"} |~ "error|exception"'
+gcx logs query -d <loki-uid> '{job="varlogs"} |~ "error|exception"'
 
 # JSON parsing
-gcx logs query <loki-uid> '{job="varlogs"} | json | level="error"'
+gcx logs query -d <loki-uid> '{job="varlogs"} | json | level="error"'
 ```
 
 ### Log Range Queries
@@ -180,11 +180,11 @@ Query logs over time:
 
 ```bash
 # Last hour of logs
-gcx logs query <loki-uid> '{job="varlogs"}' \
+gcx logs query -d <loki-uid> '{job="varlogs"}' \
   --from now-1h --to now
 
 # Specific time range
-gcx logs query <loki-uid> '{namespace="prod"}' \
+gcx logs query -d <loki-uid> '{namespace="prod"}' \
   --from 2026-03-01T00:00:00Z --to 2026-03-01T12:00:00Z
 ```
 
@@ -194,17 +194,17 @@ Calculate metrics from logs:
 
 ```bash
 # Log rate per second
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   'rate({job="varlogs"}[5m])' \
   --from now-1h --to now --step 1m
 
 # Sum of log rates
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   'sum(rate({namespace="production"}[5m]))' \
   --from now-6h --to now --step 5m
 
 # Count by level
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   'sum by(level) (rate({job="varlogs"} | json [5m]))' \
   --from now-1h --to now --step 1m
 ```
@@ -213,12 +213,12 @@ gcx logs query <loki-uid> \
 
 ```bash
 # Visualize log volume
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   'sum(rate({job="varlogs"}[5m]))' \
   --from now-6h --to now --step 5m -o graph
 
 # Error rate over time
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   'sum(rate({job="app"} |= "error" [5m]))' \
   --from now-24h --to now --step 15m -o graph
 ```
@@ -257,7 +257,7 @@ gcx metrics labels -d <uid> --label job
 
 3. Query specific job:
 ```bash
-gcx metrics query <uid> 'up{job="prometheus"}'
+gcx metrics query -d <uid> 'up{job="prometheus"}'
 ```
 
 4. Explore available metrics for that job:
@@ -302,7 +302,7 @@ gcx logs series -d <loki-uid> -M '{job="varlogs"}'
 
 4. Query specific stream:
 ```bash
-gcx logs query <loki-uid> '{job="varlogs",namespace="prod"}'
+gcx logs query -d <loki-uid> '{job="varlogs",namespace="prod"}'
 ```
 
 ## Output Formats
@@ -312,7 +312,7 @@ gcx logs query <loki-uid> '{job="varlogs",namespace="prod"}'
 For Prometheus queries, shows metric values in a table:
 
 ```bash
-gcx metrics query <uid> 'up'
+gcx metrics query -d <uid> 'up'
 # Output:
 # METRIC    VALUE  TIMESTAMP
 # up{...}   1      2026-03-03T12:00:00Z
@@ -321,7 +321,7 @@ gcx metrics query <uid> 'up'
 For Loki queries, shows raw log lines:
 
 ```bash
-gcx logs query <loki-uid> '{job="varlogs"}' --from now-5m --to now
+gcx logs query -d <loki-uid> '{job="varlogs"}' --from now-5m --to now
 # Output:
 # ts=2026-03-06T10:30:00Z level=info msg="request completed" status=200
 # ts=2026-03-06T10:30:01Z level=error msg="connection refused"
@@ -332,7 +332,7 @@ gcx logs query <loki-uid> '{job="varlogs"}' --from now-5m --to now
 Shows all labels plus the log line:
 
 ```bash
-gcx logs query <loki-uid> '{job="varlogs"}' --from now-5m --to now -o wide
+gcx logs query -d <loki-uid> '{job="varlogs"}' --from now-5m --to now -o wide
 # Output:
 # CLUSTER        DETECTED_LEVEL  JOB       NAMESPACE  POD          LINE
 # dev-eu-west-2  info            varlogs   prod       app-abc123   ts=2026-03-06T10:30:00Z...
@@ -344,7 +344,7 @@ gcx logs query <loki-uid> '{job="varlogs"}' --from now-5m --to now -o wide
 Machine-readable for scripting:
 
 ```bash
-gcx metrics query <uid> 'up' -o json
+gcx metrics query -d <uid> 'up' -o json
 ```
 
 JSON structure:
@@ -366,20 +366,20 @@ JSON structure:
 ### YAML Format
 
 ```bash
-gcx metrics query <uid> 'up' -o yaml
+gcx metrics query -d <uid> 'up' -o yaml
 ```
 
 ### Piping to jq
 
 ```bash
 # Extract specific fields
-gcx metrics query <uid> 'up' -o json | jq '.data.result[].metric.job'
+gcx metrics query -d <uid> 'up' -o json | jq '.data.result[].metric.job'
 
 # Filter results
-gcx metrics query <uid> 'up' -o json | jq '.data.result[] | select(.value[1] == "1")'
+gcx metrics query -d <uid> 'up' -o json | jq '.data.result[] | select(.value[1] == "1")'
 
 # Count results
-gcx metrics query <uid> 'up' -o json | jq '.data.result | length'
+gcx metrics query -d <uid> 'up' -o json | jq '.data.result | length'
 ```
 
 ## Scripting Patterns
@@ -391,7 +391,7 @@ gcx metrics query <uid> 'up' -o json | jq '.data.result | length'
 DS_UID=$(gcx datasources list --type prometheus -o json | jq -r '.datasources[0].uid')
 
 # Check if service is up
-UP=$(gcx metrics query $DS_UID 'up{job="critical-service"}' -o json | \
+UP=$(gcx metrics query -d $DS_UID 'up{job="critical-service"}' -o json | \
      jq -r '.data.result[0].value[1]')
 
 if [ "$UP" != "1" ]; then
@@ -414,7 +414,7 @@ QUERIES=(
 
 for query in "${QUERIES[@]}"; do
   echo "Query: $query"
-  gcx metrics query $DS_UID "$query" --from now-5m --to now -o graph
+  gcx metrics query -d $DS_UID "$query" --from now-5m --to now -o graph
   echo "---"
 done
 ```
@@ -423,10 +423,10 @@ done
 
 ```bash
 # Export query results to file
-gcx metrics query <uid> 'cpu_usage' --from now-24h --to now --step 1m -o json > cpu-data.json
+gcx metrics query -d <uid> 'cpu_usage' --from now-24h --to now --step 1m -o json > cpu-data.json
 
 # Convert to CSV (using jq)
-gcx metrics query <uid> 'up' -o json | \
+gcx metrics query -d <uid> 'up' -o json | \
   jq -r '.data.result[] | [.metric.job, .value[0], .value[1]] | @csv' > results.csv
 ```
 
@@ -437,27 +437,27 @@ gcx metrics query <uid> 'up' -o json | \
 1. **Use specific label filters**: More specific = faster queries
 ```bash
 # Slow
-gcx metrics query <uid> 'http_requests_total'
+gcx metrics query -d <uid> 'http_requests_total'
 
 # Fast
-gcx metrics query <uid> 'http_requests_total{job="api",status="200"}'
+gcx metrics query -d <uid> 'http_requests_total{job="api",status="200"}'
 ```
 
 2. **Choose appropriate range selectors**:
 ```bash
 # For rate queries, match range to step
-gcx metrics query <uid> 'rate(requests[5m])' --step 5m
+gcx metrics query -d <uid> 'rate(requests[5m])' --step 5m
 
 # Don't use huge ranges for instant queries
-gcx metrics query <uid> 'rate(requests[5m])'  # Good
-gcx metrics query <uid> 'rate(requests[1h])'  # Usually unnecessary
+gcx metrics query -d <uid> 'rate(requests[5m])'  # Good
+gcx metrics query -d <uid> 'rate(requests[1h])'  # Usually unnecessary
 ```
 
 3. **Limit time ranges**:
 ```bash
 # Query only what you need
-gcx metrics query <uid> 'up' --from now-1h --to now  # Good
-gcx metrics query <uid> 'up' --from now-30d --to now  # Slow
+gcx metrics query -d <uid> 'up' --from now-1h --to now  # Good
+gcx metrics query -d <uid> 'up' --from now-30d --to now  # Slow
 ```
 
 ### Loki Performance
@@ -465,17 +465,17 @@ gcx metrics query <uid> 'up' --from now-30d --to now  # Slow
 1. **Use indexed labels for filtering**:
 ```bash
 # Fast (uses indexed labels)
-gcx logs query <loki-uid> '{job="varlogs",namespace="prod"}'
+gcx logs query -d <loki-uid> '{job="varlogs",namespace="prod"}'
 
 # Slow (line filter, not indexed)
-gcx logs query <loki-uid> '{job="varlogs"} |= "namespace:prod"'
+gcx logs query -d <loki-uid> '{job="varlogs"} |= "namespace:prod"'
 ```
 
 2. **Limit log queries**:
 ```bash
 # The default limit is 1000 lines
 # For production, consider increasing or narrowing time range
-gcx logs query <loki-uid> '{job="varlogs"}' --from now-5m --to now
+gcx logs query -d <loki-uid> '{job="varlogs"}' --from now-5m --to now
 ```
 
 ### Querying at Scale
@@ -484,12 +484,12 @@ Loki metric queries (`rate()`, `count_over_time()`, etc.) produce one series per
 
 ```bash
 # BAD — one series per pod/namespace/level/... combination
-gcx logs query <loki-uid> 'count_over_time({job="app"} [5m])'
+gcx logs query -d <loki-uid> 'count_over_time({job="app"} [5m])'
 
 # GOOD — aggregate down to what you need
-gcx logs query <loki-uid> 'sum(count_over_time({job="app"} [5m]))'
-gcx logs query <loki-uid> 'sum by(level) (count_over_time({job="app"} | json [5m]))'
-gcx logs query <loki-uid> 'topk(10, sum by(pod) (rate({job="app"} [5m])))'
+gcx logs query -d <loki-uid> 'sum(count_over_time({job="app"} [5m]))'
+gcx logs query -d <loki-uid> 'sum by(level) (count_over_time({job="app"} | json [5m]))'
+gcx logs query -d <loki-uid> 'topk(10, sum by(pod) (rate({job="app"} [5m])))'
 ```
 
 Rule of thumb: if your query uses `rate()`, `count_over_time()`, or `bytes_over_time()`, wrap it with `sum()`, `sum by(label)`, or `topk()`.
@@ -516,14 +516,14 @@ Common mistakes:
 
 ```bash
 # Check if services are up
-gcx metrics query <uid> 'up{job="critical-service"}' | grep "1"
+gcx metrics query -d <uid> 'up{job="critical-service"}' | grep "1"
 ```
 
 ### Error Rate
 
 ```bash
 # HTTP error rate
-gcx metrics query <uid> 'rate(http_requests_total{status=~"5.."}[5m])' \
+gcx metrics query -d <uid> 'rate(http_requests_total{status=~"5.."}[5m])' \
   --from now-1h --to now --step 1m -o graph
 ```
 
@@ -531,14 +531,14 @@ gcx metrics query <uid> 'rate(http_requests_total{status=~"5.."}[5m])' \
 
 ```bash
 # Memory usage by pod
-gcx metrics query <uid> 'container_memory_usage_bytes{namespace="production"}' -o graph
+gcx metrics query -d <uid> 'container_memory_usage_bytes{namespace="production"}' -o graph
 ```
 
 ### Log Analysis
 
 ```bash
 # Count errors in last hour
-gcx logs query <loki-uid> \
+gcx logs query -d <loki-uid> \
   'count_over_time({job="app"} |= "error" [1h])'
 ```
 
@@ -546,6 +546,6 @@ gcx logs query <loki-uid> \
 
 ```bash
 # Compare current vs 24h ago
-gcx metrics query <uid> 'rate(requests[5m])' --from now-1h --to now -o json > now.json
-gcx metrics query <uid> 'rate(requests[5m])' --from now-25h --to now-24h -o json > yesterday.json
+gcx metrics query -d <uid> 'rate(requests[5m])' --from now-1h --to now -o json > now.json
+gcx metrics query -d <uid> 'rate(requests[5m])' --from now-25h --to now-24h -o json > yesterday.json
 ```

--- a/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
@@ -89,6 +89,25 @@ gcx supports multiple time formats:
 --from 1709280000 --to 1709366400
 ```
 
+### Valid vs Invalid Time Expressions
+
+```bash
+# Valid relative expressions
+--from now-6h --to now
+--from now-1h --to now-30m
+--step 5m
+--step 300s
+
+# Valid absolute timestamp
+--from 2026-03-01T00:00:00Z
+
+# INVALID — cannot chain subtractions
+--from now-6h-1m     # Use now-361m instead
+
+# INVALID — step needs a unit suffix
+--step 300           # Use --step 300s or --step 5m
+```
+
 ### Step Interval
 
 Choose step based on time range:

--- a/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
@@ -17,7 +17,8 @@ gcx datasources list --type prometheus
 gcx datasources list --type loki
 
 # Get JSON for scripting
-DS_UID=$(gcx datasources list --type prometheus -o json | jq -r '.datasources[0].uid')
+DS_UID=$(gcx datasources list --type prometheus -o json 2>/dev/null | \
+  python3 -c "import json,sys; print(json.load(sys.stdin)['datasources'][0]['uid'])")
 ```
 
 ### Setting Default Datasource
@@ -369,18 +370,24 @@ JSON structure:
 gcx metrics query -d <uid> 'up' -o yaml
 ```
 
-### Piping to jq
+### Field Selection
+
+Use `--json` to select fields without external tools:
 
 ```bash
-# Extract specific fields
-gcx metrics query -d <uid> 'up' -o json | jq '.data.result[].metric.job'
+# Discover available fields
+gcx metrics query -d <uid> 'up' --json list
 
-# Filter results
-gcx metrics query -d <uid> 'up' -o json | jq '.data.result[] | select(.value[1] == "1")'
+# Select specific fields
+gcx metrics query -d <uid> 'up' --json metric,value
 
-# Count results
-gcx metrics query -d <uid> 'up' -o json | jq '.data.result | length'
+# For complex filtering, pipe to python3 (jq may not be installed)
+gcx metrics query -d <uid> 'up' -o json 2>/dev/null | \
+  python3 -c "import json,sys; data=json.load(sys.stdin); print(len(data['data']['result']))"
 ```
+
+> **Piping caution**: Never use `2>&1` when piping gcx JSON output — gcx writes
+> hints to stderr that break JSON parsers. Use `2>/dev/null` instead.
 
 ## Scripting Patterns
 
@@ -388,11 +395,12 @@ gcx metrics query -d <uid> 'up' -o json | jq '.data.result | length'
 
 ```bash
 #!/bin/bash
-DS_UID=$(gcx datasources list --type prometheus -o json | jq -r '.datasources[0].uid')
+DS_UID=$(gcx datasources list --type prometheus -o json 2>/dev/null | \
+  python3 -c "import json,sys; print(json.load(sys.stdin)['datasources'][0]['uid'])")
 
 # Check if service is up
-UP=$(gcx metrics query -d $DS_UID 'up{job="critical-service"}' -o json | \
-     jq -r '.data.result[0].value[1]')
+UP=$(gcx metrics query -d $DS_UID 'up{job="critical-service"}' -o json 2>/dev/null | \
+     python3 -c "import json,sys; print(json.load(sys.stdin)['data']['result'][0]['value'][1])")
 
 if [ "$UP" != "1" ]; then
   echo "ALERT: critical-service is down!"
@@ -425,9 +433,9 @@ done
 # Export query results to file
 gcx metrics query -d <uid> 'cpu_usage' --from now-24h --to now --step 1m -o json > cpu-data.json
 
-# Convert to CSV (using jq)
-gcx metrics query -d <uid> 'up' -o json | \
-  jq -r '.data.result[] | [.metric.job, .value[0], .value[1]] | @csv' > results.csv
+# Convert to CSV
+gcx metrics query -d <uid> 'up' -o json 2>/dev/null | \
+  python3 -c "import json,sys,csv; w=csv.writer(sys.stdout); data=json.load(sys.stdin); [w.writerow([r['metric'].get('job',''),r['value'][0],r['value'][1]]) for r in data['data']['result']]" > results.csv
 ```
 
 ## Performance Tips

--- a/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
@@ -557,3 +557,9 @@ gcx logs query -d <loki-uid> \
 gcx metrics query -d <uid> 'rate(requests[5m])' --from now-1h --to now -o json > now.json
 gcx metrics query -d <uid> 'rate(requests[5m])' --from now-25h --to now-24h -o json > yesterday.json
 ```
+
+## Tempo / TraceQL Patterns
+
+For TraceQL query syntax, `traces query` vs `traces get`, attribute scoping
+rules, and common trace search patterns, see
+[`traceql-patterns.md`](traceql-patterns.md).

--- a/claude-plugin/skills/debug-with-grafana/references/traceql-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/traceql-patterns.md
@@ -1,0 +1,113 @@
+# TraceQL Patterns
+
+Workflow and query patterns for Tempo trace search using gcx.
+
+## Commands
+
+| Command | Purpose | Positional arg |
+|---------|---------|----------------|
+| `gcx traces query [TRACEQL]` | Search traces by TraceQL expression | TraceQL expression |
+| `gcx traces get TRACE_ID` | Fetch a single trace by ID | Trace ID (required) |
+| `gcx traces labels` | List label names or values | None |
+
+All commands accept `-d <uid>` for the Tempo datasource UID. `search` is an
+alias for `query`. There are no `--tag` or `--service` flags — use TraceQL
+expressions instead.
+
+## Workflow: discover → search → get
+
+### 1. Discover available tags
+
+Start by listing tags, then inspect values for the ones that scope the problem.
+
+```bash
+gcx traces labels -d <tempo-uid>
+gcx traces labels -d <tempo-uid> -l resource.service.name
+gcx traces labels -d <tempo-uid> -l span.http.status_code
+```
+
+> **Common mistake**: `-l service.name` will fail — Tempo parses the dot as an
+> identifier boundary. Always fully qualify: `-l resource.service.name`.
+> Use `--scope resource` to filter labels by scope.
+
+### 2. Search for traces
+
+Build a scoped TraceQL query using the tag values you discovered. Scope as
+tightly as possible — start with `resource.service.name` and add filters.
+
+```bash
+# Find error traces for a service
+gcx traces query -d <tempo-uid> \
+  '{ resource.service.name = "<service>" && status = error }' \
+  --from now-1h --to now
+
+# Find slow traces
+gcx traces query -d <tempo-uid> \
+  '{ resource.service.name = "<service>" && duration > 1s }' \
+  --from now-1h --to now
+
+# Filter by span name
+gcx traces query -d <tempo-uid> \
+  '{ resource.service.name = "<service>" && name = "GET /api/users" }' \
+  --from now-1h --to now
+
+# Filter by HTTP status
+gcx traces query -d <tempo-uid> \
+  '{ resource.service.name = "<service>" && span.http.status_code >= 500 }' \
+  --from now-1h --to now
+
+# Filter by root span service name
+gcx traces query -d <tempo-uid> \
+  '{ trace:rootService = "<service>" }' \
+  --from now-1h --to now
+```
+
+If a query fails, go back to `traces labels` and check `--help` instead of
+guessing further.
+
+### 3. Get a specific trace
+
+Once you have a trace ID from search results or from a log `trace_id` field:
+
+```bash
+gcx traces get -d <tempo-uid> <trace-id>
+gcx traces get -d <tempo-uid> <trace-id> --llm    # LLM-friendly format
+gcx traces get -d <tempo-uid> <trace-id> -o json
+```
+
+The trace ID is a positional argument — do not use `--trace-id` (it doesn't
+exist).
+
+## Attribute scoping rules
+
+Tempo requires scoped attribute names. Unscoped dotted names cause parse errors.
+
+**Custom attributes** use dot syntax:
+- `resource.service.name`, `resource.k8s.namespace.name`
+- `span.http.status_code`, `span.http.route`, `span.db.system`
+
+**Intrinsics** use unscoped shorthand or colon syntax:
+
+| Intrinsic | Type | Notes |
+|-----------|------|-------|
+| `name` / `span:name` | string | span operation name |
+| `duration` / `span:duration` | duration | span duration |
+| `status` / `span:status` | enum | `error`, `ok`, or `unset` |
+| `kind` / `span:kind` | enum | `server`, `client`, `producer`, `consumer`, `internal` |
+| `trace:rootName` | string | name of the root span |
+| `trace:rootService` | string | service name of the root span |
+| `trace:duration` | duration | end-to-end trace duration |
+
+```bash
+# WRONG — unscoped custom attribute
+gcx traces query -d <tempo-uid> '{ service.name = "api" }'
+
+# CORRECT — resource-scoped
+gcx traces query -d <tempo-uid> '{ resource.service.name = "api" }'
+
+# WRONG — these identifiers don't exist
+gcx traces query -d <tempo-uid> '{ rootServiceName = "api" }'
+
+# CORRECT — trace-scoped intrinsic
+gcx traces query -d <tempo-uid> '{ trace:rootService = "api" }'
+```

--- a/claude-plugin/skills/explore-datasources/SKILL.md
+++ b/claude-plugin/skills/explore-datasources/SKILL.md
@@ -102,7 +102,7 @@ After setting defaults, you can omit the `-d` flag in datasource commands.
 **Actions:**
 1. List Prometheus datasources: `gcx datasources list --type prometheus`
 2. Get datasource UID from output
-3. Search for HTTP metrics: `gcx metrics metadata -d <uid> -o json | jq '.data | to_entries[] | select(.key | contains("http"))'`
+3. Search for HTTP metrics: `gcx metrics metadata -d <uid> -o json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin)['data']; [print(k,d[k][0]['type'],d[k][0]['help']) for k in sorted(d) if 'http' in k]"`
 4. Get details on specific metric: `gcx metrics metadata -d <uid> --metric http_requests_total`
 
 **Result:** Metric name, type (counter/gauge), and help text showing what the metric measures.
@@ -219,7 +219,7 @@ All commands support `-o json` or `-o yaml` for programmatic use:
 gcx metrics labels -d <uid> -o json
 
 # Example: Count total metrics
-gcx metrics metadata -d <uid> -o json | jq '.data | length'
+gcx metrics metadata -d <uid> -o json 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin)['data']))"
 ```
 
 Default output is `table` format for human readability.

--- a/claude-plugin/skills/explore-datasources/SKILL.md
+++ b/claude-plugin/skills/explore-datasources/SKILL.md
@@ -71,10 +71,10 @@ Once you've identified available data, verify with a test query.
 
 ```bash
 # For Prometheus - instant query
-gcx metrics query <datasource-uid> 'up'
+gcx metrics query -d <datasource-uid> 'up'
 
 # For Prometheus - range query
-gcx metrics query <datasource-uid> 'rate(http_requests_total[5m])' --from now-1h --to now
+gcx metrics query -d <datasource-uid> 'rate(http_requests_total[5m])' --from now-1h --to now
 ```
 
 **Expected output:** Table showing metric values with labels and timestamps.

--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -53,10 +53,10 @@ right group:
 | Synthetic Monitoring checks | `synthetic-monitoring` | `gcx synthetic-monitoring checks list` |
 | IRM (OnCall + Incidents) | `irm` | `gcx irm oncall schedules list`, `gcx irm incidents list` |
 | k6 load tests, projects, runs | `k6` | `gcx k6 load-tests list` |
-| PromQL / Adaptive Metrics | `metrics` | `gcx metrics query 'up'` |
-| LogQL / Adaptive Logs | `logs` | `gcx logs query '{app="foo"}'` |
+| PromQL / Adaptive Metrics | `metrics` | `gcx metrics query -d <uid> 'up'` |
+| LogQL / Adaptive Logs | `logs` | `gcx logs query -d <uid> '{app="foo"}'` |
 | Profiling (Pyroscope) | `profiles` | `gcx profiles query` |
-| Tracing (Tempo) | `traces` | `gcx traces query` |
+| Tracing (Tempo) | `traces` | `gcx traces query -d <uid> '{ status = error }'` |
 | Datasource info and queries | `datasources` | `gcx datasources list` |
 | Fleet pipelines, collectors | `fleet` | `gcx fleet pipelines list` |
 | Knowledge Graph (Asserts) | `kg` | `gcx kg entities list` |


### PR DESCRIPTION

I ran gcx with gcx skills installed through [o11y-bench](https://github.com/grafana/o11y-bench), and analysed the agent activity to pick up any obvious issues with how the agent used gcx. I ran the full test suite with sonnet 4.6 and opus 4.6, and used the activity logs from both test suites to identify issues.

The full reports are attached at the bottom of this PR description.


Here are the errors, collected into categories, with the most impactful issues first:

| # | Error Category | Opus (occurrences / trials) | Sonnet (occurrences / trials) | Combined | Impact |
|---|------|------|--------|----------|--------|
| 1 | **Datasource UID as positional arg** | 131 / 70 | 211 / 129 | **342 / ~170 trials** | HIGH — blocks query entirely |
| 2 | **gcx JSON output pipe failure** | 76 / 48 | 127 / 81 | **203 / ~110 trials** | HIGH — wastes tokens retrying |
| 3 | **Unknown flags/commands** | 30 / 24 | 70 / 61 | **100 / ~70 trials** | MEDIUM — recoverable but wasteful |
| 4 | **Missing tool: jq** | 16 / 16 | 0 / 0 | **16 / 16 trials** | MEDIUM — skills teach jq patterns |
| 5 | **Tempo label name format** | 9 / 8 | 7 / 5 | **16 / ~12 trials** | MEDIUM — Tempo-specific syntax trap |
| 6 | **TraceQL syntax errors** | 4 / 2 | 4 / 4 | **8 / ~6 trials** | LOW — infrequent |
| 7 | **LogQL empty selector `{}`** | 3 / 3 | 5 / 5 | **8 / ~7 trials** | LOW — Loki rejects `{}` |
| 8 | **Missing tool: go** | 5 / 4 | 0 / 0 | **5 / 4 trials** | LOW — env issue |
| 9 | **Invalid time formats** | incl. in #1 | 10 / ~8 | ~10 | LOW — `now-6h-1m`, `now-11h50m` |
| 10 | **Dashboard apiVersion mismatch** | 2 / 2 | 7 / 6 | **9 / ~7 trials** | LOW — `v1alpha1` vs live API |


Here are examples of each of those categories of error:

**Datasource UID as positional arg** 
this is just wrong - there is no way to set a positional uid for `gcx metrics query`

```
$ gcx metrics query prometheus 'up{job="user-service"}' --from now-24h --to now --step 5m -o json
{"error":{"summary":"Accepts between 0 and 1 arg(s), received 2","exitCode":1}}
```

**JSON pipe failure (2>&1 + hint line)**
The agent pipes gcx output to python with 2>&1, which merges the stderr hint into stdout:
```
  $ gcx metrics query -d prometheus 'up' -o json 2>&1
  hint: use --json list to discover fields, --json field1,field2 to select — no external parsing needed
  {
    "status": "success",
    "data": { ... }
  }

  python3 -c "json.load(sys.stdin)" fails because the hint line is not valid JSON.
```
  **Unknown flags/commands**
```
  $ gcx metrics search -d prometheus 'cache' -o json
  {"error":{"summary":"Unknown shorthand flag","exitCode":1,"details":"'d' in -d"}}
```
  **Invalid query params**
step needs to be e.g. `5m` in this example
```
$ gcx metrics query -d prometheus 'rate(http_requests_total[5m])' --since 2h --step 300 -o json
  {"error":{"summary":"Invalid --step duration","exitCode":1}}
```
  **LogQL parse errors**
```
  $ gcx logs query -d loki '{} |~ "deploy|deployment|version|release" | json' --from 2026-04-29T02:00:00Z --to now -o json
  {"error":{"summary":"Invalid LogQL query","exitCode":1,"details":"parse error : queries require at least one regexp or equality matcher..."}}
```
  **Tempo label name format**
Needs `--label resource.service.name` in this example, so it knows its a resource attribute
```
  $ gcx traces labels -d tempo --label service.name -o json
  {"error":{"summary":"Invalid Tempo tag values query","exitCode":1,"details":"please provide a valid tagName: failed to parse identifier service.name: parse error at line 1, col 2: unknown identifier: service..."}}
```
  **TraceQL syntax errors**
```
  $ gcx traces query -d tempo '{http.status_code=500}' --limit 10 -o json
  {"error":{"summary":"Invalid TraceQL query","exitCode":1,"details":"invalid TraceQL query: parse error at line 1, col 2: unknown identifier: http..."}}
```


This PR contains changes to the gcx skills to try and mitigate some of these issues. Here are the changes:
  - fix all signal query examples to use -d flag for datasource UID instead of passing it as a positional arg (which fails with "Accepts between 0 and 1 arg(s)")
  - replace jq piping patterns with python3 -c / --json field selectors; add guidance against 2>&1 when piping JSON output
  - add TraceQL skill content: new traceql-patterns.md reference, Step 5b in the debug workflow, attribute scoping rules, traces query vs traces get
  - add LogQL {} selector pitfall, time format valid/invalid reference, and Failure Mode 6 to error recovery

  
After making the changes, I ran the full test suite against the updated skills, to measure the difference. Here are the top-level results:

  o11y-bench results (Sonnet 4.6, 189 trials, before & after skills change)
```
  ┌──────────────────────┬────────┬───────┬────────┐
  │        Metric        │ Before │ After │ Change │
  ├──────────────────────┼────────┼───────┼────────┤
  │ Mean score           │ 0.615  │ 0.623 │ +0.008 │
  ├──────────────────────┼────────┼───────┼────────┤
  │ Total errors         │ 555    │ 211   │ -62%   │
  ├──────────────────────┼────────┼───────┼────────┤
  │ Trials with ≥1 error │ 157    │ 82    │ -48%   │
  ├──────────────────────┼────────┼───────┼────────┤
  │ Timeouts             │ 8      │ 3     │ -63%   │
  └──────────────────────┴────────┴───────┴────────┘
```

And here are the counts of each category of error after the skills change:
```  ┌───────────────────────────────────────┬────────┬───────┬────────┐
  │                 Error                 │ Before │ After │ Change │
  ├───────────────────────────────────────┼────────┼───────┼────────┤
  │ Datasource UID as positional arg      │ 241    │ 27    │ -89%   │
  ├───────────────────────────────────────┼────────┼───────┼────────┤
  │ JSON pipe failures (2>&1 + hint line) │ 127    │ 24    │ -81%   │
  ├───────────────────────────────────────┼────────┼───────┼────────┤
  │ Unknown flags/commands                │ 66     │ 24    │ -64%   │
  ├───────────────────────────────────────┼────────┼───────┼────────┤
  │ Invalid query params                  │ 12     │ 2     │ -83%   │
  ├───────────────────────────────────────┼────────┼───────┼────────┤
  │ LogQL parse errors                    │ 5      │ 0     │ -100%  │
  ├───────────────────────────────────────┼────────┼───────┼────────┤
  │ Tempo label name format               │ 7      │ 7     │ 0%     │
  ├───────────────────────────────────────┼────────┼───────┼────────┤
  │ TraceQL syntax errors                 │ 4      │ 6     │ +50%   │
  └───────────────────────────────────────┴────────┴───────┴────────┘
```

Other notes

- Tempo label scoping errors didn't improve — the model's prior that service.name is valid (from OpenTelemetry conventions) overrides the positive examples. Added explicit "common mistake" callouts in a follow-up commit to address this, but I haven't run the test suite again to measure.

#### Reviewing this PR

The fix for each category of error has been put into a separate commit:

  a296a82b — fix positional UID syntax: bulk find-and-replace of gcx metrics query <uid> → gcx metrics query -d <uid> across all skill files. ~95% of query examples had the wrong form. This was the single biggest error source (342 occurrences across both models).

  e09d7117 — replace jq with python3/--json: skills taught | jq patterns (43 occurrences) but jq wasn't available in the bench env. Agents fell back to | python3 with 2>&1, which merged gcx's stderr hint into the JSON stream. Replaced jq examples and added a piping callout.

  9e25c151 — add TraceQL content: no skill covered traces before, so agents invented flags like --tag, --service, --trace-id. New traceql-patterns.md reference + Step 5b in the debug workflow with correct TraceQL syntax, attribute scoping, and label discovery.

  dc15ed4d — LogQL/time pitfalls + error recovery: agents used {} as a catch-all (Loki rejects it), tried now-6h-1m (invalid), and --step 300 (needs unit). Added callouts and a new failure mode to error-recovery.md.

---

Here are the raw run reports:

[original sonnet 4.6 run run_report.html](https://github.com/user-attachments/files/27434337/run_report.html)
[original opus 4.6 run_report.html](https://github.com/user-attachments/files/27434366/run_report.html)
[updated skills sonnet 4.6 run_report.html](https://github.com/user-attachments/files/27434379/run_report.html)

