### PR TITLE
feat(assistant): add dashboard subcommand and fix --agent-id flag

### DIFF
--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -77,6 +77,7 @@ Service account tokens are not supported.`,
 
 	configOpts.BindFlags(cmd.PersistentFlags())
 	cmd.AddCommand(promptCommand(configOpts))
+	cmd.AddCommand(dashboardCommand(configOpts))
 
 	// Create a ConfigLoader for investigations that shares the same --config/--context
 	// flags already bound by configOpts. Wire the values via PersistentPreRunE so that
@@ -111,13 +112,18 @@ type promptOpts struct {
 	agentID   string
 }
 
-func (o *promptOpts) setup(cmd *cobra.Command) {
+// setup binds the shared streaming flags. If exposeAgentID is true, the
+// --agent-id flag is also bound; subcommands that target a fixed agent (e.g.
+// `assistant dashboard`) pass false and pre-populate o.agentID instead.
+func (o *promptOpts) setup(cmd *cobra.Command, exposeAgentID bool) {
 	cmd.Flags().IntVar(&o.timeout, "timeout", 300, "Timeout in seconds when waiting for a response")
 	cmd.Flags().StringVar(&o.contextID, "context-id", "", "Context ID for conversation threading")
 	cmd.Flags().BoolVar(&o.cont, "continue", false, "Continue the previous chat session")
 	cmd.Flags().BoolVar(&o.jsonOut, "json", false, "Output as JSON (streams NDJSON events by default)")
 	cmd.Flags().BoolVar(&o.noStream, "no-stream", false, "With --json, emit a single JSON object instead of streaming events")
-	cmd.Flags().StringVar(&o.agentID, "agent-id", assistant.DefaultAgentID, "Agent ID to target")
+	if exposeAgentID {
+		cmd.Flags().StringVar(&o.agentID, "agent-id", assistant.DefaultAgentID, "Agent ID to target (e.g. grafana_assistant_cli, grafana_dashboarding)")
+	}
 }
 
 func (o *promptOpts) Validate() error {
@@ -149,23 +155,69 @@ func promptCommand(configOpts *cmdconfig.Options) *cobra.Command {
 		Long: `Send a single message to Grafana Assistant and receive the response.
 
 This is useful for scripting and automation. The response streams via
-the A2A (Agent-to-Agent) protocol over Server-Sent Events.`,
-		Args:    cobra.ExactArgs(1),
-		Example: "  gcx assistant prompt \"What alerts are firing?\"\n  gcx assistant prompt \"Show CPU usage\" --json\n  gcx assistant prompt \"Follow up\" --continue",
+the A2A (Agent-to-Agent) protocol over Server-Sent Events.
+
+Known agent IDs:
+  grafana_assistant_cli   General-purpose assistant (default)
+  grafana_dashboarding    Dashboard builder — queries live Prometheus to discover
+                          metrics and returns complete dashboard JSON ready for
+                          'gcx resources push'. See also: gcx assistant dashboard`,
+		Args: cobra.ExactArgs(1),
+		Example: `  gcx assistant prompt "What alerts are firing?"
+  gcx assistant prompt "Show CPU usage" --json
+  gcx assistant prompt "Follow up" --continue
+  gcx assistant prompt "Build a CPU dashboard" --agent-id grafana_dashboarding`,
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "large",
 			agent.AnnotationLLMHint:   "Prefer deterministic gcx commands (gcx metrics query, gcx slo definitions status, gcx alert instances list) for precise data retrieval. Use assistant prompt for reasoning: root cause analysis, holistic health questions, or when you don't know which metrics/labels exist — the Assistant's Infrastructure Memories know your stack topology. Example: \"Why is checkout-latency spiking?\" --json",
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.Validate(); err != nil {
-				return err
-			}
-			return runPrompt(cmd, args[0], opts, configOpts)
-		},
+		RunE: promptRunE(opts, configOpts),
 	}
 
-	opts.setup(cmd)
+	opts.setup(cmd, true)
 	return cmd
+}
+
+// dashboardCommand returns a subcommand that routes to the grafana_dashboarding
+// agent. It queries live Prometheus to discover metrics and returns complete
+// dashboard JSON ready for 'gcx resources push'.
+func dashboardCommand(configOpts *cmdconfig.Options) *cobra.Command {
+	opts := &promptOpts{agentID: "grafana_dashboarding"}
+
+	cmd := &cobra.Command{
+		Use:   "dashboard <message>",
+		Short: "Build a dashboard using the Grafana dashboarding agent",
+		Long: `Send a dashboard creation request to the Grafana dashboarding agent.
+
+The agent queries live Prometheus to discover available clusters and metric
+names, then returns complete dashboard JSON that can be pushed directly with
+'gcx resources push'.
+
+This is equivalent to:
+  gcx assistant prompt --agent-id grafana_dashboarding <message>`,
+		Args: cobra.ExactArgs(1),
+		Example: `  gcx assistant dashboard "Build a CPU usage dashboard across all clusters"
+  gcx assistant dashboard "Create a dashboard for HTTP error rates by service" --json`,
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "large",
+			agent.AnnotationLLMHint:   "Use assistant dashboard to build Grafana dashboards from natural language. The agent discovers live Prometheus metrics and returns complete dashboard JSON. Pipe the result to 'gcx resources push' to publish it.",
+		},
+		RunE: promptRunE(opts, configOpts),
+	}
+
+	opts.setup(cmd, false)
+	return cmd
+}
+
+// promptRunE returns the RunE used by both `prompt` and `dashboard` — the only
+// per-command difference is the pre-populated agent ID on opts.
+func promptRunE(opts *promptOpts, configOpts *cmdconfig.Options) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := opts.Validate(); err != nil {
+			return err
+		}
+		return runPrompt(cmd, args[0], opts, configOpts)
+	}
 }
 
 func runPrompt(cmd *cobra.Command, message string, opts *promptOpts, configOpts *cmdconfig.Options) error {
@@ -197,7 +249,7 @@ func runPrompt(cmd *cobra.Command, message string, opts *promptOpts, configOpts 
 		contextID = lastContextID
 	}
 
-	clientOpts, err := resolveAssistantClientOptions(ctx, configOpts, opts.timeout)
+	clientOpts, err := resolveAssistantClientOptions(ctx, configOpts, opts.timeout, opts.agentID)
 	if err != nil {
 		if opts.jsonOut {
 			return jsonError(err)
@@ -360,7 +412,7 @@ func handlePromptResult(cmd *cobra.Command, result assistant.StreamResult, opts 
 // resolveAssistantClientOptions loads the gcx config and returns assistant
 // ClientOptions for assistant prompt, including an HTTP client whose Timeout
 // matches streamTimeoutSeconds (see --timeout and SSE body reads).
-func resolveAssistantClientOptions(ctx context.Context, configOpts *cmdconfig.Options, streamTimeoutSeconds int) (assistant.ClientOptions, error) {
+func resolveAssistantClientOptions(ctx context.Context, configOpts *cmdconfig.Options, streamTimeoutSeconds int, agentID string) (assistant.ClientOptions, error) {
 	cfg, err := configOpts.LoadConfig(ctx)
 	if err != nil {
 		return assistant.ClientOptions{}, err
@@ -386,6 +438,7 @@ func resolveAssistantClientOptions(ctx context.Context, configOpts *cmdconfig.Op
 			GrafanaURL:     grafana.Server,
 			Token:          grafana.OAuthToken,
 			APIEndpoint:    grafana.ProxyEndpoint,
+			AgentID:        agentID,
 			TokenRefresher: refresher,
 			HTTPClient:     httpClient,
 		}, nil
@@ -395,6 +448,7 @@ func resolveAssistantClientOptions(ctx context.Context, configOpts *cmdconfig.Op
 		return assistant.ClientOptions{
 			GrafanaURL: grafana.Server,
 			Token:      grafana.APIToken,
+			AgentID:    agentID,
 			HTTPClient: httpClient,
 		}, nil
 

--- a/cmd/gcx/assistant/command_test.go
+++ b/cmd/gcx/assistant/command_test.go
@@ -110,6 +110,66 @@ func TestConventions_PromptAnnotations(t *testing.T) {
 	}
 }
 
+// TestConventions_DashboardSubcommandExists verifies that the assistant group
+// command exposes a 'dashboard' subcommand for discoverability of the
+// dashboarding agent.
+func TestConventions_DashboardSubcommandExists(t *testing.T) {
+	cmd := assistant.Command()
+
+	var dashCmd *cobra.Command
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "dashboard" {
+			dashCmd = sub
+			break
+		}
+	}
+	if dashCmd == nil {
+		t.Fatal("expected to find 'dashboard' subcommand under assistant")
+	}
+}
+
+// TestConventions_DashboardSubcommandHasAnnotations verifies that the dashboard
+// subcommand carries agent annotations matching the prompt subcommand.
+func TestConventions_DashboardSubcommandHasAnnotations(t *testing.T) {
+	cmd := assistant.Command()
+
+	var dashCmd *cobra.Command
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "dashboard" {
+			dashCmd = sub
+			break
+		}
+	}
+	if dashCmd == nil {
+		t.Fatal("expected to find 'dashboard' subcommand")
+	}
+
+	if _, ok := dashCmd.Annotations["agent.token_cost"]; !ok {
+		t.Fatal("expected dashboard command to have agent.token_cost annotation")
+	}
+}
+
+// TestConventions_DashboardSubcommandNoAgentIDFlag verifies that the dashboard
+// subcommand does NOT expose --agent-id, since its agent is fixed.
+func TestConventions_DashboardSubcommandNoAgentIDFlag(t *testing.T) {
+	cmd := assistant.Command()
+
+	var dashCmd *cobra.Command
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "dashboard" {
+			dashCmd = sub
+			break
+		}
+	}
+	if dashCmd == nil {
+		t.Fatal("expected to find 'dashboard' subcommand")
+	}
+
+	if dashCmd.Flags().Lookup("agent-id") != nil {
+		t.Fatal("dashboard subcommand should not expose --agent-id; the agent is fixed to grafana_dashboarding")
+	}
+}
+
 func TestRequireGrafanaCloud(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/docs/reference/cli/gcx_assistant.md
+++ b/docs/reference/cli/gcx_assistant.md
@@ -30,6 +30,7 @@ Service account tokens are not supported.
 ### SEE ALSO
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx assistant dashboard](gcx_assistant_dashboard.md)	 - Build a dashboard using the Grafana dashboarding agent
 * [gcx assistant investigations](gcx_assistant_investigations.md)	 - Manage Grafana Assistant investigations.
 * [gcx assistant prompt](gcx_assistant_prompt.md)	 - Send a single message to Grafana Assistant
 

--- a/docs/reference/cli/gcx_assistant_dashboard.md
+++ b/docs/reference/cli/gcx_assistant_dashboard.md
@@ -1,40 +1,35 @@
-## gcx assistant prompt
+## gcx assistant dashboard
 
-Send a single message to Grafana Assistant
+Build a dashboard using the Grafana dashboarding agent
 
 ### Synopsis
 
-Send a single message to Grafana Assistant and receive the response.
+Send a dashboard creation request to the Grafana dashboarding agent.
 
-This is useful for scripting and automation. The response streams via
-the A2A (Agent-to-Agent) protocol over Server-Sent Events.
+The agent queries live Prometheus to discover available clusters and metric
+names, then returns complete dashboard JSON that can be pushed directly with
+'gcx resources push'.
 
-Known agent IDs:
-  grafana_assistant_cli   General-purpose assistant (default)
-  grafana_dashboarding    Dashboard builder — queries live Prometheus to discover
-                          metrics and returns complete dashboard JSON ready for
-                          'gcx resources push'. See also: gcx assistant dashboard
+This is equivalent to:
+  gcx assistant prompt --agent-id grafana_dashboarding <message>
 
 ```
-gcx assistant prompt <message> [flags]
+gcx assistant dashboard <message> [flags]
 ```
 
 ### Examples
 
 ```
-  gcx assistant prompt "What alerts are firing?"
-  gcx assistant prompt "Show CPU usage" --json
-  gcx assistant prompt "Follow up" --continue
-  gcx assistant prompt "Build a CPU dashboard" --agent-id grafana_dashboarding
+  gcx assistant dashboard "Build a CPU usage dashboard across all clusters"
+  gcx assistant dashboard "Create a dashboard for HTTP error rates by service" --json
 ```
 
 ### Options
 
 ```
-      --agent-id string     Agent ID to target (e.g. grafana_assistant_cli, grafana_dashboarding) (default "grafana_assistant_cli")
       --context-id string   Context ID for conversation threading
       --continue            Continue the previous chat session
-  -h, --help                help for prompt
+  -h, --help                help for dashboard
       --json                Output as JSON (streams NDJSON events by default)
       --no-stream           With --json, emit a single JSON object instead of streaming events
       --timeout int         Timeout in seconds when waiting for a response (default 300)

--- a/internal/assistant/client.go
+++ b/internal/assistant/client.go
@@ -100,7 +100,6 @@ func (c *Client) GetGrafanaURL() string {
 	return c.grafanaURL
 }
 
-// GetAgentID returns the agent ID used for A2A routing.
 func (c *Client) GetAgentID() string {
 	return c.agentID
 }

--- a/internal/assistant/client.go
+++ b/internal/assistant/client.go
@@ -18,6 +18,7 @@ type Client struct {
 	grafanaURL     string
 	baseURL        string
 	token          string
+	agentID        string
 	logger         Logger
 	tokenRefresher TokenRefresher
 	httpClient     *http.Client
@@ -37,10 +38,16 @@ func New(opts ClientOptions) *Client {
 		httpClient = httputils.NewDefaultClient(context.Background())
 	}
 
+	agentID := opts.AgentID
+	if agentID == "" {
+		agentID = DefaultAgentID
+	}
+
 	return &Client{
 		grafanaURL:     grafanaURL,
 		baseURL:        baseURL,
 		token:          opts.Token,
+		agentID:        agentID,
 		logger:         NopLogger{},
 		tokenRefresher: opts.TokenRefresher,
 		httpClient:     httpClient,
@@ -63,7 +70,7 @@ func (c *Client) ChatWithApproval(ctx context.Context, prompt string, opts Strea
 
 	promptWithContext := prompt + "\n" + FormatTimeContext()
 
-	return StreamChatWithApproval(ctx, c.baseURL, c.freshToken(), DefaultAgentID, promptWithContext, opts, c.logger, approvalHandler, c.httpClient)
+	return StreamChatWithApproval(ctx, c.baseURL, c.freshToken(), c.agentID, promptWithContext, opts, c.logger, approvalHandler, c.httpClient)
 }
 
 // GetChat fetches a single chat by ID.
@@ -91,6 +98,11 @@ func (c *Client) GetBaseURL() string {
 // GetGrafanaURL returns the Grafana instance URL.
 func (c *Client) GetGrafanaURL() string {
 	return c.grafanaURL
+}
+
+// GetAgentID returns the agent ID used for A2A routing.
+func (c *Client) GetAgentID() string {
+	return c.agentID
 }
 
 // GetToken returns the current authentication token.

--- a/internal/assistant/client_test.go
+++ b/internal/assistant/client_test.go
@@ -186,3 +186,26 @@ func TestNew_BaseURL_DirectAPITrailingSlash(t *testing.T) {
 		t.Errorf("GetBaseURL() = %q, want %q", c.GetBaseURL(), want)
 	}
 }
+
+func TestNew_DefaultAgentID(t *testing.T) {
+	c := assistant.New(assistant.ClientOptions{
+		GrafanaURL: "https://test.grafana.net",
+		Token:      "test-token",
+	})
+
+	if c.GetAgentID() != assistant.DefaultAgentID {
+		t.Errorf("GetAgentID() = %q, want %q (default)", c.GetAgentID(), assistant.DefaultAgentID)
+	}
+}
+
+func TestNew_CustomAgentID(t *testing.T) {
+	c := assistant.New(assistant.ClientOptions{
+		GrafanaURL: "https://test.grafana.net",
+		Token:      "test-token",
+		AgentID:    "grafana_dashboarding",
+	})
+
+	if c.GetAgentID() != "grafana_dashboarding" {
+		t.Errorf("GetAgentID() = %q, want %q", c.GetAgentID(), "grafana_dashboarding")
+	}
+}

--- a/internal/assistant/types.go
+++ b/internal/assistant/types.go
@@ -203,9 +203,11 @@ type TokenRefresher func() (string, error)
 
 // ClientOptions represents options for creating a Client.
 type ClientOptions struct {
-	GrafanaURL     string
-	Token          string
-	APIEndpoint    string
+	GrafanaURL  string
+	Token       string
+	APIEndpoint string
+	// AgentID is the A2A agent to route requests to. Defaults to DefaultAgentID if empty.
+	AgentID        string
 	TokenRefresher TokenRefresher
 	// HTTPClient is an optional custom HTTP client. If nil, httputils.NewDefaultClient(context.Background()) is used.
 	// Callers that need context-aware behaviour (e.g. --log-http-payload) should set this field explicitly


### PR DESCRIPTION
## Summary

- **Fixes broken `--agent-id` flag** on `gcx assistant prompt` — the flag was defined but never wired to the streaming call; the client always used the hardcoded `DefaultAgentID` constant.
- **Adds `gcx assistant dashboard` subcommand** as a named shortcut for `--agent-id grafana_dashboarding`, making the dashboarding capability easy to discover and use.
- **Improves `gcx assistant prompt` help text** with a known-agent-IDs section and an example showing `--agent-id grafana_dashboarding`.

## Changes

| File | Change |
|------|--------|
| `internal/assistant/types.go` | Add `AgentID string` to `ClientOptions` |
| `internal/assistant/client.go` | Store `agentID` on `Client`, set from `ClientOptions` in `New()`, use it in `ChatWithApproval()` instead of hardcoded constant; add `GetAgentID()` accessor |
| `cmd/gcx/assistant/command.go` | Wire `opts.agentID` through `resolveAssistantClientOptions()`; add `dashboardCommand()`; improve `promptCommand()` Long/Example; refactor shared flag-binding to reduce duplication |
| `docs/reference/cli/` | Regenerated: updated `gcx_assistant_prompt.md`, new `gcx_assistant_dashboard.md` |
| Tests | New tests for agent ID plumbing and dashboard subcommand structure |

## Test Plan

- [x] `go test ./internal/assistant/... ./cmd/gcx/assistant/...` — all pass
- [x] `go test -race -count=1 ./...` — all pass, no failures
- [x] `golangci-lint run ./internal/assistant/... ./cmd/gcx/assistant/...` — 0 issues
- [x] `GCX_AGENT_MODE=false mise run reference` — reference docs regenerated, no drift

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)