### PR TITLE
fix(adapter): honor DryRun option in typedAdapter.Delete

### DIFF
--- a/internal/resources/adapter/typed.go
+++ b/internal/resources/adapter/typed.go
@@ -425,9 +425,13 @@ func (a *typedAdapter[T]) Update(ctx context.Context, obj *unstructured.Unstruct
 	return &u, nil
 }
 
-func (a *typedAdapter[T]) Delete(ctx context.Context, name string, _ metav1.DeleteOptions) error {
+func (a *typedAdapter[T]) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	if a.crud.DeleteFn == nil {
 		return errors.ErrUnsupported
+	}
+
+	if isDryRun(opts.DryRun) {
+		return nil
 	}
 
 	return a.crud.DeleteFn(ctx, name)

--- a/internal/resources/adapter/typed_test.go
+++ b/internal/resources/adapter/typed_test.go
@@ -697,6 +697,33 @@ func TestTypedCRUD_UpdateDryRun(t *testing.T) {
 	})
 }
 
+func TestTypedCRUD_DeleteDryRun(t *testing.T) {
+	deleteCalled := false
+	crud := newWidgetCRUD(nil)
+	crud.DeleteFn = func(_ context.Context, _ string) error {
+		deleteCalled = true
+		return nil
+	}
+
+	a := crud.AsAdapter()
+
+	t.Run("skips DeleteFn when DryRun is set", func(t *testing.T) {
+		deleteCalled = false
+		err := a.Delete(t.Context(), "w-target", metav1.DeleteOptions{
+			DryRun: []string{metav1.DryRunAll},
+		})
+		require.NoError(t, err)
+		assert.False(t, deleteCalled, "DeleteFn must not be called during dry run")
+	})
+
+	t.Run("calls DeleteFn without DryRun", func(t *testing.T) {
+		deleteCalled = false
+		err := a.Delete(t.Context(), "w-target", metav1.DeleteOptions{})
+		require.NoError(t, err)
+		assert.True(t, deleteCalled, "DeleteFn must be called without dry run")
+	})
+}
+
 func TestTypedCRUD_DryRunWithValidateFn(t *testing.T) {
 	t.Run("calls ValidateFn on Create dry run", func(t *testing.T) {
 		validateCalled := false


### PR DESCRIPTION
## Summary
- `typedAdapter.Delete` was discarding `metav1.DeleteOptions` entirely (the parameter was `_`), causing real deletes to execute even when `--dry-run` was set
- Added the same `isDryRun` guard that `Create` and `Update` already use — returns `nil` on dry-run, matching server-side k8s dry-run semantics
- Added `TestTypedCRUD_DeleteDryRun` regression test mirroring the existing `TestTypedCRUD_CreateDryRun` and `TestTypedCRUD_UpdateDryRun`

## Changes
- `internal/resources/adapter/typed.go:428` — renamed `_` param to `opts` and added `isDryRun(opts.DryRun)` short-circuit
- `internal/resources/adapter/typed_test.go` — added `TestTypedCRUD_DeleteDryRun` with sub-tests for both the dry-run guard and normal delete path

## Test Plan
- [x] `go test ./internal/resources/adapter/ -run TestTypedCRUD_DeleteDryRun -v` — new test passes
- [x] `go test ./internal/resources/adapter/ -run "TestTypedCRUD_(Create|Update|Delete|DryRun)" -v` — all dry-run tests pass
- [x] `go test -mod=mod ./internal/resources/...` — full resources package passes
- [ ] Note: `mise run lint` is failing in main due to pre-existing vendor drift (`vendor/modules.txt` out of sync with go.mod); not caused by this change

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)