### PR TITLE
feat(vulnobs): add read-only Vulnerability Observability provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,8 @@ internal/
 │   ├── aio11y/     AI Observability provider (conversations, agents, generations, evaluators, rules, templates, scores, judge, saved-conversations, collections — via grafana-sigil-app plugin API)
 │   ├── slo/        SLO provider (definitions, reports)
 │   ├── synth/      Synthetic Monitoring provider (checks, probes)
-│   └── traces/     Traces signal provider (Tempo queries + Adaptive Traces commands)
+│   ├── traces/     Traces signal provider (Tempo queries + Adaptive Traces commands)
+│   └── vulnobs/    Vulnerability Observability provider (read-only: groups, sources/projects, issues sub-resource) via grafana-vulnerabilityobs-app plugin proxy GraphQL
 ├── deeplink/    Deep link URL template registry and browser opener
 ├── dashboards/  Dashboard Image Renderer client (PNG snapshots)
 ├── datasources/ Datasource HTTP client, DatasourceProvider interface + registry

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,6 +189,9 @@ Multiple auth mechanisms for different tiers.
 | [016](docs/adrs/dashboards-provider/001-dashboards-provider-design.md) | Dashboards provider: CRUD shorthands, search, and version history | accepted |
 | [017](docs/adrs/traces-get-table/001-tree-table-render-for-traces-get.md) | Tree-table rendering for `traces get` | accepted |
 | [018](docs/adrs/instrumentation/002-cli-redesign.md) | `gcx instrumentation` CLI redesign: action verbs over Set/Get + observed state | accepted |
+| [019a](docs/adrs/vulnobs-provider/001-auth-strategy.md) | Vulnobs provider: reuse Grafana token via NamespacedRESTConfig | proposed |
+| [019b](docs/adrs/vulnobs-provider/002-graphql-client.md) | Vulnobs provider: hand-rolled GraphQL POSTer (no codegen, no persisted hashes) | proposed |
+| [019c](docs/adrs/vulnobs-provider/003-command-shape-and-no-typed-resources.md) | Vulnobs provider: Source typed-registered (read-only); Issue as sub-resource per CONSTITUTION L130–135 | proposed |
 
 See [docs/adrs/](docs/adrs/) for all ADRs.
 

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/grafana/gcx/internal/providers/stacks"          // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/synth"           // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/traces"          // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/vulnobs"         // Provider registrations — blank imports trigger init() self-registration.
 	"github.com/grafana/gcx/internal/style"
 	"github.com/grafana/gcx/internal/terminal"
 	appversion "github.com/grafana/gcx/internal/version"

--- a/docs/adrs/vulnobs-provider/001-auth-strategy.md
+++ b/docs/adrs/vulnobs-provider/001-auth-strategy.md
@@ -1,0 +1,49 @@
+# Vulnerability Observability Provider: Auth Strategy
+
+**Created**: 2026-05-15
+**Status**: proposed
+**Supersedes**: none
+
+## Context
+
+Vulnerability Observability is exposed to clients only through Grafana's
+instance plugin proxy at `/api/plugin-proxy/grafana-vulnerabilityobs-app/`.
+The plugin stamps the user's existing Grafana auth onto upstream requests;
+there is no separate token for the vulnerability-obs backend.
+
+Two existing provider patterns are in scope as references:
+
+| Pattern | Used by | Notes |
+|---------|---------|-------|
+| Same Grafana token (plugin proxy / plugin resources) | `kg`, `dashboards`, `slo`, `aio11y`, `appo11y`, `faro` | Reuses `config.NamespacedRESTConfig`; no new config keys. |
+| Separate URL + token (external service) | `synth`, `irm` (some endpoints) | Adds provider-specific config keys. |
+
+The vulnerability-obs API has no equivalent of a direct backend URL exposed
+to clients — every call must traverse the plugin proxy.
+
+## Decision
+
+Reuse the same Grafana token via `config.NamespacedRESTConfig`, identical
+to the KG provider. The HTTP client is built with `rest.HTTPClientFor(&cfg.Config)`
+and requests target `/api/plugin-proxy/grafana-vulnerabilityobs-app/api-proxy/graphql/query`
+on the active context's Grafana host.
+
+Explicitly rejected:
+
+- **Separate vulnerability-obs token / URL.** No upstream endpoint is
+  documented and the plugin proxy is the supported integration point.
+  Adding config keys would create a degree of freedom that doesn't exist
+  in the product.
+- **Configurable plugin ID.** The plugin's slug is part of its public
+  contract on the Grafana instance; treat it as a constant in the client.
+
+## Consequences
+
+- Provider works out of the box for any user with an authenticated `gcx`
+  context that can access the vulnerability-obs plugin in the Grafana
+  instance (e.g., the `ops` context that points at
+  `https://ops.grafana-ops.net`).
+- No new config keys; no surface area in `gcx config view` / redaction
+  to maintain.
+- If Grafana ever exposes a direct backend URL or a CLI-friendly access
+  policy scope, this ADR will need to be revisited.

--- a/docs/adrs/vulnobs-provider/002-graphql-client.md
+++ b/docs/adrs/vulnobs-provider/002-graphql-client.md
@@ -1,0 +1,65 @@
+# Vulnerability Observability Provider: GraphQL Client
+
+**Created**: 2026-05-15
+**Status**: proposed
+**Supersedes**: none
+
+## Context
+
+The vulnerability-obs backend is a GraphQL service. All other gcx providers
+target REST APIs and use the standard "hand-rolled HTTP client (~200 LOC)"
+pattern documented in the provider guide. Three options for adapting:
+
+1. **Bring in a GraphQL client library** (e.g., `github.com/Khan/genqlient`,
+   `github.com/hasura/go-graphql-client`). Generated typed clients;
+   compile-time guarantees on operations.
+2. **Hand-roll a thin GraphQL POSTer.** Same shape as the REST clients in
+   `kg/`, `slo/`, etc., but the body is `{operationName, query, variables}`
+   instead of REST path + JSON.
+3. **Use persisted-query hashes.** Match the UI's transport contract.
+
+The product server **accepts unpersisted GraphQL documents** even though
+the UI uses persisted queries (confirmed in research). Introspection is
+disabled, so no codegen is possible without scraping the UI's `.graphql`
+files (which we do not have access to without finding the plugin source).
+
+## Decision
+
+Hand-roll a thin GraphQL POSTer (option 2). The client exposes one private
+method:
+
+```go
+func (c *Client) do(ctx context.Context, op, query string, vars any, out any) error
+```
+
+It marshals `{operationName, query, variables}` to JSON, POSTs to
+`/api/plugin-proxy/grafana-vulnerabilityobs-app/api-proxy/graphql/query`,
+checks for top-level `errors[]`, and unmarshals `data` into `out`.
+
+Query documents are kept as Go string constants alongside the typed
+response structs (one per query: `groups`, `sources`, `issues`).
+
+Explicitly rejected:
+
+- **Generated GraphQL client.** Adds a build-time dependency and codegen
+  step for three small queries. The schema is undocumented and would
+  drift silently. Not worth the complexity at v1 scope.
+- **Persisted-query hashes.** Pinning hashes that the UI controls couples
+  gcx releases to UI deployments; the unpersisted path avoids this
+  coupling entirely.
+
+## Consequences
+
+- Provider client stays ~150 LOC and matches the structural shape of
+  every other gcx provider client.
+- Each new query is a string constant + a response struct + a one-line
+  call. Adding `severityFilter`-aware `issues` or paginated `sources`
+  later is mechanical.
+- If the server ever stops accepting unpersisted queries (unlikely;
+  Apollo Server's `forbidUnpersistedQueries` is opt-in and not currently
+  enabled), gcx will break and the provider will need to switch to the
+  persisted-query transport. Test coverage will catch this on the next
+  smoke-test run.
+- Type drift is detected at runtime, not compile time. Mitigation: every
+  response struct has its own unit test that decodes a real captured
+  payload.

--- a/docs/adrs/vulnobs-provider/003-command-shape-and-no-typed-resources.md
+++ b/docs/adrs/vulnobs-provider/003-command-shape-and-no-typed-resources.md
@@ -1,0 +1,133 @@
+# Vulnerability Observability Provider: Command Shape & Typed Resource Strategy
+
+**Created**: 2026-05-15
+**Status**: proposed
+**Supersedes**: none
+
+## Context
+
+CONSTITUTION.md requires providers to register typed resource adapters via
+`TypedRegistrations()` so that domain data flows through the unified
+`gcx resources` pipeline (line 28–32). The single documented exception is
+the `dashboards` provider, which uses the K8s dynamic tier instead
+(`docs/adrs/dashboards-provider/001-...`). All other providers — including
+read-only ones like `alert` — typed-register at least one resource.
+
+CONSTITUTION line 42–47 explicitly accommodates read-only typed resources:
+
+> The `Example` field MAY be nil for read-only resources (those without
+> Create/Update support) since examples serve as templates for writable
+> operations.
+
+The KG provider has a `newListOnlyFactory` helper for exactly this case
+(`internal/providers/kg/resource_adapter.go:227`) — `ListFn` is set,
+`CreateFn`/`UpdateFn` are nil, and TypedCRUD falls back to list + name
+filtering for `Get`.
+
+Vulnerability Observability exposes two natural candidate types:
+
+| Type | Listable without a parent? | Identity field | Notes |
+|------|----------------------------|----------------|-------|
+| `Source` (repo) | **Yes** | `name` (e.g. `grafana/faro-web-sdk`) | Top-level resource. Sources have stable names across scans. |
+| `Issue` (CVE finding) | **No** — `IssueFilters.versionId` is required; calls without it return HTTP 502 from the upstream. | `id` (large int; appears persistent across same-day calls; cross-scan stability not empirically tested) | One row per scanner-run per finding, so the same logical CVE in a repo's `main` branch produces N rows (one per scanner: grype, trivy, dependabot, osv-scanner) — and **another N rows** for each tagged version of the same repo. |
+
+CONSTITUTION line 130–135 governs the `Issue` case directly:
+
+> **Sub-resources nest under their parent command.** If a resource cannot
+> be listed or addressed without a parent ID (e.g. alerts require an
+> alert group), it is a sub-resource. Sub-resources must not be
+> registered as standalone typed adapters (no `ListFn` that ignores the
+> parent).
+
+`Issue` matches this definition: it cannot be listed without a parent
+`versionId`. The CONSTITUTION rule is the load-bearing reason to leave
+`Issue` outside `TypedRegistrations()`; the identity-multiplication
+concern (one logical CVE × N scanners × N versions) reinforces it but is
+not the primary justification.
+
+## Decision
+
+**Hybrid approach:**
+
+1. **Register `Source` as a read-only typed resource.**
+   - GVK: `vulnobs.grafana.app/v1alpha1` `Source`, plural `sources`,
+     singular `source`.
+   - Identity: `Source.Name` (e.g. `grafana/faro-web-sdk`).
+   - Adapter uses KG's `newListOnlyFactory` pattern: `ListFn` returns
+     all sources for the active context (with the same filters
+     `gcx vulnobs projects list` accepts), `GetFn` is nil (TypedCRUD
+     falls back to list+filter for name lookup).
+   - `Schema` field is the standard envelope with a `spec` capturing
+     `groups`, `integration`, `origin`, `visibility`, `versions[]` and
+     `cveCounts`. `Example` is nil per CONSTITUTION line 45.
+   - Available through both `gcx vulnobs projects list` (table-friendly,
+     domain-shaped columns) and `gcx resources get sources.vulnobs.grafana.app`
+     (k8s envelope, unified pipeline).
+
+2. **Expose `Issue` as a sub-resource verb under `vulnobs projects`.** Per
+   CONSTITUTION line 130–135, sub-resources nest under their parent and
+   use the `$PARENT $VERB-$CHILD $PARENT_ID` shape:
+
+   ```
+   gcx vulnobs projects list-issues <versionId>
+   gcx vulnobs projects list-issues --repo <owner/name> [--tag <tag>]
+   ```
+
+   `--repo`/`--tag` is a UX convenience that resolves to a `versionId`
+   internally via one extra `sources` query. The positional `<versionId>`
+   form satisfies the strict CONSTITUTION grammar; the flag form is
+   syntactic sugar for agents who think in repo names.
+
+3. **Per CONSTITUTION line 122–128**: because `Issue` is not adapter-
+   registered, the sub-resource command must not mimic adapter verbs.
+   `list-issues` is permitted; no `create-issue` / `update-issue` /
+   `delete-issue` / `get-issue` aliases.
+
+The full command surface becomes:
+
+```
+gcx vulnobs groups list                                  # provider-only (groups have no spec — just id+name)
+gcx vulnobs projects list [--group <name|id>] ...        # mirrors typed-resource list with friendly columns
+gcx vulnobs projects list-issues <versionId>             # sub-resource of Version (under Source)
+gcx vulnobs projects list-issues --repo <name> [--tag t] # convenience alias for above
+
+# Via the typed-resource tier:
+gcx resources list sources.vulnobs.grafana.app
+gcx resources get  source.vulnobs.grafana.app/grafana--faro-web-sdk
+gcx api-resources | grep vulnobs
+gcx explain source.vulnobs                               # schema lookup
+```
+
+Explicitly rejected:
+
+- **No typed registrations at all** (the path proposed in the first draft
+  of this ADR). The hybrid is closer to the spirit of CONSTITUTION line
+  28–32, and `Source` cleanly fits the read-only typed-resource pattern
+  KG already uses.
+- **Typed `Issue` resource (with any identity scheme).** Sub-resources
+  must not be registered as standalone typed adapters per CONSTITUTION
+  line 130–135 — the rule is parent-ID-required, and `IssueFilters.versionId`
+  is required by the upstream. Reviewable if the upstream ever adds a
+  parentless `issues` query.
+- **Standalone top-level `vulnobs issues list` command.** Sub-resources
+  must nest under the parent command per the same CONSTITUTION rule.
+  `vulnobs projects list-issues <versionId>` is the prescribed shape.
+- **`vulnobs plan` / `vulnobs apply` in the provider.** These reach the
+  local filesystem and `gh`. Providers are CRUD over a remote API. The
+  fix workflow lives in the `grafanacloud-vuln-obs` Agent Skill.
+
+## Consequences
+
+- One new GVK in `gcx api-resources`. Agents discover `Source` through
+  the unified discovery path; humans get readable tables through
+  `gcx vulnobs projects list`. Both paths read from the same client.
+- ~150 LOC added beyond the original spec (one extra file:
+  `resource_adapter.go`, plus a `_test.go` covering identity round-trip
+  and adapter wiring) — total stays well under 1000 LOC.
+- `Groups` stay outside the typed-resource tier as well. They're an
+  enum-shaped tag namespace, not a resource people would `pull` or
+  `diff`. If demand emerges, register later.
+- If the upstream API ever exposes a parentless `issues` query (Issues
+  listable without a `versionId`) or surfaces a deterministic
+  cross-version finding identifier, revisit this ADR to add an `Issue`
+  typed registration.

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -51,4 +51,5 @@ gcx is a unified CLI for managing Grafana resources, dashboards, datasources, al
 * [gcx synthetic-monitoring](gcx_synthetic-monitoring.md)	 - Manage Grafana Synthetic Monitoring checks and probes
 * [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces
 * [gcx version](gcx_version.md)	 - Print version information.
+* [gcx vulnobs](gcx_vulnobs.md)	 - Inspect Grafana Vulnerability Observability data (read-only).
 

--- a/docs/reference/cli/gcx_vulnobs.md
+++ b/docs/reference/cli/gcx_vulnobs.md
@@ -1,0 +1,42 @@
+## gcx vulnobs
+
+Inspect Grafana Vulnerability Observability data (read-only).
+
+### Synopsis
+
+Inspect Grafana Vulnerability Observability data (read-only).
+
+The vulnerability-obs API is read-only from clients; mutations happen on the
+server as scanners ingest findings. This command tree exposes groups,
+projects (sources), and CVE findings (issues) through the same plugin-proxy
+GraphQL endpoint the Grafana UI uses.
+
+Source data is also available through the unified resources tier:
+
+    gcx resources list sources.vulnobs.grafana.app
+
+
+### Options
+
+```
+      --config string   Path to the configuration file to use
+  -h, --help            help for vulnobs
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx vulnobs groups](gcx_vulnobs_groups.md)	 - Manage vulnerability-obs groups (read-only).
+* [gcx vulnobs projects](gcx_vulnobs_projects.md)	 - Manage vulnerability-obs projects (sources) and their findings.
+

--- a/docs/reference/cli/gcx_vulnobs_groups.md
+++ b/docs/reference/cli/gcx_vulnobs_groups.md
@@ -1,0 +1,27 @@
+## gcx vulnobs groups
+
+Manage vulnerability-obs groups (read-only).
+
+### Options
+
+```
+  -h, --help   help for groups
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx vulnobs](gcx_vulnobs.md)	 - Inspect Grafana Vulnerability Observability data (read-only).
+* [gcx vulnobs groups list](gcx_vulnobs_groups_list.md)	 - List all vulnerability-obs groups.
+

--- a/docs/reference/cli/gcx_vulnobs_groups_list.md
+++ b/docs/reference/cli/gcx_vulnobs_groups_list.md
@@ -1,0 +1,32 @@
+## gcx vulnobs groups list
+
+List all vulnerability-obs groups.
+
+```
+gcx vulnobs groups list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx vulnobs groups](gcx_vulnobs_groups.md)	 - Manage vulnerability-obs groups (read-only).
+

--- a/docs/reference/cli/gcx_vulnobs_projects.md
+++ b/docs/reference/cli/gcx_vulnobs_projects.md
@@ -1,0 +1,28 @@
+## gcx vulnobs projects
+
+Manage vulnerability-obs projects (sources) and their findings.
+
+### Options
+
+```
+  -h, --help   help for projects
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx vulnobs](gcx_vulnobs.md)	 - Inspect Grafana Vulnerability Observability data (read-only).
+* [gcx vulnobs projects list](gcx_vulnobs_projects_list.md)	 - List projects with CVE counts.
+* [gcx vulnobs projects list-issues](gcx_vulnobs_projects_list-issues.md)	 - List CVE findings for a project version (sub-resource).
+

--- a/docs/reference/cli/gcx_vulnobs_projects_list-issues.md
+++ b/docs/reference/cli/gcx_vulnobs_projects_list-issues.md
@@ -1,0 +1,51 @@
+## gcx vulnobs projects list-issues
+
+List CVE findings for a project version (sub-resource).
+
+### Synopsis
+
+List CVE findings for a project version.
+
+Issues are sub-resources of a Source's Version: every query requires a
+versionId. Pass it either as a positional argument or resolve it from
+--repo (and optionally --tag, default "main").
+
+Examples:
+
+  gcx vulnobs projects list-issues 10355
+  gcx vulnobs projects list-issues --repo grafana/faro-web-sdk
+  gcx vulnobs projects list-issues --repo grafana/faro-web-sdk --tag v2.6.3 \
+      --severity CRITICAL,HIGH
+
+
+```
+gcx vulnobs projects list-issues [<versionId>] [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for list-issues
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: agents, json, table, yaml (default "table")
+      --repo string       Resolve from repo (owner/name); alternative to positional versionId
+      --severity string   Comma-separated severities to include (CRITICAL,HIGH,...)
+      --tag string        Tag to resolve when --repo is used (default "main")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx vulnobs projects](gcx_vulnobs_projects.md)	 - Manage vulnerability-obs projects (sources) and their findings.
+

--- a/docs/reference/cli/gcx_vulnobs_projects_list.md
+++ b/docs/reference/cli/gcx_vulnobs_projects_list.md
@@ -1,0 +1,37 @@
+## gcx vulnobs projects list
+
+List projects with CVE counts.
+
+```
+gcx vulnobs projects list [flags]
+```
+
+### Options
+
+```
+      --first int       Maximum number of projects to return (default 30)
+      --group string    Filter to one group (name or numeric id)
+  -h, --help            help for list
+      --include-k8s     Include k8s-scan versions
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+      --show-archived   Include archived sources
+      --sort string     Sort order: CRITICALS_DESC, HIGHS_DESC, SLO_ASC (default "CRITICALS_DESC")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx vulnobs projects](gcx_vulnobs_projects.md)	 - Manage vulnerability-obs projects (sources) and their findings.
+

--- a/docs/research/2026-05-15-vulnobs-provider.md
+++ b/docs/research/2026-05-15-vulnobs-provider.md
@@ -1,0 +1,206 @@
+# Research: Vulnerability Observability Provider
+
+**Date**: 2026-05-15
+**Status**: exploratory
+**Confidence**: Medium — API mapped empirically; introspection disabled; no public schema docs
+**Sources**: Direct API probes against `https://ops.grafana-ops.net` via `gcx api`
+
+## Executive Summary
+
+- The `grafana-vulnerabilityobs-app` plugin exposes vulnerability findings
+  via a **plugin-proxied GraphQL endpoint**, not REST. It is read-only from
+  the user's perspective; all mutations are driven by scanner ingestion on
+  the server side.
+- The endpoint accepts **unpersisted GraphQL documents** in addition to
+  Apollo persisted-query hashes used by the UI. This means a gcx provider
+  does not need to track operation hashes, but **introspection is
+  disabled** so the schema must be discovered empirically.
+- Three queries cover the v1 scope: `groups`, `sources` (projects), and
+  `issues` (CVE findings). The same CVE may appear multiple times per
+  version when reported by multiple scanners; consumers must deduplicate
+  on `(package, target)` when summarizing.
+- Auth model matches the existing KG (Asserts) provider: requests flow
+  through Grafana's instance plugin proxy, so reusing the active Grafana
+  session via `config.NamespacedRESTConfig` works as-is.
+
+## Problem
+
+A team lead asked whether gcx can surface Grafana Vulnerability
+Observability data (CVEs, SLO posture, fix recommendations) for a repo or
+group. Today the only way to get this data programmatically is to dig
+operation names and persisted-query hashes out of the UI and call
+`gcx api` directly. That works for one-off scripting but isn't a stable
+contract — operation hashes rotate, and consumers must reimplement the
+GraphQL wiring each time.
+
+## Findings
+
+### API surface
+
+| Path | Notes |
+|------|-------|
+| `POST /api/plugin-proxy/grafana-vulnerabilityobs-app/api-proxy/graphql/query` | All queries. Single GraphQL endpoint. |
+| `Content-Type: application/json` | Body: `{operationName, query, variables}`. |
+| Persisted-query extension is **optional** | Plain documents work too — confirmed below. |
+| `__schema` introspection | **Disabled.** Returns `{"data":{"__schema":null}, "errors":[{"message":"introspection disabled", ...}]}`. |
+
+### Auth model
+
+- Plugin proxy on the Grafana instance. The plugin forwards to the
+  vulnerability-obs backend after stamping the user's Grafana auth.
+- No separate token, no separate URL. Inherits the same auth as the active
+  Grafana session.
+- Matches the KG provider's model (`/api/plugins/grafana-asserts-app/...`)
+  and the IRM-plugin variants — `rest.HTTPClientFor(&cfg.Config)` on a
+  `config.NamespacedRESTConfig` is sufficient.
+
+### Operations confirmed
+
+The UI uses Apollo persisted queries; we re-mapped each to an unpersisted
+GraphQL document and confirmed responses against ops.
+
+#### `groups` — list all teams/groups
+
+```graphql
+query Groups {
+  groups { id name }
+}
+```
+
+No variables. Returns 50+ groups (e.g., `feO11y` = id 57, `o11y` = 16,
+`RUM` = 69, `mobileO11y` = 68).
+
+#### `sources` — list projects, paginated
+
+```graphql
+query Projects($filters: SourceFilters!, $first: Int, $after: Int) {
+  sources(filters: $filters, first: $first, after: $after) {
+    metadata { totalCount }
+    response {
+      id
+      name              # e.g. "grafana/faro-web-sdk"
+      type              # "repository"
+      origin            # "github"
+      visibility        # "public" | "private"
+      integration { id name type }
+      groups { id name }
+      versions {
+        id
+        tag             # "main", "v2.6.3", ...
+        publishDate
+        lowestSloRemaining
+        totalCveCounts { critical high medium low }
+      }
+    }
+  }
+}
+```
+
+`SourceFilters` (confirmed):
+
+| Field | Type | Notes |
+|---|---|---|
+| `groupId` | `String!` (stringified int) | Filter to one group. |
+| `name` | `String` | Substring match on `name`. |
+| `sortBy` | enum | `CRITICALS_DESC`, `HIGHS_DESC`, etc. |
+| `enabledOnly` | `Boolean` | Hide disabled sources. |
+| `versionFilters` | `{ hideK8s, showArchived }` | Excludes k8s-scan versions, archived sources. |
+
+Fields tried that are **not** on `SourceFilters` (errored at 422):
+`first`, `after` (they're on `sources(...)`, not on filters);
+`cveCountsScope` (sits on the persisted-query selector, not on filters);
+`searchTerm`, `search`, `query`, `keyword` (use `name`).
+
+#### `issues` — CVE findings for a version
+
+```graphql
+query Issues($filters: IssueFilters!) {
+  issues(filters: $filters) {
+    response {
+      id
+      package
+      installedVersion
+      fixedVersion
+      target              # "yarn.lock", "go.mod", "/yarn.lock", ...
+      sloRemaining        # days; negative = breached
+      tool { name }       # "grype" | "trivy" | "dependabot" | "osv-scanner"
+      cve { cve severity cvssScore title }
+    }
+  }
+}
+```
+
+`IssueFilters` confirmed field: `versionId` (`String!`). Other fields
+likely exist (severity, tool) but were not probed since client-side
+filtering is trivial for the v1 scope.
+
+### Resource relationships
+
+```
+Group ── many ─── Source (repo)
+                    │
+                    └── many ─── Version (tag, e.g. "main", "v2.6.3")
+                                  │
+                                  └── many ─── Issue (CVE finding, per-scanner)
+```
+
+A single CVE may appear N times per version (once per scanner that flagged
+it). Consumers that summarize must deduplicate on `(package, target)`.
+
+### Sample real call
+
+```
+$ gcx api '/api/plugin-proxy/grafana-vulnerabilityobs-app/api-proxy/graphql/query' \
+    -X POST -H 'Content-Type: application/json' \
+    -d '{"query":"query I($f: IssueFilters!) { issues(filters:$f) { response { package fixedVersion cve { cve severity } } } }","variables":{"f":{"versionId":"10355"}}}'
+{"data":{"issues":{"response":[
+  {"package":"axios","fixedVersion":"1.15.2","cve":{"cve":"CVE-2026-42044","severity":"CRITICAL"}},
+  ...
+]}}}
+```
+
+feO11y group snapshot at the time of this research:
+
+| Repo | versionId (main) | Crit | High | Med | Low | Worst SLO |
+|---|---:|---:|---:|---:|---:|---:|
+| grafana/faro-javascript-bundler-plugins | 10355 | 3 | 6 | 6 | 1 | -2 |
+| grafana/faro-web-sdk | 10354 | 3 | 4 | 5 | 1 | 21 |
+| grafana/app-o11y-kwl-endpoint | 6525 | 0 | 12 | 4 | 0 | -41 |
+| grafana/app-o11y-kwl | 10350 | 0 | 3 | 8 | 1 | 8 |
+
+## Recommendations
+
+- Build a **read-only** provider, modeled on `internal/providers/kg/`.
+  - `gcx vulnobs groups list`
+  - `gcx vulnobs projects list [--group <name|id>]`
+  - `gcx vulnobs issues list --version <id> | --repo <name> [--tag <tag>]`
+- Reuse `config.NamespacedRESTConfig` for auth; no new config keys needed.
+- Skip the `TypedRegistrations()` / k8s envelope mapping for v1 — the API
+  has no mutations, so there's nothing to push/pull as a Resource. List
+  output uses the standard output codecs (`-o json/yaml/text`).
+- Keep the fix/remediation workflow **out** of the provider. That logic
+  reaches the local filesystem and `gh`, neither of which belong inside a
+  CRUD-over-remote-API provider. It stays in the
+  `grafanacloud-vuln-obs` Agent Skill, which will be retargeted to call
+  `gcx vulnobs ...` instead of `gcx api`.
+
+## Open questions
+
+- **`versionId` resolution.** UI uses `versionId` directly; agents will
+  more naturally pass `--repo grafana/faro-web-sdk [--tag main]`. The
+  provider will need to do a `sources` lookup to resolve repo+tag →
+  versionId. Cache TTL? For v1, no cache — issue is a one-call surface.
+- **Pagination on `issues`.** We did not see pagination args on `issues`
+  in the persisted queries we captured; first-call results have always
+  returned the full list. Confirm during implementation.
+- **Severity / tool filters on `issues`.** Likely exist server-side. For
+  v1 we'll filter client-side; revisit if response sizes grow.
+
+## Sources
+
+1. `https://ops.grafana-ops.net` Vulnerability Observability UI — captured
+   request URLs for `getGroupsFilter`, `getProjectsList`,
+   `getProjectsSummary`, `getVersionVulnerabilities` operations.
+2. Direct API probes via `gcx api` (see "Sample real call" above).
+3. KG provider implementation at `internal/providers/kg/` — reference
+   for plugin-proxy auth pattern and command surface shape.

--- a/docs/specs/vulnobs-provider/2026-05-15-vulnobs-provider-plan.md
+++ b/docs/specs/vulnobs-provider/2026-05-15-vulnobs-provider-plan.md
@@ -1,0 +1,203 @@
+---
+type: feature-plan
+title: "Vulnerability Observability Provider"
+status: draft
+research: docs/research/2026-05-15-vulnobs-provider.md
+created: 2026-05-15
+---
+
+# Vulnerability Observability Provider — Implementation Plan
+
+Read-only gcx provider for Grafana Vulnerability Observability. Surfaces
+groups, projects (sources), and CVE findings (issues) from the
+`grafana-vulnerabilityobs-app` plugin via the Grafana instance plugin
+proxy.
+
+Single-stage scope. The provider has no typed resource registrations, no
+push/pull/edit, no new config keys — so it can ship as one PR without
+phasing.
+
+## Pipeline Architecture
+
+```
+cmd/gcx/root (Cobra root)
+  └─ providers.Register() init()
+       └─ vulnobs.VulnobsProvider (NEW)
+            ├─ Commands(): "vulnobs groups list" | "vulnobs projects list" | "vulnobs issues list"
+            └─ Client (NEW)
+                 → POST /api/plugin-proxy/grafana-vulnerabilityobs-app/api-proxy/graphql/query
+                    (auth: rest.HTTPClientFor(cfg.Config) — same Grafana token)
+```
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Hand-rolled GraphQL POSTer, not codegen | [ADR-002](../../adrs/vulnobs-provider/002-graphql-client.md) — schema undocumented, three small queries, drift caught by unit tests against captured payloads. |
+| Reuse Grafana token via `NamespacedRESTConfig` | [ADR-001](../../adrs/vulnobs-provider/001-auth-strategy.md) — only access path is the plugin proxy on the Grafana instance. |
+| `Source` typed-registered read-only; `Issue` provider-only | [ADR-003](../../adrs/vulnobs-provider/003-command-shape-and-no-typed-resources.md) — `Source.name` is stable; `Issue` has no stable identity. Uses KG's `newListOnlyFactory` pattern. |
+| Repo+tag shorthand for `issues list` | UX: agents naturally pass `--repo grafana/faro-web-sdk --tag main`; the provider resolves to `versionId` internally with one extra `sources` lookup. |
+| Client-side `--severity` filter | Trivial response sizes; saves probing for the right server-side filter field. Revisit if data volumes grow. |
+
+## File Tree
+
+```
+internal/providers/vulnobs/
+  provider.go               # VulnobsProvider type + init() + Provider iface + TypedRegistrations(Source)
+  client.go                 # HTTP client + GraphQL POSTer + repo/version resolution
+  client_test.go            # httptest-backed unit tests
+  commands.go               # cobra commands: groups, projects, issues
+  commands_test.go          # command wiring tests
+  types.go                  # GraphQL response structs + ResourceIdentity on Source
+  types_identity_test.go    # GetResourceName / SetResourceName round-trip
+  resource_adapter.go       # Source adapter via newListOnlyFactory pattern + Schema
+  resource_adapter_test.go  # adapter wiring + descriptor + schema-non-nil
+
+cmd/gcx/root/command.go
+  # add: _ "github.com/grafana/gcx/internal/providers/vulnobs"
+
+docs/research/2026-05-15-vulnobs-provider.md   # (already written)
+docs/adrs/vulnobs-provider/{001,002,003}*.md   # (already written)
+docs/specs/vulnobs-provider/2026-05-15-*.md    # (this file)
+```
+
+Estimated size: ~700-800 LOC including tests.
+
+## Command Surface
+
+```
+gcx vulnobs                              Vulnerability Observability data
+gcx vulnobs groups list                  List all groups (id + name)              # provider-only
+gcx vulnobs projects list                List projects with CVE counts            # mirrors typed-resource list with friendly columns
+   --group <name|id>                     Filter to one group (looks up name -> id)
+   --sort CRITICALS_DESC|HIGHS_DESC|SLO_ASC
+   --first N (default 30)
+   --show-archived
+   --include-k8s
+gcx vulnobs projects list-issues <versionId>   List CVE findings for a Version    # sub-resource per CONSTITUTION line 130-135
+   --repo <owner/name>                   OR resolve from repo+tag (replaces positional <versionId>)
+   --tag <tag> (default "main")          Tag to resolve when --repo is used
+   --severity CRITICAL,HIGH              Comma-separated severity filter (client-side)
+
+# Via the typed-resource tier (powered by the same client):
+gcx resources list sources.vulnobs.grafana.app
+gcx resources get  source.vulnobs.grafana.app/grafana--faro-web-sdk
+gcx api-resources | grep vulnobs
+gcx explain source.vulnobs               # schema lookup
+```
+
+All commands honor `-o json|yaml|text|wide` via the standard codec
+registry. `list-issues` accepts either a positional `<versionId>` (the
+canonical sub-resource form) or `--repo <name> [--tag <tag>]` (resolves
+to versionId via one extra `sources` query).
+
+## Compatibility
+
+- **Continues working unchanged**: every existing command.
+- **Deprecated**: nothing.
+- **Newly available**: `gcx vulnobs ...` subtree (3 commands).
+- **Skill update (separate)**: `grafanacloud-skills/skills/grafanacloud-vuln-obs/scripts/vulnobs` will be retargeted in a follow-up to call `gcx vulnobs` instead of `gcx api`. That change is out of scope for this PR; the provider can ship first.
+
+## Verification (Smoke Test Plan)
+
+Executed in Stage 4 against `https://ops.grafana-ops.net` with an
+authenticated `ops` context.
+
+```bash
+# Build
+GCX_AGENT_MODE=false mise run all
+
+# Provider registered
+gcx providers | grep vulnobs
+
+# Config view does not produce vulnobs keys (no keys to redact)
+gcx config view | grep -i vulnobs || echo "ok: no vulnobs config keys"
+
+# Help tree includes vulnobs
+gcx help-tree | grep vulnobs
+
+# Groups
+gcx vulnobs groups list | head -5
+gcx vulnobs groups list -o json | jq '.[0]'
+
+# Projects
+gcx vulnobs projects list --group feO11y
+gcx vulnobs projects list --group feO11y -o json | jq '.[0].name'
+gcx vulnobs projects list --group 57 -o json | jq 'length'   # numeric group ID
+
+# Issues (canonical sub-resource form: positional versionId)
+gcx vulnobs projects list-issues 10355 -o json | jq '.[0].cve.cve'
+
+# Issues (repo shorthand)
+gcx vulnobs projects list-issues --repo grafana/faro-web-sdk --tag main \
+  --severity CRITICAL,HIGH | head -10
+gcx vulnobs projects list-issues --repo grafana/faro-web-sdk -o json \
+  | jq 'map(select(.cve.severity == "CRITICAL")) | length'
+
+# Typed-resource tier
+gcx api-resources | grep vulnobs                                     # sources.vulnobs.grafana.app listed
+gcx resources list sources.vulnobs.grafana.app                       # same data as `vulnobs projects list`
+gcx resources get  source.vulnobs.grafana.app/grafana--faro-web-sdk  # one source as k8s envelope
+gcx explain source.vulnobs.grafana.app                               # JSON Schema (Example MAY be nil per CONSTITUTION line 45)
+
+# Bad inputs
+gcx vulnobs projects list-issues                              # no positional or --repo -> validation error
+gcx vulnobs projects list-issues doesnotexist                 # graphql 502 surfaces as actionable error
+gcx vulnobs projects list-issues 10355 --repo grafana/x       # mutual exclusion violation -> validation error
+gcx vulnobs projects list --group doesnotexist                # actionable "unknown group" error
+```
+
+Pass criteria: every command exits 0 on the happy path; the three
+"bad inputs" cases produce single-line, actionable error messages and
+non-zero exit codes per `DESIGN.md`.
+
+## Test Plan
+
+### Unit (`go test ./internal/providers/vulnobs/...`)
+
+- `client_test.go`:
+  - `do()` posts JSON, sets `Content-Type: application/json`, surfaces
+    GraphQL `errors[]` as Go errors.
+  - `Groups()`, `Projects()`, `Issues()` decode captured fixtures
+    (one per query, copied from real `gcx api` output).
+  - `ResolveVersion("grafana/faro-web-sdk", "main")` does the
+    `Projects` call and returns the right `versionId`.
+- `commands_test.go`:
+  - `vulnobs projects list-issues` validation: requires positional XOR `--repo`; mutually exclusive.
+  - `vulnobs projects list --group` accepts numeric and named groups.
+- `types_identity_test.go`:
+  - `Source.GetResourceName()` round-trips through `SetResourceName(name)`
+    (CONSTITUTION line 33–36 requirement).
+- `resource_adapter_test.go`:
+  - Registration descriptor matches GVK `vulnobs.grafana.app/v1alpha1 Source`.
+  - `Schema` field is non-nil and parses as JSON Schema.
+  - Adapter `List()` returns the same data as the client's `Projects()`.
+  - Create/Update/Delete return a "not supported" error.
+
+### Integration / Smoke
+
+Manual against ops (see Verification section above).
+
+## Acceptance Criteria
+
+- GIVEN an authenticated `ops` context
+  WHEN running `gcx vulnobs projects list --group feO11y`
+  THEN four repos are listed with CVE counts matching the UI.
+- GIVEN any context
+  WHEN running `gcx vulnobs projects list-issues` with neither a positional `<versionId>` nor `--repo`
+  THEN gcx exits 2 with a single-line error suggesting either input.
+- GIVEN a `vulnobs` provider config (none required)
+  WHEN running `gcx config view`
+  THEN no vulnobs keys appear (nothing to redact).
+- GIVEN `mise run all`
+  THEN it passes with the new provider added.
+
+## Negative Constraints
+
+- MUST NOT add new config keys to the provider.
+- MUST NOT introduce a GraphQL client library dependency.
+- MUST register `Source` as a read-only typed resource (no Create/Update/Delete).
+- MUST NOT register `Issue` as a typed resource (no stable identity).
+- MUST NOT expose mutations on provider commands (no `create`, `update`, `delete` verbs).
+- MUST NOT shell out to `gh` or touch the local filesystem from the
+  provider; the fix workflow stays in the Agent Skill.

--- a/docs/specs/vulnobs-provider/2026-05-15-vulnobs-provider-plan.md
+++ b/docs/specs/vulnobs-provider/2026-05-15-vulnobs-provider-plan.md
@@ -13,9 +13,10 @@ groups, projects (sources), and CVE findings (issues) from the
 `grafana-vulnerabilityobs-app` plugin via the Grafana instance plugin
 proxy.
 
-Single-stage scope. The provider has no typed resource registrations, no
-push/pull/edit, no new config keys — so it can ship as one PR without
-phasing.
+Single-stage scope. The provider registers `Source` as a read-only typed
+resource (no Create/Update/Delete); `Issue` stays as a sub-resource under
+`projects` per CONSTITUTION line 130–135. No push/pull/edit, no new config
+keys — so it can ship as one PR without phasing.
 
 ## Pipeline Architecture
 
@@ -23,7 +24,8 @@ phasing.
 cmd/gcx/root (Cobra root)
   └─ providers.Register() init()
        └─ vulnobs.VulnobsProvider (NEW)
-            ├─ Commands(): "vulnobs groups list" | "vulnobs projects list" | "vulnobs issues list"
+            ├─ Commands(): "vulnobs groups list" | "vulnobs projects list" | "vulnobs projects list-issues"
+            ├─ TypedRegistrations(): Source (read-only) → sources.vulnobs.grafana.app
             └─ Client (NEW)
                  → POST /api/plugin-proxy/grafana-vulnerabilityobs-app/api-proxy/graphql/query
                     (auth: rest.HTTPClientFor(cfg.Config) — same Grafana token)

--- a/internal/providers/vulnobs/client.go
+++ b/internal/providers/vulnobs/client.go
@@ -1,0 +1,310 @@
+package vulnobs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/gcx/internal/config"
+	"k8s.io/client-go/rest"
+)
+
+// gqlPath is the plugin-proxy GraphQL endpoint. The plugin slug is part of
+// the plugin's public contract on the Grafana instance and is therefore a
+// constant here (see ADR-001).
+const gqlPath = "/api/plugin-proxy/grafana-vulnerabilityobs-app/api-proxy/graphql/query"
+
+// Client posts GraphQL requests to the vulnerability-obs plugin proxy on
+// the active Grafana instance, using the same Grafana token the rest of
+// gcx uses.
+type Client struct {
+	httpClient *http.Client
+	host       string
+}
+
+// NewClient creates a vulnerability-obs client from a NamespacedRESTConfig.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	httpClient, err := rest.HTTPClientFor(&cfg.Config)
+	if err != nil {
+		return nil, fmt.Errorf("vulnobs: failed to create HTTP client: %w", err)
+	}
+	return &Client{httpClient: httpClient, host: cfg.Host}, nil
+}
+
+// gqlRequest is the on-the-wire shape of a GraphQL POST body.
+type gqlRequest struct {
+	OperationName string `json:"operationName"`
+	Query         string `json:"query"`
+	Variables     any    `json:"variables"`
+}
+
+// gqlResponse[T] is the on-the-wire shape of a GraphQL response.
+type gqlResponse[T any] struct {
+	Data   T            `json:"data"`
+	Errors []gqlMessage `json:"errors,omitempty"`
+}
+
+// gqlMessage is one entry in the `errors[]` array of a GraphQL response.
+// Decoded only; never sent on the wire, so no omitempty is needed.
+type gqlMessage struct {
+	Message    string         `json:"message"`
+	Path       []string       `json:"path"`
+	Extensions gqlMessageMeta `json:"extensions"`
+}
+
+// gqlMessageMeta is the `extensions` block on a GraphQL error.
+type gqlMessageMeta struct {
+	Code string `json:"code"`
+}
+
+// do posts a GraphQL document and decodes `data` into out.
+func do[T any](ctx context.Context, c *Client, op, query string, vars any) (T, error) {
+	var zero T
+
+	body, err := json.Marshal(gqlRequest{OperationName: op, Query: query, Variables: vars})
+	if err != nil {
+		return zero, fmt.Errorf("vulnobs: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.host+gqlPath, bytes.NewReader(body))
+	if err != nil {
+		return zero, fmt.Errorf("vulnobs: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return zero, fmt.Errorf("vulnobs: execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return zero, fmt.Errorf("vulnobs: read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return zero, fmt.Errorf("vulnobs: %s returned HTTP %d: %s", op, resp.StatusCode, snippet(raw))
+	}
+
+	var out gqlResponse[T]
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return zero, fmt.Errorf("vulnobs: decode %s response: %w", op, err)
+	}
+	if len(out.Errors) > 0 {
+		msgs := make([]string, len(out.Errors))
+		for i, e := range out.Errors {
+			msgs[i] = e.Message
+		}
+		return zero, fmt.Errorf("vulnobs: %s graphql errors: %s", op, strings.Join(msgs, "; "))
+	}
+	return out.Data, nil
+}
+
+func snippet(b []byte) string {
+	const maxLen = 200
+	if len(b) > maxLen {
+		return string(b[:maxLen]) + "...(truncated)"
+	}
+	return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+const groupsQuery = `query Groups { groups { id name } }`
+
+const projectsQuery = `query Projects($filters: SourceFilters!, $first: Int, $after: Int) {
+  sources(filters: $filters, first: $first, after: $after) {
+    metadata { totalCount }
+    response {
+      id name type origin visibility
+      integration { id name type }
+      groups { id name }
+      versions {
+        id tag publishDate lowestSloRemaining
+        totalCveCounts { critical high medium low }
+      }
+    }
+  }
+}`
+
+const issuesQuery = `query Issues($filters: IssueFilters!) {
+  issues(filters: $filters) {
+    response {
+      id package installedVersion fixedVersion target sloRemaining
+      tool { name }
+      cve { cve severity cvssScore title }
+    }
+  }
+}`
+
+// ---------------------------------------------------------------------------
+// Public methods
+// ---------------------------------------------------------------------------
+
+// Groups returns every vulnerability-obs group (team/tag namespace).
+func (c *Client) Groups(ctx context.Context) ([]Group, error) {
+	type resp struct {
+		Groups []Group `json:"groups"`
+	}
+	d, err := do[resp](ctx, c, "Groups", groupsQuery, struct{}{})
+	if err != nil {
+		return nil, err
+	}
+	return d.Groups, nil
+}
+
+// ResolveGroupID accepts either a numeric group ID or a group name (case
+// insensitive) and returns the canonical numeric ID as a string.
+func (c *Client) ResolveGroupID(ctx context.Context, ref string) (string, error) {
+	if ref == "" {
+		return "", nil
+	}
+	if _, err := strconv.Atoi(ref); err == nil {
+		return ref, nil
+	}
+	groups, err := c.Groups(ctx)
+	if err != nil {
+		return "", err
+	}
+	low := strings.ToLower(ref)
+	for _, g := range groups {
+		if strings.ToLower(g.Name) == low {
+			return strconv.Itoa(g.ID), nil
+		}
+	}
+	return "", fmt.Errorf("vulnobs: unknown group %q (try `gcx vulnobs groups list`)", ref)
+}
+
+// ProjectsOptions controls a `Projects` query.
+type ProjectsOptions struct {
+	GroupID      string // already a numeric string; use ResolveGroupID first
+	Name         string // substring match on Source.name (server-side)
+	SortBy       string // e.g. CRITICALS_DESC; empty for server default
+	First        int    // page size; defaults to 30 when 0
+	After        int    // cursor; defaults to 0
+	HideK8s      bool   // exclude k8s-scan versions
+	ShowArchived bool   // include archived sources
+}
+
+// Projects returns sources matching the given options.
+func (c *Client) Projects(ctx context.Context, opts ProjectsOptions) ([]Source, int, error) {
+	first := opts.First
+	if first == 0 {
+		first = 30
+	}
+	if opts.SortBy == "" {
+		opts.SortBy = "CRITICALS_DESC"
+	}
+	filters := SourceFilters{
+		GroupID:     opts.GroupID,
+		Name:        opts.Name,
+		SortBy:      opts.SortBy,
+		EnabledOnly: true,
+		VersionFilters: &VersionFilters{
+			HideK8s:      opts.HideK8s,
+			ShowArchived: opts.ShowArchived,
+		},
+	}
+	vars := map[string]any{
+		"filters": filters,
+		"first":   first,
+		"after":   opts.After,
+	}
+	type resp struct {
+		Sources struct {
+			Metadata struct {
+				TotalCount int `json:"totalCount"`
+			} `json:"metadata"`
+			Response []Source `json:"response"`
+		} `json:"sources"`
+	}
+	d, err := do[resp](ctx, c, "Projects", projectsQuery, vars)
+	if err != nil {
+		return nil, 0, err
+	}
+	return d.Sources.Response, d.Sources.Metadata.TotalCount, nil
+}
+
+// Issues returns CVE findings for a single Version.
+func (c *Client) Issues(ctx context.Context, versionID string) ([]Issue, error) {
+	if versionID == "" {
+		return nil, errors.New("vulnobs: versionID is required")
+	}
+	vars := map[string]any{"filters": IssueFilters{VersionID: versionID}}
+	type resp struct {
+		Issues struct {
+			Response []Issue `json:"response"`
+		} `json:"issues"`
+	}
+	d, err := do[resp](ctx, c, "Issues", issuesQuery, vars)
+	if err != nil {
+		return nil, err
+	}
+	return d.Issues.Response, nil
+}
+
+// ResolveVersion resolves "owner/repo" + tag to a versionId. Tag defaults to
+// "main" when empty. Falls back to the most recently published version if the
+// requested tag is not found.
+func (c *Client) ResolveVersion(ctx context.Context, repo, tag string) (string, error) {
+	if repo == "" {
+		return "", errors.New("vulnobs: repo is required")
+	}
+	if tag == "" {
+		tag = "main"
+	}
+	sources, _, err := c.Projects(ctx, ProjectsOptions{
+		Name:         repo,
+		ShowArchived: true,
+		First:        50,
+	})
+	if err != nil {
+		return "", err
+	}
+	var match *Source
+	for i := range sources {
+		if sources[i].Name == repo {
+			match = &sources[i]
+			break
+		}
+	}
+	if match == nil {
+		// Fall back to suffix match for shorthand like "faro-web-sdk".
+		low := strings.ToLower(repo)
+		for i := range sources {
+			n := strings.ToLower(sources[i].Name)
+			if n == low || strings.HasSuffix(n, "/"+low) {
+				match = &sources[i]
+				break
+			}
+		}
+	}
+	if match == nil {
+		return "", fmt.Errorf("vulnobs: repo %q not found", repo)
+	}
+	for _, v := range match.Versions {
+		if v.Tag == tag {
+			return strconv.Itoa(v.ID), nil
+		}
+	}
+	// Fallback: most-recent by publish date.
+	if len(match.Versions) == 0 {
+		return "", fmt.Errorf("vulnobs: repo %q has no versions", repo)
+	}
+	latest := match.Versions[0]
+	for _, v := range match.Versions[1:] {
+		if v.PublishDate > latest.PublishDate {
+			latest = v
+		}
+	}
+	return strconv.Itoa(latest.ID), nil
+}

--- a/internal/providers/vulnobs/client.go
+++ b/internal/providers/vulnobs/client.go
@@ -51,16 +51,11 @@ type gqlResponse[T any] struct {
 }
 
 // gqlMessage is one entry in the `errors[]` array of a GraphQL response.
-// Decoded only; never sent on the wire, so no omitempty is needed.
+// Only `message` is decoded — `path` (which the GraphQL spec types as
+// `[String | Int]`, mixed) and `extensions` would need bespoke decoders, and
+// nothing currently consumes them.
 type gqlMessage struct {
-	Message    string         `json:"message"`
-	Path       []string       `json:"path"`
-	Extensions gqlMessageMeta `json:"extensions"`
-}
-
-// gqlMessageMeta is the `extensions` block on a GraphQL error.
-type gqlMessageMeta struct {
-	Code string `json:"code"`
+	Message string `json:"message"`
 }
 
 // do posts a GraphQL document and decodes `data` into out.
@@ -234,6 +229,31 @@ func (c *Client) Projects(ctx context.Context, opts ProjectsOptions) ([]Source, 
 	return d.Sources.Response, d.Sources.Metadata.TotalCount, nil
 }
 
+// AllProjects fetches every Source matching opts by paginating through the
+// `sources` query until totalCount is reached (or a page comes back short).
+// opts.First sets the page size (default 200); opts.After is ignored.
+func (c *Client) AllProjects(ctx context.Context, opts ProjectsOptions) ([]Source, error) {
+	pageSize := opts.First
+	if pageSize <= 0 {
+		pageSize = 200
+	}
+	opts.First = pageSize
+	opts.After = 0
+
+	var all []Source
+	for {
+		page, total, err := c.Projects(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		if len(page) < pageSize || len(all) >= total {
+			return all, nil
+		}
+		opts.After = len(all)
+	}
+}
+
 // Issues returns CVE findings for a single Version.
 func (c *Client) Issues(ctx context.Context, versionID string) ([]Issue, error) {
 	if versionID == "" {
@@ -296,15 +316,16 @@ func (c *Client) ResolveVersion(ctx context.Context, repo, tag string) (string, 
 			return strconv.Itoa(v.ID), nil
 		}
 	}
-	// Fallback: most-recent by publish date.
+	// Tag didn't match — surface available tags instead of silently
+	// substituting a different version (which would cause `--tag <typo>` to
+	// return findings for the wrong release).
 	if len(match.Versions) == 0 {
 		return "", fmt.Errorf("vulnobs: repo %q has no versions", repo)
 	}
-	latest := match.Versions[0]
-	for _, v := range match.Versions[1:] {
-		if v.PublishDate > latest.PublishDate {
-			latest = v
-		}
+	tags := make([]string, 0, len(match.Versions))
+	for _, v := range match.Versions {
+		tags = append(tags, v.Tag)
 	}
-	return strconv.Itoa(latest.ID), nil
+	return "", fmt.Errorf("vulnobs: tag %q not found for %q (available: %s)",
+		tag, repo, strings.Join(tags, ", "))
 }

--- a/internal/providers/vulnobs/client_test.go
+++ b/internal/providers/vulnobs/client_test.go
@@ -3,6 +3,7 @@ package vulnobs_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -227,4 +228,67 @@ func TestClient_ResolveVersion(t *testing.T) {
 	got, err = c.ResolveVersion(ctx, "faro-web-sdk", "main")
 	require.NoError(t, err, "suffix match should work")
 	assert.Equal(t, "10354", got)
+}
+
+func TestClient_ResolveVersion_UnknownTag_ListsAvailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeData(t, w, map[string]any{
+			"sources": map[string]any{
+				"metadata": map[string]any{"totalCount": 1},
+				"response": []map[string]any{
+					{
+						"id":   1064,
+						"name": "grafana/faro-web-sdk",
+						"versions": []map[string]any{
+							{"id": 10354, "tag": "main", "publishDate": "2026-05-15"},
+							{"id": 6297262, "tag": "v2.6.3", "publishDate": "2026-05-11"},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv).ResolveVersion(context.Background(), "grafana/faro-web-sdk", "v9.9.9")
+	require.Error(t, err, "explicit unknown tag must error, not silently fall back")
+	assert.Contains(t, err.Error(), `tag "v9.9.9" not found`)
+	// Available tags must be listed so the user can correct the typo.
+	assert.Contains(t, err.Error(), "main")
+	assert.Contains(t, err.Error(), "v2.6.3")
+}
+
+func TestClient_AllProjects_PaginatesUntilTotalCount(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_, _, vars := requestBody(t, r)
+		after, _ := vars["after"].(float64)
+		first, _ := vars["first"].(float64)
+
+		// Three pages total (3 sources × 2 + 1 = 7 sources, page size 3).
+		const total = 7
+		pageSize := int(first)
+		start := int(after)
+		end := min(start+pageSize, total)
+		var page []map[string]any
+		for i := start; i < end; i++ {
+			page = append(page, map[string]any{
+				"id":   1000 + i,
+				"name": fmt.Sprintf("owner/repo-%d", i),
+			})
+		}
+		writeData(t, w, map[string]any{
+			"sources": map[string]any{
+				"metadata": map[string]any{"totalCount": total},
+				"response": page,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	all, err := newTestClient(t, srv).AllProjects(context.Background(), vulnobs.ProjectsOptions{First: 3})
+	require.NoError(t, err)
+	require.Len(t, all, 7, "should accumulate every source across pages")
+	assert.Equal(t, 3, calls, "should issue ceil(7/3)=3 paged calls")
 }

--- a/internal/providers/vulnobs/client_test.go
+++ b/internal/providers/vulnobs/client_test.go
@@ -1,0 +1,230 @@
+package vulnobs_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/vulnobs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *vulnobs.Client {
+	t.Helper()
+	c, err := vulnobs.NewClient(config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: srv.URL},
+		Namespace: "stack-123",
+	})
+	require.NoError(t, err)
+	return c
+}
+
+// requestBody decodes the incoming POST body into a generic GraphQL request shape.
+func requestBody(t *testing.T, r *http.Request) (string, string, map[string]any) {
+	t.Helper()
+	b, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	var body struct {
+		OperationName string         `json:"operationName"`
+		Query         string         `json:"query"`
+		Variables     map[string]any `json:"variables"`
+	}
+	require.NoError(t, json.Unmarshal(b, &body))
+	return body.OperationName, body.Query, body.Variables
+}
+
+func writeData(t *testing.T, w http.ResponseWriter, data any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"data": data}))
+}
+
+func writeErrors(t *testing.T, w http.ResponseWriter, messages ...string) {
+	t.Helper()
+	errs := make([]map[string]any, 0, len(messages))
+	for _, m := range messages {
+		errs = append(errs, map[string]any{"message": m})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"errors": errs}))
+}
+
+func TestClient_Groups_PostsAndDecodes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/plugin-proxy/grafana-vulnerabilityobs-app/api-proxy/graphql/query", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		op, query, _ := requestBody(t, r)
+		assert.Equal(t, "Groups", op)
+		assert.Contains(t, query, "groups")
+		writeData(t, w, map[string]any{
+			"groups": []map[string]any{
+				{"id": 57, "name": "feO11y"},
+				{"id": 16, "name": "o11y"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv).Groups(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, vulnobs.Group{ID: 57, Name: "feO11y"}, got[0])
+}
+
+func TestClient_GraphQLErrors_Surface(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeErrors(t, w, "introspection disabled")
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv).Groups(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "introspection disabled")
+}
+
+func TestClient_HTTPErrors_Surface(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream unavailable"))
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv).Issues(context.Background(), "10355")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 502")
+	assert.Contains(t, err.Error(), "upstream unavailable")
+}
+
+func TestClient_Projects_PassesFilters(t *testing.T) {
+	var captured map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _, vars := requestBody(t, r)
+		captured = vars
+		writeData(t, w, map[string]any{
+			"sources": map[string]any{
+				"metadata": map[string]any{"totalCount": 1},
+				"response": []map[string]any{
+					{
+						"id":   1064,
+						"name": "grafana/faro-web-sdk",
+						"versions": []map[string]any{
+							{"id": 10354, "tag": "main", "totalCveCounts": map[string]any{"critical": 3}},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	sources, total, err := newTestClient(t, srv).Projects(context.Background(), vulnobs.ProjectsOptions{
+		GroupID:      "57",
+		SortBy:       "CRITICALS_DESC",
+		First:        30,
+		HideK8s:      true,
+		ShowArchived: false,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, sources, 1)
+	assert.Equal(t, "grafana/faro-web-sdk", sources[0].Name)
+	assert.Equal(t, 3, sources[0].Versions[0].TotalCveCounts.Critical)
+
+	// Variables shape sanity-check: top-level first/after, filters nested.
+	assert.EqualValues(t, 30, captured["first"])
+	filters, ok := captured["filters"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "57", filters["groupId"])
+	assert.Equal(t, "CRITICALS_DESC", filters["sortBy"])
+	vf, ok := filters["versionFilters"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, vf["hideK8s"])
+	assert.Equal(t, false, vf["showArchived"])
+}
+
+func TestClient_Issues_RequiresVersionID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("server should not be called when versionId is empty")
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv).Issues(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "versionID is required")
+}
+
+func TestClient_ResolveGroupID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeData(t, w, map[string]any{
+			"groups": []map[string]any{
+				{"id": 57, "name": "feO11y"},
+				{"id": 16, "name": "o11y"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	ctx := context.Background()
+
+	got, err := c.ResolveGroupID(ctx, "57")
+	require.NoError(t, err)
+	assert.Equal(t, "57", got, "numeric pass-through")
+
+	got, err = c.ResolveGroupID(ctx, "feO11y")
+	require.NoError(t, err)
+	assert.Equal(t, "57", got, "name lookup")
+
+	got, err = c.ResolveGroupID(ctx, "FEO11Y")
+	require.NoError(t, err)
+	assert.Equal(t, "57", got, "case-insensitive name lookup")
+
+	_, err = c.ResolveGroupID(ctx, "no-such-group")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown group")
+}
+
+func TestClient_ResolveVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		op, _, _ := requestBody(t, r)
+		assert.Equal(t, "Projects", op)
+		writeData(t, w, map[string]any{
+			"sources": map[string]any{
+				"metadata": map[string]any{"totalCount": 1},
+				"response": []map[string]any{
+					{
+						"id":   1064,
+						"name": "grafana/faro-web-sdk",
+						"versions": []map[string]any{
+							{"id": 10354, "tag": "main", "publishDate": "2026-05-15"},
+							{"id": 6297262, "tag": "v2.6.3", "publishDate": "2026-05-11"},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	ctx := context.Background()
+
+	got, err := c.ResolveVersion(ctx, "grafana/faro-web-sdk", "main")
+	require.NoError(t, err)
+	assert.Equal(t, "10354", got)
+
+	got, err = c.ResolveVersion(ctx, "grafana/faro-web-sdk", "v2.6.3")
+	require.NoError(t, err)
+	assert.Equal(t, "6297262", got)
+
+	got, err = c.ResolveVersion(ctx, "faro-web-sdk", "main")
+	require.NoError(t, err, "suffix match should work")
+	assert.Equal(t, "10354", got)
+}

--- a/internal/providers/vulnobs/commands.go
+++ b/internal/providers/vulnobs/commands.go
@@ -1,0 +1,371 @@
+package vulnobs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/fail"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// usageError builds a DetailedError with ExitCode=2 (usage/validation),
+// matching gcx's convention so that bad input yields a single, actionable
+// message and a non-1 exit code per DESIGN.md.
+func usageError(summary, details string) error {
+	code := fail.ExitUsageError
+	return &fail.DetailedError{
+		Summary:  summary,
+		Details:  details,
+		ExitCode: &code,
+	}
+}
+
+// newVulnobsCommand returns the root `vulnobs` cobra command.
+func newVulnobsCommand(loader RESTConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vulnobs",
+		Short: "Inspect Grafana Vulnerability Observability data (read-only).",
+		Long: `Inspect Grafana Vulnerability Observability data (read-only).
+
+The vulnerability-obs API is read-only from clients; mutations happen on the
+server as scanners ingest findings. This command tree exposes groups,
+projects (sources), and CVE findings (issues) through the same plugin-proxy
+GraphQL endpoint the Grafana UI uses.
+
+Source data is also available through the unified resources tier:
+
+    gcx resources list sources.vulnobs.grafana.app
+`,
+	}
+
+	cmd.AddCommand(
+		newGroupsCommand(loader),
+		newProjectsCommand(loader),
+	)
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// groups
+// ---------------------------------------------------------------------------
+
+type groupsListOpts struct {
+	IO cmdio.Options
+}
+
+func (o *groupsListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &GroupTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newGroupsCommand(loader RESTConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "groups",
+		Short: "Manage vulnerability-obs groups (read-only).",
+	}
+	opts := &groupsListOpts{}
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all vulnerability-obs groups.",
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "small",
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			client, err := newClientFromLoader(cmd, loader)
+			if err != nil {
+				return err
+			}
+			groups, err := client.Groups(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), groups)
+		},
+	}
+	opts.setup(listCmd.Flags())
+	cmd.AddCommand(listCmd)
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// projects
+// ---------------------------------------------------------------------------
+
+type projectsListOpts struct {
+	IO           cmdio.Options
+	Group        string
+	Sort         string
+	First        int
+	ShowArchived bool
+	IncludeK8s   bool
+}
+
+func (o *projectsListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ProjectTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Group, "group", "", "Filter to one group (name or numeric id)")
+	flags.StringVar(&o.Sort, "sort", "CRITICALS_DESC", "Sort order: CRITICALS_DESC, HIGHS_DESC, SLO_ASC")
+	flags.IntVar(&o.First, "first", 30, "Maximum number of projects to return")
+	flags.BoolVar(&o.ShowArchived, "show-archived", false, "Include archived sources")
+	flags.BoolVar(&o.IncludeK8s, "include-k8s", false, "Include k8s-scan versions")
+}
+
+type projectsListIssuesOpts struct {
+	IO         cmdio.Options
+	Repo       string
+	Tag        string
+	Severities string
+}
+
+func (o *projectsListIssuesOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &IssueTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Repo, "repo", "", "Resolve from repo (owner/name); alternative to positional versionId")
+	flags.StringVar(&o.Tag, "tag", "main", "Tag to resolve when --repo is used")
+	flags.StringVar(&o.Severities, "severity", "", "Comma-separated severities to include (CRITICAL,HIGH,...)")
+}
+
+func newProjectsCommand(loader RESTConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "projects",
+		Short: "Manage vulnerability-obs projects (sources) and their findings.",
+	}
+
+	listOpts := &projectsListOpts{}
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List projects with CVE counts.",
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "medium",
+			agent.AnnotationLLMHint:   `gcx vulnobs projects list --group feO11y -o json`,
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := listOpts.IO.Validate(); err != nil {
+				return err
+			}
+			client, err := newClientFromLoader(cmd, loader)
+			if err != nil {
+				return err
+			}
+			groupID, err := client.ResolveGroupID(cmd.Context(), listOpts.Group)
+			if err != nil {
+				return err
+			}
+			sources, _, err := client.Projects(cmd.Context(), ProjectsOptions{
+				GroupID:      groupID,
+				SortBy:       listOpts.Sort,
+				First:        listOpts.First,
+				ShowArchived: listOpts.ShowArchived,
+				HideK8s:      !listOpts.IncludeK8s,
+			})
+			if err != nil {
+				return err
+			}
+			return listOpts.IO.Encode(cmd.OutOrStdout(), sources)
+		},
+	}
+	listOpts.setup(listCmd.Flags())
+
+	listIssuesOpts := &projectsListIssuesOpts{}
+	listIssuesCmd := &cobra.Command{
+		Use:   "list-issues [<versionId>]",
+		Short: "List CVE findings for a project version (sub-resource).",
+		Long: `List CVE findings for a project version.
+
+Issues are sub-resources of a Source's Version: every query requires a
+versionId. Pass it either as a positional argument or resolve it from
+--repo (and optionally --tag, default "main").
+
+Examples:
+
+  gcx vulnobs projects list-issues 10355
+  gcx vulnobs projects list-issues --repo grafana/faro-web-sdk
+  gcx vulnobs projects list-issues --repo grafana/faro-web-sdk --tag v2.6.3 \
+      --severity CRITICAL,HIGH
+`,
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "medium",
+			agent.AnnotationLLMHint:   `gcx vulnobs projects list-issues --repo grafana/faro-web-sdk --severity CRITICAL,HIGH -o json`,
+		},
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := listIssuesOpts.IO.Validate(); err != nil {
+				return err
+			}
+			var versionID string
+			switch {
+			case len(args) == 1 && listIssuesOpts.Repo != "":
+				return usageError("vulnobs: conflicting inputs",
+					"pass either a positional <versionId> or --repo, not both")
+			case len(args) == 1:
+				versionID = args[0]
+			case listIssuesOpts.Repo != "":
+				// fall through; resolved below.
+			default:
+				return usageError("vulnobs: missing input",
+					"a versionId or --repo is required")
+			}
+
+			client, err := newClientFromLoader(cmd, loader)
+			if err != nil {
+				return err
+			}
+			if versionID == "" {
+				versionID, err = client.ResolveVersion(cmd.Context(), listIssuesOpts.Repo, listIssuesOpts.Tag)
+				if err != nil {
+					return err
+				}
+			}
+			issues, err := client.Issues(cmd.Context(), versionID)
+			if err != nil {
+				return err
+			}
+			if listIssuesOpts.Severities != "" {
+				wanted := map[string]bool{}
+				for s := range strings.SplitSeq(listIssuesOpts.Severities, ",") {
+					wanted[strings.ToUpper(strings.TrimSpace(s))] = true
+				}
+				filtered := issues[:0]
+				for _, iss := range issues {
+					if wanted[strings.ToUpper(iss.Cve.Severity)] {
+						filtered = append(filtered, iss)
+					}
+				}
+				issues = filtered
+			}
+			return listIssuesOpts.IO.Encode(cmd.OutOrStdout(), issues)
+		},
+	}
+	listIssuesOpts.setup(listIssuesCmd.Flags())
+
+	cmd.AddCommand(listCmd, listIssuesCmd)
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func newClientFromLoader(cmd *cobra.Command, loader RESTConfigLoader) (*Client, error) {
+	cfg, err := loader.LoadGrafanaConfig(cmd.Context())
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(cfg)
+}
+
+// ---------------------------------------------------------------------------
+// Table codecs
+// ---------------------------------------------------------------------------
+
+// GroupTableCodec renders groups as a table.
+type GroupTableCodec struct{}
+
+func (c *GroupTableCodec) Format() format.Format { return "table" }
+func (c *GroupTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+func (c *GroupTableCodec) Encode(w io.Writer, v any) error {
+	groups, ok := v.([]Group)
+	if !ok {
+		return fmt.Errorf("vulnobs: GroupTableCodec: unexpected type %T", v)
+	}
+	t := style.NewTable("ID", "NAME")
+	for _, g := range groups {
+		t.Row(strconv.Itoa(g.ID), g.Name)
+	}
+	return t.Render(w)
+}
+
+// ProjectTableCodec renders projects (sources) as a table.
+type ProjectTableCodec struct{}
+
+func (c *ProjectTableCodec) Format() format.Format { return "table" }
+func (c *ProjectTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+func (c *ProjectTableCodec) Encode(w io.Writer, v any) error {
+	sources, ok := v.([]Source)
+	if !ok {
+		return fmt.Errorf("vulnobs: ProjectTableCodec: unexpected type %T", v)
+	}
+	t := style.NewTable("REPO", "TAG", "CRIT", "HIGH", "MED", "LOW", "SLO")
+	for _, s := range sources {
+		latest := latestVersion(s)
+		if latest == nil {
+			t.Row(s.Name, "-", "0", "0", "0", "0", "")
+			continue
+		}
+		t.Row(
+			s.Name,
+			latest.Tag,
+			strconv.Itoa(latest.TotalCveCounts.Critical),
+			strconv.Itoa(latest.TotalCveCounts.High),
+			strconv.Itoa(latest.TotalCveCounts.Medium),
+			strconv.Itoa(latest.TotalCveCounts.Low),
+			strconv.Itoa(latest.LowestSloRemaining),
+		)
+	}
+	return t.Render(w)
+}
+
+func latestVersion(s Source) *Version {
+	var best *Version
+	for i := range s.Versions {
+		v := &s.Versions[i]
+		if best == nil || v.PublishDate > best.PublishDate {
+			best = v
+		}
+	}
+	return best
+}
+
+// IssueTableCodec renders issues as a table.
+type IssueTableCodec struct{}
+
+func (c *IssueTableCodec) Format() format.Format { return "table" }
+func (c *IssueTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+func (c *IssueTableCodec) Encode(w io.Writer, v any) error {
+	issues, ok := v.([]Issue)
+	if !ok {
+		return fmt.Errorf("vulnobs: IssueTableCodec: unexpected type %T", v)
+	}
+	t := style.NewTable("SEV", "CVSS", "CVE", "PACKAGE", "INSTALLED", "FIXED", "TARGET", "TOOL", "SLO")
+	for _, iss := range issues {
+		t.Row(
+			iss.Cve.Severity,
+			strconv.FormatFloat(iss.Cve.CvssScore, 'f', -1, 64),
+			iss.Cve.CVE,
+			iss.Package,
+			fallback(iss.InstalledVersion, "-"),
+			fallback(iss.FixedVersion, "-"),
+			iss.Target,
+			iss.Tool.Name,
+			strconv.Itoa(iss.SloRemaining),
+		)
+	}
+	return t.Render(w)
+}
+
+func fallback(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
+}

--- a/internal/providers/vulnobs/commands_test.go
+++ b/internal/providers/vulnobs/commands_test.go
@@ -1,0 +1,96 @@
+package vulnobs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/providers/vulnobs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVulnobsProvider_Metadata(t *testing.T) {
+	p := &vulnobs.VulnobsProvider{}
+
+	assert.Equal(t, "vulnobs", p.Name())
+	assert.NotEmpty(t, p.ShortDesc())
+
+	regs := p.TypedRegistrations()
+	require.Len(t, regs, 1, "Source should be the only typed registration; Issue is a sub-resource")
+
+	r := regs[0]
+	assert.Equal(t, vulnobs.SourceDescriptor().GroupVersionKind(), r.GVK)
+	assert.NotEmpty(t, r.Schema, "Schema is required by CONSTITUTION line 42-47")
+	assert.Nil(t, r.Example, "Example may be nil for read-only resources (CONSTITUTION line 45)")
+
+	// No config keys; auth is inherited from the active Grafana context.
+	assert.Nil(t, p.ConfigKeys())
+	assert.NoError(t, p.Validate(nil))
+}
+
+func TestVulnobsProvider_Commands_Structure(t *testing.T) {
+	p := &vulnobs.VulnobsProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1, "single top-level vulnobs command")
+
+	root := cmds[0]
+	assert.Equal(t, "vulnobs", root.Name())
+
+	subNames := map[string]bool{}
+	for _, sub := range root.Commands() {
+		subNames[sub.Name()] = true
+	}
+	assert.True(t, subNames["groups"], "must have groups subcommand")
+	assert.True(t, subNames["projects"], "must have projects subcommand")
+	assert.False(t, subNames["issues"], "Issue must NOT be a top-level command (CONSTITUTION line 130-135)")
+}
+
+func TestProjectsCommand_HasListIssuesSubcommand(t *testing.T) {
+	p := &vulnobs.VulnobsProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+
+	var projectsCmd, listIssuesCmd = (func() (string, string) {
+		root := cmds[0]
+		for _, sub := range root.Commands() {
+			if sub.Name() != "projects" {
+				continue
+			}
+			for _, leaf := range sub.Commands() {
+				if leaf.Name() == "list-issues" {
+					return sub.Name(), leaf.Name()
+				}
+			}
+			return sub.Name(), ""
+		}
+		return "", ""
+	})()
+	assert.Equal(t, "projects", projectsCmd)
+	assert.Equal(t, "list-issues", listIssuesCmd,
+		"list-issues must nest under projects per CONSTITUTION line 130-135")
+}
+
+// fakeLoader returns a fixed config; used only to confirm the loader is
+// implemented for AdapterFactory wiring. No HTTP calls are made.
+type fakeLoader struct{ host string }
+
+func (f fakeLoader) LoadGrafanaConfig(_ context.Context) (config.NamespacedRESTConfig, error) {
+	cfg := config.NamespacedRESTConfig{}
+	cfg.Host = f.host
+	cfg.Namespace = "stack-x"
+	return cfg, nil
+}
+
+func TestNewSourceAdapterFactory_BuildsAdapter(t *testing.T) {
+	// Use a real ConfigLoader's interface shape via our fake; the factory only
+	// reads cfg.Host/Namespace and constructs a TypedCRUD wrapper.
+	factory := vulnobs.NewSourceAdapterFactory(fakeLoader{host: "http://example.test"})
+	a, err := factory(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, a)
+}
+
+// Compile-time check that VulnobsProvider satisfies providers.Provider.
+var _ providers.Provider = (*vulnobs.VulnobsProvider)(nil)

--- a/internal/providers/vulnobs/provider.go
+++ b/internal/providers/vulnobs/provider.go
@@ -1,0 +1,63 @@
+package vulnobs
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/spf13/cobra"
+)
+
+// Note: package init() is only in provider.go (calls providers.Register).
+// Resource adapter registrations are returned by TypedRegistrations().
+
+var _ providers.Provider = &VulnobsProvider{}
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	providers.Register(&VulnobsProvider{})
+}
+
+// VulnobsProvider exposes Grafana Vulnerability Observability data through
+// gcx. It is read-only by design (see ADR-003) — Source is registered as a
+// typed adapter; Issue is a sub-resource accessed via
+// `gcx vulnobs projects list-issues`.
+type VulnobsProvider struct{}
+
+// Name returns the unique identifier for this provider.
+func (p *VulnobsProvider) Name() string { return "vulnobs" }
+
+// ShortDesc returns a one-line description of the provider.
+func (p *VulnobsProvider) ShortDesc() string {
+	return "Inspect Grafana Vulnerability Observability data (read-only)"
+}
+
+// Commands returns the Cobra commands contributed by this provider.
+func (p *VulnobsProvider) Commands() []*cobra.Command {
+	loader := &providers.ConfigLoader{}
+
+	cmd := newVulnobsCommand(loader)
+	loader.BindFlags(cmd.PersistentFlags())
+	return []*cobra.Command{cmd}
+}
+
+// Validate checks that the given provider configuration is valid.
+// The provider has no config keys (ADR-001), so any config map is valid.
+func (p *VulnobsProvider) Validate(_ map[string]string) error { return nil }
+
+// ConfigKeys returns the configuration keys used by this provider.
+// Auth is inherited from the active Grafana context; no provider-local keys.
+func (p *VulnobsProvider) ConfigKeys() []providers.ConfigKey { return nil }
+
+// TypedRegistrations returns adapter registrations for vulnobs resource
+// types. `Source` is registered as a read-only typed resource per ADR-003;
+// `Issue` is intentionally a sub-resource and not typed-registered (per
+// CONSTITUTION line 130–135).
+func (p *VulnobsProvider) TypedRegistrations() []adapter.Registration {
+	loader := &providers.ConfigLoader{}
+	return []adapter.Registration{
+		{
+			Factory:    NewSourceAdapterFactory(loader),
+			Descriptor: sourceDescriptor,
+			GVK:        sourceDescriptor.GroupVersionKind(),
+			Schema:     SourceSchema(),
+		},
+	}
+}

--- a/internal/providers/vulnobs/resource_adapter.go
+++ b/internal/providers/vulnobs/resource_adapter.go
@@ -1,0 +1,167 @@
+package vulnobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	internalconfig "github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	// APIVersion is the GVK group/version for vulnobs typed resources.
+	APIVersion = "vulnobs.grafana.app/v1alpha1"
+	// SourceKind is the Kind for `Source` (repository) resources.
+	SourceKind = "Source"
+)
+
+//nolint:gochecknoglobals // Static descriptors used in init() self-registration pattern.
+var (
+	vulnobsGroupVersion = schema.GroupVersion{Group: "vulnobs.grafana.app", Version: "v1alpha1"}
+
+	sourceDescriptor = resources.Descriptor{
+		GroupVersion: vulnobsGroupVersion,
+		Kind:         SourceKind,
+		Singular:     "source",
+		Plural:       "sources",
+	}
+)
+
+// SourceDescriptor exposes the Source descriptor for tests and registration.
+func SourceDescriptor() resources.Descriptor { return sourceDescriptor }
+
+// SourceSchema returns a JSON Schema for the Source resource. Example is
+// nil per CONSTITUTION line 45 because Source is read-only (no Create/Update).
+func SourceSchema() json.RawMessage {
+	specProps := map[string]any{
+		"name":       map[string]any{"type": "string", "description": "Canonical source name, e.g. owner/repo."},
+		"type":       map[string]any{"type": "string", "description": `Source type. Always "repository" for current Grafana usage.`},
+		"origin":     map[string]any{"type": "string", "description": `Upstream origin. Typically "github".`},
+		"visibility": map[string]any{"type": "string", "enum": []string{"public", "private"}},
+		"integration": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"id":   map[string]any{"type": "integer"},
+				"name": map[string]any{"type": "string"},
+				"type": map[string]any{"type": "string"},
+			},
+		},
+		"groups": map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"id":   map[string]any{"type": "integer"},
+					"name": map[string]any{"type": "string"},
+				},
+			},
+		},
+		"versions": map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"id":                 map[string]any{"type": "integer"},
+					"tag":                map[string]any{"type": "string"},
+					"publishDate":        map[string]any{"type": "string"},
+					"lowestSloRemaining": map[string]any{"type": "integer"},
+					"totalCveCounts": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"critical": map[string]any{"type": "integer"},
+							"high":     map[string]any{"type": "integer"},
+							"medium":   map[string]any{"type": "integer"},
+							"low":      map[string]any{"type": "integer"},
+						},
+					},
+				},
+			},
+		},
+	}
+	s := map[string]any{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id":     "https://grafana.com/schemas/VulnobsSource",
+		"type":    "object",
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string", "const": APIVersion},
+			"kind":       map[string]any{"type": "string", "const": SourceKind},
+			"metadata": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name":      map[string]any{"type": "string"},
+					"namespace": map[string]any{"type": "string"},
+				},
+			},
+			"spec": map[string]any{
+				"type":       "object",
+				"properties": specProps,
+				"required":   []string{"name"},
+			},
+		},
+		"required": []string{"apiVersion", "kind", "metadata", "spec"},
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic(fmt.Sprintf("vulnobs: failed to marshal Source schema: %v", err))
+	}
+	return b
+}
+
+// RESTConfigLoader can load a NamespacedRESTConfig from the active context.
+type RESTConfigLoader interface {
+	LoadGrafanaConfig(ctx context.Context) (internalconfig.NamespacedRESTConfig, error)
+}
+
+// NewSourceAdapterFactory returns a lazy adapter.Factory for vulnobs Sources.
+// The adapter is read-only: List is satisfied via the Projects query, Get
+// falls back to list-then-filter (TypedCRUD default), Create/Update/Delete
+// are unset and return adapter's standard "not supported" errors.
+func NewSourceAdapterFactory(loader RESTConfigLoader) adapter.Factory {
+	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
+		cfg, err := loader.LoadGrafanaConfig(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("vulnobs: failed to load REST config: %w", err)
+		}
+		client, err := NewClient(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("vulnobs: failed to create client: %w", err)
+		}
+		crud := &adapter.TypedCRUD[Source]{
+			ListFn: adapter.LimitedListFn(func(ctx context.Context) ([]Source, error) {
+				sources, _, err := client.Projects(ctx, ProjectsOptions{
+					ShowArchived: true,
+					First:        1000,
+				})
+				return sources, err
+			}),
+			Namespace:  cfg.Namespace,
+			Descriptor: sourceDescriptor,
+		}
+		return crud.AsAdapter(), nil
+	}
+}
+
+// SourceToResource converts a Source to a gcx Resource for codec output.
+func SourceToResource(src Source, namespace string) (*resources.Resource, error) {
+	data, err := json.Marshal(src)
+	if err != nil {
+		return nil, fmt.Errorf("vulnobs: marshal Source: %w", err)
+	}
+	var specMap map[string]any
+	if err := json.Unmarshal(data, &specMap); err != nil {
+		return nil, fmt.Errorf("vulnobs: unmarshal Source: %w", err)
+	}
+	obj := map[string]any{
+		"apiVersion": APIVersion,
+		"kind":       SourceKind,
+		"metadata": map[string]any{
+			"name":      src.GetResourceName(),
+			"namespace": namespace,
+		},
+		"spec": specMap,
+	}
+	return resources.MustFromObject(obj, resources.SourceInfo{}), nil
+}

--- a/internal/providers/vulnobs/resource_adapter.go
+++ b/internal/providers/vulnobs/resource_adapter.go
@@ -130,12 +130,15 @@ func NewSourceAdapterFactory(loader RESTConfigLoader) adapter.Factory {
 			return nil, fmt.Errorf("vulnobs: failed to create client: %w", err)
 		}
 		crud := &adapter.TypedCRUD[Source]{
+			// Paginate through `sources` instead of capping at a fixed page —
+			// stacks can have more sources than any single page returns, and
+			// silently truncating the typed-resource inventory would mislead
+			// `gcx resources list/get`.
 			ListFn: adapter.LimitedListFn(func(ctx context.Context) ([]Source, error) {
-				sources, _, err := client.Projects(ctx, ProjectsOptions{
+				return client.AllProjects(ctx, ProjectsOptions{
 					ShowArchived: true,
-					First:        1000,
+					First:        200,
 				})
-				return sources, err
 			}),
 			Namespace:  cfg.Namespace,
 			Descriptor: sourceDescriptor,

--- a/internal/providers/vulnobs/resource_adapter_test.go
+++ b/internal/providers/vulnobs/resource_adapter_test.go
@@ -1,0 +1,82 @@
+package vulnobs_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/vulnobs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceDescriptor_GVK(t *testing.T) {
+	d := vulnobs.SourceDescriptor()
+	gvk := d.GroupVersionKind()
+	assert.Equal(t, "vulnobs.grafana.app", gvk.Group)
+	assert.Equal(t, "v1alpha1", gvk.Version)
+	assert.Equal(t, "Source", gvk.Kind)
+	assert.Equal(t, "sources", d.Plural)
+	assert.Equal(t, "source", d.Singular)
+}
+
+func TestSourceSchema_NonNilAndValidJSONSchema(t *testing.T) {
+	raw := vulnobs.SourceSchema()
+	require.NotEmpty(t, raw)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+
+	assert.Equal(t, "https://json-schema.org/draft/2020-12/schema", parsed["$schema"])
+	assert.Equal(t, "object", parsed["type"])
+
+	props, ok := parsed["properties"].(map[string]any)
+	require.True(t, ok)
+	apiVersion, ok := props["apiVersion"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, vulnobs.APIVersion, apiVersion["const"])
+	kind, ok := props["kind"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, vulnobs.SourceKind, kind["const"])
+
+	// Spec captures the domain-relevant fields.
+	spec, ok := props["spec"].(map[string]any)
+	require.True(t, ok)
+	specProps, ok := spec["properties"].(map[string]any)
+	require.True(t, ok)
+	for _, k := range []string{"name", "type", "origin", "visibility", "integration", "groups", "versions"} {
+		assert.Contains(t, specProps, k, "spec should describe field %q", k)
+	}
+}
+
+func TestSourceToResource_RoundTrip(t *testing.T) {
+	src := vulnobs.Source{
+		ID:         1064,
+		Name:       "grafana/faro-web-sdk",
+		Type:       "repository",
+		Origin:     "github",
+		Visibility: "public",
+		Groups: []vulnobs.Group{
+			{ID: 57, Name: "feO11y"},
+		},
+		Versions: []vulnobs.Version{
+			{ID: 10354, Tag: "main"},
+		},
+	}
+
+	res, err := vulnobs.SourceToResource(src, "stacks-123")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	obj := res.Object.Object
+	assert.Equal(t, vulnobs.APIVersion, obj["apiVersion"])
+	assert.Equal(t, vulnobs.SourceKind, obj["kind"])
+
+	meta, ok := obj["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "grafana--faro-web-sdk", meta["name"], "slash must be replaced for k8s metadata.name")
+	assert.Equal(t, "stacks-123", meta["namespace"])
+
+	spec, ok := obj["spec"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "grafana/faro-web-sdk", spec["name"], "spec preserves original owner/repo form")
+}

--- a/internal/providers/vulnobs/types.go
+++ b/internal/providers/vulnobs/types.go
@@ -1,0 +1,150 @@
+// Package vulnobs provides a client for Grafana Vulnerability Observability
+// (the grafana-vulnerabilityobs-app plugin) via its plugin-proxied GraphQL
+// endpoint.
+package vulnobs
+
+// Group is a vulnerability-obs team/group (tag namespace for sources).
+type Group struct {
+	ID   int    `json:"id" yaml:"id"`
+	Name string `json:"name" yaml:"name"`
+}
+
+// GetResourceName implements adapter.ResourceNamer for Group. Groups are not
+// typed-registered (see ADR-003), but the helper is useful for output codecs
+// and consistency with other domain types.
+func (g Group) GetResourceName() string { return g.Name }
+
+// CveCounts is the rollup of findings by severity for a Version.
+type CveCounts struct {
+	Critical int `json:"critical" yaml:"critical"`
+	High     int `json:"high" yaml:"high"`
+	Medium   int `json:"medium" yaml:"medium"`
+	Low      int `json:"low" yaml:"low"`
+}
+
+// Integration is the upstream connection through which a Source was ingested.
+type Integration struct {
+	ID   int    `json:"id" yaml:"id"`
+	Name string `json:"name" yaml:"name"`
+	Type string `json:"type" yaml:"type"`
+}
+
+// Version is a single scanned version (tag) of a Source.
+type Version struct {
+	ID                 int       `json:"id" yaml:"id"`
+	Tag                string    `json:"tag" yaml:"tag"`
+	PublishDate        string    `json:"publishDate,omitempty" yaml:"publishDate,omitempty"`
+	LowestSloRemaining int       `json:"lowestSloRemaining" yaml:"lowestSloRemaining"`
+	TotalCveCounts     CveCounts `json:"totalCveCounts" yaml:"totalCveCounts"`
+}
+
+// Source is a scanned project (typically a Git repository).
+//
+// GetResourceName must be value-receiver to satisfy adapter.ResourceNamer
+// (the TypedCRUD[T] constraint), and SetResourceName must be pointer-receiver
+// to mutate the underlying field. Matches the KG provider's Rule pattern.
+//
+//nolint:recvcheck // ResourceIdentity requires the mixed-receiver shape:
+type Source struct {
+	ID          int         `json:"id" yaml:"id"`
+	Name        string      `json:"name" yaml:"name"`
+	Type        string      `json:"type" yaml:"type"`
+	Origin      string      `json:"origin" yaml:"origin"`
+	Visibility  string      `json:"visibility" yaml:"visibility"`
+	Integration Integration `json:"integration" yaml:"integration"`
+	Groups      []Group     `json:"groups" yaml:"groups"`
+	Versions    []Version   `json:"versions" yaml:"versions"`
+}
+
+// GetResourceName satisfies adapter.ResourceIdentity. The Source name (e.g.
+// "grafana/faro-web-sdk") is stable across scans, but contains a slash which
+// is not a valid k8s metadata.name character — substitute with "--" for the
+// resource identity while keeping the original in the spec.
+//
+// Value receiver is required so Source satisfies adapter.ResourceNamer used
+// as the TypedCRUD[T] constraint. SetResourceName uses a pointer receiver to
+// mutate the underlying field, matching the KG provider's Rule pattern.
+//
+
+func (s Source) GetResourceName() string { return resourceNameFromSource(s.Name) }
+
+// SetResourceName implements adapter.ResourceIdentity. Restores the original
+// "owner/repo" form from the metadata.name placeholder.
+func (s *Source) SetResourceName(name string) { s.Name = sourceNameFromResource(name) }
+
+// Cve is metadata about a single CVE assignment for an Issue.
+type Cve struct {
+	CVE       string  `json:"cve" yaml:"cve"`
+	Severity  string  `json:"severity" yaml:"severity"`
+	CvssScore float64 `json:"cvssScore" yaml:"cvssScore"`
+	Title     string  `json:"title,omitempty" yaml:"title,omitempty"`
+}
+
+// Tool identifies the scanner that produced an Issue.
+type Tool struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+// Issue is a single CVE finding reported by a scanner against a Version.
+// Issues are sub-resources of Source.Versions[] and are not typed-registered
+// (see ADR-003); upstream IssueFilters require a versionId.
+type Issue struct {
+	ID               int    `json:"id" yaml:"id"`
+	Package          string `json:"package" yaml:"package"`
+	InstalledVersion string `json:"installedVersion,omitempty" yaml:"installedVersion,omitempty"`
+	FixedVersion     string `json:"fixedVersion,omitempty" yaml:"fixedVersion,omitempty"`
+	Target           string `json:"target" yaml:"target"`
+	SloRemaining     int    `json:"sloRemaining" yaml:"sloRemaining"`
+	Tool             Tool   `json:"tool" yaml:"tool"`
+	Cve              Cve    `json:"cve" yaml:"cve"`
+}
+
+// SourceFilters is the input shape for the `sources` query. See ADR-002 /
+// research notes for the empirically-verified subset of fields; only the
+// fields actually accepted by the upstream are present here.
+type SourceFilters struct {
+	GroupID        string          `json:"groupId,omitempty"`
+	Name           string          `json:"name,omitempty"`
+	SortBy         string          `json:"sortBy,omitempty"`
+	EnabledOnly    bool            `json:"enabledOnly"`
+	VersionFilters *VersionFilters `json:"versionFilters,omitempty"`
+}
+
+// VersionFilters is the nested filter on versions returned per Source.
+type VersionFilters struct {
+	HideK8s      bool `json:"hideK8s"`
+	ShowArchived bool `json:"showArchived"`
+}
+
+// IssueFilters is the input shape for the `issues` query.
+type IssueFilters struct {
+	VersionID string `json:"versionId"`
+}
+
+// resourceNameFromSource turns "grafana/faro-web-sdk" into "grafana--faro-web-sdk"
+// for use as a k8s metadata.name (which forbids "/").
+func resourceNameFromSource(s string) string {
+	out := make([]byte, 0, len(s)+1)
+	for i := range len(s) {
+		if s[i] == '/' {
+			out = append(out, '-', '-')
+			continue
+		}
+		out = append(out, s[i])
+	}
+	return string(out)
+}
+
+// sourceNameFromResource is the inverse of resourceNameFromSource. The
+// substitution is a non-injective mapping in pathological cases (a real
+// repo named "foo--bar" would round-trip to "foo--bar"), so we only
+// replace the first occurrence of "--" — the GitHub convention is
+// exactly one slash separating owner from repo.
+func sourceNameFromResource(s string) string {
+	for i := range len(s) - 1 {
+		if s[i] == '-' && s[i+1] == '-' {
+			return s[:i] + "/" + s[i+2:]
+		}
+	}
+	return s
+}

--- a/internal/providers/vulnobs/types_identity_test.go
+++ b/internal/providers/vulnobs/types_identity_test.go
@@ -1,0 +1,65 @@
+package vulnobs_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/vulnobs"
+	"github.com/grafana/gcx/internal/resources/adapter"
+)
+
+// Compile-time assertion: Source satisfies ResourceIdentity.
+var _ adapter.ResourceIdentity = &vulnobs.Source{}
+
+func TestSource_ResourceIdentity_Roundtrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		sourceName  string
+		wantID      string
+		setTo       string
+		wantAfter   string
+		wantSetName string
+	}{
+		{
+			name:        "github owner/repo",
+			sourceName:  "grafana/faro-web-sdk",
+			wantID:      "grafana--faro-web-sdk",
+			setTo:       "grafana--faro-web-sdk",
+			wantAfter:   "grafana--faro-web-sdk",
+			wantSetName: "grafana/faro-web-sdk",
+		},
+		{
+			name:        "no slash",
+			sourceName:  "single-name",
+			wantID:      "single-name",
+			setTo:       "single-name",
+			wantAfter:   "single-name",
+			wantSetName: "single-name",
+		},
+		{
+			name:        "set from owner--repo",
+			sourceName:  "",
+			wantID:      "",
+			setTo:       "grafana--mimir",
+			wantAfter:   "grafana--mimir",
+			wantSetName: "grafana/mimir",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &vulnobs.Source{Name: tt.sourceName}
+			if got := s.GetResourceName(); got != tt.wantID {
+				t.Errorf("GetResourceName() = %q, want %q", got, tt.wantID)
+			}
+			s.SetResourceName(tt.setTo)
+			if s.Name != tt.wantSetName {
+				t.Errorf("Name after SetResourceName(%q) = %q, want %q",
+					tt.setTo, s.Name, tt.wantSetName)
+			}
+			if got := s.GetResourceName(); got != tt.wantAfter {
+				t.Errorf("GetResourceName() after SetResourceName(%q) = %q, want %q",
+					tt.setTo, got, tt.wantAfter)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Domas note: Seems really useful for solving CVEs. But vuln obs is not a public plugin I think, so not sure this has a place in gcx :thinking: 

## Summary

- Adds `internal/providers/vulnobs/` with three commands (`vulnobs groups list`, `vulnobs projects list`, `vulnobs projects list-issues`) wrapping the `grafana-vulnerabilityobs-app` plugin-proxy GraphQL endpoint. `Source` is registered as a read-only typed resource (`sources.vulnobs.grafana.app`); `Issue` stays as a sub-resource under `projects` per CONSTITUTION line 130-135 since it requires a parent `versionId`.
- Auth reuses the active Grafana token via `NamespacedRESTConfig` (same pattern as `kg`); no new config keys.
- Hand-rolled GraphQL POSTer (no codegen — schema is undocumented, introspection disabled, three small queries). Rationale and design in [research report](docs/research/2026-05-15-vulnobs-provider.md) and [ADRs](docs/adrs/vulnobs-provider/).

Scope is intentionally narrow — only the slice of the API needed to drive CVE-resolution workflows from an Agent Skill on top. Most of the upstream surface (per-source detail queries, scan settings, SLO configuration, suppression management) is out of scope and would land in follow-ups if demand emerges.

## Test plan

- [x] `go test -race ./...` passes (including the consistency tests for `agent.token_cost` / `agent.llm_hint` annotations).
- [x] `golangci-lint run ./internal/providers/vulnobs/...` reports 0 issues.
- [x] Live smoke against `ops.grafana-ops.net`: groups/projects/list-issues all return real data, validation errors exit 2 with actionable messages, typed-resource tier exposes `sources.vulnobs.grafana.app` end-to-end.
- [x] `mise run reference:cli` regenerated; 6 new vulnobs entries appear.
- [x] `AGENTS.md` package map and `ARCHITECTURE.md` ADR table updated.

_PR description authored by Claude on Domas's behalf._