### PR TITLE
fix: exit cleanly on Ctrl+C instead of showing noisy error

### DIFF
--- a/internal/gcxerrors/detailed.go
+++ b/internal/gcxerrors/detailed.go
@@ -55,8 +55,8 @@ type DetailedError struct {
 	ExitCode *int
 }
 
-// Unwrap returns the parent error, enabling errors.Is/As to traverse through
-// DetailedError wrappers (e.g. detecting context.Canceled for clean SIGINT exit).
+// Unwrap lets errors.Is/As traverse through DetailedError to detect wrapped
+// sentinels (e.g. context.Canceled for clean SIGINT exit).
 func (e DetailedError) Unwrap() error {
 	return e.Parent
 }

--- a/internal/gcxerrors/detailed.go
+++ b/internal/gcxerrors/detailed.go
@@ -55,6 +55,12 @@ type DetailedError struct {
 	ExitCode *int
 }
 
+// Unwrap returns the parent error, enabling errors.Is/As to traverse through
+// DetailedError wrappers (e.g. detecting context.Canceled for clean SIGINT exit).
+func (e DetailedError) Unwrap() error {
+	return e.Parent
+}
+
 func (e DetailedError) Error() string {
 	buffer := strings.Builder{}
 

--- a/internal/gcxerrors/detailed_test.go
+++ b/internal/gcxerrors/detailed_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDetailedError_Unwrap(t *testing.T) {
-	err := &fail.DetailedError{
+	err := gcxerrors.DetailedError{
 		Summary: "Authentication failed",
 		Parent:  context.Canceled,
 	}

--- a/internal/gcxerrors/detailed_test.go
+++ b/internal/gcxerrors/detailed_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDetailedError_Unwrap_ExposesCanceledContext(t *testing.T) {
+func TestDetailedError_Unwrap(t *testing.T) {
 	err := &fail.DetailedError{
 		Summary: "Authentication failed",
 		Parent:  context.Canceled,

--- a/internal/gcxerrors/detailed_test.go
+++ b/internal/gcxerrors/detailed_test.go
@@ -1,6 +1,7 @@
 package gcxerrors_test
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -9,6 +10,15 @@ import (
 	"github.com/grafana/gcx/internal/gcxerrors"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestDetailedError_Unwrap_ExposesCanceledContext(t *testing.T) {
+	err := &fail.DetailedError{
+		Summary: "Authentication failed",
+		Parent:  context.Canceled,
+	}
+
+	assert.ErrorIs(t, err, context.Canceled)
+}
 
 func TestDetailedError_Error_OmitsDuplicateParentDetails(t *testing.T) {
 	oldNoColor := color.NoColor


### PR DESCRIPTION
## Problem

Ctrl+C during a running command shows a full error box with suggestions instead of exiting silently:

```
^CError: Authentication failed
│
├─ Details:
│
│ context canceled
│
├─ Suggestions:
│
│ • Check that the GCOM API URL is correct
│ • Ensure you are logged in to Grafana Cloud in your browser
│ • Try again with: gcx cloud login --api-url <url>
│
└─
```

## Fix

`handleError` in `main.go` already has a fast-path for `context.Canceled` that exits cleanly with code 5 and no output. But `DetailedError` had no `Unwrap()` method, so `errors.Is(err, context.Canceled)` couldn't see through commands that wrapped the cancellation in a `DetailedError` (via the `Parent` field). The fast-path was skipped and the full error renderer kicked in.

Adding `Unwrap()` to `DetailedError` lets `errors.Is` traverse through the wrapper and hit the fast-path.

Now, with Ctrl+C while waiting for the oauth response, we don't see anything.