### PR TITLE
fix(config): use-context writes to the right file when local .gcx.yaml is loaded

### DIFF
--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -479,24 +478,25 @@ user config), use --file to choose which layer to update.`,
 	# Update the local .gcx.yaml when both user and local configs exist
 	gcx config use-context --file local dev-instance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Load without env overrides so env-sourced secrets are never persisted.
-			cfg, err := config.LoadLayered(cmd.Context(), configOpts.ConfigFile)
+			// Cross-layer existence check: a context defined only in the user
+			// layer is still a valid target when --file local is specified.
+			layered, err := config.LoadLayered(cmd.Context(), configOpts.ConfigFile)
 			if err != nil {
 				return err
 			}
-
-			if !cfg.HasContext(args[0]) {
+			if !layered.HasContext(args[0]) {
 				return config.ContextNotFound(args[0])
+			}
+
+			// Load only the target layer so we don't write cross-layer entries.
+			cfg, target, err := config.LoadForWrite(cmd.Context(), configOpts.ConfigFile, fileType)
+			if err != nil {
+				return err
 			}
 
 			cfg.CurrentContext = args[0]
 
-			targetSource, err := resolveWriteTarget(configOpts, fileType, cmd.Context())
-			if err != nil {
-				return err
-			}
-
-			if err := config.Write(cmd.Context(), targetSource, cfg); err != nil {
+			if err := config.Write(cmd.Context(), target, cfg); err != nil {
 				return err
 			}
 
@@ -508,45 +508,6 @@ user config), use --file to choose which layer to update.`,
 	cmd.Flags().StringVar(&fileType, "file", "", "Config layer to write to (system, user, local)")
 
 	return cmd
-}
-
-// resolveWriteTarget determines which config file to write to based on --config flag,
-// --file flag, and the number of discovered sources.
-func resolveWriteTarget(configOpts *Options, fileType string, ctx context.Context) (config.Source, error) {
-	// --config flag always wins.
-	if configOpts.ConfigFile != "" {
-		return config.ExplicitConfigFile(configOpts.ConfigFile), nil
-	}
-
-	// --file flag targets a specific layer.
-	if fileType != "" {
-		layered, err := config.LoadLayered(ctx, "")
-		if err != nil {
-			return nil, err
-		}
-		for _, s := range layered.Sources {
-			if s.Type == fileType {
-				return config.ExplicitConfigFile(s.Path), nil
-			}
-		}
-		return nil, fmt.Errorf("no %s config file found", fileType)
-	}
-
-	// No flags — pick the unambiguous target.
-	layered, err := config.LoadLayered(ctx, "")
-	if err != nil {
-		return nil, err
-	}
-	switch len(layered.Sources) {
-	case 0:
-		// No discovered files — let StandardLocation create the default user config.
-		return configOpts.ConfigSource(), nil
-	case 1:
-		// Exactly one source — write to it.
-		return config.ExplicitConfigFile(layered.Sources[0].Path), nil
-	default:
-		return nil, errors.New("multiple config files loaded; specify which to update with --file (system, user, local)")
-	}
 }
 
 func setCmd(configOpts *Options) *cobra.Command {
@@ -576,12 +537,7 @@ PROPERTY_VALUE is the new value to set.`,
 	# Set a value in the local config layer
 	gcx config set --file local contexts.prod.cloud.token my-token`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			targetSource, err := resolveWriteTarget(configOpts, fileType, cmd.Context())
-			if err != nil {
-				return err
-			}
-
-			cfg, err := config.Load(cmd.Context(), targetSource)
+			cfg, target, err := config.LoadForWrite(cmd.Context(), configOpts.ConfigFile, fileType)
 			if err != nil {
 				return err
 			}
@@ -595,7 +551,7 @@ PROPERTY_VALUE is the new value to set.`,
 				return err
 			}
 
-			return config.Write(cmd.Context(), targetSource, cfg)
+			return config.Write(cmd.Context(), target, cfg)
 		},
 	}
 
@@ -629,12 +585,7 @@ A bare path (e.g. "cloud.token") is resolved against the current context and is 
 	# Unset a value in the local config layer
 	gcx config unset --file local contexts.prod.cloud.token`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			targetSource, err := resolveWriteTarget(configOpts, fileType, cmd.Context())
-			if err != nil {
-				return err
-			}
-
-			cfg, err := config.Load(cmd.Context(), targetSource)
+			cfg, target, err := config.LoadForWrite(cmd.Context(), configOpts.ConfigFile, fileType)
 			if err != nil {
 				return err
 			}
@@ -648,7 +599,7 @@ A bare path (e.g. "cloud.token") is resolved against the current context and is 
 				return err
 			}
 
-			return config.Write(cmd.Context(), targetSource, cfg)
+			return config.Write(cmd.Context(), target, cfg)
 		},
 	}
 

--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -462,13 +462,22 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 }
 
 func useContextCmd(configOpts *Options) *cobra.Command {
+	var fileType string
+
 	cmd := &cobra.Command{
 		Use:     "use-context CONTEXT_NAME",
 		Args:    cobra.ExactArgs(1),
 		Aliases: []string{"use"},
 		Short:   "Set the current context",
-		Long:    "Set the current context and updates the configuration file.",
-		Example: "\n\tgcx config use-context dev-instance",
+		Long: `Set the current context and updates the configuration file.
+
+When multiple config files are loaded (e.g. a local .gcx.yaml alongside the
+user config), use --file to choose which layer to update.`,
+		Example: `
+	gcx config use-context dev-instance
+
+	# Update the local .gcx.yaml when both user and local configs exist
+	gcx config use-context --file local dev-instance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Load without env overrides so env-sourced secrets are never persisted.
 			cfg, err := config.LoadLayered(cmd.Context(), configOpts.ConfigFile)
@@ -482,7 +491,12 @@ func useContextCmd(configOpts *Options) *cobra.Command {
 
 			cfg.CurrentContext = args[0]
 
-			if err := config.Write(cmd.Context(), configOpts.ConfigSource(), cfg); err != nil {
+			targetSource, err := resolveWriteTarget(configOpts, fileType, cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			if err := config.Write(cmd.Context(), targetSource, cfg); err != nil {
 				return err
 			}
 
@@ -490,6 +504,8 @@ func useContextCmd(configOpts *Options) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&fileType, "file", "", "Config layer to write to (system, user, local)")
 
 	return cmd
 }
@@ -516,17 +532,21 @@ func resolveWriteTarget(configOpts *Options, fileType string, ctx context.Contex
 		return nil, fmt.Errorf("no %s config file found", fileType)
 	}
 
-	// No flags — check if ambiguous.
+	// No flags — pick the unambiguous target.
 	layered, err := config.LoadLayered(ctx, "")
 	if err != nil {
 		return nil, err
 	}
-	if len(layered.Sources) > 1 {
-		return nil, errors.New("multiple config files loaded; specify which to edit with --file (system, user, local)")
+	switch len(layered.Sources) {
+	case 0:
+		// No discovered files — let StandardLocation create the default user config.
+		return configOpts.ConfigSource(), nil
+	case 1:
+		// Exactly one source — write to it.
+		return config.ExplicitConfigFile(layered.Sources[0].Path), nil
+	default:
+		return nil, errors.New("multiple config files loaded; specify which to update with --file (system, user, local)")
 	}
-
-	// Single source or no sources — use existing behavior.
-	return configOpts.ConfigSource(), nil
 }
 
 func setCmd(configOpts *Options) *cobra.Command {

--- a/cmd/gcx/config/command_test.go
+++ b/cmd/gcx/config/command_test.go
@@ -1,13 +1,66 @@
 package config_test
 
 import (
+	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/adrg/xdg"
 	"github.com/grafana/gcx/cmd/gcx/config"
 	"github.com/grafana/gcx/internal/testutils"
+	"github.com/stretchr/testify/require"
 )
+
+// isolatedConfigEnv points HOME and XDG_CONFIG_HOME at empty temp dirs and
+// chdirs into a working directory, so layered config discovery only sees what
+// the test writes. Returns the user-config directory and the working directory.
+func isolatedConfigEnv(t *testing.T) (string, string) {
+	t.Helper()
+	userDir := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", userDir)
+	t.Setenv("GCX_CONFIG", "")
+	xdg.Reload()
+	t.Chdir(workDir)
+	return userDir, workDir
+}
+
+// writeLocalConfig creates a `.gcx.yaml` in workDir with the given content and
+// returns its path.
+func writeLocalConfig(t *testing.T, workDir, content string) string {
+	t.Helper()
+	path := filepath.Join(workDir, ".gcx.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// writeUserConfig creates the user config file (XDG_CONFIG_HOME/gcx/config.yaml)
+// with the given content and returns its path.
+func writeUserConfig(t *testing.T, userDir, content string) string {
+	t.Helper()
+	path := filepath.Join(userDir, "gcx", "config.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// runConfigCmd executes a `gcx config ...` invocation against a fresh command
+// tree and returns the combined stdout/stderr plus error.
+func runConfigCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := config.Command()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
 
 func Test_CurrentContextCommand(t *testing.T) {
 	testCase := testutils.CommandTestCase{
@@ -539,4 +592,104 @@ current-context: default
 	}
 
 	testCase.Run(t)
+}
+
+// Regression test for #564: when only a local .gcx.yaml exists, use-context
+// must update that file instead of silently creating/writing the user config.
+func Test_UseContextCommand_writesToLocalConfigWhenOnlySource(t *testing.T) {
+	_, workDir := isolatedConfigEnv(t)
+	localPath := writeLocalConfig(t, workDir, `current-context: old
+contexts:
+  old: {}
+  new: {}
+`)
+
+	out, err := runConfigCmd(t, "use-context", "new")
+	require.NoError(t, err, out)
+	require.Contains(t, out, `Context set to "new"`)
+
+	contents, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+	require.Contains(t, string(contents), "current-context: new")
+
+	userPath := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "gcx", "config.yaml")
+	_, statErr := os.Stat(userPath)
+	require.True(t, os.IsNotExist(statErr), "user config must not be created, got: %v", statErr)
+}
+
+// When both user and local configs exist, use-context cannot guess which to
+// update, so it errors with guidance pointing at --file. This matches the
+// behaviour of `gcx config set` / `unset`.
+func Test_UseContextCommand_multipleSourcesRequiresFileFlag(t *testing.T) {
+	userDir, workDir := isolatedConfigEnv(t)
+	userPath := writeUserConfig(t, userDir, `current-context: user-ctx
+contexts:
+  user-ctx: {}
+  new: {}
+`)
+	localPath := writeLocalConfig(t, workDir, `current-context: local-ctx
+contexts:
+  local-ctx: {}
+  new: {}
+`)
+
+	out, err := runConfigCmd(t, "use-context", "new")
+	require.Error(t, err, out)
+	require.Contains(t, err.Error(), "--file")
+
+	for _, p := range []string{userPath, localPath} {
+		contents, readErr := os.ReadFile(p)
+		require.NoError(t, readErr)
+		require.NotContains(t, string(contents), "current-context: new",
+			"file %s must not be modified", p)
+	}
+}
+
+// --file selects the target layer explicitly when multiple sources exist.
+func Test_UseContextCommand_fileFlagSelectsLayer(t *testing.T) {
+	userDir, workDir := isolatedConfigEnv(t)
+	userPath := writeUserConfig(t, userDir, `current-context: user-ctx
+contexts:
+  user-ctx: {}
+  new: {}
+`)
+	localPath := writeLocalConfig(t, workDir, `current-context: local-ctx
+contexts:
+  local-ctx: {}
+  new: {}
+`)
+
+	out, err := runConfigCmd(t, "use-context", "--file", "local", "new")
+	require.NoError(t, err, out)
+
+	localContents, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+	require.Contains(t, string(localContents), "current-context: new")
+
+	userContents, err := os.ReadFile(userPath)
+	require.NoError(t, err)
+	require.Contains(t, string(userContents), "current-context: user-ctx",
+		"user config must be untouched when --file local is given")
+}
+
+// Regression test for the same latent bug in `gcx config set`: with only a
+// local .gcx.yaml, set must write to that file rather than fabricating a user
+// config.
+func Test_SetCommand_writesToLocalConfigWhenOnlySource(t *testing.T) {
+	_, workDir := isolatedConfigEnv(t)
+	localPath := writeLocalConfig(t, workDir, `current-context: dev
+contexts:
+  dev: {}
+`)
+
+	_, err := runConfigCmd(t, "set", "contexts.dev.grafana.server", "https://example.test")
+	require.NoError(t, err)
+
+	contents, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+	require.Contains(t, string(contents), "server: https://example.test")
+
+	userPath := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "gcx", "config.yaml")
+	_, statErr := os.Stat(userPath)
+	require.True(t, os.IsNotExist(statErr), "user config must not be created, got: %v", statErr)
 }

--- a/cmd/gcx/config/command_test.go
+++ b/cmd/gcx/config/command_test.go
@@ -665,11 +665,15 @@ contexts:
 	localContents, err := os.ReadFile(localPath)
 	require.NoError(t, err)
 	require.Contains(t, string(localContents), "current-context: new")
+	require.NotContains(t, string(localContents), "user-ctx",
+		"local config must not absorb user-layer contexts")
 
 	userContents, err := os.ReadFile(userPath)
 	require.NoError(t, err)
 	require.Contains(t, string(userContents), "current-context: user-ctx",
 		"user config must be untouched when --file local is given")
+	require.NotContains(t, string(userContents), "local-ctx",
+		"user config must not absorb local-layer contexts")
 }
 
 // Regression test for the same latent bug in `gcx config set`: with only a

--- a/docs/reference/cli/gcx_config_use-context.md
+++ b/docs/reference/cli/gcx_config_use-context.md
@@ -6,6 +6,9 @@ Set the current context
 
 Set the current context and updates the configuration file.
 
+When multiple config files are loaded (e.g. a local .gcx.yaml alongside the
+user config), use --file to choose which layer to update.
+
 ```
 gcx config use-context CONTEXT_NAME [flags]
 ```
@@ -15,12 +18,16 @@ gcx config use-context CONTEXT_NAME [flags]
 ```
 
 	gcx config use-context dev-instance
+
+	# Update the local .gcx.yaml when both user and local configs exist
+	gcx config use-context --file local dev-instance
 ```
 
 ### Options
 
 ```
-  -h, --help   help for use-context
+      --file string   Config layer to write to (system, user, local)
+  -h, --help          help for use-context
 ```
 
 ### Options inherited from parent commands

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -420,6 +420,53 @@ func LoadLayered(ctx context.Context, explicitFile string, overrides ...Override
 	return merged, nil
 }
 
+// LoadForWrite resolves the target config layer, loads only that layer, and
+// returns both the Config and its Source. Callers should mutate the Config
+// and pass the Source to Write, preserving layer separation when multiple
+// config files are present.
+//
+// explicitFile is the value of the --config flag; fileType is the value of
+// the --file flag. Both may be empty.
+func LoadForWrite(ctx context.Context, explicitFile, fileType string) (Config, Source, error) {
+	if explicitFile != "" {
+		src := ExplicitConfigFile(explicitFile)
+		cfg, err := Load(ctx, src)
+		return cfg, src, err
+	}
+
+	if fileType != "" {
+		layered, err := LoadLayered(ctx, "")
+		if err != nil {
+			return Config{}, nil, err
+		}
+		for _, s := range layered.Sources {
+			if s.Type == fileType {
+				src := ExplicitConfigFile(s.Path)
+				cfg, err := Load(ctx, src)
+				return cfg, src, err
+			}
+		}
+		return Config{}, nil, fmt.Errorf("no %s config file found", fileType)
+	}
+
+	layered, err := LoadLayered(ctx, "")
+	if err != nil {
+		return Config{}, nil, err
+	}
+	switch len(layered.Sources) {
+	case 0:
+		src := StandardLocation()
+		cfg, err := Load(ctx, src)
+		return cfg, src, err
+	case 1:
+		src := ExplicitConfigFile(layered.Sources[0].Path)
+		cfg, err := Load(ctx, src)
+		return cfg, src, err
+	default:
+		return Config{}, nil, errors.New("multiple config files loaded; specify which to update with --file (system, user, local)")
+	}
+}
+
 // loadExplicit loads a single explicit config file, bypassing layered discovery.
 func loadExplicit(ctx context.Context, path string, overrides ...Override) (Config, error) {
 	cfg, err := Load(ctx, ExplicitConfigFile(path), overrides...)

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -341,6 +341,87 @@ func TestCheckDuplicateUserConfig_BothExist(t *testing.T) {
 	assert.Equal(t, xdgFile, dup.Ignored)
 }
 
+// isolatedLoaderEnv isolates HOME and XDG_CONFIG_HOME so source discovery only
+// sees files the test creates. Returns the user-config dir and working dir.
+func isolatedLoaderEnv(t *testing.T) (string, string) {
+	t.Helper()
+	userDir := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", userDir)
+	t.Setenv("GCX_CONFIG", "")
+	xdg.Reload()
+	t.Chdir(workDir)
+	return userDir, workDir
+}
+
+func writeLoaderConfig(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+func TestLoadForWrite_explicitFile(t *testing.T) {
+	userDir, _ := isolatedLoaderEnv(t)
+	userPath := filepath.Join(userDir, "gcx", "config.yaml")
+	writeLoaderConfig(t, userPath, "current-context: dev\ncontexts:\n  dev: {}\n")
+
+	cfg, src, err := config.LoadForWrite(t.Context(), userPath, "")
+	require.NoError(t, err)
+	require.Equal(t, "dev", cfg.CurrentContext)
+
+	filename, err := src()
+	require.NoError(t, err)
+	require.Equal(t, userPath, filename)
+}
+
+func TestLoadForWrite_fileType_targetsNamedLayer(t *testing.T) {
+	userDir, workDir := isolatedLoaderEnv(t)
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
+		"contexts:\n  user-ctx: {}\ncurrent-context: user-ctx\n")
+	writeLoaderConfig(t, filepath.Join(workDir, ".gcx.yaml"),
+		"contexts:\n  local-ctx: {}\ncurrent-context: local-ctx\n")
+
+	cfg, _, err := config.LoadForWrite(t.Context(), "", "local")
+	require.NoError(t, err)
+	require.Equal(t, "local-ctx", cfg.CurrentContext)
+	require.Contains(t, cfg.Contexts, "local-ctx")
+	require.NotContains(t, cfg.Contexts, "user-ctx",
+		"LoadForWrite must not merge other layers into the result")
+}
+
+func TestLoadForWrite_fileType_notFound_errors(t *testing.T) {
+	userDir, _ := isolatedLoaderEnv(t)
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
+		"current-context: dev\ncontexts:\n  dev: {}\n")
+
+	_, _, err := config.LoadForWrite(t.Context(), "", "local")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no local config file found")
+}
+
+func TestLoadForWrite_singleSource_autoDetects(t *testing.T) {
+	userDir, _ := isolatedLoaderEnv(t)
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
+		"current-context: dev\ncontexts:\n  dev: {}\n")
+
+	cfg, _, err := config.LoadForWrite(t.Context(), "", "")
+	require.NoError(t, err)
+	require.Equal(t, "dev", cfg.CurrentContext)
+}
+
+func TestLoadForWrite_multipleSources_errors(t *testing.T) {
+	userDir, workDir := isolatedLoaderEnv(t)
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
+		"current-context: dev\ncontexts:\n  dev: {}\n")
+	writeLoaderConfig(t, filepath.Join(workDir, ".gcx.yaml"),
+		"current-context: local\ncontexts:\n  local: {}\n")
+
+	_, _, err := config.LoadForWrite(t.Context(), "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--file")
+}
+
 func TestCheckDuplicateUserConfig_NoDuplicate(t *testing.T) {
 	homeDir := t.TempDir()
 	xdgDir := t.TempDir()


### PR DESCRIPTION
## Summary

- `gcx config use-context` was always writing to the global user config via `StandardLocation()`, ignoring any local `.gcx.yaml` that was being loaded. The higher-priority local file kept shadowing the update, so the command appeared to be a silent no-op.
- Route `use-context` through `resolveWriteTarget` (already used by `set`/`unset`) and fix its single-source fallback to target the discovered file rather than `StandardLocation()`.
- Add a `--file` flag to `use-context` to disambiguate when both user and local configs are present.

## Behavior

| Situation | Behavior |
|-----------|----------|
| Only `.gcx.yaml` exists | Writes to `.gcx.yaml` (was: wrote to user config) |
| Only user config exists | Writes to user config (unchanged) |
| Both exist, no `--file` | Errors: `multiple config files loaded; specify which to update with --file (system, user, local)` |
| `--file local`/`user`/`system` | Writes to that layer |
| `--config <path>` | Writes to that path (unchanged) |
| Neither exists | Creates default user config (unchanged) |

The same latent bug existed in `gcx config set`/`unset` for the single-source case; the `resolveWriteTarget` fix covers them too.

## Test Plan

- [x] New regression tests in `cmd/gcx/config/command_test.go`:
  - `Test_UseContextCommand_writesToLocalConfigWhenOnlySource` — only `.gcx.yaml` → write hits local
  - `Test_UseContextCommand_multipleSourcesRequiresFileFlag` — local + user → error w/ `--file` guidance
  - `Test_UseContextCommand_fileFlagSelectsLayer` — `--file local` writes to local layer
  - `Test_SetCommand_writesToLocalConfigWhenOnlySource` — covers the same latent bug for `set`
- [x] `GCX_AGENT_MODE=false mise run all` passes (lint + tests + build + docs)
- [x] CLI reference regenerated (`docs/reference/cli/gcx_config_use-context.md`)

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)