### PR TITLE
add CODEOWNERS with product team co-ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,76 +1,41 @@
-# gcx CODEOWNERS
-#
-# Last matching pattern wins. The grafana-gcx team owns the entire codebase
-# as a platform team, and product teams co-own their provider directories.
+# Last matching pattern wins. grafana-gcx owns the entire codebase;
+# product teams co-own their provider directories.
 
-# Default: gcx platform team owns everything
 * @grafana/grafana-gcx
 
-# Provider: SLO
+# Providers
 /internal/providers/slo/ @grafana/grafana-gcx @grafana/slo-squad
-/cmd/gcx/providers/ @grafana/grafana-gcx
-
-# Provider: Synthetic Monitoring
 /internal/providers/synth/ @grafana/grafana-gcx @grafana/synthetic-monitoring-dev
-
-# Provider: IRM (OnCall + Incidents)
 /internal/providers/irm/ @grafana/grafana-gcx @grafana/grafana-irm-backend
-
-# Provider: k6
 /internal/providers/k6/ @grafana/grafana-gcx @grafana/k6-backend
-
-# Provider: Frontend Observability (Faro)
 /internal/providers/faro/ @grafana/grafana-gcx @grafana/kowalski
-
-# Provider: Fleet Management
 /internal/providers/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend
 /internal/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend
-
-# Provider: Instrumentation Hub
 /internal/providers/instrumentation/ @grafana/grafana-gcx @grafana/o11y-ingest
 /cmd/gcx/instrumentation/ @grafana/grafana-gcx @grafana/o11y-ingest
-
-# Provider: Knowledge Graph (Asserts)
 /internal/providers/kg/ @grafana/grafana-gcx @grafana/asserts-team
-
-# Provider: App Observability
 /internal/providers/appo11y/ @grafana/grafana-gcx @grafana/app-o11y-visualizations
-
-# Provider: AI Observability (Sigil)
 /internal/providers/aio11y/ @grafana/grafana-gcx @grafana/grafana-assistant-loop
 
-# Signal provider: Logs (Loki)
+# Signal providers (provider + datasource + query layers)
 /internal/providers/logs/ @grafana/grafana-gcx @grafana/loki-team
 /internal/datasources/loki/ @grafana/grafana-gcx @grafana/loki-team
 /internal/query/loki/ @grafana/grafana-gcx @grafana/loki-team
 
-# Signal provider: Metrics (Prometheus/Mimir)
 /internal/providers/metrics/ @grafana/grafana-gcx @grafana/cortex-team
 /internal/datasources/prometheus/ @grafana/grafana-gcx @grafana/cortex-team
 /internal/query/prometheus/ @grafana/grafana-gcx @grafana/cortex-team
 
-# Signal provider: Traces (Tempo)
 /internal/providers/traces/ @grafana/grafana-gcx @grafana/tempo
 /internal/datasources/tempo/ @grafana/grafana-gcx @grafana/tempo
 /internal/query/tempo/ @grafana/grafana-gcx @grafana/tempo
 
-# Signal provider: Profiles (Pyroscope)
 /internal/providers/profiles/ @grafana/grafana-gcx @grafana/pyroscope-team
 /internal/datasources/pyroscope/ @grafana/grafana-gcx @grafana/pyroscope-team
 /internal/query/pyroscope/ @grafana/grafana-gcx @grafana/pyroscope-team
 
-# Adaptive Telemetry (shared across signal providers)
 /internal/auth/adaptive/ @grafana/grafana-gcx @grafana/adaptive-telemetry
 
 # Assistant / AI
 /internal/assistant/ @grafana/grafana-gcx @grafana/grafana-assistant-loop
 /cmd/gcx/assistant/ @grafana/grafana-gcx @grafana/grafana-assistant-loop
-
-# Linter (Rego rules)
-/internal/linter/ @grafana/grafana-gcx
-
-# Documentation
-/docs/ @grafana/grafana-gcx
-
-# Claude plugin / agent skills
-/claude-plugin/ @grafana/grafana-gcx

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,12 @@
-# Last matching pattern wins. grafana-gcx owns the entire codebase;
-# product teams co-own their provider directories.
+# Last matching pattern wins, so add @grafana/grafana-gcx to every rule that 
+# also takes another team. We want grafana-gcx to be a required reviewer for 
+# all changes.
 
+# Default / fallback rule
 * @grafana/grafana-gcx
+
+/cmd/gcx/instrumentation/ @grafana/grafana-gcx @grafana/o11y-ingest
+/cmd/gcx/assistant/ @grafana/grafana-gcx @grafana/grafana-assistant-loop
 
 # Providers
 /internal/providers/slo/ @grafana/grafana-gcx @grafana/slo-squad
@@ -12,30 +17,24 @@
 /internal/providers/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend
 /internal/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend
 /internal/providers/instrumentation/ @grafana/grafana-gcx @grafana/o11y-ingest
-/cmd/gcx/instrumentation/ @grafana/grafana-gcx @grafana/o11y-ingest
 /internal/providers/kg/ @grafana/grafana-gcx @grafana/asserts-team
 /internal/providers/appo11y/ @grafana/grafana-gcx @grafana/app-o11y-visualizations
 /internal/providers/aio11y/ @grafana/grafana-gcx @grafana/grafana-assistant-loop
-
-# Signal providers (provider + datasource + query layers)
 /internal/providers/logs/ @grafana/grafana-gcx @grafana/loki-team
-/internal/datasources/loki/ @grafana/grafana-gcx @grafana/loki-team
-/internal/query/loki/ @grafana/grafana-gcx @grafana/loki-team
-
 /internal/providers/metrics/ @grafana/grafana-gcx @grafana/cortex-team
-/internal/datasources/prometheus/ @grafana/grafana-gcx @grafana/cortex-team
-/internal/query/prometheus/ @grafana/grafana-gcx @grafana/cortex-team
-
+/internal/providers/profiles/ @grafana/grafana-gcx @grafana/pyroscope-team
 /internal/providers/traces/ @grafana/grafana-gcx @grafana/tempo
+
+/internal/datasources/loki/ @grafana/grafana-gcx @grafana/loki-team
+/internal/datasources/prometheus/ @grafana/grafana-gcx @grafana/cortex-team
+/internal/datasources/pyroscope/ @grafana/grafana-gcx @grafana/pyroscope-team
 /internal/datasources/tempo/ @grafana/grafana-gcx @grafana/tempo
+
+/internal/query/loki/ @grafana/grafana-gcx @grafana/loki-team
+/internal/query/prometheus/ @grafana/grafana-gcx @grafana/cortex-team
+/internal/query/pyroscope/ @grafana/grafana-gcx @grafana/pyroscope-team
 /internal/query/tempo/ @grafana/grafana-gcx @grafana/tempo
 
-/internal/providers/profiles/ @grafana/grafana-gcx @grafana/pyroscope-team
-/internal/datasources/pyroscope/ @grafana/grafana-gcx @grafana/pyroscope-team
-/internal/query/pyroscope/ @grafana/grafana-gcx @grafana/pyroscope-team
+/internal/assistant/ @grafana/grafana-gcx @grafana/grafana-assistant-loop
 
 /internal/auth/adaptive/ @grafana/grafana-gcx @grafana/adaptive-telemetry
-
-# Assistant / AI
-/internal/assistant/ @grafana/grafana-gcx @grafana/grafana-assistant-loop
-/cmd/gcx/assistant/ @grafana/grafana-gcx @grafana/grafana-assistant-loop

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,76 @@
-* @grafana/grafana-app-platform-squad
+# gcx CODEOWNERS
+#
+# Last matching pattern wins. The grafana-gcx team owns the entire codebase
+# as a platform team, and product teams co-own their provider directories.
+
+# Default: gcx platform team owns everything
+* @grafana/grafana-gcx
+
+# Provider: SLO
+/internal/providers/slo/ @grafana/grafana-gcx @grafana/slo-squad
+/cmd/gcx/providers/ @grafana/grafana-gcx
+
+# Provider: Synthetic Monitoring
+/internal/providers/synth/ @grafana/grafana-gcx @grafana/synthetic-monitoring-dev
+
+# Provider: IRM (OnCall + Incidents)
+/internal/providers/irm/ @grafana/grafana-gcx @grafana/grafana-irm-backend
+
+# Provider: k6
+/internal/providers/k6/ @grafana/grafana-gcx @grafana/k6-backend
+
+# Provider: Frontend Observability (Faro)
+/internal/providers/faro/ @grafana/grafana-gcx @grafana/kowalski
+
+# Provider: Fleet Management
+/internal/providers/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend
+/internal/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend
+
+# Provider: Instrumentation Hub
+/internal/providers/instrumentation/ @grafana/grafana-gcx @grafana/o11y-ingest
+/cmd/gcx/instrumentation/ @grafana/grafana-gcx @grafana/o11y-ingest
+
+# Provider: Knowledge Graph (Asserts)
+/internal/providers/kg/ @grafana/grafana-gcx @grafana/asserts-team
+
+# Provider: App Observability
+/internal/providers/appo11y/ @grafana/grafana-gcx @grafana/app-o11y-visualizations
+
+# Provider: AI Observability (Sigil)
+/internal/providers/aio11y/ @grafana/grafana-gcx @grafana/grafana-assistant-loop
+
+# Signal provider: Logs (Loki)
+/internal/providers/logs/ @grafana/grafana-gcx @grafana/loki-team
+/internal/datasources/loki/ @grafana/grafana-gcx @grafana/loki-team
+/internal/query/loki/ @grafana/grafana-gcx @grafana/loki-team
+
+# Signal provider: Metrics (Prometheus/Mimir)
+/internal/providers/metrics/ @grafana/grafana-gcx @grafana/cortex-team
+/internal/datasources/prometheus/ @grafana/grafana-gcx @grafana/cortex-team
+/internal/query/prometheus/ @grafana/grafana-gcx @grafana/cortex-team
+
+# Signal provider: Traces (Tempo)
+/internal/providers/traces/ @grafana/grafana-gcx @grafana/tempo
+/internal/datasources/tempo/ @grafana/grafana-gcx @grafana/tempo
+/internal/query/tempo/ @grafana/grafana-gcx @grafana/tempo
+
+# Signal provider: Profiles (Pyroscope)
+/internal/providers/profiles/ @grafana/grafana-gcx @grafana/pyroscope-team
+/internal/datasources/pyroscope/ @grafana/grafana-gcx @grafana/pyroscope-team
+/internal/query/pyroscope/ @grafana/grafana-gcx @grafana/pyroscope-team
+
+# Adaptive Telemetry (shared across signal providers)
+/internal/auth/adaptive/ @grafana/grafana-gcx @grafana/adaptive-telemetry
+
+# Assistant / AI
+/internal/assistant/ @grafana/grafana-gcx @grafana/grafana-assistant-loop
+/cmd/gcx/assistant/ @grafana/grafana-gcx @grafana/grafana-assistant-loop
+
+# Linter (Rego rules)
+/internal/linter/ @grafana/grafana-gcx
+
+# Documentation
+/docs/ @grafana/grafana-gcx
+
+# Claude plugin / agent skills
+/claude-plugin/ @grafana/grafana-gcx


### PR DESCRIPTION
## Summary

- Replace placeholder `@grafana/grafana-app-platform-squad` with `@grafana/grafana-gcx` as the default owner for all files
- Add product teams as co-owners for their provider, datasource, and query directories (SLO, Synthetic Monitoring, IRM, k6, Faro, Fleet, Instrumentation Hub, Knowledge Graph, App O11y, AI O11y, Logs, Metrics, Traces, Profiles, Adaptive Telemetry, Assistant)
- All teams verified to exist in the grafana GitHub org
- All paths verified to exist in the repo