### PR TITLE
fix(k6): correct non-existent command in token piping warning

### DIFF
--- a/internal/providers/k6/commands.go
+++ b/internal/providers/k6/commands.go
@@ -1213,7 +1213,7 @@ func newTokenCommand(loader CloudConfigLoader) *cobra.Command {
 				return err
 			}
 			if !terminal.IsPiped() {
-				fmt.Fprintln(cmd.ErrOrStderr(), "Warning: printing API token to terminal. Use `gcx k6 auth print-token | ...` in scripts.")
+				fmt.Fprintln(cmd.ErrOrStderr(), "Warning: printing API token to terminal. Use `gcx k6 auth token | ...` in scripts.")
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), client.Token())
 			return nil


### PR DESCRIPTION
closes https://github.com/grafana/gcx/issues/721

The `gcx k6 auth token` command warns about piping and suggests using `gcx k6 auth print-token`, which doesn't exist. Fixed to reference the actual command: `gcx k6 auth token`.

**Before**: `Use gcx k6 auth print-token | ... in scripts.`
**After**: `Use gcx k6 auth token | ... in scripts.`