### PR TITLE
feat(aio11y): add guards subcommand for hook rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ internal/
 │   ├── metrics/    Metrics signal provider (Prometheus queries + Adaptive Metrics commands)
 │   ├── appo11y/    App Observability provider (overrides, settings — singleton resources)
 │   ├── profiles/   Profiles signal provider (Pyroscope queries + adaptive stub)
-│   ├── aio11y/     AI Observability provider (conversations, agents, generations, evaluators, rules, templates, scores, judge, saved-conversations, collections — via grafana-sigil-app plugin API)
+│   ├── aio11y/     AI Observability provider (conversations, agents, generations, evaluators, rules, hook-rules (guards), templates, scores, judge, saved-conversations, collections — via grafana-sigil-app plugin API)
 │   ├── slo/        SLO provider (definitions, reports)
 │   ├── synth/      Synthetic Monitoring provider (checks, probes)
 │   └── traces/     Traces signal provider (Tempo queries + Adaptive Traces commands)

--- a/docs/reference/cli/gcx_aio11y.md
+++ b/docs/reference/cli/gcx_aio11y.md
@@ -28,6 +28,7 @@ Manage Grafana AI Observability resources
 * [gcx aio11y conversations](gcx_aio11y_conversations.md)	 - Query AI Observability conversations.
 * [gcx aio11y evaluators](gcx_aio11y_evaluators.md)	 - Manage evaluator definitions (LLM judge, regex, heuristic).
 * [gcx aio11y generations](gcx_aio11y_generations.md)	 - Inspect individual LLM generations.
+* [gcx aio11y guards](gcx_aio11y_guards.md)	 - Manage synchronous policy guards (hook rules) that evaluate generations on the request path.
 * [gcx aio11y judge](gcx_aio11y_judge.md)	 - List LLM providers and models available for LLM-judge evaluators.
 * [gcx aio11y rules](gcx_aio11y_rules.md)	 - Manage rules that route generations to evaluators.
 * [gcx aio11y saved-conversations](gcx_aio11y_saved-conversations.md)	 - Bookmark live conversations as fixed inputs for evaluation runs.

--- a/docs/reference/cli/gcx_aio11y_guards.md
+++ b/docs/reference/cli/gcx_aio11y_guards.md
@@ -1,0 +1,38 @@
+## gcx aio11y guards
+
+Manage synchronous policy guards (hook rules) that evaluate generations on the request path.
+
+### Synopsis
+
+Guards (hook rules) are synchronous policies evaluated before or after each generation.
+They can deny, warn, or transform a generation based on evaluators, regex patterns, or blocked tool names.
+
+Unlike eval rules (gcx aio11y rules), guards run inline on the request path and short-circuit by default.
+
+### Options
+
+```
+  -h, --help   help for guards
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y](gcx_aio11y.md)	 - Manage Grafana AI Observability resources
+* [gcx aio11y guards create](gcx_aio11y_guards_create.md)	 - Create a hook rule (guard) from a file.
+* [gcx aio11y guards delete](gcx_aio11y_guards_delete.md)	 - Delete hook rules (guards).
+* [gcx aio11y guards get](gcx_aio11y_guards_get.md)	 - Get a single hook rule (guard).
+* [gcx aio11y guards list](gcx_aio11y_guards_list.md)	 - List hook rules (guards).
+* [gcx aio11y guards update](gcx_aio11y_guards_update.md)	 - Update a hook rule (guard) from a file. Full replace; omitted fields reset to defaults.
+

--- a/docs/reference/cli/gcx_aio11y_guards_create.md
+++ b/docs/reference/cli/gcx_aio11y_guards_create.md
@@ -1,0 +1,46 @@
+## gcx aio11y guards create
+
+Create a hook rule (guard) from a file.
+
+```
+gcx aio11y guards create [flags]
+```
+
+### Examples
+
+```
+  # Create a guard from a YAML file.
+  gcx aio11y guards create -f guard.yaml
+
+  # Create from stdin.
+  gcx aio11y guards create -f -
+
+  # Create and output as YAML.
+  gcx aio11y guards create -f guard.json -o yaml
+```
+
+### Options
+
+```
+  -f, --filename string   File containing the hook rule definition (use - for stdin)
+  -h, --help              help for create
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y guards](gcx_aio11y_guards.md)	 - Manage synchronous policy guards (hook rules) that evaluate generations on the request path.
+

--- a/docs/reference/cli/gcx_aio11y_guards_delete.md
+++ b/docs/reference/cli/gcx_aio11y_guards_delete.md
@@ -1,0 +1,31 @@
+## gcx aio11y guards delete
+
+Delete hook rules (guards).
+
+```
+gcx aio11y guards delete ID... [flags]
+```
+
+### Options
+
+```
+      --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y guards](gcx_aio11y_guards.md)	 - Manage synchronous policy guards (hook rules) that evaluate generations on the request path.
+

--- a/docs/reference/cli/gcx_aio11y_guards_get.md
+++ b/docs/reference/cli/gcx_aio11y_guards_get.md
@@ -1,0 +1,32 @@
+## gcx aio11y guards get
+
+Get a single hook rule (guard).
+
+```
+gcx aio11y guards get <rule-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y guards](gcx_aio11y_guards.md)	 - Manage synchronous policy guards (hook rules) that evaluate generations on the request path.
+

--- a/docs/reference/cli/gcx_aio11y_guards_list.md
+++ b/docs/reference/cli/gcx_aio11y_guards_list.md
@@ -1,0 +1,33 @@
+## gcx aio11y guards list
+
+List hook rules (guards).
+
+```
+gcx aio11y guards list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of hook rules to return (0 for no limit) (default 50)
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y guards](gcx_aio11y_guards.md)	 - Manage synchronous policy guards (hook rules) that evaluate generations on the request path.
+

--- a/docs/reference/cli/gcx_aio11y_guards_update.md
+++ b/docs/reference/cli/gcx_aio11y_guards_update.md
@@ -1,0 +1,40 @@
+## gcx aio11y guards update
+
+Update a hook rule (guard) from a file. Full replace; omitted fields reset to defaults.
+
+```
+gcx aio11y guards update <rule-id> [flags]
+```
+
+### Examples
+
+```
+  # Update a guard from a YAML file.
+  gcx aio11y guards update my-guard -f guard.yaml
+```
+
+### Options
+
+```
+  -f, --filename string   File containing the full hook rule definition (use - for stdin)
+  -h, --help              help for update
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y guards](gcx_aio11y_guards.md)	 - Manage synchronous policy guards (hook rules) that evaluate generations on the request path.
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -400,6 +400,12 @@ var commandAnnotations = map[string]annotation{
 
 	"gcx aio11y generations get": {Cost: "medium", Hint: "<generation-id> -o json"},
 
+	"gcx aio11y guards create": {Cost: "small"},
+	"gcx aio11y guards delete": {Cost: "small"},
+	"gcx aio11y guards get":    {Cost: "small"},
+	"gcx aio11y guards list":   {Cost: "small"},
+	"gcx aio11y guards update": {Cost: "small"},
+
 	"gcx aio11y judge models":    {Cost: "small"},
 	"gcx aio11y judge providers": {Cost: "small"},
 

--- a/internal/providers/aio11y/eval/guards/client.go
+++ b/internal/providers/aio11y/eval/guards/client.go
@@ -1,0 +1,126 @@
+package guards
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval"
+	"github.com/grafana/gcx/internal/resources/adapter"
+)
+
+const (
+	basePath        = "/eval/hook-rules"
+	hookRuleByIDFmt = basePath + "/%s"
+)
+
+// ErrNotFound wraps adapter.ErrNotFound so resource push can create missing hook rules.
+var ErrNotFound = fmt.Errorf("hook rule: %w", adapter.ErrNotFound)
+
+// Client is an HTTP client for AI Observability hook-rule (guard) endpoints.
+type Client struct {
+	base *aio11yhttp.Client
+}
+
+// NewClient creates a new guards client.
+func NewClient(base *aio11yhttp.Client) *Client {
+	return &Client{base: base}
+}
+
+// List returns all hook rules (paginated).
+func (c *Client) List(ctx context.Context) ([]eval.HookRuleDefinition, error) {
+	return aio11yhttp.ListAll[eval.HookRuleDefinition](ctx, c.base, basePath, nil)
+}
+
+// Get returns a single hook rule by ID.
+func (c *Client) Get(ctx context.Context, id string) (*eval.HookRuleDefinition, error) {
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(hookRuleByIDFmt, url.PathEscape(id)), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hook rule %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("hook rule %s: %w", id, ErrNotFound)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, aio11yhttp.HandleErrorResponse(resp)
+	}
+
+	var rule eval.HookRuleDefinition
+	if err := json.NewDecoder(resp.Body).Decode(&rule); err != nil {
+		return nil, fmt.Errorf("failed to decode hook rule response: %w", err)
+	}
+	return &rule, nil
+}
+
+// Create creates a new hook rule.
+func (c *Client) Create(ctx context.Context, rule *eval.HookRuleDefinition) (*eval.HookRuleDefinition, error) {
+	body, err := json.Marshal(rule)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal hook rule: %w", err)
+	}
+
+	resp, err := c.base.DoRequest(ctx, http.MethodPost, basePath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create hook rule: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, aio11yhttp.HandleErrorResponse(resp)
+	}
+
+	var created eval.HookRuleDefinition
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		return nil, fmt.Errorf("failed to decode hook rule response: %w", err)
+	}
+	return &created, nil
+}
+
+// Update replaces a hook rule with the full definition. The hook-rules API
+// does not support PATCH; omitted fields reset to server defaults, so callers
+// must send the complete state.
+func (c *Client) Update(ctx context.Context, id string, rule *eval.HookRuleDefinition) (*eval.HookRuleDefinition, error) {
+	body, err := json.Marshal(rule)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal hook rule: %w", err)
+	}
+
+	resp, err := c.base.DoRequest(ctx, http.MethodPut, fmt.Sprintf(hookRuleByIDFmt, url.PathEscape(id)), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to update hook rule: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, aio11yhttp.HandleErrorResponse(resp)
+	}
+
+	var updated eval.HookRuleDefinition
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		return nil, fmt.Errorf("failed to decode hook rule response: %w", err)
+	}
+	return &updated, nil
+}
+
+// Delete deletes a hook rule by ID.
+//
+// Sigil returns 204 No Content on success; 200 is also accepted for forward
+// compatibility.
+func (c *Client) Delete(ctx context.Context, id string) error {
+	resp, err := c.base.DoRequest(ctx, http.MethodDelete, fmt.Sprintf(hookRuleByIDFmt, url.PathEscape(id)), nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete hook rule %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return aio11yhttp.HandleErrorResponse(resp)
+	}
+	return nil
+}

--- a/internal/providers/aio11y/eval/guards/client_test.go
+++ b/internal/providers/aio11y/eval/guards/client_test.go
@@ -1,0 +1,204 @@
+package guards_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/guards"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func writeJSON(w http.ResponseWriter, v any) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func newTestClient(t *testing.T, handler http.Handler) *guards.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: srv.URL},
+		Namespace: "default",
+	}
+	base, err := aio11yhttp.NewClient(cfg)
+	require.NoError(t, err)
+	return guards.NewClient(base)
+}
+
+func TestClient_List(t *testing.T) {
+	// Two-page list: first response returns a next_cursor, second response is empty.
+	pageCalls := 0
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/hook-rules")
+
+		w.Header().Set("Content-Type", "application/json")
+		pageCalls++
+		if pageCalls == 1 {
+			writeJSON(w, map[string]any{
+				"items": []eval.HookRuleDefinition{
+					{RuleID: "guard-1", Enabled: true, Phase: "preflight", Selector: "all", ActionOnFail: "deny", ShortCircuit: true, EvaluatorIDs: []string{"eval-1"}},
+				},
+				"next_cursor": "next-cursor-value",
+			})
+			return
+		}
+		// Subsequent pages: no items, no cursor → list terminates.
+		writeJSON(w, map[string]any{
+			"items": []eval.HookRuleDefinition{
+				{RuleID: "guard-2", Enabled: false, Phase: "postflight", Selector: "user_visible_turn", ActionOnFail: "warn"},
+			},
+		})
+	}))
+
+	items, err := client.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, "guard-1", items[0].RuleID)
+	assert.True(t, items[0].Enabled)
+	assert.Equal(t, "preflight", items[0].Phase)
+	assert.Equal(t, "deny", items[0].ActionOnFail)
+	assert.Equal(t, "guard-2", items[1].RuleID)
+	assert.False(t, items[1].Enabled)
+	assert.Equal(t, 2, pageCalls, "expected pagination across two pages")
+}
+
+func TestClient_Get(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/hook-rules/guard-1")
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, eval.HookRuleDefinition{
+			RuleID:       "guard-1",
+			Enabled:      true,
+			Phase:        "preflight",
+			Priority:     5,
+			Selector:     "all",
+			ActionOnFail: "deny",
+			ShortCircuit: true,
+			EvaluatorIDs: []string{"eval-1", "eval-2"},
+		})
+	}))
+
+	r, err := client.Get(context.Background(), "guard-1")
+	require.NoError(t, err)
+	assert.Equal(t, "guard-1", r.RuleID)
+	assert.Equal(t, "preflight", r.Phase)
+	assert.Equal(t, 5, r.Priority)
+	assert.Len(t, r.EvaluatorIDs, 2)
+}
+
+func TestClient_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+
+	_, err := client.Get(context.Background(), "nonexistent")
+	require.Error(t, err)
+	require.ErrorIs(t, err, guards.ErrNotFound)
+	require.ErrorIs(t, err, adapter.ErrNotFound)
+}
+
+func TestClient_Create(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/hook-rules")
+
+		var def eval.HookRuleDefinition
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&def))
+		assert.Equal(t, "new-guard", def.RuleID)
+
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(w, eval.HookRuleDefinition{
+			RuleID:       "new-guard",
+			Enabled:      true,
+			Phase:        "preflight",
+			Selector:     "all",
+			ActionOnFail: "warn",
+			ShortCircuit: true,
+			EvaluatorIDs: []string{"eval-1"},
+		})
+	}))
+
+	created, err := client.Create(context.Background(), &eval.HookRuleDefinition{
+		RuleID:       "new-guard",
+		Enabled:      true,
+		Phase:        "preflight",
+		Selector:     "all",
+		ActionOnFail: "warn",
+		ShortCircuit: true,
+		EvaluatorIDs: []string{"eval-1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "new-guard", created.RuleID)
+	assert.True(t, created.Enabled)
+}
+
+func TestClient_Update_UsesPUT(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "hook-rules Update must be PUT (full replace), not PATCH")
+		assert.Contains(t, r.URL.Path, "/eval/hook-rules/guard-1")
+
+		var def eval.HookRuleDefinition
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&def))
+		assert.Equal(t, "warn", def.ActionOnFail)
+
+		writeJSON(w, eval.HookRuleDefinition{
+			RuleID:       "guard-1",
+			ActionOnFail: "warn",
+		})
+	}))
+
+	updated, err := client.Update(context.Background(), "guard-1", &eval.HookRuleDefinition{
+		RuleID:       "guard-1",
+		ActionOnFail: "warn",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "guard-1", updated.RuleID)
+	assert.Equal(t, "warn", updated.ActionOnFail)
+}
+
+func TestClient_Update_AcceptsCreated(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(w, eval.HookRuleDefinition{RuleID: "guard-1"})
+	}))
+
+	updated, err := client.Update(context.Background(), "guard-1", &eval.HookRuleDefinition{RuleID: "guard-1"})
+	require.NoError(t, err)
+	assert.Equal(t, "guard-1", updated.RuleID)
+}
+
+func TestClient_Delete_NoContent(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/hook-rules/guard-1")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	err := client.Delete(context.Background(), "guard-1")
+	require.NoError(t, err)
+}
+
+func TestClient_Delete_OK(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	err := client.Delete(context.Background(), "guard-1")
+	require.NoError(t, err)
+}

--- a/internal/providers/aio11y/eval/guards/commands.go
+++ b/internal/providers/aio11y/eval/guards/commands.go
@@ -1,0 +1,404 @@
+package guards
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Commands returns the guards command group.
+func Commands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "guards",
+		Short: "Manage synchronous policy guards (hook rules) that evaluate generations on the request path.",
+		Long: `Guards (hook rules) are synchronous policies evaluated before or after each generation.
+They can deny, warn, or transform a generation based on evaluators, regex patterns, or blocked tool names.
+
+Unlike eval rules (gcx aio11y rules), guards run inline on the request path and short-circuit by default.`,
+	}
+	cmd.AddCommand(
+		newListCommand(),
+		newGetCommand(),
+		newCreateCommand(),
+		newUpdateCommand(),
+		newDeleteCommand(),
+	)
+	return cmd
+}
+
+// --- list ---
+
+type listOpts struct {
+	IO    cmdio.Options
+	Limit int64
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &TableCodec{})
+	o.IO.RegisterCustomCodec("wide", &TableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of hook rules to return (0 for no limit)")
+}
+
+func newListCommand() *cobra.Command {
+	opts := &listOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List hook rules (guards).",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, namespace, err := NewTypedCRUD(ctx)
+			if err != nil {
+				return err
+			}
+
+			typedObjs, err := crud.List(ctx, opts.Limit)
+			if err != nil {
+				return err
+			}
+
+			specs := make([]eval.HookRuleDefinition, len(typedObjs))
+			for i := range typedObjs {
+				specs[i] = typedObjs[i].Spec
+			}
+
+			if opts.IO.OutputFormat == "table" || opts.IO.OutputFormat == "wide" {
+				return opts.IO.Encode(cmd.OutOrStdout(), specs)
+			}
+
+			objs := make([]unstructured.Unstructured, 0, len(specs))
+			for _, spec := range specs {
+				u, err := specToUnstructured(spec, namespace)
+				if err != nil {
+					return err
+				}
+				objs = append(objs, u)
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), objs)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- get ---
+
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("yaml")
+	o.IO.BindFlags(flags)
+}
+
+func newGetCommand() *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:   "get <rule-id>",
+		Short: "Get a single hook rule (guard).",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, namespace, err := NewTypedCRUD(ctx)
+			if err != nil {
+				return err
+			}
+
+			typedObj, err := crud.Get(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			u, err := specToUnstructured(typedObj.Spec, namespace)
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), &u)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- create ---
+
+type createOpts struct {
+	File string
+	IO   cmdio.Options
+}
+
+func (o *createOpts) setup(flags *pflag.FlagSet) {
+	flags.StringVarP(&o.File, "filename", "f", "", "File containing the hook rule definition (use - for stdin)")
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+}
+
+func (o *createOpts) Validate() error {
+	if o.File == "" {
+		return errors.New("--filename/-f is required")
+	}
+	return o.IO.Validate()
+}
+
+func newCreateCommand() *cobra.Command {
+	opts := &createOpts{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a hook rule (guard) from a file.",
+		Example: `  # Create a guard from a YAML file.
+  gcx aio11y guards create -f guard.yaml
+
+  # Create from stdin.
+  gcx aio11y guards create -f -
+
+  # Create and output as YAML.
+  gcx aio11y guards create -f guard.json -o yaml`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			rule, err := ReadHookRuleFile(opts.File, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx)
+			if err != nil {
+				return err
+			}
+
+			typedObj := &adapter.TypedObject[eval.HookRuleDefinition]{Spec: *rule}
+			created, err := crud.Create(ctx, typedObj)
+			if err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.ErrOrStderr(), "Guard %s created", created.Spec.RuleID)
+			return opts.IO.Encode(cmd.OutOrStdout(), created.Spec)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- update ---
+
+type updateOpts struct {
+	File string
+	IO   cmdio.Options
+}
+
+func (o *updateOpts) setup(flags *pflag.FlagSet) {
+	flags.StringVarP(&o.File, "filename", "f", "", "File containing the full hook rule definition (use - for stdin)")
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+}
+
+func (o *updateOpts) Validate() error {
+	if o.File == "" {
+		return errors.New("--filename/-f is required")
+	}
+	return o.IO.Validate()
+}
+
+func newUpdateCommand() *cobra.Command {
+	opts := &updateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update <rule-id>",
+		Short: "Update a hook rule (guard) from a file. Full replace; omitted fields reset to defaults.",
+		Example: `  # Update a guard from a YAML file.
+  gcx aio11y guards update my-guard -f guard.yaml`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			rule, err := ReadHookRuleFile(opts.File, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx)
+			if err != nil {
+				return err
+			}
+
+			typedObj := &adapter.TypedObject[eval.HookRuleDefinition]{Spec: *rule}
+			updated, err := crud.Update(ctx, args[0], typedObj)
+			if err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.ErrOrStderr(), "Guard %s updated", updated.Spec.RuleID)
+			return opts.IO.Encode(cmd.OutOrStdout(), updated.Spec)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- delete ---
+
+type deleteOpts struct {
+	Force bool
+}
+
+func (o *deleteOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
+}
+
+func newDeleteCommand() *cobra.Command {
+	opts := &deleteOpts{}
+	cmd := &cobra.Command{
+		Use:   "delete ID...",
+		Short: "Delete hook rules (guards).",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.ErrOrStderr(), opts.Force,
+				fmt.Sprintf("Delete %d guard(s)?", len(args)))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx)
+			if err != nil {
+				return err
+			}
+
+			for _, id := range args {
+				if err := crud.Delete(ctx, id); err != nil {
+					return fmt.Errorf("deleting hook rule %s: %w", id, err)
+				}
+				cmdio.Success(cmd.ErrOrStderr(), "Deleted guard %s", id)
+			}
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func ReadFile(path string, stdin io.Reader) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(stdin)
+	}
+	return os.ReadFile(path)
+}
+
+func ReadHookRuleFile(path string, stdin io.Reader) (*eval.HookRuleDefinition, error) {
+	data, err := ReadFile(path, stdin)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var def eval.HookRuleDefinition
+	if err := json.Unmarshal(data, &def); err != nil {
+		var yamlDef eval.HookRuleDefinition
+		if yamlErr := yaml.Unmarshal(data, &yamlDef); yamlErr != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, yamlErr)
+		}
+		return &yamlDef, nil
+	}
+	return &def, nil
+}
+
+// --- table codec ---
+
+type TableCodec struct {
+	Wide bool
+}
+
+func (c *TableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *TableCodec) Encode(w io.Writer, v any) error {
+	rules, ok := v.([]eval.HookRuleDefinition)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []HookRuleDefinition")
+	}
+
+	var t *style.TableBuilder
+	if c.Wide {
+		t = style.NewTable("ID", "ENABLED", "PHASE", "PRIORITY", "SELECTOR", "ACTION", "EVALUATORS", "TRANSFORM", "TOOL FILTER", "CREATED BY", "CREATED AT")
+	} else {
+		t = style.NewTable("ID", "ENABLED", "PHASE", "PRIORITY", "SELECTOR", "ACTION")
+	}
+
+	for _, r := range rules {
+		c.appendRow(t, r)
+	}
+	return t.Render(w)
+}
+
+func (c *TableCodec) appendRow(t *style.TableBuilder, r eval.HookRuleDefinition) {
+	enabled := "no"
+	if r.Enabled {
+		enabled = "yes"
+	}
+	priority := strconv.Itoa(r.Priority)
+
+	if !c.Wide {
+		t.Row(r.RuleID, enabled, r.Phase, priority, r.Selector, r.ActionOnFail)
+		return
+	}
+
+	evalIDs := strings.Join(r.EvaluatorIDs, ", ")
+	if evalIDs == "" {
+		evalIDs = "-"
+	}
+	transform := "no"
+	if r.Transform != nil && len(r.Transform.Patterns) > 0 {
+		transform = "yes"
+	}
+	toolFilter := "no"
+	if r.ToolFilter != nil && len(r.ToolFilter.BlockedNames) > 0 {
+		toolFilter = "yes"
+	}
+	createdBy := r.CreatedBy
+	if createdBy == "" {
+		createdBy = "-"
+	}
+	t.Row(r.RuleID, enabled, r.Phase, priority, r.Selector, r.ActionOnFail, evalIDs, transform, toolFilter, createdBy, aio11yhttp.FormatTime(r.CreatedAt))
+}
+
+func (c *TableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}

--- a/internal/providers/aio11y/eval/guards/commands_test.go
+++ b/internal/providers/aio11y/eval/guards/commands_test.go
@@ -1,0 +1,107 @@
+package guards_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/providers/aio11y/eval"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/guards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableCodec_Encode(t *testing.T) {
+	items := []eval.HookRuleDefinition{
+		{
+			RuleID:       "guard-1",
+			Enabled:      true,
+			Phase:        "preflight",
+			Priority:     10,
+			Selector:     "all",
+			ActionOnFail: "deny",
+			EvaluatorIDs: []string{"eval-1", "eval-2"},
+			Transform:    &eval.TransformConfig{Patterns: []eval.TransformPattern{{Regex: "secret", Replacement: "[redacted]"}}},
+			ToolFilter:   &eval.ToolFilterConfig{BlockedNames: []string{"bad-tool"}},
+			CreatedBy:    "admin",
+			CreatedAt:    time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			RuleID:       "guard-2",
+			Enabled:      false,
+			Phase:        "postflight",
+			Selector:     "user_visible_turn",
+			ActionOnFail: "warn",
+		},
+	}
+
+	tests := []struct {
+		name string
+		wide bool
+		want []string
+	}{
+		{
+			name: "table format",
+			wide: false,
+			want: []string{"ID", "ENABLED", "PHASE", "PRIORITY", "SELECTOR", "ACTION",
+				"guard-1", "yes", "preflight", "10", "all", "deny"},
+		},
+		{
+			name: "wide includes evaluators and transform",
+			wide: true,
+			want: []string{"EVALUATORS", "TRANSFORM", "TOOL FILTER", "CREATED BY", "CREATED AT",
+				"eval-1, eval-2", "yes", "admin", "2026-04-01 10:00"},
+		},
+		{
+			name: "disabled row shows no",
+			wide: false,
+			want: []string{"guard-2", "no", "postflight"},
+		},
+		{
+			name: "wide row without transform/filter shows no",
+			wide: true,
+			want: []string{"guard-2", "no", "-"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			codec := &guards.TableCodec{Wide: tc.wide}
+			var buf bytes.Buffer
+			require.NoError(t, codec.Encode(&buf, items))
+
+			output := buf.String()
+			for _, s := range tc.want {
+				assert.Contains(t, output, s)
+			}
+		})
+	}
+}
+
+func TestTableCodec_WrongType(t *testing.T) {
+	codec := &guards.TableCodec{}
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, "not-a-slice")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected []HookRuleDefinition")
+}
+
+func TestTableCodec_Format(t *testing.T) {
+	tests := []struct {
+		wide   bool
+		expect string
+	}{
+		{false, "table"},
+		{true, "wide"},
+	}
+	for _, tc := range tests {
+		codec := &guards.TableCodec{Wide: tc.wide}
+		assert.Equal(t, tc.expect, string(codec.Format()))
+	}
+}
+
+func TestTableCodec_DecodeUnsupported(t *testing.T) {
+	codec := &guards.TableCodec{}
+	err := codec.Decode(nil, nil)
+	require.Error(t, err)
+}

--- a/internal/providers/aio11y/eval/guards/read_test.go
+++ b/internal/providers/aio11y/eval/guards/read_test.go
@@ -1,0 +1,52 @@
+package guards_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/guards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_readHookRuleFile_YAMLErrorReported(t *testing.T) {
+	content := "rule_id: my-guard\nselector:\n  - invalid:\n  bad indent"
+	path := filepath.Join(t.TempDir(), "bad.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	_, err := guards.ReadHookRuleFile(path, nil)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "looking for beginning of value")
+}
+
+func Test_readHookRuleFile_ValidYAML(t *testing.T) {
+	content := `rule_id: my-guard
+enabled: true
+phase: preflight
+priority: 10
+selector: all
+action_on_fail: warn
+short_circuit: true
+evaluator_ids:
+  - eval-1
+transform:
+  patterns:
+    - regex: secret
+      replacement: "[REDACTED]"
+`
+	path := filepath.Join(t.TempDir(), "guard.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	def, err := guards.ReadHookRuleFile(path, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "my-guard", def.RuleID)
+	assert.True(t, def.Enabled)
+	assert.Equal(t, "preflight", def.Phase)
+	assert.Equal(t, 10, def.Priority)
+	assert.Equal(t, "warn", def.ActionOnFail)
+	assert.True(t, def.ShortCircuit)
+	require.NotNil(t, def.Transform)
+	require.Len(t, def.Transform.Patterns, 1)
+	assert.Equal(t, "secret", def.Transform.Patterns[0].Regex)
+}

--- a/internal/providers/aio11y/eval/guards/resource_adapter.go
+++ b/internal/providers/aio11y/eval/guards/resource_adapter.go
@@ -1,0 +1,115 @@
+package guards
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval"
+	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// StaticDescriptor returns the resource descriptor for AI Observability hook rules (guards).
+func StaticDescriptor() resources.Descriptor {
+	return resources.Descriptor{
+		GroupVersion: schema.GroupVersion{
+			Group:   "sigil.ext.grafana.app",
+			Version: "v1alpha1",
+		},
+		Kind:     "HookRule",
+		Singular: "hookrule",
+		Plural:   "hookrules",
+	}
+}
+
+// HookRuleSchema returns a JSON Schema for the HookRule resource type.
+func HookRuleSchema() json.RawMessage {
+	return adapter.SchemaFromType[eval.HookRuleDefinition](StaticDescriptor())
+}
+
+func hookRuleStripFields() []string {
+	return []string{
+		"rule_id", "tenant_id",
+		"created_by", "updated_by", "deleted_at", "created_at", "updated_at",
+	}
+}
+
+// NewTypedCRUD creates a TypedCRUD for AI Observability hook rules.
+func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.HookRuleDefinition], string, error) {
+	var loader providers.ConfigLoader
+
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to load REST config for AI Observability hook rules: %w", err)
+	}
+
+	base, err := aio11yhttp.NewClient(cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create AI Observability HTTP client: %w", err)
+	}
+	client := NewClient(base)
+
+	crud := &adapter.TypedCRUD[eval.HookRuleDefinition]{
+		ListFn: adapter.LimitedListFn(client.List),
+		GetFn: func(ctx context.Context, name string) (*eval.HookRuleDefinition, error) {
+			return client.Get(ctx, name)
+		},
+		CreateFn: func(ctx context.Context, item *eval.HookRuleDefinition) (*eval.HookRuleDefinition, error) {
+			return client.Create(ctx, item)
+		},
+		UpdateFn: func(ctx context.Context, name string, item *eval.HookRuleDefinition) (*eval.HookRuleDefinition, error) {
+			return client.Update(ctx, name, item)
+		},
+		DeleteFn:    client.Delete,
+		Namespace:   cfg.Namespace,
+		StripFields: hookRuleStripFields(),
+		Descriptor:  StaticDescriptor(),
+	}
+	return crud, cfg.Namespace, nil
+}
+
+// NewLazyFactory returns an adapter.Factory for AI Observability hook rules.
+func NewLazyFactory() adapter.Factory {
+	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
+		crud, _, err := NewTypedCRUD(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return crud.AsAdapter(), nil
+	}
+}
+
+// specToUnstructured converts a HookRuleDefinition to a K8s-style unstructured
+// envelope, stripping server-managed fields so JSON/YAML output matches the
+// resources pipeline.
+func specToUnstructured(item eval.HookRuleDefinition, namespace string) (unstructured.Unstructured, error) {
+	data, err := json.Marshal(item)
+	if err != nil {
+		return unstructured.Unstructured{}, fmt.Errorf("failed to marshal hook rule: %w", err)
+	}
+
+	var specMap map[string]any
+	if err := json.Unmarshal(data, &specMap); err != nil {
+		return unstructured.Unstructured{}, fmt.Errorf("failed to unmarshal hook rule spec: %w", err)
+	}
+
+	for _, f := range hookRuleStripFields() {
+		delete(specMap, f)
+	}
+
+	desc := StaticDescriptor()
+	return unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": desc.GroupVersion.String(),
+		"kind":       desc.Kind,
+		"metadata": map[string]any{
+			"name":      item.RuleID,
+			"namespace": namespace,
+		},
+		"spec": specMap,
+	}}, nil
+}

--- a/internal/providers/aio11y/eval/types.go
+++ b/internal/providers/aio11y/eval/types.go
@@ -72,6 +72,53 @@ func (r RuleDefinition) GetResourceName() string { return r.RuleID }
 // SetResourceName implements adapter.ResourceIdentity.
 func (r *RuleDefinition) SetResourceName(name string) { r.RuleID = name }
 
+//nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
+type HookRuleDefinition struct {
+	// User-provided fields (spec)
+	RuleID       string            `json:"rule_id"`
+	Enabled      bool              `json:"enabled"`
+	Phase        string            `json:"phase"` // preflight | postflight
+	Priority     int               `json:"priority"`
+	Selector     string            `json:"selector"` // user_visible_turn | all_assistant_generations | tool_call_steps | errored_generations | all
+	Match        map[string]any    `json:"match,omitempty"`
+	EvaluatorIDs []string          `json:"evaluator_ids,omitempty"`
+	ActionOnFail string            `json:"action_on_fail"` // deny | warn
+	ShortCircuit bool              `json:"short_circuit"`
+	ToolFilter   *ToolFilterConfig `json:"tool_filter,omitempty"`
+	Transform    *TransformConfig  `json:"transform,omitempty"`
+
+	// Server-generated fields (stripped on push)
+	TenantID  string     `json:"tenant_id,omitempty"`
+	CreatedBy string     `json:"created_by,omitempty"`
+	UpdatedBy string     `json:"updated_by,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
+	CreatedAt time.Time  `json:"created_at,omitzero"`
+	UpdatedAt time.Time  `json:"updated_at,omitzero"`
+}
+
+// GetResourceName implements adapter.ResourceNamer.
+func (r HookRuleDefinition) GetResourceName() string { return r.RuleID }
+
+// SetResourceName implements adapter.ResourceIdentity.
+func (r *HookRuleDefinition) SetResourceName(name string) { r.RuleID = name }
+
+// ToolFilterConfig blocks named tool calls from reaching the model.
+type ToolFilterConfig struct {
+	BlockedNames []string `json:"blocked_names"`
+}
+
+// TransformConfig rewrites generation content with regex-based patterns.
+type TransformConfig struct {
+	Patterns []TransformPattern `json:"patterns"`
+}
+
+// TransformPattern is a single regex/replacement pair applied by a transform.
+type TransformPattern struct {
+	ID          string `json:"id,omitempty"`
+	Regex       string `json:"regex"`
+	Replacement string `json:"replacement,omitempty"`
+}
+
 // TemplateDefinition is a list item from GET /eval/templates.
 type TemplateDefinition struct {
 	TemplateID    string     `json:"template_id"`

--- a/internal/providers/aio11y/eval/types_test.go
+++ b/internal/providers/aio11y/eval/types_test.go
@@ -30,6 +30,13 @@ func TestResourceIdentity(t *testing.T) {
 			initial:  "rule-1",
 			updated:  "rule-2",
 		},
+		{
+			name:     "HookRuleDefinition",
+			namer:    eval.HookRuleDefinition{RuleID: "hook-1"},
+			identity: &eval.HookRuleDefinition{RuleID: "hook-1"},
+			initial:  "hook-1",
+			updated:  "hook-2",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/providers/aio11y/integration_test.go
+++ b/internal/providers/aio11y/integration_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/conversations"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/evaluators"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/guards"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/rules"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/templates"
 	"github.com/stretchr/testify/assert"
@@ -137,6 +138,29 @@ func fakePluginMux() *http.ServeMux {
 				"items": []map[string]any{
 					{"rule_id": "rule-1", "enabled": true, "selector": "user_visible_turn",
 						"sample_rate": 1.0, "evaluator_ids": []string{"eval-1"}},
+				},
+			})
+		})
+
+	hookRulesCalls := 0
+	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/eval/hook-rules",
+		func(w http.ResponseWriter, _ *http.Request) {
+			hookRulesCalls++
+			if hookRulesCalls == 1 {
+				writeJSON(w, map[string]any{
+					"items": []map[string]any{
+						{"rule_id": "guard-1", "enabled": true, "phase": "preflight",
+							"priority": 10, "selector": "all", "action_on_fail": "deny",
+							"short_circuit": true, "evaluator_ids": []string{"eval-1"}},
+					},
+					"next_cursor": "next",
+				})
+				return
+			}
+			writeJSON(w, map[string]any{
+				"items": []map[string]any{
+					{"rule_id": "guard-2", "enabled": false, "phase": "postflight",
+						"selector": "user_visible_turn", "action_on_fail": "warn"},
 				},
 			})
 		})
@@ -321,6 +345,33 @@ func TestIntegration_RulesListToTable(t *testing.T) {
 	assert.Contains(t, output, "rule-1")
 	assert.Contains(t, output, "user_visible_turn")
 	assert.Contains(t, output, "eval-1")
+}
+
+func TestIntegration_GuardsListToTable(t *testing.T) {
+	base := newBase(t, fakePluginMux())
+	client := guards.NewClient(base)
+
+	items, err := client.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, items, 2, "pagination should pull both pages of hook rules")
+	assert.Equal(t, "guard-1", items[0].RuleID)
+	assert.Equal(t, "guard-2", items[1].RuleID)
+
+	var buf bytes.Buffer
+	codec := &guards.TableCodec{}
+	require.NoError(t, codec.Encode(&buf, items))
+
+	output := buf.String()
+	assert.Contains(t, output, "ID")
+	assert.Contains(t, output, "PHASE")
+	assert.Contains(t, output, "PRIORITY")
+	assert.Contains(t, output, "SELECTOR")
+	assert.Contains(t, output, "ACTION")
+	assert.Contains(t, output, "guard-1")
+	assert.Contains(t, output, "preflight")
+	assert.Contains(t, output, "deny")
+	assert.Contains(t, output, "guard-2")
+	assert.Contains(t, output, "warn")
 }
 
 func TestIntegration_EvalTestRunTest(t *testing.T) {

--- a/internal/providers/aio11y/provider.go
+++ b/internal/providers/aio11y/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/conversations"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/collections"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/evaluators"
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/guards"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/judge"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/rules"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/savedconversations"
@@ -72,6 +73,12 @@ func (p *AIO11yProvider) Commands() []*cobra.Command {
 		agent.AnnotationLLMHint:   `gcx aio11y rules list -o json; gcx aio11y rules get <id> -o yaml; gcx aio11y rules create -f rule.yaml -o json; gcx aio11y rules update <id> -f patch.yaml -o json; gcx aio11y rules delete <id> --force`,
 	}
 
+	guardsCmd := guards.Commands()
+	guardsCmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "low",
+		agent.AnnotationLLMHint:   `gcx aio11y guards list -o json; gcx aio11y guards get <id> -o yaml; gcx aio11y guards create -f guard.yaml -o json; gcx aio11y guards update <id> -f guard.yaml -o json; gcx aio11y guards delete <id> --force`,
+	}
+
 	templatesCmd := templates.Commands(loader)
 	templatesCmd.Annotations = map[string]string{
 		agent.AnnotationTokenCost: "low",
@@ -108,7 +115,7 @@ func (p *AIO11yProvider) Commands() []*cobra.Command {
 		agent.AnnotationLLMHint:   `gcx aio11y collections list -o json; gcx aio11y collections get <id> -o yaml; gcx aio11y collections create --name '...' -o json; gcx aio11y collections update <id> --name '...' -o json; gcx aio11y collections delete <id> --force; gcx aio11y collections conversations list <id> -o json; gcx aio11y collections conversations add <id> <saved-id>; gcx aio11y collections conversations remove <id> <saved-id>`,
 	}
 
-	aio11yCmd.AddCommand(convsCmd, agentsCmd, evaluatorsCmd, rulesCmd, templatesCmd, generationsCmd, scoresCmd, judgeCmd, savedConvsCmd, collectionsCmd)
+	aio11yCmd.AddCommand(convsCmd, agentsCmd, evaluatorsCmd, rulesCmd, guardsCmd, templatesCmd, generationsCmd, scoresCmd, judgeCmd, savedConvsCmd, collectionsCmd)
 
 	return []*cobra.Command{aio11yCmd}
 }
@@ -135,6 +142,7 @@ func (p *AIO11yProvider) ConfigKeys() []providers.ConfigKey {
 func (p *AIO11yProvider) TypedRegistrations() []adapter.Registration {
 	evalDesc := evaluators.StaticDescriptor()
 	ruleDesc := rules.StaticDescriptor()
+	guardDesc := guards.StaticDescriptor()
 	collectionDesc := collections.StaticDescriptor()
 
 	return []adapter.Registration{
@@ -151,6 +159,13 @@ func (p *AIO11yProvider) TypedRegistrations() []adapter.Registration {
 			GVK:         ruleDesc.GroupVersionKind(),
 			Schema:      rules.RuleSchema(),
 			URLTemplate: "/a/grafana-sigil-app/rules/{name}",
+		},
+		{
+			Factory:     guards.NewLazyFactory(),
+			Descriptor:  guardDesc,
+			GVK:         guardDesc.GroupVersionKind(),
+			Schema:      guards.HookRuleSchema(),
+			URLTemplate: "/a/grafana-sigil-app/guards/{name}",
 		},
 		{
 			Factory:     collections.NewLazyFactory(),

--- a/internal/providers/aio11y/provider_test.go
+++ b/internal/providers/aio11y/provider_test.go
@@ -28,7 +28,7 @@ func TestAIO11yProvider_Commands(t *testing.T) {
 	assert.Equal(t, "aio11y", aio11yCmd.Use)
 
 	subNames := commandNames(aio11yCmd)
-	for _, exp := range []string{"conversations", "agents", "evaluators", "rules"} {
+	for _, exp := range []string{"conversations", "agents", "evaluators", "rules", "guards"} {
 		assert.Contains(t, subNames, exp)
 	}
 


### PR DESCRIPTION
Adds a new command group under `gcx aio11y`: `guards`.

`gcx aio11y guards` manages [Grafana AI o11y Guards](https://grafana.com/docs/grafana-cloud/machine-learning/ai-observability/guides/guards/).

- `list`
- `get`
- `create`
- `update`
- `delete`

Examples:

```bash
gcx aio11y guards list
gcx aio11y guards get my-guard
gcx aio11y guards create -f guard.yaml
gcx aio11y guards update my-guard -f guard.yaml
gcx aio11y guards delete my-guard
```