### PR TITLE
refactor(kg): drop hardcoded inspect filters for raw, agent-friendly view

### DIFF
--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1439,13 +1439,9 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 					Name:  name,
 					Scope: toAnyMap(scope),
 				}},
-				SuggestionSrcEntities:                         []EntityKey{},
-				GroupAssertions:                               true,
-				AlertCategories:                               []string{"saturation", "amend", "anomaly", "failure", "error"},
-				HideAssertionsOlderThanNHours:                 48,
-				HideAssertionsPresentMoreThanPercentageOfTime: 90,
-				IncludeSuggestions:                            true,
-				IncludeRcaPatterns:                            false,
+				SuggestionSrcEntities: []EntityKey{},
+				IncludeSuggestions:    true,
+				IncludeRcaPatterns:    false,
 			}
 			result, err := client.LLMSummary(cmd.Context(), llmReq)
 			if err != nil {

--- a/internal/providers/kg/types.go
+++ b/internal/providers/kg/types.go
@@ -375,7 +375,6 @@ type LLMSummaryRequest struct {
 	EndTime                                       int64       `json:"endTime"`
 	EntityKeys                                    []EntityKey `json:"entityKeys"`
 	SuggestionSrcEntities                         []EntityKey `json:"suggestionSrcEntities"`
-	GroupAssertions                               bool        `json:"groupAssertions"`
 	AlertCategories                               []string    `json:"alertCategories,omitempty"`
 	HideAssertionsOlderThanNHours                 int         `json:"hideAssertionsOlderThanNHours"`
 	HideAssertionsPresentMoreThanPercentageOfTime int         `json:"hideAssertionsPresentMoreThanPercentageOfTime"`


### PR DESCRIPTION
## Summary

- Remove hardcoded noise filters (`HideAssertionsOlderThanNHours=48`, `HideAssertionsPresentMoreThanPercentageOfTime=90`) from `entities inspect` so agents get the unfiltered window by default, matching `insights query` semantics.
- Drop the pinned `AlertCategories` list (`saturation, amend, anomaly, failure, error`) — backend treats an empty set as "all categories," so agents now see the full category surface rather than the workbench-curated subset.
- Remove the unused `GroupAssertions` field — the backend `LlmRcaSummaryReqDto` has no such field and silently drops it via `@JsonIgnoreProperties(ignoreUnknown = true)`.

These were UI-tuned defaults inherited from RCA Workbench. For the agentic use case (where `entities inspect` is the primary single-entity insight surface), opinionated server-side filtering and category narrowing hide data agents may need.

## Test plan
- [x] `mise run build` succeeds
- [x] `mise run tests` passes
- [x] `mise run lint` 0 issues
- [x] `GCX_AGENT_MODE=false mise run reference` produces no drift
- [x] Smoke-test `gcx kg entities inspect <Type>--<Name>` against a real stack — verify the response contains assertions older than 48h and from any tenant-defined category (not just the previously hardcoded five), with no NPE in the suggestion picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)