### PR TITLE
feat(kg): improve entities help text and surface scope props in schema

### DIFF
--- a/docs/reference/cli/gcx_kg_entities.md
+++ b/docs/reference/cli/gcx_kg_entities.md
@@ -24,6 +24,6 @@ Manage Knowledge Graph entities.
 
 * [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
 * [gcx kg entities inspect](gcx_kg_entities_inspect.md)	 - Show detailed info, insights, and summary for a single entity, including a link to the RCA Workbench.
-* [gcx kg entities list](gcx_kg_entities_list.md)	 - List Knowledge Graph entities for a given type.
-* [gcx kg entities query](gcx_kg_entities_query.md)	 - Run a read-only Cypher query against the Knowledge Graph.
+* [gcx kg entities list](gcx_kg_entities_list.md)	 - List Knowledge Graph entities for a given type, env, site, namespace.
+* [gcx kg entities query](gcx_kg_entities_query.md)	 - Query entities by running a read-only Cypher query against the Knowledge Graph.
 

--- a/docs/reference/cli/gcx_kg_entities_list.md
+++ b/docs/reference/cli/gcx_kg_entities_list.md
@@ -1,6 +1,6 @@
 ## gcx kg entities list
 
-List Knowledge Graph entities for a given type.
+List Knowledge Graph entities for a given type, env, site, namespace.
 
 ```
 gcx kg entities list [flags]

--- a/docs/reference/cli/gcx_kg_entities_query.md
+++ b/docs/reference/cli/gcx_kg_entities_query.md
@@ -1,6 +1,12 @@
 ## gcx kg entities query
 
-Run a read-only Cypher query against the Knowledge Graph.
+Query entities by running a read-only Cypher query against the Knowledge Graph.
+
+### Synopsis
+
+Query entities by running a read-only Cypher query against the Knowledge Graph.
+
+Run 'gcx kg meta schema' to discover valid entity types, property names, and relationship names.
 
 ```
 gcx kg entities query <cypher-query> [flags]

--- a/docs/reference/cli/gcx_kg_entities_query.md
+++ b/docs/reference/cli/gcx_kg_entities_query.md
@@ -8,14 +8,25 @@ Query entities by running a read-only Cypher query against the Knowledge Graph.
 
 Run 'gcx kg meta schema' to discover valid entity types, property names, and relationship names.
 
+Response shape (not raw Cypher rows — results are aggregated into this envelope):
+
+  {
+    "entities": [ { "type", "name", "scope", "properties", "insights" }, ... ],
+    "edges":    [ { "type", "sourceName", "sourceType", "sourceScope",
+                    "destinationName", "destinationType", "destinationScope" }, ... ],
+    "pageNum":  <int>,
+    "lastPage": <bool>
+  }
+
 Tips:
   - Prefer whole-entity projections like 'RETURN s, d' over scalar projections
-    like 'RETURN d.name'. Whole entities round-trip cleanly through the output
-    codecs; scalar rows are harder to address downstream.
-  - The --json flag filters top-level response envelope keys
-    (entities, edges, pageNum, lastPage) — it does NOT filter properties inside
-    entities. Run with '--json list' to see available top-level keys, then use
-    e.g. '--json entities' and pipe to jq/python for per-entity shaping.
+    like 'RETURN d.name'. Whole entities populate the 'entities' array with
+    full type/name/scope/properties; scalar projections do not round-trip
+    through this envelope.
+  - The --json flag selects keys from the envelope above (entities, edges,
+    pageNum, lastPage) — it does NOT filter properties inside each entity.
+    Use '--json list' to see the envelope keys, then '--json entities' and
+    pipe to jq/python for per-entity field shaping.
 
 ```
 gcx kg entities query <cypher-query> [flags]

--- a/docs/reference/cli/gcx_kg_entities_query.md
+++ b/docs/reference/cli/gcx_kg_entities_query.md
@@ -8,6 +8,15 @@ Query entities by running a read-only Cypher query against the Knowledge Graph.
 
 Run 'gcx kg meta schema' to discover valid entity types, property names, and relationship names.
 
+Tips:
+  - Prefer whole-entity projections like 'RETURN s, d' over scalar projections
+    like 'RETURN d.name'. Whole entities round-trip cleanly through the output
+    codecs; scalar rows are harder to address downstream.
+  - The --json flag filters top-level response envelope keys
+    (entities, edges, pageNum, lastPage) — it does NOT filter properties inside
+    entities. Run with '--json list' to see available top-level keys, then use
+    e.g. '--json entities' and pipe to jq/python for per-entity shaping.
+
 ```
 gcx kg entities query <cypher-query> [flags]
 ```

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1620,14 +1620,25 @@ func newCypherCommand(loader RESTConfigLoader) *cobra.Command {
 
 Run 'gcx kg meta schema' to discover valid entity types, property names, and relationship names.
 
+Response shape (not raw Cypher rows — results are aggregated into this envelope):
+
+  {
+    "entities": [ { "type", "name", "scope", "properties", "insights" }, ... ],
+    "edges":    [ { "type", "sourceName", "sourceType", "sourceScope",
+                    "destinationName", "destinationType", "destinationScope" }, ... ],
+    "pageNum":  <int>,
+    "lastPage": <bool>
+  }
+
 Tips:
   - Prefer whole-entity projections like 'RETURN s, d' over scalar projections
-    like 'RETURN d.name'. Whole entities round-trip cleanly through the output
-    codecs; scalar rows are harder to address downstream.
-  - The --json flag filters top-level response envelope keys
-    (entities, edges, pageNum, lastPage) — it does NOT filter properties inside
-    entities. Run with '--json list' to see available top-level keys, then use
-    e.g. '--json entities' and pipe to jq/python for per-entity shaping.`,
+    like 'RETURN d.name'. Whole entities populate the 'entities' array with
+    full type/name/scope/properties; scalar projections do not round-trip
+    through this envelope.
+  - The --json flag selects keys from the envelope above (entities, edges,
+    pageNum, lastPage) — it does NOT filter properties inside each entity.
+    Use '--json list' to see the envelope keys, then '--json entities' and
+    pipe to jq/python for per-entity field shaping.`,
 		Example: `  gcx kg entities query "MATCH (s:Service) RETURN s LIMIT 10"
   gcx kg entities query "MATCH (s:Service)-[:CALLS]->(d:Service) RETURN s, d" --since 1h
   gcx kg entities query "MATCH (s:Service {namespace: 'prod'}) RETURN s" --since 1h`,

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1618,7 +1618,16 @@ func newCypherCommand(loader RESTConfigLoader) *cobra.Command {
 		Short: "Query entities by running a read-only Cypher query against the Knowledge Graph.",
 		Long: `Query entities by running a read-only Cypher query against the Knowledge Graph.
 
-Run 'gcx kg meta schema' to discover valid entity types, property names, and relationship names.`,
+Run 'gcx kg meta schema' to discover valid entity types, property names, and relationship names.
+
+Tips:
+  - Prefer whole-entity projections like 'RETURN s, d' over scalar projections
+    like 'RETURN d.name'. Whole entities round-trip cleanly through the output
+    codecs; scalar rows are harder to address downstream.
+  - The --json flag filters top-level response envelope keys
+    (entities, edges, pageNum, lastPage) — it does NOT filter properties inside
+    entities. Run with '--json list' to see available top-level keys, then use
+    e.g. '--json entities' and pipe to jq/python for per-entity shaping.`,
 		Example: `  gcx kg entities query "MATCH (s:Service) RETURN s LIMIT 10"
   gcx kg entities query "MATCH (s:Service)-[:CALLS]->(d:Service) RETURN s, d" --since 1h
   gcx kg entities query "MATCH (s:Service {namespace: 'prod'}) RETURN s" --since 1h`,

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -815,7 +815,7 @@ func newEntitiesCommand(loader RESTConfigLoader) *cobra.Command {
 	listOpts := &entitiesListOpts{}
 	listCmd := &cobra.Command{
 		Use:   "list",
-		Short: "List Knowledge Graph entities for a given type.",
+		Short: "List Knowledge Graph entities for a given type, env, site, namespace.",
 		Example: `  gcx kg entities list --type Service
   gcx kg entities list --type Service --namespace mimir-prod-01 --property name=model-builder
   gcx kg entities list --type Service --with-insights any
@@ -1615,7 +1615,10 @@ func newCypherCommand(loader RESTConfigLoader) *cobra.Command {
 	ioOpts := &cypherOpts{}
 	cmd := &cobra.Command{
 		Use:   "query <cypher-query>",
-		Short: "Run a read-only Cypher query against the Knowledge Graph.",
+		Short: "Query entities by running a read-only Cypher query against the Knowledge Graph.",
+		Long: `Query entities by running a read-only Cypher query against the Knowledge Graph.
+
+Run 'gcx kg meta schema' to discover valid entity types, property names, and relationship names.`,
 		Example: `  gcx kg entities query "MATCH (s:Service) RETURN s LIMIT 10"
   gcx kg entities query "MATCH (s:Service)-[:CALLS]->(d:Service) RETURN s, d" --since 1h
   gcx kg entities query "MATCH (s:Service {namespace: 'prod'}) RETURN s" --since 1h`,
@@ -1720,9 +1723,20 @@ func processGraphSchema(resp GraphSchemaResponse) KGSchemaResult {
 		if _, ok := typeProps[name]; !ok {
 			typeProps[name] = map[string]bool{"name": true}
 		}
+		scopeRename := map[string]string{
+			"scope_env":       "env",
+			"scope_site":      "site",
+			"scope_namespace": "namespace",
+		}
 		for prop := range e.Properties {
-			if ignoredProps[prop] || strings.HasPrefix(prop, "_") ||
-				strings.HasPrefix(prop, "scope_") || strings.HasPrefix(prop, "lookup_") {
+			if ignoredProps[prop] || strings.HasPrefix(prop, "_") || strings.HasPrefix(prop, "lookup_") {
+				continue
+			}
+			if renamed, ok := scopeRename[prop]; ok {
+				typeProps[name][renamed] = true
+				continue
+			}
+			if strings.HasPrefix(prop, "scope_") {
 				continue
 			}
 			typeProps[name][prop] = true


### PR DESCRIPTION
## Summary
- Clarify `Short` descriptions for `gcx kg entities query` and `gcx kg entities list`
- Add `Long` help on `query` that documents the response envelope shape (entities/edges/pageNum/lastPage) and points users to `gcx kg meta schema` for valid entity types, properties, and relationships
- Rename `scope_env`/`scope_site`/`scope_namespace` to `env`/`site`/`namespace` in `gcx kg meta schema` output instead of dropping them

## Rationale
Because the output structure of `query` is a bit unintuitive (results are aggregated into a response envelope, not returned as raw Cypher rows), it's better we specify the structure in the help. Also a hint on `gcx kg meta schema` is needed so users can discover valid entity types, property names, and relationship names without trial and error. Observed in agent transcripts: ~6 of 10 query calls were wasted iterating around the `--json` filter (which targets envelope keys, not entity properties) and around scalar projections like `RETURN d.name` that don't round-trip through the envelope.

## Test plan
- [x] `mise run lint`
- [x] `go test ./internal/providers/kg/...`
- [x] `GCX_AGENT_MODE=false mise run reference` (CLI reference docs regenerated, no drift)
- [x] Manually verify `gcx kg entities -h`, `gcx kg entities query -h`, and `gcx kg meta schema` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)