### PR TITLE
refactor(kg)!: rename health to summary, restructure output, fix scope/time leaks

### DIFF
--- a/docs/reference/cli/gcx_kg.md
+++ b/docs/reference/cli/gcx_kg.md
@@ -25,7 +25,6 @@ Manage Grafana Knowledge Graph rules, entities, and insights
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx kg cypher](gcx_kg_cypher.md)	 - Run a read-only Cypher query against the Knowledge Graph.
 * [gcx kg entities](gcx_kg_entities.md)	 - Manage Knowledge Graph entities.
-* [gcx kg health](gcx_kg_health.md)	 - Show a health summary with active insight counts.
 * [gcx kg insights](gcx_kg_insights.md)	 - Search insights and fetch their backing metrics.
 * [gcx kg meta](gcx_kg_meta.md)	 - Show Knowledge Graph metadata: entity types, valid env/namespace/site values, and telemetry query configs.
 * [gcx kg model-rules](gcx_kg_model-rules.md)	 - Push model rules to the Knowledge Graph.
@@ -34,5 +33,6 @@ Manage Grafana Knowledge Graph rules, entities, and insights
 * [gcx kg rules](gcx_kg_rules.md)	 - Manage Knowledge Graph prom rules.
 * [gcx kg scopes](gcx_kg_scopes.md)	 - Manage Knowledge Graph entity scopes.
 * [gcx kg status](gcx_kg_status.md)	 - Show Knowledge Graph stack status.
+* [gcx kg summary](gcx_kg_summary.md)	 - Show a summary of entities and active insights, broken down by type, severity, and insight name.
 * [gcx kg suppressions](gcx_kg_suppressions.md)	 - Manage alert suppressions in the Knowledge Graph.
 

--- a/docs/reference/cli/gcx_kg_summary.md
+++ b/docs/reference/cli/gcx_kg_summary.md
@@ -1,9 +1,9 @@
-## gcx kg health
+## gcx kg summary
 
-Show a health summary with active insight counts.
+Show a summary of entities and active insights, broken down by type, severity, and insight name.
 
 ```
-gcx kg health [flags]
+gcx kg summary [flags]
 ```
 
 ### Options
@@ -11,7 +11,7 @@ gcx kg health [flags]
 ```
       --env string         Environment scope
       --from string        Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
-  -h, --help               help for health
+  -h, --help               help for summary
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --namespace string   Namespace scope
   -o, --output string      Output format. One of: agents, json, yaml (default "json")

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -251,7 +251,7 @@ var commandAnnotations = map[string]annotation{
 	// -----------------------------------------------------------------------
 	"gcx kg cypher":                  {Cost: "medium", Hint: "\"MATCH (s:Service) RETURN s LIMIT 10\" [--since 1h] | read-only Cypher query; always include LIMIT for targeted lookups; omit for broad discovery"},
 	"gcx kg entities list":           {Cost: "medium", Hint: "--type <type> [--env <env>] [--namespace <ns>] --since 1h -o json | use --property name=<value> to fetch a single entity by name | use --with-insights [any|critical|warning|info] to filter to entities with active insights | use --json type,name,scope when only entity identity is needed to reduce output size | run gcx kg meta scopes first to discover valid env/namespace/site values"},
-	"gcx kg health":                  {Cost: "medium", Hint: "--type <type> --since 1h -o json"},
+	"gcx kg summary":                 {Cost: "medium", Hint: "--type <type> --since 1h -o json"},
 	"gcx kg insights entity-metric":  {Cost: "medium", Hint: "<Type--Name> --insight-id <id>"},
 	"gcx kg insights search":         {Cost: "medium", Hint: "--type <type> --since 1h"},
 	"gcx kg insights source-metrics": {Cost: "medium", Hint: "--insight-id <id> --since 1h"},

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -339,14 +339,11 @@ func (c *Client) LookupEntity(ctx context.Context, entityType, name string, scop
 	return &result, nil
 }
 
-// CountEntityTypes retrieves entity type counts for the last hour.
-func (c *Client) CountEntityTypes(ctx context.Context) (map[string]int64, error) {
-	now := time.Now()
+// CountEntityTypes retrieves entity type counts for the given time window and scope.
+func (c *Client) CountEntityTypes(ctx context.Context, startMs, endMs int64, sc *ScopeCriteria) (map[string]int64, error) {
 	body := EntityCountRequest{
-		TimeCriteria: &TimeCriteria{
-			Start: now.Add(-1 * time.Hour).UnixMilli(),
-			End:   now.UnixMilli(),
-		},
+		TimeCriteria:  &TimeCriteria{Start: startMs, End: endMs},
+		ScopeCriteria: sc,
 	}
 	var result map[string]int64
 	if err := c.postJSON(ctx, entityCountPath, body, &result); err != nil {

--- a/internal/providers/kg/client_test.go
+++ b/internal/providers/kg/client_test.go
@@ -180,7 +180,7 @@ func TestClient_CountEntityTypes(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(t, server)
-	counts, err := client.CountEntityTypes(t.Context())
+	counts, err := client.CountEntityTypes(t.Context(), 0, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(42), counts["Service"])
 	assert.Equal(t, int64(5), counts["Namespace"])

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -334,7 +334,8 @@ func searchByTypes(ctx context.Context, cmd *cobra.Command, client *Client, enti
 }
 
 func collectEntityTypes(cmd *cobra.Command, client *Client) ([]string, error) {
-	counts, err := client.CountEntityTypes(cmd.Context())
+	now := time.Now()
+	counts, err := client.CountEntityTypes(cmd.Context(), now.Add(-1*time.Hour).UnixMilli(), now.UnixMilli(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get entity types: %w", err)
 	}
@@ -1520,18 +1521,18 @@ func rcaWorkbenchURL(host, entityType, name string, scope map[string]string, sta
 }
 
 // ---------------------------------------------------------------------------
-// Health command
+// Summary command
 // ---------------------------------------------------------------------------
 
-func newHealthCommand(loader RESTConfigLoader) *cobra.Command {
+func newSummaryCommand(loader RESTConfigLoader) *cobra.Command {
 	var (
-		healthScope      scopeFlags
-		healthEntityType string
+		summaryScope      scopeFlags
+		summaryEntityType string
 	)
-	ioOpts := &healthOpts{}
+	ioOpts := &summaryOpts{}
 	cmd := &cobra.Command{
-		Use:   "health",
-		Short: "Show a health summary with active insight counts.",
+		Use:   "summary",
+		Short: "Show a summary of entities and active insights, broken down by type, severity, and insight name.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := ioOpts.IO.Validate(); err != nil {
 				return err
@@ -1544,59 +1545,88 @@ func newHealthCommand(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			startMs, endMs, err := healthScope.resolveTime()
+			startMs, endMs, err := summaryScope.resolveTime()
 			if err != nil {
 				return err
 			}
-			if err := healthScope.validateScopes(cmd.Context(), client); err != nil {
+			if err := summaryScope.validateScopes(cmd.Context(), client); err != nil {
 				return err
 			}
 
-			counts, err := client.CountEntityTypes(cmd.Context())
+			counts, err := client.CountEntityTypes(cmd.Context(), startMs, endMs, summaryScope.scopeCriteria())
 			if err != nil {
 				return err
 			}
+			typeCounts := map[string]int64{}
 			var entityTypes []string
-			var totalEntities int
+			var totalEntities int64
 			for t, cnt := range counts {
-				totalEntities += int(cnt)
+				totalEntities += cnt
 				if cnt > 0 {
+					typeCounts[t] = cnt
 					entityTypes = append(entityTypes, t)
 				}
 			}
-			if healthEntityType != "" {
-				entityTypes = []string{healthEntityType}
+			if summaryEntityType != "" {
+				entityTypes = []string{summaryEntityType}
 			}
-			results, err := searchByTypes(cmd.Context(), cmd, client, entityTypes, true, false, healthScope.scopeCriteria(), startMs, endMs, 0, nil)
+			results, err := searchByTypes(cmd.Context(), cmd, client, entityTypes, true, false, summaryScope.scopeCriteria(), startMs, endMs, 0, nil)
 			if err != nil {
 				return err
 			}
 			sevCounts := map[string]int{}
+			nameCounts := map[string]int{}
+			totalInsights := 0
 			for _, r := range results {
-				if s, ok := r.Assertion["severity"].(string); ok {
-					sevCounts[strings.ToUpper(s)]++
-				} else {
-					sevCounts["UNKNOWN"]++
+				assertions, _ := r.Assertion["assertions"].([]any)
+				for _, a := range assertions {
+					m, ok := a.(map[string]any)
+					if !ok {
+						continue
+					}
+					totalInsights++
+					name, _ := m["assertionName"].(string)
+					if name == "" {
+						name = "UNKNOWN"
+					}
+					nameCounts[name]++
+					sev, _ := m["severity"].(string)
+					if sev == "" {
+						sevCounts["UNKNOWN"]++
+					} else {
+						sevCounts[strings.ToUpper(sev)]++
+					}
 				}
 			}
-			return ioOpts.IO.Encode(cmd.OutOrStdout(), map[string]any{
-				"severityCounts": sevCounts,
-				"totalEntities":  totalEntities,
-				"totalInsights":  len(results),
+			type entitiesSummary struct {
+				Total  int64            `json:"total" yaml:"total"`
+				ByType map[string]int64 `json:"byType" yaml:"byType"`
+			}
+			type insightsSummary struct {
+				Total      int            `json:"total" yaml:"total"`
+				BySeverity map[string]int `json:"bySeverity" yaml:"bySeverity"`
+				ByName     map[string]int `json:"byName" yaml:"byName"`
+			}
+			return ioOpts.IO.Encode(cmd.OutOrStdout(), struct {
+				Entities entitiesSummary `json:"entities" yaml:"entities"`
+				Insights insightsSummary `json:"insights" yaml:"insights"`
+			}{
+				Entities: entitiesSummary{Total: totalEntities, ByType: typeCounts},
+				Insights: insightsSummary{Total: totalInsights, BySeverity: sevCounts, ByName: nameCounts},
 			})
 		},
 	}
-	healthScope.register(cmd)
-	cmd.Flags().StringVar(&healthEntityType, "type", "", "Limit to a specific entity type")
+	summaryScope.register(cmd)
+	cmd.Flags().StringVar(&summaryEntityType, "type", "", "Limit to a specific entity type")
 	ioOpts.setup(cmd.Flags())
 	return cmd
 }
 
-type healthOpts struct {
+type summaryOpts struct {
 	IO cmdio.Options
 }
 
-func (o *healthOpts) setup(flags *pflag.FlagSet) {
+func (o *summaryOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("json")
 	o.IO.BindFlags(flags)
 }

--- a/internal/providers/kg/provider.go
+++ b/internal/providers/kg/provider.go
@@ -54,7 +54,7 @@ func (p *KGProvider) Commands() []*cobra.Command {
 		newAssertionsCommand(loader),
 		newDescribeCommand(loader),
 		// High-level
-		newHealthCommand(loader),
+		newSummaryCommand(loader),
 		newOpenCommand(loader),
 	)
 


### PR DESCRIPTION
## Summary

- Renames `gcx kg health` → `gcx kg summary`. The command produces a rolled-up snapshot of entities and active insights, which is broader than the original "is anything broken" framing implied.
- Restructures output into `entities` and `insights` sub-objects, each with `total` and `by{Type,Severity,Name}` aggregates. Counts are now per-insight (iterating the nested `assertions[]` array) instead of per-entity, so `bySeverity` and `byName` are consistent.
- Fixes a latent bug where the entity count call hardcoded the last hour and ignored scope: `CountEntityTypes` now takes a time window and `*ScopeCriteria`, so `entities.total` / `entities.byType` honor `--since`/`--env`/`--namespace` and align with the insight search.

### Breaking changes

- Command renamed: `gcx kg health` → `gcx kg summary`.
- Output JSON structure changed (top-level keys, field names, and counting semantics).

### Output shape

```json
{
  "entities": {
    "total": 1964,
    "byType": { "Database": 84, "Service": 264, ... }
  },
  "insights": {
    "total": 505,
    "bySeverity": { "CRITICAL": 127, "WARNING": 377, "INFO": 1 },
    "byName": { "CPU:USAGE::ResourceRateAnomaly": 91, ... }
  }
}
```

## Test plan

- [x] `mise run lint`
- [x] `mise run tests`
- [x] `GCX_AGENT_MODE=false mise run reference` (regenerated CLI docs)
- [x] `mise run docs`
- [x] Smoke: `gcx kg summary --since 1h` and `gcx kg summary --since 1h --namespace <ns>` against an ops stack — verified `entities.byType` and `insights.byName` reflect the scope/window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)