### PR TITLE
fix(irm): use registered codec for oncall action commands

### DIFF
--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups acknowledge <id> [flags]
 ```
   -h, --help            help for acknowledge
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
@@ -9,9 +9,7 @@ gcx irm oncall alert-groups acknowledge <id> [flags]
 ### Options
 
 ```
-  -h, --help            help for acknowledge
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -h, --help   help for acknowledge
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
@@ -9,7 +9,9 @@ gcx irm oncall alert-groups acknowledge <id> [flags]
 ### Options
 
 ```
-  -h, --help   help for acknowledge
+  -h, --help            help for acknowledge
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
@@ -9,7 +9,9 @@ gcx irm oncall alert-groups delete <id> [flags]
 ### Options
 
 ```
-  -h, --help   help for delete
+  -h, --help            help for delete
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
@@ -9,9 +9,7 @@ gcx irm oncall alert-groups delete <id> [flags]
 ### Options
 
 ```
-  -h, --help            help for delete
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -h, --help   help for delete
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups delete <id> [flags]
 ```
   -h, --help            help for delete
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups resolve <id> [flags]
 ```
   -h, --help            help for resolve
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
@@ -9,9 +9,7 @@ gcx irm oncall alert-groups resolve <id> [flags]
 ### Options
 
 ```
-  -h, --help            help for resolve
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -h, --help   help for resolve
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
@@ -9,7 +9,9 @@ gcx irm oncall alert-groups resolve <id> [flags]
 ### Options
 
 ```
-  -h, --help   help for resolve
+  -h, --help            help for resolve
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
@@ -9,10 +9,8 @@ gcx irm oncall alert-groups silence <id> [flags]
 ### Options
 
 ```
-      --duration int    Duration to silence in seconds (default 3600)
-  -h, --help            help for silence
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+      --duration int   Duration to silence in seconds (default 3600)
+  -h, --help           help for silence
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
@@ -9,8 +9,10 @@ gcx irm oncall alert-groups silence <id> [flags]
 ### Options
 
 ```
-      --duration int   Duration to silence in seconds (default 3600)
-  -h, --help           help for silence
+      --duration int    Duration to silence in seconds (default 3600)
+  -h, --help            help for silence
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
@@ -12,7 +12,7 @@ gcx irm oncall alert-groups silence <id> [flags]
       --duration int    Duration to silence in seconds (default 3600)
   -h, --help            help for silence
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups unacknowledge <id> [flags]
 ```
   -h, --help            help for unacknowledge
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
@@ -9,9 +9,7 @@ gcx irm oncall alert-groups unacknowledge <id> [flags]
 ### Options
 
 ```
-  -h, --help            help for unacknowledge
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -h, --help   help for unacknowledge
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
@@ -9,7 +9,9 @@ gcx irm oncall alert-groups unacknowledge <id> [flags]
 ### Options
 
 ```
-  -h, --help   help for unacknowledge
+  -h, --help            help for unacknowledge
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups unresolve <id> [flags]
 ```
   -h, --help            help for unresolve
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
@@ -9,9 +9,7 @@ gcx irm oncall alert-groups unresolve <id> [flags]
 ### Options
 
 ```
-  -h, --help            help for unresolve
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -h, --help   help for unresolve
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
@@ -9,7 +9,9 @@ gcx irm oncall alert-groups unresolve <id> [flags]
 ### Options
 
 ```
-  -h, --help   help for unresolve
+  -h, --help            help for unresolve
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
@@ -11,7 +11,7 @@ gcx irm oncall alert-groups unsilence <id> [flags]
 ```
   -h, --help            help for unsilence
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
@@ -9,9 +9,7 @@ gcx irm oncall alert-groups unsilence <id> [flags]
 ### Options
 
 ```
-  -h, --help            help for unsilence
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -h, --help   help for unsilence
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
@@ -9,7 +9,9 @@ gcx irm oncall alert-groups unsilence <id> [flags]
 ### Options
 
 ```
-  -h, --help   help for unsilence
+  -h, --help            help for unsilence
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_escalate.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalate.md
@@ -13,7 +13,7 @@ gcx irm oncall escalate [flags]
       --important          Mark as important
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --message string     Message for the escalation
-  -o, --output string      Output format. One of: agents, json, yaml (default "text")
+  -o, --output string      Output format. One of: agents, json, yaml (default "json")
       --team string        Team ID
       --title string       Title of the escalation (required)
       --user-ids strings   User IDs (comma-separated)

--- a/docs/reference/cli/gcx_irm_oncall_escalate.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalate.md
@@ -11,9 +11,7 @@ gcx irm oncall escalate [flags]
 ```
   -h, --help               help for escalate
       --important          Mark as important
-      --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --message string     Message for the escalation
-  -o, --output string      Output format. One of: agents, json, yaml (default "json")
       --team string        Team ID
       --title string       Title of the escalation (required)
       --user-ids strings   User IDs (comma-separated)

--- a/docs/reference/cli/gcx_irm_oncall_escalate.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalate.md
@@ -11,7 +11,9 @@ gcx irm oncall escalate [flags]
 ```
   -h, --help               help for escalate
       --important          Mark as important
+      --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --message string     Message for the escalation
+  -o, --output string      Output format. One of: agents, json, yaml (default "json")
       --team string        Team ID
       --title string       Title of the escalation (required)
       --user-ids strings   User IDs (comma-separated)

--- a/internal/providers/irm/export_test.go
+++ b/internal/providers/irm/export_test.go
@@ -2,6 +2,7 @@ package irm
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // NewTestListCommand creates a list command for testing validation.
@@ -20,4 +21,21 @@ func NewTestListCommand(labels []string, dateFrom, dateTo string) *cobra.Command
 	}
 	opts.setup(cmd.Flags())
 	return cmd
+}
+
+// ValidateAlertGroupActionDefaultIO sets up alertGroupActionOpts with default
+// flags and returns the result of IO.Validate(). Used to guard against the
+// DefaultFormat being a value the codec registry doesn't recognise.
+func ValidateAlertGroupActionDefaultIO() error {
+	o := &alertGroupActionOpts{}
+	o.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
+	return o.IO.Validate()
+}
+
+// ValidateEscalateDefaultIO is the escalateOpts counterpart of
+// ValidateAlertGroupActionDefaultIO.
+func ValidateEscalateDefaultIO() error {
+	o := &escalateOpts{}
+	o.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
+	return o.IO.Validate()
 }

--- a/internal/providers/irm/oncall_commands_extra.go
+++ b/internal/providers/irm/oncall_commands_extra.go
@@ -155,26 +155,12 @@ func newAlertGroupListAlertsCommand(loader OnCallConfigLoader) *cobra.Command {
 	return cmd
 }
 
-type alertGroupActionOpts struct {
-	IO cmdio.Options
-}
-
-func (o *alertGroupActionOpts) setup(flags *pflag.FlagSet) {
-	o.IO.DefaultFormat("json")
-	o.IO.BindFlags(flags)
-}
-
 func newAlertGroupActionCommand(loader OnCallConfigLoader, name, short string, actionFn func(OnCallAPI, *cobra.Command, string) error) *cobra.Command {
-	opts := &alertGroupActionOpts{}
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   name + " <id>",
 		Short: short,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.IO.Validate(); err != nil {
-				return err
-			}
-
 			client, _, err := loader.LoadOnCallClient(cmd.Context())
 			if err != nil {
 				return err
@@ -189,22 +175,15 @@ func newAlertGroupActionCommand(loader OnCallConfigLoader, name, short string, a
 			return nil
 		},
 	}
-	opts.setup(cmd.Flags())
-	return cmd
 }
 
 func newAlertGroupSilenceCommand(loader OnCallConfigLoader) *cobra.Command {
-	opts := &alertGroupActionOpts{}
 	var duration int
 	cmd := &cobra.Command{
 		Use:   "silence <id>",
 		Short: "Silence an alert group for a specified duration.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.IO.Validate(); err != nil {
-				return err
-			}
-
 			client, _, err := loader.LoadOnCallClient(cmd.Context())
 			if err != nil {
 				return err
@@ -219,7 +198,6 @@ func newAlertGroupSilenceCommand(loader OnCallConfigLoader) *cobra.Command {
 			return nil
 		},
 	}
-	opts.setup(cmd.Flags())
 	cmd.Flags().IntVar(&duration, "duration", 3600, "Duration to silence in seconds")
 	return cmd
 }
@@ -370,7 +348,6 @@ func newUsersCurrentCommand(loader OnCallConfigLoader) *cobra.Command {
 // ---------------------------------------------------------------------------
 
 type escalateOpts struct {
-	IO        cmdio.Options
 	Title     string
 	Message   string
 	Team      string
@@ -379,8 +356,6 @@ type escalateOpts struct {
 }
 
 func (o *escalateOpts) setup(flags *pflag.FlagSet) {
-	o.IO.DefaultFormat("json")
-	o.IO.BindFlags(flags)
 	flags.StringVar(&o.Title, "title", "", "Title of the escalation (required)")
 	flags.StringVar(&o.Message, "message", "", "Message for the escalation")
 	flags.StringVar(&o.Team, "team", "", "Team ID")
@@ -401,9 +376,6 @@ func newEscalateCommand(loader OnCallConfigLoader) *cobra.Command {
 		Use:   "escalate",
 		Short: "Create a direct escalation.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := opts.IO.Validate(); err != nil {
-				return err
-			}
 			if err := opts.Validate(); err != nil {
 				return err
 			}

--- a/internal/providers/irm/oncall_commands_extra.go
+++ b/internal/providers/irm/oncall_commands_extra.go
@@ -160,7 +160,7 @@ type alertGroupActionOpts struct {
 }
 
 func (o *alertGroupActionOpts) setup(flags *pflag.FlagSet) {
-	o.IO.DefaultFormat("text")
+	o.IO.DefaultFormat("json")
 	o.IO.BindFlags(flags)
 }
 
@@ -379,7 +379,7 @@ type escalateOpts struct {
 }
 
 func (o *escalateOpts) setup(flags *pflag.FlagSet) {
-	o.IO.DefaultFormat("text")
+	o.IO.DefaultFormat("json")
 	o.IO.BindFlags(flags)
 	flags.StringVar(&o.Title, "title", "", "Title of the escalation (required)")
 	flags.StringVar(&o.Message, "message", "", "Message for the escalation")

--- a/internal/providers/irm/oncall_commands_extra.go
+++ b/internal/providers/irm/oncall_commands_extra.go
@@ -155,12 +155,26 @@ func newAlertGroupListAlertsCommand(loader OnCallConfigLoader) *cobra.Command {
 	return cmd
 }
 
+type alertGroupActionOpts struct {
+	IO cmdio.Options
+}
+
+func (o *alertGroupActionOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+}
+
 func newAlertGroupActionCommand(loader OnCallConfigLoader, name, short string, actionFn func(OnCallAPI, *cobra.Command, string) error) *cobra.Command {
-	return &cobra.Command{
+	opts := &alertGroupActionOpts{}
+	cmd := &cobra.Command{
 		Use:   name + " <id>",
 		Short: short,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
 			client, _, err := loader.LoadOnCallClient(cmd.Context())
 			if err != nil {
 				return err
@@ -175,15 +189,22 @@ func newAlertGroupActionCommand(loader OnCallConfigLoader, name, short string, a
 			return nil
 		},
 	}
+	opts.setup(cmd.Flags())
+	return cmd
 }
 
 func newAlertGroupSilenceCommand(loader OnCallConfigLoader) *cobra.Command {
+	opts := &alertGroupActionOpts{}
 	var duration int
 	cmd := &cobra.Command{
 		Use:   "silence <id>",
 		Short: "Silence an alert group for a specified duration.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
 			client, _, err := loader.LoadOnCallClient(cmd.Context())
 			if err != nil {
 				return err
@@ -198,6 +219,7 @@ func newAlertGroupSilenceCommand(loader OnCallConfigLoader) *cobra.Command {
 			return nil
 		},
 	}
+	opts.setup(cmd.Flags())
 	cmd.Flags().IntVar(&duration, "duration", 3600, "Duration to silence in seconds")
 	return cmd
 }
@@ -348,6 +370,7 @@ func newUsersCurrentCommand(loader OnCallConfigLoader) *cobra.Command {
 // ---------------------------------------------------------------------------
 
 type escalateOpts struct {
+	IO        cmdio.Options
 	Title     string
 	Message   string
 	Team      string
@@ -356,6 +379,8 @@ type escalateOpts struct {
 }
 
 func (o *escalateOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
 	flags.StringVar(&o.Title, "title", "", "Title of the escalation (required)")
 	flags.StringVar(&o.Message, "message", "", "Message for the escalation")
 	flags.StringVar(&o.Team, "team", "", "Team ID")
@@ -376,6 +401,9 @@ func newEscalateCommand(loader OnCallConfigLoader) *cobra.Command {
 		Use:   "escalate",
 		Short: "Create a direct escalation.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
 			if err := opts.Validate(); err != nil {
 				return err
 			}

--- a/internal/providers/irm/oncall_commands_extra_test.go
+++ b/internal/providers/irm/oncall_commands_extra_test.go
@@ -1,10 +1,10 @@
-package irm
+package irm_test
 
 import (
 	"testing"
 
 	"github.com/grafana/gcx/internal/agent"
-	"github.com/spf13/pflag"
+	"github.com/grafana/gcx/internal/providers/irm"
 )
 
 // Regression: alert-group action commands and escalate set a DefaultFormat
@@ -20,17 +20,13 @@ func TestActionOptsDefaultFormatIsValid(t *testing.T) {
 	t.Cleanup(agent.ResetForTesting)
 
 	t.Run("alertGroupActionOpts", func(t *testing.T) {
-		o := &alertGroupActionOpts{}
-		o.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
-		if err := o.IO.Validate(); err != nil {
+		if err := irm.ValidateAlertGroupActionDefaultIO(); err != nil {
 			t.Fatalf("default IO.Validate() returned error: %v", err)
 		}
 	})
 
 	t.Run("escalateOpts", func(t *testing.T) {
-		o := &escalateOpts{}
-		o.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
-		if err := o.IO.Validate(); err != nil {
+		if err := irm.ValidateEscalateDefaultIO(); err != nil {
 			t.Fatalf("default IO.Validate() returned error: %v", err)
 		}
 	})

--- a/internal/providers/irm/oncall_commands_extra_test.go
+++ b/internal/providers/irm/oncall_commands_extra_test.go
@@ -1,0 +1,37 @@
+package irm
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/spf13/pflag"
+)
+
+// Regression: alert-group action commands and escalate set a DefaultFormat
+// that must correspond to a registered codec, otherwise IO.Validate()
+// rejects the default value with "unknown output format".
+// See https://github.com/grafana/gcx/issues/681.
+//
+// Force agent mode off so BindFlags doesn't override the per-command default
+// with the agents codec — that override would mask the bug.
+func TestActionOptsDefaultFormatIsValid(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	t.Run("alertGroupActionOpts", func(t *testing.T) {
+		o := &alertGroupActionOpts{}
+		o.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
+		if err := o.IO.Validate(); err != nil {
+			t.Fatalf("default IO.Validate() returned error: %v", err)
+		}
+	})
+
+	t.Run("escalateOpts", func(t *testing.T) {
+		o := &escalateOpts{}
+		o.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
+		if err := o.IO.Validate(); err != nil {
+			t.Fatalf("default IO.Validate() returned error: %v", err)
+		}
+	})
+}

--- a/internal/providers/irm/oncall_commands_extra_test.go
+++ b/internal/providers/irm/oncall_commands_extra_test.go
@@ -1,48 +1,37 @@
 package irm
 
 import (
-	"context"
 	"testing"
 
-	"github.com/spf13/cobra"
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/spf13/pflag"
 )
 
-// Regression: alert-group action commands and escalate previously set
-// a DefaultFormat ("text") that had no registered codec, so the commands
-// failed with "unknown output format". The idiomatic gcx pattern for
-// action-only commands (sibling delete/close commands across providers)
-// is to skip cmdio.Options entirely — no -o flag, no Validate(), just
-// cmdio.Success() on completion. This test asserts those commands do
-// not expose an -o/--output flag.
+// Regression: alert-group action commands and escalate set a DefaultFormat
+// that must correspond to a registered codec, otherwise IO.Validate()
+// rejects the default value with "unknown output format".
 // See https://github.com/grafana/gcx/issues/681.
-func TestActionCommandsHaveNoOutputFlag(t *testing.T) {
-	t.Parallel()
+//
+// Force agent mode off so BindFlags doesn't override the per-command default
+// with the agents codec — that override would mask the bug.
+func TestActionOptsDefaultFormatIsValid(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
 
-	loader := stubLoader{}
+	t.Run("alertGroupActionOpts", func(t *testing.T) {
+		o := &alertGroupActionOpts{}
+		o.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
+		if err := o.IO.Validate(); err != nil {
+			t.Fatalf("default IO.Validate() returned error: %v", err)
+		}
+	})
 
-	cases := []*cobra.Command{
-		newAlertGroupActionCommand(loader, "resolve", "Resolve.", nil),
-		newAlertGroupActionCommand(loader, "acknowledge", "Acknowledge.", nil),
-		newAlertGroupActionCommand(loader, "unsilence", "Unsilence.", nil),
-		newAlertGroupSilenceCommand(loader),
-		newEscalateCommand(loader),
-	}
-
-	for _, cmd := range cases {
-		t.Run(cmd.Name(), func(t *testing.T) {
-			t.Parallel()
-			if f := cmd.Flags().Lookup("output"); f != nil {
-				t.Errorf("%s exposes --output flag; action-only commands should skip cmdio.Options", cmd.Name())
-			}
-			if f := cmd.Flags().Lookup("json"); f != nil {
-				t.Errorf("%s exposes --json flag; action-only commands should skip cmdio.Options", cmd.Name())
-			}
-		})
-	}
-}
-
-type stubLoader struct{}
-
-func (stubLoader) LoadOnCallClient(_ context.Context) (OnCallAPI, string, error) {
-	return nil, "", nil
+	t.Run("escalateOpts", func(t *testing.T) {
+		o := &escalateOpts{}
+		o.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
+		if err := o.IO.Validate(); err != nil {
+			t.Fatalf("default IO.Validate() returned error: %v", err)
+		}
+	})
 }

--- a/internal/providers/irm/oncall_commands_extra_test.go
+++ b/internal/providers/irm/oncall_commands_extra_test.go
@@ -1,37 +1,48 @@
 package irm
 
 import (
+	"context"
 	"testing"
 
-	"github.com/grafana/gcx/internal/agent"
-	"github.com/spf13/pflag"
+	"github.com/spf13/cobra"
 )
 
-// Regression: alert-group action commands and escalate set a DefaultFormat
-// that must correspond to a registered codec, otherwise IO.Validate()
-// rejects the default value with "unknown output format".
+// Regression: alert-group action commands and escalate previously set
+// a DefaultFormat ("text") that had no registered codec, so the commands
+// failed with "unknown output format". The idiomatic gcx pattern for
+// action-only commands (sibling delete/close commands across providers)
+// is to skip cmdio.Options entirely — no -o flag, no Validate(), just
+// cmdio.Success() on completion. This test asserts those commands do
+// not expose an -o/--output flag.
 // See https://github.com/grafana/gcx/issues/681.
-//
-// Force agent mode off so BindFlags doesn't override the per-command default
-// with the agents codec — that override would mask the bug.
-func TestActionOptsDefaultFormatIsValid(t *testing.T) {
-	t.Setenv("GCX_AGENT_MODE", "false")
-	agent.ResetForTesting()
-	t.Cleanup(agent.ResetForTesting)
+func TestActionCommandsHaveNoOutputFlag(t *testing.T) {
+	t.Parallel()
 
-	t.Run("alertGroupActionOpts", func(t *testing.T) {
-		o := &alertGroupActionOpts{}
-		o.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
-		if err := o.IO.Validate(); err != nil {
-			t.Fatalf("default IO.Validate() returned error: %v", err)
-		}
-	})
+	loader := stubLoader{}
 
-	t.Run("escalateOpts", func(t *testing.T) {
-		o := &escalateOpts{}
-		o.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
-		if err := o.IO.Validate(); err != nil {
-			t.Fatalf("default IO.Validate() returned error: %v", err)
-		}
-	})
+	cases := []*cobra.Command{
+		newAlertGroupActionCommand(loader, "resolve", "Resolve.", nil),
+		newAlertGroupActionCommand(loader, "acknowledge", "Acknowledge.", nil),
+		newAlertGroupActionCommand(loader, "unsilence", "Unsilence.", nil),
+		newAlertGroupSilenceCommand(loader),
+		newEscalateCommand(loader),
+	}
+
+	for _, cmd := range cases {
+		t.Run(cmd.Name(), func(t *testing.T) {
+			t.Parallel()
+			if f := cmd.Flags().Lookup("output"); f != nil {
+				t.Errorf("%s exposes --output flag; action-only commands should skip cmdio.Options", cmd.Name())
+			}
+			if f := cmd.Flags().Lookup("json"); f != nil {
+				t.Errorf("%s exposes --json flag; action-only commands should skip cmdio.Options", cmd.Name())
+			}
+		})
+	}
+}
+
+type stubLoader struct{}
+
+func (stubLoader) LoadOnCallClient(_ context.Context) (OnCallAPI, string, error) {
+	return nil, "", nil
 }


### PR DESCRIPTION
## Summary
- `gcx irm oncall alert-groups {resolve,acknowledge,silence,unsilence,...}` and `gcx irm oncall escalate` set `DefaultFormat("text")` but no `text` codec is registered, so `Validate()` rejected the default and `--help` showed an unreachable `(default "text")`.
- These commands only print a success message via `cmdio.Success()` and never call `Encode()`, so the output format is functionally irrelevant — switch the default to `json` (the project-wide default).
- Adds a regression test that disables agent-mode auto-detection (which would otherwise override the default at `BindFlags` time and mask the bug).

## Changes
- `internal/providers/irm/oncall_commands_extra.go`: `alertGroupActionOpts.setup` and `escalateOpts.setup` now use `DefaultFormat("json")`.
- `internal/providers/irm/oncall_commands_extra_test.go`: new regression test asserting `IO.Validate()` succeeds for both option types.
- `docs/reference/cli/gcx_irm_oncall_alert-groups_*.md`, `docs/reference/cli/gcx_irm_oncall_escalate.md`: regenerated to reflect the new default.

## Out of scope
These action commands print unstructured prose via `cmdio.Success()` instead of emitting a structured operation summary through the codec system. The CONSTITUTION (Dual-Purpose Design) calls for the latter, and the same gap exists across several sibling action commands (`alert delete`, `contact-points delete`, `incidents close`, `probes delete`, `dashboards delete`, ...). That broader compliance work is intentionally left out of this bug fix and should be addressed uniformly in a separate change.

## Test Plan
- [x] `go test ./internal/providers/irm/...`
- [x] `GCX_AGENT_MODE=false mise run lint`
- [x] `GCX_AGENT_MODE=false go test -race -count=1 ./...`
- [x] `GCX_AGENT_MODE=false mise run reference` (no further drift)
- [x] End-to-end on a real stack: `alert-groups acknowledge <id>` and `alert-groups resolve <id>` both succeed; `--help` shows coherent `(default "json")`.
- [x] New regression test verified to fail when `DefaultFormat("text")` is restored

## History
The branch also contains a refactor commit (`ba3eacf`) that removed the `cmdio.Options` machinery entirely and a revert (`734b68a`) undoing it. Rationale: the refactor matched a *prevalent codebase pattern* but moved further from CONSTITUTION compliance (dropped the Options-pattern taste rule; bypassed the codec system). Reverted so this PR stays a narrow bug fix.

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)