### PR TITLE
feat(kg): add insight filter flags to entities inspect

### DIFF
--- a/docs/reference/cli/gcx_kg_entities_inspect.md
+++ b/docs/reference/cli/gcx_kg_entities_inspect.md
@@ -9,19 +9,23 @@ gcx kg entities inspect [Type--Name] [flags]
 ### Options
 
 ```
-      --env string         Environment scope (run 'gcx kg meta scopes' to see valid values)
-      --from string        Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
-  -h, --help               help for inspect
-      --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --name string        Entity name
-      --namespace string   Namespace scope (run 'gcx kg meta scopes' to see valid values)
-      --open               Open the entity in the RCA Workbench in your browser
-  -o, --output string      Output format. One of: agents, json, yaml (default "json")
-      --share-link         Print the RCA Workbench URL for this entity to stderr
-      --since string       Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
-      --site string        Site scope (run 'gcx kg meta scopes' to see valid values)
-      --to string          End time (RFC3339, Unix timestamp, or relative like 'now')
-      --type string        Entity type (run 'gcx kg meta schema' to see available types)
+      --env string                         Environment scope (run 'gcx kg meta scopes' to see valid values)
+      --from string                        Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
+  -h, --help                               help for inspect
+      --insight-categories strings         Filter insights by category (comma-separated, e.g. saturation,anomaly,failure); empty = all categories
+      --insight-hide-chronic-above int     Hide insights present more than this percent of the window (0-100); overrides --insight-hide-noise on this axis
+      --insight-hide-noise                 Apply RCA Workbench noise filter: hide insights older than 48h or present >90% of the window
+      --insight-hide-older-than duration   Hide insights older than this duration (e.g. 24h); overrides --insight-hide-noise on this axis
+      --json string                        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --name string                        Entity name
+      --namespace string                   Namespace scope (run 'gcx kg meta scopes' to see valid values)
+      --open                               Open the entity in the RCA Workbench in your browser
+  -o, --output string                      Output format. One of: agents, json, yaml (default "json")
+      --share-link                         Print the RCA Workbench URL for this entity to stderr
+      --since string                       Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --site string                        Site scope (run 'gcx kg meta scopes' to see valid values)
+      --to string                          End time (RFC3339, Unix timestamp, or relative like 'now')
+      --type string                        Entity type (run 'gcx kg meta schema' to see available types)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_entities_inspect.md
+++ b/docs/reference/cli/gcx_kg_entities_inspect.md
@@ -15,7 +15,7 @@ gcx kg entities inspect [Type--Name] [flags]
       --insight-categories strings         Filter insights by category (comma-separated, e.g. saturation,anomaly,failure); empty = all categories
       --insight-hide-chronic-above int     Hide insights present more than this percent of the window (0-100); overrides --insight-hide-noise on this axis
       --insight-hide-noise                 Apply RCA Workbench noise filter: hide insights older than 48h or present >90% of the window
-      --insight-hide-older-than duration   Hide insights older than this duration (e.g. 24h); overrides --insight-hide-noise on this axis
+      --insight-hide-older-than duration   Hide insights older than a whole number of hours (e.g. 24h); overrides --insight-hide-noise on this axis
       --json string                        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string                        Entity name
       --namespace string                   Namespace scope (run 'gcx kg meta scopes' to see valid values)

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1536,7 +1536,9 @@ func (o *inspectOpts) Validate(flags *pflag.FlagSet) error {
 
 // resolveInsightFilters returns the hours and percent thresholds to send to the
 // LLM summary API, applying the --insight-hide-noise preset and per-axis overrides.
-func (o *inspectOpts) resolveInsightFilters(flags *pflag.FlagSet) (hideOlderHours, hideChronicPct int) {
+func (o *inspectOpts) resolveInsightFilters(flags *pflag.FlagSet) (int, int) {
+	hideOlderHours := 0
+	hideChronicPct := 0
 	if o.InsightHideNoise {
 		hideOlderHours = 48
 		hideChronicPct = 90
@@ -1547,7 +1549,7 @@ func (o *inspectOpts) resolveInsightFilters(flags *pflag.FlagSet) (hideOlderHour
 	if flags.Changed("insight-hide-chronic-above") {
 		hideChronicPct = o.InsightHideChronicAbove
 	}
-	return
+	return hideOlderHours, hideChronicPct
 }
 
 // rcaWorkbenchURL builds a deep link to the Asserts RCA Workbench for a single entity.

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1399,18 +1399,12 @@ func discoverEntityScope(cmd *cobra.Command, client *Client, entityType, name st
 func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 	var inspectScope scopeFlags
 	ioOpts := &inspectOpts{}
-	var (
-		insightCategories       []string
-		insightHideNoise        bool
-		insightHideOlderThan    time.Duration
-		insightHideChronicAbove int
-	)
 	cmd := &cobra.Command{
 		Use:   "inspect [Type--Name]",
 		Short: "Show detailed info, insights, and summary for a single entity, including a link to the RCA Workbench.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := ioOpts.IO.Validate(); err != nil {
+			if err := ioOpts.Validate(cmd.Flags()); err != nil {
 				return err
 			}
 			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
@@ -1441,21 +1435,7 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 				scope = discovered
 			}
 
-			hideOlderHours := 0
-			hideChronicPct := 0
-			if insightHideNoise {
-				hideOlderHours = 48
-				hideChronicPct = 90
-			}
-			if cmd.Flags().Changed("insight-hide-older-than") {
-				hideOlderHours = int(insightHideOlderThan.Hours())
-			}
-			if cmd.Flags().Changed("insight-hide-chronic-above") {
-				if insightHideChronicAbove < 0 || insightHideChronicAbove > 100 {
-					return fmt.Errorf("--insight-hide-chronic-above must be between 0 and 100, got %d", insightHideChronicAbove)
-				}
-				hideChronicPct = insightHideChronicAbove
-			}
+			hideOlderHours, hideChronicPct := ioOpts.resolveInsightFilters(cmd.Flags())
 
 			llmReq := LLMSummaryRequest{
 				StartTime: startMs,
@@ -1466,7 +1446,7 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 					Scope: toAnyMap(scope),
 				}},
 				SuggestionSrcEntities:                         []EntityKey{},
-				AlertCategories:                               insightCategories,
+				AlertCategories:                               ioOpts.InsightCategories,
 				HideAssertionsOlderThanNHours:                 hideOlderHours,
 				HideAssertionsPresentMoreThanPercentageOfTime: hideChronicPct,
 				IncludeSuggestions:                            true,
@@ -1512,18 +1492,18 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd.Flags().Lookup("env").Usage = "Environment scope (run 'gcx kg meta scopes' to see valid values)"
 	cmd.Flags().Lookup("namespace").Usage = "Namespace scope (run 'gcx kg meta scopes' to see valid values)"
 	cmd.Flags().Lookup("site").Usage = "Site scope (run 'gcx kg meta scopes' to see valid values)"
-	cmd.Flags().StringSliceVar(&insightCategories, "insight-categories", nil, "Filter insights by category (comma-separated, e.g. saturation,anomaly,failure); empty = all categories")
-	cmd.Flags().BoolVar(&insightHideNoise, "insight-hide-noise", false, "Apply RCA Workbench noise filter: hide insights older than 48h or present >90% of the window")
-	cmd.Flags().DurationVar(&insightHideOlderThan, "insight-hide-older-than", 0, "Hide insights older than this duration (e.g. 24h); overrides --insight-hide-noise on this axis")
-	cmd.Flags().IntVar(&insightHideChronicAbove, "insight-hide-chronic-above", 0, "Hide insights present more than this percent of the window (0-100); overrides --insight-hide-noise on this axis")
 	ioOpts.setup(cmd.Flags())
 	return cmd
 }
 
 type inspectOpts struct {
-	IO        cmdio.Options
-	ShareLink bool
-	Open      bool
+	IO                      cmdio.Options
+	ShareLink               bool
+	Open                    bool
+	InsightCategories       []string
+	InsightHideNoise        bool
+	InsightHideOlderThan    time.Duration
+	InsightHideChronicAbove int
 }
 
 func (o *inspectOpts) setup(flags *pflag.FlagSet) {
@@ -1531,6 +1511,43 @@ func (o *inspectOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 	flags.BoolVar(&o.ShareLink, "share-link", false, "Print the RCA Workbench URL for this entity to stderr")
 	flags.BoolVar(&o.Open, "open", false, "Open the entity in the RCA Workbench in your browser")
+	flags.StringSliceVar(&o.InsightCategories, "insight-categories", nil, "Filter insights by category (comma-separated, e.g. saturation,anomaly,failure); empty = all categories")
+	flags.BoolVar(&o.InsightHideNoise, "insight-hide-noise", false, "Apply RCA Workbench noise filter: hide insights older than 48h or present >90% of the window")
+	flags.DurationVar(&o.InsightHideOlderThan, "insight-hide-older-than", 0, "Hide insights older than a whole number of hours (e.g. 24h); overrides --insight-hide-noise on this axis")
+	flags.IntVar(&o.InsightHideChronicAbove, "insight-hide-chronic-above", 0, "Hide insights present more than this percent of the window (0-100); overrides --insight-hide-noise on this axis")
+}
+
+func (o *inspectOpts) Validate(flags *pflag.FlagSet) error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+	if flags.Changed("insight-hide-older-than") {
+		if o.InsightHideOlderThan <= 0 || o.InsightHideOlderThan%time.Hour != 0 {
+			return fmt.Errorf("--insight-hide-older-than must be a positive whole number of hours (e.g. 24h), got %s", o.InsightHideOlderThan)
+		}
+	}
+	if flags.Changed("insight-hide-chronic-above") {
+		if o.InsightHideChronicAbove < 0 || o.InsightHideChronicAbove > 100 {
+			return fmt.Errorf("--insight-hide-chronic-above must be between 0 and 100, got %d", o.InsightHideChronicAbove)
+		}
+	}
+	return nil
+}
+
+// resolveInsightFilters returns the hours and percent thresholds to send to the
+// LLM summary API, applying the --insight-hide-noise preset and per-axis overrides.
+func (o *inspectOpts) resolveInsightFilters(flags *pflag.FlagSet) (hideOlderHours, hideChronicPct int) {
+	if o.InsightHideNoise {
+		hideOlderHours = 48
+		hideChronicPct = 90
+	}
+	if flags.Changed("insight-hide-older-than") {
+		hideOlderHours = int(o.InsightHideOlderThan.Hours())
+	}
+	if flags.Changed("insight-hide-chronic-above") {
+		hideChronicPct = o.InsightHideChronicAbove
+	}
+	return
 }
 
 // rcaWorkbenchURL builds a deep link to the Asserts RCA Workbench for a single entity.

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1399,6 +1399,12 @@ func discoverEntityScope(cmd *cobra.Command, client *Client, entityType, name st
 func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 	var inspectScope scopeFlags
 	ioOpts := &inspectOpts{}
+	var (
+		insightCategories       []string
+		insightHideNoise        bool
+		insightHideOlderThan    time.Duration
+		insightHideChronicAbove int
+	)
 	cmd := &cobra.Command{
 		Use:   "inspect [Type--Name]",
 		Short: "Show detailed info, insights, and summary for a single entity, including a link to the RCA Workbench.",
@@ -1435,6 +1441,22 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 				scope = discovered
 			}
 
+			hideOlderHours := 0
+			hideChronicPct := 0
+			if insightHideNoise {
+				hideOlderHours = 48
+				hideChronicPct = 90
+			}
+			if cmd.Flags().Changed("insight-hide-older-than") {
+				hideOlderHours = int(insightHideOlderThan.Hours())
+			}
+			if cmd.Flags().Changed("insight-hide-chronic-above") {
+				if insightHideChronicAbove < 0 || insightHideChronicAbove > 100 {
+					return fmt.Errorf("--insight-hide-chronic-above must be between 0 and 100, got %d", insightHideChronicAbove)
+				}
+				hideChronicPct = insightHideChronicAbove
+			}
+
 			llmReq := LLMSummaryRequest{
 				StartTime: startMs,
 				EndTime:   endMs,
@@ -1443,9 +1465,12 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 					Name:  name,
 					Scope: toAnyMap(scope),
 				}},
-				SuggestionSrcEntities: []EntityKey{},
-				IncludeSuggestions:    true,
-				IncludeRcaPatterns:    false,
+				SuggestionSrcEntities:                         []EntityKey{},
+				AlertCategories:                               insightCategories,
+				HideAssertionsOlderThanNHours:                 hideOlderHours,
+				HideAssertionsPresentMoreThanPercentageOfTime: hideChronicPct,
+				IncludeSuggestions:                            true,
+				IncludeRcaPatterns:                            false,
 			}
 			result, err := client.LLMSummary(cmd.Context(), llmReq)
 			if err != nil {
@@ -1487,6 +1512,10 @@ func newEntitiesInspectCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd.Flags().Lookup("env").Usage = "Environment scope (run 'gcx kg meta scopes' to see valid values)"
 	cmd.Flags().Lookup("namespace").Usage = "Namespace scope (run 'gcx kg meta scopes' to see valid values)"
 	cmd.Flags().Lookup("site").Usage = "Site scope (run 'gcx kg meta scopes' to see valid values)"
+	cmd.Flags().StringSliceVar(&insightCategories, "insight-categories", nil, "Filter insights by category (comma-separated, e.g. saturation,anomaly,failure); empty = all categories")
+	cmd.Flags().BoolVar(&insightHideNoise, "insight-hide-noise", false, "Apply RCA Workbench noise filter: hide insights older than 48h or present >90% of the window")
+	cmd.Flags().DurationVar(&insightHideOlderThan, "insight-hide-older-than", 0, "Hide insights older than this duration (e.g. 24h); overrides --insight-hide-noise on this axis")
+	cmd.Flags().IntVar(&insightHideChronicAbove, "insight-hide-chronic-above", 0, "Hide insights present more than this percent of the window (0-100); overrides --insight-hide-noise on this axis")
 	ioOpts.setup(cmd.Flags())
 	return cmd
 }


### PR DESCRIPTION
## Summary

Follow-up to #648 — that PR removed the hardcoded RCA Workbench filters from `gcx kg entities inspect` to give agents a raw view. This PR puts those filters back as **opt-in flags**, so users who want the curated view can still get it without editing source.

Four flags, designed to keep the common case to one flag:

- `--insight-categories` — comma-separated alert category filter (default empty = all)
- `--insight-hide-noise` — bool preset matching RCA Workbench (`48h` + `90%`)
- `--insight-hide-older-than` — duration override for the time axis
- `--insight-hide-chronic-above` — percent (0-100) override for the presence axis

### Override semantics

- Neither set → no filtering (current default, unchanged).
- `--insight-hide-noise` alone → 48h + 90% (the preset).
- `--insight-hide-noise --insight-hide-older-than=24h` → 24h + 90% (granular flag wins on its axis).
- `--insight-hide-older-than=24h` alone → 24h on the time axis, no presence filter (one-axis filtering without buying the preset).

### Naming rationale

All four flags share the `--insight-*` prefix to group them as a family in `--help`, and use the verb "hide" consistently with the underlying API fields (`HideAssertionsOlderThanNHours`, `HideAssertionsPresentMoreThanPercentageOfTime`).

## Test plan

- [x] `mise run build` succeeds
- [x] `go test ./internal/providers/kg/...` passes
- [x] `go test ./...` passes
- [x] `GCX_AGENT_MODE=false mise run reference` regenerates `docs/reference/cli/gcx_kg_entities_inspect.md` (included)
- [x] `mise run docs` succeeds
- [x] `mise run lint` — 0 issues in touched files
- [x] Smoke-test against a real stack: `gcx kg entities inspect <Type>--<Name> --insight-hide-noise` returns a filtered view; bare invocation still returns raw

🤖 Generated with [Claude Code](https://claude.com/claude-code)