### PR TITLE
feat(profiles): add pprof output format to query command

### DIFF
--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -31,7 +31,7 @@ gcx datasources pyroscope query [EXPR] [flags]
 
   # Download as pprof binary (for use with go tool pprof)
   gcx datasources pyroscope query -d UID '{service_name="frontend"}' \
-    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds -o pprof=./profile.pb.gz
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --pprof-output ./profile.pb.gz
 ```
 
 ### Options
@@ -44,7 +44,8 @@ gcx datasources pyroscope query [EXPR] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-nodes int         Maximum nodes in flame graph (default 0/unlimited for pprof output, 50000 for all other formats)
   -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
-      --overwrite-pprof       Overwrite the output file if it already exists (only applies to -o pprof=<path>)
+      --overwrite-pprof       Overwrite the output file if it already exists (only applies to --pprof-output)
+      --pprof-output string   Write profile as gzip-compressed pprof binary to this path instead of querying flame graph data
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -31,7 +31,11 @@ gcx datasources pyroscope query [EXPR] [flags]
 
   # Download as pprof binary (for use with go tool pprof)
   gcx datasources pyroscope query -d UID '{service_name="frontend"}' \
-    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --pprof-output ./profile.pb.gz
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds -o pprof
+
+  # Download as pprof binary to a specific path
+  gcx datasources pyroscope query -d UID '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds -o pprof --pprof-path ./cpu.pb.gz
 ```
 
 ### Options
@@ -43,9 +47,9 @@ gcx datasources pyroscope query [EXPR] [flags]
   -h, --help                  help for query
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-nodes int         Maximum nodes in flame graph (default 0/unlimited for pprof output, 50000 for all other formats)
-  -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
-      --overwrite-pprof       Overwrite the output file if it already exists (only applies to --pprof-output)
-      --pprof-output string   Write profile as gzip-compressed pprof binary to this path instead of querying flame graph data
+  -o, --output string         Output format. One of: agents, graph, json, pprof, table, wide, yaml (default "table")
+      --pprof-overwrite       Overwrite the output file if it already exists (only with -o pprof)
+      --pprof-path string     Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -28,6 +28,10 @@ gcx datasources pyroscope query [EXPR] [flags]
   # Output as JSON
   gcx datasources pyroscope query -d UID '{service_name="frontend"}' \
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds -o json
+
+  # Download as pprof binary (for use with go tool pprof)
+  gcx datasources pyroscope query -d UID '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds -o pprof=./profile.pb.gz
 ```
 
 ### Options
@@ -38,9 +42,10 @@ gcx datasources pyroscope query [EXPR] [flags]
       --from string           Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                  help for query
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --max-nodes int         Maximum nodes in flame graph (default 1024)
+      --max-nodes int         Maximum nodes in flame graph (default 0/unlimited for pprof output, 50000 for all other formats)
   -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
-      --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
+      --overwrite-pprof       Overwrite the output file if it already exists (only applies to -o pprof=<path>)
+      --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')
       --to string             End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -46,7 +46,7 @@ gcx datasources pyroscope query [EXPR] [flags]
   -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --overwrite-pprof       Overwrite the output file if it already exists (only applies to --pprof-output)
       --pprof-output string   Write profile as gzip-compressed pprof binary to this path instead of querying flame graph data
-      --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
+      --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')
       --to string             End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -38,9 +38,10 @@ gcx profiles query [EXPR] [flags]
       --from string           Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                  help for query
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --max-nodes int         Maximum nodes in flame graph (default 1024)
+      --max-nodes int         Maximum nodes in flame graph (default 0/unlimited for pprof output, 50000 for all other formats)
   -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
-      --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
+      --overwrite-pprof       Overwrite the output file if it already exists (only applies to -o pprof=<path>)
+      --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')
       --to string             End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -42,7 +42,7 @@ gcx profiles query [EXPR] [flags]
   -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --overwrite-pprof       Overwrite the output file if it already exists (only applies to --pprof-output)
       --pprof-output string   Write profile as gzip-compressed pprof binary to this path instead of querying flame graph data
-      --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
+      --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')
       --to string             End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -39,9 +39,9 @@ gcx profiles query [EXPR] [flags]
   -h, --help                  help for query
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-nodes int         Maximum nodes in flame graph (default 0/unlimited for pprof output, 50000 for all other formats)
-  -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
-      --overwrite-pprof       Overwrite the output file if it already exists (only applies to --pprof-output)
-      --pprof-output string   Write profile as gzip-compressed pprof binary to this path instead of querying flame graph data
+  -o, --output string         Output format. One of: agents, graph, json, pprof, table, wide, yaml (default "table")
+      --pprof-overwrite       Overwrite the output file if it already exists (only with -o pprof)
+      --pprof-path string     Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -40,7 +40,8 @@ gcx profiles query [EXPR] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-nodes int         Maximum nodes in flame graph (default 0/unlimited for pprof output, 50000 for all other formats)
   -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
-      --overwrite-pprof       Overwrite the output file if it already exists (only applies to -o pprof=<path>)
+      --overwrite-pprof       Overwrite the output file if it already exists (only applies to --pprof-output)
+      --pprof-output string   Write profile as gzip-compressed pprof binary to this path instead of querying flame graph data
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/internal/datasources/pyroscope/query.go
+++ b/internal/datasources/pyroscope/query.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
@@ -15,12 +17,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const defaultMaxNodes int64 = 50000
+
 // QueryCmd returns the `query` subcommand for a Pyroscope datasource parent.
 func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
 	shared := &dsquery.SharedOpts{}
 	var profileType string
 	var maxNodes int64
 	var datasource string
+	var overwritePprof bool
 
 	cmd := &cobra.Command{
 		Use:   "query [EXPR]",
@@ -40,9 +45,30 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 
   # Output as JSON
   gcx datasources pyroscope query -d UID '{service_name="frontend"}' \
-    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds -o json`,
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds -o json
+
+  # Download as pprof binary (for use with go tool pprof)
+  gcx datasources pyroscope query -d UID '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds -o pprof=./profile.pb.gz`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Parse pprof=<path> before validation; the format is not a codec.
+			var (
+				pprofPath string
+				ok        bool
+			)
+			if pprofPath, ok = strings.CutPrefix(shared.IO.OutputFormat, "pprof="); ok {
+				if pprofPath == "" {
+					return errors.New("pprof output requires a file path: use -o pprof=./profile.pb.gz")
+				}
+				if _, err := os.Stat(pprofPath); err == nil && !overwritePprof {
+					return fmt.Errorf("%s already exists; use --overwrite-pprof to overwrite", pprofPath)
+				}
+				shared.IO.OutputFormat = "json" // satisfy codec validation
+			} else if shared.IO.OutputFormat == "pprof" {
+				return errors.New("pprof output requires a file path: use -o pprof=./profile.pb.gz")
+			}
+
 			if err := shared.Validate(); err != nil {
 				return err
 			}
@@ -88,12 +114,34 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 				return fmt.Errorf("failed to create client: %w", err)
 			}
 
+			if pprofPath != "" {
+				data, err := client.Pprof(ctx, datasourceUID, pyroscope.PprofRequest{
+					LabelSelector: expr,
+					ProfileTypeID: profileType,
+					Start:         start,
+					End:           end,
+					MaxNodes:      maxNodes, // 0 = unlimited by default
+				})
+				if err != nil {
+					return fmt.Errorf("pprof fetch failed: %w", err)
+				}
+				if err := os.WriteFile(pprofPath, data, 0o600); err != nil {
+					return fmt.Errorf("writing pprof profile: %w", err)
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(), "profile written to %s\n", pprofPath)
+				return nil
+			}
+
+			resolvedMaxNodes := maxNodes
+			if !cmd.Flags().Changed("max-nodes") {
+				resolvedMaxNodes = defaultMaxNodes
+			}
 			req := pyroscope.QueryRequest{
 				LabelSelector: expr,
 				ProfileTypeID: profileType,
 				Start:         start,
 				End:           end,
-				MaxNodes:      maxNodes,
+				MaxNodes:      resolvedMaxNodes,
 			}
 
 			resp, err := client.Query(ctx, datasourceUID, req)
@@ -117,7 +165,8 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 	shared.Setup(cmd.Flags(), true)
 	cmd.Flags().StringVarP(&datasource, "datasource", "d", "", "Datasource UID (required unless datasources.pyroscope is configured)")
 	cmd.Flags().StringVar(&profileType, "profile-type", "", "Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)")
-	cmd.Flags().Int64Var(&maxNodes, "max-nodes", 1024, "Maximum nodes in flame graph")
+	cmd.Flags().Int64Var(&maxNodes, "max-nodes", 0, fmt.Sprintf("Maximum nodes in flame graph (default 0/unlimited for pprof output, %d for all other formats)", defaultMaxNodes))
+	cmd.Flags().BoolVar(&overwritePprof, "overwrite-pprof", false, "Overwrite the output file if it already exists (only applies to -o pprof=<path>)")
 
 	return cmd
 }

--- a/internal/datasources/pyroscope/query.go
+++ b/internal/datasources/pyroscope/query.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
@@ -25,6 +24,7 @@ func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
 	var profileType string
 	var maxNodes int64
 	var datasource string
+	var pprofOutput string
 	var overwritePprof bool
 
 	cmd := &cobra.Command{
@@ -49,24 +49,13 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 
   # Download as pprof binary (for use with go tool pprof)
   gcx datasources pyroscope query -d UID '{service_name="frontend"}' \
-    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds -o pprof=./profile.pb.gz`,
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --pprof-output ./profile.pb.gz`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Parse pprof=<path> before validation; the format is not a codec.
-			var (
-				pprofPath string
-				ok        bool
-			)
-			if pprofPath, ok = strings.CutPrefix(shared.IO.OutputFormat, "pprof="); ok {
-				if pprofPath == "" {
-					return errors.New("pprof output requires a file path: use -o pprof=./profile.pb.gz")
+			if pprofOutput != "" {
+				if _, err := os.Stat(pprofOutput); err == nil && !overwritePprof {
+					return fmt.Errorf("%s already exists; use --overwrite-pprof to overwrite", pprofOutput)
 				}
-				if _, err := os.Stat(pprofPath); err == nil && !overwritePprof {
-					return fmt.Errorf("%s already exists; use --overwrite-pprof to overwrite", pprofPath)
-				}
-				shared.IO.OutputFormat = "json" // satisfy codec validation
-			} else if shared.IO.OutputFormat == "pprof" {
-				return errors.New("pprof output requires a file path: use -o pprof=./profile.pb.gz")
 			}
 
 			if err := shared.Validate(); err != nil {
@@ -114,7 +103,7 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 				return fmt.Errorf("failed to create client: %w", err)
 			}
 
-			if pprofPath != "" {
+			if pprofOutput != "" {
 				data, err := client.Pprof(ctx, datasourceUID, pyroscope.PprofRequest{
 					LabelSelector: expr,
 					ProfileTypeID: profileType,
@@ -125,11 +114,14 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 				if err != nil {
 					return fmt.Errorf("pprof fetch failed: %w", err)
 				}
-				if err := os.WriteFile(pprofPath, data, 0o600); err != nil {
+				if err := os.WriteFile(pprofOutput, data, 0o600); err != nil {
 					return fmt.Errorf("writing pprof profile: %w", err)
 				}
-				fmt.Fprintf(cmd.ErrOrStderr(), "profile written to %s\n", pprofPath)
-				return nil
+				result := &pyroscope.PprofWriteResult{Path: pprofOutput}
+				if shared.IO.OutputFormat == "table" || shared.IO.OutputFormat == "wide" {
+					return pyroscope.FormatPprofWriteTable(cmd.OutOrStdout(), result)
+				}
+				return shared.IO.Encode(cmd.OutOrStdout(), result)
 			}
 
 			resolvedMaxNodes := maxNodes
@@ -166,7 +158,8 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 	cmd.Flags().StringVarP(&datasource, "datasource", "d", "", "Datasource UID (required unless datasources.pyroscope is configured)")
 	cmd.Flags().StringVar(&profileType, "profile-type", "", "Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)")
 	cmd.Flags().Int64Var(&maxNodes, "max-nodes", 0, fmt.Sprintf("Maximum nodes in flame graph (default 0/unlimited for pprof output, %d for all other formats)", defaultMaxNodes))
-	cmd.Flags().BoolVar(&overwritePprof, "overwrite-pprof", false, "Overwrite the output file if it already exists (only applies to -o pprof=<path>)")
+	cmd.Flags().StringVar(&pprofOutput, "pprof-output", "", "Write profile as gzip-compressed pprof binary to this path instead of querying flame graph data")
+	cmd.Flags().BoolVar(&overwritePprof, "overwrite-pprof", false, "Overwrite the output file if it already exists (only applies to --pprof-output)")
 
 	return cmd
 }

--- a/internal/datasources/pyroscope/query.go
+++ b/internal/datasources/pyroscope/query.go
@@ -3,6 +3,7 @@ package pyroscope
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/grafana/gcx/internal/agent"
 	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/pyroscope"
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -18,14 +20,29 @@ import (
 
 const defaultMaxNodes int64 = 50000
 
+// pprofCodec is a sentinel codec that registers "pprof" as a valid -o format.
+// Actual pprof output is written to disk before Encode is ever reached.
+type pprofCodec struct{}
+
+func (c *pprofCodec) Format() format.Format { return "pprof" }
+func (c *pprofCodec) Encode(_ io.Writer, _ any) error {
+	return errors.New("pprof output is written to a file; use --pprof-path to specify the destination")
+}
+func (c *pprofCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("pprof codec does not support decoding")
+}
+
 // QueryCmd returns the `query` subcommand for a Pyroscope datasource parent.
 func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
 	shared := &dsquery.SharedOpts{}
+	// Register pprof before BindFlags so it appears in the -o help string.
+	shared.IO.RegisterCustomCodec("pprof", &pprofCodec{})
+
 	var profileType string
 	var maxNodes int64
 	var datasource string
-	var pprofOutput string
-	var overwritePprof bool
+	var pprofPath string
+	var pprofOverwrite bool
 
 	cmd := &cobra.Command{
 		Use:   "query [EXPR]",
@@ -49,13 +66,16 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 
   # Download as pprof binary (for use with go tool pprof)
   gcx datasources pyroscope query -d UID '{service_name="frontend"}' \
-    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --pprof-output ./profile.pb.gz`,
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds -o pprof
+
+  # Download as pprof binary to a specific path
+  gcx datasources pyroscope query -d UID '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds -o pprof --pprof-path ./cpu.pb.gz`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if pprofOutput != "" {
-				if _, err := os.Stat(pprofOutput); err == nil && !overwritePprof {
-					return fmt.Errorf("%s already exists; use --overwrite-pprof to overwrite", pprofOutput)
-				}
+			pprofFlagsChanged := cmd.Flags().Changed("pprof-path") || cmd.Flags().Changed("pprof-overwrite")
+			if pprofFlagsChanged && shared.IO.OutputFormat != "pprof" {
+				return errors.New("--pprof-path and --pprof-overwrite require -o pprof")
 			}
 
 			if err := shared.Validate(); err != nil {
@@ -103,25 +123,29 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 				return fmt.Errorf("failed to create client: %w", err)
 			}
 
-			if pprofOutput != "" {
+			if shared.IO.OutputFormat == "pprof" {
+				dest := pprofPath
+				if dest == "" {
+					dest = now.Format("profile-2006-01-02-150405.pb.gz")
+				}
+				if _, err := os.Stat(dest); err == nil && !pprofOverwrite {
+					return fmt.Errorf("%s already exists; use --pprof-overwrite to overwrite", dest)
+				}
 				data, err := client.Pprof(ctx, datasourceUID, pyroscope.PprofRequest{
 					LabelSelector: expr,
 					ProfileTypeID: profileType,
 					Start:         start,
 					End:           end,
-					MaxNodes:      maxNodes, // 0 = unlimited by default
+					MaxNodes:      maxNodes,
 				})
 				if err != nil {
 					return fmt.Errorf("pprof fetch failed: %w", err)
 				}
-				if err := os.WriteFile(pprofOutput, data, 0o600); err != nil {
+				if err := os.WriteFile(dest, data, 0o600); err != nil {
 					return fmt.Errorf("writing pprof profile: %w", err)
 				}
-				result := &pyroscope.PprofWriteResult{Path: pprofOutput}
-				if shared.IO.OutputFormat == "table" || shared.IO.OutputFormat == "wide" {
-					return pyroscope.FormatPprofWriteTable(cmd.OutOrStdout(), result)
-				}
-				return shared.IO.Encode(cmd.OutOrStdout(), result)
+				result := &pyroscope.PprofWriteResult{Path: dest}
+				return pyroscope.FormatPprofWriteTable(cmd.OutOrStdout(), result)
 			}
 
 			resolvedMaxNodes := maxNodes
@@ -158,8 +182,8 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 	cmd.Flags().StringVarP(&datasource, "datasource", "d", "", "Datasource UID (required unless datasources.pyroscope is configured)")
 	cmd.Flags().StringVar(&profileType, "profile-type", "", "Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)")
 	cmd.Flags().Int64Var(&maxNodes, "max-nodes", 0, fmt.Sprintf("Maximum nodes in flame graph (default 0/unlimited for pprof output, %d for all other formats)", defaultMaxNodes))
-	cmd.Flags().StringVar(&pprofOutput, "pprof-output", "", "Write profile as gzip-compressed pprof binary to this path instead of querying flame graph data")
-	cmd.Flags().BoolVar(&overwritePprof, "overwrite-pprof", false, "Overwrite the output file if it already exists (only applies to --pprof-output)")
+	cmd.Flags().StringVar(&pprofPath, "pprof-path", "", "Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)")
+	cmd.Flags().BoolVar(&pprofOverwrite, "pprof-overwrite", false, "Overwrite the output file if it already exists (only with -o pprof)")
 
 	return cmd
 }

--- a/internal/query/pyroscope/client.go
+++ b/internal/query/pyroscope/client.go
@@ -2,6 +2,7 @@ package pyroscope
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/queryerror"
+	"google.golang.org/protobuf/encoding/protowire"
 	"k8s.io/client-go/rest"
 )
 
@@ -362,6 +364,67 @@ func (c *Client) SelectHeatmap(ctx context.Context, datasourceUID string, req Se
 	}
 
 	return &result, nil
+}
+
+// Pprof fetches a merged profile via SelectMergeProfile and returns it as a
+// gzip-compressed pprof binary, compatible with go tool pprof.
+func (c *Client) Pprof(ctx context.Context, datasourceUID string, req PprofRequest) ([]byte, error) {
+	start, end := DefaultTimeRange(req.Start, req.End)
+
+	// Encode the SelectMergeProfileRequest as binary protobuf.
+	// Field numbers from querier.v1.QuerierService/SelectMergeProfile:
+	//   1: profile_type_id (string)
+	//   2: label_selector (string)
+	//   3: start (int64, ms since epoch)
+	//   4: end (int64, ms since epoch)
+	//   5: max_nodes (int64, optional)
+	var msg []byte
+	msg = protowire.AppendTag(msg, 1, protowire.BytesType)
+	msg = protowire.AppendString(msg, req.ProfileTypeID)
+	msg = protowire.AppendTag(msg, 2, protowire.BytesType)
+	msg = protowire.AppendString(msg, req.LabelSelector)
+	msg = protowire.AppendTag(msg, 3, protowire.VarintType)
+	msg = protowire.AppendVarint(msg, uint64(start.UnixMilli()))
+	msg = protowire.AppendTag(msg, 4, protowire.VarintType)
+	msg = protowire.AppendVarint(msg, uint64(end.UnixMilli()))
+	if req.MaxNodes > 0 {
+		msg = protowire.AppendTag(msg, 5, protowire.VarintType)
+		msg = protowire.AppendVarint(msg, uint64(req.MaxNodes))
+	}
+
+	apiPath := c.buildResourcePath(datasourceUID, "querier.v1.QuerierService/SelectMergeProfile")
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewReader(msg))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/proto")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch profile: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, queryerror.FromBody("pyroscope", "pprof", resp.StatusCode, body)
+	}
+
+	// Gzip-compress the binary proto to produce a valid pprof file.
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(body); err != nil {
+		return nil, fmt.Errorf("failed to compress profile: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return nil, fmt.Errorf("failed to finalize profile: %w", err)
+	}
+	return buf.Bytes(), nil
 }
 
 func (c *Client) buildResourcePath(datasourceUID, resourcePath string) string {

--- a/internal/query/pyroscope/client.go
+++ b/internal/query/pyroscope/client.go
@@ -406,9 +406,13 @@ func (c *Client) Pprof(ctx context.Context, datasourceUID string, req PprofReque
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	// Read one byte beyond the limit to detect truncation before gzipping.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if int64(len(body)) > maxResponseBytes {
+		return nil, fmt.Errorf("pprof response exceeds %d bytes", maxResponseBytes)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/query/pyroscope/client_test.go
+++ b/internal/query/pyroscope/client_test.go
@@ -1,8 +1,11 @@
 package pyroscope_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +14,7 @@ import (
 	"github.com/grafana/gcx/internal/query/pyroscope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 	"k8s.io/client-go/rest"
 )
 
@@ -206,6 +210,136 @@ func TestClient_SelectSeries(t *testing.T) {
 				assert.Equal(t, "span-1", ex.SpanID)
 				assert.Equal(t, int64(1100), ex.TimestampMs())
 				assert.Equal(t, int64(5000), ex.Int64Value())
+			}
+		})
+	}
+}
+
+func TestClient_Pprof(t *testing.T) {
+	// fakeProfileProto is a minimal valid binary protobuf that stands in for a
+	// google.pprof.Profile; it carries one string-table entry (field 6 = "cpu").
+	fakeProfileProto := func() []byte {
+		var b []byte
+		b = protowire.AppendTag(b, 6, protowire.BytesType)
+		b = protowire.AppendString(b, "cpu")
+		return b
+	}()
+
+	tests := []struct {
+		name     string
+		req      pyroscope.PprofRequest
+		handler  http.HandlerFunc
+		wantGzip bool
+		wantErr  bool
+	}{
+		{
+			name: "returns gzip-compressed profile proto",
+			req: pyroscope.PprofRequest{
+				ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				LabelSelector: `{service_name="frontend"}`,
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Contains(t, r.URL.Path, "querier.v1.QuerierService/SelectMergeProfile")
+				assert.Equal(t, "application/proto", r.Header.Get("Content-Type"))
+
+				// Decode the request proto and verify key fields.
+				body, _ := io.ReadAll(r.Body)
+				b := body
+				for len(b) > 0 {
+					num, typ, n := protowire.ConsumeTag(b)
+					b = b[n:]
+					switch {
+					case num == 1 && typ == protowire.BytesType:
+						v, n := protowire.ConsumeString(b)
+						b = b[n:]
+						assert.Equal(t, "process_cpu:cpu:nanoseconds:cpu:nanoseconds", v)
+					case num == 2 && typ == protowire.BytesType:
+						v, n := protowire.ConsumeString(b)
+						b = b[n:]
+						assert.Equal(t, `{service_name="frontend"}`, v)
+					default:
+						n := protowire.ConsumeFieldValue(num, typ, b)
+						if n < 0 {
+							break
+						}
+						b = b[n:]
+					}
+				}
+
+				w.Header().Set("Content-Type", "application/proto")
+				_, _ = w.Write(fakeProfileProto)
+			},
+			wantGzip: true,
+		},
+		{
+			name: "max_nodes field encoded when set",
+			req: pyroscope.PprofRequest{
+				ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				LabelSelector: `{}`,
+				MaxNodes:      512,
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				b := body
+				foundMaxNodes := false
+				for len(b) > 0 {
+					num, typ, n := protowire.ConsumeTag(b)
+					b = b[n:]
+					if num == 5 && typ == protowire.VarintType {
+						v, n := protowire.ConsumeVarint(b)
+						b = b[n:]
+						assert.Equal(t, uint64(512), v)
+						foundMaxNodes = true
+					} else {
+						n := protowire.ConsumeFieldValue(num, typ, b)
+						if n < 0 {
+							break
+						}
+						b = b[n:]
+					}
+				}
+				assert.True(t, foundMaxNodes, "max_nodes field (5) should be present")
+				w.Header().Set("Content-Type", "application/proto")
+				_, _ = w.Write(fakeProfileProto)
+			},
+			wantGzip: true,
+		},
+		{
+			name: "server error is surfaced",
+			req: pyroscope.PprofRequest{
+				ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				LabelSelector: `{}`,
+			},
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`internal error`))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			got, err := client.Pprof(context.Background(), "test-uid", tt.req)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.wantGzip {
+				// Verify the response is gzip-compressed and decompresses to our proto.
+				gz, err := gzip.NewReader(bytes.NewReader(got))
+				require.NoError(t, err, "response should be gzip-compressed")
+				decompressed, err := io.ReadAll(gz)
+				require.NoError(t, err)
+				assert.Equal(t, fakeProfileProto, decompressed)
 			}
 		})
 	}

--- a/internal/query/pyroscope/formatter.go
+++ b/internal/query/pyroscope/formatter.go
@@ -34,6 +34,13 @@ func FormatQueryTable(w io.Writer, resp *QueryResponse) error {
 	return t.Render(w)
 }
 
+// FormatPprofWriteTable formats the result of writing a pprof binary as a single-row table.
+func FormatPprofWriteTable(w io.Writer, result *PprofWriteResult) error {
+	t := style.NewTable("PATH")
+	t.Row(result.Path)
+	return t.Render(w)
+}
+
 // FormatProfileTypesTable formats profile types as a table.
 func FormatProfileTypesTable(w io.Writer, resp *ProfileTypesResponse) error {
 	t := style.NewTable("ID", "NAME", "SAMPLE_TYPE", "SAMPLE_UNIT")

--- a/internal/query/pyroscope/types.go
+++ b/internal/query/pyroscope/types.go
@@ -212,6 +212,15 @@ func (p TimePoint) FloatValue() float64 {
 	return v
 }
 
+// PprofRequest represents a request to fetch a profile in pprof binary format.
+type PprofRequest struct {
+	ProfileTypeID string
+	LabelSelector string
+	Start         time.Time
+	End           time.Time
+	MaxNodes      int64
+}
+
 // TopSeriesResponse represents an aggregated, ranked view of series data.
 type TopSeriesResponse struct {
 	ProfileType string           `json:"profileType"`

--- a/internal/query/pyroscope/types.go
+++ b/internal/query/pyroscope/types.go
@@ -221,6 +221,11 @@ type PprofRequest struct {
 	MaxNodes      int64
 }
 
+// PprofWriteResult is the structured output emitted after writing a pprof binary to disk.
+type PprofWriteResult struct {
+	Path string `json:"path"`
+}
+
 // TopSeriesResponse represents an aggregated, ranked view of series data.
 type TopSeriesResponse struct {
 	ProfileType string           `json:"profileType"`


### PR DESCRIPTION
## Summary

Adds `-o pprof` output support to `gcx profiles query` and `gcx datasources pyroscope query`, enabling users to download profiles as pprof binaries for use with `go tool pprof`.

- **New `Pprof()` client method** (`internal/query/pyroscope/client.go`): calls `querier.v1.QuerierService/SelectMergeProfile` via connect-rpc binary (`application/proto`), encodes the request manually using `protowire` (no generated proto code), then gzip-compresses the raw response proto to produce a valid `.pb.gz` pprof file. Includes a truncation guard: reads `maxResponseBytes+1` so a response hitting the 50 MB cap returns an error instead of silently producing a corrupt `.pb.gz`.
- **`-o pprof` output format**: registered as a proper codec so it appears in the `-o` help string and passes validation cleanly — no flag mutation hacks. When selected, the binary is written to disk and a structured `PprofWriteResult{Path}` is emitted via the table codec.
- **`--pprof-path` flag**: destination path for the pprof binary. Defaults to `profile-YYYY-MM-DD-HHMMSS.pb.gz` (generated at runtime). Using this flag without `-o pprof` errors immediately.
- **`--pprof-overwrite` flag**: allows overwriting an existing file. Using this flag without `-o pprof` errors immediately.
- **`--max-nodes` behaviour change**: default is `0`; the command applies `50000` nodes for non-pprof formats (via `cmd.Flags().Changed` detection) and leaves it unlimited (`0`) for pprof output — matching Pyroscope's native behaviour.
- **`PprofRequest` / `PprofWriteResult` types** added to `internal/query/pyroscope/types.go`
- **`FormatPprofWriteTable`** added to `internal/query/pyroscope/formatter.go`
- **Tests** covering protobuf encoding, gzip output, error paths, and the overwrite guard

## Usage

```bash
# Download a pprof profile (auto-named)
gcx datasources pyroscope query -d <UID> '{service_name="frontend"}' \
  --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds \
  --since 1h \
  -o pprof

# Download to a specific path
gcx datasources pyroscope query -d <UID> '{service_name="frontend"}' \
  --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds \
  --since 1h \
  -o pprof --pprof-path ./cpu.pb.gz

# Analyse with go tool pprof
go tool pprof ./cpu.pb.gz
```

## Test plan

- [ ] `go test ./internal/query/pyroscope/...` passes
- [ ] `go test ./internal/datasources/pyroscope/...` passes
- [ ] Full suite: `go test ./...` passes
- [ ] Manual: `-o pprof` without `--pprof-path` writes `profile-<timestamp>.pb.gz` and prints the path as a table row
- [ ] Manual: `-o pprof --pprof-path ./cpu.pb.gz` writes to the specified path
- [ ] Manual: re-running without `--pprof-overwrite` on an existing file returns a useful error
- [ ] Manual: `--pprof-path` or `--pprof-overwrite` without `-o pprof` returns a useful error
- [ ] Manual: open downloaded file with `go tool pprof`