### PR TITLE
fix: consolidation stacks delete — rename --yes to --force, add agent mode check

### DIFF
--- a/docs/reference/cli/gcx_stacks_delete.md
+++ b/docs/reference/cli/gcx_stacks_delete.md
@@ -19,8 +19,8 @@ gcx stacks delete <stack-slug> [flags]
 
 ```
       --dry-run   Preview the operation without executing it
+      --force     Skip confirmation prompt
   -h, --help      help for delete
-  -y, --yes       Skip confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/internal/providers/confirm.go
+++ b/internal/providers/confirm.go
@@ -12,17 +12,20 @@ import (
 	cmdio "github.com/grafana/gcx/internal/output"
 )
 
-// ConfirmDestructive prompts the user to confirm a destructive operation.
+// ErrAgentModeRequiresForce is returned when agent mode is active but --force
+// was not passed. Exported so callers with custom prompts can check for it.
+var ErrAgentModeRequiresForce = errors.New("destructive operation requires --force in agent mode")
+
+// CheckDestructiveBypass runs the bypass chain for destructive operations.
+// Returns (true, nil) if the operation should proceed without prompting
+// (--force or GCX_AUTO_APPROVE), (false, nil) if the caller should prompt
+// interactively, or (false, error) if the operation must be rejected
+// (agent mode without --force).
 //
-// Bypass chain:
-//  1. --force flag → proceed immediately
-//  2. GCX_AUTO_APPROVE env var → proceed (CI/CD pipelines)
-//  3. Agent mode detected without --force → fail with actionable error
-//  4. Otherwise → interactive prompt (returns false on EOF or "no")
-//
-// Agent mode requires explicit --force so that agents must deliberately
-// acknowledge destructive operations rather than silently proceeding.
-func ConfirmDestructive(in io.Reader, out io.Writer, force bool, prompt string) (bool, error) {
+// This is the single source of truth for bypass logic. Both
+// [ConfirmDestructive] and callers with custom prompts (e.g. slug-typing
+// confirmation for stack deletion) should use this.
+func CheckDestructiveBypass(force bool) (bool, error) {
 	if force {
 		return true, nil
 	}
@@ -37,7 +40,26 @@ func ConfirmDestructive(in io.Reader, out io.Writer, force bool, prompt string) 
 	}
 
 	if agent.IsAgentMode() {
-		return false, errors.New("destructive operation requires --force in agent mode")
+		return false, ErrAgentModeRequiresForce
+	}
+
+	return false, nil
+}
+
+// ConfirmDestructive prompts the user to confirm a destructive operation.
+//
+// Bypass chain (via [CheckDestructiveBypass]):
+//  1. --force flag → proceed immediately
+//  2. GCX_AUTO_APPROVE env var → proceed (CI/CD pipelines)
+//  3. Agent mode detected without --force → fail with actionable error
+//  4. Otherwise → interactive [y/N] prompt (returns false on EOF or "no")
+//
+// Agent mode requires explicit --force so that agents must deliberately
+// acknowledge destructive operations rather than silently proceeding.
+func ConfirmDestructive(in io.Reader, out io.Writer, force bool, prompt string) (bool, error) {
+	bypass, err := CheckDestructiveBypass(force)
+	if bypass || err != nil {
+		return bypass, err
 	}
 
 	fmt.Fprintf(out, "%s [y/N] ", prompt)

--- a/internal/providers/stacks/commands.go
+++ b/internal/providers/stacks/commands.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/cloud"
-	"github.com/grafana/gcx/internal/config"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/spf13/cobra"
@@ -317,12 +316,12 @@ changes with the user and prefer --dry-run first.`,
 // ---------------------------------------------------------------------------
 
 type deleteOpts struct {
-	Yes    bool
+	Force  bool
 	DryRun bool
 }
 
 func (o *deleteOpts) setup(flags *pflag.FlagSet) {
-	flags.BoolVarP(&o.Yes, "yes", "y", false, "Skip confirmation prompt")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
 	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview the operation without executing it")
 }
 
@@ -352,22 +351,8 @@ IRREVERSIBLE. Always confirm with the user by name before executing. Prefer
 				return nil
 			}
 
-			cliOpts, err := config.LoadCLIOptions()
-			if err != nil {
+			if err := confirmStackDelete(cmd, slug, opts.Force); err != nil {
 				return err
-			}
-
-			if !opts.Yes && !cliOpts.AutoApprove {
-				fmt.Fprintf(cmd.OutOrStdout(),
-					"WARNING: This will permanently delete stack %q and ALL its data.\n"+
-						"Type the stack slug to confirm: ", slug)
-
-				scanner := bufio.NewScanner(cmd.InOrStdin())
-				scanner.Scan()
-				confirmation := strings.TrimSpace(scanner.Text())
-				if confirmation != slug {
-					return fmt.Errorf("confirmation did not match: expected %q, got %q", slug, confirmation)
-				}
 			}
 
 			ctx := cmd.Context()
@@ -386,6 +371,37 @@ IRREVERSIBLE. Always confirm with the user by name before executing. Prefer
 	}
 	opts.setup(cmd.Flags())
 	return cmd
+}
+
+// confirmStackDelete handles the slug-typing confirmation for stack deletion.
+// Unlike other destructive commands that use providers.ConfirmDestructive with
+// a simple y/N prompt, stack deletion requires typing the slug name because
+// the operation is irreversible and destroys all data.
+//
+// The bypass chain (--force, AutoApprove, agent mode guard) is delegated to
+// providers.CheckDestructiveBypass so it stays in sync with ConfirmDestructive.
+func confirmStackDelete(cmd *cobra.Command, slug string, force bool) error {
+	bypass, err := providers.CheckDestructiveBypass(force)
+	if err != nil {
+		return err
+	}
+	if bypass {
+		return nil
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"WARNING: This will permanently delete stack %q and ALL its data.\n"+
+			"Type the stack slug to confirm: ", slug)
+
+	scanner := bufio.NewScanner(cmd.InOrStdin())
+	scanner.Scan()
+
+	confirmation := strings.TrimSpace(scanner.Text())
+	if confirmation != slug {
+		return fmt.Errorf("confirmation did not match: expected %q, got %q", slug, confirmation)
+	}
+
+	return nil
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`gcx stacks delete` uses `--yes`/`-y` instead of `--force`, inconsistent with the rest of the CLI. It also has no agent mode check — an agent without `--yes` hangs on the slug-typing prompt.

## Fix

- Rename `--yes`/`-y` to `--force` (no shorthand per naming.md § 9.4)
- Add agent mode check: returns `"destructive operation requires --force in agent mode"` instead of hanging
- Extract `confirmStackDelete` helper with the same bypass chain as `providers.ConfirmDestructive` (`--force` → `AutoApprove` → agent mode error) while keeping the slug-typing confirmation gate for interactive users
- Fixes lint warnings (nestif, gocritic) from the inline if-else chain

Stack deletion is intentionally stricter than other destructive commands — interactive users must type the slug name to confirm, not just `y/N`. The `--force` flag bypasses this entirely for agents and CI/CD.