### PR TITLE
feat(irm): add incidents contexts list command

### DIFF
--- a/docs/reference/cli/gcx_irm_incidents_contexts.md
+++ b/docs/reference/cli/gcx_irm_incidents_contexts.md
@@ -1,0 +1,27 @@
+## gcx irm incidents contexts
+
+Manage incident contexts (linked alert groups, dashboards, etc.).
+
+### Options
+
+```
+  -h, --help   help for contexts
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx irm incidents](gcx_irm_incidents.md)	 - Manage incidents.
+* [gcx irm incidents contexts list](gcx_irm_incidents_contexts_list.md)	 - List contexts attached to an incident.
+

--- a/docs/reference/cli/gcx_irm_incidents_contexts_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_contexts_list.md
@@ -1,11 +1,21 @@
-## gcx irm incidents
+## gcx irm incidents contexts list
 
-Manage incidents.
+List contexts attached to an incident.
+
+```
+gcx irm incidents contexts list <incident-id> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for incidents
+      --alert-group-id string   Filter by linked alert group ID
+  -h, --help                    help for list
+      --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int               Maximum number of contexts to return (0 = server default)
+  -o, --output string           Output format. One of: agents, json, table, wide, yaml (default "table")
+      --status string           Filter by context status
+      --type string             Filter by context type (e.g. genericURL, grafana.dashboard, code.github.pr). Note: alert-group links are encoded as genericURL contexts with alertGroupID set — use --alert-group-id to filter those.
 ```
 
 ### Options inherited from parent commands
@@ -22,13 +32,5 @@ Manage incidents.
 
 ### SEE ALSO
 
-* [gcx irm](gcx_irm.md)	 - Manage Grafana IRM (OnCall + Incidents)
-* [gcx irm incidents activity](gcx_irm_incidents_activity.md)	 - Manage incident activity timeline.
-* [gcx irm incidents close](gcx_irm_incidents_close.md)	 - Close (resolve) an incident.
 * [gcx irm incidents contexts](gcx_irm_incidents_contexts.md)	 - Manage incident contexts (linked alert groups, dashboards, etc.).
-* [gcx irm incidents create](gcx_irm_incidents_create.md)	 - Create a new incident from a file.
-* [gcx irm incidents get](gcx_irm_incidents_get.md)	 - Get a single incident by ID.
-* [gcx irm incidents list](gcx_irm_incidents_list.md)	 - List incidents.
-* [gcx irm incidents open](gcx_irm_incidents_open.md)	 - Open an incident in the browser.
-* [gcx irm incidents severities](gcx_irm_incidents_severities.md)	 - Manage incident severity levels.
 

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -208,6 +208,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx irm incidents activity add":    {Cost: "small"},
 	"gcx irm incidents activity list":   {Cost: "small"},
 	"gcx irm incidents close":           {Cost: "small"},
+	"gcx irm incidents contexts list":   {Cost: "small"},
 	"gcx irm incidents create":          {Cost: "small"},
 	"gcx irm incidents get":             {Cost: "small"},
 	"gcx irm incidents list":            {Cost: "small"},

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,6 +28,7 @@ const (
 	actQueryPath      = incidentBasePath + "/ActivityService.QueryActivity"
 	actAddPath        = incidentBasePath + "/ActivityService.AddActivity"
 	sevGetPath        = incidentBasePath + "/SeveritiesService.GetOrgSeverities"
+	ctxQueryPath      = incidentBasePath + "/IncidentContextService.QueryIncidentContext"
 )
 
 // Client is an HTTP client for the Grafana IRM Incidents API.
@@ -239,6 +241,37 @@ func (c *IncidentClient) AddActivity(ctx context.Context, incidentID, body strin
 	}
 
 	return nil
+}
+
+// QueryIncidentContext returns the contexts (alert groups, dashboards, …)
+// attached to an incident. Additional fields on query — Type, Status,
+// AlertGroupID, etc. — narrow the result; only IncidentID is required.
+func (c *IncidentClient) QueryIncidentContext(ctx context.Context, query IncidentContextQuery) ([]IncidentContext, error) {
+	if query.IncidentID == "" {
+		return nil, errors.New("incidents: QueryIncidentContext: incidentID is required")
+	}
+
+	body, err := json.Marshal(queryIncidentContextRequest{Query: query})
+	if err != nil {
+		return nil, fmt.Errorf("incidents: marshal context query: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, ctxQueryPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("incidents: query context for %s: %w", query.IncidentID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, handleIncidentErrorResponse(resp)
+	}
+
+	var result queryIncidentContextResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("incidents: decode context response: %w", err)
+	}
+
+	return result.IncidentContexts, nil
 }
 
 // GetSeverities retrieves the organization's severity levels.

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -263,6 +263,87 @@ func TestClient_QueryActivity(t *testing.T) {
 	}
 }
 
+func TestClient_QueryIncidentContext(t *testing.T) {
+	alertGroupID := "ag-42"
+
+	tests := []struct {
+		name    string
+		query   irm.IncidentContextQuery
+		handler http.HandlerFunc
+		wantLen int
+		wantErr string
+	}{
+		{
+			name: "returns contexts and forwards filters",
+			query: irm.IncidentContextQuery{
+				IncidentID:   "inc-123",
+				Type:         "genericURL",
+				Status:       "active",
+				AlertGroupID: alertGroupID,
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Contains(t, r.URL.Path, "IncidentContextService.QueryIncidentContext")
+				var body map[string]any
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				query, _ := body["query"].(map[string]any)
+				assert.Equal(t, "inc-123", query["incidentID"])
+				assert.Equal(t, "genericURL", query["type"])
+				assert.Equal(t, "active", query["status"])
+				assert.Equal(t, alertGroupID, query["alertGroupID"])
+				writeJSON(w, map[string]any{
+					"incidentContexts": []map[string]any{
+						{"contextID": "ctx-1", "incidentID": "inc-123", "type": "genericURL", "alertGroupID": alertGroupID},
+						{"contextID": "ctx-2", "incidentID": "inc-123", "type": "grafana.dashboard"},
+					},
+				})
+			},
+			wantLen: 2,
+		},
+		{
+			name:  "returns empty list",
+			query: irm.IncidentContextQuery{IncidentID: "inc-empty"},
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, map[string]any{"incidentContexts": []map[string]any{}})
+			},
+			wantLen: 0,
+		},
+		{
+			name:    "missing incident ID is rejected client-side",
+			query:   irm.IncidentContextQuery{},
+			handler: func(_ http.ResponseWriter, _ *http.Request) { t.Fatal("server should not be hit") },
+			wantErr: "incidentID is required",
+		},
+		{
+			name:  "propagates server error",
+			query: irm.IncidentContextQuery{IncidentID: "inc-err"},
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				writeJSON(w, map[string]string{"error": "internal error"})
+			},
+			wantErr: "internal error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			c := newTestClient(t, server)
+			contexts, err := c.QueryIncidentContext(t.Context(), tt.query)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, contexts, tt.wantLen)
+		})
+	}
+}
+
 func TestClient_AddActivity(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/providers/irm/incidents_commands.go
+++ b/internal/providers/irm/incidents_commands.go
@@ -17,6 +17,7 @@ func newIncidentsCmd(loader GrafanaConfigLoader) *cobra.Command {
 		NewCreateCommand(loader),
 		NewCloseCommand(loader),
 		NewActivityCommand(loader),
+		NewContextsCommand(loader),
 		NewSeveritiesCommand(loader),
 		NewOpenCommand(loader),
 	)

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -669,3 +669,147 @@ func (c *SeverityTableCodec) Encode(w io.Writer, v any) error {
 func (c *SeverityTableCodec) Decode(_ io.Reader, _ any) error {
 	return errors.New("table format does not support decoding")
 }
+
+// ---------------------------------------------------------------------------
+// contexts commands
+// ---------------------------------------------------------------------------
+
+func NewContextsCommand(loader GrafanaConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "contexts",
+		Short:   "Manage incident contexts (linked alert groups, dashboards, etc.).",
+		Aliases: []string{"context", "ctx"},
+	}
+	cmd.AddCommand(newContextsListCommand(loader))
+	return cmd
+}
+
+type contextsListOpts struct {
+	IO           cmdio.Options
+	Limit        int
+	Type         string
+	Status       string
+	AlertGroupID string
+}
+
+func (o *contextsListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &IncidentContextTableCodec{})
+	o.IO.RegisterCustomCodec("wide", &IncidentContextTableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.IntVar(&o.Limit, "limit", 0, "Maximum number of contexts to return (0 = server default)")
+	flags.StringVar(&o.Type, "type", "", "Filter by context type (e.g. genericURL, grafana.dashboard, code.github.pr). Note: alert-group links are encoded as genericURL contexts with alertGroupID set — use --alert-group-id to filter those.")
+	flags.StringVar(&o.Status, "status", "", "Filter by context status")
+	flags.StringVar(&o.AlertGroupID, "alert-group-id", "", "Filter by linked alert group ID")
+}
+
+func newContextsListCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &contextsListOpts{}
+	cmd := &cobra.Command{
+		Use:   "list <incident-id>",
+		Short: "List contexts attached to an incident.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			incidentID := args[0]
+
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			client, err := NewIncidentClient(restCfg)
+			if err != nil {
+				return err
+			}
+
+			contexts, err := client.QueryIncidentContext(ctx, IncidentContextQuery{
+				IncidentID:   incidentID,
+				Limit:        opts.Limit,
+				Type:         opts.Type,
+				Status:       opts.Status,
+				AlertGroupID: opts.AlertGroupID,
+			})
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), contexts)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// IncidentContextTableCodec renders incident contexts as a table.
+type IncidentContextTableCodec struct {
+	Wide bool
+}
+
+func (c *IncidentContextTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *IncidentContextTableCodec) Encode(w io.Writer, v any) error {
+	contexts, ok := v.([]IncidentContext)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []IncidentContext")
+	}
+
+	var tbl *style.TableBuilder
+	if c.Wide {
+		tbl = style.NewTable("CONTEXTID", "TYPE", "STATUS", "ALERTGROUPID", "TITLE", "CREATED")
+	} else {
+		tbl = style.NewTable("CONTEXTID", "TYPE", "STATUS", "ALERTGROUPID", "TITLE")
+	}
+
+	for _, ctx := range contexts {
+		alertGroup := "-"
+		if ctx.AlertGroupID != nil && *ctx.AlertGroupID != "" {
+			alertGroup = *ctx.AlertGroupID
+		}
+
+		title := ctx.Title
+		if title == "" {
+			title = "-"
+		}
+		if !c.Wide && len(title) > 50 {
+			title = title[:47] + "..."
+		}
+
+		ctxType := ctx.Type
+		if ctxType == "" {
+			ctxType = "-"
+		}
+
+		status := ctx.Status
+		if status == "" {
+			status = "-"
+		}
+
+		if c.Wide {
+			created := ctx.CreatedTime
+			if created == "" {
+				created = "-"
+			} else if len(created) > 16 {
+				created = created[:16]
+			}
+			tbl.Row(ctx.ContextID, ctxType, status, alertGroup, title, created)
+		} else {
+			tbl.Row(ctx.ContextID, ctxType, status, alertGroup, title)
+		}
+	}
+
+	return tbl.Render(w)
+}
+
+func (c *IncidentContextTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}

--- a/internal/providers/irm/incidents_commands_test.go
+++ b/internal/providers/irm/incidents_commands_test.go
@@ -203,6 +203,70 @@ func TestActivityTableCodec_LongBodyTruncated(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
+// IncidentContextTableCodec tests
+// ---------------------------------------------------------------------------
+
+func TestIncidentContextTableCodec_Encode(t *testing.T) {
+	alertGroup := "ag-99"
+	contexts := []irm.IncidentContext{
+		{
+			// Alert-group links come back as genericURL contexts with
+			// alertGroupID set — there is no dedicated alertGroup type
+			// in the IRM API.
+			ContextID:    "ctx-001",
+			IncidentID:   "inc-123",
+			Type:         "genericURL",
+			Status:       "attached",
+			Title:        "Alert Group",
+			AlertGroupID: &alertGroup,
+			CreatedTime:  "2024-06-15T10:30:00Z",
+		},
+		{
+			ContextID:  "ctx-002",
+			IncidentID: "inc-123",
+			Type:       "grafana.dashboard",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		wide        bool
+		wantColumns []string
+		wantInRows  []string
+	}{
+		{
+			name:        "table format shows standard columns",
+			wide:        false,
+			wantColumns: []string{"CONTEXTID", "TYPE", "STATUS", "ALERTGROUPID", "TITLE"},
+			wantInRows:  []string{"ctx-001", "genericURL", "attached", "ag-99", "Alert Group", "ctx-002", "grafana.dashboard"},
+		},
+		{
+			name:        "wide format includes CREATED column",
+			wide:        true,
+			wantColumns: []string{"CONTEXTID", "TYPE", "STATUS", "ALERTGROUPID", "TITLE", "CREATED"},
+			wantInRows:  []string{"2024-06-15T10:30"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			codec := &irm.IncidentContextTableCodec{Wide: tt.wide}
+			var buf bytes.Buffer
+			err := codec.Encode(&buf, contexts)
+			require.NoError(t, err)
+
+			out := buf.String()
+			for _, col := range tt.wantColumns {
+				assert.Contains(t, out, col)
+			}
+			for _, want := range tt.wantInRows {
+				assert.Contains(t, out, want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // label validation tests
 // ---------------------------------------------------------------------------
 

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -256,3 +256,66 @@ type ActivityUser struct {
 	UserID string `json:"userID"`
 	Name   string `json:"name"`
 }
+
+// IncidentContextUser is a user reference returned on an incident context.
+type IncidentContextUser struct {
+	UserID       string `json:"userID"`
+	Name         string `json:"name"`
+	Email        string `json:"email,omitempty"`
+	GrafanaLogin string `json:"grafanaLogin,omitempty"`
+	PhotoURL     string `json:"photoURL,omitempty"`
+}
+
+// IncidentContextField is a key/value entry in an incident context's metadata.
+type IncidentContextField struct {
+	Key         string `json:"key"`
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+	Value       string `json:"value"`
+	Secret      bool   `json:"secret,omitempty"`
+	Checked     bool   `json:"checked,omitempty"`
+	Hidden      bool   `json:"hidden,omitempty"`
+}
+
+// IncidentContext is a single context entry attached to an incident — for
+// example a linked alert group, dashboard, or other reference surface.
+type IncidentContext struct {
+	IncidentID    string                 `json:"incidentID"`
+	ContextID     string                 `json:"contextID"`
+	CreatedByUser IncidentContextUser    `json:"createdByUser"`
+	CreatedTime   string                 `json:"createdTime,omitempty"`
+	ModifiedTime  string                 `json:"modifiedTime,omitempty"`
+	LastRun       string                 `json:"lastRun,omitempty"`
+	Title         string                 `json:"title,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	Type          string                 `json:"type,omitempty"`
+	Payload       string                 `json:"payload,omitempty"`
+	Metadata      []IncidentContextField `json:"metadata,omitempty"`
+	Status        string                 `json:"status,omitempty"`
+	ProcessStatus string                 `json:"processStatus,omitempty"`
+	ProcessError  string                 `json:"processError,omitempty"`
+	ProcessorInfo string                 `json:"processorInfo,omitempty"`
+	AlertGroupID  *string                `json:"alertGroupID,omitempty"`
+}
+
+// IncidentContextQuery represents the filters accepted by the
+// IncidentContextService.QueryIncidentContext endpoint.
+type IncidentContextQuery struct {
+	IncidentID     string `json:"incidentID"`
+	Limit          int    `json:"limit,omitempty"`
+	Status         string `json:"status,omitempty"`
+	Type           string `json:"type,omitempty"`
+	AlertGroupID   string `json:"alertGroupID,omitempty"`
+	OrderField     string `json:"orderField,omitempty"`
+	OrderDirection string `json:"orderDirection,omitempty"`
+}
+
+// queryIncidentContextRequest is the request body for QueryIncidentContext.
+type queryIncidentContextRequest struct {
+	Query IncidentContextQuery `json:"query"`
+}
+
+// queryIncidentContextResponse wraps the response from QueryIncidentContext.
+type queryIncidentContextResponse struct {
+	IncidentContexts []IncidentContext `json:"incidentContexts"`
+}


### PR DESCRIPTION
## Summary

- Adds `gcx irm incidents contexts list <incident-id>` (alias `context`, `ctx`), exposing `IncidentContextService.QueryIncidentContext`. Supports `--type`, `--status`, `--alert-group-id`, and `--limit` filters and renders a table by default with a `wide` variant.
- Adds the matching client method, types, table codec, and tests (client + codec).
- Registers the new leaf under `internal/agent/command_annotations.go` (`small` cost) so the agent-mode consistency test passes.

## Why

The incident-context endpoint is the only way to discover the alert groups (and other context surfaces) linked to an incident. Until now, anyone needing this from the CLI had to drop down to a raw `curl` against the IRM plugin proxy with a hand-managed bearer token. This makes it a normal `gcx` call.

One non-obvious thing the smoke-test surfaced: alert-group links come back as `type=genericURL` contexts with the `alertGroupID` field set — there is no dedicated `alertGroup` type value in the IRM API. The `--type` flag help calls this out and points users to `--alert-group-id` for that case.

## Test plan

- [x] `go test ./internal/providers/irm/...` — new client + codec tests pass
- [x] `go test ./cmd/gcx/root/...` — consistency test passes (new leaf has token-cost annotation)
- [x] `mise run lint` — clean
- [x] `GCX_AGENT_MODE=false mise run reference` — regenerated CLI reference docs are committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)