### PR TITLE
feat(instrumentation): add clusters CLI subtree (gcx instrumentation clusters)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ cmd/gcx/
   commands/     Commands catalog (agent metadata)
   helptree/     Help tree for agent context
   setup/        Onboarding + instrumentation
+  instrumentation/  Instrumentation Hub commands (clusters list/get/configure/remove/wait; clusters apps subtree)
   skills/       Portable Agent Skills installer for .agents-compatible tools
   dev/          Developer tools (import, scaffold, generate, lint, serve)
   fail/         Structured error conversion

--- a/cmd/gcx/instrumentation/clusters/apps/command.go
+++ b/cmd/gcx/instrumentation/clusters/apps/command.go
@@ -1,0 +1,88 @@
+// Package apps provides the "gcx instrumentation clusters apps" subcommand tree:
+// list, get, configure, remove, wait — all scoped to a single cluster's
+// namespace-level Beyla instrumentation configuration.
+//
+// The apps tree operates on:
+//   - Declared state:  GetAppInstrumentation / SetAppInstrumentation (per-cluster blob)
+//   - Observed state:  RunK8sDiscovery (fleet-wide workload status, filtered client-side)
+//
+// Read-modify-write (RMW) operations use the rmw.Update helper (T4) with AppEqual
+// as the equality function for client-side optimistic-lock detection.
+// All write operations preserve other namespaces' entries byte-equal.
+package apps
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/spf13/cobra"
+)
+
+// appsClient is the minimal interface required by this package's commands.
+// The real *instrumentation.Client satisfies this interface; tests use fakes.
+type appsClient interface {
+	GetAppInstrumentation(ctx context.Context, clusterName string) (*instrumentation.GetAppInstrumentationResponse, error)
+	SetAppInstrumentation(ctx context.Context, clusterName string, namespaces []instrumentation.App, urls instrumentation.BackendURLs) error
+	RunK8sDiscovery(ctx context.Context, promHeaders instrumentation.PromHeaders) (*instrumentation.RunK8sDiscoveryResponse, error)
+	IsNamespaceDiscovered(ctx context.Context, promHeaders instrumentation.PromHeaders, cluster, namespace string) (bool, error)
+	ListPipelines(ctx context.Context) ([]instrumentation.Pipeline, error)
+}
+
+// appClientFactory is a deferred client constructor. It is called inside each
+// command's RunE — after cobra has parsed all flags (including --context) — so
+// client construction is always lazy and never happens at Command() call time.
+//
+// Returning all three values from a single call ensures a single
+// fleet.LoadClientWithStack round-trip per command invocation.
+type appClientFactory = func(ctx context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error)
+
+// factoryFromLoader returns an appClientFactory that lazily constructs the
+// instrumentation client from the given fleet.ConfigLoader.
+//
+// The loader is captured eagerly (at Command() call time), but the actual client
+// construction (fleet.LoadClientWithStack call) is deferred until the returned
+// function is invoked inside a command's RunE.
+func factoryFromLoader(loader fleet.ConfigLoader) appClientFactory {
+	return func(ctx context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
+		r, err := fleet.LoadClientWithStack(ctx, loader)
+		if err != nil {
+			return nil, instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, fmt.Errorf("apps: %w", err)
+		}
+		return instrumentation.NewClient(r.Client),
+			instrumentation.BackendURLsFromStack(r.Stack),
+			instrumentation.PromHeadersFromStack(r.Stack), nil
+	}
+}
+
+// Command returns the cobra parent command for the apps subtree.
+// Subcommands: list, get, configure, remove, wait.
+// The command is registered into clusters/command.go.
+//
+// loader is used to lazily construct the instrumentation client inside each
+// subcommand's RunE, after the --context flag has been parsed by cobra.
+func Command(loader fleet.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "apps",
+		Short: "Manage namespace-level Beyla instrumentation for a cluster",
+		Long: `Manage namespace-level Beyla auto-instrumentation configuration for a cluster.
+
+Commands operate on the declared state stored in Grafana Cloud's
+instrumentation service (GetAppInstrumentation / SetAppInstrumentation).
+The wait command reads observed state from RunK8sDiscovery.
+
+Identity is positional: configure and remove take <cluster> and <namespace> as
+the first two positional arguments.`,
+	}
+
+	factory := factoryFromLoader(loader)
+
+	cmd.AddCommand(makeListCmd(factory))
+	cmd.AddCommand(makeGetCmd(factory))
+	cmd.AddCommand(makeConfigureCmd(factory))
+	cmd.AddCommand(makeRemoveCmd(factory))
+	cmd.AddCommand(makeWaitCmd(factory))
+
+	return cmd
+}

--- a/cmd/gcx/instrumentation/clusters/apps/configure.go
+++ b/cmd/gcx/instrumentation/clusters/apps/configure.go
@@ -1,0 +1,378 @@
+package apps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instoutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation/rmw"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type configureOpts struct {
+	useDefaults     bool
+	yes             bool
+	tracing         bool
+	logging         bool
+	processMetrics  bool
+	extendedMetrics bool
+	profiling       bool
+}
+
+func (o *configureOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.useDefaults, "use-defaults", false, "Apply all-on canonical defaults. Requires --yes.")
+	flags.BoolVar(&o.yes, "yes", false, "Confirm the --use-defaults operation (required with --use-defaults)")
+	flags.BoolVar(&o.tracing, "tracing", false, "Set distributed tracing collection. Pass --tracing=false to disable.")
+	flags.BoolVar(&o.logging, "logging", false, "Set log collection. Pass --logging=false to disable.")
+	flags.BoolVar(&o.processMetrics, "process-metrics", false, "Set process-level metrics collection. Pass --process-metrics=false to disable.")
+	flags.BoolVar(&o.extendedMetrics, "extended-metrics", false, "Set extended Beyla metrics collection. Pass --extended-metrics=false to disable.")
+	flags.BoolVar(&o.profiling, "profiling", false, "Set continuous profiling collection. Pass --profiling=false to disable.")
+}
+
+// Validate of the mutually-exclusive-mode and --yes-required-for-defaults rules
+// requires inspecting flags.Changed(), which depends on the *cobra.Command
+// instance. Those checks live in the RunE body where the command is in scope.
+// Keeping Validate as a no-op here satisfies the canonical opts pattern.
+func (o *configureOpts) Validate() error { return nil }
+
+// makeConfigureCmd builds the "apps configure <cluster> <namespace>" command.
+//
+// Two mutually exclusive modes:
+//
+//  1. --use-defaults --yes: overwrites the namespace entry with all-on defaults
+//     (Autoinstrument=true, all signals true).
+//
+//  2. One or more --<feat> flags: RMW update — only the explicitly-set flags
+//     are changed; unspecified flags preserve their current value.
+//
+// factory is called inside RunE — after cobra has parsed all flags — to
+// lazily construct the appsClient and BackendURLs.
+func makeConfigureCmd(factory appClientFactory) *cobra.Command {
+	opts := &configureOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "configure <cluster> <namespace>",
+		Short: "Configure Beyla instrumentation for a namespace",
+		Long: `Configure Beyla auto-instrumentation for a namespace within the given cluster.
+
+Two mutually exclusive modes:
+
+  --use-defaults --yes
+      Apply all-on canonical defaults, overwriting current state. Requires --yes.
+      Defaults: autoinstrument=true, all signals enabled.
+
+  --<feat>[=true|false] (one or more)
+      Set listed features; unspecified features preserve their current value (RMW).
+      Idempotent. No confirmation required.
+
+Combining --use-defaults with any --<feat> flag is an error.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			client, urls, promHeaders, err := factory(ctx)
+			if err != nil {
+				return err
+			}
+			cluster := args[0]
+			namespace := args[1]
+
+			flags := cmd.Flags()
+			useDefaultsSet := flags.Changed("use-defaults")
+			anyFeatureSet := flags.Changed("tracing") || flags.Changed("logging") ||
+				flags.Changed("process-metrics") || flags.Changed("extended-metrics") ||
+				flags.Changed("profiling")
+
+			if useDefaultsSet && anyFeatureSet {
+				return errors.New("apps configure: --use-defaults and feature flags are mutually exclusive")
+			}
+			if !useDefaultsSet && !anyFeatureSet {
+				return errors.New("apps configure: requires either --use-defaults --yes or one or more --<feat> flags")
+			}
+
+			// --use-defaults mode: overwrite with all-on defaults, requires --yes.
+			if useDefaultsSet { //nolint:nestif // inherited control flow complexity from RMW/use-defaults modes; extracting further reduces readability without reducing actual nesting
+				if !opts.yes {
+					return errors.New("apps configure --use-defaults: --yes is required to confirm this operation")
+				}
+				resp, err := client.GetAppInstrumentation(ctx, cluster)
+				if err != nil {
+					return err
+				}
+				defaults := defaultAppConfig(namespace)
+				updated := replaceOrAppendNamespace(resp.Namespaces, namespace, defaults)
+				if equal, _ := appListEqual(resp.Namespaces, updated); equal {
+					// No write — discover post-state before emitting result.
+					disc, discErr := client.IsNamespaceDiscovered(ctx, promHeaders, cluster, namespace)
+					if discErr != nil {
+						return fmt.Errorf("apps configure: %w", discErr)
+					}
+					return instoutput.MutationResult{
+						Action:     "configure",
+						Target:     instoutput.Target{Cluster: cluster, Namespace: namespace},
+						Changed:    false,
+						Discovered: boolPtr(disc), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+					}.Emit(cmd.OutOrStdout())
+				}
+				if err := client.SetAppInstrumentation(ctx, cluster, updated, urls); err != nil {
+					return err
+				}
+				// Discover post-write state.
+				disc, discErr := client.IsNamespaceDiscovered(ctx, promHeaders, cluster, namespace)
+				if discErr != nil {
+					return fmt.Errorf("apps configure: %w", discErr)
+				}
+				return instoutput.MutationResult{
+					Action:     "configure",
+					Target:     instoutput.Target{Cluster: cluster, Namespace: namespace},
+					Changed:    true,
+					Discovered: boolPtr(disc), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				}.Emit(cmd.OutOrStdout())
+			}
+
+			// RMW mode: set listed flags, preserve unspecified.
+
+			// Pre-check: compute resolved post-state and skip write if no-op.
+			preResp, err := client.GetAppInstrumentation(ctx, cluster)
+			if err != nil {
+				return err
+			}
+			pre := preResp.Namespaces
+			post := applyAppMutations(pre, namespace, flags,
+				opts.tracing, opts.logging, opts.processMetrics, opts.extendedMetrics, opts.profiling)
+			if equal, _ := appListEqual(pre, post); equal {
+				disc, discErr := client.IsNamespaceDiscovered(ctx, promHeaders, cluster, namespace)
+				if discErr != nil {
+					return fmt.Errorf("apps configure: %w", discErr)
+				}
+				return instoutput.MutationResult{
+					Action:     "configure",
+					Target:     instoutput.Target{Cluster: cluster, Namespace: namespace},
+					Changed:    false,
+					Discovered: boolPtr(disc), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				}.Emit(cmd.OutOrStdout())
+			}
+
+			getFn := func(ctx context.Context) ([]instrumentation.App, error) {
+				resp, err := client.GetAppInstrumentation(ctx, cluster)
+				if err != nil {
+					return nil, err
+				}
+				return resp.Namespaces, nil
+			}
+			mutateFn := func(namespaces []instrumentation.App) []instrumentation.App {
+				return applyAppMutations(namespaces, namespace, flags,
+					opts.tracing, opts.logging, opts.processMetrics, opts.extendedMetrics, opts.profiling)
+			}
+			setFn := func(ctx context.Context, namespaces []instrumentation.App) error {
+				return client.SetAppInstrumentation(ctx, cluster, namespaces, urls)
+			}
+
+			err = rmw.Update(ctx, getFn, mutateFn, setFn, appListEqual, 2)
+			if err != nil {
+				var ce rmw.ConflictError
+				if errors.As(err, &ce) {
+					ce.Command = "apps configure"
+					ce.Namespace = namespace
+					return ce
+				}
+				return err
+			}
+			// Discover post-write state.
+			disc, discErr := client.IsNamespaceDiscovered(ctx, promHeaders, cluster, namespace)
+			if discErr != nil {
+				return fmt.Errorf("apps configure: %w", discErr)
+			}
+			return instoutput.MutationResult{
+				Action:     "configure",
+				Target:     instoutput.Target{Cluster: cluster, Namespace: namespace},
+				Changed:    true,
+				Discovered: boolPtr(disc), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+			}.Emit(cmd.OutOrStdout())
+		},
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// newConfigureCmd is a test-facing constructor that injects a pre-built appsClient
+// and BackendURLs. Production code uses makeConfigureCmd(factoryFromLoader(loader)) instead.
+func newConfigureCmd(client appsClient, urls instrumentation.BackendURLs) *cobra.Command {
+	return makeConfigureCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
+		return client, urls, instrumentation.PromHeaders{}, nil
+	})
+}
+
+// defaultAppConfig returns all-on canonical defaults for --use-defaults mode.
+func defaultAppConfig(name string) instrumentation.App {
+	t := true
+	return instrumentation.App{
+		Name:            name,
+		Autoinstrument:  &t,
+		Tracing:         &t,
+		Logging:         &t,
+		ProcessMetrics:  &t,
+		ExtendedMetrics: &t,
+		Profiling:       &t,
+	}
+}
+
+// replaceOrAppendNamespace replaces the entry with the given name in namespaces,
+// or appends it if not found. Returns a new slice; does not modify the input.
+func replaceOrAppendNamespace(namespaces []instrumentation.App, name string, entry instrumentation.App) []instrumentation.App {
+	result := make([]instrumentation.App, 0, len(namespaces)+1)
+	found := false
+	for _, ns := range namespaces {
+		if ns.Name == name {
+			result = append(result, entry)
+			found = true
+		} else {
+			result = append(result, ns)
+		}
+	}
+	if !found {
+		result = append(result, entry)
+	}
+	return result
+}
+
+// applyAppMutations applies Autoinstrument=true and the given flag mutations
+// to the target namespace within the full list. If the namespace is not present, a
+// new entry is inserted. Other namespace entries are returned unchanged.
+//
+// Only flags that have been explicitly set (cobra flags.Changed) are applied.
+func applyAppMutations(
+	namespaces []instrumentation.App,
+	target string,
+	flags interface{ Changed(name string) bool },
+	tracing, logging, processMetrics, extendedMetrics, profiling bool,
+) []instrumentation.App {
+	result := make([]instrumentation.App, 0, len(namespaces)+1)
+	found := false
+
+	for _, ns := range namespaces {
+		if ns.Name != target {
+			result = append(result, ns)
+			continue
+		}
+		found = true
+		result = append(result, applyMutationsToNS(ns, flags, tracing, logging, processMetrics, extendedMetrics, profiling))
+	}
+
+	if !found {
+		result = append(result, newNamespaceEntry(target, flags, tracing, logging, processMetrics, extendedMetrics, profiling))
+	}
+
+	return result
+}
+
+// applyMutationsToNS applies Autoinstrument=true and flag mutations to
+// an existing namespace entry. Returns a new copy; does not modify the input.
+func applyMutationsToNS(
+	ns instrumentation.App,
+	flags interface{ Changed(name string) bool },
+	tracing, logging, processMetrics, extendedMetrics, profiling bool,
+) instrumentation.App {
+	t := true
+	ns.Autoinstrument = &t
+	if flags.Changed("tracing") {
+		ns.Tracing = boolPtr(tracing) //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+	}
+	if flags.Changed("logging") {
+		ns.Logging = boolPtr(logging) //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+	}
+	if flags.Changed("process-metrics") {
+		ns.ProcessMetrics = boolPtr(processMetrics) //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+	}
+	if flags.Changed("extended-metrics") {
+		ns.ExtendedMetrics = boolPtr(extendedMetrics) //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+	}
+	if flags.Changed("profiling") {
+		ns.Profiling = boolPtr(profiling) //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+	}
+	return ns
+}
+
+// newNamespaceEntry builds a fresh namespace entry with Autoinstrument=true and
+// the given flag mutations applied. Used when the namespace is absent
+// from the current configuration.
+func newNamespaceEntry(
+	name string,
+	flags interface{ Changed(name string) bool },
+	tracing, logging, processMetrics, extendedMetrics, profiling bool,
+) instrumentation.App {
+	t := true
+	ns := instrumentation.App{
+		Name:           name,
+		Autoinstrument: &t,
+	}
+	if flags.Changed("tracing") {
+		ns.Tracing = boolPtr(tracing) //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+	}
+	if flags.Changed("logging") {
+		ns.Logging = boolPtr(logging) //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+	}
+	if flags.Changed("process-metrics") {
+		ns.ProcessMetrics = boolPtr(processMetrics) //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+	}
+	if flags.Changed("extended-metrics") {
+		ns.ExtendedMetrics = boolPtr(extendedMetrics) //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+	}
+	if flags.Changed("profiling") {
+		ns.Profiling = boolPtr(profiling) //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+	}
+	return ns
+}
+
+// boolPtr returns a pointer to the given bool value.
+//
+//nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+func boolPtr(b bool) *bool { return &b }
+
+// appListEqual compares two namespace lists for equality. Comparison is by
+// namespace name key; ordering differences within each namespace's Apps[] are
+// handled by rmw.AppEqual. Returns (true, "") when equal; (false, diff) when not.
+func appListEqual(a, b []instrumentation.App) (bool, string) {
+	// Build maps by name for order-independent comparison.
+	aMap := make(map[string]instrumentation.App, len(a))
+	for _, ns := range a {
+		aMap[ns.Name] = ns
+	}
+	bMap := make(map[string]instrumentation.App, len(b))
+	for _, ns := range b {
+		bMap[ns.Name] = ns
+	}
+
+	var diffs []string
+
+	// Check for removed or changed entries (in a, absent or changed in b).
+	for name, aNS := range aMap {
+		bNS, ok := bMap[name]
+		if !ok {
+			diffs = append(diffs, "removed namespace: "+name)
+			continue
+		}
+		if equal, d := rmw.AppEqual(aNS, bNS); !equal {
+			diffs = append(diffs, d)
+		}
+	}
+
+	// Check for added entries (in b, absent in a).
+	for name := range bMap {
+		if _, ok := aMap[name]; !ok {
+			diffs = append(diffs, "added namespace: "+name)
+		}
+	}
+
+	if len(diffs) == 0 {
+		return true, ""
+	}
+	return false, strings.Join(diffs, "; ")
+}

--- a/cmd/gcx/instrumentation/clusters/apps/configure_test.go
+++ b/cmd/gcx/instrumentation/clusters/apps/configure_test.go
@@ -1,0 +1,429 @@
+//nolint:testpackage,modernize // tests require access to unexported fakeAppsClient; boolp(true) != new(bool) (creates *false)
+package apps
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/grafana/gcx/internal/providers/instrumentation/rmw"
+)
+
+func TestConfigureCmd(t *testing.T) {
+	tests := []struct {
+		name               string
+		args               []string
+		initial            []instrumentation.App
+		wantErr            string
+		wantNS             *instrumentation.App
+		wantOtherPreserved string
+		wantOtherApps      []instrumentation.AppOverride
+		wantNoSet          bool  // true when SetAppInstrumentation must NOT be called (no-op)
+		wantChanged        *bool // nil means "don't check"; pointer to expected value
+	}{
+		{
+			name:    "no flags → error",
+			args:    []string{"c1", "grotshop"},
+			initial: nil,
+			wantErr: "requires either --use-defaults --yes or one or more --<feat> flags",
+		},
+		{
+			name:    "--use-defaults without --yes → error",
+			args:    []string{"c1", "grotshop", "--use-defaults"},
+			initial: nil,
+			wantErr: "--yes is required",
+		},
+		{
+			name:    "--use-defaults with feature flag → mutually exclusive error",
+			args:    []string{"c1", "grotshop", "--use-defaults", "--tracing"},
+			initial: nil,
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "--use-defaults --yes: applies all-on defaults",
+			args:    []string{"c1", "grotshop", "--use-defaults", "--yes"},
+			initial: nil,
+			wantNS: &instrumentation.App{
+				Name:            "grotshop",
+				Autoinstrument:  boolp(true),
+				Tracing:         boolp(true),
+				Logging:         boolp(true),
+				ProcessMetrics:  boolp(true),
+				ExtendedMetrics: boolp(true),
+				Profiling:       boolp(true),
+			},
+		},
+		{
+			name:    "configure new namespace — autoinstrument set true",
+			args:    []string{"c1", "grotshop", "--tracing"},
+			initial: nil,
+			wantNS: &instrumentation.App{
+				Name:           "grotshop",
+				Autoinstrument: boolp(true),
+				Tracing:        boolp(true),
+			},
+		},
+		{
+			name: "configure with --tracing=false sets tracing=false",
+			args: []string{"c1", "grotshop", "--tracing=false"},
+			initial: []instrumentation.App{
+				{Name: "grotshop", Autoinstrument: boolp(true), Tracing: boolp(true)},
+			},
+			wantNS: &instrumentation.App{
+				Name:           "grotshop",
+				Autoinstrument: boolp(true),
+				Tracing:        boolp(false),
+			},
+		},
+		{
+			// other namespaces including their apps[] overrides must be
+			// byte-equal after configure on a different namespace.
+			name: "preserves checkout namespace with apps[] overrides",
+			args: []string{"c1", "grotshop", "--tracing"},
+			initial: []instrumentation.App{
+				{Name: "grotshop", Autoinstrument: boolp(true)},
+				{
+					Name:           "checkout",
+					Autoinstrument: boolp(true),
+					Apps: []instrumentation.AppOverride{
+						{Name: "payment-svc", Selection: "SELECTION_INCLUDED"},
+					},
+				},
+			},
+			wantNS: &instrumentation.App{
+				Name:           "grotshop",
+				Autoinstrument: boolp(true),
+				Tracing:        boolp(true),
+			},
+			wantOtherPreserved: "checkout",
+			wantOtherApps: []instrumentation.AppOverride{
+				{Name: "payment-svc", Selection: "SELECTION_INCLUDED"},
+			},
+		},
+		{
+			// Idempotent re-run: existing state already matches desired state.
+			// SetAppInstrumentation must NOT be called; changed: false.
+			name: "idempotent re-run same flags — no write, changed:false",
+			args: []string{"c1", "grotshop", "--tracing", "--logging"},
+			initial: []instrumentation.App{
+				{
+					Name:           "grotshop",
+					Autoinstrument: boolp(true),
+					Tracing:        boolp(true),
+					Logging:        boolp(true),
+				},
+			},
+			wantNoSet:   true,
+			wantChanged: boolp(false),
+		},
+		{
+			// Partial idempotent: only one flag changes — write must happen; changed: true.
+			name: "flip one flag — write happens, changed:true",
+			args: []string{"c1", "grotshop", "--logging"},
+			initial: []instrumentation.App{
+				{
+					Name:           "grotshop",
+					Autoinstrument: boolp(true),
+					Tracing:        boolp(true),
+					Logging:        boolp(false),
+				},
+			},
+			wantNS: &instrumentation.App{
+				Name:           "grotshop",
+				Autoinstrument: boolp(true),
+				Logging:        boolp(true),
+			},
+			wantChanged: boolp(true),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Supply three identical GET responses to cover all paths:
+			//   - pre-check GET (RMW mode: before deciding to write)
+			//   - rmw.Update's first GET
+			//   - rmw.Update's re-check GET
+			// use-defaults mode only needs one GET, extra responses don't hurt.
+			responses := []getResponse{
+				{namespaces: tc.initial},
+				{namespaces: tc.initial},
+				{namespaces: tc.initial},
+			}
+			client := &fakeAppsClient{getResponses: responses}
+
+			cmd := newConfigureCmd(client, instrumentation.BackendURLs{})
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("expected error %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.wantNoSet {
+				if len(client.setCalls) != 0 {
+					t.Errorf("expected SetAppInstrumentation NOT to be called (no-op), but got %d call(s)", len(client.setCalls))
+				}
+			} else {
+				if len(client.setCalls) == 0 {
+					t.Fatal("expected SetAppInstrumentation to be called")
+				}
+				assertConfigureNSState(t, client.setCalls[len(client.setCalls)-1].namespaces, tc.wantNS, tc.wantOtherPreserved, tc.wantOtherApps)
+			}
+
+			if tc.wantChanged != nil {
+				// Output is JSON in agent mode ("changed":true / "changed":false)
+				// or human-readable text in non-agent mode ("done" / "no changes").
+				// Accept both formats to be environment-independent.
+				outStr := out.String()
+				var wantStr, humanStr string
+				if *tc.wantChanged {
+					wantStr, humanStr = `"changed":true`, "done"
+				} else {
+					wantStr, humanStr = `"changed":false`, "no changes"
+				}
+				if !strings.Contains(outStr, wantStr) && !strings.Contains(outStr, humanStr) {
+					t.Errorf("output %q does not indicate changed=%v", outStr, *tc.wantChanged)
+				}
+			}
+		})
+	}
+}
+
+// TestConfigureCmd_ConflictError tests concurrent configure produces a
+// ConflictError with the correct command/namespace fields in the error message.
+func TestConfigureCmd_ConflictError(t *testing.T) {
+	client := &fakeAppsClient{
+		getResponses: []getResponse{
+			// Pre-check GET: tracing=false (state differs from desired, proceed to rmw).
+			{namespaces: []instrumentation.App{
+				{Name: "grotshop", Autoinstrument: boolp(true), Tracing: boolp(false)},
+			}},
+			// rmw first GET: tracing=false.
+			{namespaces: []instrumentation.App{
+				{Name: "grotshop", Autoinstrument: boolp(true), Tracing: boolp(false)},
+			}},
+			// rmw re-check GET (pre-write): tracing=true — simulates a concurrent change.
+			{namespaces: []instrumentation.App{
+				{Name: "grotshop", Autoinstrument: boolp(true), Tracing: boolp(true)},
+			}},
+		},
+	}
+
+	cmd := newConfigureCmd(client, instrumentation.BackendURLs{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"c1", "grotshop", "--tracing"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !rmw.IsConflictError(err) {
+		t.Fatalf("expected ConflictError, got %T: %v", err, err)
+	}
+	errStr := err.Error()
+	for _, want := range []string{"apps configure", "grotshop", "cannot write"} {
+		if !strings.Contains(errStr, want) {
+			t.Errorf("error missing %q: %q", want, errStr)
+		}
+	}
+}
+
+// TestAppListEqual tests the internal appListEqual helper.
+func TestAppListEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     []instrumentation.App
+		wantEq   bool
+		wantDiff string
+	}{
+		{"empty lists", nil, nil, true, ""},
+		{"same single ns", buildNamespaces(true, "ns1"), buildNamespaces(true, "ns1"), true, ""},
+		{
+			"added namespace in b",
+			buildNamespaces(true, "ns1"),
+			buildNamespaces(true, "ns1", "ns2"),
+			false, "added namespace: ns2",
+		},
+		{
+			"removed namespace in b",
+			buildNamespaces(true, "ns1", "ns2"),
+			buildNamespaces(true, "ns1"),
+			false, "removed namespace: ns2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			eq, diff := appListEqual(tc.a, tc.b)
+			if eq != tc.wantEq {
+				t.Errorf("equal: want %v, got %v (diff=%q)", tc.wantEq, eq, diff)
+			}
+			if tc.wantDiff != "" && !strings.Contains(diff, tc.wantDiff) {
+				t.Errorf("diff: want %q in %q", tc.wantDiff, diff)
+			}
+		})
+	}
+}
+
+// TestConfigureCmd_Discovered verifies that the MutationResult returned by
+// apps configure includes the discovered field reflecting RunK8sDiscovery state
+// at the time of the call. Tested directly on the MutationResult by
+// invoking configure in agent mode (GCX_AGENT_MODE=true) so JSON output is emitted.
+func TestConfigureCmd_Discovered(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		initial        []instrumentation.App
+		discoverItems  []instrumentation.DiscoveryItem
+		wantDiscovered bool
+	}{
+		{
+			name:    "namespace discovered after write",
+			args:    []string{"c1", "grotshop", "--tracing"},
+			initial: nil,
+			discoverItems: []instrumentation.DiscoveryItem{
+				{ClusterName: "c1", Namespace: "grotshop", Name: "svc"},
+			},
+			wantDiscovered: true,
+		},
+		{
+			name:           "namespace not discovered after write",
+			args:           []string{"c1", "grotshop", "--tracing"},
+			initial:        nil,
+			discoverItems:  nil,
+			wantDiscovered: false,
+		},
+		{
+			// Idempotent (no-op) path: discovered field still present.
+			name: "idempotent configure — namespace discovered",
+			args: []string{"c1", "grotshop", "--tracing"},
+			initial: []instrumentation.App{
+				{Name: "grotshop", Autoinstrument: boolp(true), Tracing: boolp(true)},
+			},
+			discoverItems: []instrumentation.DiscoveryItem{
+				{ClusterName: "c1", Namespace: "grotshop", Name: "svc"},
+			},
+			wantDiscovered: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Enable agent mode so MutationResult.Emit() outputs JSON.
+			// agent.IsAgentMode() uses a cached init()-time value, so ResetForTesting()
+			// must be called after t.Setenv to re-run detection from the new env.
+			t.Setenv("GCX_AGENT_MODE", "true")
+			agent.ResetForTesting()
+			t.Cleanup(func() { agent.ResetForTesting() }) // restore after test
+
+			responses := []getResponse{
+				{namespaces: tc.initial},
+				{namespaces: tc.initial},
+				{namespaces: tc.initial},
+			}
+			client := &fakeAppsClient{
+				getResponses:  responses,
+				discoverItems: tc.discoverItems,
+			}
+
+			cmd := newConfigureCmd(client, instrumentation.BackendURLs{})
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tc.args)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// In agent mode, MutationResult.Emit() outputs JSON.
+			outStr := strings.TrimSpace(out.String())
+			if !strings.HasPrefix(outStr, "{") {
+				t.Fatalf("expected JSON output in agent mode, got: %q", outStr)
+			}
+			var result map[string]any
+			if err := json.Unmarshal([]byte(outStr), &result); err != nil {
+				t.Fatalf("failed to parse JSON output: %v\noutput: %s", err, outStr)
+			}
+			disc, ok := result["discovered"]
+			if !ok {
+				t.Fatalf("expected 'discovered' field in JSON output: %s", outStr)
+			}
+			if disc != tc.wantDiscovered {
+				t.Errorf("discovered: want %v, got %v\noutput: %s", tc.wantDiscovered, disc, outStr)
+			}
+		})
+	}
+}
+
+// assertConfigureNSState verifies the target namespace state and other-namespace preservation.
+func assertConfigureNSState(t *testing.T, setNSs []instrumentation.App, wantNS *instrumentation.App, wantOther string, wantOtherApps []instrumentation.AppOverride) {
+	t.Helper()
+	if wantNS == nil {
+		return
+	}
+
+	found := false
+	for _, ns := range setNSs {
+		if ns.Name != wantNS.Name {
+			continue
+		}
+		found = true
+		if wantNS.Autoinstrument != nil && (ns.Autoinstrument == nil || *ns.Autoinstrument != *wantNS.Autoinstrument) {
+			t.Errorf("autoinstrument: want %v, got %v", *wantNS.Autoinstrument, ns.Autoinstrument)
+		}
+		if wantNS.Tracing != nil && (ns.Tracing == nil || *ns.Tracing != *wantNS.Tracing) {
+			t.Errorf("tracing: want %v, got %v", *wantNS.Tracing, ns.Tracing)
+		}
+		if wantNS.Logging != nil && (ns.Logging == nil || *ns.Logging != *wantNS.Logging) {
+			t.Errorf("logging: want %v, got %v", *wantNS.Logging, ns.Logging)
+		}
+		if wantNS.ProcessMetrics != nil && (ns.ProcessMetrics == nil || *ns.ProcessMetrics != *wantNS.ProcessMetrics) {
+			t.Errorf("process-metrics: want %v, got %v", *wantNS.ProcessMetrics, ns.ProcessMetrics)
+		}
+		if wantNS.ExtendedMetrics != nil && (ns.ExtendedMetrics == nil || *ns.ExtendedMetrics != *wantNS.ExtendedMetrics) {
+			t.Errorf("extended-metrics: want %v, got %v", *wantNS.ExtendedMetrics, ns.ExtendedMetrics)
+		}
+		if wantNS.Profiling != nil && (ns.Profiling == nil || *ns.Profiling != *wantNS.Profiling) {
+			t.Errorf("profiling: want %v, got %v", *wantNS.Profiling, ns.Profiling)
+		}
+	}
+	if !found {
+		t.Errorf("namespace %q not found in set payload", wantNS.Name)
+	}
+
+	if wantOther == "" {
+		return
+	}
+	for _, ns := range setNSs {
+		if ns.Name != wantOther {
+			continue
+		}
+		if len(ns.Apps) != len(wantOtherApps) {
+			t.Errorf("other namespace apps: want %d overrides, got %d", len(wantOtherApps), len(ns.Apps))
+			return
+		}
+		for i, ov := range ns.Apps {
+			if ov.Name != wantOtherApps[i].Name || ov.Selection != wantOtherApps[i].Selection {
+				t.Errorf("other namespace apps[%d]: want %+v, got %+v", i, wantOtherApps[i], ov)
+			}
+		}
+	}
+}

--- a/cmd/gcx/instrumentation/clusters/apps/fake_test.go
+++ b/cmd/gcx/instrumentation/clusters/apps/fake_test.go
@@ -1,0 +1,133 @@
+//nolint:testpackage,modernize // internal fake needs access to unexported types; boolp(true) != new(bool)
+package apps
+
+import (
+	"context"
+	"sync"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+)
+
+// fakeAppsClient is a test double for appsClient.
+// It tracks calls and allows tests to inject controlled responses.
+type fakeAppsClient struct {
+	mu sync.Mutex
+
+	// getResponses is the queue of GetAppInstrumentation responses to return.
+	// Each call pops the first response; if empty, returns the last response.
+	getResponses []getResponse
+
+	// getCalls counts how many times GetAppInstrumentation was called.
+	getCalls int
+
+	// setErr is the error to return from SetAppInstrumentation.
+	setErr error
+
+	// discoverItems is the list returned by RunK8sDiscovery.
+	discoverItems []instrumentation.DiscoveryItem
+
+	// discoverErr is the error to return from RunK8sDiscovery / IsNamespaceDiscovered.
+	discoverErr error
+
+	// setCalls records the arguments passed to SetAppInstrumentation.
+	setCalls []setCall
+
+	// pipelines is the list returned by ListPipelines.
+	pipelines []instrumentation.Pipeline
+
+	// listPipelinesErr is the error to return from ListPipelines.
+	listPipelinesErr error
+}
+
+type getResponse struct {
+	namespaces []instrumentation.App
+	err        error
+}
+
+type setCall struct {
+	clusterName string
+	namespaces  []instrumentation.App
+}
+
+func (f *fakeAppsClient) GetAppInstrumentation(_ context.Context, clusterName string) (*instrumentation.GetAppInstrumentationResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.getCalls++
+	_ = clusterName
+	if len(f.getResponses) == 0 {
+		return &instrumentation.GetAppInstrumentationResponse{Namespaces: nil}, nil
+	}
+	resp := f.getResponses[0]
+	if len(f.getResponses) > 1 {
+		f.getResponses = f.getResponses[1:]
+	}
+	if resp.err != nil {
+		return nil, resp.err
+	}
+	return &instrumentation.GetAppInstrumentationResponse{Namespaces: resp.namespaces}, nil
+}
+
+func (f *fakeAppsClient) SetAppInstrumentation(_ context.Context, clusterName string, namespaces []instrumentation.App, _ instrumentation.BackendURLs) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.setCalls = append(f.setCalls, setCall{clusterName: clusterName, namespaces: namespaces})
+	return f.setErr
+}
+
+func (f *fakeAppsClient) RunK8sDiscovery(_ context.Context, _ instrumentation.PromHeaders) (*instrumentation.RunK8sDiscoveryResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.discoverErr != nil {
+		return nil, f.discoverErr
+	}
+	return &instrumentation.RunK8sDiscoveryResponse{Items: f.discoverItems}, nil
+}
+
+func (f *fakeAppsClient) IsNamespaceDiscovered(_ context.Context, _ instrumentation.PromHeaders, cluster, namespace string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.discoverErr != nil {
+		return false, f.discoverErr
+	}
+	for _, item := range f.discoverItems {
+		if item.ClusterName == cluster && item.Namespace == namespace {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *fakeAppsClient) ListPipelines(_ context.Context) ([]instrumentation.Pipeline, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.pipelines, f.listPipelinesErr
+}
+
+// helpers
+
+func boolp(b bool) *bool { return &b }
+
+// buildNamespaces creates an App slice from the given namespace names with
+// all signal flags set to the given value.
+//
+//nolint:unparam // allOn is always true in current tests; keep the param for future false cases.
+func buildNamespaces(allOn bool, names ...string) []instrumentation.App {
+	apps := make([]instrumentation.App, 0, len(names))
+	for _, name := range names {
+		apps = append(apps, instrumentation.App{
+			Name:            name,
+			Autoinstrument:  boolp(allOn),
+			Tracing:         boolp(allOn),
+			Logging:         boolp(allOn),
+			ProcessMetrics:  boolp(allOn),
+			ExtendedMetrics: boolp(allOn),
+			Profiling:       boolp(allOn),
+		})
+	}
+	return apps
+}

--- a/cmd/gcx/instrumentation/clusters/apps/get.go
+++ b/cmd/gcx/instrumentation/clusters/apps/get.go
@@ -1,0 +1,121 @@
+package apps
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instoutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/cobra"
+)
+
+// makeGetCmd builds the "apps get <cluster> <namespace>" command.
+// Calls GetAppInstrumentation, filters client-side to <namespace>.
+// Emits a CLI-level not-found error when the namespace is absent.
+//
+// factory is called inside RunE — after cobra has parsed all flags — to
+// lazily construct the appsClient.
+func makeGetCmd(factory appClientFactory) *cobra.Command {
+	opts := &output.Options{}
+	opts.DefaultFormat("text")
+	opts.RegisterCustomCodec("text", &instoutput.AppTableCodec{Wide: false})
+	opts.RegisterCustomCodec("wide", &instoutput.AppTableCodec{Wide: true})
+	opts.SetJSONFieldValidator(output.MakeFieldValidator(instoutput.AppView{}))
+
+	cmd := &cobra.Command{
+		Use:   "get <cluster> <namespace>",
+		Short: "Get the app instrumentation entry for a single namespace",
+		Long: `Get the declared Beyla instrumentation configuration for a single namespace
+within the given cluster.
+
+Reads declared state from GetAppInstrumentation and filters client-side to the
+requested namespace. Exits non-zero with a not-found error when the
+namespace has no declared configuration.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, _, promHeaders, err := factory(ctx)
+			if err != nil {
+				return err
+			}
+			cluster := args[0]
+			namespace := args[1]
+
+			resp, err := client.GetAppInstrumentation(ctx, cluster)
+			if err != nil {
+				return err
+			}
+
+			// Cross-reference with RunK8sDiscovery to populate the discovered field.
+			// Discovery RPC error short-circuits — callers can retry.
+			discovered, err := client.IsNamespaceDiscovered(ctx, promHeaders, cluster, namespace)
+			if err != nil {
+				return fmt.Errorf("apps get: %w", err)
+			}
+
+			for _, ns := range resp.Namespaces {
+				if ns.Name != namespace {
+					continue
+				}
+				view := instoutput.AppView{
+					ClusterName:     cluster,
+					Name:            ns.Name,
+					Autoinstrument:  ns.Autoinstrument,
+					Tracing:         ns.Tracing,
+					Logging:         ns.Logging,
+					ProcessMetrics:  ns.ProcessMetrics,
+					ExtendedMetrics: ns.ExtendedMetrics,
+					Profiling:       ns.Profiling,
+					Overrides:       len(ns.Apps),
+					Discovered:      discovered,
+				}
+				// Table/wide codecs expect []AppView; JSON/YAML encode the single view directly.
+				if opts.OutputFormat == "text" || opts.OutputFormat == "wide" {
+					return opts.Encode(cmd.OutOrStdout(), []instoutput.AppView{view})
+				}
+				return opts.Encode(cmd.OutOrStdout(), view)
+			}
+
+			// Namespace is neither declared nor discovered — exit 1.
+			if !discovered {
+				exitCode := fail.ExitGeneralError
+				return &fail.DetailedError{
+					Summary: "Resource not found",
+					Details: fmt.Sprintf("namespace %q not found in cluster %q", namespace, cluster),
+					Suggestions: []string{
+						"Run: gcx instrumentation clusters apps list " + cluster,
+					},
+					ExitCode: &exitCode,
+				}
+			}
+
+			// Namespace is discovered but not declared — show with discovered:true, no config.
+			view := instoutput.AppView{
+				ClusterName: cluster,
+				Name:        namespace,
+				Discovered:  true,
+			}
+			if opts.OutputFormat == "text" || opts.OutputFormat == "wide" {
+				return opts.Encode(cmd.OutOrStdout(), []instoutput.AppView{view})
+			}
+			return opts.Encode(cmd.OutOrStdout(), view)
+		},
+	}
+
+	opts.BindFlags(cmd.Flags())
+	return cmd
+}
+
+// newGetCmd is a test-facing constructor that injects a pre-built appsClient.
+// Production code uses makeGetCmd(factoryFromLoader(loader)) instead.
+func newGetCmd(client appsClient) *cobra.Command {
+	return makeGetCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
+		return client, instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, nil
+	})
+}

--- a/cmd/gcx/instrumentation/clusters/apps/get_test.go
+++ b/cmd/gcx/instrumentation/clusters/apps/get_test.go
@@ -1,0 +1,213 @@
+//nolint:testpackage // tests require access to unexported fakeAppsClient
+package apps
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instoutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+)
+
+func TestGetCmd_JSONOutputShape(t *testing.T) {
+	client := &fakeAppsClient{
+		getResponses: []getResponse{{namespaces: buildNamespaces(true, "grotshop", "checkout")}},
+		discoverItems: []instrumentation.DiscoveryItem{
+			{ClusterName: "c1", Namespace: "grotshop", Name: "svc"},
+		},
+	}
+
+	cmd := newGetCmd(client)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"-o", "json", "c1", "grotshop"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	outStr := strings.TrimSpace(out.String())
+	if strings.HasPrefix(outStr, "[") {
+		t.Errorf("apps get must return single JSON object, not array; got: %s", outStr)
+	}
+	if !strings.HasPrefix(outStr, "{") {
+		t.Errorf("apps get must return single JSON object starting with '{'; got: %s", outStr)
+	}
+}
+
+// TestGetCmd_Discovered covers all four (configured/not, discovered/not) combinations.
+func TestGetCmd_Discovered(t *testing.T) {
+	discoveredItems := []instrumentation.DiscoveryItem{
+		{ClusterName: "c1", Namespace: "grotshop", Name: "svc"},
+	}
+
+	tests := []struct {
+		name           string
+		args           []string
+		namespaces     []instrumentation.App
+		discoverItems  []instrumentation.DiscoveryItem
+		wantDiscovered *bool // nil = check not applicable (error path)
+		wantExitCode   *int  // nil = expect exit 0
+		wantErrSummary string
+		wantJSON       bool
+	}{
+		{
+			// Configured AND discovered → exit 0, discovered:true
+			name:           "configured + discovered — exit 0 discovered true",
+			args:           []string{"-o", "json", "c1", "grotshop"},
+			namespaces:     buildNamespaces(true, "grotshop"),
+			discoverItems:  discoveredItems,
+			wantDiscovered: boolp(true), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+		},
+		{
+			// Configured but NOT discovered → exit 0, discovered:false
+			name:           "configured + not discovered — exit 0 discovered false",
+			args:           []string{"-o", "json", "c1", "grotshop"},
+			namespaces:     buildNamespaces(true, "grotshop"),
+			discoverItems:  nil,
+			wantDiscovered: boolp(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+		},
+		{
+			// NOT configured but discovered → exit 0, discovered:true (show empty view)
+			name:           "not configured + discovered — exit 0 discovered true",
+			args:           []string{"-o", "json", "c1", "grotshop"},
+			namespaces:     nil,
+			discoverItems:  discoveredItems,
+			wantDiscovered: boolp(true), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+		},
+		{
+			// Neither configured nor discovered → exit 1, Resource not found
+			name:           "not configured + not discovered — exit 1",
+			args:           []string{"-o", "json", "c1", "grotshop"},
+			namespaces:     nil,
+			discoverItems:  nil,
+			wantExitCode:   intptr(fail.ExitGeneralError),
+			wantErrSummary: "Resource not found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeAppsClient{
+				getResponses:  []getResponse{{namespaces: tc.namespaces}},
+				discoverItems: tc.discoverItems,
+			}
+
+			cmd := newGetCmd(client)
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+
+			if tc.wantExitCode != nil {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				var de *fail.DetailedError
+				if !errors.As(err, &de) {
+					t.Fatalf("expected *fail.DetailedError, got %T: %v", err, err)
+				}
+				if de.Summary != tc.wantErrSummary {
+					t.Errorf("expected summary %q, got %q", tc.wantErrSummary, de.Summary)
+				}
+				if de.ExitCode == nil || *de.ExitCode != *tc.wantExitCode {
+					t.Errorf("expected exit code %d, got %v", *tc.wantExitCode, de.ExitCode)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.wantDiscovered != nil {
+				var view instoutput.AppView
+				if err2 := json.Unmarshal(out.Bytes(), &view); err2 != nil {
+					t.Fatalf("failed to parse JSON output: %v\noutput: %s", err2, out.String())
+				}
+				if view.Discovered != *tc.wantDiscovered {
+					t.Errorf("expected discovered=%v, got %v\noutput: %s", *tc.wantDiscovered, view.Discovered, out.String())
+				}
+			}
+		})
+	}
+}
+
+func TestGetCmd(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		namespaces    []instrumentation.App
+		discoverItems []instrumentation.DiscoveryItem
+		wantOutput    string
+		wantErr       string
+	}{
+		{
+			name:       "found namespace — declared and discovered",
+			args:       []string{"c1", "grotshop"},
+			namespaces: buildNamespaces(true, "grotshop", "checkout"),
+			discoverItems: []instrumentation.DiscoveryItem{
+				{ClusterName: "c1", Namespace: "grotshop", Name: "svc"},
+			},
+			wantOutput: "grotshop",
+		},
+		{
+			// namespace not in declared list AND not discovered → exit 1 Resource not found
+			name:          "namespace not found — neither declared nor discovered",
+			args:          []string{"c1", "missing"},
+			namespaces:    buildNamespaces(true, "grotshop"),
+			discoverItems: nil,
+			wantErr:       `Resource not found`,
+		},
+		{
+			// namespace not in declared list AND not discovered (empty cluster)
+			name:          "empty cluster — not discovered — not found",
+			args:          []string{"c1", "grotshop"},
+			namespaces:    nil,
+			discoverItems: nil,
+			wantErr:       `Resource not found`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeAppsClient{
+				getResponses:  []getResponse{{namespaces: tc.namespaces}},
+				discoverItems: tc.discoverItems,
+			}
+
+			cmd := newGetCmd(client)
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("expected error %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantOutput != "" && !bytes.Contains(out.Bytes(), []byte(tc.wantOutput)) {
+				t.Errorf("expected output to contain %q, got:\n%s", tc.wantOutput, out.String())
+			}
+		})
+	}
+}
+
+// intptr returns a pointer to an int literal.
+func intptr(i int) *int { return &i } //nolint:modernize // intptr(x) cannot simplify to new(x) — new(int) creates *0, not *x

--- a/cmd/gcx/instrumentation/clusters/apps/list.go
+++ b/cmd/gcx/instrumentation/clusters/apps/list.go
@@ -1,0 +1,105 @@
+package apps
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instoutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/cobra"
+)
+
+// makeListCmd builds the "apps list <cluster>" command.
+// Calls GetAppInstrumentation (single RPC) and returns all namespace
+// entries via the AppTableCodec.
+//
+// factory is called inside RunE — after cobra has parsed all flags — to
+// lazily construct the appsClient.
+func makeListCmd(factory appClientFactory) *cobra.Command {
+	opts := &output.Options{}
+	opts.DefaultFormat("text")
+	opts.RegisterCustomCodec("text", &instoutput.AppTableCodec{Wide: false})
+	opts.RegisterCustomCodec("wide", &instoutput.AppTableCodec{Wide: true})
+	opts.SetJSONFieldValidator(output.MakeFieldValidator(instoutput.AppView{}))
+
+	cmd := &cobra.Command{
+		Use:   "list <cluster>",
+		Short: "List all namespace app instrumentation entries for a cluster",
+		Long: `List all namespace-level Beyla instrumentation entries for the given cluster.
+
+Reads declared state from GetAppInstrumentation (a single RPC call). The output
+reflects the configuration stored in Grafana Cloud, not the live observed state.
+Use "gcx instrumentation status" for observed-state status.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			// --json list (field discovery): introspect AppView shape without
+			// requiring a cluster positional or making any API call.
+			if opts.JSONDiscovery {
+				return opts.Encode(cmd.OutOrStdout(), instoutput.AppListEnvelope{Items: []instoutput.AppView{{}}})
+			}
+
+			if len(args) != 1 {
+				return fmt.Errorf("accepts 1 arg(s), received %d", len(args))
+			}
+
+			ctx := cmd.Context()
+			client, _, promHeaders, err := factory(ctx)
+			if err != nil {
+				return err
+			}
+			cluster := args[0]
+
+			resp, err := client.GetAppInstrumentation(ctx, cluster)
+			if err != nil {
+				return err
+			}
+
+			// Call RunK8sDiscovery once and build a namespace set for this cluster.
+			// This populates the discovered field on each AppView.
+			discResp, err := client.RunK8sDiscovery(ctx, promHeaders)
+			if err != nil {
+				return err
+			}
+			discoveredNS := make(map[string]bool, len(discResp.Items))
+			for _, item := range discResp.Items {
+				if item.ClusterName == cluster {
+					discoveredNS[item.Namespace] = true
+				}
+			}
+
+			views := make([]instoutput.AppView, 0, len(resp.Namespaces))
+			for _, ns := range resp.Namespaces {
+				views = append(views, instoutput.AppView{
+					ClusterName:     cluster,
+					Name:            ns.Name,
+					Discovered:      discoveredNS[ns.Name],
+					Autoinstrument:  ns.Autoinstrument,
+					Tracing:         ns.Tracing,
+					Logging:         ns.Logging,
+					ProcessMetrics:  ns.ProcessMetrics,
+					ExtendedMetrics: ns.ExtendedMetrics,
+					Profiling:       ns.Profiling,
+					Overrides:       len(ns.Apps),
+				})
+			}
+
+			return opts.Encode(cmd.OutOrStdout(), instoutput.AppListEnvelope{Items: views})
+		},
+	}
+
+	opts.BindFlags(cmd.Flags())
+	return cmd
+}
+
+// newListCmd is a test-facing constructor that injects a pre-built appsClient.
+// Production code uses makeListCmd(factoryFromLoader(loader)) instead.
+func newListCmd(client appsClient) *cobra.Command {
+	return makeListCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
+		return client, instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, nil
+	})
+}

--- a/cmd/gcx/instrumentation/clusters/apps/list_test.go
+++ b/cmd/gcx/instrumentation/clusters/apps/list_test.go
@@ -1,0 +1,288 @@
+//nolint:testpackage // tests require access to unexported fakeAppsClient
+package apps
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instoutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListCmd(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespaces []instrumentation.App
+		wantRows   []string
+		wantErr    bool
+	}{
+		{
+			name:       "empty cluster returns empty table",
+			namespaces: nil,
+			wantRows:   nil, // header only
+		},
+		{
+			name:       "single namespace",
+			namespaces: buildNamespaces(true, "grotshop"),
+			wantRows:   []string{"grotshop"},
+		},
+		{
+			name:       "multiple namespaces",
+			namespaces: buildNamespaces(true, "ns-a", "ns-b", "ns-c"),
+			wantRows:   []string{"ns-a", "ns-b", "ns-c"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeAppsClient{
+				getResponses: []getResponse{{namespaces: tc.namespaces}},
+			}
+
+			cmd := newListCmd(client)
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{"c1"})
+
+			err := cmd.Execute()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			output := out.String()
+			for _, row := range tc.wantRows {
+				if !bytes.Contains(out.Bytes(), []byte(row)) {
+					t.Errorf("expected row %q in output, got:\n%s", row, output)
+				}
+			}
+		})
+	}
+}
+
+// TestListCmd_JSONEnvelope_Empty verifies empty apps list outputs
+// {"items":[]} not [] or null.
+func TestListCmd_JSONEnvelope_Empty(t *testing.T) {
+	client := &fakeAppsClient{
+		getResponses: []getResponse{{namespaces: nil}},
+	}
+
+	cmd := newListCmd(client)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--output", "json", "c1"})
+
+	require.NoError(t, cmd.Execute())
+	assert.JSONEq(t, `{"items":[]}`, out.String())
+}
+
+// TestListCmd_JSONEnvelope_NonEmpty verifies non-empty apps list
+// wraps results in {"items":[...]} envelope.
+func TestListCmd_JSONEnvelope_NonEmpty(t *testing.T) {
+	client := &fakeAppsClient{
+		getResponses: []getResponse{{namespaces: buildNamespaces(true, "checkout")}},
+	}
+
+	cmd := newListCmd(client)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--output", "json", "c1"})
+
+	require.NoError(t, cmd.Execute())
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got), "output must be a JSON object; got: %s", out.String())
+	items, ok := got["items"]
+	require.True(t, ok, "output must have 'items' key")
+	itemsSlice, ok := items.([]any)
+	require.True(t, ok)
+	assert.Len(t, itemsSlice, 1)
+}
+
+// TestListCmd_Discovered verifies apps list populates the discovered field
+// from RunK8sDiscovery — items whose namespace appears in the discovery response get
+// discovered:true; others get discovered:false.
+func TestListCmd_Discovered(t *testing.T) {
+	client := &fakeAppsClient{
+		getResponses: []getResponse{{namespaces: buildNamespaces(true, "checkout", "payments")}},
+		discoverItems: []instrumentation.DiscoveryItem{
+			{ClusterName: "c1", Namespace: "checkout"},
+			// "payments" intentionally absent — should surface as discovered:false.
+			{ClusterName: "other-cluster", Namespace: "payments"}, // different cluster — must not count.
+		},
+	}
+
+	cmd := newListCmd(client)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--output", "json", "c1"})
+
+	require.NoError(t, cmd.Execute())
+
+	var envelope instoutput.AppListEnvelope
+	require.NoError(t, json.Unmarshal(out.Bytes(), &envelope), "output must be AppListEnvelope; got: %s", out.String())
+	require.Len(t, envelope.Items, 2)
+
+	byName := make(map[string]instoutput.AppView, len(envelope.Items))
+	for _, item := range envelope.Items {
+		byName[item.Name] = item
+	}
+
+	assert.True(t, byName["checkout"].Discovered, "checkout is in discoverItems for c1 — should be discovered:true")
+	assert.False(t, byName["payments"].Discovered, "payments is absent from c1 discoverItems — should be discovered:false")
+}
+
+// TestListCmd_JSONFieldSelection_Unknown verifies --json bogus,name
+// on apps list returns UnknownFieldSelectionError.
+func TestListCmd_JSONFieldSelection_Unknown(t *testing.T) {
+	client := &fakeAppsClient{
+		getResponses: []getResponse{{namespaces: buildNamespaces(true, "checkout")}},
+	}
+
+	cmd := newListCmd(client)
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"--json", "bogus,name", "c1"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	var fieldErr cmdio.UnknownFieldSelectionError
+	require.ErrorAs(t, err, &fieldErr)
+	assert.Contains(t, fieldErr.Fields, "bogus")
+}
+
+// TestListCmd_JSONFieldSelection_Valid verifies that --json with valid fields
+// applies per-item projection wrapped in {"items":[...]}.
+func TestListCmd_JSONFieldSelection_Valid(t *testing.T) {
+	client := &fakeAppsClient{
+		getResponses: []getResponse{{namespaces: buildNamespaces(true, "checkout")}},
+	}
+
+	cmd := newListCmd(client)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--json", "name", "c1"})
+
+	require.NoError(t, cmd.Execute())
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got), "output must be JSON object; got: %s", out.String())
+	items, ok := got["items"]
+	require.True(t, ok, "output must have 'items' key")
+	itemsSlice, ok := items.([]any)
+	require.True(t, ok)
+	require.Len(t, itemsSlice, 1)
+	firstItem, ok := itemsSlice[0].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, firstItem, "name")
+	assert.NotContains(t, firstItem, "autoInstrument")
+}
+
+// TestListCmd_JSONList verifies that --json list behavior is unchanged (returns
+// field names, one per line, not JSON).
+func TestListCmd_JSONList(t *testing.T) {
+	client := &fakeAppsClient{
+		getResponses: []getResponse{{namespaces: buildNamespaces(true, "checkout")}},
+	}
+
+	cmd := newListCmd(client)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--json", "list", "c1"})
+
+	require.NoError(t, cmd.Execute())
+
+	// Output must NOT be JSON; must be field names one per line.
+	var decoded any
+	require.Error(t, json.Unmarshal(out.Bytes(), &decoded), "--json list output must not be JSON")
+
+	// Must contain known AppView field names.
+	fields := strings.Split(strings.TrimSpace(out.String()), "\n")
+	fieldSet := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		fieldSet[strings.TrimSpace(f)] = true
+	}
+	// All discovered fields from AppView{} must be accepted by --json without error.
+	validator := cmdio.MakeFieldValidator(instoutput.AppView{})
+	require.NotNil(t, validator)
+	require.NoError(t, validator(fields), "all --json list fields must pass the validator")
+}
+
+// TestListCmd_JSONDiscovery_NoClusterArg verifies that --json list with no
+// cluster positional exits 0, prints non-empty discovery output, and never
+// invokes the API client.
+//
+// AC-F2-1 / AC-F2-4.
+func TestListCmd_JSONDiscovery_NoClusterArg(t *testing.T) {
+	client := &fakeAppsClient{}
+
+	cmd := newListCmd(client)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--json", "list"})
+
+	require.NoError(t, cmd.Execute(), "expected exit 0 for --json list with no cluster arg")
+
+	// Output must be non-empty field discovery output (not JSON).
+	require.NotEmpty(t, out.String(), "expected non-empty discovery output")
+	var decoded any
+	require.Error(t, json.Unmarshal(out.Bytes(), &decoded), "--json list output must not be JSON")
+
+	// Output must contain at least one known AppView field.
+	assert.Contains(t, out.String(), "name", "expected 'name' in discovery output")
+
+	// API client must NEVER have been called.
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	assert.Equal(t, 0, client.getCalls, "GetAppInstrumentation must not be called for --json list discovery")
+}
+
+// TestListCmd_NoArgs_NormalOutput verifies that running the command with no
+// args and no --json flag returns a cobra-style validation error and exits 1.
+//
+// AC-F2-2.
+func TestListCmd_NoArgs_NormalOutput(t *testing.T) {
+	client := &fakeAppsClient{}
+
+	cmd := newListCmd(client)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err, "expected error when no cluster arg is given in normal mode")
+	// Error text must match cobra's prior ExactArgs(1) verbatim phrasing.
+	assert.Equal(t, "accepts 1 arg(s), received 0", err.Error())
+}
+
+// TestListCmd_TooManyArgs verifies that two positionals are rejected by cobra's
+// MaximumNArgs(1) validator with the expected error message.
+//
+// AC-F2-2 (upper-bound).
+func TestListCmd_TooManyArgs(t *testing.T) {
+	client := &fakeAppsClient{}
+
+	cmd := newListCmd(client)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"a", "b"})
+
+	err := cmd.Execute()
+	require.Error(t, err, "expected error when two positional args are given")
+	// Error text must match cobra's MaximumNArgs(1) verbatim phrasing.
+	assert.Equal(t, "accepts at most 1 arg(s), received 2", err.Error())
+}

--- a/cmd/gcx/instrumentation/clusters/apps/remove.go
+++ b/cmd/gcx/instrumentation/clusters/apps/remove.go
@@ -1,0 +1,111 @@
+package apps
+
+import (
+	"context"
+	"errors"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instoutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type removeOpts struct {
+	yes bool
+}
+
+func (o *removeOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.yes, "yes", false, "Confirm removal of namespace app instrumentation")
+}
+
+func (o *removeOpts) Validate() error {
+	if !o.yes {
+		return errors.New("apps remove: requires --yes to proceed (this removes namespace app instrumentation)")
+	}
+	return nil
+}
+
+// makeRemoveCmd builds the "apps remove <cluster> <namespace>" command.
+//
+// Removes the namespace entry from the cluster's namespaces[] list via
+// SetAppInstrumentation. Requires --yes to proceed.
+//
+// factory is called inside RunE — after cobra has parsed all flags — to
+// lazily construct the appsClient and BackendURLs.
+func makeRemoveCmd(factory appClientFactory) *cobra.Command {
+	opts := &removeOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "remove <cluster> <namespace>",
+		Short: "Remove Beyla instrumentation for a namespace",
+		Long: `Remove Beyla auto-instrumentation for a namespace by removing its entry
+from the cluster's app instrumentation configuration.
+
+The namespace entry is removed from namespaces[] via a whole-list replacement
+(SetAppInstrumentation). When no namespace entries remain with included content,
+the backend deletes the app pipeline entirely.
+
+This command requires --yes to proceed.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, urls, _, err := factory(ctx)
+			if err != nil {
+				return err
+			}
+			cluster := args[0]
+			namespace := args[1]
+
+			return runAppRemove(ctx, client, cluster, namespace, urls, cmd.OutOrStdout())
+		},
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// runAppRemove performs the core remove logic. Separated from makeRemoveCmd
+// for testability with fake clients.
+func runAppRemove(
+	ctx context.Context,
+	client appsClient,
+	cluster, namespace string,
+	urls instrumentation.BackendURLs,
+	w interface{ Write(p []byte) (int, error) },
+) error {
+	resp, err := client.GetAppInstrumentation(ctx, cluster)
+	if err != nil {
+		return err
+	}
+
+	// Remove the target namespace from the list.
+	updated := make([]instrumentation.App, 0, len(resp.Namespaces))
+	for _, ns := range resp.Namespaces {
+		if ns.Name == namespace {
+			continue
+		}
+		updated = append(updated, ns)
+	}
+
+	if err := client.SetAppInstrumentation(ctx, cluster, updated, urls); err != nil {
+		return err
+	}
+
+	return instoutput.MutationResult{
+		Action:  "remove",
+		Target:  instoutput.Target{Cluster: cluster, Namespace: namespace},
+		Changed: true,
+	}.Emit(w)
+}
+
+// newRemoveCmd is a test-facing constructor that injects a pre-built appsClient
+// and BackendURLs. Production code uses makeRemoveCmd(factoryFromLoader(loader)) instead.
+func newRemoveCmd(client appsClient, urls instrumentation.BackendURLs) *cobra.Command {
+	return makeRemoveCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
+		return client, urls, instrumentation.PromHeaders{}, nil
+	})
+}

--- a/cmd/gcx/instrumentation/clusters/apps/remove_test.go
+++ b/cmd/gcx/instrumentation/clusters/apps/remove_test.go
@@ -1,0 +1,82 @@
+//nolint:testpackage // tests require access to unexported fakeAppsClient
+package apps
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+)
+
+func TestRemoveCmd(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		initial    []instrumentation.App
+		wantErr    string
+		wantSetLen int // expected number of namespaces passed to Set
+	}{
+		{
+			name:    "requires --yes flag",
+			args:    []string{"c1", "grotshop"},
+			initial: buildNamespaces(true, "grotshop"),
+			wantErr: "requires --yes",
+		},
+		{
+			name:       "removes target namespace",
+			args:       []string{"c1", "grotshop", "--yes"},
+			initial:    buildNamespaces(true, "grotshop", "checkout"),
+			wantSetLen: 1, // "checkout" remains
+		},
+		{
+			name:       "removing only namespace results in empty list",
+			args:       []string{"c1", "grotshop", "--yes"},
+			initial:    buildNamespaces(true, "grotshop"),
+			wantSetLen: 0,
+		},
+		{
+			name:       "no-op when namespace not present",
+			args:       []string{"c1", "missing", "--yes"},
+			initial:    buildNamespaces(true, "grotshop"),
+			wantSetLen: 1, // "grotshop" still there
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeAppsClient{
+				getResponses: []getResponse{{namespaces: tc.initial}},
+			}
+
+			cmd := newRemoveCmd(client, instrumentation.BackendURLs{})
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("expected error %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(client.setCalls) == 0 {
+				t.Fatal("expected SetAppInstrumentation to be called")
+			}
+			got := client.setCalls[0].namespaces
+			if len(got) != tc.wantSetLen {
+				t.Errorf("expected %d namespaces after remove, got %d: %+v", tc.wantSetLen, len(got), got)
+			}
+		})
+	}
+}

--- a/cmd/gcx/instrumentation/clusters/apps/wait.go
+++ b/cmd/gcx/instrumentation/clusters/apps/wait.go
@@ -1,0 +1,256 @@
+package apps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instrOutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// pollInterval is the wait poll cadence matching the collector-app UI.
+const pollInterval = 5 * time.Second
+
+type waitOpts struct {
+	timeout time.Duration
+}
+
+func (o *waitOpts) setup(flags *pflag.FlagSet) {
+	flags.DurationVar(&o.timeout, "timeout", 5*time.Minute, "Maximum time to wait (e.g. 5m, 10m, 1h)")
+}
+
+func (o *waitOpts) Validate() error {
+	if o.timeout <= 0 {
+		return errors.New("apps wait: --timeout must be positive")
+	}
+	return nil
+}
+
+// makeWaitCmd builds the "apps wait <cluster> <namespace>" command.
+//
+//   - Polls RunK8sDiscovery at 5-second intervals, filtering client-side to (cluster, namespace).
+//   - Aggregates per-workload statuses to namespace level.
+//   - Exits 0 when the namespace transitions to a non-pending, non-error state.
+//   - Exits non-zero on INSTRUMENTATION_ERROR or timeout.
+//   - Default timeout: 5m.
+//
+// Aggregation rule:
+//   - No items for (cluster, namespace) → treat as PENDING_INSTRUMENTATION (keep polling).
+//   - Any item with INSTRUMENTATION_ERROR → exit non-zero immediately.
+//   - Any item with PENDING_INSTRUMENTATION or PENDING_UNINSTRUMENTATION → keep polling.
+//   - Otherwise (all INSTRUMENTED, EXCLUDED, or other terminal non-error states) → exit 0.
+//
+// factory is called inside RunE — after cobra has parsed all flags — to
+// lazily construct the appsClient and PromHeaders.
+func makeWaitCmd(factory appClientFactory) *cobra.Command {
+	opts := &waitOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "wait <cluster> <namespace>",
+		Short: "Wait for namespace instrumentation to reach a stable state",
+		Long: `Wait for the namespace Beyla instrumentation to transition out of a pending
+state by polling RunK8sDiscovery at 5-second intervals.
+
+Exit 0 when the namespace's workloads reach a stable non-pending state
+(INSTRUMENTED, NOT_INSTRUMENTED, EXCLUDED, or any terminal non-error state).
+
+Exit non-zero when:
+  - INSTRUMENTATION_ERROR is observed for any workload.
+  - The --timeout duration elapses while still in a pending state.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			cluster := args[0]
+			namespace := args[1]
+
+			timeout := opts.timeout
+
+			ctx := cmd.Context()
+			client, _, promHeaders, err := factory(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Capture agent mode once at call site.
+			agentMode := agent.IsAgentMode()
+			stdout := cmd.OutOrStdout()
+			stderr := cmd.ErrOrStderr()
+
+			start := time.Now()
+			deadline := time.Now().Add(timeout)
+			ticker := time.NewTicker(pollInterval)
+			defer ticker.Stop()
+
+			var lastRawStatus instrumentation.InstrumentationStatus
+
+			for {
+				// outcome is WaitOutcome; rawStatus is the wire string for logging.
+				outcome, rawStatus, pollErr := pollNamespaceStatus(ctx, client, promHeaders, cluster, namespace)
+				if pollErr != nil {
+					return fmt.Errorf("apps wait: poll error: %w", pollErr)
+				}
+				lastRawStatus = rawStatus
+
+				switch outcome {
+				case instrumentation.WaitError:
+					return fmt.Errorf("apps wait: namespace %q in cluster %q reached INSTRUMENTATION_ERROR", namespace, cluster)
+				case instrumentation.WaitPending:
+					// Emit per-poll progress to stderr.
+					progress := instrOutput.WaitProgress{
+						Event:     "waiting",
+						Target:    instrOutput.Target{Cluster: cluster, Namespace: namespace},
+						Status:    string(rawStatus),
+						ElapsedMs: time.Since(start).Milliseconds(),
+					}
+					_ = progress.EmitTo(stderr, agentMode)
+				default: // WaitSuccess
+					result := instrOutput.WaitResult{
+						Outcome:   "success",
+						Target:    instrOutput.Target{Cluster: cluster, Namespace: namespace},
+						Status:    string(rawStatus),
+						ElapsedMs: time.Since(start).Milliseconds(),
+					}
+					return result.Emit(stdout, agentMode)
+				}
+
+				remaining := time.Until(deadline)
+				if remaining <= 0 {
+					// Emit fused WaitResult with Error field, then return sentinel.
+					timeoutMsg := fmt.Sprintf("timed out after %s waiting for namespace %q in cluster %q%s",
+						timeout, namespace, cluster, probePipelineMsg(ctx, client, cluster))
+					result := instrOutput.WaitResult{
+						Outcome:   "timeout",
+						Target:    instrOutput.Target{Cluster: cluster, Namespace: namespace},
+						Status:    string(lastRawStatus),
+						ElapsedMs: time.Since(start).Milliseconds(),
+						Error: &instrOutput.WaitError{
+							Summary:  fmt.Sprintf("timed out waiting for namespace %q in cluster %q", namespace, cluster),
+							Details:  timeoutMsg,
+							ExitCode: 1,
+						},
+					}
+					_ = result.Emit(stdout, agentMode)
+					return fmt.Errorf("apps wait: %w", instrumentation.ErrWaitTimeoutEmitted)
+				}
+
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(remaining):
+					// Emit fused WaitResult with Error field, then return sentinel.
+					timeoutMsg := fmt.Sprintf("timed out after %s waiting for namespace %q in cluster %q%s",
+						timeout, namespace, cluster, probePipelineMsg(ctx, client, cluster))
+					result := instrOutput.WaitResult{
+						Outcome:   "timeout",
+						Target:    instrOutput.Target{Cluster: cluster, Namespace: namespace},
+						Status:    string(lastRawStatus),
+						ElapsedMs: time.Since(start).Milliseconds(),
+						Error: &instrOutput.WaitError{
+							Summary:  fmt.Sprintf("timed out waiting for namespace %q in cluster %q", namespace, cluster),
+							Details:  timeoutMsg,
+							ExitCode: 1,
+						},
+					}
+					_ = result.Emit(stdout, agentMode)
+					return fmt.Errorf("apps wait: %w", instrumentation.ErrWaitTimeoutEmitted)
+				case <-ticker.C:
+				}
+			}
+		},
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// newWaitCmd is a test-facing constructor that injects a pre-built appsClient
+// and PromHeaders. Production code uses makeWaitCmd(factoryFromLoader(loader)) instead.
+func newWaitCmd(client appsClient, promHeaders instrumentation.PromHeaders) *cobra.Command {
+	return makeWaitCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
+		return client, instrumentation.BackendURLs{}, promHeaders, nil
+	})
+}
+
+// probePipelineMsg checks whether a Fleet Management pipeline named
+// "beyla_k8s_appo11y_<cluster>" exists and returns a diagnostic suffix for
+// timeout error messages. Returns an empty string when ListPipelines fails so
+// that the diagnostic enrichment never obscures the original timeout cause.
+func probePipelineMsg(ctx context.Context, client appsClient, cluster string) string {
+	pipelineName := "beyla_k8s_appo11y_" + cluster
+	pipelines, err := client.ListPipelines(ctx)
+	if err != nil {
+		return ""
+	}
+	for _, p := range pipelines {
+		if p.Name == pipelineName {
+			return fmt.Sprintf("; Fleet Management pipeline %q exists (may not yet be synced to alloy-daemon)", pipelineName)
+		}
+	}
+	return fmt.Sprintf("; Fleet Management pipeline %q not found — run 'gcx fleet pipelines list' to verify", pipelineName)
+}
+
+// pollNamespaceStatus calls RunK8sDiscovery and aggregates per-workload statuses
+// for the (cluster, namespace) pair. Returns the aggregated WaitOutcome, the
+// representative raw status string for logging, and any RPC error.
+//
+// Aggregation rule:
+//   - No items → (WaitPending, "INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION", nil)
+//   - Any WaitError item → (WaitError, that item's raw status, nil)
+//   - Any WaitPending item → (WaitPending, first pending item's raw status, nil)
+//   - All WaitSuccess → (WaitSuccess, first success item's raw status, nil)
+func pollNamespaceStatus(
+	ctx context.Context,
+	client appsClient,
+	promHeaders instrumentation.PromHeaders,
+	cluster, namespace string,
+) (instrumentation.WaitOutcome, instrumentation.InstrumentationStatus, error) {
+	resp, err := client.RunK8sDiscovery(ctx, promHeaders)
+	if err != nil {
+		return instrumentation.WaitPending, "", err
+	}
+
+	// Filter to (cluster, namespace).
+	var items []instrumentation.DiscoveryItem
+	for _, item := range resp.Items {
+		if item.ClusterName == cluster && item.Namespace == namespace {
+			items = append(items, item)
+		}
+	}
+
+	if len(items) == 0 {
+		return instrumentation.WaitPending,
+			"INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION", nil
+	}
+
+	hasPending := false
+	firstPendingStatus := instrumentation.InstrumentationStatus("")
+	firstSuccessStatus := instrumentation.InstrumentationStatus("")
+
+	for _, item := range items {
+		switch instrumentation.ClassifyInstrumentationStatus(item.InstrumentationStatus) {
+		case instrumentation.WaitError:
+			return instrumentation.WaitError, item.InstrumentationStatus, nil
+		case instrumentation.WaitPending:
+			hasPending = true
+			if firstPendingStatus == "" {
+				firstPendingStatus = item.InstrumentationStatus
+			}
+		default: // WaitSuccess
+			if firstSuccessStatus == "" {
+				firstSuccessStatus = item.InstrumentationStatus
+			}
+		}
+	}
+
+	if hasPending {
+		return instrumentation.WaitPending, firstPendingStatus, nil
+	}
+	return instrumentation.WaitSuccess, firstSuccessStatus, nil
+}

--- a/cmd/gcx/instrumentation/clusters/apps/wait_test.go
+++ b/cmd/gcx/instrumentation/clusters/apps/wait_test.go
@@ -1,0 +1,302 @@
+//nolint:testpackage // tests require access to unexported pollNamespaceStatus and fakeAppsClient
+package apps
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+)
+
+func TestPollNamespaceStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		items         []instrumentation.DiscoveryItem
+		cluster       string
+		namespace     string
+		wantOutcome   instrumentation.WaitOutcome
+		wantRawStatus instrumentation.InstrumentationStatus
+		wantErr       bool
+	}{
+		{
+			name:          "no items → WaitPending",
+			items:         nil,
+			cluster:       "c1",
+			namespace:     "grotshop",
+			wantOutcome:   instrumentation.WaitPending,
+			wantRawStatus: "INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION",
+		},
+		{
+			name: "items from other cluster/namespace ignored",
+			items: []instrumentation.DiscoveryItem{
+				{ClusterName: "other-cluster", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_INSTRUMENTED"},
+				{ClusterName: "c1", Namespace: "other-ns", InstrumentationStatus: "INSTRUMENTATION_STATUS_INSTRUMENTED"},
+			},
+			cluster:       "c1",
+			namespace:     "grotshop",
+			wantOutcome:   instrumentation.WaitPending, // no items for (c1, grotshop)
+			wantRawStatus: "INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION",
+		},
+		{
+			name: "INSTRUMENTATION_ERROR trumps all — full wire prefix",
+			items: []instrumentation.DiscoveryItem{
+				{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_INSTRUMENTED"},
+				{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_INSTRUMENTATION_ERROR"},
+			},
+			cluster:       "c1",
+			namespace:     "grotshop",
+			wantOutcome:   instrumentation.WaitError,
+			wantRawStatus: "INSTRUMENTATION_STATUS_INSTRUMENTATION_ERROR",
+		},
+		{
+			name: "pending present → WaitPending — full wire prefix",
+			items: []instrumentation.DiscoveryItem{
+				{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_INSTRUMENTED"},
+				{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION"},
+			},
+			cluster:       "c1",
+			namespace:     "grotshop",
+			wantOutcome:   instrumentation.WaitPending,
+			wantRawStatus: "INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION",
+		},
+		{
+			name: "all INSTRUMENTED → WaitSuccess — full wire prefix",
+			items: []instrumentation.DiscoveryItem{
+				{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_INSTRUMENTED"},
+				{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_INSTRUMENTED"},
+			},
+			cluster:       "c1",
+			namespace:     "grotshop",
+			wantOutcome:   instrumentation.WaitSuccess,
+			wantRawStatus: "INSTRUMENTATION_STATUS_INSTRUMENTED",
+		},
+		{
+			// Case A (wire bug): all workloads report full-prefix PENDING.
+			// Old code: compared against shorthand "PENDING_INSTRUMENTATION" → no match
+			// → treated as terminal → exited 0 immediately (bug).
+			// New code: ClassifyInstrumentationStatus recognises full prefix → WaitPending.
+			name: "Case A: all PENDING full-wire-prefix → WaitPending (not Success)",
+			items: []instrumentation.DiscoveryItem{
+				{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION"},
+				{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION"},
+			},
+			cluster:       "c1",
+			namespace:     "grotshop",
+			wantOutcome:   instrumentation.WaitPending,
+			wantRawStatus: "INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION",
+		},
+		{
+			// Case B: one workload reports full-prefix INSTRUMENTATION_ERROR → WaitError.
+			name: "Case B: INSTRUMENTATION_ERROR full-wire-prefix → WaitError",
+			items: []instrumentation.DiscoveryItem{
+				{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_INSTRUMENTATION_ERROR"},
+			},
+			cluster:       "c1",
+			namespace:     "grotshop",
+			wantOutcome:   instrumentation.WaitError,
+			wantRawStatus: "INSTRUMENTATION_STATUS_INSTRUMENTATION_ERROR",
+		},
+		{
+			// Case C: all workloads report full-prefix INSTRUMENTED → WaitSuccess.
+			name: "Case C: all INSTRUMENTED full-wire-prefix → WaitSuccess",
+			items: []instrumentation.DiscoveryItem{
+				{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_INSTRUMENTED"},
+			},
+			cluster:       "c1",
+			namespace:     "grotshop",
+			wantOutcome:   instrumentation.WaitSuccess,
+			wantRawStatus: "INSTRUMENTATION_STATUS_INSTRUMENTED",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeAppsClient{
+				discoverItems: tc.items,
+			}
+
+			ctx := t.Context()
+			outcome, rawStatus, err := pollNamespaceStatus(ctx, client, instrumentation.PromHeaders{}, tc.cluster, tc.namespace)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if outcome != tc.wantOutcome {
+				t.Errorf("outcome: want %v, got %v", tc.wantOutcome, outcome)
+			}
+			if rawStatus != tc.wantRawStatus {
+				t.Errorf("rawStatus: want %q, got %q", tc.wantRawStatus, rawStatus)
+			}
+		})
+	}
+}
+
+func TestWaitCmd_Timeout(t *testing.T) {
+	// Always returns full-prefix PENDING_INSTRUMENTATION — should timeout quickly.
+	// Timeout emits a fused WaitResult (with Error) to stdout and returns
+	// ErrWaitTimeoutEmitted (sentinel), not a plain "timed out" error string.
+	//
+	// Pin agent mode so JSON assertions are stable in CI (where CLAUDECODE is not set).
+	// agent.IsAgentMode() uses a cached init()-time value, so ResetForTesting() must
+	// be called after t.Setenv to re-run env detection.
+	t.Setenv("GCX_AGENT_MODE", "true")
+	agent.ResetForTesting()
+	t.Cleanup(func() { agent.ResetForTesting() }) // restore after test
+
+	client := &fakeAppsClient{
+		discoverItems: []instrumentation.DiscoveryItem{
+			{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_PENDING_INSTRUMENTATION"},
+		},
+	}
+
+	cmd := newWaitCmd(client, instrumentation.PromHeaders{})
+
+	// Use a very short timeout to keep the test fast.
+	cmd.SetArgs([]string{"c1", "grotshop", "--timeout=100ms"})
+
+	var stdout, stderr strings.Builder
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	start := time.Now()
+	err := cmd.Execute()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	// timeout now returns the sentinel, not a "timed out" message string.
+	if !errors.Is(err, instrumentation.ErrWaitTimeoutEmitted) {
+		t.Errorf("expected ErrWaitTimeoutEmitted sentinel, got: %v", err)
+	}
+	// stdout must have the fused WaitResult with outcome:timeout and error field.
+	stdoutStr := stdout.String()
+	if !strings.Contains(stdoutStr, `"outcome":"timeout"`) {
+		t.Errorf("stdout must contain outcome:timeout, got: %q", stdoutStr)
+	}
+	if !strings.Contains(stdoutStr, `"error"`) {
+		t.Errorf("stdout must contain error field in fused envelope, got: %q", stdoutStr)
+	}
+	// Sanity: should not have run for more than 10 seconds.
+	if elapsed > 10*time.Second {
+		t.Errorf("test took too long: %v", elapsed)
+	}
+}
+
+func TestWaitCmd_ErrorStatus(t *testing.T) {
+	// Returns full-prefix INSTRUMENTATION_ERROR immediately.
+	client := &fakeAppsClient{
+		discoverItems: []instrumentation.DiscoveryItem{
+			{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_INSTRUMENTATION_ERROR"},
+		},
+	}
+
+	cmd := newWaitCmd(client, instrumentation.PromHeaders{})
+	cmd.SetArgs([]string{"c1", "grotshop", "--timeout=5m"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error on INSTRUMENTATION_ERROR, got nil")
+	}
+	if !strings.Contains(err.Error(), "INSTRUMENTATION_ERROR") {
+		t.Errorf("expected INSTRUMENTATION_ERROR in error, got: %v", err)
+	}
+}
+
+func TestWaitCmd_Success(t *testing.T) {
+	// Returns full-prefix INSTRUMENTED immediately.
+	// success output goes to stdout; no progress text bleeds to stdout.
+	client := &fakeAppsClient{
+		discoverItems: []instrumentation.DiscoveryItem{
+			{ClusterName: "c1", Namespace: "grotshop", InstrumentationStatus: "INSTRUMENTATION_STATUS_INSTRUMENTED"},
+		},
+	}
+
+	cmd := newWaitCmd(client, instrumentation.PromHeaders{})
+	cmd.SetArgs([]string{"c1", "grotshop", "--timeout=5m"})
+
+	var stdout, stderr strings.Builder
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// stdout: success message with namespace and cluster.
+	stdoutStr := stdout.String()
+	if !strings.Contains(stdoutStr, "grotshop") {
+		t.Errorf("stdout should contain namespace, got: %q", stdoutStr)
+	}
+	if !strings.Contains(stdoutStr, "INSTRUMENTED") {
+		t.Errorf("stdout should contain status, got: %q", stdoutStr)
+	}
+	// No progress text should bleed into stdout.
+	if strings.Contains(stdoutStr, "waiting:") {
+		t.Errorf("progress text must not appear on stdout, got: %q", stdoutStr)
+	}
+}
+
+func TestProbePipelineMsg(t *testing.T) {
+	tests := []struct {
+		name             string
+		cluster          string
+		pipelines        []instrumentation.Pipeline
+		listPipelinesErr error
+		wantContains     string
+		wantEmpty        bool
+	}{
+		{
+			name:    "pipeline found → exists message",
+			cluster: "prod-k8s",
+			pipelines: []instrumentation.Pipeline{
+				{Name: "beyla_k8s_appo11y_prod-k8s"},
+			},
+			wantContains: `"beyla_k8s_appo11y_prod-k8s" exists`,
+		},
+		{
+			name:         "pipeline not found → not found message with hint",
+			cluster:      "prod-k8s",
+			pipelines:    nil,
+			wantContains: `"beyla_k8s_appo11y_prod-k8s" not found`,
+		},
+		{
+			name:    "other pipelines present but not matching → not found message",
+			cluster: "prod-k8s",
+			pipelines: []instrumentation.Pipeline{
+				{Name: "beyla_k8s_appo11y_other-cluster"},
+			},
+			wantContains: `"beyla_k8s_appo11y_prod-k8s" not found`,
+		},
+		{
+			name:             "ListPipelines error → empty string (no diagnostic noise)",
+			cluster:          "prod-k8s",
+			listPipelinesErr: errors.New("permission denied"),
+			wantEmpty:        true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeAppsClient{
+				pipelines:        tc.pipelines,
+				listPipelinesErr: tc.listPipelinesErr,
+			}
+
+			got := probePipelineMsg(t.Context(), client, tc.cluster)
+
+			if tc.wantEmpty {
+				if got != "" {
+					t.Errorf("expected empty string, got: %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.wantContains) {
+				t.Errorf("expected %q in result, got: %q", tc.wantContains, got)
+			}
+		})
+	}
+}

--- a/cmd/gcx/instrumentation/clusters/client.go
+++ b/cmd/gcx/instrumentation/clusters/client.go
@@ -1,0 +1,90 @@
+package clusters
+
+import (
+	"context"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+)
+
+// clusterClient is the minimal interface required by cluster commands.
+// Satisfied by *instrumentation.Client created via instrumentation.NewClient.
+// Used for dependency injection in tests.
+type clusterClient interface {
+	GetK8SInstrumentation(ctx context.Context, clusterName string) (*instrumentation.GetK8SInstrumentationResponse, error)
+	SetK8SInstrumentation(ctx context.Context, clusterName string, k8s instrumentation.Cluster, urls instrumentation.BackendURLs) error
+	RunK8sMonitoring(ctx context.Context, promHeaders instrumentation.PromHeaders) (*instrumentation.RunK8sMonitoringResponse, error)
+	ListPipelines(ctx context.Context) ([]instrumentation.Pipeline, error)
+}
+
+// monitoringAdapter adapts a clusterClient + PromHeaders to the
+// enumerate.MonitoringClient interface, which expects RunK8sMonitoring(ctx)
+// without PromHeaders. PromHeaders are bound at construction time.
+type monitoringAdapter struct {
+	client      clusterClient
+	promHeaders instrumentation.PromHeaders
+}
+
+func (a *monitoringAdapter) RunK8sMonitoring(ctx context.Context) ([]instrumentation.ClusterObservedState, error) {
+	resp, err := a.client.RunK8sMonitoring(ctx, a.promHeaders)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Clusters, nil
+}
+
+// declaredStateClient is the minimal interface for the wait command's
+// pre-flight check: verify the cluster is declared before polling.
+type declaredStateClient interface {
+	GetK8SInstrumentation(ctx context.Context, clusterName string) (*instrumentation.GetK8SInstrumentationResponse, error)
+}
+
+// pipelineAdapter adapts a clusterClient to the enumerate.PipelineClient interface.
+type pipelineAdapter struct {
+	client clusterClient
+}
+
+func (a *pipelineAdapter) ListPipelines(ctx context.Context) ([]instrumentation.Pipeline, error) {
+	return a.client.ListPipelines(ctx)
+}
+
+// boolPtr returns a pointer to b. Used when converting flag bool values to
+// *bool tri-state domain fields.
+//
+//nolint:modernize // ptr() creates pointer to value, not pointer to type like new()
+func boolPtr(b bool) *bool { return &b }
+
+// k8sMonitoringPipelineType is the metadata "type" value that identifies K8s
+// monitoring pipelines. Mirrors the value in the enumerate package.
+const k8sMonitoringPipelineType = "k8s_monitoring"
+
+// pipelineFallbackStatus checks whether clusterName has a K8s monitoring
+// pipeline in pipelines. Returns StatusPendingInstrumentation if found,
+// StatusNotInstrumented if not. Used by get when the cluster is
+// absent from RunK8sMonitoring.
+func pipelineFallbackStatus(clusterName string, pipelines []instrumentation.Pipeline) instrumentation.InstrumentationStatus {
+	for _, p := range pipelines {
+		if p.Metadata == nil {
+			continue
+		}
+		typeVal, ok := p.Metadata["type"]
+		if !ok {
+			continue
+		}
+		typeStr, ok := typeVal.(string)
+		if !ok || typeStr != k8sMonitoringPipelineType {
+			continue
+		}
+		// Accept both "cluster_name" (grafana-cloud-onboarding) and "cluster" (legacy).
+		for _, key := range []string{"cluster_name", "cluster"} {
+			clusterVal, ok := p.Metadata[key]
+			if !ok {
+				continue
+			}
+			clusterStr, ok := clusterVal.(string)
+			if ok && clusterStr == clusterName {
+				return instrumentation.StatusPendingInstrumentation
+			}
+		}
+	}
+	return instrumentation.StatusNotInstrumented
+}

--- a/cmd/gcx/instrumentation/clusters/client_test.go
+++ b/cmd/gcx/instrumentation/clusters/client_test.go
@@ -1,0 +1,126 @@
+//nolint:testpackage // white-box testing: tests access unexported run* functions and clusterClient interface.
+package clusters
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+)
+
+// fakeClient implements clusterClient for tests.
+type fakeClient struct {
+	GetK8SInstrumentationFn func(ctx context.Context, clusterName string) (*instrumentation.GetK8SInstrumentationResponse, error)
+	SetK8SInstrumentationFn func(ctx context.Context, clusterName string, k8s instrumentation.Cluster, urls instrumentation.BackendURLs) error
+	RunK8sMonitoringFn      func(ctx context.Context, promHeaders instrumentation.PromHeaders) (*instrumentation.RunK8sMonitoringResponse, error)
+	ListPipelinesFn         func(ctx context.Context) ([]instrumentation.Pipeline, error)
+}
+
+func (f *fakeClient) GetK8SInstrumentation(ctx context.Context, clusterName string) (*instrumentation.GetK8SInstrumentationResponse, error) {
+	if f.GetK8SInstrumentationFn != nil {
+		return f.GetK8SInstrumentationFn(ctx, clusterName)
+	}
+	return nil, errors.New("fakeClient: GetK8SInstrumentation not configured")
+}
+
+func (f *fakeClient) SetK8SInstrumentation(ctx context.Context, clusterName string, k8s instrumentation.Cluster, urls instrumentation.BackendURLs) error {
+	if f.SetK8SInstrumentationFn != nil {
+		return f.SetK8SInstrumentationFn(ctx, clusterName, k8s, urls)
+	}
+	return errors.New("fakeClient: SetK8SInstrumentation not configured")
+}
+
+func (f *fakeClient) RunK8sMonitoring(ctx context.Context, promHeaders instrumentation.PromHeaders) (*instrumentation.RunK8sMonitoringResponse, error) {
+	if f.RunK8sMonitoringFn != nil {
+		return f.RunK8sMonitoringFn(ctx, promHeaders)
+	}
+	return nil, errors.New("fakeClient: RunK8sMonitoring not configured")
+}
+
+func (f *fakeClient) ListPipelines(ctx context.Context) ([]instrumentation.Pipeline, error) {
+	if f.ListPipelinesFn != nil {
+		return f.ListPipelinesFn(ctx)
+	}
+	return nil, errors.New("fakeClient: ListPipelines not configured")
+}
+
+// fakeMonitoringClient implements enumerate.MonitoringClient for testing.
+// Uses a function field so tests can return different results per call.
+type fakeMonitoringClient struct {
+	RunK8sMonitoringFn func(ctx context.Context) ([]instrumentation.ClusterObservedState, error)
+}
+
+func (f *fakeMonitoringClient) RunK8sMonitoring(ctx context.Context) ([]instrumentation.ClusterObservedState, error) {
+	if f.RunK8sMonitoringFn != nil {
+		return f.RunK8sMonitoringFn(ctx)
+	}
+	return nil, errors.New("fakeMonitoringClient: RunK8sMonitoringFn not configured")
+}
+
+// fakePipelineClient implements enumerate.PipelineClient for testing.
+type fakePipelineClient struct {
+	Pipelines []instrumentation.Pipeline
+	Err       error
+}
+
+func (f *fakePipelineClient) ListPipelines(_ context.Context) ([]instrumentation.Pipeline, error) {
+	return f.Pipelines, f.Err
+}
+
+// intVal returns a pointer to an int literal, for use in test table literals.
+func intVal(i int) *int { return &i } //nolint:modernize // returns pointer to value, not zero pointer like new()
+
+// makeK8sPipeline creates a fake K8s monitoring pipeline for a given cluster.
+func makeK8sPipeline(clusterName string) instrumentation.Pipeline {
+	return instrumentation.Pipeline{
+		ID:   "pipe-" + clusterName,
+		Name: "k8s-monitoring-" + clusterName,
+		Metadata: map[string]any{
+			"type":    "k8s_monitoring",
+			"cluster": clusterName,
+		},
+	}
+}
+
+func TestPipelineFallbackStatus_LiberalKeys(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		pipelines   []instrumentation.Pipeline
+		want        instrumentation.InstrumentationStatus
+	}{
+		{
+			name:        "cluster key matches",
+			clusterName: "prod-eu",
+			pipelines: []instrumentation.Pipeline{
+				{Metadata: map[string]any{"type": "k8s_monitoring", "cluster": "prod-eu"}},
+			},
+			want: instrumentation.StatusPendingInstrumentation,
+		},
+		{
+			name:        "cluster_name key matches",
+			clusterName: "prod-eu",
+			pipelines: []instrumentation.Pipeline{
+				{Metadata: map[string]any{"type": "k8s_monitoring", "cluster_name": "prod-eu"}},
+			},
+			want: instrumentation.StatusPendingInstrumentation,
+		},
+		{
+			name:        "no matching cluster returns not instrumented",
+			clusterName: "prod-eu",
+			pipelines: []instrumentation.Pipeline{
+				{Metadata: map[string]any{"type": "k8s_monitoring", "cluster_name": "other"}},
+			},
+			want: instrumentation.StatusNotInstrumented,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pipelineFallbackStatus(tc.clusterName, tc.pipelines)
+			if got != tc.want {
+				t.Errorf("pipelineFallbackStatus() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/gcx/instrumentation/clusters/command.go
+++ b/cmd/gcx/instrumentation/clusters/command.go
@@ -1,0 +1,47 @@
+// Package clusters provides the "gcx instrumentation clusters" command group.
+//
+// It implements declared/observed state management for K8s monitoring clusters
+// following the action-verb CLI design from ADR-018.
+//
+// Commands:
+//
+//	list      — enumerate all clusters
+//	get       — get a single cluster
+//	configure — configure K8s monitoring flags
+//	remove    — remove K8s monitoring pipeline
+//	wait      — poll until INSTRUMENTED
+//	apps      — namespace-level Beyla instrumentation management
+package clusters
+
+import (
+	"github.com/grafana/gcx/cmd/gcx/instrumentation/clusters/apps"
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/spf13/cobra"
+)
+
+// Command returns the "clusters" cobra command group and registers all
+// cluster-level verb subcommands and the apps subcommand group.
+func Command(loader fleet.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clusters",
+		Short: "Manage K8s monitoring configuration for clusters",
+		Long: `Manage K8s monitoring configuration for clusters.
+
+Subcommands:
+  list      List all clusters with their instrumentation status
+  get       Show declared config and observed status for a single cluster
+  configure Configure K8s monitoring flags (RMW or apply defaults)
+  remove    Remove K8s monitoring from a cluster
+  wait      Wait until a cluster reaches INSTRUMENTED status
+  apps      Manage namespace-level Beyla instrumentation for a cluster`,
+	}
+
+	cmd.AddCommand(newListCommand(loader))
+	cmd.AddCommand(newGetCommand(loader))
+	cmd.AddCommand(newConfigureCommand(loader))
+	cmd.AddCommand(newRemoveCommand(loader))
+	cmd.AddCommand(newWaitCommand(loader))
+	cmd.AddCommand(apps.Command(loader))
+
+	return cmd
+}

--- a/cmd/gcx/instrumentation/clusters/configure.go
+++ b/cmd/gcx/instrumentation/clusters/configure.go
@@ -39,6 +39,12 @@ type configureOpts struct {
 	nodeLogs      bool
 }
 
+// Validate of the mutually-exclusive-mode and --yes-required-for-defaults rules
+// requires inspecting flags.Changed(), which depends on the *cobra.Command
+// instance. Those checks live in runConfigure where the command is in scope.
+// Keeping Validate as a no-op here satisfies the canonical opts pattern.
+func (o *configureOpts) Validate() error { return nil }
+
 func (o *configureOpts) setup(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.useDefaults, "use-defaults", false,
 		"Apply canonical defaults (costMetrics=true, clusterEvents=true, energyMetrics=false, nodeLogs=false). Requires --yes.")
@@ -82,6 +88,9 @@ Combining --use-defaults with any --<feat> flag is an error.`,
   # Disable node logs (RMW)
   gcx instrumentation clusters configure prod-eu --node-logs=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
 			ctx := cmd.Context()
 			clusterName := args[0]
 			r, err := fleet.LoadClientWithStack(ctx, loader)

--- a/cmd/gcx/instrumentation/clusters/configure.go
+++ b/cmd/gcx/instrumentation/clusters/configure.go
@@ -1,0 +1,205 @@
+package clusters
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instoutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation/rmw"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// defaultClusterConfig returns the default K8s monitoring configuration.
+// defaults: costMetrics=true, clusterEvents=true, energyMetrics=false, nodeLogs=false,
+// Selection=SELECTION_INCLUDED.
+func defaultClusterConfig(clusterName string) instrumentation.Cluster {
+	t := true
+	f := false
+	return instrumentation.Cluster{
+		Name:          clusterName,
+		Selection:     "SELECTION_INCLUDED",
+		CostMetrics:   &t,
+		EnergyMetrics: &f,
+		ClusterEvents: &t,
+		NodeLogs:      &f,
+	}
+}
+
+type configureOpts struct {
+	useDefaults   bool
+	yes           bool
+	costMetrics   bool
+	energyMetrics bool
+	clusterEvents bool
+	nodeLogs      bool
+}
+
+func (o *configureOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.useDefaults, "use-defaults", false,
+		"Apply canonical defaults (costMetrics=true, clusterEvents=true, energyMetrics=false, nodeLogs=false). Requires --yes.")
+	flags.BoolVar(&o.yes, "yes", false,
+		"Confirm the --use-defaults operation (required with --use-defaults)")
+	flags.BoolVar(&o.costMetrics, "cost-metrics", false,
+		"Set costMetrics. Pass --cost-metrics=false to disable. Omit to preserve current value.")
+	flags.BoolVar(&o.energyMetrics, "energy-metrics", false,
+		"Set energyMetrics. Pass --energy-metrics=false to disable.")
+	flags.BoolVar(&o.clusterEvents, "cluster-events", false,
+		"Set clusterEvents. Pass --cluster-events=false to disable.")
+	flags.BoolVar(&o.nodeLogs, "node-logs", false,
+		"Set nodeLogs. Pass --node-logs=false to disable.")
+}
+
+func newConfigureCommand(loader fleet.ConfigLoader) *cobra.Command {
+	opts := &configureOpts{}
+	cmd := &cobra.Command{
+		Use:   "configure <cluster>",
+		Short: "Configure K8s monitoring flags on a cluster",
+		Long: `Configure K8s monitoring feature flags on a cluster.
+
+Two mutually exclusive modes:
+
+  --use-defaults --yes
+      Apply canonical defaults, overwriting current state. Requires --yes.
+      Defaults: costMetrics=true, clusterEvents=true, energyMetrics=false, nodeLogs=false.
+
+  --<feat>[=true|false] (one or more)
+      Set listed features; unspecified features preserve their current value (RMW).
+      Idempotent. No confirmation required.
+
+Combining --use-defaults with any --<feat> flag is an error.`,
+		Args: cobra.ExactArgs(1),
+		Example: `  # Apply defaults to cluster "prod-eu"
+  gcx instrumentation clusters configure prod-eu --use-defaults --yes
+
+  # Enable cost metrics, preserving other flags (RMW)
+  gcx instrumentation clusters configure prod-eu --cost-metrics
+
+  # Disable node logs (RMW)
+  gcx instrumentation clusters configure prod-eu --node-logs=false`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			clusterName := args[0]
+			r, err := fleet.LoadClientWithStack(ctx, loader)
+			if err != nil {
+				return fmt.Errorf("clusters configure: %w", err)
+			}
+			client := instrumentation.NewClient(r.Client)
+			backendURLs := instrumentation.BackendURLsFromStack(r.Stack)
+			return runConfigure(ctx, cmd, opts, client, clusterName, backendURLs, cmd.OutOrStdout())
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// runConfigure performs the configure operation. It supports two mutually
+// exclusive modes (--use-defaults --yes vs. one or more --<feat> flags).
+// cmd is needed to inspect Flags().Changed() for distinguishing "set to false"
+// from "not set" semantics.
+func runConfigure(
+	ctx context.Context,
+	cmd *cobra.Command,
+	opts *configureOpts,
+	client clusterClient,
+	clusterName string,
+	backendURLs instrumentation.BackendURLs,
+	w io.Writer,
+) error {
+	flags := cmd.Flags()
+	useDefaultsSet := flags.Changed("use-defaults")
+	anyFeatureSet := flags.Changed("cost-metrics") || flags.Changed("energy-metrics") ||
+		flags.Changed("cluster-events") || flags.Changed("node-logs")
+
+	if useDefaultsSet && anyFeatureSet {
+		return errors.New("clusters configure: --use-defaults and feature flags are mutually exclusive; " +
+			"use one or more --<feat> flags for incremental edit, or --use-defaults --yes to apply defaults")
+	}
+	if !useDefaultsSet && !anyFeatureSet {
+		return errors.New("clusters configure: requires either --use-defaults --yes (apply defaults) " +
+			"or one or more --<feat> flags (incremental edit)")
+	}
+
+	// --use-defaults mode: destructive overwrite, requires --yes.
+	if useDefaultsSet {
+		if !opts.yes {
+			return errors.New("clusters configure --use-defaults: --yes is required to confirm this destructive operation")
+		}
+		defaults := defaultClusterConfig(clusterName)
+		if err := client.SetK8SInstrumentation(ctx, clusterName, defaults, backendURLs); err != nil {
+			return fmt.Errorf("clusters configure: %w", err)
+		}
+		return instoutput.MutationResult{
+			Action:  "configure",
+			Target:  instoutput.Target{Cluster: clusterName},
+			Changed: true,
+			Fields:  []instoutput.FieldChange{{Name: "use-defaults", From: "custom", To: "defaults"}},
+		}.Emit(w)
+	}
+
+	// RMW mode: set listed flags, preserve unspecified.
+	getFn := func(ctx context.Context) (instrumentation.Cluster, error) {
+		resp, err := client.GetK8SInstrumentation(ctx, clusterName)
+		if err != nil {
+			return instrumentation.Cluster{}, fmt.Errorf("clusters configure: %w", err)
+		}
+		return resp.Cluster, nil
+	}
+	mutateFn := func(current instrumentation.Cluster) instrumentation.Cluster {
+		mutated := current
+		mutated.Selection = "SELECTION_INCLUDED"
+		if flags.Changed("cost-metrics") {
+			mutated.CostMetrics = boolPtr(opts.costMetrics) //nolint:modernize
+		}
+		if flags.Changed("energy-metrics") {
+			mutated.EnergyMetrics = boolPtr(opts.energyMetrics) //nolint:modernize
+		}
+		if flags.Changed("cluster-events") {
+			mutated.ClusterEvents = boolPtr(opts.clusterEvents) //nolint:modernize
+		}
+		if flags.Changed("node-logs") {
+			mutated.NodeLogs = boolPtr(opts.nodeLogs) //nolint:modernize
+		}
+		return mutated
+	}
+	setFn := func(ctx context.Context, updated instrumentation.Cluster) error {
+		return client.SetK8SInstrumentation(ctx, clusterName, updated, backendURLs)
+	}
+
+	// Pre-check: read current state and compute the proposed post-state.
+	// If they are equal, skip the write and report changed:false. This
+	// makes idempotent re-runs observable without a redundant API call.
+	// (Note: rmw.Update also performs a GET internally; the extra GET here is
+	// an intentional trade-off for accurate no-op detection before writing.)
+	preResp, err := client.GetK8SInstrumentation(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("clusters configure: %w", err)
+	}
+	post := mutateFn(preResp.Cluster)
+	if equal, _ := rmw.ClusterEqual(preResp.Cluster, post); equal {
+		return instoutput.MutationResult{
+			Action:  "configure",
+			Target:  instoutput.Target{Cluster: clusterName},
+			Changed: false,
+		}.Emit(w)
+	}
+
+	err = rmw.Update[instrumentation.Cluster](ctx, getFn, mutateFn, setFn, rmw.ClusterEqual, 2)
+	if err != nil {
+		var ce rmw.ConflictError
+		if errors.As(err, &ce) {
+			ce.Command = "clusters configure"
+			return ce
+		}
+		return err
+	}
+	return instoutput.MutationResult{
+		Action:  "configure",
+		Target:  instoutput.Target{Cluster: clusterName},
+		Changed: true,
+	}.Emit(w)
+}

--- a/cmd/gcx/instrumentation/clusters/configure_test.go
+++ b/cmd/gcx/instrumentation/clusters/configure_test.go
@@ -1,0 +1,111 @@
+//nolint:testpackage // white-box testing: accesses unexported runConfigure and types.
+package clusters
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/spf13/cobra"
+)
+
+// TestRunConfigure_ChangeDetection verifies that runConfigure emits changed:false
+// (and skips SetK8SInstrumentation) when the proposed state matches the current state.
+func TestRunConfigure_ChangeDetection(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string // feature flags passed to the command
+		existingCluster instrumentation.Cluster
+		wantChanged     bool   // true → SetK8SInstrumentation must be called; false → must NOT be called
+		wantOutput      string // substring expected in the output
+	}{
+		{
+			// Idempotent re-run: cluster already has CostMetrics=true; user passes --cost-metrics.
+			// Expected: changed=false, SetK8SInstrumentation NOT called.
+			name: "idempotent re-run same flag",
+			args: []string{"--cost-metrics"},
+			existingCluster: instrumentation.Cluster{
+				Name:        "prod-eu",
+				Selection:   "SELECTION_INCLUDED",
+				CostMetrics: func() *bool { v := true; return &v }(),
+			},
+			wantChanged: false,
+			wantOutput:  "no changes",
+		},
+		{
+			// State differs: cluster has CostMetrics=false; user passes --cost-metrics.
+			// Expected: changed=true, SetK8SInstrumentation IS called.
+			name: "flip one flag",
+			args: []string{"--cost-metrics"},
+			existingCluster: instrumentation.Cluster{
+				Name:        "prod-eu",
+				Selection:   "SELECTION_INCLUDED",
+				CostMetrics: func() *bool { v := false; return &v }(),
+			},
+			wantChanged: true,
+			wantOutput:  "done",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Force non-agent mode so MutationResult.Emit writes human-readable
+			// output ("no changes" / "done") that we can assert against consistently,
+			// regardless of whether CLAUDECODE or similar env vars are set.
+			t.Setenv("GCX_AGENT_MODE", "false")
+			agent.ResetForTesting()
+			t.Cleanup(agent.ResetForTesting)
+
+			var setCalls int
+			client := &fakeClient{
+				GetK8SInstrumentationFn: func(_ context.Context, clusterName string) (*instrumentation.GetK8SInstrumentationResponse, error) {
+					c := tt.existingCluster
+					c.Name = clusterName
+					return &instrumentation.GetK8SInstrumentationResponse{Cluster: c}, nil
+				},
+				SetK8SInstrumentationFn: func(_ context.Context, _ string, _ instrumentation.Cluster, _ instrumentation.BackendURLs) error {
+					setCalls++
+					return nil
+				},
+			}
+
+			// Build a minimal Cobra command with the configure flags so we can
+			// use flags.Changed() semantics inside runConfigure.
+			opts := &configureOpts{}
+			cmd := &cobra.Command{}
+			opts.setup(cmd.Flags())
+			if err := cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("flag parse error: %v", err)
+			}
+
+			var buf bytes.Buffer
+			err := runConfigure(
+				context.Background(),
+				cmd,
+				opts,
+				client,
+				"prod-eu",
+				instrumentation.BackendURLs{},
+				&buf,
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantChanged && setCalls == 0 {
+				t.Error("expected SetK8SInstrumentation to be called, but it was not")
+			}
+			if !tt.wantChanged && setCalls > 0 {
+				t.Errorf("expected SetK8SInstrumentation NOT to be called, but it was called %d time(s)", setCalls)
+			}
+
+			out := buf.String()
+			if tt.wantOutput != "" && !strings.Contains(out, tt.wantOutput) {
+				t.Errorf("output: want %q in %q", tt.wantOutput, out)
+			}
+		})
+	}
+}

--- a/cmd/gcx/instrumentation/clusters/get.go
+++ b/cmd/gcx/instrumentation/clusters/get.go
@@ -1,0 +1,147 @@
+package clusters
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/fleet"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instrOutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &instrOutput.ClusterTableCodec{Wide: false})
+	o.IO.RegisterCustomCodec("wide", &instrOutput.ClusterTableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.SetJSONFieldValidator(cmdio.MakeFieldValidator(instrOutput.ClusterView{}))
+	o.IO.BindFlags(flags)
+}
+
+func (o *getOpts) Validate() error {
+	return o.IO.Validate()
+}
+
+func newGetCommand(loader fleet.ConfigLoader) *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:   "get <cluster>",
+		Short: "Show declared config and observed status for a cluster",
+		Long: `Show the declared K8s monitoring configuration and observed instrumentation
+status for a single cluster.
+
+The declared configuration is fetched via GetK8SInstrumentation. The observed
+status is cross-referenced with RunK8sMonitoring. If the cluster is absent from
+RunK8sMonitoring, ListPipelines is checked: a K8s monitoring pipeline present
+means PENDING_INSTRUMENTATION; absent means NOT_INSTRUMENTED.`,
+		Args: cobra.ExactArgs(1),
+		Example: `  # Get cluster "prod-eu" in table format
+  gcx instrumentation clusters get prod-eu
+
+  # Get in JSON format
+  gcx instrumentation clusters get prod-eu -o json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			clusterName := args[0]
+
+			r, err := fleet.LoadClientWithStack(ctx, loader)
+			if err != nil {
+				return fmt.Errorf("clusters get: %w", err)
+			}
+			client := instrumentation.NewClient(r.Client)
+			promHeaders := instrumentation.PromHeadersFromStack(r.Stack)
+
+			return runGet(ctx, opts, client, clusterName, promHeaders, cmd.OutOrStdout())
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// runGet implements the core get logic. Separated from newGetCommand for
+// testability with fake clients.
+func runGet(
+	ctx context.Context,
+	opts *getOpts,
+	client clusterClient,
+	clusterName string,
+	promHeaders instrumentation.PromHeaders,
+	w io.Writer,
+) error {
+	// Fetch declared configuration.
+	resp, err := client.GetK8SInstrumentation(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("clusters get: %w", err)
+	}
+	cl := resp.Cluster
+
+	// Backend returns HTTP 200 with zero-valued proto for unknown clusters.
+	// Detect client-side via the empty-default shape and exit 1 (ExitGeneralError)
+	// for not-found — exit 4 is reserved for ExitPartialFailure per
+	// docs/design/exit-codes.md.
+	if instrumentation.IsEmptyDefaultCluster(cl) {
+		exitCode := fail.ExitGeneralError
+		return &fail.DetailedError{
+			Summary: "Resource not found",
+			Details: fmt.Sprintf("cluster %q has no K8s monitoring configuration", clusterName),
+			Suggestions: []string{
+				"Run: gcx instrumentation clusters list",
+			},
+			ExitCode: &exitCode,
+		}
+	}
+
+	// Cross-reference with observed state from RunK8sMonitoring.
+	monResp, err := client.RunK8sMonitoring(ctx, promHeaders)
+	if err != nil {
+		return fmt.Errorf("clusters get: RunK8sMonitoring: %w", err)
+	}
+
+	cv := instrOutput.ClusterView{
+		Name:          cl.Name,
+		Selection:     cl.Selection,
+		CostMetrics:   cl.CostMetrics,
+		EnergyMetrics: cl.EnergyMetrics,
+		ClusterEvents: cl.ClusterEvents,
+		NodeLogs:      cl.NodeLogs,
+	}
+
+	// Merge observed state if the cluster is visible to RunK8sMonitoring.
+	for _, state := range monResp.Clusters {
+		if state.Name == clusterName {
+			cv.InstrumentationStatus = state.InstrumentationStatus
+			cv.Namespaces = len(state.Namespaces)
+			cv.Workloads = state.Workloads
+			cv.Pods = state.Pods
+			cv.Nodes = state.Nodes
+			break
+		}
+	}
+
+	// If not visible in RunK8sMonitoring, fall back to ListPipelines.
+	if cv.InstrumentationStatus == "" {
+		pipelines, err := client.ListPipelines(ctx)
+		if err != nil {
+			return fmt.Errorf("clusters get: ListPipelines: %w", err)
+		}
+		cv.InstrumentationStatus = pipelineFallbackStatus(clusterName, pipelines)
+	}
+
+	// For table/wide formats, the codec expects []ClusterView; for JSON/YAML
+	// encode the single view directly.
+	if opts.IO.OutputFormat == "table" || opts.IO.OutputFormat == "wide" {
+		return opts.IO.Encode(w, []instrOutput.ClusterView{cv})
+	}
+	return opts.IO.Encode(w, cv)
+}

--- a/cmd/gcx/instrumentation/clusters/get_test.go
+++ b/cmd/gcx/instrumentation/clusters/get_test.go
@@ -1,0 +1,169 @@
+//nolint:testpackage // white-box testing: accesses unexported run* functions and types.
+package clusters
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instrOutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunGet(t *testing.T) {
+	tests := []struct {
+		name            string
+		clusterName     string
+		getCluster      instrumentation.Cluster
+		getErr          error
+		monClusters     []instrumentation.ClusterObservedState
+		monErr          error
+		pipelines       []instrumentation.Pipeline
+		pipeErr         error
+		wantErr         bool
+		wantDetailedErr bool
+		wantErrSummary  string
+		wantExitCode    *int
+		wantStatus      instrumentation.InstrumentationStatus
+		wantInOutput    string
+	}{
+		{
+			name:        "cluster found in monitoring — status from RunK8sMonitoring",
+			clusterName: "prod-eu",
+			getCluster: instrumentation.Cluster{
+				Name:          "prod-eu",
+				Selection:     "SELECTION_INCLUDED",
+				CostMetrics:   boolVal(true), //nolint:modernize
+				ClusterEvents: boolVal(true), //nolint:modernize
+			},
+			monClusters: []instrumentation.ClusterObservedState{
+				{
+					Name:                  "prod-eu",
+					InstrumentationStatus: instrumentation.StatusInstrumented,
+					Workloads:             3,
+				},
+			},
+			wantStatus:   instrumentation.StatusInstrumented,
+			wantInOutput: "prod-eu",
+		},
+		{
+			name:        "cluster absent from monitoring — pipeline fallback PENDING",
+			clusterName: "new-cluster",
+			getCluster: instrumentation.Cluster{
+				Name:      "new-cluster",
+				Selection: "SELECTION_INCLUDED",
+			},
+			monClusters: nil,
+			pipelines:   []instrumentation.Pipeline{makeK8sPipeline("new-cluster")},
+			wantStatus:  instrumentation.StatusPendingInstrumentation,
+		},
+		{
+			name:        "cluster absent from monitoring — no pipeline — NOT_INSTRUMENTED",
+			clusterName: "ghost-cluster",
+			getCluster: instrumentation.Cluster{
+				Name:      "ghost-cluster",
+				Selection: "SELECTION_INCLUDED",
+			},
+			monClusters: nil,
+			pipelines:   nil,
+			wantStatus:  instrumentation.StatusNotInstrumented,
+		},
+		{
+			name:        "GetK8SInstrumentation error propagates",
+			clusterName: "prod-eu",
+			getErr:      assert.AnError,
+			wantErr:     true,
+		},
+		{
+			name:        "RunK8sMonitoring error propagates",
+			clusterName: "prod-eu",
+			getCluster: instrumentation.Cluster{
+				Name:      "prod-eu",
+				Selection: "SELECTION_INCLUDED",
+			},
+			monErr:  assert.AnError,
+			wantErr: true,
+		},
+		{
+			name:        "unknown cluster — backend returns zero-valued proto — exit 1 DetailedError",
+			clusterName: "unknown-cluster",
+			// zero-valued Cluster: Selection == "", all flags nil — matches IsEmptyDefaultCluster
+			getCluster:      instrumentation.Cluster{},
+			wantErr:         true,
+			wantDetailedErr: true,
+			wantErrSummary:  "Resource not found",
+			wantExitCode:    intVal(1), //nolint:modernize
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeClient{
+				GetK8SInstrumentationFn: func(_ context.Context, name string) (*instrumentation.GetK8SInstrumentationResponse, error) {
+					if tt.getErr != nil {
+						return nil, tt.getErr
+					}
+					c := tt.getCluster
+					c.Name = name
+					return &instrumentation.GetK8SInstrumentationResponse{Cluster: c}, nil
+				},
+				RunK8sMonitoringFn: func(_ context.Context, _ instrumentation.PromHeaders) (*instrumentation.RunK8sMonitoringResponse, error) {
+					if tt.monErr != nil {
+						return nil, tt.monErr
+					}
+					return &instrumentation.RunK8sMonitoringResponse{Clusters: tt.monClusters}, nil
+				},
+				ListPipelinesFn: func(_ context.Context) ([]instrumentation.Pipeline, error) {
+					if tt.pipeErr != nil {
+						return nil, tt.pipeErr
+					}
+					return tt.pipelines, nil
+				},
+			}
+
+			opts := &getOpts{}
+			opts.IO.RegisterCustomCodec("table", &instrOutput.ClusterTableCodec{Wide: false})
+			opts.IO.RegisterCustomCodec("wide", &instrOutput.ClusterTableCodec{Wide: true})
+			opts.IO.DefaultFormat("table")
+			opts.IO.OutputFormat = "json"
+
+			var buf bytes.Buffer
+			err := runGet(
+				context.Background(),
+				opts,
+				client,
+				tt.clusterName,
+				instrumentation.PromHeaders{},
+				&buf,
+			)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantDetailedErr {
+					var de *fail.DetailedError
+					require.ErrorAs(t, err, &de, "expected *fail.DetailedError, got %T: %v", err, err)
+					assert.Equal(t, tt.wantErrSummary, de.Summary)
+					if tt.wantExitCode != nil {
+						require.NotNil(t, de.ExitCode, "expected non-nil ExitCode")
+						assert.Equal(t, *tt.wantExitCode, *de.ExitCode)
+					}
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			out := buf.String()
+			if tt.wantStatus != "" {
+				assert.Contains(t, out, string(tt.wantStatus),
+					"expected status %q in output:\n%s", tt.wantStatus, out)
+			}
+			if tt.wantInOutput != "" {
+				assert.Contains(t, out, tt.wantInOutput,
+					"expected %q in output:\n%s", tt.wantInOutput, out)
+			}
+		})
+	}
+}

--- a/cmd/gcx/instrumentation/clusters/list.go
+++ b/cmd/gcx/instrumentation/clusters/list.go
@@ -1,0 +1,140 @@
+package clusters
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/fleet"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/grafana/gcx/internal/providers/instrumentation/enumerate"
+	instrOutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+)
+
+type listOpts struct {
+	IO cmdio.Options
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &instrOutput.ClusterTableCodec{Wide: false})
+	o.IO.RegisterCustomCodec("wide", &instrOutput.ClusterTableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.SetJSONFieldValidator(cmdio.MakeFieldValidator(instrOutput.ClusterView{}))
+	o.IO.BindFlags(flags)
+}
+
+func (o *listOpts) Validate() error {
+	return o.IO.Validate()
+}
+
+func newListCommand(loader fleet.ConfigLoader) *cobra.Command {
+	opts := &listOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all clusters with their instrumentation status",
+		Long: `List all clusters with their K8s monitoring configuration and observed status.
+
+Merges RunK8sMonitoring with ListPipelines to surface clusters that have been
+configured but whose Alloy collector has not yet started reporting (pre-Alloy
+clusters appear with PENDING_INSTRUMENTATION status).
+
+For each cluster, the declared configuration is fetched concurrently via
+GetK8SInstrumentation (up to 10 concurrent requests).`,
+		Example: `  # List all clusters (table output)
+  gcx instrumentation clusters list
+
+  # List in wide format (shows all flag columns)
+  gcx instrumentation clusters list -o wide
+
+  # Output as JSON
+  gcx instrumentation clusters list -o json`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			r, err := fleet.LoadClientWithStack(ctx, loader)
+			if err != nil {
+				return fmt.Errorf("clusters list: %w", err)
+			}
+			client := instrumentation.NewClient(r.Client)
+			promHeaders := instrumentation.PromHeadersFromStack(r.Stack)
+
+			monClient := &monitoringAdapter{client: client, promHeaders: promHeaders}
+			pipeClient := &pipelineAdapter{client: client}
+
+			return runList(ctx, opts, monClient, pipeClient, client, cmd.OutOrStdout())
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// runList implements the core list logic. Separated from newListCommand for
+// testability with fake clients.
+func runList(
+	ctx context.Context,
+	opts *listOpts,
+	monClient enumerate.MonitoringClient,
+	pipeClient enumerate.PipelineClient,
+	instrClient clusterClient,
+	w io.Writer,
+) error {
+	// Enumerate merges RunK8sMonitoring + ListPipelines.
+	observed, err := enumerate.Enumerate(ctx, monClient, pipeClient)
+	if err != nil {
+		return fmt.Errorf("clusters list: enumerate: %w", err)
+	}
+
+	// Fan out GetK8SInstrumentation per cluster (cap 10 concurrent).
+	clusters := make([]instrumentation.Cluster, len(observed))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+	for i, oc := range observed {
+		name := oc.Name
+		g.Go(func() error {
+			resp, err := instrClient.GetK8SInstrumentation(gctx, name)
+			if err != nil {
+				return fmt.Errorf("clusters list: GetK8SInstrumentation %q: %w", name, err)
+			}
+			clusters[i] = resp.Cluster // safe: i is per-iteration scoped (Go 1.22+)
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Build []ClusterView merging declared config + observed state.
+	views := make([]instrOutput.ClusterView, len(observed))
+	for i, oc := range observed {
+		cl := clusters[i]
+		cv := instrOutput.ClusterView{
+			Name:                  cl.Name,
+			Selection:             cl.Selection,
+			CostMetrics:           cl.CostMetrics,
+			EnergyMetrics:         cl.EnergyMetrics,
+			ClusterEvents:         cl.ClusterEvents,
+			NodeLogs:              cl.NodeLogs,
+			InstrumentationStatus: oc.Status,
+		}
+		// Fallback: use observed name if declared name is empty (edge case).
+		if cv.Name == "" {
+			cv.Name = oc.Name
+		}
+		// Merge observed counters when available.
+		if oc.State != nil {
+			cv.Namespaces = len(oc.State.Namespaces)
+			cv.Workloads = oc.State.Workloads
+			cv.Pods = oc.State.Pods
+			cv.Nodes = oc.State.Nodes
+		}
+		views[i] = cv
+	}
+
+	return opts.IO.Encode(w, instrOutput.ClusterListEnvelope{Items: views})
+}

--- a/cmd/gcx/instrumentation/clusters/list_test.go
+++ b/cmd/gcx/instrumentation/clusters/list_test.go
@@ -1,0 +1,257 @@
+//nolint:testpackage // white-box testing: accesses unexported run* functions and types.
+package clusters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instrOutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:modernize // boolVal(x) is clearer than new(*bool) + dereference assignment in test data.
+func boolVal(b bool) *bool { return &b }
+
+func TestRunList(t *testing.T) {
+	tests := []struct {
+		name        string
+		monClusters []instrumentation.ClusterObservedState
+		monErr      error
+		pipelines   []instrumentation.Pipeline
+		pipeErr     error
+		getCluster  instrumentation.Cluster
+		getErr      error
+		wantErr     bool
+		wantNames   []string // cluster names expected in output
+	}{
+		{
+			name: "single cluster from monitoring",
+			monClusters: []instrumentation.ClusterObservedState{
+				{
+					Name:                  "prod-eu",
+					InstrumentationStatus: instrumentation.StatusInstrumented,
+					Namespaces:            []instrumentation.NamespaceObservedState{{Name: "default"}},
+					Workloads:             5,
+					Pods:                  10,
+					Nodes:                 3,
+				},
+			},
+			pipelines: nil,
+			getCluster: instrumentation.Cluster{
+				Name:          "prod-eu",
+				Selection:     "SELECTION_INCLUDED",
+				CostMetrics:   boolVal(true),  //nolint:modernize
+				ClusterEvents: boolVal(true),  //nolint:modernize
+				EnergyMetrics: boolVal(false), //nolint:modernize
+				NodeLogs:      boolVal(false), //nolint:modernize
+			},
+			wantNames: []string{"prod-eu"},
+		},
+		{
+			name:        "pre-alloy cluster from pipeline only",
+			monClusters: nil,
+			pipelines:   []instrumentation.Pipeline{makeK8sPipeline("staging-us")},
+			getCluster: instrumentation.Cluster{
+				Name:      "staging-us",
+				Selection: "SELECTION_INCLUDED",
+			},
+			wantNames: []string{"staging-us"},
+		},
+		{
+			name:        "no clusters returns empty table",
+			monClusters: nil,
+			pipelines:   nil,
+			getCluster:  instrumentation.Cluster{},
+			wantNames:   nil,
+		},
+		{
+			name:    "monitoring error propagates",
+			monErr:  assert.AnError,
+			wantErr: true,
+		},
+		{
+			name:        "GetK8SInstrumentation error propagates",
+			monClusters: []instrumentation.ClusterObservedState{{Name: "prod-eu"}},
+			getErr:      assert.AnError,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			monClusters := tt.monClusters
+			monErr := tt.monErr
+			monClient := &fakeMonitoringClient{
+				RunK8sMonitoringFn: func(_ context.Context) ([]instrumentation.ClusterObservedState, error) {
+					return monClusters, monErr
+				},
+			}
+			pipeClient := &fakePipelineClient{
+				Pipelines: tt.pipelines,
+				Err:       tt.pipeErr,
+			}
+
+			instrClient := &fakeClient{
+				GetK8SInstrumentationFn: func(_ context.Context, clusterName string) (*instrumentation.GetK8SInstrumentationResponse, error) {
+					if tt.getErr != nil {
+						return nil, tt.getErr
+					}
+					c := tt.getCluster
+					c.Name = clusterName
+					return &instrumentation.GetK8SInstrumentationResponse{Cluster: c}, nil
+				},
+			}
+
+			opts := &listOpts{}
+			opts.IO.RegisterCustomCodec("table", &instrOutput.ClusterTableCodec{Wide: false})
+			opts.IO.RegisterCustomCodec("wide", &instrOutput.ClusterTableCodec{Wide: true})
+			opts.IO.DefaultFormat("table")
+			opts.IO.OutputFormat = "table"
+
+			var buf bytes.Buffer
+			err := runList(context.Background(), opts, monClient, pipeClient, instrClient, &buf)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			out := buf.String()
+			for _, name := range tt.wantNames {
+				assert.Contains(t, out, name,
+					"expected cluster %q in output, got:\n%s", name, out)
+			}
+		})
+	}
+}
+
+func TestRunList_MultipleClustersSorted(t *testing.T) {
+	// Verify alphabetical sorting from enumerate.
+	monClusters := []instrumentation.ClusterObservedState{
+		{Name: "z-cluster", InstrumentationStatus: instrumentation.StatusInstrumented},
+		{Name: "a-cluster", InstrumentationStatus: instrumentation.StatusInstrumented},
+		{Name: "m-cluster", InstrumentationStatus: instrumentation.StatusInstrumented},
+	}
+	monClient := &fakeMonitoringClient{
+		RunK8sMonitoringFn: func(_ context.Context) ([]instrumentation.ClusterObservedState, error) {
+			return monClusters, nil
+		},
+	}
+	pipeClient := &fakePipelineClient{}
+	instrClient := &fakeClient{
+		GetK8SInstrumentationFn: func(_ context.Context, name string) (*instrumentation.GetK8SInstrumentationResponse, error) {
+			return &instrumentation.GetK8SInstrumentationResponse{
+				Cluster: instrumentation.Cluster{Name: name, Selection: "SELECTION_INCLUDED"},
+			}, nil
+		},
+	}
+
+	opts := &listOpts{IO: cmdio.Options{OutputFormat: "json"}}
+
+	var buf bytes.Buffer
+	err := runList(context.Background(), opts, monClient, pipeClient, instrClient, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "a-cluster")
+	assert.Contains(t, out, "m-cluster")
+	assert.Contains(t, out, "z-cluster")
+}
+
+// TestRunList_JSONEnvelope_Empty verifies empty result emits {"items":[]}
+// not [] or null.
+func TestRunList_JSONEnvelope_Empty(t *testing.T) {
+	monClient := &fakeMonitoringClient{
+		RunK8sMonitoringFn: func(_ context.Context) ([]instrumentation.ClusterObservedState, error) {
+			return nil, nil
+		},
+	}
+	pipeClient := &fakePipelineClient{}
+	instrClient := &fakeClient{
+		GetK8SInstrumentationFn: func(_ context.Context, _ string) (*instrumentation.GetK8SInstrumentationResponse, error) {
+			return &instrumentation.GetK8SInstrumentationResponse{Cluster: instrumentation.Cluster{}}, nil
+		},
+	}
+
+	opts := &listOpts{IO: cmdio.Options{OutputFormat: "json"}}
+
+	var buf bytes.Buffer
+	err := runList(context.Background(), opts, monClient, pipeClient, instrClient, &buf)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"items":[]}`, buf.String())
+}
+
+// TestRunList_JSONEnvelope_NonEmpty verifies non-empty result is wrapped
+// in {"items":[{...},...]} and not a flat array.
+func TestRunList_JSONEnvelope_NonEmpty(t *testing.T) {
+	monClient := &fakeMonitoringClient{
+		RunK8sMonitoringFn: func(_ context.Context) ([]instrumentation.ClusterObservedState, error) {
+			return []instrumentation.ClusterObservedState{
+				{Name: "prod-eu", InstrumentationStatus: instrumentation.StatusInstrumented},
+			}, nil
+		},
+	}
+	pipeClient := &fakePipelineClient{}
+	instrClient := &fakeClient{
+		GetK8SInstrumentationFn: func(_ context.Context, name string) (*instrumentation.GetK8SInstrumentationResponse, error) {
+			return &instrumentation.GetK8SInstrumentationResponse{
+				Cluster: instrumentation.Cluster{Name: name, Selection: "SELECTION_INCLUDED"},
+			}, nil
+		},
+	}
+
+	opts := &listOpts{IO: cmdio.Options{OutputFormat: "json"}}
+
+	var buf bytes.Buffer
+	err := runList(context.Background(), opts, monClient, pipeClient, instrClient, &buf)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got), "output must be a JSON object; got: %s", buf.String())
+	items, ok := got["items"]
+	require.True(t, ok, "output must have 'items' key")
+	itemsSlice, ok := items.([]any)
+	require.True(t, ok)
+	assert.Len(t, itemsSlice, 1)
+}
+
+// TestRunList_JSONFieldSelection_Unknown verifies --json with unknown field
+// returns UnknownFieldSelectionError.
+func TestRunList_JSONFieldSelection_Unknown(t *testing.T) {
+	monClient := &fakeMonitoringClient{
+		RunK8sMonitoringFn: func(_ context.Context) ([]instrumentation.ClusterObservedState, error) {
+			return []instrumentation.ClusterObservedState{
+				{Name: "prod-eu"},
+			}, nil
+		},
+	}
+	pipeClient := &fakePipelineClient{}
+	instrClient := &fakeClient{
+		GetK8SInstrumentationFn: func(_ context.Context, name string) (*instrumentation.GetK8SInstrumentationResponse, error) {
+			return &instrumentation.GetK8SInstrumentationResponse{
+				Cluster: instrumentation.Cluster{Name: name},
+			}, nil
+		},
+	}
+
+	opts := &listOpts{}
+	opts.IO.RegisterCustomCodec("table", &instrOutput.ClusterTableCodec{Wide: false})
+	opts.IO.DefaultFormat("table")
+	opts.IO.SetJSONFieldValidator(cmdio.MakeFieldValidator(instrOutput.ClusterView{}))
+	opts.IO.OutputFormat = "json"
+	opts.IO.JSONFields = []string{"bogus", "name"}
+
+	var buf bytes.Buffer
+	err := runList(context.Background(), opts, monClient, pipeClient, instrClient, &buf)
+	require.Error(t, err)
+	var fieldErr cmdio.UnknownFieldSelectionError
+	require.ErrorAs(t, err, &fieldErr)
+	assert.Contains(t, fieldErr.Fields, "bogus")
+}

--- a/cmd/gcx/instrumentation/clusters/remove.go
+++ b/cmd/gcx/instrumentation/clusters/remove.go
@@ -1,0 +1,96 @@
+package clusters
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instoutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type removeOpts struct {
+	Yes bool
+}
+
+func (o *removeOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.Yes, "yes", false, "Confirm the remove operation (required)")
+}
+
+func (o *removeOpts) Validate() error {
+	if !o.Yes {
+		return errors.New("clusters remove: --yes is required to confirm this destructive operation")
+	}
+	return nil
+}
+
+func newRemoveCommand(loader fleet.ConfigLoader) *cobra.Command {
+	opts := &removeOpts{}
+	cmd := &cobra.Command{
+		Use:   "remove <cluster>",
+		Short: "Remove K8s monitoring from a cluster",
+		Long: `Remove K8s monitoring from a cluster.
+
+Calls SetK8SInstrumentation with Selection=SELECTION_EXCLUDED. The backend
+interprets this as a request to delete the K8s monitoring pipeline for the
+cluster.
+
+IMPORTANT: After removing, the cluster's status takes approximately 5 minutes
+to transition from INSTRUMENTED to NOT_INSTRUMENTED. During this decay window,
+the cluster may still appear as INSTRUMENTED in status output. This is expected
+behaviour — the Alloy collector drains its in-flight telemetry before stopping.
+
+Requires --yes to confirm the destructive operation.`,
+		Args: cobra.ExactArgs(1),
+		Example: `  # Remove K8s monitoring for cluster "prod-eu"
+  gcx instrumentation clusters remove prod-eu --yes`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			clusterName := args[0]
+
+			r, err := fleet.LoadClientWithStack(ctx, loader)
+			if err != nil {
+				return fmt.Errorf("clusters remove: %w", err)
+			}
+			client := instrumentation.NewClient(r.Client)
+			backendURLs := instrumentation.BackendURLsFromStack(r.Stack)
+
+			return runRemove(ctx, client, clusterName, backendURLs, cmd.OutOrStdout())
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// runRemove implements the core remove logic. Separated from newRemoveCommand
+// for testability with fake clients.
+func runRemove(
+	ctx context.Context,
+	client clusterClient,
+	clusterName string,
+	backendURLs instrumentation.BackendURLs,
+	w io.Writer,
+) error {
+	// Single-shot write with Selection=SELECTION_EXCLUDED.
+	// Other fields are left at zero — the backend treats SELECTION_EXCLUDED
+	// as "delete the pipeline" regardless of other fields.
+	excluded := instrumentation.Cluster{
+		Name:      clusterName,
+		Selection: "SELECTION_EXCLUDED",
+	}
+	if err := client.SetK8SInstrumentation(ctx, clusterName, excluded, backendURLs); err != nil {
+		return fmt.Errorf("clusters remove: %w", err)
+	}
+	return instoutput.MutationResult{
+		Action:  "remove",
+		Target:  instoutput.Target{Cluster: clusterName},
+		Changed: true,
+	}.Emit(w)
+}

--- a/cmd/gcx/instrumentation/clusters/wait.go
+++ b/cmd/gcx/instrumentation/clusters/wait.go
@@ -1,0 +1,216 @@
+package clusters
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/grafana/gcx/internal/providers/instrumentation/enumerate"
+	instrOutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const (
+	waitPollInterval   = 5 * time.Second
+	waitDefaultTimeout = 5 * time.Minute
+)
+
+// errInstrumentationError is returned when INSTRUMENTATION_ERROR is observed
+// during wait. Causes a non-zero exit.
+var errInstrumentationError = errors.New("cluster reached INSTRUMENTATION_ERROR status")
+
+type waitOpts struct {
+	Timeout   time.Duration
+	agentMode bool
+	// pollInterval controls how often RunK8sMonitoring is polled. Defaults to
+	// waitPollInterval (5s). Exposed as a field so tests can override
+	// without flag machinery.
+	pollInterval time.Duration
+}
+
+func (o *waitOpts) setup(flags *pflag.FlagSet) {
+	flags.DurationVar(&o.Timeout, "timeout", waitDefaultTimeout, "Maximum time to wait for INSTRUMENTED status")
+}
+
+func (o *waitOpts) Validate() error {
+	if o.Timeout <= 0 {
+		return errors.New("clusters wait: --timeout must be positive")
+	}
+	return nil
+}
+
+func (o *waitOpts) effectivePollInterval() time.Duration {
+	if o.pollInterval > 0 {
+		return o.pollInterval
+	}
+	return waitPollInterval
+}
+
+func newWaitCommand(loader fleet.ConfigLoader) *cobra.Command {
+	opts := &waitOpts{}
+	cmd := &cobra.Command{
+		Use:   "wait <cluster>",
+		Short: "Wait until a cluster reaches INSTRUMENTED status",
+		Long: `Poll until the specified cluster reaches INSTRUMENTED status.
+
+The command polls RunK8sMonitoring every 5 seconds. Before starting
+the polling loop, it performs a pre-flight check to verify the cluster has
+been declared (via gcx instrumentation setup) — if not configured, it
+returns an error immediately with a remediation hint.
+
+Exit codes:
+  0  Cluster reached INSTRUMENTED status (or a non-error terminal state)
+  1  Timeout reached before INSTRUMENTED status
+  1  INSTRUMENTATION_ERROR status observed
+  1  Pre-flight check failed (cluster not declared)`,
+		Args: cobra.ExactArgs(1),
+		Example: `  # Wait with default 5-minute timeout
+  gcx instrumentation clusters wait prod-eu
+
+  # Wait with a custom timeout
+  gcx instrumentation clusters wait prod-eu --timeout 10m`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			opts.agentMode = agent.IsAgentMode()
+			ctx := cmd.Context()
+			clusterName := args[0]
+
+			r, err := fleet.LoadClientWithStack(ctx, loader)
+			if err != nil {
+				return fmt.Errorf("clusters wait: %w", err)
+			}
+			client := instrumentation.NewClient(r.Client)
+			promHeaders := instrumentation.PromHeadersFromStack(r.Stack)
+
+			monClient := &monitoringAdapter{client: client, promHeaders: promHeaders}
+
+			return runWait(ctx, opts, client, monClient, clusterName, cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// runWait implements the core wait logic. Separated from newWaitCommand for
+// testability with fake clients.
+//
+// stdout receives the final WaitResult envelope (agent mode) or success message.
+// stderr receives all progress updates (banner, per-poll status).
+func runWait(
+	ctx context.Context,
+	opts *waitOpts,
+	declaredClient declaredStateClient,
+	monClient enumerate.MonitoringClient,
+	clusterName string,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	// Pre-flight: verify cluster is declared.
+	// Absent declaration = permanent user error; fail-fast with remediation hint.
+	// Pipeline not yet materialized = transient; must poll.
+	resp, err := declaredClient.GetK8SInstrumentation(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("clusters wait: pre-flight: %w", err)
+	}
+	if resp.Cluster.Name == "" {
+		return &fail.DetailedError{
+			Summary: "cluster is not declared",
+			Details: fmt.Sprintf("cluster %q has no K8s monitoring configuration", clusterName),
+			Suggestions: []string{
+				fmt.Sprintf("Run: gcx instrumentation setup %s --use-defaults", clusterName),
+			},
+		}
+	}
+
+	// Emit banner to stderr: all human progress routes to stderr.
+	banner := instrOutput.WaitBanner{
+		Event:   "waiting_started",
+		Target:  instrOutput.Target{Cluster: clusterName},
+		Timeout: opts.Timeout.String(),
+	}
+	_ = banner.EmitTo(stderr, opts.agentMode)
+
+	start := time.Now()
+	timeoutCh := time.After(opts.Timeout)
+	ticker := time.NewTicker(opts.effectivePollInterval())
+	defer ticker.Stop()
+
+	var lastStatus instrumentation.InstrumentationStatus
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("clusters wait: %w", ctx.Err())
+		case <-timeoutCh:
+			// Emit fused WaitResult with Error field to stdout, then
+			// return ErrWaitTimeoutEmitted so the fail converter suppresses the
+			// secondary DetailedError envelope.
+			timeoutMsg := fmt.Sprintf(
+				"timeout after %s waiting for cluster %q to reach INSTRUMENTED — "+
+					"alloy-daemon may not have registered with Fleet Management yet; "+
+					"check 'helm status grafana-cloud -n monitoring' and 'kubectl logs -n monitoring -l app.kubernetes.io/name=alloy-daemon --context <ctx>'",
+				opts.Timeout, clusterName)
+			result := instrOutput.WaitResultForCluster("timeout", clusterName, string(lastStatus), start)
+			result.Error = &instrOutput.WaitError{
+				Summary:  fmt.Sprintf("timeout waiting for cluster %q", clusterName),
+				Details:  timeoutMsg,
+				ExitCode: 1,
+			}
+			_ = result.Emit(stdout, opts.agentMode)
+			return fmt.Errorf("clusters wait: %w", instrumentation.ErrWaitTimeoutEmitted)
+		case <-ticker.C:
+			clusters, err := monClient.RunK8sMonitoring(ctx)
+			if err != nil {
+				fmt.Fprintf(stderr, "  poll error (retrying): %v\n", err)
+				continue
+			}
+
+			current := findClusterStatus(clusters, clusterName)
+			lastStatus = current
+
+			// Emit per-poll progress to stderr.
+			progress := instrOutput.WaitProgress{
+				Event:     "waiting",
+				Target:    instrOutput.Target{Cluster: clusterName},
+				Status:    string(current),
+				ElapsedMs: time.Since(start).Milliseconds(),
+			}
+			_ = progress.EmitTo(stderr, opts.agentMode)
+
+			// Use typed classifier to match full proto enum names from wire
+			// (e.g., "K8S_MONITORING_STATUS_INSTRUMENTED", not "INSTRUMENTED").
+			switch instrumentation.ClassifyK8sMonitoringStatus(current) {
+			case instrumentation.WaitSuccess:
+				result := instrOutput.WaitResultForCluster("success", clusterName, string(current), start)
+				return result.Emit(stdout, opts.agentMode)
+
+			case instrumentation.WaitError:
+				// INSTRUMENTATION_ERROR must exit non-zero immediately.
+				return fmt.Errorf("clusters wait: %w", errInstrumentationError)
+
+			default:
+				// WaitPending: continue polling (PENDING_INSTRUMENTATION, PENDING_UNINSTRUMENTATION, etc.).
+			}
+		}
+	}
+}
+
+// findClusterStatus returns the InstrumentationStatus for clusterName from the
+// monitoring response. Returns StatusNotInstrumented if not found.
+func findClusterStatus(clusters []instrumentation.ClusterObservedState, clusterName string) instrumentation.InstrumentationStatus {
+	for _, c := range clusters {
+		if c.Name == clusterName {
+			return c.InstrumentationStatus
+		}
+	}
+	return instrumentation.StatusNotInstrumented
+}

--- a/cmd/gcx/instrumentation/clusters/wait_test.go
+++ b/cmd/gcx/instrumentation/clusters/wait_test.go
@@ -1,0 +1,342 @@
+//nolint:testpackage // white-box testing: accesses unexported run* functions and types.
+package clusters
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDeclaredClient implements declaredStateClient for wait tests.
+type fakeDeclaredClient struct {
+	Resp *instrumentation.GetK8SInstrumentationResponse
+	Err  error
+}
+
+func (f *fakeDeclaredClient) GetK8SInstrumentation(_ context.Context, _ string) (*instrumentation.GetK8SInstrumentationResponse, error) {
+	return f.Resp, f.Err
+}
+
+// declaredCluster returns a fakeDeclaredClient that reports the cluster as declared.
+func declaredCluster(name string) *fakeDeclaredClient {
+	return &fakeDeclaredClient{
+		Resp: &instrumentation.GetK8SInstrumentationResponse{
+			Cluster: instrumentation.Cluster{Name: name},
+		},
+	}
+}
+
+// undeclaredCluster returns a fakeDeclaredClient that reports the cluster as not declared
+// (empty Cluster.Name — the sentinel value for "never configured").
+func undeclaredCluster() *fakeDeclaredClient {
+	return &fakeDeclaredClient{
+		Resp: &instrumentation.GetK8SInstrumentationResponse{
+			Cluster: instrumentation.Cluster{Name: ""},
+		},
+	}
+}
+
+func TestRunWait(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		// declaredClient controls the pre-flight declared-state check.
+		declaredClient *fakeDeclaredClient
+		// monSequence is the sequence of statuses to return on each poll.
+		// The last entry is repeated for all subsequent calls.
+		monSequence []instrumentation.InstrumentationStatus
+		monErr      error
+		timeout     time.Duration
+		wantErr     bool
+		wantErrMsgs []string
+	}{
+		{
+			name:           "cluster is already INSTRUMENTED on first poll",
+			clusterName:    "prod-eu",
+			declaredClient: declaredCluster("prod-eu"),
+			monSequence: []instrumentation.InstrumentationStatus{
+				instrumentation.StatusInstrumented,
+			},
+			timeout: 30 * time.Second,
+		},
+		{
+			name:           "cluster transitions PENDING → INSTRUMENTED",
+			clusterName:    "prod-eu",
+			declaredClient: declaredCluster("prod-eu"),
+			monSequence: []instrumentation.InstrumentationStatus{
+				instrumentation.StatusPendingInstrumentation,
+				instrumentation.StatusPendingInstrumentation,
+				instrumentation.StatusInstrumented,
+			},
+			timeout: 30 * time.Second,
+		},
+		{
+			name:           "INSTRUMENTATION_ERROR exits non-zero immediately",
+			clusterName:    "prod-eu",
+			declaredClient: declaredCluster("prod-eu"),
+			monSequence: []instrumentation.InstrumentationStatus{
+				instrumentation.StatusError,
+			},
+			timeout:     30 * time.Second,
+			wantErr:     true,
+			wantErrMsgs: []string{"INSTRUMENTATION_ERROR"},
+		},
+		{
+			name:           "undeclared cluster → fail-fast with declared error",
+			clusterName:    "new-cluster",
+			declaredClient: undeclaredCluster(),
+			timeout:        30 * time.Second,
+			wantErr:        true,
+			wantErrMsgs:    []string{"cluster is not declared"},
+		},
+		{
+			name:        "GetK8SInstrumentation error propagates",
+			clusterName: "prod-eu",
+			declaredClient: &fakeDeclaredClient{
+				Err: assert.AnError,
+			},
+			timeout: 30 * time.Second,
+			wantErr: true,
+		},
+		{
+			name:           "timeout returns ErrWaitTimeoutEmitted sentinel",
+			clusterName:    "prod-eu",
+			declaredClient: declaredCluster("prod-eu"),
+			monSequence: []instrumentation.InstrumentationStatus{
+				instrumentation.StatusPendingInstrumentation,
+			},
+			timeout:     1 * time.Millisecond,
+			wantErr:     true,
+			wantErrMsgs: []string{instrumentation.ErrWaitTimeoutEmitted.Error()},
+		},
+		{
+			name:           "NOT_INSTRUMENTED continues polling (backend may not have observed yet)",
+			clusterName:    "fresh-cluster",
+			declaredClient: declaredCluster("fresh-cluster"),
+			// NOT_INSTRUMENTED is a pending state per spec: backend may not have observed
+			// the cluster yet. Continue polling; timeout if no transition to terminal state.
+			monSequence: []instrumentation.InstrumentationStatus{
+				instrumentation.StatusNotInstrumented,
+			},
+			timeout:     1 * time.Millisecond, // timeout quickly since we won't reach terminal state
+			wantErr:     true,
+			wantErrMsgs: []string{instrumentation.ErrWaitTimeoutEmitted.Error()},
+		},
+		{
+			name:           "full proto enum K8S_MONITORING_STATUS_INSTRUMENTED exits with success",
+			clusterName:    "prod-eu",
+			declaredClient: declaredCluster("prod-eu"),
+			// Wire returns full proto enum names, not shorthand constants.
+			// Classifier must match "K8S_MONITORING_STATUS_INSTRUMENTED".
+			monSequence: []instrumentation.InstrumentationStatus{
+				instrumentation.InstrumentationStatus("K8S_MONITORING_STATUS_INSTRUMENTED"),
+			},
+			timeout: 30 * time.Second,
+			wantErr: false,
+		},
+		{
+			name:           "full proto enum K8S_MONITORING_STATUS_ERROR exits non-zero",
+			clusterName:    "prod-eu",
+			declaredClient: declaredCluster("prod-eu"),
+			// Wire returns full proto enum name for error state.
+			monSequence: []instrumentation.InstrumentationStatus{
+				instrumentation.InstrumentationStatus("K8S_MONITORING_STATUS_ERROR"),
+			},
+			timeout:     30 * time.Second,
+			wantErr:     true,
+			wantErrMsgs: []string{"INSTRUMENTATION_ERROR"},
+		},
+		{
+			name:           "full proto enum K8S_MONITORING_STATUS_PENDING_INSTRUMENTATION continues polling",
+			clusterName:    "prod-eu",
+			declaredClient: declaredCluster("prod-eu"),
+			// Wire returns full proto enum name for pending state.
+			// Classifier returns WaitPending → continue polling.
+			monSequence: []instrumentation.InstrumentationStatus{
+				instrumentation.InstrumentationStatus("K8S_MONITORING_STATUS_PENDING_INSTRUMENTATION"),
+			},
+			timeout:     1 * time.Millisecond, // timeout quickly since we won't reach terminal state
+			wantErr:     true,
+			wantErrMsgs: []string{instrumentation.ErrWaitTimeoutEmitted.Error()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pollCount := 0
+			monSeq := tt.monSequence
+			clusterName := tt.clusterName
+			monErr := tt.monErr
+			monClient := &fakeMonitoringClient{
+				RunK8sMonitoringFn: func(_ context.Context) ([]instrumentation.ClusterObservedState, error) {
+					if monErr != nil {
+						return nil, monErr
+					}
+					var status instrumentation.InstrumentationStatus
+					if pollCount < len(monSeq) {
+						status = monSeq[pollCount]
+					} else if len(monSeq) > 0 {
+						status = monSeq[len(monSeq)-1]
+					}
+					pollCount++
+					return []instrumentation.ClusterObservedState{
+						{Name: clusterName, InstrumentationStatus: status},
+					}, nil
+				},
+			}
+
+			opts := &waitOpts{
+				Timeout:      tt.timeout,
+				pollInterval: 1 * time.Millisecond, // fast polling for tests
+			}
+
+			var stdout, stderr bytes.Buffer
+			err := runWait(context.Background(), opts, tt.declaredClient, monClient, tt.clusterName, &stdout, &stderr)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				for _, sub := range tt.wantErrMsgs {
+					assert.Contains(t, err.Error(), sub,
+						"expected %q in error message, got: %v", sub, err)
+				}
+				return
+			}
+			require.NoError(t, err)
+			// Success: stdout should have the terminal state message; stderr should have
+			// the banner and progress updates (stream split).
+			assert.Contains(t, stdout.String(), "INSTRUMENTED",
+				"success output on stdout should mention INSTRUMENTED")
+			assert.Contains(t, stderr.String(), "Waiting for cluster",
+				"stderr should have the wait banner")
+		})
+	}
+}
+
+func TestRunWait_ProgressOnStderr(t *testing.T) {
+	// Verifies that all progress (banner + per-poll status) routes to stderr;
+	// stdout contains only the final WaitResult.
+	client := declaredCluster("prod-eu")
+	monClient := &fakeMonitoringClient{
+		RunK8sMonitoringFn: func(_ context.Context) ([]instrumentation.ClusterObservedState, error) {
+			return []instrumentation.ClusterObservedState{
+				{Name: "prod-eu", InstrumentationStatus: instrumentation.StatusInstrumented},
+			}, nil
+		},
+	}
+	opts := &waitOpts{
+		Timeout:      30 * time.Second,
+		pollInterval: 1 * time.Millisecond,
+		agentMode:    false,
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runWait(context.Background(), opts, client, monClient, "prod-eu", &stdout, &stderr)
+	require.NoError(t, err)
+
+	// stdout: final success message only (non-agent mode uses plain text).
+	assert.Contains(t, stdout.String(), "prod-eu", "stdout should mention cluster")
+	assert.Contains(t, stdout.String(), "INSTRUMENTED", "stdout should mention status")
+	// No progress text should bleed into stdout.
+	assert.NotContains(t, stdout.String(), "Waiting for cluster", "banner must not appear on stdout")
+	assert.NotContains(t, stdout.String(), "status:", "per-poll status must not appear on stdout")
+
+	// stderr: banner + per-poll progress.
+	assert.Contains(t, stderr.String(), "Waiting for cluster", "banner must be on stderr")
+	assert.Contains(t, stderr.String(), "status:", "per-poll status must be on stderr")
+}
+
+func TestRunWait_AgentModeProgressNDJSON(t *testing.T) {
+	// Verifies agent mode: per-poll progress events are NDJSON lines on stderr.
+	client := declaredCluster("prod-eu")
+	pollCall := 0
+	monClient := &fakeMonitoringClient{
+		RunK8sMonitoringFn: func(_ context.Context) ([]instrumentation.ClusterObservedState, error) {
+			pollCall++
+			// First poll: pending; second poll: instrumented.
+			status := instrumentation.StatusPendingInstrumentation
+			if pollCall >= 2 {
+				status = instrumentation.StatusInstrumented
+			}
+			return []instrumentation.ClusterObservedState{
+				{Name: "prod-eu", InstrumentationStatus: status},
+			}, nil
+		},
+	}
+	opts := &waitOpts{
+		Timeout:      30 * time.Second,
+		pollInterval: 1 * time.Millisecond,
+		agentMode:    true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runWait(context.Background(), opts, client, monClient, "prod-eu", &stdout, &stderr)
+	require.NoError(t, err)
+
+	// stderr: NDJSON progress events.
+	stderrStr := stderr.String()
+	assert.Contains(t, stderrStr, `"event":"waiting"`, "progress NDJSON should have event:waiting")
+	assert.Contains(t, stderrStr, `"cluster":"prod-eu"`, "progress NDJSON should have cluster name")
+
+	// stdout: final success JSON envelope.
+	stdoutStr := stdout.String()
+	assert.Contains(t, stdoutStr, `"outcome":"success"`, "stdout should have outcome:success")
+	assert.Contains(t, stdoutStr, `"status":"INSTRUMENTED"`, "stdout should have status")
+}
+
+func TestRunWait_TimeoutEmitsFusedEnvelope(t *testing.T) {
+	// Verifies that timeout emits fused WaitResult with Error field to stdout
+	// and returns ErrWaitTimeoutEmitted (not a plain timeout string).
+	client := declaredCluster("prod-eu")
+	monClient := &fakeMonitoringClient{
+		RunK8sMonitoringFn: func(_ context.Context) ([]instrumentation.ClusterObservedState, error) {
+			return []instrumentation.ClusterObservedState{
+				{Name: "prod-eu", InstrumentationStatus: instrumentation.StatusPendingInstrumentation},
+			}, nil
+		},
+	}
+	opts := &waitOpts{
+		Timeout:      1 * time.Millisecond,
+		pollInterval: 1 * time.Millisecond,
+		agentMode:    true,
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runWait(context.Background(), opts, client, monClient, "prod-eu", &stdout, &stderr)
+
+	// Must return the sentinel error.
+	require.ErrorIs(t, err, instrumentation.ErrWaitTimeoutEmitted,
+		"timeout must return ErrWaitTimeoutEmitted sentinel")
+
+	// stdout must have exactly one JSON doc with outcome:timeout and error field.
+	stdoutStr := stdout.String()
+	assert.Contains(t, stdoutStr, `"outcome":"timeout"`, "stdout should have outcome:timeout")
+	assert.Contains(t, stdoutStr, `"error"`, "stdout should have error field")
+}
+
+func TestWaitOpts_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		wantErr bool
+	}{
+		{name: "positive timeout is valid", timeout: 5 * time.Minute},
+		{name: "zero timeout is invalid", timeout: 0, wantErr: true},
+		{name: "negative timeout is invalid", timeout: -1 * time.Second, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &waitOpts{Timeout: tt.timeout}
+			err := opts.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/gcx/instrumentation/command.go
+++ b/cmd/gcx/instrumentation/command.go
@@ -1,0 +1,50 @@
+// Package instrumentation provides the top-level "gcx instrumentation" command
+// and its action-verb subcommand tree for managing Grafana Instrumentation Hub.
+//
+// The command tree follows the action-verb design from ADR-018:
+//
+//	gcx instrumentation
+//	├── setup      — guided onboarding wizard
+//	├── status     — cross-cutting observed-state view
+//	├── clusters   — declared/observed state per cluster
+//	│   └── apps   — namespace-level RMW operations
+//	└── services   — workload-level observed state + overrides
+//
+// This package does NOT import from internal/providers/instrumentation to avoid a
+// cmd → internal/providers cycle. Subcommands are wired here after all
+// subcommand packages exist.
+package instrumentation
+
+import (
+	"github.com/grafana/gcx/cmd/gcx/instrumentation/clusters"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+)
+
+// Command returns the top-level "instrumentation" cobra command with all
+// subcommands registered. The loader is created here and bound to
+// PersistentFlags so --context and --config are available to all subcommands.
+func Command() *cobra.Command {
+	loader := &providers.ConfigLoader{}
+
+	cmd := &cobra.Command{
+		Use:   "instrumentation",
+		Short: "Manage Grafana Instrumentation Hub",
+		Long: `Manage Grafana Instrumentation Hub using action-verb commands.
+
+The instrumentation command tree provides:
+
+  clusters   Declared and observed state per K8s cluster:
+             list, get, configure, remove, wait.
+             Sub-group "apps" manages namespace-level Beyla configuration.`,
+	}
+
+	// Bind --context and --config persistently so all subcommands inherit them.
+	loader.BindFlags(cmd.PersistentFlags())
+
+	cmd.AddCommand(
+		clusters.Command(loader),
+	)
+
+	return cmd
+}

--- a/cmd/gcx/instrumentation/command_test.go
+++ b/cmd/gcx/instrumentation/command_test.go
@@ -1,0 +1,40 @@
+package instrumentation_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/instrumentation"
+)
+
+// TestInstrumentationCommandLongDescriptionMentionsRealVerbs asserts that the
+// parent "gcx instrumentation --help" Long description reflects the actual
+// subcommand names after PR #597 renamed clusters subcommands:
+//
+//   - enable  → configure
+//   - disable → remove
+//
+// "reset" was never a registered subcommand in this tree.
+//
+// This is a regression guard: if the Long text drifts from the real cobra
+// subcommand registry again, this test will catch it.
+func TestInstrumentationCommandLongDescriptionMentionsRealVerbs(t *testing.T) {
+	cmd := instrumentation.Command()
+	long := cmd.Long
+
+	// Stale verbs that must NOT appear.
+	staleVerbs := []string{"enable", "disable", "reset"}
+	for _, verb := range staleVerbs {
+		if strings.Contains(long, verb) {
+			t.Errorf("Long description contains stale verb %q — update the description to match the current subcommand names", verb)
+		}
+	}
+
+	// Current verbs that MUST appear.
+	currentVerbs := []string{"configure", "remove"}
+	for _, verb := range currentVerbs {
+		if !strings.Contains(long, verb) {
+			t.Errorf("Long description does not contain current verb %q — it may need to be added", verb)
+		}
+	}
+}

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/gcx/cmd/gcx/datasources"
 	"github.com/grafana/gcx/cmd/gcx/dev"
 	"github.com/grafana/gcx/cmd/gcx/helptree"
+	instrumentationcmd "github.com/grafana/gcx/cmd/gcx/instrumentation"
 	logincmd "github.com/grafana/gcx/cmd/gcx/login"
 	cmdproviders "github.com/grafana/gcx/cmd/gcx/providers"
 	"github.com/grafana/gcx/cmd/gcx/resources"
@@ -29,22 +30,23 @@ import (
 	"github.com/grafana/gcx/internal/logs"
 	"github.com/grafana/gcx/internal/notifier"
 	"github.com/grafana/gcx/internal/providers"
-	_ "github.com/grafana/gcx/internal/providers/aio11y"     // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/alert"      // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/appo11y"    // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/dashboards" // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/faro"       // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/fleet"      // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/irm"        // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/k6"         // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/kg"         // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/logs"       // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/metrics"    // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/profiles"   // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/slo"        // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/stacks"     // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/synth"      // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/traces"     // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/aio11y"          // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/alert"           // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/appo11y"         // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/dashboards"      // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/faro"            // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/fleet"           // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/instrumentation" // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/irm"             // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/k6"              // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/kg"              // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/logs"            // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/metrics"         // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/profiles"        // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/slo"             // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/stacks"          // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/synth"           // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/traces"          // Provider registrations — blank imports trigger init() self-registration.
 	"github.com/grafana/gcx/internal/style"
 	"github.com/grafana/gcx/internal/terminal"
 	appversion "github.com/grafana/gcx/internal/version"
@@ -229,6 +231,7 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 	rootCmd.AddCommand(dev.Command())
 	rootCmd.AddCommand(setup.Command())
 	rootCmd.AddCommand(versioncmd.Command())
+	rootCmd.AddCommand(instrumentationcmd.Command())
 	rootCmd.AddCommand(datasources.Command())
 	rootCmd.AddCommand(resources.Command())
 

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -35,6 +35,7 @@ gcx is a unified CLI for managing Grafana resources, dashboards, datasources, al
 * [gcx fleet](gcx_fleet.md)	 - Manage Grafana Fleet Management pipelines and collectors
 * [gcx frontend](gcx_frontend.md)	 - Manage Grafana Frontend Observability resources
 * [gcx help-tree](gcx_help-tree.md)	 - Print a compact command tree for agent context injection
+* [gcx instrumentation](gcx_instrumentation.md)	 - Manage Grafana Instrumentation Hub
 * [gcx irm](gcx_irm.md)	 - Manage Grafana IRM (OnCall + Incidents)
 * [gcx k6](gcx_k6.md)	 - Manage Grafana k6 Cloud projects, load tests, and schedules
 * [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights

--- a/docs/reference/cli/gcx_instrumentation.md
+++ b/docs/reference/cli/gcx_instrumentation.md
@@ -1,0 +1,37 @@
+## gcx instrumentation
+
+Manage Grafana Instrumentation Hub
+
+### Synopsis
+
+Manage Grafana Instrumentation Hub using action-verb commands.
+
+The instrumentation command tree provides:
+
+  clusters   Declared and observed state per K8s cluster:
+             list, get, configure, remove, wait.
+             Sub-group "apps" manages namespace-level Beyla configuration.
+
+### Options
+
+```
+      --config string   Path to the configuration file to use
+  -h, --help            help for instrumentation
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx instrumentation clusters](gcx_instrumentation_clusters.md)	 - Manage K8s monitoring configuration for clusters
+

--- a/docs/reference/cli/gcx_instrumentation_clusters.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters.md
@@ -1,0 +1,44 @@
+## gcx instrumentation clusters
+
+Manage K8s monitoring configuration for clusters
+
+### Synopsis
+
+Manage K8s monitoring configuration for clusters.
+
+Subcommands:
+  list      List all clusters with their instrumentation status
+  get       Show declared config and observed status for a single cluster
+  configure Configure K8s monitoring flags (RMW or apply defaults)
+  remove    Remove K8s monitoring from a cluster
+  wait      Wait until a cluster reaches INSTRUMENTED status
+  apps      Manage namespace-level Beyla instrumentation for a cluster
+
+### Options
+
+```
+  -h, --help   help for clusters
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation](gcx_instrumentation.md)	 - Manage Grafana Instrumentation Hub
+* [gcx instrumentation clusters apps](gcx_instrumentation_clusters_apps.md)	 - Manage namespace-level Beyla instrumentation for a cluster
+* [gcx instrumentation clusters configure](gcx_instrumentation_clusters_configure.md)	 - Configure K8s monitoring flags on a cluster
+* [gcx instrumentation clusters get](gcx_instrumentation_clusters_get.md)	 - Show declared config and observed status for a cluster
+* [gcx instrumentation clusters list](gcx_instrumentation_clusters_list.md)	 - List all clusters with their instrumentation status
+* [gcx instrumentation clusters remove](gcx_instrumentation_clusters_remove.md)	 - Remove K8s monitoring from a cluster
+* [gcx instrumentation clusters wait](gcx_instrumentation_clusters_wait.md)	 - Wait until a cluster reaches INSTRUMENTED status
+

--- a/docs/reference/cli/gcx_instrumentation_clusters_apps.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_apps.md
@@ -1,0 +1,42 @@
+## gcx instrumentation clusters apps
+
+Manage namespace-level Beyla instrumentation for a cluster
+
+### Synopsis
+
+Manage namespace-level Beyla auto-instrumentation configuration for a cluster.
+
+Commands operate on the declared state stored in Grafana Cloud's
+instrumentation service (GetAppInstrumentation / SetAppInstrumentation).
+The wait command reads observed state from RunK8sDiscovery.
+
+Identity is positional: configure and remove take <cluster> and <namespace> as
+the first two positional arguments.
+
+### Options
+
+```
+  -h, --help   help for apps
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation clusters](gcx_instrumentation_clusters.md)	 - Manage K8s monitoring configuration for clusters
+* [gcx instrumentation clusters apps configure](gcx_instrumentation_clusters_apps_configure.md)	 - Configure Beyla instrumentation for a namespace
+* [gcx instrumentation clusters apps get](gcx_instrumentation_clusters_apps_get.md)	 - Get the app instrumentation entry for a single namespace
+* [gcx instrumentation clusters apps list](gcx_instrumentation_clusters_apps_list.md)	 - List all namespace app instrumentation entries for a cluster
+* [gcx instrumentation clusters apps remove](gcx_instrumentation_clusters_apps_remove.md)	 - Remove Beyla instrumentation for a namespace
+* [gcx instrumentation clusters apps wait](gcx_instrumentation_clusters_apps_wait.md)	 - Wait for namespace instrumentation to reach a stable state
+

--- a/docs/reference/cli/gcx_instrumentation_clusters_apps_configure.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_apps_configure.md
@@ -1,0 +1,53 @@
+## gcx instrumentation clusters apps configure
+
+Configure Beyla instrumentation for a namespace
+
+### Synopsis
+
+Configure Beyla auto-instrumentation for a namespace within the given cluster.
+
+Two mutually exclusive modes:
+
+  --use-defaults --yes
+      Apply all-on canonical defaults, overwriting current state. Requires --yes.
+      Defaults: autoinstrument=true, all signals enabled.
+
+  --<feat>[=true|false] (one or more)
+      Set listed features; unspecified features preserve their current value (RMW).
+      Idempotent. No confirmation required.
+
+Combining --use-defaults with any --<feat> flag is an error.
+
+```
+gcx instrumentation clusters apps configure <cluster> <namespace> [flags]
+```
+
+### Options
+
+```
+      --extended-metrics   Set extended Beyla metrics collection. Pass --extended-metrics=false to disable.
+  -h, --help               help for configure
+      --logging            Set log collection. Pass --logging=false to disable.
+      --process-metrics    Set process-level metrics collection. Pass --process-metrics=false to disable.
+      --profiling          Set continuous profiling collection. Pass --profiling=false to disable.
+      --tracing            Set distributed tracing collection. Pass --tracing=false to disable.
+      --use-defaults       Apply all-on canonical defaults. Requires --yes.
+      --yes                Confirm the --use-defaults operation (required with --use-defaults)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation clusters apps](gcx_instrumentation_clusters_apps.md)	 - Manage namespace-level Beyla instrumentation for a cluster
+

--- a/docs/reference/cli/gcx_instrumentation_clusters_apps_get.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_apps_get.md
@@ -1,0 +1,41 @@
+## gcx instrumentation clusters apps get
+
+Get the app instrumentation entry for a single namespace
+
+### Synopsis
+
+Get the declared Beyla instrumentation configuration for a single namespace
+within the given cluster.
+
+Reads declared state from GetAppInstrumentation and filters client-side to the
+requested namespace. Exits non-zero with a not-found error when the
+namespace has no declared configuration.
+
+```
+gcx instrumentation clusters apps get <cluster> <namespace> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, text, wide, yaml (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation clusters apps](gcx_instrumentation_clusters_apps.md)	 - Manage namespace-level Beyla instrumentation for a cluster
+

--- a/docs/reference/cli/gcx_instrumentation_clusters_apps_list.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_apps_list.md
@@ -1,0 +1,40 @@
+## gcx instrumentation clusters apps list
+
+List all namespace app instrumentation entries for a cluster
+
+### Synopsis
+
+List all namespace-level Beyla instrumentation entries for the given cluster.
+
+Reads declared state from GetAppInstrumentation (a single RPC call). The output
+reflects the configuration stored in Grafana Cloud, not the live observed state.
+Use "gcx instrumentation status" for observed-state status.
+
+```
+gcx instrumentation clusters apps list <cluster> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, text, wide, yaml (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation clusters apps](gcx_instrumentation_clusters_apps.md)	 - Manage namespace-level Beyla instrumentation for a cluster
+

--- a/docs/reference/cli/gcx_instrumentation_clusters_apps_remove.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_apps_remove.md
@@ -1,0 +1,42 @@
+## gcx instrumentation clusters apps remove
+
+Remove Beyla instrumentation for a namespace
+
+### Synopsis
+
+Remove Beyla auto-instrumentation for a namespace by removing its entry
+from the cluster's app instrumentation configuration.
+
+The namespace entry is removed from namespaces[] via a whole-list replacement
+(SetAppInstrumentation). When no namespace entries remain with included content,
+the backend deletes the app pipeline entirely.
+
+This command requires --yes to proceed.
+
+```
+gcx instrumentation clusters apps remove <cluster> <namespace> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+      --yes    Confirm removal of namespace app instrumentation
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation clusters apps](gcx_instrumentation_clusters_apps.md)	 - Manage namespace-level Beyla instrumentation for a cluster
+

--- a/docs/reference/cli/gcx_instrumentation_clusters_apps_wait.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_apps_wait.md
@@ -1,0 +1,43 @@
+## gcx instrumentation clusters apps wait
+
+Wait for namespace instrumentation to reach a stable state
+
+### Synopsis
+
+Wait for the namespace Beyla instrumentation to transition out of a pending
+state by polling RunK8sDiscovery at 5-second intervals.
+
+Exit 0 when the namespace's workloads reach a stable non-pending state
+(INSTRUMENTED, NOT_INSTRUMENTED, EXCLUDED, or any terminal non-error state).
+
+Exit non-zero when:
+  - INSTRUMENTATION_ERROR is observed for any workload.
+  - The --timeout duration elapses while still in a pending state.
+
+```
+gcx instrumentation clusters apps wait <cluster> <namespace> [flags]
+```
+
+### Options
+
+```
+  -h, --help               help for wait
+      --timeout duration   Maximum time to wait (e.g. 5m, 10m, 1h) (default 5m0s)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation clusters apps](gcx_instrumentation_clusters_apps.md)	 - Manage namespace-level Beyla instrumentation for a cluster
+

--- a/docs/reference/cli/gcx_instrumentation_clusters_configure.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_configure.md
@@ -1,0 +1,65 @@
+## gcx instrumentation clusters configure
+
+Configure K8s monitoring flags on a cluster
+
+### Synopsis
+
+Configure K8s monitoring feature flags on a cluster.
+
+Two mutually exclusive modes:
+
+  --use-defaults --yes
+      Apply canonical defaults, overwriting current state. Requires --yes.
+      Defaults: costMetrics=true, clusterEvents=true, energyMetrics=false, nodeLogs=false.
+
+  --<feat>[=true|false] (one or more)
+      Set listed features; unspecified features preserve their current value (RMW).
+      Idempotent. No confirmation required.
+
+Combining --use-defaults with any --<feat> flag is an error.
+
+```
+gcx instrumentation clusters configure <cluster> [flags]
+```
+
+### Examples
+
+```
+  # Apply defaults to cluster "prod-eu"
+  gcx instrumentation clusters configure prod-eu --use-defaults --yes
+
+  # Enable cost metrics, preserving other flags (RMW)
+  gcx instrumentation clusters configure prod-eu --cost-metrics
+
+  # Disable node logs (RMW)
+  gcx instrumentation clusters configure prod-eu --node-logs=false
+```
+
+### Options
+
+```
+      --cluster-events   Set clusterEvents. Pass --cluster-events=false to disable.
+      --cost-metrics     Set costMetrics. Pass --cost-metrics=false to disable. Omit to preserve current value.
+      --energy-metrics   Set energyMetrics. Pass --energy-metrics=false to disable.
+  -h, --help             help for configure
+      --node-logs        Set nodeLogs. Pass --node-logs=false to disable.
+      --use-defaults     Apply canonical defaults (costMetrics=true, clusterEvents=true, energyMetrics=false, nodeLogs=false). Requires --yes.
+      --yes              Confirm the --use-defaults operation (required with --use-defaults)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation clusters](gcx_instrumentation_clusters.md)	 - Manage K8s monitoring configuration for clusters
+

--- a/docs/reference/cli/gcx_instrumentation_clusters_get.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_get.md
@@ -1,0 +1,52 @@
+## gcx instrumentation clusters get
+
+Show declared config and observed status for a cluster
+
+### Synopsis
+
+Show the declared K8s monitoring configuration and observed instrumentation
+status for a single cluster.
+
+The declared configuration is fetched via GetK8SInstrumentation. The observed
+status is cross-referenced with RunK8sMonitoring. If the cluster is absent from
+RunK8sMonitoring, ListPipelines is checked: a K8s monitoring pipeline present
+means PENDING_INSTRUMENTATION; absent means NOT_INSTRUMENTED.
+
+```
+gcx instrumentation clusters get <cluster> [flags]
+```
+
+### Examples
+
+```
+  # Get cluster "prod-eu" in table format
+  gcx instrumentation clusters get prod-eu
+
+  # Get in JSON format
+  gcx instrumentation clusters get prod-eu -o json
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation clusters](gcx_instrumentation_clusters.md)	 - Manage K8s monitoring configuration for clusters
+

--- a/docs/reference/cli/gcx_instrumentation_clusters_list.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_list.md
@@ -1,0 +1,56 @@
+## gcx instrumentation clusters list
+
+List all clusters with their instrumentation status
+
+### Synopsis
+
+List all clusters with their K8s monitoring configuration and observed status.
+
+Merges RunK8sMonitoring with ListPipelines to surface clusters that have been
+configured but whose Alloy collector has not yet started reporting (pre-Alloy
+clusters appear with PENDING_INSTRUMENTATION status).
+
+For each cluster, the declared configuration is fetched concurrently via
+GetK8SInstrumentation (up to 10 concurrent requests).
+
+```
+gcx instrumentation clusters list [flags]
+```
+
+### Examples
+
+```
+  # List all clusters (table output)
+  gcx instrumentation clusters list
+
+  # List in wide format (shows all flag columns)
+  gcx instrumentation clusters list -o wide
+
+  # Output as JSON
+  gcx instrumentation clusters list -o json
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation clusters](gcx_instrumentation_clusters.md)	 - Manage K8s monitoring configuration for clusters
+

--- a/docs/reference/cli/gcx_instrumentation_clusters_remove.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_remove.md
@@ -1,0 +1,53 @@
+## gcx instrumentation clusters remove
+
+Remove K8s monitoring from a cluster
+
+### Synopsis
+
+Remove K8s monitoring from a cluster.
+
+Calls SetK8SInstrumentation with Selection=SELECTION_EXCLUDED. The backend
+interprets this as a request to delete the K8s monitoring pipeline for the
+cluster.
+
+IMPORTANT: After removing, the cluster's status takes approximately 5 minutes
+to transition from INSTRUMENTED to NOT_INSTRUMENTED. During this decay window,
+the cluster may still appear as INSTRUMENTED in status output. This is expected
+behaviour — the Alloy collector drains its in-flight telemetry before stopping.
+
+Requires --yes to confirm the destructive operation.
+
+```
+gcx instrumentation clusters remove <cluster> [flags]
+```
+
+### Examples
+
+```
+  # Remove K8s monitoring for cluster "prod-eu"
+  gcx instrumentation clusters remove prod-eu --yes
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+      --yes    Confirm the remove operation (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation clusters](gcx_instrumentation_clusters.md)	 - Manage K8s monitoring configuration for clusters
+

--- a/docs/reference/cli/gcx_instrumentation_clusters_wait.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_wait.md
@@ -1,0 +1,56 @@
+## gcx instrumentation clusters wait
+
+Wait until a cluster reaches INSTRUMENTED status
+
+### Synopsis
+
+Poll until the specified cluster reaches INSTRUMENTED status.
+
+The command polls RunK8sMonitoring every 5 seconds. Before starting
+the polling loop, it performs a pre-flight check to verify the cluster has
+been declared (via gcx instrumentation setup) — if not configured, it
+returns an error immediately with a remediation hint.
+
+Exit codes:
+  0  Cluster reached INSTRUMENTED status (or a non-error terminal state)
+  1  Timeout reached before INSTRUMENTED status
+  1  INSTRUMENTATION_ERROR status observed
+  1  Pre-flight check failed (cluster not declared)
+
+```
+gcx instrumentation clusters wait <cluster> [flags]
+```
+
+### Examples
+
+```
+  # Wait with default 5-minute timeout
+  gcx instrumentation clusters wait prod-eu
+
+  # Wait with a custom timeout
+  gcx instrumentation clusters wait prod-eu --timeout 10m
+```
+
+### Options
+
+```
+  -h, --help               help for wait
+      --timeout duration   Maximum time to wait for INSTRUMENTED status (default 5m0s)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation clusters](gcx_instrumentation_clusters.md)	 - Manage K8s monitoring configuration for clusters
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -90,6 +90,24 @@ var commandAnnotations = map[string]annotation{
 	"gcx setup instrumentation show":     {Cost: "medium", Hint: "<cluster> -o json"},
 	"gcx setup instrumentation status":   {Cost: "small"},
 
+	// -----------------------------------------------------------------------
+	// Instrumentation provider (action-verb tree — ADR-018)
+	// -----------------------------------------------------------------------
+
+	// clusters verb group
+	"gcx instrumentation clusters list":      {Cost: "large", Hint: "-o json"},
+	"gcx instrumentation clusters get":       {Cost: "medium", Hint: "<cluster> -o json"},
+	"gcx instrumentation clusters configure": {Cost: "small"},
+	"gcx instrumentation clusters remove":    {Cost: "small"},
+	"gcx instrumentation clusters wait":      {Cost: "small"},
+
+	// clusters apps verb group
+	"gcx instrumentation clusters apps list":      {Cost: "medium", Hint: "<cluster> -o json"},
+	"gcx instrumentation clusters apps get":       {Cost: "medium", Hint: "<cluster> <namespace> -o json"},
+	"gcx instrumentation clusters apps configure": {Cost: "small"},
+	"gcx instrumentation clusters apps remove":    {Cost: "small"},
+	"gcx instrumentation clusters apps wait":      {Cost: "small"},
+
 	// skills
 	"gcx agent skills install":   {Cost: "small"},
 	"gcx agent skills list":      {Cost: "small"},


### PR DESCRIPTION
## What

Adds the first slice of the `gcx instrumentation` command tree, built on the provider package from the prior stack PR.

`gcx instrumentation clusters [list|get|configure|remove|wait]` provides declared-state read/write across the cluster set with tri-state flag semantics on `configure` (`--cost-metrics`, `--cluster-events`, etc.) and a per-namespace optimistic-lock guard on RMW.

`gcx instrumentation clusters apps [list|get|configure|remove|wait]` adds namespace-level Beyla configuration as a sub-group using the same RMW and tri-state pattern.

The root `gcx instrumentation` command is registered in this PR alongside the provider blank import (which triggers provider self-registration via `init()`). Token-cost annotations are added for all new leaf commands. CLI reference docs are regenerated for the clusters subtree; services, setup, and status follow in the next stack PR.

## Why

The instrumentation command tree is split into reviewable slices to keep individual PRs focused. The clusters subtree is the foundational slice: it establishes the command structure and RMW pattern that subsequent subtrees follow.

The root command intentionally registers only the clusters subtree at this point so the stack stays compilable; the next PR extends its `Long` description and `AddCommand` block to include the remaining subtrees.

## How it was tested

- [x] `go test ./cmd/gcx/instrumentation/...` — clusters and clusters apps tests pass
- [x] `go test ./...` — full suite passes with no regressions
- [x] `go build ./cmd/gcx/` — binary builds cleanly with the instrumentation root command registered

## Related

- Relates to #597

---
**Generated by Claude Code**

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #655**
  * **PR #656** 👈
    * **PR #657**
      * **PR #658**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->
