### PR TITLE
fix(login): suggest config check after login

### DIFF
--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -636,9 +636,9 @@ func existingContextNames(cfg config.Config) []string {
 }
 
 // printResult converts the login.Result into a LoginResult and writes it to
-// stdout using the configured output codec. Advisory prose (the CAP token
-// note) is routed to stderr so that JSON/YAML consumers receive clean,
-// parseable output on stdout.
+// stdout using the configured output codec. Advisory prose (next-step and
+// CAP-token guidance) is routed to stderr so that JSON/YAML consumers receive
+// clean, parseable output on stdout.
 func printResult(cmd *cobra.Command, ioOpts *cmdio.Options, server string, result login.Result) error {
 	if server == "" {
 		server = result.ContextName
@@ -655,11 +655,16 @@ func printResult(cmd *cobra.Command, ioOpts *cmdio.Options, server string, resul
 	if err := ioOpts.Encode(cmd.OutOrStdout(), lr); err != nil {
 		return err
 	}
+
 	// Route advisory prose to stderr. This keeps stdout parseable for
-	// json/yaml consumers while still surfacing the CAP-token guidance
-	// to humans (terminals typically merge stderr into the visible stream).
+	// json/yaml consumers while still surfacing guidance to humans
+	// (terminals typically merge stderr into the visible stream).
+	ew := cmd.ErrOrStderr()
+	if ioOpts.OutputFormat == "text" {
+		fmt.Fprintln(ew)
+		fmt.Fprintln(ew, "Next: gcx config check")
+	}
 	if result.IsCloud && !result.HasCloudToken {
-		ew := cmd.ErrOrStderr()
 		fmt.Fprintln(ew)
 		fmt.Fprintln(ew, "Note: Cloud API commands require a Cloud Access Policy (CAP) token.")
 		fmt.Fprintln(ew, "See: https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/")

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -232,8 +232,8 @@ func TestLoginOptsValidate(t *testing.T) {
 
 // TestPrintResult_TextCodec is a golden comparison that confirms the text
 // codec produces the expected multi-line summary for representative
-// LoginResult fixtures, and that the CAP-token advisory goes to stderr
-// (never stdout) so JSON/YAML consumers receive a clean stream.
+// LoginResult fixtures, and that advisory guidance goes to stderr (never
+// stdout) so JSON/YAML consumers receive a clean stream.
 //
 // Intentionally not run with t.Parallel(): subtests mutate process-level env
 // vars via t.Setenv (to disable agent-mode detection that would otherwise
@@ -266,7 +266,9 @@ func TestPrintResult_TextCodec(t *testing.T) {
   Grafana Cloud: yes
   Stack:       mystack
 `,
-			noStderr: true,
+			wantStderrSubs: []string{
+				"Next: gcx config check",
+			},
 		},
 		{
 			name:   "cloud_without_cap_token_emits_advisory_on_stderr",
@@ -285,6 +287,7 @@ func TestPrintResult_TextCodec(t *testing.T) {
   Stack:       stack
 `,
 			wantStderrSubs: []string{
+				"Next: gcx config check",
 				"Note: Cloud API commands require a Cloud Access Policy (CAP) token.",
 				"grafana.com/docs/grafana-cloud/security-and-account-management",
 				"gcx login --context stack --cloud-token",
@@ -305,7 +308,9 @@ func TestPrintResult_TextCodec(t *testing.T) {
   Version:     11.5.0
   Grafana Cloud: no
 `,
-			noStderr: true,
+			wantStderrSubs: []string{
+				"Next: gcx config check",
+			},
 		},
 		{
 			name:   "empty_server_falls_back_to_context_name",
@@ -320,7 +325,9 @@ func TestPrintResult_TextCodec(t *testing.T) {
   Auth method: token
   Grafana Cloud: no
 `,
-			noStderr: true,
+			wantStderrSubs: []string{
+				"Next: gcx config check",
+			},
 		},
 	}
 


### PR DESCRIPTION
Add a human-readable next step after successful `gcx login`: `gcx config check`.


