### PR TITLE
docs: surface diagnose-entity-graph and document how skills get invoked

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,12 +281,6 @@ Install the bundle into `~/.agents/skills` with:
 gcx agent skills install --all
 ```
 
-Or install a single skill by name:
-
-```sh
-gcx agent skills install diagnose-entity-graph
-```
-
 If your installed skills drift from the bundle shipped in your current `gcx`
 version, `gcx` may show an interactive reminder suggesting:
 
@@ -299,19 +293,6 @@ To disable that reminder entirely, set:
 ```sh
 export GCX_NO_UPDATE_NOTIFIER=1
 ```
-
-### How to use a skill
-
-You do not name skills. Once installed, your agent loads each skill's
-`description` frontmatter at the start of a conversation and auto-invokes
-the matching SKILL.md when your phrasing matches its trigger words.
-
-For example, saying *"my entity graph looks empty"* or *"diagnose knowledge
-graph"* matches `diagnose-entity-graph` and pulls in its full step-by-step
-workflow — no need to know the skill name.
-
-If a skill doesn't trigger automatically, name it explicitly:
-*"use the diagnose-entity-graph skill"*.
 
 ## The Agentic Workflow
 

--- a/README.md
+++ b/README.md
@@ -245,8 +245,12 @@ gcx traces query '{.cluster="dev-us-central-0"}' --since 1h
 
 gcx ships a portable Agent Skills bundle for setup, dashboard GitOps,
 datasource exploration, alert investigation, structured debugging, SLO
-management, Synthetic Monitoring workflows, project scaffolding, resource
-generation and import, and end-to-end observability rollout.
+management, Synthetic Monitoring workflows, Knowledge Graph diagnosis,
+project scaffolding, resource generation and import, and end-to-end
+observability rollout.
+
+See the [full skill inventory](claude-plugin/README.md#skills) in the Claude
+plugin README.
 
 **For Claude Code**
 
@@ -263,9 +267,10 @@ For example: OpenAI Codex, OpenCode, and Pi. View the skills shipped in the bund
 
 ```sh
 gcx agent skills list
-18 skill(s) bundled with gcx
+20 skill(s) bundled with gcx
 
 SKILL                      INSTALLED    DESCRIPTION
+diagnose-entity-graph      no           Diagnose Knowledge Graph problems: missing entities, missing edges, ...
 explore-datasources        yes          Discover what datasources, metrics, labels, and log streams are available in a Grafana instance.
 gcx-observability          yes          (Experimental) End-to-end observability setup for Grafana Cloud.
 ....
@@ -274,6 +279,12 @@ gcx-observability          yes          (Experimental) End-to-end observability 
 Install the bundle into `~/.agents/skills` with:
 ```sh
 gcx agent skills install --all
+```
+
+Or install a single skill by name:
+
+```sh
+gcx agent skills install diagnose-entity-graph
 ```
 
 If your installed skills drift from the bundle shipped in your current `gcx`
@@ -288,6 +299,19 @@ To disable that reminder entirely, set:
 ```sh
 export GCX_NO_UPDATE_NOTIFIER=1
 ```
+
+### How to use a skill
+
+You do not name skills. Once installed, your agent loads each skill's
+`description` frontmatter at the start of a conversation and auto-invokes
+the matching SKILL.md when your phrasing matches its trigger words.
+
+For example, saying *"my entity graph looks empty"* or *"diagnose knowledge
+graph"* matches `diagnose-entity-graph` and pulls in its full step-by-step
+workflow — no need to know the skill name.
+
+If a skill doesn't trigger automatically, name it explicitly:
+*"use the diagnose-entity-graph skill"*.
 
 ## The Agentic Workflow
 

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -61,22 +61,9 @@ Do not add distributable gcx skills under repo-local `.agents/skills/`. Tools
 that follow the `.agents` convention treat that path as repo-context guidance
 for working on this repository, not as a globally installable skill bundle.
 
-### How skills get invoked
-
-You do not name skills. Describe the symptom or task in plain English and the
-agent matches your request against each skill's `description` frontmatter — the
-matching SKILL.md is loaded into context automatically.
-
-For example, saying *"my entity graph looks empty"* or *"no edges in entity
-graph"* matches the `diagnose-entity-graph` skill's trigger phrases and pulls
-in its full diagnostic workflow without you having to know the skill's name.
-
-If auto-trigger misses, you can always name a skill explicitly:
-*"use the diagnose-entity-graph skill"*. In Claude Code, skills packaged
-as plugins are also exposed as slash commands (e.g. `/setup-gcx`).
-
-The table below is the current inventory of the canonical portable skill
-bundle.
+Skills are triggered automatically when you describe what you want. You do not
+need to invoke them by name. The table below is the current inventory of the
+canonical portable skill bundle.
 
 | Skill | Purpose |
 |-------|---------|

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -61,9 +61,22 @@ Do not add distributable gcx skills under repo-local `.agents/skills/`. Tools
 that follow the `.agents` convention treat that path as repo-context guidance
 for working on this repository, not as a globally installable skill bundle.
 
-Skills are triggered automatically when you describe what you want. You do not
-need to invoke them by name. The table below is the current inventory of the
-canonical portable skill bundle.
+### How skills get invoked
+
+You do not name skills. Describe the symptom or task in plain English and the
+agent matches your request against each skill's `description` frontmatter — the
+matching SKILL.md is loaded into context automatically.
+
+For example, saying *"my entity graph looks empty"* or *"no edges in entity
+graph"* matches the `diagnose-entity-graph` skill's trigger phrases and pulls
+in its full diagnostic workflow without you having to know the skill's name.
+
+If auto-trigger misses, you can always name a skill explicitly:
+*"use the diagnose-entity-graph skill"*. In Claude Code, skills packaged
+as plugins are also exposed as slash commands (e.g. `/setup-gcx`).
+
+The table below is the current inventory of the canonical portable skill
+bundle.
 
 | Skill | Purpose |
 |-------|---------|
@@ -76,6 +89,7 @@ canonical portable skill bundle.
 | `explore-datasources` | Discover datasources, metrics, labels, and log streams |
 | `investigate-alert` | Investigate why a Grafana alert is firing and what it impacts |
 | `debug-with-grafana` | Run a structured diagnostic workflow across metrics, logs, and dashboards |
+| `diagnose-entity-graph` | Diagnose Knowledge Graph problems: missing entities, missing edges, broken trace context propagation, service-name collisions |
 | `slo-check-status` | Check SLO health and summarize current status |
 | `slo-investigate` | Diagnose why a specific SLO is breaching or alerting |
 | `slo-manage` | Create, update, pull, push, and delete SLO definitions |


### PR DESCRIPTION
## Summary

Closes a documentation gap around the `diagnose-entity-graph` skill (added
recently, but not yet listed in either README) and adds a short
"how to use a skill" section that answers a common new-user question:
*do I have to prompt my agent in a special way to invoke a skill?*

## Changes

### `claude-plugin/README.md`

- Add `diagnose-entity-graph` row to the Skills table.
- Promote the one-line "skills are triggered automatically" note into a
  proper **How skills get invoked** subsection covering:
  - Describe symptoms in plain English — don't name skills.
  - Explicit-name escape hatch when auto-trigger misses.
  - Claude Code's slash-command exposure for installed plugins.

### `README.md` (main)

- Mention "Knowledge Graph diagnosis" in the bundle overview blurb.
- Link to the full skill inventory in `claude-plugin/README.md` rather
  than duplicating the table.
- Fix the stale `18 skill(s)` example output → `20 skill(s)` and add
  `diagnose-entity-graph` to the example listing.
- Add a single-skill install example
  (`gcx agent skills install diagnose-entity-graph`).
- Add a parallel **How to use a skill** subsection.

## What's not in this PR

- No SKILL.md content changes (those live in #726).
- No `gcx kg diagnose` code changes (those live in #727).
- No new skills.

## Validation

- `go run ./scripts/validate-skills` → `validated claude-plugin/skills`
- No skill metadata, frontmatter, or structure changes — pure README prose.
