### PR TITLE
feat: add structured version subcommand

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -54,12 +54,13 @@ OnCall, Fleet Management, etc.) using product-specific REST APIs.
   `gcx logs query`). Tooling commands (`dev`, `config`)
   may use `$AREA $VERB` when there is no meaningful noun — these operate on
   the project or CLI itself, not on Grafana resources. Bare top-level
-  verbs (single-token commands) are permitted only for foundational
-  bootstrapping that precedes any area or resource context:
-  `gcx login`, `gcx setup`, and Cobra-provided `help`/`completion`. This
-  is an explicit, closed enumeration — any new top-level command must
-  follow `$AREA $NOUN $VERB` or `$AREA $VERB`; it does not qualify as a
-  bare verb by analogy.
+  verbs (single-token commands) are permitted only for two narrow
+  categories: (1) foundational bootstrapping that precedes any area or
+  resource context — `gcx login`, `gcx setup`; and (2) CLI-meta commands
+  that report on the binary itself rather than on Grafana — `gcx version`
+  and Cobra-provided `help`/`completion`. This is an explicit, closed
+  enumeration — any new top-level command must follow `$AREA $NOUN $VERB`
+  or `$AREA $VERB`; it does not qualify as a bare verb by analogy.
 - **Extension commands nest under their resource type.** Domain-specific
   operations (`status`, `timeline`, `acknowledge`) live alongside CRUD verbs,
   never as top-level commands. Extensions must not duplicate CRUD semantics —

--- a/cmd/gcx/main.go
+++ b/cmd/gcx/main.go
@@ -37,6 +37,7 @@ func main() {
 
 	formattedVersion := formatVersion()
 	appversion.Set(version)
+	appversion.SetBuildInfo(commit, date)
 	if err := root.ValidateArgs(root.Command(formattedVersion), os.Args[1:]); err != nil {
 		handleError(err)
 	}

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -21,6 +21,7 @@ import (
 	cmdproviders "github.com/grafana/gcx/cmd/gcx/providers"
 	"github.com/grafana/gcx/cmd/gcx/resources"
 	"github.com/grafana/gcx/cmd/gcx/setup"
+	versioncmd "github.com/grafana/gcx/cmd/gcx/version"
 	"github.com/grafana/gcx/internal/agent"
 	internalconfig "github.com/grafana/gcx/internal/config"
 	_ "github.com/grafana/gcx/internal/datasources/providers" // DatasourceProvider registrations — blank imports trigger init() self-registration.
@@ -227,6 +228,7 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 	rootCmd.AddCommand(config.Command())
 	rootCmd.AddCommand(dev.Command())
 	rootCmd.AddCommand(setup.Command())
+	rootCmd.AddCommand(versioncmd.Command())
 	rootCmd.AddCommand(datasources.Command())
 	rootCmd.AddCommand(resources.Command())
 

--- a/cmd/gcx/version/command.go
+++ b/cmd/gcx/version/command.go
@@ -1,0 +1,73 @@
+package version
+
+import (
+	"errors"
+	"fmt"
+	goio "io"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/style"
+	appversion "github.com/grafana/gcx/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// Command returns the "version" subcommand with structured output support.
+func Command() *cobra.Command {
+	opts := &cmdio.Options{}
+	opts.DefaultFormat("text")
+	opts.RegisterCustomCodec("text", &versionTextCodec{})
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print version information.",
+		Long:  "Print version, commit, build date, Go version, OS, and architecture. Supports structured output via --output json/yaml.",
+		Example: `  # Human-readable version
+  gcx version
+
+  # JSON output for automation
+  gcx version -o json
+
+  # Select specific fields
+  gcx version --json version,commit`,
+		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "small",
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			return opts.Encode(cmd.OutOrStdout(), appversion.Info())
+		},
+	}
+
+	opts.BindFlags(cmd.Flags())
+
+	return cmd
+}
+
+// versionTextCodec renders version info as a key-value table.
+type versionTextCodec struct{}
+
+func (c *versionTextCodec) Format() format.Format { return "text" }
+
+func (c *versionTextCodec) Encode(output goio.Writer, value any) error {
+	info, ok := value.(appversion.InfoData)
+	if !ok {
+		return fmt.Errorf("unexpected type %T", value)
+	}
+	t := style.NewTable("FIELD", "VALUE")
+	t.Row("Version", info.Version)
+	t.Row("Commit", info.Commit)
+	t.Row("Build Date", info.BuildDate)
+	t.Row("Go", info.Go)
+	t.Row("OS", info.OS)
+	t.Row("Arch", info.Arch)
+	return t.Render(output)
+}
+
+func (c *versionTextCodec) Decode(_ goio.Reader, _ any) error {
+	return errors.New("version text codec does not support decoding")
+}

--- a/cmd/gcx/version/command_test.go
+++ b/cmd/gcx/version/command_test.go
@@ -1,0 +1,85 @@
+package version_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	versioncmd "github.com/grafana/gcx/cmd/gcx/version"
+	appversion "github.com/grafana/gcx/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionCommand_JSON(t *testing.T) {
+	appversion.Set("1.2.3")
+	appversion.SetBuildInfo("abc1234", "2026-05-07T12:00:00Z")
+	t.Cleanup(func() {
+		appversion.Set("")
+		appversion.SetBuildInfo("", "")
+	})
+
+	cmd := versioncmd.Command()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"-o", "json"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	var info appversion.InfoData
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &info))
+
+	assert.Equal(t, "1.2.3", info.Version)
+	assert.Equal(t, "abc1234", info.Commit)
+	assert.Equal(t, "2026-05-07T12:00:00Z", info.BuildDate)
+	assert.NotEmpty(t, info.Go)
+	assert.NotEmpty(t, info.OS)
+	assert.NotEmpty(t, info.Arch)
+}
+
+func TestVersionCommand_Text(t *testing.T) {
+	appversion.Set("2.0.0")
+	appversion.SetBuildInfo("def5678", "2026-01-01T00:00:00Z")
+	t.Cleanup(func() {
+		appversion.Set("")
+		appversion.SetBuildInfo("", "")
+	})
+
+	cmd := versioncmd.Command()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"-o", "text"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "2.0.0")
+	assert.Contains(t, out, "def5678")
+	assert.Contains(t, out, "2026-01-01T00:00:00Z")
+}
+
+func TestVersionCommand_Defaults(t *testing.T) {
+	appversion.Set("")
+	appversion.SetBuildInfo("", "")
+	t.Cleanup(func() {
+		appversion.Set("")
+		appversion.SetBuildInfo("", "")
+	})
+
+	cmd := versioncmd.Command()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"-o", "json"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	var info appversion.InfoData
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &info))
+
+	assert.Equal(t, "SNAPSHOT", info.Version)
+	assert.Equal(t, "unknown", info.Commit)
+	assert.Equal(t, "unknown", info.BuildDate)
+}

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -49,4 +49,5 @@ gcx is a unified CLI for managing Grafana resources, dashboards, datasources, al
 * [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
 * [gcx synthetic-monitoring](gcx_synthetic-monitoring.md)	 - Manage Grafana Synthetic Monitoring checks and probes
 * [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces
+* [gcx version](gcx_version.md)	 - Print version information.
 

--- a/docs/reference/cli/gcx_version.md
+++ b/docs/reference/cli/gcx_version.md
@@ -28,7 +28,7 @@ gcx version [flags]
 ```
   -h, --help            help for version
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_version.md
+++ b/docs/reference/cli/gcx_version.md
@@ -1,0 +1,48 @@
+## gcx version
+
+Print version information.
+
+### Synopsis
+
+Print version, commit, build date, Go version, OS, and architecture. Supports structured output via --output json/yaml.
+
+```
+gcx version [flags]
+```
+
+### Examples
+
+```
+  # Human-readable version
+  gcx version
+
+  # JSON output for automation
+  gcx version -o json
+
+  # Select specific fields
+  gcx version --json version,commit
+```
+
+### Options
+
+```
+  -h, --help            help for version
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: json, text, yaml (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,10 +5,21 @@ import (
 	"runtime"
 )
 
-var ver string //nolint:gochecknoglobals // Set once from main at startup.
+//nolint:gochecknoglobals // Set once from main at startup.
+var (
+	ver    string
+	commit string
+	date   string
+)
 
 // Set stores the application version. Call from main() before HTTP clients are created.
 func Set(v string) { ver = v }
+
+// SetBuildInfo stores commit hash and build date alongside the version.
+func SetBuildInfo(c, d string) {
+	commit = c
+	date = d
+}
 
 // Get returns the raw version string, defaulting to "SNAPSHOT".
 func Get() string {
@@ -18,7 +29,45 @@ func Get() string {
 	return ver
 }
 
+// GetCommit returns the short commit hash, or "unknown" if not set.
+func GetCommit() string {
+	if commit == "" {
+		return "unknown"
+	}
+	return commit
+}
+
+// GetDate returns the build date, or "unknown" if not set.
+func GetDate() string {
+	if date == "" {
+		return "unknown"
+	}
+	return date
+}
+
 // UserAgent returns the formatted User-Agent: gcx/{version} ({os}/{arch}).
 func UserAgent() string {
 	return fmt.Sprintf("gcx/%s (%s/%s)", Get(), runtime.GOOS, runtime.GOARCH)
+}
+
+// Info returns a structured snapshot of all version metadata.
+func Info() InfoData {
+	return InfoData{
+		Version:   Get(),
+		Commit:    GetCommit(),
+		BuildDate: GetDate(),
+		Go:        runtime.Version(),
+		OS:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+	}
+}
+
+// InfoData holds structured version metadata for JSON/YAML serialization.
+type InfoData struct {
+	Version   string `json:"version"   yaml:"version"`
+	Commit    string `json:"commit"    yaml:"commit"`
+	BuildDate string `json:"buildDate" yaml:"buildDate"`
+	Go        string `json:"go"        yaml:"go"`
+	OS        string `json:"os"        yaml:"os"`
+	Arch      string `json:"arch"      yaml:"arch"`
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -32,3 +32,39 @@ func TestUserAgent_SNAPSHOT(t *testing.T) {
 	expected := fmt.Sprintf("gcx/SNAPSHOT (%s/%s)", runtime.GOOS, runtime.GOARCH)
 	assert.Equal(t, expected, version.UserAgent())
 }
+
+func TestGetCommit_Default(t *testing.T) {
+	version.SetBuildInfo("", "")
+	t.Cleanup(func() { version.SetBuildInfo("", "") })
+	assert.Equal(t, "unknown", version.GetCommit())
+}
+
+func TestGetDate_Default(t *testing.T) {
+	version.SetBuildInfo("", "")
+	t.Cleanup(func() { version.SetBuildInfo("", "") })
+	assert.Equal(t, "unknown", version.GetDate())
+}
+
+func TestSetBuildInfo(t *testing.T) {
+	version.SetBuildInfo("abc1234", "2026-05-07T12:00:00Z")
+	t.Cleanup(func() { version.SetBuildInfo("", "") })
+	assert.Equal(t, "abc1234", version.GetCommit())
+	assert.Equal(t, "2026-05-07T12:00:00Z", version.GetDate())
+}
+
+func TestInfo(t *testing.T) {
+	version.Set("3.0.0")
+	version.SetBuildInfo("fff9999", "2026-12-25T00:00:00Z")
+	t.Cleanup(func() {
+		version.Set("")
+		version.SetBuildInfo("", "")
+	})
+
+	info := version.Info()
+	assert.Equal(t, "3.0.0", info.Version)
+	assert.Equal(t, "fff9999", info.Commit)
+	assert.Equal(t, "2026-12-25T00:00:00Z", info.BuildDate)
+	assert.Equal(t, runtime.Version(), info.Go)
+	assert.Equal(t, runtime.GOOS, info.OS)
+	assert.Equal(t, runtime.GOARCH, info.Arch)
+}


### PR DESCRIPTION
## What

Add `gcx version` subcommand with structured output support (JSON/YAML/text) via the standard codec system.

## Why

The existing `gcx --version` flag outputs a plain string that is not machine-parseable. LLM agents and automation need structured version metadata (version, commit, build date, Go version, OS, arch) in JSON format.

## Usage

```bash
# Human-readable table
gcx version

# Structured JSON for automation
gcx version -o json

# Field selection
gcx version --json version,commit

# Agent mode auto-defaults to JSON
GCX_AGENT_MODE=true gcx version
```

## CONSTITUTION amendment

This PR also amends the bare top-level verb enumeration in `CONSTITUTION.md` to add `version` as a CLI-meta command, alongside `help`/`completion`. Rationale: `version` reports on the binary, not on Grafana resources, and shares that property with the existing CLI-meta entries. The amendment splits the existing rule into two narrow categories — foundational bootstrapping (`login`, `setup`) and CLI-meta (`version`, `help`, `completion`) — to make the underlying principle explicit. The "no extension by analogy" rule is preserved; future bare verbs still require explicit amendment.

The amendment lives in its own commit (`docs(constitution): permit version as CLI-meta bare verb`) so it remains reviewable on its own.