### PR TITLE
feat(diag): log failed agent invocations for capability-gap analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ internal/
 │   ├── assistanthttp/  Base HTTP client for grafana-assistant-app plugin API
 │   └── investigations/ Investigation CRUD commands, table codecs, API client
 ├── agent/       Agent mode detection, command annotations, known-resource registry with operation hints
+├── agentlog/    Agent invocation failure logger (opt-in JSONL disk log, XDG state dir — wired into handleError in cmd/gcx/main.go)
 ├── style/       Terminal styling (Grafana Neon Dark theme, TableBuilder, ASCII banner, glamour help)
 ├── terminal/    TTY/pipe detection (IsPiped, NoTruncate, Detect) for output suppression
 ├── linter/      Linting engine (Rego rules, report aggregation, PromQL/LogQL validators)

--- a/cmd/gcx/main.go
+++ b/cmd/gcx/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/grafana/gcx/internal/agentlog"
 	internalconfig "github.com/grafana/gcx/internal/config"
 	appversion "github.com/grafana/gcx/internal/version"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/mod/module"
 )
 
@@ -36,16 +38,22 @@ func main() {
 	// root.Command() because io.Options.BindFlags() reads agent.IsAgentMode()
 	// during command construction to set the default output format.
 	preParseAgentFlag()
-	agentlog.Configure(loadDiagnosticsConfig())
+	if agent.IsAgentMode() {
+		agentlog.Configure(loadDiagnosticsConfig())
+	}
 
 	formattedVersion := formatVersion()
 	appversion.Set(version)
 	appversion.SetBuildInfo(commit, date)
-	if err := root.ValidateArgs(root.Command(formattedVersion), os.Args[1:]); err != nil {
-		handleError(err)
+
+	cmd := root.Command(formattedVersion)
+	boolFlags := collectBoolFlags(cmd)
+	subCmds := collectSubCmds(cmd)
+	if err := root.ValidateArgs(cmd, os.Args[1:]); err != nil {
+		handleError(err, boolFlags, subCmds)
 	}
 
-	handleError(root.Command(formattedVersion).ExecuteContext(ctx))
+	handleError(cmd.ExecuteContext(ctx), boolFlags, subCmds)
 }
 
 // preParseAgentFlag scans os.Args for --agent / --agent=true / --agent=false
@@ -69,7 +77,7 @@ func preParseAgentFlag() {
 	}
 }
 
-func handleError(err error) {
+func handleError(err error, boolFlags map[string]struct{}, subCmds map[string]bool) {
 	if err == nil {
 		return
 	}
@@ -95,9 +103,9 @@ func handleError(err error) {
 		_ = agentlog.Append(agentlog.Entry{
 			Timestamp: time.Now(),
 			Version:   appversion.Get(),
-			Args:      agentlog.StripArgValues(os.Args[1:]),
+			Args:      agentlog.StripArgValues(os.Args[1:], boolFlags, subCmds),
 			ErrorKind: agentlog.KindFromExitCode(exitCode),
-			Error:     detailedErr.Summary,
+			Error:     truncate(detailedErr.Summary, 200),
 			ExitCode:  exitCode,
 		})
 	}
@@ -116,28 +124,66 @@ func handleError(err error) {
 	os.Exit(exitCode)
 }
 
-// loadDiagnosticsConfig reads diagnostics settings from the gcx config file on
-// a best-effort basis. Any error (missing file, parse failure) returns a
-// disabled config so the caller is never affected by a config read failure.
-func loadDiagnosticsConfig() agentlog.Config {
-	// GCX_CONFIG bypasses discovery, mirroring LoadLayered behaviour.
-	if explicit := os.Getenv(internalconfig.ConfigFileEnvVar); explicit != "" {
-		return loadDiagnosticsFromFile(explicit)
+// collectBoolFlags walks the full command tree and returns a set of all boolean
+// flag names (and their shorthands) so StripArgValues can skip consuming the
+// next token for flags that take no value argument.
+func collectBoolFlags(cmd *cobra.Command) map[string]struct{} {
+	bools := make(map[string]struct{})
+	var visit func(c *cobra.Command)
+	visit = func(c *cobra.Command) {
+		addBools := func(f *pflag.Flag) {
+			if f.Value.Type() == "bool" || f.NoOptDefVal != "" {
+				bools[f.Name] = struct{}{}
+				if f.Shorthand != "" {
+					bools[f.Shorthand] = struct{}{}
+				}
+			}
+		}
+		c.Flags().VisitAll(addBools)
+		c.PersistentFlags().VisitAll(addBools)
+		for _, sub := range c.Commands() {
+			visit(sub)
+		}
 	}
-	sources, err := internalconfig.DiscoverSources()
-	if err != nil || len(sources) == 0 {
-		return agentlog.Config{}
-	}
-	// Use the highest-priority source (last in slice — local overrides user overrides system).
-	return loadDiagnosticsFromFile(sources[len(sources)-1].Path)
+	visit(cmd)
+	return bools
 }
 
-func loadDiagnosticsFromFile(path string) agentlog.Config {
-	cfg, err := internalconfig.Load(context.Background(), func() (string, error) { return path, nil })
+// collectSubCmds walks the full command tree and returns a set of all registered
+// subcommand names (and aliases). Positional args matching this set are safe to
+// log; all other positionals are treated as values and redacted.
+func collectSubCmds(cmd *cobra.Command) map[string]bool {
+	names := make(map[string]bool)
+	var walk func(*cobra.Command)
+	walk = func(c *cobra.Command) {
+		for _, sub := range c.Commands() {
+			names[sub.Name()] = true
+			for _, alias := range sub.Aliases {
+				names[alias] = true
+			}
+			walk(sub)
+		}
+	}
+	walk(cmd)
+	return names
+}
+
+// loadDiagnosticsConfig reads diagnostics settings from the layered gcx config.
+// Any error (missing file, parse failure) returns a disabled config so the
+// caller is never affected by a config read failure.
+func loadDiagnosticsConfig() agentlog.Config {
+	cfg, err := internalconfig.LoadLayered(context.Background(), "")
 	if err != nil || cfg.Diagnostics == nil || !cfg.Diagnostics.AgentInvocationLog {
 		return agentlog.Config{}
 	}
 	return agentlog.Config{Enabled: true, LogDir: cfg.Diagnostics.LogDir}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
 }
 
 func formatVersion() string {

--- a/cmd/gcx/main.go
+++ b/cmd/gcx/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/cmd/gcx/root"
 	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/agentlog"
+	internalconfig "github.com/grafana/gcx/internal/config"
 	appversion "github.com/grafana/gcx/internal/version"
 	"golang.org/x/mod/module"
 )
@@ -34,6 +36,7 @@ func main() {
 	// root.Command() because io.Options.BindFlags() reads agent.IsAgentMode()
 	// during command construction to set the default output format.
 	preParseAgentFlag()
+	agentlog.Configure(loadDiagnosticsConfig())
 
 	formattedVersion := formatVersion()
 	appversion.Set(version)
@@ -88,6 +91,17 @@ func handleError(err error) {
 		exitCode = *detailedErr.ExitCode
 	}
 
+	if agent.IsAgentMode() && agentlog.IsEnabled() {
+		_ = agentlog.Append(agentlog.Entry{
+			Timestamp: time.Now(),
+			Version:   appversion.Get(),
+			Args:      agentlog.StripArgValues(os.Args[1:]),
+			ErrorKind: agentlog.KindFromExitCode(exitCode),
+			Error:     detailedErr.Summary,
+			ExitCode:  exitCode,
+		})
+	}
+
 	if agent.IsAgentMode() || root.IsJSONFlagActive() {
 		// Machine consumers get JSON on stdout only — the human-formatted
 		// stderr error is noise for agents and scripts.
@@ -100,6 +114,30 @@ func handleError(err error) {
 	}
 
 	os.Exit(exitCode)
+}
+
+// loadDiagnosticsConfig reads diagnostics settings from the gcx config file on
+// a best-effort basis. Any error (missing file, parse failure) returns a
+// disabled config so the caller is never affected by a config read failure.
+func loadDiagnosticsConfig() agentlog.Config {
+	// GCX_CONFIG bypasses discovery, mirroring LoadLayered behaviour.
+	if explicit := os.Getenv(internalconfig.ConfigFileEnvVar); explicit != "" {
+		return loadDiagnosticsFromFile(explicit)
+	}
+	sources, err := internalconfig.DiscoverSources()
+	if err != nil || len(sources) == 0 {
+		return agentlog.Config{}
+	}
+	// Use the highest-priority source (last in slice — local overrides user overrides system).
+	return loadDiagnosticsFromFile(sources[len(sources)-1].Path)
+}
+
+func loadDiagnosticsFromFile(path string) agentlog.Config {
+	cfg, err := internalconfig.Load(context.Background(), func() (string, error) { return path, nil })
+	if err != nil || cfg.Diagnostics == nil || !cfg.Diagnostics.AgentInvocationLog {
+		return agentlog.Config{}
+	}
+	return agentlog.Config{Enabled: true, LogDir: cfg.Diagnostics.LogDir}
 }
 
 func formatVersion() string {

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -28,6 +28,7 @@ gcx/
 │
 ├── internal/                 # All non-public packages (Go enforced)
 │   ├── agent/                # Agent-mode detection, command annotations, known-resource registry with operation hints
+│   ├── agentlog/             # Agent invocation failure logger (opt-in JSONL disk log, XDG state dir — wired into handleError in cmd/gcx/main.go)
 │   ├── auth/                 # OAuth PKCE flow, token refresh transport
 │   │   └── adaptive/         # Shared adaptive telemetry auth (GCOM caching, Basic auth)
 │   ├── cloud/                # Grafana Cloud stack discovery via GCOM API

--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -125,4 +125,14 @@ contexts:
           string
 # CurrentContext is the name of the context currently in use.
 current-context: string
+# Diagnostics holds optional local diagnostic settings. All features are off by default.
+diagnostics: 
+  # DiagnosticsConfig controls optional local diagnostic features.
+  # AgentInvocationLog enables logging of failed agent-mode invocations to disk.
+  # Off by default. When enabled, errors from agent-driven gcx calls are written
+  # to LogDir (JSONL format) for capability-gap analysis.
+  agent-invocation-log: bool
+  # LogDir overrides the output directory for agent invocation log files.
+  # Default: $XDG_STATE_HOME/gcx/ (platform-specific).
+  log-dir: string
 ```

--- a/internal/agentlog/agentlog.go
+++ b/internal/agentlog/agentlog.go
@@ -1,6 +1,7 @@
 package agentlog
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -10,7 +11,12 @@ import (
 	"github.com/adrg/xdg"
 )
 
-const logFileName = "agent-invocation-errors.jsonl"
+const (
+	logFileName = "agent-invocation-errors.jsonl"
+	// maxEntries is the maximum number of JSONL records kept in the log file.
+	// When exceeded, the oldest entries are dropped to stay at this limit.
+	maxEntries = 1000
+)
 
 // Config holds agentlog settings extracted from DiagnosticsConfig at startup.
 type Config struct {
@@ -46,7 +52,7 @@ type Entry struct {
 	ExitCode  int       `json:"exit_code"`
 }
 
-// Append writes entry to the log file as a JSONL record.
+// Append writes entry to the log file as a JSONL record and trims to maxEntries.
 func Append(entry Entry) error {
 	path := LogPath()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -61,9 +67,36 @@ func Append(entry Entry) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	_, err = f.Write(data)
-	return err
+	_, writeErr := f.Write(data)
+	f.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return trimLog(path, maxEntries)
+}
+
+// trimLog keeps only the last max entries in the JSONL file, dropping the oldest.
+// It is a no-op when the file has max or fewer entries.
+func trimLog(path string, limit int) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	count := bytes.Count(data, []byte("\n"))
+	if count <= limit {
+		return nil
+	}
+	drop := count - limit
+	for i := range data {
+		if data[i] == '\n' {
+			drop--
+			if drop == 0 {
+				data = data[i+1:]
+				break
+			}
+		}
+	}
+	return os.WriteFile(path, data, 0o600)
 }
 
 // StripArgValues returns a copy of args with all flag values replaced by

--- a/internal/agentlog/agentlog.go
+++ b/internal/agentlog/agentlog.go
@@ -24,7 +24,7 @@ type Config struct {
 	LogDir  string
 }
 
-//nolint:gochecknoglobals
+//nolint:gochecknoglobals // set once from Configure() before any command runs; no concurrent access
 var cfg Config
 
 // Configure sets agentlog options. Called once from main() before command execution.
@@ -55,7 +55,7 @@ type Entry struct {
 // Append writes entry to the log file as a JSONL record and trims to maxEntries.
 func Append(entry Entry) error {
 	path := LogPath()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 	data, err := json.Marshal(entry)
@@ -103,13 +103,21 @@ func trimLog(path string, limit int) error {
 // "<value>", keeping only command names and flag names. This prevents any
 // user-supplied data (including secrets) from reaching the log.
 //
+// boolFlags is the set of flag names (without leading dashes) that take no
+// value argument; these flags do not consume the following token.
+//
+// subCmds is the set of all registered subcommand names. Positional args that
+// match a known subcommand are kept verbatim; all other positionals (resource
+// names, key-value arguments, etc.) are replaced with "<value>". Passing nil
+// keeps all positionals (for callers without access to the command tree).
+//
 // Rules:
-//   - "--flag=value" becomes "--flag=<value>"
-//   - "--flag value" becomes "--flag", "<value>" (next token is the value)
-//   - "-f value" follows the same rule for single-char flags
+//   - "--flag=value" or "-f=value" becomes "--flag=<value>" / "-f=<value>"
+//   - "-fVALUE" (POSIX attached form) becomes "-f<value>"
+//   - "--flag value" or "-f value" becomes "--flag", "<value>" unless flag is in boolFlags
 //   - args after "--" are dropped entirely
-//   - standalone positional args (subcommand names, resource kinds) are kept
-func StripArgValues(args []string) []string {
+//   - positionals matching a known subcommand are kept; others become "<value>"
+func StripArgValues(args []string, boolFlags map[string]struct{}, subCmds map[string]bool) []string {
 	out := make([]string, 0, len(args))
 	consumeNext := false
 	for _, arg := range args {
@@ -122,17 +130,37 @@ func StripArgValues(args []string) []string {
 			continue
 		}
 		isLongFlag := strings.HasPrefix(arg, "--")
-		isShortFlag := len(arg) == 2 && arg[0] == '-' && arg[1] != '-'
-		if isLongFlag || isShortFlag {
-			if before, _, ok := strings.Cut(arg, "="); ok {
-				out = append(out, before+"=<value>")
-			} else {
+		isShortFlag := len(arg) >= 2 && arg[0] == '-' && arg[1] != '-'
+		if !isLongFlag && !isShortFlag {
+			// Positional: keep if it is a known subcommand name, redact otherwise.
+			if subCmds == nil || subCmds[arg] {
 				out = append(out, arg)
-				consumeNext = true
+			} else {
+				out = append(out, "<value>")
 			}
-		} else {
-			out = append(out, arg)
 			consumeNext = false
+			continue
+		}
+		if before, _, ok := strings.Cut(arg, "="); ok {
+			// --flag=value or -f=value
+			out = append(out, before+"=<value>")
+			continue
+		}
+		if isShortFlag && len(arg) > 2 {
+			// -fVALUE: value directly attached, no separator
+			out = append(out, "-"+string(arg[1])+"<value>")
+			continue
+		}
+		// Bare --flag or -f: consume the next token unless it is a boolean flag.
+		out = append(out, arg)
+		var name string
+		if isShortFlag {
+			name = string(arg[1]) // -f → "f"
+		} else {
+			name = strings.TrimPrefix(arg, "--") // --flag → "flag"
+		}
+		if _, isBool := boolFlags[name]; !isBool {
+			consumeNext = true
 		}
 	}
 	return out

--- a/internal/agentlog/agentlog.go
+++ b/internal/agentlog/agentlog.go
@@ -1,0 +1,122 @@
+package agentlog
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/adrg/xdg"
+)
+
+const logFileName = "agent-invocation-errors.jsonl"
+
+// Config holds agentlog settings extracted from DiagnosticsConfig at startup.
+type Config struct {
+	Enabled bool
+	LogDir  string
+}
+
+//nolint:gochecknoglobals
+var cfg Config
+
+// Configure sets agentlog options. Called once from main() before command execution.
+func Configure(c Config) { cfg = c }
+
+// IsEnabled reports whether agent invocation logging is active.
+func IsEnabled() bool { return cfg.Enabled }
+
+// LogPath returns the full path to the log file.
+func LogPath() string {
+	dir := cfg.LogDir
+	if dir == "" {
+		dir = filepath.Join(xdg.StateHome, "gcx")
+	}
+	return filepath.Join(dir, logFileName)
+}
+
+// Entry is one logged failed invocation.
+type Entry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Version   string    `json:"version"`
+	Args      []string  `json:"args"`
+	ErrorKind string    `json:"error_kind"`
+	Error     string    `json:"error"`
+	ExitCode  int       `json:"exit_code"`
+}
+
+// Append writes entry to the log file as a JSONL record.
+func Append(entry Entry) error {
+	path := LogPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(data)
+	return err
+}
+
+// StripArgValues returns a copy of args with all flag values replaced by
+// "<value>", keeping only command names and flag names. This prevents any
+// user-supplied data (including secrets) from reaching the log.
+//
+// Rules:
+//   - "--flag=value" becomes "--flag=<value>"
+//   - "--flag value" becomes "--flag", "<value>" (next token is the value)
+//   - "-f value" follows the same rule for single-char flags
+//   - args after "--" are dropped entirely
+//   - standalone positional args (subcommand names, resource kinds) are kept
+func StripArgValues(args []string) []string {
+	out := make([]string, 0, len(args))
+	consumeNext := false
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
+		if consumeNext {
+			out = append(out, "<value>")
+			consumeNext = false
+			continue
+		}
+		isLongFlag := strings.HasPrefix(arg, "--")
+		isShortFlag := len(arg) == 2 && arg[0] == '-' && arg[1] != '-'
+		if isLongFlag || isShortFlag {
+			if before, _, ok := strings.Cut(arg, "="); ok {
+				out = append(out, before+"=<value>")
+			} else {
+				out = append(out, arg)
+				consumeNext = true
+			}
+		} else {
+			out = append(out, arg)
+			consumeNext = false
+		}
+	}
+	return out
+}
+
+// KindFromExitCode maps an exit code to a human-readable error kind.
+func KindFromExitCode(code int) string {
+	switch code {
+	case 2:
+		return "usage_error"
+	case 3:
+		return "auth_failure"
+	case 4:
+		return "partial_failure"
+	case 6:
+		return "version_incompatible"
+	default:
+		return "error"
+	}
+}

--- a/internal/agentlog/agentlog_test.go
+++ b/internal/agentlog/agentlog_test.go
@@ -1,0 +1,174 @@
+package agentlog_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/agentlog"
+)
+
+func TestStripArgValues(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "command only",
+			in:   []string{"kg", "list"},
+			want: []string{"kg", "list"},
+		},
+		{
+			name: "long flag space separated",
+			in:   []string{"kg", "list", "--format", "json"},
+			want: []string{"kg", "list", "--format", "<value>"},
+		},
+		{
+			name: "long flag equals form",
+			in:   []string{"kg", "list", "--format=json"},
+			want: []string{"kg", "list", "--format=<value>"},
+		},
+		{
+			name: "short flag space separated",
+			in:   []string{"kg", "list", "-n", "myns"},
+			want: []string{"kg", "list", "-n", "<value>"},
+		},
+		{
+			name: "token flag value hidden",
+			in:   []string{"--token", "mysecrettoken"},
+			want: []string{"--token", "<value>"},
+		},
+		{
+			name: "token flag equals value hidden",
+			in:   []string{"--token=mysecrettoken"},
+			want: []string{"--token=<value>"},
+		},
+		{
+			name: "double dash stops processing",
+			in:   []string{"run", "--", "--format", "json"},
+			want: []string{"run"},
+		},
+		{
+			name: "no args",
+			in:   []string{},
+			want: []string{},
+		},
+		{
+			name: "flag at end with no value",
+			in:   []string{"list", "--json"},
+			want: []string{"list", "--json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agentlog.StripArgValues(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(got)=%d, len(want)=%d: got=%v, want=%v", len(got), len(tt.want), got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("got[%d]=%q, want[%d]=%q", i, got[i], i, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestKindFromExitCode(t *testing.T) {
+	tests := []struct {
+		code int
+		want string
+	}{
+		{0, "error"}, // success shouldn't be logged but map defensively
+		{1, "error"},
+		{2, "usage_error"},
+		{3, "auth_failure"},
+		{4, "partial_failure"},
+		{6, "version_incompatible"},
+		{99, "error"},
+	}
+	for _, tt := range tests {
+		if got := agentlog.KindFromExitCode(tt.code); got != tt.want {
+			t.Errorf("KindFromExitCode(%d)=%q, want %q", tt.code, got, tt.want)
+		}
+	}
+}
+
+func TestAppend(t *testing.T) {
+	dir := t.TempDir()
+	agentlog.Configure(agentlog.Config{Enabled: true, LogDir: dir})
+	t.Cleanup(func() { agentlog.Configure(agentlog.Config{}) })
+
+	e1 := agentlog.Entry{
+		Timestamp: time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC),
+		Version:   "0.2.12",
+		Args:      []string{"kg", "nonexistent"},
+		ErrorKind: "usage_error",
+		Error:     `unknown command "nonexistent" for "gcx kg"`,
+		ExitCode:  2,
+	}
+	e2 := agentlog.Entry{
+		Timestamp: time.Date(2026, 5, 6, 11, 0, 0, 0, time.UTC),
+		Version:   "0.2.12",
+		Args:      []string{"metrics", "query", "--datasource=<value>"},
+		ErrorKind: "error",
+		Error:     "datasource not found",
+		ExitCode:  1,
+	}
+
+	if err := agentlog.Append(e1); err != nil {
+		t.Fatalf("first Append: %v", err)
+	}
+	if err := agentlog.Append(e2); err != nil {
+		t.Fatalf("second Append: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "agent-invocation-errors.jsonl"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+
+	lines := splitLines(data)
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %d", len(lines))
+	}
+
+	var got1, got2 agentlog.Entry
+	if err := json.Unmarshal([]byte(lines[0]), &got1); err != nil {
+		t.Fatalf("parse line 1: %v", err)
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &got2); err != nil {
+		t.Fatalf("parse line 2: %v", err)
+	}
+
+	if got1.ErrorKind != "usage_error" {
+		t.Errorf("line1 error_kind=%q, want usage_error", got1.ErrorKind)
+	}
+	if got2.ExitCode != 1 {
+		t.Errorf("line2 exit_code=%d, want 1", got2.ExitCode)
+	}
+
+	// Verify file permissions.
+	info, _ := os.Stat(filepath.Join(dir, "agent-invocation-errors.jsonl"))
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("file mode=%o, want 0600", info.Mode().Perm())
+	}
+}
+
+func splitLines(data []byte) []string {
+	var out []string
+	start := 0
+	for i, b := range data {
+		if b == '\n' {
+			if i > start {
+				out = append(out, string(data[start:i]))
+			}
+			start = i + 1
+		}
+	}
+	return out
+}

--- a/internal/agentlog/agentlog_test.go
+++ b/internal/agentlog/agentlog_test.go
@@ -11,61 +11,138 @@ import (
 )
 
 func TestStripArgValues(t *testing.T) {
+	noBools := map[string]struct{}{}
+	bools := map[string]struct{}{"agent": {}, "json": {}, "v": {}}
+	// Subset of real gcx subcommand names used in tests below.
+	subCmds := map[string]bool{
+		"kg": true, "list": true, "get": true, "dashboards": true,
+		"config": true, "set": true, "run": true,
+	}
+
 	tests := []struct {
-		name string
-		in   []string
-		want []string
+		name      string
+		in        []string
+		boolFlags map[string]struct{}
+		subCmds   map[string]bool
+		want      []string
 	}{
 		{
-			name: "command only",
-			in:   []string{"kg", "list"},
-			want: []string{"kg", "list"},
+			name:      "command only",
+			in:        []string{"kg", "list"},
+			boolFlags: noBools,
+			subCmds:   subCmds,
+			want:      []string{"kg", "list"},
 		},
 		{
-			name: "long flag space separated",
-			in:   []string{"kg", "list", "--format", "json"},
-			want: []string{"kg", "list", "--format", "<value>"},
+			name:      "long flag space separated",
+			in:        []string{"kg", "list", "--format", "json"},
+			boolFlags: noBools,
+			subCmds:   subCmds,
+			want:      []string{"kg", "list", "--format", "<value>"},
 		},
 		{
-			name: "long flag equals form",
-			in:   []string{"kg", "list", "--format=json"},
-			want: []string{"kg", "list", "--format=<value>"},
+			name:      "long flag equals form",
+			in:        []string{"kg", "list", "--format=json"},
+			boolFlags: noBools,
+			subCmds:   subCmds,
+			want:      []string{"kg", "list", "--format=<value>"},
 		},
 		{
-			name: "short flag space separated",
-			in:   []string{"kg", "list", "-n", "myns"},
-			want: []string{"kg", "list", "-n", "<value>"},
+			name:      "short flag space separated",
+			in:        []string{"kg", "list", "-n", "myns"},
+			boolFlags: noBools,
+			subCmds:   subCmds,
+			want:      []string{"kg", "list", "-n", "<value>"},
 		},
 		{
-			name: "token flag value hidden",
-			in:   []string{"--token", "mysecrettoken"},
-			want: []string{"--token", "<value>"},
+			name:      "short flag equals form",
+			in:        []string{"-t=mysecrettoken"},
+			boolFlags: noBools,
+			subCmds:   nil,
+			want:      []string{"-t=<value>"},
 		},
 		{
-			name: "token flag equals value hidden",
-			in:   []string{"--token=mysecrettoken"},
-			want: []string{"--token=<value>"},
+			name:      "short flag attached value (POSIX)",
+			in:        []string{"-tmysecrettoken"},
+			boolFlags: noBools,
+			subCmds:   nil,
+			want:      []string{"-t<value>"},
 		},
 		{
-			name: "double dash stops processing",
-			in:   []string{"run", "--", "--format", "json"},
-			want: []string{"run"},
+			name:      "token flag value hidden",
+			in:        []string{"--token", "mysecrettoken"},
+			boolFlags: noBools,
+			subCmds:   nil,
+			want:      []string{"--token", "<value>"},
 		},
 		{
-			name: "no args",
-			in:   []string{},
-			want: []string{},
+			name:      "token flag equals value hidden",
+			in:        []string{"--token=mysecrettoken"},
+			boolFlags: noBools,
+			subCmds:   nil,
+			want:      []string{"--token=<value>"},
 		},
 		{
-			name: "flag at end with no value",
-			in:   []string{"list", "--json"},
-			want: []string{"list", "--json"},
+			name:      "double dash stops processing",
+			in:        []string{"run", "--", "--format", "json"},
+			boolFlags: noBools,
+			subCmds:   subCmds,
+			want:      []string{"run"},
+		},
+		{
+			name:      "no args",
+			in:        []string{},
+			boolFlags: noBools,
+			subCmds:   nil,
+			want:      []string{},
+		},
+		{
+			name:      "flag at end with no value",
+			in:        []string{"list", "--json"},
+			boolFlags: noBools,
+			subCmds:   subCmds,
+			want:      []string{"list", "--json"},
+		},
+		{
+			name:      "bool flag does not consume next positional",
+			in:        []string{"--agent", "get", "dashboards"},
+			boolFlags: bools,
+			subCmds:   subCmds,
+			want:      []string{"--agent", "get", "dashboards"},
+		},
+		{
+			name:      "bool flag at end",
+			in:        []string{"list", "--json"},
+			boolFlags: bools,
+			subCmds:   subCmds,
+			want:      []string{"list", "--json"},
+		},
+		{
+			name:      "short bool flag does not consume next positional",
+			in:        []string{"-v", "get", "dashboards"},
+			boolFlags: bools,
+			subCmds:   subCmds,
+			want:      []string{"-v", "get", "dashboards"},
+		},
+		{
+			name:      "positional value after subcommand chain is redacted",
+			in:        []string{"config", "set", "cloud.token", "glsa_MYTOKEN"},
+			boolFlags: noBools,
+			subCmds:   subCmds,
+			want:      []string{"config", "set", "<value>", "<value>"},
+		},
+		{
+			name:      "nil subCmds keeps all positionals (backward compat)",
+			in:        []string{"config", "set", "cloud.token", "glsa_MYTOKEN"},
+			boolFlags: noBools,
+			subCmds:   nil,
+			want:      []string{"config", "set", "cloud.token", "glsa_MYTOKEN"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := agentlog.StripArgValues(tt.in)
+			got := agentlog.StripArgValues(tt.in, tt.boolFlags, tt.subCmds)
 			if len(got) != len(tt.want) {
 				t.Fatalf("len(got)=%d, len(want)=%d: got=%v, want=%v", len(got), len(tt.want), got, tt.want)
 			}

--- a/internal/agentlog/trim_test.go
+++ b/internal/agentlog/trim_test.go
@@ -1,0 +1,77 @@
+//nolint:testpackage // needs access to unexported trimLog
+package agentlog
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTrimLog(t *testing.T) {
+	write := func(t *testing.T, path string, n int) {
+		t.Helper()
+		var buf bytes.Buffer
+		for i := range n {
+			fmt.Fprintf(&buf, `{"i":%d}`+"\n", i)
+		}
+		if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	countLines := func(t *testing.T, path string) int {
+		t.Helper()
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		return bytes.Count(data, []byte("\n"))
+	}
+	firstLine := func(t *testing.T, path string) string {
+		t.Helper()
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		line, _, _ := bytes.Cut(data, []byte("\n"))
+		return string(line)
+	}
+
+	t.Run("no-op when under limit", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "log.jsonl")
+		write(t, path, 5)
+		if err := trimLog(path, 10); err != nil {
+			t.Fatal(err)
+		}
+		if got := countLines(t, path); got != 5 {
+			t.Errorf("lines=%d, want 5", got)
+		}
+	})
+
+	t.Run("no-op at exactly limit", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "log.jsonl")
+		write(t, path, 10)
+		if err := trimLog(path, 10); err != nil {
+			t.Fatal(err)
+		}
+		if got := countLines(t, path); got != 10 {
+			t.Errorf("lines=%d, want 10", got)
+		}
+	})
+
+	t.Run("trims oldest entries", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "log.jsonl")
+		write(t, path, 15)
+		if err := trimLog(path, 10); err != nil {
+			t.Fatal(err)
+		}
+		if got := countLines(t, path); got != 10 {
+			t.Errorf("lines=%d, want 10", got)
+		}
+		// Entry i=5 is the first kept (0-4 dropped).
+		if got := firstLine(t, path); got != `{"i":5}` {
+			t.Errorf("first line=%q, want {\"i\":5}", got)
+		}
+	})
+}

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -26,6 +26,27 @@ func MergeConfigs(base, over Config) Config {
 		}
 	}
 
+	// Diagnostics: propagate from any layer that enables it.
+	if over.Diagnostics != nil {
+		if result.Diagnostics == nil {
+			result.Diagnostics = over.Diagnostics
+		} else {
+			merged := mergeDiagnosticsConfig(result.Diagnostics, over.Diagnostics)
+			result.Diagnostics = &merged
+		}
+	}
+
+	return result
+}
+
+func mergeDiagnosticsConfig(base, over *DiagnosticsConfig) DiagnosticsConfig {
+	result := *base
+	if over.AgentInvocationLog {
+		result.AgentInvocationLog = true
+	}
+	if over.LogDir != "" {
+		result.LogDir = over.LogDir
+	}
 	return result
 }
 

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -177,3 +177,33 @@ contexts:
 	// current-context: "prod" from system, not overridden (user/local don't set it).
 	assert.Equal(t, "prod", merged.CurrentContext)
 }
+
+func TestMergeConfigs_DiagnosticsLayering(t *testing.T) {
+	// User config enables the feature; local config omits the diagnostics block.
+	// The user-layer value must survive.
+	userCfg := config.Config{
+		Diagnostics: &config.DiagnosticsConfig{AgentInvocationLog: true},
+	}
+	localCfg := config.Config{} // no Diagnostics block
+
+	merged := config.MergeConfigs(userCfg, localCfg)
+
+	require.NotNil(t, merged.Diagnostics, "diagnostics from user layer must survive")
+	assert.True(t, merged.Diagnostics.AgentInvocationLog)
+}
+
+func TestMergeConfigs_DiagnosticsOverride(t *testing.T) {
+	// Local config can override individual diagnostics fields.
+	userCfg := config.Config{
+		Diagnostics: &config.DiagnosticsConfig{AgentInvocationLog: true, LogDir: "/user/logs"},
+	}
+	localCfg := config.Config{
+		Diagnostics: &config.DiagnosticsConfig{LogDir: "/local/logs"},
+	}
+
+	merged := config.MergeConfigs(userCfg, localCfg)
+
+	require.NotNil(t, merged.Diagnostics)
+	assert.True(t, merged.Diagnostics.AgentInvocationLog, "feature stays enabled from user layer")
+	assert.Equal(t, "/local/logs", merged.Diagnostics.LogDir, "local override wins for LogDir")
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -31,6 +31,21 @@ type Config struct {
 
 	// CurrentContext is the name of the context currently in use.
 	CurrentContext string `json:"current-context" yaml:"current-context"`
+
+	// Diagnostics holds optional local diagnostic settings. All features are off by default.
+	Diagnostics *DiagnosticsConfig `json:"diagnostics,omitempty" yaml:"diagnostics,omitempty"`
+}
+
+// DiagnosticsConfig controls optional local diagnostic features.
+type DiagnosticsConfig struct {
+	// AgentInvocationLog enables logging of failed agent-mode invocations to disk.
+	// Off by default. When enabled, errors from agent-driven gcx calls are written
+	// to LogDir (JSONL format) for capability-gap analysis.
+	AgentInvocationLog bool `json:"agent-invocation-log,omitempty" yaml:"agent-invocation-log,omitempty"`
+
+	// LogDir overrides the output directory for agent invocation log files.
+	// Default: $XDG_STATE_HOME/gcx/ (platform-specific).
+	LogDir string `json:"log-dir,omitempty" yaml:"log-dir,omitempty"`
 }
 
 func (config *Config) HasContext(name string) bool {

--- a/internal/providers/slo/definitions/status.go
+++ b/internal/providers/slo/definitions/status.go
@@ -184,7 +184,7 @@ func ComputeStatus(s Slo, sli *float64, objective float64) string {
 	if s.ReadOnly != nil && s.ReadOnly.Status != nil {
 		switch strings.ToLower(s.ReadOnly.Status.Type) {
 		case "creating", "updating", "deleting", "error":
-			return strings.Title(s.ReadOnly.Status.Type) //nolint:staticcheck
+			return strings.Title(s.ReadOnly.Status.Type) //nolint:staticcheck // deprecated but no x/text dep here
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds opt-in JSONL logging of failed agent-mode gcx invocations to disk, so unknown commands, unknown flags, and other capability gaps can be discovered and analysed
- Off by default — enable via `diagnostics.agent-invocation-log: true` in the gcx config file
- All flag values are stripped before logging; only command names and flag names are recorded — no secrets or user data reach the log

## Configuration

```yaml
diagnostics:
  agent-invocation-log: true
  log-dir: /optional/override   # defaults to $XDG_STATE_HOME/gcx/
```

Log file: `$XDG_STATE_HOME/gcx/agent-invocation-errors.jsonl`

Example log line:
```json
{"timestamp":"2026-05-06T10:30:00Z","version":"0.2.12","args":["kg","search","--format=<value>"],"error_kind":"usage_error","error":"unknown command \"search\" for \"gcx kg\"","exit_code":2}
```

## Implementation

- `internal/agentlog/` — new package: `Entry` type, `Append()`, `StripArgValues()` (strips all flag values to `<value>`), `KindFromExitCode()`
- `internal/config/types.go` — new `DiagnosticsConfig` struct + `Diagnostics` field on `Config`
- `cmd/gcx/main.go` — best-effort config load before `ValidateArgs` + log call in `handleError()` (covers both pre-validation and runtime errors)
- Config reference auto-regenerated

## Test plan

- [ ] `go test ./internal/agentlog/...` — unit tests for `StripArgValues`, `Append`, `KindFromExitCode`
- [ ] Enable in config and trigger `gcx kg nonexistent` with `CLAUDECODE=1`; confirm JSONL entry appears
- [ ] Confirm `--token secret` becomes `--token <value>` in the log (no secret leakage)
- [ ] Confirm no log is written when `diagnostics.agent-invocation-log` is absent
- [ ] Confirm no log is written outside agent mode (`CLAUDECODE=` unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)