### PR TITLE
feat(output): agents codec with temp-file spill for token-efficient agent output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ internal/
 ├── testutils/   Shared test utilities
 ├── server/      Live dev server (Chi router, reverse proxy, websocket reload)
 ├── grafana/     OpenAPI client (health checks, version detection)
-├── output/      Output codec registry (json, yaml, text, wide — field selection, discovery, k8s unstructured handling)
+├── output/      Output codec registry (json, yaml, text, wide, agents — field selection, discovery, k8s unstructured handling, temp-file spill)
 ├── format/      JSON/YAML codecs with format auto-detection
 ├── retry/       Retry transport (429, 502/503/504, transient connection errors — wraps all HTTP tiers)
 ├── httputils/   HTTP helpers (used by serve command's proxy)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -32,7 +32,7 @@ Every command works identically for humans and agents. Agent mode changes defaul
 
 | Aspect | Human mode | Agent mode |
 |--------|-----------|------------|
-| Default output | `text` (table) | `json` |
+| Default output | `text` (table) | `agents` (compact JSON with spill) |
 | Colors | On (TTY) | Off |
 | Truncation | On (TTY) | Off |
 | Prompts | Interactive | Auto-approved |
@@ -58,7 +58,7 @@ Default formats by command type:
 | `list`, `get` | `text` (table) | Human-scannable |
 | `config view` | `yaml` | Config is YAML-native |
 | `push`, `pull`, `delete` | Status messages | Operations, not data |
-| Agent mode | `json` | Machine-parseable |
+| Agent mode | `agents` | Compact JSON with temp-file spill |
 
 The `--json field1,field2` flag selects specific fields. `--json ?` discovers available field paths.
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Use the dedicated [Claude Code plugin](claude-plugin/README.md):
 For example: OpenAI Codex, OpenCode, and Pi. View the skills shipped in the bundle with:
 
 ```sh
-gcx skills list
+gcx agent skills list
 18 skill(s) bundled with gcx
 
 SKILL                      INSTALLED    DESCRIPTION
@@ -273,14 +273,14 @@ gcx-observability          yes          (Experimental) End-to-end observability 
 
 Install the bundle into `~/.agents/skills` with:
 ```sh
-gcx skills install --all
+gcx agent skills install --all
 ```
 
 If your installed skills drift from the bundle shipped in your current `gcx`
 version, `gcx` may show an interactive reminder suggesting:
 
 ```sh
-gcx skills update
+gcx agent skills update
 ```
 
 To disable that reminder entirely, set:

--- a/cmd/gcx/agent/command.go
+++ b/cmd/gcx/agent/command.go
@@ -1,0 +1,17 @@
+// Package agent provides agent utility commands for gcx agent mode.
+package agent
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Command returns the agent utility command group.
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agent",
+		Short: "Agent mode utilities",
+		Long:  "Utilities for gcx agent mode: manage spill files and other agent session housekeeping.",
+	}
+	cmd.AddCommand(pruneCommand())
+	return cmd
+}

--- a/cmd/gcx/agent/command.go
+++ b/cmd/gcx/agent/command.go
@@ -2,6 +2,7 @@
 package agent
 
 import (
+	skillscmd "github.com/grafana/gcx/cmd/gcx/skills"
 	"github.com/spf13/cobra"
 )
 
@@ -10,8 +11,9 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "agent",
 		Short: "Agent mode utilities",
-		Long:  "Utilities for gcx agent mode: manage spill files and other agent session housekeeping.",
+		Long:  "Utilities for gcx agent mode: manage spill files, install and update Agent Skills, and other agent session housekeeping.",
 	}
 	cmd.AddCommand(pruneCommand())
+	cmd.AddCommand(skillscmd.Command())
 	return cmd
 }

--- a/cmd/gcx/agent/prune.go
+++ b/cmd/gcx/agent/prune.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/grafana/gcx/internal/agent"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// PruneSpillFiles deletes gcx agent spill files in dir that are older than olderThan.
+// Returns the number of files deleted.
+func PruneSpillFiles(dir string, olderThan time.Duration) (int, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, cmdio.SpillFilePattern))
+	if err != nil {
+		return 0, fmt.Errorf("glob spill files: %w", err)
+	}
+
+	cutoff := time.Now().Add(-olderThan)
+	var deleted int
+	for _, match := range matches {
+		info, err := os.Stat(match)
+		if err != nil {
+			continue // deleted between glob and stat
+		}
+		if info.ModTime().Before(cutoff) {
+			if err := os.Remove(match); err != nil && !os.IsNotExist(err) {
+				return deleted, fmt.Errorf("remove %s: %w", match, err)
+			}
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+func pruneCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "prune",
+		Short: "Remove gcx agent spill files older than 30 minutes",
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "small",
+		},
+		Long: `Remove gcx agent spill files (` + cmdio.SpillFilePattern + `) from the system temp directory that are older than 30 minutes.
+
+These files are created when a command response exceeds the spill threshold (default 100 KiB). Run prune periodically to keep the temp directory clean, or call it at the end of an agent session.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			n, err := PruneSpillFiles(os.TempDir(), 30*time.Minute)
+			if err != nil {
+				return err
+			}
+			if n == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "no spill files found older than 30 minutes")
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "removed %d spill file(s)\n", n)
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/gcx/agent/prune_test.go
+++ b/cmd/gcx/agent/prune_test.go
@@ -1,0 +1,95 @@
+package agent_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/cmd/gcx/agent"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrune_DeletesOldSpillFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	old := filepath.Join(dir, "gcx-results-old.json")
+	require.NoError(t, os.WriteFile(old, []byte(`{"test":true}`), 0o600))
+	oldTime := time.Now().Add(-31 * time.Minute)
+	require.NoError(t, os.Chtimes(old, oldTime, oldTime))
+
+	deleted, err := agent.PruneSpillFiles(dir, 30*time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+	_, statErr := os.Stat(old)
+	assert.True(t, os.IsNotExist(statErr), "old spill file must be deleted")
+}
+
+func TestPrune_KeepsRecentSpillFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	recent := filepath.Join(dir, "gcx-results-recent.json")
+	require.NoError(t, os.WriteFile(recent, []byte(`{"test":true}`), 0o600))
+
+	deleted, err := agent.PruneSpillFiles(dir, 30*time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+	_, statErr := os.Stat(recent)
+	require.NoError(t, statErr, "recent spill file must not be deleted")
+}
+
+func TestPrune_IgnoresNonSpillFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	other := filepath.Join(dir, "not-a-spill.json")
+	require.NoError(t, os.WriteFile(other, []byte(`{}`), 0o600))
+	oldTime := time.Now().Add(-60 * time.Minute)
+	require.NoError(t, os.Chtimes(other, oldTime, oldTime))
+
+	deleted, err := agent.PruneSpillFiles(dir, 30*time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleted, "non-spill files must not be deleted")
+	_, statErr := os.Stat(other)
+	require.NoError(t, statErr, "non-spill file must still exist")
+}
+
+func TestPrune_NoFiles_ReturnsZero(t *testing.T) {
+	dir := t.TempDir()
+	deleted, err := agent.PruneSpillFiles(dir, 30*time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+}
+
+func TestPruneCommand_DeletesOldFiles_ReportsCount(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+
+	old := filepath.Join(dir, "gcx-results-cmd.json")
+	require.NoError(t, os.WriteFile(old, []byte(`{"test":true}`), 0o600))
+	oldTime := time.Now().Add(-31 * time.Minute)
+	require.NoError(t, os.Chtimes(old, oldTime, oldTime))
+
+	cmd := agent.Command()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"prune"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "1")
+}
+
+func TestPruneCommand_Structure(t *testing.T) {
+	cmd := agent.Command()
+
+	var pruneCmd *cobra.Command
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "prune" {
+			pruneCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, pruneCmd, "agent command must have a prune subcommand")
+	assert.NotEmpty(t, pruneCmd.Short)
+}

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -21,7 +21,6 @@ import (
 	cmdproviders "github.com/grafana/gcx/cmd/gcx/providers"
 	"github.com/grafana/gcx/cmd/gcx/resources"
 	"github.com/grafana/gcx/cmd/gcx/setup"
-	skillscmd "github.com/grafana/gcx/cmd/gcx/skills"
 	"github.com/grafana/gcx/internal/agent"
 	internalconfig "github.com/grafana/gcx/internal/config"
 	_ "github.com/grafana/gcx/internal/datasources/providers" // DatasourceProvider registrations — blank imports trigger init() self-registration.
@@ -228,7 +227,6 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 	rootCmd.AddCommand(config.Command())
 	rootCmd.AddCommand(dev.Command())
 	rootCmd.AddCommand(setup.Command())
-	rootCmd.AddCommand(skillscmd.Command())
 	rootCmd.AddCommand(datasources.Command())
 	rootCmd.AddCommand(resources.Command())
 

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/go-logr/logr"
+	agentcmd "github.com/grafana/gcx/cmd/gcx/agent"
 	"github.com/grafana/gcx/cmd/gcx/api"
 	assistantcmd "github.com/grafana/gcx/cmd/gcx/assistant"
 	"github.com/grafana/gcx/cmd/gcx/commands"
@@ -220,6 +221,7 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 	rootCmd.SetErr(os.Stderr)
 	rootCmd.SetIn(os.Stdin)
 
+	rootCmd.AddCommand(agentcmd.Command())
 	rootCmd.AddCommand(api.Command())
 	rootCmd.AddCommand(assistantcmd.Command())
 	rootCmd.AddCommand(logincmd.Command())

--- a/cmd/gcx/root/command_test.go
+++ b/cmd/gcx/root/command_test.go
@@ -185,7 +185,7 @@ func TestSkillsInstallUpdate_EndToEndThroughRootCommand(t *testing.T) {
 
 	installRoot := filepath.Join(t.TempDir(), ".agents")
 
-	stdout, stderr, err := executeRootCommandForTest("skills", "list", "--dir", installRoot, "-o", "json")
+	stdout, stderr, err := executeRootCommandForTest("agent", "skills", "list", "--dir", installRoot, "-o", "json")
 	require.NoError(t, err, stderr)
 
 	var list struct {
@@ -200,7 +200,7 @@ func TestSkillsInstallUpdate_EndToEndThroughRootCommand(t *testing.T) {
 	expected, err := fs.ReadFile(claudeplugin.SkillsFS(), path.Join(skillName, "SKILL.md"))
 	require.NoError(t, err)
 
-	stdout, stderr, err = executeRootCommandForTest("skills", "install", "--dir", installRoot, skillName)
+	stdout, stderr, err = executeRootCommandForTest("agent", "skills", "install", "--dir", installRoot, skillName)
 	require.NoError(t, err, stderr)
 	require.Contains(t, stdout, "Installed 1 skill(s)")
 
@@ -214,7 +214,7 @@ func TestSkillsInstallUpdate_EndToEndThroughRootCommand(t *testing.T) {
 	require.NoError(t, os.Chmod(installedPath, 0o600))
 	require.NoError(t, os.WriteFile(installedPath, []byte("local-change"), 0o600))
 
-	stdout, stderr, err = executeRootCommandForTest("skills", "update", "--dir", installRoot, skillName)
+	stdout, stderr, err = executeRootCommandForTest("agent", "skills", "update", "--dir", installRoot, skillName)
 	require.NoError(t, err, stderr)
 	require.Contains(t, stdout, "Updated 1 skill(s)")
 

--- a/cmd/gcx/skills/command.go
+++ b/cmd/gcx/skills/command.go
@@ -82,11 +82,11 @@ func newInstallCommand(source fs.FS) *cobra.Command {
 		Use:   "install [SKILL]...",
 		Short: "Install bundled gcx skills into ~/.agents/skills",
 		Long:  "Install one or more bundled gcx Agent Skills into a user-level .agents directory for tools that follow the .agents skill convention. Use --all to install the entire bundle.",
-		Example: `  gcx skills install setup-gcx
-  gcx skills install setup-gcx debug-with-grafana explore-datasources
-  gcx skills install --all
-  gcx skills install --all --dry-run
-  gcx skills install setup-gcx --force`,
+		Example: `  gcx agent skills install setup-gcx
+  gcx agent skills install setup-gcx debug-with-grafana explore-datasources
+  gcx agent skills install --all
+  gcx agent skills install --all --dry-run
+  gcx agent skills install setup-gcx --force`,
 		Args: cobra.ArbitraryArgs,
 		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			names, err := skillops.BundledSkillNames(source)
@@ -220,9 +220,9 @@ func newUpdateCommand(source fs.FS) *cobra.Command {
 		Use:   "update [SKILL]...",
 		Short: "Update installed gcx skills in ~/.agents/skills",
 		Long:  "Update gcx-managed skills in a user-level .agents skills directory. With no skill names, gcx updates only bundled skills that are already installed locally.",
-		Example: `  gcx skills update
-  gcx skills update --dry-run
-  gcx skills update setup-gcx explore-datasources`,
+		Example: `  gcx agent skills update
+  gcx agent skills update --dry-run
+  gcx agent skills update setup-gcx explore-datasources`,
 		Args: cobra.ArbitraryArgs,
 		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			names, err := skillops.BundledSkillNames(source)
@@ -301,8 +301,8 @@ func newListCommand(source fs.FS) *cobra.Command {
 		Use:   "list",
 		Short: "List skills bundled with the gcx binary",
 		Long:  "List skills bundled with the gcx binary, including each skill's short description and install status.",
-		Example: `  gcx skills list
-  gcx skills list -o json`,
+		Example: `  gcx agent skills list
+  gcx agent skills list -o json`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.Validate(); err != nil {
@@ -537,10 +537,10 @@ func newUninstallCommand(source fs.FS) *cobra.Command {
 		Use:   "uninstall [SKILL]...",
 		Short: "Uninstall gcx-managed skills from ~/.agents/skills",
 		Long:  "Remove one or more gcx-managed skills from a user-level .agents skills directory. Only skills bundled with gcx can be uninstalled; non-gcx skills are never touched.",
-		Example: `  gcx skills uninstall setup-gcx
-  gcx skills uninstall setup-gcx debug-with-grafana
-  gcx skills uninstall --all --yes
-  gcx skills uninstall --all --yes --dry-run`,
+		Example: `  gcx agent skills uninstall setup-gcx
+  gcx agent skills uninstall setup-gcx debug-with-grafana
+  gcx agent skills uninstall --all --yes
+  gcx agent skills uninstall --all --yes --dry-run`,
 		Args: cobra.ArbitraryArgs,
 		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			names, err := skillops.BundledSkillNames(source)
@@ -584,7 +584,7 @@ func newUninstallCommand(source fs.FS) *cobra.Command {
 			} else {
 				for _, name := range args {
 					if _, ok := bundledSet[name]; !ok {
-						return fmt.Errorf("unknown skill %q (use 'gcx skills list' to see gcx-managed skills)", name)
+						return fmt.Errorf("unknown skill %q (use 'gcx agent skills list' to see gcx-managed skills)", name)
 					}
 				}
 			}

--- a/docs/design/agent-mode.md
+++ b/docs/design/agent-mode.md
@@ -34,8 +34,10 @@ Reference: `internal/agent/agent.go`
 ### 6.2 Behavior Changes
 
 When agent mode is active:
-1. **Default output format** becomes `json` for all commands (overrides
-   per-command `DefaultFormat()` in `io.Options.BindFlags()`)
+1. **Default output format** becomes `agents` for all commands (overrides
+   per-command `DefaultFormat()` in `io.Options.BindFlags()`). The `agents`
+   codec emits compact JSON when the payload is ≤ 100 KiB and spills to a
+   temp file otherwise — see [output.md § Agents Codec](output.md#111-agents-codec)
 2. **Color** is disabled (`color.NoColor = true` in `PersistentPreRun`)
 3. **Pipe-aware behavior** is forced: `IsPiped=true`, `NoTruncate=true`
    regardless of actual TTY state (see [pipe-awareness.md § TTY Detection](pipe-awareness.md#51-tty-detection))
@@ -61,11 +63,13 @@ deleted entirely.
 ### 6.3 Opt-Out
 
 Explicit flags override agent mode defaults:
-- `-o text` or `-o yaml` overrides the JSON default
+- `-o json` forces full compact JSON to stdout (no spill)
+- `-o text` or `-o yaml` overrides the agents default
 - `-o wide` retains human table output even in agent mode (explicit-override semantics — the
   operator has explicitly requested wide table format, so the JSON default is not applied)
 - `--agent=false` disables agent mode entirely (even when env vars are set)
 - `GCX_AGENT_MODE=0` disables agent mode regardless of other env vars
+- `GCX_AGENT_SPILL_BYTES=<n>` adjusts the spill threshold (bytes; default 102400)
 
 ### 6.4 Exempt Commands
 

--- a/docs/design/environment-variables.md
+++ b/docs/design/environment-variables.md
@@ -50,6 +50,7 @@ Accepts: `1`, `true`, `0`, `false` (parsed by `caarlos0/env/v11`)
 | Variable | Source | Effect |
 |----------|--------|--------|
 | `GCX_AGENT_MODE` | Explicit opt-in/out | `1`/`true`/`yes` enables agent mode; `0`/`false`/`no` disables (overrides all others) |
+| `GCX_AGENT_SPILL_BYTES` | Output tuning | Spill threshold in bytes for the `agents` codec (default `102400` = 100 KiB). Payloads above this are written to a temp file; a summary is printed instead. Invalid values fall back to the default. See [output.md § Agents Codec](output.md#111-agents-codec) |
 | `CLAUDECODE` | Claude Code | Truthy value activates agent mode |
 | `CLAUDE_CODE` | Claude Code | Truthy value activates agent mode |
 | `CURSOR_AGENT` | Cursor | Truthy value activates agent mode |

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -45,7 +45,7 @@ spill threshold (default **100 KiB**), and spills to a temp file otherwise.
 | `spilled_to` | yes | Absolute path to the full-payload file |
 | `bytes` | yes | Byte size of the full payload |
 | `items` | only for lists | Element count |
-| `preview` | yes | First 3 items (or the whole value if not list-shaped) |
+| `preview` | yes | First 3 items for list shapes; sorted top-level key names for object/map shapes; `null` for other shapes |
 
 **Override:** `-o json` forces full compact JSON to stdout regardless of size.
 `-o text` renders the human table.

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -35,8 +35,9 @@ spill threshold (default **100 KiB**), and spills to a temp file otherwise.
 {
   "spilled_to": "/tmp/gcx-results-3781234567.json",
   "bytes": 143200,
-  "items": 312,
-  "preview": [ { ... }, { ... }, { ... } ]
+  "total_items": 312,
+  "preview_sample": [ { ... }, { ... }, { ... } ],
+  "message": "Response too large for stdout (143200 bytes). Full data written to ..."
 }
 ```
 
@@ -44,8 +45,9 @@ spill threshold (default **100 KiB**), and spills to a temp file otherwise.
 |-------|---------------|-------------|
 | `spilled_to` | yes | Absolute path to the full-payload file |
 | `bytes` | yes | Byte size of the full payload |
-| `items` | only for lists | Element count |
-| `preview` | yes | First 3 items for list shapes; sorted top-level key names for object/map shapes; `null` for other shapes |
+| `total_items` | only for lists | Element count — named `total_items` (not `items`) to avoid collision with the k8s list `items` array shape |
+| `preview_sample` | yes | First 3 items for list shapes; sorted top-level key names for object/map shapes; `null` for other shapes. Named `preview_sample` (not `preview`) to signal it is never the complete dataset |
+| `message` | yes | Human-readable guidance: references `spilled_to` path and opt-outs |
 
 **Override:** `-o json` forces full compact JSON to stdout regardless of size.
 `-o text` renders the human table.

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -10,14 +10,54 @@ Reference alongside [cli-layer.md](../architecture/cli-layer.md) for command str
 
 ### 1.1 Built-in Codecs
 
-Every command gets `json` and `yaml` output for free via `io.Options`. These
-produce the full resource object as returned by the API — no envelope wrapping,
-no field filtering. This output is stable.
+Every command gets `json`, `yaml`, and `agents` output for free via `io.Options`.
+The `json` and `yaml` codecs produce the full resource object as returned by
+the API — no envelope wrapping, no field filtering. This output is stable.
+The `agents` codec is described in [§ 1.1.1](#111-agents-codec) below.
 
 ```go
 ioOpts := &io.Options{}
 ioOpts.BindFlags(cmd.Flags())
 ```
+
+#### 1.1.1 Agents Codec
+
+The `agents` codec is optimised for AI-agent contexts. It emits compact JSON
+(no indentation, no HTML escaping) when the serialised payload is within the
+spill threshold (default **100 KiB**), and spills to a temp file otherwise.
+
+**Below threshold** — output is compact JSON identical in content to `-o json`.
+
+**Above threshold** — the full payload is written to
+`$TMPDIR/gcx-results-<random>.json` and a short summary is printed to stdout:
+
+```json
+{
+  "spilled_to": "/tmp/gcx-results-3781234567.json",
+  "bytes": 143200,
+  "items": 312,
+  "preview": [ { ... }, { ... }, { ... } ]
+}
+```
+
+| Field | Always present | Description |
+|-------|---------------|-------------|
+| `spilled_to` | yes | Absolute path to the full-payload file |
+| `bytes` | yes | Byte size of the full payload |
+| `items` | only for lists | Element count |
+| `preview` | yes | First 3 items (or the whole value if not list-shaped) |
+
+**Override:** `-o json` forces full compact JSON to stdout regardless of size.
+`-o text` renders the human table.
+
+**Threshold configuration:** `GCX_AGENT_SPILL_BYTES` (int, bytes; default
+`102400`). Invalid or missing values fall back to the default.
+
+**Guidance for provider authors:** Do **not** pre-truncate output for agent
+mode. The codec handles oversized payloads. Pre-truncation defeats the spill
+mechanism because agents that need the full data can no longer retrieve it.
+
+**Implementation:** `internal/output/agents.go`
 
 ### 1.2 Custom Codecs
 
@@ -44,7 +84,7 @@ JSON/YAML to silently omit fields. See Pattern 13 in `patterns.md`.
 | `list`, `get` | `text` (with table codec) | Human-scannable |
 | `config view` | `yaml` | Config is YAML-native |
 | `push`, `pull`, `delete` | Status messages only | Operations, not data |
-| Agent mode ([agent-mode.md](agent-mode.md)) | `json` | Machine-parseable |
+| Agent mode ([agent-mode.md](agent-mode.md)) | `agents` | Token-efficient: compact JSON below 100 KiB, temp-file spill above (see [§ 1.1.1](#111-agents-codec)) |
 
 When building a new command: call `ioOpts.DefaultFormat("text")` for data
 display commands and register a table codec. Don't leave `json` as the default
@@ -119,7 +159,8 @@ resource object. `--json` is an independent mechanism (NC-002).
 
 All data-display and mutation commands must register a `text` table codec
 and call `DefaultFormat("text")`. The `text` codec is the human default;
-`json` becomes the default only in agent mode.
+`agents` becomes the default in agent mode (compact JSON with spill — see
+[§ 1.1.1](#111-agents-codec)).
 
 Codec registration happens in `setup(flags)`, not in `RunE`.
 

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -45,7 +45,6 @@ gcx is a unified CLI for managing Grafana resources, dashboards, datasources, al
 * [gcx providers](gcx_providers.md)	 - Manage registered providers
 * [gcx resources](gcx_resources.md)	 - Manipulate Grafana resources
 * [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
-* [gcx skills](gcx_skills.md)	 - Manage portable gcx Agent Skills
 * [gcx slo](gcx_slo.md)	 - Manage Grafana SLO definitions and reports
 * [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
 * [gcx synthetic-monitoring](gcx_synthetic-monitoring.md)	 - Manage Grafana Synthetic Monitoring checks and probes

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -20,6 +20,7 @@ gcx is a unified CLI for managing Grafana resources, dashboards, datasources, al
 
 ### SEE ALSO
 
+* [gcx agent](gcx_agent.md)	 - Agent mode utilities
 * [gcx aio11y](gcx_aio11y.md)	 - Manage Grafana AI Observability resources
 * [gcx alert](gcx_alert.md)	 - Manage Grafana alert rules and alert groups
 * [gcx api](gcx_api.md)	 - Make direct HTTP requests to the Grafana API

--- a/docs/reference/cli/gcx_agent.md
+++ b/docs/reference/cli/gcx_agent.md
@@ -4,7 +4,7 @@ Agent mode utilities
 
 ### Synopsis
 
-Utilities for gcx agent mode: manage spill files and other agent session housekeeping.
+Utilities for gcx agent mode: manage spill files, install and update Agent Skills, and other agent session housekeeping.
 
 ### Options
 
@@ -27,4 +27,5 @@ Utilities for gcx agent mode: manage spill files and other agent session houseke
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx agent prune](gcx_agent_prune.md)	 - Remove gcx agent spill files older than 30 minutes
+* [gcx agent skills](gcx_agent_skills.md)	 - Manage portable gcx Agent Skills
 

--- a/docs/reference/cli/gcx_agent.md
+++ b/docs/reference/cli/gcx_agent.md
@@ -1,0 +1,30 @@
+## gcx agent
+
+Agent mode utilities
+
+### Synopsis
+
+Utilities for gcx agent mode: manage spill files and other agent session housekeeping.
+
+### Options
+
+```
+  -h, --help   help for agent
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx agent prune](gcx_agent_prune.md)	 - Remove gcx agent spill files older than 30 minutes
+

--- a/docs/reference/cli/gcx_agent_prune.md
+++ b/docs/reference/cli/gcx_agent_prune.md
@@ -1,0 +1,35 @@
+## gcx agent prune
+
+Remove gcx agent spill files older than 30 minutes
+
+### Synopsis
+
+Remove gcx agent spill files (gcx-results-*.json) from the system temp directory that are older than 30 minutes.
+
+These files are created when a command response exceeds the spill threshold (default 100 KiB). Run prune periodically to keep the temp directory clean, or call it at the end of an agent session.
+
+```
+gcx agent prune [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for prune
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx agent](gcx_agent.md)	 - Agent mode utilities
+

--- a/docs/reference/cli/gcx_agent_skills.md
+++ b/docs/reference/cli/gcx_agent_skills.md
@@ -1,4 +1,4 @@
-## gcx skills
+## gcx agent skills
 
 Manage portable gcx Agent Skills
 
@@ -25,9 +25,9 @@ Install the canonical portable gcx Agent Skills bundle for .agents-compatible ag
 
 ### SEE ALSO
 
-* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
-* [gcx skills install](gcx_skills_install.md)	 - Install bundled gcx skills into ~/.agents/skills
-* [gcx skills list](gcx_skills_list.md)	 - List skills bundled with the gcx binary
-* [gcx skills uninstall](gcx_skills_uninstall.md)	 - Uninstall gcx-managed skills from ~/.agents/skills
-* [gcx skills update](gcx_skills_update.md)	 - Update installed gcx skills in ~/.agents/skills
+* [gcx agent](gcx_agent.md)	 - Agent mode utilities
+* [gcx agent skills install](gcx_agent_skills_install.md)	 - Install bundled gcx skills into ~/.agents/skills
+* [gcx agent skills list](gcx_agent_skills_list.md)	 - List skills bundled with the gcx binary
+* [gcx agent skills uninstall](gcx_agent_skills_uninstall.md)	 - Uninstall gcx-managed skills from ~/.agents/skills
+* [gcx agent skills update](gcx_agent_skills_update.md)	 - Update installed gcx skills in ~/.agents/skills
 

--- a/docs/reference/cli/gcx_agent_skills_install.md
+++ b/docs/reference/cli/gcx_agent_skills_install.md
@@ -1,27 +1,33 @@
-## gcx skills list
+## gcx agent skills install
 
-List skills bundled with the gcx binary
+Install bundled gcx skills into ~/.agents/skills
 
 ### Synopsis
 
-List skills bundled with the gcx binary, including each skill's short description and install status.
+Install one or more bundled gcx Agent Skills into a user-level .agents directory for tools that follow the .agents skill convention. Use --all to install the entire bundle.
 
 ```
-gcx skills list [flags]
+gcx agent skills install [SKILL]... [flags]
 ```
 
 ### Examples
 
 ```
-  gcx skills list
-  gcx skills list -o json
+  gcx agent skills install setup-gcx
+  gcx agent skills install setup-gcx debug-with-grafana explore-datasources
+  gcx agent skills install --all
+  gcx agent skills install --all --dry-run
+  gcx agent skills install setup-gcx --force
 ```
 
 ### Options
 
 ```
-      --dir string      Root directory for the .agents installation (used to check installed status) (default "~/.agents")
-  -h, --help            help for list
+      --all             Install all bundled skills
+      --dir string      Root directory for the .agents installation (default "~/.agents")
+      --dry-run         Preview the installation without writing files
+      --force           Overwrite existing differing files managed by the gcx skills bundle
+  -h, --help            help for install
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
@@ -39,5 +45,5 @@ gcx skills list [flags]
 
 ### SEE ALSO
 
-* [gcx skills](gcx_skills.md)	 - Manage portable gcx Agent Skills
+* [gcx agent skills](gcx_agent_skills.md)	 - Manage portable gcx Agent Skills
 

--- a/docs/reference/cli/gcx_agent_skills_list.md
+++ b/docs/reference/cli/gcx_agent_skills_list.md
@@ -1,34 +1,29 @@
-## gcx skills uninstall
+## gcx agent skills list
 
-Uninstall gcx-managed skills from ~/.agents/skills
+List skills bundled with the gcx binary
 
 ### Synopsis
 
-Remove one or more gcx-managed skills from a user-level .agents skills directory. Only skills bundled with gcx can be uninstalled; non-gcx skills are never touched.
+List skills bundled with the gcx binary, including each skill's short description and install status.
 
 ```
-gcx skills uninstall [SKILL]... [flags]
+gcx agent skills list [flags]
 ```
 
 ### Examples
 
 ```
-  gcx skills uninstall setup-gcx
-  gcx skills uninstall setup-gcx debug-with-grafana
-  gcx skills uninstall --all --yes
-  gcx skills uninstall --all --yes --dry-run
+  gcx agent skills list
+  gcx agent skills list -o json
 ```
 
 ### Options
 
 ```
-      --all             Uninstall all gcx-managed skills
-      --dir string      Root directory for the .agents installation (default "~/.agents")
-      --dry-run         Preview the uninstall without removing files
-  -h, --help            help for uninstall
+      --dir string      Root directory for the .agents installation (used to check installed status) (default "~/.agents")
+  -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
-  -y, --yes             Auto-approve uninstalling all skills
 ```
 
 ### Options inherited from parent commands
@@ -44,5 +39,5 @@ gcx skills uninstall [SKILL]... [flags]
 
 ### SEE ALSO
 
-* [gcx skills](gcx_skills.md)	 - Manage portable gcx Agent Skills
+* [gcx agent skills](gcx_agent_skills.md)	 - Manage portable gcx Agent Skills
 

--- a/docs/reference/cli/gcx_agent_skills_uninstall.md
+++ b/docs/reference/cli/gcx_agent_skills_uninstall.md
@@ -1,35 +1,34 @@
-## gcx skills install
+## gcx agent skills uninstall
 
-Install bundled gcx skills into ~/.agents/skills
+Uninstall gcx-managed skills from ~/.agents/skills
 
 ### Synopsis
 
-Install one or more bundled gcx Agent Skills into a user-level .agents directory for tools that follow the .agents skill convention. Use --all to install the entire bundle.
+Remove one or more gcx-managed skills from a user-level .agents skills directory. Only skills bundled with gcx can be uninstalled; non-gcx skills are never touched.
 
 ```
-gcx skills install [SKILL]... [flags]
+gcx agent skills uninstall [SKILL]... [flags]
 ```
 
 ### Examples
 
 ```
-  gcx skills install setup-gcx
-  gcx skills install setup-gcx debug-with-grafana explore-datasources
-  gcx skills install --all
-  gcx skills install --all --dry-run
-  gcx skills install setup-gcx --force
+  gcx agent skills uninstall setup-gcx
+  gcx agent skills uninstall setup-gcx debug-with-grafana
+  gcx agent skills uninstall --all --yes
+  gcx agent skills uninstall --all --yes --dry-run
 ```
 
 ### Options
 
 ```
-      --all             Install all bundled skills
+      --all             Uninstall all gcx-managed skills
       --dir string      Root directory for the .agents installation (default "~/.agents")
-      --dry-run         Preview the installation without writing files
-      --force           Overwrite existing differing files managed by the gcx skills bundle
-  -h, --help            help for install
+      --dry-run         Preview the uninstall without removing files
+  -h, --help            help for uninstall
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -y, --yes             Auto-approve uninstalling all skills
 ```
 
 ### Options inherited from parent commands
@@ -45,5 +44,5 @@ gcx skills install [SKILL]... [flags]
 
 ### SEE ALSO
 
-* [gcx skills](gcx_skills.md)	 - Manage portable gcx Agent Skills
+* [gcx agent skills](gcx_agent_skills.md)	 - Manage portable gcx Agent Skills
 

--- a/docs/reference/cli/gcx_agent_skills_update.md
+++ b/docs/reference/cli/gcx_agent_skills_update.md
@@ -1,4 +1,4 @@
-## gcx skills update
+## gcx agent skills update
 
 Update installed gcx skills in ~/.agents/skills
 
@@ -7,15 +7,15 @@ Update installed gcx skills in ~/.agents/skills
 Update gcx-managed skills in a user-level .agents skills directory. With no skill names, gcx updates only bundled skills that are already installed locally.
 
 ```
-gcx skills update [SKILL]... [flags]
+gcx agent skills update [SKILL]... [flags]
 ```
 
 ### Examples
 
 ```
-  gcx skills update
-  gcx skills update --dry-run
-  gcx skills update setup-gcx explore-datasources
+  gcx agent skills update
+  gcx agent skills update --dry-run
+  gcx agent skills update setup-gcx explore-datasources
 ```
 
 ### Options
@@ -41,5 +41,5 @@ gcx skills update [SKILL]... [flags]
 
 ### SEE ALSO
 
-* [gcx skills](gcx_skills.md)	 - Manage portable gcx Agent Skills
+* [gcx agent skills](gcx_agent_skills.md)	 - Manage portable gcx Agent Skills
 

--- a/docs/reference/cli/gcx_aio11y_agents_get.md
+++ b/docs/reference/cli/gcx_aio11y_agents_get.md
@@ -15,7 +15,7 @@ gcx aio11y agents get <agent-name> [flags]
 ```
   -h, --help             help for get
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: json, yaml (default "yaml")
+  -o, --output string    Output format. One of: agents, json, yaml (default "yaml")
       --version string   Specific effective version to look up
 ```
 

--- a/docs/reference/cli/gcx_aio11y_agents_list.md
+++ b/docs/reference/cli/gcx_aio11y_agents_list.md
@@ -12,7 +12,7 @@ gcx aio11y agents list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of agents to return (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_agents_versions.md
+++ b/docs/reference/cli/gcx_aio11y_agents_versions.md
@@ -11,7 +11,7 @@ gcx aio11y agents versions <agent-name> [flags]
 ```
   -h, --help            help for versions
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_collections_conversations_list.md
+++ b/docs/reference/cli/gcx_aio11y_collections_conversations_list.md
@@ -12,7 +12,7 @@ gcx aio11y collections conversations list <collection-id> [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of saved conversations to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_collections_create.md
+++ b/docs/reference/cli/gcx_aio11y_collections_create.md
@@ -24,7 +24,7 @@ gcx aio11y collections create [flags]
   -h, --help                 help for create
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string          Collection name (required if --filename is not given)
-  -o, --output string        Output format. One of: json, yaml (default "json")
+  -o, --output string        Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_collections_get.md
+++ b/docs/reference/cli/gcx_aio11y_collections_get.md
@@ -11,7 +11,7 @@ gcx aio11y collections get <collection-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_collections_list.md
+++ b/docs/reference/cli/gcx_aio11y_collections_list.md
@@ -12,7 +12,7 @@ gcx aio11y collections list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of collections to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_collections_update.md
+++ b/docs/reference/cli/gcx_aio11y_collections_update.md
@@ -13,7 +13,7 @@ gcx aio11y collections update <collection-id> [flags]
   -h, --help                 help for update
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string          New collection name
-  -o, --output string        Output format. One of: json, yaml (default "json")
+  -o, --output string        Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_conversations_get.md
+++ b/docs/reference/cli/gcx_aio11y_conversations_get.md
@@ -11,7 +11,7 @@ gcx aio11y conversations get <conversation-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_conversations_list.md
+++ b/docs/reference/cli/gcx_aio11y_conversations_list.md
@@ -12,7 +12,7 @@ gcx aio11y conversations list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of conversations to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_conversations_search.md
+++ b/docs/reference/cli/gcx_aio11y_conversations_search.md
@@ -37,7 +37,7 @@ gcx aio11y conversations search [flags]
       --from string      Start of time range (RFC3339, e.g. 2026-01-01T00:00:00Z)
   -h, --help             help for search
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
       --page-size int    Number of results per page (default 50)
       --to string        End of time range (RFC3339, e.g. 2026-12-31T23:59:59Z)
 ```

--- a/docs/reference/cli/gcx_aio11y_evaluators_create.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_create.md
@@ -26,7 +26,7 @@ gcx aio11y evaluators create [flags]
   -f, --filename string   File containing the evaluator definition (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_evaluators_get.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_get.md
@@ -11,7 +11,7 @@ gcx aio11y evaluators get <evaluator-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_evaluators_list.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_list.md
@@ -12,7 +12,7 @@ gcx aio11y evaluators list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of evaluators to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_evaluators_test.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_test.md
@@ -28,7 +28,7 @@ gcx aio11y evaluators test [flags]
   -g, --generation string        Generation ID to evaluate
   -h, --help                     help for test
       --json string              Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string            Output format. One of: json, table, yaml (default "table")
+  -o, --output string            Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_generations_get.md
+++ b/docs/reference/cli/gcx_aio11y_generations_get.md
@@ -15,7 +15,7 @@ gcx aio11y generations get <generation-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_judge_models.md
+++ b/docs/reference/cli/gcx_aio11y_judge_models.md
@@ -11,7 +11,7 @@ gcx aio11y judge models --provider <id> [flags]
 ```
   -h, --help              help for models
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, table, yaml (default "table")
+  -o, --output string     Output format. One of: agents, json, table, yaml (default "table")
       --provider string   Provider ID (required, see 'judge providers')
 ```
 

--- a/docs/reference/cli/gcx_aio11y_judge_providers.md
+++ b/docs/reference/cli/gcx_aio11y_judge_providers.md
@@ -11,7 +11,7 @@ gcx aio11y judge providers [flags]
 ```
   -h, --help            help for providers
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_rules_create.md
+++ b/docs/reference/cli/gcx_aio11y_rules_create.md
@@ -25,7 +25,7 @@ gcx aio11y rules create [flags]
   -f, --filename string   File containing the rule definition (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_rules_get.md
+++ b/docs/reference/cli/gcx_aio11y_rules_get.md
@@ -11,7 +11,7 @@ gcx aio11y rules get <rule-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_rules_list.md
+++ b/docs/reference/cli/gcx_aio11y_rules_list.md
@@ -12,7 +12,7 @@ gcx aio11y rules list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of rules to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_rules_update.md
+++ b/docs/reference/cli/gcx_aio11y_rules_update.md
@@ -19,7 +19,7 @@ gcx aio11y rules update <rule-id> [flags]
   -f, --filename string   File containing the full rule definition (use - for stdin)
   -h, --help              help for update
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_collections.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_collections.md
@@ -11,7 +11,7 @@ gcx aio11y saved-conversations collections <saved-id> [flags]
 ```
   -h, --help            help for collections
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_get.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_get.md
@@ -11,7 +11,7 @@ gcx aio11y saved-conversations get <saved-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_list.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_list.md
@@ -12,7 +12,7 @@ gcx aio11y saved-conversations list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of saved conversations to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
       --source string   Filter by source (telemetry or manual)
 ```
 

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_save.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_save.md
@@ -28,7 +28,7 @@ gcx aio11y saved-conversations save <conversation-id> [flags]
   -h, --help              help for save
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string       Human-readable name for the bookmark (required)
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
       --saved-id string   Bookmark ID; defaults to saved-<conversation-id>
       --tag stringArray   Tag in key=value form (repeatable)
 ```

--- a/docs/reference/cli/gcx_aio11y_scores_list.md
+++ b/docs/reference/cli/gcx_aio11y_scores_list.md
@@ -16,7 +16,7 @@ gcx aio11y scores list <generation-id> [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of scores to return (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_templates_get.md
+++ b/docs/reference/cli/gcx_aio11y_templates_get.md
@@ -26,7 +26,7 @@ gcx aio11y templates get <template-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_templates_list.md
+++ b/docs/reference/cli/gcx_aio11y_templates_list.md
@@ -22,7 +22,7 @@ gcx aio11y templates list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of templates to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
       --scope string    Filter by scope: "global" or "tenant"
 ```
 

--- a/docs/reference/cli/gcx_aio11y_templates_versions.md
+++ b/docs/reference/cli/gcx_aio11y_templates_versions.md
@@ -11,7 +11,7 @@ gcx aio11y templates versions <template-id> [flags]
 ```
   -h, --help            help for versions
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_contact-points_create.md
+++ b/docs/reference/cli/gcx_alert_contact-points_create.md
@@ -12,7 +12,7 @@ gcx alert contact-points create [flags]
   -f, --filename string   File containing the contact point definition (JSON/YAML, use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_contact-points_get.md
+++ b/docs/reference/cli/gcx_alert_contact-points_get.md
@@ -11,7 +11,7 @@ gcx alert contact-points get UID [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_contact-points_list.md
+++ b/docs/reference/cli/gcx_alert_contact-points_list.md
@@ -12,7 +12,7 @@ gcx alert contact-points list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_contact-points_update.md
+++ b/docs/reference/cli/gcx_alert_contact-points_update.md
@@ -12,7 +12,7 @@ gcx alert contact-points update UID [flags]
   -f, --filename string   File containing the contact point definition (JSON/YAML, use - for stdin)
   -h, --help              help for update
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_groups_get.md
+++ b/docs/reference/cli/gcx_alert_groups_get.md
@@ -11,7 +11,7 @@ gcx alert groups get NAME [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_groups_list.md
+++ b/docs/reference/cli/gcx_alert_groups_list.md
@@ -12,7 +12,7 @@ gcx alert groups list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_groups_status.md
+++ b/docs/reference/cli/gcx_alert_groups_status.md
@@ -11,7 +11,7 @@ gcx alert groups status [NAME] [flags]
 ```
   -h, --help            help for status
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_instances_list.md
+++ b/docs/reference/cli/gcx_alert_instances_list.md
@@ -15,7 +15,7 @@ gcx alert instances list [flags]
   -h, --help                help for list
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string         Filter by rule name (regex, e.g. 'Tempo.*')
-  -o, --output string       Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --rule string         Filter by rule UID
       --state string        Filter by alert instance state (firing, pending, inactive)
 ```

--- a/docs/reference/cli/gcx_alert_mute-timings_create.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_create.md
@@ -12,7 +12,7 @@ gcx alert mute-timings create [flags]
   -f, --filename string   File containing the mute timing definition (JSON/YAML, use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_mute-timings_get.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_get.md
@@ -11,7 +11,7 @@ gcx alert mute-timings get NAME [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_mute-timings_list.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_list.md
@@ -12,7 +12,7 @@ gcx alert mute-timings list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_mute-timings_update.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_update.md
@@ -12,7 +12,7 @@ gcx alert mute-timings update NAME [flags]
   -f, --filename string   File containing the mute timing definition (JSON/YAML, use - for stdin)
   -h, --help              help for update
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_notification-policies_get.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_get.md
@@ -11,7 +11,7 @@ gcx alert notification-policies get [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_rules_get.md
+++ b/docs/reference/cli/gcx_alert_rules_get.md
@@ -11,7 +11,7 @@ gcx alert rules get UID [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_rules_list.md
+++ b/docs/reference/cli/gcx_alert_rules_list.md
@@ -14,7 +14,7 @@ gcx alert rules list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
       --state string    Filter by rule state (firing, pending, inactive)
 ```
 

--- a/docs/reference/cli/gcx_alert_templates_get.md
+++ b/docs/reference/cli/gcx_alert_templates_get.md
@@ -11,7 +11,7 @@ gcx alert templates get NAME [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_templates_list.md
+++ b/docs/reference/cli/gcx_alert_templates_list.md
@@ -12,7 +12,7 @@ gcx alert templates list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_templates_upsert.md
+++ b/docs/reference/cli/gcx_alert_templates_upsert.md
@@ -19,7 +19,7 @@ gcx alert templates upsert [flags]
   -f, --filename string   File containing the template definition (JSON/YAML, use - for stdin)
   -h, --help              help for upsert
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_appo11y_overrides_get.md
+++ b/docs/reference/cli/gcx_appo11y_overrides_get.md
@@ -11,7 +11,7 @@ gcx appo11y overrides get [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_appo11y_settings_get.md
+++ b/docs/reference/cli/gcx_appo11y_settings_get.md
@@ -11,7 +11,7 @@ gcx appo11y settings get [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_approvals.md
+++ b/docs/reference/cli/gcx_assistant_investigations_approvals.md
@@ -11,7 +11,7 @@ gcx assistant investigations approvals <id> [flags]
 ```
   -h, --help            help for approvals
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_cancel.md
+++ b/docs/reference/cli/gcx_assistant_investigations_cancel.md
@@ -11,7 +11,7 @@ gcx assistant investigations cancel <id> [flags]
 ```
   -h, --help            help for cancel
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_create.md
+++ b/docs/reference/cli/gcx_assistant_investigations_create.md
@@ -22,7 +22,7 @@ gcx assistant investigations create [flags]
       --description string   Investigation description
   -h, --help                 help for create
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string        Output format. One of: json, yaml (default "yaml")
+  -o, --output string        Output format. One of: agents, json, yaml (default "yaml")
       --title string         Investigation title (required)
 ```
 

--- a/docs/reference/cli/gcx_assistant_investigations_document.md
+++ b/docs/reference/cli/gcx_assistant_investigations_document.md
@@ -11,7 +11,7 @@ gcx assistant investigations document <investigation-id> <document-id> [flags]
 ```
   -h, --help            help for document
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_get.md
+++ b/docs/reference/cli/gcx_assistant_investigations_get.md
@@ -12,7 +12,7 @@ gcx assistant investigations get <id> [flags]
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open            Open the investigation in the default browser
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_list.md
+++ b/docs/reference/cli/gcx_assistant_investigations_list.md
@@ -17,7 +17,7 @@ gcx assistant investigations list [flags]
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of investigations to return (default 50)
       --offset int      Number of investigations to skip (for pagination)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
       --state string    Filter by investigation state (e.g. running, completed, cancelled)
 ```
 

--- a/docs/reference/cli/gcx_assistant_investigations_report.md
+++ b/docs/reference/cli/gcx_assistant_investigations_report.md
@@ -11,7 +11,7 @@ gcx assistant investigations report <id> [flags]
 ```
   -h, --help            help for report
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_timeline.md
+++ b/docs/reference/cli/gcx_assistant_investigations_timeline.md
@@ -11,7 +11,7 @@ gcx assistant investigations timeline <id> [flags]
 ```
   -h, --help            help for timeline
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_todos.md
+++ b/docs/reference/cli/gcx_assistant_investigations_todos.md
@@ -11,7 +11,7 @@ gcx assistant investigations todos <id> [flags]
 ```
   -h, --help            help for todos
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_commands.md
+++ b/docs/reference/cli/gcx_commands.md
@@ -24,7 +24,7 @@ gcx commands [flags]
   -h, --help             help for commands
       --include-hidden   Include hidden commands in the output
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: json, text, yaml (default "json")
+  -o, --output string    Output format. One of: agents, json, text, yaml (default "json")
       --validate         Validate catalog against a live Grafana instance (requires configured context)
 ```
 

--- a/docs/reference/cli/gcx_config_view.md
+++ b/docs/reference/cli/gcx_config_view.md
@@ -19,7 +19,7 @@ gcx config view [flags]
   -h, --help            help for view
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --minify          Remove all information not used by current-context from the output
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
       --raw             Display sensitive information
 ```
 

--- a/docs/reference/cli/gcx_dashboards_get.md
+++ b/docs/reference/cli/gcx_dashboards_get.md
@@ -18,7 +18,7 @@ gcx dashboards get <name> [flags]
       --api-version string   API version to use (e.g. dashboard.grafana.app/v1); defaults to server preferred version
   -h, --help                 help for get
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string        Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_dashboards_list.md
+++ b/docs/reference/cli/gcx_dashboards_list.md
@@ -12,7 +12,7 @@ gcx dashboards list [flags]
       --api-version string   API version to use (e.g. dashboard.grafana.app/v1); defaults to server preferred version
   -h, --help                 help for list
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string        Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_dashboards_search.md
+++ b/docs/reference/cli/gcx_dashboards_search.md
@@ -41,7 +41,7 @@ gcx dashboards search [query] [flags]
   -h, --help                 help for search
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int            Maximum number of results (0 for no limit) (default 50)
-  -o, --output string        Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
       --sort string          Sort key (e.g. name_sort)
       --tag stringArray      Filter by tag (repeatable)
 ```

--- a/docs/reference/cli/gcx_dashboards_versions_list.md
+++ b/docs/reference/cli/gcx_dashboards_versions_list.md
@@ -13,7 +13,7 @@ gcx dashboards versions list <name> [flags]
   -h, --help                 help for list
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int            Maximum number of revisions to return (0 = all)
-  -o, --output string        Output format. One of: json, table, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_get.md
+++ b/docs/reference/cli/gcx_datasources_get.md
@@ -28,7 +28,7 @@ gcx datasources get UID [flags]
       --context string   Name of the context to use
   -h, --help             help for get
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: json, yaml (default "yaml")
+  -o, --output string    Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_list.md
+++ b/docs/reference/cli/gcx_datasources_list.md
@@ -32,7 +32,7 @@ gcx datasources list [flags]
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of datasources to return (default 50)
-  -o, --output string    Output format. One of: json, table, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, yaml (default "table")
   -t, --type string      Filter by datasource type (e.g., prometheus, loki)
 ```
 

--- a/docs/reference/cli/gcx_datasources_loki_labels.md
+++ b/docs/reference/cli/gcx_datasources_loki_labels.md
@@ -31,7 +31,7 @@ gcx datasources loki labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_loki_metrics.md
+++ b/docs/reference/cli/gcx_datasources_loki_metrics.md
@@ -50,7 +50,7 @@ gcx datasources loki metrics [EXPR] [flags]
   -h, --help                help for metrics
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_loki_query.md
+++ b/docs/reference/cli/gcx_datasources_loki_query.md
@@ -50,7 +50,7 @@ gcx datasources loki query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of log lines to return (0 means no limit) (default 50)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: json, raw, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, raw, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_loki_series.md
+++ b/docs/reference/cli/gcx_datasources_loki_series.md
@@ -34,7 +34,7 @@ gcx datasources loki series [flags]
   -h, --help                help for series
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -M, --match stringArray   LogQL stream selector (required, e.g., '{job="varlogs"}')
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_prometheus_labels.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_labels.md
@@ -31,7 +31,7 @@ gcx datasources prometheus labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_prometheus_metadata.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_metadata.md
@@ -31,7 +31,7 @@ gcx datasources prometheus metadata [flags]
   -h, --help                help for metadata
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -m, --metric string       Filter by metric name
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_prometheus_query.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_query.md
@@ -45,7 +45,7 @@ gcx datasources prometheus query [EXPR] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_pyroscope_exemplars_profile.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_exemplars_profile.md
@@ -37,7 +37,7 @@ gcx datasources pyroscope exemplars profile [EXPR] [flags]
   -h, --help                    help for profile
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
-  -o, --output string           Output format. One of: json, table, yaml (default "table")
+  -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
       --since string            Duration before --to (or now if omitted); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_pyroscope_exemplars_span.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_exemplars_span.md
@@ -37,7 +37,7 @@ gcx datasources pyroscope exemplars span [EXPR] [flags]
   -h, --help                    help for span
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
-  -o, --output string           Output format. One of: json, table, yaml (default "table")
+  -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
       --since string            Duration before --to (or now if omitted); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_pyroscope_labels.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_labels.md
@@ -31,7 +31,7 @@ gcx datasources pyroscope labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_pyroscope_metrics.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_metrics.md
@@ -56,7 +56,7 @@ gcx datasources pyroscope metrics [EXPR] [flags]
   -h, --help                  help for metrics
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int             Maximum number of series to return (default 10)
-  -o, --output string         Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_pyroscope_profile-types.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_profile-types.md
@@ -27,7 +27,7 @@ gcx datasources pyroscope profile-types [flags]
   -d, --datasource string   Datasource UID (required unless default-pyroscope-datasource is configured)
   -h, --help                help for profile-types
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -39,7 +39,7 @@ gcx datasources pyroscope query [EXPR] [flags]
   -h, --help                  help for query
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-nodes int         Maximum nodes in flame graph (default 1024)
-  -o, --output string         Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_query.md
+++ b/docs/reference/cli/gcx_datasources_query.md
@@ -43,7 +43,7 @@ gcx datasources query DATASOURCE_UID [EXPR] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int             Maximum number of log lines to return for loki queries (0 means no limit) (default 50)
       --max-nodes int         Maximum nodes in flame graph (pyroscope only) (default 1024)
-  -o, --output string         Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --profile-type string   Profile type ID for pyroscope queries (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds')
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_tempo_get.md
+++ b/docs/reference/cli/gcx_datasources_tempo_get.md
@@ -45,7 +45,7 @@ gcx datasources tempo get TRACE_ID [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --llm                 Request LLM-friendly trace format
       --open                Open the retrieved trace in Grafana Explore
-  -o, --output string       Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_tempo_labels.md
+++ b/docs/reference/cli/gcx_datasources_tempo_labels.md
@@ -45,7 +45,7 @@ gcx datasources tempo labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)
 ```

--- a/docs/reference/cli/gcx_datasources_tempo_metrics.md
+++ b/docs/reference/cli/gcx_datasources_tempo_metrics.md
@@ -53,7 +53,7 @@ gcx datasources tempo metrics [TRACEQL] [flags]
       --instant             Run an instant query over the selected time range instead of a range query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_tempo_query.md
+++ b/docs/reference/cli/gcx_datasources_tempo_query.md
@@ -46,7 +46,7 @@ gcx datasources tempo query [TRACEQL] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of traces to return (0 means no limit) (default 20)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_dev_lint_rules.md
+++ b/docs/reference/cli/gcx_dev_lint_rules.md
@@ -29,7 +29,7 @@ gcx dev lint rules [flags]
 ```
   -h, --help                help for rules
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: json, yaml (default "yaml")
+  -o, --output string       Output format. One of: agents, json, yaml (default "yaml")
   -r, --rules stringArray   Path to custom rules.
 ```
 

--- a/docs/reference/cli/gcx_dev_lint_run.md
+++ b/docs/reference/cli/gcx_dev_lint_run.md
@@ -71,7 +71,7 @@ gcx dev lint run PATH... [flags]
   -h, --help                           help for run
       --json string                    Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-concurrent int             Maximum number of concurrent operations (default 10)
-  -o, --output string                  Output format. One of: compact, json, pretty, yaml (default "pretty")
+  -o, --output string                  Output format. One of: agents, compact, json, pretty, yaml (default "pretty")
   -r, --rules stringArray              Path to custom rules
 ```
 

--- a/docs/reference/cli/gcx_fleet_collectors_get.md
+++ b/docs/reference/cli/gcx_fleet_collectors_get.md
@@ -11,7 +11,7 @@ gcx fleet collectors get <id|name> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_fleet_collectors_list.md
+++ b/docs/reference/cli/gcx_fleet_collectors_list.md
@@ -12,7 +12,7 @@ gcx fleet collectors list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_fleet_pipelines_get.md
+++ b/docs/reference/cli/gcx_fleet_pipelines_get.md
@@ -11,7 +11,7 @@ gcx fleet pipelines get <id|name> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_fleet_pipelines_list.md
+++ b/docs/reference/cli/gcx_fleet_pipelines_list.md
@@ -12,7 +12,7 @@ gcx fleet pipelines list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_fleet_tenant_limits.md
+++ b/docs/reference/cli/gcx_fleet_tenant_limits.md
@@ -11,7 +11,7 @@ gcx fleet tenant limits [flags]
 ```
   -h, --help            help for limits
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_frontend_apps_get.md
+++ b/docs/reference/cli/gcx_frontend_apps_get.md
@@ -22,7 +22,7 @@ gcx frontend apps get [slug-id] [flags]
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string     Get Frontend Observability app by name instead of slug-id
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_frontend_apps_list.md
+++ b/docs/reference/cli/gcx_frontend_apps_list.md
@@ -12,7 +12,7 @@ gcx frontend apps list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_frontend_apps_show-sourcemaps.md
+++ b/docs/reference/cli/gcx_frontend_apps_show-sourcemaps.md
@@ -25,7 +25,7 @@ gcx frontend apps show-sourcemaps <app-name> [flags]
   -h, --help            help for show-sourcemaps
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of sourcemaps to return (0 for all)
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_help-tree.md
+++ b/docs/reference/cli/gcx_help-tree.md
@@ -20,7 +20,7 @@ gcx help-tree [COMMAND...] [flags]
       --depth int       Maximum nesting depth (1 = root + direct children, 0 = unlimited)
   -h, --help            help for help-tree
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_incidents_activity_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_activity_list.md
@@ -12,7 +12,7 @@ gcx irm incidents activity list <incident-id> [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of activity items to return (default 50)
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_incidents_create.md
+++ b/docs/reference/cli/gcx_irm_incidents_create.md
@@ -12,7 +12,7 @@ gcx irm incidents create [flags]
   -f, --filename string   File containing the incident manifest (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "yaml")
+  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_incidents_get.md
+++ b/docs/reference/cli/gcx_irm_incidents_get.md
@@ -11,7 +11,7 @@ gcx irm incidents get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_incidents_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_list.md
@@ -14,7 +14,7 @@ gcx irm incidents list [flags]
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --labels strings   Filter by labels (key:value format, may be repeated)
       --limit int        Maximum number of incidents to return (default 50)
-  -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
       --to string        End of time range (RFC3339, unix timestamp, or relative e.g. now)
 ```
 

--- a/docs/reference/cli/gcx_irm_incidents_severities_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_severities_list.md
@@ -11,7 +11,7 @@ gcx irm incidents severities list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups acknowledge <id> [flags]
 ```
   -h, --help            help for acknowledge
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups delete <id> [flags]
 ```
   -h, --help            help for delete
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_get.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_list-alerts.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_list-alerts.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups list-alerts <alert-group-id> [flags]
 ```
   -h, --help            help for list-alerts
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_list.md
@@ -12,7 +12,7 @@ gcx irm oncall alert-groups list [flags]
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-age string   Exclude groups older than this duration (e.g. 1h, 24h, 7d)
-  -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups resolve <id> [flags]
 ```
   -h, --help            help for resolve
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
@@ -12,7 +12,7 @@ gcx irm oncall alert-groups silence <id> [flags]
       --duration int    Duration to silence in seconds (default 3600)
   -h, --help            help for silence
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups unacknowledge <id> [flags]
 ```
   -h, --help            help for unacknowledge
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups unresolve <id> [flags]
 ```
   -h, --help            help for unresolve
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups unsilence <id> [flags]
 ```
   -h, --help            help for unsilence
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alerts_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_alerts_get.md
@@ -11,7 +11,7 @@ gcx irm oncall alerts get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_escalate.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalate.md
@@ -13,7 +13,7 @@ gcx irm oncall escalate [flags]
       --important          Mark as important
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --message string     Message for the escalation
-  -o, --output string      Output format. One of: json, yaml (default "text")
+  -o, --output string      Output format. One of: agents, json, yaml (default "text")
       --team string        Team ID
       --title string       Title of the escalation (required)
       --user-ids strings   User IDs (comma-separated)

--- a/docs/reference/cli/gcx_irm_oncall_escalation-chains_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-chains_get.md
@@ -11,7 +11,7 @@ gcx irm oncall escalation-chains get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_escalation-chains_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-chains_list.md
@@ -11,7 +11,7 @@ gcx irm oncall escalation-chains list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_escalation-policies_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-policies_get.md
@@ -11,7 +11,7 @@ gcx irm oncall escalation-policies get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_escalation-policies_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-policies_list.md
@@ -11,7 +11,7 @@ gcx irm oncall escalation-policies list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_integrations_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_integrations_get.md
@@ -11,7 +11,7 @@ gcx irm oncall integrations get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_integrations_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_integrations_list.md
@@ -11,7 +11,7 @@ gcx irm oncall integrations list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_organizations_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_organizations_get.md
@@ -11,7 +11,7 @@ gcx irm oncall organizations get [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_resolution-notes_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_resolution-notes_get.md
@@ -11,7 +11,7 @@ gcx irm oncall resolution-notes get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_resolution-notes_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_resolution-notes_list.md
@@ -11,7 +11,7 @@ gcx irm oncall resolution-notes list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_routes_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_routes_get.md
@@ -11,7 +11,7 @@ gcx irm oncall routes get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_routes_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_routes_list.md
@@ -11,7 +11,7 @@ gcx irm oncall routes list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_schedules_final-shifts.md
+++ b/docs/reference/cli/gcx_irm_oncall_schedules_final-shifts.md
@@ -12,7 +12,7 @@ gcx irm oncall schedules final-shifts <schedule-id> [flags]
       --end string      End date (YYYY-MM-DD) (default "YYYY-MM-DD")
   -h, --help            help for final-shifts
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
       --start string    Start date (YYYY-MM-DD) (default "YYYY-MM-DD")
 ```
 

--- a/docs/reference/cli/gcx_irm_oncall_schedules_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_schedules_get.md
@@ -11,7 +11,7 @@ gcx irm oncall schedules get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_schedules_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_schedules_list.md
@@ -11,7 +11,7 @@ gcx irm oncall schedules list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_shift-swaps_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_shift-swaps_get.md
@@ -11,7 +11,7 @@ gcx irm oncall shift-swaps get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_shift-swaps_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_shift-swaps_list.md
@@ -11,7 +11,7 @@ gcx irm oncall shift-swaps list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_shifts_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_shifts_get.md
@@ -11,7 +11,7 @@ gcx irm oncall shifts get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_shifts_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_shifts_list.md
@@ -11,7 +11,7 @@ gcx irm oncall shifts list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_slack-channels_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_slack-channels_list.md
@@ -11,7 +11,7 @@ gcx irm oncall slack-channels list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_teams_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_teams_get.md
@@ -11,7 +11,7 @@ gcx irm oncall teams get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_teams_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_teams_list.md
@@ -11,7 +11,7 @@ gcx irm oncall teams list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_user-groups_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_user-groups_list.md
@@ -11,7 +11,7 @@ gcx irm oncall user-groups list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_users_current.md
+++ b/docs/reference/cli/gcx_irm_oncall_users_current.md
@@ -11,7 +11,7 @@ gcx irm oncall users current [flags]
 ```
   -h, --help            help for current
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_users_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_users_get.md
@@ -11,7 +11,7 @@ gcx irm oncall users get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_users_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_users_list.md
@@ -11,7 +11,7 @@ gcx irm oncall users list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_webhooks_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_webhooks_get.md
@@ -11,7 +11,7 @@ gcx irm oncall webhooks get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_webhooks_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_webhooks_list.md
@@ -11,7 +11,7 @@ gcx irm oncall webhooks list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_env-vars_list.md
+++ b/docs/reference/cli/gcx_k6_env-vars_list.md
@@ -12,7 +12,7 @@ gcx k6 env-vars list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_load-tests_create.md
+++ b/docs/reference/cli/gcx_k6_load-tests_create.md
@@ -13,7 +13,7 @@ gcx k6 load-tests create [flags]
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string       Test name (required when --filename not used)
-  -o, --output string     Output format. One of: json, yaml (default "yaml")
+  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
       --project-id int    Project ID (required when --filename not used)
       --script string     Path to k6 script file (required when --filename not used)
 ```

--- a/docs/reference/cli/gcx_k6_load-tests_get.md
+++ b/docs/reference/cli/gcx_k6_load-tests_get.md
@@ -11,7 +11,7 @@ gcx k6 load-tests get <id-or-name> [flags]
 ```
   -h, --help             help for get
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: json, yaml (default "yaml")
+  -o, --output string    Output format. One of: agents, json, yaml (default "yaml")
       --project-id int   Project ID (required when looking up by name)
 ```
 

--- a/docs/reference/cli/gcx_k6_load-tests_list.md
+++ b/docs/reference/cli/gcx_k6_load-tests_list.md
@@ -12,7 +12,7 @@ gcx k6 load-tests list [flags]
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of items to return (0 for all) (default 50)
-  -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
       --project-id int   Filter by project ID
 ```
 

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones_list.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones_list.md
@@ -11,7 +11,7 @@ gcx k6 load-zones allowed-load-zones list <project-id> [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-projects_list.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-projects_list.md
@@ -11,7 +11,7 @@ gcx k6 load-zones allowed-projects list <load-zone-id> [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_load-zones_list.md
+++ b/docs/reference/cli/gcx_k6_load-zones_list.md
@@ -12,7 +12,7 @@ gcx k6 load-zones list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_projects_create.md
+++ b/docs/reference/cli/gcx_k6_projects_create.md
@@ -12,7 +12,7 @@ gcx k6 projects create [flags]
   -f, --filename string   File containing the project manifest (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "yaml")
+  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_projects_get.md
+++ b/docs/reference/cli/gcx_k6_projects_get.md
@@ -11,7 +11,7 @@ gcx k6 projects get <id-or-name> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_projects_list.md
+++ b/docs/reference/cli/gcx_k6_projects_list.md
@@ -12,7 +12,7 @@ gcx k6 projects list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_runs_list.md
+++ b/docs/reference/cli/gcx_k6_runs_list.md
@@ -13,7 +13,7 @@ gcx k6 runs list [id-or-name] [flags]
       --id int           Load test ID (skip name lookup)
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of items to return (0 for all) (default 50)
-  -o, --output string    Output format. One of: json, table, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, yaml (default "table")
       --project-id int   Project ID (required when looking up by name)
 ```
 

--- a/docs/reference/cli/gcx_k6_schedules_get.md
+++ b/docs/reference/cli/gcx_k6_schedules_get.md
@@ -11,7 +11,7 @@ gcx k6 schedules get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_schedules_list.md
+++ b/docs/reference/cli/gcx_k6_schedules_list.md
@@ -12,7 +12,7 @@ gcx k6 schedules list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_test-run_runs_list.md
+++ b/docs/reference/cli/gcx_k6_test-run_runs_list.md
@@ -13,7 +13,7 @@ gcx k6 test-run runs list [test-name] [flags]
       --id int           Load test ID (skip name lookup)
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of items to return (0 for all) (default 50)
-  -o, --output string    Output format. One of: json, table, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, yaml (default "table")
       --project-id int   k6 Cloud project ID (required when using name lookup)
 ```
 

--- a/docs/reference/cli/gcx_kg_cypher.md
+++ b/docs/reference/cli/gcx_kg_cypher.md
@@ -21,7 +21,7 @@ gcx kg cypher <query> [flags]
   -h, --help            help for cypher
       --insights-only   Return only entities with active insights
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
       --page int        Page number (0-based)
       --since string    Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
       --to string       End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_kg_entities_inspect.md
+++ b/docs/reference/cli/gcx_kg_entities_inspect.md
@@ -16,7 +16,7 @@ gcx kg entities inspect [Type--Name] [flags]
       --name string        Entity name
       --namespace string   Namespace scope (run 'gcx kg meta scopes' to see valid values)
       --open               Open the entity in the RCA Workbench in your browser
-  -o, --output string      Output format. One of: json, yaml (default "json")
+  -o, --output string      Output format. One of: agents, json, yaml (default "json")
       --share-link         Print the RCA Workbench URL for this entity to stderr
       --since string       Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
       --site string        Site scope (run 'gcx kg meta scopes' to see valid values)

--- a/docs/reference/cli/gcx_kg_entities_list.md
+++ b/docs/reference/cli/gcx_kg_entities_list.md
@@ -25,7 +25,7 @@ gcx kg entities list [flags]
       --json string            Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int              Maximum number of items to return (0 for all; the backend may still page results — use --page to paginate) (default 50)
       --namespace string       Namespace scope (run 'gcx kg meta scopes' to see valid values)
-  -o, --output string          Output format. One of: json, table, yaml (default "table")
+  -o, --output string          Output format. One of: agents, json, table, yaml (default "table")
       --page int               Page number (0-based)
       --property stringArray   Filter by property: name=value (exact) or name=~value (contains); repeatable (run 'gcx kg meta schema' to list property names)
       --since string           Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)

--- a/docs/reference/cli/gcx_kg_health.md
+++ b/docs/reference/cli/gcx_kg_health.md
@@ -14,7 +14,7 @@ gcx kg health [flags]
   -h, --help               help for health
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --namespace string   Namespace scope
-  -o, --output string      Output format. One of: json, yaml (default "json")
+  -o, --output string      Output format. One of: agents, json, yaml (default "json")
       --since string       Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
       --site string        Site scope
       --to string          End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_kg_meta_all.md
+++ b/docs/reference/cli/gcx_kg_meta_all.md
@@ -12,7 +12,7 @@ gcx kg meta all [flags]
       --from string     Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help            help for all
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
       --since string    Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
       --to string       End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_kg_meta_logs.md
+++ b/docs/reference/cli/gcx_kg_meta_logs.md
@@ -11,7 +11,7 @@ gcx kg meta logs [flags]
 ```
   -h, --help            help for logs
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_meta_profiles.md
+++ b/docs/reference/cli/gcx_kg_meta_profiles.md
@@ -11,7 +11,7 @@ gcx kg meta profiles [flags]
 ```
   -h, --help            help for profiles
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_meta_schema.md
+++ b/docs/reference/cli/gcx_kg_meta_schema.md
@@ -12,7 +12,7 @@ gcx kg meta schema [flags]
       --from string     Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help            help for schema
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
       --since string    Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
       --to string       End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_kg_meta_scopes.md
+++ b/docs/reference/cli/gcx_kg_meta_scopes.md
@@ -11,7 +11,7 @@ gcx kg meta scopes [flags]
 ```
   -h, --help            help for scopes
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_meta_traces.md
+++ b/docs/reference/cli/gcx_kg_meta_traces.md
@@ -11,7 +11,7 @@ gcx kg meta traces [flags]
 ```
   -h, --help            help for traces
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_rules_get.md
+++ b/docs/reference/cli/gcx_kg_rules_get.md
@@ -11,7 +11,7 @@ gcx kg rules get <name> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_rules_list.md
+++ b/docs/reference/cli/gcx_kg_rules_list.md
@@ -12,7 +12,7 @@ gcx kg rules list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_scopes_list.md
+++ b/docs/reference/cli/gcx_kg_scopes_list.md
@@ -12,7 +12,7 @@ gcx kg scopes list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_status.md
+++ b/docs/reference/cli/gcx_kg_status.md
@@ -11,7 +11,7 @@ gcx kg status [flags]
 ```
   -h, --help            help for status
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_suppressions_list.md
+++ b/docs/reference/cli/gcx_kg_suppressions_list.md
@@ -11,7 +11,7 @@ gcx kg suppressions list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_login.md
+++ b/docs/reference/cli/gcx_login.md
@@ -40,7 +40,7 @@ gcx login [CONTEXT_NAME] [flags]
   -h, --help                      help for login
       --json string               Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --oauth-callback-port int   Fixed local port for the OAuth callback server (default: auto-pick from 54321-54399). Useful when only specific ports are forwarded between a remote host and your browser
-  -o, --output string             Output format. One of: json, text, yaml (default "text")
+  -o, --output string             Output format. One of: agents, json, text, yaml (default "text")
       --server string             Grafana server URL (e.g. https://my-stack.grafana.net)
       --token string              Grafana service account token
       --yes                       Non-interactive: skip optional prompts and use defaults

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_create.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_create.md
@@ -18,7 +18,7 @@ gcx logs adaptive drop-rules create [flags]
   -f, --filename string   File containing the drop rule definition (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_get.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_get.md
@@ -17,7 +17,7 @@ gcx logs adaptive drop-rules get ID [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_list.md
@@ -13,7 +13,7 @@ gcx logs adaptive drop-rules list [flags]
   -h, --help                       help for list
       --json string                Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int                  Maximum number of drop rules to return (0 for no limit) (default 50)
-  -o, --output string              Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string              Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_update.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_update.md
@@ -18,7 +18,7 @@ gcx logs adaptive drop-rules update ID [flags]
   -f, --filename string   File containing the drop rule definition (use - for stdin)
   -h, --help              help for update
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions_create.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions_create.md
@@ -11,7 +11,7 @@ gcx logs adaptive exemptions create [flags]
 ```
   -h, --help                     help for create
       --json string              Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string            Output format. One of: json, yaml (default "json")
+  -o, --output string            Output format. One of: agents, json, yaml (default "json")
       --reason string            Reason for the exemption
       --stream-selector string   Log stream selector (required)
 ```

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions_list.md
@@ -12,7 +12,7 @@ gcx logs adaptive exemptions list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of exemptions to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions_update.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions_update.md
@@ -11,7 +11,7 @@ gcx logs adaptive exemptions update ID [flags]
 ```
   -h, --help                     help for update
       --json string              Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string            Output format. One of: json, yaml (default "json")
+  -o, --output string            Output format. One of: agents, json, yaml (default "json")
       --reason string            Reason for the exemption
       --stream-selector string   Log stream selector
 ```

--- a/docs/reference/cli/gcx_logs_adaptive_patterns_show.md
+++ b/docs/reference/cli/gcx_logs_adaptive_patterns_show.md
@@ -11,7 +11,7 @@ gcx logs adaptive patterns show [flags]
 ```
   -h, --help             help for show
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
       --segment string   Only include patterns for this segment (ID column from patterns stats, or API map key / selector)
       --top int          Table only: show top N patterns by volume; 0 shows all rows with no rollup (default 10)
 ```

--- a/docs/reference/cli/gcx_logs_adaptive_patterns_stats.md
+++ b/docs/reference/cli/gcx_logs_adaptive_patterns_stats.md
@@ -11,7 +11,7 @@ gcx logs adaptive patterns stats [flags]
 ```
   -h, --help            help for stats
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_segments_create.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments_create.md
@@ -13,7 +13,7 @@ gcx logs adaptive segments create [flags]
   -h, --help                  help for create
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string           Segment name (required)
-  -o, --output string         Output format. One of: json, yaml (default "json")
+  -o, --output string         Output format. One of: agents, json, yaml (default "json")
       --selector string       Log stream selector (required)
 ```
 

--- a/docs/reference/cli/gcx_logs_adaptive_segments_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments_list.md
@@ -12,7 +12,7 @@ gcx logs adaptive segments list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of segments to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_segments_update.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments_update.md
@@ -13,7 +13,7 @@ gcx logs adaptive segments update ID [flags]
   -h, --help                  help for update
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string           Segment name
-  -o, --output string         Output format. One of: json, yaml (default "json")
+  -o, --output string         Output format. One of: agents, json, yaml (default "json")
       --selector string       Log stream selector
 ```
 

--- a/docs/reference/cli/gcx_logs_labels.md
+++ b/docs/reference/cli/gcx_logs_labels.md
@@ -31,7 +31,7 @@ gcx logs labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_metrics.md
+++ b/docs/reference/cli/gcx_logs_metrics.md
@@ -44,7 +44,7 @@ gcx logs metrics [EXPR] [flags]
   -h, --help                help for metrics
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_logs_query.md
+++ b/docs/reference/cli/gcx_logs_query.md
@@ -50,7 +50,7 @@ gcx logs query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of log lines to return (0 means no limit) (default 50)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: json, raw, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, raw, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_logs_series.md
+++ b/docs/reference/cli/gcx_logs_series.md
@@ -31,7 +31,7 @@ gcx logs series [flags]
   -h, --help                help for series
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -M, --match stringArray   LogQL stream selector (required, e.g., '{job="varlogs"}')
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_create.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_create.md
@@ -17,7 +17,7 @@ gcx metrics adaptive exemptions create [flags]
       --managed-by string         Manager identifier
       --match-type string         Match type: exact, prefix, or suffix (default "exact")
       --metric string             Metric name or pattern
-  -o, --output string             Output format. One of: json, yaml (default "json")
+  -o, --output string             Output format. One of: agents, json, yaml (default "json")
       --reason string             Reason for the exemption
       --segment string            Segment ID
 ```

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_get.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_get.md
@@ -11,7 +11,7 @@ gcx metrics adaptive exemptions get <id> [flags]
 ```
   -h, --help             help for get
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: json, table, wide, yaml (default "json")
+  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "json")
       --segment string   Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_list.md
@@ -13,7 +13,7 @@ gcx metrics adaptive exemptions list [flags]
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of exemptions to return (0 for no limit)
-  -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
       --segment string   Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_update.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_update.md
@@ -17,7 +17,7 @@ gcx metrics adaptive exemptions update <id> [flags]
       --managed-by string         Manager identifier
       --match-type string         Match type: exact, prefix, or suffix
       --metric string             Metric name or pattern
-  -o, --output string             Output format. One of: json, yaml (default "json")
+  -o, --output string             Output format. One of: agents, json, yaml (default "json")
       --reason string             Reason for the exemption
       --segment string            Segment ID
 ```

--- a/docs/reference/cli/gcx_metrics_adaptive_recommendations_diff.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_recommendations_diff.md
@@ -11,7 +11,7 @@ gcx metrics adaptive recommendations diff <metric>... [flags]
 ```
   -h, --help             help for diff
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: json, table, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, yaml (default "table")
       --segment string   Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_recommendations_show.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_recommendations_show.md
@@ -12,7 +12,7 @@ gcx metrics adaptive recommendations show [flags]
       --action stringArray   Filter by action: add, update, remove, keep (repeatable)
   -h, --help                 help for show
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string        Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
       --reverse              Reverse the default sort order
       --segment string       Segment ID
       --sort string          Sort by: metric, savings, series-before, series-after, action (default "metric")

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_create.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_create.md
@@ -19,7 +19,7 @@ gcx metrics adaptive rules create [flags]
       --keep-labels strings           Labels to keep (comma-separated)
       --match-type string             Match type: exact, prefix, or suffix (default "exact")
       --metric string                 Metric name (required)
-  -o, --output string                 Output format. One of: json, yaml (default "json")
+  -o, --output string                 Output format. One of: agents, json, yaml (default "json")
       --segment string                Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_get.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_get.md
@@ -11,7 +11,7 @@ gcx metrics adaptive rules get <metric> [flags]
 ```
   -h, --help             help for get
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: json, yaml (default "json")
+  -o, --output string    Output format. One of: agents, json, yaml (default "json")
       --segment string   Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_list.md
@@ -12,7 +12,7 @@ gcx metrics adaptive rules list [flags]
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of rules to return (0 for no limit) (default 50)
-  -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
       --segment string   Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_update.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_update.md
@@ -18,7 +18,7 @@ gcx metrics adaptive rules update <metric> [flags]
       --json string                   Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --keep-labels strings           Labels to keep (comma-separated)
       --match-type string             Match type: exact, prefix, or suffix
-  -o, --output string                 Output format. One of: json, yaml (default "json")
+  -o, --output string                 Output format. One of: agents, json, yaml (default "json")
       --segment string                Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_create.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_create.md
@@ -14,7 +14,7 @@ gcx metrics adaptive segments create [flags]
   -h, --help                  help for create
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string           Segment name (required)
-  -o, --output string         Output format. One of: json, yaml (default "json")
+  -o, --output string         Output format. One of: agents, json, yaml (default "json")
       --selector string       PromQL label selector (required)
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_get.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_get.md
@@ -11,7 +11,7 @@ gcx metrics adaptive segments get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_list.md
@@ -12,7 +12,7 @@ gcx metrics adaptive segments list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of segments to return (0 for no limit)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_update.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_update.md
@@ -14,7 +14,7 @@ gcx metrics adaptive segments update <id> [flags]
   -h, --help                  help for update
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string           Segment name
-  -o, --output string         Output format. One of: json, yaml (default "json")
+  -o, --output string         Output format. One of: agents, json, yaml (default "json")
       --selector string       PromQL label selector
 ```
 

--- a/docs/reference/cli/gcx_metrics_billing_labels.md
+++ b/docs/reference/cli/gcx_metrics_billing_labels.md
@@ -31,7 +31,7 @@ gcx metrics billing labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_billing_query.md
+++ b/docs/reference/cli/gcx_metrics_billing_query.md
@@ -42,7 +42,7 @@ gcx metrics billing query [EXPR] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_metrics_billing_series.md
+++ b/docs/reference/cli/gcx_metrics_billing_series.md
@@ -35,7 +35,7 @@ gcx metrics billing series [SELECTOR] [flags]
   -h, --help                help for series
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --match stringArray   Additional series selector(s); repeatable
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_metrics_labels.md
+++ b/docs/reference/cli/gcx_metrics_labels.md
@@ -31,7 +31,7 @@ gcx metrics labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_metadata.md
+++ b/docs/reference/cli/gcx_metrics_metadata.md
@@ -31,7 +31,7 @@ gcx metrics metadata [flags]
   -h, --help                help for metadata
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -m, --metric string       Filter by metric name
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_query.md
+++ b/docs/reference/cli/gcx_metrics_query.md
@@ -45,7 +45,7 @@ gcx metrics query [EXPR] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_metrics_series.md
+++ b/docs/reference/cli/gcx_metrics_series.md
@@ -35,7 +35,7 @@ gcx metrics series [SELECTOR] [flags]
   -h, --help                help for series
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --match stringArray   Additional series selector(s); repeatable
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_profiles_exemplars_profile.md
+++ b/docs/reference/cli/gcx_profiles_exemplars_profile.md
@@ -37,7 +37,7 @@ gcx profiles exemplars profile [EXPR] [flags]
   -h, --help                    help for profile
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
-  -o, --output string           Output format. One of: json, table, yaml (default "table")
+  -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
       --since string            Duration before --to (or now if omitted); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_profiles_exemplars_span.md
+++ b/docs/reference/cli/gcx_profiles_exemplars_span.md
@@ -37,7 +37,7 @@ gcx profiles exemplars span [EXPR] [flags]
   -h, --help                    help for span
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
-  -o, --output string           Output format. One of: json, table, yaml (default "table")
+  -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
       --since string            Duration before --to (or now if omitted); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_profiles_labels.md
+++ b/docs/reference/cli/gcx_profiles_labels.md
@@ -31,7 +31,7 @@ gcx profiles labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_profiles_metrics.md
+++ b/docs/reference/cli/gcx_profiles_metrics.md
@@ -48,7 +48,7 @@ gcx profiles metrics [EXPR] [flags]
   -h, --help                  help for metrics
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int             Maximum number of series to return (default 10)
-  -o, --output string         Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_profiles_profile-types.md
+++ b/docs/reference/cli/gcx_profiles_profile-types.md
@@ -27,7 +27,7 @@ gcx profiles profile-types [flags]
   -d, --datasource string   Datasource UID (required unless default-pyroscope-datasource is configured)
   -h, --help                help for profile-types
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -39,7 +39,7 @@ gcx profiles query [EXPR] [flags]
   -h, --help                  help for query
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-nodes int         Maximum nodes in flame graph (default 1024)
-  -o, --output string         Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_providers_list.md
+++ b/docs/reference/cli/gcx_providers_list.md
@@ -11,7 +11,7 @@ gcx providers list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_resources_edit.md
+++ b/docs/reference/cli/gcx_resources_edit.md
@@ -38,7 +38,7 @@ gcx resources edit RESOURCE_SELECTOR [flags]
 ```
   -h, --help            help for edit
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_resources_examples.md
+++ b/docs/reference/cli/gcx_resources_examples.md
@@ -29,7 +29,7 @@ gcx resources examples [RESOURCE_SELECTOR] [flags]
 ```
   -h, --help            help for examples
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, wide, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_resources_get.md
+++ b/docs/reference/cli/gcx_resources_get.md
@@ -79,7 +79,7 @@ gcx resources get [RESOURCE_SELECTOR]... [flags]
                             fail   — continue processing all resources and exit 1 if any failed (default)
                             abort  — stop on the first error and exit 1 (default "fail")
       --open              Open the resource in the default browser
-  -o, --output string     Output format. One of: json, text, wide, yaml (default "text")
+  -o, --output string     Output format. One of: agents, json, text, wide, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_resources_pull.md
+++ b/docs/reference/cli/gcx_resources_pull.md
@@ -69,7 +69,7 @@ gcx resources pull [RESOURCE_SELECTOR]... [flags]
                             ignore — continue processing all resources and exit 0
                             fail   — continue processing all resources and exit 1 if any failed (default)
                             abort  — stop on the first error and exit 1 (default "fail")
-  -o, --output string     Output format. One of: json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
   -p, --path string       Path on disk in which the resources will be written (default "./resources")
 ```
 

--- a/docs/reference/cli/gcx_resources_schemas.md
+++ b/docs/reference/cli/gcx_resources_schemas.md
@@ -30,7 +30,7 @@ gcx resources schemas [RESOURCE_SELECTOR] [flags]
   -h, --help            help for schemas
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --no-schema       Skip fetching OpenAPI spec schemas (faster, omits schema info and unlistable resource types)
-  -o, --output string   Output format. One of: json, text, wide, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, wide, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_resources_validate.md
+++ b/docs/reference/cli/gcx_resources_validate.md
@@ -41,7 +41,7 @@ gcx resources validate [RESOURCE_SELECTOR]... [flags]
                                ignore — continue processing all resources and exit 0
                                fail   — continue processing all resources and exit 1 if any failed (default)
                                abort  — stop on the first error and exit 1 (default "fail")
-  -o, --output string        Output format. One of: json, text, yaml (default "text")
+  -o, --output string        Output format. One of: agents, json, text, yaml (default "text")
   -p, --path strings         Paths on disk from which to read the resources. (default [./resources])
 ```
 

--- a/docs/reference/cli/gcx_setup_instrumentation_discover.md
+++ b/docs/reference/cli/gcx_setup_instrumentation_discover.md
@@ -12,7 +12,7 @@ gcx setup instrumentation discover [flags]
       --cluster string   Cluster name (required)
   -h, --help             help for discover
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_setup_instrumentation_show.md
+++ b/docs/reference/cli/gcx_setup_instrumentation_show.md
@@ -11,7 +11,7 @@ gcx setup instrumentation show <cluster> [flags]
 ```
   -h, --help            help for show
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_setup_instrumentation_status.md
+++ b/docs/reference/cli/gcx_setup_instrumentation_status.md
@@ -12,7 +12,7 @@ gcx setup instrumentation status [flags]
       --cluster string   Filter by cluster name
   -h, --help             help for status
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_skills_install.md
+++ b/docs/reference/cli/gcx_skills_install.md
@@ -29,7 +29,7 @@ gcx skills install [SKILL]... [flags]
       --force           Overwrite existing differing files managed by the gcx skills bundle
   -h, --help            help for install
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_skills_list.md
+++ b/docs/reference/cli/gcx_skills_list.md
@@ -23,7 +23,7 @@ gcx skills list [flags]
       --dir string      Root directory for the .agents installation (used to check installed status) (default "~/.agents")
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_skills_uninstall.md
+++ b/docs/reference/cli/gcx_skills_uninstall.md
@@ -27,7 +27,7 @@ gcx skills uninstall [SKILL]... [flags]
       --dry-run         Preview the uninstall without removing files
   -h, --help            help for uninstall
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
   -y, --yes             Auto-approve uninstalling all skills
 ```
 

--- a/docs/reference/cli/gcx_skills_update.md
+++ b/docs/reference/cli/gcx_skills_update.md
@@ -25,7 +25,7 @@ gcx skills update [SKILL]... [flags]
       --dry-run         Preview the update without writing files
   -h, --help            help for update
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_definitions_get.md
+++ b/docs/reference/cli/gcx_slo_definitions_get.md
@@ -11,7 +11,7 @@ gcx slo definitions get UUID [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_definitions_list.md
+++ b/docs/reference/cli/gcx_slo_definitions_list.md
@@ -12,7 +12,7 @@ gcx slo definitions list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return after fetch (0 for all; use a positive value to trim output only)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_definitions_status.md
+++ b/docs/reference/cli/gcx_slo_definitions_status.md
@@ -38,7 +38,7 @@ gcx slo definitions status [UUID] [flags]
 ```
   -h, --help            help for status
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, graph, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_definitions_timeline.md
+++ b/docs/reference/cli/gcx_slo_definitions_timeline.md
@@ -39,7 +39,7 @@ gcx slo definitions timeline [UUID] [flags]
       --from string     Start of the time range (e.g. now-7d, now-24h, RFC3339, Unix timestamp) (default "now-7d")
   -h, --help            help for timeline
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: graph, json, table, yaml (default "graph")
+  -o, --output string   Output format. One of: agents, graph, json, table, yaml (default "graph")
       --since string    Duration before now (e.g. 1h, 7d). Equivalent to --from now-<since> --to now.
       --step string     Query step (e.g. 5m, 1h). Defaults to auto-computed value.
       --to string       End of the time range (e.g. now, RFC3339, Unix timestamp) (default "now")

--- a/docs/reference/cli/gcx_slo_reports_get.md
+++ b/docs/reference/cli/gcx_slo_reports_get.md
@@ -11,7 +11,7 @@ gcx slo reports get UUID [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_reports_list.md
+++ b/docs/reference/cli/gcx_slo_reports_list.md
@@ -12,7 +12,7 @@ gcx slo reports list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_reports_status.md
+++ b/docs/reference/cli/gcx_slo_reports_status.md
@@ -37,7 +37,7 @@ gcx slo reports status [UUID] [flags]
 ```
   -h, --help            help for status
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, graph, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_reports_timeline.md
+++ b/docs/reference/cli/gcx_slo_reports_timeline.md
@@ -40,7 +40,7 @@ gcx slo reports timeline [UUID] [flags]
       --from string     Start of the time range (e.g. now-7d, now-24h, RFC3339, Unix timestamp) (default "now-7d")
   -h, --help            help for timeline
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: graph, json, table, yaml (default "graph")
+  -o, --output string   Output format. One of: agents, graph, json, table, yaml (default "graph")
       --since string    Duration before now (e.g. 1h, 7d). Equivalent to --from now-<since> --to now.
       --step string     Query step (e.g. 5m, 1h). Defaults to auto-computed value.
       --to string       End of the time range (e.g. now, RFC3339, Unix timestamp) (default "now")

--- a/docs/reference/cli/gcx_stacks_create.md
+++ b/docs/reference/cli/gcx_stacks_create.md
@@ -24,7 +24,7 @@ gcx stacks create [flags]
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --labels strings       Labels in key=value format (may be repeated)
       --name string          Stack name (required)
-  -o, --output string        Output format. One of: json, table, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, table, yaml (default "table")
       --region string        Region slug (e.g. us, eu). Use 'gcx stacks regions' to list.
       --slug string          Stack slug / subdomain (required)
       --url string           Custom domain URL

--- a/docs/reference/cli/gcx_stacks_get.md
+++ b/docs/reference/cli/gcx_stacks_get.md
@@ -11,7 +11,7 @@ gcx stacks get <stack-slug> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_stacks_list.md
+++ b/docs/reference/cli/gcx_stacks_list.md
@@ -12,7 +12,7 @@ gcx stacks list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --org string      Organisation slug (required)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_stacks_regions.md
+++ b/docs/reference/cli/gcx_stacks_regions.md
@@ -11,7 +11,7 @@ gcx stacks regions [flags]
 ```
   -h, --help            help for regions
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_stacks_update.md
+++ b/docs/reference/cli/gcx_stacks_update.md
@@ -25,7 +25,7 @@ gcx stacks update <stack-slug> [flags]
       --labels strings         Labels in key=value format (replaces all labels)
       --name string            New stack name
       --no-delete-protection   Disable delete protection
-  -o, --output string          Output format. One of: json, table, yaml (default "table")
+  -o, --output string          Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_get.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_get.md
@@ -24,7 +24,7 @@ gcx synthetic-monitoring checks get NAME [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
       --show-status     Query and display the check's current execution status from Prometheus
 ```
 

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_list.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_list.md
@@ -27,7 +27,7 @@ gcx synthetic-monitoring checks list [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --label stringArray   Filter by label key=value (repeatable, e.g. --label env=prod)
       --limit int           Maximum number of items to return (0 for all) (default 50)
-  -o, --output string       Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_status.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_status.md
@@ -44,7 +44,7 @@ gcx synthetic-monitoring checks status [ID] [flags]
       --job string              Filter by job name glob pattern (e.g. --job 'shopk8s-*')
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --label stringArray       Filter by label key=value (repeatable, e.g. --label env=prod)
-  -o, --output string           Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string           Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --status string           Filter results by status: OK, FAILING, or NODATA
 ```
 

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_timeline.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_timeline.md
@@ -40,7 +40,7 @@ gcx synthetic-monitoring checks timeline ID [flags]
       --from string             Start of the time range (e.g. now-6h, now-24h, RFC3339, Unix timestamp)
   -h, --help                    help for timeline
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string           Output format. One of: graph, json, table, yaml (default "graph")
+  -o, --output string           Output format. One of: agents, graph, json, table, yaml (default "graph")
       --since string            Duration before now to display (e.g. 1h, 6h, 24h, 7d) (default "6h")
       --to string               End of the time range (e.g. now, RFC3339, Unix timestamp)
 ```

--- a/docs/reference/cli/gcx_synthetic-monitoring_probes_list.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_probes_list.md
@@ -12,7 +12,7 @@ gcx synthetic-monitoring probes list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_adaptive_policies_create.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_create.md
@@ -12,7 +12,7 @@ gcx traces adaptive policies create [flags]
   -f, --filename string   File containing the policy definition (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "yaml")
+  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_adaptive_policies_get.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_get.md
@@ -11,7 +11,7 @@ gcx traces adaptive policies get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_adaptive_policies_list.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_list.md
@@ -12,7 +12,7 @@ gcx traces adaptive policies list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of policies to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_adaptive_policies_update.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_update.md
@@ -12,7 +12,7 @@ gcx traces adaptive policies update <id> [flags]
   -f, --filename string   File containing the policy definition (use - for stdin)
   -h, --help              help for update
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: json, yaml (default "yaml")
+  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_adaptive_recommendations_show.md
+++ b/docs/reference/cli/gcx_traces_adaptive_recommendations_show.md
@@ -11,7 +11,7 @@ gcx traces adaptive recommendations show [flags]
 ```
   -h, --help            help for show
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_get.md
+++ b/docs/reference/cli/gcx_traces_get.md
@@ -39,7 +39,7 @@ gcx traces get TRACE_ID [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --llm                 Request LLM-friendly trace format
       --open                Open the retrieved trace in Grafana Explore
-  -o, --output string       Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_traces_labels.md
+++ b/docs/reference/cli/gcx_traces_labels.md
@@ -33,7 +33,7 @@ gcx traces labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)
 ```

--- a/docs/reference/cli/gcx_traces_metrics.md
+++ b/docs/reference/cli/gcx_traces_metrics.md
@@ -44,7 +44,7 @@ gcx traces metrics [TRACEQL] [flags]
       --instant             Run an instant query over the selected time range instead of a range query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_traces_query.md
+++ b/docs/reference/cli/gcx_traces_query.md
@@ -40,7 +40,7 @@ gcx traces query [TRACEQL] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of traces to return (0 means no limit) (default 20)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -91,10 +91,10 @@ var commandAnnotations = map[string]annotation{
 	"gcx setup instrumentation status":   {Cost: "small"},
 
 	// skills
-	"gcx skills install":   {Cost: "small"},
-	"gcx skills list":      {Cost: "small"},
-	"gcx skills update":    {Cost: "small"},
-	"gcx skills uninstall": {Cost: "small"},
+	"gcx agent skills install":   {Cost: "small"},
+	"gcx agent skills list":      {Cost: "small"},
+	"gcx agent skills update":    {Cost: "small"},
+	"gcx agent skills uninstall": {Cost: "small"},
 
 	// -----------------------------------------------------------------------
 	// Dashboards provider

--- a/internal/notifier/run_test.go
+++ b/internal/notifier/run_test.go
@@ -39,7 +39,7 @@ func TestMaybeNotifySkillsAt_WritesMessageAndStateWhenDue(t *testing.T) {
 	if err := maybeNotifySkillsAt(testRunSkillsFS(), &out, statePath, root, now); err != nil {
 		t.Fatalf("maybeNotifySkillsAt() error = %v", err)
 	}
-	if !strings.Contains(out.String(), "Run: gcx skills update") {
+	if !strings.Contains(out.String(), "Run: gcx agent skills update") {
 		t.Fatalf("output = %q, want skills update hint", out.String())
 	}
 

--- a/internal/notifier/skills.go
+++ b/internal/notifier/skills.go
@@ -6,7 +6,7 @@ import (
 	skillops "github.com/grafana/gcx/internal/skills"
 )
 
-const skillsUpdateCommand = "gcx skills update"
+const skillsUpdateCommand = "gcx agent skills update"
 
 // SkillsUpdateMessage returns a human-facing notification message when the
 // installed skills differ from the bundled skills in the current gcx binary.

--- a/internal/notifier/skills_test.go
+++ b/internal/notifier/skills_test.go
@@ -70,7 +70,7 @@ func TestSkillsUpdateMessage_InstalledSkillDiffersFromBundle(t *testing.T) {
 	if msg == "" {
 		t.Fatal("SkillsUpdateMessage() = empty, want message")
 	}
-	if want := "Run: gcx skills update"; !strings.HasSuffix(msg, want) {
+	if want := "Run: gcx agent skills update"; !strings.HasSuffix(msg, want) {
 		t.Fatalf("SkillsUpdateMessage() = %q, want suffix %q", msg, want)
 	}
 }

--- a/internal/output/agents.go
+++ b/internal/output/agents.go
@@ -19,12 +19,22 @@ const (
 	agentsSpillEnv                  = "GCX_AGENT_SPILL_BYTES"
 	defaultSpillBytes               = 100 * 1024 // 100 KiB
 	spillPreviewItems               = 3
-	spillFilePattern                = "gcx-results-*.json"
+
+	// SpillFilePattern is the glob pattern for agent spill files. Exported so
+	// companion commands (e.g. gcx agent prune) can locate them.
+	SpillFilePattern = "gcx-results-*.json"
 )
 
-type agentsCodec struct{}
+type agentsCodec struct {
+	errWriter io.Writer
+}
 
-func newAgentsCodec() *agentsCodec { return &agentsCodec{} }
+func newAgentsCodec(errWriter io.Writer) *agentsCodec {
+	if errWriter == nil {
+		errWriter = os.Stderr
+	}
+	return &agentsCodec{errWriter: errWriter}
+}
 
 func (c *agentsCodec) Format() format.Format { return agentsFormat }
 
@@ -49,7 +59,7 @@ func (c *agentsCodec) Encode(dst io.Writer, value any) error {
 }
 
 func (c *agentsCodec) spill(dst io.Writer, value any, payload []byte) error {
-	f, err := os.CreateTemp("", spillFilePattern)
+	f, err := os.CreateTemp("", SpillFilePattern)
 	if err != nil {
 		return fmt.Errorf("create spill file: %w", err)
 	}
@@ -62,14 +72,25 @@ func (c *agentsCodec) spill(dst io.Writer, value any, payload []byte) error {
 		return fmt.Errorf("close spill file: %w", err)
 	}
 
+	msg := fmt.Sprintf(
+		"Response too large for stdout (%d bytes). Full data written to %s. Read that file for complete results, or rerun with -o json to force inline output.",
+		len(payload), f.Name(),
+	)
+
 	summary := map[string]any{
 		"spilled_to": f.Name(),
 		"bytes":      len(payload),
 		"preview":    previewOf(value),
+		"message":    msg,
 	}
 	if n, ok := itemCount(value); ok {
 		summary["items"] = n
 	}
+
+	fmt.Fprintf(c.errWriter,
+		"hint: response too large for stdout (%d bytes) — read %s for full data, or use -o json to force inline\n",
+		len(payload), f.Name(),
+	)
 
 	out := json.NewEncoder(dst)
 	out.SetEscapeHTML(false)

--- a/internal/output/agents.go
+++ b/internal/output/agents.go
@@ -1,0 +1,133 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strconv"
+
+	"github.com/grafana/gcx/internal/format"
+)
+
+const (
+	agentsFormat      format.Format = "agents"
+	agentsSpillEnv                  = "GCX_AGENT_SPILL_BYTES"
+	defaultSpillBytes               = 100 * 1024 // 100 KiB
+	spillPreviewItems               = 3
+	spillFilePattern                = "gcx-results-*.json"
+)
+
+type agentsCodec struct{}
+
+func newAgentsCodec() *agentsCodec { return &agentsCodec{} }
+
+func (c *agentsCodec) Format() format.Format { return agentsFormat }
+
+func (c *agentsCodec) Decode(io.Reader, any) error {
+	return errors.New("agents codec does not support decoding")
+}
+
+func (c *agentsCodec) Encode(dst io.Writer, value any) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(value); err != nil {
+		return err
+	}
+
+	if buf.Len() <= spillThreshold() {
+		_, err := io.Copy(dst, &buf)
+		return err
+	}
+
+	return c.spill(dst, value, buf.Bytes())
+}
+
+func (c *agentsCodec) spill(dst io.Writer, value any, payload []byte) error {
+	f, err := os.CreateTemp("", spillFilePattern)
+	if err != nil {
+		return fmt.Errorf("create spill file: %w", err)
+	}
+	if _, err := f.Write(payload); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return fmt.Errorf("write spill file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close spill file: %w", err)
+	}
+
+	summary := map[string]any{
+		"spilled_to": f.Name(),
+		"bytes":      len(payload),
+		"preview":    previewOf(value),
+	}
+	if n, ok := itemCount(value); ok {
+		summary["items"] = n
+	}
+
+	out := json.NewEncoder(dst)
+	out.SetEscapeHTML(false)
+	return out.Encode(summary)
+}
+
+func spillThreshold() int {
+	if v := os.Getenv(agentsSpillEnv); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultSpillBytes
+}
+
+// itemCount returns the length of slice/array values and a true bool.
+// Also handles structs with an Items slice field (e.g. unstructured.UnstructuredList).
+func itemCount(value any) (int, bool) {
+	v := reflect.ValueOf(value)
+	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return 0, false
+		}
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		return v.Len(), true
+	case reflect.Struct:
+		items := v.FieldByName("Items")
+		if items.IsValid() && (items.Kind() == reflect.Slice || items.Kind() == reflect.Array) {
+			return items.Len(), true
+		}
+	}
+	return 0, false
+}
+
+// previewOf returns the first spillPreviewItems elements for slices/lists,
+// or the value itself for scalar/map shapes.
+func previewOf(value any) any {
+	v := reflect.ValueOf(value)
+	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return value
+		}
+		v = v.Elem()
+	}
+	take := func(slice reflect.Value) any {
+		n := min(slice.Len(), spillPreviewItems)
+		return slice.Slice(0, n).Interface()
+	}
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		return take(v)
+	case reflect.Struct:
+		items := v.FieldByName("Items")
+		if items.IsValid() && (items.Kind() == reflect.Slice || items.Kind() == reflect.Array) {
+			return take(items)
+		}
+	}
+	return value
+}

--- a/internal/output/agents.go
+++ b/internal/output/agents.go
@@ -78,13 +78,13 @@ func (c *agentsCodec) spill(dst io.Writer, value any, payload []byte) error {
 	)
 
 	summary := map[string]any{
-		"spilled_to": f.Name(),
-		"bytes":      len(payload),
-		"preview":    previewOf(value),
-		"message":    msg,
+		"spilled_to":     f.Name(),
+		"bytes":          len(payload),
+		"preview_sample": previewOf(value),
+		"message":        msg,
 	}
 	if n, ok := itemCount(value); ok {
-		summary["items"] = n
+		summary["total_items"] = n
 	}
 
 	fmt.Fprintf(c.errWriter,

--- a/internal/output/agents.go
+++ b/internal/output/agents.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 
 	"github.com/grafana/gcx/internal/format"
@@ -107,12 +108,12 @@ func itemCount(value any) (int, bool) {
 }
 
 // previewOf returns the first spillPreviewItems elements for slices/lists,
-// or the value itself for scalar/map shapes.
+// the sorted top-level key names for map shapes, or nil for other shapes.
 func previewOf(value any) any {
 	v := reflect.ValueOf(value)
 	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
 		if v.IsNil() {
-			return value
+			return nil
 		}
 		v = v.Elem()
 	}
@@ -128,6 +129,16 @@ func previewOf(value any) any {
 		if items.IsValid() && (items.Kind() == reflect.Slice || items.Kind() == reflect.Array) {
 			return take(items)
 		}
+	case reflect.Map:
+		keys := v.MapKeys()
+		names := make([]string, 0, len(keys))
+		for _, k := range keys {
+			if k.Kind() == reflect.String {
+				names = append(names, k.String())
+			}
+		}
+		sort.Strings(names)
+		return names
 	}
-	return value
+	return nil
 }

--- a/internal/output/agents.go
+++ b/internal/output/agents.go
@@ -29,6 +29,14 @@ type agentsCodec struct {
 	errWriter io.Writer
 }
 
+type spillSummary struct {
+	SpilledTo     string `json:"spilled_to"`
+	Bytes         int    `json:"bytes"`
+	PreviewSample any    `json:"preview_sample"`
+	Message       string `json:"message"`
+	TotalItems    *int   `json:"total_items,omitempty"`
+}
+
 func newAgentsCodec(errWriter io.Writer) *agentsCodec {
 	if errWriter == nil {
 		errWriter = os.Stderr
@@ -77,14 +85,14 @@ func (c *agentsCodec) spill(dst io.Writer, value any, payload []byte) error {
 		len(payload), f.Name(),
 	)
 
-	summary := map[string]any{
-		"spilled_to":     f.Name(),
-		"bytes":          len(payload),
-		"preview_sample": previewOf(value),
-		"message":        msg,
+	s := spillSummary{
+		SpilledTo:     f.Name(),
+		Bytes:         len(payload),
+		PreviewSample: previewOf(value),
+		Message:       msg,
 	}
 	if n, ok := itemCount(value); ok {
-		summary["total_items"] = n
+		s.TotalItems = &n
 	}
 
 	fmt.Fprintf(c.errWriter,
@@ -94,7 +102,7 @@ func (c *agentsCodec) spill(dst io.Writer, value any, payload []byte) error {
 
 	out := json.NewEncoder(dst)
 	out.SetEscapeHTML(false)
-	return out.Encode(summary)
+	return out.Encode(s)
 }
 
 func spillThreshold() int {

--- a/internal/output/agents_test.go
+++ b/internal/output/agents_test.go
@@ -1,0 +1,147 @@
+package output_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentsCodec_BelowThreshold(t *testing.T) {
+	codec := cmdio.NewAgentsCodecForTesting()
+
+	data := []map[string]any{
+		{"name": "alpha", "kind": "Dashboard"},
+		{"name": "beta", "kind": "Dashboard"},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, data, got)
+}
+
+func TestAgentsCodec_AboveThreshold_Spills(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "50")
+	t.Setenv("TMPDIR", t.TempDir())
+
+	codec := cmdio.NewAgentsCodecForTesting()
+
+	data := []map[string]any{
+		{"name": "alpha", "kind": "Dashboard"},
+		{"name": "beta", "kind": "Dashboard"},
+		{"name": "gamma", "kind": "Dashboard"},
+		{"name": "delta", "kind": "Dashboard"},
+		{"name": "epsilon", "kind": "Dashboard"},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+
+	spillPath, ok := summary["spilled_to"].(string)
+	require.True(t, ok, "summary must contain spilled_to")
+	assert.True(t, strings.HasPrefix(spillPath, os.Getenv("TMPDIR")), "spill file should be in TMPDIR")
+
+	_, err := os.Stat(spillPath)
+	require.NoError(t, err, "spill file must exist")
+
+	spillBytes, err := os.ReadFile(spillPath)
+	require.NoError(t, err)
+	var full []map[string]any
+	require.NoError(t, json.Unmarshal(spillBytes, &full))
+	assert.Equal(t, data, full)
+
+	assert.Contains(t, summary, "bytes")
+	assert.Contains(t, summary, "items")
+	assert.EqualValues(t, len(data), summary["items"])
+
+	preview, ok := summary["preview"].([]any)
+	require.True(t, ok, "preview must be an array")
+	assert.LessOrEqual(t, len(preview), 3)
+}
+
+func TestAgentsCodec_NonSlice_OmitsItems(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
+	t.Setenv("TMPDIR", t.TempDir())
+
+	codec := cmdio.NewAgentsCodecForTesting()
+
+	data := map[string]any{"name": "alpha", "kind": "Dashboard"}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+
+	assert.NotContains(t, summary, "items", "non-slice value should not include items count")
+	assert.Contains(t, summary, "spilled_to")
+}
+
+func TestAgentsCodec_StructWithItems_CountsItems(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
+	t.Setenv("TMPDIR", t.TempDir())
+
+	type listValue struct {
+		Items []map[string]any
+	}
+
+	codec := cmdio.NewAgentsCodecForTesting()
+
+	data := listValue{Items: []map[string]any{
+		{"name": "alpha"},
+		{"name": "beta"},
+		{"name": "gamma"},
+		{"name": "delta"},
+	}}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+
+	assert.EqualValues(t, 4, summary["items"])
+
+	preview, ok := summary["preview"].([]any)
+	require.True(t, ok)
+	assert.LessOrEqual(t, len(preview), 3)
+}
+
+func TestAgentsCodec_InvalidEnvVar_FallsBackToDefault(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "not-a-number")
+
+	codec := cmdio.NewAgentsCodecForTesting()
+
+	// Build a payload just under 100 KiB — should NOT spill.
+	data := map[string]string{"payload": strings.Repeat("x", 100*1024-200)}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	// Output should be raw JSON, not a spill summary.
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got), "expected plain JSON, not spill summary")
+	assert.Equal(t, data, got)
+}
+
+func TestAgentsCodec_Format(t *testing.T) {
+	codec := cmdio.NewAgentsCodecForTesting()
+	assert.Equal(t, "agents", string(codec.Format()))
+}
+
+func TestAgentsCodec_DecodeReturnsError(t *testing.T) {
+	codec := cmdio.NewAgentsCodecForTesting()
+	err := codec.Decode(strings.NewReader("{}"), &map[string]any{})
+	require.Error(t, err)
+}

--- a/internal/output/agents_test.go
+++ b/internal/output/agents_test.go
@@ -88,6 +88,34 @@ func TestAgentsCodec_NonSlice_OmitsItems(t *testing.T) {
 	assert.Contains(t, summary, "spilled_to")
 }
 
+func TestAgentsCodec_NonSlice_PreviewIsKeyNames(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
+	t.Setenv("TMPDIR", t.TempDir())
+
+	codec := cmdio.NewAgentsCodecForTesting()
+
+	// Large map that would be expensive to embed verbatim in the spill envelope.
+	data := map[string]any{
+		"name":    "alpha",
+		"payload": strings.Repeat("x", 10_000),
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+
+	// stdout must be much smaller than the full payload — the preview must
+	// not embed the full map values.
+	assert.Less(t, buf.Len(), 500, "spill envelope must not embed the full payload")
+
+	// Preview should be the sorted top-level key names, not the full value.
+	preview, ok := summary["preview"].([]any)
+	require.True(t, ok, "preview for map should be key names as a slice")
+	assert.ElementsMatch(t, []any{"name", "payload"}, preview)
+}
+
 func TestAgentsCodec_StructWithItems_CountsItems(t *testing.T) {
 	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
 	t.Setenv("TMPDIR", t.TempDir())

--- a/internal/output/agents_test.go
+++ b/internal/output/agents_test.go
@@ -163,6 +163,56 @@ func TestAgentsCodec_InvalidEnvVar_FallsBackToDefault(t *testing.T) {
 	assert.Equal(t, data, got)
 }
 
+func TestAgentsCodec_Spill_HasMessageField(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
+	t.Setenv("TMPDIR", t.TempDir())
+
+	var errBuf bytes.Buffer
+	codec := cmdio.NewAgentsCodecWithErrWriter(&errBuf)
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, map[string]any{"name": "alpha"}))
+
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+
+	msg, ok := summary["message"].(string)
+	require.True(t, ok, "spill envelope must contain a string message field")
+	spillPath, _ := summary["spilled_to"].(string)
+	assert.Contains(t, msg, spillPath, "message must reference the spill file path")
+}
+
+func TestAgentsCodec_Spill_EmitsStderrHint(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
+	t.Setenv("TMPDIR", t.TempDir())
+
+	var errBuf bytes.Buffer
+	codec := cmdio.NewAgentsCodecWithErrWriter(&errBuf)
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, map[string]any{"name": "alpha"}))
+
+	hint := errBuf.String()
+	require.NotEmpty(t, hint, "spill must emit a hint to errWriter")
+
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+	spillPath, _ := summary["spilled_to"].(string)
+	assert.Contains(t, hint, spillPath, "hint must reference the spill file path")
+}
+
+func TestAgentsCodec_NoSpill_NoStderrHint(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "1000000")
+
+	var errBuf bytes.Buffer
+	codec := cmdio.NewAgentsCodecWithErrWriter(&errBuf)
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, map[string]any{"name": "alpha"}))
+
+	assert.Empty(t, errBuf.String(), "no spill means no stderr hint")
+}
+
 func TestAgentsCodec_Format(t *testing.T) {
 	codec := cmdio.NewAgentsCodecForTesting()
 	assert.Equal(t, "agents", string(codec.Format()))

--- a/internal/output/agents_test.go
+++ b/internal/output/agents_test.go
@@ -62,10 +62,10 @@ func TestAgentsCodec_AboveThreshold_Spills(t *testing.T) {
 	assert.Equal(t, data, full)
 
 	assert.Contains(t, summary, "bytes")
-	assert.Contains(t, summary, "items")
-	assert.EqualValues(t, len(data), summary["items"])
+	assert.Contains(t, summary, "total_items")
+	assert.EqualValues(t, len(data), summary["total_items"])
 
-	preview, ok := summary["preview"].([]any)
+	preview, ok := summary["preview_sample"].([]any)
 	require.True(t, ok, "preview must be an array")
 	assert.LessOrEqual(t, len(preview), 3)
 }
@@ -84,7 +84,7 @@ func TestAgentsCodec_NonSlice_OmitsItems(t *testing.T) {
 	var summary map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
 
-	assert.NotContains(t, summary, "items", "non-slice value should not include items count")
+	assert.NotContains(t, summary, "total_items", "non-slice value should not include total_items count")
 	assert.Contains(t, summary, "spilled_to")
 }
 
@@ -111,7 +111,7 @@ func TestAgentsCodec_NonSlice_PreviewIsKeyNames(t *testing.T) {
 	assert.Less(t, buf.Len(), 500, "spill envelope must not embed the full payload")
 
 	// Preview should be the sorted top-level key names, not the full value.
-	preview, ok := summary["preview"].([]any)
+	preview, ok := summary["preview_sample"].([]any)
 	require.True(t, ok, "preview for map should be key names as a slice")
 	assert.ElementsMatch(t, []any{"name", "payload"}, preview)
 }
@@ -139,9 +139,9 @@ func TestAgentsCodec_StructWithItems_CountsItems(t *testing.T) {
 	var summary map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
 
-	assert.EqualValues(t, 4, summary["items"])
+	assert.EqualValues(t, 4, summary["total_items"])
 
-	preview, ok := summary["preview"].([]any)
+	preview, ok := summary["preview_sample"].([]any)
 	require.True(t, ok)
 	assert.LessOrEqual(t, len(preview), 3)
 }
@@ -161,6 +161,40 @@ func TestAgentsCodec_InvalidEnvVar_FallsBackToDefault(t *testing.T) {
 	var got map[string]string
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &got), "expected plain JSON, not spill summary")
 	assert.Equal(t, data, got)
+}
+
+func TestAgentsCodec_SpillEnvelope_UsesTotalItems(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
+	t.Setenv("TMPDIR", t.TempDir())
+
+	codec := cmdio.NewAgentsCodecForTesting()
+	data := []map[string]any{{"name": "alpha"}, {"name": "beta"}}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+
+	assert.Contains(t, summary, "total_items", "envelope must use total_items (not items) to avoid k8s shape collision")
+	assert.NotContains(t, summary, "items", "envelope must not use items — collides with k8s list shape")
+}
+
+func TestAgentsCodec_SpillEnvelope_UsesPreviewSample(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
+	t.Setenv("TMPDIR", t.TempDir())
+
+	codec := cmdio.NewAgentsCodecForTesting()
+	data := []map[string]any{{"name": "alpha"}, {"name": "beta"}}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+
+	assert.Contains(t, summary, "preview_sample", "envelope must use preview_sample (not preview) to avoid mistaking it for the full dataset")
+	assert.NotContains(t, summary, "preview", "envelope must not use preview — too easy to treat as complete data")
 }
 
 func TestAgentsCodec_Spill_HasMessageField(t *testing.T) {

--- a/internal/output/export_test.go
+++ b/internal/output/export_test.go
@@ -1,8 +1,18 @@
 package output
 
-import "github.com/grafana/gcx/internal/format"
+import (
+	"io"
+
+	"github.com/grafana/gcx/internal/format"
+)
 
 // NewAgentsCodecForTesting exposes the unexported agentsCodec for unit tests.
+// Uses os.Stderr as the error writer.
 func NewAgentsCodecForTesting() format.Codec {
-	return newAgentsCodec()
+	return newAgentsCodec(nil)
+}
+
+// NewAgentsCodecWithErrWriter exposes the agentsCodec with a custom errWriter for testing.
+func NewAgentsCodecWithErrWriter(w io.Writer) format.Codec {
+	return newAgentsCodec(w)
 }

--- a/internal/output/export_test.go
+++ b/internal/output/export_test.go
@@ -1,0 +1,8 @@
+package output
+
+import "github.com/grafana/gcx/internal/format"
+
+// NewAgentsCodecForTesting exposes the unexported agentsCodec for unit tests.
+func NewAgentsCodecForTesting() format.Codec {
+	return newAgentsCodec()
+}

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -120,7 +120,9 @@ func (opts *Options) applyJSONFlag() error {
 	// Only reject when -o is explicitly set to a non-JSON format.
 	// -o json (or omitted) is fine — --json implies JSON anyway.
 	outputFlag := opts.flags.Lookup("output")
-	if outputFlag != nil && outputFlag.Changed && outputFlag.Value.String() != "json" {
+	if outputFlag != nil && outputFlag.Changed &&
+		outputFlag.Value.String() != "json" &&
+		outputFlag.Value.String() != string(agentsFormat) {
 		return fmt.Errorf("--json requires JSON output, but -o %s was specified", outputFlag.Value.String())
 	}
 

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"os"
 	"reflect"
 	"slices"
 	"sort"
@@ -36,10 +37,14 @@ type Options struct {
 	// Populated from terminal.NoTruncate() during BindFlags.
 	NoTruncate bool
 
+	// ErrWriter is the writer for hints and diagnostics (defaults to os.Stderr).
+	ErrWriter io.Writer
+
 	customCodecs       map[string]format.Codec
 	defaultFormat      string
 	flags              *pflag.FlagSet
 	jsonFieldValidator func(fields []string) error // optional; invoked before field extraction when --json is used
+	agentHintShown     bool
 }
 
 // SetJSONFieldValidator registers an optional validator invoked before field
@@ -71,10 +76,10 @@ func (opts *Options) BindFlags(flags *pflag.FlagSet) {
 		defaultFormat = opts.defaultFormat
 	}
 
-	// Agent mode: override any per-command default with JSON.
+	// Agent mode: override any per-command default with the agents codec.
 	// Explicit -o flag from user still takes precedence (via cobra flag parsing).
 	if agent.IsAgentMode() {
-		defaultFormat = "json"
+		defaultFormat = string(agentsFormat)
 	}
 
 	// Populate pipe/truncation state from package-level terminal detection.
@@ -159,11 +164,25 @@ func (opts *Options) Encode(dst io.Writer, value any) error {
 		return err
 	}
 
+	// In agent mode, nudge toward --json field selection when the command
+	// outputs JSON without explicit --json usage. The hint is emitted
+	// once per command invocation to stderr so it doesn't pollute stdout.
+	isJSONLike := codec.Format() == format.JSON || codec.Format() == agentsFormat
+	if !opts.agentHintShown && agent.IsAgentMode() && isJSONLike && len(opts.JSONFields) == 0 && !opts.JSONDiscovery {
+		opts.agentHintShown = true
+		w := opts.ErrWriter
+		if w == nil {
+			w = os.Stderr
+		}
+		fmt.Fprintln(w, "hint: use --json list to discover fields, --json field1,field2 to select — no external parsing needed")
+	}
+
+
 	// Intercept JSON field discovery and field selection when the resolved
-	// codec is JSON. Commands that already check JSONFields/JSONDiscovery
+	// codec is JSON-like. Commands that already check JSONFields/JSONDiscovery
 	// before calling Encode() will never reach here (they return early), so
 	// there is no double-application risk.
-	if codec.Format() == format.JSON {
+	if isJSONLike {
 		if opts.JSONDiscovery {
 			return opts.encodeDiscovery(dst, value)
 		}
@@ -298,8 +317,9 @@ func (opts *Options) codecFor(format string) format.Codec { //nolint:ireturn
 
 func (opts *Options) builtinCodecs() map[string]format.Codec {
 	return map[string]format.Codec{
-		"yaml": format.NewYAMLCodec(),
-		"json": format.NewJSONCodec(),
+		"yaml":   format.NewYAMLCodec(),
+		"json":   format.NewJSONCodec(),
+		"agents": newAgentsCodec(),
 	}
 }
 

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -106,7 +106,9 @@ func (opts *Options) Validate() error {
 // applyJSONFlag processes the --json flag value. When -o/--output is explicitly
 // set to a non-JSON format, it returns an error because field selection only
 // works with JSON output. Combining -o json with --json is allowed since
-// there is no conflict.
+// there is no conflict. The agents format is intentionally excluded — in agent
+// mode the implicit default is agents, and users should pass only --json
+// (without an explicit -o) to combine field selection with the agents codec.
 func (opts *Options) applyJSONFlag() error {
 	if opts.flags == nil {
 		return nil
@@ -121,8 +123,7 @@ func (opts *Options) applyJSONFlag() error {
 	// -o json (or omitted) is fine — --json implies JSON anyway.
 	outputFlag := opts.flags.Lookup("output")
 	if outputFlag != nil && outputFlag.Changed &&
-		outputFlag.Value.String() != "json" &&
-		outputFlag.Value.String() != string(agentsFormat) {
+		outputFlag.Value.String() != "json" {
 		return fmt.Errorf("--json requires JSON output, but -o %s was specified", outputFlag.Value.String())
 	}
 

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -180,7 +180,6 @@ func (opts *Options) Encode(dst io.Writer, value any) error {
 		fmt.Fprintln(w, "hint: use --json list to discover fields, --json field1,field2 to select — no external parsing needed")
 	}
 
-
 	// Intercept JSON field discovery and field selection when the resolved
 	// codec is JSON-like. Commands that already check JSONFields/JSONDiscovery
 	// before calling Encode() will never reach here (they return early), so

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -318,10 +318,14 @@ func (opts *Options) codecFor(format string) format.Codec { //nolint:ireturn
 }
 
 func (opts *Options) builtinCodecs() map[string]format.Codec {
+	errWriter := opts.ErrWriter
+	if errWriter == nil {
+		errWriter = os.Stderr
+	}
 	return map[string]format.Codec{
 		"yaml":   format.NewYAMLCodec(),
 		"json":   format.NewJSONCodec(),
-		"agents": newAgentsCodec(),
+		"agents": newAgentsCodec(errWriter),
 	}
 }
 

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -22,18 +22,18 @@ func TestBindFlags_AgentModeOverridesDefaultFormat(t *testing.T) {
 		wantFormat     string
 	}{
 		{
-			name:       "agent mode forces json when no command default set",
+			name:       "agent mode forces agents when no command default set",
 			agentMode:  true,
-			wantFormat: "json",
+			wantFormat: "agents",
 		},
 		{
-			name:          "agent mode forces json when command sets text default",
+			name:          "agent mode forces agents when command sets text default",
 			agentMode:     true,
 			defaultFormat: "text",
-			wantFormat:    "json",
+			wantFormat:    "agents",
 		},
 		{
-			name:           "explicit -o yaml overrides agent mode json default",
+			name:           "explicit -o yaml overrides agent mode agents default",
 			agentMode:      true,
 			defaultFormat:  "text",
 			explicitOutput: "yaml",

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -147,6 +147,13 @@ func TestJSONFlag_Parsing(t *testing.T) {
 			wantJSONFields:   []string{"name"},
 			wantOutputFormat: "json",
 		},
+		{
+			name:             "--json and -o agents is allowed",
+			jsonFlagValue:    "name",
+			outputFlagValue:  "agents",
+			wantJSONFields:   []string{"name"},
+			wantOutputFormat: "json",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -151,11 +151,10 @@ func TestJSONFlag_Parsing(t *testing.T) {
 			wantOutputFormat: "json",
 		},
 		{
-			name:             "--json and -o agents is allowed",
-			jsonFlagValue:    "name",
-			outputFlagValue:  "agents",
-			wantJSONFields:   []string{"name"},
-			wantOutputFormat: "json",
+			name:            "--json and -o agents is rejected (use --json without -o in agent mode)",
+			jsonFlagValue:   "name",
+			outputFlagValue: "agents",
+			wantErr:         true,
 		},
 	}
 

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -78,6 +78,9 @@ func TestBindFlags_AgentModeOverridesDefaultFormat(t *testing.T) {
 }
 
 func TestJSONFlag_Parsing(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(agent.ResetForTesting)
+
 	tests := []struct {
 		name              string
 		defaultFormat     string // empty = use package default ("json")

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -88,7 +88,7 @@ func Install(source fs.FS, root string, filter map[string]struct{}, force bool, 
 		}
 		for name := range filter {
 			if _, ok := avail[name]; !ok {
-				return InstallResult{}, fmt.Errorf("unknown skill %q (use 'gcx skills list' to see available skills)", name)
+				return InstallResult{}, fmt.Errorf("unknown skill %q (use 'gcx agent skills list' to see available skills)", name)
 			}
 		}
 	}
@@ -148,7 +148,7 @@ func Install(source fs.FS, root string, filter map[string]struct{}, force bool, 
 	return result, nil
 }
 
-// Update applies the same targeting semantics as `gcx skills update`.
+// Update applies the same targeting semantics as `gcx agent skills update`.
 // With no targets, only already-installed bundled skills are updated.
 func Update(source fs.FS, root string, targets []string, dryRun bool) (InstallResult, error) {
 	installedTargets, err := InstalledBundledSkillNames(source, root)
@@ -177,10 +177,10 @@ func Update(source fs.FS, root string, targets []string, dryRun bool) (InstallRe
 
 		for _, name := range resolvedTargets {
 			if _, ok := bundledSet[name]; !ok {
-				return InstallResult{}, fmt.Errorf("unknown skill %q (use 'gcx skills list' to see available skills)", name)
+				return InstallResult{}, fmt.Errorf("unknown skill %q (use 'gcx agent skills list' to see available skills)", name)
 			}
 			if _, ok := installedSet[name]; !ok {
-				return InstallResult{}, fmt.Errorf("skill %q is not installed; use 'gcx skills install %s' to install it first", name, name)
+				return InstallResult{}, fmt.Errorf("skill %q is not installed; use 'gcx agent skills install %s' to install it first", name, name)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Adds a new built-in `agents` output codec (`internal/output/agents.go`) that emits compact JSON below a configurable threshold and spills oversized payloads to a temp file
- Changes the agent-mode default from `json` → `agents` so every gcx invocation from an AI agent automatically gets spill protection
- Documents the codec in `docs/design/output.md`, `agent-mode.md`, and `environment-variables.md`

## Changes

| File | Change |
|------|--------|
| `internal/output/agents.go` | New `agents` codec — compact JSON + spill logic |
| `internal/output/agents_test.go` | Table-driven tests: below/above threshold, slice shapes, env var config |
| `internal/output/export_test.go` | Exports `newAgentsCodec` for white-box tests |
| `internal/output/format.go` | Register `agents` as builtin; change agent-mode default to `agents`; extend JSON hint to cover `agents` format; extend field-discovery intercept to `agents` |
| `internal/output/format_test.go` | Update 2 test cases to expect `agents` instead of `json` |
| `docs/design/output.md` | New § 1.1.1 Agents Codec; update default-format table and codec requirements table |
| `docs/design/agent-mode.md` | Update default output format description + opt-out section |
| `docs/design/environment-variables.md` | Add `GCX_AGENT_SPILL_BYTES` to Agent Mode Variables table |
| `docs/reference/cli/*.md` | Regenerated — all commands now list `agents` in `-o` allowed values |

## Behaviour

**Below 100 KiB** (default threshold):
```json
[{"name":"alpha","kind":"Dashboard"},{"name":"beta","kind":"Dashboard"}]
```

**Above threshold** (or with `GCX_AGENT_SPILL_BYTES=200`):
```json
{"spilled_to":"/tmp/gcx-results-3781234567.json","bytes":143200,"items":312,"preview":[{"name":"alpha"},{"name":"beta"},{"name":"gamma"}]}
```

**Overrides still work:**
- `-o json` → full compact JSON to stdout, no spill
- `-o text` → human table
- `--json field1,field2` → field-selected JSON (rewrites format to `json`, never spills)
- `GCX_AGENT_SPILL_BYTES=<n>` → adjusts threshold

## Test Plan

- [x] Tests pass locally (`GCX_AGENT_MODE=false mise run all`)
- [x] New tests cover: below/above threshold, non-slice values, struct-with-Items, invalid env var, Format(), Decode()
- [x] Lint clean (`mise run lint`)
- [x] Reference docs regenerated (`GCX_AGENT_MODE=false mise run reference`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)