### PR TITLE
perf(datasources): eliminate redundant GET /api/datasources/uid/{uid} after auto-discovery

### DIFF
--- a/internal/datasources/loki/metrics.go
+++ b/internal/datasources/loki/metrics.go
@@ -77,16 +77,8 @@ open it in your browser after the query succeeds.`,
 				return err
 			}
 
-			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, datasource, cfgCtx, cfg, "loki")
+			datasourceUID, dsType, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, datasource, cfgCtx, cfg, "loki")
 			if err != nil {
-				return err
-			}
-
-			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			if err := dsquery.ValidateDatasourceType(dsType, "loki"); err != nil {
 				return err
 			}
 

--- a/internal/datasources/loki/query.go
+++ b/internal/datasources/loki/query.go
@@ -77,16 +77,8 @@ open it in your browser after the query succeeds.`,
 				return err
 			}
 
-			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, datasource, cfgCtx, cfg, "loki")
+			datasourceUID, dsType, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, datasource, cfgCtx, cfg, "loki")
 			if err != nil {
-				return err
-			}
-
-			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			if err := dsquery.ValidateDatasourceType(dsType, "loki"); err != nil {
 				return err
 			}
 

--- a/internal/datasources/prometheus/query.go
+++ b/internal/datasources/prometheus/query.go
@@ -83,16 +83,8 @@ open it in your browser after the query succeeds.`,
 				effectiveDS = defaultDS
 			}
 
-			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, effectiveDS, cfgCtx, cfg, "prometheus")
+			datasourceUID, dsType, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, effectiveDS, cfgCtx, cfg, "prometheus")
 			if err != nil {
-				return err
-			}
-
-			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			if err := dsquery.ValidateDatasourceType(dsType, "prometheus"); err != nil {
 				return err
 			}
 

--- a/internal/datasources/pyroscope/exemplars.go
+++ b/internal/datasources/pyroscope/exemplars.go
@@ -146,16 +146,8 @@ EXPR is the label selector (e.g. '{service_name="frontend"}').`,
 			} else {
 				cfgCtx = fullCfg.GetCurrentContext()
 			}
-			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "pyroscope")
+			datasourceUID, _, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "pyroscope")
 			if err != nil {
-				return err
-			}
-
-			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			if err := dsquery.ValidateDatasourceType(dsType, "pyroscope"); err != nil {
 				return err
 			}
 
@@ -238,16 +230,8 @@ EXPR is the label selector (e.g. '{service_name="frontend"}').`,
 			} else {
 				cfgCtx = fullCfg.GetCurrentContext()
 			}
-			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "pyroscope")
+			datasourceUID, _, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "pyroscope")
 			if err != nil {
-				return err
-			}
-
-			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			if err := dsquery.ValidateDatasourceType(dsType, "pyroscope"); err != nil {
 				return err
 			}
 

--- a/internal/datasources/pyroscope/query.go
+++ b/internal/datasources/pyroscope/query.go
@@ -72,16 +72,8 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 				return err
 			}
 
-			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, datasource, cfgCtx, cfg, "pyroscope")
+			datasourceUID, _, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, datasource, cfgCtx, cfg, "pyroscope")
 			if err != nil {
-				return err
-			}
-
-			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			if err := dsquery.ValidateDatasourceType(dsType, "pyroscope"); err != nil {
 				return err
 			}
 

--- a/internal/datasources/pyroscope/series.go
+++ b/internal/datasources/pyroscope/series.go
@@ -130,16 +130,8 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 				return err
 			}
 
-			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "pyroscope")
+			datasourceUID, _, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "pyroscope")
 			if err != nil {
-				return err
-			}
-
-			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			if err := dsquery.ValidateDatasourceType(dsType, "pyroscope"); err != nil {
 				return err
 			}
 

--- a/internal/datasources/query/resolve.go
+++ b/internal/datasources/query/resolve.go
@@ -36,6 +36,7 @@ func ResolveDatasourceFlag(flagValue string, cfgCtx *config.Context, kind string
 // DatasourceResolution describes the outcome of datasource resolution.
 type DatasourceResolution struct {
 	UID     string
+	Type    string // populated when discovery already fetched the datasource object
 	Persist bool
 }
 
@@ -84,6 +85,44 @@ func ResolveAndSaveDatasource(ctx context.Context, saver DatasourceSaver, flagVa
 	}
 
 	return resolved.UID, nil
+}
+
+// ResolveValidateAndSaveDatasource resolves a datasource UID, validates its type matches
+// the expected kind, and best-effort persists it to config. When auto-discovery already
+// fetched the datasource object (including its type), the validation is performed inline
+// without an additional API call to GET /api/datasources/uid/{uid}.
+// It returns the UID and the raw datasource plugin type (e.g. "prometheus",
+// "grafana-pyroscope-datasource") for use in explore URLs.
+func ResolveValidateAndSaveDatasource(ctx context.Context, saver DatasourceSaver, flagValue string, cfgCtx *config.Context, restCfg config.NamespacedRESTConfig, kind string) (string, string, error) {
+	resolved, err := ResolveDatasource(ctx, flagValue, cfgCtx, restCfg, kind)
+	if err != nil {
+		return "", "", err
+	}
+
+	dsType := resolved.Type
+	if dsType == "" {
+		dsType, err = GetDatasourceType(ctx, restCfg, resolved.UID)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	if err := ValidateDatasourceType(dsType, kind); err != nil {
+		return "", "", err
+	}
+
+	if resolved.Persist && saver != nil {
+		if saveErr := saver.SaveDatasourceUID(ctx, kind, resolved.UID); saveErr != nil {
+			logging.FromContext(ctx).Warn(
+				"could not save discovered datasource UID to config",
+				slog.String("datasource_kind", kind),
+				slog.String("uid", resolved.UID),
+				slog.String("error", saveErr.Error()),
+			)
+		}
+	}
+
+	return resolved.UID, dsType, nil
 }
 
 // ResolveTypedArgs parses positional args for typed subcommands.
@@ -161,7 +200,7 @@ func discoverDatasourceUID(ctx context.Context, restCfg config.NamespacedRESTCon
 	case 0:
 		return DatasourceResolution{}, fmt.Errorf("no %s datasource found in Grafana: use -d flag or set datasources.%s in config", kind, kind)
 	case 1:
-		return DatasourceResolution{UID: matches[0].UID}, nil
+		return DatasourceResolution{UID: matches[0].UID, Type: matches[0].Type}, nil
 	}
 
 	if stackSlug == "" {
@@ -169,7 +208,7 @@ func discoverDatasourceUID(ctx context.Context, restCfg config.NamespacedRESTCon
 	}
 
 	if canonical := canonicalCloudDatasource(matches, kind, stackSlug); canonical != nil {
-		return DatasourceResolution{UID: canonical.UID, Persist: true}, nil
+		return DatasourceResolution{UID: canonical.UID, Type: canonical.Type, Persist: true}, nil
 	}
 
 	return DatasourceResolution{}, fmt.Errorf("multiple %s datasources found (%s): use -d flag or set datasources.%s in config", kind, formatDatasourceChoices(matches), kind)

--- a/internal/datasources/query/resolve_test.go
+++ b/internal/datasources/query/resolve_test.go
@@ -145,6 +145,135 @@ func TestResolveDatasource(t *testing.T) {
 	})
 }
 
+func TestResolveDatasource_TypePopulated(t *testing.T) {
+	t.Run("single match populates Type", func(t *testing.T) {
+		restCfg := testDatasourceRESTConfig(t, []map[string]any{
+			{"uid": "loki-1", "name": "logs", "type": "loki"},
+		})
+
+		resolved, err := dsquery.ResolveDatasource(context.Background(), "", nil, restCfg, "loki")
+		require.NoError(t, err)
+		assert.Equal(t, "loki-1", resolved.UID)
+		assert.Equal(t, "loki", resolved.Type)
+	})
+
+	t.Run("canonical cloud match populates Type", func(t *testing.T) {
+		restCfg := testDatasourceRESTConfig(t, []map[string]any{
+			{"uid": "prom-1", "name": "other-prom", "type": "prometheus"},
+			{"uid": "prom-cloud", "name": "grafanacloud-ops-prom", "type": "prometheus"},
+		})
+
+		resolved, err := dsquery.ResolveDatasource(context.Background(), "", &config.Context{
+			Cloud: &config.CloudConfig{Stack: "ops"},
+		}, restCfg, "prometheus")
+		require.NoError(t, err)
+		assert.Equal(t, "prom-cloud", resolved.UID)
+		assert.Equal(t, "prometheus", resolved.Type)
+	})
+
+	t.Run("explicit flag does not populate Type", func(t *testing.T) {
+		resolved, err := dsquery.ResolveDatasource(
+			context.Background(),
+			"explicit-uid",
+			nil,
+			config.NamespacedRESTConfig{},
+			"loki",
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "explicit-uid", resolved.UID)
+		assert.Empty(t, resolved.Type)
+	})
+
+	t.Run("pyroscope plugin id preserved in Type", func(t *testing.T) {
+		restCfg := testDatasourceRESTConfig(t, []map[string]any{
+			{"uid": "pyro-1", "name": "profiles", "type": "grafana-pyroscope-datasource"},
+		})
+
+		resolved, err := dsquery.ResolveDatasource(context.Background(), "", nil, restCfg, "pyroscope")
+		require.NoError(t, err)
+		assert.Equal(t, "pyro-1", resolved.UID)
+		assert.Equal(t, "grafana-pyroscope-datasource", resolved.Type)
+	})
+}
+
+func TestResolveValidateAndSaveDatasource(t *testing.T) {
+	t.Run("skips GET when type already known from discovery", func(t *testing.T) {
+		var apiCalls int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			apiCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"uid": "loki-1", "name": "logs", "type": "loki"},
+			})
+		}))
+		t.Cleanup(srv.Close)
+
+		restCfg := config.NamespacedRESTConfig{
+			Config:    rest.Config{Host: srv.URL},
+			Namespace: "default",
+		}
+
+		uid, dsType, err := dsquery.ResolveValidateAndSaveDatasource(context.Background(), nil, "", nil, restCfg, "loki")
+		require.NoError(t, err)
+		assert.Equal(t, "loki-1", uid)
+		assert.Equal(t, "loki", dsType)
+		assert.Equal(t, 1, apiCalls, "should only call /api/datasources (List), not /api/datasources/uid/*")
+	})
+
+	t.Run("fetches type when UID from flag", func(t *testing.T) {
+		var paths []string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			paths = append(paths, r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"uid": "prom-1", "name": "metrics", "type": "prometheus",
+			})
+		}))
+		t.Cleanup(srv.Close)
+
+		restCfg := config.NamespacedRESTConfig{
+			Config:    rest.Config{Host: srv.URL},
+			Namespace: "default",
+		}
+
+		uid, dsType, err := dsquery.ResolveValidateAndSaveDatasource(context.Background(), nil, "prom-1", nil, restCfg, "prometheus")
+		require.NoError(t, err)
+		assert.Equal(t, "prom-1", uid)
+		assert.Equal(t, "prometheus", dsType)
+		require.Len(t, paths, 1)
+		assert.Equal(t, "/api/datasources/uid/prom-1", paths[0])
+	})
+
+	t.Run("returns error on type mismatch", func(t *testing.T) {
+		restCfg := testDatasourceRESTConfig(t, []map[string]any{
+			{"uid": "prom-1", "name": "metrics", "type": "prometheus"},
+		})
+
+		_, _, err := dsquery.ResolveValidateAndSaveDatasource(context.Background(), nil, "", nil, restCfg, "loki")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no loki datasource found")
+	})
+
+	t.Run("returns error on type mismatch from flag path", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"uid": "prom-1", "name": "metrics", "type": "prometheus",
+			})
+		}))
+		t.Cleanup(srv.Close)
+
+		restCfg := config.NamespacedRESTConfig{
+			Config:    rest.Config{Host: srv.URL},
+			Namespace: "default",
+		}
+
+		_, _, err := dsquery.ResolveValidateAndSaveDatasource(context.Background(), nil, "prom-1", nil, restCfg, "loki")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "datasource is type prometheus, not loki")
+	})
+}
+
 func testDatasourceRESTConfig(t *testing.T, payload any) config.NamespacedRESTConfig {
 	t.Helper()
 

--- a/internal/datasources/tempo/metrics.go
+++ b/internal/datasources/tempo/metrics.go
@@ -83,16 +83,8 @@ open it in your browser after the query succeeds.`,
 				return err
 			}
 
-			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, datasource, cfgCtx, cfg, "tempo")
+			datasourceUID, dsType, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, datasource, cfgCtx, cfg, "tempo")
 			if err != nil {
-				return err
-			}
-
-			dsType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			if err := dsquery.ValidateDatasourceType(dsType, "tempo"); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
## Summary

- Adds a `Type` field to `DatasourceResolution` so that auto-discovery propagates the datasource type it already fetched via `GET /api/datasources`
- Introduces `ResolveValidateAndSaveDatasource` which combines resolution + type validation + config persistence, skipping the redundant `GET /api/datasources/uid/{uid}` when the type is already known
- Updates all 7 typed-command call sites (loki query/metrics, prometheus query, tempo metrics, pyroscope query/series/exemplars) to use the new function

## Motivation

Usage telemetry shows `/api/datasources/uid/grafanacloud-logs` as the most heavily hit endpoint. Every typed datasource command was making a redundant round-trip: first fetching all datasources for auto-discovery (which already includes the type), then re-fetching the same datasource by UID solely to validate its type. This eliminates that extra API call on the discovery path.

When the UID comes from a flag or config (no discovery), the behavior is unchanged — the type is still fetched via `GetByUID`.

## Test plan

- [x] New tests in `resolve_test.go` verify Type propagation from discovery
- [x] New tests verify `ResolveValidateAndSaveDatasource` makes only 1 API call (List) on discovery path
- [x] New tests verify the flag/config path still fetches type via GetByUID
- [x] New tests verify type mismatch errors are returned correctly
- [x] All existing tests pass (`go test ./internal/datasources/... ./cmd/gcx/datasources/...`)

Made with [Cursor](https://cursor.com)