### PR TITLE
fix: migrate all remaining provider delete commands to providers.ConfirmDestructive

### DIFF
--- a/docs/design/safety.md
+++ b/docs/design/safety.md
@@ -20,12 +20,12 @@ Do NOT prompt for:
 ### 3.2 The `--force` Flag and `providers.ConfirmDestructive` `[IMPLEMENTED]`
 
 All destructive provider commands use the shared `providers.ConfirmDestructive()`
-helper. It applies a 4-layer bypass chain before falling through to an
+helper. It applies a 3-layer bypass chain before falling through to an
 interactive prompt:
 
 1. **`--force` flag** — explicit per-invocation bypass
-2. **Agent mode** — auto-approves when `agent.IsAgentMode()` is true (see [agent-mode.md](agent-mode.md))
-3. **`GCX_AUTO_APPROVE` env var** — enables non-interactive operation in CI/CD
+2. **`GCX_AUTO_APPROVE` env var** — enables non-interactive operation in CI/CD
+3. **Agent mode without `--force`** — fails with actionable error
 4. **Interactive prompt** — asks the user to confirm (`[y/N]`)
 
 If none of the bypass conditions are met and stdin is closed/empty, the prompt's
@@ -55,11 +55,13 @@ The `resources delete` command additionally supports `--yes` (`-y`) which
 auto-enables the `--force` flag. This is a legacy pattern specific to the
 resources layer; new provider commands should use `--force` directly.
 
-### 3.3 Agent Mode Auto-Approve `[IMPLEMENTED]`
+### 3.3 Agent Mode Requires Explicit `--force` `[IMPLEMENTED]`
 
 When agent mode is active ([agent-mode.md](agent-mode.md)), `providers.ConfirmDestructive`
-auto-approves without prompting. Agents cannot interact with TTY prompts, so
-blocking on stdin would hang the process indefinitely.
+**rejects** the operation with an actionable error unless `--force` is passed.
+This forces agents to deliberately acknowledge destructive operations rather
+than silently proceeding — creating an explicit audit trail and preventing
+rogue agents from accidentally deleting resources.
 
 ### 3.4 Dry-Run
 

--- a/docs/reference/cli/gcx_aio11y_collections_delete.md
+++ b/docs/reference/cli/gcx_aio11y_collections_delete.md
@@ -9,7 +9,7 @@ gcx aio11y collections delete COLLECTION-ID... [flags]
 ### Options
 
 ```
-  -f, --force   Skip confirmation prompt
+      --force   Skip confirmation prompt
   -h, --help    help for delete
 ```
 

--- a/docs/reference/cli/gcx_aio11y_evaluators_delete.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_delete.md
@@ -9,7 +9,7 @@ gcx aio11y evaluators delete ID... [flags]
 ### Options
 
 ```
-  -f, --force   Skip confirmation prompt
+      --force   Skip confirmation prompt
   -h, --help    help for delete
 ```
 

--- a/docs/reference/cli/gcx_aio11y_rules_delete.md
+++ b/docs/reference/cli/gcx_aio11y_rules_delete.md
@@ -9,7 +9,7 @@ gcx aio11y rules delete ID... [flags]
 ### Options
 
 ```
-  -f, --force   Skip confirmation prompt
+      --force   Skip confirmation prompt
   -h, --help    help for delete
 ```
 

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_delete.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_delete.md
@@ -9,7 +9,7 @@ gcx aio11y saved-conversations delete SAVED-ID... [flags]
 ### Options
 
 ```
-  -f, --force   Skip confirmation prompt
+      --force   Skip confirmation prompt
   -h, --help    help for delete
 ```
 

--- a/docs/reference/cli/gcx_dashboards_delete.md
+++ b/docs/reference/cli/gcx_dashboards_delete.md
@@ -10,8 +10,8 @@ gcx dashboards delete <name> [flags]
 
 ```
       --api-version string   API version to use (e.g. dashboard.grafana.app/v1); defaults to server preferred version
+      --force                Skip confirmation prompt
   -h, --help                 help for delete
-  -y, --yes                  Skip confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_dashboards_versions_restore.md
+++ b/docs/reference/cli/gcx_dashboards_versions_restore.md
@@ -10,9 +10,9 @@ gcx dashboards versions restore <name> <version> [flags]
 
 ```
       --api-version string   API version to use (e.g. dashboard.grafana.app/v1); defaults to server preferred version
+      --force                Skip confirmation prompt
   -h, --help                 help for restore
       --message string       Commit message for the restored revision (default: "Restored from version N")
-  -y, --yes                  Skip confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_suppressions_delete.md
+++ b/docs/reference/cli/gcx_kg_suppressions_delete.md
@@ -9,8 +9,8 @@ gcx kg suppressions delete <name> [flags]
 ### Options
 
 ```
-  -h, --help   help for delete
-  -y, --yes    Skip confirmation prompt
+      --force   Skip confirmation prompt
+  -h, --help    help for delete
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_definitions_delete.md
+++ b/docs/reference/cli/gcx_slo_definitions_delete.md
@@ -9,7 +9,7 @@ gcx slo definitions delete UUID... [flags]
 ### Options
 
 ```
-  -f, --force   Skip confirmation prompt
+      --force   Skip confirmation prompt
   -h, --help    help for delete
 ```
 

--- a/docs/reference/cli/gcx_slo_reports_delete.md
+++ b/docs/reference/cli/gcx_slo_reports_delete.md
@@ -9,7 +9,7 @@ gcx slo reports delete UUID... [flags]
 ### Options
 
 ```
-  -f, --force   Skip confirmation prompt
+      --force   Skip confirmation prompt
   -h, --help    help for delete
 ```
 

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_delete.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_delete.md
@@ -9,7 +9,7 @@ gcx synthetic-monitoring checks delete NAME... [flags]
 ### Options
 
 ```
-  -f, --force   Skip confirmation prompt
+      --force   Skip confirmation prompt
   -h, --help    help for delete
 ```
 

--- a/docs/reference/cli/gcx_synthetic-monitoring_probes_delete.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_probes_delete.md
@@ -9,7 +9,7 @@ gcx synthetic-monitoring probes delete ID... [flags]
 ### Options
 
 ```
-  -f, --force   Skip confirmation prompt
+      --force   Skip confirmation prompt
   -h, --help    help for delete
 ```
 

--- a/internal/providers/aio11y/eval/collections/commands.go
+++ b/internal/providers/aio11y/eval/collections/commands.go
@@ -1,7 +1,6 @@
 package collections
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -329,7 +328,7 @@ type deleteOpts struct {
 }
 
 func (o *deleteOpts) setup(flags *pflag.FlagSet) {
-	flags.BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 }
 
 func newDeleteCommand() *cobra.Command {
@@ -339,18 +338,13 @@ func newDeleteCommand() *cobra.Command {
 		Short: "Delete collections.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !opts.Force {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Delete %d collection(s)? [y/N] ", len(args))
-				reader := bufio.NewReader(cmd.InOrStdin())
-				answer, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("reading confirmation: %w", err)
-				}
-				answer = strings.TrimSpace(strings.ToLower(answer))
-				if answer != "y" && answer != "yes" {
-					cmdio.Info(cmd.ErrOrStderr(), "Aborted.")
-					return nil
-				}
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.ErrOrStderr(), opts.Force,
+				fmt.Sprintf("Delete %d collection(s)?", len(args)))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
 			}
 
 			ctx := cmd.Context()

--- a/internal/providers/aio11y/eval/evaluators/commands.go
+++ b/internal/providers/aio11y/eval/evaluators/commands.go
@@ -1,14 +1,12 @@
 package evaluators
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/goccy/go-yaml"
 	"github.com/grafana/gcx/internal/format"
@@ -18,7 +16,6 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/eval"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
-	"github.com/grafana/gcx/internal/terminal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -215,7 +212,7 @@ type deleteOpts struct {
 }
 
 func (o *deleteOpts) setup(flags *pflag.FlagSet) {
-	flags.BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 }
 
 func newDeleteCommand() *cobra.Command {
@@ -225,21 +222,13 @@ func newDeleteCommand() *cobra.Command {
 		Short: "Delete evaluators.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !opts.Force {
-				if terminal.IsPiped() {
-					return errors.New("stdin is not a terminal, use --force to skip confirmation")
-				}
-				fmt.Fprintf(cmd.ErrOrStderr(), "Delete %d evaluator(s)? [y/N] ", len(args))
-				reader := bufio.NewReader(cmd.InOrStdin())
-				answer, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("reading confirmation: %w", err)
-				}
-				answer = strings.TrimSpace(strings.ToLower(answer))
-				if answer != "y" && answer != "yes" {
-					cmdio.Info(cmd.ErrOrStderr(), "Aborted.")
-					return nil
-				}
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.ErrOrStderr(), opts.Force,
+				fmt.Sprintf("Delete %d evaluator(s)?", len(args)))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
 			}
 
 			ctx := cmd.Context()

--- a/internal/providers/aio11y/eval/rules/commands.go
+++ b/internal/providers/aio11y/eval/rules/commands.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,11 +12,11 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
-	"github.com/grafana/gcx/internal/terminal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -271,7 +270,7 @@ type deleteOpts struct {
 }
 
 func (o *deleteOpts) setup(flags *pflag.FlagSet) {
-	flags.BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 }
 
 func newDeleteCommand() *cobra.Command {
@@ -281,21 +280,13 @@ func newDeleteCommand() *cobra.Command {
 		Short: "Delete evaluation rules.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !opts.Force {
-				if terminal.IsPiped() {
-					return errors.New("stdin is not a terminal, use --force to skip confirmation")
-				}
-				fmt.Fprintf(cmd.ErrOrStderr(), "Delete %d rule(s)? [y/N] ", len(args))
-				reader := bufio.NewReader(cmd.InOrStdin())
-				answer, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("reading confirmation: %w", err)
-				}
-				answer = strings.TrimSpace(strings.ToLower(answer))
-				if answer != "y" && answer != "yes" {
-					cmdio.Info(cmd.ErrOrStderr(), "Aborted.")
-					return nil
-				}
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.ErrOrStderr(), opts.Force,
+				fmt.Sprintf("Delete %d rule(s)?", len(args)))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
 			}
 
 			ctx := cmd.Context()

--- a/internal/providers/aio11y/eval/savedconversations/commands.go
+++ b/internal/providers/aio11y/eval/savedconversations/commands.go
@@ -1,7 +1,6 @@
 package savedconversations
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -215,7 +214,7 @@ type deleteOpts struct {
 }
 
 func (o *deleteOpts) setup(flags *pflag.FlagSet) {
-	flags.BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 }
 
 func newDeleteCommand(loader *providers.ConfigLoader) *cobra.Command {
@@ -225,18 +224,13 @@ func newDeleteCommand(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "Delete saved conversations.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !opts.Force {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Delete %d saved conversation(s)? [y/N] ", len(args))
-				reader := bufio.NewReader(cmd.InOrStdin())
-				answer, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("reading confirmation: %w", err)
-				}
-				answer = strings.TrimSpace(strings.ToLower(answer))
-				if answer != "y" && answer != "yes" {
-					cmdio.Info(cmd.ErrOrStderr(), "Aborted.")
-					return nil
-				}
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.ErrOrStderr(), opts.Force,
+				fmt.Sprintf("Delete %d saved conversation(s)?", len(args)))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
 			}
 
 			client, err := newClient(cmd, loader)

--- a/internal/providers/confirm.go
+++ b/internal/providers/confirm.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -12,15 +13,17 @@ import (
 )
 
 // ConfirmDestructive prompts the user to confirm a destructive operation.
-// It auto-approves when force is true, agent mode is active, stdin is not a
-// terminal, or the GCX_AUTO_APPROVE env var is truthy. Returns true if the
-// caller should proceed.
+//
+// Bypass chain:
+//  1. --force flag → proceed immediately
+//  2. GCX_AUTO_APPROVE env var → proceed (CI/CD pipelines)
+//  3. Agent mode detected without --force → fail with actionable error
+//  4. Otherwise → interactive prompt (returns false on EOF or "no")
+//
+// Agent mode requires explicit --force so that agents must deliberately
+// acknowledge destructive operations rather than silently proceeding.
 func ConfirmDestructive(in io.Reader, out io.Writer, force bool, prompt string) (bool, error) {
 	if force {
-		return true, nil
-	}
-
-	if agent.IsAgentMode() {
 		return true, nil
 	}
 
@@ -31,6 +34,10 @@ func ConfirmDestructive(in io.Reader, out io.Writer, force bool, prompt string) 
 
 	if cliOpts.AutoApprove {
 		return true, nil
+	}
+
+	if agent.IsAgentMode() {
+		return false, errors.New("destructive operation requires --force in agent mode")
 	}
 
 	fmt.Fprintf(out, "%s [y/N] ", prompt)

--- a/internal/providers/dashboards/crud.go
+++ b/internal/providers/dashboards/crud.go
@@ -1,18 +1,17 @@
 package dashboards
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/dashboards/descriptor"
 	"github.com/grafana/gcx/internal/resources/dynamic"
 	"github.com/spf13/cobra"
@@ -21,12 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
-
-// cliOptionsLoader is satisfied by config.LoadCLIOptions.
-// Defined as a variable so tests can substitute a no-op.
-//
-//nolint:gochecknoglobals // test seam; package-level by design.
-var cliOptionsLoader = config.LoadCLIOptions
 
 // GrafanaConfigLoader is the subset of providers.ConfigLoader used by CRUD commands.
 // Defined as a local interface so commands can be tested with a stub.
@@ -340,11 +333,11 @@ Recommended workflow:
 
 type deleteOpts struct {
 	APIVersion string
-	Yes        bool
+	Force      bool
 }
 
 func (o *deleteOpts) setup(flags *pflag.FlagSet) {
-	flags.BoolVarP(&o.Yes, "yes", "y", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 	flags.StringVar(&o.APIVersion, "api-version", "", "API version to use (e.g. dashboard.grafana.app/v1); defaults to server preferred version")
 }
 
@@ -369,15 +362,13 @@ func newDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
 
 			name := args[0]
 
-			cliOpts, err := cliOptionsLoader()
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.OutOrStdout(), opts.Force,
+				fmt.Sprintf("Delete dashboard %q?", name))
 			if err != nil {
 				return err
 			}
-
-			if !opts.Yes && !cliOpts.AutoApprove {
-				if !confirmDelete(cmd.OutOrStdout(), cmd.InOrStdin(), name) {
-					return nil
-				}
+			if !proceed {
+				return nil
 			}
 
 			ctx := cmd.Context()
@@ -408,19 +399,6 @@ func newDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts.setup(cmd.Flags())
 
 	return cmd
-}
-
-// confirmDelete asks the user to confirm a destructive operation.
-// Returns true if confirmed, false if the user aborted.
-func confirmDelete(w io.Writer, r io.Reader, name string) bool {
-	fmt.Fprintf(w, "Delete dashboard %q? [y/N] ", name)
-	scanner := bufio.NewScanner(r)
-	if !scanner.Scan() {
-		// EOF or scanner error is treated as "no" — correct behavior for non-interactive pipelines.
-		return false
-	}
-	answer := strings.TrimSpace(scanner.Text())
-	return strings.EqualFold(answer, "y") || strings.EqualFold(answer, "yes")
 }
 
 // wrapUpdateError augments an Update error with workflow guidance when the

--- a/internal/providers/dashboards/crud_test.go
+++ b/internal/providers/dashboards/crud_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/dashboards"
 	"github.com/grafana/gcx/internal/resources/dynamic"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -255,15 +256,16 @@ func TestWrapUpdateError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// confirmDelete tests
+// ConfirmDestructive tests (via providers.ConfirmDestructive)
 // ---------------------------------------------------------------------------
 
-func TestConfirmDelete(t *testing.T) {
+func TestConfirmDestructive(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string // text the "user" types; empty string simulates EOF
-		addNL bool   // whether to append "\n" (simulate line-terminated input)
-		want  bool
+		name    string
+		input   string // text the "user" types
+		addNL   bool   // whether to append "\n" (simulate line-terminated input)
+		want    bool
+		wantErr bool
 	}{
 		{name: "y lowercase", input: "y", addNL: true, want: true},
 		{name: "yes lowercase", input: "yes", addNL: true, want: true},
@@ -274,8 +276,10 @@ func TestConfirmDelete(t *testing.T) {
 		{name: "no lowercase", input: "no", addNL: true, want: false},
 		{name: "N uppercase", input: "N", addNL: true, want: false},
 		{name: "empty string", input: "", addNL: true, want: false},
-		// EOF: reader has no bytes at all — scanner returns false immediately.
-		{name: "EOF no input", input: "", addNL: false, want: false},
+		// EOF: reader has no bytes at all — ReadString returns io.EOF error.
+		{name: "EOF no input", input: "", addNL: false, want: false, wantErr: true},
+		// --force bypasses prompt entirely.
+		{name: "force flag", input: "", addNL: false, want: true},
 	}
 
 	for _, tt := range tests {
@@ -287,15 +291,26 @@ func TestConfirmDelete(t *testing.T) {
 			r := strings.NewReader(rawInput)
 
 			var w bytes.Buffer
-			got := dashboards.ConfirmDeleteForTest(&w, r, "my-dashboard")
+			force := tt.name == "force flag"
+			got, err := providers.ConfirmDestructive(r, &w, force, `Delete dashboard "my-dashboard"?`)
 
-			if got != tt.want {
-				t.Errorf("confirmDelete(%q) = %v, want %v", tt.input, got, tt.want)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ConfirmDestructive(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ConfirmDestructive(%q) unexpected error: %v", tt.input, err)
 			}
 
-			// Prompt must always be written regardless of the answer.
-			if !strings.Contains(w.String(), "my-dashboard") {
-				t.Errorf("confirmDelete() output missing dashboard name: %q", w.String())
+			if got != tt.want {
+				t.Errorf("ConfirmDestructive(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+
+			// Prompt must be written for non-force cases.
+			if !force && !strings.Contains(w.String(), "my-dashboard") {
+				t.Errorf("ConfirmDestructive() output missing dashboard name: %q", w.String())
 			}
 		})
 	}

--- a/internal/providers/dashboards/export_test.go
+++ b/internal/providers/dashboards/export_test.go
@@ -1,7 +1,5 @@
 package dashboards
 
-import "io"
-
 // Exported aliases for unexported types and functions, available to external
 // test packages only (codec_test.go, provider_test.go, crud_test.go).
 
@@ -24,11 +22,6 @@ var DecodeManifestForTest = decodeManifest
 //
 //nolint:gochecknoglobals // test-only export; required to expose unexported function to dashboards_test package.
 var ReadManifestForTest = readManifest
-
-// ConfirmDeleteForTest exposes the unexported confirmDelete function for table-driven tests.
-func ConfirmDeleteForTest(w io.Writer, r io.Reader, name string) bool {
-	return confirmDelete(w, r, name)
-}
 
 // WrapUpdateErrorForTest exposes the unexported wrapUpdateError function for
 // table-driven tests.

--- a/internal/providers/dashboards/versions/commands.go
+++ b/internal/providers/dashboards/versions/commands.go
@@ -2,17 +2,14 @@
 package versions
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/grafana/gcx/internal/config"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/dashboards/descriptor"
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/resources/dynamic"
@@ -172,13 +169,13 @@ func newListCommand(deps *commandDeps) *cobra.Command {
 // ---------------------------------------------------------------------------
 
 type versionsRestoreOpts struct {
-	Yes        bool
+	Force      bool
 	Message    string
 	APIVersion string
 }
 
 func (o *versionsRestoreOpts) setup(flags *pflag.FlagSet) {
-	flags.BoolVarP(&o.Yes, "yes", "y", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 	flags.StringVar(&o.Message, "message", "", `Commit message for the restored revision (default: "Restored from version N")`)
 	flags.StringVar(&o.APIVersion, "api-version", "", "API version to use (e.g. dashboard.grafana.app/v1); defaults to server preferred version")
 }
@@ -261,11 +258,14 @@ func newRestoreCommand(deps *commandDeps) *cobra.Command {
 				return nil
 			}
 
-			// Step 5: Prompt unless --yes.
-			if !opts.Yes {
-				if !confirmRestore(cmd.ErrOrStderr(), cmd.InOrStdin(), name, targetGen) {
-					return nil
-				}
+			// Step 5: Prompt unless --force.
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.ErrOrStderr(), opts.Force,
+				fmt.Sprintf("Restore dashboard %q to version %d?", name, targetGen))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
 			}
 
 			// Step 6: Construct update object.
@@ -318,19 +318,4 @@ func newRestoreCommand(deps *commandDeps) *cobra.Command {
 	opts.setup(cmd.Flags())
 
 	return cmd
-}
-
-// confirmRestore asks the user to confirm the restore operation.
-// Returns true if confirmed, false if the user aborted.
-func confirmRestore(w io.Writer, r io.Reader, name string, version int64) bool {
-	fmt.Fprintf(w, "Restore dashboard %q to version %d? [y/N] ", name, version)
-	scanner := bufio.NewScanner(r)
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			fmt.Fprintf(os.Stderr, "error reading confirmation: %v\n", err)
-		}
-		return false
-	}
-	answer := strings.TrimSpace(scanner.Text())
-	return strings.EqualFold(answer, "y") || strings.EqualFold(answer, "yes")
 }

--- a/internal/providers/dashboards/versions/commands_test.go
+++ b/internal/providers/dashboards/versions/commands_test.go
@@ -337,7 +337,7 @@ func TestVersionsRestore_HappyPath(t *testing.T) {
 		updatedItem: updatedDashboard(3),
 	}
 
-	_, errOut, err := runVersionsCmd(t, fc, []string{"restore", "foo", "1", "--yes"}, "")
+	_, errOut, err := runVersionsCmd(t, fc, []string{"restore", "foo", "1", "--force"}, "")
 	require.NoError(t, err, "restore to a valid version must succeed")
 
 	// Must have called LIST, GET, and UPDATE.
@@ -377,7 +377,7 @@ func TestVersionsRestore_MessageOverride(t *testing.T) {
 	}
 
 	_, _, err := runVersionsCmd(t, fc,
-		[]string{"restore", "foo", "1", "--yes", "--message", "rolling back last week's change"},
+		[]string{"restore", "foo", "1", "--force", "--message", "rolling back last week's change"},
 		"")
 	require.NoError(t, err)
 	require.True(t, fc.updateCalled)
@@ -404,7 +404,7 @@ func TestVersionsRestore_409Conflict(t *testing.T) {
 		updateErr:   conflictErr,
 	}
 
-	_, _, err := runVersionsCmd(t, fc, []string{"restore", "foo", "1", "--yes"}, "")
+	_, _, err := runVersionsCmd(t, fc, []string{"restore", "foo", "1", "--force"}, "")
 	require.Error(t, err, "409 conflict must result in a non-zero exit")
 
 	assert.True(t, fc.updateCalled, "Update must be called before the 409 is observed")
@@ -419,7 +419,7 @@ func TestVersionsRestore_NoOpWhenAlreadyAtTarget(t *testing.T) {
 		currentItem: currentDashboard(3, "rv-current", map[string]any{"title": "v3"}),
 	}
 
-	_, errOut, err := runVersionsCmd(t, fc, []string{"restore", "foo", "3", "--yes"}, "")
+	_, errOut, err := runVersionsCmd(t, fc, []string{"restore", "foo", "3", "--force"}, "")
 	require.NoError(t, err, "no-op restore must exit 0")
 
 	assert.False(t, fc.updateCalled, "no PUT must be issued when already at target version")
@@ -437,7 +437,7 @@ func TestVersionsRestore_TargetNotFound(t *testing.T) {
 		currentItem: currentDashboard(2, "rv-x", map[string]any{}),
 	}
 
-	_, _, err := runVersionsCmd(t, fc, []string{"restore", "foo", "99", "--yes"}, "")
+	_, _, err := runVersionsCmd(t, fc, []string{"restore", "foo", "99", "--force"}, "")
 	require.Error(t, err, "missing target version must be a non-zero exit")
 	assert.Contains(t, err.Error(), "99",
 		"error must mention the requested version number")
@@ -449,7 +449,7 @@ func TestVersionsRestore_NonIntegerVersionFails(t *testing.T) {
 	// Scenario H: non-integer <version> must fail with parse error before any HTTP.
 	fc := &fakeVersionsClient{}
 
-	_, _, err := runVersionsCmd(t, fc, []string{"restore", "foo", "notaninteger", "--yes"}, "")
+	_, _, err := runVersionsCmd(t, fc, []string{"restore", "foo", "notaninteger", "--force"}, "")
 	require.Error(t, err, "non-integer version must cause parse error")
 
 	assert.False(t, fc.listCalled,
@@ -475,7 +475,7 @@ func TestVersionsRestore_NoLegacyRestoreEndpoint(t *testing.T) {
 		updatedItem: updatedDashboard(4),
 	}
 
-	_, _, err := runVersionsCmd(t, fc, []string{"restore", "foo", "1", "--yes"}, "")
+	_, _, err := runVersionsCmd(t, fc, []string{"restore", "foo", "1", "--force"}, "")
 	require.NoError(t, err)
 
 	// The only update call must go through our fake's Update method.
@@ -493,7 +493,7 @@ func TestVersionsRestore_RestoreListSelectors(t *testing.T) {
 		updatedItem: updatedDashboard(4),
 	}
 
-	_, _, err := runVersionsCmd(t, fc, []string{"restore", "foo", "1", "--yes"}, "")
+	_, _, err := runVersionsCmd(t, fc, []string{"restore", "foo", "1", "--force"}, "")
 	require.NoError(t, err)
 
 	assert.Equal(t, "grafana.app/get-history=true", fc.capturedListOpts.LabelSelector,
@@ -503,7 +503,7 @@ func TestVersionsRestore_RestoreListSelectors(t *testing.T) {
 }
 
 func TestVersionsRestore_ConfirmPromptAbort(t *testing.T) {
-	// When --yes is NOT set, restore must prompt on stderr and abort on "n".
+	// When --force is NOT set, restore must prompt on stderr and abort on "n".
 	fc := &fakeVersionsClient{
 		historyItems: []unstructured.Unstructured{
 			historyItem(1, "", "", "", map[string]any{"title": "v1"}),
@@ -521,7 +521,7 @@ func TestVersionsRestore_ConfirmPromptAbort(t *testing.T) {
 }
 
 func TestVersionsRestore_ConfirmPromptProceed(t *testing.T) {
-	// When --yes is NOT set and user types "y", restore must proceed.
+	// When --force is NOT set and user types "y", restore must proceed.
 	fc := &fakeVersionsClient{
 		historyItems: []unstructured.Unstructured{
 			historyItem(1, "", "", "", map[string]any{"title": "v1"}),

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1,7 +1,6 @@
 package kg
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -17,10 +16,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/deeplink"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/shared"
 	"github.com/grafana/gcx/internal/style"
@@ -690,25 +689,20 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 	}
 	createCmd.Flags().StringVarP(&fileFlag, "file", "f", "", "Input file (YAML), or '-' for stdin. Reads from stdin if omitted.")
 
-	var yes bool
+	var force bool
 	deleteCmd := &cobra.Command{
 		Use:   "delete <name>",
 		Short: "Delete a suppression by name.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-			if !yes {
-				cliOpts, err := config.LoadCLIOptions()
-				if err != nil {
-					return err
-				}
-				if !cliOpts.AutoApprove {
-					fmt.Fprintf(cmd.OutOrStdout(), "Delete suppression %q? [y/N] ", name)
-					scanner := bufio.NewScanner(cmd.InOrStdin())
-					if !scanner.Scan() || !strings.EqualFold(strings.TrimSpace(scanner.Text()), "y") {
-						return nil
-					}
-				}
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.OutOrStdout(), force,
+				fmt.Sprintf("Delete suppression %q?", name))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
 			}
 			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
 			if err != nil {
@@ -725,7 +719,7 @@ func newSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 			return nil
 		},
 	}
-	deleteCmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
+	deleteCmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
 
 	cmd.AddCommand(listCmd, createCmd, deleteCmd)
 	return cmd

--- a/internal/providers/slo/definitions/commands.go
+++ b/internal/providers/slo/definitions/commands.go
@@ -1,7 +1,6 @@
 package definitions
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
@@ -408,7 +408,7 @@ type deleteOpts struct {
 }
 
 func (o *deleteOpts) setup(flags *pflag.FlagSet) {
-	flags.BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 }
 
 func newDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
@@ -420,19 +420,13 @@ func newDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			if !opts.Force {
-				fmt.Fprintf(cmd.OutOrStdout(), "Delete %d SLO definition(s)? [y/N] ", len(args))
-				reader := bufio.NewReader(cmd.InOrStdin())
-				answer, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("failed to read confirmation: %w", err)
-				}
-
-				answer = strings.TrimSpace(strings.ToLower(answer))
-				if answer != "y" && answer != "yes" {
-					cmdio.Info(cmd.OutOrStdout(), "Aborted.")
-					return nil
-				}
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.OutOrStdout(), opts.Force,
+				fmt.Sprintf("Delete %d SLO definition(s)?", len(args)))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
 			}
 
 			crud, _, err := NewTypedCRUD(ctx, loader)

--- a/internal/providers/slo/reports/commands.go
+++ b/internal/providers/slo/reports/commands.go
@@ -1,7 +1,6 @@
 package reports
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
@@ -421,7 +421,7 @@ type deleteOpts struct {
 }
 
 func (o *deleteOpts) setup(flags *pflag.FlagSet) {
-	flags.BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 }
 
 func newDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
@@ -433,19 +433,13 @@ func newDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			if !opts.Force {
-				fmt.Fprintf(cmd.OutOrStdout(), "Delete %d report(s)? [y/N] ", len(args))
-				reader := bufio.NewReader(cmd.InOrStdin())
-				answer, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("failed to read confirmation: %w", err)
-				}
-
-				answer = strings.TrimSpace(strings.ToLower(answer))
-				if answer != "y" && answer != "yes" {
-					cmdio.Info(cmd.OutOrStdout(), "Aborted.")
-					return nil
-				}
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.OutOrStdout(), opts.Force,
+				fmt.Sprintf("Delete %d report(s)?", len(args)))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
 			}
 
 			restCfg, err := loader.LoadGrafanaConfig(ctx)

--- a/internal/providers/synth/checks/commands.go
+++ b/internal/providers/synth/checks/commands.go
@@ -1,7 +1,6 @@
 package checks
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/synth/smcfg"
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/resources/adapter"
@@ -576,7 +576,7 @@ type deleteOpts struct {
 }
 
 func (o *deleteOpts) setup(flags *pflag.FlagSet) {
-	flags.BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 }
 
 func newDeleteCommand(loader smcfg.Loader) *cobra.Command {
@@ -588,18 +588,13 @@ func newDeleteCommand(loader smcfg.Loader) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			if !opts.Force {
-				fmt.Fprintf(cmd.OutOrStdout(), "Delete %d check(s)? [y/N] ", len(args))
-				reader := bufio.NewReader(cmd.InOrStdin())
-				answer, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("reading confirmation: %w", err)
-				}
-				answer = strings.TrimSpace(strings.ToLower(answer))
-				if answer != "y" && answer != "yes" {
-					cmdio.Info(cmd.OutOrStdout(), "Aborted.")
-					return nil
-				}
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.OutOrStdout(), opts.Force,
+				fmt.Sprintf("Delete %d check(s)?", len(args)))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
 			}
 
 			crud, _, err := NewTypedCRUD(ctx, loader)

--- a/internal/providers/synth/probes/commands.go
+++ b/internal/providers/synth/probes/commands.go
@@ -1,7 +1,6 @@
 package probes
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/synth/smcfg"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
@@ -200,7 +200,7 @@ type deleteOpts struct {
 }
 
 func (o *deleteOpts) setup(flags *pflag.FlagSet) {
-	flags.BoolVarP(&o.Force, "force", "f", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 }
 
 func (o *deleteOpts) Validate() error {
@@ -221,18 +221,13 @@ func newDeleteCommand(loader smcfg.Loader) *cobra.Command {
 			ctx := cmd.Context()
 			w := cmd.OutOrStdout()
 
-			if !opts.Force {
-				fmt.Fprintf(w, "Delete %d probe(s)? [y/N] ", len(args))
-				reader := bufio.NewReader(cmd.InOrStdin())
-				answer, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("reading confirmation: %w", err)
-				}
-				answer = strings.TrimSpace(strings.ToLower(answer))
-				if answer != "y" && answer != "yes" {
-					cmdio.Info(w, "Aborted.")
-					return nil
-				}
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), w, opts.Force,
+				fmt.Sprintf("Delete %d probe(s)?", len(args)))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
 			}
 
 			crud, _, err := NewTypedCRUD(ctx, loader)

--- a/internal/providers/traces/adaptive/commands.go
+++ b/internal/providers/traces/adaptive/commands.go
@@ -1,7 +1,6 @@
 package traces
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -16,7 +15,6 @@ import (
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
-	"github.com/grafana/gcx/internal/terminal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -536,21 +534,13 @@ func (h *tracesHelper) policiesDeleteCommand() *cobra.Command {
 		Short: "Delete one or more Adaptive Traces sampling policies.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !opts.Force {
-				if terminal.IsPiped() {
-					return errors.New("stdin is not a terminal, use --force to skip confirmation")
-				}
-				fmt.Fprintf(cmd.ErrOrStderr(), "Delete %d policy(ies)? [y/N] ", len(args))
-				reader := bufio.NewReader(cmd.InOrStdin())
-				answer, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("reading confirmation: %w", err)
-				}
-				answer = strings.TrimSpace(strings.ToLower(answer))
-				if answer != "y" && answer != "yes" {
-					cmdio.Info(cmd.ErrOrStderr(), "Aborted.")
-					return nil
-				}
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.ErrOrStderr(), opts.Force,
+				fmt.Sprintf("Delete %d policy(ies)?", len(args)))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
 			}
 
 			ctx := cmd.Context()


### PR DESCRIPTION
## Problem

After #666 landed the shared `providers.ConfirmDestructive` helper, 9 provider commands still used inline `bufio.NewReader` confirmation prompts. These prompts lack agent mode detection and `GCX_AUTO_APPROVE` support — an agent invoking any of them hangs forever waiting for input.

Affected commands:
- `gcx traces adaptive policies delete`
- `gcx ai saved-conversations delete`
- `gcx ai evaluators delete`
- `gcx ai rules delete`
- `gcx ai collections delete`
- `gcx synth checks delete`
- `gcx synth probes delete`
- `gcx slo definitions delete`
- `gcx slo reports delete`

## Fix

Mechanical migration: replace each inline prompt block with `providers.ConfirmDestructive(...)`. Every command now gets the full bypass chain (--force → agent mode → GCX_AUTO_APPROVE → interactive prompt).

