### PR TITLE
fix: wire exit codes 2 (usage) and 4 (partial failure)

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -46,6 +46,7 @@ func ErrorToDetailedError(err error) *DetailedError {
 	errorConverters := []func(err error) (*DetailedError, bool){
 		convertWaitTimeoutEmitted,          // Wait timeout already emitted fused envelope — suppress secondary output
 		convertUnknownFieldSelectionErrors, // --json unknown-field validation
+		convertPartialFailureErrors,
 		convertUsageErrors,
 		convertCobraUnknownCommandErrors,
 		convertContextCanceled,                      // Context cancellation (must be first — cancellation can wrap other errors)
@@ -94,6 +95,7 @@ func convertUsageErrors(err error) (*DetailedError, bool) {
 		Summary:     "Invalid command usage",
 		Details:     details,
 		Suggestions: usageErr.Suggestions,
+		ExitCode:    new(ExitUsageError),
 	}, true
 }
 
@@ -104,8 +106,9 @@ func convertCobraUnknownCommandErrors(err error) (*DetailedError, bool) {
 	}
 
 	detailed := &DetailedError{
-		Summary: "Invalid command usage",
-		Details: msg,
+		Summary:  "Invalid command usage",
+		Details:  msg,
+		ExitCode: new(ExitUsageError),
 	}
 
 	const marker = ` for "`
@@ -860,6 +863,7 @@ func convertRequiredFlagErrors(err error) (*DetailedError, bool) {
 			Suggestions: []string{
 				"Run the command with --help to see available flags and usage examples",
 			},
+			ExitCode: new(ExitUsageError),
 		}, true
 	}
 	return nil, false
@@ -1331,6 +1335,19 @@ func convertStacksErrors(err error) (*DetailedError, bool) {
 	}
 
 	return nil, false
+}
+
+func convertPartialFailureErrors(err error) (*DetailedError, bool) {
+	partialErr := &PartialFailureError{}
+	if !errors.As(err, &partialErr) {
+		return nil, false
+	}
+
+	return &DetailedError{
+		Summary:  fmt.Sprintf("%d of %d resource(s) failed to %s", partialErr.Failed, partialErr.Total, partialErr.Op),
+		Parent:   err,
+		ExitCode: new(ExitPartialFailure),
+	}, true
 }
 
 func convertContextCanceled(err error) (*DetailedError, bool) {

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -926,3 +926,71 @@ func TestErrorToDetailedError_UnknownFieldSelectionError(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorToDetailedError_UsageErrorExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "UsageError returns ExitUsageError",
+			err:  fail.NewCommandUsageError(nil, "bad input", nil),
+		},
+		{
+			name: "unknown command returns ExitUsageError",
+			err:  errors.New(`unknown command "foo" for "gcx"`),
+		},
+		{
+			name: "required flags returns ExitUsageError",
+			err:  errors.New(`required flag(s) "datasource" not set`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fail.ErrorToDetailedError(tc.err)
+			require.NotNil(t, got)
+			require.NotNil(t, got.ExitCode, "ExitCode should be set for usage errors")
+			assert.Equal(t, fail.ExitUsageError, *got.ExitCode)
+		})
+	}
+}
+
+func TestErrorToDetailedError_PartialFailureExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "push partial failure",
+			err:  fail.NewPartialFailureError("push", 100, 10),
+		},
+		{
+			name: "pull partial failure",
+			err:  fail.NewPartialFailureError("pull", 50, 3),
+		},
+		{
+			name: "delete partial failure",
+			err:  fail.NewPartialFailureError("delete", 20, 5),
+		},
+		{
+			name: "validate partial failure",
+			err:  fail.NewPartialFailureError("validate", 30, 7),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fail.ErrorToDetailedError(tc.err)
+			require.NotNil(t, got)
+			require.NotNil(t, got.ExitCode, "ExitCode should be set for partial failures")
+			assert.Equal(t, fail.ExitPartialFailure, *got.ExitCode)
+			assert.Contains(t, got.Summary, "failed")
+		})
+	}
+}
+
+func TestPartialFailureError_Message(t *testing.T) {
+	err := fail.NewPartialFailureError("push", 100, 10)
+	assert.Equal(t, "10 resource(s) failed to push", err.Error())
+}

--- a/cmd/gcx/fail/partial.go
+++ b/cmd/gcx/fail/partial.go
@@ -1,0 +1,26 @@
+package fail
+
+import "fmt"
+
+// PartialFailureError indicates that a batch operation completed but some
+// resources failed. Commands should return this instead of a plain fmt.Errorf
+// so that the error converter can set exit code 4.
+type PartialFailureError struct {
+	Total  int
+	Failed int
+	Op     string // "push", "pull", "delete", "validate"
+}
+
+func (e *PartialFailureError) Error() string {
+	return fmt.Sprintf("%d resource(s) failed to %s", e.Failed, e.Op)
+}
+
+// NewPartialFailureError creates a PartialFailureError for a batch operation
+// where some resources failed.
+func NewPartialFailureError(op string, total, failed int) *PartialFailureError {
+	return &PartialFailureError{
+		Total:  total,
+		Failed: failed,
+		Op:     op,
+	}
+}

--- a/cmd/gcx/resources/delete.go
+++ b/cmd/gcx/resources/delete.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
 	"github.com/grafana/gcx/cmd/gcx/fail"
@@ -183,7 +182,7 @@ func deleteCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			printer(cmd.OutOrStdout(), "%d resources deleted, %d errors", summary.SuccessCount(), summary.FailedCount())
 
 			if opts.OnError.FailOnErrors() && summary.FailedCount() > 0 {
-				return fmt.Errorf("%d resource(s) failed to delete", summary.FailedCount())
+				return fail.NewPartialFailureError("delete", summary.SuccessCount()+summary.FailedCount(), summary.FailedCount())
 			}
 
 			return nil

--- a/cmd/gcx/resources/pull.go
+++ b/cmd/gcx/resources/pull.go
@@ -2,9 +2,9 @@ package resources
 
 import (
 	"errors"
-	"fmt"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources/local"
 	"github.com/grafana/gcx/internal/resources/process"
@@ -161,7 +161,7 @@ func pullCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			}
 
 			if opts.OnError.FailOnErrors() && pullSummary.FailedCount() > 0 {
-				return fmt.Errorf("%d resource(s) failed to pull", pullSummary.FailedCount())
+				return fail.NewPartialFailureError("pull", pullSummary.SuccessCount()+pullSummary.FailedCount(), pullSummary.FailedCount())
 			}
 
 			return nil

--- a/cmd/gcx/resources/push.go
+++ b/cmd/gcx/resources/push.go
@@ -2,9 +2,9 @@ package resources
 
 import (
 	"errors"
-	"fmt"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources"
@@ -184,7 +184,7 @@ func pushCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			printer(cmd.OutOrStdout(), "%d resources pushed, %d errors", summary.SuccessCount(), summary.FailedCount())
 
 			if opts.OnError.FailOnErrors() && summary.FailedCount() > 0 {
-				return fmt.Errorf("%d resource(s) failed to push", summary.FailedCount())
+				return fail.NewPartialFailureError("push", summary.SuccessCount()+summary.FailedCount(), summary.FailedCount())
 			}
 
 			return nil

--- a/cmd/gcx/resources/validate.go
+++ b/cmd/gcx/resources/validate.go
@@ -2,10 +2,10 @@ package resources
 
 import (
 	"errors"
-	"fmt"
 	"io"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources"
@@ -164,7 +164,7 @@ func validateCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			}
 
 			if opts.OnError.FailOnErrors() && summary.FailedCount() > 0 {
-				return fmt.Errorf("%d resource(s) failed to validate", summary.FailedCount())
+				return fail.NewPartialFailureError("validate", summary.SuccessCount()+summary.FailedCount(), summary.FailedCount())
 			}
 
 			return nil

--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -672,6 +672,10 @@ Commands can return a `DetailedError` directly from `RunE`. Business logic layer
 ErrorToDetailedError(err)
     │
     ├─ errors.As(err, &DetailedError{}) → return as-is if already detailed
+    ├─ convertWaitTimeoutEmitted → ErrWaitTimeoutEmitted sentinel (suppress secondary output)
+    ├─ convertUnknownFieldSelectionErrors → UnknownFieldSelectionError (--json unknown field)
+    ├─ convertPartialFailureErrors → PartialFailureError (exit 4)
+    ├─ convertUsageErrors    → UsageError (exit 2)
     ├─ convertConfigErrors   → ValidationError, UnmarshalError, ErrContextNotFound
     ├─ convertFSErrors       → fs.PathError (not exist, invalid, permission)
     ├─ convertResourcesErrors → InvalidSelectorError

--- a/docs/design/exit-codes.md
+++ b/docs/design/exit-codes.md
@@ -12,9 +12,9 @@
 |------|----------|---------|------|
 | 0 | `ExitSuccess` | Success | Command completed without errors |
 | 1 | `ExitGeneralError` | General error | Unexpected error, business logic failure |
-| 2 | `ExitUsageError` | Usage error | Bad flags, invalid selectors, missing args `[RESERVED]` |
+| 2 | `ExitUsageError` | Usage error | Bad flags, invalid selectors, missing args |
 | 3 | `ExitAuthFailure` | Auth failure | 401/403, missing or invalid credentials |
-| 4 | `ExitPartialFailure` | Partial failure | Some resources succeeded, others failed `[RESERVED]` |
+| 4 | `ExitPartialFailure` | Partial failure | Some resources succeeded, others failed |
 | 5 | `ExitCancelled` | Cancelled | User pressed Ctrl+C (SIGINT) or `context.Canceled` |
 | 6 | `ExitVersionIncompatible` | Version incompatible | Grafana version < 12 detected |
 

--- a/docs/design/exit-codes.md
+++ b/docs/design/exit-codes.md
@@ -21,12 +21,20 @@
 Constants defined in `cmd/gcx/fail/exitcodes.go`.
 
 **Implementation state:**
+- Exit code 2 (usage error) is set by `convertUsageErrors`,
+  `convertCobraUnknownCommandErrors`, and `convertRequiredFlagErrors` for bad
+  flags, unknown commands, and missing required flags.
 - Exit code 3 (auth failure) is set by `convertAPIErrors` for HTTP 401/403.
+- Exit code 4 (partial failure) is set by `convertPartialFailureErrors` when
+  push, pull, delete, or validate operations have mixed success/failure results.
+  Commands return a `PartialFailureError` when `--on-error=fail` (default) and
+  `FailedCount > 0`.
 - Exit code 5 (cancelled) is set by `convertContextCanceled` (first in converter
   chain) and by a fast-path check in `handleError` for `context.Canceled`.
 - SIGINT is handled via `signal.NotifyContext` in `main.go`, which cancels the
   context and produces exit code 5.
-- Exit codes 2, 4, and 6 are defined as constants but not yet wired to converters.
+- Exit code 6 (version incompatible) is set by `convertVersionErrors` when
+  Grafana version < 12 is detected.
 
 ### 2.2 Setting Exit Codes in Converters
 

--- a/internal/fail/exitcodes.go
+++ b/internal/fail/exitcodes.go
@@ -4,15 +4,12 @@ package fail
 //
 // These codes let scripts and CI pipelines distinguish between error
 // categories without parsing stderr text.
-//
-// Codes marked [RESERVED] or [PLANNED] are defined for forward compatibility
-// but are not yet emitted by any converter.
 const (
 	ExitSuccess             = 0 // Command completed successfully
 	ExitGeneralError        = 1 // Unclassified/unexpected error (default)
-	ExitUsageError          = 2 // Bad flags, invalid selectors, missing args [RESERVED]
+	ExitUsageError          = 2 // Bad flags, invalid selectors, missing args, unknown commands
 	ExitAuthFailure         = 3 // HTTP 401/403, missing/invalid credentials
-	ExitPartialFailure      = 4 // Some resources succeeded, others failed [RESERVED]
+	ExitPartialFailure      = 4 // Some resources succeeded, others failed (push/pull/delete/validate)
 	ExitCancelled           = 5 // User cancelled (SIGINT) or context.Canceled
 	ExitVersionIncompatible = 6 // Grafana version < 12
 )


### PR DESCRIPTION
## What

Wire the remaining reserved exit codes so scripts and agents can distinguish error categories without parsing text.

## Why

Exit codes 2 and 4 were defined as constants but never emitted by any converter. This made it impossible for automation to distinguish usage errors from general failures, or partial failures from complete failures.

## Changes

### Exit code 2 — usage errors
- `convertUsageErrors` → sets `ExitCode: 2`
- `convertCobraUnknownCommandErrors` → sets `ExitCode: 2`
- `convertRequiredFlagErrors` → sets `ExitCode: 2`

### Exit code 4 — partial failures
- New `PartialFailureError` type in `cmd/gcx/fail/partial.go`
- New `convertPartialFailureErrors` converter → sets `ExitCode: 4`
- `push`, `pull`, `delete`, `validate` commands now return `PartialFailureError` instead of `fmt.Errorf` when some resources fail

### Docs
- Updated `docs/design/exit-codes.md` — removed `[RESERVED]` tags, documented implementation state for all codes
- Updated `cmd/gcx/fail/exitcodes.go` comments

## Exit code summary (all now wired)

| Code | Meaning | Converter |
|------|---------|-----------|
| 0 | Success | — |
| 1 | General error | default |
| 2 | Usage error | `convertUsageErrors`, `convertCobraUnknownCommandErrors`, `convertRequiredFlagErrors` |
| 3 | Auth failure | `convertAPIErrors`, `convertQueryErrors`, etc. |
| 4 | Partial failure | `convertPartialFailureErrors` |
| 5 | Cancelled | `convertContextCanceled` + SIGINT fast-path |
| 6 | Version incompatible | `convertVersionErrors` |