### PR TITLE
feat(instrumentation): add services, setup, and status CLI subtrees

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -1104,7 +1104,6 @@ func convertInstrumentationErrors(err error) (*DetailedError, bool) {
 		Parent:  err,
 	}, true
 }
-
 func adaptiveScopeSuggestionFromSignalPrefix(msg string) string {
 	switch {
 	case strings.Contains(msg, "adaptive-logs:"):

--- a/cmd/gcx/instrumentation/clusters/configure.go
+++ b/cmd/gcx/instrumentation/clusters/configure.go
@@ -39,12 +39,6 @@ type configureOpts struct {
 	nodeLogs      bool
 }
 
-// Validate of the mutually-exclusive-mode and --yes-required-for-defaults rules
-// requires inspecting flags.Changed(), which depends on the *cobra.Command
-// instance. Those checks live in runConfigure where the command is in scope.
-// Keeping Validate as a no-op here satisfies the canonical opts pattern.
-func (o *configureOpts) Validate() error { return nil }
-
 func (o *configureOpts) setup(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.useDefaults, "use-defaults", false,
 		"Apply canonical defaults (costMetrics=true, clusterEvents=true, energyMetrics=false, nodeLogs=false). Requires --yes.")
@@ -88,9 +82,6 @@ Combining --use-defaults with any --<feat> flag is an error.`,
   # Disable node logs (RMW)
   gcx instrumentation clusters configure prod-eu --node-logs=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.Validate(); err != nil {
-				return err
-			}
 			ctx := cmd.Context()
 			clusterName := args[0]
 			r, err := fleet.LoadClientWithStack(ctx, loader)

--- a/cmd/gcx/instrumentation/clusters/configure.go
+++ b/cmd/gcx/instrumentation/clusters/configure.go
@@ -39,6 +39,12 @@ type configureOpts struct {
 	nodeLogs      bool
 }
 
+// Validate of the mutually-exclusive-mode and --yes-required-for-defaults rules
+// requires inspecting flags.Changed(), which depends on the *cobra.Command
+// instance. Those checks live in runConfigure where the command is in scope.
+// Keeping Validate as a no-op here satisfies the canonical opts pattern.
+func (o *configureOpts) Validate() error { return nil }
+
 func (o *configureOpts) setup(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.useDefaults, "use-defaults", false,
 		"Apply canonical defaults (costMetrics=true, clusterEvents=true, energyMetrics=false, nodeLogs=false). Requires --yes.")

--- a/cmd/gcx/instrumentation/command.go
+++ b/cmd/gcx/instrumentation/command.go
@@ -17,6 +17,9 @@ package instrumentation
 
 import (
 	"github.com/grafana/gcx/cmd/gcx/instrumentation/clusters"
+	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
+	"github.com/grafana/gcx/cmd/gcx/instrumentation/setup"
+	"github.com/grafana/gcx/cmd/gcx/instrumentation/status"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/spf13/cobra"
 )
@@ -34,16 +37,28 @@ func Command() *cobra.Command {
 
 The instrumentation command tree provides:
 
+  setup      Guided onboarding wizard: configures a cluster end-to-end and
+             prints a runnable helm install command.
+
+  status     Cross-cutting observed state for clusters and namespaces
+             (RunK8sMonitoring + ListPipelines merge).
+
   clusters   Declared and observed state per K8s cluster:
              list, get, configure, remove, wait.
-             Sub-group "apps" manages namespace-level Beyla configuration.`,
+             Sub-group "apps" manages namespace-level Beyla configuration.
+
+  services   Workload-level observed state and per-workload inclusion
+             overrides across the fleet: list, get, include, exclude, clear.`,
 	}
 
 	// Bind --context and --config persistently so all subcommands inherit them.
 	loader.BindFlags(cmd.PersistentFlags())
 
 	cmd.AddCommand(
+		setup.Command(loader),
+		status.Command(loader),
 		clusters.Command(loader),
+		services.Command(loader),
 	)
 
 	return cmd

--- a/cmd/gcx/instrumentation/services/clear.go
+++ b/cmd/gcx/instrumentation/services/clear.go
@@ -1,0 +1,139 @@
+//nolint:dupl // clear, include and exclude are intentionally symmetric DWIM commands; duplication is acceptable here.
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instoutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation/rmw"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// clearOpts holds flag-bound options for the "services clear" command.
+// The command takes only positional args today, so the struct is empty;
+// it exists to satisfy the canonical opts struct + setup + Validate pattern.
+type clearOpts struct{}
+
+func (o *clearOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *clearOpts) Validate() error { return nil }
+
+func newClearCommand(loader fleet.ConfigLoader) *cobra.Command {
+	opts := &clearOpts{}
+	cmd := &cobra.Command{
+		Use:   "clear <cluster> <namespace> <service>",
+		Short: "Remove a per-workload override, inheriting namespace default",
+		Long: `Remove any per-workload inclusion or exclusion override for a workload.
+
+After clearing, the workload inherits the namespace autoinstrument default.
+
+The operation is idempotent: if no override exists for the workload,
+the command exits 0 without making any backend calls.
+
+The write uses an optimistic-lock guard (rmw.Update) when a change is needed:
+if the namespace list changes between the initial read and the pre-write re-check,
+the command returns a conflict error and must be retried.
+
+Examples:
+  gcx instrumentation services clear prod-1 checkout frontend`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			r, err := fleet.LoadClientWithStack(ctx, loader)
+			if err != nil {
+				return fmt.Errorf("services clear: %w", err)
+			}
+			client := instrumentation.NewClient(r.Client)
+			urls := instrumentation.BackendURLsFromStack(r.Stack)
+			return runClear(ctx, client, args[0], args[1], args[2], urls, instrumentation.PromHeadersFromStack(r.Stack), cmd.OutOrStdout())
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// runClear removes any per-workload override for the given service.
+// If the namespace is not found or has no override for the service, it returns
+// nil (idempotent no-op) without making any backend call.
+func runClear(
+	ctx context.Context,
+	client *instrumentation.Client,
+	cluster, namespace, service string,
+	urls instrumentation.BackendURLs,
+	promHeaders instrumentation.PromHeaders,
+	out io.Writer,
+) error {
+	// Workload existence pre-flight: verify the service appears in discovery.
+	if err := validateWorkloadExists(ctx, client, promHeaders, cluster, namespace, service); err != nil {
+		return err
+	}
+
+	// Idempotence pre-check: if the namespace doesn't exist or has no override,
+	// there is nothing to clear.
+	resp, err := client.GetAppInstrumentation(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("services clear: %w", err)
+	}
+
+	ns := findNamespace(resp.Namespaces, namespace)
+	if ns == nil {
+		// Namespace not configured — nothing to clear; idempotent no-op.
+		return instoutput.MutationResult{
+			Action:  "clear",
+			Target:  instoutput.Target{Cluster: cluster, Namespace: namespace, Service: service},
+			Changed: false,
+		}.Emit(out)
+	}
+
+	proposed := applyClearMutation(*ns, service)
+	equal, _ := rmw.AppEqual(*ns, proposed)
+	if equal {
+		// No override exists for the service — idempotent no-op.
+		return instoutput.MutationResult{
+			Action:  "clear",
+			Target:  instoutput.Target{Cluster: cluster, Namespace: namespace, Service: service},
+			Changed: false,
+		}.Emit(out)
+	}
+
+	getFn := func(ctx context.Context) ([]instrumentation.App, error) {
+		r, err := client.GetAppInstrumentation(ctx, cluster)
+		if err != nil {
+			return nil, err
+		}
+		return r.Namespaces, nil
+	}
+	mutateFn := func(namespaces []instrumentation.App) []instrumentation.App {
+		return applyMutationToNamespaces(namespaces, namespace, func(n instrumentation.App) instrumentation.App {
+			return applyClearMutation(n, service)
+		})
+	}
+	setFn := func(ctx context.Context, namespaces []instrumentation.App) error {
+		return client.SetAppInstrumentation(ctx, cluster, namespaces, urls)
+	}
+
+	if err := rmw.Update(ctx, getFn, mutateFn, setFn, namespacesEqual, 3); err != nil {
+		var ce rmw.ConflictError
+		if errors.As(err, &ce) {
+			ce.Command = "services clear"
+			ce.Namespace = namespace
+			return ce
+		}
+		return fmt.Errorf("services clear: %w", err)
+	}
+
+	return instoutput.MutationResult{
+		Action:  "clear",
+		Target:  instoutput.Target{Cluster: cluster, Namespace: namespace, Service: service},
+		Changed: true,
+	}.Emit(out)
+}

--- a/cmd/gcx/instrumentation/services/clear_test.go
+++ b/cmd/gcx/instrumentation/services/clear_test.go
@@ -1,0 +1,217 @@
+package services_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunClear_RemovesOverride verifies clear removes a per-workload override
+// so the service falls back to the namespace default.
+func TestRunClear_RemovesOverride(t *testing.T) {
+	// Namespace has a SELECTION_INCLUDED override on "frontend".
+	resp := buildGetAppResp(t, "c1", "grotshop", nil, []map[string]any{
+		{"name": "frontend", "selection": "SELECTION_INCLUDED"},
+	})
+
+	ts := &includeTestServer{
+		getAppResp: resp,
+		discoveryItems: []map[string]any{
+			{"clusterName": "c1", "namespace": "grotshop", "name": "frontend"},
+		},
+	}
+	srv := ts.start(t)
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.NoError(t, err, "clear must succeed")
+	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to remove the override")
+}
+
+// TestRunClear_NoOp_NoOverride verifies clear is idempotent — if no override
+// exists for the service, no Set call is made.
+func TestRunClear_NoOp_NoOverride(t *testing.T) {
+	// Namespace has no per-workload overrides.
+	resp := buildGetAppResp(t, "c1", "grotshop", nil, nil)
+
+	ts := &includeTestServer{
+		getAppResp: resp,
+		discoveryItems: []map[string]any{
+			{"clusterName": "c1", "namespace": "grotshop", "name": "frontend"},
+		},
+	}
+	srv := ts.start(t)
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.NoError(t, err, "clear with no override must be a no-op (exit 0)")
+	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when no override exists")
+}
+
+// TestRunClear_NoOp_NamespaceNotFound verifies that clear is a no-op when the namespace
+// is not configured in the cluster's app configuration.
+// The workload is present in discovery (pre-flight passes), but GetAppInstrumentation
+// returns an empty namespace list, so runClear hits the namespace-not-found no-op path.
+func TestRunClear_NoOp_NamespaceNotFound(t *testing.T) {
+	ts := &includeTestServer{
+		getAppResp: `{"cluster":{"name":"c1","namespaces":[]}}`,
+		discoveryItems: []map[string]any{
+			{"clusterName": "c1", "namespace": "missing-ns", "name": "svc"},
+		},
+	}
+	srv := ts.start(t)
+	client := makeIncludeClient(t, srv.URL)
+
+	err := services.RunClear(context.Background(), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	require.NoError(t, err, "clear on missing namespace must be a no-op")
+	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call for missing namespace")
+}
+
+// TestRunClear_Idempotent_TwoCalls verifies that running clear twice exits 0 both times
+// and the second call is a no-op.
+func TestRunClear_Idempotent_TwoCalls(t *testing.T) {
+	withOverrideResp := buildGetAppResp(t, "c1", "grotshop", nil, []map[string]any{
+		{"name": "frontend", "selection": "SELECTION_INCLUDED"},
+	})
+	withoutOverrideResp := buildGetAppResp(t, "c1", "grotshop", nil, nil)
+
+	callCount := 0
+	ts := &includeTestServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{
+			{"clusterName": "c1", "namespace": "grotshop", "name": "frontend"},
+		}})
+	})
+	mux.HandleFunc("/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// First 3 calls: pre-check + 2 RMW reads use the with-override state.
+		// Subsequent calls: without-override state (post-clear).
+		if callCount < 3 {
+			_, _ = w.Write([]byte(withOverrideResp))
+		} else {
+			_, _ = w.Write([]byte(withoutOverrideResp))
+		}
+		callCount++
+	})
+	mux.HandleFunc("/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+		ts.setAppCalled.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := makeIncludeClient(t, srv.URL)
+
+	// First clear: removes the INCLUDED override.
+	err1 := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	require.NoError(t, err1, "first clear must succeed")
+	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "first clear must call Set once")
+
+	// Second clear: no override → no-op.
+	err2 := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	require.NoError(t, err2, "second clear must succeed (exit 0)")
+	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "second clear must be a no-op (no additional Set)")
+}
+
+// TestRunClear_WorkloadNotFound verifies that clear returns a workload-not-found
+// error when RunK8sDiscovery does not contain the requested service, and does NOT
+// call GetAppInstrumentation (pre-flight short-circuits the operation).
+//
+//nolint:dupl // WorkloadNotFound tests for exclude/include/clear are intentionally symmetric.
+func TestRunClear_WorkloadNotFound(t *testing.T) {
+	callCounts := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		callCounts[r.URL.Path]++
+		switch r.URL.Path {
+		case "/discovery.v1.DiscoveryService/RunK8sDiscovery":
+			// Return empty items — workload not found.
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunClear(context.Background(), client, "prod-eu", "checkout", "nonexistent-svc",
+		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Resource not found")
+	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).
+	assert.Zero(t, callCounts["/instrumentation.v1.InstrumentationService/GetAppInstrumentation"],
+		"GetAppInstrumentation must not be called after pre-flight failure")
+}
+
+// ─── Unit tests for applyClearMutation ───────────────────────────────────────
+
+// TestApplyClearMutation_RemovesIncluded verifies that clear removes an INCLUDED override.
+func TestApplyClearMutation_RemovesIncluded(t *testing.T) {
+	ns := instrumentation.App{
+		Name: "ns",
+		Apps: []instrumentation.AppOverride{
+			{Name: "svc", Selection: "SELECTION_INCLUDED"},
+		},
+	}
+	result := services.ApplyClearMutation(ns, "svc")
+	assert.Empty(t, result.Apps, "INCLUDED override must be removed")
+}
+
+// TestApplyClearMutation_RemovesExcluded verifies that clear removes an EXCLUDED override.
+func TestApplyClearMutation_RemovesExcluded(t *testing.T) {
+	ns := instrumentation.App{
+		Name: "ns",
+		Apps: []instrumentation.AppOverride{
+			{Name: "svc", Selection: "SELECTION_EXCLUDED"},
+		},
+	}
+	result := services.ApplyClearMutation(ns, "svc")
+	assert.Empty(t, result.Apps, "EXCLUDED override must be removed")
+}
+
+// TestApplyClearMutation_PreservesOtherOverrides verifies that clear only removes
+// the targeted service's override, leaving other overrides intact.
+func TestApplyClearMutation_PreservesOtherOverrides(t *testing.T) {
+	ns := instrumentation.App{
+		Name: "ns",
+		Apps: []instrumentation.AppOverride{
+			{Name: "svc-a", Selection: "SELECTION_INCLUDED"},
+			{Name: "svc-b", Selection: "SELECTION_EXCLUDED"},
+		},
+	}
+	result := services.ApplyClearMutation(ns, "svc-a")
+	require.Len(t, result.Apps, 1, "only svc-a override must be removed")
+	assert.Equal(t, "svc-b", result.Apps[0].Name)
+}
+
+// TestApplyClearMutation_Idempotent verifies that clearing twice gives the same result.
+func TestApplyClearMutation_Idempotent(t *testing.T) {
+	ns := instrumentation.App{
+		Name: "ns",
+		Apps: []instrumentation.AppOverride{
+			{Name: "svc", Selection: "SELECTION_INCLUDED"},
+		},
+	}
+	once := services.ApplyClearMutation(ns, "svc")
+	twice := services.ApplyClearMutation(once, "svc")
+	assert.Empty(t, twice.Apps, "clearing twice must still result in no overrides")
+}

--- a/cmd/gcx/instrumentation/services/command.go
+++ b/cmd/gcx/instrumentation/services/command.go
@@ -1,0 +1,44 @@
+// Package services provides the "gcx instrumentation services" command tree
+// for managing workload-level observed state and per-workload overrides.
+//
+// The command tree implements ADR-018 action-verb design:
+//
+//	gcx instrumentation services
+//	├── list     — fleet-wide RunK8sDiscovery with client-side filters
+//	├── get      — single workload lookup by (cluster, namespace, service)
+//	├── include  — DWIM per-workload include override
+//	├── exclude  — DWIM per-workload exclude override
+//	└── clear    — remove any per-workload override
+package services
+
+import (
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/spf13/cobra"
+)
+
+// Command returns the "services" cobra command with list/get/include/exclude/clear
+// subcommands registered.
+func Command(loader fleet.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "services",
+		Short: "Manage workload-level instrumentation across the fleet",
+		Long: `Manage workload-level observed state and per-workload inclusion
+overrides across the fleet.
+
+Subcommands:
+
+  list     List all discovered workloads, with optional filtering.
+  get      Get a single workload by (cluster, namespace, service).
+  include  Include a workload for instrumentation (DWIM, idempotent).
+  exclude  Exclude a workload from instrumentation (DWIM, idempotent).
+  clear    Remove a per-workload override, inheriting namespace default.`,
+	}
+
+	cmd.AddCommand(newListCommand(loader))
+	cmd.AddCommand(newGetCommand(loader))
+	cmd.AddCommand(newIncludeCommand(loader))
+	cmd.AddCommand(newExcludeCommand(loader))
+	cmd.AddCommand(newClearCommand(loader))
+
+	return cmd
+}

--- a/cmd/gcx/instrumentation/services/exclude.go
+++ b/cmd/gcx/instrumentation/services/exclude.go
@@ -1,0 +1,139 @@
+//nolint:dupl // exclude and include are intentionally symmetric; duplication is acceptable here.
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instoutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation/rmw"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// excludeOpts holds flag-bound options for the "services exclude" command.
+// The command takes only positional args today, so the struct is empty;
+// it exists to satisfy the canonical opts struct + setup + Validate pattern.
+type excludeOpts struct{}
+
+func (o *excludeOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *excludeOpts) Validate() error { return nil }
+
+func newExcludeCommand(loader fleet.ConfigLoader) *cobra.Command {
+	opts := &excludeOpts{}
+	cmd := &cobra.Command{
+		Use:   "exclude <cluster> <namespace> <service>",
+		Short: "Exclude a workload from instrumentation (DWIM, idempotent)",
+		Long: `Exclude a specific workload from instrumentation using DWIM semantics.
+
+DWIM logic:
+  - Removes any existing INCLUDED override for the workload.
+  - Adds an EXCLUDED override iff the namespace autoinstrument is explicitly
+    true (i.e. the namespace default is on, so an explicit opt-out is needed).
+  - If the namespace autoinstrument is false/nil, no override is added (the
+    namespace default is already off — adding EXCLUDED would be redundant).
+
+The operation is idempotent: running it twice with the same args exits 0 and
+the second call is a no-op against the backend.
+
+The write uses an optimistic-lock guard (rmw.Update): if the namespace list
+changes between the initial read and the pre-write re-check, the command returns
+a conflict error and must be retried.
+
+Examples:
+  gcx instrumentation services exclude prod-1 checkout payment-svc`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			r, err := fleet.LoadClientWithStack(ctx, loader)
+			if err != nil {
+				return fmt.Errorf("services exclude: %w", err)
+			}
+			client := instrumentation.NewClient(r.Client)
+			urls := instrumentation.BackendURLsFromStack(r.Stack)
+			return runExclude(ctx, client, args[0], args[1], args[2], urls, instrumentation.PromHeadersFromStack(r.Stack), cmd.OutOrStdout())
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// runExclude executes the DWIM exclude operation for a single workload.
+// Symmetric to runInclude (see include.go for full design notes).
+func runExclude(
+	ctx context.Context,
+	client *instrumentation.Client,
+	cluster, namespace, service string,
+	urls instrumentation.BackendURLs,
+	promHeaders instrumentation.PromHeaders,
+	out io.Writer,
+) error {
+	// Workload existence pre-flight: verify the service appears in discovery.
+	if err := validateWorkloadExists(ctx, client, promHeaders, cluster, namespace, service); err != nil {
+		return err
+	}
+
+	// Idempotence pre-check.
+	resp, err := client.GetAppInstrumentation(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("services exclude: %w", err)
+	}
+
+	ns := findNamespace(resp.Namespaces, namespace)
+	if ns == nil {
+		return fmt.Errorf("services exclude: namespace %q not found in cluster %q; "+
+			"run 'gcx instrumentation clusters apps enable %s %s' first",
+			namespace, cluster, cluster, namespace)
+	}
+
+	proposed := applyExcludeMutation(*ns, service)
+	equal, _ := rmw.AppEqual(*ns, proposed)
+	if equal {
+		// Already in the desired state — idempotent no-op.
+		return instoutput.MutationResult{
+			Action:  "exclude",
+			Target:  instoutput.Target{Cluster: cluster, Namespace: namespace, Service: service},
+			Changed: false,
+		}.Emit(out)
+	}
+
+	getFn := func(ctx context.Context) ([]instrumentation.App, error) {
+		r, err := client.GetAppInstrumentation(ctx, cluster)
+		if err != nil {
+			return nil, err
+		}
+		return r.Namespaces, nil
+	}
+	mutateFn := func(namespaces []instrumentation.App) []instrumentation.App {
+		return applyMutationToNamespaces(namespaces, namespace, func(n instrumentation.App) instrumentation.App {
+			return applyExcludeMutation(n, service)
+		})
+	}
+	setFn := func(ctx context.Context, namespaces []instrumentation.App) error {
+		return client.SetAppInstrumentation(ctx, cluster, namespaces, urls)
+	}
+
+	if err := rmw.Update(ctx, getFn, mutateFn, setFn, namespacesEqual, 3); err != nil {
+		var ce rmw.ConflictError
+		if errors.As(err, &ce) {
+			ce.Command = "services exclude"
+			ce.Namespace = namespace
+			return ce
+		}
+		return fmt.Errorf("services exclude: %w", err)
+	}
+
+	return instoutput.MutationResult{
+		Action:  "exclude",
+		Target:  instoutput.Target{Cluster: cluster, Namespace: namespace, Service: service},
+		Changed: true,
+	}.Emit(out)
+}

--- a/cmd/gcx/instrumentation/services/exclude_test.go
+++ b/cmd/gcx/instrumentation/services/exclude_test.go
@@ -1,0 +1,269 @@
+package services_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunExclude_AutoinstrumentTrue_AddsExcluded verifies DWIM exclude logic:
+// when autoinstrument=true, an EXCLUDED override must be added.
+func TestRunExclude_AutoinstrumentTrue_AddsExcluded(t *testing.T) {
+	trueVal := true
+	resp := buildGetAppResp(t, "c1", "ns", &trueVal, nil)
+
+	ts := &includeTestServer{
+		getAppResp: resp,
+		discoveryItems: []map[string]any{
+			{"clusterName": "c1", "namespace": "ns", "name": "svc"},
+		},
+	}
+	srv := ts.start(t)
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to add EXCLUDED override when autoinstrument=true")
+}
+
+// TestRunExclude_AutoinstrumentFalse_NoOp verifies DWIM exclude logic:
+// when autoinstrument=false the namespace default is already off — no override needed.
+func TestRunExclude_AutoinstrumentFalse_NoOp(t *testing.T) {
+	falseVal := false
+	resp := buildGetAppResp(t, "c1", "ns", &falseVal, nil)
+
+	ts := &includeTestServer{
+		getAppResp: resp,
+		discoveryItems: []map[string]any{
+			{"clusterName": "c1", "namespace": "ns", "name": "svc"},
+		},
+	}
+	srv := ts.start(t)
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=false (namespace default is already off)")
+}
+
+// TestRunExclude_NilAutoinstrument_NoOp verifies DWIM exclude logic:
+// nil autoinstrument is treated the same as false — namespace default is off, no-op.
+func TestRunExclude_NilAutoinstrument_NoOp(t *testing.T) {
+	resp := buildGetAppResp(t, "c1", "ns", nil, nil)
+
+	ts := &includeTestServer{
+		getAppResp: resp,
+		discoveryItems: []map[string]any{
+			{"clusterName": "c1", "namespace": "ns", "name": "svc"},
+		},
+	}
+	srv := ts.start(t)
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=nil")
+}
+
+// TestRunExclude_RemovesIncludedOverride verifies that exclude removes an existing
+// INCLUDED override (and adds EXCLUDED since autoinstrument=true).
+func TestRunExclude_RemovesIncludedOverride(t *testing.T) {
+	trueVal := true
+	resp := buildGetAppResp(t, "c1", "ns", &trueVal, []map[string]any{
+		{"name": "svc", "selection": "SELECTION_INCLUDED"},
+	})
+
+	ts := &includeTestServer{
+		getAppResp: resp,
+		discoveryItems: []map[string]any{
+			{"clusterName": "c1", "namespace": "ns", "name": "svc"},
+		},
+	}
+	srv := ts.start(t)
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to replace INCLUDED with EXCLUDED")
+}
+
+// TestRunExclude_NamespaceNotFound verifies that exclude returns an error when the
+// namespace is not in the cluster's app configuration.
+// The workload is present in discovery (pre-flight passes), but GetAppInstrumentation
+// returns an empty namespace list, so the original namespace-not-found error fires.
+func TestRunExclude_NamespaceNotFound(t *testing.T) {
+	ts := &includeTestServer{
+		getAppResp: `{"cluster":{"name":"c1","namespaces":[]}}`,
+		discoveryItems: []map[string]any{
+			{"clusterName": "c1", "namespace": "missing-ns", "name": "svc"},
+		},
+	}
+	srv := ts.start(t)
+	client := makeIncludeClient(t, srv.URL)
+
+	err := services.RunExclude(context.Background(), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "services exclude")
+	assert.Contains(t, err.Error(), "missing-ns")
+}
+
+// TestRunExclude_Idempotent verifies that calling exclude twice when autoinstrument=true
+// only results in one Set call (second call is a no-op).
+func TestRunExclude_Idempotent(t *testing.T) {
+	trueVal := true
+	// Initial state: autoinstrument=true, no overrides.
+	initialResp := buildGetAppResp(t, "c1", "ns", &trueVal, nil)
+	// After first exclude: EXCLUDED override is present.
+	afterFirstResp := buildGetAppResp(t, "c1", "ns", &trueVal, []map[string]any{
+		{"name": "svc", "selection": "SELECTION_EXCLUDED"},
+	})
+
+	callCount := 0
+	ts := &includeTestServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{
+			{"clusterName": "c1", "namespace": "ns", "name": "svc"},
+		}})
+	})
+	mux.HandleFunc("/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// First 3 calls (pre-check + 2 RMW reads) use initial state.
+		// Subsequent calls (second invocation's pre-check) use post-write state.
+		if callCount < 3 {
+			_, _ = w.Write([]byte(initialResp))
+		} else {
+			_, _ = w.Write([]byte(afterFirstResp))
+		}
+		callCount++
+	})
+	mux.HandleFunc("/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+		ts.setAppCalled.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := makeIncludeClient(t, srv.URL)
+
+	// First invocation: should call SetApp once.
+	var out1 bytes.Buffer
+	err1 := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out1)
+	require.NoError(t, err1, "first exclude must succeed")
+	firstCallCount := ts.setAppCalled.Load()
+	assert.Equal(t, int64(1), firstCallCount, "first exclude must call SetApp once")
+
+	// Second invocation: reads post-write state (EXCLUDED already present) → no-op.
+	var out2 bytes.Buffer
+	err2 := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out2)
+	require.NoError(t, err2, "second exclude must succeed (exit 0)")
+	secondCallCount := ts.setAppCalled.Load()
+	assert.Equal(t, firstCallCount, secondCallCount, "second exclude must be a no-op: no additional Set calls")
+}
+
+// TestRunExclude_WorkloadNotFound verifies that exclude returns a workload-not-found
+// error when RunK8sDiscovery does not contain the requested service, and does NOT
+// call GetAppInstrumentation (pre-flight short-circuits the operation).
+//
+//nolint:dupl // WorkloadNotFound tests for exclude/include/clear are intentionally symmetric.
+func TestRunExclude_WorkloadNotFound(t *testing.T) {
+	callCounts := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		callCounts[r.URL.Path]++
+		switch r.URL.Path {
+		case "/discovery.v1.DiscoveryService/RunK8sDiscovery":
+			// Return empty items — workload not found.
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunExclude(context.Background(), client, "prod-eu", "checkout", "nonexistent-svc",
+		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Resource not found")
+	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).
+	assert.Zero(t, callCounts["/instrumentation.v1.InstrumentationService/GetAppInstrumentation"],
+		"GetAppInstrumentation must not be called after pre-flight failure")
+}
+
+// ─── Unit tests for applyExcludeMutation ─────────────────────────────────────
+
+// TestApplyExcludeMutation_AddsExcluded verifies that exclude adds EXCLUDED when autoinstrument=true.
+func TestApplyExcludeMutation_AddsExcluded(t *testing.T) {
+	trueVal := true
+	ns := instrumentation.App{Name: "ns", Autoinstrument: &trueVal}
+	result := services.ApplyExcludeMutation(ns, "svc")
+
+	require.Len(t, result.Apps, 1)
+	assert.Equal(t, "svc", result.Apps[0].Name)
+	assert.Equal(t, "SELECTION_EXCLUDED", result.Apps[0].Selection)
+}
+
+// TestApplyExcludeMutation_NoOverrideWhenAutoinstrumentFalse verifies that exclude
+// does NOT add EXCLUDED when autoinstrument=false (namespace default is already off).
+func TestApplyExcludeMutation_NoOverrideWhenAutoinstrumentFalse(t *testing.T) {
+	falseVal := false
+	ns := instrumentation.App{Name: "ns", Autoinstrument: &falseVal}
+	result := services.ApplyExcludeMutation(ns, "svc")
+	assert.Empty(t, result.Apps)
+}
+
+// TestApplyExcludeMutation_NoOverrideWhenAutoinstrumentNil verifies that exclude
+// does NOT add EXCLUDED when autoinstrument=nil (treated same as false).
+func TestApplyExcludeMutation_NoOverrideWhenAutoinstrumentNil(t *testing.T) {
+	ns := instrumentation.App{Name: "ns", Autoinstrument: nil}
+	result := services.ApplyExcludeMutation(ns, "svc")
+	assert.Empty(t, result.Apps)
+}
+
+// TestApplyExcludeMutation_RemovesIncluded verifies that exclude removes an INCLUDED override.
+func TestApplyExcludeMutation_RemovesIncluded(t *testing.T) {
+	trueVal := true
+	ns := instrumentation.App{
+		Name:           "ns",
+		Autoinstrument: &trueVal,
+		Apps: []instrumentation.AppOverride{
+			{Name: "svc", Selection: "SELECTION_INCLUDED"},
+		},
+	}
+	result := services.ApplyExcludeMutation(ns, "svc")
+	// INCLUDED removed; EXCLUDED added (autoinstrument=true).
+	require.Len(t, result.Apps, 1)
+	assert.Equal(t, "SELECTION_EXCLUDED", result.Apps[0].Selection)
+}
+
+// TestApplyExcludeMutation_Idempotent verifies that applying exclude twice returns the same state.
+func TestApplyExcludeMutation_Idempotent(t *testing.T) {
+	trueVal := true
+	ns := instrumentation.App{Name: "ns", Autoinstrument: &trueVal}
+	once := services.ApplyExcludeMutation(ns, "svc")
+	twice := services.ApplyExcludeMutation(once, "svc")
+	// Both should have exactly one EXCLUDED override, no duplicates.
+	require.Len(t, twice.Apps, 1)
+	assert.Equal(t, "SELECTION_EXCLUDED", twice.Apps[0].Selection)
+}

--- a/cmd/gcx/instrumentation/services/export_test.go
+++ b/cmd/gcx/instrumentation/services/export_test.go
@@ -1,0 +1,102 @@
+package services
+
+import (
+	"context"
+	"io"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+)
+
+// RunList exposes the internal runList function for use in external test packages.
+func RunList(
+	ctx context.Context,
+	opts *ListOpts,
+	outOpts *cmdio.Options,
+	client *instrumentation.Client,
+	promHeaders instrumentation.PromHeaders,
+	out io.Writer,
+) error {
+	return runList(ctx, opts, outOpts, client, promHeaders, out)
+}
+
+// ListOpts is an alias for listOpts so external tests can construct opts.
+type ListOpts = listOpts
+
+// RunGet exposes the internal runGet function for use in external test packages.
+func RunGet(
+	ctx context.Context,
+	outOpts *cmdio.Options,
+	client *instrumentation.Client,
+	cluster, namespace, service string,
+	promHeaders instrumentation.PromHeaders,
+	out io.Writer,
+) error {
+	return runGet(ctx, outOpts, client, cluster, namespace, service, promHeaders, out)
+}
+
+// RunInclude exposes the internal runInclude function for use in external test packages.
+func RunInclude(
+	ctx context.Context,
+	client *instrumentation.Client,
+	cluster, namespace, service string,
+	urls instrumentation.BackendURLs,
+	promHeaders instrumentation.PromHeaders,
+	out io.Writer,
+) error {
+	return runInclude(ctx, client, cluster, namespace, service, urls, promHeaders, out)
+}
+
+// RunExclude exposes the internal runExclude function for use in external test packages.
+func RunExclude(
+	ctx context.Context,
+	client *instrumentation.Client,
+	cluster, namespace, service string,
+	urls instrumentation.BackendURLs,
+	promHeaders instrumentation.PromHeaders,
+	out io.Writer,
+) error {
+	return runExclude(ctx, client, cluster, namespace, service, urls, promHeaders, out)
+}
+
+// RunClear exposes the internal runClear function for use in external test packages.
+func RunClear(
+	ctx context.Context,
+	client *instrumentation.Client,
+	cluster, namespace, service string,
+	urls instrumentation.BackendURLs,
+	promHeaders instrumentation.PromHeaders,
+	out io.Writer,
+) error {
+	return runClear(ctx, client, cluster, namespace, service, urls, promHeaders, out)
+}
+
+// ApplyIncludeMutation exposes applyIncludeMutation for unit tests.
+func ApplyIncludeMutation(ns instrumentation.App, service string) instrumentation.App {
+	return applyIncludeMutation(ns, service)
+}
+
+// ApplyExcludeMutation exposes applyExcludeMutation for unit tests.
+func ApplyExcludeMutation(ns instrumentation.App, service string) instrumentation.App {
+	return applyExcludeMutation(ns, service)
+}
+
+// ApplyClearMutation exposes applyClearMutation for unit tests.
+func ApplyClearMutation(ns instrumentation.App, service string) instrumentation.App {
+	return applyClearMutation(ns, service)
+}
+
+// NormalizeStatus exposes normalizeStatus for unit tests.
+func NormalizeStatus(s string) instrumentation.InstrumentationStatus {
+	return normalizeStatus(s)
+}
+
+// ValidateWorkloadExists exposes validateWorkloadExists for unit tests.
+func ValidateWorkloadExists(
+	ctx context.Context,
+	client *instrumentation.Client,
+	promHeaders instrumentation.PromHeaders,
+	cluster, namespace, service string,
+) error {
+	return validateWorkloadExists(ctx, client, promHeaders, cluster, namespace, service)
+}

--- a/cmd/gcx/instrumentation/services/get.go
+++ b/cmd/gcx/instrumentation/services/get.go
@@ -11,14 +11,27 @@ import (
 	"github.com/grafana/gcx/internal/providers/instrumentation"
 	instrumout "github.com/grafana/gcx/internal/providers/instrumentation/output"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("text")
+	o.IO.RegisterCustomCodec("text", &instrumout.ServiceTableCodec{Wide: false})
+	o.IO.RegisterCustomCodec("wide", &instrumout.ServiceTableCodec{Wide: true})
+	o.IO.SetJSONFieldValidator(cmdio.MakeFieldValidator(instrumout.ServiceView{}))
+	o.IO.BindFlags(flags)
+}
+
+func (o *getOpts) Validate() error {
+	return o.IO.Validate()
+}
+
 func newGetCommand(loader fleet.ConfigLoader) *cobra.Command {
-	outOpts := &cmdio.Options{}
-	outOpts.DefaultFormat("text")
-	outOpts.RegisterCustomCodec("text", &instrumout.ServiceTableCodec{Wide: false})
-	outOpts.RegisterCustomCodec("wide", &instrumout.ServiceTableCodec{Wide: true})
-	outOpts.SetJSONFieldValidator(cmdio.MakeFieldValidator(instrumout.ServiceView{}))
+	opts := &getOpts{}
 
 	cmd := &cobra.Command{
 		Use:   "get <cluster> <namespace> <service>",
@@ -35,7 +48,7 @@ Examples:
 Workload-level Selection / override state is not surfaced on this command. To inspect a workload's override, run "gcx instrumentation clusters apps list --cluster=<cluster> --namespace=<namespace>".`,
 		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := outOpts.Validate(); err != nil {
+			if err := opts.Validate(); err != nil {
 				return err
 			}
 			ctx := cmd.Context()
@@ -45,11 +58,11 @@ Workload-level Selection / override state is not surfaced on this command. To in
 			}
 			client := instrumentation.NewClient(r.Client)
 			promHeaders := instrumentation.PromHeadersFromStack(r.Stack)
-			return runGet(ctx, outOpts, client, args[0], args[1], args[2], promHeaders, cmd.OutOrStdout())
+			return runGet(ctx, &opts.IO, client, args[0], args[1], args[2], promHeaders, cmd.OutOrStdout())
 		},
 	}
 
-	outOpts.BindFlags(cmd.Flags())
+	opts.setup(cmd.Flags())
 	return cmd
 }
 

--- a/cmd/gcx/instrumentation/services/get.go
+++ b/cmd/gcx/instrumentation/services/get.go
@@ -1,0 +1,103 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/fleet"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instrumout "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/cobra"
+)
+
+func newGetCommand(loader fleet.ConfigLoader) *cobra.Command {
+	outOpts := &cmdio.Options{}
+	outOpts.DefaultFormat("text")
+	outOpts.RegisterCustomCodec("text", &instrumout.ServiceTableCodec{Wide: false})
+	outOpts.RegisterCustomCodec("wide", &instrumout.ServiceTableCodec{Wide: true})
+	outOpts.SetJSONFieldValidator(cmdio.MakeFieldValidator(instrumout.ServiceView{}))
+
+	cmd := &cobra.Command{
+		Use:   "get <cluster> <namespace> <service>",
+		Short: "Get a single discovered workload by (cluster, namespace, service)",
+		Long: `Get a single workload discovered by the Beyla survey collector.
+
+Calls RunK8sDiscovery() (fleet-wide RPC) and filters to the requested workload.
+Returns an error if the workload is not found.
+
+Examples:
+  gcx instrumentation services get prod-1 checkout frontend
+  gcx instrumentation services get prod-1 checkout frontend -o json
+
+Workload-level Selection / override state is not surfaced on this command. To inspect a workload's override, run "gcx instrumentation clusters apps list --cluster=<cluster> --namespace=<namespace>".`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := outOpts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			r, err := fleet.LoadClientWithStack(ctx, loader)
+			if err != nil {
+				return fmt.Errorf("services get: %w", err)
+			}
+			client := instrumentation.NewClient(r.Client)
+			promHeaders := instrumentation.PromHeadersFromStack(r.Stack)
+			return runGet(ctx, outOpts, client, args[0], args[1], args[2], promHeaders, cmd.OutOrStdout())
+		},
+	}
+
+	outOpts.BindFlags(cmd.Flags())
+	return cmd
+}
+
+// runGet performs the RunK8sDiscovery call and filters to the requested workload.
+// Returns an error if the workload is not found.
+// Separated from RunE for testability.
+func runGet(
+	ctx context.Context,
+	outOpts *cmdio.Options,
+	client *instrumentation.Client,
+	cluster, namespace, service string,
+	promHeaders instrumentation.PromHeaders,
+	out io.Writer,
+) error {
+	resp, err := client.RunK8sDiscovery(ctx, promHeaders)
+	if err != nil {
+		return fmt.Errorf("services get: %w", err)
+	}
+
+	for _, item := range resp.Items {
+		if item.ClusterName == cluster && item.Namespace == namespace && item.Name == service {
+			view := instrumout.ServiceView{
+				ClusterName:           item.ClusterName,
+				Namespace:             item.Namespace,
+				Name:                  item.Name,
+				WorkloadType:          item.WorkloadType,
+				DisplayNamespace:      item.DisplayNamespace,
+				DisplayName:           item.DisplayName,
+				OS:                    item.OS,
+				Lang:                  item.Lang,
+				InstrumentationStatus: item.InstrumentationStatus,
+			}
+			// For table/text/wide: wrap in a slice so the codec can render a single row.
+			// For JSON/YAML: encode the single object directly (mirrors clusters/get.go pattern).
+			if outOpts.OutputFormat == "text" || outOpts.OutputFormat == "wide" {
+				return outOpts.Encode(out, []instrumout.ServiceView{view})
+			}
+			return outOpts.Encode(out, view)
+		}
+	}
+
+	exitCode := fail.ExitGeneralError
+	return &fail.DetailedError{
+		Summary: "Resource not found",
+		Details: fmt.Sprintf("workload %q not found in namespace %q (cluster %q)", service, namespace, cluster),
+		Suggestions: []string{
+			fmt.Sprintf("Run: gcx instrumentation services list --cluster=%s --namespace=%s", cluster, namespace),
+		},
+		ExitCode: &exitCode,
+	}
+}

--- a/cmd/gcx/instrumentation/services/get_test.go
+++ b/cmd/gcx/instrumentation/services/get_test.go
@@ -1,0 +1,180 @@
+package services_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunGet_HappyPath verifies that runGet returns the matching workload when found.
+func TestRunGet_HappyPath(t *testing.T) {
+	ts := &discoveryTestServer{
+		items: []map[string]any{
+			{
+				"clusterName":           "prod-1",
+				"namespace":             "checkout",
+				"name":                  "frontend",
+				"workloadType":          "Deployment",
+				"instrumentationStatus": "INSTRUMENTED",
+			},
+			{
+				"clusterName":           "prod-1",
+				"namespace":             "checkout",
+				"name":                  "payment",
+				"instrumentationStatus": "NOT_INSTRUMENTED",
+			},
+		},
+	}
+	srv := ts.start(t)
+	client := makeDiscoveryClient(t, srv.URL)
+
+	outOpts := makeListOutOpts()
+	require.NoError(t, outOpts.Validate())
+
+	var buf bytes.Buffer
+	err := services.RunGet(
+		context.Background(),
+		outOpts,
+		client,
+		"prod-1", "checkout", "frontend",
+		instrumentation.PromHeaders{},
+		&buf,
+	)
+	require.NoError(t, err)
+
+	output := buf.String()
+	// The requested workload must appear in output.
+	assert.Contains(t, output, "frontend")
+	// The other workload must NOT appear.
+	assert.NotContains(t, output, "payment")
+}
+
+// TestRunGet_NotFound verifies that runGet returns a canonical *fail.DetailedError
+// when the workload is not present in the discovery response.
+func TestRunGet_NotFound(t *testing.T) {
+	ts := &discoveryTestServer{
+		items: []map[string]any{
+			{
+				"clusterName":           "prod-1",
+				"namespace":             "checkout",
+				"name":                  "payment",
+				"instrumentationStatus": "INSTRUMENTED",
+			},
+		},
+	}
+	srv := ts.start(t)
+	client := makeDiscoveryClient(t, srv.URL)
+
+	outOpts := makeListOutOpts()
+	require.NoError(t, outOpts.Validate())
+
+	err := services.RunGet(
+		context.Background(),
+		outOpts,
+		client,
+		"prod-1", "checkout", "missing-svc",
+		instrumentation.PromHeaders{},
+		&bytes.Buffer{},
+	)
+	require.Error(t, err)
+
+	// Legacy string checks — kept to lock in the rendered-string contract.
+	assert.Contains(t, err.Error(), "missing-svc")
+	assert.Contains(t, err.Error(), "not found")
+
+	// Field-level assertions on the canonical *fail.DetailedError shape (AC-F1-2).
+	var detailed *fail.DetailedError
+	require.ErrorAs(t, err, &detailed, "error must be a *fail.DetailedError, got: %T", err)
+	assert.Equal(t, "Resource not found", detailed.Summary)
+	assert.Contains(t, detailed.Details, "missing-svc")
+	assert.Contains(t, detailed.Details, "checkout")
+	assert.Contains(t, detailed.Details, "prod-1")
+	require.Len(t, detailed.Suggestions, 1)
+	assert.Equal(t, "Run: gcx instrumentation services list --cluster=prod-1 --namespace=checkout", detailed.Suggestions[0])
+	require.NotNil(t, detailed.ExitCode)
+	assert.Equal(t, fail.ExitGeneralError, *detailed.ExitCode)
+}
+
+// TestRunGet_WrongCluster verifies that runGet returns not-found when the cluster
+// matches but the service does not exist in that cluster.
+func TestRunGet_WrongCluster(t *testing.T) {
+	ts := &discoveryTestServer{
+		items: []map[string]any{
+			{
+				"clusterName":           "prod-1",
+				"namespace":             "checkout",
+				"name":                  "frontend",
+				"instrumentationStatus": "INSTRUMENTED",
+			},
+		},
+	}
+	srv := ts.start(t)
+	client := makeDiscoveryClient(t, srv.URL)
+
+	outOpts := makeListOutOpts()
+	require.NoError(t, outOpts.Validate())
+
+	err := services.RunGet(
+		context.Background(),
+		outOpts,
+		client,
+		"prod-2", "checkout", "frontend", // wrong cluster
+		instrumentation.PromHeaders{},
+		&bytes.Buffer{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestRunGet_JSON_SingleObject verifies that JSON output is a single object {},
+// not an array [{}] (J.1).
+func TestRunGet_JSON_SingleObject(t *testing.T) {
+	ts := &discoveryTestServer{
+		items: []map[string]any{
+			{
+				"clusterName":           "prod-1",
+				"namespace":             "checkout",
+				"name":                  "frontend",
+				"workloadType":          "Deployment",
+				"instrumentationStatus": "INSTRUMENTED",
+			},
+		},
+	}
+	srv := ts.start(t)
+	client := makeDiscoveryClient(t, srv.URL)
+
+	// Build JSON-format output options.
+	outOpts := &cmdio.Options{}
+	outOpts.DefaultFormat("json")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	outOpts.BindFlags(fs)
+	require.NoError(t, outOpts.Validate())
+
+	var buf bytes.Buffer
+	err := services.RunGet(
+		context.Background(),
+		outOpts,
+		client,
+		"prod-1", "checkout", "frontend",
+		instrumentation.PromHeaders{},
+		&buf,
+	)
+	require.NoError(t, err)
+
+	output := strings.TrimSpace(buf.String())
+	// Must start with '{' (single object), not '[' (array).
+	assert.True(t, strings.HasPrefix(output, "{"), "JSON output should be a single object, got: %s", output)
+	// Must not wrap in an array.
+	assert.False(t, strings.HasPrefix(output, "["), "JSON output must not be an array, got: %s", output)
+	// The workload name must appear in the output.
+	assert.Contains(t, output, "frontend")
+}

--- a/cmd/gcx/instrumentation/services/helpers.go
+++ b/cmd/gcx/instrumentation/services/helpers.go
@@ -1,0 +1,220 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/grafana/gcx/internal/providers/instrumentation/rmw"
+)
+
+// validateWorkloadExists checks whether the given (cluster, namespace, service)
+// tuple appears in RunK8sDiscovery results. Returns a fail.DetailedError if not
+// found, nil if found.
+func validateWorkloadExists(
+	ctx context.Context,
+	client *instrumentation.Client,
+	promHeaders instrumentation.PromHeaders,
+	cluster, namespace, service string,
+) error {
+	resp, err := client.RunK8sDiscovery(ctx, promHeaders)
+	if err != nil {
+		return fmt.Errorf("workload validation: %w", err)
+	}
+	for _, item := range resp.Items {
+		if item.ClusterName == cluster && item.Namespace == namespace && item.Name == service {
+			return nil
+		}
+	}
+	exitCode := fail.ExitGeneralError
+	return &fail.DetailedError{
+		Summary: "Resource not found",
+		Details: fmt.Sprintf("workload %q not found in namespace %q (cluster %q) via RunK8sDiscovery", service, namespace, cluster),
+		Suggestions: []string{
+			fmt.Sprintf("Run: gcx instrumentation services list --cluster=%s --namespace=%s", cluster, namespace),
+		},
+		ExitCode: &exitCode,
+	}
+}
+
+const (
+	selectionIncluded = "SELECTION_INCLUDED"
+	selectionExcluded = "SELECTION_EXCLUDED"
+)
+
+// normalizeStatus maps short alias status names to their full proto-enum values.
+// "ERROR" → StatusError ("INSTRUMENTATION_ERROR"); full proto enum values pass through.
+// Input is trimmed and uppercased for case-insensitive matching.
+func normalizeStatus(s string) instrumentation.InstrumentationStatus {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "ERROR":
+		return instrumentation.StatusError
+	case "INSTRUMENTED":
+		return instrumentation.StatusInstrumented
+	case "PENDING_INSTRUMENTATION":
+		return instrumentation.StatusPendingInstrumentation
+	case "PENDING_UNINSTRUMENTATION":
+		return instrumentation.StatusPendingUninstrumentation
+	case "NOT_INSTRUMENTED":
+		return instrumentation.StatusNotInstrumented
+	case "EXCLUDED":
+		return instrumentation.StatusExcluded
+	default:
+		// Pass through as-is (callers may provide the full proto enum value).
+		return instrumentation.InstrumentationStatus(strings.ToUpper(strings.TrimSpace(s)))
+	}
+}
+
+// findNamespace returns a pointer to the App entry with the given name, or nil.
+func findNamespace(apps []instrumentation.App, name string) *instrumentation.App {
+	for i := range apps {
+		if apps[i].Name == name {
+			return &apps[i]
+		}
+	}
+	return nil
+}
+
+// copyApp returns a shallow copy of app with a deep-copied Apps slice.
+// AppOverride contains only string fields, so copying the slice is sufficient.
+func copyApp(app instrumentation.App) instrumentation.App {
+	result := app
+	if app.Apps != nil {
+		result.Apps = make([]instrumentation.AppOverride, len(app.Apps))
+		copy(result.Apps, app.Apps)
+	}
+	return result
+}
+
+// filterOverrides returns a copy of overrides excluding any entry with the given name
+// and the given selection. If selection is "", all entries with the name are removed.
+func filterOverrides(overrides []instrumentation.AppOverride, name, selection string) []instrumentation.AppOverride {
+	result := make([]instrumentation.AppOverride, 0, len(overrides))
+	for _, o := range overrides {
+		if o.Name == name && (selection == "" || o.Selection == selection) {
+			continue
+		}
+		result = append(result, o)
+	}
+	return result
+}
+
+// hasOverride reports whether overrides contains an entry with the given name and selection.
+func hasOverride(overrides []instrumentation.AppOverride, name, selection string) bool {
+	for _, o := range overrides {
+		if o.Name == name && o.Selection == selection {
+			return true
+		}
+	}
+	return false
+}
+
+// applyIncludeMutation returns a copy of ns with the include DWIM mutation applied for service.
+//
+// DWIM semantics:
+//   - Remove any existing EXCLUDED override for service.
+//   - Add INCLUDED override iff namespace autoinstrument is NOT explicitly true
+//     (i.e., nil or false — the namespace default is off, so explicit opt-in is needed).
+//   - If autoinstrument is true, no override is added (namespace default is already on).
+func applyIncludeMutation(ns instrumentation.App, service string) instrumentation.App {
+	result := copyApp(ns)
+	// Remove any existing EXCLUDED override.
+	result.Apps = filterOverrides(result.Apps, service, selectionExcluded)
+	// Add INCLUDED override iff namespace autoinstrument is not explicitly true.
+	if ns.Autoinstrument == nil || !*ns.Autoinstrument {
+		if !hasOverride(result.Apps, service, selectionIncluded) {
+			result.Apps = append(result.Apps, instrumentation.AppOverride{
+				Name:      service,
+				Selection: selectionIncluded,
+			})
+		}
+	}
+	return result
+}
+
+// applyExcludeMutation returns a copy of ns with the exclude DWIM mutation applied for service.
+//
+// DWIM semantics:
+//   - Remove any existing INCLUDED override for service.
+//   - Add EXCLUDED override iff namespace autoinstrument is explicitly true
+//     (the namespace default is on, so explicit opt-out is needed).
+//   - If autoinstrument is false/nil, no override is added (namespace default is already off).
+func applyExcludeMutation(ns instrumentation.App, service string) instrumentation.App {
+	result := copyApp(ns)
+	// Remove any existing INCLUDED override.
+	result.Apps = filterOverrides(result.Apps, service, selectionIncluded)
+	// Add EXCLUDED override iff namespace autoinstrument is explicitly true.
+	if ns.Autoinstrument != nil && *ns.Autoinstrument {
+		if !hasOverride(result.Apps, service, selectionExcluded) {
+			result.Apps = append(result.Apps, instrumentation.AppOverride{
+				Name:      service,
+				Selection: selectionExcluded,
+			})
+		}
+	}
+	return result
+}
+
+// applyClearMutation returns a copy of ns with any per-workload override for service removed.
+// Both INCLUDED and EXCLUDED overrides are removed, restoring namespace-default behavior.
+func applyClearMutation(ns instrumentation.App, service string) instrumentation.App {
+	result := copyApp(ns)
+	result.Apps = filterOverrides(result.Apps, service, "")
+	return result
+}
+
+// applyMutationToNamespaces applies the mutate function to the namespace entry with the given
+// name and returns a new []App. If the namespace is not found the original slice is returned.
+func applyMutationToNamespaces(namespaces []instrumentation.App, namespace string, mutate func(instrumentation.App) instrumentation.App) []instrumentation.App {
+	result := make([]instrumentation.App, len(namespaces))
+	copy(result, namespaces)
+	for i, ns := range result {
+		if ns.Name == namespace {
+			result[i] = mutate(ns)
+			return result
+		}
+	}
+	return result
+}
+
+// namespacesEqual compares two []App slices order-independently (matched by Name).
+// Returns (true, "") when equal; (false, diffSummary) when not.
+// Used as the equalsFn for rmw.Update.
+func namespacesEqual(a, b []instrumentation.App) (bool, string) {
+	aMap := make(map[string]instrumentation.App, len(a))
+	for _, app := range a {
+		aMap[app.Name] = app
+	}
+	bMap := make(map[string]instrumentation.App, len(b))
+	for _, app := range b {
+		bMap[app.Name] = app
+	}
+
+	var diffs []string
+
+	for name, appA := range aMap {
+		appB, ok := bMap[name]
+		if !ok {
+			diffs = append(diffs, "removed namespace: "+name)
+			continue
+		}
+		equal, diff := rmw.AppEqual(appA, appB)
+		if !equal {
+			diffs = append(diffs, diff)
+		}
+	}
+	for name := range bMap {
+		if _, ok := aMap[name]; !ok {
+			diffs = append(diffs, "added namespace: "+name)
+		}
+	}
+
+	if len(diffs) == 0 {
+		return true, ""
+	}
+	sort.Strings(diffs)
+	return false, strings.Join(diffs, ", ")
+}

--- a/cmd/gcx/instrumentation/services/include.go
+++ b/cmd/gcx/instrumentation/services/include.go
@@ -1,0 +1,143 @@
+//nolint:dupl // include and exclude are intentionally symmetric; duplication is acceptable here.
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instoutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation/rmw"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// includeOpts holds flag-bound options for the "services include" command.
+// The command takes only positional args today, so the struct is empty;
+// it exists to satisfy the canonical opts struct + setup + Validate pattern.
+type includeOpts struct{}
+
+func (o *includeOpts) setup(_ *pflag.FlagSet) {}
+
+func (o *includeOpts) Validate() error { return nil }
+
+func newIncludeCommand(loader fleet.ConfigLoader) *cobra.Command {
+	opts := &includeOpts{}
+	cmd := &cobra.Command{
+		Use:   "include <cluster> <namespace> <service>",
+		Short: "Include a workload for instrumentation (DWIM, idempotent)",
+		Long: `Include a specific workload for instrumentation using DWIM semantics.
+
+DWIM logic:
+  - Removes any existing EXCLUDED override for the workload.
+  - Adds an INCLUDED override iff the namespace autoinstrument is NOT explicitly
+    true (i.e. the namespace default is off, so an explicit opt-in is needed).
+  - If the namespace autoinstrument is true, no override is added (namespace
+    default is already on — adding INCLUDED would be redundant).
+
+The operation is idempotent: running it twice with the same args exits 0
+and the second call is a no-op against the backend.
+
+The write uses an optimistic-lock guard (rmw.Update): if the namespace list
+changes between the initial read and the pre-write re-check, the command returns
+a conflict error and must be retried.
+
+Examples:
+  gcx instrumentation services include prod-1 checkout frontend`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			r, err := fleet.LoadClientWithStack(ctx, loader)
+			if err != nil {
+				return fmt.Errorf("services include: %w", err)
+			}
+			client := instrumentation.NewClient(r.Client)
+			urls := instrumentation.BackendURLsFromStack(r.Stack)
+			return runInclude(ctx, client, args[0], args[1], args[2], urls, instrumentation.PromHeadersFromStack(r.Stack), cmd.OutOrStdout())
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// runInclude executes the DWIM include operation for a single workload.
+// It first performs an idempotence pre-check: if the proposed mutation equals
+// the current state, it returns nil immediately (zero Set calls). Otherwise it
+// calls rmw.Update which handles retries and optimistic-lock detection.
+func runInclude(
+	ctx context.Context,
+	client *instrumentation.Client,
+	cluster, namespace, service string,
+	urls instrumentation.BackendURLs,
+	promHeaders instrumentation.PromHeaders,
+	out io.Writer,
+) error {
+	// Workload existence pre-flight: verify the service appears in discovery.
+	if err := validateWorkloadExists(ctx, client, promHeaders, cluster, namespace, service); err != nil {
+		return err
+	}
+
+	// Idempotence pre-check: read current state, compute mutation, compare.
+	// If already in the desired state, return nil without calling Set.
+	resp, err := client.GetAppInstrumentation(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("services include: %w", err)
+	}
+
+	ns := findNamespace(resp.Namespaces, namespace)
+	if ns == nil {
+		return fmt.Errorf("services include: namespace %q not found in cluster %q; "+
+			"run 'gcx instrumentation clusters apps enable %s %s' first",
+			namespace, cluster, cluster, namespace)
+	}
+
+	proposed := applyIncludeMutation(*ns, service)
+	equal, _ := rmw.AppEqual(*ns, proposed)
+	if equal {
+		// Already in the desired state — idempotent no-op; exit 0 with no Set call.
+		return instoutput.MutationResult{
+			Action:  "include",
+			Target:  instoutput.Target{Cluster: cluster, Namespace: namespace, Service: service},
+			Changed: false,
+		}.Emit(out)
+	}
+
+	// Not a no-op: run the full RMW with optimistic-lock guard.
+	getFn := func(ctx context.Context) ([]instrumentation.App, error) {
+		r, err := client.GetAppInstrumentation(ctx, cluster)
+		if err != nil {
+			return nil, err
+		}
+		return r.Namespaces, nil
+	}
+	mutateFn := func(namespaces []instrumentation.App) []instrumentation.App {
+		return applyMutationToNamespaces(namespaces, namespace, func(n instrumentation.App) instrumentation.App {
+			return applyIncludeMutation(n, service)
+		})
+	}
+	setFn := func(ctx context.Context, namespaces []instrumentation.App) error {
+		return client.SetAppInstrumentation(ctx, cluster, namespaces, urls)
+	}
+
+	if err := rmw.Update(ctx, getFn, mutateFn, setFn, namespacesEqual, 3); err != nil {
+		var ce rmw.ConflictError
+		if errors.As(err, &ce) {
+			ce.Command = "services include"
+			ce.Namespace = namespace
+			return ce
+		}
+		return fmt.Errorf("services include: %w", err)
+	}
+
+	return instoutput.MutationResult{
+		Action:  "include",
+		Target:  instoutput.Target{Cluster: cluster, Namespace: namespace, Service: service},
+		Changed: true,
+	}.Emit(out)
+}

--- a/cmd/gcx/instrumentation/services/include_test.go
+++ b/cmd/gcx/instrumentation/services/include_test.go
@@ -1,0 +1,344 @@
+package services_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// includeTestServer tracks GetApp and SetApp calls for include/exclude/clear tests.
+type includeTestServer struct {
+	getAppResp     string // JSON response body for GetAppInstrumentation
+	setAppCalled   atomic.Int64
+	setAppStatus   int
+	getAppStatus   int
+	discoveryItems []map[string]any // items returned by RunK8sDiscovery; nil returns empty list
+}
+
+func (s *includeTestServer) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	if s.getAppStatus == 0 {
+		s.getAppStatus = http.StatusOK
+	}
+	if s.setAppStatus == 0 {
+		s.setAppStatus = http.StatusOK
+	}
+	if s.getAppResp == "" {
+		s.getAppResp = `{}`
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(s.getAppStatus)
+		_, _ = w.Write([]byte(s.getAppResp))
+	})
+	mux.HandleFunc("/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+		s.setAppCalled.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(s.setAppStatus)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		items := s.discoveryItems
+		if items == nil {
+			items = []map[string]any{}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func makeIncludeClient(t *testing.T, serverURL string) *instrumentation.Client {
+	t.Helper()
+	f := fleet.NewClient(context.Background(), serverURL, "inst-id", "api-token", true, nil)
+	return instrumentation.NewClient(f)
+}
+
+// buildGetAppResp builds a JSON GetAppInstrumentation response with one namespace.
+//
+//nolint:unparam // clusterName is designed to be flexible; current tests all use "c1" by convention.
+func buildGetAppResp(t *testing.T, clusterName, nsName string, autoinstrument *bool, apps []map[string]any) string {
+	t.Helper()
+	ns := map[string]any{"name": nsName}
+	if autoinstrument != nil {
+		ns["autoinstrument"] = *autoinstrument
+	}
+	if len(apps) > 0 {
+		ns["apps"] = apps
+	}
+	body := map[string]any{
+		"cluster": map[string]any{
+			"name":       clusterName,
+			"namespaces": []any{ns},
+		},
+	}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+	return string(data)
+}
+
+// TestRunInclude_Idempotent_AutoinstrumentDefault tests // A namespace with namespace-default autoinstrument (nil) and no overrides.
+// First call adds INCLUDED override; second call is a no-op (zero Set calls).
+func TestRunInclude_Idempotent_AutoinstrumentDefault(t *testing.T) {
+	// Initial: autoinstrument=nil (namespace default), no per-workload overrides.
+	initialResp := buildGetAppResp(t, "c1", "grotshop", nil, nil)
+
+	// After first include: INCLUDED override is present.
+	afterFirstResp := buildGetAppResp(t, "c1", "grotshop", nil, []map[string]any{
+		{"name": "frontend", "selection": "SELECTION_INCLUDED"},
+	})
+
+	callCount := 0
+	ts := &includeTestServer{}
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{
+			{"clusterName": "c1", "namespace": "grotshop", "name": "frontend"},
+		}})
+	})
+	mux.HandleFunc("/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if callCount == 0 || callCount == 1 || callCount == 2 {
+			// First 3 calls (pre-check + 2 RMW reads) use initial state.
+			_, _ = w.Write([]byte(initialResp))
+		} else {
+			// Subsequent calls (second invocation's pre-check) use post-write state.
+			_, _ = w.Write([]byte(afterFirstResp))
+		}
+		callCount++
+	})
+	mux.HandleFunc("/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+		ts.setAppCalled.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := makeIncludeClient(t, srv.URL)
+
+	// First invocation: should call SetApp once.
+	var out1 bytes.Buffer
+	err1 := services.RunInclude(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out1)
+	require.NoError(t, err1, "first include must succeed (exit 0)")
+	firstCallCount := ts.setAppCalled.Load()
+	assert.Equal(t, int64(1), firstCallCount, "first include must call SetApp once")
+
+	// Second invocation: reads post-write state (INCLUDED already present) → no-op.
+	var out2 bytes.Buffer
+	err2 := services.RunInclude(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out2)
+	require.NoError(t, err2, "second include must succeed (exit 0)")
+	secondCallCount := ts.setAppCalled.Load()
+	assert.Equal(t, firstCallCount, secondCallCount,
+		"second include must be a no-op: no additional Set calls")
+}
+
+// TestRunInclude_AutoinstrumentTrue_NoOverrideAdded verifies that when autoinstrument=true,
+// include does NOT add a redundant INCLUDED override.
+func TestRunInclude_AutoinstrumentTrue_NoOverrideAdded(t *testing.T) {
+	trueVal := true
+	resp := buildGetAppResp(t, "c1", "ns", &trueVal, nil)
+
+	ts := &includeTestServer{
+		getAppResp: resp,
+		discoveryItems: []map[string]any{
+			{"clusterName": "c1", "namespace": "ns", "name": "svc"},
+		},
+	}
+	srv := ts.start(t)
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunInclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.NoError(t, err)
+	// autoinstrument=true: namespace default is on, no override needed → no-op.
+	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=true and service is not excluded")
+}
+
+// TestRunInclude_RemovesExcludedOverride verifies that include removes an existing
+// EXCLUDED override (and adds INCLUDED if needed).
+func TestRunInclude_RemovesExcludedOverride(t *testing.T) {
+	falseVal := false
+	resp := buildGetAppResp(t, "c1", "ns", &falseVal, []map[string]any{
+		{"name": "svc", "selection": "SELECTION_EXCLUDED"},
+	})
+
+	ts := &includeTestServer{
+		getAppResp: resp,
+		discoveryItems: []map[string]any{
+			{"clusterName": "c1", "namespace": "ns", "name": "svc"},
+		},
+	}
+	srv := ts.start(t)
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunInclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to remove EXCLUDED override")
+}
+
+// TestRunInclude_NamespaceNotFound verifies that include returns an error when the
+// namespace is not in the cluster's app configuration.
+// The workload is present in discovery (pre-flight passes), but GetAppInstrumentation
+// returns an empty namespace list, so the original namespace-not-found error fires.
+func TestRunInclude_NamespaceNotFound(t *testing.T) {
+	// Empty namespace list; workload exists in discovery so pre-flight passes.
+	ts := &includeTestServer{
+		getAppResp: `{"cluster":{"name":"c1","namespaces":[]}}`,
+		discoveryItems: []map[string]any{
+			{"clusterName": "c1", "namespace": "missing-ns", "name": "svc"},
+		},
+	}
+	srv := ts.start(t)
+	client := makeIncludeClient(t, srv.URL)
+
+	err := services.RunInclude(context.Background(), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "services include")
+	assert.Contains(t, err.Error(), "missing-ns")
+}
+
+// TestRunInclude_WorkloadNotFound verifies that include returns a workload-not-found
+// error when RunK8sDiscovery does not contain the requested service, and does NOT
+// call GetAppInstrumentation (pre-flight short-circuits the operation).
+//
+//nolint:dupl // WorkloadNotFound tests for exclude/include/clear are intentionally symmetric.
+func TestRunInclude_WorkloadNotFound(t *testing.T) {
+	callCounts := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		callCounts[r.URL.Path]++
+		switch r.URL.Path {
+		case "/discovery.v1.DiscoveryService/RunK8sDiscovery":
+			// Return empty items — workload not found.
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunInclude(context.Background(), client, "prod-eu", "checkout", "nonexistent-svc",
+		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Resource not found")
+	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).
+	assert.Zero(t, callCounts["/instrumentation.v1.InstrumentationService/GetAppInstrumentation"],
+		"GetAppInstrumentation must not be called after pre-flight failure")
+}
+
+// TestRunInclude_WorkloadNotFound_ExitCode1 verifies validateWorkloadExists
+// returns a fail.DetailedError with ExitCode 1 (ExitGeneralError) when the workload
+// is absent from RunK8sDiscovery. This confirms the explicit ExitCode introduced in
+// services/helpers.go (was implicit default 1; now explicit).
+func TestRunInclude_WorkloadNotFound_ExitCode1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/discovery.v1.DiscoveryService/RunK8sDiscovery":
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+
+	client := makeIncludeClient(t, srv.URL)
+
+	var out bytes.Buffer
+	err := services.RunInclude(context.Background(), client, "prod-eu", "checkout", "nonexistent-svc",
+		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	require.Error(t, err)
+
+	var de *fail.DetailedError
+	require.ErrorAs(t, err, &de, "expected *fail.DetailedError, got %T: %v", err, err)
+	assert.Equal(t, "Resource not found", de.Summary)
+	require.NotNil(t, de.ExitCode, "ExitCode must be set explicitly")
+	assert.Equal(t, 1, *de.ExitCode, "ExitCode must be 1 (ExitGeneralError)")
+}
+
+// ─── Unit tests for mutation helpers ─────────────────────────────────────────
+
+// TestApplyIncludeMutation_AddsIncluded verifies that include adds INCLUDED when autoinstrument=false.
+func TestApplyIncludeMutation_AddsIncluded(t *testing.T) {
+	falseVal := false
+	ns := instrumentation.App{Name: "ns", Autoinstrument: &falseVal}
+	result := services.ApplyIncludeMutation(ns, "svc")
+
+	require.Len(t, result.Apps, 1)
+	assert.Equal(t, "svc", result.Apps[0].Name)
+	assert.Equal(t, "SELECTION_INCLUDED", result.Apps[0].Selection)
+}
+
+// TestApplyIncludeMutation_NoOverrideWhenAutoinstrumentTrue verifies that include
+// does NOT add INCLUDED when autoinstrument=true (no redundant override).
+func TestApplyIncludeMutation_NoOverrideWhenAutoinstrumentTrue(t *testing.T) {
+	trueVal := true
+	ns := instrumentation.App{Name: "ns", Autoinstrument: &trueVal}
+	result := services.ApplyIncludeMutation(ns, "svc")
+	assert.Empty(t, result.Apps)
+}
+
+// TestApplyIncludeMutation_RemovesExcluded verifies that include removes EXCLUDED override.
+func TestApplyIncludeMutation_RemovesExcluded(t *testing.T) {
+	falseVal := false
+	ns := instrumentation.App{
+		Name:           "ns",
+		Autoinstrument: &falseVal,
+		Apps: []instrumentation.AppOverride{
+			{Name: "svc", Selection: "SELECTION_EXCLUDED"},
+		},
+	}
+	result := services.ApplyIncludeMutation(ns, "svc")
+	// EXCLUDED removed; INCLUDED added (autoinstrument=false).
+	require.Len(t, result.Apps, 1)
+	assert.Equal(t, "SELECTION_INCLUDED", result.Apps[0].Selection)
+}
+
+// TestApplyIncludeMutation_NilAutoinstrument verifies that include adds INCLUDED
+// when autoinstrument is nil (unset, treated as off).
+func TestApplyIncludeMutation_NilAutoinstrument(t *testing.T) {
+	ns := instrumentation.App{Name: "ns", Autoinstrument: nil}
+	result := services.ApplyIncludeMutation(ns, "svc")
+	require.Len(t, result.Apps, 1)
+	assert.Equal(t, "SELECTION_INCLUDED", result.Apps[0].Selection)
+}
+
+// TestApplyIncludeMutation_Idempotent verifies that applying include twice returns the same state.
+func TestApplyIncludeMutation_Idempotent(t *testing.T) {
+	falseVal := false
+	ns := instrumentation.App{Name: "ns", Autoinstrument: &falseVal}
+	once := services.ApplyIncludeMutation(ns, "svc")
+	twice := services.ApplyIncludeMutation(once, "svc")
+	// Both should have exactly one INCLUDED override, no duplicates.
+	require.Len(t, twice.Apps, 1)
+	assert.Equal(t, "SELECTION_INCLUDED", twice.Apps[0].Selection)
+}

--- a/cmd/gcx/instrumentation/services/list.go
+++ b/cmd/gcx/instrumentation/services/list.go
@@ -1,0 +1,142 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/fleet"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instrumout "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type listOpts struct {
+	Cluster   string
+	Namespace string
+	Status    string
+	All       bool
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	flags.StringVar(&o.Cluster, "cluster", "", "Filter by cluster name")
+	flags.StringVarP(&o.Namespace, "namespace", "n", "", "Filter by Kubernetes namespace")
+	flags.StringVar(&o.Status, "status", "", "Filter by instrumentation status (e.g. ERROR, INSTRUMENTED)")
+	flags.BoolVarP(&o.All, "all", "A", false, "Show services from all namespaces (fleet-wide)")
+}
+
+func (o *listOpts) Validate() error {
+	return nil
+}
+
+func newListCommand(loader fleet.ConfigLoader) *cobra.Command {
+	opts := &listOpts{}
+	outOpts := &cmdio.Options{}
+	outOpts.DefaultFormat("text")
+	outOpts.RegisterCustomCodec("text", &instrumout.ServiceTableCodec{Wide: false})
+	outOpts.RegisterCustomCodec("wide", &instrumout.ServiceTableCodec{Wide: true})
+	outOpts.SetJSONFieldValidator(cmdio.MakeFieldValidator(instrumout.ServiceView{}))
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Args:  cobra.NoArgs,
+		Short: "List discovered workloads across the fleet",
+		Long: `List all workloads discovered by the Beyla survey collector.
+
+Calls RunK8sDiscovery() (fleet-wide RPC) and applies client-side filters.
+
+Examples:
+  # List all workloads
+  gcx instrumentation services list
+
+  # Filter to a specific cluster
+  gcx instrumentation services list --cluster prod-1
+
+  # Filter to a specific namespace
+  gcx instrumentation services list --namespace checkout
+
+  # Show only workloads in terminal error state
+  gcx instrumentation services list --status=ERROR
+
+  # Wide output with extra columns
+  gcx instrumentation services list -o wide
+
+Workload-level Selection / override state is not surfaced on this command. To inspect a workload's override, run "gcx instrumentation clusters apps list --cluster=<cluster> --namespace=<namespace>".`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			if err := outOpts.Validate(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			r, err := fleet.LoadClientWithStack(ctx, loader)
+			if err != nil {
+				return fmt.Errorf("services list: %w", err)
+			}
+			client := instrumentation.NewClient(r.Client)
+			promHeaders := instrumentation.PromHeadersFromStack(r.Stack)
+			return runList(ctx, opts, outOpts, client, promHeaders, cmd.OutOrStdout())
+		},
+	}
+
+	flags := cmd.Flags()
+	opts.setup(flags)
+	outOpts.BindFlags(flags)
+
+	return cmd
+}
+
+// runList performs the RunK8sDiscovery call and applies client-side filters.
+// Separated from RunE for testability.
+func runList(
+	ctx context.Context,
+	opts *listOpts,
+	outOpts *cmdio.Options,
+	client *instrumentation.Client,
+	promHeaders instrumentation.PromHeaders,
+	out io.Writer,
+) error {
+	resp, err := client.RunK8sDiscovery(ctx, promHeaders)
+	if err != nil {
+		return fmt.Errorf("services list: %w", err)
+	}
+
+	// Resolve the status filter (supports short alias "ERROR" → INSTRUMENTATION_ERROR).
+	var statusFilter instrumentation.InstrumentationStatus
+	if opts.Status != "" {
+		statusFilter = normalizeStatus(opts.Status)
+	}
+
+	// Apply client-side filters and convert to ServiceView.
+	// Initialise with make(..., 0) to guarantee [] output in JSON.
+	views := make([]instrumout.ServiceView, 0, len(resp.Items))
+	for _, item := range resp.Items {
+		if opts.Cluster != "" && item.ClusterName != opts.Cluster {
+			continue
+		}
+		// --all overrides --namespace: when set, namespace scoping is disabled and
+		// the full fleet-wide result is returned regardless of --namespace value.
+		if opts.Namespace != "" && !opts.All && item.Namespace != opts.Namespace {
+			continue
+		}
+		if statusFilter != "" && item.InstrumentationStatus != statusFilter {
+			continue
+		}
+		views = append(views, instrumout.ServiceView{
+			ClusterName:           item.ClusterName,
+			Namespace:             item.Namespace,
+			Name:                  item.Name,
+			WorkloadType:          item.WorkloadType,
+			DisplayNamespace:      item.DisplayNamespace,
+			DisplayName:           item.DisplayName,
+			OS:                    item.OS,
+			Lang:                  item.Lang,
+			InstrumentationStatus: item.InstrumentationStatus,
+		})
+	}
+
+	return outOpts.Encode(out, instrumout.ServiceListEnvelope{Items: views})
+}

--- a/cmd/gcx/instrumentation/services/list_test.go
+++ b/cmd/gcx/instrumentation/services/list_test.go
@@ -1,0 +1,465 @@
+package services_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
+	"github.com/grafana/gcx/internal/fleet"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instrumout "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// discoveryTestServer serves fake RunK8sDiscovery responses.
+type discoveryTestServer struct {
+	items []map[string]any
+}
+
+func (s *discoveryTestServer) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]any{"items": s.items}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func makeDiscoveryClient(t *testing.T, serverURL string) *instrumentation.Client {
+	t.Helper()
+	f := fleet.NewClient(context.Background(), serverURL, "inst-id", "api-token", true, nil)
+	return instrumentation.NewClient(f)
+}
+
+func makeListOutOpts() *cmdio.Options {
+	opts := &cmdio.Options{}
+	opts.DefaultFormat("text")
+	opts.RegisterCustomCodec("text", &instrumout.ServiceTableCodec{Wide: false})
+	opts.RegisterCustomCodec("wide", &instrumout.ServiceTableCodec{Wide: true})
+	// BindFlags initialises OutputFormat to the default ("text") via pflag default.
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.BindFlags(fs)
+	return opts
+}
+
+// TestRunList_StatusFilter_ERROR verifies --status=ERROR filters to only
+// services in terminal-error state (INSTRUMENTATION_ERROR).
+func TestRunList_StatusFilter_ERROR(t *testing.T) {
+	ts := &discoveryTestServer{
+		items: []map[string]any{
+			{
+				"clusterName":           "c1",
+				"namespace":             "checkout",
+				"name":                  "frontend",
+				"instrumentationStatus": "INSTRUMENTED",
+			},
+			{
+				"clusterName":           "c1",
+				"namespace":             "checkout",
+				"name":                  "payment",
+				"instrumentationStatus": "INSTRUMENTATION_ERROR",
+			},
+			{
+				"clusterName":           "c1",
+				"namespace":             "checkout",
+				"name":                  "cart",
+				"instrumentationStatus": "NOT_INSTRUMENTED",
+			},
+		},
+	}
+	srv := ts.start(t)
+
+	client := makeDiscoveryClient(t, srv.URL)
+	outOpts := makeListOutOpts()
+	require.NoError(t, outOpts.Validate())
+
+	var buf bytes.Buffer
+	err := services.RunList(
+		context.Background(),
+		&services.ListOpts{Status: "ERROR"},
+		outOpts,
+		client,
+		instrumentation.PromHeaders{},
+		&buf,
+	)
+	require.NoError(t, err)
+
+	// Only "payment" (INSTRUMENTATION_ERROR) must appear in output.
+	output := buf.String()
+	assert.Contains(t, output, "payment")
+	assert.NotContains(t, output, "frontend")
+	assert.NotContains(t, output, "cart")
+}
+
+// TestRunList_StatusFilter_FullEnum verifies that full proto enum values also work.
+func TestRunList_StatusFilter_FullEnum(t *testing.T) {
+	ts := &discoveryTestServer{
+		items: []map[string]any{
+			{
+				"clusterName":           "c1",
+				"namespace":             "ns",
+				"name":                  "svc-a",
+				"instrumentationStatus": "INSTRUMENTED",
+			},
+			{
+				"clusterName":           "c1",
+				"namespace":             "ns",
+				"name":                  "svc-b",
+				"instrumentationStatus": "INSTRUMENTATION_ERROR",
+			},
+		},
+	}
+	srv := ts.start(t)
+
+	client := makeDiscoveryClient(t, srv.URL)
+	outOpts := makeListOutOpts()
+	require.NoError(t, outOpts.Validate())
+
+	var buf bytes.Buffer
+	err := services.RunList(
+		context.Background(),
+		&services.ListOpts{Status: "INSTRUMENTATION_ERROR"},
+		outOpts,
+		client,
+		instrumentation.PromHeaders{},
+		&buf,
+	)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "svc-b")
+	assert.NotContains(t, output, "svc-a")
+}
+
+// TestRunList_ClusterFilter verifies that --cluster narrows to the specified cluster.
+func TestRunList_ClusterFilter(t *testing.T) {
+	ts := &discoveryTestServer{
+		items: []map[string]any{
+			{"clusterName": "c1", "namespace": "ns", "name": "svc-a", "instrumentationStatus": "INSTRUMENTED"},
+			{"clusterName": "c2", "namespace": "ns", "name": "svc-b", "instrumentationStatus": "INSTRUMENTED"},
+		},
+	}
+	srv := ts.start(t)
+
+	client := makeDiscoveryClient(t, srv.URL)
+	outOpts := makeListOutOpts()
+	require.NoError(t, outOpts.Validate())
+
+	var buf bytes.Buffer
+	err := services.RunList(
+		context.Background(),
+		&services.ListOpts{Cluster: "c1"},
+		outOpts,
+		client,
+		instrumentation.PromHeaders{},
+		&buf,
+	)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "svc-a")
+	assert.NotContains(t, output, "svc-b")
+}
+
+// TestRunList_NamespaceFilter verifies that --namespace narrows to the specified namespace.
+func TestRunList_NamespaceFilter(t *testing.T) {
+	ts := &discoveryTestServer{
+		items: []map[string]any{
+			{"clusterName": "c1", "namespace": "checkout", "name": "svc-a", "instrumentationStatus": "INSTRUMENTED"},
+			{"clusterName": "c1", "namespace": "payments", "name": "svc-b", "instrumentationStatus": "INSTRUMENTED"},
+		},
+	}
+	srv := ts.start(t)
+
+	client := makeDiscoveryClient(t, srv.URL)
+	outOpts := makeListOutOpts()
+	require.NoError(t, outOpts.Validate())
+
+	var buf bytes.Buffer
+	err := services.RunList(
+		context.Background(),
+		&services.ListOpts{Namespace: "checkout"},
+		outOpts,
+		client,
+		instrumentation.PromHeaders{},
+		&buf,
+	)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "svc-a")
+	assert.NotContains(t, output, "svc-b")
+}
+
+// TestRunList_EmptyResult verifies empty list outputs [] in JSON, never null.
+func TestRunList_EmptyResult(t *testing.T) {
+	ts := &discoveryTestServer{items: nil}
+	srv := ts.start(t)
+
+	client := makeDiscoveryClient(t, srv.URL)
+	outOpts := &cmdio.Options{}
+	outOpts.DefaultFormat("json")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	outOpts.BindFlags(fs)
+	require.NoError(t, outOpts.Validate())
+
+	var buf bytes.Buffer
+	err := services.RunList(
+		context.Background(),
+		&services.ListOpts{},
+		outOpts,
+		client,
+		instrumentation.PromHeaders{},
+		&buf,
+	)
+	require.NoError(t, err)
+
+	// JSON output must be {"items":[]} not [] or null.
+	assert.JSONEq(t, `{"items":[]}`, buf.String())
+}
+
+// TestRunList_JSONEnvelope_NonEmpty verifies non-empty JSON output is
+// wrapped in {"items":[...]} (canonical list envelope).
+func TestRunList_JSONEnvelope_NonEmpty(t *testing.T) {
+	ts := &discoveryTestServer{
+		items: []map[string]any{
+			{"clusterName": "c1", "namespace": "ns", "name": "svc-a", "instrumentationStatus": "INSTRUMENTED"},
+		},
+	}
+	srv := ts.start(t)
+
+	client := makeDiscoveryClient(t, srv.URL)
+	outOpts := &cmdio.Options{}
+	outOpts.DefaultFormat("json")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	outOpts.BindFlags(fs)
+	require.NoError(t, outOpts.Validate())
+
+	var buf bytes.Buffer
+	err := services.RunList(
+		context.Background(),
+		&services.ListOpts{},
+		outOpts,
+		client,
+		instrumentation.PromHeaders{},
+		&buf,
+	)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got), "output must be a JSON object")
+	items, ok := got["items"]
+	require.True(t, ok, "output must have 'items' key")
+	itemsSlice, ok := items.([]any)
+	require.True(t, ok, "'items' must be a JSON array")
+	assert.Len(t, itemsSlice, 1)
+}
+
+// TestRunList_JSONFieldSelection_Valid verifies that --json with valid fields
+// applies per-item projection and wraps the result in {"items":[...]}.
+func TestRunList_JSONFieldSelection_Valid(t *testing.T) {
+	ts := &discoveryTestServer{
+		items: []map[string]any{
+			{"clusterName": "c1", "namespace": "ns", "name": "svc-a", "instrumentationStatus": "INSTRUMENTED"},
+		},
+	}
+	srv := ts.start(t)
+
+	client := makeDiscoveryClient(t, srv.URL)
+	outOpts := &cmdio.Options{}
+	outOpts.DefaultFormat("json")
+	outOpts.SetJSONFieldValidator(cmdio.MakeFieldValidator(instrumout.ServiceView{}))
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	outOpts.BindFlags(fs)
+	// Set --json name,namespace
+	require.NoError(t, fs.Set("json", "name,namespace"))
+	require.NoError(t, outOpts.Validate())
+
+	var buf bytes.Buffer
+	err := services.RunList(
+		context.Background(),
+		&services.ListOpts{},
+		outOpts,
+		client,
+		instrumentation.PromHeaders{},
+		&buf,
+	)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got), "output must be a JSON object; got: %s", buf.String())
+	items, ok := got["items"]
+	require.True(t, ok, "output must have 'items' key")
+	itemsSlice, ok := items.([]any)
+	require.True(t, ok)
+	require.Len(t, itemsSlice, 1)
+	firstItem, ok := itemsSlice[0].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, firstItem, "name")
+	assert.Contains(t, firstItem, "namespace")
+	assert.NotContains(t, firstItem, "clusterName")
+}
+
+// TestRunList_JSONFieldSelection_Unknown verifies --json with an
+// unknown field name returns UnknownFieldSelectionError (which the converter
+// maps to exit 2 + DetailedError).
+func TestRunList_JSONFieldSelection_Unknown(t *testing.T) {
+	ts := &discoveryTestServer{
+		items: []map[string]any{
+			{"clusterName": "c1", "namespace": "ns", "name": "svc-a"},
+		},
+	}
+	srv := ts.start(t)
+
+	client := makeDiscoveryClient(t, srv.URL)
+	outOpts := &cmdio.Options{}
+	outOpts.DefaultFormat("json")
+	outOpts.SetJSONFieldValidator(cmdio.MakeFieldValidator(instrumout.ServiceView{}))
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	outOpts.BindFlags(fs)
+	require.NoError(t, fs.Set("json", "bogus,name"))
+	require.NoError(t, outOpts.Validate())
+
+	var buf bytes.Buffer
+	err := services.RunList(
+		context.Background(),
+		&services.ListOpts{},
+		outOpts,
+		client,
+		instrumentation.PromHeaders{},
+		&buf,
+	)
+	require.Error(t, err)
+	var fieldErr cmdio.UnknownFieldSelectionError
+	require.ErrorAs(t, err, &fieldErr, "error must be UnknownFieldSelectionError")
+	assert.Contains(t, fieldErr.Fields, "bogus")
+}
+
+// noopConfigLoader satisfies fleet.ConfigLoader but never makes a network call.
+// Used for tests that only exercise cobra.Args validation without RunE.
+type noopConfigLoader struct{}
+
+func (noopConfigLoader) LoadCloudConfig(_ context.Context) (providers.CloudRESTConfig, error) {
+	return providers.CloudRESTConfig{}, errors.New("noop loader: not connected")
+}
+
+// TestListCmd_RejectsPositionalArgs verifies that cobra.NoArgs enforcement
+// rejects any positional arguments passed to "services list".
+func TestListCmd_RejectsPositionalArgs(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name:    "no positional args — cobra.NoArgs passes",
+			args:    []string{},
+			wantErr: false,
+		},
+		{
+			name:            "one positional arg rejected",
+			args:            []string{"prod-1"},
+			wantErr:         true,
+			wantErrContains: "unknown command",
+		},
+		{
+			name:            "two positional args rejected",
+			args:            []string{"prod-1", "checkout"},
+			wantErr:         true,
+			wantErrContains: "unknown command",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build the services parent command (noopConfigLoader — no live client needed).
+			parentCmd := services.Command(noopConfigLoader{})
+			// Navigate to the "list" subcommand.
+			listCmd, _, findErr := parentCmd.Find([]string{"list"})
+			require.NoError(t, findErr, "list subcommand must exist under services")
+			require.NotNil(t, listCmd)
+
+			// Call Args directly — exercises the cobra.NoArgs validator without RunE.
+			argsErr := listCmd.Args(listCmd, tt.args)
+			if tt.wantErr {
+				require.Error(t, argsErr)
+				assert.Contains(t, argsErr.Error(), tt.wantErrContains)
+			} else {
+				require.NoError(t, argsErr)
+			}
+		})
+	}
+}
+
+// TestValidateWorkloadExists_SuggestionFlagForm verifies that the "workload not found"
+// error suggestion uses flag form (--cluster=, --namespace=) not positional form.
+func TestValidateWorkloadExists_SuggestionFlagForm(t *testing.T) {
+	// Serve empty discovery results — workload will not be found.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+	}))
+	defer srv.Close()
+
+	client := makeDiscoveryClient(t, srv.URL)
+
+	err := services.ValidateWorkloadExists(
+		context.Background(),
+		client,
+		instrumentation.PromHeaders{},
+		"prod-1", "checkout", "frontend",
+	)
+	require.Error(t, err)
+
+	var de *fail.DetailedError
+	require.ErrorAs(t, err, &de, "error must be *fail.DetailedError")
+	require.NotEmpty(t, de.Suggestions, "Suggestions must be non-empty")
+
+	// Every suggestion must use flag form, not positional form.
+	for _, s := range de.Suggestions {
+		assert.Contains(t, s, "--cluster=", "suggestion must use --cluster= form")
+		assert.Contains(t, s, "--namespace=", "suggestion must use --namespace= form")
+		assert.NotContains(t, s, "services list prod-1 checkout",
+			"suggestion must not use old positional form")
+	}
+}
+
+// TestNormalizeStatus verifies that short alias "ERROR" maps to StatusError.
+func TestNormalizeStatus(t *testing.T) {
+	tests := []struct {
+		input string
+		want  instrumentation.InstrumentationStatus
+	}{
+		{"ERROR", instrumentation.StatusError},
+		{"error", instrumentation.StatusError},
+		{"INSTRUMENTED", instrumentation.StatusInstrumented},
+		{"instrumented", instrumentation.StatusInstrumented},
+		{"PENDING_INSTRUMENTATION", instrumentation.StatusPendingInstrumentation},
+		{"NOT_INSTRUMENTED", instrumentation.StatusNotInstrumented},
+		{"EXCLUDED", instrumentation.StatusExcluded},
+		// Full proto enum value passes through.
+		{"INSTRUMENTATION_ERROR", instrumentation.StatusError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := services.NormalizeStatus(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cmd/gcx/instrumentation/setup/command.go
+++ b/cmd/gcx/instrumentation/setup/command.go
@@ -1,0 +1,145 @@
+// Package setup implements the "gcx instrumentation setup <cluster>"
+// onboarding command.
+package setup
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/grafana/gcx/internal/fleet"
+	instrum "github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/term"
+)
+
+// accessPolicyTokenPlaceholder is substituted into the helm command output.
+// Minting a real Cloud Access Policy token is out of scope for setup.
+//
+//nolint:gosec // Not a real credential — this is a placeholder string shown in user-facing output.
+const accessPolicyTokenPlaceholder = "<YOUR_CLOUD_ACCESS_TOKEN>"
+
+// opts holds all flag values parsed by Command.
+type opts struct {
+	useDefaults   bool
+	printHelmOnly bool
+
+	// Per-flag overrides for --use-defaults mode. Canonical idiom is
+	// --feat=true|false; no paired --no-* variants exist.
+	costMetrics   bool
+	clusterEvents bool
+	energyMetrics bool
+	nodeLogs      bool
+
+	// *Set fields record whether the corresponding flag was explicitly supplied
+	// by the caller (via cmd.Flags().Changed). Used by resolveYes to distinguish
+	// "not passed" from "passed as false" (pflag cannot distinguish these on bool
+	// fields without the Changed check).
+	costMetricsSet   bool
+	clusterEventsSet bool
+	energyMetricsSet bool
+	nodeLogsSet      bool
+}
+
+func (o *opts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.useDefaults, "use-defaults", false,
+		"Apply defaults without prompting (required when stdin is not a TTY)")
+	flags.BoolVar(&o.printHelmOnly, "print-helm-only", false,
+		"Print the helm command and exit; no server calls are made")
+
+	flags.BoolVar(&o.costMetrics, "cost-metrics", false,
+		"Set costMetrics under --use-defaults. Pass --cost-metrics=false to disable. Omit to use default (true).")
+	flags.BoolVar(&o.clusterEvents, "cluster-events", false,
+		"Set clusterEvents under --use-defaults. Pass --cluster-events=false to disable. Omit to use default (true).")
+	flags.BoolVar(&o.energyMetrics, "energy-metrics", false,
+		"Set energyMetrics under --use-defaults. Pass --energy-metrics=false to disable. Omit to use default (false).")
+	flags.BoolVar(&o.nodeLogs, "node-logs", false,
+		"Set nodeLogs under --use-defaults. Pass --node-logs=false to disable. Omit to use default (false).")
+}
+
+// Validate is a no-op for the setup opts. The mutually-exclusive flag pair
+// validation was removed: the --no-* paired forms were
+// dropped, so there are no conflicting pairs to check.
+func (o *opts) Validate() error {
+	return nil
+}
+
+// Command returns the "gcx instrumentation setup <cluster>" cobra command.
+// loader is used to resolve fleet configuration and backend URLs from the
+// active gcx context.
+func Command(loader fleet.ConfigLoader) *cobra.Command {
+	o := &opts{}
+	cmd := &cobra.Command{
+		Use:   "setup <cluster>",
+		Short: "Onboard a Kubernetes cluster for Grafana Instrumentation Hub",
+		Long: `Onboard a Kubernetes cluster end-to-end by configuring K8s monitoring
+and printing a runnable helm install command.
+
+Steps performed:
+  1. Calls SetupK8sDiscovery — idempotent, safe to re-run.
+  2. Reads the cluster's current K8s monitoring configuration.
+  3. Resolves desired flag values: prompts interactively (when stdin is a TTY
+     and --use-defaults is absent) or applies defaults under --use-defaults:
+       costMetrics=true  clusterEvents=true  energyMetrics=false  nodeLogs=false
+     Per-flag overrides (--cost-metrics[=true|false], --cluster-events[=true|false],
+     --energy-metrics[=true|false], --node-logs[=true|false]) take precedence over defaults.
+  4. Calls SetK8SInstrumentation only when at least one flag changed.
+  5. Emits a mutation summary to stderr.
+  6. Prints a parameterized helm command to stdout.
+
+Re-running with unchanged inputs is safe and idempotent.
+
+The helm command installs grafana-cloud-onboarding and connects the cluster to
+Grafana Cloud via Fleet Management. Replace <YOUR_CLOUD_ACCESS_TOKEN> with a
+Cloud Access Policy token scoped to metrics:read and set:alloy-data-write.`,
+
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Capture which flags were explicitly supplied. pflag cannot
+			// distinguish "not passed" from "--flag=false" on plain bool fields;
+			// Changed() is the only reliable way to detect explicit false.
+			o.costMetricsSet = cmd.Flags().Changed("cost-metrics")
+			o.clusterEventsSet = cmd.Flags().Changed("cluster-events")
+			o.energyMetricsSet = cmd.Flags().Changed("energy-metrics")
+			o.nodeLogsSet = cmd.Flags().Changed("node-logs")
+
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			cluster := args[0]
+			ctx := cmd.Context()
+
+			// Load fleet configuration to resolve stack URLs.
+			// This is config loading — not an instrumentation API call.
+			r, err := fleet.LoadClientWithStack(ctx, loader)
+			if err != nil {
+				return fmt.Errorf("setup: %w", err)
+			}
+			urls := instrum.BackendURLsFromStack(r.Stack)
+			promHdrs := instrum.PromHeadersFromStack(r.Stack)
+			fm := instrum.FleetManagementFromStack(r.Stack)
+
+			rn := &runner{
+				urls:     urls,
+				fm:       fm,
+				promHdrs: promHdrs,
+				token:    accessPolicyTokenPlaceholder,
+				orgSlug:  r.Stack.OrgSlug,
+				stdout:   cmd.OutOrStdout(),
+				stderr:   cmd.ErrOrStderr(),
+				isTTY:    term.IsTerminal(int(os.Stdin.Fd())),
+				promptFn: defaultPromptFn(cmd.InOrStdin(), cmd.ErrOrStderr()),
+			}
+
+			// Do NOT construct the instrumentation Client when --print-helm-only
+			// is set: structural guarantee that no API calls can occur.
+			if !o.printHelmOnly {
+				rn.client = instrum.NewClient(r.Client)
+			}
+
+			return run(ctx, o, cluster, rn)
+		},
+	}
+	o.setup(cmd.Flags())
+	return cmd
+}

--- a/cmd/gcx/instrumentation/setup/run.go
+++ b/cmd/gcx/instrumentation/setup/run.go
@@ -43,7 +43,7 @@ type runner struct {
 	stdout  io.Writer
 	stderr  io.Writer
 	// isTTY reports whether stdin is an interactive terminal. When true and
-	// --yes is not set, setup prompts for each K8s flag interactively.
+	// --use-defaults is not set, setup prompts for each K8s flag interactively.
 	isTTY bool
 	// promptFn is called once per K8s flag in interactive mode. name is the
 	// human-readable flag name (e.g. "costMetrics"); current is its declared
@@ -59,8 +59,8 @@ type runner struct {
 //     calls are made (structural guarantee).
 //  2. SetupK8sDiscovery (idempotent server-side).
 //  3. GetK8SInstrumentation to capture current declared state.
-//  4. Resolve desired flag values: interactive prompts when TTY && !--yes,
-//     or defaults + per-flag overrides under --yes.
+//  4. Resolve desired flag values: interactive prompts when TTY && !--use-defaults,
+//     or defaults + per-flag overrides under --use-defaults.
 //  5. SetK8SInstrumentation only when at least one flag differs.
 //  6. Emit mutation summary to stderr.
 //  7. Print helm command to stdout.
@@ -164,7 +164,7 @@ func resolveDesired(o *opts, r *runner, current instrumentation.Cluster) (instru
 		return resolveInteractive(r, current)
 	default:
 		return instrumentation.Cluster{}, errors.New(
-			"setup: stdin is not a TTY; use --yes for non-interactive mode")
+			"setup: stdin is not a TTY; use --use-defaults for non-interactive mode")
 	}
 }
 

--- a/cmd/gcx/instrumentation/setup/run.go
+++ b/cmd/gcx/instrumentation/setup/run.go
@@ -1,0 +1,321 @@
+// Package setup implements the "gcx instrumentation setup <cluster>"
+// onboarding command.
+package setup
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/grafana/gcx/internal/agent"
+	instrumentation "github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/grafana/gcx/internal/providers/instrumentation/helm"
+	instroutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+)
+
+// clientInterface abstracts the three instrumentation API calls made by setup.
+// The concrete implementation is *instrumentation.Client; tests inject a fake.
+type clientInterface interface {
+	SetupK8sDiscovery(ctx context.Context, urls instrumentation.BackendURLs, promHeaders instrumentation.PromHeaders) error
+	GetK8SInstrumentation(ctx context.Context, clusterName string) (*instrumentation.GetK8SInstrumentationResponse, error)
+	SetK8SInstrumentation(ctx context.Context, clusterName string, k8s instrumentation.Cluster, urls instrumentation.BackendURLs) error
+}
+
+// runner holds all injected dependencies for the setup orchestration.
+// Explicit fields (rather than closure captures) make dependencies visible and
+// allow table-driven tests to vary individual components.
+type runner struct {
+	// client is nil when --print-helm-only is set (structural no-call guarantee).
+	client   clientInterface
+	urls     instrumentation.BackendURLs
+	fm       instrumentation.FleetManagement // used by helm.Format
+	promHdrs instrumentation.PromHeaders
+	// token is substituted into the helm command as the access-policy password.
+	token string
+	// orgSlug is the Grafana Cloud org slug used to build the access-policies URL
+	// in human-mode output and the agent-mode JSON envelope.
+	// When empty the literal placeholder <your-org> is substituted (fallback).
+	orgSlug string
+	stdout  io.Writer
+	stderr  io.Writer
+	// isTTY reports whether stdin is an interactive terminal. When true and
+	// --yes is not set, setup prompts for each K8s flag interactively.
+	isTTY bool
+	// promptFn is called once per K8s flag in interactive mode. name is the
+	// human-readable flag name (e.g. "costMetrics"); current is its declared
+	// value. Returns the desired value. Injected to enable test doubles.
+	promptFn func(name string, current bool) (bool, error)
+}
+
+// run executes the setup workflow. All dependencies are injected through r so
+// the function is fully testable without an HTTP server.
+//
+// Flow:
+//  1. --print-helm-only: print helm command and return immediately; no server
+//     calls are made (structural guarantee).
+//  2. SetupK8sDiscovery (idempotent server-side).
+//  3. GetK8SInstrumentation to capture current declared state.
+//  4. Resolve desired flag values: interactive prompts when TTY && !--yes,
+//     or defaults + per-flag overrides under --yes.
+//  5. SetK8SInstrumentation only when at least one flag differs.
+//  6. Emit mutation summary to stderr.
+//  7. Print helm command to stdout.
+func run(ctx context.Context, o *opts, cluster string, r *runner) error {
+	// Step 1: --print-helm-only short-circuit.
+	// client is nil on this path — structural guarantee no server calls occur.
+	// Under agent mode, the helm command is wrapped in a JSON envelope.
+	if o.printHelmOnly {
+		return printHelmCommand(r.stdout, helm.Format(cluster, r.fm, r.token), r.orgSlug)
+	}
+
+	// Step 2: SetupK8sDiscovery is idempotent — always call.
+	if err := r.client.SetupK8sDiscovery(ctx, r.urls, r.promHdrs); err != nil {
+		return fmt.Errorf("setup: %w", err)
+	}
+	fmt.Fprintln(r.stderr, "SetupK8sDiscovery: ok")
+
+	// Step 3: Capture current declared K8s configuration.
+	resp, err := r.client.GetK8SInstrumentation(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("setup: %w", err)
+	}
+	current := resp.Cluster
+
+	// Step 4: Resolve desired flag values.
+	desired, err := resolveDesired(o, r, current)
+	if err != nil {
+		return err
+	}
+	desired.Name = cluster
+	desired.Selection = "SELECTION_INCLUDED"
+
+	// Step 5+6: Compare, conditionally write, and emit summary.
+	anyChanged := emitFlagSummary(r.stderr, current, desired)
+	if anyChanged {
+		if err := r.client.SetK8SInstrumentation(ctx, cluster, desired, r.urls); err != nil {
+			return fmt.Errorf("setup: %w", err)
+		}
+	} else {
+		fmt.Fprintln(r.stderr, "no changes")
+	}
+
+	// Step 7: Print helm command to stdout.
+	return printHelmCommand(r.stdout, helm.Format(cluster, r.fm, r.token), r.orgSlug)
+}
+
+// printHelmCommand writes the helm command to w, enriched with access-policies
+// guidance.
+//
+// In agent mode, emits a single JSON object with helmCommand, accessPoliciesURL,
+// and requiredScopes.
+//
+// In human mode, emits the raw helm command followed by the required-scopes
+// list and the access-policies URL. The recommended file-source pattern is also
+// appended so users avoid placing the token in shell history.
+//
+// orgSlug is the Grafana Cloud org slug used to build the URL. When empty,
+// the literal placeholder <your-org> is substituted (fallback spec).
+func printHelmCommand(w io.Writer, cmd string, orgSlug string) error {
+	policyURL := instroutput.AccessPoliciesURL(orgSlug)
+
+	if agent.IsAgentMode() {
+		env := instroutput.SetupHelmEnvelope{
+			HelmCommand:       cmd,
+			AccessPoliciesURL: policyURL,
+			RequiredScopes:    instroutput.SetupRequiredScopes,
+		}
+		data, err := json.Marshal(env)
+		if err != nil {
+			return fmt.Errorf("setup: marshal helm command: %w", err)
+		}
+		_, err = fmt.Fprintln(w, string(data))
+		return err
+	}
+
+	// Human mode: emit the helm command, then the access-policies guidance block.
+	if _, err := fmt.Fprintln(w, cmd); err != nil {
+		return err
+	}
+
+	// Access policy guidance block.
+	fmt.Fprintln(w, "\nYou will need a Cloud Access Policy token with these scopes:")
+	for _, scope := range instroutput.SetupRequiredScopes {
+		fmt.Fprintf(w, "  - %s\n", scope)
+	}
+	fmt.Fprintf(w, "\nCreate the policy at %s\n", policyURL)
+
+	// Recommended file-source pattern to avoid token in shell history.
+	fmt.Fprintf(w, "\nRecommended: store your token in ~/.grafana-cloud-token (chmod 600) then re-run with:\n")
+	fmt.Fprintf(w, "  --set grafanaCloud.fleetManagement.auth.password=$(cat ~/.grafana-cloud-token)\n")
+	return nil
+}
+
+// resolveDesired determines desired Cluster flag values from opts and (when
+// interactive) from user prompts via r.promptFn.
+func resolveDesired(o *opts, r *runner, current instrumentation.Cluster) (instrumentation.Cluster, error) {
+	switch {
+	case o.useDefaults:
+		return resolveYes(o), nil
+	case r.isTTY:
+		return resolveInteractive(r, current)
+	default:
+		return instrumentation.Cluster{}, errors.New(
+			"setup: stdin is not a TTY; use --yes for non-interactive mode")
+	}
+}
+
+// resolveYes applies defaults with per-flag override precedence.
+//
+// The cluster's PRIOR state is intentionally NOT consulted — setup is
+// "apply this configuration", not RMW-preserve like clusters enable/disable.
+// Idempotence is achieved when the prior state already matches the
+// resolved set, not by incorporating prior state into the resolution.
+//
+// Per-flag overrides use the *Set fields (populated by cmd.Flags().Changed in
+// Command) to distinguish "flag explicitly provided" from "flag not mentioned".
+// This is required because pflag cannot distinguish --flag=false from an absent
+// flag on plain bool fields — Changed() is the only reliable test.
+func resolveYes(o *opts) instrumentation.Cluster {
+	// Recommended defaults.
+	cost, events, energy, logs := true, true, false, false
+
+	// Per-flag overrides take precedence over defaults.
+	// Use *Set fields (not raw value) to detect explicit --feat=false.
+	if o.costMetricsSet {
+		cost = o.costMetrics
+	}
+	if o.clusterEventsSet {
+		events = o.clusterEvents
+	}
+	if o.energyMetricsSet {
+		energy = o.energyMetrics
+	}
+	if o.nodeLogsSet {
+		logs = o.nodeLogs
+	}
+
+	return instrumentation.Cluster{
+		CostMetrics:   boolPtr(cost),   //nolint:modernize // boolPtr allocates and sets; new() only allocates.
+		ClusterEvents: boolPtr(events), //nolint:modernize
+		EnergyMetrics: boolPtr(energy), //nolint:modernize
+		NodeLogs:      boolPtr(logs),   //nolint:modernize
+	}
+}
+
+// resolveInteractive calls r.promptFn for each K8s flag with context-sensitive
+// defaults:
+//   - Unconfigured cluster (current.Name == ""): defaults to recommended
+//     values (cost=true, events=true, energy=false, logs=false).
+//   - Configured cluster: defaults to the cluster's current declared values.
+func resolveInteractive(r *runner, current instrumentation.Cluster) (instrumentation.Cluster, error) {
+	// choose prompt defaults based on configured vs unconfigured state.
+	// An empty Name in the wire response signals a cluster that has never been Set.
+	defCost, defEvents, defEnergy, defLogs := interactiveDefaults(current)
+
+	cost, err := r.promptFn("costMetrics", defCost)
+	if err != nil {
+		return instrumentation.Cluster{}, fmt.Errorf("setup: prompt costMetrics: %w", err)
+	}
+	events, err := r.promptFn("clusterEvents", defEvents)
+	if err != nil {
+		return instrumentation.Cluster{}, fmt.Errorf("setup: prompt clusterEvents: %w", err)
+	}
+	energy, err := r.promptFn("energyMetrics", defEnergy)
+	if err != nil {
+		return instrumentation.Cluster{}, fmt.Errorf("setup: prompt energyMetrics: %w", err)
+	}
+	logs, err := r.promptFn("nodeLogs", defLogs)
+	if err != nil {
+		return instrumentation.Cluster{}, fmt.Errorf("setup: prompt nodeLogs: %w", err)
+	}
+	return instrumentation.Cluster{
+		CostMetrics:   boolPtr(cost),   //nolint:modernize // boolPtr allocates and sets; new() only allocates.
+		ClusterEvents: boolPtr(events), //nolint:modernize
+		EnergyMetrics: boolPtr(energy), //nolint:modernize
+		NodeLogs:      boolPtr(logs),   //nolint:modernize
+	}, nil
+}
+
+// interactiveDefaults returns the prompt default values for interactive mode.
+// For an unconfigured cluster (Name==""), the recommended set is used.
+// For a configured cluster, the current declared values are the defaults.
+// Return order: cost, events, energy, logs.
+func interactiveDefaults(current instrumentation.Cluster) (bool, bool, bool, bool) {
+	if current.Name == "" {
+		// Unconfigured: default to recommended values.
+		return true, true, false, false
+	}
+	return derefBool(current.CostMetrics),
+		derefBool(current.ClusterEvents),
+		derefBool(current.EnergyMetrics),
+		derefBool(current.NodeLogs)
+}
+
+// emitFlagSummary writes one diff line per flag that changed between current
+// and desired, and returns true when at least one flag changed. Iteration order
+// is stable: costMetrics, clusterEvents, energyMetrics, nodeLogs.
+func emitFlagSummary(w io.Writer, current, desired instrumentation.Cluster) bool {
+	type flagSpec struct {
+		name string
+		cur  *bool
+		des  *bool
+	}
+	specs := []flagSpec{
+		{"costMetrics", current.CostMetrics, desired.CostMetrics},
+		{"clusterEvents", current.ClusterEvents, desired.ClusterEvents},
+		{"energyMetrics", current.EnergyMetrics, desired.EnergyMetrics},
+		{"nodeLogs", current.NodeLogs, desired.NodeLogs},
+	}
+	changed := false
+	for _, s := range specs {
+		if derefBool(s.cur) != derefBool(s.des) {
+			fmt.Fprintf(w, "flag %s: %v → %v\n", s.name, derefBool(s.cur), derefBool(s.des))
+			changed = true
+		}
+	}
+	return changed
+}
+
+// defaultPromptFn returns a promptFn that reads y/n answers line-by-line from
+// in and writes questions to errOut. Used by Command() for real interactive
+// terminal sessions. Tests inject their own promptFn instead.
+func defaultPromptFn(in io.Reader, errOut io.Writer) func(name string, current bool) (bool, error) {
+	scanner := bufio.NewScanner(in)
+	return func(name string, current bool) (bool, error) {
+		def := "n"
+		if current {
+			def = "y"
+		}
+		fmt.Fprintf(errOut, "%s [y/n, default %s]: ", name, def)
+		if !scanner.Scan() {
+			// EOF or error → use current value as-is.
+			return current, scanner.Err()
+		}
+		switch strings.ToLower(strings.TrimSpace(scanner.Text())) {
+		case "y", "yes":
+			return true, nil
+		case "n", "no":
+			return false, nil
+		default:
+			// Unrecognized input → keep current value.
+			return current, nil
+		}
+	}
+}
+
+// boolPtr returns a pointer to b.
+//
+//nolint:modernize // boolPtr allocates and sets the value; new(bool) only allocates (zero value).
+func boolPtr(b bool) *bool { return &b }
+
+// derefBool dereferences b, returning false for nil.
+func derefBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
+}

--- a/cmd/gcx/instrumentation/setup/run_test.go
+++ b/cmd/gcx/instrumentation/setup/run_test.go
@@ -1,0 +1,570 @@
+//nolint:testpackage // White-box test: exercises unexported run(), opts, runner, and fakeClient directly.
+package setup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/agent"
+	instrumentation "github.com/grafana/gcx/internal/providers/instrumentation"
+	instroutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClient is a test double for clientInterface. It records which methods
+// were called and the arguments passed to SetK8SInstrumentation.
+type fakeClient struct {
+	setupCalled bool
+	getCalled   bool
+	setCalled   bool
+
+	// setCluster is the Cluster value passed to SetK8SInstrumentation.
+	setCluster instrumentation.Cluster
+
+	// Errors to return for each method. nil means success.
+	setupErr error
+	getErr   error
+	setErr   error
+
+	// getResponse is returned by GetK8SInstrumentation.
+	getResponse *instrumentation.GetK8SInstrumentationResponse
+}
+
+func (f *fakeClient) SetupK8sDiscovery(_ context.Context, _ instrumentation.BackendURLs, _ instrumentation.PromHeaders) error {
+	f.setupCalled = true
+	return f.setupErr
+}
+
+func (f *fakeClient) GetK8SInstrumentation(_ context.Context, _ string) (*instrumentation.GetK8SInstrumentationResponse, error) {
+	f.getCalled = true
+	return f.getResponse, f.getErr
+}
+
+func (f *fakeClient) SetK8SInstrumentation(_ context.Context, _ string, k8s instrumentation.Cluster, _ instrumentation.BackendURLs) error {
+	f.setCalled = true
+	f.setCluster = k8s
+	return f.setErr
+}
+
+// newFakeClient returns a fakeClient whose GetK8SInstrumentation returns the
+// given cluster as the current declared state.
+func newFakeClient(current instrumentation.Cluster) *fakeClient {
+	return &fakeClient{
+		getResponse: &instrumentation.GetK8SInstrumentationResponse{Cluster: current},
+	}
+}
+
+// acceptDefaults is a promptFn that returns the current value unchanged for
+// every flag — simulating a user who presses Enter at every prompt.
+func acceptDefaults(_ string, current bool) (bool, error) {
+	return current, nil
+}
+
+// prompts returns a promptFn that answers flags in the given order.
+// flags are matched by call order, not by name.
+func prompts(answers ...bool) func(string, bool) (bool, error) {
+	idx := 0
+	return func(_ string, _ bool) (bool, error) {
+		if idx >= len(answers) {
+			return false, nil
+		}
+		v := answers[idx]
+		idx++
+		return v, nil
+	}
+}
+
+func TestRun(t *testing.T) { //nolint:maintidx // intentionally large table-driven test; complexity from test case variety, not logical branching
+	clusterName := "prod-cluster"
+
+	// Helper to build a runner from a fakeClient and optional overrides.
+	makeRunner := func(client clientInterface, isTTY bool, pFn func(string, bool) (bool, error)) *runner {
+		return &runner{
+			client:   client,
+			urls:     instrumentation.BackendURLs{},
+			fm:       instrumentation.FleetManagement{URL: "https://fleet.test", Username: "42"},
+			promHdrs: instrumentation.PromHeaders{},
+			token:    "<TOKEN>",
+			stdout:   &bytes.Buffer{},
+			stderr:   &bytes.Buffer{},
+			isTTY:    isTTY,
+			promptFn: pFn,
+		}
+	}
+
+	tests := []struct {
+		name string
+		opts opts
+		// current is the server's declared cluster state.
+		current instrumentation.Cluster
+		isTTY   bool
+		// promptFn answers; nil means no prompts expected.
+		promptAnswers []bool
+		// orgSlug is threaded into runner.orgSlug to test URL substitution.
+		orgSlug string
+
+		// Expected outcomes.
+		wantErr            bool
+		wantSetCalled      bool
+		wantSetupCalled    bool
+		wantGetCalled      bool
+		wantStderrContains []string
+		wantStdoutContains []string
+		// wantCluster is checked when wantSetCalled is true.
+		wantCluster instrumentation.Cluster
+	}{
+		// (a) Idempotent re-run: cluster already matches defaults;
+		//     second --use-defaults run must produce "no changes".
+		{
+			name: "(a) idempotent re-run reports no changes",
+			opts: opts{useDefaults: true},
+			current: instrumentation.Cluster{
+				CostMetrics:   boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				ClusterEvents: boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				EnergyMetrics: boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				NodeLogs:      boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+			},
+			wantSetupCalled:    true,
+			wantGetCalled:      true,
+			wantSetCalled:      false,
+			wantStderrContains: []string{"SetupK8sDiscovery: ok", "no changes"},
+			wantStdoutContains: []string{"helm upgrade", "fleet.test", "42"},
+		},
+
+		// (b) --use-defaults applied to unconfigured cluster: defaults are written
+		//     and the mutation summary lists the changed flags.
+		{
+			name:            "(b) --use-defaults applies defaults to unconfigured cluster",
+			opts:            opts{useDefaults: true},
+			current:         instrumentation.Cluster{}, // all nil / false
+			wantSetupCalled: true,
+			wantGetCalled:   true,
+			wantSetCalled:   true,
+			wantCluster: instrumentation.Cluster{
+				Name:          clusterName,
+				Selection:     "SELECTION_INCLUDED",
+				CostMetrics:   boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				ClusterEvents: boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				EnergyMetrics: boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				NodeLogs:      boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+			},
+			wantStderrContains: []string{
+				"SetupK8sDiscovery: ok",
+				"flag costMetrics: false → true",
+				"flag clusterEvents: false → true",
+			},
+			wantStdoutContains: []string{"helm upgrade"},
+		},
+
+		// (c) --use-defaults --energy-metrics=false --node-logs: per-flag overrides take precedence over
+		//     defaults. energy is explicitly set false (overrides default false,
+		//     net effect same). logs becomes true (--node-logs overrides default false).
+		//     Uses *Set fields to simulate cmd.Flags().Changed() behavior.
+		{
+			name: "(c) --use-defaults --energy-metrics=false --node-logs: override precedence",
+			opts: opts{
+				useDefaults:      true,
+				energyMetrics:    false, // --energy-metrics=false
+				energyMetricsSet: true,  // cmd.Flags().Changed("energy-metrics") == true
+				nodeLogs:         true,  // --node-logs (=true)
+				nodeLogsSet:      true,  // cmd.Flags().Changed("node-logs") == true
+			},
+			current:         instrumentation.Cluster{}, // all nil / false
+			wantSetupCalled: true,
+			wantGetCalled:   true,
+			wantSetCalled:   true,
+			wantCluster: instrumentation.Cluster{
+				Name:          clusterName,
+				Selection:     "SELECTION_INCLUDED",
+				CostMetrics:   boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				ClusterEvents: boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				EnergyMetrics: boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				NodeLogs:      boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+			},
+			wantStderrContains: []string{
+				"flag costMetrics: false → true",
+				"flag clusterEvents: false → true",
+				"flag nodeLogs: false → true",
+			},
+			wantStdoutContains: []string{"helm upgrade"},
+		},
+
+		// (d) --print-helm-only: no server calls made at all.
+		{
+			name:               "(d) --print-helm-only makes no server calls",
+			opts:               opts{printHelmOnly: true},
+			wantSetupCalled:    false,
+			wantGetCalled:      false,
+			wantSetCalled:      false,
+			wantStdoutContains: []string{"helm upgrade", "fleet.test", "42"},
+		},
+
+		// (e) stderr mutation summary lists every server call and flag change
+		//     under --use-defaults against a partially-configured cluster.
+		{
+			name: "(e) stderr lists all mutations under --use-defaults",
+			opts: opts{useDefaults: true},
+			current: instrumentation.Cluster{
+				// cost is already false, events is already true — only cost will change.
+				CostMetrics:   boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				ClusterEvents: boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				EnergyMetrics: boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				NodeLogs:      boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+			},
+			wantSetupCalled: true,
+			wantGetCalled:   true,
+			wantSetCalled:   true,
+			wantCluster: instrumentation.Cluster{
+				Name:          clusterName,
+				Selection:     "SELECTION_INCLUDED",
+				CostMetrics:   boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				ClusterEvents: boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				EnergyMetrics: boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				NodeLogs:      boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+			},
+			wantStderrContains: []string{
+				"SetupK8sDiscovery: ok",
+				"flag costMetrics: false → true",
+			},
+			wantStdoutContains: []string{"helm upgrade"},
+		},
+
+		// (f) Interactive prompts default to current declared values.
+		//     When the user accepts all defaults, no flag changes occur.
+		{
+			name:  "(f) interactive prompts default to current declared values",
+			opts:  opts{useDefaults: false},
+			isTTY: true,
+			current: instrumentation.Cluster{
+				Name:          clusterName,    // non-empty → configured cluster path in interactiveDefaults
+				CostMetrics:   boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				ClusterEvents: boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				EnergyMetrics: boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				NodeLogs:      boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+			},
+			// acceptDefaults returns each prompt's current value unchanged.
+			promptAnswers:      nil, // signals: use acceptDefaults
+			wantSetupCalled:    true,
+			wantGetCalled:      true,
+			wantSetCalled:      false,
+			wantStderrContains: []string{"SetupK8sDiscovery: ok", "no changes"},
+			wantStdoutContains: []string{"helm upgrade"},
+		},
+
+		// (g) Unconfigured cluster + TTY + !--yes: prompt defaults must be
+		//     the recommended set (cost=true, events=true, energy=false,
+		//     logs=false), not the cluster's nil/false values.
+		//     acceptDefaults returns whatever default it receives unchanged, so
+		//     if interactiveDefaults() correctly uses the recommended set for
+		//     Name=="", the write will flip cost and events from false→true,
+		//     proving the defaults came from the recommended set rather than
+		//     the zero/nil cluster values.
+		{
+			name:            "(g) interactive prompts use defaults for unconfigured cluster",
+			opts:            opts{useDefaults: false},
+			isTTY:           true,
+			current:         instrumentation.Cluster{}, // unconfigured: Name==""
+			promptAnswers:   nil,                       // acceptDefaults: echoes prompt defaults back
+			wantSetupCalled: true,
+			wantGetCalled:   true,
+			wantSetCalled:   true, // cost+events defaulted true → changed from nil/false
+			wantCluster: instrumentation.Cluster{
+				Name:          clusterName,
+				Selection:     "SELECTION_INCLUDED",
+				CostMetrics:   boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				ClusterEvents: boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				EnergyMetrics: boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				NodeLogs:      boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+			},
+			wantStderrContains: []string{
+				"SetupK8sDiscovery: ok",
+				"flag costMetrics: false → true",
+				"flag clusterEvents: false → true",
+			},
+			wantStdoutContains: []string{"helm upgrade"},
+		},
+
+		// (h) org slug is substituted into the access-policies URL in
+		//     the human-mode output block.
+		{
+			name:            "(h) org slug substituted in human-mode output",
+			opts:            opts{useDefaults: true},
+			orgSlug:         "igor-org",
+			current:         instrumentation.Cluster{},
+			wantSetupCalled: true,
+			wantGetCalled:   true,
+			wantSetCalled:   true,
+			wantCluster: instrumentation.Cluster{
+				Name:          clusterName,
+				Selection:     "SELECTION_INCLUDED",
+				CostMetrics:   boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				ClusterEvents: boolPtr(true),  //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				EnergyMetrics: boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+				NodeLogs:      boolPtr(false), //nolint:modernize // boolPtr(x) cannot simplify to new(x) — new(T) creates *zero-value, not *x
+			},
+			wantStdoutContains: []string{
+				"helm upgrade",
+				"https://grafana.com/orgs/igor-org/access-policies",
+				"$(cat ~/.grafana-cloud-token)",
+			},
+		},
+
+		// (i) --print-helm-only with org slug shows URL in stdout
+		//     without making any server calls (human mode via --print-helm-only).
+		{
+			name:    "(i) --print-helm-only with org slug shows URL",
+			opts:    opts{printHelmOnly: true},
+			orgSlug: "igor-org",
+			wantStdoutContains: []string{
+				"helm upgrade",
+				"https://grafana.com/orgs/igor-org/access-policies",
+				"$(cat ~/.grafana-cloud-token)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// TestRun exercises human-mode output paths. Force human mode so the
+			// test is deterministic regardless of the CI / agent environment.
+			setAgentMode(t, false)
+
+			var stdout, stderr bytes.Buffer
+
+			// For --print-helm-only, no client is needed (structural guarantee).
+			var client clientInterface
+			if !tt.opts.printHelmOnly {
+				client = newFakeClient(tt.current)
+			}
+
+			// Determine prompt function.
+			pFn := acceptDefaults
+			if tt.promptAnswers != nil {
+				pFn = prompts(tt.promptAnswers...)
+			}
+
+			rn := makeRunner(client, tt.isTTY, pFn)
+			rn.stdout = &stdout
+			rn.stderr = &stderr
+			rn.orgSlug = tt.orgSlug
+
+			err := run(context.Background(), &tt.opts, clusterName, rn)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Verify server call expectations.
+			if !tt.opts.printHelmOnly {
+				fc, ok := client.(*fakeClient)
+				require.True(t, ok, "client must be *fakeClient")
+				assert.Equal(t, tt.wantSetupCalled, fc.setupCalled, "SetupK8sDiscovery called")
+				assert.Equal(t, tt.wantGetCalled, fc.getCalled, "GetK8SInstrumentation called")
+				assert.Equal(t, tt.wantSetCalled, fc.setCalled, "SetK8SInstrumentation called")
+				if tt.wantSetCalled {
+					assert.Equal(t, tt.wantCluster, fc.setCluster, "SetK8SInstrumentation cluster arg")
+				}
+			} else {
+				// --print-helm-only: client is nil; assert no Set was attempted
+				// (run() must short-circuit before accessing client).
+				assert.Nil(t, rn.client)
+			}
+
+			// Verify stderr content.
+			for _, want := range tt.wantStderrContains {
+				assert.Contains(t, stderr.String(), want, "stderr should contain %q", want)
+			}
+
+			// Verify stdout content.
+			for _, want := range tt.wantStdoutContains {
+				assert.Contains(t, stdout.String(), want, "stdout should contain %q", want)
+			}
+		})
+	}
+}
+
+// setAgentMode sets GCX_AGENT_MODE and re-runs agent detection, then restores
+// the previous state via t.Cleanup. This is needed because agent.IsAgentMode()
+// caches its result at init() time and requires agent.ResetForTesting() to
+// re-read env vars set via t.Setenv.
+func setAgentMode(t *testing.T, enabled bool) {
+	t.Helper()
+	v := "false"
+	if enabled {
+		v = "1"
+	}
+	// t.Setenv cleans up the env var after the test; we also need to reset the
+	// cached agent mode state.
+	t.Setenv("GCX_AGENT_MODE", v)
+	agent.ResetForTesting()
+	t.Cleanup(func() {
+		// agent.ResetForTesting re-reads env; after t.Setenv restores the original
+		// value, we must also re-run detection so the cache is consistent.
+		agent.ResetForTesting()
+	})
+}
+
+// TestPrintHelmCommand_OrgSlug verifies access-policies URL behaviour for
+// printHelmCommand:
+//
+//   - Human mode with a known org slug: output contains the substituted URL.
+//   - Human mode: output contains the $(cat ...) file-source pattern.
+//   - Human mode with empty slug: output falls back to <your-org> placeholder.
+//   - Agent mode: stdout contains a single JSON object with helmCommand,
+//     accessPoliciesURL (slug substituted), and requiredScopes.
+//   - Non-agent mode (regression): stdout contains raw shell text ("helm upgrade").
+func TestPrintHelmCommand_OrgSlug(t *testing.T) {
+	const helmCmd = "helm upgrade --install grafana-cloud grafana/grafana-cloud-onboarding"
+
+	t.Run("human mode contains substituted URL", func(t *testing.T) {
+		// Force human mode: agent.IsAgentMode() is cached at init(); setAgentMode
+		// calls agent.ResetForTesting() so the change takes effect immediately.
+		setAgentMode(t, false)
+
+		var buf bytes.Buffer
+		require.NoError(t, printHelmCommand(&buf, helmCmd, "igor-org"))
+		out := buf.String()
+
+		assert.Contains(t, out, "https://grafana.com/orgs/igor-org/access-policies",
+			"human mode must include the substituted access-policies URL")
+	})
+
+	t.Run("human mode contains file-source pattern", func(t *testing.T) {
+		setAgentMode(t, false)
+
+		var buf bytes.Buffer
+		require.NoError(t, printHelmCommand(&buf, helmCmd, "igor-org"))
+		out := buf.String()
+
+		assert.Contains(t, out, "$(cat ~/.grafana-cloud-token)",
+			"human mode must include file-source pattern for token")
+	})
+
+	t.Run("human mode empty slug falls back to placeholder", func(t *testing.T) {
+		setAgentMode(t, false)
+
+		var buf bytes.Buffer
+		require.NoError(t, printHelmCommand(&buf, helmCmd, ""))
+		out := buf.String()
+
+		assert.Contains(t, out, "https://grafana.com/orgs/<your-org>/access-policies",
+			"empty slug must fall back to <your-org> placeholder in URL")
+		assert.NotContains(t, out, "https://grafana.com/orgs//access-policies",
+			"empty slug must not produce bare // in URL")
+	})
+
+	t.Run("agent mode emits JSON envelope with all three fields", func(t *testing.T) {
+		setAgentMode(t, true)
+
+		var buf bytes.Buffer
+		require.NoError(t, printHelmCommand(&buf, helmCmd, "igor-org"))
+
+		// Must parse as a single JSON object.
+		var env instroutput.SetupHelmEnvelope
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &env),
+			"agent mode output must be a single valid JSON object")
+
+		assert.Equal(t, helmCmd, env.HelmCommand, "helmCommand field must be the raw helm command")
+		assert.Equal(t, "https://grafana.com/orgs/igor-org/access-policies", env.AccessPoliciesURL,
+			"accessPoliciesURL field must contain the substituted URL")
+		assert.Equal(t, instroutput.SetupRequiredScopes, env.RequiredScopes,
+			"requiredScopes field must match SetupRequiredScopes constant")
+	})
+
+	t.Run("non-agent --print-helm-only regression: raw shell text", func(t *testing.T) {
+		// Regression contract: non-agent mode must not
+		// emit JSON; stdout must contain the raw helm command text.
+		setAgentMode(t, false)
+
+		var buf bytes.Buffer
+		require.NoError(t, printHelmCommand(&buf, helmCmd, "igor-org"))
+		out := buf.String()
+
+		assert.Contains(t, out, "helm upgrade",
+			"non-agent mode must contain raw helm command text")
+		// Must not be a JSON object.
+		assert.NotEqual(t, '{', []byte(strings.TrimSpace(out))[0],
+			"non-agent mode must not emit a JSON object")
+	})
+}
+
+// TestFlagParsing_NoVariantsDropped verifies the --no-*
+// paired flags are removed from setup; only the canonical --feat=true|false
+// idiom is accepted.
+//
+// These tests operate at the flag-parsing layer (pflag.FlagSet) rather than
+// through the full Cobra command tree to avoid the fleet.ConfigLoader
+// dependency, while still exercising the exact flags declared by opts.setup.
+func TestFlagParsing_NoVariantsDropped(t *testing.T) {
+	// parseSetupFlags is a helper that builds a fresh FlagSet, registers the
+	// setup flags on it, and parses the given args. Returns the populated opts
+	// and any parse error.
+	parseSetupFlags := func(args []string) (*opts, error) {
+		o := &opts{}
+		fs := pflag.NewFlagSet("setup-test", pflag.ContinueOnError)
+		o.setup(fs)
+		err := fs.Parse(args)
+		if err == nil {
+			// Mirror what Command.RunE does: capture Changed state.
+			o.costMetricsSet = fs.Changed("cost-metrics")
+			o.clusterEventsSet = fs.Changed("cluster-events")
+			o.energyMetricsSet = fs.Changed("energy-metrics")
+			o.nodeLogsSet = fs.Changed("node-logs")
+		}
+		return o, err
+	}
+
+	t.Run("--no-cost-metrics is rejected with unknown flag", func(t *testing.T) {
+		// AC: gcx instrumentation setup <cluster> --use-defaults --no-cost-metrics
+		// must exit non-zero with "unknown flag: --no-cost-metrics".
+		_, err := parseSetupFlags([]string{"--use-defaults", "--no-cost-metrics"})
+		require.Error(t, err, "parsing --no-cost-metrics should fail")
+		assert.True(t,
+			strings.Contains(err.Error(), "unknown flag") || strings.Contains(err.Error(), "no-cost-metrics"),
+			"error message should reference unknown flag or the flag name, got: %v", err,
+		)
+	})
+
+	t.Run("--cost-metrics=false sets costMetrics.enabled=false", func(t *testing.T) {
+		// AC: gcx instrumentation setup <cluster> --use-defaults --cost-metrics=false
+		// must parse successfully and resolve costMetrics.enabled=false (overrides default true).
+		o, err := parseSetupFlags([]string{"--use-defaults", "--cost-metrics=false"})
+		require.NoError(t, err, "parsing --cost-metrics=false should succeed")
+
+		// Verify the Changed flag was captured.
+		assert.True(t, o.costMetricsSet, "costMetricsSet must be true after --cost-metrics=false")
+		assert.False(t, o.costMetrics, "costMetrics value must be false")
+
+		// Verify resolveYes honours the explicit override.
+		cluster := resolveYes(o)
+		require.NotNil(t, cluster.CostMetrics)
+		assert.False(t, *cluster.CostMetrics,
+			"resolveYes with --cost-metrics=false must produce costMetrics.enabled=false")
+	})
+
+	t.Run("--cost-metrics --cost-metrics=false applies last value false (no error)", func(t *testing.T) {
+		// AC: --cost-metrics --cost-metrics=false → Cobra applies last value (false);
+		// no mutually-exclusive error (the --no-* form is gone).
+		o, err := parseSetupFlags([]string{"--use-defaults", "--cost-metrics", "--cost-metrics=false"})
+		require.NoError(t, err, "parsing --cost-metrics --cost-metrics=false should succeed")
+
+		// Validate must not return an error (no paired-flag validation any more).
+		require.NoError(t, o.Validate())
+
+		// pflag applies the last value; assert it is false.
+		assert.True(t, o.costMetricsSet, "costMetricsSet must be true")
+		assert.False(t, o.costMetrics, "last value wins: costMetrics should be false")
+
+		cluster := resolveYes(o)
+		require.NotNil(t, cluster.CostMetrics)
+		assert.False(t, *cluster.CostMetrics,
+			"resolveYes should honour the last-wins false value")
+	})
+}

--- a/cmd/gcx/instrumentation/status/command.go
+++ b/cmd/gcx/instrumentation/status/command.go
@@ -1,0 +1,117 @@
+package status
+
+import (
+	"fmt"
+
+	fleetbase "github.com/grafana/gcx/internal/fleet"
+	cmdio "github.com/grafana/gcx/internal/output"
+	instrum "github.com/grafana/gcx/internal/providers/instrumentation"
+	instroutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type statusOpts struct {
+	IO        cmdio.Options
+	Cluster   string
+	Namespace string
+	loader    fleetbase.ConfigLoader
+}
+
+func (o *statusOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Cluster, "cluster", "", "Filter output to a specific cluster")
+	flags.StringVar(&o.Namespace, "namespace", "", "Filter to a specific namespace; switches to workload-level view")
+}
+
+// Validate registers the mode-dependent codecs (driven by --namespace) and
+// validates the resolved IO options. Output codecs depend on --namespace, so
+// registration must happen here — after flag parsing but before IO.Validate.
+func (o *statusOpts) Validate() error {
+	if o.Namespace != "" {
+		o.IO.RegisterCustomCodec("table", &instroutput.ServiceTableCodec{})
+		o.IO.RegisterCustomCodec("wide", &instroutput.ServiceTableCodec{Wide: true})
+		o.IO.SetJSONFieldValidator(cmdio.MakeFieldValidator(instroutput.ServiceView{}))
+	} else {
+		o.IO.RegisterCustomCodec("table", &instroutput.ClusterTableCodec{})
+		o.IO.RegisterCustomCodec("wide", &instroutput.ClusterTableCodec{Wide: true})
+		o.IO.SetJSONFieldValidator(cmdio.MakeFieldValidator(instroutput.ClusterView{}))
+	}
+	return o.IO.Validate()
+}
+
+// Command returns the "gcx instrumentation status" cobra command.
+//
+// Without flags, lists all clusters — including pre-Alloy clusters that have
+// been configured but whose Alloy collector has not yet started reporting —
+// with their observed InstrumentationStatus.
+//
+// --cluster narrows the result to a single cluster.
+// --namespace additionally calls RunK8sDiscovery and switches the output to a
+// workload-level (service) view for the given namespace.
+//
+// loader is passed from the instrumentation umbrella command, which binds
+// --context and --config on its PersistentFlags.
+func Command(loader fleetbase.ConfigLoader) *cobra.Command {
+	opts := &statusOpts{loader: loader}
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show observed instrumentation state for clusters and namespaces.",
+		Long: `Show observed instrumentation state across all clusters, or narrow to a
+specific cluster or namespace.
+
+Without flags, lists all clusters including pre-Alloy clusters that have been
+configured but whose Alloy collector has not yet started reporting (shown as
+PENDING_INSTRUMENTATION).
+
+Use --cluster to filter to a single cluster. Add --namespace to drill down to
+workload-level status for a specific namespace, powered by RunK8sDiscovery.`,
+
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return fmt.Errorf("instrumentation status: %w", err)
+			}
+
+			ctx := cmd.Context()
+
+			r, err := fleetbase.LoadClientWithStack(ctx, opts.loader)
+			if err != nil {
+				return fmt.Errorf("instrumentation status: %w", err)
+			}
+
+			client := instrum.NewClient(r.Client)
+			promHdrs := instrum.PromHeadersFromStack(r.Stack)
+
+			mon := &monitoringAdapter{client: client, promHeaders: promHdrs}
+			// *instrum.Client satisfies pipelineSource directly (ListPipelines matches).
+			var pipe pipelineSource = client
+			disc := &discoveryAdapter{client: client, promHeaders: promHdrs}
+
+			result, err := run(ctx, opts.Cluster, opts.Namespace, mon, pipe, disc)
+			if err != nil {
+				return fmt.Errorf("instrumentation status: %w", err)
+			}
+
+			// Wrap the result in the canonical list envelope for JSON output
+			// (docs/design/output.md §101: list endpoints emit {"items":[...]}).
+			// Table/wide codecs unwrap the envelope at the codec boundary.
+			var encoded any
+			switch v := result.(type) {
+			case []instroutput.ClusterView:
+				encoded = instroutput.ClusterListEnvelope{Items: v}
+			case []instroutput.ServiceView:
+				encoded = instroutput.ServiceListEnvelope{Items: v}
+			default:
+				encoded = result
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), encoded)
+		},
+	}
+
+	opts.setup(cmd.Flags())
+
+	return cmd
+}

--- a/cmd/gcx/instrumentation/status/run.go
+++ b/cmd/gcx/instrumentation/status/run.go
@@ -1,0 +1,165 @@
+// Package status implements the "gcx instrumentation status" command.
+// It provides a cross-cutting observed-state view combining RunK8sMonitoring,
+// ListPipelines (via the enumerate helper), and — when --namespace is set —
+// RunK8sDiscovery for namespace-level workload status.
+package status
+
+import (
+	"context"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	"github.com/grafana/gcx/internal/providers/instrumentation/enumerate"
+	instroutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+)
+
+// monitoringSource is the minimal interface required to call RunK8sMonitoring
+// without PromHeaders in the signature. The real *instrumentation.Client
+// requires PromHeaders; the monitoringAdapter struct binds them at construction.
+// Structurally identical to enumerate.MonitoringClient.
+type monitoringSource interface {
+	RunK8sMonitoring(ctx context.Context) ([]instrumentation.ClusterObservedState, error)
+}
+
+// pipelineSource is the minimal interface required to call ListPipelines.
+// Structurally identical to enumerate.PipelineClient.
+// *instrumentation.Client satisfies this interface directly.
+type pipelineSource interface {
+	ListPipelines(ctx context.Context) ([]instrumentation.Pipeline, error)
+}
+
+// discoverySource is the minimal interface required to call RunK8sDiscovery
+// without PromHeaders in the signature. The discoveryAdapter binds them at
+// construction time.
+type discoverySource interface {
+	RunK8sDiscovery(ctx context.Context) ([]instrumentation.DiscoveryItem, error)
+}
+
+// monitoringAdapter adapts *instrumentation.Client to the monitoringSource
+// interface expected by enumerate.Enumerate. PromHeaders are bound at
+// construction so callers can pass this as enumerate.MonitoringClient.
+type monitoringAdapter struct {
+	client      *instrumentation.Client
+	promHeaders instrumentation.PromHeaders
+}
+
+// RunK8sMonitoring satisfies monitoringSource (and enumerate.MonitoringClient).
+func (a *monitoringAdapter) RunK8sMonitoring(ctx context.Context) ([]instrumentation.ClusterObservedState, error) {
+	resp, err := a.client.RunK8sMonitoring(ctx, a.promHeaders)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Clusters, nil
+}
+
+// discoveryAdapter adapts *instrumentation.Client to the discoverySource
+// interface. PromHeaders are bound at construction.
+type discoveryAdapter struct {
+	client      *instrumentation.Client
+	promHeaders instrumentation.PromHeaders
+}
+
+// RunK8sDiscovery satisfies discoverySource.
+func (a *discoveryAdapter) RunK8sDiscovery(ctx context.Context) ([]instrumentation.DiscoveryItem, error) {
+	resp, err := a.client.RunK8sDiscovery(ctx, a.promHeaders)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+}
+
+// run executes the status command business logic and returns the data to encode.
+//
+// When namespaceFilter is non-empty it returns []instroutput.ServiceView
+// (workload-level view via RunK8sDiscovery, filtered by clusterFilter and
+// namespaceFilter).
+//
+// When namespaceFilter is empty it returns []instroutput.ClusterView
+// (cluster-level view via enumerate.Enumerate, optionally filtered by
+// clusterFilter).
+//
+// Both paths use make([]T, 0) for F-AGENT-01 compliance (empty JSON array,
+// not null).
+func run(
+	ctx context.Context,
+	clusterFilter, namespaceFilter string,
+	mon monitoringSource,
+	pipe pipelineSource,
+	disc discoverySource,
+) (any, error) {
+	if namespaceFilter != "" {
+		return runServiceView(ctx, clusterFilter, namespaceFilter, disc)
+	}
+	return runClusterView(ctx, clusterFilter, mon, pipe)
+}
+
+// runClusterView builds the cluster-level view using enumerate.Enumerate.
+// Pre-Alloy clusters (source = PipelineSource only) appear with
+// StatusPendingInstrumentation and zero observed metrics.
+func runClusterView(
+	ctx context.Context,
+	clusterFilter string,
+	mon monitoringSource,
+	pipe pipelineSource,
+) ([]instroutput.ClusterView, error) {
+	observed, err := enumerate.Enumerate(ctx, mon, pipe)
+	if err != nil {
+		return nil, err
+	}
+
+	views := make([]instroutput.ClusterView, 0, len(observed))
+	for _, oc := range observed {
+		if clusterFilter != "" && oc.Name != clusterFilter {
+			continue
+		}
+		v := instroutput.ClusterView{
+			Name:                  oc.Name,
+			InstrumentationStatus: oc.Status,
+		}
+		// Populate observed metrics only when the cluster is visible to
+		// RunK8sMonitoring (State is nil for pre-Alloy PipelineSource clusters).
+		if oc.State != nil {
+			v.Namespaces = len(oc.State.Namespaces)
+			v.Workloads = oc.State.Workloads
+			v.Pods = oc.State.Pods
+			v.Nodes = oc.State.Nodes
+		}
+		views = append(views, v)
+	}
+	return views, nil
+}
+
+// runServiceView builds the workload-level view using RunK8sDiscovery.
+// Results are filtered client-side by clusterFilter (if non-empty) and by
+// namespaceFilter.
+func runServiceView(
+	ctx context.Context,
+	clusterFilter, namespaceFilter string,
+	disc discoverySource,
+) ([]instroutput.ServiceView, error) {
+	items, err := disc.RunK8sDiscovery(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	views := make([]instroutput.ServiceView, 0, len(items))
+	for _, item := range items {
+		if clusterFilter != "" && item.ClusterName != clusterFilter {
+			continue
+		}
+		if item.Namespace != namespaceFilter {
+			continue
+		}
+		views = append(views, instroutput.ServiceView{
+			ClusterName:           item.ClusterName,
+			Namespace:             item.Namespace,
+			Name:                  item.Name,
+			WorkloadType:          item.WorkloadType,
+			DisplayNamespace:      item.DisplayNamespace,
+			DisplayName:           item.DisplayName,
+			OS:                    item.OS,
+			Lang:                  item.Lang,
+			InstrumentationStatus: item.InstrumentationStatus,
+		})
+	}
+	return views, nil
+}

--- a/cmd/gcx/instrumentation/status/run_test.go
+++ b/cmd/gcx/instrumentation/status/run_test.go
@@ -1,0 +1,371 @@
+//nolint:testpackage // white-box testing: accesses unexported run function and source interfaces.
+package status
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/instrumentation"
+	instroutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Test fakes ───────────────────────────────────────────────────────────────
+
+// fakeMonitoringSource implements monitoringSource using a fixed slice.
+type fakeMonitoringSource struct {
+	clusters []instrumentation.ClusterObservedState
+	err      error
+}
+
+func (f *fakeMonitoringSource) RunK8sMonitoring(_ context.Context) ([]instrumentation.ClusterObservedState, error) {
+	return f.clusters, f.err
+}
+
+// fakePipelineSource implements pipelineSource using a fixed slice.
+type fakePipelineSource struct {
+	pipelines []instrumentation.Pipeline
+	err       error
+}
+
+func (f *fakePipelineSource) ListPipelines(_ context.Context) ([]instrumentation.Pipeline, error) {
+	return f.pipelines, f.err
+}
+
+// fakeDiscoverySource implements discoverySource using a fixed slice.
+type fakeDiscoverySource struct {
+	items []instrumentation.DiscoveryItem
+	err   error
+}
+
+func (f *fakeDiscoverySource) RunK8sDiscovery(_ context.Context) ([]instrumentation.DiscoveryItem, error) {
+	return f.items, f.err
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// k8sPipeline builds a K8s monitoring pipeline fixture for a cluster name.
+func k8sPipeline(id, clusterName string) instrumentation.Pipeline {
+	return instrumentation.Pipeline{
+		ID:   id,
+		Name: "k8s-monitoring-" + clusterName,
+		Metadata: map[string]any{
+			"type":    "k8s_monitoring",
+			"cluster": clusterName,
+		},
+	}
+}
+
+// ─── Cluster-view tests ───────────────────────────────────────────────────────
+
+func TestRunClusterView(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusterFilter string
+		monClusters   []instrumentation.ClusterObservedState
+		pipes         []instrumentation.Pipeline
+		monErr        error
+		pipeErr       error
+		wantErr       bool
+		wantNames     []string // expected cluster names; nil means empty result
+		wantChecks    func(t *testing.T, got []instroutput.ClusterView)
+	}{
+		{
+			// cluster enumeration includes pre-Alloy clusters that have
+			// been Set but whose Alloy collector has not yet started reporting.
+			name:        "pre-Alloy cluster appears with StatusPendingInstrumentation",
+			monClusters: nil, // RunK8sMonitoring returns nothing
+			pipes:       []instrumentation.Pipeline{k8sPipeline("p1", "new-cluster")},
+			wantNames:   []string{"new-cluster"},
+			wantChecks: func(t *testing.T, got []instroutput.ClusterView) {
+				t.Helper()
+				require.Len(t, got, 1)
+				assert.Equal(t, "new-cluster", got[0].Name)
+				assert.Equal(t, instrumentation.StatusPendingInstrumentation, got[0].InstrumentationStatus)
+				// Pre-Alloy cluster: no observed metrics.
+				assert.Equal(t, 0, got[0].Namespaces)
+				assert.Equal(t, 0, got[0].Nodes)
+				assert.Equal(t, 0, got[0].Workloads)
+				assert.Equal(t, 0, got[0].Pods)
+			},
+		},
+		{
+			// cluster visible in RunK8sMonitoring gets its status and metrics.
+			name: "instrumented cluster surfaces with observed metrics",
+			monClusters: []instrumentation.ClusterObservedState{
+				{
+					Name:                  "my-cluster",
+					InstrumentationStatus: instrumentation.StatusInstrumented,
+					Nodes:                 3,
+					Workloads:             5,
+					Pods:                  10,
+					Namespaces: []instrumentation.NamespaceObservedState{
+						{Name: "ns1"},
+						{Name: "ns2"},
+					},
+				},
+			},
+			pipes:     nil,
+			wantNames: []string{"my-cluster"},
+			wantChecks: func(t *testing.T, got []instroutput.ClusterView) {
+				t.Helper()
+				require.Len(t, got, 1)
+				assert.Equal(t, instrumentation.StatusInstrumented, got[0].InstrumentationStatus)
+				assert.Equal(t, 3, got[0].Nodes)
+				assert.Equal(t, 5, got[0].Workloads)
+				assert.Equal(t, 10, got[0].Pods)
+				assert.Equal(t, 2, got[0].Namespaces)
+			},
+		},
+		{
+			// cluster present in both monitoring and pipelines keeps
+			// monitoring-side status (BothSources via enumerate).
+			name: "cluster in both sources uses monitoring-side status",
+			monClusters: []instrumentation.ClusterObservedState{
+				{Name: "shared-cluster", InstrumentationStatus: instrumentation.StatusInstrumented},
+			},
+			pipes:     []instrumentation.Pipeline{k8sPipeline("p1", "shared-cluster")},
+			wantNames: []string{"shared-cluster"},
+			wantChecks: func(t *testing.T, got []instroutput.ClusterView) {
+				t.Helper()
+				require.Len(t, got, 1)
+				assert.Equal(t, instrumentation.StatusInstrumented, got[0].InstrumentationStatus)
+			},
+		},
+		{
+			// --cluster flag narrows the result to a single cluster.
+			name:          "--cluster filter returns only that cluster",
+			clusterFilter: "cluster-a",
+			monClusters: []instrumentation.ClusterObservedState{
+				{Name: "cluster-a", InstrumentationStatus: instrumentation.StatusInstrumented},
+				{Name: "cluster-b", InstrumentationStatus: instrumentation.StatusInstrumented},
+			},
+			pipes:     nil,
+			wantNames: []string{"cluster-a"},
+		},
+		{
+			// non-existent cluster name yields an empty result.
+			name:          "--cluster filter for unknown cluster returns empty",
+			clusterFilter: "no-such-cluster",
+			monClusters: []instrumentation.ClusterObservedState{
+				{Name: "cluster-a", InstrumentationStatus: instrumentation.StatusInstrumented},
+			},
+			pipes:     nil,
+			wantNames: nil,
+		},
+		{
+			name:      "empty monitoring and pipelines returns empty slice",
+			wantNames: nil,
+		},
+		{
+			name:    "monitoring RPC error is propagated",
+			monErr:  errors.New("monitoring RPC failed"),
+			wantErr: true,
+		},
+		{
+			name:    "pipeline RPC error is propagated",
+			pipeErr: errors.New("pipeline RPC failed"),
+			wantErr: true,
+		},
+		{
+			// Alphabetical sort is delegated to enumerate; verify via multi-cluster case.
+			name: "results are sorted alphabetically by cluster name",
+			monClusters: []instrumentation.ClusterObservedState{
+				{Name: "zebra", InstrumentationStatus: instrumentation.StatusInstrumented},
+				{Name: "alpha", InstrumentationStatus: instrumentation.StatusInstrumented},
+				{Name: "moose", InstrumentationStatus: instrumentation.StatusInstrumented},
+			},
+			pipes:     nil,
+			wantNames: []string{"alpha", "moose", "zebra"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mon := &fakeMonitoringSource{clusters: tt.monClusters, err: tt.monErr}
+			pipe := &fakePipelineSource{pipelines: tt.pipes, err: tt.pipeErr}
+			disc := &fakeDiscoverySource{} // not used in cluster-level path
+
+			result, err := run(context.Background(), tt.clusterFilter, "", mon, pipe, disc)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			views, ok := result.([]instroutput.ClusterView)
+			require.True(t, ok, "expected []ClusterView, got %T", result)
+
+			var gotNames []string
+			for _, v := range views {
+				gotNames = append(gotNames, v.Name)
+			}
+			assert.Equal(t, tt.wantNames, gotNames)
+
+			if tt.wantChecks != nil {
+				tt.wantChecks(t, views)
+			}
+		})
+	}
+}
+
+// ─── Service-view tests ───────────────────────────────────────────────────────
+
+func TestRunServiceView(t *testing.T) {
+	tests := []struct {
+		name            string
+		clusterFilter   string
+		namespaceFilter string
+		items           []instrumentation.DiscoveryItem
+		discErr         error
+		wantErr         bool
+		wantNames       []string // expected workload names; nil means empty result
+		wantChecks      func(t *testing.T, got []instroutput.ServiceView)
+	}{
+		{
+			// --namespace switches the command to workload-level output.
+			name:            "--namespace switches to service view and filters by namespace",
+			namespaceFilter: "my-ns",
+			items: []instrumentation.DiscoveryItem{
+				{
+					ClusterName:           "c1",
+					Namespace:             "my-ns",
+					Name:                  "svc1",
+					InstrumentationStatus: instrumentation.StatusInstrumented,
+				},
+				{
+					ClusterName:           "c1",
+					Namespace:             "other-ns",
+					Name:                  "svc2",
+					InstrumentationStatus: instrumentation.StatusNotInstrumented,
+				},
+			},
+			wantNames: []string{"svc1"},
+		},
+		{
+			// --cluster + --namespace combine as AND filters.
+			name:            "--cluster and --namespace both applied",
+			clusterFilter:   "cluster-a",
+			namespaceFilter: "my-ns",
+			items: []instrumentation.DiscoveryItem{
+				{ClusterName: "cluster-a", Namespace: "my-ns", Name: "svc1"},
+				{ClusterName: "cluster-b", Namespace: "my-ns", Name: "svc2"},
+				{ClusterName: "cluster-a", Namespace: "other-ns", Name: "svc3"},
+			},
+			wantNames: []string{"svc1"},
+		},
+		{
+			name:            "ServiceView fields are populated correctly",
+			namespaceFilter: "my-ns",
+			items: []instrumentation.DiscoveryItem{
+				{
+					ClusterName:           "c1",
+					Namespace:             "my-ns",
+					Name:                  "worker",
+					WorkloadType:          "deployment",
+					DisplayNamespace:      "My Namespace",
+					DisplayName:           "Worker Service",
+					OS:                    "linux",
+					Lang:                  "go",
+					InstrumentationStatus: instrumentation.StatusInstrumented,
+				},
+			},
+			wantNames: []string{"worker"},
+			wantChecks: func(t *testing.T, got []instroutput.ServiceView) {
+				t.Helper()
+				require.Len(t, got, 1)
+				v := got[0]
+				assert.Equal(t, "c1", v.ClusterName)
+				assert.Equal(t, "my-ns", v.Namespace)
+				assert.Equal(t, "worker", v.Name)
+				assert.Equal(t, "deployment", v.WorkloadType)
+				assert.Equal(t, "My Namespace", v.DisplayNamespace)
+				assert.Equal(t, "Worker Service", v.DisplayName)
+				assert.Equal(t, "linux", v.OS)
+				assert.Equal(t, "go", v.Lang)
+				assert.Equal(t, instrumentation.StatusInstrumented, v.InstrumentationStatus)
+			},
+		},
+		{
+			name:            "no matching namespace returns empty slice",
+			namespaceFilter: "no-such-ns",
+			items: []instrumentation.DiscoveryItem{
+				{ClusterName: "c1", Namespace: "my-ns", Name: "svc1"},
+			},
+			wantNames: nil,
+		},
+		{
+			name:            "discovery RPC error is propagated",
+			namespaceFilter: "my-ns",
+			discErr:         errors.New("discovery RPC failed"),
+			wantErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mon := &fakeMonitoringSource{} // not used in service-view path
+			pipe := &fakePipelineSource{}  // not used in service-view path
+			disc := &fakeDiscoverySource{items: tt.items, err: tt.discErr}
+
+			result, err := run(context.Background(), tt.clusterFilter, tt.namespaceFilter, mon, pipe, disc)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			views, ok := result.([]instroutput.ServiceView)
+			require.True(t, ok, "expected []ServiceView, got %T", result)
+
+			var gotNames []string
+			for _, v := range views {
+				gotNames = append(gotNames, v.Name)
+			}
+			assert.Equal(t, tt.wantNames, gotNames)
+
+			if tt.wantChecks != nil {
+				tt.wantChecks(t, views)
+			}
+		})
+	}
+}
+
+// TestRun_ReturnsRawSlices verifies that the run() function still returns raw
+// []ClusterView / []ServiceView (not envelopes). The command.go caller is
+// responsible for wrapping in the canonical envelope before encoding.
+func TestRun_ReturnsRawSlices(t *testing.T) {
+	t.Run("cluster view returns []ClusterView", func(t *testing.T) {
+		mon := &fakeMonitoringSource{
+			clusters: []instrumentation.ClusterObservedState{
+				{Name: "c1", InstrumentationStatus: instrumentation.StatusInstrumented},
+			},
+		}
+		pipe := &fakePipelineSource{}
+		disc := &fakeDiscoverySource{}
+
+		result, err := run(context.Background(), "", "", mon, pipe, disc)
+		require.NoError(t, err)
+		_, ok := result.([]instroutput.ClusterView)
+		assert.True(t, ok, "cluster view must return []ClusterView, got %T", result)
+	})
+
+	t.Run("service view returns []ServiceView", func(t *testing.T) {
+		mon := &fakeMonitoringSource{}
+		pipe := &fakePipelineSource{}
+		disc := &fakeDiscoverySource{
+			items: []instrumentation.DiscoveryItem{
+				{ClusterName: "c1", Namespace: "ns1", Name: "svc1"},
+			},
+		}
+
+		result, err := run(context.Background(), "", "ns1", mon, pipe, disc)
+		require.NoError(t, err)
+		_, ok := result.([]instroutput.ServiceView)
+		assert.True(t, ok, "service view must return []ServiceView, got %T", result)
+	})
+}

--- a/docs/reference/cli/gcx_instrumentation.md
+++ b/docs/reference/cli/gcx_instrumentation.md
@@ -8,9 +8,18 @@ Manage Grafana Instrumentation Hub using action-verb commands.
 
 The instrumentation command tree provides:
 
+  setup      Guided onboarding wizard: configures a cluster end-to-end and
+             prints a runnable helm install command.
+
+  status     Cross-cutting observed state for clusters and namespaces
+             (RunK8sMonitoring + ListPipelines merge).
+
   clusters   Declared and observed state per K8s cluster:
              list, get, configure, remove, wait.
              Sub-group "apps" manages namespace-level Beyla configuration.
+
+  services   Workload-level observed state and per-workload inclusion
+             overrides across the fleet: list, get, include, exclude, clear.
 
 ### Options
 
@@ -34,4 +43,7 @@ The instrumentation command tree provides:
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx instrumentation clusters](gcx_instrumentation_clusters.md)	 - Manage K8s monitoring configuration for clusters
+* [gcx instrumentation services](gcx_instrumentation_services.md)	 - Manage workload-level instrumentation across the fleet
+* [gcx instrumentation setup](gcx_instrumentation_setup.md)	 - Onboard a Kubernetes cluster for Grafana Instrumentation Hub
+* [gcx instrumentation status](gcx_instrumentation_status.md)	 - Show observed instrumentation state for clusters and namespaces.
 

--- a/docs/reference/cli/gcx_instrumentation_services.md
+++ b/docs/reference/cli/gcx_instrumentation_services.md
@@ -1,0 +1,44 @@
+## gcx instrumentation services
+
+Manage workload-level instrumentation across the fleet
+
+### Synopsis
+
+Manage workload-level observed state and per-workload inclusion
+overrides across the fleet.
+
+Subcommands:
+
+  list     List all discovered workloads, with optional filtering.
+  get      Get a single workload by (cluster, namespace, service).
+  include  Include a workload for instrumentation (DWIM, idempotent).
+  exclude  Exclude a workload from instrumentation (DWIM, idempotent).
+  clear    Remove a per-workload override, inheriting namespace default.
+
+### Options
+
+```
+  -h, --help   help for services
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation](gcx_instrumentation.md)	 - Manage Grafana Instrumentation Hub
+* [gcx instrumentation services clear](gcx_instrumentation_services_clear.md)	 - Remove a per-workload override, inheriting namespace default
+* [gcx instrumentation services exclude](gcx_instrumentation_services_exclude.md)	 - Exclude a workload from instrumentation (DWIM, idempotent)
+* [gcx instrumentation services get](gcx_instrumentation_services_get.md)	 - Get a single discovered workload by (cluster, namespace, service)
+* [gcx instrumentation services include](gcx_instrumentation_services_include.md)	 - Include a workload for instrumentation (DWIM, idempotent)
+* [gcx instrumentation services list](gcx_instrumentation_services_list.md)	 - List discovered workloads across the fleet
+

--- a/docs/reference/cli/gcx_instrumentation_services_clear.md
+++ b/docs/reference/cli/gcx_instrumentation_services_clear.md
@@ -1,0 +1,46 @@
+## gcx instrumentation services clear
+
+Remove a per-workload override, inheriting namespace default
+
+### Synopsis
+
+Remove any per-workload inclusion or exclusion override for a workload.
+
+After clearing, the workload inherits the namespace autoinstrument default.
+
+The operation is idempotent: if no override exists for the workload,
+the command exits 0 without making any backend calls.
+
+The write uses an optimistic-lock guard (rmw.Update) when a change is needed:
+if the namespace list changes between the initial read and the pre-write re-check,
+the command returns a conflict error and must be retried.
+
+Examples:
+  gcx instrumentation services clear prod-1 checkout frontend
+
+```
+gcx instrumentation services clear <cluster> <namespace> <service> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for clear
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation services](gcx_instrumentation_services.md)	 - Manage workload-level instrumentation across the fleet
+

--- a/docs/reference/cli/gcx_instrumentation_services_exclude.md
+++ b/docs/reference/cli/gcx_instrumentation_services_exclude.md
@@ -1,0 +1,51 @@
+## gcx instrumentation services exclude
+
+Exclude a workload from instrumentation (DWIM, idempotent)
+
+### Synopsis
+
+Exclude a specific workload from instrumentation using DWIM semantics.
+
+DWIM logic:
+  - Removes any existing INCLUDED override for the workload.
+  - Adds an EXCLUDED override iff the namespace autoinstrument is explicitly
+    true (i.e. the namespace default is on, so an explicit opt-out is needed).
+  - If the namespace autoinstrument is false/nil, no override is added (the
+    namespace default is already off — adding EXCLUDED would be redundant).
+
+The operation is idempotent: running it twice with the same args exits 0 and
+the second call is a no-op against the backend.
+
+The write uses an optimistic-lock guard (rmw.Update): if the namespace list
+changes between the initial read and the pre-write re-check, the command returns
+a conflict error and must be retried.
+
+Examples:
+  gcx instrumentation services exclude prod-1 checkout payment-svc
+
+```
+gcx instrumentation services exclude <cluster> <namespace> <service> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for exclude
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation services](gcx_instrumentation_services.md)	 - Manage workload-level instrumentation across the fleet
+

--- a/docs/reference/cli/gcx_instrumentation_services_get.md
+++ b/docs/reference/cli/gcx_instrumentation_services_get.md
@@ -1,0 +1,45 @@
+## gcx instrumentation services get
+
+Get a single discovered workload by (cluster, namespace, service)
+
+### Synopsis
+
+Get a single workload discovered by the Beyla survey collector.
+
+Calls RunK8sDiscovery() (fleet-wide RPC) and filters to the requested workload.
+Returns an error if the workload is not found.
+
+Examples:
+  gcx instrumentation services get prod-1 checkout frontend
+  gcx instrumentation services get prod-1 checkout frontend -o json
+
+Workload-level Selection / override state is not surfaced on this command. To inspect a workload's override, run "gcx instrumentation clusters apps list --cluster=<cluster> --namespace=<namespace>".
+
+```
+gcx instrumentation services get <cluster> <namespace> <service> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, text, wide, yaml (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation services](gcx_instrumentation_services.md)	 - Manage workload-level instrumentation across the fleet
+

--- a/docs/reference/cli/gcx_instrumentation_services_include.md
+++ b/docs/reference/cli/gcx_instrumentation_services_include.md
@@ -1,0 +1,51 @@
+## gcx instrumentation services include
+
+Include a workload for instrumentation (DWIM, idempotent)
+
+### Synopsis
+
+Include a specific workload for instrumentation using DWIM semantics.
+
+DWIM logic:
+  - Removes any existing EXCLUDED override for the workload.
+  - Adds an INCLUDED override iff the namespace autoinstrument is NOT explicitly
+    true (i.e. the namespace default is off, so an explicit opt-in is needed).
+  - If the namespace autoinstrument is true, no override is added (namespace
+    default is already on — adding INCLUDED would be redundant).
+
+The operation is idempotent: running it twice with the same args exits 0
+and the second call is a no-op against the backend.
+
+The write uses an optimistic-lock guard (rmw.Update): if the namespace list
+changes between the initial read and the pre-write re-check, the command returns
+a conflict error and must be retried.
+
+Examples:
+  gcx instrumentation services include prod-1 checkout frontend
+
+```
+gcx instrumentation services include <cluster> <namespace> <service> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for include
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation services](gcx_instrumentation_services.md)	 - Manage workload-level instrumentation across the fleet
+

--- a/docs/reference/cli/gcx_instrumentation_services_list.md
+++ b/docs/reference/cli/gcx_instrumentation_services_list.md
@@ -1,0 +1,60 @@
+## gcx instrumentation services list
+
+List discovered workloads across the fleet
+
+### Synopsis
+
+List all workloads discovered by the Beyla survey collector.
+
+Calls RunK8sDiscovery() (fleet-wide RPC) and applies client-side filters.
+
+Examples:
+  # List all workloads
+  gcx instrumentation services list
+
+  # Filter to a specific cluster
+  gcx instrumentation services list --cluster prod-1
+
+  # Filter to a specific namespace
+  gcx instrumentation services list --namespace checkout
+
+  # Show only workloads in terminal error state
+  gcx instrumentation services list --status=ERROR
+
+  # Wide output with extra columns
+  gcx instrumentation services list -o wide
+
+Workload-level Selection / override state is not surfaced on this command. To inspect a workload's override, run "gcx instrumentation clusters apps list --cluster=<cluster> --namespace=<namespace>".
+
+```
+gcx instrumentation services list [flags]
+```
+
+### Options
+
+```
+  -A, --all                Show services from all namespaces (fleet-wide)
+      --cluster string     Filter by cluster name
+  -h, --help               help for list
+      --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -n, --namespace string   Filter by Kubernetes namespace
+  -o, --output string      Output format. One of: agents, json, text, wide, yaml (default "text")
+      --status string      Filter by instrumentation status (e.g. ERROR, INSTRUMENTED)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation services](gcx_instrumentation_services.md)	 - Manage workload-level instrumentation across the fleet
+

--- a/docs/reference/cli/gcx_instrumentation_setup.md
+++ b/docs/reference/cli/gcx_instrumentation_setup.md
@@ -1,0 +1,59 @@
+## gcx instrumentation setup
+
+Onboard a Kubernetes cluster for Grafana Instrumentation Hub
+
+### Synopsis
+
+Onboard a Kubernetes cluster end-to-end by configuring K8s monitoring
+and printing a runnable helm install command.
+
+Steps performed:
+  1. Calls SetupK8sDiscovery — idempotent, safe to re-run.
+  2. Reads the cluster's current K8s monitoring configuration.
+  3. Resolves desired flag values: prompts interactively (when stdin is a TTY
+     and --use-defaults is absent) or applies defaults under --use-defaults:
+       costMetrics=true  clusterEvents=true  energyMetrics=false  nodeLogs=false
+     Per-flag overrides (--cost-metrics[=true|false], --cluster-events[=true|false],
+     --energy-metrics[=true|false], --node-logs[=true|false]) take precedence over defaults.
+  4. Calls SetK8SInstrumentation only when at least one flag changed.
+  5. Emits a mutation summary to stderr.
+  6. Prints a parameterized helm command to stdout.
+
+Re-running with unchanged inputs is safe and idempotent.
+
+The helm command installs grafana-cloud-onboarding and connects the cluster to
+Grafana Cloud via Fleet Management. Replace <YOUR_CLOUD_ACCESS_TOKEN> with a
+Cloud Access Policy token scoped to metrics:read and set:alloy-data-write.
+
+```
+gcx instrumentation setup <cluster> [flags]
+```
+
+### Options
+
+```
+      --cluster-events    Set clusterEvents under --use-defaults. Pass --cluster-events=false to disable. Omit to use default (true).
+      --cost-metrics      Set costMetrics under --use-defaults. Pass --cost-metrics=false to disable. Omit to use default (true).
+      --energy-metrics    Set energyMetrics under --use-defaults. Pass --energy-metrics=false to disable. Omit to use default (false).
+  -h, --help              help for setup
+      --node-logs         Set nodeLogs under --use-defaults. Pass --node-logs=false to disable. Omit to use default (false).
+      --print-helm-only   Print the helm command and exit; no server calls are made
+      --use-defaults      Apply defaults without prompting (required when stdin is not a TTY)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation](gcx_instrumentation.md)	 - Manage Grafana Instrumentation Hub
+

--- a/docs/reference/cli/gcx_instrumentation_status.md
+++ b/docs/reference/cli/gcx_instrumentation_status.md
@@ -1,0 +1,46 @@
+## gcx instrumentation status
+
+Show observed instrumentation state for clusters and namespaces.
+
+### Synopsis
+
+Show observed instrumentation state across all clusters, or narrow to a
+specific cluster or namespace.
+
+Without flags, lists all clusters including pre-Alloy clusters that have been
+configured but whose Alloy collector has not yet started reporting (shown as
+PENDING_INSTRUMENTATION).
+
+Use --cluster to filter to a single cluster. Add --namespace to drill down to
+workload-level status for a specific namespace, powered by RunK8sDiscovery.
+
+```
+gcx instrumentation status [flags]
+```
+
+### Options
+
+```
+      --cluster string     Filter output to a specific cluster
+  -h, --help               help for status
+      --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --namespace string   Filter to a specific namespace; switches to workload-level view
+  -o, --output string      Output format. One of: agents, json, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation](gcx_instrumentation.md)	 - Manage Grafana Instrumentation Hub
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -108,6 +108,17 @@ var commandAnnotations = map[string]annotation{
 	"gcx instrumentation clusters apps remove":    {Cost: "small"},
 	"gcx instrumentation clusters apps wait":      {Cost: "small"},
 
+	// top-level single commands
+	"gcx instrumentation setup":  {Cost: "medium", Hint: "<cluster> --yes -o json"},
+	"gcx instrumentation status": {Cost: "medium", Hint: "-o json"},
+
+	// services verb group
+	"gcx instrumentation services list":    {Cost: "large", Hint: "--cluster <name> --namespace <ns> -o json"},
+	"gcx instrumentation services get":     {Cost: "medium", Hint: "<cluster> <namespace> <service> -o json"},
+	"gcx instrumentation services include": {Cost: "small"},
+	"gcx instrumentation services exclude": {Cost: "small"},
+	"gcx instrumentation services clear":   {Cost: "small"},
+
 	// skills
 	"gcx agent skills install":   {Cost: "small"},
 	"gcx agent skills list":      {Cost: "small"},

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -109,7 +109,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx instrumentation clusters apps wait":      {Cost: "small"},
 
 	// top-level single commands
-	"gcx instrumentation setup":  {Cost: "medium", Hint: "<cluster> --yes -o json"},
+	"gcx instrumentation setup":  {Cost: "medium", Hint: "<cluster> --use-defaults -o json"},
 	"gcx instrumentation status": {Cost: "medium", Hint: "-o json"},
 
 	// services verb group


### PR DESCRIPTION
## What

Completes the `gcx instrumentation` command tree by adding the remaining three subtrees.

`gcx instrumentation services [list|get|include|exclude|clear]` provides an observed-state fleet sweep via `RunK8sDiscovery` with DWIM single-workload mutation. `list` supports optional `--cluster`/`--namespace` narrowing; `include`/`exclude` flip per-workload selection; `clear` strips all overrides.

`gcx instrumentation setup <cluster>` is a loud, mutating, idempotent onboarding wizard that calls `SetupK8sDiscovery`, applies declared K8s monitoring config only when something changed, and prints a parameterized helm install command. Mutually exclusive flag pairs surface as canonical `DetailedError`.

`gcx instrumentation status` provides a cross-cutting observed view across cluster → namespace → service by merging `RunK8sMonitoring`, `ListPipelines`, and `RunK8sDiscovery` so that list/get/status results stay consistent.

The root command's `Long` description and `AddCommand` block are extended to register all four subtrees. Token-cost annotations and the full CLI reference docs are updated for the seven new leaf commands.

## Why

Services, setup, and status complete the operational surface for the Instrumentation Hub. Separating them from the clusters subtree (prior stack PR) limits each PR's review scope while keeping the stack compilable at every step.

## How it was tested

- [x] `go test ./cmd/gcx/instrumentation/...` — services, setup, and status tests pass
- [x] `go test ./...` — full suite passes with no regressions
- [x] `go build ./cmd/gcx/` — binary builds with all four subtrees registered

## Related

- Relates to #597

---
**Generated by Claude Code**

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #655**
  * **PR #656**
    * **PR #657** 👈
      * **PR #658**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->
