### PR TITLE
fix(config): classify .grafana.com hosts and stack-id as Cloud in config check

### DIFF
--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -29,7 +29,7 @@ func requireGrafanaCloud(ctx *config.Context) error {
 	if ctx.Grafana == nil || ctx.Grafana.Server == "" {
 		return nil
 	}
-	if ctx.ResolveStackSlug() == "" {
+	if !ctx.IsCloud() {
 		return fail.DetailedError{
 			Summary: "Unsupported command",
 			Details: "Due to technical limitations of how gcx interacts with Grafana Assistant, " +

--- a/cmd/gcx/assistant/command_test.go
+++ b/cmd/gcx/assistant/command_test.go
@@ -190,6 +190,37 @@ func TestRequireGrafanaCloud(t *testing.T) {
 			},
 		},
 		{
+			name: "grafana.com host (demokit-style)",
+			ctx: &config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://emea.cloud.demokit.grafana.com"},
+			},
+		},
+		{
+			name: "grafana-dev.com host",
+			ctx: &config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-dev.com"},
+			},
+		},
+		{
+			name: "grafana-ops.com host",
+			ctx: &config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-ops.com"},
+			},
+		},
+		{
+			name: "grafana.stack-id non-zero with custom domain",
+			ctx: &config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://grafana.example.com", StackID: 12345},
+			},
+		},
+		{
+			name: "bare grafana.com is not a subdomain",
+			ctx: &config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://grafana.com"},
+			},
+			wantErr: true,
+		},
+		{
 			name: "self-hosted instance",
 			ctx: &config.Context{
 				Grafana: &config.GrafanaConfig{Server: "https://grafana.example.com"},

--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -413,7 +413,7 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 	}
 	cmdio.Info(stdout, "Auth method: %s", authMethod)
 
-	isCloud := gCtx.ResolveStackSlug() != ""
+	isCloud := gCtx.IsCloud()
 	contextType := "On-prem"
 	if isCloud {
 		contextType = "Grafana Cloud"

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -118,6 +118,32 @@ func (context *Context) ToRESTConfig(ctx context.Context) (NamespacedRESTConfig,
 	return NewNamespacedRESTConfig(ctx, *context)
 }
 
+// IsCloud reports whether this context targets Grafana Cloud.
+// Any one of the following signals is sufficient:
+//   - Cloud.Stack is explicitly set
+//   - Grafana.StackID is non-zero
+//   - Grafana.Server hostname belongs to a Grafana-run Cloud domain
+//     (*.grafana.net, *.grafana.com, and their -dev/-ops variants)
+func (context *Context) IsCloud() bool {
+	if context.Cloud != nil && context.Cloud.Stack != "" {
+		return true
+	}
+	if context.Grafana == nil {
+		return false
+	}
+	if context.Grafana.StackID != 0 {
+		return true
+	}
+	if context.Grafana.Server == "" {
+		return false
+	}
+	parsed, err := url.Parse(context.Grafana.Server)
+	if err != nil {
+		return false
+	}
+	return IsGrafanaCloudHost(strings.ToLower(parsed.Hostname()))
+}
+
 // ResolveStackSlug returns the Grafana Cloud stack slug for this context.
 // It checks Cloud.Stack first; if not set, attempts to derive the slug from
 // Grafana.Server by extracting the subdomain from *.grafana.net or *.grafana-dev.net URLs.

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -316,6 +316,93 @@ func TestContext_ResolveStackSlug(t *testing.T) {
 	}
 }
 
+func TestContext_IsCloud(t *testing.T) {
+	cases := []struct {
+		name string
+		ctx  config.Context
+		want bool
+	}{
+		{
+			name: "explicit cloud.stack",
+			ctx:  config.Context{Cloud: &config.CloudConfig{Stack: "mystack"}},
+			want: true,
+		},
+		{
+			name: "grafana.stack-id non-zero",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: "https://grafana.mycompany.com", StackID: 12345}},
+			want: true,
+		},
+		{
+			name: "grafana.net stack URL",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana.net"}},
+			want: true,
+		},
+		{
+			name: "grafana-dev.net stack URL",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-dev.net"}},
+			want: true,
+		},
+		{
+			name: "grafana-ops.net stack URL",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-ops.net"}},
+			want: true,
+		},
+		{
+			name: "grafana.com host (demokit-style)",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: "https://emea.cloud.demokit.grafana.com"}},
+			want: true,
+		},
+		{
+			name: "grafana-dev.com host",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-dev.com"}},
+			want: true,
+		},
+		{
+			name: "grafana-ops.com host",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-ops.com"}},
+			want: true,
+		},
+		{
+			name: "mixed-case grafana.com host",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: "https://MyStack.Grafana.Com"}},
+			want: true,
+		},
+		{
+			name: "on-prem custom domain",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: "https://grafana.mycompany.com"}},
+			want: false,
+		},
+		{
+			name: "bare grafana.com is not a subdomain",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: "https://grafana.com"}},
+			want: false,
+		},
+		{
+			name: "no grafana config",
+			ctx:  config.Context{},
+			want: false,
+		},
+		{
+			name: "empty server URL",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: ""}},
+			want: false,
+		},
+		{
+			name: "malformed server URL",
+			ctx:  config.Context{Grafana: &config.GrafanaConfig{Server: "://bad-url"}},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ctx.IsCloud(); got != tc.want {
+				t.Fatalf("IsCloud() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestContextNameFromServerURL(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Both `gcx config check` and `gcx assistant` used `ResolveStackSlug() == ""` (or `!= ""`) as a Cloud-vs-on-prem classifier. `ResolveStackSlug` only recognises `*.grafana.net` stack URLs — it returns `""` for `*.grafana.com` domains (e.g. `emea.cloud.demokit.grafana.com`), causing those Grafana-run hosts to be misclassified as on-prem.

This PR adds `Context.IsCloud()` with the correct three-way check and wires it into both call sites.

## Changes

| File | What changed |
|------|-------------|
| `internal/config/types.go` | Added `Context.IsCloud()` — checks `cloud.stack`, `grafana.stack-id != 0`, or `Grafana.Server` hostname via existing `IsGrafanaCloudHost()` |
| `cmd/gcx/config/command.go` | `config check` classifier: `ResolveStackSlug() != ""` → `IsCloud()` |
| `cmd/gcx/assistant/command.go` | `requireGrafanaCloud` gate: `ResolveStackSlug() == ""` → `!IsCloud()` |
| `internal/config/types_test.go` | 14-case `TestContext_IsCloud` table |
| `cmd/gcx/assistant/command_test.go` | Extended `TestRequireGrafanaCloud` with demokit, `-dev.com`, `-ops.com`, `stack-id` cases |

**Audit note:** all other `ResolveStackSlug` callers (datasource resolution, GCOM stack lookup, login validation) were reviewed and confirmed legitimate — they use the slug as a genuine identifier, not as a Cloud gate. No other sites required changes.

## Reproduction

```bash
# config check: before → "Context type: On-prem", after → "Context type: Grafana Cloud"
gcx config check --context <context-with-server-https://emea.cloud.demokit.grafana.com>

# assistant: before → "Unsupported command: ...do not currently work with self-hosted instances"
# after → proceeds to call the assistant
gcx assistant prompt "hello" --context <context-with-server-https://emea.cloud.demokit.grafana.com>
```

## Test Plan

- [x] `TestContext_IsCloud` — 14 cases (demokit `.grafana.com`, `stack-id`, explicit `cloud.stack`, on-prem, bare domains, malformed URL)
- [x] `TestRequireGrafanaCloud` — 10 cases (`.grafana.com`, `-dev.com`, `-ops.com`, `stack-id`, on-prem regression guard, bare domain guard)
- [x] `TestContext_ResolveStackSlug` — existing cases unaffected (semantics unchanged)
- [x] Full `go test ./...` passes in worktree
- [x] `gofmt` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)