### PR TITLE
PoC of a `gcx cloud login` command

### DIFF
--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -503,7 +503,7 @@ func buildTokenRefresher(ctx context.Context, configOpts *cmdconfig.Options, ctx
 		}
 
 		// Do the refresh
-		rr, err := auth.DoRefresh(ctx, proxyEndpoint, refreshToken)
+		rr, err := auth.ProxyRefresh(ctx, proxyEndpoint, refreshToken)
 		if err != nil {
 			return token, err // return stale token on failure
 		}

--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -1,0 +1,173 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/internal/auth"
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/fail"
+	"github.com/spf13/cobra"
+)
+
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cloud",
+		Short: "Manage Grafana Cloud resources",
+	}
+
+	configOpts := &cmdconfig.Options{}
+	configOpts.BindFlags(cmd.PersistentFlags())
+
+	cmd.AddCommand(loginCmd(configOpts))
+
+	return cmd
+}
+
+const defaultClientID = "gcx"
+
+func loginCmd(configOpts *cmdconfig.Options) *cobra.Command {
+	var (
+		apiURL     string
+		scopes     []string
+		cloudToken string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate with the Grafana Cloud API (GCOM)",
+		Long: `Authenticate with the Grafana Cloud API and store the token in the gcx config.
+
+This is different from "gcx login", which authenticates to a specific
+Grafana stack instance. "gcx cloud login" authenticates against the
+Grafana Cloud platform API (grafana.com), enabling commands that manage
+Cloud resources like stacks and access policies.
+
+By default, opens a browser for interactive OAuth2 authentication where
+you can choose which scopes and organization to grant access to.
+
+For non-interactive use (CI/CD, scripts), pass a Cloud Access Policy token
+directly via --cloud-token.`,
+		Example: `  gcx cloud login
+  gcx cloud login --cloud-token glsa_abc123
+  gcx cloud login --api-url https://grafana-dev.com`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if cloudToken != "" {
+				return runTokenLogin(cmd.Context(), configOpts, cloudToken, apiURL)
+			}
+			return runOAuthLogin(cmd.Context(), configOpts, apiURL, scopes)
+		},
+	}
+
+	cmd.Flags().StringVar(&cloudToken, "cloud-token", "", "Cloud Access Policy token (skips interactive OAuth flow)")
+	cmd.Flags().StringVar(&apiURL, "api-url", "https://grafana.com", "GCOM API base URL")
+	cmd.Flags().StringSliceVar(&scopes, "scope", []string{
+		"stacks:read", "stacks:write", "stacks:delete",
+		"accesspolicies:read", "accesspolicies:write", "accesspolicies:delete",
+	}, "OAuth2 scopes to request")
+
+	return cmd
+}
+
+func runTokenLogin(ctx context.Context, configOpts *cmdconfig.Options, token, apiURL string) error {
+	cloud := &config.CloudConfig{
+		Token:  token,
+		APIUrl: apiURL,
+	}
+	if err := saveCloudConfig(ctx, configOpts, cloud); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "Cloud token saved.")
+	return nil
+}
+
+func runOAuthLogin(ctx context.Context, configOpts *cmdconfig.Options, apiURL string, scopes []string) error {
+	flow := auth.NewGCOMFlow(auth.GCOMOptions{
+		ClientID: defaultClientID,
+		GCOMURL:  apiURL,
+		Scopes:   scopes,
+		Writer:   os.Stderr,
+	})
+
+	result, err := flow.Run(ctx)
+	if err != nil {
+		return &fail.DetailedError{
+			Summary: "Authentication failed",
+			Parent:  err,
+			Suggestions: []string{
+				"Check that the GCOM API URL is correct",
+				"Ensure you are logged in to Grafana Cloud in your browser",
+				"Try again with: gcx cloud login --api-url <url>",
+			},
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Authenticated as %s (%s)\n", result.Info.Login, result.Info.Email)
+	fmt.Fprintf(os.Stderr, "Scopes: %s\n", result.Scope)
+	if result.OrgSlug != "" {
+		fmt.Fprintf(os.Stderr, "Organization: %s\n", result.OrgSlug)
+	}
+
+	cloud := &config.CloudConfig{
+		Token:            result.AccessToken,
+		TokenExpiresAt:   time.Now().Add(time.Duration(result.ExpiresIn) * time.Second).Format(time.RFC3339),
+		RefreshToken:     result.RefreshToken,
+		RefreshExpiresAt: result.RefreshExpiresAt,
+		Org:              result.OrgSlug,
+		APIUrl:           apiURL,
+	}
+	return saveCloudConfig(ctx, configOpts, cloud)
+}
+
+func saveCloudConfig(ctx context.Context, configOpts *cmdconfig.Options, cloud *config.CloudConfig) error {
+	source := configOpts.ConfigSource()
+	if source == nil {
+		source = config.StandardLocation()
+	}
+
+	cfg, err := config.Load(ctx, source)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return &fail.DetailedError{
+			Summary: "Failed to load config",
+			Parent:  err,
+			Suggestions: []string{
+				"Check your config file syntax: gcx config edit",
+				"Or reset with: rm ~/.config/gcx/config.yaml && gcx cloud login",
+			},
+		}
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		cfg = config.Config{}
+	}
+
+	contextName := cfg.CurrentContext
+	if contextName == "" {
+		contextName = config.DefaultContextName
+	}
+
+	if !cfg.HasContext(contextName) {
+		cfg.SetContext(contextName, true, config.Context{})
+	}
+	curCtx := cfg.Contexts[contextName]
+	// replace the entire cloud config — clears any stale OAuth fields
+	// when switching from OAuth to SA token or vice versa
+	curCtx.Cloud = cloud
+
+	if err := config.Write(ctx, source, cfg); err != nil {
+		return &fail.DetailedError{
+			Summary: "Failed to save config",
+			Parent:  err,
+			Suggestions: []string{
+				"Check file permissions on " + contextName,
+				"Try: gcx config edit",
+			},
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Token saved to context %q\n", contextName)
+	return nil
+}

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -12,6 +12,7 @@ import (
 	agentcmd "github.com/grafana/gcx/cmd/gcx/agent"
 	"github.com/grafana/gcx/cmd/gcx/api"
 	assistantcmd "github.com/grafana/gcx/cmd/gcx/assistant"
+	cloudcmd "github.com/grafana/gcx/cmd/gcx/cloud"
 	"github.com/grafana/gcx/cmd/gcx/commands"
 	"github.com/grafana/gcx/cmd/gcx/config"
 	"github.com/grafana/gcx/cmd/gcx/datasources"
@@ -226,6 +227,7 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 	rootCmd.AddCommand(agentcmd.Command())
 	rootCmd.AddCommand(api.Command())
 	rootCmd.AddCommand(assistantcmd.Command())
+	rootCmd.AddCommand(cloudcmd.Command())
 	rootCmd.AddCommand(logincmd.Command())
 	rootCmd.AddCommand(config.Command())
 	rootCmd.AddCommand(dev.Command())

--- a/internal/auth/cloud_refresh.go
+++ b/internal/auth/cloud_refresh.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// CloudRefreshTransportConfig holds the parameters for building a RefreshTransport
+// that refreshes tokens via the GCOM OAuth2 token endpoint.
+type CloudRefreshTransportConfig struct {
+	Base             http.RoundTripper
+	GCOMURL          string
+	ClientID         string
+	Token            string
+	RefreshToken     string
+	ExpiresAt        time.Time
+	RefreshExpiresAt time.Time
+}
+
+// NewCloudRefreshTransport returns a RefreshTransport that refreshes tokens
+// via the GCOM OAuth2 endpoint instead of the proxy refresh endpoint.
+func NewCloudRefreshTransport(cfg CloudRefreshTransportConfig) *RefreshTransport {
+	rt := &RefreshTransport{
+		Base:             cfg.Base,
+		Token:            cfg.Token,
+		RefreshToken:     cfg.RefreshToken,
+		ExpiresAt:        cfg.ExpiresAt,
+		RefreshExpiresAt: cfg.RefreshExpiresAt,
+	}
+
+	rt.DoRefresh = func(ctx context.Context, refreshToken string) (RefreshResult, error) {
+		return doGCOMRefresh(ctx, rt.base(), cfg.GCOMURL, cfg.ClientID, refreshToken)
+	}
+
+	return rt
+}
+
+// gcomRefreshResponse holds the parsed response from a GCOM token refresh.
+type gcomRefreshResponse struct {
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token"`
+	RefreshExpiresAt string `json:"refresh_expires_at"`
+	ExpiresIn        int    `json:"expires_in"`
+}
+
+func doGCOMRefresh(ctx context.Context, base http.RoundTripper, gcomURL, clientID, refreshToken string) (RefreshResult, error) {
+	body, err := json.Marshal(map[string]string{
+		"grant_type":    "refresh_token",
+		"client_id":     clientID,
+		"refresh_token": refreshToken,
+	})
+	if err != nil {
+		return RefreshResult{}, err
+	}
+
+	refreshURL := gcomURL + "/api/oauth2/token"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, refreshURL, bytes.NewReader(body))
+	if err != nil {
+		return RefreshResult{}, fmt.Errorf("failed to build cloud refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := base.RoundTrip(req)
+	if err != nil {
+		return RefreshResult{}, fmt.Errorf("cloud refresh request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	limitedBody := io.LimitReader(resp.Body, maxResponseBytes)
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		respBody, _ := io.ReadAll(limitedBody)
+		return RefreshResult{}, fmt.Errorf("cloud refresh returned status %d: %s: %w", resp.StatusCode, string(respBody), ErrRefreshTokenExpired)
+	}
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(limitedBody)
+		return RefreshResult{}, fmt.Errorf("cloud refresh returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result gcomRefreshResponse
+	if err := json.NewDecoder(limitedBody).Decode(&result); err != nil {
+		return RefreshResult{}, fmt.Errorf("failed to parse cloud refresh response: %w", err)
+	}
+
+	return RefreshResult{
+		Token:            result.AccessToken,
+		RefreshToken:     result.RefreshToken,
+		ExpiresAt:        time.Now().Add(time.Duration(result.ExpiresIn) * time.Second).Format(time.RFC3339),
+		RefreshExpiresAt: result.RefreshExpiresAt,
+	}, nil
+}

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -1,0 +1,272 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// GCOMResult contains the result of a GCOM OAuth2 PKCE authentication flow.
+type GCOMResult struct {
+	AccessToken      string
+	RefreshToken     string
+	RefreshExpiresAt string
+	Scope            string
+	ExpiresIn        int
+	UserID           int
+	OrgSlug          string
+	Info             struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+		Login string `json:"login"`
+	}
+}
+
+// GCOMOptions configures the GCOM OAuth2 PKCE flow.
+type GCOMOptions struct {
+	// ClientID is the OAuth2 client ID registered in GCOM.
+	ClientID string
+
+	// GCOMURL is the base URL of the GCOM API (e.g. "https://grafana.com").
+	GCOMURL string
+
+	// Scopes is the list of OAuth2 scopes to request.
+	Scopes []string
+
+	// Port specifies a fixed port for the callback server. 0 = auto.
+	Port int
+
+	// BindAddress for the callback server. Defaults to "127.0.0.1".
+	BindAddress string
+
+	// Writer for user-facing messages. Defaults to os.Stderr.
+	Writer io.Writer
+}
+
+// GCOMFlow manages a direct GCOM OAuth2 PKCE authentication flow.
+type GCOMFlow struct {
+	opts   GCOMOptions
+	writer io.Writer
+}
+
+// NewGCOMFlow creates a new GCOM OAuth2 PKCE flow.
+func NewGCOMFlow(opts GCOMOptions) *GCOMFlow {
+	if opts.BindAddress == "" {
+		opts.BindAddress = "127.0.0.1"
+	}
+	if opts.GCOMURL == "" {
+		opts.GCOMURL = "https://grafana.com"
+	}
+	w := opts.Writer
+	if w == nil {
+		w = os.Stderr
+	}
+	return &GCOMFlow{opts: opts, writer: w}
+}
+
+// Run executes the GCOM OAuth2 PKCE flow.
+func (f *GCOMFlow) Run(ctx context.Context) (*GCOMResult, error) {
+	listener, port, err := listenOnCallbackPort(ctx, f.opts.BindAddress, f.opts.Port)
+	if err != nil {
+		return nil, fmt.Errorf("no available port: %w", err)
+	}
+
+	state, err := generateState()
+	if err != nil {
+		_ = listener.Close()
+		return nil, fmt.Errorf("failed to generate state: %w", err)
+	}
+
+	codeVerifier, err := generateCodeVerifier()
+	if err != nil {
+		_ = listener.Close()
+		return nil, fmt.Errorf("failed to generate PKCE code verifier: %w", err)
+	}
+	codeChallenge := generateCodeChallenge(codeVerifier)
+
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+
+	resultCh := make(chan *GCOMResult, 1)
+	errCh := make(chan error, 1)
+	server := f.startGCOMCallbackServer(ctx, listener, state, codeVerifier, redirectURI, resultCh, errCh)
+
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	gcomURL := strings.TrimSuffix(f.opts.GCOMURL, "/")
+	scope := strings.Join(f.opts.Scopes, " ")
+
+	authURL := fmt.Sprintf("%s/oauth2/authorize?client_id=%s&redirect_uri=%s&scope=%s&code_challenge=%s&code_challenge_method=S256&state=%s&scope_selection=true&response_type=code",
+		gcomURL,
+		url.QueryEscape(f.opts.ClientID),
+		url.QueryEscape(redirectURI),
+		url.QueryEscape(scope),
+		url.QueryEscape(codeChallenge),
+		url.QueryEscape(state),
+	)
+
+	fmt.Fprintln(f.writer, "Opening browser to authenticate with Grafana Cloud...")
+	fmt.Fprintf(f.writer, "If browser doesn't open, visit:\n  %s\n\n", authURL)
+
+	if err := openBrowser(ctx, authURL); err != nil {
+		fmt.Fprintln(f.writer, "(Could not open browser automatically)")
+	}
+
+	fmt.Fprintln(f.writer, "Waiting for authentication...")
+
+	select {
+	case result := <-resultCh:
+		return result, nil
+	case err := <-errCh:
+		return nil, err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (f *GCOMFlow) startGCOMCallbackServer(ctx context.Context, listener net.Listener, expectedState, codeVerifier, redirectURI string, resultCh chan<- *GCOMResult, errCh chan<- error) *http.Server {
+	var once sync.Once
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		handled := false
+		once.Do(func() {
+			handled = true
+			state := r.URL.Query().Get("state")
+			if state != expectedState {
+				errCh <- errors.New("invalid state - possible CSRF attack")
+				renderErrorPage(w, "Invalid state parameter")
+				return
+			}
+
+			if errMsg := r.URL.Query().Get("error"); errMsg != "" {
+				errCh <- fmt.Errorf("authentication denied: %s", StripControlChars(errMsg))
+				renderErrorPage(w, StripControlChars(errMsg))
+				return
+			}
+
+			code := r.URL.Query().Get("code")
+			if code == "" {
+				errCh <- errors.New("no authorization code received")
+				renderErrorPage(w, "No authorization code received")
+				return
+			}
+
+			result, err := f.exchangeGCOMToken(ctx, code, codeVerifier, redirectURI)
+			if err != nil {
+				errCh <- fmt.Errorf("token exchange failed: %w", err)
+				renderErrorPage(w, "Token exchange failed")
+				return
+			}
+
+			result.OrgSlug = r.URL.Query().Get("org_slug")
+			resultCh <- result
+			renderSuccessPage(w)
+		})
+		if !handled {
+			http.Error(w, "Authentication already processed", http.StatusGone)
+		}
+	})
+
+	server := &http.Server{
+		Addr:              listener.Addr().String(),
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- fmt.Errorf("callback server error: %w", err)
+		}
+	}()
+
+	return server
+}
+
+type gcomTokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token"`
+	RefreshExpiresAt string `json:"refresh_expires_at"`
+	TokenType        string `json:"token_type"`
+	ExpiresIn        int    `json:"expires_in"`
+	Scope            string `json:"scope"`
+	UID              int    `json:"uid"`
+	Info             struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+		Login string `json:"login"`
+	} `json:"info"`
+}
+
+func (f *GCOMFlow) exchangeGCOMToken(ctx context.Context, code, codeVerifier, redirectURI string) (*GCOMResult, error) {
+	gcomURL := strings.TrimSuffix(f.opts.GCOMURL, "/")
+	tokenURL := gcomURL + "/api/oauth2/token"
+
+	body, err := json.Marshal(map[string]string{
+		"grant_type":    "authorization_code",
+		"client_id":     f.opts.ClientID,
+		"code":          code,
+		"code_verifier": codeVerifier,
+		"redirect_uri":  redirectURI,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal token request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token exchange returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var tokenResp gcomTokenResponse
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, errors.New("token response missing access_token")
+	}
+
+	return &GCOMResult{
+		AccessToken:      tokenResp.AccessToken,
+		RefreshToken:     tokenResp.RefreshToken,
+		RefreshExpiresAt: tokenResp.RefreshExpiresAt,
+		Scope:            tokenResp.Scope,
+		ExpiresIn:        tokenResp.ExpiresIn,
+		UserID:           tokenResp.UID,
+		Info:             tokenResp.Info,
+	}, nil
+}

--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -39,6 +39,10 @@ type StoredTokens struct {
 // persisted tokens are available.
 type TokenReloader func() (StoredTokens, bool, error)
 
+// Refresher performs the network refresh call and returns new token credentials.
+// When nil, RefreshTransport uses its built-in proxy refresh endpoint.
+type Refresher func(ctx context.Context, refreshToken string) (RefreshResult, error)
+
 // RefreshTransport wraps an http.RoundTripper and transparently refreshes
 // the gat_ access token when it is close to expiry.
 type RefreshTransport struct {
@@ -58,6 +62,10 @@ type RefreshTransport struct {
 	// refresh. If another process has already refreshed, its tokens are
 	// adopted and the network refresh is skipped.
 	Reload TokenReloader
+
+	// DoRefresh, if set, replaces the built-in proxy refresh with a custom
+	// implementation (e.g. GCOM OAuth2 token refresh).
+	DoRefresh Refresher
 
 	mu         sync.Mutex
 	cond       *sync.Cond
@@ -180,7 +188,13 @@ func (t *RefreshTransport) maybeRefresh(req *http.Request) error {
 	defer cancel()
 
 	// Network call happens outside the in-process mutex.
-	result, err := t.doRefresh(refreshCtx, refreshToken)
+	var result RefreshResult
+	var err error
+	if t.DoRefresh != nil {
+		result, err = t.DoRefresh(refreshCtx, refreshToken)
+	} else {
+		result, err = t.doProxyRefresh(refreshCtx, refreshToken)
+	}
 	if err != nil {
 		return err
 	}
@@ -189,13 +203,13 @@ func (t *RefreshTransport) maybeRefresh(req *http.Request) error {
 	// already consumed the old refresh token and rotated it, so discarding
 	// the response would leave the client with an invalid refresh token.
 	t.mu.Lock()
-	t.Token = result.Data.Token
-	if result.Data.RefreshToken != "" {
-		t.RefreshToken = result.Data.RefreshToken
+	t.Token = result.Token
+	if result.RefreshToken != "" {
+		t.RefreshToken = result.RefreshToken
 	}
 	// Unparseable expiry falls back to zero time so the next request re-refreshes.
-	t.ExpiresAt, _ = time.Parse(time.RFC3339, result.Data.ExpiresAt)
-	if rp, err := time.Parse(time.RFC3339, result.Data.RefreshExpiresAt); err == nil {
+	t.ExpiresAt, _ = time.Parse(time.RFC3339, result.ExpiresAt)
+	if rp, err := time.Parse(time.RFC3339, result.RefreshExpiresAt); err == nil {
 		t.RefreshExpiresAt = rp
 	}
 	storedRefresh := t.RefreshToken
@@ -204,10 +218,10 @@ func (t *RefreshTransport) maybeRefresh(req *http.Request) error {
 
 	if onRefresh != nil {
 		if err := onRefresh(
-			result.Data.Token,
+			result.Token,
 			storedRefresh,
-			result.Data.ExpiresAt,
-			result.Data.RefreshExpiresAt,
+			result.ExpiresAt,
+			result.RefreshExpiresAt,
 		); err != nil {
 			return fmt.Errorf("failed to persist refreshed tokens: %w", err)
 		}
@@ -216,7 +230,7 @@ func (t *RefreshTransport) maybeRefresh(req *http.Request) error {
 	return nil
 }
 
-type refreshResponse struct {
+type proxyRefreshResponse struct {
 	Data struct {
 		Token            string `json:"token"`
 		ExpiresAt        string `json:"expires_at"`
@@ -225,24 +239,24 @@ type refreshResponse struct {
 	} `json:"data"`
 }
 
-func (t *RefreshTransport) doRefresh(ctx context.Context, refreshToken string) (*refreshResponse, error) {
+func (t *RefreshTransport) doProxyRefresh(ctx context.Context, refreshToken string) (RefreshResult, error) {
 	body, err := json.Marshal(map[string]string{
 		"refresh_token": refreshToken,
 	})
 	if err != nil {
-		return nil, err
+		return RefreshResult{}, err
 	}
 
 	refreshURL := t.ProxyEndpoint + "/api/cli/v1/auth/refresh"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, refreshURL, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("failed to build refresh request: %w", err)
+		return RefreshResult{}, fmt.Errorf("failed to build refresh request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := t.base().RoundTrip(req)
 	if err != nil {
-		return nil, fmt.Errorf("refresh request failed: %w", err)
+		return RefreshResult{}, fmt.Errorf("refresh request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -250,19 +264,24 @@ func (t *RefreshTransport) doRefresh(ctx context.Context, refreshToken string) (
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		respBody, _ := io.ReadAll(limitedBody)
-		return nil, fmt.Errorf("refresh returned status %d: %s: %w", resp.StatusCode, string(respBody), ErrRefreshTokenExpired)
+		return RefreshResult{}, fmt.Errorf("refresh returned status %d: %s: %w", resp.StatusCode, string(respBody), ErrRefreshTokenExpired)
 	}
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(limitedBody)
-		return nil, fmt.Errorf("refresh returned status %d: %s", resp.StatusCode, string(respBody))
+		return RefreshResult{}, fmt.Errorf("refresh returned status %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	var result refreshResponse
+	var result proxyRefreshResponse
 	if err := json.NewDecoder(limitedBody).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to parse refresh response: %w", err)
+		return RefreshResult{}, fmt.Errorf("failed to parse refresh response: %w", err)
 	}
 
-	return &result, nil
+	return RefreshResult{
+		Token:            result.Data.Token,
+		RefreshToken:     result.Data.RefreshToken,
+		ExpiresAt:        result.Data.ExpiresAt,
+		RefreshExpiresAt: result.Data.RefreshExpiresAt,
+	}, nil
 }
 
 // RefreshResult holds the token credentials returned by a successful refresh.
@@ -273,19 +292,10 @@ type RefreshResult struct {
 	RefreshExpiresAt string
 }
 
-// DoRefresh calls the proxy refresh endpoint and returns new token credentials.
+// ProxyRefresh calls the proxy refresh endpoint and returns new token credentials.
 // This is used by the assistant command's token refresher, which needs to refresh
 // tokens outside of an HTTP round-trip context.
-func DoRefresh(ctx context.Context, proxyEndpoint, refreshTok string) (RefreshResult, error) {
+func ProxyRefresh(ctx context.Context, proxyEndpoint, refreshTok string) (RefreshResult, error) {
 	t := &RefreshTransport{ProxyEndpoint: proxyEndpoint}
-	result, err := t.doRefresh(ctx, refreshTok)
-	if err != nil {
-		return RefreshResult{}, err
-	}
-	return RefreshResult{
-		Token:            result.Data.Token,
-		RefreshToken:     result.Data.RefreshToken,
-		ExpiresAt:        result.Data.ExpiresAt,
-		RefreshExpiresAt: result.Data.RefreshExpiresAt,
-	}, nil
+	return t.doProxyRefresh(ctx, refreshTok)
 }

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -90,6 +90,7 @@ type Region struct {
 type CreateStackRequest struct {
 	Name             string            `json:"name"`
 	Slug             string            `json:"slug"`
+	Org              string            `json:"org,omitempty"`
 	URL              string            `json:"url,omitempty"`
 	Region           string            `json:"region,omitempty"`
 	Description      string            `json:"description,omitempty"`
@@ -131,6 +132,13 @@ type GCOMClient struct {
 // The client uses a 30-second timeout and will not follow HTTP redirects to a
 // different domain than baseURL.
 func NewGCOMClient(baseURL, token string) (*GCOMClient, error) {
+	return NewGCOMClientWithTransport(baseURL, token, nil)
+}
+
+// NewGCOMClientWithTransport is like NewGCOMClient but allows injecting a
+// custom http.RoundTripper that wraps the default transport stack. When
+// transport is nil, the default UserAgent + retry stack is used directly.
+func NewGCOMClientWithTransport(baseURL, token string, transport http.RoundTripper) (*GCOMClient, error) {
 	baseURL = strings.TrimRight(baseURL, "/")
 
 	parsedBase, err := url.Parse(baseURL)
@@ -142,9 +150,13 @@ func NewGCOMClient(baseURL, token string) (*GCOMClient, error) {
 		return nil, fmt.Errorf("gcom client: base URL must use HTTPS (got %q)", parsedBase.Scheme)
 	}
 
+	if transport == nil {
+		transport = &httputils.UserAgentTransport{Base: &retry.Transport{}}
+	}
+
 	httpClient := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: &httputils.UserAgentTransport{Base: &retry.Transport{}},
+		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if req.URL.Host != parsedBase.Host {
 				return fmt.Errorf("gcom client: refusing cross-domain redirect to %s (configured base: %s)",

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -151,6 +151,18 @@ func mergeCloudConfig(base, over *CloudConfig) CloudConfig {
 	if over.Token != "" {
 		result.Token = over.Token
 	}
+	if over.TokenExpiresAt != "" {
+		result.TokenExpiresAt = over.TokenExpiresAt
+	}
+	if over.RefreshToken != "" {
+		result.RefreshToken = over.RefreshToken
+	}
+	if over.RefreshExpiresAt != "" {
+		result.RefreshExpiresAt = over.RefreshExpiresAt
+	}
+	if over.Org != "" {
+		result.Org = over.Org
+	}
 	if over.Stack != "" {
 		result.Stack = over.Stack
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -77,6 +77,20 @@ type CloudConfig struct {
 	// Token is a Grafana Cloud API token used to authenticate against GCOM.
 	Token string `datapolicy:"secret" env:"GRAFANA_CLOUD_TOKEN" json:"token,omitempty" yaml:"token,omitempty"`
 
+	// TokenExpiresAt is the token expiration time in RFC3339 format.
+	// Only set for OAuth tokens obtained via `gcx cloud login`.
+	TokenExpiresAt string `json:"token-expires-at,omitempty" yaml:"token-expires-at,omitempty"`
+
+	// RefreshToken is the OAuth refresh token for renewing the access token.
+	RefreshToken string `datapolicy:"secret" json:"refresh-token,omitempty" yaml:"refresh-token,omitempty"`
+
+	// RefreshExpiresAt is the refresh token expiration time in RFC3339 format.
+	RefreshExpiresAt string `json:"refresh-expires-at,omitempty" yaml:"refresh-expires-at,omitempty"`
+
+	// Org is the Grafana Cloud organization slug selected during OAuth login.
+	// Used as the default org for cloud commands like `gcx stacks create`.
+	Org string `env:"GRAFANA_CLOUD_ORG" json:"org,omitempty" yaml:"org,omitempty"`
+
 	// Stack is the Grafana Cloud stack slug (e.g. "mystack").
 	// Optional: if not set, the slug may be derived from Grafana.Server.
 	Stack string `env:"GRAFANA_CLOUD_STACK" json:"stack,omitempty" yaml:"stack,omitempty"`

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -8,10 +8,14 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/gofrs/flock"
+	"github.com/grafana/gcx/internal/auth"
 	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/httputils"
+	"github.com/grafana/gcx/internal/retry"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/rest"
@@ -237,7 +241,13 @@ func (l *ConfigLoader) loadCloudBase(ctx context.Context) (cloudBase, error) {
 
 	token := curCtx.Cloud.Token
 	gcomURL := curCtx.ResolveGCOMURL()
-	client, err := cloud.NewGCOMClient(gcomURL, token)
+
+	var transport http.RoundTripper
+	if curCtx.Cloud.RefreshToken != "" {
+		transport = l.buildCloudRefreshTransport(ctx, curCtx, gcomURL, loaded.CurrentContext, loaded.Sources)
+	}
+
+	client, err := cloud.NewGCOMClientWithTransport(gcomURL, token, transport)
 	if err != nil {
 		return cloudBase{}, fmt.Errorf("failed to create GCOM client: %w", err)
 	}
@@ -248,6 +258,87 @@ func (l *ConfigLoader) loadCloudBase(ctx context.Context) (cloudBase, error) {
 		loaded: loaded,
 		curCtx: curCtx,
 	}, nil
+}
+
+func (l *ConfigLoader) buildCloudRefreshTransport(ctx context.Context, curCtx *config.Context, gcomURL, contextName string, sources []config.ConfigSource) http.RoundTripper {
+	rt := auth.NewCloudRefreshTransport(auth.CloudRefreshTransportConfig{
+		Base:             &httputils.UserAgentTransport{Base: &retry.Transport{}},
+		GCOMURL:          gcomURL,
+		ClientID:         "gcx",
+		Token:            curCtx.Cloud.Token,
+		RefreshToken:     curCtx.Cloud.RefreshToken,
+		ExpiresAt:        parseRFC3339OrZero(curCtx.Cloud.TokenExpiresAt),
+		RefreshExpiresAt: parseRFC3339OrZero(curCtx.Cloud.RefreshExpiresAt),
+	})
+
+	persistSource := config.ResolveTokenPersistenceSource(ctx, l.configSource(), contextName, sources)
+	persistCtx := context.WithoutCancel(ctx)
+
+	rt.Lock = func(reqCtx context.Context) (func(), error) {
+		path, err := persistSource()
+		if err != nil {
+			return nil, err
+		}
+		lock := flock.New(path + ".lock")
+		lockCtx, cancel := context.WithTimeout(context.WithoutCancel(reqCtx), 30*time.Second)
+		defer cancel()
+		if ok, err := lock.TryLockContext(lockCtx, 100*time.Millisecond); err != nil || !ok {
+			return nil, err
+		}
+		return func() { _ = lock.Unlock() }, nil
+	}
+
+	rt.Reload = func() (auth.StoredTokens, bool, error) {
+		fresh, err := config.Load(persistCtx, persistSource)
+		if err != nil {
+			return auth.StoredTokens{}, false, err
+		}
+		c := fresh.Contexts[contextName]
+		if c == nil || c.Cloud == nil || c.Cloud.RefreshToken == "" {
+			return auth.StoredTokens{}, false, nil
+		}
+		return auth.StoredTokens{
+			Token:            c.Cloud.Token,
+			RefreshToken:     c.Cloud.RefreshToken,
+			ExpiresAt:        parseRFC3339OrZero(c.Cloud.TokenExpiresAt),
+			RefreshExpiresAt: parseRFC3339OrZero(c.Cloud.RefreshExpiresAt),
+		}, true, nil
+	}
+
+	rt.OnRefresh = func(token, refreshToken, expiresAt, refreshExpiresAt string) error {
+		fresh, err := config.Load(persistCtx, persistSource)
+		if err != nil {
+			return err
+		}
+
+		c := fresh.Contexts[contextName]
+		if c == nil {
+			c = &config.Context{}
+			if fresh.Contexts == nil {
+				fresh.Contexts = make(map[string]*config.Context)
+			}
+			fresh.Contexts[contextName] = c
+		}
+		if c.Cloud == nil {
+			c.Cloud = &config.CloudConfig{}
+		}
+
+		c.Cloud.Token = token
+		c.Cloud.RefreshToken = refreshToken
+		c.Cloud.TokenExpiresAt = expiresAt
+		c.Cloud.RefreshExpiresAt = refreshExpiresAt
+		return config.Write(persistCtx, persistSource, fresh)
+	}
+
+	return rt
+}
+
+func parseRFC3339OrZero(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, _ := time.Parse(time.RFC3339, s)
+	return t
 }
 
 // CloudTokenConfig holds the minimal cloud credentials needed for
@@ -461,6 +552,22 @@ func (l *ConfigLoader) SaveProviderConfig(ctx context.Context, providerName, key
 
 // LoadFullConfig loads the full config from the config file, applying env var
 // overrides and context flags. Returns a pointer to the resolved Config.
+// CloudOrgSlug returns the cloud.org value from the current context config,
+// or "" if not set. This is used as the default org for cloud commands.
+func (l *ConfigLoader) CloudOrgSlug() string {
+	cfg, err := config.LoadLayered(context.Background(), l.configFile,
+		contextSelectionOverride(l.ctxName),
+	)
+	if err != nil {
+		return ""
+	}
+	curCtx := cfg.GetCurrentContext()
+	if curCtx == nil || curCtx.Cloud == nil {
+		return ""
+	}
+	return curCtx.Cloud.Org
+}
+
 func (l *ConfigLoader) LoadFullConfig(ctx context.Context) (*config.Config, error) {
 	ctxName := l.resolvedContextName(ctx)
 	overrides := []config.Override{

--- a/internal/providers/stacks/commands.go
+++ b/internal/providers/stacks/commands.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/cloud"
+	"github.com/grafana/gcx/internal/fail"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/spf13/cobra"
@@ -127,6 +128,7 @@ type createOpts struct {
 	IO               cmdio.Options
 	Name             string
 	Slug             string
+	Org              string
 	Region           string
 	Description      string
 	Labels           []string
@@ -141,6 +143,7 @@ func (o *createOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 	flags.StringVar(&o.Name, "name", "", "Stack name (required)")
 	flags.StringVar(&o.Slug, "slug", "", "Stack slug / subdomain (required)")
+	flags.StringVar(&o.Org, "org", "", "Organisation slug (defaults to cloud.stack from config)")
 	flags.StringVar(&o.Region, "region", "", "Region slug (e.g. us, eu). Use 'gcx stacks regions' to list.")
 	flags.StringVar(&o.Description, "description", "", "Short description")
 	flags.StringSliceVar(&o.Labels, "labels", nil, "Labels in key=value format (may be repeated)")
@@ -177,9 +180,24 @@ user before executing. Prefer --dry-run first.`,
 				return err
 			}
 
+			org := opts.Org
+			if org == "" {
+				org = loader.CloudOrgSlug()
+			}
+			if org == "" {
+				return &fail.DetailedError{
+					Summary: "Organization is required",
+					Suggestions: []string{
+						"Pass --org <slug> to specify the organization",
+						"Or re-run gcx cloud login and select an organization",
+					},
+				}
+			}
+
 			req := cloud.CreateStackRequest{
 				Name:        opts.Name,
 				Slug:        opts.Slug,
+				Org:         org,
 				Region:      opts.Region,
 				Description: opts.Description,
 				Labels:      labels,


### PR DESCRIPTION
Part of https://github.com/grafana/gcx-internal/issues/13. Use with https://github.com/grafana/grafana-com/pull/18538 to try out the OAuth flow locally.

This has not been reviewed properly yet.

- feat: add cloud OAuth fields to CloudConfig
- refactor: add DoRefresh callback to RefreshTransport
- feat: implement GCOM OAuth2 PKCE flow and cloud token refresh
- feat: add gcx cloud login command with org support
