### PR TITLE
fix(datasources): recognize Prometheus flavor plugins in NormalizeKind

### DIFF
--- a/internal/datasources/query/resolve.go
+++ b/internal/datasources/query/resolve.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -157,8 +158,17 @@ func NormalizeKind(pluginID string) string {
 	case "grafana-pyroscope-datasource":
 		return "pyroscope"
 	default:
+		if isPromFlavor(pluginID) {
+			return "prometheus"
+		}
 		return pluginID
 	}
+}
+
+var promFlavorRe = regexp.MustCompile(`^grafana-[0-9a-z]+prometheus-datasource$`)
+
+func isPromFlavor(pluginID string) bool {
+	return pluginID == "prometheus" || promFlavorRe.MatchString(pluginID)
 }
 
 // ValidateDatasourceType checks that the datasource's actual type matches the expected kind.

--- a/internal/datasources/query/resolve_test.go
+++ b/internal/datasources/query/resolve_test.go
@@ -274,6 +274,28 @@ func TestResolveValidateAndSaveDatasource(t *testing.T) {
 	})
 }
 
+func TestNormalizeKind(t *testing.T) {
+	tests := []struct {
+		pluginID string
+		want     string
+	}{
+		{"prometheus", "prometheus"},
+		{"loki", "loki"},
+		{"tempo", "tempo"},
+		{"grafana-pyroscope-datasource", "pyroscope"},
+		{"grafana-amazonprometheus-datasource", "prometheus"},
+		{"grafana-azureprometheus-datasource", "prometheus"},
+		{"unknown-datasource", "unknown-datasource"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pluginID, func(t *testing.T) {
+			assert.Equal(t, tt.want, dsquery.NormalizeKind(tt.pluginID))
+		})
+	}
+}
+
 func testDatasourceRESTConfig(t *testing.T, payload any) config.NamespacedRESTConfig {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- `NormalizeKind()` now recognizes cloud-specific Prometheus datasource plugins (e.g. `grafana-amazonprometheus-datasource`, `grafana-azureprometheus-datasource`) as `prometheus`
- Uses a regex pattern (`^grafana-[0-9a-z]+prometheus-datasource$`) matching Grafana's own frontend logic (`isPromFlavor` in `packages/grafana-data/src/utils/matchPluginId.ts`) rather than hardcoding individual plugin IDs — this future-proofs against new cloud Prometheus variants.

Fixes #714

## Test plan

- [x] `gcx datasources prometheus query -d <amp-uid> '<promql>'` succeeds where it previously errored with `Datasource is type grafana-amazonprometheus-datasource, not prometheus`
- [x] `gcx datasources query <amp-uid> '<promql>'` auto-routes correctly
- [x] New `TestNormalizeKind` table-driven test covers AMP, Azure, pyroscope, and unknown types
- [x] Existing test suite passes (`go test -race`)

Generated with [Claude Code](https://claude.com/claude-code)