### PR TITLE
feat: add option to configure organization ID on login

### DIFF
--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -48,6 +48,7 @@ type loginOpts struct {
 	Yes                 bool
 	AllowServerOverride bool
 	OAuthCallbackPort   int
+	OrgID               int
 }
 
 func (opts *loginOpts) setup(flags *pflag.FlagSet) {
@@ -67,6 +68,7 @@ func (opts *loginOpts) setup(flags *pflag.FlagSet) {
 	flags.BoolVar(&opts.Yes, "yes", false, "Non-interactive: skip optional prompts and use defaults")
 	flags.BoolVar(&opts.AllowServerOverride, "allow-server-override", false, "Allow re-pointing an existing context at a different server URL")
 	flags.IntVar(&opts.OAuthCallbackPort, "oauth-callback-port", 0, "Fixed local port for the OAuth callback server (default: auto-pick from 54321-54399). Useful when only specific ports are forwarded between a remote host and your browser")
+	flags.IntVar(&opts.OrgID, "org-id", 0, "Grafana organization ID (defaults to 1 for on-prem)")
 }
 
 // Validate checks opts and args for internal consistency before runLogin executes.
@@ -202,6 +204,7 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 			CloudAPIURL:       flags.CloudAPIURL,
 			OAuthCallbackPort: flags.OAuthCallbackPort,
 			Yes:               flags.Yes,
+			OrgID:             flags.OrgID,
 			Writer:            cmd.ErrOrStderr(),
 			TLS:               existingTLS,
 		},

--- a/docs/reference/cli/gcx_login.md
+++ b/docs/reference/cli/gcx_login.md
@@ -40,6 +40,7 @@ gcx login [CONTEXT_NAME] [flags]
   -h, --help                      help for login
       --json string               Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --oauth-callback-port int   Fixed local port for the OAuth callback server (default: auto-pick from 54321-54399). Useful when only specific ports are forwarded between a remote host and your browser
+      --org-id int                Grafana organization ID (defaults to 1 for on-prem)
   -o, --output string             Output format. One of: agents, json, text, yaml (default "text")
       --server string             Grafana server URL (e.g. https://my-stack.grafana.net)
       --token string              Grafana service account token

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -35,6 +35,7 @@ type Inputs struct {
 	GrafanaToken string
 	CloudToken   string
 	CloudAPIURL  string
+	OrgID        int
 	UseOAuth     bool
 	// OAuthCallbackPort fixes the local port for the OAuth callback server.
 	// Zero means auto-pick from the default range. Useful when only specific
@@ -364,6 +365,7 @@ func resolveGrafanaAuth(ctx context.Context, opts Options, target Target) (strin
 
 	grafanaCfg := &config.GrafanaConfig{
 		Server: opts.Server,
+		OrgID:  int64(opts.OrgID),
 		TLS:    opts.TLS,
 	}
 

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -516,7 +516,7 @@ func persistContext(ctx context.Context, opts Options, contextName string, tempC
 
 	// Re-auth mode: preserve existing context fields, update only auth.
 	if existing != nil {
-		mergeAuthIntoExisting(existing, tempCtx)
+		mergeAuthIntoExisting(existing, tempCtx, opts.OrgID)
 		cfg.CurrentContext = contextName // make current on success, same as new-context path
 	} else {
 		cfg.SetContext(contextName, true, tempCtx)
@@ -530,7 +530,7 @@ func persistContext(ctx context.Context, opts Options, contextName string, tempC
 
 // mergeAuthIntoExisting updates only auth-related fields on an existing context,
 // preserving all other user-configured fields (OrgID, Datasources, Providers, etc.).
-func mergeAuthIntoExisting(existing *config.Context, incoming config.Context) {
+func mergeAuthIntoExisting(existing *config.Context, incoming config.Context, explicitOrgID int) {
 	if existing.Grafana == nil {
 		existing.Grafana = &config.GrafanaConfig{}
 	}
@@ -553,6 +553,10 @@ func mergeAuthIntoExisting(existing *config.Context, incoming config.Context) {
 	g.OAuthTokenExpiresAt = src.OAuthTokenExpiresAt
 	g.OAuthRefreshExpiresAt = src.OAuthRefreshExpiresAt
 	g.ProxyEndpoint = src.ProxyEndpoint
+
+	if explicitOrgID != 0 {
+		g.OrgID = int64(explicitOrgID)
+	}
 
 	// Sync TLS settings so that re-auth with updated or cleared certs
 	// takes effect. Setting to src.TLS (which may be nil) handles both

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -283,6 +283,61 @@ func TestRun(t *testing.T) { //nolint:maintidx // 8 table-driven cases; complexi
 			},
 		},
 		{
+			// Explicit OrgID on a fresh on-prem login is persisted instead of
+			// being set to the OrgID=1 default.
+			name: "onprem_explicit_orgid_persisted",
+			opts: func(dir string) login.Options {
+				return login.Options{
+					Inputs: login.Inputs{
+						Server:       "https://grafana.example.com",
+						Target:       login.TargetOnPrem,
+						GrafanaToken: "glsa_test",
+						OrgID:        7,
+					},
+					Hooks: login.Hooks{
+						ConfigSource: configSource(dir),
+						ValidateFn:   noopValidate,
+					},
+				}
+			},
+			checkConfig: func(t *testing.T, cfg config.Config) {
+				t.Helper()
+				ctx := cfg.Contexts["grafana-example-com"]
+				require.NotNil(t, ctx)
+				assert.EqualValues(t, 7, ctx.Grafana.OrgID, "explicit OrgID must override the on-prem default")
+			},
+		},
+		{
+			// Explicit OrgID on a Cloud login is persisted (the on-prem
+			// default-to-1 guard does not apply, but a user-supplied value
+			// must still be respected).
+			name: "cloud_explicit_orgid_persisted",
+			opts: func(dir string) login.Options {
+				return login.Options{
+					Inputs: login.Inputs{
+						Server:   "https://mystack.grafana.net",
+						Target:   login.TargetCloud,
+						UseOAuth: true,
+						Yes:      true,
+						OrgID:    42,
+					},
+					Hooks: login.Hooks{
+						ConfigSource: configSource(dir),
+						NewAuthFlow: func(_ string, _ auth.Options) login.AuthFlow {
+							return &stubAuthFlow{result: oauthResult}
+						},
+						ValidateFn: noopValidate,
+					},
+				}
+			},
+			checkConfig: func(t *testing.T, cfg config.Config) {
+				t.Helper()
+				ctx := cfg.Contexts["mystack"]
+				require.NotNil(t, ctx)
+				assert.EqualValues(t, 42, ctx.Grafana.OrgID, "explicit OrgID must be persisted on Cloud login")
+			},
+		},
+		{
 			// AC-005: Ambiguous URL + --yes defaults to on-prem (D10)
 			name: "ambiguous_url_yes_defaults_onprem",
 			opts: func(dir string) login.Options {

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -474,6 +474,47 @@ func TestRun(t *testing.T) { //nolint:maintidx // 8 table-driven cases; complexi
 			},
 		},
 		{
+			// Re-auth with explicit OrgID updates the existing context's OrgID.
+			name: "reauth_explicit_orgid_updates_existing",
+			opts: func(dir string) login.Options {
+				src := configSource(dir)
+				path, _ := src()
+				existingCfg := config.Config{
+					Contexts: map[string]*config.Context{
+						"grafana-example-com": {
+							Grafana: &config.GrafanaConfig{
+								Server:     "https://grafana.example.com",
+								APIToken:   "old-token",
+								AuthMethod: "token",
+								OrgID:      1,
+							},
+						},
+					},
+					CurrentContext: "grafana-example-com",
+				}
+				require.NoError(t, config.Write(context.Background(), config.ExplicitConfigFile(path), existingCfg))
+
+				return login.Options{
+					Inputs: login.Inputs{
+						Server:       "https://grafana.example.com",
+						Target:       login.TargetOnPrem,
+						GrafanaToken: "rotated-token",
+						OrgID:        5,
+					},
+					Hooks: login.Hooks{
+						ConfigSource: src,
+						ValidateFn:   noopValidate,
+					},
+				}
+			},
+			checkConfig: func(t *testing.T, cfg config.Config) {
+				t.Helper()
+				ctx := cfg.Contexts["grafana-example-com"]
+				require.NotNil(t, ctx)
+				assert.EqualValues(t, 5, ctx.Grafana.OrgID, "explicit OrgID on re-auth must update existing context")
+			},
+		},
+		{
 			// AC-013: Redirect to grafana.com on empty server selection
 			name: "redirect_grafana_com_empty_server",
 			opts: func(dir string) login.Options {


### PR DESCRIPTION
## What
Allow users to configure the organization ID on login. 

## Why
Unable to set the organization ID using the login flow. This means that I have to manually modify the configuration file if I want to authenticate to multiple organizations. Added the flag so that the ID can be set on login only (re-auth will not modify this value)

## Changes
Adds the flag `--org-id`. All other existing behavior is preserved.

### Docs
- Updated `docs/reference/cli/gcx_login.md` — added `--org-id int` flag entry to the options table                                                       
- Added `--org-id` flag to `gcx login` (`cmd/gcx/login/command.go`) — sets `GrafanaContext.OrgID` on the saved context; defaults to `0`, on-prem login still falls back to `1` when unset                                                                                                                                 
- Threaded `OrgID` through `login.Inputs` and into `GrafanaContext` (`internal/login/login.go`) 
- Added `internal/login/login_test.go` cases: `onprem_explicit_orgid_persisted` and `cloud_explicit_orgid_persisted`