### PR TITLE
fix(config): prevent env var secrets from being persisted to config file

### DIFF
--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -381,7 +381,7 @@ func resolveAssistantClientOptions(ctx context.Context, configOpts *cmdconfig.Op
 	switch {
 	case grafana.ProxyEndpoint != "" && grafana.OAuthToken != "":
 		// OAuth path: direct API via ProxyEndpoint
-		refresher := buildTokenRefresher(ctx, configOpts, &cfg, cfg.CurrentContext, grafana)
+		refresher := buildTokenRefresher(ctx, configOpts, cfg.CurrentContext, grafana)
 		return assistant.ClientOptions{
 			GrafanaURL:     grafana.Server,
 			Token:          grafana.OAuthToken,
@@ -426,7 +426,7 @@ func newAssistantStreamingHTTPClient(ctx context.Context, streamTimeoutSeconds i
 const refreshThreshold = 5 * time.Minute
 
 // buildTokenRefresher creates a TokenRefresher that uses gcx's auth refresh mechanism.
-func buildTokenRefresher(ctx context.Context, configOpts *cmdconfig.Options, cfg *config.Config, ctxName string, grafana *config.GrafanaConfig) assistant.TokenRefresher {
+func buildTokenRefresher(ctx context.Context, configOpts *cmdconfig.Options, ctxName string, grafana *config.GrafanaConfig) assistant.TokenRefresher {
 	var mu sync.Mutex
 	token := grafana.OAuthToken
 	refreshToken := grafana.OAuthRefreshToken
@@ -467,14 +467,20 @@ func buildTokenRefresher(ctx context.Context, configOpts *cmdconfig.Options, cfg
 		}
 
 		// Persist to config
-		persistRefreshedTokens(ctx, configOpts, cfg, ctxName, rr.Token, rr.RefreshToken, rr.ExpiresAt, rr.RefreshExpiresAt)
+		persistRefreshedTokens(ctx, configOpts, ctxName, rr.Token, rr.RefreshToken, rr.ExpiresAt, rr.RefreshExpiresAt)
 
 		return token, nil
 	}
 }
 
-func persistRefreshedTokens(ctx context.Context, configOpts *cmdconfig.Options, cfg *config.Config, ctxName, token, refreshToken, expiresAt, refreshExpiresAt string) {
-	curCtx := cfg.Contexts[ctxName]
+func persistRefreshedTokens(ctx context.Context, configOpts *cmdconfig.Options, ctxName, token, refreshToken, expiresAt, refreshExpiresAt string) {
+	// Re-read from disk so env-sourced secrets (GRAFANA_TOKEN, etc.) are not persisted.
+	source := configOpts.ConfigSource()
+	raw, err := config.Load(ctx, source)
+	if err != nil {
+		return
+	}
+	curCtx := raw.Contexts[ctxName]
 	if curCtx == nil || curCtx.Grafana == nil {
 		return
 	}
@@ -484,7 +490,7 @@ func persistRefreshedTokens(ctx context.Context, configOpts *cmdconfig.Options, 
 	}
 	curCtx.Grafana.OAuthTokenExpiresAt = expiresAt
 	curCtx.Grafana.OAuthRefreshExpiresAt = refreshExpiresAt
-	_ = config.Write(ctx, configOpts.ConfigSource(), *cfg)
+	_ = config.Write(ctx, source, raw)
 }
 
 func parseRFC3339OrZero(s string) time.Time {

--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -470,7 +470,8 @@ func useContextCmd(configOpts *Options) *cobra.Command {
 		Long:    "Set the current context and updates the configuration file.",
 		Example: "\n\tgcx config use-context dev-instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := configOpts.LoadConfigTolerant(cmd.Context())
+			// Load without env overrides so env-sourced secrets are never persisted.
+			cfg, err := config.LoadLayered(cmd.Context(), configOpts.ConfigFile)
 			if err != nil {
 				return err
 			}

--- a/cmd/gcx/config/command_test.go
+++ b/cmd/gcx/config/command_test.go
@@ -1,6 +1,8 @@
 package config_test
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/config"
@@ -57,6 +59,59 @@ contexts:
 		},
 	}
 	newConfigTest.Run(t)
+}
+
+func Test_UseContextCommand_doesNotPersistEnvSecrets(t *testing.T) {
+	cfg := `current-context: old
+contexts:
+  old: {}
+  new: {}`
+
+	for _, tc := range []struct {
+		name   string
+		env    map[string]string
+		secret string
+	}{
+		{
+			name:   "GRAFANA_TOKEN",
+			env:    map[string]string{"GRAFANA_TOKEN": "secret-from-env"},
+			secret: "secret-from-env",
+		},
+		{
+			name:   "GRAFANA_PASSWORD",
+			env:    map[string]string{"GRAFANA_PASSWORD": "pass-from-env"},
+			secret: "pass-from-env",
+		},
+		{
+			name:   "GRAFANA_PROVIDER_SLO_TOKEN",
+			env:    map[string]string{"GRAFANA_PROVIDER_SLO_TOKEN": "slo-secret-from-env"},
+			secret: "slo-secret-from-env",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configFile := testutils.CreateTempFile(t, cfg)
+
+			testutils.CommandTestCase{
+				Cmd:     config.Command(),
+				Command: []string{"use-context", "--config", configFile, "new"},
+				Assertions: []testutils.CommandAssertion{
+					testutils.CommandSuccess(),
+				},
+				Env: tc.env,
+			}.Run(t)
+
+			contents, err := os.ReadFile(configFile)
+			if err != nil {
+				t.Fatalf("reading config file: %v", err)
+			}
+			if strings.Contains(string(contents), tc.secret) {
+				t.Errorf("env secret %q leaked into config file:\n%s", tc.secret, contents)
+			}
+			if !strings.Contains(string(contents), "current-context: new") {
+				t.Errorf("expected current-context to be updated; got:\n%s", contents)
+			}
+		})
+	}
 }
 
 func Test_UseContextCommand_withUnknownContext(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Bug confirmed real:** When `GRAFANA_TOKEN` (or `GRAFANA_PASSWORD`, `GRAFANA_USER`, `GRAFANA_PROVIDER_*`) was set in the environment, `gcx config use-context` leaked those values into the on-disk config YAML.
- **Root cause:** `useContextCmd` called `LoadConfigTolerant`, which merges env vars into the in-memory config via `ParseEnvIntoContext`, then `config.Write` serialised the entire mutated struct to disk.
- **Fix (use-context):** Switch to `config.LoadLayered` with no env overrides — the safe pattern already used by `set`/`unset`.
- **Fix (assistant):** `persistRefreshedTokens` re-reads the raw on-disk config before applying OAuth token updates, so env-sourced secrets in the live session config are never persisted.

## Changes

- `cmd/gcx/config/command.go`: `useContextCmd` now calls `config.LoadLayered` (no env overrides) instead of `LoadConfigTolerant`.
- `cmd/gcx/assistant/command.go`: `persistRefreshedTokens` re-reads from disk; drops the unused `*config.Config` parameter; `buildTokenRefresher` signature updated accordingly.
- `cmd/gcx/config/command_test.go`: Regression tests for `GRAFANA_TOKEN`, `GRAFANA_PASSWORD`, and `GRAFANA_PROVIDER_SLO_TOKEN` — each verifies the env secret is absent from the on-disk file after `use-context`.

## Test Plan

- [x] New regression tests pass (`go test ./cmd/gcx/config/... -run UseContext -v`)
- [x] Full test suite passes (`go test ./...` — exit 0)
- [x] Manual end-to-end verified: `GRAFANA_TOKEN=secret ./bin/gcx config use-context --config <file> new` → secret absent from file
- [x] `go vet` clean on changed packages
- [x] `gofmt` clean on changed files

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)