### PR TITLE
refactor(release): mint homebrew tap App token via broker

### DIFF
--- a/.github/workflows/publish-homebrew-formula.yml
+++ b/.github/workflows/publish-homebrew-formula.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read           # checkout gcx at the tag
-      id-token: write          # required by get-vault-secrets OIDC exchange
+      id-token: write          # required by create-github-app-token broker OIDC exchange
 
     env:
       TAG: ${{ inputs.tag }}
@@ -125,29 +125,12 @@ jobs:
           echo "---"
           echo "rb_path=${GITHUB_WORKSPACE}/gcx.rb" >> "${GITHUB_OUTPUT}"
 
-      - name: Get App credentials from Vault
-        if: steps.tag.outputs.skip != 'true'
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
-        with:
-          vault_instance: ops
-          export_env: false
-          # Secret path names are stored in repository Actions variables
-          # (Settings → Variables) so they can be updated without a code
-          # change when the App is swapped for a dedicated gcx-scoped App.
-          repo_secrets: |
-            GITHUB_APP_ID=${{ vars.VAULT_APP_ID_PATH }}
-            GITHUB_APP_PRIVATE_KEY=${{ vars.VAULT_APP_PRIVATE_KEY_PATH }}
-
       - name: Mint App installation token
         if: steps.tag.outputs.skip != 'true'
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          owner: grafana
-          repositories: homebrew-grafana
+          github_app: ${{ vars.PUBLISHER_APP_NAME }}
 
       - name: Open tap pull request
         if: steps.tag.outputs.skip != 'true'


### PR DESCRIPTION
## What

Replaces the two-step `get-vault-secrets` + `actions/create-github-app-token@v3.1.1` pair in `.github/workflows/publish-homebrew-formula.yml` with a single `grafana/shared-workflows/actions/create-github-app-token@v0.2.2` step. The GitHub App private key now stays inside the GitHub App Token Broker; the runner only ever sees the resulting installation token.

The App name is held in the repo Actions variable `PUBLISHER_APP_NAME` (currently `grafana-assistant-cli-publisher`) so it can be rotated without a code change. The variable's value MUST match the `app:` field in `grafana/deployment_tools/terraform/repositories/gcx/github-app-configs/config.yaml` — divergence will fail the token mint.

What stays unchanged on purpose:

- Step id remains `app-token`, so `${{ steps.app-token.outputs.token }}` in the downstream "Open tap pull request" step is byte-identical.
- Job-level `permissions:` remain `contents: read` + `id-token: write` (the broker action needs `id-token: write` for the OIDC handshake).
- The idempotency guard in "Open tap pull request" — byte-identical formula exits 0 without opening a duplicate PR.
- The workflow's triggers (`workflow_call` from `release.yaml`, `workflow_dispatch` for manual re-runs).

The legacy `vars.VAULT_APP_ID_PATH` and `vars.VAULT_APP_PRIVATE_KEY_PATH` Actions variables are **intentionally left in place** by this PR. They are orphaned by this change and will be deleted in a separate cleanup PR after `workflow_dispatch` validation passes on `main`. Keeping them present during the validation window means a revert is a single-line edit.

## Why

The legacy flow pulled the App private key into the runner's process env via Vault and signed the JWT locally. Any compromised step in the same job could exfiltrate it. The broker pattern keeps the private key in HashiCorp Vault on the broker side; the runner authenticates with its OIDC identity and receives only a scoped, short-lived installation token.

App identity (via `PUBLISHER_APP_NAME`), target repository (`homebrew-grafana`), and granted permissions (`contents: write`, `pull_requests: write`) are declared declaratively in `grafana/deployment_tools` rather than in tribal GitHub App console knowledge.

## How it was tested

- `GCX_AGENT_MODE=false mise run all` — lint (0 issues), build, tests, docs all green locally.
- The action SHA `ae92934a14a48b94494dbc06d74a81d47fe08a40` was resolved via `gh api /repos/grafana/shared-workflows/git/refs/tags/create-github-app-token/v0.2.2` and cross-checked against ~20 live `deployment_tools` workflows currently using the same pin.
- The broker config bound_claims target `sub: repo:grafana/gcx:*` and `workflow_ref: grafana/gcx/.github/workflows/publish-homebrew-formula.yml@refs/*`, matching this workflow exactly.

**Post-merge validation (gating the cleanup PR):** trigger `Publish Homebrew Formula` via `workflow_dispatch` on a past stable tag from `main`. Expected: the run reaches the idempotency guard and exits 0 without opening a duplicate PR on `grafana/homebrew-grafana`. If that fails, revert this PR (single-line workflow swap back to the legacy action); the Vault Actions variables are still present so the legacy path is immediately functional again.

## Related

- `grafana/deployment_tools#590637` — broker config declaring the policy this workflow now consumes (merged, Terraform applied).
- `actions/create-github-app-token` → `grafana/shared-workflows/actions/create-github-app-token` (broker variant maintained by `@grafana/platform-productivity`).

---
**Generated by Claude Code**