### PR TITLE
feat(instrumentation): add Instrumentation Hub provider package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,11 @@ internal/
 │   ├── dashboards/ Dashboards provider (CRUD, search, versions, snapshot)
 │   ├── faro/       Frontend Observability provider (apps CRUD, sourcemaps sub-resource) — CLI: `gcx frontend`
 │   ├── fleet/      Fleet Management provider (pipeline and collector resources)
+│   ├── instrumentation/  Instrumentation Hub provider (typed connect-go client, RMW with optimistic-lock, output codecs, helm formatter, enumerate helper)
+│   │   ├── enumerate/  Cluster enumeration helper (RunK8sMonitoring ⋃ ListPipelines merge)
+│   │   ├── helm/       Helm command formatter for the setup wizard
+│   │   ├── output/     View types and codecs (clusters, apps, services; wait/mutation envelopes)
+│   │   └── rmw/        Read-modify-write helper with optimistic-lock guard (ConflictError)
 │   ├── irm/        IRM provider (OnCall + Incidents — schedules, integrations, escalation chains, incidents)
 │   ├── k6/         k6 Cloud provider (projects, tests, runs, envvars)
 │   ├── kg/         Knowledge Graph (Asserts) provider

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,17 +109,26 @@ Observability-as-code workflows for managing Grafana resources as typed Go code 
 
 The linter engine is also used by `gcx resources validate` for pre-push validation. See [VISION.md § Observability as Code](VISION.md#observability-as-code) for the full workflow vision.
 
-### 5. Setup & Instrumentation (`gcx setup`)
+### 5. Setup (`gcx setup`)
 
-Onboarding and declarative product configuration. Not a provider — standalone command area.
+Cross-product onboarding helpers. Not a provider — standalone command area.
 
-- **`setup status`** — Check connection, auth, and product availability
-- **`setup instrumentation discover`** — Discover instrumentable workloads via Fleet Management
-- **`setup instrumentation show/apply`** — View and apply instrumentation configs with optimistic lock comparison
+- **`setup status`** — Aggregated connection, auth, and product-availability snapshot
 
-Uses `internal/fleet/` (shared fleet base client) and `internal/setup/instrumentation/` (manifest types, instrumentation client). The fleet base client is shared between the setup system and the fleet provider.
+The instrumentation onboarding wizard lives under the Instrumentation Hub provider (`gcx instrumentation setup`), not under `gcx setup`. See ADR-018 for the rationale.
 
-### 6. Configuration
+### 6. Instrumentation Hub (`gcx instrumentation`)
+
+Action-verb command tree for Grafana Cloud's Instrumentation Hub. Backed by fleet-management `Set/Get` + observed-state RPCs; registers no GVK and is not addressable through `gcx resources push/pull`.
+
+- **`instrumentation setup <cluster>`** — End-to-end onboarding wizard; calls `SetupK8sDiscovery`, applies declared K8s monitoring config, prints a parameterized helm command
+- **`instrumentation status`** — Cross-cutting observed view across cluster → namespace → service hierarchy
+- **`instrumentation clusters [list|get|configure|remove|wait]`** + nested **`apps`** — Declared-state read/write with tri-state flag semantics on `configure` and a per-namespace optimistic-lock guard
+- **`instrumentation services [list|get|include|exclude|clear]`** — Observed-state fleet sweep via `RunK8sDiscovery` with DWIM single-workload mutation
+
+Uses `internal/providers/instrumentation/` (provider, types, output codecs, RMW helper, helm formatter, enumeration helper) and `internal/fleet/` (shared base HTTP client, also used by the fleet provider). See ADR-018 for the design.
+
+### 7. Configuration
 
 kubectl-inspired context-based multi-environment configuration.
 
@@ -142,7 +151,7 @@ contexts:
 
 **Deep-dive:** [config-system.md](docs/architecture/config-system.md).
 
-### 7. Authentication
+### 8. Authentication
 
 Multiple auth mechanisms for different tiers.
 
@@ -175,10 +184,11 @@ Multiple auth mechanisms for different tiers.
 | [011](docs/adrs/adaptive-provider/001-cli-ux-and-resource-adapter-design.md) | Adaptive telemetry provider: CLI UX, adapter scope, verb naming | proposed |
 | [012](docs/adrs/migrate-provider-rewrite/002-five-phase-pipeline-redesign.md) | Five-phase pipeline redesign for /migrate-provider | accepted |
 | [013](docs/adrs/appo11y-provider/001-cli-ux-and-resource-adapter-design.md) | App O11y provider: singleton TypedCRUD, ETag-as-annotation, verb naming | accepted |
-| [014](docs/adrs/instrumentation/001-instrumentation-provider-design.md) | Declarative Instrumentation Setup under `gcx setup` | proposed |
+| [014](docs/adrs/instrumentation/001-instrumentation-provider-design.md) | Declarative Instrumentation Setup under `gcx setup` | superseded by [018] |
 | [015](docs/adrs/faro-provider/001-faro-provider-design.md) | Faro provider: CLI UX, TypedCRUD adapter, sourcemaps as sub-resource verbs | proposed |
 | [016](docs/adrs/dashboards-provider/001-dashboards-provider-design.md) | Dashboards provider: CRUD shorthands, search, and version history | accepted |
 | [017](docs/adrs/traces-get-table/001-tree-table-render-for-traces-get.md) | Tree-table rendering for `traces get` | accepted |
+| [018](docs/adrs/instrumentation/002-cli-redesign.md) | `gcx instrumentation` CLI redesign: action verbs over Set/Get + observed state | accepted |
 
 See [docs/adrs/](docs/adrs/) for all ADRs.
 

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -1069,18 +1069,19 @@ func convertFleetHTTPErrors(err error) (*DetailedError, bool) {
 	return nil, false
 }
 
-// convertInstrumentationMutualExclusiveErrors detects errors from setup's flag
-// Validate() when the user provides mutually exclusive flag pairs (e.g.
-// --costmetrics and --no-costmetrics). Returns summary "Invalid command usage".
+// convertInstrumentationMutualExclusiveErrors detects the
+// instrumentation.ErrMutuallyExclusiveFlags sentinel returned by command
+// Validate() when the user supplies mutually exclusive flag pairs (e.g.
+// --costmetrics and --no-costmetrics). Returns summary "Invalid command
+// usage" with the wrapped error's message as details.
 func convertInstrumentationMutualExclusiveErrors(err error) (*DetailedError, bool) {
-	msg := err.Error()
-	if strings.Contains(msg, "mutually exclusive") {
-		return &DetailedError{
-			Summary: "Invalid command usage",
-			Details: msg,
-		}, true
+	if !errors.Is(err, instrumentation.ErrMutuallyExclusiveFlags) {
+		return nil, false
 	}
-	return nil, false
+	return &DetailedError{
+		Summary: "Invalid command usage",
+		Details: err.Error(),
+	}, true
 }
 
 // convertInstrumentationErrors converts RMW ConflictErrors from the

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -17,9 +17,13 @@ import (
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/datasources"
 	ifail "github.com/grafana/gcx/internal/fail"
+	"github.com/grafana/gcx/internal/fleet"
 	"github.com/grafana/gcx/internal/grafana"
 	"github.com/grafana/gcx/internal/linter"
 	"github.com/grafana/gcx/internal/login"
+	cmdoutput "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/grafana/gcx/internal/providers/instrumentation/rmw"
 	"github.com/grafana/gcx/internal/queryerror"
 	"github.com/grafana/gcx/internal/resources"
 	k8sapi "k8s.io/apimachinery/pkg/api/errors"
@@ -28,38 +32,46 @@ import (
 const reauthSuggestion = "Re-authenticate if needed: gcx login"
 
 func ErrorToDetailedError(err error) *DetailedError {
-	var converted bool
-	detailedErr := &DetailedError{}
-	if errors.As(err, detailedErr) {
-		return detailedErr
+	// errors.As requires a pointer-to-the-target-type. Since commands return
+	// *DetailedError (pointer type), the target must be **DetailedError so that
+	// errors.As can match the pointer. Using *DetailedError as the target only
+	// matches value-typed DetailedError, causing *DetailedError to fall through
+	// to fallbackDetailedError which renders box chars via err.Error().
+	var ptr *DetailedError
+	if errors.As(err, &ptr) {
+		return ptr
 	}
 
 	// Try to convert the error for common error categories
 	errorConverters := []func(err error) (*DetailedError, bool){
+		convertWaitTimeoutEmitted,          // Wait timeout already emitted fused envelope — suppress secondary output
+		convertUnknownFieldSelectionErrors, // --json unknown-field validation
 		convertUsageErrors,
 		convertCobraUnknownCommandErrors,
-		convertContextCanceled,       // Context cancellation (must be first — cancellation can wrap other errors)
-		convertRequiredFlagErrors,    // Cobra required-flag errors — must appear before generic checks
-		convertConfigErrors,          // Config-related
-		convertAuthErrors,            // Auth-related (expired tokens)
-		convertQueryErrors,           // Datasource query errors
-		convertDatasourceErrors,      // Grafana datasource REST API errors
-		convertServiceAPIErrors,      // Other structured HTTP API errors
-		convertFSErrors,              // FS-related
-		convertResourcesErrors,       // Resources-related
-		convertNetworkErrors,         // Network-related errors
-		convertAPIErrors,             // API-related errors
-		convertLoginValidationErrors, // Login connectivity validation (must precede generic version check)
-		convertVersionErrors,         // Version incompatibility errors
-		convertLinterErrors,          // Linter-related errors
-		convertSMConfigErrors,        // Synthetic Monitoring config errors
-		convertCloudConfigErrors,     // Cloud config / fleet / setup errors
-		convertStacksErrors,          // Stacks management GCOM errors
+		convertContextCanceled,                      // Context cancellation (must be first — cancellation can wrap other errors)
+		convertRequiredFlagErrors,                   // Cobra required-flag errors — must appear before generic checks
+		convertConfigErrors,                         // Config-related
+		convertAuthErrors,                           // Auth-related (expired tokens)
+		convertQueryErrors,                          // Datasource query errors
+		convertDatasourceErrors,                     // Grafana datasource REST API errors
+		convertServiceAPIErrors,                     // Other structured HTTP API errors
+		convertFSErrors,                             // FS-related
+		convertResourcesErrors,                      // Resources-related
+		convertNetworkErrors,                        // Network-related errors
+		convertAPIErrors,                            // API-related errors
+		convertLoginValidationErrors,                // Login connectivity validation (must precede generic version check)
+		convertVersionErrors,                        // Version incompatibility errors
+		convertLinterErrors,                         // Linter-related errors
+		convertSMConfigErrors,                       // Synthetic Monitoring config errors
+		convertCloudConfigErrors,                    // Cloud config / fleet / setup errors
+		convertStacksErrors,                         // Stacks management GCOM errors
+		convertFleetHTTPErrors,                      // Fleet Management HTTP 401/403 typed errors
+		convertInstrumentationErrors,                // Instrumentation RMW conflict errors
+		convertInstrumentationMutualExclusiveErrors, // setup: mutually exclusive flag pairs
 	}
 
 	for _, converter := range errorConverters {
-		detailedErr, converted = converter(err)
-		if converted {
+		if detailedErr, converted := converter(err); converted {
 			return detailedErr
 		}
 	}
@@ -695,6 +707,17 @@ func convertLinterErrors(err error) (*DetailedError, bool) {
 	return nil, false
 }
 
+// convertWaitTimeoutEmitted suppresses the secondary DetailedError JSON envelope
+// when a wait command has already emitted a fused WaitResult (with Error populated)
+// to stdout. The secondary envelope would duplicate the error payload.
+// Returns (nil, true) so the caller exits 1 but writes no additional JSON.
+func convertWaitTimeoutEmitted(err error) (*DetailedError, bool) {
+	if errors.Is(err, instrumentation.ErrWaitTimeoutEmitted) {
+		return nil, true
+	}
+	return nil, false
+}
+
 func convertLoginValidationErrors(err error) (*DetailedError, bool) {
 	var gcomErr *login.GCOMStackError
 	if errors.As(err, &gcomErr) {
@@ -1004,18 +1027,77 @@ func convertCloudConfigErrors(err error) (*DetailedError, bool) {
 		}, true
 	}
 
-	// Setup/instrumentation prefixed errors — surface them directly instead of "Unexpected error".
-	if strings.HasPrefix(msg, "setup/instrumentation:") || strings.Contains(msg, "setup/instrumentation:") {
-		// Extract the message after the prefix for the summary.
-		summary := "Setup instrumentation error"
+	return nil, false
+}
+
+// convertFleetHTTPErrors converts fleet.HTTPError values (non-2xx HTTP
+// responses from the Fleet Management API) into structured DetailedErrors with
+// actionable auth suggestions for 401 and 403 responses.
+func convertFleetHTTPErrors(err error) (*DetailedError, bool) {
+	var httpErr *fleet.HTTPError
+	if !errors.As(err, &httpErr) {
+		return nil, false
+	}
+
+	switch httpErr.Status {
+	case http.StatusUnauthorized:
 		return &DetailedError{
-			Summary: summary,
-			Details: msg,
 			Parent:  err,
+			Summary: "Authentication failed",
+			Details: "HTTP 401 from " + httpErr.Path,
+			Suggestions: []string{
+				"Ensure cloud.token is set: gcx config set cloud.token <TOKEN>",
+				"Verify the token has not expired: gcx config view",
+				reauthSuggestion,
+			},
+			ExitCode: new(ExitAuthFailure),
+		}, true
+	case http.StatusForbidden:
+		return &DetailedError{
+			Parent:  err,
+			Summary: "Authorization failed",
+			Details: "HTTP 403 from " + httpErr.Path,
+			Suggestions: []string{
+				"Ensure your Cloud Access Policy includes the fleet-management:read scope",
+				"Ensure your Cloud Access Policy includes the fleet-management:write scope for mutation commands",
+				reauthSuggestion,
+			},
+			ExitCode: new(ExitAuthFailure),
 		}, true
 	}
 
 	return nil, false
+}
+
+// convertInstrumentationMutualExclusiveErrors detects errors from setup's flag
+// Validate() when the user provides mutually exclusive flag pairs (e.g.
+// --costmetrics and --no-costmetrics). Returns summary "Invalid command usage".
+func convertInstrumentationMutualExclusiveErrors(err error) (*DetailedError, bool) {
+	msg := err.Error()
+	if strings.Contains(msg, "mutually exclusive") {
+		return &DetailedError{
+			Summary: "Invalid command usage",
+			Details: msg,
+		}, true
+	}
+	return nil, false
+}
+
+// convertInstrumentationErrors converts RMW ConflictErrors from the
+// instrumentation provider into structured DetailedErrors. This ensures that
+// concurrent-modification conflicts surface a readable summary and full diff
+// details under agent mode.
+func convertInstrumentationErrors(err error) (*DetailedError, bool) {
+	var ce rmw.ConflictError
+	if !errors.As(err, &ce) {
+		return nil, false
+	}
+
+	return &DetailedError{
+		Summary: "Resource conflict",
+		Details: ce.Error(),
+		Parent:  err,
+	}, true
 }
 
 func adaptiveScopeSuggestionFromSignalPrefix(msg string) string {
@@ -1075,6 +1157,27 @@ func adaptiveMetricsScopeFromError(msg string) string {
 		}
 	}
 	return ""
+}
+
+// convertUnknownFieldSelectionErrors converts UnknownFieldSelectionError (from
+// the --json field validator) into a structured DetailedError with exit code 2
+// (ExitUsageError). The suggestion directs users to run the command with
+// --json list to discover valid field names.
+func convertUnknownFieldSelectionErrors(err error) (*DetailedError, bool) {
+	var fieldErr cmdoutput.UnknownFieldSelectionError
+	if !errors.As(err, &fieldErr) {
+		return nil, false
+	}
+
+	exitCode := ExitUsageError
+	return &DetailedError{
+		Summary:  "Invalid command usage",
+		Details:  fieldErr.Error(),
+		ExitCode: &exitCode,
+		Suggestions: []string{
+			"Run the command with --json list to enumerate valid field names",
+		},
+	}, true
 }
 
 func fallbackDetailedError(err error) *DetailedError {

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -851,6 +851,28 @@ func TestErrorToDetailedError_WaitTimeoutEmittedBeforeOtherConverters(t *testing
 		"sentinel converter must fire before generic converters — expected nil, not %+v", got)
 }
 
+func TestErrorToDetailedError_MutuallyExclusiveFlagsSentinel(t *testing.T) {
+	// Wrapping the typed sentinel must produce the "Invalid command usage"
+	// envelope with the wrapped message as details. A bare error whose text
+	// happens to contain "mutually exclusive" must NOT match — only the typed
+	// sentinel triggers this converter.
+	wrapped := fmt.Errorf("--costmetrics and --no-costmetrics: %w", instrumentation.ErrMutuallyExclusiveFlags)
+
+	got := fail.ErrorToDetailedError(wrapped)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Invalid command usage", got.Summary)
+	assert.Contains(t, got.Details, "--costmetrics and --no-costmetrics")
+
+	// Bare string must fall through to the generic fallback (no Suggestions,
+	// no typed-error semantics).
+	bare := errors.New("--foo and --bar are mutually exclusive")
+	bareGot := fail.ErrorToDetailedError(bare)
+	require.NotNil(t, bareGot)
+	assert.NotEqual(t, "Invalid command usage", bareGot.Summary,
+		"converter must only match the typed sentinel, not arbitrary strings")
+}
+
 // TestErrorToDetailedError_UnknownFieldSelectionError verifies that
 // UnknownFieldSelectionError is converted to a DetailedError with:
 //   - Summary: "Invalid command usage"

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -12,8 +12,11 @@ import (
 	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/fleet"
 	"github.com/grafana/gcx/internal/grafana"
 	"github.com/grafana/gcx/internal/login"
+	cmdoutput "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
 	"github.com/grafana/gcx/internal/queryerror"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -760,6 +763,46 @@ func TestErrorToDetailedError_LoginVersionCheck(t *testing.T) {
 	assert.Equal(t, fail.ExitVersionIncompatible, *got.ExitCode)
 }
 
+func TestConvertFleetHTTPErrors(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantSummary  string
+		wantAuthExit bool
+	}{
+		{
+			name:         "401 from fleet management",
+			err:          fmt.Errorf("clusters list: %w", &fleet.HTTPError{Status: 401, Path: "/instrumentation.v1.InstrumentationService/GetK8SInstrumentation"}),
+			wantSummary:  "Authentication failed",
+			wantAuthExit: true,
+		},
+		{
+			name:         "403 from fleet management",
+			err:          fmt.Errorf("clusters list: %w", &fleet.HTTPError{Status: 403, Path: "/instrumentation.v1.InstrumentationService/GetK8SInstrumentation"}),
+			wantSummary:  "Authorization failed",
+			wantAuthExit: true,
+		},
+		{
+			name: "404 not handled by this converter",
+			err:  &fleet.HTTPError{Status: 404, Path: "/foo"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			de := fail.ErrorToDetailedError(tc.err)
+			if tc.wantSummary == "" {
+				return // just verify no panic
+			}
+			assert.Equal(t, tc.wantSummary, de.Summary)
+			if tc.wantAuthExit {
+				require.NotNil(t, de.ExitCode)
+				// ExitAuthFailure should be non-zero
+				assert.NotZero(t, *de.ExitCode)
+			}
+		})
+	}
+}
+
 type fakeServiceAPIError struct {
 	statusCode int
 	service    string
@@ -780,4 +823,84 @@ func (e fakeServiceAPIError) APIServiceName() string {
 
 func (e fakeServiceAPIError) APIUserMessage() string {
 	return e.message
+}
+
+func TestErrorToDetailedError_WaitTimeoutEmittedSuppressesEnvelope(t *testing.T) {
+	// ErrWaitTimeoutEmitted must be recognised FIRST in the converter
+	// chain and suppress the secondary DetailedError JSON envelope.
+	// ErrorToDetailedError must return nil so that main.go exits 1 without
+	// writing a second JSON document to stdout.
+	err := fmt.Errorf("clusters wait: %w", instrumentation.ErrWaitTimeoutEmitted)
+
+	got := fail.ErrorToDetailedError(err)
+
+	// nil means "already handled; suppress secondary output" — matches
+	// the convertLinterErrors(ErrTestsFailed) precedent.
+	assert.Nil(t, got, "ErrWaitTimeoutEmitted must suppress the DetailedError envelope (return nil)")
+}
+
+func TestErrorToDetailedError_WaitTimeoutEmittedBeforeOtherConverters(t *testing.T) {
+	// Verify that the sentinel converter runs BEFORE other converters that might
+	// also match. Wrap ErrWaitTimeoutEmitted alongside a usage error; the
+	// sentinel must win and return nil, not the usage error's DetailedError.
+	sentinelErr := fmt.Errorf("apps wait: %w", instrumentation.ErrWaitTimeoutEmitted)
+
+	got := fail.ErrorToDetailedError(sentinelErr)
+
+	assert.Nil(t, got,
+		"sentinel converter must fire before generic converters — expected nil, not %+v", got)
+}
+
+// TestErrorToDetailedError_UnknownFieldSelectionError verifies that
+// UnknownFieldSelectionError is converted to a DetailedError with:
+//   - Summary: "Invalid command usage"
+//   - ExitCode: 2 (ExitUsageError)
+//   - Details containing the offending field names
+//   - A suggestion to run --json list
+func TestErrorToDetailedError_UnknownFieldSelectionError(t *testing.T) {
+	tests := []struct {
+		name           string
+		fields         []string
+		wantInDetails  string
+		wantExitCode   int
+		wantSuggestion string
+	}{
+		{
+			name:           "single unknown field",
+			fields:         []string{"bogus"},
+			wantInDetails:  "bogus",
+			wantExitCode:   fail.ExitUsageError,
+			wantSuggestion: "--json list",
+		},
+		{
+			name:          "multiple unknown fields",
+			fields:        []string{"foo", "bar"},
+			wantInDetails: "foo",
+			wantExitCode:  fail.ExitUsageError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := cmdoutput.UnknownFieldSelectionError{Fields: tc.fields}
+
+			got := fail.ErrorToDetailedError(err)
+
+			require.NotNil(t, got)
+			assert.Equal(t, "Invalid command usage", got.Summary)
+			require.NotNil(t, got.ExitCode)
+			assert.Equal(t, tc.wantExitCode, *got.ExitCode)
+			assert.Contains(t, got.Details, tc.wantInDetails)
+			if tc.wantSuggestion != "" {
+				found := false
+				for _, s := range got.Suggestions {
+					if strings.Contains(s, tc.wantSuggestion) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected suggestion containing %q in %v", tc.wantSuggestion, got.Suggestions)
+			}
+		})
+	}
 }

--- a/docs/adrs/instrumentation/001-instrumentation-provider-design.md
+++ b/docs/adrs/instrumentation/001-instrumentation-provider-design.md
@@ -1,7 +1,7 @@
 # Declarative Instrumentation Setup under `gcx setup`
 
 **Created**: 2026-03-30
-**Status**: proposed
+**Status**: superseded by [002-cli-redesign.md](002-cli-redesign.md)
 **Bead**: gcx-4r1g
 **Supersedes**: none
 
@@ -230,3 +230,32 @@ Stage 2 as `add`.
 - Add pipeline protection guard to fleet provider
 - Update CONSTITUTION.md, architecture docs, migration-gap-analysis.md
 - Stage 2: `add` verb for imperative flag-based configuration
+
+## Architecture notes
+
+### Beyla is embedded in Alloy, not a standalone DaemonSet
+
+The `grafana-cloud-onboarding` chart sets `beyla.enabled: false` intentionally:
+
+```yaml
+beyla:
+  # As we're using the Beyla embedded into Alloy (via the beyla.ebpf
+  # component), we set this to false.
+  enabled: false
+```
+
+Beyla runs as a `beyla.ebpf` component **inside the alloy-daemon pod**. The alloy-daemon pod
+appears as `2/2 Running` (Alloy plus its config-reload sidecar). The chart deploys alloy-daemon
+with the eBPF prerequisites (`privileged: true`, `hostPID: true`, `cgroup` mount). When
+`apps configure` declares a namespace, Fleet Management creates a
+`beyla_k8s_appo11y_<cluster>` pipeline and pushes it to alloy-daemon at the 30-second poll
+interval. alloy-daemon then loads the `beyla.ebpf` component for the declared workloads.
+
+The absence of a standalone Beyla DaemonSet in `kubectl -n monitoring get pods` is **intentional
+and correct** — not a bug. The iteration-2 smoke test's "Beyla daemon still missing" finding
+(B-597-it2-04) was a misdiagnosis resolved by reading the chart values directly.
+
+**Verification:** After `apps configure <cluster> <namespace>` and ~30s delay, run
+`kubectl -n monitoring logs -l app.kubernetes.io/name=alloy-daemon | grep beyla` to confirm
+the `beyla.ebpf` component is active. Also run `gcx fleet pipelines list` and filter for
+`beyla_k8s_appo11y_<cluster>` to confirm FM has pushed the pipeline.

--- a/docs/adrs/instrumentation/002-cli-redesign.md
+++ b/docs/adrs/instrumentation/002-cli-redesign.md
@@ -1,0 +1,521 @@
+# `gcx instrumentation` CLI redesign: action verbs over Set/Get + observed state
+
+**Created**: 2026-04-25
+**Last updated**: 2026-04-28
+**Status**: accepted
+**Supersedes**: [docs/adrs/instrumentation/001-instrumentation-provider-design.md](001-instrumentation-provider-design.md)
+**Implementation**: PR [#597](https://github.com/grafana/gcx/pull/597)
+
+<!-- Status lifecycle: proposed -> accepted -> deprecated | superseded -->
+
+## Context
+
+Grafana Cloud's Instrumentation Hub is backed by two fleet-management
+services: `instrumentation.v1.InstrumentationService` (per-cluster `Set/Get`
+on a configuration blob) and `discovery.v1.DiscoveryService` (collector-
+observed monitoring state with a built-in
+`PENDING_INSTRUMENTATION → INSTRUMENTED → PENDING_UNINSTRUMENTATION → NOT_INSTRUMENTED`
+state machine). The two are joined server-side at read time, but exposed as
+RPCs — there is no per-resource CRUD, no `resourceVersion`, no `status`
+subresource, no per-cluster delete RPC.
+
+The previous instrumentation work (PR #531, now closed) exposed this
+backend as an `instrumentation.grafana.app/v1alpha1` CRD-style facade:
+`kind: Cluster`, `kind: App`, push/pull through `gcx resources`. A smoke
+loop run against PR-531's build found a coherent set of bugs whose root
+cause is the abstraction leak rather than independent defects:
+
+| Finding | Symptom | Root cause |
+|---|---|---|
+| B-531-02 | `apps get` returns not-found right after `push` succeeded | declared state stored, observed state queried — no overlap window |
+| B-531-05 | `list`/`status` return `[]` for a cluster that `get` returns | `list` reads observed state, which lags Alloy registration |
+| B-531-08 | `delete` has no effect — Alloy keeps re-registering the cluster | backend has no tombstone; CRD `delete` semantics promise something the API can't deliver |
+| B-531-01 | `resources pull` returns 0 for kinds `push` just accepted | round-trip parity is part of the `gcx resources` contract; backend can't honor it |
+
+PR #531's surface produced these symptoms because it spoke a CRUD vocabulary
+that the backend does not implement.
+
+The smoke-loop document framed the resolution as a binary: **Design A**
+(fully declarative CRUD — push writes desired state, list/get expose
+declared+observed via a `status` subfield) or **Design B** (drop the CRUD
+costume — action verbs, observed state as primary, no `gcx resources`
+integration). Design A requires backend changes (true CRUD endpoints,
+resource versions, server-side tombstones) that are not on the immediate
+roadmap; Design B fits the backend as it exists today.
+
+ADR #014 (`001-instrumentation-provider-design.md`) staked an earlier
+position — instrumentation as a declarative-manifest workflow under a
+`gcx setup` framework with optimistic-locking `apply -f`. PR #531
+implemented an evolution of that direction (top-level `gcx instrumentation`
+with CRD kinds plus push/pull) and the smoke loop demonstrated that the
+declarative facade does not survive contact with the Set/Get + observed-
+state backend. ADR #014 is superseded by this redesign; the rationale that
+remained valid (per-namespace/per-workload granularity, agent-friendliness,
+shared `internal/fleet/` client) is preserved here in non-declarative form.
+
+The audiences for this surface are locked from prior brainstorming:
+
+- **Primary — A**, day-1 onboarding operator: "I have a new cluster, I want
+  it instrumented end-to-end." Pulls `setup`, action verbs, `wait` for
+  state-machine transitions.
+- **Secondary — C**, day-N investigator/SRE: "An app isn't producing
+  telemetry — show me what Beyla sees." Pulls `status`, `services list
+  --status=ERROR`, granular per-workload reads.
+- **Deferred — B**, GitOps/platform engineer: listed for completeness; does
+  not constrain this design and is blocked on backend evolution.
+
+## Decision
+
+We will replace the PR-531 CRD facade with an action-verb command tree
+grounded in the actual fleet-management API shape. The `instrumentation`
+provider registers no GVKs and is not addressable through `gcx resources
+push/pull/get/delete`.
+
+> **Note on verb names.** This section records the verbs as originally
+> proposed (`enable` / `disable` / `reset`). Iteration 2 renamed
+> `enable` → `configure`, `disable` → `remove`, and folded `reset` into
+> `configure --use-defaults --yes`; iteration 3 standardized boolean
+> flags as `--feat=true|false` (no `--no-*` paired variants). Current
+> verb names live in the Amendments sections below; the verb semantics
+> here remain accurate.
+
+### Command tree
+
+```
+gcx instrumentation
+├── setup <cluster>                                    # D2 onboarding wizard, mutating, loud
+├── status [--cluster X] [--namespace ns]              # observed view across hierarchy
+├── clusters
+│   ├── list
+│   ├── get <cluster>
+│   ├── enable <cluster> [flag-mods]                   # RMW; tri-state flags
+│   ├── disable <cluster>                              # destructive; --yes-gated
+│   ├── reset <cluster>                                # destructive; --yes-gated
+│   ├── wait <cluster> [--timeout=5m]
+│   └── apps
+│       ├── list <cluster>
+│       ├── get <cluster> <namespace>
+│       ├── enable <cluster> <namespace> [flag-mods]
+│       ├── disable <cluster> <namespace>
+│       ├── reset <cluster> <namespace>
+│       └── wait <cluster> <namespace>
+└── services
+    ├── list [--cluster X] [--namespace ns] [--status STATE] [--all]
+    ├── get <cluster> <namespace> <service>
+    ├── include <cluster> <namespace> <service>        # DWIM: ensure instrumented
+    ├── exclude <cluster> <namespace> <service>        # DWIM: ensure NOT instrumented
+    └── clear <cluster> <namespace> <service>          # remove override → namespace default
+```
+
+### Tree placement rationale
+
+`clusters` and `clusters apps` are the **configuration tree** — declared
+state lives per-cluster (`Get/SetK8SInstrumentation`,
+`Get/SetAppInstrumentation`), and `App` namespace entries are stored as rows
+inside the cluster blob. Nesting apps under clusters mirrors that storage
+shape.
+
+`services` is the **observation tree** — `RunK8sDiscovery` is a single
+fleet-wide RPC; services are not stored entities but a projection over
+Prometheus + per-namespace config. Top-level placement honors the API shape
+and preserves the audience-C "find broken services across the fleet" path.
+
+`status` is the cross-cutting **observed view**, drilling from cluster →
+namespace → service via flags rather than verbs (consistent with the D9
+"`status` always reads observed state at any level" contract).
+
+### Read paths split by intent
+
+| Command | API path |
+|---|---|
+| `clusters list` | merge `RunK8sMonitoring()` ⋃ `PipelineService.ListPipelines()` filtered by K8s monitoring metadata (clusters present only in pipeline state appear with status `PENDING_INSTRUMENTATION`); then fan out `GetK8SInstrumentation` per cluster (parallel, capped at 10). See Update §2026-04-28 below for empirical justification. |
+| `clusters get <c>` | `GetK8SInstrumentation(c)` + cross-ref status from a single `RunK8sMonitoring()`; if `<c>` is absent from `RunK8sMonitoring()`, fall back to `PipelineService.ListPipelines()` to determine status (pipeline present → `PENDING_INSTRUMENTATION`; absent → `NOT_INSTRUMENTED`). |
+| `clusters apps list <cluster>` | `GetAppInstrumentation(cluster)` (single RPC) |
+| `clusters apps get <c> <ns>` | `GetAppInstrumentation(c)` + filter; CLI-level not-found if absent |
+| `services list` | `RunK8sDiscovery()` (single RPC, fleet-wide) + client-side filtering |
+| `services get <c> <ns> <s>` | `RunK8sDiscovery()` + filter |
+| `services include\|exclude\|clear` | `GetAppInstrumentation(c)` → mutate `apps[]` → `SetAppInstrumentation(c, …)` |
+| `status` | same cluster set as `clusters list` (merge with `ListPipelines` so pre-Alloy clusters appear); `RunK8sDiscovery()` when drilling to namespace via `--namespace`. |
+| `wait` | poll `RunK8sMonitoring()` at 5s intervals; treat absence from response as `PENDING_INSTRUMENTATION` and continue polling; declared-state pre-flight (`GetK8SInstrumentation`) avoids polling-to-timeout when no cluster has been declared (Amendment B). |
+
+`get`/`list` treat declared-state endpoints (`Get*`, `ListPipelines` for
+enumeration fallback) as the source of truth for resource existence and
+configuration; observed-state endpoints (`RunK8sMonitoring`) are
+cross-referenced for STATUS only. `status`/`wait` go through observed-state
+endpoints with the same merge so the cluster set agrees with `list`/`get`.
+Both read paths exist because both questions are real ("what did I
+configure?" vs "what is Beyla actually seeing?"); collapsing them into
+one verb is what produced B-531-02 and B-531-05. The original draft of
+this ADR specified single-source enumeration on `list`/`get`; Open
+Question 1 was resolved empirically (see Update §2026-04-28) and the
+merge was introduced before implementation.
+
+### Verb semantics
+
+- **`setup`** — D2-mandated onboarding command. Loud, mutating, idempotent.
+  Calls `SetupK8sDiscovery` (server-side idempotent), then prompts for K8s
+  flags (or applies defaults under `--yes`), calls `SetK8SInstrumentation`
+  if anything changed, prints a parameterized helm command, and emits a
+  mutation summary on stderr. `--print-helm-only` is the explicit
+  non-mutating opt-in.
+- **`enable`** — read-modify-write with tri-state flags
+  (`--flag` / `--no-flag` / unset → preserve). For `apps enable` the
+  namespace entry is the unit of RMW: existing per-workload `apps[]`
+  overrides and other namespaces are preserved. Client-side optimistic-lock
+  check fixes the misleading PR-531 error text (B-531-04).
+- **`disable`** — destructive. `clusters disable` calls
+  `SetK8SInstrumentation(Selection=EXCLUDED)`, which the backend translates
+  to pipeline deletion. `apps disable` removes the namespace from
+  `namespaces[]`. `--yes`-gated. State machine: cluster transitions
+  `INSTRUMENTED → PENDING_UNINSTRUMENTATION → NOT_INSTRUMENTED` and
+  naturally drops out of `list` once the collector stops reporting (no
+  synthetic tombstone).
+- **`reset`** — destructive. Restores defaults, wiping user customization.
+  Distinct from `disable`: end state is "instrumented with defaults," not
+  "not instrumented."
+- **`wait`** — poll the appropriate observed-state endpoint at 5s intervals
+  (matching the UI's polling cadence). Exits 0 when STATUS leaves
+  `PENDING_*`, non-zero on timeout (default 5m) or terminal
+  `INSTRUMENTATION_ERROR`.
+- **`services include`/`exclude`/`clear`** — DWIM. Each operates on one
+  workload via a single `Get` + targeted `apps[]` mutation +
+  `SetAppInstrumentation` round-trip with optimistic-lock guard. All
+  idempotent.
+
+### Output contracts
+
+Per Contract 1 (D9): `NAME` first, `STATUS` second-to-last, `AGE` last.
+STATUS values follow Contract 3 normalization (`OK` / `FAILING` / `NODATA`)
+for cross-provider parity, with the underlying state-machine value
+available in JSON/YAML and `wide` format.
+
+JSON/YAML output is the **bare domain type** — no K8s envelope, no `kind:`
+or `apiVersion:` field. This is a deliberate divergence from D9 Contract 2,
+justified because the resources are not registered with the adapter and not
+addressable via `gcx resources`. The Contract 2 envelope exists to support
+round-tripping through `gcx resources push/pull`, which we are explicitly
+not supporting here.
+
+### Adapter registry change
+
+The `instrumentation` provider's `Registrations()` returns an empty slice —
+no GVK is registered, no schema is exposed via `gcx resources schemas`, no
+kind is accepted by `gcx resources push`. The `wire/wire.go` bootstrap
+still registers the command tree but skips the adapter pipeline. Schema
+files in `observability/instrumentation/` (`cluster.yaml`, `apps.yaml`)
+are deleted.
+
+### Internal types
+
+`internal/providers/instrumentation/types.go` is rewritten:
+
+- **Drop** `App.Selection` (dead field — `pkg/instrumentation/v1/k8s_beyla.go:291`
+  confirms backend ignores `AppNamespace.selection`).
+- **Add** `App.Autoinstrument bool` — the actual on/off knob for
+  namespace-level instrumentation. Likely root cause of B-531-06: PR-531
+  types had no `Autoinstrument` field, so it was never set, so the backend
+  produced no Beyla pipeline.
+- **`Cluster.Selection`** stays in the type for serialization correctness
+  (it is a real backend field) but is not user-controllable. Visible in
+  JSON/YAML output for diagnostics; not in table or wide output (redundant
+  with STATUS).
+- **Add** observed status fields populated from `RunK8sMonitoring` for
+  table/wide output, refined to use the proto enum directly rather than
+  freeform strings.
+- **Remove** `metadata.name` enforcement on App (`validateAppIdentity`).
+  App identity is `(cluster, namespace)` positionally on every command.
+
+### Migration
+
+Breaking change. PR #531 was preview-status with no committed users; no
+backward-compatibility aliases are provided. The mapping at a glance
+(reflecting iteration-2 verb renames captured in Amendment D):
+`clusters create -f` and `clusters update -f` collapse into
+`clusters configure [flags]`; `clusters delete` becomes `clusters remove`;
+`clusters setup` moves to top-level `gcx instrumentation setup`. The
+same shape applies for apps under `clusters apps`. `gcx resources push
+-p observability/instrumentation` rejects any
+`instrumentation.grafana.app/v1alpha1` documents with "unknown kind",
+and the schema files under `observability/instrumentation/` are deleted.
+A migration note in the breaking-changes section of the PR body and
+CHANGELOG explains the move.
+
+### Rejected alternatives
+
+**Design A — Fully declarative CRUD (matches PR-531's API shape).** Push
+writes desired state; `list`/`get` return desired state plus a
+`status`/`observed` subfield reporting what Alloy sees. "Pushed but not
+yet observed" becomes a first-class state. Matches the CRD mental model
+and honors the `gcx resources push` uniform-pipeline promise.
+**Rejected** because the backend has no `resourceVersion`, no per-resource
+delete, no server-side tombstone, and no list-of-configured-clusters RPC.
+Implementing Design A means either (a) accepting a thin client-side
+simulation of CRUD that lies about its guarantees — which is what PR-531
+did, with the documented bug shape — or (b) blocking on a fleet-management
+API redesign that is not on the roadmap. Revisit when the backend grows
+true CRUD; out-of-scope future work below references this.
+
+**Design B-as-PR-531 — Keep the CRD kinds, fix the symptoms tactically.**
+Continue to register `kind: Cluster` and `kind: App`; address each
+B-531-* finding with a targeted fix (e.g., make `apps get` read declared
+state, make `delete` synthesize a "stop reporting" tombstone, etc.).
+**Rejected** because the smoke-loop analysis shows the bugs are
+manifestations of one design mismatch; tactical fixes will keep producing
+indistinguishable bug reports each time someone new encounters the
+abstraction leak. Better stderr hints reduce the frequency, not the shape.
+
+**Hybrid — keep `gcx resources` integration, add imperative commands
+alongside.** Surface both paths and let users pick. **Rejected** because
+the `gcx resources` integration cannot be made coherent against this
+backend (Design A's blockers apply); a half-working second path is worse
+than none, and divides command-discovery effort across two surfaces. When
+the backend supports it, `instrumentation apply -f` re-enters as a single
+addition rather than a coexistence.
+
+**Keep `gcx setup instrumentation` framework from ADR #014.** Earlier
+ADR placed instrumentation under a dedicated `setup` area with declarative
+manifests and `apply -f`. **Rejected** because (a) the manifest workflow
+ran into the same backend blockers as Design A, (b) the `setup` area
+generalization to other products did not materialize, and (c) the
+audience-A onboarding path is better served by a single top-level
+`gcx instrumentation setup <cluster>` wizard than by a multi-product
+framework. ADR #014 marked superseded.
+
+## Consequences
+
+### Positive
+
+- **Bug shape fixed at the root.** B-531-02, -05, -08 disappear by
+  construction: `apps get` reads declared state with no race, `clusters
+  list` reads the same observed-state endpoint as `status`, `disable`
+  deletes the pipeline and the cluster transitions through the documented
+  state machine instead of "zombie".
+- **B-531-06 fix candidate**. New types include `App.Autoinstrument`;
+  `enable` always sets it true, exercising the backend's pipeline-create
+  path that PR-531 silently bypassed.
+- **Audience-A onboarding stays one-command** (`gcx instrumentation setup
+  <cluster>`) with idempotent re-run and a loud mutation summary that
+  resolves B-531-03's silent-overwrite complaint.
+- **Audience-C investigation gets a richer observed view** via
+  `status --cluster --namespace` drilldown and `services list --status=ERROR`,
+  matching what Beyla actually surfaces.
+- **No false promises.** Removing `gcx resources` integration eliminates
+  B-531-01 (round-trip parity) and the "uniform pipeline" narrative that
+  PR-531's docs leaned on. Schema files are deleted; `gcx resources schemas`
+  no longer advertises kinds we cannot honor.
+- **Improved error messages.** Optimistic-lock errors name the conflicting
+  namespace and the change detected (B-531-04 fix).
+
+### Negative
+
+- **GitOps users have no migration path today.** Users who want
+  `apply -f instrumentation.yaml` semantics must wait for backend evolution
+  or maintain config out-of-band. Documented as out-of-scope future work.
+- **Breaking change.** Any caller built against the PR-531 CRD surface
+  must rewrite to the new imperative commands. Mitigated by PR-531 being
+  preview-status with no committed users; full migration table provided.
+- **Two read paths to learn.** `get`/`list` (declared) and `status`/`wait`
+  (observed) are distinct verbs with distinct semantics. The contract is
+  documented and consistent, but it is a more nuanced model than "one
+  read verb, always the truth." Help text and examples must teach this
+  explicitly.
+- **`disable` UX has a 5-minute decay window.** A disabled cluster stays
+  visible in `list`/`status` (with state machine moving through
+  `PENDING_UNINSTRUMENTATION` → `NOT_INSTRUMENTED`) until the collector
+  stops reporting. This is honest about backend behavior but surprising
+  to users expecting immediate disappearance. Documented in `disable
+  --help`.
+- **D9 Contract 2 (K8s envelope) divergence.** `instrumentation`
+  JSON/YAML output is bare domain types, not envelope-wrapped. Justified
+  but it is a documented exception that future readers of the contract
+  will need to understand.
+
+### Neutral / Follow-up
+
+- **PR-531 commit `e14256a` salvage.** Plumbing — fleet client extraction,
+  table builders, status-enum parsing — may be cherry-picked into the new
+  branch in a separate session. Not part of this ADR.
+- **Smoke-loop revalidation.** After implementation, the smoke matrix is
+  re-run with PASS criteria updated for B-531-02/05/08 to reflect the
+  reclassified-as-by-design semantics. Acceptance is tracked outside this
+  ADR.
+- **Open question 1 — RESOLVED (2026-04-28).** Empirical reading of
+  `grafana/fleet-management/pkg/discovery/v1/prometheus.go:204-306`
+  showed the original investigation hypothesis was incorrect:
+  `RunK8sMonitoring`'s cluster set is built by `extractSurveyInfoClusters`,
+  which queries `survey_info{}` (Beyla survey) and only enters clusters
+  that already have that metric series. The state-machine join at
+  `pkg/discovery/v1/http.go:264-268` only runs over clusters already in
+  the iteration. Therefore: clusters that have been `Set` but whose Alloy
+  collector has not started reporting `survey_info` are NOT surfaced by
+  `RunK8sMonitoring` (they are absent from the response, not present with
+  `PENDING_INSTRUMENTATION`). The required mitigation is a merge with
+  `PipelineService.ListPipelines` filtered by K8s monitoring pipeline
+  metadata. The read-paths table above and the Update §2026-04-28 below
+  reflect the resolution.
+- **Cross-cutting agent-mode fixes** (empty-list shape, create-error
+  details, agent-mode confirmation prompts, source-file mutation) are
+  orthogonal to this redesign and addressed via Amendments C and the
+  output codec changes here.
+- **Out-of-scope future work, contingent on backend evolution.**
+  - GitOps integration: when fleet-management exposes `Cluster` and `App`
+    as true CRUD with `resourceVersion` and a `status` subresource,
+    register them in `gcx resources` and add `instrumentation apply -f`.
+  - Embedded helm install / access policy mint: tracked in #546.
+  - Auto-detection of cluster context from `KUBECONFIG` for `setup`.
+  - Per-workload override flags on `apps configure`: revisit if
+    `services include/exclude/clear` proves too verbose.
+
+## Update — 2026-04-28 (Open Question 1 resolution)
+
+This section records the empirical correction to the original ADR draft
+that landed before implementation began.
+
+### What changed
+
+1. **Open Question 1 resolved.** The original investigation hypothesis —
+   that `RunK8sMonitoring` surfaces `Set`-but-not-Alloy-reporting clusters
+   via the stored-state path — was wrong. Empirical reading of
+   `grafana/fleet-management/pkg/discovery/v1/prometheus.go:204-306`
+   confirmed `extractSurveyInfoClusters` gates the cluster set on the
+   `survey_info{}` Prometheus metric; clusters with no `survey_info` are
+   absent from the RPC response, not present with `PENDING_INSTRUMENTATION`.
+2. **Read-paths table updated.** `clusters list`, `clusters get`,
+   `status`, and `clusters wait` now require a merge with
+   `PipelineService.ListPipelines` filtered by K8s monitoring pipeline
+   metadata so pre-Alloy clusters appear with status
+   `PENDING_INSTRUMENTATION`.
+3. **Read-path-split prose tightened.** The original framing
+   ("`get`/`list` are declared, `status`/`wait` are observed") was
+   technically correct in spirit but read as an absolute prohibition on
+   cross-reference. The corrected framing acknowledges that `list`/`get`
+   may consult observed-state for STATUS only and `ListPipelines` for
+   enumeration fallback, while preserving the no-collapse rule (declared
+   writes never lag through an observed read; `list` enumeration agrees
+   with `get` lookup).
+4. **Bug taxonomy unaffected.** B-531-02, -05, -08 root-cause analysis
+   stands. The merge fix means `list` now positively surfaces audience-A's
+   just-configured cluster (rather than rendering it invisible); without
+   the merge the post-redesign `list` would have re-introduced a
+   B-531-05-style "list returns [] for a cluster that get returns" symptom
+   in the pre-Alloy window. The merge closes that gap by construction.
+5. **Status moved `proposed` → `accepted`** to reflect that the design is
+   locked.
+
+### What did NOT change
+
+- The action-verb command tree, audience locking (A primary, C secondary,
+  B deferred), bare-domain-type output (no K8s envelope), no-GVK
+  registration, tri-state flag semantics, optimistic-lock conflict
+  surfacing, and the `setup` wizard contract are unchanged from the
+  original ADR.
+- Rejected alternatives (Design A, tactical CRUD-with-fixes, hybrid,
+  ADR-014 setup framework) remain rejected for the same reasons.
+
+## Amendments — 2026-04-30 (post-smoke-test)
+
+The following amendments were applied based on findings from the PR #597 pre-merge smoke test
+against the `igorgcxtest` stack (gcx build `296a8339`).
+
+### A — Helm bootstrap
+
+- Chart switched from `grafana/k8s-monitoring` to `grafana/grafana-cloud-onboarding` (v0.4.x).
+- The new chart deploys an `alloy-daemon` collector that connects to Fleet Management;
+  Fleet Management pushes per-signal collector pipelines (K8s monitoring, Beyla, Kepler).
+- New four-key helm value schema: `cluster.name`, `grafanaCloud.fleetManagement.url`,
+  `grafanaCloud.fleetManagement.auth.username`, `grafanaCloud.fleetManagement.auth.password`.
+- New `FleetManagement` type and `FleetManagementFromStack` helper in the instrumentation client.
+  `BackendURLs` is no longer passed to the helm formatter (only to API call sites).
+
+### B — Cross-cutting cluster visibility
+
+- `k8sMonitoringClusterName` filter accepts both `metadata["cluster_name"]` (grafana-cloud-onboarding v0.4.x)
+  and `metadata["cluster"]` (legacy), with `cluster_name` taking precedence.
+- `clusters wait` pre-flight changed: from `ListPipelines` pipeline-existence check to
+  `GetK8SInstrumentation` declared-state check. Pipeline materialization is the wait condition,
+  not a pre-flight gate. Undeclared cluster → fail-fast with `DetailedError`; declared cluster
+  with no pipeline yet → polls until timeout.
+
+### C — Agent-mode contracts
+
+- `fleet.HTTPError` typed error added. All non-2xx responses from the instrumentation client
+  are now wrapped with `fleet.HTTPError`, enabling the `convertFleetHTTPErrors` converter to
+  produce actionable `DetailedError` output for HTTP 401 (authentication failed) and
+  HTTP 403 (authorization failed: scope insufficient).
+- `MutationResult` type added to `internal/providers/instrumentation/output/`. All mutation
+  commands emit JSON in agent mode and a one-line summary in non-agent mode. Idempotent
+  no-ops emit `{"changed": false}`.
+- `apps get` returns a single JSON object (not an array).
+- `FieldSelectCodec` for plain Go slices now preserves array shape (`[...]`) instead of
+  wrapping in `{"items":[...]}`.
+- Agent-mode hint banner (`"hint: use --json list..."`) was previously emitted in agent mode
+  only; it has been removed entirely (no hint in any mode).
+- `--json list` field discovery now works on empty typed slices via reflection-based field
+  enumeration (`reflectFields`).
+
+### D — CLI ergonomics
+
+- `clusters enable` → `clusters configure`. Two modes:
+  - `--use-defaults --yes`: apply FR-040 canonical defaults (destructive).
+  - `--<feat>[=true|false]` (one or more): incremental RMW, unspecified flags preserved.
+  - Combining `--use-defaults` with feature flags is an error.
+- `clusters disable` → `clusters remove`.
+- `clusters reset` → deleted; folded into `clusters configure --use-defaults --yes`.
+- Same renames for `clusters apps` subtree (`apps enable` → `apps configure`, etc.).
+- `apps configure --use-defaults --yes` applies all-on canonical defaults:
+  `tracing=true, logging=true, processMetrics=true, extendedMetrics=true, profiling=true`.
+- `setup` flags renamed: `--yes` → `--use-defaults`; `--cost/--no-cost` →
+  `--costmetrics/--no-costmetrics`; `--events/--no-events` → `--clusterevents/--no-clusterevents`;
+  `--energy/--no-energy` → `--energymetrics/--no-energymetrics`; `--logs/--no-logs` →
+  `--nodelogs/--no-nodelogs`.
+- `services exclude/include/clear` now validate workload existence via `RunK8sDiscovery`
+  before writing. Missing workload → `DetailedError` with `services list` suggestion.
+- JSON response field names use camelCase: `costMetrics`, `clusterEvents`, `energyMetrics`,
+  `nodeLogs`, `processMetrics`, `extendedMetrics`, `autoInstrument`.
+
+### E — Selection enum hygiene
+
+Wire-fixture tests confirm the client mapper and request construction correctly handle
+`SELECTION_EXCLUDED`. If the live stack returns `""` after a remove operation, the bug
+is server-side and requires a fleet-management fix.
+
+## Amendments — Iteration 2 (2026-05-02, PR #597 iteration-2 bugfixes)
+
+### Amendment E — Flag casing migration to kebab-case
+
+Multi-word instrumentation flags migrated from lowercase-concat to kebab-case:
+`--costmetrics` → `--cost-metrics`, `--clusterevents` → `--cluster-events`,
+`--energymetrics` → `--energy-metrics`, `--nodelogs` → `--node-logs`,
+`--processmetrics` → `--process-metrics`, `--extendedmetrics` → `--extended-metrics`.
+Note: Amendment D's commit message (`ad1236e6`) claimed "camelCase" but shipped lowercase-concat;
+Amendment E corrects to kebab-case.
+
+### Amendment F — Wait predicate uses typed classifier
+
+`clusters wait` and `apps wait` now use `ClassifyK8sMonitoringStatus` /
+`ClassifyInstrumentationStatus` to match full proto enum wire names
+(`K8S_MONITORING_STATUS_INSTRUMENTED`, not shorthand `INSTRUMENTED`).
+
+### Amendment G — Agent-mode output contract gate
+
+- `--print-helm-only` wraps helm command in `{"helmCommand": "..."}` JSON under agent mode.
+- Wait commands emit `WaitResult` JSON under agent mode.
+- Error `Details` stripped of box characters in agent-mode JSON envelopes.
+- `NormalizeStatus` maps full proto wire names to `OK`/`FAILING`/`NODATA`.
+- `--json ?`/`--json list` correctly triggers field discovery for table-default commands.
+
+## Amendments — iteration 3 (2026-05-04)
+
+These amendments correct and extend the iteration-2 decisions based on the iter-3 smoke-test findings (PR #597).
+
+**O: Canonical boolean-flag idiom (`--feat=true|false`)**
+
+The canonical boolean-flag idiom across the instrumentation provider tree is `--feat=true|false`. Setup commands MUST NOT declare `--no-*` paired variants. Configure commands already follow this idiom; setup is migrated to match (Theme O). This eliminates the need for mutually-exclusive flag validation in setup and unifies the surface seen by agents.
+
+**P: Not-found family exits 1 (corrects iter-2 Theme G)**
+
+The iter-2 choice of exit 4 for `clusters get` not-found was a misapplication: `docs/design/exit-codes.md` reserves exit 4 for `ExitPartialFailure` (partial-failure batch operations), not for not-found. The correct exit code for all "Resource not found" errors in the instrumentation tree is **1** (`ExitGeneralError`). The not-found family now consistently exits 1 across `clusters get`, `services include/exclude/clear` workload-not-found, and `apps get` namespace-entirely-unknown. The error envelope (Summary / Details / Suggestions[]) is the canonical `DetailedError` schema; the same schema is applied to the fleet-provider managed-pipeline guard (Theme Q follow-up).
+
+**M.4: Instrumentation list endpoints wrap in `{"items":[]}` envelope**
+
+Instrumentation tree list endpoints now emit the canonical `{"items":[...]}` envelope shape per `docs/design/output.md` § List/collection. Empty results emit `{"items":[]}` (never `null`, never bare `[]`). This aligns the instrumentation tree with the broader CLI (dashboards, folders, K8s-style resources already use this envelope).

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -49,13 +49,13 @@
          |            |   redaction    |  |   (no k8s      |
          |            +----------------+  |    machinery)  |  +------------------+
          |                               +----------------+  | Setup Layer      |
-         |                                                    | (cmd/gcx/setup/, |
-         |            +----------------+                      |  internal/setup/)|
-         |            | Shared Fleet   |                      | - Instrumentation|
-         |            | (internal/     |<---------------------+   config & apply |
-         |            |  fleet/)       |                      | - Declarative    |
-         |            | - Base HTTP    |                      |   manifests      |
-         |            |   client       |                      +------------------+
+         |                                                    | (cmd/gcx/setup/) |
+         |            +----------------+                      | - Aggregated     |
+         |            | Shared Fleet   |                      |   product status |
+         |            | (internal/     |<---------------------+                  |
+         |            |  fleet/)       |                      +------------------+
+         |            | - Base HTTP    |
+         |            |   client       |
          |            | - Auth/config  |
          |            +----------------+
          |                               +----------------+  | Linter Layer     |
@@ -362,8 +362,15 @@ gcx
   |     (single command: list registered providers)
   +-- setup                (--config, --context as persistent flags)
   |     +-- status         (aggregated product status)
-  |     +-- instrumentation
-  |           +-- status, discover, show, apply
+  +-- instrumentation      (--config, --context as persistent flags)
+  |     +-- setup <cluster>      (onboarding wizard; helm command + access-policy guidance)
+  |     +-- status               (cross-cutting observed view)
+  |     +-- clusters
+  |     |     +-- list, get, configure, remove, wait
+  |     |     +-- apps
+  |     |           +-- list, get, configure, remove, wait
+  |     +-- services
+  |           +-- list, get, include, exclude, clear
   +-- dev
         (import, scaffold, generate, lint, serve subcommands for code scaffolding/dev workflows)
 ```
@@ -723,23 +730,36 @@ Each LGTM signal has its own provider in `internal/providers/{signal}/` that reg
 
 | File | Purpose |
 |------|---------|
-| `internal/fleet/client.go` | Shared fleet base HTTP client (used by fleet provider and setup/instrumentation) |
+| `internal/fleet/client.go` | Shared fleet base HTTP client (used by fleet provider and instrumentation provider) |
 | `internal/fleet/config.go` | Config loading, `LoadClientWithStack` helper |
 | `internal/fleet/errors.go` | Fleet API error types |
 
-### Setup / Instrumentation
+### Setup
 
 | File | Purpose |
 |------|---------|
-| `cmd/gcx/setup/command.go` | Setup command area: aggregated status, wires instrumentation subcommands |
-| `cmd/gcx/setup/instrumentation/command.go` | Instrumentation subcommand group |
-| `cmd/gcx/setup/instrumentation/apply.go` | Apply InstrumentationConfig manifest with optimistic lock |
-| `cmd/gcx/setup/instrumentation/show.go` | Export current remote config as portable manifest |
-| `cmd/gcx/setup/instrumentation/discover.go` | Discover instrumentable workloads |
-| `cmd/gcx/setup/instrumentation/status.go` | Per-cluster instrumentation status with Beyla error query |
-| `internal/setup/instrumentation/types.go` | InstrumentationConfig manifest types |
-| `internal/setup/instrumentation/client.go` | Instrumentation API client (GET/SET app/k8s, discovery, monitoring) |
-| `internal/setup/instrumentation/compare.go` | Optimistic lock diff comparison logic |
+| `cmd/gcx/setup/command.go` | Setup command area: aggregated cross-product `status` |
+
+### Instrumentation Hub Provider
+
+Provider command tree backed by fleet-management `Set/Get` + observed-state RPCs. Registers no GVK; not addressable through `gcx resources`. See ADR-018 for the design.
+
+| File | Purpose |
+|------|---------|
+| `cmd/gcx/instrumentation/command.go` | Top-level `gcx instrumentation` group |
+| `cmd/gcx/instrumentation/setup/` | Onboarding wizard (`SetupK8sDiscovery` + helm command print) |
+| `cmd/gcx/instrumentation/status/` | Cross-cutting observed view (cluster → namespace → service) |
+| `cmd/gcx/instrumentation/clusters/` | Cluster-level commands (list, get, configure, remove, wait) |
+| `cmd/gcx/instrumentation/clusters/apps/` | Namespace-level Beyla commands under a cluster (list, get, configure, remove, wait) |
+| `cmd/gcx/instrumentation/services/` | Workload-level commands (list, get, include, exclude, clear) |
+| `internal/providers/instrumentation/provider.go` | Provider registration; `TypedRegistrations()` returns nil (no GVK) |
+| `internal/providers/instrumentation/client.go` | Instrumentation, discovery, and pipeline RPC client over fleet-management Connect endpoints |
+| `internal/providers/instrumentation/types.go` | Domain types: `Cluster`, `App`, `AppOverride`, observed-state structs |
+| `internal/providers/instrumentation/wait.go` | `WaitOutcome` classifier for proto enum status strings |
+| `internal/providers/instrumentation/enumerate/` | Cluster enumeration helper (`RunK8sMonitoring` ⋃ `ListPipelines` merge) |
+| `internal/providers/instrumentation/helm/` | Helm command formatter for the setup wizard |
+| `internal/providers/instrumentation/output/` | View types, table/JSON codecs, wait/mutation envelopes |
+| `internal/providers/instrumentation/rmw/` | Read-modify-write helper with client-side optimistic-lock guard |
 
 ### k6 Cloud Provider
 

--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -94,19 +94,34 @@ gcx (root)
 ├── setup                    [cmd/gcx/setup/command.go]
 │   ├── --config             [persistent: inherited from providers.ConfigLoader]
 │   ├── --context            [persistent: inherited from root command]
-│   ├── status               Aggregated setup status across all products
-│   └── instrumentation      [cmd/gcx/setup/instrumentation/command.go]
-│       ├── status           Per-cluster instrumentation state + Beyla errors
-│       │   ├── --cluster    Filter by cluster name
-│       │   └── --output / -o  table|wide|json|yaml
-│       ├── discover         Find instrumentable workloads in a cluster
-│       │   ├── --cluster    Cluster name (required)
-│       │   └── --output / -o  table|wide|json|yaml
-│       ├── show <CLUSTER>   Export current config as portable InstrumentationConfig manifest
-│       │   └── --output / -o  yaml|json
-│       └── apply            Apply an InstrumentationConfig manifest
-│           ├── --filename / -f  Path to manifest file (required)
-│           └── --dry-run    Preview changes without applying
+│   └── status               Aggregated setup status across all products
+│
+├── instrumentation          [cmd/gcx/instrumentation/command.go]
+│   ├── status               Workload-level instrumentation status (observed state)
+│   │   └── --output / -o    table|wide|json|yaml
+│   ├── setup <CLUSTER>      Generate helm install command + access-policy guidance
+│   │   ├── --use-defaults   Apply FR-040 defaults without prompting
+│   │   ├── --cost-metrics[=true|false]  Override costMetrics default
+│   │   ├── --print-helm-only  Print helm command and exit
+│   │   └── --output / -o    table|wide|json|yaml
+│   ├── clusters             Cluster-level instrumentation management
+│   │   ├── list             List all configured clusters
+│   │   ├── get <CLUSTER>    Get cluster instrumentation config
+│   │   ├── configure <CLUSTER>  Configure cluster instrumentation
+│   │   ├── remove <CLUSTER> Remove cluster instrumentation config
+│   │   ├── wait <CLUSTER>   Wait for cluster to reach INSTRUMENTED status
+│   │   └── apps             Namespace-level Beyla app instrumentation
+│   │       ├── list <CLUSTER>           List namespace entries
+│   │       ├── get <CLUSTER> <NS>       Get namespace instrumentation
+│   │       ├── configure <CLUSTER> <NS> Configure namespace instrumentation
+│   │       ├── remove <CLUSTER> <NS>    Remove namespace instrumentation
+│   │       └── wait <CLUSTER> <NS>      Wait for namespace to be instrumented
+│   └── services             Service-level workload inclusion/exclusion
+│       ├── list             List workloads with inclusion state
+│       ├── get              Get workload inclusion state
+│       ├── include          Include a workload
+│       ├── exclude          Exclude a workload
+│       └── clear            Clear workload inclusion override
 │
 ├── skills                   [cmd/gcx/skills/command.go]
 │   ├── install             Install the canonical portable gcx Agent Skills bundle into a .agents root
@@ -266,14 +281,14 @@ cmd/gcx/
 ├── providers/
 │   └── command.go           providers command — lists registered providers
 ├── setup/
-│   ├── command.go           setup group + aggregated status (wires providers.ConfigLoader)
-│   └── instrumentation/
-│       ├── command.go       instrumentation group (wires status, discover, show, apply)
-│       ├── status.go        instrumentation status — Beyla errors via promql-builder
-│       ├── discover.go      instrumentation discover — K8s workload discovery
-│       ├── show.go          instrumentation show — export InstrumentationConfig manifest
-│       ├── apply.go         instrumentation apply — apply manifest with optimistic lock
-│       └── export_test.go   test package aliases for unexported types
+│   └── command.go           setup group + aggregated status (wires providers.ConfigLoader)
+├── instrumentation/
+│   ├── command.go           instrumentation group (wires all subcommands)
+│   ├── status/              instrumentation status — workload-level observed state
+│   ├── setup/               instrumentation setup — helm command + access-policy guidance
+│   ├── clusters/            cluster-level instrumentation (list, get, configure, remove, wait)
+│   │   └── apps/            namespace-level Beyla app instrumentation (list, get, configure, remove, wait)
+│   └── services/            service-level workload inclusion/exclusion (list, get, include, exclude, clear)
 ├── linter/
 │   ├── command.go           lint subgroup (run, new, rules, test subcommands; mounted under dev lint)
 │   ├── lint.go              dev lint run — lint resources against configured rules  [Use: "run"]

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -15,8 +15,12 @@ gcx/
 │       │   └── query/        # Auto-detecting query command (GenericCmd only)
 │       ├── commands/         # 'commands' catalog (agent metadata, resource types, live validation)
 │       ├── helptree/        # 'help-tree' compact text tree for agent context injection
-│       ├── setup/            # 'setup' command area (onboarding, product config)
-│       │   └── instrumentation/  # Instrumentation subcommands (status, discover, show, apply)
+│       ├── setup/            # 'setup' command area (cross-product onboarding helpers)
+│       ├── instrumentation/  # 'instrumentation' provider command tree (setup wizard, status, clusters, services)
+│       │   ├── clusters/     #   cluster-level subcommands (list, get, configure, remove, wait, apps subtree)
+│       │   ├── services/     #   workload-level subcommands (list, get, include, exclude, clear)
+│       │   ├── setup/        #   onboarding wizard (helm command + access-policy guidance)
+│       │   └── status/       #   cross-cutting observed view
 │       ├── skills/           # 'skills' subcommand (portable Agent Skills installer for .agents bundles)
 │       ├── dev/              # 'dev' subcommand (import, scaffold, generate, lint, serve)
 │       ├── providers/        # 'providers' subcommand implementation
@@ -27,9 +31,7 @@ gcx/
 │   ├── auth/                 # OAuth PKCE flow, token refresh transport
 │   │   └── adaptive/         # Shared adaptive telemetry auth (GCOM caching, Basic auth)
 │   ├── cloud/                # Grafana Cloud stack discovery via GCOM API
-│   ├── fleet/                # Shared fleet base client (HTTP, auth, config — shared by fleet provider and setup/instrumentation)
-│   ├── setup/
-│   │   └── instrumentation/  # InstrumentationConfig manifest types, API client, optimistic lock comparison
+│   ├── fleet/                # Shared fleet base client (HTTP, auth, config — shared by fleet provider and instrumentation provider)
 │   ├── config/               # Config loading, context management, auth types
 │   │   └── testdata/         # YAML fixtures for config unit tests
 │   ├── format/               # JSON/YAML codec, format auto-detection
@@ -62,6 +64,11 @@ gcx/
 │   │   │   └── versions/     # Version history list + restore via dashboard.grafana.app
 │   │   ├── faro/             # Frontend Observability provider (apps CRUD, sourcemaps sub-resource) — CLI: `gcx frontend`
 │   │   ├── fleet/            # Fleet Management provider (pipeline and collector resources)
+│   │   ├── instrumentation/  # Instrumentation Hub provider (clusters, apps, services; helm formatter; RMW helper; output codecs; enumerate helper)
+│   │   │   ├── enumerate/    # Cluster enumeration helper (RunK8sMonitoring ⋃ ListPipelines merge)
+│   │   │   ├── helm/         # Helm command formatter for the setup wizard
+│   │   │   ├── output/       # View types and table/JSON codecs (clusters, apps, services; wait/mutation envelopes)
+│   │   │   └── rmw/          # Read-modify-write helper with optimistic-lock guard
 │   │   ├── incidents/        # IRM Incidents provider
 │   │   ├── k6/              # k6 Cloud provider (projects, tests, runs, envvars)
 │   │   ├── kg/               # Knowledge Graph (Asserts) provider

--- a/internal/providers/instrumentation/client.go
+++ b/internal/providers/instrumentation/client.go
@@ -1,0 +1,635 @@
+package instrumentation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/gcx/internal/cloud"
+	"github.com/grafana/gcx/internal/fleet"
+)
+
+// Connect endpoint paths for the instrumentation, discovery, and pipeline services.
+const (
+	pathGetAppInstrumentation = "/instrumentation.v1.InstrumentationService/GetAppInstrumentation"
+	pathSetAppInstrumentation = "/instrumentation.v1.InstrumentationService/SetAppInstrumentation"
+	pathGetK8SInstrumentation = "/instrumentation.v1.InstrumentationService/GetK8SInstrumentation"
+	pathSetK8SInstrumentation = "/instrumentation.v1.InstrumentationService/SetK8SInstrumentation"
+	pathSetupK8sDiscovery     = "/discovery.v1.DiscoveryService/SetupK8sDiscovery"
+	pathRunK8sDiscovery       = "/discovery.v1.DiscoveryService/RunK8sDiscovery"
+	pathRunK8sMonitoring      = "/discovery.v1.DiscoveryService/RunK8sMonitoring"
+	pathListPipelines         = "/pipeline.v1.PipelineService/ListPipelines"
+)
+
+// Client is the instrumentation-specific HTTP client built on top of the
+// shared fleet base client. It adds methods for all instrumentation.v1,
+// discovery.v1, and pipeline.v1 Connect endpoints. No connectrpc library
+// is used.
+type Client struct {
+	fleet *fleet.Client
+}
+
+// NewClient creates a new instrumentation Client using the provided fleet base client.
+func NewClient(f *fleet.Client) *Client {
+	return &Client{fleet: f}
+}
+
+// BackendURLs holds the datasource write endpoints required by Set and
+// SetupDiscovery requests. These are auto-resolved from the Grafana Cloud
+// stack info and MUST NOT appear in any user-facing manifest.
+type BackendURLs struct {
+	MimirURL          string `json:"mimir_url"`
+	MimirUsername     string `json:"mimir_username"`
+	LokiURL           string `json:"loki_url"`
+	LokiUsername      string `json:"loki_username"`
+	TempoURL          string `json:"tempo_url"`
+	TempoUsername     string `json:"tempo_username"`
+	PyroscopeURL      string `json:"pyroscope_url"`
+	PyroscopeUsername string `json:"pyroscope_username"`
+}
+
+// BackendURLsFromStack resolves datasource write endpoints from the Grafana
+// Cloud stack info returned by GCOM. The URLs include the required push path
+// suffixes. The Tempo URL is converted to gRPC host:port format.
+func BackendURLsFromStack(stack cloud.StackInfo) BackendURLs {
+	return BackendURLs{
+		MimirURL:          appendPath(stack.HMInstancePromURL, "/api/prom/push"),
+		MimirUsername:     strconv.Itoa(stack.HMInstancePromID),
+		LokiURL:           appendPath(stack.HLInstanceURL, "/loki/api/v1/push"),
+		LokiUsername:      strconv.Itoa(stack.HLInstanceID),
+		TempoURL:          toGRPCHostPort(stack.HTInstanceURL),
+		TempoUsername:     strconv.Itoa(stack.HTInstanceID),
+		PyroscopeURL:      appendPath(stack.HPInstanceURL, "/ingest"),
+		PyroscopeUsername: strconv.Itoa(stack.HPInstanceID),
+	}
+}
+
+// FleetManagement holds the fleet management connection parameters used by the
+// grafana-cloud-onboarding helm chart. Decoupled from BackendURLs because the
+// onboarding chart does not take per-signal datasource URLs — Fleet Management
+// owns destination routing in the pipelines it pushes to alloy-daemon.
+type FleetManagement struct {
+	// URL is the Fleet Management gRPC endpoint (AgentManagementInstanceURL).
+	URL string
+	// Username is the Fleet Management instance ID used as the basic-auth username.
+	Username string
+}
+
+// FleetManagementFromStack resolves Fleet Management connection parameters
+// from the Grafana Cloud stack info returned by GCOM.
+func FleetManagementFromStack(stack cloud.StackInfo) FleetManagement {
+	return FleetManagement{
+		URL:      stack.AgentManagementInstanceURL,
+		Username: strconv.Itoa(stack.AgentManagementInstanceID),
+	}
+}
+
+// PromHeaders holds the X-Prom-* header values required by discovery/monitoring endpoints.
+type PromHeaders struct {
+	ClusterID  string
+	InstanceID string
+}
+
+// PromHeadersFromStack extracts the X-Prom-* header values from stack info.
+func PromHeadersFromStack(stack cloud.StackInfo) PromHeaders {
+	return PromHeaders{
+		ClusterID:  strconv.Itoa(stack.HMInstancePromClusterID),
+		InstanceID: strconv.Itoa(stack.HMInstancePromID),
+	}
+}
+
+func (h PromHeaders) toMap() map[string]string {
+	return map[string]string{
+		"X-Prom-Cluster-ID":  h.ClusterID,
+		"X-Prom-Instance-ID": h.InstanceID,
+	}
+}
+
+// --- Wire-format types (internal to client.go) ---
+//
+// Wire types use concrete bool fields for JSON marshaling / unmarshaling.
+// Conversion to domain types (which use *bool for tri-state semantics) is
+// performed in each method. On write paths, nil *bool fields collapse to false
+// (derefBool) since the RMW preserve logic lives in the rmw helper (T4).
+
+// wireAppOverride is the on-wire per-workload override.
+type wireAppOverride struct {
+	Name      string `json:"name"`
+	Selection string `json:"selection"`
+}
+
+// wireAppNamespace is the on-wire namespace entry within an app cluster.
+type wireAppNamespace struct {
+	Name            string            `json:"name"`
+	Autoinstrument  bool              `json:"autoinstrument"`
+	Tracing         bool              `json:"tracing"`
+	Logging         bool              `json:"logging"`
+	ProcessMetrics  bool              `json:"processmetrics"`
+	ExtendedMetrics bool              `json:"extendedmetrics"`
+	Profiling       bool              `json:"profiling"`
+	Apps            []wireAppOverride `json:"apps,omitempty"`
+}
+
+// wireAppCluster is the on-wire cluster object for app instrumentation.
+type wireAppCluster struct {
+	Name       string             `json:"name"`
+	Namespaces []wireAppNamespace `json:"namespaces,omitempty"`
+}
+
+// getAppRequest is the request body for GetAppInstrumentation.
+type getAppRequest struct {
+	ClusterName string `json:"cluster_name"`
+}
+
+// getAppResponse is the response envelope for GetAppInstrumentation.
+type getAppResponse struct {
+	Cluster wireAppCluster `json:"cluster"`
+}
+
+// setAppRequest is the request body for SetAppInstrumentation.
+type setAppRequest struct {
+	BackendURLs
+
+	Cluster wireAppCluster `json:"cluster"`
+}
+
+// wireK8sCluster is the on-wire cluster object for K8s instrumentation.
+type wireK8sCluster struct {
+	Name          string `json:"name"`
+	Selection     string `json:"selection"`
+	CostMetrics   bool   `json:"costmetrics"`
+	EnergyMetrics bool   `json:"energymetrics"`
+	ClusterEvents bool   `json:"clusterevents"`
+	NodeLogs      bool   `json:"nodelogs"`
+}
+
+// getK8SRequest is the request body for GetK8SInstrumentation.
+type getK8SRequest struct {
+	ClusterName string `json:"cluster_name"`
+}
+
+// getK8SResponse is the response envelope for GetK8SInstrumentation.
+type getK8SResponse struct {
+	Cluster wireK8sCluster `json:"cluster"`
+}
+
+// setK8SRequest is the request body for SetK8SInstrumentation.
+type setK8SRequest struct {
+	BackendURLs
+
+	Cluster wireK8sCluster `json:"cluster"`
+}
+
+// setupDiscoveryRequest includes backend URLs but no cluster name.
+type setupDiscoveryRequest struct {
+	BackendURLs
+}
+
+// wireDiscoveryItem is the on-wire item from RunK8sDiscovery.
+type wireDiscoveryItem struct {
+	ClusterName           string `json:"clusterName,omitempty"`
+	Namespace             string `json:"namespace,omitempty"`
+	Name                  string `json:"name,omitempty"`
+	WorkloadType          string `json:"workloadType,omitempty"`
+	DisplayNamespace      string `json:"displayNamespace,omitempty"`
+	DisplayName           string `json:"displayName,omitempty"`
+	OS                    string `json:"os,omitempty"`
+	Lang                  string `json:"lang,omitempty"`
+	InstrumentationStatus string `json:"instrumentationStatus,omitempty"`
+}
+
+// wireRunK8sDiscoveryResponse is the on-wire response from RunK8sDiscovery.
+type wireRunK8sDiscoveryResponse struct {
+	Items []wireDiscoveryItem `json:"items,omitempty"`
+}
+
+// wireMonitoringNamespace is the on-wire per-namespace entry from RunK8sMonitoring.
+type wireMonitoringNamespace struct {
+	Name                        string `json:"name,omitempty"`
+	InstrumentationStatus       string `json:"instrumentationStatus,omitempty"`
+	InstrumentationErrorMessage string `json:"instrumentationErrorMessage,omitempty"`
+	Workloads                   int    `json:"workloads,omitempty"`
+	Pods                        int    `json:"pods,omitempty"`
+}
+
+// wireClusterState is the on-wire per-cluster state from RunK8sMonitoring.
+type wireClusterState struct {
+	Name                        string                    `json:"name,omitempty"`
+	InstrumentationStatus       string                    `json:"instrumentationStatus,omitempty"`
+	InstrumentationErrorMessage string                    `json:"instrumentationErrorMessage,omitempty"`
+	Namespaces                  []wireMonitoringNamespace `json:"namespaces,omitempty"`
+	Nodes                       int                       `json:"nodes,omitempty"`
+	Workloads                   int                       `json:"workloads,omitempty"`
+	Pods                        int                       `json:"pods,omitempty"`
+}
+
+// wireRunK8sMonitoringResponse is the on-wire response from RunK8sMonitoring.
+type wireRunK8sMonitoringResponse struct {
+	Clusters []wireClusterState `json:"clusters,omitempty"`
+}
+
+// wirePipeline is the on-wire pipeline object from ListPipelines.
+type wirePipeline struct {
+	ID       string         `json:"id,omitempty"`
+	Name     string         `json:"name,omitempty"`
+	Enabled  *bool          `json:"enabled,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// wireListPipelinesResponse is the on-wire response from ListPipelines.
+type wireListPipelinesResponse struct {
+	Pipelines []wirePipeline `json:"pipelines,omitempty"`
+}
+
+// --- Response types ---
+
+// GetAppInstrumentationResponse is the unwrapped response from GetAppInstrumentation.
+type GetAppInstrumentationResponse struct {
+	// Namespaces is the list of configured namespace entries.
+	Namespaces []App
+}
+
+// GetK8SInstrumentationResponse is the unwrapped response from GetK8SInstrumentation.
+type GetK8SInstrumentationResponse struct {
+	// Cluster holds the declared K8s monitoring configuration.
+	Cluster Cluster
+}
+
+// RunK8sDiscoveryResponse holds discovered workloads returned by RunK8sDiscovery.
+type RunK8sDiscoveryResponse struct {
+	// Items is the list of discovered workloads.
+	Items []DiscoveryItem
+}
+
+// RunK8sMonitoringResponse holds per-cluster monitoring state from RunK8sMonitoring.
+type RunK8sMonitoringResponse struct {
+	// Clusters is the list of observed cluster states.
+	Clusters []ClusterObservedState
+}
+
+// --- Client methods ---
+
+// GetAppInstrumentation retrieves the app instrumentation configuration for the given cluster.
+func (c *Client) GetAppInstrumentation(ctx context.Context, clusterName string) (*GetAppInstrumentationResponse, error) {
+	resp, err := c.fleet.DoRequest(ctx, pathGetAppInstrumentation, getAppRequest{ClusterName: clusterName})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GetAppInstrumentation: %w", &fleet.HTTPError{
+			Status: resp.StatusCode,
+			Path:   pathGetAppInstrumentation,
+			Body:   fleet.ReadErrorBody(resp),
+		})
+	}
+
+	var envelope getAppResponse
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("GetAppInstrumentation: decode response: %w", err)
+	}
+
+	namespaces := make([]App, 0, len(envelope.Cluster.Namespaces))
+	for _, wns := range envelope.Cluster.Namespaces {
+		apps := make([]AppOverride, 0, len(wns.Apps))
+		for _, wa := range wns.Apps {
+			apps = append(apps, AppOverride(wa))
+		}
+		namespaces = append(namespaces, App{
+			Name:            wns.Name,
+			Autoinstrument:  boolPtr(wns.Autoinstrument),  //nolint:modernize // ptr() creates pointer to value, not pointer to type like new()
+			Tracing:         boolPtr(wns.Tracing),         //nolint:modernize
+			Logging:         boolPtr(wns.Logging),         //nolint:modernize
+			ProcessMetrics:  boolPtr(wns.ProcessMetrics),  //nolint:modernize
+			ExtendedMetrics: boolPtr(wns.ExtendedMetrics), //nolint:modernize
+			Profiling:       boolPtr(wns.Profiling),       //nolint:modernize
+			Apps:            apps,
+		})
+	}
+	return &GetAppInstrumentationResponse{Namespaces: namespaces}, nil
+}
+
+// SetAppInstrumentation sets app instrumentation configuration for the given cluster.
+// The namespaces slice is a whole-list replacement of the cluster's app config.
+func (c *Client) SetAppInstrumentation(ctx context.Context, clusterName string, namespaces []App, urls BackendURLs) error {
+	wireNS := make([]wireAppNamespace, 0, len(namespaces))
+	for _, ns := range namespaces {
+		apps := make([]wireAppOverride, 0, len(ns.Apps))
+		for _, a := range ns.Apps {
+			apps = append(apps, wireAppOverride(a))
+		}
+		wireNS = append(wireNS, wireAppNamespace{
+			Name:            ns.Name,
+			Autoinstrument:  derefBool(ns.Autoinstrument),
+			Tracing:         derefBool(ns.Tracing),
+			Logging:         derefBool(ns.Logging),
+			ProcessMetrics:  derefBool(ns.ProcessMetrics),
+			ExtendedMetrics: derefBool(ns.ExtendedMetrics),
+			Profiling:       derefBool(ns.Profiling),
+			Apps:            apps,
+		})
+	}
+
+	resp, err := c.fleet.DoRequest(ctx, pathSetAppInstrumentation, setAppRequest{
+		BackendURLs: urls,
+		Cluster:     wireAppCluster{Name: clusterName, Namespaces: wireNS},
+	})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("SetAppInstrumentation: %w", &fleet.HTTPError{
+			Status: resp.StatusCode,
+			Path:   pathSetAppInstrumentation,
+			Body:   fleet.ReadErrorBody(resp),
+		})
+	}
+	return nil
+}
+
+// GetK8SInstrumentation retrieves the K8s monitoring configuration for the given cluster.
+//
+// Note: wire-fixture tests confirm the response mapper
+// correctly preserves SELECTION_EXCLUDED. If the live stack returns "" after
+// SetK8SInstrumentation(SELECTION_EXCLUDED), the bug is server-side.
+// See docs/adrs/instrumentation/002-cli-redesign.md § "E — Selection enum hygiene".
+func (c *Client) GetK8SInstrumentation(ctx context.Context, clusterName string) (*GetK8SInstrumentationResponse, error) {
+	resp, err := c.fleet.DoRequest(ctx, pathGetK8SInstrumentation, getK8SRequest{ClusterName: clusterName})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GetK8SInstrumentation: %w", &fleet.HTTPError{
+			Status: resp.StatusCode,
+			Path:   pathGetK8SInstrumentation,
+			Body:   fleet.ReadErrorBody(resp),
+		})
+	}
+
+	var envelope getK8SResponse
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("GetK8SInstrumentation: decode response: %w", err)
+	}
+
+	return &GetK8SInstrumentationResponse{
+		Cluster: Cluster{
+			Name:          envelope.Cluster.Name,
+			Selection:     envelope.Cluster.Selection,
+			CostMetrics:   boolPtr(envelope.Cluster.CostMetrics),   //nolint:modernize // ptr() creates pointer to value, not pointer to type like new()
+			EnergyMetrics: boolPtr(envelope.Cluster.EnergyMetrics), //nolint:modernize
+			ClusterEvents: boolPtr(envelope.Cluster.ClusterEvents), //nolint:modernize
+			NodeLogs:      boolPtr(envelope.Cluster.NodeLogs),      //nolint:modernize
+		},
+	}, nil
+}
+
+// SetK8SInstrumentation sets K8s monitoring configuration for the given cluster.
+// When Selection is SELECTION_EXCLUDED, the backend deletes the K8s monitoring pipeline.
+func (c *Client) SetK8SInstrumentation(ctx context.Context, clusterName string, k8s Cluster, urls BackendURLs) error {
+	selection := k8s.Selection
+	if selection == "" {
+		selection = "SELECTION_INCLUDED"
+	}
+
+	resp, err := c.fleet.DoRequest(ctx, pathSetK8SInstrumentation, setK8SRequest{
+		BackendURLs: urls,
+		Cluster: wireK8sCluster{
+			Name:          clusterName,
+			Selection:     selection,
+			CostMetrics:   derefBool(k8s.CostMetrics),
+			EnergyMetrics: derefBool(k8s.EnergyMetrics),
+			ClusterEvents: derefBool(k8s.ClusterEvents),
+			NodeLogs:      derefBool(k8s.NodeLogs),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("SetK8SInstrumentation: %w", &fleet.HTTPError{
+			Status: resp.StatusCode,
+			Path:   pathSetK8SInstrumentation,
+			Body:   fleet.ReadErrorBody(resp),
+		})
+	}
+	return nil
+}
+
+// SetupK8sDiscovery initializes K8s discovery datasource endpoints.
+// This call is idempotent: if a Beyla survey pipeline already exists,
+// the backend returns success without modification.
+func (c *Client) SetupK8sDiscovery(ctx context.Context, urls BackendURLs, promHeaders PromHeaders) error {
+	resp, err := c.fleet.DoRequestWithHeaders(ctx, pathSetupK8sDiscovery, setupDiscoveryRequest{BackendURLs: urls}, promHeaders.toMap())
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("SetupK8sDiscovery: %w", &fleet.HTTPError{
+			Status: resp.StatusCode,
+			Path:   pathSetupK8sDiscovery,
+			Body:   fleet.ReadErrorBody(resp),
+		})
+	}
+	return nil
+}
+
+// RunK8sDiscovery executes discovery and returns all discovered workloads
+// across all clusters. Filtering by cluster, namespace, or status is performed
+// client-side by the callers.
+func (c *Client) RunK8sDiscovery(ctx context.Context, promHeaders PromHeaders) (*RunK8sDiscoveryResponse, error) {
+	resp, err := c.fleet.DoRequestWithHeaders(ctx, pathRunK8sDiscovery, struct{}{}, promHeaders.toMap())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("RunK8sDiscovery: %w", &fleet.HTTPError{
+			Status: resp.StatusCode,
+			Path:   pathRunK8sDiscovery,
+			Body:   fleet.ReadErrorBody(resp),
+		})
+	}
+
+	var wire wireRunK8sDiscoveryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wire); err != nil {
+		return nil, fmt.Errorf("RunK8sDiscovery: decode response: %w", err)
+	}
+
+	items := make([]DiscoveryItem, 0, len(wire.Items))
+	for _, wi := range wire.Items {
+		items = append(items, DiscoveryItem{
+			ClusterName:           wi.ClusterName,
+			Namespace:             wi.Namespace,
+			Name:                  wi.Name,
+			WorkloadType:          wi.WorkloadType,
+			DisplayNamespace:      wi.DisplayNamespace,
+			DisplayName:           wi.DisplayName,
+			OS:                    wi.OS,
+			Lang:                  wi.Lang,
+			InstrumentationStatus: InstrumentationStatus(wi.InstrumentationStatus),
+		})
+	}
+	return &RunK8sDiscoveryResponse{Items: items}, nil
+}
+
+// RunK8sMonitoring retrieves the instrumentation monitoring state for all clusters.
+// Clusters that have been Set but are not yet reporting survey_info will be absent
+// from this response — the enumerate helper (T5) resolves them via ListPipelines.
+func (c *Client) RunK8sMonitoring(ctx context.Context, promHeaders PromHeaders) (*RunK8sMonitoringResponse, error) {
+	resp, err := c.fleet.DoRequestWithHeaders(ctx, pathRunK8sMonitoring, struct{}{}, promHeaders.toMap())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("RunK8sMonitoring: %w", &fleet.HTTPError{
+			Status: resp.StatusCode,
+			Path:   pathRunK8sMonitoring,
+			Body:   fleet.ReadErrorBody(resp),
+		})
+	}
+
+	var wire wireRunK8sMonitoringResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wire); err != nil {
+		return nil, fmt.Errorf("RunK8sMonitoring: decode response: %w", err)
+	}
+
+	clusters := make([]ClusterObservedState, 0, len(wire.Clusters))
+	for _, wc := range wire.Clusters {
+		namespaces := make([]NamespaceObservedState, 0, len(wc.Namespaces))
+		for _, wn := range wc.Namespaces {
+			namespaces = append(namespaces, NamespaceObservedState{
+				Name:                        wn.Name,
+				InstrumentationStatus:       InstrumentationStatus(wn.InstrumentationStatus),
+				InstrumentationErrorMessage: wn.InstrumentationErrorMessage,
+				Workloads:                   wn.Workloads,
+				Pods:                        wn.Pods,
+			})
+		}
+		clusters = append(clusters, ClusterObservedState{
+			Name:                        wc.Name,
+			InstrumentationStatus:       InstrumentationStatus(wc.InstrumentationStatus),
+			InstrumentationErrorMessage: wc.InstrumentationErrorMessage,
+			Namespaces:                  namespaces,
+			Nodes:                       wc.Nodes,
+			Workloads:                   wc.Workloads,
+			Pods:                        wc.Pods,
+		})
+	}
+	return &RunK8sMonitoringResponse{Clusters: clusters}, nil
+}
+
+// ListPipelines returns all pipelines from the fleet management pipeline service.
+// Callers (the enumerate helper, T5) perform client-side filtering by K8s monitoring
+// pipeline metadata to identify clusters that have been Set but are not yet reporting
+// survey_info.
+func (c *Client) ListPipelines(ctx context.Context) ([]Pipeline, error) {
+	resp, err := c.fleet.DoRequest(ctx, pathListPipelines, struct{}{})
+	if err != nil {
+		return nil, fmt.Errorf("ListPipelines: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ListPipelines: %w", &fleet.HTTPError{
+			Status: resp.StatusCode,
+			Path:   pathListPipelines,
+			Body:   fleet.ReadErrorBody(resp),
+		})
+	}
+
+	var wire wireListPipelinesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wire); err != nil {
+		return nil, fmt.Errorf("ListPipelines: decode response: %w", err)
+	}
+
+	pipelines := make([]Pipeline, 0, len(wire.Pipelines))
+	for _, wp := range wire.Pipelines {
+		pipelines = append(pipelines, Pipeline(wp))
+	}
+	return pipelines, nil
+}
+
+// IsNamespaceDiscovered returns true iff the named namespace appears under
+// the named cluster in RunK8sDiscovery's response. A fresh discovery call is
+// made each time; no caching. Discovery RPC error is propagated as a wrapped
+// error (callers handle it).
+//
+// The RunK8sDiscovery response is a flat list of workloads (DiscoveryItems).
+// A namespace is considered "discovered" iff at least one workload with
+// ClusterName == cluster and Namespace == namespace exists in the response.
+func (c *Client) IsNamespaceDiscovered(ctx context.Context, promHeaders PromHeaders, cluster, namespace string) (bool, error) {
+	resp, err := c.RunK8sDiscovery(ctx, promHeaders)
+	if err != nil {
+		return false, fmt.Errorf("discovery: %w", err)
+	}
+	for _, item := range resp.Items {
+		if item.ClusterName == cluster && item.Namespace == namespace {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// --- helpers ---
+
+// boolPtr returns a pointer to the given bool value. Used when converting
+// wire bool fields to domain *bool fields.
+//
+//nolint:modernize // ptr() creates pointer to value, not pointer to type like new()
+func boolPtr(b bool) *bool { return &b }
+
+// derefBool dereferences a *bool, returning false for nil. Used when converting
+// domain *bool fields to wire bool fields on write paths.
+// NOTE: nil means "preserve existing value" in the RMW context; collapsing to false
+// here is intentional — the RMW helper (T4) is responsible for re-reading and
+// merging the current value before invoking Set methods.
+func derefBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
+}
+
+// appendPath joins base and suffix, removing any trailing slash from base.
+func appendPath(base, suffix string) string {
+	if base == "" {
+		return ""
+	}
+	return strings.TrimRight(base, "/") + suffix
+}
+
+// toGRPCHostPort converts an HTTP(S) URL to a gRPC-compatible host:port string.
+func toGRPCHostPort(httpURL string) string {
+	if httpURL == "" {
+		return ""
+	}
+	u, err := url.Parse(httpURL)
+	if err != nil {
+		return httpURL
+	}
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return u.Hostname() + ":" + port
+}

--- a/internal/providers/instrumentation/client_test.go
+++ b/internal/providers/instrumentation/client_test.go
@@ -1,0 +1,703 @@
+package instrumentation_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient creates an instrumentation Client pointed at the given test server URL.
+func newTestClient(serverURL string) *instrumentation.Client {
+	f := fleet.NewClient(context.Background(), serverURL, "inst-id", "api-token", true, nil)
+	return instrumentation.NewClient(f)
+}
+
+// captureHandler returns an http.HandlerFunc that captures the request and writes
+// the provided JSON response body with the given status code.
+func captureHandler(t *testing.T, statusCode int, respBody string) (http.HandlerFunc, *capturedRequest) {
+	t.Helper()
+	cr := &capturedRequest{}
+	return func(w http.ResponseWriter, r *http.Request) {
+		cr.Method = r.Method
+		cr.Path = r.URL.Path
+		cr.ContentType = r.Header.Get("Content-Type")
+		cr.Accept = r.Header.Get("Accept")
+		b, _ := io.ReadAll(r.Body)
+		cr.Body = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(respBody))
+	}, cr
+}
+
+type capturedRequest struct {
+	Method      string
+	Path        string
+	ContentType string
+	Accept      string
+	Body        string
+}
+
+// assertConnectRequest verifies that a captured request conforms to the Connect RPC
+// over HTTP POST contract (NC-006): POST method, application/json content type and accept.
+func assertConnectRequest(t *testing.T, cr *capturedRequest, wantPath string) {
+	t.Helper()
+	assert.Equal(t, http.MethodPost, cr.Method, "must use POST")
+	assert.Equal(t, "application/json", cr.ContentType, "must set Content-Type: application/json")
+	assert.Equal(t, "application/json", cr.Accept, "must set Accept: application/json")
+	assert.True(t, strings.HasSuffix(cr.Path, wantPath), "expected path suffix %q, got %q", wantPath, cr.Path)
+}
+
+func TestClient_GetAppInstrumentation(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		respStatus  int
+		respBody    string
+		wantErr     bool
+		wantNSCount int
+	}{
+		{
+			name:        "returns namespaces on 200",
+			clusterName: "prod-1",
+			respStatus:  http.StatusOK,
+			respBody:    `{"cluster":{"name":"prod-1","namespaces":[{"name":"default","autoinstrument":true,"tracing":true}]}}`,
+			wantNSCount: 1,
+		},
+		{
+			name:        "empty namespaces on 200",
+			clusterName: "empty-cluster",
+			respStatus:  http.StatusOK,
+			respBody:    `{"cluster":{"name":"empty-cluster"}}`,
+			wantNSCount: 0,
+		},
+		{
+			name:        "HTTP error returns error",
+			clusterName: "bad-cluster",
+			respStatus:  http.StatusInternalServerError,
+			respBody:    `{"error":"internal"}`,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, cr := captureHandler(t, tt.respStatus, tt.respBody)
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			client := newTestClient(srv.URL)
+			resp, err := client.GetAppInstrumentation(context.Background(), tt.clusterName)
+
+			assertConnectRequest(t, cr, "/instrumentation.v1.InstrumentationService/GetAppInstrumentation")
+			assert.Contains(t, cr.Body, tt.clusterName)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, resp.Namespaces, tt.wantNSCount)
+		})
+	}
+}
+
+// TestClient_GetAppInstrumentation_Converts verifies that wire bool fields are
+// converted to *bool in the domain type (D-06).
+func TestClient_GetAppInstrumentation_Converts(t *testing.T) {
+	respBody := `{"cluster":{"name":"c1","namespaces":[{"name":"default","autoinstrument":true,"tracing":true,"logging":false,"processmetrics":false,"extendedmetrics":false,"profiling":false}]}}`
+
+	handler, _ := captureHandler(t, http.StatusOK, respBody)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := newTestClient(srv.URL).GetAppInstrumentation(context.Background(), "c1")
+	require.NoError(t, err)
+	require.Len(t, resp.Namespaces, 1)
+
+	ns := resp.Namespaces[0]
+	assert.Equal(t, "default", ns.Name)
+	// Wire bool true → *bool true
+	require.NotNil(t, ns.Autoinstrument)
+	assert.True(t, *ns.Autoinstrument)
+	// Wire bool false → *bool false (not nil)
+	require.NotNil(t, ns.Logging)
+	assert.False(t, *ns.Logging)
+}
+
+func TestClient_SetAppInstrumentation(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		namespaces  []instrumentation.App
+		respStatus  int
+		respBody    string
+		wantErr     bool
+	}{
+		{
+			name:        "successful set",
+			clusterName: "prod-1",
+			namespaces: []instrumentation.App{
+				{Name: "default", Autoinstrument: boolPtr(true), Tracing: boolPtr(true)}, //nolint:modernize // ptr() creates pointer to value, not pointer to type like new()
+			},
+			respStatus: http.StatusOK,
+			respBody:   `{}`,
+		},
+		{
+			name:        "HTTP error returns error",
+			clusterName: "bad-cluster",
+			respStatus:  http.StatusBadRequest,
+			respBody:    `{"error":"bad request"}`,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, cr := captureHandler(t, tt.respStatus, tt.respBody)
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			client := newTestClient(srv.URL)
+			err := client.SetAppInstrumentation(context.Background(), tt.clusterName, tt.namespaces, instrumentation.BackendURLs{})
+
+			assertConnectRequest(t, cr, "/instrumentation.v1.InstrumentationService/SetAppInstrumentation")
+			assert.Contains(t, cr.Body, tt.clusterName)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestClient_GetK8SInstrumentation(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		respStatus  int
+		respBody    string
+		wantErr     bool
+		wantCost    bool
+	}{
+		{
+			name:        "returns k8s config on 200",
+			clusterName: "prod-1",
+			respStatus:  http.StatusOK,
+			respBody:    `{"cluster":{"name":"prod-1","selection":"SELECTION_INCLUDED","costmetrics":true,"clusterevents":false}}`,
+			wantCost:    true,
+		},
+		{
+			name:        "HTTP error returns error",
+			clusterName: "bad",
+			respStatus:  http.StatusNotFound,
+			respBody:    `{}`,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, cr := captureHandler(t, tt.respStatus, tt.respBody)
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			client := newTestClient(srv.URL)
+			resp, err := client.GetK8SInstrumentation(context.Background(), tt.clusterName)
+
+			assertConnectRequest(t, cr, "/instrumentation.v1.InstrumentationService/GetK8SInstrumentation")
+			assert.Contains(t, cr.Body, tt.clusterName)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, resp.Cluster.CostMetrics)
+			assert.Equal(t, tt.wantCost, *resp.Cluster.CostMetrics)
+			// Selection must always be populated from the wire response (FR-013)
+			assert.Equal(t, "SELECTION_INCLUDED", resp.Cluster.Selection)
+		})
+	}
+}
+
+func TestClient_SetK8SInstrumentation(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		k8s         instrumentation.Cluster
+		respStatus  int
+		respBody    string
+		wantErr     bool
+	}{
+		{
+			name:        "successful set",
+			clusterName: "prod-1",
+			k8s:         instrumentation.Cluster{CostMetrics: boolPtr(true), NodeLogs: boolPtr(true)}, //nolint:modernize // ptr() creates pointer to value, not pointer to type like new()
+			respStatus:  http.StatusOK,
+			respBody:    `{}`,
+		},
+		{
+			name:        "HTTP error returns error",
+			clusterName: "bad",
+			respStatus:  http.StatusInternalServerError,
+			respBody:    `{"error":"server error"}`,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, cr := captureHandler(t, tt.respStatus, tt.respBody)
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			client := newTestClient(srv.URL)
+			err := client.SetK8SInstrumentation(context.Background(), tt.clusterName, tt.k8s, instrumentation.BackendURLs{})
+
+			assertConnectRequest(t, cr, "/instrumentation.v1.InstrumentationService/SetK8SInstrumentation")
+			assert.Contains(t, cr.Body, tt.clusterName)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestGetK8SInstrumentation_SelectionRoundTrip verifies that the response mapper
+// correctly preserves SELECTION_EXCLUDED when the server returns it.
+// This is the symmetric case for SELECTION_INCLUDED tested in TestClient_GetK8SInstrumentation.
+// Theme E (2026-04-30): if the live stack returns "" after clusters remove, the bug
+// is server-side — not in this mapper. See docs/adrs/instrumentation/002-cli-redesign.md § "E — Selection enum hygiene".
+func TestGetK8SInstrumentation_SelectionRoundTrip(t *testing.T) {
+	wireResp := `{"cluster":{"name":"test-cluster","selection":"SELECTION_EXCLUDED","costmetrics":false,"energymetrics":false,"clusterevents":false,"nodelogs":false}}`
+	handler, _ := captureHandler(t, http.StatusOK, wireResp)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := newTestClient(srv.URL).GetK8SInstrumentation(context.Background(), "test-cluster")
+	require.NoError(t, err)
+	assert.Equal(t, "SELECTION_EXCLUDED", resp.Cluster.Selection,
+		"Selection must survive wire→domain mapping")
+}
+
+// TestSetK8SInstrumentation_SendsSelectionExcluded verifies that SetK8SInstrumentation
+// sends "SELECTION_EXCLUDED" verbatim in the request body when that value is set.
+func TestSetK8SInstrumentation_SendsSelectionExcluded(t *testing.T) {
+	var capturedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		capturedBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	excluded := instrumentation.Cluster{
+		Name:      "test-cluster",
+		Selection: "SELECTION_EXCLUDED",
+	}
+	err := newTestClient(srv.URL).SetK8SInstrumentation(context.Background(), "test-cluster", excluded, instrumentation.BackendURLs{})
+	require.NoError(t, err)
+	assert.Contains(t, capturedBody, `"SELECTION_EXCLUDED"`,
+		"SetK8SInstrumentation must send SELECTION_EXCLUDED in request body")
+}
+
+// TestClient_SetK8SInstrumentation_DefaultsSelection verifies that when Cluster.Selection
+// is empty, the wire request uses SELECTION_INCLUDED.
+func TestClient_SetK8SInstrumentation_DefaultsSelection(t *testing.T) {
+	var capturedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		capturedBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	err := newTestClient(srv.URL).SetK8SInstrumentation(context.Background(), "c1",
+		instrumentation.Cluster{Name: "c1"}, instrumentation.BackendURLs{})
+	require.NoError(t, err)
+	assert.Contains(t, capturedBody, "SELECTION_INCLUDED", "empty Selection must default to SELECTION_INCLUDED")
+}
+
+func TestClient_SetupK8sDiscovery(t *testing.T) {
+	tests := []struct {
+		name       string
+		respStatus int
+		respBody   string
+		wantErr    bool
+	}{
+		{
+			name:       "successful setup",
+			respStatus: http.StatusOK,
+			respBody:   `{}`,
+		},
+		{
+			name:       "HTTP error returns error",
+			respStatus: http.StatusForbidden,
+			respBody:   `{"error":"forbidden"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, cr := captureHandler(t, tt.respStatus, tt.respBody)
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			client := newTestClient(srv.URL)
+			err := client.SetupK8sDiscovery(context.Background(),
+				instrumentation.BackendURLs{},
+				instrumentation.PromHeaders{ClusterID: "42", InstanceID: "123"})
+
+			assertConnectRequest(t, cr, "/discovery.v1.DiscoveryService/SetupK8sDiscovery")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestClient_RunK8sDiscovery(t *testing.T) {
+	tests := []struct {
+		name          string
+		respStatus    int
+		respBody      string
+		wantErr       bool
+		wantItemCount int
+	}{
+		{
+			name:          "returns discovered items",
+			respStatus:    http.StatusOK,
+			respBody:      `{"items":[{"clusterName":"cluster-1","namespace":"default","name":"web","workloadType":"deployment","instrumentationStatus":"INSTRUMENTED"}]}`,
+			wantItemCount: 1,
+		},
+		{
+			name:          "empty discovery result",
+			respStatus:    http.StatusOK,
+			respBody:      `{}`,
+			wantItemCount: 0,
+		},
+		{
+			name:       "HTTP error returns error",
+			respStatus: http.StatusInternalServerError,
+			respBody:   `{"error":"server error"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, cr := captureHandler(t, tt.respStatus, tt.respBody)
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			client := newTestClient(srv.URL)
+			resp, err := client.RunK8sDiscovery(context.Background(),
+				instrumentation.PromHeaders{ClusterID: "42", InstanceID: "123"})
+
+			assertConnectRequest(t, cr, "/discovery.v1.DiscoveryService/RunK8sDiscovery")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, resp.Items, tt.wantItemCount)
+		})
+	}
+}
+
+// TestClient_IsNamespaceDiscovered verifies the IsNamespaceDiscovered helper
+// that cross-references RunK8sDiscovery items for the (cluster, namespace) pair.
+func TestClient_IsNamespaceDiscovered(t *testing.T) {
+	// Discovery response with one item for cluster "c1" / namespace "ns1".
+	discoveryBody := `{"items":[
+		{"clusterName":"c1","namespace":"ns1","name":"web"},
+		{"clusterName":"c1","namespace":"ns2","name":"api"},
+		{"clusterName":"c2","namespace":"ns1","name":"svc"}
+	]}`
+
+	tests := []struct {
+		name       string
+		respStatus int
+		respBody   string
+		cluster    string
+		namespace  string
+		wantResult bool
+		wantErr    bool
+	}{
+		{
+			name:       "cluster present, namespace present — true",
+			respStatus: http.StatusOK,
+			respBody:   discoveryBody,
+			cluster:    "c1",
+			namespace:  "ns1",
+			wantResult: true,
+		},
+		{
+			name:       "cluster present, namespace absent — false",
+			respStatus: http.StatusOK,
+			respBody:   discoveryBody,
+			cluster:    "c1",
+			namespace:  "missing",
+			wantResult: false,
+		},
+		{
+			name:       "cluster absent — false",
+			respStatus: http.StatusOK,
+			respBody:   discoveryBody,
+			cluster:    "unknown-cluster",
+			namespace:  "ns1",
+			wantResult: false,
+		},
+		{
+			name:       "same namespace name under different cluster — false",
+			respStatus: http.StatusOK,
+			respBody:   discoveryBody,
+			cluster:    "c2",
+			namespace:  "ns2",
+			wantResult: false,
+		},
+		{
+			name:       "RPC error propagates",
+			respStatus: http.StatusInternalServerError,
+			respBody:   `{"error":"server error"}`,
+			cluster:    "c1",
+			namespace:  "ns1",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, _ := captureHandler(t, tt.respStatus, tt.respBody)
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			client := newTestClient(srv.URL)
+			got, err := client.IsNamespaceDiscovered(context.Background(),
+				instrumentation.PromHeaders{ClusterID: "1", InstanceID: "2"},
+				tt.cluster, tt.namespace)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantResult, got)
+		})
+	}
+}
+
+// TestClient_RunK8sDiscovery_StatusConversion verifies that InstrumentationStatus
+// is properly converted from wire string to typed constant.
+func TestClient_RunK8sDiscovery_StatusConversion(t *testing.T) {
+	respBody := `{"items":[{"clusterName":"c1","name":"web","instrumentationStatus":"PENDING_INSTRUMENTATION"}]}`
+	handler, _ := captureHandler(t, http.StatusOK, respBody)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := newTestClient(srv.URL).RunK8sDiscovery(context.Background(),
+		instrumentation.PromHeaders{ClusterID: "1", InstanceID: "2"})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, instrumentation.StatusPendingInstrumentation, resp.Items[0].InstrumentationStatus)
+}
+
+func TestClient_RunK8sMonitoring(t *testing.T) {
+	tests := []struct {
+		name           string
+		respStatus     int
+		respBody       string
+		wantErr        bool
+		wantCluster    string
+		wantClusterLen int
+	}{
+		{
+			name:           "returns cluster states",
+			respStatus:     http.StatusOK,
+			respBody:       `{"clusters":[{"name":"prod-1","instrumentationStatus":"INSTRUMENTED"}]}`,
+			wantCluster:    "prod-1",
+			wantClusterLen: 1,
+		},
+		{
+			name:       "empty response",
+			respStatus: http.StatusOK,
+			respBody:   `{}`,
+		},
+		{
+			name:       "HTTP error returns error",
+			respStatus: http.StatusInternalServerError,
+			respBody:   `{"error":"server error"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, cr := captureHandler(t, tt.respStatus, tt.respBody)
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			client := newTestClient(srv.URL)
+			resp, err := client.RunK8sMonitoring(context.Background(),
+				instrumentation.PromHeaders{ClusterID: "42", InstanceID: "123"})
+
+			assertConnectRequest(t, cr, "/discovery.v1.DiscoveryService/RunK8sMonitoring")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantClusterLen > 0 {
+				require.Len(t, resp.Clusters, tt.wantClusterLen)
+				assert.Equal(t, tt.wantCluster, resp.Clusters[0].Name)
+			}
+		})
+	}
+}
+
+func TestClient_ListPipelines(t *testing.T) {
+	tests := []struct {
+		name       string
+		respStatus int
+		respBody   string
+		wantErr    bool
+		wantCount  int
+	}{
+		{
+			name:       "returns pipelines",
+			respStatus: http.StatusOK,
+			respBody:   `{"pipelines":[{"id":"abc","name":"k8s-monitoring","metadata":{"type":"k8s_monitoring","cluster":"prod-1"}}]}`,
+			wantCount:  1,
+		},
+		{
+			name:       "empty pipeline list",
+			respStatus: http.StatusOK,
+			respBody:   `{}`,
+			wantCount:  0,
+		},
+		{
+			name:       "HTTP error returns error",
+			respStatus: http.StatusInternalServerError,
+			respBody:   `{"error":"server error"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, cr := captureHandler(t, tt.respStatus, tt.respBody)
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			client := newTestClient(srv.URL)
+			pipelines, err := client.ListPipelines(context.Background())
+
+			assertConnectRequest(t, cr, "/pipeline.v1.PipelineService/ListPipelines")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, pipelines, tt.wantCount)
+		})
+	}
+}
+
+// TestClient_ListPipelines_MetadataPreserved verifies that pipeline metadata
+// is preserved so the enumerate helper can filter by it (D-14).
+func TestClient_ListPipelines_MetadataPreserved(t *testing.T) {
+	respBody := `{"pipelines":[{"id":"abc","name":"k8s-monitoring","metadata":{"type":"k8s_monitoring","cluster":"prod-1"}}]}`
+	handler, _ := captureHandler(t, http.StatusOK, respBody)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	pipelines, err := newTestClient(srv.URL).ListPipelines(context.Background())
+	require.NoError(t, err)
+	require.Len(t, pipelines, 1)
+	assert.Equal(t, "abc", pipelines[0].ID)
+	assert.Equal(t, "k8s_monitoring", pipelines[0].Metadata["type"])
+	assert.Equal(t, "prod-1", pipelines[0].Metadata["cluster"])
+}
+
+// TestClient_AllEndpoints_RequestBodyContainsClusterName verifies that each
+// relevant endpoint sends the cluster name in the request body.
+func TestClient_AllEndpoints_RequestBodyContainsClusterName(t *testing.T) {
+	tests := []struct {
+		name           string
+		invoke         func(client *instrumentation.Client) error
+		wantPathSuffix string
+		checkBody      func(t *testing.T, body map[string]json.RawMessage)
+	}{
+		{
+			name: "GetAppInstrumentation sends cluster_name",
+			invoke: func(client *instrumentation.Client) error {
+				_, err := client.GetAppInstrumentation(context.Background(), "my-cluster")
+				return err
+			},
+			wantPathSuffix: "/instrumentation.v1.InstrumentationService/GetAppInstrumentation",
+			checkBody: func(t *testing.T, body map[string]json.RawMessage) {
+				t.Helper()
+				assert.Contains(t, body, "cluster_name", "request body must contain cluster_name field (snake_case)")
+			},
+		},
+		{
+			name: "SetK8SInstrumentation sends cluster envelope",
+			invoke: func(client *instrumentation.Client) error {
+				return client.SetK8SInstrumentation(context.Background(), "my-cluster",
+					instrumentation.Cluster{}, instrumentation.BackendURLs{})
+			},
+			wantPathSuffix: "/instrumentation.v1.InstrumentationService/SetK8SInstrumentation",
+			checkBody: func(t *testing.T, body map[string]json.RawMessage) {
+				t.Helper()
+				assert.Contains(t, body, "cluster", "request body must contain cluster envelope")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedBody string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, _ := io.ReadAll(r.Body)
+				capturedBody = string(b)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer srv.Close()
+
+			err := tt.invoke(newTestClient(srv.URL))
+			require.NoError(t, err)
+
+			var body map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal([]byte(capturedBody), &body))
+			tt.checkBody(t, body)
+		})
+	}
+}

--- a/internal/providers/instrumentation/enumerate/enumerate.go
+++ b/internal/providers/instrumentation/enumerate/enumerate.go
@@ -1,0 +1,182 @@
+// Package enumerate implements the cluster-enumeration helper.
+//
+// RunK8sMonitoring builds its cluster set from survey_info{} Prometheus queries.
+// Clusters that have been Set via SetK8SInstrumentation but whose Alloy collector
+// has not yet started reporting survey_info{} are invisible to that RPC. To surface
+// these "pre-Alloy" clusters, Enumerate merges RunK8sMonitoring() with
+// PipelineService.ListPipelines() filtered to K8s monitoring pipelines
+// (metadata["type"] == "k8s_monitoring"). Clusters present only in ListPipelines
+// are returned with Status=StatusPendingInstrumentation.
+//
+// This helper is used by clusters list, clusters get,
+// status, and clusters wait.
+package enumerate
+
+import (
+	"context"
+	"sort"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"golang.org/x/sync/errgroup"
+)
+
+// k8sMonitoringPipelineType is the metadata "type" value that identifies K8s
+// monitoring pipelines. Matches the value emitted by the fleet-management backend
+// and verified in T1 client_test.go wire fixtures.
+const k8sMonitoringPipelineType = "k8s_monitoring"
+
+// MonitoringClient is the minimal interface required by Enumerate to call
+// RunK8sMonitoring. The real *instrumentation.Client satisfies this via an
+// adapter (PromHeaders are bound at the call site).
+type MonitoringClient interface {
+	RunK8sMonitoring(ctx context.Context) ([]instrumentation.ClusterObservedState, error)
+}
+
+// PipelineClient is the minimal interface required by Enumerate to call
+// ListPipelines.
+type PipelineClient interface {
+	ListPipelines(ctx context.Context) ([]instrumentation.Pipeline, error)
+}
+
+// Source indicates which backend source(s) surfaced an ObservedCluster.
+type Source int
+
+const (
+	// MonitoringSource means the cluster was returned only by RunK8sMonitoring.
+	MonitoringSource Source = iota
+	// PipelineSource means the cluster was returned only by ListPipelines (pre-Alloy).
+	PipelineSource
+	// BothSources means the cluster appeared in both RunK8sMonitoring and ListPipelines.
+	BothSources
+)
+
+// ObservedCluster is the merged view of a single cluster from both backends.
+type ObservedCluster struct {
+	// Name is the cluster name.
+	Name string
+	// Status is the observed instrumentation status. Clusters that are present
+	// only in pipeline state are assigned StatusPendingInstrumentation.
+	Status instrumentation.InstrumentationStatus
+	// State is populated from RunK8sMonitoring when the cluster is visible to
+	// that RPC. Nil for pre-Alloy clusters (Source == PipelineSource).
+	State *instrumentation.ClusterObservedState
+	// Source indicates which backend surfaced this cluster.
+	Source Source
+}
+
+// Enumerate merges the cluster sets from RunK8sMonitoring and ListPipelines,
+// returning a unified []ObservedCluster sorted alphabetically by cluster name.
+//
+// Both RPCs are called concurrently. Clusters present only in ListPipelines
+// (whose pipeline metadata["type"] == "k8s_monitoring" and metadata["cluster"]
+// or metadata["cluster_name"] is non-empty) are added with
+// Status=StatusPendingInstrumentation and Source=PipelineSource. Clusters
+// present in both sources have Source=BothSources and their status is taken
+// from RunK8sMonitoring.
+func Enumerate(ctx context.Context, mon MonitoringClient, pipe PipelineClient) ([]ObservedCluster, error) {
+	var (
+		monClusters   []instrumentation.ClusterObservedState
+		pipePipelines []instrumentation.Pipeline
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(2)
+
+	g.Go(func() error {
+		var err error
+		monClusters, err = mon.RunK8sMonitoring(gctx)
+		return err
+	})
+
+	g.Go(func() error {
+		var err error
+		pipePipelines, err = pipe.ListPipelines(gctx)
+		return err
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	// Build the result map keyed by cluster name from RunK8sMonitoring.
+	clusterMap := make(map[string]*ObservedCluster, len(monClusters))
+	for i := range monClusters {
+		c := &monClusters[i]
+		clusterMap[c.Name] = &ObservedCluster{
+			Name:   c.Name,
+			Status: c.InstrumentationStatus,
+			State:  c,
+			Source: MonitoringSource,
+		}
+	}
+
+	// Merge K8s monitoring pipelines from ListPipelines. A pipeline is a K8s
+	// monitoring pipeline if it has metadata["type"] == "k8s_monitoring" and
+	// metadata["cluster_name"] or metadata["cluster"] is a non-empty string.
+	// Pipelines not matching this filter are ignored (e.g. Beyla survey
+	// pipelines, app pipelines, etc.).
+	for _, p := range pipePipelines {
+		clusterName, ok := k8sMonitoringClusterName(p)
+		if !ok {
+			continue
+		}
+
+		if existing, found := clusterMap[clusterName]; found {
+			// Cluster already visible in RunK8sMonitoring — mark as both.
+			existing.Source = BothSources
+		} else {
+			// Pre-Alloy cluster: Set but not yet reporting survey_info.
+			clusterMap[clusterName] = &ObservedCluster{
+				Name:   clusterName,
+				Status: instrumentation.StatusPendingInstrumentation,
+				State:  nil,
+				Source: PipelineSource,
+			}
+		}
+	}
+
+	// Collect and sort alphabetically by cluster name.
+	result := make([]ObservedCluster, 0, len(clusterMap))
+	for _, oc := range clusterMap {
+		result = append(result, *oc)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result, nil
+}
+
+// k8sMonitoringClusterName returns the cluster name from a pipeline's metadata
+// if it is a K8s monitoring pipeline. Accepts both "cluster_name"
+// (grafana-cloud-onboarding v0.4.x) and "cluster" (legacy) as the cluster-name
+// metadata key, with "cluster_name" taking precedence.
+func k8sMonitoringClusterName(p instrumentation.Pipeline) (string, bool) {
+	if p.Metadata == nil {
+		return "", false
+	}
+
+	pipeType, ok := p.Metadata["type"]
+	if !ok {
+		return "", false
+	}
+	typeStr, ok := pipeType.(string)
+	if !ok || typeStr != k8sMonitoringPipelineType {
+		return "", false
+	}
+
+	// Accept "cluster_name" (new, grafana-cloud-onboarding) first,
+	// then fall back to "cluster" (legacy).
+	for _, key := range []string{"cluster_name", "cluster"} {
+		val, ok := p.Metadata[key]
+		if !ok {
+			continue
+		}
+		name, ok := val.(string)
+		if ok && name != "" {
+			return name, true
+		}
+	}
+
+	return "", false
+}

--- a/internal/providers/instrumentation/enumerate/enumerate_internal_test.go
+++ b/internal/providers/instrumentation/enumerate/enumerate_internal_test.go
@@ -1,0 +1,71 @@
+package enumerate
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+)
+
+func TestK8sMonitoringClusterName_LiberalKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		pipeline instrumentation.Pipeline
+		wantName string
+		wantOK   bool
+	}{
+		{
+			name: "cluster key accepted",
+			pipeline: instrumentation.Pipeline{
+				Metadata: map[string]any{"type": "k8s_monitoring", "cluster": "prod-eu"},
+			},
+			wantName: "prod-eu",
+			wantOK:   true,
+		},
+		{
+			name: "cluster_name key accepted",
+			pipeline: instrumentation.Pipeline{
+				Metadata: map[string]any{"type": "k8s_monitoring", "cluster_name": "prod-eu"},
+			},
+			wantName: "prod-eu",
+			wantOK:   true,
+		},
+		{
+			name: "cluster_name takes precedence when both present",
+			pipeline: instrumentation.Pipeline{
+				Metadata: map[string]any{"type": "k8s_monitoring", "cluster": "old", "cluster_name": "new"},
+			},
+			wantName: "new",
+			wantOK:   true,
+		},
+		{
+			name: "wrong type rejected",
+			pipeline: instrumentation.Pipeline{
+				Metadata: map[string]any{"type": "beyla", "cluster_name": "prod-eu"},
+			},
+			wantName: "",
+			wantOK:   false,
+		},
+		{
+			name:     "nil metadata rejected",
+			pipeline: instrumentation.Pipeline{Metadata: nil},
+			wantName: "",
+			wantOK:   false,
+		},
+		{
+			name: "empty cluster name rejected",
+			pipeline: instrumentation.Pipeline{
+				Metadata: map[string]any{"type": "k8s_monitoring", "cluster_name": ""},
+			},
+			wantName: "",
+			wantOK:   false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := k8sMonitoringClusterName(tc.pipeline)
+			if got != tc.wantName || ok != tc.wantOK {
+				t.Errorf("k8sMonitoringClusterName() = (%q, %v), want (%q, %v)", got, ok, tc.wantName, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/providers/instrumentation/enumerate/enumerate_test.go
+++ b/internal/providers/instrumentation/enumerate/enumerate_test.go
@@ -1,0 +1,276 @@
+package enumerate_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/grafana/gcx/internal/providers/instrumentation/enumerate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMonitoringClient implements enumerate.MonitoringClient using a fixed
+// slice. An error field lets tests exercise error paths.
+type fakeMonitoringClient struct {
+	clusters []instrumentation.ClusterObservedState
+	err      error
+}
+
+func (f *fakeMonitoringClient) RunK8sMonitoring(_ context.Context) ([]instrumentation.ClusterObservedState, error) {
+	return f.clusters, f.err
+}
+
+// fakePipelineClient implements enumerate.PipelineClient using a fixed slice.
+type fakePipelineClient struct {
+	pipelines []instrumentation.Pipeline
+	err       error
+}
+
+func (f *fakePipelineClient) ListPipelines(_ context.Context) ([]instrumentation.Pipeline, error) {
+	return f.pipelines, f.err
+}
+
+// k8sPipeline builds a K8s monitoring pipeline with the given cluster name.
+func k8sPipeline(id, clusterName string) instrumentation.Pipeline {
+	return instrumentation.Pipeline{
+		ID:   id,
+		Name: "k8s-monitoring-" + clusterName,
+		Metadata: map[string]any{
+			"type":    "k8s_monitoring",
+			"cluster": clusterName,
+		},
+	}
+}
+
+// otherPipeline builds a pipeline that is NOT a K8s monitoring pipeline.
+func otherPipeline(id string) instrumentation.Pipeline {
+	return instrumentation.Pipeline{
+		ID:   id,
+		Name: "beyla-survey",
+		Metadata: map[string]any{
+			"type": "beyla_survey",
+		},
+	}
+}
+
+func TestEnumerate(t *testing.T) {
+	tests := []struct {
+		name string
+
+		monClusters []instrumentation.ClusterObservedState
+		pipelines   []instrumentation.Pipeline
+
+		monErr  error
+		pipeErr error
+
+		wantErr    bool
+		wantNames  []string // expected cluster names, in sorted order
+		wantChecks func(t *testing.T, got []enumerate.ObservedCluster)
+	}{
+		{
+			name:        "both empty returns empty result",
+			monClusters: nil,
+			pipelines:   nil,
+			wantNames:   nil,
+		},
+		{
+			name: "only monitoring populated returns those clusters with MonitoringSource",
+			monClusters: []instrumentation.ClusterObservedState{
+				{Name: "cluster-b", InstrumentationStatus: instrumentation.StatusInstrumented},
+				{Name: "cluster-a", InstrumentationStatus: instrumentation.StatusPendingInstrumentation},
+			},
+			pipelines: nil,
+			wantNames: []string{"cluster-a", "cluster-b"},
+			wantChecks: func(t *testing.T, got []enumerate.ObservedCluster) {
+				t.Helper()
+				for _, oc := range got {
+					assert.Equal(t, enumerate.MonitoringSource, oc.Source, "cluster %q should have MonitoringSource", oc.Name)
+					assert.NotNil(t, oc.State, "cluster %q should have non-nil State", oc.Name)
+				}
+				assert.Equal(t, "cluster-a", got[0].Name)
+				assert.Equal(t, instrumentation.StatusPendingInstrumentation, got[0].Status)
+				assert.Equal(t, "cluster-b", got[1].Name)
+				assert.Equal(t, instrumentation.StatusInstrumented, got[1].Status)
+			},
+		},
+		{
+			name:        "only pipelines (pre-Alloy) returns cluster with StatusPendingInstrumentation",
+			monClusters: nil,
+			pipelines:   []instrumentation.Pipeline{k8sPipeline("p1", "new-cluster")},
+			wantNames:   []string{"new-cluster"},
+			wantChecks: func(t *testing.T, got []enumerate.ObservedCluster) {
+				t.Helper()
+				require.Len(t, got, 1)
+				assert.Equal(t, enumerate.PipelineSource, got[0].Source)
+				assert.Equal(t, instrumentation.StatusPendingInstrumentation, got[0].Status)
+				assert.Nil(t, got[0].State, "pre-Alloy cluster should have nil State")
+			},
+		},
+		{
+			name: "both populated disjoint returns merged and sorted result",
+			monClusters: []instrumentation.ClusterObservedState{
+				{Name: "zebra-cluster", InstrumentationStatus: instrumentation.StatusInstrumented},
+			},
+			pipelines: []instrumentation.Pipeline{
+				k8sPipeline("p1", "alpha-cluster"),
+			},
+			wantNames: []string{"alpha-cluster", "zebra-cluster"},
+			wantChecks: func(t *testing.T, got []enumerate.ObservedCluster) {
+				t.Helper()
+				require.Len(t, got, 2)
+				// alpha-cluster: from pipeline only
+				assert.Equal(t, "alpha-cluster", got[0].Name)
+				assert.Equal(t, enumerate.PipelineSource, got[0].Source)
+				assert.Equal(t, instrumentation.StatusPendingInstrumentation, got[0].Status)
+				assert.Nil(t, got[0].State)
+				// zebra-cluster: from monitoring only
+				assert.Equal(t, "zebra-cluster", got[1].Name)
+				assert.Equal(t, enumerate.MonitoringSource, got[1].Source)
+				assert.Equal(t, instrumentation.StatusInstrumented, got[1].Status)
+				assert.NotNil(t, got[1].State)
+			},
+		},
+		{
+			name: "both populated with overlap uses monitoring-side status and BothSources",
+			monClusters: []instrumentation.ClusterObservedState{
+				{Name: "shared-cluster", InstrumentationStatus: instrumentation.StatusInstrumented},
+			},
+			pipelines: []instrumentation.Pipeline{
+				k8sPipeline("p1", "shared-cluster"),
+			},
+			wantNames: []string{"shared-cluster"},
+			wantChecks: func(t *testing.T, got []enumerate.ObservedCluster) {
+				t.Helper()
+				require.Len(t, got, 1)
+				assert.Equal(t, enumerate.BothSources, got[0].Source)
+				assert.Equal(t, instrumentation.StatusInstrumented, got[0].Status,
+					"monitoring-side status must win on overlap")
+				assert.NotNil(t, got[0].State)
+			},
+		},
+		{
+			name:        "non-K8s-monitoring pipelines are filtered out",
+			monClusters: nil,
+			pipelines: []instrumentation.Pipeline{
+				otherPipeline("p1"),
+				{
+					ID:   "p2",
+					Name: "no-metadata-pipeline",
+					// no Metadata
+				},
+				{
+					ID:   "p3",
+					Name: "wrong-type",
+					Metadata: map[string]any{
+						"type":    "app_monitoring",
+						"cluster": "some-cluster",
+					},
+				},
+				{
+					ID:   "p4",
+					Name: "missing-cluster-key",
+					Metadata: map[string]any{
+						"type": "k8s_monitoring",
+						// no "cluster" key
+					},
+				},
+				{
+					ID:   "p5",
+					Name: "empty-cluster-name",
+					Metadata: map[string]any{
+						"type":    "k8s_monitoring",
+						"cluster": "",
+					},
+				},
+			},
+			wantNames: nil, // all pipelines filtered
+		},
+		{
+			name:        "monitoring error is propagated",
+			monClusters: nil,
+			pipelines:   nil,
+			monErr:      errors.New("monitoring RPC failed"),
+			wantErr:     true,
+		},
+		{
+			name:        "pipeline error is propagated",
+			monClusters: nil,
+			pipelines:   nil,
+			pipeErr:     errors.New("pipeline RPC failed"),
+			wantErr:     true,
+		},
+		{
+			name: "multiple monitoring clusters are sorted alphabetically",
+			monClusters: []instrumentation.ClusterObservedState{
+				{Name: "charlie", InstrumentationStatus: instrumentation.StatusInstrumented},
+				{Name: "alice", InstrumentationStatus: instrumentation.StatusInstrumented},
+				{Name: "bob", InstrumentationStatus: instrumentation.StatusInstrumented},
+			},
+			pipelines: nil,
+			wantNames: []string{"alice", "bob", "charlie"},
+		},
+		{
+			name:        "multiple pipeline clusters are sorted alphabetically",
+			monClusters: nil,
+			pipelines: []instrumentation.Pipeline{
+				k8sPipeline("p3", "charlie"),
+				k8sPipeline("p1", "alice"),
+				k8sPipeline("p2", "bob"),
+			},
+			wantNames: []string{"alice", "bob", "charlie"},
+		},
+		{
+			name: "cluster present in monitoring has State pointer to correct entry",
+			monClusters: []instrumentation.ClusterObservedState{
+				{
+					Name:                        "my-cluster",
+					InstrumentationStatus:       instrumentation.StatusInstrumented,
+					InstrumentationErrorMessage: "",
+					Nodes:                       3,
+					Workloads:                   10,
+					Pods:                        20,
+				},
+			},
+			pipelines: nil,
+			wantNames: []string{"my-cluster"},
+			wantChecks: func(t *testing.T, got []enumerate.ObservedCluster) {
+				t.Helper()
+				require.Len(t, got, 1)
+				require.NotNil(t, got[0].State)
+				assert.Equal(t, "my-cluster", got[0].State.Name)
+				assert.Equal(t, 3, got[0].State.Nodes)
+				assert.Equal(t, 10, got[0].State.Workloads)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mon := &fakeMonitoringClient{clusters: tt.monClusters, err: tt.monErr}
+			pipe := &fakePipelineClient{pipelines: tt.pipelines, err: tt.pipeErr}
+
+			got, err := enumerate.Enumerate(context.Background(), mon, pipe)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Check names (sorted). Use append so the result stays nil when
+			// got is empty — matching wantNames: nil in table rows.
+			var gotNames []string
+			for _, oc := range got {
+				gotNames = append(gotNames, oc.Name)
+			}
+			assert.Equal(t, tt.wantNames, gotNames)
+
+			// Run per-test additional assertions.
+			if tt.wantChecks != nil {
+				tt.wantChecks(t, got)
+			}
+		})
+	}
+}

--- a/internal/providers/instrumentation/errors.go
+++ b/internal/providers/instrumentation/errors.go
@@ -1,0 +1,10 @@
+package instrumentation
+
+import "errors"
+
+// ErrMutuallyExclusiveFlags is the sentinel returned by command Validate()
+// implementations when the user supplies a pair of mutually exclusive flags
+// (e.g. --costmetrics together with --no-costmetrics). The fail converter
+// surfaces it as the standard "Invalid command usage" envelope, with the
+// wrapped error's message providing the per-call detail.
+var ErrMutuallyExclusiveFlags = errors.New("mutually exclusive flags")

--- a/internal/providers/instrumentation/helm/format.go
+++ b/internal/providers/instrumentation/helm/format.go
@@ -1,0 +1,52 @@
+// Package helm formats the parameterized helm install command printed by
+// gcx instrumentation setup. gcx never executes helm; the package only
+// produces a copy-pasteable command string.
+package helm
+
+import (
+	"strings"
+
+	instrumentation "github.com/grafana/gcx/internal/providers/instrumentation"
+)
+
+// Format returns a runnable helm command string that installs
+// grafana-cloud-onboarding with the given cluster name, fleet management
+// connection parameters, and access-policy token.
+//
+// Flags appear in stable alphabetical order by key, one --set per line,
+// backslash-continued, followed by --wait. All values are single-quote-escaped
+// so the command is safe to paste into any POSIX shell.
+func Format(cluster string, fm instrumentation.FleetManagement, accessPolicyToken string) string {
+	type setFlag struct {
+		key string
+		val string
+	}
+
+	// Flags in stable alphabetical order by key.
+	flags := []setFlag{
+		{"cluster.name", cluster},
+		{"grafanaCloud.fleetManagement.auth.password", accessPolicyToken},
+		{"grafanaCloud.fleetManagement.auth.username", fm.Username},
+		{"grafanaCloud.fleetManagement.url", fm.URL},
+	}
+
+	var sb strings.Builder
+	sb.WriteString("helm upgrade --install grafana-cloud grafana/grafana-cloud-onboarding \\\n")
+	sb.WriteString("  --namespace monitoring --create-namespace")
+
+	for _, f := range flags {
+		sb.WriteString(" \\\n  --set ")
+		sb.WriteString(f.key)
+		sb.WriteByte('=')
+		sb.WriteString(shellQuote(f.val))
+	}
+
+	sb.WriteString(" \\\n  --wait")
+	return sb.String()
+}
+
+// shellQuote wraps val in single quotes, escaping any embedded single quotes
+// using the canonical POSIX form (end-quote, backslash-escaped quote, re-open-quote).
+func shellQuote(val string) string {
+	return "'" + strings.ReplaceAll(val, "'", `'\''`) + "'"
+}

--- a/internal/providers/instrumentation/helm/format_test.go
+++ b/internal/providers/instrumentation/helm/format_test.go
@@ -1,0 +1,94 @@
+package helm_test
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	instrumentation "github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/grafana/gcx/internal/providers/instrumentation/helm"
+)
+
+func testFleetManagement() instrumentation.FleetManagement {
+	return instrumentation.FleetManagement{
+		URL:      "https://fleet-management-prod-001.grafana.net",
+		Username: "987654",
+	}
+}
+
+const knownToken = "glc_someAccessPolicyToken=="
+const knownCluster = "my-cluster"
+
+// golden is the expected output matching the IHub UI for grafana-cloud-onboarding.
+const golden = `helm upgrade --install grafana-cloud grafana/grafana-cloud-onboarding \
+  --namespace monitoring --create-namespace \
+  --set cluster.name='my-cluster' \
+  --set grafanaCloud.fleetManagement.auth.password='glc_someAccessPolicyToken==' \
+  --set grafanaCloud.fleetManagement.auth.username='987654' \
+  --set grafanaCloud.fleetManagement.url='https://fleet-management-prod-001.grafana.net' \
+  --wait`
+
+func TestFormat_Golden(t *testing.T) {
+	got := helm.Format(knownCluster, testFleetManagement(), knownToken)
+	if got != golden {
+		t.Errorf("Format output does not match golden fixture.\ngot:\n%s\n\nwant:\n%s", got, golden)
+	}
+}
+
+func TestFormat_StableOutput(t *testing.T) {
+	first := helm.Format(knownCluster, testFleetManagement(), knownToken)
+	second := helm.Format(knownCluster, testFleetManagement(), knownToken)
+	if first != second {
+		t.Errorf("Format is not stable: two calls with identical inputs produced different output")
+	}
+}
+
+func TestFormat_NoTrailingBackslash(t *testing.T) {
+	out := helm.Format(knownCluster, testFleetManagement(), knownToken)
+	if strings.HasSuffix(out, "\\") {
+		t.Errorf("Format output must not end with a backslash continuation; got:\n%s", out)
+	}
+}
+
+func TestFormat_ShellSafety(t *testing.T) {
+	fm := testFleetManagement()
+	tests := []struct {
+		name    string
+		cluster string
+		token   string
+	}{
+		{name: "cluster with spaces", cluster: "my cluster name", token: knownToken},
+		{name: "cluster with single quote", cluster: "it's-a-cluster", token: knownToken},
+		{name: "token with single quote", cluster: "plain-cluster", token: "glc_it's_a_token"},
+	}
+
+	bash, err := exec.LookPath("bash")
+	hasBash := err == nil
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := helm.Format(tc.cluster, fm, tc.token)
+			if hasBash {
+				cmd := exec.CommandContext(context.Background(), bash, "-n")
+				cmd.Stdin = strings.NewReader(out)
+				if err := cmd.Run(); err != nil {
+					t.Errorf("bash -n rejected the formatted command: %v\ncommand:\n%s", err, out)
+				}
+			}
+			if !strings.Contains(out, "--set cluster.name=") {
+				t.Errorf("output missing --set cluster.name flag:\n%s", out)
+			}
+			if !strings.Contains(out, "grafana-cloud-onboarding") {
+				t.Errorf("output must reference grafana-cloud-onboarding chart:\n%s", out)
+			}
+		})
+	}
+}
+
+func TestFormat_EscapedSingleQuote(t *testing.T) {
+	out := helm.Format("it's-a-cluster", testFleetManagement(), knownToken)
+	if !strings.Contains(out, `'it'\''s-a-cluster'`) {
+		t.Errorf("single-quote in cluster name not escaped with canonical POSIX form.\ngot:\n%s", out)
+	}
+}

--- a/internal/providers/instrumentation/output/codec.go
+++ b/internal/providers/instrumentation/output/codec.go
@@ -1,0 +1,472 @@
+// Package output provides output codec adapters for the instrumentation provider.
+// Codecs plug instrumentation types into gcx's existing output system without
+// a K8s envelope. JSON and YAML output the bare domain type
+// directly; table and wide output use custom codecs with specific column
+// inventories.
+package output
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/grafana/gcx/internal/format"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/grafana/gcx/internal/style"
+)
+
+// ─── View types ──────────────────────────────────────────────────────────────
+//
+// View types combine declared configuration (from the instrumentation client)
+// with observed state (from RunK8sMonitoring). They are used for ALL output
+// formats: JSON/YAML marshals the struct tags directly; table/wide codecs read
+// the fields for column values.
+//
+// JSON/YAML/wide expose the underlying proto enum value for status.
+// Human-facing table (default) normalizes status to OK/FAILING/NODATA.
+
+// ClusterView is the unified view type for a single cluster, combining the
+// declared Cluster config with observed ClusterObservedState. All output
+// formats (JSON, YAML, table, wide) consume this type.
+//
+// Selection is present in JSON/YAML (no omitempty) but table
+// and wide codecs do NOT render a SELECTION column.
+type ClusterView struct {
+	// Declared config fields — mirrors instrumentation.Cluster.
+	Name          string `json:"name" yaml:"name"`
+	Selection     string `json:"selection" yaml:"selection"` // always serialized; never omitempty
+	CostMetrics   *bool  `json:"costMetrics,omitempty" yaml:"costMetrics,omitempty"`
+	EnergyMetrics *bool  `json:"energyMetrics,omitempty" yaml:"energyMetrics,omitempty"`
+	ClusterEvents *bool  `json:"clusterEvents,omitempty" yaml:"clusterEvents,omitempty"`
+	NodeLogs      *bool  `json:"nodeLogs,omitempty" yaml:"nodeLogs,omitempty"`
+
+	// Observed state fields — merged from ClusterObservedState.
+	InstrumentationStatus instrumentation.InstrumentationStatus `json:"instrumentationStatus,omitempty" yaml:"instrumentationStatus,omitempty"`
+	Namespaces            int                                   `json:"namespaces,omitempty" yaml:"namespaces,omitempty"`
+	Workloads             int                                   `json:"workloads,omitempty" yaml:"workloads,omitempty"`
+	Pods                  int                                   `json:"pods,omitempty" yaml:"pods,omitempty"`
+	Nodes                 int                                   `json:"nodes,omitempty" yaml:"nodes,omitempty"`
+
+	// Age is a pre-formatted human-readable age string set by the command layer.
+	Age string `json:"age,omitempty" yaml:"age,omitempty"`
+}
+
+// AppView is the unified view type for a single namespace-level app
+// instrumentation entry, combining declared App config with observed
+// NamespaceObservedState.
+//
+// ClusterName is table-only context (excluded from JSON/YAML via json:"-"); it
+// carries the cluster name for the CLUSTER column in table output, where the
+// command always knows which cluster was queried.
+type AppView struct {
+	// ClusterName is the cluster this app belongs to. Excluded from JSON/YAML
+	// because it is contextual (always known from the --cluster flag) and not
+	// part of the App's own data model.
+	ClusterName string `json:"-" yaml:"-"`
+
+	// Declared config fields — mirrors instrumentation.App.
+	Name            string `json:"name" yaml:"name"`
+	Autoinstrument  *bool  `json:"autoInstrument,omitempty" yaml:"autoInstrument,omitempty"`
+	Tracing         *bool  `json:"tracing,omitempty" yaml:"tracing,omitempty"`
+	Logging         *bool  `json:"logging,omitempty" yaml:"logging,omitempty"`
+	ProcessMetrics  *bool  `json:"processMetrics,omitempty" yaml:"processMetrics,omitempty"`
+	ExtendedMetrics *bool  `json:"extendedMetrics,omitempty" yaml:"extendedMetrics,omitempty"`
+	Profiling       *bool  `json:"profiling,omitempty" yaml:"profiling,omitempty"`
+
+	// Observed state fields — merged from NamespaceObservedState.
+	InstrumentationStatus instrumentation.InstrumentationStatus `json:"instrumentationStatus,omitempty" yaml:"instrumentationStatus,omitempty"`
+	Workloads             int                                   `json:"workloads,omitempty" yaml:"workloads,omitempty"`
+	Pods                  int                                   `json:"pods,omitempty" yaml:"pods,omitempty"`
+
+	// Overrides is the count of per-workload AppOverride entries (len(App.Apps)).
+	Overrides int `json:"overrides,omitempty" yaml:"overrides,omitempty"`
+
+	// Discovered reports whether the namespace appears in RunK8sDiscovery's response.
+	// No omitempty — false is meaningful (namespace declared but not observed on-cluster).
+	Discovered bool `json:"discovered" yaml:"discovered"`
+
+	// Age is a pre-formatted human-readable age string set by the command layer.
+	Age string `json:"age,omitempty" yaml:"age,omitempty"`
+}
+
+// ServiceView is the unified view type for a single discovered workload
+// (service), based on instrumentation.DiscoveryItem with an additional
+// InstrumentationErrorMessage field for wide output.
+type ServiceView struct {
+	ClusterName                 string                                `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
+	Namespace                   string                                `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Name                        string                                `json:"name,omitempty" yaml:"name,omitempty"`
+	WorkloadType                string                                `json:"workloadType,omitempty" yaml:"workloadType,omitempty"`
+	DisplayNamespace            string                                `json:"displayNamespace,omitempty" yaml:"displayNamespace,omitempty"`
+	DisplayName                 string                                `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	OS                          string                                `json:"os,omitempty" yaml:"os,omitempty"`
+	Lang                        string                                `json:"lang,omitempty" yaml:"lang,omitempty"`
+	InstrumentationStatus       instrumentation.InstrumentationStatus `json:"instrumentationStatus,omitempty" yaml:"instrumentationStatus,omitempty"`
+	InstrumentationErrorMessage string                                `json:"instrumentationErrorMessage,omitempty" yaml:"instrumentationErrorMessage,omitempty"`
+
+	// Age is a pre-formatted human-readable age string set by the command layer.
+	Age string `json:"age,omitempty" yaml:"age,omitempty"`
+}
+
+// ─── Setup envelope ──────────────────────────────────────────────────────────
+
+// SetupRequiredScopes is the canonical list of Cloud Access Policy scopes
+// required for the grafana-cloud-onboarding helm chart. Defined once and
+// reused by both the human-mode output text and the agent-mode JSON envelope.
+var SetupRequiredScopes = []string{"set:alloy-data-write", "metrics:read"} //nolint:gochecknoglobals // package-level constant list; Go doesn't support const slices, var is the only option
+
+// SetupHelmEnvelope is the agent-mode JSON envelope emitted by
+// `gcx instrumentation setup <cluster> --print-helm-only --agent`.
+//
+// HelmCommand is the copy-pasteable helm upgrade command string.
+// AccessPoliciesURL is the fully-qualified Grafana Cloud access-policies URL
+// with the org slug substituted; falls back to literal <your-org> when the
+// slug is unknown (empty string in OrgSlug).
+// RequiredScopes lists the Cloud Access Policy scopes required by the helm chart.
+type SetupHelmEnvelope struct {
+	HelmCommand       string   `json:"helmCommand"`
+	AccessPoliciesURL string   `json:"accessPoliciesURL"`
+	RequiredScopes    []string `json:"requiredScopes"`
+}
+
+// AccessPoliciesURL returns the Grafana Cloud access-policies URL for the
+// given org slug. When slug is empty the literal placeholder <your-org> is
+// used so callers always get a valid URL string regardless of context type
+// (fallback spec Step 4).
+func AccessPoliciesURL(orgSlug string) string {
+	if orgSlug == "" {
+		orgSlug = "<your-org>"
+	}
+	return "https://grafana.com/orgs/" + orgSlug + "/access-policies"
+}
+
+// ─── List envelope types ─────────────────────────────────────────────────────
+//
+// Instrumentation list commands wrap their results in these canonical envelopes
+// so that JSON output matches the documented contract:
+//
+//	{"items": [...]}    (non-empty)
+//	{"items": []}       (empty — never null)
+//
+// docs/design/output.md §101: all list endpoints emit the items envelope.
+// The Items slice is initialized via make([]T, 0) in the command layer to
+// guarantee [] (not null) for empty results.
+
+// ClusterListEnvelope is the JSON envelope for the clusters list command.
+type ClusterListEnvelope struct {
+	Items []ClusterView `json:"items"`
+}
+
+// ServiceListEnvelope is the JSON envelope for the services list command.
+type ServiceListEnvelope struct {
+	Items []ServiceView `json:"items"`
+}
+
+// AppListEnvelope is the JSON envelope for the clusters apps list command.
+type AppListEnvelope struct {
+	Items []AppView `json:"items"`
+}
+
+// ─── STATUS normalization ─────────────────────────────────────────────────────
+
+// NormalizeStatus maps a raw proto-enum InstrumentationStatus to the
+// human-facing display value used in default table output.
+//
+// Handles both proto enum families and shorthand constants:
+//
+//	K8S_MONITORING_STATUS_INSTRUMENTED            → OK
+//	K8S_MONITORING_STATUS_ERROR                   → FAILING
+//	INSTRUMENTATION_STATUS_INSTRUMENTED           → OK
+//	INSTRUMENTATION_STATUS_INSTRUMENTATION_ERROR  → FAILING
+//	INSTRUMENTED (shorthand)                      → OK
+//	INSTRUMENTATION_ERROR (shorthand)             → FAILING
+//	everything else (PENDING_*, NOT_*, EXCLUDED, unknown) → NODATA
+//
+// Note: EXCLUDED maps to NODATA (not OK) — excluded clusters are not actively
+// instrumented. This differs from the wait classifier (ClassifyK8sMonitoringStatus)
+// which treats EXCLUDED as WaitSuccess for the purpose of exiting the wait loop.
+func NormalizeStatus(status instrumentation.InstrumentationStatus) string {
+	switch status {
+	// Full wire names — K8s monitoring enum (from RunK8sMonitoring).
+	case "K8S_MONITORING_STATUS_INSTRUMENTED":
+		return "OK"
+	case "K8S_MONITORING_STATUS_ERROR":
+		return "FAILING"
+	// Full wire names — Discovery item enum (from RunK8sDiscovery).
+	case "INSTRUMENTATION_STATUS_INSTRUMENTED":
+		return "OK"
+	case "INSTRUMENTATION_STATUS_INSTRUMENTATION_ERROR":
+		return "FAILING"
+	// Shorthand constants (backward compat — types.go values).
+	case instrumentation.StatusInstrumented:
+		return "OK"
+	case instrumentation.StatusError:
+		return "FAILING"
+	}
+	// All PENDING_*, NOT_INSTRUMENTED, EXCLUDED, UNSPECIFIED, and unknown values.
+	return "NODATA"
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// boolDisplay returns "true", "false", or "" for a tri-state *bool.
+func boolDisplay(b *bool) string {
+	if b == nil {
+		return ""
+	}
+	if *b {
+		return "true"
+	}
+	return "false"
+}
+
+// itoa converts an int to its decimal string representation.
+func itoa(n int) string {
+	return strconv.Itoa(n)
+}
+
+// displayName returns the human-friendly display name, falling back to the
+// canonical name when DisplayName is empty.
+func displayName(displayName, name string) string {
+	if displayName != "" {
+		return displayName
+	}
+	return name
+}
+
+// displayNamespace returns the human-friendly display namespace, falling back
+// to the canonical namespace when DisplayNamespace is empty.
+func displayNamespace(displayNS, ns string) string {
+	if displayNS != "" {
+		return displayNS
+	}
+	return ns
+}
+
+// ─── ClusterTableCodec ────────────────────────────────────────────────────────
+
+// ClusterTableCodec renders []ClusterView as a table or wide table.
+//
+// Default columns: NAME NAMESPACES WORKLOADS PODS STATUS
+// Wide adds:       COST EVENTS ENERGY LOGS NODES
+//
+// Selection is NOT rendered as a column in either table or wide output.
+// Default table STATUS is normalized to OK/FAILING/NODATA.
+// Wide table STATUS is the raw proto enum value.
+type ClusterTableCodec struct {
+	Wide bool
+}
+
+var _ format.Codec = (*ClusterTableCodec)(nil)
+
+func (c *ClusterTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *ClusterTableCodec) Encode(w io.Writer, v any) error {
+	var clusters []ClusterView
+	switch val := v.(type) {
+	case []ClusterView:
+		clusters = val
+	case ClusterListEnvelope:
+		clusters = val.Items
+	default:
+		return fmt.Errorf("ClusterTableCodec: expected []ClusterView or ClusterListEnvelope, got %T", v)
+	}
+
+	var t *style.TableBuilder
+	if c.Wide {
+		t = style.NewTable("NAME", "NAMESPACES", "WORKLOADS", "PODS", "COST", "EVENTS", "ENERGY", "LOGS", "NODES", "STATUS")
+	} else {
+		t = style.NewTable("NAME", "NAMESPACES", "WORKLOADS", "PODS", "STATUS")
+	}
+
+	for _, cl := range clusters {
+		if c.Wide {
+			t.Row(
+				cl.Name,
+				itoa(cl.Namespaces),
+				itoa(cl.Workloads),
+				itoa(cl.Pods),
+				boolDisplay(cl.CostMetrics),
+				boolDisplay(cl.ClusterEvents),
+				boolDisplay(cl.EnergyMetrics),
+				boolDisplay(cl.NodeLogs),
+				itoa(cl.Nodes),
+				string(cl.InstrumentationStatus),
+			)
+		} else {
+			t.Row(
+				cl.Name,
+				itoa(cl.Namespaces),
+				itoa(cl.Workloads),
+				itoa(cl.Pods),
+				NormalizeStatus(cl.InstrumentationStatus),
+			)
+		}
+	}
+
+	return t.Render(w)
+}
+
+func (c *ClusterTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// ─── AppTableCodec ────────────────────────────────────────────────────────────
+
+// AppTableCodec renders []AppView as a table or wide table.
+//
+// Default columns: NAME CLUSTER WORKLOADS PODS AUTOINSTRUMENT STATUS
+// Wide adds:       TRACING LOGGING PROCESS_METRICS EXTENDED_METRICS PROFILING OVERRIDES
+//
+// Default table STATUS is normalized to OK/FAILING/NODATA.
+// Wide table STATUS is the raw proto enum value.
+type AppTableCodec struct {
+	Wide bool
+}
+
+var _ format.Codec = (*AppTableCodec)(nil)
+
+func (c *AppTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *AppTableCodec) Encode(w io.Writer, v any) error {
+	var apps []AppView
+	switch val := v.(type) {
+	case []AppView:
+		apps = val
+	case AppListEnvelope:
+		apps = val.Items
+	default:
+		return fmt.Errorf("AppTableCodec: expected []AppView or AppListEnvelope, got %T", v)
+	}
+
+	var t *style.TableBuilder
+	if c.Wide {
+		t = style.NewTable("NAME", "CLUSTER", "WORKLOADS", "PODS", "AUTOINSTRUMENT", "TRACING", "LOGGING", "PROCESS_METRICS", "EXTENDED_METRICS", "PROFILING", "OVERRIDES", "STATUS")
+	} else {
+		t = style.NewTable("NAME", "CLUSTER", "WORKLOADS", "PODS", "AUTOINSTRUMENT", "STATUS")
+	}
+
+	for _, a := range apps {
+		if c.Wide {
+			t.Row(
+				a.Name,
+				a.ClusterName,
+				itoa(a.Workloads),
+				itoa(a.Pods),
+				boolDisplay(a.Autoinstrument),
+				boolDisplay(a.Tracing),
+				boolDisplay(a.Logging),
+				boolDisplay(a.ProcessMetrics),
+				boolDisplay(a.ExtendedMetrics),
+				boolDisplay(a.Profiling),
+				itoa(a.Overrides),
+				string(a.InstrumentationStatus),
+			)
+		} else {
+			t.Row(
+				a.Name,
+				a.ClusterName,
+				itoa(a.Workloads),
+				itoa(a.Pods),
+				boolDisplay(a.Autoinstrument),
+				NormalizeStatus(a.InstrumentationStatus),
+			)
+		}
+	}
+
+	return t.Render(w)
+}
+
+func (c *AppTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// ─── ServiceTableCodec ────────────────────────────────────────────────────────
+
+// ServiceTableCodec renders []ServiceView as a table or wide table.
+//
+// Default columns: NAME CLUSTER NAMESPACE TYPE LANG STATUS
+// Wide adds:       OS INSTRUMENTATION_ERROR
+//
+// TYPE is the K8s workload type (e.g. deployment, daemonset).
+//
+// Default table STATUS is normalized to OK/FAILING/NODATA.
+// Wide table STATUS is the raw proto enum value.
+//
+// Table NAME renders DisplayName when set, falling back to Name.
+// Table NAMESPACE renders DisplayNamespace when set, falling back to Namespace.
+type ServiceTableCodec struct {
+	Wide bool
+}
+
+var _ format.Codec = (*ServiceTableCodec)(nil)
+
+func (c *ServiceTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *ServiceTableCodec) Encode(w io.Writer, v any) error {
+	var services []ServiceView
+	switch val := v.(type) {
+	case []ServiceView:
+		services = val
+	case ServiceListEnvelope:
+		services = val.Items
+	default:
+		return fmt.Errorf("ServiceTableCodec: expected []ServiceView or ServiceListEnvelope, got %T", v)
+	}
+
+	var t *style.TableBuilder
+	if c.Wide {
+		t = style.NewTable("NAME", "CLUSTER", "NAMESPACE", "TYPE", "LANG", "OS", "INSTRUMENTATION_ERROR", "STATUS")
+	} else {
+		t = style.NewTable("NAME", "CLUSTER", "NAMESPACE", "TYPE", "LANG", "STATUS")
+	}
+
+	for _, svc := range services {
+		name := displayName(svc.DisplayName, svc.Name)
+		ns := displayNamespace(svc.DisplayNamespace, svc.Namespace)
+
+		if c.Wide {
+			t.Row(
+				name,
+				svc.ClusterName,
+				ns,
+				svc.WorkloadType,
+				svc.Lang,
+				svc.OS,
+				svc.InstrumentationErrorMessage,
+				string(svc.InstrumentationStatus),
+			)
+		} else {
+			t.Row(
+				name,
+				svc.ClusterName,
+				ns,
+				svc.WorkloadType,
+				svc.Lang,
+				NormalizeStatus(svc.InstrumentationStatus),
+			)
+		}
+	}
+
+	return t.Render(w)
+}
+
+func (c *ServiceTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}

--- a/internal/providers/instrumentation/output/codec_test.go
+++ b/internal/providers/instrumentation/output/codec_test.go
@@ -1,0 +1,688 @@
+package output_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	goyaml "github.com/goccy/go-yaml"
+	"github.com/grafana/gcx/internal/format"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instroutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// boolPtr returns a pointer to a bool literal.
+//
+//nolint:modernize // boolPtr() creates pointer to value, not pointer to type like new()
+func boolPtr(b bool) *bool { return &b }
+
+// ─── NormalizeStatus ──────────────────────────────────────────────────────────
+
+func TestNormalizeStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status instrumentation.InstrumentationStatus
+		want   string
+	}{
+		// Shorthand constants (backward compat — types.go values).
+		{
+			name:   "INSTRUMENTED maps to OK",
+			status: instrumentation.StatusInstrumented,
+			want:   "OK",
+		},
+		{
+			name:   "INSTRUMENTATION_ERROR maps to FAILING",
+			status: instrumentation.StatusError,
+			want:   "FAILING",
+		},
+		{
+			name:   "PENDING_INSTRUMENTATION maps to NODATA",
+			status: instrumentation.StatusPendingInstrumentation,
+			want:   "NODATA",
+		},
+		{
+			name:   "PENDING_UNINSTRUMENTATION maps to NODATA",
+			status: instrumentation.StatusPendingUninstrumentation,
+			want:   "NODATA",
+		},
+		{
+			name:   "NOT_INSTRUMENTED maps to NODATA",
+			status: instrumentation.StatusNotInstrumented,
+			want:   "NODATA",
+		},
+		{
+			name:   "EXCLUDED maps to NODATA",
+			status: instrumentation.StatusExcluded,
+			want:   "NODATA",
+		},
+		{
+			name:   "empty string maps to NODATA",
+			status: instrumentation.InstrumentationStatus(""),
+			want:   "NODATA",
+		},
+		// Full proto enum names — K8s monitoring family (wire values from RunK8sMonitoring).
+		{
+			name:   "K8S_MONITORING_STATUS_INSTRUMENTED maps to OK",
+			status: "K8S_MONITORING_STATUS_INSTRUMENTED",
+			want:   "OK",
+		},
+		{
+			name:   "K8S_MONITORING_STATUS_ERROR maps to FAILING",
+			status: "K8S_MONITORING_STATUS_ERROR",
+			want:   "FAILING",
+		},
+		{
+			name:   "K8S_MONITORING_STATUS_NOT_INSTRUMENTED maps to NODATA",
+			status: "K8S_MONITORING_STATUS_NOT_INSTRUMENTED",
+			want:   "NODATA",
+		},
+		{
+			name:   "K8S_MONITORING_STATUS_PENDING_INSTRUMENTATION maps to NODATA",
+			status: "K8S_MONITORING_STATUS_PENDING_INSTRUMENTATION",
+			want:   "NODATA",
+		},
+		{
+			name:   "K8S_MONITORING_STATUS_PENDING_UNINSTRUMENTATION maps to NODATA",
+			status: "K8S_MONITORING_STATUS_PENDING_UNINSTRUMENTATION",
+			want:   "NODATA",
+		},
+		{
+			name:   "K8S_MONITORING_STATUS_EXCLUDED maps to NODATA",
+			status: "K8S_MONITORING_STATUS_EXCLUDED",
+			want:   "NODATA",
+		},
+		// Full proto enum names — Discovery item family (wire values from RunK8sDiscovery).
+		{
+			name:   "INSTRUMENTATION_STATUS_INSTRUMENTED maps to OK",
+			status: "INSTRUMENTATION_STATUS_INSTRUMENTED",
+			want:   "OK",
+		},
+		{
+			name:   "INSTRUMENTATION_STATUS_INSTRUMENTATION_ERROR maps to FAILING",
+			status: "INSTRUMENTATION_STATUS_INSTRUMENTATION_ERROR",
+			want:   "FAILING",
+		},
+		{
+			name:   "INSTRUMENTATION_STATUS_NOT_INSTRUMENTED maps to NODATA",
+			status: "INSTRUMENTATION_STATUS_NOT_INSTRUMENTED",
+			want:   "NODATA",
+		},
+		{
+			name:   "INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION maps to NODATA",
+			status: "INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION",
+			want:   "NODATA",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, instroutput.NormalizeStatus(tc.status))
+		})
+	}
+}
+
+// ─── ClusterTableCodec ────────────────────────────────────────────────────────
+
+func TestClusterTableCodec_Format(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, format.Format("table"), (&instroutput.ClusterTableCodec{}).Format())
+	assert.Equal(t, format.Format("wide"), (&instroutput.ClusterTableCodec{Wide: true}).Format())
+}
+
+func TestClusterTableCodec_Decode_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	err := (&instroutput.ClusterTableCodec{}).Decode(strings.NewReader(""), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support decoding")
+}
+
+func TestClusterTableCodec_Encode_InvalidType(t *testing.T) {
+	t.Parallel()
+
+	err := (&instroutput.ClusterTableCodec{}).Encode(&bytes.Buffer{}, "not a slice")
+	require.Error(t, err)
+}
+
+func TestClusterTableCodec_DefaultColumns(t *testing.T) {
+	t.Parallel()
+
+	clusters := []instroutput.ClusterView{
+		{
+			Name:                  "prod",
+			Selection:             "SELECTION_INCLUDED",
+			InstrumentationStatus: instrumentation.StatusInstrumented,
+			Namespaces:            3,
+			Workloads:             10,
+			Pods:                  20,
+			Nodes:                 5,
+			Age:                   "2d",
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, (&instroutput.ClusterTableCodec{}).Encode(&buf, clusters))
+	out := buf.String()
+
+	// Default columns present in headers.
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "NAMESPACES")
+	assert.Contains(t, out, "WORKLOADS")
+	assert.Contains(t, out, "PODS")
+	assert.Contains(t, out, "STATUS")
+	assert.NotContains(t, out, "AGE")
+
+	// SELECTION must NOT appear in table output.
+	assert.NotContains(t, out, "SELECTION")
+
+	// Wide columns must NOT appear in default table.
+	assert.NotContains(t, out, "COST")
+	assert.NotContains(t, out, "ENERGY")
+	assert.NotContains(t, out, "EVENTS")
+	assert.NotContains(t, out, "NODES")
+
+	// STATUS is normalized to OK.
+	assert.Contains(t, out, "OK")
+	assert.NotContains(t, out, "INSTRUMENTED\t")
+
+	// Data values present.
+	assert.Contains(t, out, "prod")
+	assert.Contains(t, out, "3")
+}
+
+func TestClusterTableCodec_DefaultColumns_StatusNormalization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status instrumentation.InstrumentationStatus
+		want   string
+	}{
+		{"instrumented->OK", instrumentation.StatusInstrumented, "OK"},
+		{"error->FAILING", instrumentation.StatusError, "FAILING"},
+		{"pending->NODATA", instrumentation.StatusPendingInstrumentation, "NODATA"},
+		{"not-instrumented->NODATA", instrumentation.StatusNotInstrumented, "NODATA"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			clusters := []instroutput.ClusterView{{Name: "c1", InstrumentationStatus: tc.status}}
+			var buf bytes.Buffer
+			require.NoError(t, (&instroutput.ClusterTableCodec{}).Encode(&buf, clusters))
+			assert.Contains(t, buf.String(), tc.want)
+		})
+	}
+}
+
+func TestClusterTableCodec_WideColumns(t *testing.T) {
+	t.Parallel()
+
+	clusters := []instroutput.ClusterView{
+		{
+			Name:                  "prod",
+			Selection:             "SELECTION_INCLUDED",
+			CostMetrics:           boolPtr(true),  //nolint:modernize
+			EnergyMetrics:         boolPtr(false), //nolint:modernize
+			ClusterEvents:         boolPtr(true),  //nolint:modernize
+			NodeLogs:              boolPtr(false), //nolint:modernize
+			InstrumentationStatus: instrumentation.StatusError,
+			Namespaces:            2,
+			Workloads:             5,
+			Pods:                  15,
+			Nodes:                 3,
+			Age:                   "1h",
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, (&instroutput.ClusterTableCodec{Wide: true}).Encode(&buf, clusters))
+	out := buf.String()
+
+	// Wide adds extra columns.
+	assert.Contains(t, out, "COST")
+	assert.Contains(t, out, "EVENTS")
+	assert.Contains(t, out, "ENERGY")
+	assert.Contains(t, out, "LOGS")
+	assert.Contains(t, out, "NODES")
+
+	// SELECTION still must NOT appear in wide output.
+	assert.NotContains(t, out, "SELECTION")
+
+	// Wide STATUS is raw proto enum, not normalized.
+	assert.Contains(t, out, "INSTRUMENTATION_ERROR")
+	assert.NotContains(t, out, "FAILING")
+
+	// NAME first, STATUS last.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.NotEmpty(t, lines)
+	hdr := lines[0]
+	nameIdx := strings.Index(hdr, "NAME")
+	costIdx := strings.Index(hdr, "COST")
+	statusIdx := strings.Index(hdr, "STATUS")
+	assert.Less(t, nameIdx, costIdx, "NAME must come before COST")
+	assert.Less(t, costIdx, statusIdx, "COST must come before STATUS")
+	assert.NotContains(t, hdr, "AGE")
+}
+
+func TestClusterTableCodec_EmptySlice(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	require.NoError(t, (&instroutput.ClusterTableCodec{}).Encode(&buf, []instroutput.ClusterView{}))
+	out := buf.String()
+	// Headers still rendered even for empty slice.
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "STATUS")
+	assert.NotContains(t, out, "AGE")
+}
+
+// ─── AppTableCodec ────────────────────────────────────────────────────────────
+
+func TestAppTableCodec_Format(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, format.Format("table"), (&instroutput.AppTableCodec{}).Format())
+	assert.Equal(t, format.Format("wide"), (&instroutput.AppTableCodec{Wide: true}).Format())
+}
+
+func TestAppTableCodec_Decode_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	err := (&instroutput.AppTableCodec{}).Decode(strings.NewReader(""), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support decoding")
+}
+
+func TestAppTableCodec_Encode_InvalidType(t *testing.T) {
+	t.Parallel()
+
+	err := (&instroutput.AppTableCodec{}).Encode(&bytes.Buffer{}, 42)
+	require.Error(t, err)
+}
+
+func TestAppTableCodec_DefaultColumns(t *testing.T) {
+	t.Parallel()
+
+	apps := []instroutput.AppView{
+		{
+			ClusterName:           "prod",
+			Name:                  "payments",
+			Autoinstrument:        boolPtr(true), //nolint:modernize
+			InstrumentationStatus: instrumentation.StatusInstrumented,
+			Workloads:             3,
+			Pods:                  9,
+			Overrides:             2,
+			Age:                   "5h",
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, (&instroutput.AppTableCodec{}).Encode(&buf, apps))
+	out := buf.String()
+
+	// Default columns present in headers.
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "CLUSTER")
+	assert.Contains(t, out, "WORKLOADS")
+	assert.Contains(t, out, "PODS")
+	assert.Contains(t, out, "AUTOINSTRUMENT")
+	assert.Contains(t, out, "STATUS")
+	assert.NotContains(t, out, "AGE")
+
+	// Wide columns must NOT appear in default table.
+	assert.NotContains(t, out, "TRACING")
+	assert.NotContains(t, out, "LOGGING")
+	assert.NotContains(t, out, "PROCESS_METRICS")
+	assert.NotContains(t, out, "EXTENDED_METRICS")
+	assert.NotContains(t, out, "PROFILING")
+	assert.NotContains(t, out, "OVERRIDES")
+
+	// STATUS normalized.
+	assert.Contains(t, out, "OK")
+
+	// Data values.
+	assert.Contains(t, out, "payments")
+	assert.Contains(t, out, "prod")
+	assert.Contains(t, out, "true")
+}
+
+func TestAppTableCodec_WideColumns(t *testing.T) {
+	t.Parallel()
+
+	apps := []instroutput.AppView{
+		{
+			ClusterName:           "prod",
+			Name:                  "payments",
+			Autoinstrument:        boolPtr(true),  //nolint:modernize
+			Tracing:               boolPtr(true),  //nolint:modernize
+			Logging:               boolPtr(false), //nolint:modernize
+			ProcessMetrics:        boolPtr(true),  //nolint:modernize
+			ExtendedMetrics:       boolPtr(false), //nolint:modernize
+			Profiling:             boolPtr(true),  //nolint:modernize
+			InstrumentationStatus: instrumentation.StatusPendingInstrumentation,
+			Workloads:             3,
+			Pods:                  9,
+			Overrides:             2,
+			Age:                   "5h",
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, (&instroutput.AppTableCodec{Wide: true}).Encode(&buf, apps))
+	out := buf.String()
+
+	// Wide columns present.
+	assert.Contains(t, out, "TRACING")
+	assert.Contains(t, out, "LOGGING")
+	assert.Contains(t, out, "PROCESS_METRICS")
+	assert.Contains(t, out, "EXTENDED_METRICS")
+	assert.Contains(t, out, "PROFILING")
+	assert.Contains(t, out, "OVERRIDES")
+
+	// Wide STATUS is raw proto enum.
+	assert.Contains(t, out, "PENDING_INSTRUMENTATION")
+	assert.NotContains(t, out, "NODATA")
+
+	// header ordering.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.NotEmpty(t, lines)
+	hdr := lines[0]
+	nameIdx := strings.Index(hdr, "NAME")
+	tracingIdx := strings.Index(hdr, "TRACING")
+	statusIdx := strings.Index(hdr, "STATUS")
+	assert.Less(t, nameIdx, tracingIdx, "NAME must come before TRACING")
+	assert.Less(t, tracingIdx, statusIdx, "TRACING must come before STATUS")
+	assert.NotContains(t, hdr, "AGE")
+}
+
+// ─── ServiceTableCodec ────────────────────────────────────────────────────────
+
+func TestServiceTableCodec_Format(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, format.Format("table"), (&instroutput.ServiceTableCodec{}).Format())
+	assert.Equal(t, format.Format("wide"), (&instroutput.ServiceTableCodec{Wide: true}).Format())
+}
+
+func TestServiceTableCodec_Decode_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	err := (&instroutput.ServiceTableCodec{}).Decode(strings.NewReader(""), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support decoding")
+}
+
+func TestServiceTableCodec_Encode_InvalidType(t *testing.T) {
+	t.Parallel()
+
+	err := (&instroutput.ServiceTableCodec{}).Encode(&bytes.Buffer{}, struct{}{})
+	require.Error(t, err)
+}
+
+func TestServiceTableCodec_DefaultColumns(t *testing.T) {
+	t.Parallel()
+
+	services := []instroutput.ServiceView{
+		{
+			ClusterName:           "prod",
+			Namespace:             "payments",
+			Name:                  "checkout",
+			WorkloadType:          "deployment",
+			Lang:                  "go",
+			InstrumentationStatus: instrumentation.StatusInstrumented,
+			Age:                   "3d",
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, (&instroutput.ServiceTableCodec{}).Encode(&buf, services))
+	out := buf.String()
+
+	// Default columns present in headers.
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "CLUSTER")
+	assert.Contains(t, out, "NAMESPACE")
+	assert.Contains(t, out, "TYPE")
+	assert.Contains(t, out, "LANG")
+	assert.Contains(t, out, "STATUS")
+	assert.NotContains(t, out, "AGE")
+
+	// Wide columns must NOT appear.
+	assert.NotContains(t, out, "WORKLOAD_TYPE")
+	assert.NotContains(t, out, "OS")
+	assert.NotContains(t, out, "INSTRUMENTATION_ERROR")
+
+	// STATUS normalized.
+	assert.Contains(t, out, "OK")
+
+	// Data values.
+	assert.Contains(t, out, "checkout")
+	assert.Contains(t, out, "prod")
+	assert.Contains(t, out, "payments")
+	assert.Contains(t, out, "deployment")
+	assert.Contains(t, out, "go")
+}
+
+func TestServiceTableCodec_DisplayNameFallback(t *testing.T) {
+	t.Parallel()
+
+	services := []instroutput.ServiceView{
+		{
+			ClusterName:      "prod",
+			Namespace:        "ns",
+			DisplayNamespace: "NS Display",
+			Name:             "svc",
+			DisplayName:      "SVC Display",
+			WorkloadType:     "deployment",
+			Lang:             "python",
+			Age:              "1h",
+		},
+		{
+			ClusterName:  "prod",
+			Namespace:    "ns2",
+			Name:         "svc2",
+			WorkloadType: "daemonset",
+			Lang:         "java",
+			Age:          "2h",
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, (&instroutput.ServiceTableCodec{}).Encode(&buf, services))
+	out := buf.String()
+
+	// DisplayName and DisplayNamespace used when set.
+	assert.Contains(t, out, "SVC Display")
+	assert.Contains(t, out, "NS Display")
+
+	// Fallback to Name/Namespace when Display fields absent.
+	assert.Contains(t, out, "svc2")
+	assert.Contains(t, out, "ns2")
+}
+
+func TestServiceTableCodec_WideColumns(t *testing.T) {
+	t.Parallel()
+
+	services := []instroutput.ServiceView{
+		{
+			ClusterName:                 "prod",
+			Namespace:                   "payments",
+			Name:                        "checkout",
+			WorkloadType:                "deployment",
+			OS:                          "linux",
+			Lang:                        "go",
+			InstrumentationStatus:       instrumentation.StatusError,
+			InstrumentationErrorMessage: "agent failed to start",
+			Age:                         "3d",
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, (&instroutput.ServiceTableCodec{Wide: true}).Encode(&buf, services))
+	out := buf.String()
+
+	// Wide columns present.
+	assert.Contains(t, out, "OS")
+	assert.Contains(t, out, "INSTRUMENTATION_ERROR")
+	// TYPE renders WorkloadType; WORKLOAD_TYPE has been dropped to avoid
+	// duplicating TYPE (no distinct field exists for a separate column).
+	assert.NotContains(t, out, "WORKLOAD_TYPE")
+
+	// Wide STATUS is raw proto enum.
+	assert.Contains(t, out, "INSTRUMENTATION_ERROR")
+	assert.Contains(t, out, "agent failed to start")
+
+	// header ordering.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.NotEmpty(t, lines)
+	hdr := lines[0]
+	nameIdx := strings.Index(hdr, "NAME")
+	osIdx := strings.Index(hdr, "OS")
+	statusIdx := strings.Index(hdr, "STATUS")
+	assert.Less(t, nameIdx, osIdx, "NAME must come before OS")
+	assert.Less(t, osIdx, statusIdx, "OS must come before STATUS")
+	assert.NotContains(t, hdr, "AGE")
+}
+
+// ─── JSON/YAML bare-type output ───────────────────────────────────────────────
+// JSON/YAML output must be the bare domain type with no
+// kind: or apiVersion: fields at the top level.
+
+func TestClusterView_JSON_NoBareEnvelope(t *testing.T) {
+	t.Parallel()
+
+	cv := instroutput.ClusterView{
+		Name:                  "prod",
+		Selection:             "SELECTION_INCLUDED",
+		InstrumentationStatus: instrumentation.StatusInstrumented,
+		Namespaces:            2,
+		Age:                   "1d",
+	}
+
+	b, err := json.Marshal(cv)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(b, &raw))
+
+	// no K8s envelope fields.
+	assert.NotContains(t, raw, "kind", "kind must not appear in JSON output")
+	assert.NotContains(t, raw, "apiVersion", "apiVersion must not appear in JSON output")
+
+	// Selection IS present in JSON (no omitempty).
+	assert.Contains(t, raw, "selection", "selection must appear in JSON output")
+
+	// Raw proto enum value for status.
+	assert.Equal(t, "INSTRUMENTED", raw["instrumentationStatus"])
+}
+
+func TestClusterView_YAML_NoBareEnvelope(t *testing.T) {
+	t.Parallel()
+
+	cv := instroutput.ClusterView{
+		Name:                  "prod",
+		Selection:             "SELECTION_INCLUDED",
+		InstrumentationStatus: instrumentation.StatusError,
+	}
+
+	b, err := goyaml.Marshal(cv)
+	require.NoError(t, err)
+	out := string(b)
+
+	// no K8s envelope fields.
+	assert.NotContains(t, out, "kind:")
+	assert.NotContains(t, out, "apiVersion:")
+
+	// selection IS present in YAML (no omitempty).
+	assert.Contains(t, out, "selection:")
+
+	// raw proto enum.
+	assert.Contains(t, out, "INSTRUMENTATION_ERROR")
+}
+
+func TestAppView_JSON_ClusterNameExcluded(t *testing.T) {
+	t.Parallel()
+
+	av := instroutput.AppView{
+		ClusterName:           "prod",
+		Name:                  "payments",
+		Autoinstrument:        boolPtr(true), //nolint:modernize
+		InstrumentationStatus: instrumentation.StatusInstrumented,
+	}
+
+	b, err := json.Marshal(av)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(b, &raw))
+
+	// ClusterName must NOT appear in JSON (json:"-").
+	assert.NotContains(t, raw, "clusterName", "clusterName must not appear in JSON output for AppView")
+
+	// No K8s envelope.
+	assert.NotContains(t, raw, "kind")
+	assert.NotContains(t, raw, "apiVersion")
+
+	// raw proto enum.
+	assert.Equal(t, "INSTRUMENTED", raw["instrumentationStatus"])
+}
+
+func TestServiceView_JSON_NoBareEnvelope(t *testing.T) {
+	t.Parallel()
+
+	sv := instroutput.ServiceView{
+		ClusterName:           "prod",
+		Namespace:             "payments",
+		Name:                  "checkout",
+		WorkloadType:          "deployment",
+		InstrumentationStatus: instrumentation.StatusPendingInstrumentation,
+	}
+
+	b, err := json.Marshal(sv)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(b, &raw))
+
+	// no K8s envelope fields.
+	assert.NotContains(t, raw, "kind")
+	assert.NotContains(t, raw, "apiVersion")
+
+	// raw proto enum.
+	assert.Equal(t, "PENDING_INSTRUMENTATION", raw["instrumentationStatus"])
+}
+
+// ─── Slice-of-views JSON (raw enum in JSON/YAML list) ────────────────────────
+
+func TestClusterView_JSON_SliceRawEnum(t *testing.T) {
+	t.Parallel()
+
+	clusters := []instroutput.ClusterView{
+		{Name: "c1", Selection: "SELECTION_INCLUDED", InstrumentationStatus: instrumentation.StatusPendingInstrumentation},
+		{Name: "c2", Selection: "SELECTION_INCLUDED", InstrumentationStatus: instrumentation.StatusInstrumented},
+	}
+
+	b, err := json.Marshal(clusters)
+	require.NoError(t, err)
+
+	var raw []map[string]any
+	require.NoError(t, json.Unmarshal(b, &raw))
+	require.Len(t, raw, 2)
+
+	assert.Equal(t, "PENDING_INSTRUMENTATION", raw[0]["instrumentationStatus"])
+	assert.Equal(t, "INSTRUMENTED", raw[1]["instrumentationStatus"])
+
+	// No K8s envelope fields in any element.
+	for _, elem := range raw {
+		assert.NotContains(t, elem, "kind")
+		assert.NotContains(t, elem, "apiVersion")
+	}
+}

--- a/internal/providers/instrumentation/output/mutation.go
+++ b/internal/providers/instrumentation/output/mutation.go
@@ -1,0 +1,69 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/agent"
+)
+
+// MutationResult is the structured result emitted by mutation commands.
+// In agent mode it is serialized as JSON to stdout; in non-agent mode
+// it is rendered as a one-line human summary.
+type MutationResult struct {
+	Action  string        `json:"action"`
+	Target  Target        `json:"target"`
+	Changed bool          `json:"changed"`
+	Fields  []FieldChange `json:"fields,omitempty"`
+	// Discovered is set by apps configure to indicate whether the namespace
+	// appears in RunK8sDiscovery at the time of the call. Omitted for non-apps
+	// mutation results (cluster, service) where the concept does not apply.
+	Discovered *bool `json:"discovered,omitempty"`
+}
+
+// Target identifies the resource that was mutated.
+type Target struct {
+	Cluster   string `json:"cluster,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Service   string `json:"service,omitempty"`
+}
+
+// FieldChange records one field's before/after values.
+type FieldChange struct {
+	Name string `json:"name"`
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// Emit writes the MutationResult to w.
+// In agent mode: writes a single JSON object followed by newline.
+// In non-agent mode: writes a one-line human summary.
+func (r MutationResult) Emit(w io.Writer) error {
+	if agent.IsAgentMode() {
+		data, err := json.Marshal(r)
+		if err != nil {
+			return fmt.Errorf("mutation result: marshal: %w", err)
+		}
+		_, err = fmt.Fprintln(w, string(data))
+		return err
+	}
+
+	target := r.targetString()
+	if r.Changed {
+		fmt.Fprintf(w, "%s %q: done\n", r.Action, target)
+	} else {
+		fmt.Fprintf(w, "%s %q: no changes\n", r.Action, target)
+	}
+	return nil
+}
+
+func (r MutationResult) targetString() string {
+	if r.Target.Service != "" {
+		return fmt.Sprintf("%s/%s/%s", r.Target.Cluster, r.Target.Namespace, r.Target.Service)
+	}
+	if r.Target.Namespace != "" {
+		return fmt.Sprintf("%s/%s", r.Target.Cluster, r.Target.Namespace)
+	}
+	return r.Target.Cluster
+}

--- a/internal/providers/instrumentation/output/mutation_test.go
+++ b/internal/providers/instrumentation/output/mutation_test.go
@@ -1,0 +1,82 @@
+package output_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMutationResult_Emit_AgentMode_Changed(t *testing.T) {
+	agent.SetFlag(true)
+	t.Cleanup(func() { agent.SetFlag(false) })
+
+	r := output.MutationResult{
+		Action:  "configure",
+		Target:  output.Target{Cluster: "prod-eu"},
+		Changed: true,
+		Fields:  []output.FieldChange{{Name: "costMetrics", From: "false", To: "true"}},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, r.Emit(&buf))
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got), "output must be valid JSON: %s", buf.String())
+	assert.Equal(t, "configure", got["action"])
+	assert.Equal(t, true, got["changed"])
+	fields, ok := got["fields"].([]any)
+	require.True(t, ok)
+	assert.Len(t, fields, 1)
+}
+
+func TestMutationResult_Emit_AgentMode_NoChange(t *testing.T) {
+	agent.SetFlag(true)
+	t.Cleanup(func() { agent.SetFlag(false) })
+
+	r := output.MutationResult{
+		Action:  "exclude",
+		Target:  output.Target{Cluster: "prod-eu", Namespace: "checkout", Service: "payment-svc"},
+		Changed: false,
+	}
+	var buf bytes.Buffer
+	require.NoError(t, r.Emit(&buf))
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, false, got["changed"])
+	// fields key should not be present (omitempty)
+	_, hasFields := got["fields"]
+	assert.False(t, hasFields)
+}
+
+func TestMutationResult_Emit_HumanMode_Changed(t *testing.T) {
+	agent.SetFlag(false)
+
+	r := output.MutationResult{
+		Action:  "remove",
+		Target:  output.Target{Cluster: "prod-eu"},
+		Changed: true,
+	}
+	var buf bytes.Buffer
+	require.NoError(t, r.Emit(&buf))
+	assert.Contains(t, buf.String(), "remove")
+	assert.Contains(t, buf.String(), "prod-eu")
+	assert.NotContains(t, buf.String(), "no changes")
+}
+
+func TestMutationResult_Emit_HumanMode_NoChange(t *testing.T) {
+	agent.SetFlag(false)
+
+	r := output.MutationResult{
+		Action:  "exclude",
+		Target:  output.Target{Cluster: "c", Namespace: "ns", Service: "svc"},
+		Changed: false,
+	}
+	var buf bytes.Buffer
+	require.NoError(t, r.Emit(&buf))
+	assert.Contains(t, buf.String(), "no changes")
+}

--- a/internal/providers/instrumentation/output/wait.go
+++ b/internal/providers/instrumentation/output/wait.go
@@ -1,0 +1,126 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// WaitBanner is the one-time start banner emitted to stderr before polling begins.
+// In agent mode it is written as an NDJSON line; in non-agent mode
+// it writes the human-readable "Waiting for …" message.
+type WaitBanner struct {
+	Event   string `json:"event"` // always "waiting_started"
+	Target  Target `json:"target"`
+	Timeout string `json:"timeout,omitempty"` // e.g. "5m0s"
+}
+
+// EmitTo writes the WaitBanner to w. agentMode true → NDJSON line; false → human text.
+func (b WaitBanner) EmitTo(w io.Writer, agentMode bool) error {
+	if agentMode {
+		data, err := json.Marshal(b)
+		if err != nil {
+			return fmt.Errorf("WaitBanner.EmitTo: %w", err)
+		}
+		_, err = fmt.Fprintln(w, string(data))
+		return err
+	}
+	if b.Target.Namespace != "" {
+		_, err := fmt.Fprintf(w, "Waiting for namespace %q in cluster %q (timeout: %s)...\n",
+			b.Target.Namespace, b.Target.Cluster, b.Timeout)
+		return err
+	}
+	_, err := fmt.Fprintf(w, "Waiting for cluster %q to reach INSTRUMENTED status (timeout: %s)...\n",
+		b.Target.Cluster, b.Timeout)
+	return err
+}
+
+// WaitProgress is the per-poll progress event emitted to stderr during wait
+// commands. In agent mode it is written as an NDJSON line; in
+// non-agent mode it writes the existing human-readable progress text.
+type WaitProgress struct {
+	Event     string `json:"event"` // always "waiting"
+	Target    Target `json:"target"`
+	Status    string `json:"status"`
+	ElapsedMs int64  `json:"elapsed_ms,omitempty"`
+}
+
+// EmitTo writes the WaitProgress to w. agentMode true → NDJSON line on stderr;
+// false → human-readable progress text.
+func (p WaitProgress) EmitTo(w io.Writer, agentMode bool) error {
+	if agentMode {
+		data, err := json.Marshal(p)
+		if err != nil {
+			return fmt.Errorf("WaitProgress.EmitTo: %w", err)
+		}
+		_, err = fmt.Fprintln(w, string(data))
+		return err
+	}
+	if p.Target.Namespace != "" {
+		_, err := fmt.Fprintf(w, "waiting: namespace %q status is %s...\n", p.Target.Namespace, p.Status)
+		return err
+	}
+	_, err := fmt.Fprintf(w, "  status: %s\n", p.Status)
+	return err
+}
+
+// WaitError carries error details inside the fused timeout envelope.
+// Populated only when Outcome is "timeout" or "error".
+type WaitError struct {
+	Summary  string `json:"summary"`
+	Details  string `json:"details"`
+	ExitCode int    `json:"exitCode"`
+}
+
+// WaitResult is the agent-mode JSON envelope emitted by wait commands. The
+// Error field is populated for fused timeout/error envelopes.
+// In non-agent mode, a one-line human summary is written instead.
+type WaitResult struct {
+	Outcome   string     `json:"outcome"` // "success", "timeout", or "error"
+	Target    Target     `json:"target"`
+	Status    string     `json:"status,omitempty"` // last observed proto enum value
+	ElapsedMs int64      `json:"elapsed_ms,omitempty"`
+	Error     *WaitError `json:"error,omitempty"` // populated on timeout/error
+}
+
+// Emit writes the WaitResult to w. agentMode true → JSON; false → one-line summary.
+func (r WaitResult) Emit(w io.Writer, agentMode bool) error {
+	if agentMode {
+		data, err := json.Marshal(r)
+		if err != nil {
+			return fmt.Errorf("WaitResult.Emit: %w", err)
+		}
+		_, err = fmt.Fprintln(w, string(data))
+		return err
+	}
+	switch r.Outcome {
+	case "success":
+		if r.Target.Namespace != "" {
+			_, err := fmt.Fprintf(w, "namespace %q in cluster %q: status is %s\n", r.Target.Namespace, r.Target.Cluster, r.Status)
+			return err
+		}
+		_, err := fmt.Fprintf(w, "Cluster %q reached terminal state %s.\n", r.Target.Cluster, r.Status)
+		return err
+	case "timeout":
+		if r.Target.Namespace != "" {
+			_, err := fmt.Fprintf(w, "timeout: namespace %q in cluster %q still in %s\n", r.Target.Namespace, r.Target.Cluster, r.Status)
+			return err
+		}
+		_, err := fmt.Fprintf(w, "timeout: %s still in %s\n", r.Target.Cluster, r.Status)
+		return err
+	default:
+		_, err := fmt.Fprintf(w, "error at %s\n", r.Target.Cluster)
+		return err
+	}
+}
+
+// WaitResultForCluster builds a WaitResult for cluster-level waits (no namespace).
+func WaitResultForCluster(outcome, clusterName, status string, start time.Time) WaitResult {
+	return WaitResult{
+		Outcome:   outcome,
+		Target:    Target{Cluster: clusterName},
+		Status:    status,
+		ElapsedMs: time.Since(start).Milliseconds(),
+	}
+}

--- a/internal/providers/instrumentation/provider.go
+++ b/internal/providers/instrumentation/provider.go
@@ -1,0 +1,45 @@
+package instrumentation
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/spf13/cobra"
+)
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	providers.Register(&InstrumentationProvider{})
+}
+
+// InstrumentationProvider manages Grafana Instrumentation Hub resources via
+// action-verb commands. It does NOT register any GVK with the resource adapter
+// pipeline — gcx resources push/pull/schemas will not list any
+// instrumentation kinds.
+type InstrumentationProvider struct{}
+
+// Name returns the unique identifier for this provider.
+func (p *InstrumentationProvider) Name() string { return "instrumentation" }
+
+// ShortDesc returns a one-line description of the provider.
+func (p *InstrumentationProvider) ShortDesc() string {
+	return "Manage Grafana Instrumentation Hub (clusters, apps, services)"
+}
+
+// Commands returns nil because the instrumentation command tree is wired
+// directly from cmd/gcx/root via a named import. The tree is NOT
+// surfaced through the provider's Commands() method to avoid a circular
+// dependency between cmd/ and internal/.
+func (p *InstrumentationProvider) Commands() []*cobra.Command { return nil }
+
+// Validate checks that the given provider configuration is valid.
+// The instrumentation provider derives all connection details from the
+// shared fleet client configuration, so no extra provider-specific keys are required.
+func (p *InstrumentationProvider) Validate(_ map[string]string) error { return nil }
+
+// ConfigKeys returns nil — the instrumentation provider uses the shared
+// fleet client configuration and does not introduce provider-specific config keys.
+func (p *InstrumentationProvider) ConfigKeys() []providers.ConfigKey { return nil }
+
+// TypedRegistrations returns nil — no GVK is registered for instrumentation
+// kinds. gcx resources schemas/push/pull/delete will not include
+// any instrumentation resource types.
+func (p *InstrumentationProvider) TypedRegistrations() []adapter.Registration { return nil }

--- a/internal/providers/instrumentation/provider_test.go
+++ b/internal/providers/instrumentation/provider_test.go
@@ -1,0 +1,43 @@
+package instrumentation_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestInstrumentationProvider_Name verifies the provider registers with the
+// expected name so gcx providers lists it correctly.
+func TestInstrumentationProvider_Name(t *testing.T) {
+	p := &instrumentation.InstrumentationProvider{}
+	assert.Equal(t, "instrumentation", p.Name())
+}
+
+// TestInstrumentationProvider_TypedRegistrationsNil verifies that TypedRegistrations
+// returns nil — no GVK is registered with the resource adapter.
+func TestInstrumentationProvider_TypedRegistrationsNil(t *testing.T) {
+	p := &instrumentation.InstrumentationProvider{}
+	assert.Nil(t, p.TypedRegistrations(), "TypedRegistrations must return nil")
+}
+
+// TestInstrumentationProvider_CommandsNil verifies that Commands returns nil —
+// the command tree is wired from cmd/gcx/root directly.
+func TestInstrumentationProvider_CommandsNil(t *testing.T) {
+	p := &instrumentation.InstrumentationProvider{}
+	assert.Nil(t, p.Commands(), "Commands must return nil — tree is wired from root")
+}
+
+// TestInstrumentationProvider_ValidateAlwaysNil verifies that Validate returns
+// nil for any input — no provider-specific config keys to validate.
+func TestInstrumentationProvider_ValidateAlwaysNil(t *testing.T) {
+	p := &instrumentation.InstrumentationProvider{}
+	assert.NoError(t, p.Validate(nil))
+	assert.NoError(t, p.Validate(map[string]string{"key": "value"}))
+}
+
+// TestInstrumentationProvider_ConfigKeysNil verifies that ConfigKeys returns nil.
+func TestInstrumentationProvider_ConfigKeysNil(t *testing.T) {
+	p := &instrumentation.InstrumentationProvider{}
+	assert.Nil(t, p.ConfigKeys())
+}

--- a/internal/providers/instrumentation/rmw/compare.go
+++ b/internal/providers/instrumentation/rmw/compare.go
@@ -1,0 +1,139 @@
+package rmw
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+)
+
+// AppEqual reports whether a and b represent the same namespace configuration.
+// Apps[] is compared order-independently (sorted by Name for canonical comparison).
+// Returns (true, "") when equal; (false, diffSummary) when not.
+// Pure function — does not modify a or b.
+func AppEqual(a, b instrumentation.App) (bool, string) {
+	var diffs []string
+
+	if a.Name != b.Name {
+		diffs = append(diffs, fmt.Sprintf("name: %q → %q", a.Name, b.Name))
+	}
+	if d := boolPtrDiff("autoinstrument", a.Autoinstrument, b.Autoinstrument); d != "" {
+		diffs = append(diffs, d)
+	}
+	if d := boolPtrDiff("tracing", a.Tracing, b.Tracing); d != "" {
+		diffs = append(diffs, d)
+	}
+	if d := boolPtrDiff("logging", a.Logging, b.Logging); d != "" {
+		diffs = append(diffs, d)
+	}
+	if d := boolPtrDiff("processmetrics", a.ProcessMetrics, b.ProcessMetrics); d != "" {
+		diffs = append(diffs, d)
+	}
+	if d := boolPtrDiff("extendedmetrics", a.ExtendedMetrics, b.ExtendedMetrics); d != "" {
+		diffs = append(diffs, d)
+	}
+	if d := boolPtrDiff("profiling", a.Profiling, b.Profiling); d != "" {
+		diffs = append(diffs, d)
+	}
+	if d := appOverridesDiff(a.Apps, b.Apps); d != "" {
+		diffs = append(diffs, d)
+	}
+
+	if len(diffs) == 0 {
+		return true, ""
+	}
+	return false, strings.Join(diffs, ", ")
+}
+
+// ClusterEqual reports whether a and b represent the same cluster configuration.
+// Returns (true, "") when equal; (false, diffSummary) when not.
+func ClusterEqual(a, b instrumentation.Cluster) (bool, string) {
+	var diffs []string
+
+	if a.Name != b.Name {
+		diffs = append(diffs, fmt.Sprintf("name: %q → %q", a.Name, b.Name))
+	}
+	if a.Selection != b.Selection {
+		diffs = append(diffs, fmt.Sprintf("selection: %q → %q", a.Selection, b.Selection))
+	}
+	if d := boolPtrDiff("costmetrics", a.CostMetrics, b.CostMetrics); d != "" {
+		diffs = append(diffs, d)
+	}
+	if d := boolPtrDiff("energymetrics", a.EnergyMetrics, b.EnergyMetrics); d != "" {
+		diffs = append(diffs, d)
+	}
+	if d := boolPtrDiff("clusterevents", a.ClusterEvents, b.ClusterEvents); d != "" {
+		diffs = append(diffs, d)
+	}
+	if d := boolPtrDiff("nodelogs", a.NodeLogs, b.NodeLogs); d != "" {
+		diffs = append(diffs, d)
+	}
+
+	if len(diffs) == 0 {
+		return true, ""
+	}
+	return false, strings.Join(diffs, ", ")
+}
+
+// boolPtrDiff returns a diff string for a named *bool field, or "" if equal.
+// Treats nil ≠ false ≠ true (tri-state semantics).
+func boolPtrDiff(name string, a, b *bool) string {
+	if a == nil && b == nil {
+		return ""
+	}
+	if a == nil {
+		return fmt.Sprintf("%s: nil → %v", name, *b)
+	}
+	if b == nil {
+		return fmt.Sprintf("%s: %v → nil", name, *a)
+	}
+	if *a != *b {
+		return fmt.Sprintf("%s: %v → %v", name, *a, *b)
+	}
+	return ""
+}
+
+// appOverridesDiff returns a diff string for AppOverride slices, or "" if equal.
+// Comparison is order-independent (by Name). Does not modify the caller's slices.
+func appOverridesDiff(a, b []instrumentation.AppOverride) string {
+	aCopy := make([]instrumentation.AppOverride, len(a))
+	bCopy := make([]instrumentation.AppOverride, len(b))
+	copy(aCopy, a)
+	copy(bCopy, b)
+
+	sort.Slice(aCopy, func(i, j int) bool { return aCopy[i].Name < aCopy[j].Name })
+	sort.Slice(bCopy, func(i, j int) bool { return bCopy[i].Name < bCopy[j].Name })
+
+	aIdx := make(map[string]string, len(aCopy))
+	for _, o := range aCopy {
+		aIdx[o.Name] = o.Selection
+	}
+	bIdx := make(map[string]string, len(bCopy))
+	for _, o := range bCopy {
+		bIdx[o.Name] = o.Selection
+	}
+
+	var diffs []string
+
+	// Removed or changed overrides (present in a, absent or changed in b).
+	for _, o := range aCopy {
+		if sel, ok := bIdx[o.Name]; !ok {
+			diffs = append(diffs, "removed apps[]: "+o.Name)
+		} else if sel != o.Selection {
+			diffs = append(diffs, fmt.Sprintf("apps[%s].selection: %s → %s", o.Name, o.Selection, sel))
+		}
+	}
+
+	// Added overrides (present in b, absent in a).
+	for _, o := range bCopy {
+		if _, ok := aIdx[o.Name]; !ok {
+			diffs = append(diffs, "added apps[]: "+o.Name)
+		}
+	}
+
+	if len(diffs) == 0 {
+		return ""
+	}
+	return strings.Join(diffs, ", ")
+}

--- a/internal/providers/instrumentation/rmw/compare_test.go
+++ b/internal/providers/instrumentation/rmw/compare_test.go
@@ -1,0 +1,299 @@
+package rmw_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/grafana/gcx/internal/providers/instrumentation/rmw"
+	"github.com/stretchr/testify/assert"
+)
+
+func boolPtr(b bool) *bool { return &b } //nolint:modernize // new(bool) gives *false, not a pointer to the given value.
+
+func TestAppEqual(t *testing.T) {
+	tests := []struct {
+		name      string
+		a         instrumentation.App
+		b         instrumentation.App
+		wantEqual bool
+		// wantDiff is checked as a substring of the diff summary when not equal.
+		wantDiff string
+	}{
+		{
+			name:      "identical apps are equal",
+			a:         instrumentation.App{Name: "default", Autoinstrument: boolPtr(true), Tracing: boolPtr(true)}, //nolint:modernize
+			b:         instrumentation.App{Name: "default", Autoinstrument: boolPtr(true), Tracing: boolPtr(true)}, //nolint:modernize
+			wantEqual: true,
+		},
+		{
+			name:      "both zero values are equal",
+			a:         instrumentation.App{},
+			b:         instrumentation.App{},
+			wantEqual: true,
+		},
+		{
+			name:      "name difference detected",
+			a:         instrumentation.App{Name: "default"},
+			b:         instrumentation.App{Name: "other"},
+			wantEqual: false,
+			wantDiff:  "name",
+		},
+		{
+			name:      "autoinstrument true→false detected",
+			a:         instrumentation.App{Name: "ns", Autoinstrument: boolPtr(true)},  //nolint:modernize
+			b:         instrumentation.App{Name: "ns", Autoinstrument: boolPtr(false)}, //nolint:modernize
+			wantEqual: false,
+			wantDiff:  "autoinstrument: true → false",
+		},
+		{
+			name:      "tracing nil→true detected",
+			a:         instrumentation.App{Name: "ns"},
+			b:         instrumentation.App{Name: "ns", Tracing: boolPtr(true)}, //nolint:modernize
+			wantEqual: false,
+			wantDiff:  "tracing: nil → true",
+		},
+		{
+			name:      "logging true→nil detected",
+			a:         instrumentation.App{Name: "ns", Logging: boolPtr(true)}, //nolint:modernize
+			b:         instrumentation.App{Name: "ns"},
+			wantEqual: false,
+			wantDiff:  "logging: true → nil",
+		},
+		{
+			name:      "processmetrics difference detected",
+			a:         instrumentation.App{Name: "ns", ProcessMetrics: boolPtr(false)}, //nolint:modernize
+			b:         instrumentation.App{Name: "ns", ProcessMetrics: boolPtr(true)},  //nolint:modernize
+			wantEqual: false,
+			wantDiff:  "processmetrics: false → true",
+		},
+		{
+			name:      "extendedmetrics difference detected",
+			a:         instrumentation.App{Name: "ns", ExtendedMetrics: boolPtr(true)},  //nolint:modernize
+			b:         instrumentation.App{Name: "ns", ExtendedMetrics: boolPtr(false)}, //nolint:modernize
+			wantEqual: false,
+			wantDiff:  "extendedmetrics: true → false",
+		},
+		{
+			name:      "profiling difference detected",
+			a:         instrumentation.App{Name: "ns", Profiling: boolPtr(false)}, //nolint:modernize
+			b:         instrumentation.App{Name: "ns", Profiling: boolPtr(true)},  //nolint:modernize
+			wantEqual: false,
+			wantDiff:  "profiling: false → true",
+		},
+		{
+			// Apps[] with same elements in different order must be treated as equal.
+			name: "apps overrides equal regardless of order",
+			a: instrumentation.App{
+				Name: "ns",
+				Apps: []instrumentation.AppOverride{
+					{Name: "frontend", Selection: "SELECTION_INCLUDED"},
+					{Name: "backend", Selection: "SELECTION_EXCLUDED"},
+				},
+			},
+			b: instrumentation.App{
+				Name: "ns",
+				Apps: []instrumentation.AppOverride{
+					{Name: "backend", Selection: "SELECTION_EXCLUDED"},
+					{Name: "frontend", Selection: "SELECTION_INCLUDED"},
+				},
+			},
+			wantEqual: true,
+		},
+		{
+			name: "added app override detected",
+			a: instrumentation.App{
+				Name: "ns",
+				Apps: []instrumentation.AppOverride{
+					{Name: "frontend", Selection: "SELECTION_INCLUDED"},
+				},
+			},
+			b: instrumentation.App{
+				Name: "ns",
+				Apps: []instrumentation.AppOverride{
+					{Name: "frontend", Selection: "SELECTION_INCLUDED"},
+					{Name: "backend", Selection: "SELECTION_EXCLUDED"},
+				},
+			},
+			wantEqual: false,
+			wantDiff:  "added apps[]: backend",
+		},
+		{
+			name: "removed app override detected",
+			a: instrumentation.App{
+				Name: "ns",
+				Apps: []instrumentation.AppOverride{
+					{Name: "frontend", Selection: "SELECTION_INCLUDED"},
+					{Name: "backend", Selection: "SELECTION_EXCLUDED"},
+				},
+			},
+			b: instrumentation.App{
+				Name: "ns",
+				Apps: []instrumentation.AppOverride{
+					{Name: "frontend", Selection: "SELECTION_INCLUDED"},
+				},
+			},
+			wantEqual: false,
+			wantDiff:  "removed apps[]: backend",
+		},
+		{
+			name: "changed app override selection detected",
+			a: instrumentation.App{
+				Name: "ns",
+				Apps: []instrumentation.AppOverride{
+					{Name: "frontend", Selection: "SELECTION_INCLUDED"},
+				},
+			},
+			b: instrumentation.App{
+				Name: "ns",
+				Apps: []instrumentation.AppOverride{
+					{Name: "frontend", Selection: "SELECTION_EXCLUDED"},
+				},
+			},
+			wantEqual: false,
+			wantDiff:  "apps[frontend].selection: SELECTION_INCLUDED → SELECTION_EXCLUDED",
+		},
+		{
+			// Verify that AppEqual does not mutate the caller's slice (order preservation).
+			name: "caller slices not mutated by sorting",
+			a: instrumentation.App{
+				Name: "ns",
+				Apps: []instrumentation.AppOverride{
+					{Name: "z-app", Selection: "SELECTION_INCLUDED"},
+					{Name: "a-app", Selection: "SELECTION_INCLUDED"},
+				},
+			},
+			b: instrumentation.App{
+				Name: "ns",
+				Apps: []instrumentation.AppOverride{
+					{Name: "z-app", Selection: "SELECTION_INCLUDED"},
+					{Name: "a-app", Selection: "SELECTION_INCLUDED"},
+				},
+			},
+			wantEqual: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original slice order for mutation check.
+			origAOrder := make([]string, len(tt.a.Apps))
+			for i, o := range tt.a.Apps {
+				origAOrder[i] = o.Name
+			}
+			origBOrder := make([]string, len(tt.b.Apps))
+			for i, o := range tt.b.Apps {
+				origBOrder[i] = o.Name
+			}
+
+			equal, diff := rmw.AppEqual(tt.a, tt.b)
+
+			assert.Equal(t, tt.wantEqual, equal, "equality result")
+			if !tt.wantEqual {
+				assert.Contains(t, diff, tt.wantDiff, "diff should contain expected substring")
+			} else {
+				assert.Empty(t, diff, "diff should be empty when equal")
+			}
+
+			// Verify slices were not mutated.
+			for i, o := range tt.a.Apps {
+				assert.Equal(t, origAOrder[i], o.Name, "caller's slice a must not be mutated")
+			}
+			for i, o := range tt.b.Apps {
+				assert.Equal(t, origBOrder[i], o.Name, "caller's slice b must not be mutated")
+			}
+		})
+	}
+}
+
+func TestClusterEqual(t *testing.T) {
+	tests := []struct {
+		name      string
+		a         instrumentation.Cluster
+		b         instrumentation.Cluster
+		wantEqual bool
+		wantDiff  string
+	}{
+		{
+			name:      "identical clusters are equal",
+			a:         instrumentation.Cluster{Name: "prod-1", Selection: "SELECTION_INCLUDED", CostMetrics: boolPtr(true)}, //nolint:modernize
+			b:         instrumentation.Cluster{Name: "prod-1", Selection: "SELECTION_INCLUDED", CostMetrics: boolPtr(true)}, //nolint:modernize
+			wantEqual: true,
+		},
+		{
+			name:      "both zero values are equal",
+			a:         instrumentation.Cluster{},
+			b:         instrumentation.Cluster{},
+			wantEqual: true,
+		},
+		{
+			name:      "name difference detected",
+			a:         instrumentation.Cluster{Name: "prod-1"},
+			b:         instrumentation.Cluster{Name: "prod-2"},
+			wantEqual: false,
+			wantDiff:  "name",
+		},
+		{
+			name:      "selection difference detected",
+			a:         instrumentation.Cluster{Name: "c1", Selection: "SELECTION_INCLUDED"},
+			b:         instrumentation.Cluster{Name: "c1", Selection: "SELECTION_EXCLUDED"},
+			wantEqual: false,
+			wantDiff:  "selection",
+		},
+		{
+			name:      "costmetrics false→true detected",
+			a:         instrumentation.Cluster{Name: "c1", CostMetrics: boolPtr(false)}, //nolint:modernize
+			b:         instrumentation.Cluster{Name: "c1", CostMetrics: boolPtr(true)},  //nolint:modernize
+			wantEqual: false,
+			wantDiff:  "costmetrics: false → true",
+		},
+		{
+			name:      "energymetrics nil→true detected",
+			a:         instrumentation.Cluster{Name: "c1"},
+			b:         instrumentation.Cluster{Name: "c1", EnergyMetrics: boolPtr(true)}, //nolint:modernize
+			wantEqual: false,
+			wantDiff:  "energymetrics: nil → true",
+		},
+		{
+			name:      "clusterevents true→false detected",
+			a:         instrumentation.Cluster{Name: "c1", ClusterEvents: boolPtr(true)},  //nolint:modernize
+			b:         instrumentation.Cluster{Name: "c1", ClusterEvents: boolPtr(false)}, //nolint:modernize
+			wantEqual: false,
+			wantDiff:  "clusterevents: true → false",
+		},
+		{
+			name:      "nodelogs difference detected",
+			a:         instrumentation.Cluster{Name: "c1", NodeLogs: boolPtr(true)},  //nolint:modernize
+			b:         instrumentation.Cluster{Name: "c1", NodeLogs: boolPtr(false)}, //nolint:modernize
+			wantEqual: false,
+			wantDiff:  "nodelogs: true → false",
+		},
+		{
+			name: "multiple fields differ — diff contains all",
+			a: instrumentation.Cluster{
+				Name:        "c1",
+				CostMetrics: boolPtr(false), //nolint:modernize
+				NodeLogs:    boolPtr(true),  //nolint:modernize
+			},
+			b: instrumentation.Cluster{
+				Name:        "c1",
+				CostMetrics: boolPtr(true),  //nolint:modernize
+				NodeLogs:    boolPtr(false), //nolint:modernize
+			},
+			wantEqual: false,
+			wantDiff:  "costmetrics",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			equal, diff := rmw.ClusterEqual(tt.a, tt.b)
+
+			assert.Equal(t, tt.wantEqual, equal, "equality result")
+			if !tt.wantEqual {
+				assert.Contains(t, diff, tt.wantDiff, "diff should contain expected substring")
+			} else {
+				assert.Empty(t, diff, "diff should be empty when equal")
+			}
+		})
+	}
+}

--- a/internal/providers/instrumentation/rmw/errors.go
+++ b/internal/providers/instrumentation/rmw/errors.go
@@ -1,0 +1,39 @@
+package rmw
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ConflictError is returned by Update when the backend state changed between the
+// initial GET and the pre-write re-check, indicating a concurrent modification.
+// The Command and Namespace fields are filled in by the calling command layer.
+type ConflictError struct {
+	// Namespace names the conflicting namespace for app-level mutations.
+	// Empty for cluster-level mutations.
+	Namespace string
+	// Diff is a human-readable description of the detected change
+	// (e.g. "tracing: true → false", "added apps[]: frontend").
+	Diff string
+	// Command is the command name as it appears in error output
+	// (e.g. "apps enable", "clusters enable").
+	Command string
+}
+
+// Error implements the error interface. Format:
+//   - namespace-level: `<Command>: cannot write — namespace "<Namespace>" was modified concurrently (<Diff>). Re-fetch and retry.`
+//   - cluster-level:   `<Command>: cannot write — cluster configuration was modified concurrently (<Diff>). Re-fetch and retry.`
+func (e ConflictError) Error() string {
+	if e.Namespace != "" {
+		return fmt.Sprintf("%s: cannot write — namespace %q was modified concurrently (%s). Re-fetch and retry.",
+			e.Command, e.Namespace, e.Diff)
+	}
+	return fmt.Sprintf("%s: cannot write — cluster configuration was modified concurrently (%s). Re-fetch and retry.",
+		e.Command, e.Diff)
+}
+
+// IsConflictError returns true when err is or wraps a ConflictError.
+func IsConflictError(err error) bool {
+	var ce ConflictError
+	return errors.As(err, &ce)
+}

--- a/internal/providers/instrumentation/rmw/update.go
+++ b/internal/providers/instrumentation/rmw/update.go
@@ -1,0 +1,75 @@
+package rmw
+
+import (
+	"context"
+	"errors"
+)
+
+// Update performs a read-modify-write with a client-side optimistic-lock check.
+//
+// On each attempt:
+//  1. getFn is called to capture snapshot1.
+//  2. mutateFn(snapshot1) produces the proposed write value.
+//  3. getFn is called again to capture snapshot2 immediately before writing.
+//  4. equalsFn(snapshot1, snapshot2) is called; if they differ, Update returns a
+//     ConflictError immediately — conflicts are never retried.
+//  5. setFn(ctx, proposed) is called; on success, nil is returned.
+//
+// If setFn returns a non-nil, non-ConflictError error, the entire sequence retries
+// up to maxRetries additional times (1 + maxRetries total attempts). Each retry starts
+// with a fresh getFn call — stale snapshots are never reused.
+//
+// The returned ConflictError has Diff populated from equalsFn; Command and Namespace
+// are left empty and must be filled in by the calling command layer before surfacing
+// the error to the user.
+func Update[T any](
+	ctx context.Context,
+	getFn func(context.Context) (T, error),
+	mutateFn func(T) T,
+	setFn func(context.Context, T) error,
+	equalsFn func(T, T) (bool, string),
+	maxRetries int,
+) error {
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		// Step 1: capture initial snapshot.
+		snapshot1, err := getFn(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Step 2: apply mutation to produce the proposed value.
+		proposed := mutateFn(snapshot1)
+
+		// Step 3: re-fetch immediately before writing.
+		snapshot2, err := getFn(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Step 4: compare snapshot1 (at-read) vs snapshot2 (pre-write).
+		// A difference means a concurrent modification — fail fast, never retry.
+		equal, diff := equalsFn(snapshot1, snapshot2)
+		if !equal {
+			return ConflictError{Diff: diff}
+		}
+
+		// Step 5: write the proposed value.
+		err = setFn(ctx, proposed)
+		if err == nil {
+			return nil
+		}
+
+		// ConflictError from setFn is never retried.
+		var ce ConflictError
+		if errors.As(err, &ce) {
+			return err
+		}
+
+		// On the last attempt, return the error as-is.
+		if attempt == maxRetries {
+			return err
+		}
+		// Otherwise, loop — next iteration re-fetches from scratch.
+	}
+	return nil
+}

--- a/internal/providers/instrumentation/rmw/update_test.go
+++ b/internal/providers/instrumentation/rmw/update_test.go
@@ -1,0 +1,306 @@
+package rmw_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation/rmw"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// simpleString is a trivial type used to test the generic Update function
+// without depending on App or Cluster types.
+type simpleString = string
+
+// errTransient is a sentinel transient error for testing retry behaviour.
+var errTransient = errors.New("transient error")
+
+func TestUpdate(t *testing.T) {
+	tests := []struct {
+		name string
+		// getFn returns values in sequence; the last value is returned for all
+		// subsequent calls beyond the sequence length.
+		getSequence []simpleString
+		// getFn errors; nil means no error for that call index.
+		getErrors []error
+		// mutateFn appends "-mutated" to the input.
+		// setErrors[i] is the error returned by the i-th setFn call.
+		setErrors  []error
+		maxRetries int
+		// wantErr is the expected error type / value checked via errors.Is. nil means success.
+		wantErr error
+		// wantAnyErr checks that any non-nil error is returned (for dynamic errors).
+		wantAnyErr   bool
+		wantConflict bool
+		// wantSetCalls is the expected number of setFn calls.
+		wantSetCalls int
+		// wantGetCalls is the expected total number of getFn calls.
+		wantGetCalls int
+	}{
+		{
+			name:         "success on first attempt",
+			getSequence:  []simpleString{"v1", "v1"},
+			setErrors:    []error{nil},
+			maxRetries:   3,
+			wantSetCalls: 1,
+			wantGetCalls: 2,
+		},
+		{
+			name:         "success after one transient setFn error",
+			getSequence:  []simpleString{"v1", "v1", "v1", "v1"},
+			setErrors:    []error{errTransient, nil},
+			maxRetries:   3,
+			wantSetCalls: 2,
+			wantGetCalls: 4,
+		},
+		{
+			name:         "fails after exhausting maxRetries on persistent transient error",
+			getSequence:  []simpleString{"v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1"},
+			setErrors:    []error{errTransient, errTransient, errTransient, errTransient},
+			maxRetries:   3,
+			wantErr:      errTransient,
+			wantSetCalls: 4,
+			wantGetCalls: 8,
+		},
+		{
+			name: "conflict detected — no retry, no setFn call",
+			// snapshot1 == "v1", snapshot2 == "v2" → conflict
+			getSequence:  []simpleString{"v1", "v2"},
+			maxRetries:   3,
+			wantConflict: true,
+			wantSetCalls: 0,
+			wantGetCalls: 2,
+		},
+		{
+			name:         "maxRetries=0 — single attempt, setFn fails → return error",
+			getSequence:  []simpleString{"v1", "v1"},
+			setErrors:    []error{errTransient},
+			maxRetries:   0,
+			wantErr:      errTransient,
+			wantSetCalls: 1,
+			wantGetCalls: 2,
+		},
+		{
+			name:         "getFn error on first call propagates immediately",
+			getErrors:    []error{errors.New("get error")},
+			maxRetries:   3,
+			wantAnyErr:   true,
+			wantSetCalls: 0,
+			wantGetCalls: 1,
+		},
+		{
+			name: "getFn error on second call propagates immediately",
+			// First get succeeds, second get fails.
+			getSequence:  []simpleString{"v1"},
+			getErrors:    []error{nil, errors.New("second get error")},
+			maxRetries:   3,
+			wantAnyErr:   true,
+			wantSetCalls: 0,
+			wantGetCalls: 2,
+		},
+		{
+			name:        "ConflictError from setFn is not retried",
+			getSequence: []simpleString{"v1", "v1"},
+			setErrors: []error{rmw.ConflictError{
+				Command: "clusters enable",
+				Diff:    "costmetrics: false → true",
+			}},
+			maxRetries:   3,
+			wantConflict: true,
+			wantSetCalls: 1,
+			wantGetCalls: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getCalls := 0
+			setCalls := 0
+
+			getFn := func(_ context.Context) (simpleString, error) {
+				idx := getCalls
+				getCalls++
+				// Return error if specified for this index.
+				if idx < len(tt.getErrors) && tt.getErrors[idx] != nil {
+					return "", tt.getErrors[idx]
+				}
+				// Return value from sequence; repeat last value when exhausted.
+				if idx < len(tt.getSequence) {
+					return tt.getSequence[idx], nil
+				}
+				if len(tt.getSequence) > 0 {
+					return tt.getSequence[len(tt.getSequence)-1], nil
+				}
+				return "", nil
+			}
+
+			mutateFn := func(s simpleString) simpleString {
+				return s + "-mutated"
+			}
+
+			setFn := func(_ context.Context, _ simpleString) error {
+				idx := setCalls
+				setCalls++
+				if idx < len(tt.setErrors) {
+					return tt.setErrors[idx]
+				}
+				return nil
+			}
+
+			// equalsFn: equal when the two values are identical strings.
+			equalsFn := func(a, b simpleString) (bool, string) {
+				if a == b {
+					return true, ""
+				}
+				return false, a + " → " + b
+			}
+
+			err := rmw.Update(context.Background(), getFn, mutateFn, setFn, equalsFn, tt.maxRetries)
+
+			switch {
+			case tt.wantConflict:
+				assert.True(t, rmw.IsConflictError(err), "expected ConflictError, got: %v", err)
+			case tt.wantErr != nil:
+				require.ErrorIs(t, err, tt.wantErr)
+			case tt.wantAnyErr:
+				require.Error(t, err, "expected any non-nil error")
+			default:
+				require.NoError(t, err)
+			}
+
+			if tt.wantSetCalls > 0 {
+				assert.Equal(t, tt.wantSetCalls, setCalls, "setFn call count")
+			}
+			if tt.wantGetCalls > 0 {
+				assert.Equal(t, tt.wantGetCalls, getCalls, "getFn call count")
+			}
+		})
+	}
+}
+
+// TestConflictError_ErrorFormat verifies the conflict-message format exactly.
+func TestConflictError_ErrorFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		ce      rmw.ConflictError
+		wantMsg string
+	}{
+		{
+			name: "namespace-level format",
+			ce: rmw.ConflictError{
+				Command:   "apps enable",
+				Namespace: "default",
+				Diff:      "tracing: true → false",
+			},
+			wantMsg: `apps enable: cannot write — namespace "default" was modified concurrently (tracing: true → false). Re-fetch and retry.`,
+		},
+		{
+			name: "cluster-level format",
+			ce: rmw.ConflictError{
+				Command: "clusters enable",
+				Diff:    "costmetrics: false → true",
+			},
+			wantMsg: `clusters enable: cannot write — cluster configuration was modified concurrently (costmetrics: false → true). Re-fetch and retry.`,
+		},
+		{
+			name: "namespace-level with multi-field diff",
+			ce: rmw.ConflictError{
+				Command:   "apps enable",
+				Namespace: "kube-system",
+				Diff:      "tracing: true → false, logging: nil → true",
+			},
+			wantMsg: `apps enable: cannot write — namespace "kube-system" was modified concurrently (tracing: true → false, logging: nil → true). Re-fetch and retry.`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantMsg, tt.ce.Error())
+		})
+	}
+}
+
+// TestUpdate_ConcurrentModification verifies the full conflict scenario:
+// two sequential getFn calls return different App values → Update returns ConflictError.
+func TestUpdate_ConcurrentModification(t *testing.T) {
+	// Simulate: operator 1 reads v1, then operator 2 changes the backend so
+	// the re-check reads v2 — conflict detected, write must not proceed.
+	callCount := 0
+	getFn := func(_ context.Context) (simpleString, error) {
+		callCount++
+		if callCount == 1 {
+			return "snapshot-v1", nil
+		}
+		return "snapshot-v2", nil // concurrent modification
+	}
+
+	mutateFn := func(s simpleString) simpleString { return s + "-enabled" }
+
+	setCalled := false
+	setFn := func(_ context.Context, _ simpleString) error {
+		setCalled = true
+		return nil
+	}
+
+	equalsFn := func(a, b simpleString) (bool, string) {
+		if a == b {
+			return true, ""
+		}
+		return false, "snapshot changed"
+	}
+
+	err := rmw.Update(context.Background(), getFn, mutateFn, setFn, equalsFn, 3)
+
+	require.Error(t, err)
+	assert.True(t, rmw.IsConflictError(err), "expected ConflictError")
+	assert.False(t, setCalled, "setFn must not be called when conflict is detected")
+
+	// Verify that augmenting with command/namespace produces the canonical conflict-error format.
+	var ce rmw.ConflictError
+	require.ErrorAs(t, err, &ce)
+	ce.Command = "apps enable"
+	ce.Namespace = "default"
+	assert.Equal(t,
+		`apps enable: cannot write — namespace "default" was modified concurrently (snapshot changed). Re-fetch and retry.`,
+		ce.Error(),
+	)
+}
+
+// TestIsConflictError verifies the helper function.
+func TestIsConflictError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil is not a ConflictError",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "ConflictError is detected",
+			err:  rmw.ConflictError{Command: "apps enable", Diff: "x"},
+			want: true,
+		},
+		{
+			name: "wrapped ConflictError is detected",
+			err:  fmt.Errorf("outer: %w", rmw.ConflictError{Diff: "x"}),
+			want: true,
+		},
+		{
+			name: "unrelated error is not a ConflictError",
+			err:  errors.New("something else"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rmw.IsConflictError(tt.err))
+		})
+	}
+}

--- a/internal/providers/instrumentation/types.go
+++ b/internal/providers/instrumentation/types.go
@@ -1,0 +1,175 @@
+package instrumentation
+
+// InstrumentationStatus is the proto enum value for the observed state-machine
+// status of a cluster or workload. Values match the fleet-management proto enum
+// directly so they can be forwarded to JSON/YAML output without translation.
+// Use the typed constants below rather than raw strings.
+type InstrumentationStatus string
+
+const (
+	// StatusPendingInstrumentation is emitted when a pipeline is configured but
+	// the Alloy collector has not yet started reporting (kube_node_info / target_info).
+	StatusPendingInstrumentation InstrumentationStatus = "PENDING_INSTRUMENTATION"
+	// StatusInstrumented is emitted when the collector is actively reporting telemetry.
+	StatusInstrumented InstrumentationStatus = "INSTRUMENTED"
+	// StatusPendingUninstrumentation is emitted when instrumentation has been disabled
+	// but the collector has not yet observed the pipeline deletion.
+	StatusPendingUninstrumentation InstrumentationStatus = "PENDING_UNINSTRUMENTATION"
+	// StatusNotInstrumented is the default state: no pipeline configured, no collector reporting.
+	StatusNotInstrumented InstrumentationStatus = "NOT_INSTRUMENTED"
+	// StatusExcluded is set when the user explicitly excluded the cluster via Selection=EXCLUDED.
+	StatusExcluded InstrumentationStatus = "EXCLUDED"
+	// StatusError is defined in the proto but reserved — never set by the current backend.
+	// wait commands MUST exit non-zero if this status is observed.
+	StatusError InstrumentationStatus = "INSTRUMENTATION_ERROR"
+)
+
+// App represents the namespace-level instrumentation configuration for a cluster.
+// App identity in all commands is positional (cluster, namespace) — no metadata.name
+// requirement. NO Selection field. Tri-state *bool fields
+// model "unset / on / off" for read-modify-write flag preservation.
+type App struct {
+	// Name is the Kubernetes namespace name.
+	Name string `json:"name" yaml:"name"`
+	// Autoinstrument is the primary on/off knob for namespace-level Beyla
+	// instrumentation. enable always sets this to true.
+	Autoinstrument *bool `json:"autoInstrument,omitempty" yaml:"autoInstrument,omitempty"`
+	// Tracing controls distributed tracing collection.
+	Tracing *bool `json:"tracing,omitempty" yaml:"tracing,omitempty"`
+	// Logging controls log collection.
+	Logging *bool `json:"logging,omitempty" yaml:"logging,omitempty"`
+	// ProcessMetrics controls process-level metrics collection.
+	ProcessMetrics *bool `json:"processMetrics,omitempty" yaml:"processMetrics,omitempty"`
+	// ExtendedMetrics controls extended Beyla metrics collection.
+	ExtendedMetrics *bool `json:"extendedMetrics,omitempty" yaml:"extendedMetrics,omitempty"`
+	// Profiling controls continuous profiling collection.
+	Profiling *bool `json:"profiling,omitempty" yaml:"profiling,omitempty"`
+	// Apps holds per-workload selection overrides within this namespace.
+	// These are the knobs driven by services include/exclude/clear.
+	Apps []AppOverride `json:"apps,omitempty" yaml:"apps,omitempty"`
+}
+
+// AppOverride represents a per-workload selection override within a namespace.
+// Unlike App, AppOverride retains Selection because the per-workload override IS
+// used by the backend (pkg/instrumentation/v1/k8s_beyla.go) — only the namespace-level
+// Selection is ignored (spec §Backend ground truth).
+type AppOverride struct {
+	// Name is the workload name.
+	Name string `json:"name" yaml:"name"`
+	// Selection is the proto enum value: SELECTION_INCLUDED or SELECTION_EXCLUDED.
+	Selection string `json:"selection" yaml:"selection"`
+}
+
+// Cluster represents the K8s monitoring configuration for a cluster.
+// Selection is retained for serialization correctness and round-trip RMW writes;
+// it must not be user-controllable via flags. Selection appears in JSON and
+// YAML output but NOT in text/wide table output.
+type Cluster struct {
+	// Name is the cluster name.
+	Name string `json:"name" yaml:"name"`
+	// Selection is the backend control field (SELECTION_INCLUDED / SELECTION_EXCLUDED).
+	// Retained for round-trip correctness; not exposed as a flag; always set by the
+	// backend and preserved on writes. Never omitempty — always serialized.
+	Selection string `json:"selection" yaml:"selection"`
+	// CostMetrics controls Kubernetes cost metrics collection.
+	CostMetrics *bool `json:"costMetrics,omitempty" yaml:"costMetrics,omitempty"`
+	// EnergyMetrics controls energy/power metrics collection.
+	EnergyMetrics *bool `json:"energyMetrics,omitempty" yaml:"energyMetrics,omitempty"`
+	// ClusterEvents controls Kubernetes cluster-event collection.
+	ClusterEvents *bool `json:"clusterEvents,omitempty" yaml:"clusterEvents,omitempty"`
+	// NodeLogs controls node-level log collection.
+	NodeLogs *bool `json:"nodeLogs,omitempty" yaml:"nodeLogs,omitempty"`
+}
+
+// NamespaceObservedState holds the observed instrumentation state for a single
+// namespace, populated from RunK8sDiscovery / RunK8sMonitoring. Used for status
+// and wait commands.
+type NamespaceObservedState struct {
+	// Name is the Kubernetes namespace name.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// InstrumentationStatus is the proto state-machine value.
+	InstrumentationStatus InstrumentationStatus `json:"instrumentationStatus,omitempty" yaml:"instrumentationStatus,omitempty"`
+	// InstrumentationErrorMessage is the error message when status is ERROR.
+	InstrumentationErrorMessage string `json:"instrumentationErrorMessage,omitempty" yaml:"instrumentationErrorMessage,omitempty"`
+	// Workloads is the number of observed workloads in this namespace.
+	Workloads int `json:"workloads,omitempty" yaml:"workloads,omitempty"`
+	// Pods is the number of observed pods in this namespace.
+	Pods int `json:"pods,omitempty" yaml:"pods,omitempty"`
+}
+
+// ClusterObservedState holds the observed instrumentation state for a single
+// cluster, populated from RunK8sMonitoring. Used for status and wait commands.
+type ClusterObservedState struct {
+	// Name is the cluster name.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// InstrumentationStatus is the proto state-machine value.
+	InstrumentationStatus InstrumentationStatus `json:"instrumentationStatus,omitempty" yaml:"instrumentationStatus,omitempty"`
+	// InstrumentationErrorMessage is the error message when status is ERROR.
+	InstrumentationErrorMessage string `json:"instrumentationErrorMessage,omitempty" yaml:"instrumentationErrorMessage,omitempty"`
+	// Namespaces holds per-namespace observed state.
+	Namespaces []NamespaceObservedState `json:"namespaces,omitempty" yaml:"namespaces,omitempty"`
+	// Nodes is the number of observed nodes in this cluster.
+	Nodes int `json:"nodes,omitempty" yaml:"nodes,omitempty"`
+	// Workloads is the number of observed workloads in this cluster.
+	Workloads int `json:"workloads,omitempty" yaml:"workloads,omitempty"`
+	// Pods is the number of observed pods in this cluster.
+	Pods int `json:"pods,omitempty" yaml:"pods,omitempty"`
+}
+
+// DiscoveryItem represents a single discovered workload from RunK8sDiscovery.
+// Used by services list/get.
+type DiscoveryItem struct {
+	// ClusterName is the cluster this workload belongs to.
+	ClusterName string `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
+	// Namespace is the Kubernetes namespace.
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	// Name is the workload name.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// WorkloadType is the Kubernetes workload kind (e.g. "deployment", "daemonset").
+	WorkloadType string `json:"workloadType,omitempty" yaml:"workloadType,omitempty"`
+	// DisplayNamespace is the human-friendly namespace display name.
+	DisplayNamespace string `json:"displayNamespace,omitempty" yaml:"displayNamespace,omitempty"`
+	// DisplayName is the human-friendly workload display name.
+	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	// OS is the detected operating system.
+	OS string `json:"os,omitempty" yaml:"os,omitempty"`
+	// Lang is the detected programming language.
+	Lang string `json:"lang,omitempty" yaml:"lang,omitempty"`
+	// InstrumentationStatus is the proto state-machine value for this workload.
+	InstrumentationStatus InstrumentationStatus `json:"instrumentationStatus,omitempty" yaml:"instrumentationStatus,omitempty"`
+}
+
+// Pipeline is a local representation of a fleet-management pipeline, used by
+// the enumerate helper (T5) to detect clusters that have been Set but are not
+// yet reporting survey_info. This type mirrors fleet.Pipeline
+// but lives in this package to avoid a cross-provider import.
+type Pipeline struct {
+	// ID is the pipeline's unique identifier.
+	ID string `json:"id,omitempty"`
+	// Name is the human-readable pipeline name.
+	Name string `json:"name,omitempty"`
+	// Enabled reports whether the pipeline is active.
+	Enabled *bool `json:"enabled,omitempty"`
+	// Metadata holds arbitrary key/value pairs used for pipeline categorization.
+	// The enumerate helper filters by K8s monitoring pipeline metadata keys.
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// IsEmptyDefaultCluster returns true when the backend returned a fully
+// zero-valued K8SInstrumentation response for an unknown cluster name.
+// The backend returns HTTP 200 with a zero-valued proto for unknown
+// identifiers, so the client must detect the not-found case itself.
+//
+// Detection: selection is empty AND every flag is nil or false.
+// A non-empty selection or any flag set to true is a positive registration signal.
+func IsEmptyDefaultCluster(c Cluster) bool {
+	if c.Selection != "" {
+		return false
+	}
+	for _, b := range []*bool{c.CostMetrics, c.EnergyMetrics, c.ClusterEvents, c.NodeLogs} {
+		if b != nil && *b {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/providers/instrumentation/types_test.go
+++ b/internal/providers/instrumentation/types_test.go
@@ -1,0 +1,305 @@
+package instrumentation_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInstrumentationStatusConstants verifies that the typed InstrumentationStatus
+// constants match the proto enum string values expected by the backend.
+func TestInstrumentationStatusConstants(t *testing.T) {
+	tests := []struct {
+		status instrumentation.InstrumentationStatus
+		want   string
+	}{
+		{instrumentation.StatusPendingInstrumentation, "PENDING_INSTRUMENTATION"},
+		{instrumentation.StatusInstrumented, "INSTRUMENTED"},
+		{instrumentation.StatusPendingUninstrumentation, "PENDING_UNINSTRUMENTATION"},
+		{instrumentation.StatusNotInstrumented, "NOT_INSTRUMENTED"},
+		{instrumentation.StatusExcluded, "EXCLUDED"},
+		{instrumentation.StatusError, "INSTRUMENTATION_ERROR"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			assert.Equal(t, tt.want, string(tt.status))
+		})
+	}
+}
+
+// TestApp_NoSelectionField verifies that App does NOT have a Selection field
+// and DOES have an Autoinstrument field.
+func TestApp_NoSelectionField(t *testing.T) {
+	app := instrumentation.App{
+		Name:           "default",
+		Autoinstrument: boolPtr(true), //nolint:modernize // ptr() creates pointer to value, not pointer to type like new()
+		Tracing:        boolPtr(true), //nolint:modernize
+	}
+
+	data, err := json.Marshal(app)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Contains(t, m, "name", "App must serialize name")
+	assert.Contains(t, m, "autoInstrument", "App must serialize autoInstrument")
+	assert.NotContains(t, m, "selection", "App must NOT have a selection field")
+}
+
+// TestApp_TriStateFields verifies that nil *bool fields are omitted from JSON
+// (supporting the tri-state "unset = preserve" semantics).
+func TestApp_TriStateFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		app        instrumentation.App
+		wantFields []string
+		wantAbsent []string
+	}{
+		{
+			name:       "all fields nil — only name serialized",
+			app:        instrumentation.App{Name: "kube-system"},
+			wantFields: []string{"name"},
+			wantAbsent: []string{"autoInstrument", "tracing", "logging", "processMetrics", "extendedMetrics", "profiling"},
+		},
+		{
+			name: "autoinstrument true — field present",
+			app: instrumentation.App{
+				Name:           "default",
+				Autoinstrument: boolPtr(true), //nolint:modernize // ptr() creates pointer to value, not pointer to type like new()
+			},
+			wantFields: []string{"name", "autoInstrument"},
+			wantAbsent: []string{"tracing", "logging"},
+		},
+		{
+			name: "autoinstrument false — field present (explicit off)",
+			app: instrumentation.App{
+				Name:           "default",
+				Autoinstrument: boolPtr(false), //nolint:modernize
+			},
+			wantFields: []string{"name", "autoInstrument"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.app)
+			require.NoError(t, err)
+
+			var m map[string]any
+			require.NoError(t, json.Unmarshal(data, &m))
+
+			for _, f := range tt.wantFields {
+				assert.Contains(t, m, f, "field %q should be present", f)
+			}
+			for _, f := range tt.wantAbsent {
+				assert.NotContains(t, m, f, "field %q should be absent", f)
+			}
+		})
+	}
+}
+
+// TestCluster_SelectionField verifies that Cluster retains a Selection field
+// and that it appears in JSON output even when empty (no omitempty).
+func TestCluster_SelectionField(t *testing.T) {
+	cluster := instrumentation.Cluster{
+		Name:      "prod-1",
+		Selection: "SELECTION_INCLUDED",
+	}
+
+	data, err := json.Marshal(cluster)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Contains(t, m, "selection", "Cluster MUST have selection field")
+	assert.Equal(t, "SELECTION_INCLUDED", m["selection"])
+}
+
+// TestCluster_SelectionAlwaysPresent verifies that selection appears even when
+// empty (no omitempty — selection is always present in JSON/YAML).
+func TestCluster_SelectionAlwaysPresent(t *testing.T) {
+	cluster := instrumentation.Cluster{Name: "prod-1"}
+
+	data, err := json.Marshal(cluster)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	_, ok := m["selection"]
+	assert.True(t, ok, "selection field must always be present in JSON output (no omitempty)")
+}
+
+// TestAppOverride_HasSelection verifies that AppOverride retains a Selection field
+// (the per-workload override knob IS used by the backend).
+func TestAppOverride_HasSelection(t *testing.T) {
+	override := instrumentation.AppOverride{
+		Name:      "web-server",
+		Selection: "SELECTION_EXCLUDED",
+	}
+
+	data, err := json.Marshal(override)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Contains(t, m, "name")
+	assert.Contains(t, m, "selection")
+	assert.Equal(t, "SELECTION_EXCLUDED", m["selection"])
+}
+
+// TestDiscoveryItem_InstrumentationStatus verifies that DiscoveryItem can hold
+// the typed InstrumentationStatus and serializes correctly.
+func TestDiscoveryItem_InstrumentationStatus(t *testing.T) {
+	item := instrumentation.DiscoveryItem{
+		ClusterName:           "prod-1",
+		Namespace:             "default",
+		Name:                  "web",
+		WorkloadType:          "deployment",
+		InstrumentationStatus: instrumentation.StatusInstrumented,
+	}
+
+	data, err := json.Marshal(item)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Equal(t, "INSTRUMENTED", m["instrumentationStatus"])
+}
+
+// TestClusterObservedState_FullRoundTrip verifies that ClusterObservedState
+// round-trips through JSON correctly.
+func TestClusterObservedState_FullRoundTrip(t *testing.T) {
+	state := instrumentation.ClusterObservedState{
+		Name:                  "prod-1",
+		InstrumentationStatus: instrumentation.StatusPendingInstrumentation,
+		Namespaces: []instrumentation.NamespaceObservedState{
+			{
+				Name:                  "default",
+				InstrumentationStatus: instrumentation.StatusInstrumented,
+				Workloads:             3,
+				Pods:                  9,
+			},
+		},
+		Nodes:     5,
+		Workloads: 3,
+		Pods:      9,
+	}
+
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	var got instrumentation.ClusterObservedState
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, state.Name, got.Name)
+	assert.Equal(t, state.InstrumentationStatus, got.InstrumentationStatus)
+	require.Len(t, got.Namespaces, 1)
+	assert.Equal(t, instrumentation.StatusInstrumented, got.Namespaces[0].InstrumentationStatus)
+}
+
+// TestCluster_JSONCamelCase verifies that Cluster uses camelCase JSON keys (D.4).
+func TestCluster_JSONCamelCase(t *testing.T) {
+	tval := true
+	c := instrumentation.Cluster{
+		Name:          "prod-eu",
+		Selection:     "SELECTION_INCLUDED",
+		CostMetrics:   &tval,
+		ClusterEvents: &tval,
+	}
+	data, err := json.Marshal(c)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.Contains(t, m, "costMetrics", "must use camelCase key costMetrics")
+	assert.NotContains(t, m, "costmetrics", "must not use lowercase costmetrics")
+	assert.Contains(t, m, "clusterEvents")
+	assert.Contains(t, m, "selection")
+	assert.Contains(t, m, "name")
+}
+
+// TestApp_JSONCamelCase verifies that App uses camelCase JSON keys (D.4).
+func TestApp_JSONCamelCase(t *testing.T) {
+	tval := true
+	a := instrumentation.App{
+		Name:            "checkout",
+		ProcessMetrics:  &tval,
+		ExtendedMetrics: &tval,
+		Autoinstrument:  &tval,
+	}
+	data, err := json.Marshal(a)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.Contains(t, m, "processMetrics")
+	assert.Contains(t, m, "extendedMetrics")
+	assert.Contains(t, m, "autoInstrument")
+	assert.NotContains(t, m, "processmetrics")
+	assert.NotContains(t, m, "autoinstrument")
+}
+
+// TestIsEmptyDefaultCluster verifies that IsEmptyDefaultCluster correctly detects
+// a zero-valued Cluster response from the backend (indicating unknown cluster name).
+// The backend returns HTTP 200 with a zero-valued proto for unknown identifiers,
+// so the client must detect the not-found case itself.
+func TestIsEmptyDefaultCluster(t *testing.T) {
+	boolFalse := false
+	boolTrue := true
+	tests := []struct {
+		name string
+		cl   instrumentation.Cluster
+		want bool
+	}{
+		{
+			name: "fully zero-valued — not-found signal",
+			cl:   instrumentation.Cluster{Name: "does-not-exist", Selection: ""},
+			want: true,
+		},
+		{
+			name: "all flags explicitly false — still empty-default",
+			cl: instrumentation.Cluster{
+				Name:          "does-not-exist",
+				Selection:     "",
+				CostMetrics:   &boolFalse,
+				EnergyMetrics: &boolFalse,
+				ClusterEvents: &boolFalse,
+				NodeLogs:      &boolFalse,
+			},
+			want: true,
+		},
+		{
+			name: "non-empty selection — registered cluster",
+			cl:   instrumentation.Cluster{Name: "k3d", Selection: "SELECTION_INCLUDED"},
+			want: false,
+		},
+		{
+			name: "one flag true — registered cluster",
+			cl: instrumentation.Cluster{
+				Name:        "k3d",
+				Selection:   "",
+				CostMetrics: &boolTrue,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := instrumentation.IsEmptyDefaultCluster(tt.cl)
+			if got != tt.want {
+				t.Errorf("IsEmptyDefaultCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+//nolint:modernize // ptr() creates pointer to value, not pointer to type like new()
+func boolPtr(b bool) *bool { return &b }

--- a/internal/providers/instrumentation/wait.go
+++ b/internal/providers/instrumentation/wait.go
@@ -1,0 +1,66 @@
+package instrumentation
+
+import "errors"
+
+// ErrWaitTimeoutEmitted is a sentinel returned by wait commands after they have
+// already emitted a fused WaitResult (with Error populated) to stdout.
+// The fail converter chain recognises this sentinel and SUPPRESSES the secondary
+// DetailedError JSON envelope — the WaitResult is the only payload.
+var ErrWaitTimeoutEmitted = errors.New("wait: timeout emitted")
+
+// WaitOutcome classifies a proto InstrumentationStatus into one of three
+// terminal states for the wait polling loop.
+type WaitOutcome int
+
+const (
+	// WaitPending means continue polling.
+	WaitPending WaitOutcome = iota
+	// WaitSuccess means the command should exit 0.
+	WaitSuccess
+	// WaitError means the command should exit non-zero.
+	WaitError
+)
+
+// ClassifyK8sMonitoringStatus classifies a K8sMonitoringStatus wire value
+// (from RunK8sMonitoring) for use by clusters wait.
+//
+// The wire returns full proto enum names like K8S_MONITORING_STATUS_INSTRUMENTED.
+// The classifier matches these full names, and also accepts shorthand constants
+// for backward compatibility with test fixtures.
+func ClassifyK8sMonitoringStatus(s InstrumentationStatus) WaitOutcome {
+	switch s {
+	// Full proto enum names from wire (terminal success states)
+	case "K8S_MONITORING_STATUS_INSTRUMENTED", "K8S_MONITORING_STATUS_EXCLUDED":
+		return WaitSuccess
+	case "K8S_MONITORING_STATUS_ERROR":
+		return WaitError
+	// Shorthand constants (for test compatibility)
+	case StatusInstrumented, StatusExcluded:
+		return WaitSuccess
+	case StatusError:
+		return WaitError
+	default:
+		// Covers UNSPECIFIED, NOT_INSTRUMENTED, PENDING_INSTRUMENTATION,
+		// PENDING_UNINSTRUMENTATION, and any future unknown values.
+		return WaitPending
+	}
+}
+
+// ClassifyInstrumentationStatus classifies a DiscoveryItem InstrumentationStatus
+// wire value (from RunK8sDiscovery) for use by apps wait.
+//
+// The two proto families differ only in the error variant name:
+//
+//	K8sMonitoringStatus uses ERROR; DiscoveryItem uses INSTRUMENTATION_ERROR.
+func ClassifyInstrumentationStatus(s InstrumentationStatus) WaitOutcome {
+	switch s {
+	case "INSTRUMENTATION_STATUS_INSTRUMENTED", "INSTRUMENTATION_STATUS_EXCLUDED":
+		return WaitSuccess
+	case "INSTRUMENTATION_STATUS_INSTRUMENTATION_ERROR":
+		return WaitError
+	default:
+		// Covers UNSPECIFIED, NOT_INSTRUMENTED, PENDING_INSTRUMENTATION,
+		// PENDING_UNINSTRUMENTATION, and any future unknown values.
+		return WaitPending
+	}
+}

--- a/internal/providers/instrumentation/wait_test.go
+++ b/internal/providers/instrumentation/wait_test.go
@@ -1,0 +1,57 @@
+package instrumentation_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+)
+
+func TestClassifyK8sMonitoringStatus(t *testing.T) {
+	tests := []struct {
+		status instrumentation.InstrumentationStatus
+		want   instrumentation.WaitOutcome
+	}{
+		{"K8S_MONITORING_STATUS_UNSPECIFIED", instrumentation.WaitPending},
+		{"K8S_MONITORING_STATUS_NOT_INSTRUMENTED", instrumentation.WaitPending},
+		{"K8S_MONITORING_STATUS_INSTRUMENTED", instrumentation.WaitSuccess},
+		{"K8S_MONITORING_STATUS_PENDING_INSTRUMENTATION", instrumentation.WaitPending},
+		{"K8S_MONITORING_STATUS_ERROR", instrumentation.WaitError},
+		{"K8S_MONITORING_STATUS_EXCLUDED", instrumentation.WaitSuccess},
+		{"K8S_MONITORING_STATUS_PENDING_UNINSTRUMENTATION", instrumentation.WaitPending},
+		{"", instrumentation.WaitPending},
+		{"UNKNOWN_VALUE", instrumentation.WaitPending},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := instrumentation.ClassifyK8sMonitoringStatus(tt.status)
+			if got != tt.want {
+				t.Errorf("ClassifyK8sMonitoringStatus(%q) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyInstrumentationStatus(t *testing.T) {
+	tests := []struct {
+		status instrumentation.InstrumentationStatus
+		want   instrumentation.WaitOutcome
+	}{
+		{"INSTRUMENTATION_STATUS_UNSPECIFIED", instrumentation.WaitPending},
+		{"INSTRUMENTATION_STATUS_NOT_INSTRUMENTED", instrumentation.WaitPending},
+		{"INSTRUMENTATION_STATUS_INSTRUMENTED", instrumentation.WaitSuccess},
+		{"INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION", instrumentation.WaitPending},
+		{"INSTRUMENTATION_STATUS_INSTRUMENTATION_ERROR", instrumentation.WaitError},
+		{"INSTRUMENTATION_STATUS_EXCLUDED", instrumentation.WaitSuccess},
+		{"INSTRUMENTATION_STATUS_PENDING_UNINSTRUMENTATION", instrumentation.WaitPending},
+		{"", instrumentation.WaitPending},
+		{"UNKNOWN_VALUE", instrumentation.WaitPending},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := instrumentation.ClassifyInstrumentationStatus(tt.status)
+			if got != tt.want {
+				t.Errorf("ClassifyInstrumentationStatus(%q) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds the internal Instrumentation Hub provider package that backs the `gcx instrumentation` command tree. The CLI command surfaces land in subsequent stack PRs.

The `internal/providers/instrumentation` package provides:

- Typed connect-go client wrapping fleet-management RPCs: `SetupK8sDiscovery`, `SetK8sInstrumentation`, `GetK8SInstrumentation`, `GetAppInstrumentation`, `ListPipelines`, `RunK8sMonitoring`, `RunK8sDiscovery`
- Declared/observed-state types with selection-enum tri-state semantics
- Output codecs for list/get/wait/mutation envelopes and a helm-snippet formatter
- Enumerate helper for the cluster-set merge and RMW compare/update helpers with optimistic-lock guard

Four new error converters are registered in the fail package: Instrumentation RMW conflict errors, mutually exclusive flag pairs from setup, fleet HTTP 401/403 typed errors, and `ErrWaitTimeoutEmitted` suppression. Tests exercise each via the public `ErrorToDetailedError` surface.

Architecture documentation is updated to split the setup section into "Setup" and new "Instrumentation Hub" subsections; ADR-002 records the action-verb redesign rationale with rejected alternatives and amendment history.

## Why

The provider package is a prerequisite for all subsequent CLI command PRs in this stack. Isolating it in its own PR lets the foundational types, client, and codecs be reviewed independently before the CLI layer is added on top.

Error converters are registered here rather than in the CLI PRs because they handle errors typed in this package; deferring them would leave the stack in a broken state at intermediate commits.

## How it was tested

- [x] `go test ./internal/providers/instrumentation/...` — all tests pass; test-to-impl ratio approximately 57% across the rmw, output, enumerate, helm, and typed client sub-packages
- [x] `go test ./cmd/gcx/fail/...` — error converter tests pass via the public `ErrorToDetailedError` surface
- [x] `go build ./cmd/gcx/` — binary builds cleanly; provider does not self-register until the next stack PR adds the blank import

## Related

- Relates to #597

---
**Generated by Claude Code**

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #655** 👈
  * **PR #656**
    * **PR #657**
      * **PR #658**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->
