### PR TITLE
feat(kg): support pagination for entities list

### DIFF
--- a/docs/reference/cli/gcx_kg_entities_list.md
+++ b/docs/reference/cli/gcx_kg_entities_list.md
@@ -23,7 +23,7 @@ gcx kg entities list [flags]
       --from string            Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                   help for list
       --json string            Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int              Maximum number of items to return (0 for all) (default 50)
+      --limit int              Maximum number of items to return (0 for all; the backend may still page results — use --page to paginate) (default 50)
       --namespace string       Namespace scope (run 'gcx kg meta scopes' to see valid values)
   -o, --output string          Output format. One of: json, table, yaml (default "table")
       --page int               Page number (0-based)

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -423,20 +423,40 @@ func (c *Client) AssertionSourceMetrics(ctx context.Context, req SourceMetricsRe
 // Search operations
 // ---------------------------------------------------------------------------
 
+// SearchPage is one page of entity search results plus the backend's
+// pagination signals. LastPage is true when no further pages exist;
+// MaxLimitHit is true when the backend's per-page result cap was reached
+// (i.e. the page is truncated and a subsequent --page would return more).
+type SearchPage struct {
+	Entities    []SearchResult
+	PageNum     int
+	LastPage    bool
+	MaxLimitHit bool
+}
+
 // Search searches for entities matching the given request.
-func (c *Client) Search(ctx context.Context, req SearchRequest) ([]SearchResult, error) {
+func (c *Client) Search(ctx context.Context, req SearchRequest) (SearchPage, error) {
 	var wrapper struct {
 		Data struct {
-			Entities []SearchResult `json:"entities"`
+			Entities                 []SearchResult `json:"entities"`
+			PageNum                  int            `json:"pageNum"`
+			LastPage                 bool           `json:"lastPage"`
+			SearchResultsMaxLimitHit bool           `json:"searchResultsMaxLimitHit"`
 		} `json:"data"`
 	}
 	if err := c.postJSON(ctx, searchPath, req, &wrapper); err != nil {
-		return nil, fmt.Errorf("kg: search: %w", err)
+		return SearchPage{}, fmt.Errorf("kg: search: %w", err)
 	}
-	if wrapper.Data.Entities == nil {
-		return []SearchResult{}, nil
+	entities := wrapper.Data.Entities
+	if entities == nil {
+		entities = []SearchResult{}
 	}
-	return wrapper.Data.Entities, nil
+	return SearchPage{
+		Entities:    entities,
+		PageNum:     wrapper.Data.PageNum,
+		LastPage:    wrapper.Data.LastPage,
+		MaxLimitHit: wrapper.Data.SearchResultsMaxLimitHit,
+	}, nil
 }
 
 // SearchAssertions searches for assertion timelines matching the given query.

--- a/internal/providers/kg/client_test.go
+++ b/internal/providers/kg/client_test.go
@@ -216,12 +216,12 @@ func TestClient_Search(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(t, server)
-	results, err := client.Search(t.Context(), kg.SearchRequest{
+	page, err := client.Search(t.Context(), kg.SearchRequest{
 		FilterCriteria: []kg.EntityMatcher{{EntityType: "Service"}},
 	})
 	require.NoError(t, err)
-	assert.Len(t, results, 2)
-	assert.Equal(t, "svc-1", results[0].Name)
+	assert.Len(t, page.Entities, 2)
+	assert.Equal(t, "svc-1", page.Entities[0].Name)
 }
 
 func TestClient_CypherSearch(t *testing.T) {

--- a/internal/providers/kg/client_test.go
+++ b/internal/providers/kg/client_test.go
@@ -224,6 +224,68 @@ func TestClient_Search(t *testing.T) {
 	assert.Equal(t, "svc-1", page.Entities[0].Name)
 }
 
+func TestClient_Search_Pagination(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req kg.SearchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		switch req.PageNum {
+		case 0:
+			writeJSON(w, map[string]any{
+				"data": map[string]any{
+					"pageNum":                  0,
+					"lastPage":                 false,
+					"searchResultsMaxLimitHit": true,
+					"entities": []map[string]any{
+						{"name": "svc-1", "type": "Service"},
+						{"name": "svc-2", "type": "Service"},
+					},
+				},
+			})
+		case 1:
+			writeJSON(w, map[string]any{
+				"data": map[string]any{
+					"pageNum":                  1,
+					"lastPage":                 true,
+					"searchResultsMaxLimitHit": false,
+					"entities": []map[string]any{
+						{"name": "svc-3", "type": "Service"},
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected pageNum: %d", req.PageNum)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+
+	first, err := client.Search(t.Context(), kg.SearchRequest{
+		FilterCriteria: []kg.EntityMatcher{{EntityType: "Service"}},
+		PageNum:        0,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, first.PageNum)
+	assert.False(t, first.LastPage)
+	assert.True(t, first.MaxLimitHit)
+	assert.Len(t, first.Entities, 2)
+	assert.Equal(t, "svc-1", first.Entities[0].Name)
+
+	second, err := client.Search(t.Context(), kg.SearchRequest{
+		FilterCriteria: []kg.EntityMatcher{{EntityType: "Service"}},
+		PageNum:        1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, second.PageNum)
+	assert.True(t, second.LastPage)
+	assert.False(t, second.MaxLimitHit)
+	assert.Len(t, second.Entities, 1)
+	assert.Equal(t, "svc-3", second.Entities[0].Name)
+}
+
 func TestClient_CypherSearch(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -290,6 +290,8 @@ func readFileOrStdin(cmd *cobra.Command, path string) ([]byte, error) {
 // searchByTypes fans out Search across multiple entity types and merges results.
 // Server-side (5xx) failures for individual entity types are logged as warnings and skipped
 // so that a broken type does not abort results for all other types.
+// When the backend signals more pages (MaxLimitHit, or !LastPage) for a per-type
+// page, a hint is emitted to stderr suggesting --page to fetch further results.
 func searchByTypes(ctx context.Context, cmd *cobra.Command, client *Client, entityTypes []string, assertionsOnly bool, sc *ScopeCriteria, startMs, endMs int64, pageNum int, propertyFilters []PropertyMatcher) ([]SearchResult, error) {
 	if startMs == 0 && endMs == 0 {
 		now := time.Now().UnixMilli()
@@ -309,7 +311,7 @@ func searchByTypes(ctx context.Context, cmd *cobra.Command, client *Client, enti
 			ScopeCriteria: sc,
 			PageNum:       pageNum,
 		}
-		results, err := client.Search(ctx, req)
+		page, err := client.Search(ctx, req)
 		if err != nil {
 			var apiErr *APIError
 			if errors.As(err, &apiErr) && apiErr.IsServerError() {
@@ -318,7 +320,12 @@ func searchByTypes(ctx context.Context, cmd *cobra.Command, client *Client, enti
 			}
 			return nil, fmt.Errorf("search entity type %s: %w", et, err)
 		}
-		allResults = append(allResults, results...)
+		if page.MaxLimitHit || (!page.LastPage && len(page.Entities) > 0) {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"hint: more results available for type %q (page %d returned %d) — use --page %d or narrow with --property/--namespace\n",
+				et, pageNum, len(page.Entities), pageNum+1)
+		}
+		allResults = append(allResults, page.Entities...)
 	}
 	if allResults == nil {
 		return []SearchResult{}, nil
@@ -809,7 +816,7 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 		listPage         int
 		listPropertyRaw  []string
 	)
-	listOpts := &entitiesShowOpts{}
+	listOpts := &entitiesListOpts{}
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List Knowledge Graph entities for a given type.",
@@ -858,6 +865,13 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 				results = filterBySeverity(results, listWithInsights)
 			}
 			results = adapter.TruncateSlice(results, listOpts.Limit)
+			if listOpts.Limit > 0 && int64(len(results)) >= listOpts.Limit {
+				w := listOpts.IO.ErrWriter
+				if w == nil {
+					w = os.Stderr
+				}
+				fmt.Fprintf(w, "hint: --limit of %d reached — results may be truncated; raise --limit or pass --limit 0 for all\n", listOpts.Limit)
+			}
 			return listOpts.IO.Encode(cmd.OutOrStdout(), results)
 		},
 	}
@@ -876,16 +890,16 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 	return cmd
 }
 
-type entitiesShowOpts struct {
+type entitiesListOpts struct {
 	IO    cmdio.Options
 	Limit int64
 }
 
-func (o *entitiesShowOpts) setup(flags *pflag.FlagSet) {
+func (o *entitiesListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &EntityTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
-	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all)")
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for all; the backend may still page results — use --page to paginate)")
 }
 
 // EntityTableCodec renders search results as a table.


### PR DESCRIPTION
## Summary
- Surface the backend's `lastPage` and `searchResultsMaxLimitHit` pagination signals from `Client.Search()` via a new `SearchPage` struct, instead of discarding them.
- Emit a stderr hint from `kg entities list` when more pages exist, recommending `--page N+1` or narrower filters — so agents/scripts no longer silently get capped results.
- Emit a stderr hint when the client-side `--limit` is reached.
- Rename misnamed `entitiesShowOpts` → `entitiesListOpts`.

## Test plan
- [x] `mise run lint` — 0 issues
- [x] `go test ./...` — full suite passes
- [x] `GCX_AGENT_MODE=false mise run reference` — CLI reference regenerated
- [x] Live verified against ops: pagination hint fires when backend caps the page; no false positive when results fit on one page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)