### PR TITLE
feat(datasources): add CloudWatch datasource support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,10 @@ internal/
 ├── deeplink/    Deep link URL template registry and browser opener
 ├── dashboards/  Dashboard Image Renderer client (PNG snapshots)
 ├── datasources/ Datasource HTTP client, DatasourceProvider interface + registry
+│   ├── cloudwatch/  CloudWatch CLI commands (query, list-namespaces, list-metrics, list-dimensions, list-regions, list-accounts)
 │   └── query/   Shared query CLI utils (time parsing, codecs, opts, resolve helpers — used by signal providers and GenericCmd)
 ├── query/       Datasource query clients
+│   ├── cloudwatch/  CloudWatch HTTP query client (metric queries, resource listing)
 │   ├── prometheus/  Prometheus HTTP query client
 │   └── loki/        Loki HTTP query client
 ├── queryerror/  Typed API error for datasource query failures (APIError type, New/FromBody constructors, IsParseError helper)

--- a/cmd/gcx/datasources/query.go
+++ b/cmd/gcx/datasources/query.go
@@ -44,17 +44,20 @@ that do not have a dedicated subcommand.`,
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --from now-1h --to now`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// 1. Validate flags first (no HTTP, no EXPR needed).
 			if err := shared.Validate(); err != nil {
 				return err
 			}
 
-			ctx := cmd.Context()
-			datasourceUID := args[0]
-			expr, err := shared.ResolveExpr(args, 1)
-			if err != nil {
-				return err
+			// Reject "both positional and --expr" before any HTTP call.
+			if len(args) > 1 && shared.Expr != "" {
+				return errors.New("provide the expression as a positional argument or via --expr, not both")
 			}
 
+			ctx := cmd.Context()
+			datasourceUID := args[0]
+
+			// 2. Load config and detect datasource type.
 			cfg, err := configOpts.LoadGrafanaConfig(ctx)
 			if err != nil {
 				return err
@@ -65,6 +68,19 @@ that do not have a dedicated subcommand.`,
 				return err
 			}
 			dsType := dsquery.NormalizeKind(rawType)
+
+			// 3. Short-circuit datasources that require structured subcommands.
+			if dsType == "cloudwatch" {
+				return errors.New("CloudWatch queries are structured (namespace, metric, dimensions, region, statistic, period); " +
+					"the generic `gcx datasources query <uid> <expr>` form can't carry them — " +
+					"use `gcx datasources cloudwatch query --namespace ... --metric ... --region ...` instead")
+			}
+
+			// 4. For all other types, EXPR is required — resolve after type check.
+			expr, err := shared.ResolveExpr(args, 1)
+			if err != nil {
+				return err
+			}
 
 			now := time.Now()
 			start, end, step, err := shared.ParseTimes(now)
@@ -155,7 +171,8 @@ that do not have a dedicated subcommand.`,
 				return shared.IO.Encode(cmd.OutOrStdout(), resp)
 
 			default:
-				return fmt.Errorf("datasource type %q is not supported (supported: prometheus, loki, pyroscope)", dsType)
+				return fmt.Errorf("datasource type %q is not supported by the generic query command (supported: prometheus, loki, pyroscope) — "+
+					"CloudWatch is supported via the structured `gcx datasources cloudwatch query --namespace ... --metric ...` subcommand", dsType)
 			}
 		},
 	}

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -84,8 +84,10 @@ gcx/
 │   ├── deeplink/             # Deep link URL template registry and browser opener
 │   ├── dashboards/           # Dashboard Image Renderer client (PNG snapshots)
 │   ├── datasources/          # Datasource HTTP client (legacy REST API)
+│   │   ├── cloudwatch/       # CloudWatch CLI commands (query, list-namespaces/metrics/dimensions/regions/accounts)
 │   │   └── query/            # Shared query CLI utils (time parsing, codecs, opts, resolve helpers)
 │   ├── query/                # Datasource query clients
+│   │   ├── cloudwatch/       # CloudWatch HTTP client (metric queries, resource listing)
 │   │   ├── prometheus/       # Prometheus HTTP client (instant + range queries)
 │   │   └── loki/             # Loki HTTP client (log + metric queries)
 │   ├── notifier/             # Skills update notifier (XDG state, throttle, message rendering)

--- a/docs/reference/cli/gcx_datasources.md
+++ b/docs/reference/cli/gcx_datasources.md
@@ -26,6 +26,7 @@ List, inspect, and query Grafana datasources. Use top-level signal commands (met
 ### SEE ALSO
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx datasources cloudwatch](gcx_datasources_cloudwatch.md)	 - Query AWS CloudWatch datasources
 * [gcx datasources get](gcx_datasources_get.md)	 - Get details of a specific datasource
 * [gcx datasources list](gcx_datasources_list.md)	 - List all datasources
 * [gcx datasources loki](gcx_datasources_loki.md)	 - Query Loki datasources

--- a/docs/reference/cli/gcx_datasources_cloudwatch.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch.md
@@ -1,0 +1,32 @@
+## gcx datasources cloudwatch
+
+Query AWS CloudWatch datasources
+
+### Options
+
+```
+      --config string   Path to the configuration file to use
+  -h, --help            help for cloudwatch
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources](gcx_datasources.md)	 - Manage and query Grafana datasources
+* [gcx datasources cloudwatch list-accounts](gcx_datasources_cloudwatch_list-accounts.md)	 - List AWS accounts accessible via cross-account monitoring
+* [gcx datasources cloudwatch list-dimensions](gcx_datasources_cloudwatch_list-dimensions.md)	 - List available dimension keys for a CloudWatch metric
+* [gcx datasources cloudwatch list-metrics](gcx_datasources_cloudwatch_list-metrics.md)	 - List available CloudWatch metrics in a namespace
+* [gcx datasources cloudwatch list-namespaces](gcx_datasources_cloudwatch_list-namespaces.md)	 - List available CloudWatch namespaces
+* [gcx datasources cloudwatch list-regions](gcx_datasources_cloudwatch_list-regions.md)	 - List available AWS regions for the CloudWatch datasource
+* [gcx datasources cloudwatch query](gcx_datasources_cloudwatch_query.md)	 - Execute a CloudWatch metric query
+

--- a/docs/reference/cli/gcx_datasources_cloudwatch_list-accounts.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_list-accounts.md
@@ -1,0 +1,48 @@
+## gcx datasources cloudwatch list-accounts
+
+List AWS accounts accessible via cross-account monitoring
+
+### Synopsis
+
+List the AWS accounts accessible via this CloudWatch datasource.
+Only returns data for cross-account monitoring datasources; other datasources
+may return a 404 which is surfaced as a clear error.
+
+```
+gcx datasources cloudwatch list-accounts [flags]
+```
+
+### Examples
+
+```
+
+  gcx datasources cloudwatch list-accounts -d UID --region us-east-1
+  gcx datasources cloudwatch list-accounts -d UID --region us-east-1 -o json
+```
+
+### Options
+
+```
+  -d, --datasource string   Datasource UID (required unless datasources.cloudwatch is configured)
+  -h, --help                help for list-accounts
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+      --region string       AWS region (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources cloudwatch](gcx_datasources_cloudwatch.md)	 - Query AWS CloudWatch datasources
+

--- a/docs/reference/cli/gcx_datasources_cloudwatch_list-dimensions.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_list-dimensions.md
@@ -1,0 +1,45 @@
+## gcx datasources cloudwatch list-dimensions
+
+List available dimension keys for a CloudWatch metric
+
+```
+gcx datasources cloudwatch list-dimensions [flags]
+```
+
+### Examples
+
+```
+
+  gcx datasources cloudwatch list-dimensions -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization
+  gcx datasources cloudwatch list-dimensions -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization -o json
+```
+
+### Options
+
+```
+      --account-id string   AWS account ID for cross-account monitoring (or 'all')
+  -d, --datasource string   Datasource UID (required unless datasources.cloudwatch is configured)
+  -h, --help                help for list-dimensions
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --metric string       CloudWatch metric name (required)
+      --namespace string    CloudWatch namespace (required)
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+      --region string       AWS region (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources cloudwatch](gcx_datasources_cloudwatch.md)	 - Query AWS CloudWatch datasources
+

--- a/docs/reference/cli/gcx_datasources_cloudwatch_list-metrics.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_list-metrics.md
@@ -1,0 +1,44 @@
+## gcx datasources cloudwatch list-metrics
+
+List available CloudWatch metrics in a namespace
+
+```
+gcx datasources cloudwatch list-metrics [flags]
+```
+
+### Examples
+
+```
+
+  gcx datasources cloudwatch list-metrics -d UID --region us-east-1 --namespace AWS/EC2
+  gcx datasources cloudwatch list-metrics -d UID --region us-east-1 --namespace AWS/Lambda -o json
+```
+
+### Options
+
+```
+      --account-id string   AWS account ID for cross-account monitoring (or 'all')
+  -d, --datasource string   Datasource UID (required unless datasources.cloudwatch is configured)
+  -h, --help                help for list-metrics
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --namespace string    CloudWatch namespace (required)
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+      --region string       AWS region (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources cloudwatch](gcx_datasources_cloudwatch.md)	 - Query AWS CloudWatch datasources
+

--- a/docs/reference/cli/gcx_datasources_cloudwatch_list-namespaces.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_list-namespaces.md
@@ -1,0 +1,43 @@
+## gcx datasources cloudwatch list-namespaces
+
+List available CloudWatch namespaces
+
+```
+gcx datasources cloudwatch list-namespaces [flags]
+```
+
+### Examples
+
+```
+
+  gcx datasources cloudwatch list-namespaces -d UID --region us-east-1
+  gcx datasources cloudwatch list-namespaces -d UID --region us-east-1 -o json
+```
+
+### Options
+
+```
+      --account-id string   AWS account ID for cross-account monitoring (or 'all')
+  -d, --datasource string   Datasource UID (required unless datasources.cloudwatch is configured)
+  -h, --help                help for list-namespaces
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+      --region string       AWS region (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources cloudwatch](gcx_datasources_cloudwatch.md)	 - Query AWS CloudWatch datasources
+

--- a/docs/reference/cli/gcx_datasources_cloudwatch_list-regions.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_list-regions.md
@@ -1,0 +1,41 @@
+## gcx datasources cloudwatch list-regions
+
+List available AWS regions for the CloudWatch datasource
+
+```
+gcx datasources cloudwatch list-regions [flags]
+```
+
+### Examples
+
+```
+
+  gcx datasources cloudwatch list-regions -d UID
+  gcx datasources cloudwatch list-regions -d UID -o json
+```
+
+### Options
+
+```
+  -d, --datasource string   Datasource UID (required unless datasources.cloudwatch is configured)
+  -h, --help                help for list-regions
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources cloudwatch](gcx_datasources_cloudwatch.md)	 - Query AWS CloudWatch datasources
+

--- a/docs/reference/cli/gcx_datasources_cloudwatch_query.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_query.md
@@ -1,0 +1,75 @@
+## gcx datasources cloudwatch query
+
+Execute a CloudWatch metric query
+
+### Synopsis
+
+Execute a CloudWatch metric query.
+
+Queries are structured (namespace, metric, region, statistic, period, dimensions) —
+there is no expression language for CloudWatch. Use --dimensions (repeatable) for
+dimension filters, or omit them to aggregate across all combinations.
+
+Use --share-link to print the equivalent Grafana Explore URL after the query.
+Note: when no --from/--to/--since flags are provided, the share link encodes
+"now-1h"/"now" (relative), not the absolute window the CLI just queried.
+
+```
+gcx datasources cloudwatch query [flags]
+```
+
+### Examples
+
+```
+
+  # Query with required flags
+  gcx datasources cloudwatch query -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization
+
+  # With time range
+  gcx datasources cloudwatch query -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization --since 1h
+
+  # With dimension filter
+  gcx datasources cloudwatch query -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization \
+    --dimensions InstanceId=i-0123456789abcdef0 --since 1h
+
+  # Print as JSON
+  gcx datasources cloudwatch query -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization -o json
+```
+
+### Options
+
+```
+      --account-id string           AWS account ID for cross-account monitoring (or 'all')
+  -d, --datasource string           Datasource UID (required unless datasources.cloudwatch is configured)
+      --dimensions stringToString   Dimension key=value pairs (repeatable, e.g. --dimensions InstanceId=i-abc) (default [])
+      --from string                 Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
+  -h, --help                        help for query
+      --json string                 Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --metric string               CloudWatch metric name, e.g. CPUUtilization (required)
+      --namespace string            CloudWatch namespace, e.g. AWS/EC2 (required)
+      --open                        Open the executed query in Grafana Explore
+  -o, --output string               Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+      --period int                  Period in seconds (must be > 0) (default 300)
+      --region string               AWS region, e.g. us-east-1 (required)
+      --share-link                  Print the Grafana Explore URL for the executed query to stderr
+      --since string                Duration before --to (or now if omitted); mutually exclusive with --from
+      --statistic string            Statistic: Average, Sum, Maximum, Minimum, or SampleCount (default "Average")
+      --to string                   End time (RFC3339, Unix timestamp, or relative like 'now')
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources cloudwatch](gcx_datasources_cloudwatch.md)	 - Query AWS CloudWatch datasources
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -60,6 +60,14 @@ var commandAnnotations = map[string]annotation{
 	"gcx datasources list":  {Cost: "small"},
 	"gcx datasources query": {Cost: "large", Hint: "Run gcx help-tree metrics (or logs, traces, profiles) to discover signal commands. Prefer gcx metrics query for PromQL, gcx logs query for LogQL, gcx traces query for TraceQL, gcx profiles query for profiling. Example: <datasource-uid> 'up' --since 1h -o json"},
 
+	// datasources cloudwatch
+	"gcx datasources cloudwatch query":           {Cost: "medium", Hint: "-d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization --since 1h -o json"},
+	"gcx datasources cloudwatch list-namespaces": {Cost: "small", Hint: "-d UID --region us-east-1 -o json"},
+	"gcx datasources cloudwatch list-metrics":    {Cost: "small", Hint: "-d UID --region us-east-1 --namespace AWS/EC2 -o json"},
+	"gcx datasources cloudwatch list-dimensions": {Cost: "small", Hint: "-d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization -o json"},
+	"gcx datasources cloudwatch list-regions":    {Cost: "small", Hint: "-d UID -o json"},
+	"gcx datasources cloudwatch list-accounts":   {Cost: "small", Hint: "-d UID --region us-east-1 -o json"},
+
 	// dev
 	"gcx dev generate":   {Cost: "small"},
 	"gcx dev import":     {Cost: "medium", Hint: "dashboards -p ./dashboards"},

--- a/internal/datasources/cloudwatch/explore.go
+++ b/internal/datasources/cloudwatch/explore.go
@@ -1,0 +1,56 @@
+package cloudwatch
+
+import (
+	"strings"
+
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
+)
+
+// CloudWatchQuery holds the structured CloudWatch query fields for Explore URL building.
+type CloudWatchQuery struct {
+	Namespace  string
+	MetricName string
+	Region     string
+	Statistic  string
+	AccountID  string
+	Dimensions map[string]string
+	MatchExact bool
+	Period     int
+}
+
+// QueryExploreURL builds a Grafana Explore URL for a structured CloudWatch metric query.
+// Returns "" when any required parameter (host, UID, namespace, metric, region) is missing.
+func QueryExploreURL(host string, base dsquery.ExploreQuery, q CloudWatchQuery) string {
+	if strings.TrimSpace(host) == "" || base.DatasourceUID == "" ||
+		q.Namespace == "" || q.MetricName == "" || q.Region == "" {
+		return ""
+	}
+
+	from, to := dsquery.ExploreRange(base.From, base.To, false)
+
+	query := map[string]any{
+		"refId":      "A",
+		"datasource": dsquery.ExploreDatasource("cloudwatch", base.DatasourceUID),
+		"queryType":  "timeSeriesQuery",
+		"namespace":  q.Namespace,
+		"metricName": q.MetricName,
+		"region":     q.Region,
+		"statistic":  q.Statistic,
+		"matchExact": q.MatchExact,
+		"dimensions": cwclient.FormatDimensionsForExplore(q.Dimensions),
+	}
+	if q.Period > 0 {
+		query["period"] = q.Period
+	}
+	if q.AccountID != "" {
+		query["accountId"] = q.AccountID
+	}
+
+	return dsquery.BuildExploreURL(
+		host,
+		base.OrgID,
+		dsquery.SinglePane(base.DatasourceUID, []any{query}, from, to, nil),
+		nil,
+	)
+}

--- a/internal/datasources/cloudwatch/explore_test.go
+++ b/internal/datasources/cloudwatch/explore_test.go
@@ -1,0 +1,126 @@
+package cloudwatch_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/grafana/gcx/internal/datasources/cloudwatch"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func baseQuery(uid string) dsquery.ExploreQuery {
+	return dsquery.ExploreQuery{
+		DatasourceUID:  uid,
+		DatasourceType: "cloudwatch",
+	}
+}
+
+func baseCloudWatchQuery() cloudwatch.CloudWatchQuery {
+	return cloudwatch.CloudWatchQuery{
+		Namespace:  "AWS/EC2",
+		MetricName: "CPUUtilization",
+		Region:     "us-east-1",
+		Statistic:  "Average",
+		Period:     300,
+	}
+}
+
+func TestQueryExploreURL_StructuredPayload(t *testing.T) {
+	got := cloudwatch.QueryExploreURL("https://test.grafana.net", baseQuery("cw-uid"), baseCloudWatchQuery())
+
+	require.NotEmpty(t, got)
+	params := mustParseURL(t, got).Query()
+	panes := params.Get("panes")
+
+	assert.Contains(t, panes, `"namespace":"AWS/EC2"`)
+	assert.Contains(t, panes, `"metricName":"CPUUtilization"`)
+	assert.Contains(t, panes, `"region":"us-east-1"`)
+	assert.Contains(t, panes, `"statistic":"Average"`)
+	assert.Contains(t, panes, `"uid":"cw-uid"`)
+}
+
+func TestQueryExploreURL_MatchExactFalseWhenNoDimensions(t *testing.T) {
+	q := baseCloudWatchQuery()
+	q.Dimensions = nil // no dimensions
+
+	got := cloudwatch.QueryExploreURL("https://test.grafana.net", baseQuery("cw-uid"), q)
+	require.NotEmpty(t, got)
+	params := mustParseURL(t, got).Query()
+	assert.Contains(t, params.Get("panes"), `"matchExact":false`)
+}
+
+func TestQueryExploreURL_MatchExactTrueWhenDimensionsSet(t *testing.T) {
+	q := baseCloudWatchQuery()
+	q.MatchExact = true
+	q.Dimensions = map[string]string{"InstanceId": "i-abc"}
+
+	got := cloudwatch.QueryExploreURL("https://test.grafana.net", baseQuery("cw-uid"), q)
+	require.NotEmpty(t, got)
+	params := mustParseURL(t, got).Query()
+	assert.Contains(t, params.Get("panes"), `"matchExact":true`)
+	assert.Contains(t, params.Get("panes"), `"InstanceId"`)
+}
+
+func TestQueryExploreURL_ExplicitTimeRange(t *testing.T) {
+	base := baseQuery("cw-uid")
+	base.From = "2026-05-17T08:00:00Z"
+	base.To = "2026-05-17T09:00:00Z"
+
+	got := cloudwatch.QueryExploreURL("https://test.grafana.net", base, baseCloudWatchQuery())
+	require.NotEmpty(t, got)
+	params := mustParseURL(t, got).Query()
+	assert.Contains(t, params.Get("panes"), `"from":"2026-05-17T08:00:00Z"`)
+	assert.Contains(t, params.Get("panes"), `"to":"2026-05-17T09:00:00Z"`)
+}
+
+func TestQueryExploreURL_DefaultTimeRange(t *testing.T) {
+	got := cloudwatch.QueryExploreURL("https://test.grafana.net", baseQuery("cw-uid"), baseCloudWatchQuery())
+	require.NotEmpty(t, got)
+	params := mustParseURL(t, got).Query()
+	// Default: "now-1h" / "now" when no From/To set.
+	assert.Contains(t, params.Get("panes"), `"from":"now-1h"`)
+	assert.Contains(t, params.Get("panes"), `"to":"now"`)
+}
+
+func TestQueryExploreURL_AccountID(t *testing.T) {
+	q := baseCloudWatchQuery()
+	q.AccountID = "123456789"
+
+	got := cloudwatch.QueryExploreURL("https://test.grafana.net", baseQuery("cw-uid"), q)
+	require.NotEmpty(t, got)
+	params := mustParseURL(t, got).Query()
+	assert.Contains(t, params.Get("panes"), `"accountId":"123456789"`)
+}
+
+func TestQueryExploreURL_ReturnsEmptyOnMissingRequired(t *testing.T) {
+	t.Run("empty host", func(t *testing.T) {
+		assert.Empty(t, cloudwatch.QueryExploreURL("", baseQuery("uid"), baseCloudWatchQuery()))
+	})
+	t.Run("empty UID", func(t *testing.T) {
+		assert.Empty(t, cloudwatch.QueryExploreURL("https://test.grafana.net", baseQuery(""), baseCloudWatchQuery()))
+	})
+	t.Run("empty namespace", func(t *testing.T) {
+		q := baseCloudWatchQuery()
+		q.Namespace = ""
+		assert.Empty(t, cloudwatch.QueryExploreURL("https://test.grafana.net", baseQuery("uid"), q))
+	})
+	t.Run("empty metric", func(t *testing.T) {
+		q := baseCloudWatchQuery()
+		q.MetricName = ""
+		assert.Empty(t, cloudwatch.QueryExploreURL("https://test.grafana.net", baseQuery("uid"), q))
+	})
+	t.Run("empty region", func(t *testing.T) {
+		q := baseCloudWatchQuery()
+		q.Region = ""
+		assert.Empty(t, cloudwatch.QueryExploreURL("https://test.grafana.net", baseQuery("uid"), q))
+	})
+}

--- a/internal/datasources/cloudwatch/list_accounts.go
+++ b/internal/datasources/cloudwatch/list_accounts.go
@@ -1,0 +1,123 @@
+package cloudwatch
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type listAccountsOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	Region     string
+}
+
+func (opts *listAccountsOpts) setup(flags *pflag.FlagSet) {
+	opts.IO.RegisterCustomCodec("table", &listAccountsTableCodec{})
+	opts.IO.DefaultFormat("table")
+	opts.IO.BindFlags(flags)
+
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.cloudwatch is configured)")
+	flags.StringVar(&opts.Region, "region", "", "AWS region (required)")
+}
+
+func (opts *listAccountsOpts) Validate() error {
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	if opts.Region == "" {
+		return errors.New("--region is required")
+	}
+	return nil
+}
+
+// ListAccountsCmd returns the `list-accounts` subcommand for CloudWatch.
+// Only meaningful for cross-account monitoring datasources.
+func ListAccountsCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listAccountsOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "list-accounts",
+		Short: "List AWS accounts accessible via cross-account monitoring",
+		Long: `List the AWS accounts accessible via this CloudWatch datasource.
+Only returns data for cross-account monitoring datasources; other datasources
+may return a 404 which is surfaced as a clear error.`,
+		Example: `
+  gcx datasources cloudwatch list-accounts -d UID --region us-east-1
+  gcx datasources cloudwatch list-accounts -d UID --region us-east-1 -o json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "cloudwatch")
+			if err != nil {
+				return err
+			}
+
+			client, err := cwclient.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			accounts, err := client.ListAccounts(ctx, datasourceUID, opts.Region)
+			if err != nil {
+				return fmt.Errorf("failed to list accounts: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), accounts)
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+		agent.AnnotationLLMHint:   "-d UID --region us-east-1 -o json",
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type listAccountsTableCodec struct{}
+
+func (c *listAccountsTableCodec) Format() format.Format { return "table" }
+
+func (c *listAccountsTableCodec) Encode(w io.Writer, data any) error {
+	accounts, ok := data.([]cwclient.Account)
+	if !ok {
+		return fmt.Errorf("listAccountsTableCodec: unexpected type %T", data)
+	}
+	return cwclient.FormatAccounts(w, accounts)
+}
+
+func (c *listAccountsTableCodec) Decode(io.Reader, any) error {
+	return errors.New("listAccountsTableCodec does not support decoding")
+}

--- a/internal/datasources/cloudwatch/list_dimensions.go
+++ b/internal/datasources/cloudwatch/list_dimensions.go
@@ -1,0 +1,131 @@
+package cloudwatch
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type listDimensionsOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	Region     string
+	Namespace  string
+	Metric     string
+	AccountID  string
+}
+
+func (opts *listDimensionsOpts) setup(flags *pflag.FlagSet) {
+	opts.IO.RegisterCustomCodec("table", &listDimensionsTableCodec{})
+	opts.IO.DefaultFormat("table")
+	opts.IO.BindFlags(flags)
+
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.cloudwatch is configured)")
+	flags.StringVar(&opts.Region, "region", "", "AWS region (required)")
+	flags.StringVar(&opts.Namespace, "namespace", "", "CloudWatch namespace (required)")
+	flags.StringVar(&opts.Metric, "metric", "", "CloudWatch metric name (required)")
+	flags.StringVar(&opts.AccountID, "account-id", "", "AWS account ID for cross-account monitoring (or 'all')")
+}
+
+func (opts *listDimensionsOpts) Validate() error {
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	if opts.Region == "" {
+		return errors.New("--region is required")
+	}
+	if opts.Namespace == "" {
+		return errors.New("--namespace is required")
+	}
+	if opts.Metric == "" {
+		return errors.New("--metric is required")
+	}
+	return nil
+}
+
+// ListDimensionsCmd returns the `list-dimensions` subcommand for CloudWatch.
+func ListDimensionsCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listDimensionsOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "list-dimensions",
+		Short: "List available dimension keys for a CloudWatch metric",
+		Example: `
+  gcx datasources cloudwatch list-dimensions -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization
+  gcx datasources cloudwatch list-dimensions -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization -o json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "cloudwatch")
+			if err != nil {
+				return err
+			}
+
+			client, err := cwclient.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			keys, err := client.ListDimensionKeys(ctx, datasourceUID, opts.Region, opts.Namespace, opts.Metric, opts.AccountID)
+			if err != nil {
+				return fmt.Errorf("failed to list dimension keys: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), keys)
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+		agent.AnnotationLLMHint:   "-d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization -o json",
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type listDimensionsTableCodec struct{}
+
+func (c *listDimensionsTableCodec) Format() format.Format { return "table" }
+
+func (c *listDimensionsTableCodec) Encode(w io.Writer, data any) error {
+	keys, ok := data.([]string)
+	if !ok {
+		return fmt.Errorf("listDimensionsTableCodec: unexpected type %T", data)
+	}
+	return cwclient.FormatDimensions(w, keys)
+}
+
+func (c *listDimensionsTableCodec) Decode(io.Reader, any) error {
+	return errors.New("listDimensionsTableCodec does not support decoding")
+}

--- a/internal/datasources/cloudwatch/list_metrics.go
+++ b/internal/datasources/cloudwatch/list_metrics.go
@@ -1,0 +1,126 @@
+package cloudwatch
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type listMetricsOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	Region     string
+	Namespace  string
+	AccountID  string
+}
+
+func (opts *listMetricsOpts) setup(flags *pflag.FlagSet) {
+	opts.IO.RegisterCustomCodec("table", &listMetricsTableCodec{})
+	opts.IO.DefaultFormat("table")
+	opts.IO.BindFlags(flags)
+
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.cloudwatch is configured)")
+	flags.StringVar(&opts.Region, "region", "", "AWS region (required)")
+	flags.StringVar(&opts.Namespace, "namespace", "", "CloudWatch namespace (required)")
+	flags.StringVar(&opts.AccountID, "account-id", "", "AWS account ID for cross-account monitoring (or 'all')")
+}
+
+func (opts *listMetricsOpts) Validate() error {
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	if opts.Region == "" {
+		return errors.New("--region is required")
+	}
+	if opts.Namespace == "" {
+		return errors.New("--namespace is required")
+	}
+	return nil
+}
+
+// ListMetricsCmd returns the `list-metrics` subcommand for CloudWatch.
+func ListMetricsCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listMetricsOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "list-metrics",
+		Short: "List available CloudWatch metrics in a namespace",
+		Example: `
+  gcx datasources cloudwatch list-metrics -d UID --region us-east-1 --namespace AWS/EC2
+  gcx datasources cloudwatch list-metrics -d UID --region us-east-1 --namespace AWS/Lambda -o json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "cloudwatch")
+			if err != nil {
+				return err
+			}
+
+			client, err := cwclient.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			metrics, err := client.ListMetrics(ctx, datasourceUID, opts.Region, opts.Namespace, opts.AccountID)
+			if err != nil {
+				return fmt.Errorf("failed to list metrics: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), metrics)
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+		agent.AnnotationLLMHint:   "-d UID --region us-east-1 --namespace AWS/EC2 -o json",
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type listMetricsTableCodec struct{}
+
+func (c *listMetricsTableCodec) Format() format.Format { return "table" }
+
+func (c *listMetricsTableCodec) Encode(w io.Writer, data any) error {
+	metrics, ok := data.([]cwclient.Metric)
+	if !ok {
+		return fmt.Errorf("listMetricsTableCodec: unexpected type %T", data)
+	}
+	return cwclient.FormatMetrics(w, metrics)
+}
+
+func (c *listMetricsTableCodec) Decode(io.Reader, any) error {
+	return errors.New("listMetricsTableCodec does not support decoding")
+}

--- a/internal/datasources/cloudwatch/list_namespaces.go
+++ b/internal/datasources/cloudwatch/list_namespaces.go
@@ -1,0 +1,121 @@
+package cloudwatch
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type listNamespacesOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	Region     string
+	AccountID  string
+}
+
+func (opts *listNamespacesOpts) setup(flags *pflag.FlagSet) {
+	opts.IO.RegisterCustomCodec("table", &listNamespacesTableCodec{})
+	opts.IO.DefaultFormat("table")
+	opts.IO.BindFlags(flags)
+
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.cloudwatch is configured)")
+	flags.StringVar(&opts.Region, "region", "", "AWS region (required)")
+	flags.StringVar(&opts.AccountID, "account-id", "", "AWS account ID for cross-account monitoring (or 'all')")
+}
+
+func (opts *listNamespacesOpts) Validate() error {
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	if opts.Region == "" {
+		return errors.New("--region is required")
+	}
+	return nil
+}
+
+// ListNamespacesCmd returns the `list-namespaces` subcommand for CloudWatch.
+func ListNamespacesCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listNamespacesOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "list-namespaces",
+		Short: "List available CloudWatch namespaces",
+		Example: `
+  gcx datasources cloudwatch list-namespaces -d UID --region us-east-1
+  gcx datasources cloudwatch list-namespaces -d UID --region us-east-1 -o json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "cloudwatch")
+			if err != nil {
+				return err
+			}
+
+			client, err := cwclient.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			namespaces, err := client.ListNamespaces(ctx, datasourceUID, opts.Region, opts.AccountID)
+			if err != nil {
+				return fmt.Errorf("failed to list namespaces: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), namespaces)
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+		agent.AnnotationLLMHint:   "-d UID --region us-east-1 -o json",
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type listNamespacesTableCodec struct{}
+
+func (c *listNamespacesTableCodec) Format() format.Format { return "table" }
+
+func (c *listNamespacesTableCodec) Encode(w io.Writer, data any) error {
+	ns, ok := data.([]string)
+	if !ok {
+		return fmt.Errorf("listNamespacesTableCodec: unexpected type %T", data)
+	}
+	return cwclient.FormatNamespaces(w, ns)
+}
+
+func (c *listNamespacesTableCodec) Decode(io.Reader, any) error {
+	return errors.New("listNamespacesTableCodec does not support decoding")
+}

--- a/internal/datasources/cloudwatch/list_regions.go
+++ b/internal/datasources/cloudwatch/list_regions.go
@@ -1,0 +1,111 @@
+package cloudwatch
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type listRegionsOpts struct {
+	IO         cmdio.Options
+	Datasource string
+}
+
+func (opts *listRegionsOpts) setup(flags *pflag.FlagSet) {
+	opts.IO.RegisterCustomCodec("table", &listRegionsTableCodec{})
+	opts.IO.DefaultFormat("table")
+	opts.IO.BindFlags(flags)
+
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.cloudwatch is configured)")
+}
+
+func (opts *listRegionsOpts) Validate() error {
+	return opts.IO.Validate()
+}
+
+// ListRegionsCmd returns the `list-regions` subcommand for CloudWatch.
+func ListRegionsCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listRegionsOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "list-regions",
+		Short: "List available AWS regions for the CloudWatch datasource",
+		Example: `
+  gcx datasources cloudwatch list-regions -d UID
+  gcx datasources cloudwatch list-regions -d UID -o json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "cloudwatch")
+			if err != nil {
+				return err
+			}
+
+			client, err := cwclient.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			regions, err := client.ListRegions(ctx, datasourceUID)
+			if err != nil {
+				return fmt.Errorf("failed to list regions: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), regions)
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+		agent.AnnotationLLMHint:   "-d UID -o json",
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type listRegionsTableCodec struct{}
+
+func (c *listRegionsTableCodec) Format() format.Format { return "table" }
+
+func (c *listRegionsTableCodec) Encode(w io.Writer, data any) error {
+	regions, ok := data.([]string)
+	if !ok {
+		return fmt.Errorf("listRegionsTableCodec: unexpected type %T", data)
+	}
+	return cwclient.FormatRegions(w, regions)
+}
+
+func (c *listRegionsTableCodec) Decode(io.Reader, any) error {
+	return errors.New("listRegionsTableCodec does not support decoding")
+}

--- a/internal/datasources/cloudwatch/query.go
+++ b/internal/datasources/cloudwatch/query.go
@@ -1,0 +1,202 @@
+package cloudwatch
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type queryOpts struct {
+	dsquery.TimeRangeOpts
+
+	IO         cmdio.Options
+	Datasource string
+	Namespace  string
+	Metric     string
+	Region     string
+	Statistic  string
+	Period     int
+	Dimensions map[string]string
+	AccountID  string
+}
+
+func (opts *queryOpts) setup(flags *pflag.FlagSet) {
+	dsquery.RegisterCodecs(&opts.IO, true)
+	opts.IO.BindFlags(flags)
+	opts.SetupTimeFlags(flags)
+
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.cloudwatch is configured)")
+	flags.StringVar(&opts.Namespace, "namespace", "", "CloudWatch namespace, e.g. AWS/EC2 (required)")
+	flags.StringVar(&opts.Metric, "metric", "", "CloudWatch metric name, e.g. CPUUtilization (required)")
+	flags.StringVar(&opts.Region, "region", "", "AWS region, e.g. us-east-1 (required)")
+	flags.StringVar(&opts.Statistic, "statistic", "Average", "Statistic: Average, Sum, Maximum, Minimum, or SampleCount")
+	flags.IntVar(&opts.Period, "period", 300, "Period in seconds (must be > 0)")
+	flags.StringToStringVar(&opts.Dimensions, "dimensions", nil, "Dimension key=value pairs (repeatable, e.g. --dimensions InstanceId=i-abc)")
+	flags.StringVar(&opts.AccountID, "account-id", "", "AWS account ID for cross-account monitoring (or 'all')")
+}
+
+func (opts *queryOpts) Validate() error {
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	if err := opts.ValidateTimeRange(); err != nil {
+		return err
+	}
+	if opts.Namespace == "" {
+		return errors.New("--namespace is required")
+	}
+	if opts.Metric == "" {
+		return errors.New("--metric is required")
+	}
+	if opts.Region == "" {
+		return errors.New("--region is required")
+	}
+	if !cwclient.IsValidStatistic(opts.Statistic) {
+		return fmt.Errorf("invalid --statistic %q: must be one of Average, Sum, Maximum, Minimum, SampleCount", opts.Statistic)
+	}
+	if opts.Period <= 0 {
+		return errors.New("--period must be > 0")
+	}
+	return nil
+}
+
+// QueryCmd returns the `query` subcommand for a CloudWatch datasource.
+func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &queryOpts{}
+	share := &dsquery.ExploreLinkOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "query",
+		Short: "Execute a CloudWatch metric query",
+		Long: `Execute a CloudWatch metric query.
+
+Queries are structured (namespace, metric, region, statistic, period, dimensions) —
+there is no expression language for CloudWatch. Use --dimensions (repeatable) for
+dimension filters, or omit them to aggregate across all combinations.
+
+Use --share-link to print the equivalent Grafana Explore URL after the query.
+Note: when no --from/--to/--since flags are provided, the share link encodes
+"now-1h"/"now" (relative), not the absolute window the CLI just queried.`,
+		Example: `
+  # Query with required flags
+  gcx datasources cloudwatch query -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization
+
+  # With time range
+  gcx datasources cloudwatch query -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization --since 1h
+
+  # With dimension filter
+  gcx datasources cloudwatch query -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization \
+    --dimensions InstanceId=i-0123456789abcdef0 --since 1h
+
+  # Print as JSON
+  gcx datasources cloudwatch query -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization -o json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			datasourceUID, _, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "cloudwatch")
+			if err != nil {
+				return err
+			}
+
+			now := time.Now()
+			start, end, err := opts.ParseTimeRange(now)
+			if err != nil {
+				return err
+			}
+			if start.IsZero() && end.IsZero() && opts.Since == "" {
+				end = now
+				start = now.Add(-1 * time.Hour)
+			}
+
+			matchExact := len(opts.Dimensions) > 0
+
+			client, err := cwclient.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			req := cwclient.QueryRequest{
+				Namespace:  opts.Namespace,
+				MetricName: opts.Metric,
+				Region:     opts.Region,
+				Statistic:  opts.Statistic,
+				Period:     opts.Period,
+				Dimensions: opts.Dimensions,
+				MatchExact: matchExact,
+				AccountID:  opts.AccountID,
+				Start:      start,
+				End:        end,
+			}
+
+			resp, err := client.Query(ctx, datasourceUID, req)
+			if err != nil {
+				return fmt.Errorf("query failed: %w", err)
+			}
+
+			exploreURL := QueryExploreURL(cfg.GrafanaURL, dsquery.ExploreQuery{
+				DatasourceUID:  datasourceUID,
+				DatasourceType: "cloudwatch",
+				From:           opts.From,
+				To:             opts.To,
+				OrgID:          dsquery.OrgID(cfgCtx),
+			}, CloudWatchQuery{
+				Namespace:  opts.Namespace,
+				MetricName: opts.Metric,
+				Region:     opts.Region,
+				Statistic:  opts.Statistic,
+				Period:     opts.Period,
+				Dimensions: opts.Dimensions,
+				MatchExact: matchExact,
+				AccountID:  opts.AccountID,
+			})
+			unavailableMsg, failedOpenMsg := dsquery.ExploreMessages("query")
+
+			return dsquery.EncodeAndHandleExplore(cmd, func() error {
+				return opts.IO.Encode(cmd.OutOrStdout(), resp)
+			}, *share, dsquery.ExploreLink{
+				URL:            exploreURL,
+				UnavailableMsg: unavailableMsg,
+				FailedOpenMsg:  failedOpenMsg,
+			})
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "medium",
+		agent.AnnotationLLMHint:   "-d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization --since 1h -o json",
+	}
+
+	opts.setup(cmd.Flags())
+	share.Setup(cmd.Flags(), "executed query")
+
+	return cmd
+}

--- a/internal/datasources/cloudwatch/query_test.go
+++ b/internal/datasources/cloudwatch/query_test.go
@@ -1,0 +1,60 @@
+package cloudwatch_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/datasources/cloudwatch"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryCmd_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "missing namespace",
+			args:    []string{"--region", "us-east-1", "--metric", "CPUUtilization"},
+			wantErr: "--namespace is required",
+		},
+		{
+			name:    "missing metric",
+			args:    []string{"--region", "us-east-1", "--namespace", "AWS/EC2"},
+			wantErr: "--metric is required",
+		},
+		{
+			name:    "missing region",
+			args:    []string{"--namespace", "AWS/EC2", "--metric", "CPUUtilization"},
+			wantErr: "--region is required",
+		},
+		{
+			name:    "invalid statistic",
+			args:    []string{"--region", "us-east-1", "--namespace", "AWS/EC2", "--metric", "CPUUtilization", "--statistic", "FooBar"},
+			wantErr: "invalid --statistic",
+		},
+		{
+			name:    "period zero",
+			args:    []string{"--region", "us-east-1", "--namespace", "AWS/EC2", "--metric", "CPUUtilization", "--period", "0"},
+			wantErr: "--period must be > 0",
+		},
+		{
+			name:    "since and from mutex",
+			args:    []string{"--region", "us-east-1", "--namespace", "AWS/EC2", "--metric", "CPUUtilization", "--since", "1h", "--from", "2026-05-17T08:00:00Z"},
+			wantErr: "--since is mutually exclusive with --from",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loader := &providers.ConfigLoader{}
+			cmd := cloudwatch.QueryCmd(loader)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/internal/datasources/providers/cloudwatch.go
+++ b/internal/datasources/providers/cloudwatch.go
@@ -1,0 +1,31 @@
+package providers
+
+import (
+	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/datasources/cloudwatch"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+)
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	datasources.RegisterProvider(&cloudwatchDSProvider{})
+}
+
+type cloudwatchDSProvider struct{}
+
+func (p *cloudwatchDSProvider) Kind() string      { return "cloudwatch" }
+func (p *cloudwatchDSProvider) ShortDesc() string { return "Query AWS CloudWatch datasources" }
+
+func (p *cloudwatchDSProvider) QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
+	return cloudwatch.QueryCmd(loader)
+}
+
+func (p *cloudwatchDSProvider) ExtraCommands(loader *providers.ConfigLoader) []*cobra.Command {
+	return []*cobra.Command{
+		cloudwatch.ListNamespacesCmd(loader),
+		cloudwatch.ListMetricsCmd(loader),
+		cloudwatch.ListDimensionsCmd(loader),
+		cloudwatch.ListRegionsCmd(loader),
+		cloudwatch.ListAccountsCmd(loader),
+	}
+}

--- a/internal/datasources/query/codecs.go
+++ b/internal/datasources/query/codecs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/gcx/internal/format"
 	"github.com/grafana/gcx/internal/graph"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/query/cloudwatch"
 	"github.com/grafana/gcx/internal/query/loki"
 	"github.com/grafana/gcx/internal/query/prometheus"
 	"github.com/grafana/gcx/internal/query/pyroscope"
@@ -35,6 +36,8 @@ func (c *queryTableCodec) Encode(w io.Writer, data any) error {
 		return tempo.FormatMetricsTable(w, resp)
 	case *tempo.GetTraceResponse:
 		return tempo.FormatTraceTable(w, resp)
+	case *cloudwatch.QueryResponse:
+		return cloudwatch.FormatTable(w, resp)
 	default:
 		return errors.New("invalid data type for query table codec")
 	}
@@ -60,6 +63,8 @@ func (c *queryWideCodec) Encode(w io.Writer, data any) error {
 		return tempo.FormatSearchTable(w, resp)
 	case *tempo.GetTraceResponse:
 		return tempo.FormatTraceWide(w, resp)
+	case *cloudwatch.QueryResponse:
+		return cloudwatch.FormatWide(w, resp)
 	default:
 		return errors.New("invalid data type for query wide codec")
 	}
@@ -94,6 +99,11 @@ func (c *queryGraphCodec) Encode(w io.Writer, data any) error {
 		}
 	case *pyroscope.QueryResponse:
 		chartData, err = graph.FromPyroscopeResponse(resp)
+		if err != nil {
+			return err
+		}
+	case *cloudwatch.QueryResponse:
+		chartData, err = graph.FromCloudWatchResponse(resp)
 		if err != nil {
 			return err
 		}

--- a/internal/datasources/query/resolve.go
+++ b/internal/datasources/query/resolve.go
@@ -157,6 +157,8 @@ func NormalizeKind(pluginID string) string {
 		return pluginID
 	case "grafana-pyroscope-datasource":
 		return "pyroscope"
+	case "cloudwatch":
+		return "cloudwatch"
 	default:
 		if isPromFlavor(pluginID) {
 			return "prometheus"

--- a/internal/datasources/query/resolve_test.go
+++ b/internal/datasources/query/resolve_test.go
@@ -285,6 +285,7 @@ func TestNormalizeKind(t *testing.T) {
 		{"grafana-pyroscope-datasource", "pyroscope"},
 		{"grafana-amazonprometheus-datasource", "prometheus"},
 		{"grafana-azureprometheus-datasource", "prometheus"},
+		{"cloudwatch", "cloudwatch"},
 		{"unknown-datasource", "unknown-datasource"},
 		{"", ""},
 	}

--- a/internal/graph/cloudwatch.go
+++ b/internal/graph/cloudwatch.go
@@ -1,0 +1,43 @@
+package graph
+
+import (
+	"github.com/grafana/gcx/internal/query/cloudwatch"
+)
+
+// FromCloudWatchResponse converts a CloudWatch query response to ChartData for visualization.
+func FromCloudWatchResponse(resp *cloudwatch.QueryResponse) (*ChartData, error) {
+	if resp == nil || len(resp.Frames) == 0 {
+		return &ChartData{}, nil
+	}
+
+	data := &ChartData{
+		Series: make([]Series, 0, len(resp.Frames)),
+	}
+
+	for _, frame := range resp.Frames {
+		label := frame.Name
+		if label == "" {
+			label = formatMetricName(frame.Labels)
+		}
+
+		points := make([]Point, 0, len(frame.Timestamps))
+		for i, ts := range frame.Timestamps {
+			if i < len(frame.Values) && frame.Values[i] != nil {
+				points = append(points, Point{
+					Time:  ts,
+					Value: *frame.Values[i],
+				})
+			}
+		}
+
+		if len(points) > 0 {
+			data.Series = append(data.Series, Series{
+				Name:   label,
+				Labels: frame.Labels,
+				Points: points,
+			})
+		}
+	}
+
+	return data, nil
+}

--- a/internal/graph/cloudwatch_test.go
+++ b/internal/graph/cloudwatch_test.go
@@ -1,0 +1,97 @@
+package graph_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/graph"
+	"github.com/grafana/gcx/internal/query/cloudwatch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cwFrame(name string, labels map[string]string, tsMs []int64, vals []*float64) cloudwatch.Frame {
+	timestamps := make([]time.Time, len(tsMs))
+	for i, ms := range tsMs {
+		timestamps[i] = time.UnixMilli(ms).UTC()
+	}
+	return cloudwatch.Frame{
+		Name:       name,
+		Labels:     labels,
+		Timestamps: timestamps,
+		Values:     vals,
+	}
+}
+
+func cwFloat(f float64) *float64 { v := f; return &v }
+
+func TestFromCloudWatchResponse_SingleSeries(t *testing.T) {
+	resp := &cloudwatch.QueryResponse{
+		Frames: []cloudwatch.Frame{
+			cwFrame("CPUUtilization", nil, []int64{1747000000000, 1747000060000}, []*float64{cwFloat(10.0), cwFloat(20.0)}),
+		},
+	}
+
+	data, err := graph.FromCloudWatchResponse(resp)
+	require.NoError(t, err)
+	require.Len(t, data.Series, 1)
+	assert.Len(t, data.Series[0].Points, 2)
+	assert.InDelta(t, 10.0, data.Series[0].Points[0].Value, 0.001)
+	assert.Equal(t, time.UnixMilli(1747000000000).UTC(), data.Series[0].Points[0].Time)
+}
+
+func TestFromCloudWatchResponse_MultiSeries(t *testing.T) {
+	resp := &cloudwatch.QueryResponse{
+		Frames: []cloudwatch.Frame{
+			cwFrame("series-a", map[string]string{"InstanceId": "i-abc"}, []int64{1747000000000}, []*float64{cwFloat(1.0)}),
+			cwFrame("series-b", map[string]string{"InstanceId": "i-xyz"}, []int64{1747000000000}, []*float64{cwFloat(2.0)}),
+		},
+	}
+
+	data, err := graph.FromCloudWatchResponse(resp)
+	require.NoError(t, err)
+	assert.Len(t, data.Series, 2)
+	assert.Equal(t, "series-a", data.Series[0].Name)
+	assert.Equal(t, "series-b", data.Series[1].Name)
+}
+
+func TestFromCloudWatchResponse_LabelPopulation(t *testing.T) {
+	labels := map[string]string{"InstanceId": "i-abc"}
+	resp := &cloudwatch.QueryResponse{
+		Frames: []cloudwatch.Frame{
+			cwFrame("", labels, []int64{1747000000000}, []*float64{cwFloat(5.0)}),
+		},
+	}
+
+	data, err := graph.FromCloudWatchResponse(resp)
+	require.NoError(t, err)
+	require.Len(t, data.Series, 1)
+	assert.Equal(t, labels, data.Series[0].Labels)
+}
+
+func TestFromCloudWatchResponse_EmptyFrames(t *testing.T) {
+	resp := &cloudwatch.QueryResponse{Frames: []cloudwatch.Frame{}}
+
+	data, err := graph.FromCloudWatchResponse(resp)
+	require.NoError(t, err)
+	assert.Empty(t, data.Series)
+}
+
+func TestFromCloudWatchResponse_NilResponse(t *testing.T) {
+	data, err := graph.FromCloudWatchResponse(nil)
+	require.NoError(t, err)
+	assert.Empty(t, data.Series)
+}
+
+func TestFromCloudWatchResponse_AllNilValues(t *testing.T) {
+	resp := &cloudwatch.QueryResponse{
+		Frames: []cloudwatch.Frame{
+			cwFrame("test", nil, []int64{1747000000000, 1747000060000}, []*float64{nil, nil}),
+		},
+	}
+
+	data, err := graph.FromCloudWatchResponse(resp)
+	require.NoError(t, err)
+	// All-nil frame produces no series points — frame is skipped.
+	assert.Empty(t, data.Series)
+}

--- a/internal/query/cloudwatch/client.go
+++ b/internal/query/cloudwatch/client.go
@@ -1,0 +1,255 @@
+package cloudwatch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/queryerror"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	maxQueryResponseBytes    = 50 << 20 // 50 MB
+	maxResourceResponseBytes = 1 << 20  // 1 MB
+)
+
+// Client is an HTTP client for CloudWatch queries and resource listing via Grafana's proxy.
+type Client struct {
+	restConfig config.NamespacedRESTConfig
+	httpClient *http.Client
+}
+
+// NewClient creates a new CloudWatch query client.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	httpClient, err := rest.HTTPClientFor(&cfg.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+	return &Client{restConfig: cfg, httpClient: httpClient}, nil
+}
+
+// Query executes a CloudWatch metric query via the Grafana datasource proxy.
+func (c *Client) Query(ctx context.Context, dsUID string, req QueryRequest) (*QueryResponse, error) {
+	query := map[string]any{
+		"refId": "A",
+		"datasource": map[string]any{
+			"type": "cloudwatch",
+			"uid":  dsUID,
+		},
+		"queryType":       "timeSeriesQuery",
+		"namespace":       req.Namespace,
+		"metricName":      req.MetricName,
+		"region":          req.Region,
+		"statistic":       req.Statistic,
+		"matchExact":      req.MatchExact,
+		"period":          strconv.Itoa(req.Period),
+		"dimensions":      dimensionMap(req.Dimensions),
+		"expression":      "",
+		"metricQueryType": 0,
+	}
+	if req.AccountID != "" {
+		query["accountId"] = req.AccountID
+	}
+
+	intervalMs := req.IntervalMs
+	if intervalMs == 0 {
+		intervalMs = int64(req.Period) * 1000
+	}
+	query["intervalMs"] = intervalMs
+
+	bodyMap := map[string]any{
+		"queries": []any{query},
+		"from":    strconv.FormatInt(req.Start.UnixMilli(), 10),
+		"to":      strconv.FormatInt(req.End.UnixMilli(), 10),
+	}
+
+	body, err := json.Marshal(bodyMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	apiPath := c.buildK8sQueryPath()
+	respBody, statusCode, err := c.post(ctx, apiPath, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fall back to legacy /api/ds/query if K8s query API is not available.
+	if statusCode == http.StatusNotFound {
+		apiPath = "/api/ds/query"
+		respBody, statusCode, err = c.post(ctx, apiPath, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if statusCode != http.StatusOK {
+		return nil, queryerror.FromBody("cloudwatch", "query", statusCode, respBody)
+	}
+
+	return ParseQueryResponse(respBody)
+}
+
+// ListNamespaces returns the available CloudWatch namespaces.
+func (c *Client) ListNamespaces(ctx context.Context, dsUID, region, accountID string) ([]string, error) {
+	params := url.Values{}
+	if region != "" {
+		params.Set("region", region)
+	}
+	if accountID != "" {
+		params.Set("accountId", accountID)
+	}
+
+	body, err := c.getResource(ctx, dsUID, "namespaces", params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseNamespaces(body)
+}
+
+// ListMetrics returns the CloudWatch metrics in a given namespace.
+func (c *Client) ListMetrics(ctx context.Context, dsUID, region, namespace, accountID string) ([]Metric, error) {
+	params := url.Values{}
+	params.Set("region", region)
+	params.Set("namespace", namespace)
+	if accountID != "" {
+		params.Set("accountId", accountID)
+	}
+
+	body, err := c.getResource(ctx, dsUID, "metrics", params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMetrics(body)
+}
+
+// ListDimensionKeys returns the available dimension keys for a metric.
+func (c *Client) ListDimensionKeys(ctx context.Context, dsUID, region, namespace, metric, accountID string) ([]string, error) {
+	params := url.Values{}
+	params.Set("region", region)
+	params.Set("namespace", namespace)
+	params.Set("metricName", metric)
+	if accountID != "" {
+		params.Set("accountId", accountID)
+	}
+
+	body, err := c.getResource(ctx, dsUID, "dimension-keys", params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDimensionKeys(body)
+}
+
+// ListRegions returns all available AWS regions for the datasource.
+func (c *Client) ListRegions(ctx context.Context, dsUID string) ([]string, error) {
+	body, err := c.getResource(ctx, dsUID, "regions", nil)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRegions(body)
+}
+
+// ListAccounts returns the AWS accounts accessible via this datasource.
+func (c *Client) ListAccounts(ctx context.Context, dsUID, region string) ([]Account, error) {
+	params := url.Values{}
+	if region != "" {
+		params.Set("region", region)
+	}
+
+	body, err := c.getResource(ctx, dsUID, "accounts", params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAccounts(body)
+}
+
+func (c *Client) getResource(ctx context.Context, dsUID, resource string, params url.Values) ([]byte, error) {
+	path := fmt.Sprintf("/api/datasources/uid/%s/resources/%s", url.PathEscape(dsUID), resource)
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.restConfig.Host+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResourceResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, queryerror.FromBody("cloudwatch", resource, resp.StatusCode, body)
+	}
+
+	return body, nil
+}
+
+func (c *Client) post(ctx context.Context, apiPath string, body []byte) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to execute query: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxQueryResponseBytes))
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	return respBody, resp.StatusCode, nil
+}
+
+func (c *Client) buildK8sQueryPath() string {
+	return fmt.Sprintf("/apis/query.grafana.app/v0alpha1/namespaces/%s/query",
+		c.restConfig.Namespace)
+}
+
+// dimensionMap converts a map[string]string to the format CloudWatch expects:
+// each dimension value stays as a string (the JSON payload accepts strings).
+func dimensionMap(dims map[string]string) map[string]string {
+	if len(dims) == 0 {
+		return map[string]string{}
+	}
+	return dims
+}
+
+// FormatDimensionsForExplore converts dimensions to map[string][]string for Grafana Explore panes.
+func FormatDimensionsForExplore(dims map[string]string) map[string][]string {
+	result := make(map[string][]string, len(dims))
+	for k, v := range dims {
+		result[k] = []string{v}
+	}
+	return result
+}
+
+// ValidStatistics returns the valid CloudWatch statistics.
+func ValidStatistics() []string {
+	return []string{"Average", "Sum", "Maximum", "Minimum", "SampleCount"}
+}
+
+// IsValidStatistic returns true if s is a valid CloudWatch statistic.
+func IsValidStatistic(s string) bool {
+	return slices.Contains(ValidStatistics(), s)
+}

--- a/internal/query/cloudwatch/client_test.go
+++ b/internal/query/cloudwatch/client_test.go
@@ -1,0 +1,290 @@
+package cloudwatch_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/query/cloudwatch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *cloudwatch.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: srv.URL},
+		Namespace: "default",
+	}
+	client, err := cloudwatch.NewClient(cfg)
+	require.NoError(t, err)
+	return client
+}
+
+// ---- typed test helpers (avoid errchkjson) ----
+
+type testField struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type testFrameData struct {
+	Values []any `json:"values"`
+}
+
+type testFrame struct {
+	Schema struct {
+		Fields []testField `json:"fields"`
+	} `json:"schema"`
+	Data testFrameData `json:"data"`
+}
+
+type testResultEntry struct {
+	Frames []testFrame `json:"frames,omitempty"`
+	Error  string      `json:"error,omitempty"`
+	Status int         `json:"status,omitempty"`
+}
+
+type testQueryResult struct {
+	Results map[string]testResultEntry `json:"results"`
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+func queryResultBody(t *testing.T, entry testResultEntry) []byte {
+	t.Helper()
+	return mustJSON(t, testQueryResult{Results: map[string]testResultEntry{"A": entry}})
+}
+
+func simpleFrame(tsMs []float64, values []any) testFrame {
+	var f testFrame
+	f.Schema.Fields = []testField{
+		{Name: "time", Type: "time"},
+		{Name: "CPUUtilization", Type: "number"},
+	}
+	f.Data.Values = []any{tsMs, values}
+	return f
+}
+
+func testQueryReq() cloudwatch.QueryRequest {
+	return cloudwatch.QueryRequest{
+		Namespace:  "AWS/EC2",
+		MetricName: "CPUUtilization",
+		Region:     "us-east-1",
+		Statistic:  "Average",
+		Period:     300,
+		Start:      time.Date(2026, 5, 17, 0, 0, 0, 0, time.UTC),
+		End:        time.Date(2026, 5, 17, 1, 0, 0, 0, time.UTC),
+	}
+}
+
+// ---- tests ----
+
+func TestClient_Query_ParsesTimeSeries(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(queryResultBody(t, testResultEntry{
+			Frames: []testFrame{
+				simpleFrame([]float64{1747000000000, 1747000060000}, []any{10.0, 20.0}),
+			},
+		}))
+	}))
+
+	resp, err := client.Query(context.Background(), "test-uid", testQueryReq())
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Frames)
+	assert.Len(t, resp.Frames[0].Timestamps, 2)
+	require.NotNil(t, resp.Frames[0].Values[0])
+	assert.InDelta(t, 10.0, *resp.Frames[0].Values[0], 0.001)
+}
+
+func TestClient_Query_MultipleFrames(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(queryResultBody(t, testResultEntry{
+			Frames: []testFrame{
+				simpleFrame([]float64{1747000000000}, []any{1.0}),
+				simpleFrame([]float64{1747000000000}, []any{2.0}),
+			},
+		}))
+	}))
+
+	resp, err := client.Query(context.Background(), "test-uid", testQueryReq())
+	require.NoError(t, err)
+	assert.Len(t, resp.Frames, 2)
+}
+
+func TestClient_Query_EmptyValues(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(queryResultBody(t, testResultEntry{
+			Frames: []testFrame{simpleFrame([]float64{}, []any{})},
+		}))
+	}))
+
+	resp, err := client.Query(context.Background(), "test-uid", testQueryReq())
+	require.NoError(t, err)
+	require.Len(t, resp.Frames, 1)
+	assert.Empty(t, resp.Frames[0].Timestamps)
+}
+
+func TestClient_Query_ErrorEnvelope(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(queryResultBody(t, testResultEntry{Error: "metric not found", Status: 400}))
+	}))
+
+	_, err := client.Query(context.Background(), "test-uid", testQueryReq())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "metric not found")
+}
+
+func TestClient_Query_HTTP4xx(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"unauthorized"}`, http.StatusUnauthorized)
+	}))
+
+	_, err := client.Query(context.Background(), "test-uid", testQueryReq())
+	require.Error(t, err)
+}
+
+func TestClient_Query_HTTP5xx(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"internal error"}`, http.StatusInternalServerError)
+	}))
+
+	_, err := client.Query(context.Background(), "test-uid", testQueryReq())
+	require.Error(t, err)
+}
+
+func TestClient_Query_K8sFallback(t *testing.T) {
+	var paths []string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path != "/api/ds/query" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(queryResultBody(t, testResultEntry{
+			Frames: []testFrame{simpleFrame([]float64{1747000000000}, []any{5.0})},
+		}))
+	}))
+
+	resp, err := client.Query(context.Background(), "test-uid", testQueryReq())
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Frames)
+	assert.Contains(t, paths, "/api/ds/query")
+}
+
+func TestClient_Query_MalformedJSON(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{not valid json}`))
+	}))
+
+	_, err := client.Query(context.Background(), "test-uid", testQueryReq())
+	require.Error(t, err)
+}
+
+// ---- resource list tests ----
+
+type testResourceItem[T any] struct {
+	Value T `json:"value"`
+}
+
+func TestClient_ListNamespaces(t *testing.T) {
+	type item = testResourceItem[string]
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/datasources/uid/test-uid/resources/namespaces", r.URL.Path)
+		_, _ = w.Write(mustJSON(t, []item{{"AWS/EC2"}, {"AWS/Lambda"}}))
+	}))
+
+	result, err := client.ListNamespaces(context.Background(), "test-uid", "us-east-1", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"AWS/EC2", "AWS/Lambda"}, result)
+}
+
+func TestClient_ListMetrics(t *testing.T) {
+	type metricVal struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	}
+	type item = testResourceItem[metricVal]
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/datasources/uid/test-uid/resources/metrics", r.URL.Path)
+		_, _ = w.Write(mustJSON(t, []item{{metricVal{"CPUUtilization", "AWS/EC2"}}}))
+	}))
+
+	result, err := client.ListMetrics(context.Background(), "test-uid", "us-east-1", "AWS/EC2", "")
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "CPUUtilization", result[0].Name)
+	assert.Equal(t, "AWS/EC2", result[0].Namespace)
+}
+
+func TestClient_ListDimensionKeys(t *testing.T) {
+	type item = testResourceItem[string]
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(mustJSON(t, []item{{"InstanceId"}}))
+	}))
+
+	result, err := client.ListDimensionKeys(context.Background(), "test-uid", "us-east-1", "AWS/EC2", "CPUUtilization", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"InstanceId"}, result)
+}
+
+func TestClient_ListRegions(t *testing.T) {
+	type regionVal struct {
+		Name string `json:"name"`
+	}
+	type item = testResourceItem[regionVal]
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(mustJSON(t, []item{{regionVal{"us-east-1"}}, {regionVal{"eu-west-1"}}}))
+	}))
+
+	result, err := client.ListRegions(context.Background(), "test-uid")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"us-east-1", "eu-west-1"}, result)
+}
+
+func TestClient_ListAccounts(t *testing.T) {
+	type accountVal struct {
+		ID    string `json:"id"`
+		Label string `json:"label"`
+		ARN   string `json:"arn"`
+	}
+	type item = testResourceItem[accountVal]
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(mustJSON(t, []item{{accountVal{"123456", "Prod", "arn:aws:iam::123456:root"}}}))
+	}))
+
+	result, err := client.ListAccounts(context.Background(), "test-uid", "us-east-1")
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "123456", result[0].ID)
+	assert.Equal(t, "Prod", result[0].Label)
+}
+
+func TestClient_ListAccounts_404_CleanError(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+
+	_, err := client.ListAccounts(context.Background(), "test-uid", "us-east-1")
+	require.Error(t, err) // must not panic
+}

--- a/internal/query/cloudwatch/formatter.go
+++ b/internal/query/cloudwatch/formatter.go
@@ -1,0 +1,149 @@
+package cloudwatch
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/gcx/internal/style"
+)
+
+// FormatTable renders query results as a compact table.
+func FormatTable(w io.Writer, resp *QueryResponse) error {
+	if len(resp.Frames) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+
+	t := style.NewTable("TIMESTAMP", "VALUE", "SERIES")
+	for _, frame := range resp.Frames {
+		label := frameLabel(frame)
+		for i, ts := range frame.Timestamps {
+			val := formatPtrValue(frame.Values[i])
+			t.Row(ts.Format("2006-01-02T15:04:05Z07:00"), val, label)
+		}
+	}
+	return t.Render(w)
+}
+
+// FormatWide renders query results as a wide table with a LABEL column.
+func FormatWide(w io.Writer, resp *QueryResponse) error {
+	if len(resp.Frames) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+
+	t := style.NewTable("TIMESTAMP", "VALUE", "SERIES", "LABEL")
+	for _, frame := range resp.Frames {
+		label := frameLabel(frame)
+		labelStr := formatLabelsMap(frame.Labels)
+		for i, ts := range frame.Timestamps {
+			val := formatPtrValue(frame.Values[i])
+			t.Row(ts.Format("2006-01-02T15:04:05Z07:00"), val, label, labelStr)
+		}
+	}
+	return t.Render(w)
+}
+
+// FormatNamespaces renders a list of CloudWatch namespaces.
+func FormatNamespaces(w io.Writer, namespaces []string) error {
+	if len(namespaces) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+	t := style.NewTable("NAMESPACE")
+	for _, ns := range namespaces {
+		t.Row(ns)
+	}
+	return t.Render(w)
+}
+
+// FormatMetrics renders a list of CloudWatch metrics.
+func FormatMetrics(w io.Writer, metrics []Metric) error {
+	if len(metrics) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+	t := style.NewTable("NAMESPACE", "METRIC")
+	for _, m := range metrics {
+		t.Row(m.Namespace, m.Name)
+	}
+	return t.Render(w)
+}
+
+// FormatDimensions renders a list of CloudWatch dimension keys.
+func FormatDimensions(w io.Writer, keys []string) error {
+	if len(keys) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+	t := style.NewTable("DIMENSION")
+	for _, k := range keys {
+		t.Row(k)
+	}
+	return t.Render(w)
+}
+
+// FormatRegions renders a list of AWS regions.
+func FormatRegions(w io.Writer, regions []string) error {
+	if len(regions) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+	t := style.NewTable("REGION")
+	for _, r := range regions {
+		t.Row(r)
+	}
+	return t.Render(w)
+}
+
+// FormatAccounts renders a list of AWS accounts.
+func FormatAccounts(w io.Writer, accounts []Account) error {
+	if len(accounts) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+	t := style.NewTable("ID", "LABEL", "ARN")
+	for _, a := range accounts {
+		t.Row(a.ID, a.Label, a.ARN)
+	}
+	return t.Render(w)
+}
+
+func frameLabel(frame Frame) string {
+	if frame.Name != "" {
+		return frame.Name
+	}
+	return formatLabelsMap(frame.Labels)
+}
+
+func formatLabelsMap(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(strconv.Quote(labels[k]))
+	}
+	return b.String()
+}
+
+func formatPtrValue(v *float64) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.FormatFloat(*v, 'f', -1, 64)
+}

--- a/internal/query/cloudwatch/formatter_test.go
+++ b/internal/query/cloudwatch/formatter_test.go
@@ -1,0 +1,164 @@
+package cloudwatch_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/query/cloudwatch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestResponse(name string, ts []time.Time, vals []*float64) *cloudwatch.QueryResponse {
+	return &cloudwatch.QueryResponse{
+		Frames: []cloudwatch.Frame{
+			{
+				Name:       name,
+				Timestamps: ts,
+				Values:     vals,
+			},
+		},
+	}
+}
+
+func pf(f float64) *float64 {
+	v := f
+	return &v
+}
+
+func ts(s string) time.Time {
+	t, _ := time.Parse(time.RFC3339, s)
+	return t
+}
+
+func TestFormatTable_Populated(t *testing.T) {
+	resp := makeTestResponse("", []time.Time{ts("2026-05-17T00:00:00Z")}, []*float64{pf(42.5)})
+
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatTable(&buf, resp))
+	assert.Contains(t, buf.String(), "TIMESTAMP")
+	assert.Contains(t, buf.String(), "VALUE")
+	assert.Contains(t, buf.String(), "2026-05-17")
+	assert.Contains(t, buf.String(), "42.5")
+	assert.NotContains(t, buf.String(), "1778") // no raw millisecond timestamps
+}
+
+func TestFormatTable_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatTable(&buf, &cloudwatch.QueryResponse{}))
+	assert.Contains(t, buf.String(), "No data")
+}
+
+func TestFormatTable_NilValue(t *testing.T) {
+	resp := makeTestResponse("", []time.Time{ts("2026-05-17T00:00:00Z")}, []*float64{nil})
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatTable(&buf, resp))
+	// nil value becomes empty string in output — no panic
+}
+
+func TestFormatWide_HasLabelColumn(t *testing.T) {
+	resp := &cloudwatch.QueryResponse{
+		Frames: []cloudwatch.Frame{
+			{
+				Name:       "CPUUtilization",
+				Labels:     map[string]string{"InstanceId": "i-abc"},
+				Timestamps: []time.Time{ts("2026-05-17T00:00:00Z")},
+				Values:     []*float64{pf(10.0)},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatWide(&buf, resp))
+	assert.Contains(t, buf.String(), "LABEL")
+	assert.Contains(t, buf.String(), "InstanceId")
+}
+
+func TestFormatWide_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatWide(&buf, &cloudwatch.QueryResponse{}))
+	assert.Contains(t, buf.String(), "No data")
+}
+
+func TestFormatNamespaces_Populated(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatNamespaces(&buf, []string{"AWS/EC2", "AWS/Lambda"}))
+	assert.Contains(t, buf.String(), "NAMESPACE")
+	assert.Contains(t, buf.String(), "AWS/EC2")
+	assert.Contains(t, buf.String(), "AWS/Lambda")
+}
+
+func TestFormatNamespaces_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatNamespaces(&buf, nil))
+	assert.Contains(t, buf.String(), "No data")
+}
+
+func TestFormatMetrics_Populated(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatMetrics(&buf, []cloudwatch.Metric{
+		{Name: "CPUUtilization", Namespace: "AWS/EC2"},
+	}))
+	assert.Contains(t, buf.String(), "NAMESPACE")
+	assert.Contains(t, buf.String(), "METRIC")
+	assert.Contains(t, buf.String(), "CPUUtilization")
+	assert.Contains(t, buf.String(), "AWS/EC2")
+}
+
+func TestFormatMetrics_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatMetrics(&buf, nil))
+	assert.Contains(t, buf.String(), "No data")
+}
+
+func TestFormatDimensions_Populated(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatDimensions(&buf, []string{"InstanceId", "AutoScalingGroupName"}))
+	assert.Contains(t, buf.String(), "DIMENSION")
+	assert.Contains(t, buf.String(), "InstanceId")
+}
+
+func TestFormatDimensions_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatDimensions(&buf, nil))
+	assert.Contains(t, buf.String(), "No data")
+}
+
+func TestFormatRegions_Populated(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatRegions(&buf, []string{"us-east-1", "eu-west-1"}))
+	assert.Contains(t, buf.String(), "REGION")
+	assert.Contains(t, buf.String(), "us-east-1")
+}
+
+func TestFormatRegions_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatRegions(&buf, nil))
+	assert.Contains(t, buf.String(), "No data")
+}
+
+func TestFormatAccounts_Populated(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatAccounts(&buf, []cloudwatch.Account{
+		{ID: "123456", Label: "Prod", ARN: "arn:aws:iam::123456:root"},
+	}))
+	assert.Contains(t, buf.String(), "ID")
+	assert.Contains(t, buf.String(), "LABEL")
+	assert.Contains(t, buf.String(), "ARN")
+	assert.Contains(t, buf.String(), "123456")
+	assert.Contains(t, buf.String(), "Prod")
+}
+
+func TestFormatAccounts_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatAccounts(&buf, nil))
+	assert.Contains(t, buf.String(), "No data")
+}
+
+func TestFormatTable_RFC3339Timestamps(t *testing.T) {
+	resp := makeTestResponse("", []time.Time{ts("2026-05-17T10:00:00Z")}, []*float64{pf(1.0)})
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatTable(&buf, resp))
+	assert.Contains(t, buf.String(), "2026-")
+}

--- a/internal/query/cloudwatch/types.go
+++ b/internal/query/cloudwatch/types.go
@@ -1,0 +1,321 @@
+package cloudwatch
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// QueryRequest represents a CloudWatch metric query request.
+type QueryRequest struct {
+	Namespace  string
+	MetricName string
+	Region     string
+	Statistic  string
+	AccountID  string
+	Dimensions map[string]string
+	MatchExact bool
+	Period     int
+	Start      time.Time
+	End        time.Time
+	IntervalMs int64
+}
+
+// Frame represents a single time-series frame from a CloudWatch query result.
+type Frame struct {
+	Name       string
+	Labels     map[string]string
+	Timestamps []time.Time
+	Values     []*float64
+}
+
+// QueryResponse holds the parsed CloudWatch query result.
+type QueryResponse struct {
+	Frames []Frame
+}
+
+// Metric represents a CloudWatch metric.
+type Metric struct {
+	Name      string
+	Namespace string
+}
+
+// Account represents an AWS account in cross-account monitoring.
+type Account struct {
+	ID    string
+	Label string
+	ARN   string
+}
+
+// grafanaQueryResponse is the raw Grafana /api/ds/query (or K8s query API) response.
+type grafanaQueryResponse struct {
+	Results map[string]grafanaResult `json:"results"`
+}
+
+type grafanaResult struct {
+	Frames      []dataFrame `json:"frames,omitempty"`
+	Error       string      `json:"error,omitempty"`
+	ErrorSource string      `json:"errorSource,omitempty"`
+	Status      int         `json:"status,omitempty"`
+}
+
+type dataFrame struct {
+	Schema dataFrameSchema `json:"schema"`
+	Data   dataFrameData   `json:"data"`
+}
+
+type dataFrameSchema struct {
+	Name   string  `json:"name,omitempty"`
+	Fields []field `json:"fields,omitempty"`
+}
+
+type fieldConfig struct {
+	DisplayNameFromDS string `json:"displayNameFromDS,omitempty"`
+}
+
+type field struct {
+	Name   string            `json:"name,omitempty"`
+	Type   string            `json:"type,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
+	Config *fieldConfig      `json:"config,omitempty"`
+}
+
+type dataFrameData struct {
+	Values []json.RawMessage `json:"values,omitempty"`
+}
+
+// resourceItem is the generic shape returned by CloudWatch resource endpoints.
+type resourceItem struct {
+	Value json.RawMessage `json:"value"`
+}
+
+// ParseQueryResponse converts the raw Grafana response bytes into a QueryResponse.
+func ParseQueryResponse(body []byte) (*QueryResponse, error) {
+	var raw grafanaQueryResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse cloudwatch response: %w", err)
+	}
+
+	result, ok := raw.Results["A"]
+	if !ok {
+		return &QueryResponse{}, nil
+	}
+
+	if result.Error != "" {
+		status := result.Status
+		if status == 0 {
+			status = 400
+		}
+		return nil, &queryError{source: "cloudwatch", op: "query", status: status, msg: result.Error, errorSource: result.ErrorSource}
+	}
+
+	resp := &QueryResponse{
+		Frames: make([]Frame, 0, len(result.Frames)),
+	}
+
+	for _, df := range result.Frames {
+		frame, ok, err := parseDataFrame(df)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			resp.Frames = append(resp.Frames, frame)
+		}
+	}
+
+	return resp, nil
+}
+
+func parseDataFrame(df dataFrame) (Frame, bool, error) {
+	if len(df.Schema.Fields) < 2 || len(df.Data.Values) < 2 {
+		return Frame{}, false, nil
+	}
+
+	var timeIdx, valueIdx = -1, -1
+	var labels map[string]string
+	var seriesName string
+
+	for i, f := range df.Schema.Fields {
+		if f.Type == "time" {
+			timeIdx = i
+		} else if f.Type == "number" || f.Name == "Value" {
+			valueIdx = i
+			labels = f.Labels
+			if f.Config != nil && f.Config.DisplayNameFromDS != "" {
+				seriesName = f.Config.DisplayNameFromDS
+			}
+		}
+	}
+
+	if timeIdx == -1 || valueIdx == -1 {
+		return Frame{}, false, nil
+	}
+
+	var tsRaw []any
+	if err := json.Unmarshal(df.Data.Values[timeIdx], &tsRaw); err != nil {
+		return Frame{}, false, fmt.Errorf("failed to parse timestamps: %w", err)
+	}
+
+	var valRaw []any
+	if err := json.Unmarshal(df.Data.Values[valueIdx], &valRaw); err != nil {
+		return Frame{}, false, fmt.Errorf("failed to parse values: %w", err)
+	}
+
+	n := min(len(tsRaw), len(valRaw))
+
+	timestamps := make([]time.Time, n)
+	values := make([]*float64, n)
+
+	for i := range n {
+		ms := toFloat64(tsRaw[i])
+		timestamps[i] = time.UnixMilli(int64(ms)).UTC()
+
+		if valRaw[i] != nil {
+			v := toFloat64(valRaw[i])
+			values[i] = &v
+		}
+	}
+
+	return Frame{
+		Name:       seriesName,
+		Labels:     labels,
+		Timestamps: timestamps,
+		Values:     values,
+	}, true, nil
+}
+
+func toFloat64(v any) float64 {
+	switch val := v.(type) {
+	case float64:
+		return val
+	case int:
+		return float64(val)
+	case int64:
+		return float64(val)
+	default:
+		return 0
+	}
+}
+
+// ParseNamespaces parses the /resources/namespaces response (shape: [{"value":"AWS/EC2"}, ...]).
+func ParseNamespaces(body []byte) ([]string, error) {
+	var items []resourceItem
+	if err := json.Unmarshal(body, &items); err != nil {
+		return nil, fmt.Errorf("failed to parse namespaces: %w", err)
+	}
+
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		var s string
+		if err := json.Unmarshal(item.Value, &s); err != nil {
+			continue
+		}
+		result = append(result, s)
+	}
+	return result, nil
+}
+
+// ParseMetrics parses the /resources/metrics response (shape: [{"value":{"name":"...","namespace":"..."}}, ...]).
+func ParseMetrics(body []byte) ([]Metric, error) {
+	var items []resourceItem
+	if err := json.Unmarshal(body, &items); err != nil {
+		return nil, fmt.Errorf("failed to parse metrics: %w", err)
+	}
+
+	type metricValue struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	}
+
+	result := make([]Metric, 0, len(items))
+	for _, item := range items {
+		var mv metricValue
+		if err := json.Unmarshal(item.Value, &mv); err != nil {
+			continue
+		}
+		result = append(result, Metric(mv))
+	}
+	return result, nil
+}
+
+// ParseDimensionKeys parses the /resources/dimension-keys response (shape: [{"value":"InstanceId"}, ...]).
+func ParseDimensionKeys(body []byte) ([]string, error) {
+	var items []resourceItem
+	if err := json.Unmarshal(body, &items); err != nil {
+		return nil, fmt.Errorf("failed to parse dimension keys: %w", err)
+	}
+
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		var s string
+		if err := json.Unmarshal(item.Value, &s); err != nil {
+			continue
+		}
+		result = append(result, s)
+	}
+	return result, nil
+}
+
+// ParseRegions parses the /resources/regions response (shape: [{"value":{"name":"us-east-1"}}, ...]).
+func ParseRegions(body []byte) ([]string, error) {
+	var items []resourceItem
+	if err := json.Unmarshal(body, &items); err != nil {
+		return nil, fmt.Errorf("failed to parse regions: %w", err)
+	}
+
+	type regionValue struct {
+		Name string `json:"name"`
+	}
+
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		var rv regionValue
+		if err := json.Unmarshal(item.Value, &rv); err != nil {
+			continue
+		}
+		if rv.Name != "" {
+			result = append(result, rv.Name)
+		}
+	}
+	return result, nil
+}
+
+// ParseAccounts parses the /resources/accounts response (shape: [{"value":{"id":"...","label":"...","arn":"..."}}, ...]).
+func ParseAccounts(body []byte) ([]Account, error) {
+	var items []resourceItem
+	if err := json.Unmarshal(body, &items); err != nil {
+		return nil, fmt.Errorf("failed to parse accounts: %w", err)
+	}
+
+	type accountValue struct {
+		ID    string `json:"id"`
+		Label string `json:"label"`
+		ARN   string `json:"arn"`
+	}
+
+	result := make([]Account, 0, len(items))
+	for _, item := range items {
+		var av accountValue
+		if err := json.Unmarshal(item.Value, &av); err != nil {
+			continue
+		}
+		result = append(result, Account(av))
+	}
+	return result, nil
+}
+
+// queryError is the internal typed error for CloudWatch API errors.
+type queryError struct {
+	source      string
+	op          string
+	status      int
+	msg         string
+	errorSource string
+}
+
+func (e *queryError) Error() string {
+	if e.errorSource != "" {
+		return fmt.Sprintf("cloudwatch %s error (status %d, source %s): %s", e.op, e.status, e.errorSource, e.msg)
+	}
+	return fmt.Sprintf("cloudwatch %s error (status %d): %s", e.op, e.status, e.msg)
+}

--- a/internal/query/cloudwatch/types_test.go
+++ b/internal/query/cloudwatch/types_test.go
@@ -1,0 +1,233 @@
+package cloudwatch_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/query/cloudwatch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseQueryResponse_TimeSeries(t *testing.T) {
+	body := []byte(`{
+		"results": {
+			"A": {
+				"frames": [{
+					"schema": {
+						"fields": [
+							{"name": "time", "type": "time"},
+							{"name": "CPUUtilization", "type": "number", "labels": {"InstanceId": "i-abc"}}
+						]
+					},
+					"data": {
+						"values": [
+							[1747000000000, 1747000060000],
+							[12.5, 15.3]
+						]
+					}
+				}]
+			}
+		}
+	}`)
+
+	resp, err := cloudwatch.ParseQueryResponse(body)
+	require.NoError(t, err)
+	require.Len(t, resp.Frames, 1)
+	assert.Len(t, resp.Frames[0].Timestamps, 2)
+	assert.Len(t, resp.Frames[0].Values, 2)
+	require.NotNil(t, resp.Frames[0].Values[0])
+	assert.InDelta(t, 12.5, *resp.Frames[0].Values[0], 0.001)
+	assert.Equal(t, "i-abc", resp.Frames[0].Labels["InstanceId"])
+}
+
+func TestParseQueryResponse_MultiFrame(t *testing.T) {
+	body := []byte(`{
+		"results": {
+			"A": {
+				"frames": [
+					{
+						"schema": {"fields": [{"name":"time","type":"time"},{"name":"v","type":"number"}]},
+						"data": {"values": [[1747000000000],[1.0]]}
+					},
+					{
+						"schema": {"fields": [{"name":"time","type":"time"},{"name":"v","type":"number","labels":{"InstanceId":"i-xyz"}}]},
+						"data": {"values": [[1747000000000],[2.0]]}
+					}
+				]
+			}
+		}
+	}`)
+
+	resp, err := cloudwatch.ParseQueryResponse(body)
+	require.NoError(t, err)
+	assert.Len(t, resp.Frames, 2)
+}
+
+func TestParseQueryResponse_EmptyValues(t *testing.T) {
+	body := []byte(`{
+		"results": {
+			"A": {
+				"frames": [{
+					"schema": {"fields": [{"name":"time","type":"time"},{"name":"v","type":"number"}]},
+					"data": {"values": [[],[]]}
+				}]
+			}
+		}
+	}`)
+
+	resp, err := cloudwatch.ParseQueryResponse(body)
+	require.NoError(t, err)
+	require.Len(t, resp.Frames, 1)
+	assert.Empty(t, resp.Frames[0].Timestamps)
+}
+
+func TestParseQueryResponse_ErrorResult(t *testing.T) {
+	body := []byte(`{
+		"results": {
+			"A": {
+				"error": "metric not found",
+				"status": 400
+			}
+		}
+	}`)
+
+	_, err := cloudwatch.ParseQueryResponse(body)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "metric not found")
+}
+
+func TestParseQueryResponse_MissingA(t *testing.T) {
+	body := []byte(`{"results": {}}`)
+	resp, err := cloudwatch.ParseQueryResponse(body)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Frames)
+}
+
+func TestParseQueryResponse_MalformedJSON(t *testing.T) {
+	_, err := cloudwatch.ParseQueryResponse([]byte(`not json`))
+	require.Error(t, err)
+}
+
+func TestParseQueryResponse_NullableValues(t *testing.T) {
+	body := []byte(`{
+		"results": {
+			"A": {
+				"frames": [{
+					"schema": {"fields": [{"name":"time","type":"time"},{"name":"v","type":"number"}]},
+					"data": {"values": [[1747000000000, 1747000060000],[null, 5.0]]}
+				}]
+			}
+		}
+	}`)
+
+	resp, err := cloudwatch.ParseQueryResponse(body)
+	require.NoError(t, err)
+	require.Len(t, resp.Frames, 1)
+	assert.Nil(t, resp.Frames[0].Values[0])
+	require.NotNil(t, resp.Frames[0].Values[1])
+	assert.InDelta(t, 5.0, *resp.Frames[0].Values[1], 0.001)
+}
+
+func TestParseQueryResponse_DisplayNameFromDS(t *testing.T) {
+	body := []byte(`{
+		"results": {
+			"A": {
+				"frames": [{
+					"schema": {
+						"fields": [
+							{"name":"time","type":"time"},
+							{"name":"value","type":"number","config":{"displayNameFromDS":"CPUUtilization (Average)"}}
+						]
+					},
+					"data": {"values": [[1747000000000],[42.0]]}
+				}]
+			}
+		}
+	}`)
+
+	resp, err := cloudwatch.ParseQueryResponse(body)
+	require.NoError(t, err)
+	require.Len(t, resp.Frames, 1)
+	assert.Equal(t, "CPUUtilization (Average)", resp.Frames[0].Name)
+}
+
+func TestParseQueryResponse_TimestampMilliseconds(t *testing.T) {
+	body := []byte(`{
+		"results": {
+			"A": {
+				"frames": [{
+					"schema": {"fields": [{"name":"time","type":"time"},{"name":"v","type":"number"}]},
+					"data": {"values": [[1747000000000],[1.0]]}
+				}]
+			}
+		}
+	}`)
+
+	resp, err := cloudwatch.ParseQueryResponse(body)
+	require.NoError(t, err)
+	require.Len(t, resp.Frames, 1)
+	expected := time.UnixMilli(1747000000000).UTC()
+	assert.Equal(t, expected, resp.Frames[0].Timestamps[0])
+}
+
+func TestParseNamespaces(t *testing.T) {
+	t.Run("parses flat value list", func(t *testing.T) {
+		body := []byte(`[{"value":"AWS/EC2"},{"value":"AWS/Lambda"}]`)
+		result, err := cloudwatch.ParseNamespaces(body)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"AWS/EC2", "AWS/Lambda"}, result)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		result, err := cloudwatch.ParseNamespaces([]byte(`[]`))
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("malformed JSON returns error", func(t *testing.T) {
+		_, err := cloudwatch.ParseNamespaces([]byte(`not json`))
+		require.Error(t, err)
+	})
+}
+
+func TestParseMetrics(t *testing.T) {
+	t.Run("parses nested value shape", func(t *testing.T) {
+		body := []byte(`[{"value":{"name":"CPUUtilization","namespace":"AWS/EC2"}},{"value":{"name":"Invocations","namespace":"AWS/Lambda"}}]`)
+		result, err := cloudwatch.ParseMetrics(body)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Equal(t, "CPUUtilization", result[0].Name)
+		assert.Equal(t, "AWS/EC2", result[0].Namespace)
+	})
+}
+
+func TestParseDimensionKeys(t *testing.T) {
+	t.Run("parses flat value list", func(t *testing.T) {
+		body := []byte(`[{"value":"InstanceId"},{"value":"AutoScalingGroupName"}]`)
+		result, err := cloudwatch.ParseDimensionKeys(body)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"InstanceId", "AutoScalingGroupName"}, result)
+	})
+}
+
+func TestParseRegions(t *testing.T) {
+	t.Run("parses nested name shape", func(t *testing.T) {
+		body := []byte(`[{"value":{"name":"us-east-1"}},{"value":{"name":"eu-west-1"}}]`)
+		result, err := cloudwatch.ParseRegions(body)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"us-east-1", "eu-west-1"}, result)
+	})
+}
+
+func TestParseAccounts(t *testing.T) {
+	t.Run("parses account shape", func(t *testing.T) {
+		body := []byte(`[{"value":{"id":"123456789","label":"My Account","arn":"arn:aws:iam::123456789:root"}}]`)
+		result, err := cloudwatch.ParseAccounts(body)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "123456789", result[0].ID)
+		assert.Equal(t, "My Account", result[0].Label)
+		assert.Equal(t, "arn:aws:iam::123456789:root", result[0].ARN)
+	})
+}


### PR DESCRIPTION
## Summary

Adds six subcommands under `gcx datasources cloudwatch`:

- **`query`** — execute a structured metric query (namespace, metric, region, statistic, period, dimensions)
- **`list-namespaces`** — list available CloudWatch namespaces for a region
- **`list-metrics`** — list metrics in a namespace
- **`list-dimensions`** — list dimension keys for a metric
- **`list-regions`** — list available AWS regions
- **`list-accounts`** — list linked AWS accounts for cross-account monitoring

Also blocks `gcx datasources query <cw-uid> <expr>` with a helpful redirect message, since CloudWatch has no expression language.

## Decisions worth maintainer review

**Flags-only design (no expression language)**

CloudWatch metric queries are structured tuples — there is no query expression language. The command uses explicit `--namespace`, `--metric`, `--region`, `--statistic`, `--period`, `--dimensions` flags rather than the `SharedOpts.Setup` pattern used by Prometheus/Loki/Tempo. This avoids surfacing `--expr` on a datasource that doesn't use it.

**`matchExact` computation**

`matchExact = len(opts.Dimensions) > 0` — computed once, passed identically to both the API client and the Explore URL builder. This differs from `mcp-grafana` which hardcodes `true`, breaking aggregation queries where no dimension filter is intended. With `false` when no dimensions are provided, Grafana returns aggregate data across all dimension combinations.

**Generic `gcx datasources query` short-circuit placement**

The short-circuit check (`if dsType == "cloudwatch" { return error }`) is placed after type detection but before `ResolveExpr`. A pre-check for "both positional and --expr" is added before the HTTP call to preserve existing mutual-exclusion test coverage.

**Explore URL time defaults**

When no `--from`/`--to`/`--since` flags are provided, the CLI queries `now-1h` to `now` (concrete times) but the share link encodes `"now-1h"`/`"now"` (relative). This matches the behavior of other datasource query commands.

## Test plan

- [ ] `gcx datasources cloudwatch query -d <cw-uid> --region <region> --namespace AWS/EC2 --metric CPUUtilization --since 1h -o json` returns data
- [ ] Query with `--dimensions` sets matchExact=true, without sets matchExact=false
- [ ] `gcx datasources cloudwatch list-namespaces -d <cw-uid> --region <region>` lists namespaces
- [ ] `gcx datasources cloudwatch list-metrics -d <cw-uid> --region <region> --namespace AWS/EC2` lists metrics
- [ ] `gcx datasources cloudwatch list-dimensions -d <cw-uid> --region <region> --namespace AWS/EC2 --metric CPUUtilization` lists dimension keys
- [ ] `gcx datasources cloudwatch list-regions -d <cw-uid>` lists AWS regions
- [ ] `gcx datasources cloudwatch list-accounts -d <cw-uid> --region <region>` lists linked accounts
- [ ] `gcx datasources query <cw-uid> '{job="test"}'` returns redirect error message
- [ ] `--share-link` produces a valid Grafana Explore URL
- [ ] `-o json` and `-o table` work for all subcommands
- [ ] Missing required flags produce clear validation errors
- [ ] Unit tests pass: `go test ./internal/query/cloudwatch/... ./internal/datasources/cloudwatch/... ./internal/graph/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)