### PR TITLE
feat(kg): surface propagated assertions in entities list

### DIFF
--- a/docs/reference/cli/gcx_kg_entities_list.md
+++ b/docs/reference/cli/gcx_kg_entities_list.md
@@ -32,7 +32,7 @@ gcx kg entities list [flags]
       --site string            Site scope (run 'gcx kg meta scopes' to see valid values)
       --to string              End time (RFC3339, Unix timestamp, or relative like 'now')
       --type string            Entity type to list (run 'gcx kg meta schema' to see available types)
-      --with-insights string   Filter to entities with active insights; narrow by severity: any, critical, warning, info
+      --with-insights string   Filter to entities with active insights (self or propagated from connected downstream entities, e.g. Pod-level alerts on a Service); narrow by severity: any, critical, warning, info
 ```
 
 ### Options inherited from parent commands

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -291,7 +291,7 @@ func readFileOrStdin(cmd *cobra.Command, path string) ([]byte, error) {
 // so that a broken type does not abort results for all other types.
 // When the backend signals more pages (MaxLimitHit, or !LastPage) for a per-type
 // page, a hint is emitted to stderr suggesting --page to fetch further results.
-func searchByTypes(ctx context.Context, cmd *cobra.Command, client *Client, entityTypes []string, assertionsOnly bool, sc *ScopeCriteria, startMs, endMs int64, pageNum int, propertyFilters []PropertyMatcher) ([]SearchResult, error) {
+func searchByTypes(ctx context.Context, cmd *cobra.Command, client *Client, entityTypes []string, assertionsOnly, includePropagated bool, sc *ScopeCriteria, startMs, endMs int64, pageNum int, propertyFilters []PropertyMatcher) ([]SearchResult, error) {
 	if startMs == 0 && endMs == 0 {
 		now := time.Now().UnixMilli()
 		startMs = now - 3600000
@@ -303,9 +303,10 @@ func searchByTypes(ctx context.Context, cmd *cobra.Command, client *Client, enti
 		req := SearchRequest{
 			TimeCriteria: &TimeCriteria{Start: startMs, End: endMs},
 			FilterCriteria: []EntityMatcher{{
-				EntityType:       et,
-				HavingAssertion:  assertionsOnly,
-				PropertyMatchers: matchers,
+				EntityType:                 et,
+				HavingAssertion:            assertionsOnly,
+				HavingPropagatedAssertions: assertionsOnly && includePropagated,
+				PropertyMatchers:           matchers,
 			}},
 			ScopeCriteria: sc,
 			PageNum:       pageNum,
@@ -851,7 +852,7 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 				propertyFilters = append(propertyFilters, pm)
 			}
 			withInsights := cmd.Flags().Changed("with-insights")
-			results, err := searchByTypes(cmd.Context(), cmd, client, entityTypes, withInsights, listScope.scopeCriteria(), startMs, endMs, listPage, propertyFilters)
+			results, err := searchByTypes(cmd.Context(), cmd, client, entityTypes, withInsights, true, listScope.scopeCriteria(), startMs, endMs, listPage, propertyFilters)
 			if err != nil {
 				return err
 			}
@@ -866,7 +867,7 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 		},
 	}
 	listCmd.Flags().StringVar(&listType, "type", "", "Entity type to list (run 'gcx kg meta schema' to see available types)")
-	listCmd.Flags().StringVar(&listWithInsights, "with-insights", "", "Filter to entities with active insights; narrow by severity: any, critical, warning, info")
+	listCmd.Flags().StringVar(&listWithInsights, "with-insights", "", "Filter to entities with active insights (self or propagated from connected downstream entities, e.g. Pod-level alerts on a Service); narrow by severity: any, critical, warning, info")
 	listCmd.Flags().IntVar(&listPage, "page", 0, "Page number (0-based)")
 	listCmd.Flags().StringArrayVar(&listPropertyRaw, "property", nil, "Filter by property: name=value (exact) or name=~value (contains); repeatable (run 'gcx kg meta schema' to list property names)")
 	listScope.register(listCmd)
@@ -1300,9 +1301,13 @@ func buildAssertionsRequestFromFlags(cmd *cobra.Command, args []string, client *
 
 func filterBySeverity(results []SearchResult, sev string) []SearchResult {
 	want := strings.ToUpper(sev)
+	matches := func(a map[string]any) bool {
+		s, ok := a["severity"].(string)
+		return ok && strings.ToUpper(s) == want
+	}
 	var out []SearchResult
 	for _, r := range results {
-		if s, ok := r.Assertion["severity"].(string); ok && strings.ToUpper(s) == want {
+		if matches(r.Assertion) || matches(r.ConnectedAssertion) {
 			out = append(out, r)
 		}
 	}
@@ -1371,7 +1376,7 @@ func discoverEntityScope(cmd *cobra.Command, client *Client, entityType, name st
 	if lookup != nil {
 		return lookup.Scope, nil
 	}
-	results, err := searchByTypes(cmd.Context(), cmd, client, []string{entityType}, false, nil, startMs, endMs, 0, []PropertyMatcher{{Name: "name", Op: "=", Value: name}})
+	results, err := searchByTypes(cmd.Context(), cmd, client, []string{entityType}, false, false, nil, startMs, endMs, 0, []PropertyMatcher{{Name: "name", Op: "=", Value: name}})
 	if err != nil {
 		return nil, err
 	}
@@ -1642,7 +1647,7 @@ func newHealthCommand(loader RESTConfigLoader) *cobra.Command {
 			if healthEntityType != "" {
 				entityTypes = []string{healthEntityType}
 			}
-			results, err := searchByTypes(cmd.Context(), cmd, client, entityTypes, true, healthScope.scopeCriteria(), startMs, endMs, 0, nil)
+			results, err := searchByTypes(cmd.Context(), cmd, client, entityTypes, true, false, healthScope.scopeCriteria(), startMs, endMs, 0, nil)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/kg/commands_test.go
+++ b/internal/providers/kg/commands_test.go
@@ -122,3 +122,78 @@ func TestScopeFlags_ValidateScopes(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterBySeverity(t *testing.T) {
+	critical := map[string]any{"severity": "CRITICAL"}
+	warning := map[string]any{"severity": "warning"}
+	info := map[string]any{"severity": "INFO"}
+
+	tests := []struct {
+		name     string
+		results  []kg.SearchResult
+		want     string
+		wantKeep []string
+	}{
+		{
+			name: "self assertion matches",
+			results: []kg.SearchResult{
+				{Name: "a", Assertion: critical},
+			},
+			want:     "critical",
+			wantKeep: []string{"a"},
+		},
+		{
+			name: "propagated assertion matches",
+			results: []kg.SearchResult{
+				{Name: "b", ConnectedAssertion: critical},
+			},
+			want:     "critical",
+			wantKeep: []string{"b"},
+		},
+		{
+			name: "both present and both match",
+			results: []kg.SearchResult{
+				{Name: "c", Assertion: critical, ConnectedAssertion: critical},
+			},
+			want:     "critical",
+			wantKeep: []string{"c"},
+		},
+		{
+			name: "neither matches requested severity",
+			results: []kg.SearchResult{
+				{Name: "d", Assertion: info, ConnectedAssertion: info},
+			},
+			want:     "critical",
+			wantKeep: nil,
+		},
+		{
+			name: "both nil",
+			results: []kg.SearchResult{
+				{Name: "e"},
+			},
+			want:     "critical",
+			wantKeep: nil,
+		},
+		{
+			name: "case-insensitive match across severities",
+			results: []kg.SearchResult{
+				{Name: "f", Assertion: warning},
+				{Name: "g", ConnectedAssertion: critical},
+				{Name: "h", Assertion: info},
+			},
+			want:     "WARNING",
+			wantKeep: []string{"f"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kg.FilterBySeverity(tt.results, tt.want)
+			var names []string
+			for _, r := range got {
+				names = append(names, r.Name)
+			}
+			assert.Equal(t, tt.wantKeep, names)
+		})
+	}
+}

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -14,3 +14,8 @@ func NewTestScopeFlags(env, site, namespace string) ScopeFlags {
 func (f ScopeFlags) ValidateScopes(ctx context.Context, c *Client) error {
 	return f.validateScopes(ctx, c)
 }
+
+// FilterBySeverity wraps the unexported filterBySeverity for testing.
+func FilterBySeverity(results []SearchResult, sev string) []SearchResult {
+	return filterBySeverity(results, sev)
+}

--- a/internal/providers/kg/types.go
+++ b/internal/providers/kg/types.go
@@ -76,9 +76,10 @@ type PropertyMatcher struct {
 
 // EntityMatcher filters entities by type and optional property matchers.
 type EntityMatcher struct {
-	EntityType       string            `json:"entityType" yaml:"entityType"`
-	PropertyMatchers []PropertyMatcher `json:"propertyMatchers,omitempty" yaml:"propertyMatchers,omitempty"`
-	HavingAssertion  bool              `json:"havingAssertion,omitempty" yaml:"havingAssertion,omitempty"`
+	EntityType                 string            `json:"entityType" yaml:"entityType"`
+	PropertyMatchers           []PropertyMatcher `json:"propertyMatchers,omitempty" yaml:"propertyMatchers,omitempty"`
+	HavingAssertion            bool              `json:"havingAssertion,omitempty" yaml:"havingAssertion,omitempty"`
+	HavingPropagatedAssertions bool              `json:"havingPropagatedAssertions,omitempty" yaml:"havingPropagatedAssertions,omitempty"`
 }
 
 // SearchRequest is the request body for POST /v1/search.
@@ -116,14 +117,15 @@ type AssertionSummary struct {
 
 // SearchResult is a single search result item.
 type SearchResult struct {
-	ID         int               `json:"id,omitempty"`
-	Name       string            `json:"name"`
-	Type       string            `json:"type"`
-	EntityType string            `json:"entityType,omitempty"`
-	Active     bool              `json:"active,omitempty"`
-	Scope      map[string]string `json:"scope,omitempty"`
-	Properties map[string]any    `json:"properties,omitempty"`
-	Assertion  map[string]any    `json:"assertion,omitempty"`
+	ID                 int               `json:"id,omitempty"`
+	Name               string            `json:"name"`
+	Type               string            `json:"type"`
+	EntityType         string            `json:"entityType,omitempty"`
+	Active             bool              `json:"active,omitempty"`
+	Scope              map[string]string `json:"scope,omitempty"`
+	Properties         map[string]any    `json:"properties,omitempty"`
+	Assertion          map[string]any    `json:"assertion,omitempty"`
+	ConnectedAssertion map[string]any    `json:"connectedAssertion,omitempty"`
 }
 
 // GraphEntity is the rich entity returned by entity get/lookup endpoints.


### PR DESCRIPTION
## Summary
- `POST /v1/search` already populates `connectedAssertion` on every `GraphEntity` (assertions firing on downstream-connected entities — e.g. Pods under a Service), but `SearchResult` in gcx silently discarded it. As a result, Pod-level alerts like `KubeContainerOomKiller` were invisible when running `gcx kg entities list --type Service`, even with `--with-insights any`.
- Adds `connectedAssertion` to `SearchResult`'s JSON output and makes `--with-insights` also set `havingPropagatedAssertions=true` on the backend filter, so Services whose only insights are propagated from Pods are no longer dropped.
- `filterBySeverity` now matches on either the self or propagated assertion summary.

### Before
```bash
$ gcx kg entities list --type Service --property name=gme-query-frontend \
    --namespace mimir-prod-22 --with-insights=any \
    --from 2026-03-16T21:00:00Z --to 2026-03-17T06:30:00Z \
    --json name,scope,assertion
[]
```
(the entity exists and was OOM-killing during the window, but is invisible)

### After
```bash
$ gcx kg entities list --type Service --property name=gme-query-frontend \
    --namespace mimir-prod-22 --with-insights=any \
    --from 2026-03-16T21:00:00Z --to 2026-03-17T06:30:00Z \
    --json name,scope,assertion,connectedAssertion
[{
  "name": "gme-query-frontend",
  "scope": {"env": "prod-eu-west-3", "namespace": "mimir-prod-22"},
  "assertion": { "amend": false },
  "connectedAssertion": {
    "severity": "critical",
    "assertions": [
      {"assertionName": "KubeContainerOomKiller", "entityType": "Pod", ...},
      {"assertionName": "Instance Unreachable", "entityType": "ServiceInstance", ...}
    ]
  }
}]
```

## Motivation
Driven by an identify-skill eval case where the agent has to disambiguate among many `query-frontend` Services using which scopes actually fired `KubeContainerOomKiller` in a window. Previously this required `gcx kg insights search` (which aggregates across connected entities). With this change, `entities list --with-insights=any` is sufficient — a single call returns both self and propagated assertions inline, no second lookup needed.

## Test plan
- [x] `mise run lint` — clean (pre-existing issues only in `.claude/worktrees/`)
- [x] `mise run tests` — pass
- [x] `mise run reference-drift` — clean after regenerating CLI reference
- [x] Verified end-to-end against a real `ops` context: the example query above returns the new `connectedAssertion` payload.
- [x] Verified `--json list` now advertises `connectedAssertion` as a selectable field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)