### PR TITLE
kg diagnose: detect broken trace context propagation

### DIFF
--- a/internal/providers/kg/diagnose.go
+++ b/internal/providers/kg/diagnose.go
@@ -331,6 +331,15 @@ func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promCli
 				return nil
 			})
 		}
+		// Check N: Trace context propagation — detect the "entities exist
+		// but no edges" failure mode where outgoing OTel SDKs aren't
+		// injecting traceparent on cross-service calls.
+		g.Go(func() error {
+			if c := checkTracePropagation(ctx, promClient, datasourceUID, scope.env); c != nil {
+				addCheck(*c)
+			}
+			return nil
+		})
 	}
 
 	_ = g.Wait() // errors are captured in CheckResults, not returned
@@ -370,6 +379,9 @@ func checkOrder(name string) int {
 	}
 	if strings.HasPrefix(name, "Edge source:") {
 		return 8
+	}
+	if name == "Trace context propagation" {
+		return 9
 	}
 	return 50
 }
@@ -862,6 +874,89 @@ func extractInstantValue(s prometheus.Sample) string {
 		}
 	}
 	return "?"
+}
+
+// ---------------------------------------------------------------------------
+// Trace context propagation detection
+// ---------------------------------------------------------------------------
+
+// checkTracePropagation detects the "entities exist but no edges" failure
+// mode (canonical Entity Graph problem #3). The telemetry signature is:
+//
+//   - traces_target_info{deployment_environment=ENV} > 0   (services exist)
+//   - traces_service_graph_request_total{server_deployment_environment=ENV,
+//     client!="user"} == 0                                  (no real edges)
+//   - traces_service_graph_request_total{server_deployment_environment=ENV,
+//     client="user"} > 0                                    (only phantom edges)
+//
+// Tempo's metrics generator synthesizes client="user" edges for SERVER spans
+// that arrive with no incoming traceparent header — the unambiguous fingerprint
+// of broken outgoing trace context propagation on the upstream service.
+//
+// Returns nil when env is unset (the check is scoped per-env), when target
+// info is empty (telemetry isn't flowing yet — let earlier checks flag that),
+// or when real edges exist (no problem to report).
+func checkTracePropagation(ctx context.Context, client *prometheus.Client, datasourceUID, env string) *CheckResult {
+	if env == "" {
+		return nil
+	}
+
+	// Gate 1: services must be emitting telemetry for this env.
+	targetResp, err := client.Query(ctx, datasourceUID, prometheus.QueryRequest{
+		Query: fmt.Sprintf(`count(traces_target_info{deployment_environment="%s"})`, env),
+	})
+	if err != nil || len(targetResp.Data.Result) == 0 {
+		// No telemetry flowing — earlier checks (or the absence of any check
+		// passing) will surface this. We don't claim "propagation is broken"
+		// when there's no telemetry to propagate.
+		return nil
+	}
+
+	// Gate 2: are there any real (non-phantom) service-to-service edges?
+	realEdgesResp, err := client.Query(ctx, datasourceUID, prometheus.QueryRequest{
+		Query: fmt.Sprintf(
+			`count(traces_service_graph_request_total{server_deployment_environment="%s",client!="user"})`,
+			env),
+	})
+	if err != nil {
+		return nil
+	}
+	if len(realEdgesResp.Data.Result) > 0 {
+		// Real edges exist — propagation is fine for this env.
+		return nil
+	}
+
+	// Gate 3: are there phantom edges? Their presence confirms data is flowing
+	// to the metrics generator but lacks incoming context.
+	phantomResp, err := client.Query(ctx, datasourceUID, prometheus.QueryRequest{
+		Query: fmt.Sprintf(
+			`count(traces_service_graph_request_total{server_deployment_environment="%s",client="user"})`,
+			env),
+	})
+	if err != nil || len(phantomResp.Data.Result) == 0 {
+		// No phantom edges either. This is a different failure mode (e.g. no
+		// SERVER spans at all yet). Don't report a propagation issue here.
+		return nil
+	}
+
+	return &CheckResult{
+		Name:   "Trace context propagation",
+		Status: CheckFail,
+		Detail: fmt.Sprintf(
+			"services emit telemetry for env %q but only phantom client=\"user\" edges exist — no real inter-service edges",
+			env),
+		Recommendation: "Outgoing HTTP calls aren't carrying traceparent headers, so the metrics generator can't link the spans into edges. " +
+			"Check the OTel SDK config on your services. Common causes: " +
+			"(1) HTTP-client auto-instrumentation is disabled or not installed — " +
+			"Python: `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` is a common culprit, or the relevant `opentelemetry-instrumentation-*` package " +
+			"(urllib, urllib3, requests) isn't installed; " +
+			"Node.js: the `@opentelemetry/instrumentation-*` registration is missing; " +
+			"Go: outgoing calls must be wired through `otelhttp.Transport` (auto-instrumentation does not apply). " +
+			"(2) The application bypasses the instrumented HTTP client (raw socket calls, a third-party SDK using its own transport). " +
+			"(3) No `TracerProvider` was registered, so no context is tracked at all — verify with `gcx traces query` that received spans have a parent. " +
+			"Once outgoing propagation is fixed, expect `traces_service_graph_request_total{client!=\"user\"}` to populate within 1–2 minutes " +
+			"and `asserts:relation:calls` to follow ~5–10 minutes after that.",
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/providers/kg/diagnose_test.go
+++ b/internal/providers/kg/diagnose_test.go
@@ -3,6 +3,7 @@ package kg_test
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -715,4 +716,187 @@ func TestLabelsDiagnoseTextCodec(t *testing.T) {
 	assert.Contains(t, output, "not mapped")
 	assert.Contains(t, output, "Diagnosis")
 	assert.Contains(t, output, "1/2 checks passed")
+}
+
+// ---------------------------------------------------------------------------
+// Trace context propagation check
+// ---------------------------------------------------------------------------
+
+// promResponseHasData returns a Grafana datasource-query response with one
+// instant-value frame (count > 0). Mirrors the shape `prometheus.Client.Query`
+// expects so that `len(resp.Data.Result) > 0` evaluates to true.
+func promResponseHasData() map[string]any {
+	return map[string]any{
+		"results": map[string]any{
+			"A": map[string]any{
+				"frames": []map[string]any{
+					{
+						"schema": map[string]any{
+							"fields": []map[string]any{
+								{"name": "Time", "type": "time"},
+								{"name": "Value", "type": "number"},
+							},
+						},
+						"data": map[string]any{
+							"values": []any{
+								[]int64{1715100000000},
+								[]float64{1},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// promResponseEmpty returns a Grafana datasource-query response with no
+// frames — the shape `prometheus.Client.Query` returns when a count query
+// matches nothing.
+func promResponseEmpty() map[string]any {
+	return map[string]any{
+		"results": map[string]any{
+			"A": map[string]any{
+				"frames": []map[string]any{},
+			},
+		},
+	}
+}
+
+// promHandlerByExpr returns an httptest handler that routes the Prometheus
+// datasource POST body to one of three responses based on substrings in the
+// `expr` field. The propagation check submits three distinct queries that
+// are unambiguous by their selector — this lets us simulate the three
+// gates independently.
+func promHandlerByExpr(targetInfo, realEdges, phantomEdges map[string]any) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		expr := string(body)
+		switch {
+		case strings.Contains(expr, "traces_target_info"):
+			writeJSON(w, targetInfo)
+		case strings.Contains(expr, `client!=\"user\"`):
+			writeJSON(w, realEdges)
+		case strings.Contains(expr, `client=\"user\"`):
+			writeJSON(w, phantomEdges)
+		default:
+			// All other metric queries the diagnose pipeline issues
+			// (asserts:*, raw metric existence, edge-source gap probes,
+			// etc.) — return empty so they don't pass and clutter the
+			// result. The cases we care about are the three above.
+			writeJSON(w, promResponseEmpty())
+		}
+	}
+}
+
+// findCheckByName locates a check by exact Name match.
+func findCheckByName(checks []kg.CheckResult, name string) *kg.CheckResult {
+	for i := range checks {
+		if checks[i].Name == name {
+			return &checks[i]
+		}
+	}
+	return nil
+}
+
+func TestRunDiagnose_TracePropagationBroken(t *testing.T) {
+	kgServer := minimalKGServer()
+	defer kgServer.Close()
+
+	// Telemetry signature of broken propagation:
+	//   target_info > 0 ; real edges empty ; phantom edges > 0
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerByExpr(
+		promResponseHasData(), // traces_target_info
+		promResponseEmpty(),   // client!="user"
+		promResponseHasData(), // client="user"
+	))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	kgClient := newTestClient(t, kgServer)
+	promClient := newTestPromClient(t, promServer)
+	scope := kg.NewTestScopeFlags("prod", "", "")
+	result := kg.RunDiagnose(t.Context(), kgClient, &scope, promClient, "test-prom-uid")
+
+	check := findCheckByName(result.Checks, "Trace context propagation")
+	require.NotNil(t, check, "expected Trace context propagation check to be present")
+	assert.Equal(t, kg.CheckFail, check.Status)
+	assert.Contains(t, check.Detail, "phantom")
+	assert.Contains(t, check.Recommendation, "traceparent")
+	assert.Contains(t, check.Recommendation, "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS")
+}
+
+func TestRunDiagnose_TracePropagationHealthy(t *testing.T) {
+	kgServer := minimalKGServer()
+	defer kgServer.Close()
+
+	// Telemetry signature of healthy propagation:
+	//   target_info > 0 ; real edges > 0 ; phantom edges irrelevant
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerByExpr(
+		promResponseHasData(), // traces_target_info
+		promResponseHasData(), // client!="user"  — real edges present
+		promResponseEmpty(),   // client="user"   — irrelevant when real edges exist
+	))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	kgClient := newTestClient(t, kgServer)
+	promClient := newTestPromClient(t, promServer)
+	scope := kg.NewTestScopeFlags("prod", "", "")
+	result := kg.RunDiagnose(t.Context(), kgClient, &scope, promClient, "test-prom-uid")
+
+	check := findCheckByName(result.Checks, "Trace context propagation")
+	assert.Nil(t, check, "Trace context propagation check should NOT appear when real edges exist")
+}
+
+func TestRunDiagnose_TracePropagationNoTelemetry(t *testing.T) {
+	kgServer := minimalKGServer()
+	defer kgServer.Close()
+
+	// No telemetry at all — earlier metric checks will surface this.
+	// The propagation check should remain silent (would otherwise
+	// double-flag the user with a misleading message).
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerByExpr(
+		promResponseEmpty(), // traces_target_info empty
+		promResponseEmpty(),
+		promResponseEmpty(),
+	))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	kgClient := newTestClient(t, kgServer)
+	promClient := newTestPromClient(t, promServer)
+	scope := kg.NewTestScopeFlags("prod", "", "")
+	result := kg.RunDiagnose(t.Context(), kgClient, &scope, promClient, "test-prom-uid")
+
+	check := findCheckByName(result.Checks, "Trace context propagation")
+	assert.Nil(t, check, "Trace context propagation check should NOT appear when there's no telemetry at all")
+}
+
+func TestRunDiagnose_TracePropagationNoEnvSkipped(t *testing.T) {
+	kgServer := minimalKGServer()
+	defer kgServer.Close()
+
+	// Even with telemetry that would otherwise look like broken propagation,
+	// the check should skip itself when no --env scope was provided (the
+	// PromQL is per-env, so a global query would be meaningless).
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerByExpr(
+		promResponseHasData(),
+		promResponseEmpty(),
+		promResponseHasData(),
+	))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	kgClient := newTestClient(t, kgServer)
+	promClient := newTestPromClient(t, promServer)
+	scope := kg.NewTestScopeFlags("", "", "") // no env
+	result := kg.RunDiagnose(t.Context(), kgClient, &scope, promClient, "test-prom-uid")
+
+	check := findCheckByName(result.Checks, "Trace context propagation")
+	assert.Nil(t, check, "Trace context propagation check should NOT run without an env scope")
 }

--- a/internal/providers/kg/diagnose_test.go
+++ b/internal/providers/kg/diagnose_test.go
@@ -789,8 +789,12 @@ func promHandlerByExpr(targetInfo, realEdges, phantomEdges map[string]any) http.
 	}
 }
 
-// findCheckByName locates a check by exact Name match.
-func findCheckByName(checks []kg.CheckResult, name string) *kg.CheckResult {
+// findCheckByName locates the Trace context propagation check in a result.
+// The helper is single-purpose (only one check name has multiple call sites
+// that need this lookup pattern); inlining the name avoids the unparam lint
+// warning that fires when a parameter only ever takes one value.
+func findCheckByName(checks []kg.CheckResult) *kg.CheckResult {
+	const name = "Trace context propagation"
 	for i := range checks {
 		if checks[i].Name == name {
 			return &checks[i]
@@ -819,7 +823,7 @@ func TestRunDiagnose_TracePropagationBroken(t *testing.T) {
 	scope := kg.NewTestScopeFlags("prod", "", "")
 	result := kg.RunDiagnose(t.Context(), kgClient, &scope, promClient, "test-prom-uid")
 
-	check := findCheckByName(result.Checks, "Trace context propagation")
+	check := findCheckByName(result.Checks)
 	require.NotNil(t, check, "expected Trace context propagation check to be present")
 	assert.Equal(t, kg.CheckFail, check.Status)
 	assert.Contains(t, check.Detail, "phantom")
@@ -847,7 +851,7 @@ func TestRunDiagnose_TracePropagationHealthy(t *testing.T) {
 	scope := kg.NewTestScopeFlags("prod", "", "")
 	result := kg.RunDiagnose(t.Context(), kgClient, &scope, promClient, "test-prom-uid")
 
-	check := findCheckByName(result.Checks, "Trace context propagation")
+	check := findCheckByName(result.Checks)
 	assert.Nil(t, check, "Trace context propagation check should NOT appear when real edges exist")
 }
 
@@ -872,7 +876,7 @@ func TestRunDiagnose_TracePropagationNoTelemetry(t *testing.T) {
 	scope := kg.NewTestScopeFlags("prod", "", "")
 	result := kg.RunDiagnose(t.Context(), kgClient, &scope, promClient, "test-prom-uid")
 
-	check := findCheckByName(result.Checks, "Trace context propagation")
+	check := findCheckByName(result.Checks)
 	assert.Nil(t, check, "Trace context propagation check should NOT appear when there's no telemetry at all")
 }
 
@@ -897,6 +901,6 @@ func TestRunDiagnose_TracePropagationNoEnvSkipped(t *testing.T) {
 	scope := kg.NewTestScopeFlags("", "", "") // no env
 	result := kg.RunDiagnose(t.Context(), kgClient, &scope, promClient, "test-prom-uid")
 
-	check := findCheckByName(result.Checks, "Trace context propagation")
+	check := findCheckByName(result.Checks)
 	assert.Nil(t, check, "Trace context propagation check should NOT run without an env scope")
 }


### PR DESCRIPTION
## Summary

Adds a new check to `gcx kg diagnose` that detects the "entities
exist but no edges" failure mode in Entity Graph.

Natural follow-up to [PR #677](https://github.com/grafana/gcx/pull/677)
which shipped the diagnose framework — and pairs with PR #726,
which adds the matching agent-facing skill content.

## What's new

A new check function `checkTracePropagation`, registered alongside
the existing per-env metric checks. Triggers when **all three**
PromQL conditions hold:

1. `count(traces_target_info{deployment_environment="ENV"}) > 0` —
   services are emitting telemetry
2. `count(traces_service_graph_request_total{server_deployment_environment="ENV", client!="user"}) == 0` —
   no real inter-service edges
3. `count(traces_service_graph_request_total{server_deployment_environment="ENV", client="user"}) > 0` —
   only phantom edges exist

The `client="user"` series is Tempo's synthetic "external caller"
edge, emitted for any SERVER span that arrives with no incoming
`traceparent`. Its presence alongside the absence of real edges is
the unambiguous fingerprint of broken outgoing trace propagation on
the upstream service — usually `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS`
disabling the HTTP client auto-instrumentation, an HTTP client that
bypasses the auto-instrumented one, or a missing `TracerProvider`
on the SDK side.

The check skips itself (returns nil) in three cases so it doesn't
add noise:
- No `--env` scope (the PromQL is per-env)
- No target info (telemetry isn't flowing at all — earlier checks
  flag that)
- Real edges exist (no problem to report)

## How it presents

When the bug is active:

```
Trace context propagation                   FAIL    services emit telemetry for env "ENV" but only phantom
                                                    client="user" edges exist — no real inter-service edges

Recommendations:
  Trace context propagation: Outgoing HTTP calls aren't carrying traceparent
  headers, so the metrics generator can't link the spans into edges. Check the
  OTel SDK config on your services: is the auto-instrumentation for your HTTP
  client (e.g. urllib, urllib3, requests, net/http) enabled?
  `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` is a common culprit. Once outgoing
  propagation is fixed, expect `traces_service_graph_request_total{client!="user"}`
  to populate within 1–2 minutes and `asserts:relation:calls` to follow ~5–10
  minutes after that.
```

On healthy or unrelated envs, the check is silent.

## Validation

### Unit tests

Four new tests covering each path of the function
(`go test ./internal/providers/kg/...`):

- `TracePropagationBroken` — full signature triggers FAIL with the
  expected detail and recommendation strings
- `TracePropagationHealthy` — real edges present, check absent
- `TracePropagationNoTelemetry` — target info empty, check absent
- `TracePropagationNoEnvSkipped` — no `--env` scope, check absent

All pass. Full `go test ./...` is green. `gofmt` + `go vet` clean.

## Companion PR

The user-facing skill that documents this failure mode and tells the
agent how to recognize it lives in
[PR #726](https://github.com/grafana/gcx/pull/726). The two PRs are
independent and can land in either order — the skill points at
`gcx kg diagnose` as a shortcut, so the new check folds in naturally
once both ship.

## What's not in this PR

- No changes to the existing checks
- No changes to the diagnose command's flags or invocation
- No new commands
