### PR TITLE
fix(kg): repoint insights search at /v1/assertions/search (#670)

### DIFF
--- a/docs/reference/cli/gcx_kg_insights.md
+++ b/docs/reference/cli/gcx_kg_insights.md
@@ -27,7 +27,7 @@ Query Knowledge Graph insights.
 * [gcx kg insights example](gcx_kg_insights_example.md)	 - Print an example insights request YAML.
 * [gcx kg insights graph](gcx_kg_insights_graph.md)	 - Query insights with graph topology.
 * [gcx kg insights query](gcx_kg_insights_query.md)	 - Query insights for a time range.
-* [gcx kg insights search](gcx_kg_insights_search.md)	 - Search for insights matching a query.
+* [gcx kg insights search](gcx_kg_insights_search.md)	 - Find entities with active insights matching the given rules.
 * [gcx kg insights source-metrics](gcx_kg_insights_source-metrics.md)	 - Get source metrics for a specific insight.
 * [gcx kg insights summary](gcx_kg_insights_summary.md)	 - Get insights summary for a time range.
 

--- a/docs/reference/cli/gcx_kg_insights_search.md
+++ b/docs/reference/cli/gcx_kg_insights_search.md
@@ -1,24 +1,41 @@
 ## gcx kg insights search
 
-Search for insights matching a query.
+Find entities with active insights matching the given rules.
+
+### Synopsis
+
+Find entities with active insights matching the given rules.
+
+Backed by the same endpoint the Asserts UI's "Entities with Insights" panel uses.
+Each --insight flag is a separate rule (ORed together); severities are ANDed
+into every rule.
 
 ```
 gcx kg insights search [flags]
 ```
 
+### Examples
+
+```
+  gcx kg insights search --insight contains=Saturation
+  gcx kg insights search --insight equals=ErrorRatioBreach --severity critical
+  gcx kg insights search --severity critical,warning --namespace mimir-prod-01
+  gcx kg insights search --type Namespace --insight starts-with=Latency --since 1h
+```
+
 ### Options
 
 ```
-      --env string         Environment scope
-  -f, --file string        Input file (YAML)
-      --from string        Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
-  -h, --help               help for search
-      --name string        Entity name filter
-      --namespace string   Namespace scope
-      --since string       Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
-      --site string        Site scope
-      --to string          End time (RFC3339, Unix timestamp, or relative like 'now')
-      --type string        Entity type filter
+      --env string            Environment scope
+      --from string           Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
+  -h, --help                  help for search
+      --insight stringArray   Insight-name rule: op=value where op is contains, starts-with, or equals (repeatable; rules are ORed)
+      --namespace string      Namespace scope
+      --severity strings      Filter by insight severity: critical, warning, info (comma-separated)
+      --since string          Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --site string           Site scope
+      --to string             End time (RFC3339, Unix timestamp, or relative like 'now')
+      --type string           Root entity type (e.g. Service, Namespace, Node) (default "Service")
 ```
 
 ### Options inherited from parent commands

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -33,6 +33,7 @@ const (
 	searchPath           = pluginResourcePath + "/asserts/api-server/v1/search"
 	searchAssertPath     = searchPath + "/assertions"
 	searchSamplePath     = searchPath + "/sample"
+	insightSearchPath    = pluginResourcePath + "/asserts/api-server/v1/assertions/search"
 	rulesPath            = pluginResourcePath + "/asserts/api-server/v1/config/prom-rules"
 	ruleByNameFmt        = rulesPath + "/%s"
 	modelRulesPath       = pluginResourcePath + "/asserts/api-server/v1/config/model-rules/"
@@ -467,6 +468,20 @@ func (c *Client) SearchAssertions(ctx context.Context, req SearchRequest) ([]Ass
 	}
 	if result == nil {
 		return []AssertionTimeline{}, nil
+	}
+	return result, nil
+}
+
+// SearchInsights finds entities with active assertions matching the given
+// label-matcher rules. Backed by POST /v1/assertions/search — the same endpoint
+// the Asserts UI's "Entities with Insights" panel uses.
+func (c *Client) SearchInsights(ctx context.Context, req InsightSearchRequest) ([]EntityKey, error) {
+	var result []EntityKey
+	if err := c.postJSON(ctx, insightSearchPath, req, &result); err != nil {
+		return nil, fmt.Errorf("kg: search insights: %w", err)
+	}
+	if result == nil {
+		return []EntityKey{}, nil
 	}
 	return result, nil
 }

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -228,7 +228,7 @@ func resolveEntityTypeAndName(cmd *cobra.Command, args []string) (string, string
 	name, _ := cmd.Flags().GetString("name")
 	entityType, _ := cmd.Flags().GetString("type")
 	if entityType == "" || name == "" {
-		return "", "", errors.New("entity type and name required: use positional arg (Type--Name) or --type/--name flags")
+		return "", "", errors.New("entity type and name required: use positional arg (Type--Name) or --type/--insight flags")
 	}
 	return entityType, name, nil
 }
@@ -972,7 +972,7 @@ func (o *scopesListOpts) setup(flags *pflag.FlagSet) {
 // Insights commands
 // ---------------------------------------------------------------------------
 
-//nolint:maintidx,gocyclo
+//nolint:maintidx
 func newAssertionsCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "insights",
@@ -1167,11 +1167,24 @@ func newAssertionsCommand(loader RESTConfigLoader) *cobra.Command {
 	}
 
 	// search subcommand
-	var searchAssertionsFile string
-	var searchAssertionsScope scopeFlags
+	var (
+		searchEntityType string
+		searchNames      []string
+		searchSeverities []string
+		searchScope      scopeFlags
+	)
 	searchCmd := &cobra.Command{
 		Use:   "search",
-		Short: "Search for insights matching a query.",
+		Short: "Find entities with active insights matching the given rules.",
+		Long: `Find entities with active insights matching the given rules.
+
+Backed by the same endpoint the Asserts UI's "Entities with Insights" panel uses.
+Each --insight flag is a separate rule (ORed together); severities are ANDed
+into every rule.`,
+		Example: `  gcx kg insights search --insight contains=Saturation
+  gcx kg insights search --insight equals=ErrorRatioBreach --severity critical
+  gcx kg insights search --severity critical,warning --namespace mimir-prod-01
+  gcx kg insights search --type Namespace --insight starts-with=Latency --since 1h`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
 			if err != nil {
@@ -1181,61 +1194,99 @@ func newAssertionsCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			var req SearchRequest
-			//nolint:nestif
-			if searchAssertionsFile != "" {
-				data, err := readFileOrStdin(cmd, searchAssertionsFile)
-				if err != nil {
-					return fmt.Errorf("failed to read file: %w", err)
-				}
-				if err := yaml.Unmarshal(data, &req); err != nil {
-					return fmt.Errorf("invalid YAML: %w", err)
-				}
-			} else {
-				entityType, _ := cmd.Flags().GetString("type")
-				entityName, _ := cmd.Flags().GetString("name")
-				startMs, endMs, err := searchAssertionsScope.resolveTime()
-				if err != nil {
-					return err
-				}
-				if err := searchAssertionsScope.validateScopes(cmd.Context(), client); err != nil {
-					return err
-				}
-				var filterCriteria []EntityMatcher
-				if entityType != "" || entityName != "" {
-					if entityType == "" {
-						entityType = "Service"
-					}
-					matcher := EntityMatcher{EntityType: entityType}
-					if entityName != "" {
-						matcher.PropertyMatchers = []PropertyMatcher{{Name: "name", Op: "=", Value: entityName}}
-					}
-					filterCriteria = []EntityMatcher{matcher}
-				}
-				req = SearchRequest{
-					TimeCriteria:   &TimeCriteria{Start: startMs, End: endMs},
-					FilterCriteria: filterCriteria,
-					ScopeCriteria:  searchAssertionsScope.scopeCriteria(),
-				}
+			startMs, endMs, err := searchScope.resolveTime()
+			if err != nil {
+				return err
 			}
-			if req.DefinitionId == nil {
-				one := 1
-				req.DefinitionId = &one
+			if err := searchScope.validateScopes(cmd.Context(), client); err != nil {
+				return err
 			}
-			result, err := client.SearchAssertions(cmd.Context(), req)
+			req, err := buildInsightSearchRequest(searchEntityType, searchNames, searchSeverities, searchScope.scopeCriteria(), startMs, endMs)
+			if err != nil {
+				return err
+			}
+			result, err := client.SearchInsights(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
 			return (&cmdio.Options{OutputFormat: "json"}).Encode(cmd.OutOrStdout(), result)
 		},
 	}
-	searchCmd.Flags().StringVarP(&searchAssertionsFile, "file", "f", "", "Input file (YAML)")
-	searchCmd.Flags().String("type", "", "Entity type filter")
-	searchCmd.Flags().String("name", "", "Entity name filter")
-	searchAssertionsScope.register(searchCmd)
+	searchCmd.Flags().StringVar(&searchEntityType, "type", "Service", "Root entity type (e.g. Service, Namespace, Node)")
+	searchCmd.Flags().StringArrayVar(&searchNames, "insight", nil, "Insight-name rule: op=value where op is contains, starts-with, or equals (repeatable; rules are ORed)")
+	searchCmd.Flags().StringSliceVar(&searchSeverities, "severity", nil, "Filter by insight severity: critical, warning, info (comma-separated)")
+	searchScope.register(searchCmd)
+	searchCmd.MarkFlagsOneRequired("insight", "severity")
 
 	cmd.AddCommand(queryCmd, summaryCmd, graphCmd, entityMetricCmd, sourceMetricsCmd, exampleCmd, searchCmd)
 	return cmd
+}
+
+// insightNameLabel and insightSeverityLabel are the backend label names that
+// drive the Assertion Search endpoint. The CLI surfaces "insight" as the
+// user-facing term; the wire labels use the legacy "asserts_" prefix.
+const (
+	insightNameLabel     = "asserts_assertion_name"
+	insightSeverityLabel = "asserts_severity"
+)
+
+// buildInsightSearchRequest assembles the request body for
+// POST /v1/assertions/search from CLI flags. Each --insight flag becomes
+// its own rule group; --insight-severity values are appended into every group
+// so they AND with the name filter (matching the UI's setSeverity behavior).
+// When only severities are given, an "IS NOT NULL" name matcher is seeded so
+// the severity matchers have somewhere to attach.
+func buildInsightSearchRequest(entityType string, insightNames, severities []string, scope *ScopeCriteria, startMs, endMs int64) (InsightSearchRequest, error) {
+	nameOps := map[string]string{
+		"contains":    "CONTAINS",
+		"starts-with": "STARTS WITH",
+		"equals":      "=",
+	}
+
+	severityMatchers := make([]LabelMatcher, 0, len(severities))
+	for _, sev := range severities {
+		sev = strings.TrimSpace(sev)
+		if sev == "" {
+			continue
+		}
+		severityMatchers = append(severityMatchers, LabelMatcher{
+			Name:  insightSeverityLabel,
+			Op:    "=",
+			Value: sev,
+		})
+	}
+
+	groups := make([]InsightSearchCriteria, 0, len(insightNames))
+	for _, raw := range insightNames {
+		op, value, ok := strings.Cut(raw, "=")
+		if !ok {
+			return InsightSearchRequest{}, fmt.Errorf("invalid --insight %q: expected op=value where op is one of contains, starts-with, equals", raw)
+		}
+		wireOp, ok := nameOps[strings.ToLower(strings.TrimSpace(op))]
+		if !ok {
+			return InsightSearchRequest{}, fmt.Errorf("invalid --insight op %q: must be one of contains, starts-with, equals", op)
+		}
+		matchers := make([]LabelMatcher, 0, 1+len(severityMatchers))
+		matchers = append(matchers, LabelMatcher{Name: insightNameLabel, Op: wireOp, Value: value})
+		matchers = append(matchers, severityMatchers...)
+		groups = append(groups, InsightSearchCriteria{LabelMatchers: matchers})
+	}
+
+	if len(groups) == 0 {
+		// Severity-only call — seed an "any name" matcher so severity has a group.
+		// The backend rejects CONTAINS "" so we use IS NOT NULL instead.
+		matchers := make([]LabelMatcher, 0, 1+len(severityMatchers))
+		matchers = append(matchers, LabelMatcher{Name: insightNameLabel, Op: "IS NOT NULL"})
+		matchers = append(matchers, severityMatchers...)
+		groups = []InsightSearchCriteria{{LabelMatchers: matchers}}
+	}
+
+	return InsightSearchRequest{
+		EntityType:     entityType,
+		SearchCriteria: groups,
+		ScopeCriteria:  scope,
+		TimeCriteria:   &TimeCriteria{Start: startMs, End: endMs},
+	}, nil
 }
 
 func buildAssertionsRequestFromFlags(cmd *cobra.Command, args []string, client *Client) (AssertionsRequest, error) {

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -228,7 +228,7 @@ func resolveEntityTypeAndName(cmd *cobra.Command, args []string) (string, string
 	name, _ := cmd.Flags().GetString("name")
 	entityType, _ := cmd.Flags().GetString("type")
 	if entityType == "" || name == "" {
-		return "", "", errors.New("entity type and name required: use positional arg (Type--Name) or --type/--insight flags")
+		return "", "", errors.New("entity type and name required: use positional arg (Type--Name) or --type/--name flags")
 	}
 	return entityType, name, nil
 }
@@ -1232,8 +1232,8 @@ const (
 
 // buildInsightSearchRequest assembles the request body for
 // POST /v1/assertions/search from CLI flags. Each --insight flag becomes
-// its own rule group; --insight-severity values are appended into every group
-// so they AND with the name filter (matching the UI's setSeverity behavior).
+// its own rule group; --severity values are appended into every group so they
+// AND with the name filter (matching the UI's setSeverity behavior).
 // When only severities are given, an "IS NOT NULL" name matcher is seeded so
 // the severity matchers have somewhere to attach.
 func buildInsightSearchRequest(entityType string, insightNames, severities []string, scope *ScopeCriteria, startMs, endMs int64) (InsightSearchRequest, error) {

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -19,3 +19,8 @@ func (f ScopeFlags) ValidateScopes(ctx context.Context, c *Client) error {
 func FilterBySeverity(results []SearchResult, sev string) []SearchResult {
 	return filterBySeverity(results, sev)
 }
+
+// BuildInsightSearchRequest exposes buildInsightSearchRequest for tests.
+//
+//nolint:gochecknoglobals // Test-only export alias.
+var BuildInsightSearchRequest = buildInsightSearchRequest

--- a/internal/providers/kg/insight_search_test.go
+++ b/internal/providers/kg/insight_search_test.go
@@ -1,0 +1,95 @@
+package kg_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/kg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildInsightSearchRequest(t *testing.T) {
+	scope := &kg.ScopeCriteria{NameAndValues: map[string][]string{"env": {"prod"}}}
+
+	t.Run("single name rule maps op", func(t *testing.T) {
+		req, err := kg.BuildInsightSearchRequest("Service", []string{"contains=Saturation"}, nil, nil, 100, 200)
+		require.NoError(t, err)
+		assert.Equal(t, "Service", req.EntityType)
+		require.Len(t, req.SearchCriteria, 1)
+		assert.Equal(t, []kg.LabelMatcher{
+			{Name: "asserts_assertion_name", Op: "CONTAINS", Value: "Saturation"},
+		}, req.SearchCriteria[0].LabelMatchers)
+		assert.Equal(t, &kg.TimeCriteria{Start: 100, End: 200}, req.TimeCriteria)
+		assert.Nil(t, req.ScopeCriteria)
+	})
+
+	t.Run("ops are case-insensitive and cover all three", func(t *testing.T) {
+		req, err := kg.BuildInsightSearchRequest("Service", []string{
+			"CONTAINS=foo",
+			"starts-with=bar",
+			"Equals=baz",
+		}, nil, nil, 0, 0)
+		require.NoError(t, err)
+		require.Len(t, req.SearchCriteria, 3)
+		assert.Equal(t, "CONTAINS", req.SearchCriteria[0].LabelMatchers[0].Op)
+		assert.Equal(t, "STARTS WITH", req.SearchCriteria[1].LabelMatchers[0].Op)
+		assert.Equal(t, "=", req.SearchCriteria[2].LabelMatchers[0].Op)
+	})
+
+	t.Run("severity matchers AND into every rule group", func(t *testing.T) {
+		req, err := kg.BuildInsightSearchRequest("Service",
+			[]string{"contains=foo", "equals=bar"},
+			[]string{"critical", "warning"},
+			nil, 0, 0)
+		require.NoError(t, err)
+		require.Len(t, req.SearchCriteria, 2)
+		for _, group := range req.SearchCriteria {
+			require.Len(t, group.LabelMatchers, 3)
+			assert.Equal(t, "asserts_assertion_name", group.LabelMatchers[0].Name)
+			assert.Equal(t, kg.LabelMatcher{Name: "asserts_severity", Op: "=", Value: "critical"}, group.LabelMatchers[1])
+			assert.Equal(t, kg.LabelMatcher{Name: "asserts_severity", Op: "=", Value: "warning"}, group.LabelMatchers[2])
+		}
+	})
+
+	t.Run("severity-only call seeds IS NOT NULL name matcher", func(t *testing.T) {
+		req, err := kg.BuildInsightSearchRequest("Service", nil, []string{"critical"}, nil, 0, 0)
+		require.NoError(t, err)
+		require.Len(t, req.SearchCriteria, 1)
+		assert.Equal(t, []kg.LabelMatcher{
+			{Name: "asserts_assertion_name", Op: "IS NOT NULL"},
+			{Name: "asserts_severity", Op: "=", Value: "critical"},
+		}, req.SearchCriteria[0].LabelMatchers)
+	})
+
+	t.Run("blank severities are skipped", func(t *testing.T) {
+		req, err := kg.BuildInsightSearchRequest("Service",
+			[]string{"contains=foo"},
+			[]string{"", " ", "critical"},
+			nil, 0, 0)
+		require.NoError(t, err)
+		require.Len(t, req.SearchCriteria, 1)
+		require.Len(t, req.SearchCriteria[0].LabelMatchers, 2)
+		assert.Equal(t, "critical", req.SearchCriteria[0].LabelMatchers[1].Value)
+	})
+
+	t.Run("scope and time propagate through", func(t *testing.T) {
+		req, err := kg.BuildInsightSearchRequest("Namespace",
+			[]string{"contains=foo"}, nil, scope, 1000, 2000)
+		require.NoError(t, err)
+		assert.Equal(t, "Namespace", req.EntityType)
+		assert.Equal(t, scope, req.ScopeCriteria)
+		assert.Equal(t, &kg.TimeCriteria{Start: 1000, End: 2000}, req.TimeCriteria)
+	})
+
+	t.Run("missing = returns error", func(t *testing.T) {
+		_, err := kg.BuildInsightSearchRequest("Service", []string{"Saturation"}, nil, nil, 0, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected op=value")
+	})
+
+	t.Run("unknown op returns error", func(t *testing.T) {
+		_, err := kg.BuildInsightSearchRequest("Service", []string{"matches=foo"}, nil, nil, 0, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be one of contains, starts-with, equals")
+	})
+}

--- a/internal/providers/kg/types.go
+++ b/internal/providers/kg/types.go
@@ -92,6 +92,31 @@ type SearchRequest struct {
 	PageNum        int               `json:"pageNum" yaml:"pageNum"`
 }
 
+// LabelMatcher is one filter within an InsightSearchCriteria group. The backend
+// matches on assertion-rule labels such as asserts_assertion_name and
+// asserts_severity. Op uses MatcherOp values: "=", "<>", "CONTAINS",
+// "STARTS WITH", "ENDS WITH", "IS NULL", "IS NOT NULL", "<", ">", "<=", ">=",
+// "IN".
+type LabelMatcher struct {
+	Name  string `json:"name" yaml:"name"`
+	Op    string `json:"op" yaml:"op"`
+	Value string `json:"value" yaml:"value"`
+}
+
+// InsightSearchCriteria is one rule group. Label matchers within a group are
+// ANDed; multiple groups in an InsightSearchRequest are ORed.
+type InsightSearchCriteria struct {
+	LabelMatchers []LabelMatcher `json:"labelMatchers" yaml:"labelMatchers"`
+}
+
+// InsightSearchRequest is the request body for POST /v1/assertions/search.
+type InsightSearchRequest struct {
+	EntityType     string                  `json:"entityType" yaml:"entityType"`
+	SearchCriteria []InsightSearchCriteria `json:"searchCriteria" yaml:"searchCriteria"`
+	ScopeCriteria  *ScopeCriteria          `json:"scopeCriteria,omitempty" yaml:"scopeCriteria,omitempty"`
+	TimeCriteria   *TimeCriteria           `json:"timeCriteria,omitempty" yaml:"timeCriteria,omitempty"`
+}
+
 // SampleSearchRequest is the request body for POST /v1/search/sample.
 type SampleSearchRequest struct {
 	TimeCriteria   *TimeCriteria   `json:"timeCriteria,omitempty" yaml:"timeCriteria,omitempty"`


### PR DESCRIPTION
## Summary

- `gcx kg insights search` was hitting `/v1/search/assertions` (generic graph search) with a `SearchRequest` payload. With no flags this returned HTTP 500 (`filterCriteria null`); with `--type` alone it returned HTTP 422. That's the wrong endpoint — the Asserts UI's "Entities with Insights" panel uses `/v1/assertions/search` with a label-matcher rule DSL.
- Repointed the command at `/v1/assertions/search` and reshaped flags to match the UI's model (`--type`, `--insight op=value` repeatable, `--severity` comma-list). Added required-flag guard so empty calls fail fast with a usage error instead of a server 500.

## Flag surface

| Flag | Purpose |
|---|---|
| `--type` | Root entity type, default `Service` |
| `--insight` | Insight-name rule `op=value` (`contains`/`starts-with`/`equals`); repeatable, ORed |
| `--severity` | Comma-list of `critical,warning,info`; ANDed into every rule |
| `--env`/`--namespace`/`--site`/`--from`/`--to`/`--since` | Shared scope/time flags |

`MarkFlagsOneRequired("insight", "severity")` shields users from the server's 500 on empty `searchCriteria` (the backend validator allows empty but PromQL fails on the resulting empty query). Severity-only calls seed an `asserts_assertion_name IS NOT NULL` matcher so severity has a group to attach to.

## Test plan

- [x] `gcx kg insights search` → "At least one of the flags in the group [insight severity] is required"
- [x] `gcx kg insights search --insight foo=bar` → "Invalid --insight op \"foo\": must be one of contains, starts-with, equals"
- [x] `gcx kg insights search --insight contains=Saturation` → returns entity list
- [x] `gcx kg insights search --severity critical` alone → returns entity list (severity-only seeding works)
- [x] `gcx kg insights search --type Namespace --insight starts-with=Latency --since 1h` → returns namespace results
- [x] Unit tests added for `buildInsightSearchRequest` (8 cases covering op mapping, severity AND-ing, seed behavior, validation errors)
- [x] `GCX_AGENT_MODE=false mise run all` — tests, build, docs all pass; lint findings limited to sibling worktrees

Fixes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)