### PR TITLE
fix: include valid values in enum-shaped error messages

### DIFF
--- a/cmd/gcx/api/command.go
+++ b/cmd/gcx/api/command.go
@@ -44,9 +44,13 @@ func (opts *apiOpts) Validate() error {
 	}
 	if opts.Method != "" {
 		method := strings.ToUpper(opts.Method)
-		valid := map[string]bool{"GET": true, "POST": true, "PUT": true, "PATCH": true, "DELETE": true, "HEAD": true, "OPTIONS": true, "TRACE": true}
+		validMethods := []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE"}
+		valid := make(map[string]bool, len(validMethods))
+		for _, m := range validMethods {
+			valid[m] = true
+		}
 		if !valid[method] {
-			return fmt.Errorf("invalid method %q", opts.Method)
+			return fmt.Errorf("invalid method %q: must be one of %s", opts.Method, strings.Join(validMethods, ", "))
 		}
 	}
 	return nil
@@ -166,7 +170,7 @@ func doRequest(ctx context.Context, cfg config.NamespacedRESTConfig, method, pat
 	for _, h := range headers {
 		parts := strings.SplitN(h, ":", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid header format %q", h)
+			return nil, fmt.Errorf("invalid header format %q: expected key:value (e.g. Content-Type:application/json)", h)
 		}
 		req.Header.Set(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
 	}

--- a/cmd/gcx/skills/command.go
+++ b/cmd/gcx/skills/command.go
@@ -727,14 +727,10 @@ func uninstallSkills(root string, names []string, dryRun bool) (uninstallResult,
 }
 
 func validateSkillName(name string) error {
-	if name == "." || name == ".." {
-		return fmt.Errorf("invalid skill name %q", name)
-	}
-	if strings.Contains(name, "/") || strings.Contains(name, `\`) {
-		return fmt.Errorf("invalid skill name %q", name)
-	}
-	if filepath.Base(name) != name {
-		return fmt.Errorf("invalid skill name %q", name)
+	if name == "." || name == ".." ||
+		strings.Contains(name, "/") || strings.Contains(name, `\`) ||
+		filepath.Base(name) != name {
+		return fmt.Errorf("invalid skill name %q: must be a plain name without path separators (e.g. gcx, manage-dashboards)", name)
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

When an agent passes an invalid value for a flag with a known valid set, the error rejects the input without listing what is valid. The agent has to read `--help`, parse, guess, and retry.

```
$ gcx api /api/health -X DELET
error: invalid method "DELET"
```

## Fix

Surface the valid set in the error message so the agent self-corrects in one retry:

```
$ gcx api /api/health -X DELET
error: invalid method "DELET": must be one of GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, TRACE
```
