### PR TITLE
feat(kg): expand kg diagnose coverage + new manage-known-errors skill

### DIFF
--- a/claude-plugin/skills/diagnose-entity-graph/SKILL.md
+++ b/claude-plugin/skills/diagnose-entity-graph/SKILL.md
@@ -236,7 +236,22 @@ drift, or another label-pipeline issue).
 
 ## Step 7: Per-Service Investigation
 
-For a specific missing or edge-less service:
+Before investigating *why* a service is broken, confirm it exists.
+If a user names an entity that doesn't appear in the graph at all,
+that is itself the finding — report it directly, don't fabricate a
+diagnosis. Cross-type search if the type is uncertain:
+
+```bash
+gcx kg entities list --property name=~SERVICE
+```
+
+If `entities list` returns no results across any type and
+`traces_target_info{service_name="SERVICE"}` is also empty, the
+entity is not on this stack. State that conclusion plainly; the
+correct next question is whether the user meant a different stack,
+env, or spelling.
+
+For a service that *does* exist but appears missing or edge-less:
 
 ```bash
 # Find in graph

--- a/claude-plugin/skills/diagnose-entity-graph/SKILL.md
+++ b/claude-plugin/skills/diagnose-entity-graph/SKILL.md
@@ -210,6 +210,19 @@ Extra `asserts_env` values (like AWS account IDs) that don't match any
 
 **Shortcut:** `gcx kg diagnose labels` automates this cross-reference.
 
+### The `image` label is also load-bearing
+
+When `gcx kg diagnose` emits a **`Container label drift: WARN`**
+check, cAdvisor `container_*` metrics in the named namespace are
+arriving with `image=""`. The downstream `asserts:resource`
+recording rule for `cpu:usage` and `memory:usage` filters on
+`image!=""` to exclude pause containers, so dropping the `image`
+label silently empties the Asserts UI's Kubernetes / CPU / Memory
+tabs for that namespace. The check's `Recommendation` field names
+the typical source (an Alloy `extraMetricProcessingRules` block
+with `labeldrop regex = "image.*"`, often added for cardinality
+reduction) and the fix.
+
 ## Step 7: Per-Service Investigation
 
 For a specific missing or edge-less service:

--- a/claude-plugin/skills/diagnose-entity-graph/SKILL.md
+++ b/claude-plugin/skills/diagnose-entity-graph/SKILL.md
@@ -180,8 +180,20 @@ Environment page as above.
 server-side with `asserts_env` already populated, bypassing the Mimir
 relabeling pipeline entirely.
 
-## Step 6: Label Pipeline
+### Service→Database edges: a special case
 
+Service→Database CALLS edges require the calling service to emit
+OpenTelemetry database-client spans (so Tempo's service graph
+processor can see `db.system` / `db.statement` / `db.operation` on
+outbound calls). HTTP auto-instrumentation alone is not enough —
+the language-specific DB instrumentation library must be installed
+and registered too.
+
+When `gcx kg diagnose` emits a **`DB instrumentation: WARN`** check
+(present when a Tempo datasource is available), no service on the
+stack is emitting DB-client spans. The check's `Recommendation`
+field names the relevant library per language and the Beyla
+ROUTES alternative; read it as the primary playbook.
 The most common issue: `deployment_environment` isn't mapped to `asserts_env`.
 
 ```bash

--- a/claude-plugin/skills/diagnose-entity-graph/SKILL.md
+++ b/claude-plugin/skills/diagnose-entity-graph/SKILL.md
@@ -243,13 +243,15 @@ drift, or another label-pipeline issue).
 Before investigating *why* a service is broken, confirm it exists.
 If a user names an entity that doesn't appear in the graph at all,
 that is itself the finding — report it directly, don't fabricate a
-diagnosis. Cross-type search if the type is uncertain:
+diagnosis. When the type is uncertain, use a cross-type Cypher
+query so the limit is enforced server-side rather than after a
+client-side fan-out:
 
 ```bash
-gcx kg entities list --property name=~SERVICE
+gcx kg entities query "MATCH (n) WHERE n.name CONTAINS 'SERVICE' RETURN n LIMIT 10" --since 1h
 ```
 
-If `entities list` returns no results across any type and
+If that query returns no results and
 `traces_target_info{service_name="SERVICE"}` is also empty, the
 entity is not on this stack. State that conclusion plainly; the
 correct next question is whether the user meant a different stack,
@@ -259,10 +261,10 @@ For a service that *does* exist but appears missing or edge-less:
 
 ```bash
 # Find in graph
-gcx kg cypher "MATCH (s:Service {name: \"SERVICE\"}) RETURN s" --since 1h
+gcx kg entities query "MATCH (s:Service {name: \"SERVICE\"}) RETURN s" --since 1h
 
 # Check relationships
-gcx kg cypher "MATCH (s:Service {name: \"SERVICE\"})-[r]-(other) RETURN s, r, other" --since 1h
+gcx kg entities query "MATCH (s:Service {name: \"SERVICE\"})-[r]-(other) RETURN s, r, other" --since 1h
 
 # Source metrics
 gcx metrics query 'count(traces_service_graph_request_total{client="SERVICE"})' --since 1h

--- a/claude-plugin/skills/diagnose-entity-graph/SKILL.md
+++ b/claude-plugin/skills/diagnose-entity-graph/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: diagnose-entity-graph
 description: >
-  Diagnose Entity Graph problems: missing entities, missing edges, disconnected
-  clusters, or filtering issues. Use when the user reports that Entity Graph
-  doesn't look right, services are missing, edges aren't appearing, or
-  environments can't be filtered. Triggers for: "entity graph is empty",
-  "services missing from entity graph", "no edges in entity graph",
+  Diagnose Entity Graph and Asserts UI problems: missing entities, missing
+  edges, disconnected clusters, filtering issues, and empty UI tabs
+  (Kubernetes, CPU, Memory). Use when the user reports that Entity Graph
+  doesn't look right, services are missing, edges aren't appearing,
+  environments can't be filtered, or specific Asserts panels are blank
+  despite the integration being installed. Triggers for: "entity graph is
+  empty", "services missing from entity graph", "no edges in entity graph",
   "disconnected services", "can't filter entity graph", "entity graph not
-  working", "diagnose entity graph", "debug knowledge graph".
+  working", "diagnose entity graph", "debug knowledge graph",
+  "Kubernetes tab is empty", "no CPU/memory data in Asserts",
+  "Memory tab shows nothing", "saturation chart is blank".
 ---
 
 # Diagnose Entity Graph

--- a/claude-plugin/skills/diagnose-entity-graph/SKILL.md
+++ b/claude-plugin/skills/diagnose-entity-graph/SKILL.md
@@ -194,6 +194,9 @@ When `gcx kg diagnose` emits a **`DB instrumentation: WARN`** check
 stack is emitting DB-client spans. The check's `Recommendation`
 field names the relevant library per language and the Beyla
 ROUTES alternative; read it as the primary playbook.
+
+## Step 6: Label Pipeline
+
 The most common issue: `deployment_environment` isn't mapped to `asserts_env`.
 
 ```bash
@@ -260,6 +263,16 @@ gcx metrics query 'count(asserts:mixin_workload_job{service="SERVICE"})' --since
 
 **Shortcut:** `gcx kg diagnose service SERVICE --env ENV` runs all checks and
 produces an interpreted diagnosis with suggested next steps.
+
+### Split-identity entities
+
+When `gcx kg diagnose` emits a **`Split identity: WARN`** check,
+one physical workload has been discovered as two distinct Service
+entities — the OTel `service.name` and the k8s workload name
+disagree. The OTel-named entity has no k8s metadata; the k8s-named
+entity has no trace data. The check's `Recommendation` names the
+fix path (align `OTEL_SERVICE_NAME` with the k8s deployment, or
+configure Asserts relabel rules to reconcile).
 
 ## Producing a Report
 

--- a/claude-plugin/skills/diagnose-entity-graph/SKILL.md
+++ b/claude-plugin/skills/diagnose-entity-graph/SKILL.md
@@ -223,6 +223,14 @@ the typical source (an Alloy `extraMetricProcessingRules` block
 with `labeldrop regex = "image.*"`, often added for cardinality
 reduction) and the fix.
 
+A complementary `Resource coverage` check runs alongside it: when
+the `asserts:resource` recording rule produces some types but is
+missing expected ones (e.g. has `cpu:throttle` but no `cpu:usage`),
+the K8s tab's CPU panel will be empty even though the underlying
+rule is partially working. The two checks together tell the user
+which UI tab is broken (Resource coverage) and why (Container label
+drift, or another label-pipeline issue).
+
 ## Step 7: Per-Service Investigation
 
 For a specific missing or edge-less service:

--- a/claude-plugin/skills/manage-known-errors/SKILL.md
+++ b/claude-plugin/skills/manage-known-errors/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: manage-known-errors
+description: >
+  Manage known, expected, or accepted Asserts insights — suppress them so
+  they stop firing, or raise their thresholds so they only fire above a
+  custom limit. Use when the user says an alert is "expected", "known",
+  "intentional", "supposed to fire", or "we know about that one";
+  when they ask to "silence", "suppress", "ignore", "ack", or "mute"
+  an Asserts insight; or when they say a service is "supposed to be slow"
+  or otherwise want to raise the bar on an assertion. Trigger phrases
+  include: "suppress this assertion", "silence this insight", "ignore
+  the X breach on Y", "set a custom threshold for X", "raise the
+  threshold for X", "this latency is expected", "this error is known".
+  For diagnosing why an insight fires in the first place, use
+  diagnose-entity-graph. For checking SLO health (a different system
+  altogether), use slo-check-status.
+allowed-tools: [gcx, Bash]
+---
+
+# Manage Known Asserts Errors
+
+Acknowledge known/expected Asserts insights so they stop creating noise.
+Two mechanisms, both shipped with gcx and both reversible.
+
+## Core Principles
+
+1. Use gcx commands exclusively — do not edit Grafana alert rules directly
+2. Confirm the insight is *intended* before silencing; if the user is
+   uncertain, route to `diagnose-entity-graph` first
+3. Use `-o yaml` to inspect a generated config before applying it
+4. Suppression and custom-threshold workflows are both reversible —
+   keep the resource name predictable so deletion is trivial later
+
+## Decision: Suppress vs. Custom Threshold
+
+| User intent | Mechanism |
+|---|---|
+| "This will always fire, ignore it forever" | **Suppression** — silences the insight regardless of value |
+| "It's fine up to X, only alert above X" | **Custom threshold** — keeps the assertion live but raises the bar |
+
+When in doubt, suppression is faster to apply, custom threshold is
+more honest about the system's behaviour. Both can be deleted later.
+
+## Workflow A: Suppress an insight
+
+Use when the user wants to silence the insight permanently regardless
+of its value.
+
+### Step 1 — Identify the insight
+
+Find the entity that's firing it and read the labels from the
+firing-alert record:
+
+```bash
+# Locate the entity (cross-type search if the user didn't name the type).
+gcx kg entities list --insight name=<InsightName> -o json --json name,scope,assertion
+
+# Inspect the entity to capture the alert labels.
+gcx kg entities inspect --type <Type> --name <Name> --env <Env> --namespace <NS> -o json
+```
+
+The `timeLines[].labels[]` field on the inspect response contains
+the labels used by the live alert: `alertname`, `job`,
+`asserts_request_context`, `asserts_request_type`, etc.
+
+### Step 2 — Build the suppression config
+
+`disabledAlertConfigs` is a list; each entry has a `name` (the
+suppression's own identifier) and a `matchLabels` map. Match as
+tightly as possible — over-broad suppression silences unrelated
+alerts:
+
+```yaml
+disabledAlertConfigs:
+  - name: known-<service>-<endpoint>-<assertion>
+    matchLabels:
+      alertname: <ErrorRatioBreach | LatencyAverageBreach | …>
+      job: <namespace/service>
+      asserts_request_context: <method-and-path-from-the-alert>
+```
+
+### Step 3 — Apply
+
+```bash
+gcx kg suppressions create -f suppressions.yaml
+```
+
+Or pipe inline:
+
+```bash
+echo 'disabledAlertConfigs:
+  - name: known-foo
+    matchLabels:
+      alertname: ErrorRatioBreach
+      job: namespace/service' | gcx kg suppressions create
+```
+
+### Step 4 — Verify
+
+```bash
+gcx kg suppressions list
+```
+
+The new entry should appear. Resolving the firing alert in Grafana
+takes one alert-evaluation cycle (~30 s by default).
+
+### Reverse
+
+```bash
+gcx kg suppressions delete <name>
+```
+
+## Workflow B: Custom threshold on an insight family
+
+Use when the user wants the assertion to remain live but only fire
+above a value they specify.
+
+Asserts assertion rules read a `<rule>:custom_threshold` recording
+rule before falling back to the automatic baseline. Pushing a
+recording rule with that name overrides the threshold for the
+matching `(env, service, job, request_context, ...)` tuple.
+
+### The naming convention
+
+Six standard custom-threshold rules exist on every Asserts stack:
+
+```
+asserts:error:ratio:custom_threshold
+asserts:request:rate:custom_threshold
+asserts:request:cardinality:custom_threshold
+asserts:latency:average:custom_threshold
+asserts:latency:p95:custom_threshold
+asserts:latency:p99:custom_threshold
+```
+
+Pick the one matching the assertion family the user wants to tune.
+Example: `LatencyP99ErrorBuildup` reads from
+`asserts:latency:p99:custom_threshold`.
+
+### Step 1 — Confirm the rule the assertion uses
+
+```bash
+# Find the firing alert's rule UID (from kg entities inspect, as above).
+gcx alert rules get <UID> -o yaml
+```
+
+Read the rule's `expr` field — it shows which `:custom_threshold`
+recording rule the alert checks against.
+
+### Step 2 — Draft the recording rule
+
+The standard pattern multiplies the source ratio/latency series by
+zero to preserve all labels, then adds the desired threshold:
+
+```yaml
+groups:
+  - name: custom-thresholds-<service>
+    rules:
+      - record: asserts:<family>:custom_threshold
+        expr: |
+          (
+            asserts:<family>{
+              asserts_env="<env>",
+              service="<service>",
+              namespace="<namespace>",
+              asserts_request_type="inbound",
+              asserts_request_context="<METHOD /path>",
+              asserts_source="<source-from-the-alert>"
+            } * 0
+          ) + <threshold-value>
+```
+
+For error-ratio assertions, the value is unitless (0–1 + slack —
+a value of `2` permanently suppresses since the ratio never exceeds 1).
+For latency assertions, the value is the threshold in the same units
+as the underlying recording rule (typically seconds for `*:average`,
+`*:p95`, `*:p99`).
+
+### Step 3 — Apply
+
+```bash
+gcx kg rules create -f custom-thresholds.yaml
+```
+
+### Step 4 — Verify
+
+```bash
+gcx kg rules list
+gcx metrics query 'asserts:<family>:custom_threshold{service="<service>"}' --since 5m
+```
+
+The custom-threshold series should appear with the value you set,
+and the alert should resolve within one evaluation cycle.
+
+### Reverse
+
+`gcx kg rules` is whole-payload — to remove just one custom
+threshold, re-push the rule group without it (or push an empty
+group).
+
+## Anti-pattern: do not "disable and replace" the base alert rule
+
+Some assistants will suggest editing or disabling the Asserts-managed
+base assertion rule. Do not. Those rules are plugin-managed and will
+be overwritten on the next Asserts plugin update — your edits are
+silent-loss-prone. The `:custom_threshold` mechanism above is the
+supported override path.
+
+## Output Format
+
+For both workflows:
+
+```
+Suppress | Custom threshold for: <InsightName> on <service> (<scope>)
+
+Generated config:
+  <yaml block>
+
+Applied: gcx kg <suppressions|rules> create
+Verification:
+  - <listing command output>
+  - <metrics query output>
+
+Reverse with: gcx kg <suppressions|rules> delete ...
+```
+
+Lead with what changed. Keep the YAML block in the output so the
+user can copy it into their GitOps repo if they want it tracked.
+
+## Error Handling
+
+| Error | Action |
+|---|---|
+| `kg suppressions create` — invalid YAML | Show the parse error; re-emit the YAML with the user's confirmation |
+| `kg suppressions list` — empty after create | The push silently no-op'd. Re-check the `-f` flag and YAML structure |
+| `kg rules create` — push succeeds but recording rule has no data | Selector likely doesn't match any live series. Verify with `gcx metrics query 'asserts:<family>{...}' --since 5m` using the same labels |
+| `kg entities inspect` — no `grafana_rule_uid` in labels | The insight isn't backed by a Grafana-managed rule. Suppression still works on the labels; custom threshold may not apply |
+| Auth errors | Check context: `gcx config view` |

--- a/internal/providers/kg/diagnose.go
+++ b/internal/providers/kg/diagnose.go
@@ -398,6 +398,20 @@ func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promCli
 			}
 			return nil
 		})
+
+		// Split-identity detection. The same physical workload can be
+		// discovered as two Service entities when OTel `service.name`
+		// disagrees with the k8s workload name — typically because the
+		// container env sets `OTEL_SERVICE_NAME` to something other
+		// than the deployment name. KG can't merge them; the
+		// OTel-named entity has no k8s metadata and the k8s-named
+		// entity has no trace data.
+		g.Go(func() error {
+			if c := checkSplitIdentity(ctx, promClient, datasourceUID, scope.env, scope.namespace); c != nil {
+				addCheck(*c)
+			}
+			return nil
+		})
 	}
 
 	// Trace-side coverage check (skip if no Tempo client). Detects whether
@@ -458,6 +472,9 @@ func checkOrder(name string) int {
 	}
 	if name == "Resource coverage" {
 		return 11
+	}
+	if name == "Split identity" {
+		return 12
 	}
 	return 50
 }
@@ -1162,6 +1179,114 @@ func checkResourceFamilyCoverage(ctx context.Context, client *prometheus.Client,
 			"For other missing types, verify the upstream raw metrics flow " +
 			"(container_cpu_*, container_memory_*, kubelet_volume_stats_*) and that the relabeling " +
 			"pipeline produces non-empty `asserts_env` for them.",
+	}
+}
+
+// checkSplitIdentity detects the case where one physical workload is
+// discovered as two distinct Service entities because OTel `service.name`
+// disagrees with the k8s workload name. KG can't merge them: the
+// OTel-named entity has no k8s metadata (`workload`, `cluster`,
+// `workload_type`), and the k8s-named entity has no trace data.
+//
+// Detection signal: `asserts:mixin_workload_job` is grouped by both
+// `job` (always the k8s `namespace/workload`) and `service` (always
+// the OTel `service.name`). When a single `job` maps to multiple
+// distinct `service` values, that's a collision.
+//
+// Returns nil when no collisions are detected, when the scope has no
+// `asserts:mixin_workload_job` series at all, or on transport error
+// (best-effort; earlier checks cover the empty case).
+func checkSplitIdentity(ctx context.Context, client *prometheus.Client, datasourceUID, env, namespace string) *CheckResult {
+	var parts []string
+	if env != "" {
+		parts = append(parts, fmt.Sprintf(`asserts_env="%s"`, env))
+	}
+	if namespace != "" {
+		parts = append(parts, fmt.Sprintf(`namespace="%s"`, namespace))
+	}
+	selector := ""
+	if len(parts) > 0 {
+		selector = "{" + strings.Join(parts, ", ") + "}"
+	}
+
+	query := fmt.Sprintf(
+		`group by (job, service) (asserts:mixin_workload_job%s)`, selector)
+	resp, err := client.Query(ctx, datasourceUID, prometheus.QueryRequest{Query: query})
+	if err != nil || len(resp.Data.Result) == 0 {
+		// No data → either no workloads in scope or earlier checks
+		// flagged the pipeline. Stay silent.
+		return nil
+	}
+
+	// Aggregate: for each `job`, collect the set of `service` values.
+	jobToServices := map[string]map[string]struct{}{}
+	for _, sample := range resp.Data.Result {
+		job := sample.Metric["job"]
+		svc := sample.Metric["service"]
+		if job == "" || svc == "" {
+			continue
+		}
+		if _, ok := jobToServices[job]; !ok {
+			jobToServices[job] = map[string]struct{}{}
+		}
+		jobToServices[job][svc] = struct{}{}
+	}
+
+	// Find jobs with more than one distinct service name.
+	type collision struct {
+		job      string
+		services []string
+	}
+	var collisions []collision
+	for job, services := range jobToServices {
+		if len(services) < 2 {
+			continue
+		}
+		names := make([]string, 0, len(services))
+		for s := range services {
+			names = append(names, s)
+		}
+		sort.Strings(names)
+		collisions = append(collisions, collision{job: job, services: names})
+	}
+
+	if len(collisions) == 0 {
+		return nil
+	}
+
+	// Stable output order for deterministic detail rendering.
+	sort.Slice(collisions, func(i, j int) bool {
+		return collisions[i].job < collisions[j].job
+	})
+
+	var bullets []string
+	for _, c := range collisions {
+		bullets = append(bullets, fmt.Sprintf("%s → %s", c.job, strings.Join(c.services, ", ")))
+	}
+
+	scopeLabel := "this stack"
+	switch {
+	case namespace != "" && env != "":
+		scopeLabel = fmt.Sprintf("namespace=%q (env=%q)", namespace, env)
+	case namespace != "":
+		scopeLabel = fmt.Sprintf("namespace=%q", namespace)
+	case env != "":
+		scopeLabel = fmt.Sprintf("env=%q", env)
+	}
+
+	return &CheckResult{
+		Name:   "Split identity",
+		Status: CheckWarn,
+		Detail: fmt.Sprintf(
+			"%d workload(s) in %s map to multiple Service entities: %s",
+			len(collisions), scopeLabel, strings.Join(bullets, "; ")),
+		Recommendation: "One physical workload is being discovered as two distinct Service entities " +
+			"because OTel `service.name` disagrees with the k8s workload name. The OTel-named entity " +
+			"has no k8s metadata and the k8s-named entity has no trace data — neither is fully usable. " +
+			"Usual cause: the container env sets `OTEL_SERVICE_NAME` (or `service.name` via " +
+			"`OTEL_RESOURCE_ATTRIBUTES`) to a value other than the deployment name. " +
+			"Fix: set `OTEL_SERVICE_NAME` to match the k8s workload, rename the workload to match, " +
+			"or configure Asserts relabel rules to reconcile the two.",
 	}
 }
 

--- a/internal/providers/kg/diagnose.go
+++ b/internal/providers/kg/diagnose.go
@@ -18,6 +18,7 @@ import (
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/query/tempo"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
@@ -116,8 +117,10 @@ auto-discovery. If unavailable, metric checks are skipped.`,
 
 			// Best-effort Prometheus client for metric checks.
 			promClient, datasourceUID := resolvePromClient(ctx, loader, cfg, opts.Datasource, cmd)
+			// Best-effort Tempo client for trace-side checks (e.g. db.* span coverage).
+			tempoClient, tempoDsUID := resolveTempoClient(ctx, loader, cfg, cmd)
 
-			result := runDiagnose(ctx, client, &opts.Scope, promClient, datasourceUID)
+			result := runDiagnose(ctx, client, &opts.Scope, promClient, datasourceUID, tempoClient, tempoDsUID)
 			return opts.IO.Encode(cmd.OutOrStdout(), result)
 		},
 	}
@@ -233,6 +236,11 @@ asserts_env values with no deployment_environment source.`,
 // (e.g., multiple Prometheus datasources exist and no stack slug is configured).
 const defaultPromDatasourceUID = "grafanacloud-prom"
 
+// defaultTempoDatasourceUID is the conventional datasource UID for the primary
+// Tempo datasource on Grafana Cloud stacks. Used for opportunistic trace-side
+// checks in `kg diagnose` (e.g. probing for db.* span attribute coverage).
+const defaultTempoDatasourceUID = "grafanacloud-traces"
+
 // resolvePromClient creates a Prometheus query client and resolves the
 // datasource UID. Falls back to "grafanacloud-prom" (the default Grafana Cloud
 // Prometheus datasource) when auto-discovery fails, since the Knowledge Graph
@@ -265,11 +273,45 @@ func resolvePromClient(ctx context.Context, loader *providers.ConfigLoader, cfg 
 	return promClient, dsUID
 }
 
+// resolveTempoClient creates a Tempo query client and resolves the
+// datasource UID. Falls back to "grafanacloud-traces" (the default Grafana
+// Cloud Tempo datasource) when auto-discovery fails. Returns (nil, "") when
+// no Tempo client can be constructed, so callers should treat any check
+// using this as best-effort and silently skip when unavailable.
+func resolveTempoClient(ctx context.Context, loader *providers.ConfigLoader, cfg config.NamespacedRESTConfig, cmd *cobra.Command) (*tempo.Client, string) {
+	var cfgCtx *config.Context
+	fullCfg, err := loader.LoadFullConfig(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Warn("could not load full config for tempo datasource resolution", slog.String("error", err.Error()))
+	} else {
+		cfgCtx = fullCfg.GetCurrentContext()
+	}
+
+	var dsUID string
+	resolved, err := dsquery.ResolveDatasource(ctx, "", cfgCtx, cfg, "tempo")
+	if err != nil {
+		// Fall back to the conventional Grafana Cloud UID. If the stack isn't
+		// Grafana Cloud or uses a non-default Tempo, the check will simply
+		// error at query time and be classified as best-effort skipped.
+		dsUID = defaultTempoDatasourceUID
+	} else {
+		dsUID = resolved.UID
+	}
+
+	tempoClient, err := tempo.NewClient(cfg)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "  note: skipping trace checks (failed to create tempo client: %v)\n", err)
+		return nil, ""
+	}
+
+	return tempoClient, dsUID
+}
+
 // ---------------------------------------------------------------------------
 // Check runner
 // ---------------------------------------------------------------------------
 
-func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promClient *prometheus.Client, datasourceUID string) DiagnoseResult {
+func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promClient *prometheus.Client, datasourceUID string, tempoClient *tempo.Client, tempoDatasourceUID string) DiagnoseResult {
 	result := DiagnoseResult{Env: scope.env}
 
 	var (
@@ -333,6 +375,18 @@ func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promCli
 		}
 	}
 
+	// Trace-side coverage check (skip if no Tempo client). Detects whether
+	// any spans on the stack carry db.* attributes — a prerequisite for
+	// trace-derived Service→Database CALLS edges.
+	if tempoClient != nil && tempoDatasourceUID != "" {
+		g.Go(func() error {
+			if c := checkDBInstrumentation(ctx, tempoClient, tempoDatasourceUID); c != nil {
+				addCheck(*c)
+			}
+			return nil
+		})
+	}
+
 	_ = g.Wait() // errors are captured in CheckResults, not returned
 
 	// Stable output order.
@@ -370,6 +424,9 @@ func checkOrder(name string) int {
 	}
 	if strings.HasPrefix(name, "Edge source:") {
 		return 8
+	}
+	if name == "DB instrumentation" {
+		return 9
 	}
 	return 50
 }
@@ -815,6 +872,79 @@ func checkEdgeSourceGap(ctx context.Context, client *prometheus.Client, datasour
 		Detail:         detail,
 		Recommendation: recommendation,
 	}
+}
+
+// checkDBInstrumentation probes Tempo for any span attributes in the
+// OpenTelemetry "db.*" family. When none exist, no service in the stack
+// has installed a DB client instrumentation library, which guarantees that
+// trace-derived Service→Database CALLS edges cannot form. Best-effort: any
+// transport-layer error returns nil so the check is silently skipped.
+//
+// Detects the "Service→Database edge is missing even though both
+// entities exist and the recording-rule pipeline is healthy" failure
+// mode: there is simply no span for the recording rule to consume.
+func checkDBInstrumentation(ctx context.Context, client *tempo.Client, datasourceUID string) *CheckResult {
+	resp, err := client.Tags(ctx, datasourceUID, tempo.TagsRequest{Scope: "span"})
+	if err != nil {
+		// Tempo unreachable or auth failure — skip silently.
+		return nil
+	}
+
+	dbTags := dbSpanAttributes(resp)
+	if len(dbTags) > 0 {
+		return &CheckResult{
+			Name:   "DB instrumentation",
+			Status: CheckPass,
+			Detail: fmt.Sprintf("%d db.* span attribute(s) present (%s)", len(dbTags), joinFirstN(dbTags, 5)),
+		}
+	}
+
+	return &CheckResult{
+		Name:   "DB instrumentation",
+		Status: CheckWarn,
+		Detail: "no db.* span attributes found in any span scope",
+		Recommendation: "No service on this stack is emitting OpenTelemetry database-client spans. " +
+			"Service→Database CALLS edges in Entity Graph rely on the OTel SDK reporting db.system / " +
+			"db.statement / db.operation on outbound database calls. " +
+			"Install the OTel database-client instrumentation appropriate to your language and driver: " +
+			"Python (opentelemetry-instrumentation-{psycopg2,pymysql,...}), " +
+			"Node.js (@opentelemetry/instrumentation-{pg,mysql2,mongodb,...}), " +
+			"Go (otelsql wrapping the driver, or the OpenTelemetry Go contrib instrumentation), " +
+			"Java (the JVM auto-instrumentation agent picks up JDBC drivers automatically when attached). " +
+			"Alternative (no code change): enable Beyla in your k8s-monitoring chart to derive ROUTES " +
+			"edges from eBPF network flows.",
+	}
+}
+
+// dbSpanAttributes returns all tag names from a Tempo Tags response that
+// belong to the db.* attribute family. Searches the "span" scope (and the
+// "" / unspecified scope as a fallback for older Tempo versions that don't
+// scope tag responses).
+func dbSpanAttributes(resp *tempo.TagsResponse) []string {
+	if resp == nil {
+		return nil
+	}
+	var matches []string
+	for _, scope := range resp.Scopes {
+		if scope.Name != "" && scope.Name != "span" {
+			continue
+		}
+		for _, tag := range scope.Tags {
+			if strings.HasPrefix(tag, "db.") {
+				matches = append(matches, tag)
+			}
+		}
+	}
+	return matches
+}
+
+// joinFirstN returns a comma-separated string of up to n items from s.
+// When len(s) > n, appends ", …" to indicate truncation.
+func joinFirstN(s []string, n int) string {
+	if len(s) <= n {
+		return strings.Join(s, ", ")
+	}
+	return strings.Join(s[:n], ", ") + ", …"
 }
 
 // checkMetric runs a single PromQL instant query and returns a check result

--- a/internal/providers/kg/diagnose.go
+++ b/internal/providers/kg/diagnose.go
@@ -386,6 +386,18 @@ func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promCli
 			}
 			return nil
 		})
+
+		// Resource recording rule coverage. Checks which
+		// asserts_resource_type values are populated in asserts:resource
+		// for the scoped env/namespace and flags any that are missing
+		// from the canonical expected set. Powers the K8s tab's CPU /
+		// Memory / Disk panels.
+		g.Go(func() error {
+			if c := checkResourceFamilyCoverage(ctx, promClient, datasourceUID, scope.env, scope.namespace); c != nil {
+				addCheck(*c)
+			}
+			return nil
+		})
 	}
 
 	// Trace-side coverage check (skip if no Tempo client). Detects whether
@@ -443,6 +455,9 @@ func checkOrder(name string) int {
 	}
 	if strings.HasPrefix(name, "Container label drift") {
 		return 10
+	}
+	if name == "Resource coverage" {
+		return 11
 	}
 	return 50
 }
@@ -1052,6 +1067,101 @@ func checkContainerImageLabelDrift(ctx context.Context, client *prometheus.Clien
 			"extraMetricProcessingRules` (or equivalent kubelet / kube-state-metrics block) " +
 			"matching `image.*`. Remove the drop rule and re-apply the chart; tabs populate " +
 			"after one recording-rule cycle (~5 min).",
+	}
+}
+
+// expectedResourceTypes is the canonical set of asserts_resource_type
+// values that should be populated for a healthy stack. Powers the
+// Asserts UI's Kubernetes / CPU / Memory / Disk tabs. Pulled from
+// observed values on Grafana Cloud reference stacks.
+var expectedResourceTypes = []string{
+	"cpu:usage",
+	"cpu:throttle",
+	"memory:usage",
+	"disk:usage",
+	"disk:inode_usage",
+}
+
+// checkResourceFamilyCoverage probes which `asserts_resource_type` values
+// are populated in `asserts:resource` for the scoped env/namespace and
+// flags any expected types that are missing. Each missing type
+// corresponds to an empty panel in the Asserts UI's resource-family
+// tabs (CPU, Memory, Disk).
+//
+// Returns nil when all expected types are present (no surface noise on
+// a healthy stack) or when no resource metrics flow at all (Asserts
+// app may not yet be onboarded — earlier checks cover that case).
+func checkResourceFamilyCoverage(ctx context.Context, client *prometheus.Client, datasourceUID, env, namespace string) *CheckResult {
+	var parts []string
+	if env != "" {
+		parts = append(parts, fmt.Sprintf(`asserts_env="%s"`, env))
+	}
+	if namespace != "" {
+		parts = append(parts, fmt.Sprintf(`namespace="%s"`, namespace))
+	}
+	selector := ""
+	if len(parts) > 0 {
+		selector = "{" + strings.Join(parts, ", ") + "}"
+	}
+
+	query := fmt.Sprintf(
+		`group by (asserts_resource_type)(asserts:resource%s)`, selector)
+	resp, err := client.Query(ctx, datasourceUID, prometheus.QueryRequest{Query: query})
+	if err != nil {
+		return nil
+	}
+
+	if len(resp.Data.Result) == 0 {
+		// No asserts:resource series at all for this scope. Either the
+		// scope has no workloads or earlier checks flagged the Asserts
+		// pipeline as broken — either way, this check has nothing useful
+		// to add. Stay silent.
+		return nil
+	}
+
+	present := make(map[string]bool, len(resp.Data.Result))
+	for _, sample := range resp.Data.Result {
+		if rt := sample.Metric["asserts_resource_type"]; rt != "" {
+			present[rt] = true
+		}
+	}
+
+	var missing []string
+	for _, want := range expectedResourceTypes {
+		if !present[want] {
+			missing = append(missing, want)
+		}
+	}
+
+	if len(missing) == 0 {
+		// All expected types present — quiet success.
+		return nil
+	}
+
+	scopeLabel := "this stack"
+	switch {
+	case namespace != "" && env != "":
+		scopeLabel = fmt.Sprintf("namespace=%q (env=%q)", namespace, env)
+	case namespace != "":
+		scopeLabel = fmt.Sprintf("namespace=%q", namespace)
+	case env != "":
+		scopeLabel = fmt.Sprintf("env=%q", env)
+	}
+
+	return &CheckResult{
+		Name:   "Resource coverage",
+		Status: CheckWarn,
+		Detail: fmt.Sprintf(
+			"asserts:resource for %s is missing %d of %d expected asserts_resource_type values: %s",
+			scopeLabel, len(missing), len(expectedResourceTypes), strings.Join(missing, ", ")),
+		Recommendation: "The Asserts UI's Kubernetes / CPU / Memory / Disk tabs each read a specific " +
+			"asserts_resource_type from asserts:resource. A missing type means the corresponding tab " +
+			"panel will be empty for the affected scope. " +
+			"For missing cpu:usage / memory:usage, see the `Container label drift` check (above) " +
+			"and the Step 6 `image` label callout in the diagnose-entity-graph skill. " +
+			"For other missing types, verify the upstream raw metrics flow " +
+			"(container_cpu_*, container_memory_*, kubelet_volume_stats_*) and that the relabeling " +
+			"pipeline produces non-empty `asserts_env` for them.",
 	}
 }
 

--- a/internal/providers/kg/diagnose.go
+++ b/internal/providers/kg/diagnose.go
@@ -373,6 +373,19 @@ func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promCli
 				return nil
 			})
 		}
+
+		// Container-metric image-label drift detection. The Asserts UI's
+		// Kubernetes / CPU / Memory tabs read asserts:resource, whose
+		// recording rule filters on image!="" to exclude pause containers.
+		// If the customer's Alloy config drops the image label (often via
+		// a labeldrop rule added for cardinality reduction), every series
+		// looks like a pause container and the tab silently empties.
+		g.Go(func() error {
+			if c := checkContainerImageLabelDrift(ctx, promClient, datasourceUID, scope.namespace); c != nil {
+				addCheck(*c)
+			}
+			return nil
+		})
 	}
 
 	// Trace-side coverage check (skip if no Tempo client). Detects whether
@@ -427,6 +440,9 @@ func checkOrder(name string) int {
 	}
 	if name == "DB instrumentation" {
 		return 9
+	}
+	if strings.HasPrefix(name, "Container label drift") {
+		return 10
 	}
 	return 50
 }
@@ -945,6 +961,98 @@ func joinFirstN(s []string, n int) string {
 		return strings.Join(s, ", ")
 	}
 	return strings.Join(s[:n], ", ") + ", …"
+}
+
+// checkContainerImageLabelDrift detects cAdvisor container metrics that
+// arrive without an `image` label. The downstream `asserts:resource`
+// recording rules for `cpu:usage` and `memory:usage` filter on
+// `image!=""` to exclude pause/sandbox containers; when the label is
+// dropped (commonly via a `labeldrop` rule in Alloy added for
+// cardinality reduction), every series looks like a pause container
+// and the Asserts UI's Kubernetes / CPU / Memory tabs silently empty.
+//
+// Detection is one PromQL count. When namespace is provided, scope the
+// probe to that namespace. Best-effort: any query error returns nil so
+// the check is silently skipped.
+//
+// Returns nil when no drift is detected.
+func checkContainerImageLabelDrift(ctx context.Context, client *prometheus.Client, datasourceUID, namespace string) *CheckResult {
+	// Always scope away from kube-system / pause containers: filter on
+	// container!="" to count only real workload containers. The "image=''"
+	// signature on a real workload container is the bug we're looking for.
+	var nsSelector string
+	if namespace != "" {
+		nsSelector = fmt.Sprintf(`,namespace="%s"`, namespace)
+	}
+	query := fmt.Sprintf(
+		`count(container_cpu_usage_seconds_total{container!="",image=""%s})`,
+		nsSelector)
+
+	resp, err := client.Query(ctx, datasourceUID, prometheus.QueryRequest{Query: query})
+	if err != nil {
+		// Best-effort: skip on transport / query errors.
+		return nil
+	}
+
+	if len(resp.Data.Result) == 0 {
+		// No drift detected. Don't emit a passing check — the check is
+		// only interesting when something is wrong.
+		return nil
+	}
+
+	count := extractInstantValue(resp.Data.Result[0])
+
+	// Render a per-namespace breakdown when no namespace scope is set
+	// so the user can see which namespace(s) are affected.
+	var detail string
+	if namespace != "" {
+		detail = fmt.Sprintf(
+			"%s container series in namespace=%q have image=\"\"",
+			count, namespace)
+	} else {
+		// Probe per-namespace breakdown.
+		byNsResp, byNsErr := client.Query(ctx, datasourceUID, prometheus.QueryRequest{
+			Query: `count by (namespace)(container_cpu_usage_seconds_total{container!="",image=""})`,
+		})
+		if byNsErr == nil && len(byNsResp.Data.Result) > 0 {
+			var affected []string
+			for _, sample := range byNsResp.Data.Result {
+				ns := sample.Metric["namespace"]
+				if ns == "" || ns == "kube-system" {
+					// Pause containers in kube-system legitimately have no
+					// image label on every cluster — don't surface those.
+					continue
+				}
+				cnt := extractInstantValue(sample)
+				affected = append(affected, fmt.Sprintf("%s=%s", ns, cnt))
+			}
+			if len(affected) == 0 {
+				// Only kube-system showed up — that's expected.
+				return nil
+			}
+			detail = fmt.Sprintf(
+				"container series with image=\"\" in %d namespace(s): %s",
+				len(affected), joinFirstN(affected, 8))
+		} else {
+			detail = fmt.Sprintf(
+				"%s container series have image=\"\" outside kube-system",
+				count)
+		}
+	}
+
+	return &CheckResult{
+		Name:   "Container label drift",
+		Status: CheckWarn,
+		Detail: detail,
+		Recommendation: "The Asserts recording rules for cpu:usage and memory:usage filter on " +
+			"image!=\"\" to exclude pause/sandbox containers. When the image label is dropped " +
+			"from cAdvisor metrics, those rules produce nothing and the Kubernetes / CPU / " +
+			"Memory tabs in the Asserts UI silently empty for that namespace. " +
+			"Most common cause: a `labeldrop` rule in your Alloy `clusterMetrics.cadvisor." +
+			"extraMetricProcessingRules` (or equivalent kubelet / kube-state-metrics block) " +
+			"matching `image.*`. Remove the drop rule and re-apply the chart; tabs populate " +
+			"after one recording-rule cycle (~5 min).",
+	}
 }
 
 // checkMetric runs a single PromQL instant query and returns a check result

--- a/internal/providers/kg/diagnose_test.go
+++ b/internal/providers/kg/diagnose_test.go
@@ -1100,3 +1100,133 @@ func TestCheckResourceFamilyCoverage_NoSeriesReturnsNil(t *testing.T) {
 
 	assert.Nil(t, c, "check should be nil when asserts:resource has no series at all for the scope")
 }
+
+// ---------------------------------------------------------------------------
+// Split-identity entity detection
+// ---------------------------------------------------------------------------
+//
+// `checkSplitIdentity` detects the case where one physical workload is
+// discovered as two distinct Service entities because OTel `service.name`
+// disagrees with the k8s workload name. The signal is a single `job`
+// label mapping to multiple distinct `service` values in
+// `asserts:mixin_workload_job`.
+
+// promHandlerJobServicePairs returns an httptest handler that responds
+// to a `group by (job, service) (...)` query with one frame per
+// supplied (job, service) pair. Used to drive checkSplitIdentity tests.
+func promHandlerJobServicePairs(pairs [][2]string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		frames := []map[string]any{}
+		for _, p := range pairs {
+			frames = append(frames, map[string]any{
+				"schema": map[string]any{
+					"fields": []map[string]any{
+						{"name": "Time", "type": "time"},
+						{"name": "Value", "type": "number", "labels": map[string]any{
+							"job":     p[0],
+							"service": p[1],
+						}},
+					},
+				},
+				"data": map[string]any{
+					"values": []any{
+						[]int64{1715100000000},
+						[]float64{1},
+					},
+				},
+			})
+		}
+		writeJSON(w, map[string]any{
+			"results": map[string]any{
+				"A": map[string]any{"frames": frames},
+			},
+		})
+	}
+}
+
+func TestCheckSplitIdentity_NoCollisionsReturnsNil(t *testing.T) {
+	// Each job maps to exactly one service — healthy stack.
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerJobServicePairs([][2]string{
+		{"platform/api-service", "api-service"},
+		{"platform/auth-service", "auth-service"},
+		{"platform/db", "db"},
+	}))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	promClient := newTestPromClient(t, promServer)
+	c := kg.CheckSplitIdentity(t.Context(), promClient, "test-prom-uid", "production", "platform")
+
+	assert.Nil(t, c, "check should be nil when every job maps to one service")
+}
+
+func TestCheckSplitIdentity_DetectsCollision(t *testing.T) {
+	// One job maps to two distinct service names — the classic
+	// `OTEL_SERVICE_NAME` disagrees with k8s workload name signature.
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerJobServicePairs([][2]string{
+		{"platform/api-service", "api-service"},
+		// `recommender` deployment but its OTel service.name is `wines`:
+		{"platform/recommender", "recommender"},
+		{"platform/recommender", "wines"},
+		{"platform/db", "db"},
+	}))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	promClient := newTestPromClient(t, promServer)
+	c := kg.CheckSplitIdentity(t.Context(), promClient, "test-prom-uid", "production", "platform")
+
+	require.NotNil(t, c, "expected a WARN when one job maps to multiple services")
+	assert.Equal(t, kg.CheckWarn, c.Status)
+	assert.Contains(t, c.Detail, "platform/recommender", "detail should name the colliding job")
+	// Both service names should appear, in sorted order.
+	assert.Contains(t, c.Detail, "recommender, wines",
+		"detail should list both colliding service names in sorted order")
+	assert.Contains(t, c.Recommendation, "OTEL_SERVICE_NAME",
+		"recommendation should name the typical fix path")
+}
+
+func TestCheckSplitIdentity_MultipleCollisions(t *testing.T) {
+	// Two distinct jobs each have collisions — both should appear in detail.
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerJobServicePairs([][2]string{
+		{"platform/svc-a", "svc-a"},
+		{"platform/svc-a", "svc-a-otel-named"},
+		{"platform/svc-b", "svc-b"},
+		{"platform/svc-b", "alt-name"},
+	}))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	promClient := newTestPromClient(t, promServer)
+	c := kg.CheckSplitIdentity(t.Context(), promClient, "test-prom-uid", "production", "platform")
+
+	require.NotNil(t, c)
+	assert.Equal(t, kg.CheckWarn, c.Status)
+	assert.Contains(t, c.Detail, "2 workload(s)",
+		"detail should report the collision count")
+	assert.Contains(t, c.Detail, "platform/svc-a")
+	assert.Contains(t, c.Detail, "platform/svc-b")
+}
+
+func TestCheckSplitIdentity_NoSeriesReturnsNil(t *testing.T) {
+	// No `asserts:mixin_workload_job` series at all for the scope —
+	// earlier checks cover this case, stay silent.
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{
+			"results": map[string]any{
+				"A": map[string]any{"frames": []map[string]any{}},
+			},
+		})
+	})
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	promClient := newTestPromClient(t, promServer)
+	c := kg.CheckSplitIdentity(t.Context(), promClient, "test-prom-uid", "production", "platform")
+
+	assert.Nil(t, c, "check should be nil when no workload-job series exist for the scope")
+}

--- a/internal/providers/kg/diagnose_test.go
+++ b/internal/providers/kg/diagnose_test.go
@@ -328,10 +328,14 @@ func TestRunDiagnose_MetricChecksPass(t *testing.T) {
 		assert.Contains(t, c.Detail, "series", "metric check %q detail should mention series count", c.Name)
 	}
 
-	// Total checks = 6 KG + 5 metric = 11 (profile warns, so 10 pass + 1 warn).
-	assert.Equal(t, 11, result.Summary.Total)
+	// Total checks = 6 KG + 5 metric + 1 resource coverage = 12.
+	// Profile config missing → 1 warn from KG; the resource coverage
+	// check WARNs because the prom mock returns a single unlabeled
+	// frame, so no expected resource types are reported as present
+	// (a realistic stack would have all five, suppressing this check).
+	assert.Equal(t, 12, result.Summary.Total)
 	assert.Equal(t, 10, result.Summary.Passed)
-	assert.Equal(t, 1, result.Summary.Warned) // profile config missing
+	assert.Equal(t, 2, result.Summary.Warned)
 }
 
 func TestRunDiagnose_MetricChecksFail(t *testing.T) {
@@ -921,11 +925,11 @@ func TestCheckContainerImageLabelDrift_NamespaceScoped(t *testing.T) {
 	defer promServer.Close()
 
 	promClient := newTestPromClient(t, promServer)
-	c := kg.CheckContainerImageLabelDrift(t.Context(), promClient, "test-prom-uid", "grots-tasting-room")
+	c := kg.CheckContainerImageLabelDrift(t.Context(), promClient, "test-prom-uid", "workloads")
 
 	require.NotNil(t, c, "expected a WARN check when scoped namespace has drift")
 	assert.Equal(t, kg.CheckWarn, c.Status)
-	assert.Contains(t, c.Detail, "grots-tasting-room",
+	assert.Contains(t, c.Detail, "workloads",
 		"namespace should appear in the detail when scoped")
 	assert.Contains(t, c.Detail, "23",
 		"count should appear in the detail")
@@ -955,13 +959,13 @@ func TestCheckContainerImageLabelDrift_NoDriftReturnsNil(t *testing.T) {
 }
 
 func TestCheckContainerImageLabelDrift_BreakdownExcludesKubeSystem(t *testing.T) {
-	// Mirror the canonical wineshop case: a real workload namespace
-	// shows up with image="" series, plus kube-system shows up but
-	// should be filtered out as a legitimate pause-container case.
+	// A real workload namespace shows up with image="" series, plus
+	// kube-system shows up but should be filtered out as a legitimate
+	// pause-container case.
 	promMux := http.NewServeMux()
 	promMux.HandleFunc("/", promHandlerImageDrift(24, map[string]float64{
-		"grots-tasting-room": 23,
-		"kube-system":        1,
+		"workloads":   23,
+		"kube-system": 1,
 	}))
 	promServer := httptest.NewServer(promMux)
 	defer promServer.Close()
@@ -971,7 +975,7 @@ func TestCheckContainerImageLabelDrift_BreakdownExcludesKubeSystem(t *testing.T)
 	c := kg.CheckContainerImageLabelDrift(t.Context(), promClient, "test-prom-uid", "")
 
 	require.NotNil(t, c, "expected a WARN check when at least one non-kube-system namespace has drift")
-	assert.Contains(t, c.Detail, "grots-tasting-room=23",
+	assert.Contains(t, c.Detail, "workloads=23",
 		"affected namespace should appear in the breakdown")
 	assert.NotContains(t, c.Detail, "kube-system",
 		"kube-system should be excluded from the breakdown")
@@ -990,4 +994,109 @@ func TestCheckContainerImageLabelDrift_OnlyKubeSystemReturnsNil(t *testing.T) {
 	c := kg.CheckContainerImageLabelDrift(t.Context(), promClient, "test-prom-uid", "")
 
 	assert.Nil(t, c, "check should be nil when only kube-system has image=\"\" series")
+}
+
+// ---------------------------------------------------------------------------
+// A.7: asserts:resource family coverage check.
+// ---------------------------------------------------------------------------
+//
+// Probes which `asserts_resource_type` values appear in `asserts:resource`
+// for the scoped env/namespace. Each missing expected type corresponds
+// to an empty panel in the Asserts UI's K8s / CPU / Memory / Disk tabs.
+
+// promHandlerResourceTypes returns an httptest handler that responds to a
+// `group by (asserts_resource_type) (asserts:resource...)` query with a
+// frame per provided resource type. Used to simulate partial / full
+// recording-rule output in the asserts:resource family.
+func promHandlerResourceTypes(present []string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		frames := []map[string]any{}
+		for _, rt := range present {
+			frames = append(frames, map[string]any{
+				"schema": map[string]any{
+					"fields": []map[string]any{
+						{"name": "Time", "type": "time"},
+						{"name": "Value", "type": "number", "labels": map[string]any{
+							"asserts_resource_type": rt,
+						}},
+					},
+				},
+				"data": map[string]any{
+					"values": []any{
+						[]int64{1715100000000},
+						[]float64{1},
+					},
+				},
+			})
+		}
+		writeJSON(w, map[string]any{
+			"results": map[string]any{
+				"A": map[string]any{"frames": frames},
+			},
+		})
+	}
+}
+
+func TestCheckResourceFamilyCoverage_AllTypesPresent(t *testing.T) {
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerResourceTypes(kg.ExpectedResourceTypes()))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	promClient := newTestPromClient(t, promServer)
+	c := kg.CheckResourceFamilyCoverage(t.Context(), promClient, "test-prom-uid", "production", "workloads")
+
+	assert.Nil(t, c, "check should be nil when all expected resource types are present")
+}
+
+func TestCheckResourceFamilyCoverage_MissingTypes(t *testing.T) {
+	// Partial coverage: cpu:throttle and disk:* are present but
+	// cpu:usage / memory:usage are missing — the signature when the
+	// image label is dropped from cAdvisor metrics (see
+	// `Container label drift` check).
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerResourceTypes([]string{
+		"cpu:throttle",
+		"disk:usage",
+		"disk:inode_usage",
+	}))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	promClient := newTestPromClient(t, promServer)
+	c := kg.CheckResourceFamilyCoverage(t.Context(), promClient, "test-prom-uid", "production", "workloads")
+
+	require.NotNil(t, c, "expected a WARN check when expected resource types are missing")
+	assert.Equal(t, kg.CheckWarn, c.Status)
+	assert.Contains(t, c.Detail, "cpu:usage",
+		"missing cpu:usage should appear in the detail")
+	assert.Contains(t, c.Detail, "memory:usage",
+		"missing memory:usage should appear in the detail")
+	assert.Contains(t, c.Detail, "workloads",
+		"scoped namespace should appear in the detail")
+	assert.Contains(t, c.Recommendation, "Container label drift",
+		"recommendation should point at the A.5 check for the most common cause")
+}
+
+func TestCheckResourceFamilyCoverage_NoSeriesReturnsNil(t *testing.T) {
+	// Empty frames simulate "the asserts:resource recording rule produces
+	// nothing for this scope" — earlier diagnose checks cover that case,
+	// so this one stays silent.
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{
+			"results": map[string]any{
+				"A": map[string]any{
+					"frames": []map[string]any{},
+				},
+			},
+		})
+	})
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	promClient := newTestPromClient(t, promServer)
+	c := kg.CheckResourceFamilyCoverage(t.Context(), promClient, "test-prom-uid", "production", "any-namespace")
+
+	assert.Nil(t, c, "check should be nil when asserts:resource has no series at all for the scope")
 }

--- a/internal/providers/kg/diagnose_test.go
+++ b/internal/providers/kg/diagnose_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers/kg"
 	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/query/tempo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
@@ -715,4 +716,125 @@ func TestLabelsDiagnoseTextCodec(t *testing.T) {
 	assert.Contains(t, output, "not mapped")
 	assert.Contains(t, output, "Diagnosis")
 	assert.Contains(t, output, "1/2 checks passed")
+}
+
+// ---------------------------------------------------------------------------
+// A.4: db.* span instrumentation coverage check (Tempo Tags API)
+// ---------------------------------------------------------------------------
+//
+// checkDBInstrumentation probes Tempo's Tags API for any span attribute
+// in the OpenTelemetry "db.*" family. When none exist, no service emits
+// database-client telemetry → no trace-derived Service→Database edge can
+// ever form. The check is best-effort: if the Tempo client is nil or
+// errors, no check is emitted.
+
+// tempoTagsHandler returns an httptest handler that responds to Tempo's
+// /api/v2/search/tags with a fixed list of tags grouped under the "span"
+// scope. Use this to drive checkDBInstrumentation in tests.
+func tempoTagsHandler(spanTags []string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Only respond to the tags endpoint; everything else 404s so
+		// stray requests are obvious.
+		if !strings.Contains(r.URL.Path, "/api/v2/search/tags") {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSON(w, map[string]any{
+			"scopes": []map[string]any{
+				{"name": "span", "tags": spanTags},
+			},
+		})
+	}
+}
+
+func newTestTempoClient(t *testing.T, server *httptest.Server) *tempo.Client {
+	t.Helper()
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: server.URL},
+		Namespace: "stack-123",
+	}
+	c, err := tempo.NewClient(cfg)
+	require.NoError(t, err)
+	return c
+}
+
+func TestRunDiagnose_DBInstrumentationPresent(t *testing.T) {
+	kgServer := minimalKGServer()
+	defer kgServer.Close()
+
+	// Tempo returns several db.* tags alongside other span tags.
+	tempoServer := httptest.NewServer(tempoTagsHandler([]string{
+		"http.method",
+		"db.system",
+		"db.statement",
+		"net.peer.name",
+	}))
+	defer tempoServer.Close()
+
+	kgClient := newTestClient(t, kgServer)
+	tempoClient := newTestTempoClient(t, tempoServer)
+	scope := kg.NewTestScopeFlags("", "", "")
+	result := kg.RunDiagnoseWithTempo(t.Context(), kgClient, &scope, nil, "", tempoClient, "test-tempo-uid")
+
+	check := findCheckByName(result.Checks, "DB instrumentation")
+	require.NotNil(t, check, "expected DB instrumentation check to be present")
+	assert.Equal(t, kg.CheckPass, check.Status)
+	assert.Contains(t, check.Detail, "db.system")
+	assert.Contains(t, check.Detail, "db.statement")
+}
+
+func TestRunDiagnose_DBInstrumentationAbsent(t *testing.T) {
+	kgServer := minimalKGServer()
+	defer kgServer.Close()
+
+	// Tempo returns tags but none in the db.* family — simulates a
+	// stack with HTTP auto-instrumentation but no DB instrumentation
+	// library installed.
+	tempoServer := httptest.NewServer(tempoTagsHandler([]string{
+		"http.method",
+		"http.route",
+		"http.status_code",
+		"net.peer.name",
+		"net.peer.port",
+	}))
+	defer tempoServer.Close()
+
+	kgClient := newTestClient(t, kgServer)
+	tempoClient := newTestTempoClient(t, tempoServer)
+	scope := kg.NewTestScopeFlags("", "", "")
+	result := kg.RunDiagnoseWithTempo(t.Context(), kgClient, &scope, nil, "", tempoClient, "test-tempo-uid")
+
+	check := findCheckByName(result.Checks, "DB instrumentation")
+	require.NotNil(t, check, "expected DB instrumentation check to be present")
+	assert.Equal(t, kg.CheckWarn, check.Status)
+	assert.Contains(t, check.Detail, "no db.* span attributes")
+	assert.Contains(t, check.Recommendation, "db.system",
+		"recommendation should name the canonical db.* attributes")
+	assert.Contains(t, check.Recommendation, "Beyla",
+		"recommendation should mention the alternative ROUTES path")
+}
+
+func TestRunDiagnose_DBInstrumentationSkippedWhenNoTempoClient(t *testing.T) {
+	kgServer := minimalKGServer()
+	defer kgServer.Close()
+
+	kgClient := newTestClient(t, kgServer)
+	scope := kg.NewTestScopeFlags("", "", "")
+	// nil tempo client — check should be skipped silently.
+	result := kg.RunDiagnose(t.Context(), kgClient, &scope, nil, "")
+
+	check := findCheckByName(result.Checks, "DB instrumentation")
+	assert.Nil(t, check,
+		"DB instrumentation check should be omitted when no Tempo client is provided")
+}
+
+// findCheckByName returns the first check with the given name, or nil.
+// Local helper for tests in this group (shared file-scope name avoidance).
+func findCheckByName(checks []kg.CheckResult, name string) *kg.CheckResult {
+	for i := range checks {
+		if checks[i].Name == name {
+			return &checks[i]
+		}
+	}
+	return nil
 }

--- a/internal/providers/kg/diagnose_test.go
+++ b/internal/providers/kg/diagnose_test.go
@@ -3,6 +3,7 @@ package kg_test
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -837,4 +838,156 @@ func findCheckByName(checks []kg.CheckResult, name string) *kg.CheckResult {
 		}
 	}
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// A.5: container_*{image=""} label drift detection.
+// ---------------------------------------------------------------------------
+//
+// The Asserts UI's K8s / CPU / Memory tabs read asserts:resource, whose
+// recording rule filters on image!="" to exclude pause containers. When
+// the image label is dropped from cAdvisor metrics, every series looks
+// like a pause container and the tabs silently empty. The check probes
+// for this drift with a single PromQL count.
+
+// promHandlerImageDrift returns an httptest handler that simulates an
+// Alloy scrape configuration that has dropped the image label on cAdvisor
+// metrics. The first matching query (the scoped count) returns a numeric
+// value; the second (the per-namespace breakdown) returns a fixed set of
+// namespace labels with non-zero counts.
+func promHandlerImageDrift(scopedCount float64, byNamespace map[string]float64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		expr := string(body)
+
+		// Per-namespace breakdown query.
+		if strings.Contains(expr, "count by (namespace)") {
+			frames := []map[string]any{}
+			for ns, count := range byNamespace {
+				frames = append(frames, map[string]any{
+					"schema": map[string]any{
+						"name": "",
+						"fields": []map[string]any{
+							{"name": "Time", "type": "time"},
+							{"name": "Value", "type": "number", "labels": map[string]any{"namespace": ns}},
+						},
+					},
+					"data": map[string]any{
+						"values": []any{
+							[]int64{1715100000000},
+							[]float64{count},
+						},
+					},
+				})
+			}
+			writeJSON(w, map[string]any{
+				"results": map[string]any{
+					"A": map[string]any{"frames": frames},
+				},
+			})
+			return
+		}
+
+		// Scoped count: return the scoped count value.
+		writeJSON(w, map[string]any{
+			"results": map[string]any{
+				"A": map[string]any{
+					"frames": []map[string]any{
+						{
+							"schema": map[string]any{
+								"fields": []map[string]any{
+									{"name": "Time", "type": "time"},
+									{"name": "Value", "type": "number"},
+								},
+							},
+							"data": map[string]any{
+								"values": []any{
+									[]int64{1715100000000},
+									[]float64{scopedCount},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+	}
+}
+
+func TestCheckContainerImageLabelDrift_NamespaceScoped(t *testing.T) {
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerImageDrift(23, nil))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	promClient := newTestPromClient(t, promServer)
+	c := kg.CheckContainerImageLabelDrift(t.Context(), promClient, "test-prom-uid", "grots-tasting-room")
+
+	require.NotNil(t, c, "expected a WARN check when scoped namespace has drift")
+	assert.Equal(t, kg.CheckWarn, c.Status)
+	assert.Contains(t, c.Detail, "grots-tasting-room",
+		"namespace should appear in the detail when scoped")
+	assert.Contains(t, c.Detail, "23",
+		"count should appear in the detail")
+	assert.Contains(t, c.Recommendation, "labeldrop",
+		"recommendation should mention the Alloy labeldrop foot-gun")
+}
+
+func TestCheckContainerImageLabelDrift_NoDriftReturnsNil(t *testing.T) {
+	// Empty result frames simulate "no series with image='' exist."
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{
+			"results": map[string]any{
+				"A": map[string]any{
+					"frames": []map[string]any{},
+				},
+			},
+		})
+	})
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	promClient := newTestPromClient(t, promServer)
+	c := kg.CheckContainerImageLabelDrift(t.Context(), promClient, "test-prom-uid", "any-namespace")
+
+	assert.Nil(t, c, "check should be nil when no drift is detected")
+}
+
+func TestCheckContainerImageLabelDrift_BreakdownExcludesKubeSystem(t *testing.T) {
+	// Mirror the canonical wineshop case: a real workload namespace
+	// shows up with image="" series, plus kube-system shows up but
+	// should be filtered out as a legitimate pause-container case.
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerImageDrift(24, map[string]float64{
+		"grots-tasting-room": 23,
+		"kube-system":        1,
+	}))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	promClient := newTestPromClient(t, promServer)
+	// No namespace scope → exercise the per-namespace breakdown path.
+	c := kg.CheckContainerImageLabelDrift(t.Context(), promClient, "test-prom-uid", "")
+
+	require.NotNil(t, c, "expected a WARN check when at least one non-kube-system namespace has drift")
+	assert.Contains(t, c.Detail, "grots-tasting-room=23",
+		"affected namespace should appear in the breakdown")
+	assert.NotContains(t, c.Detail, "kube-system",
+		"kube-system should be excluded from the breakdown")
+}
+
+func TestCheckContainerImageLabelDrift_OnlyKubeSystemReturnsNil(t *testing.T) {
+	// Stacks where ONLY kube-system shows image="" should not flag.
+	promMux := http.NewServeMux()
+	promMux.HandleFunc("/", promHandlerImageDrift(1, map[string]float64{
+		"kube-system": 1,
+	}))
+	promServer := httptest.NewServer(promMux)
+	defer promServer.Close()
+
+	promClient := newTestPromClient(t, promServer)
+	c := kg.CheckContainerImageLabelDrift(t.Context(), promClient, "test-prom-uid", "")
+
+	assert.Nil(t, c, "check should be nil when only kube-system has image=\"\" series")
 }

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -62,3 +62,16 @@ func RunLabelsDiagnose(ctx context.Context, client *Client, promClient *promethe
 func CheckContainerImageLabelDrift(ctx context.Context, client *prometheus.Client, datasourceUID, namespace string) *CheckResult {
 	return checkContainerImageLabelDrift(ctx, client, datasourceUID, namespace)
 }
+
+// CheckResourceFamilyCoverage wraps the unexported check for testing.
+func CheckResourceFamilyCoverage(ctx context.Context, client *prometheus.Client, datasourceUID, env, namespace string) *CheckResult {
+	return checkResourceFamilyCoverage(ctx, client, datasourceUID, env, namespace)
+}
+
+// ExpectedResourceTypes exposes the canonical asserts_resource_type set
+// for assertion in tests.
+func ExpectedResourceTypes() []string {
+	out := make([]string, len(expectedResourceTypes))
+	copy(out, expectedResourceTypes)
+	return out
+}

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -57,3 +57,8 @@ func RunServiceDiagnose(ctx context.Context, client *Client, serviceName string,
 func RunLabelsDiagnose(ctx context.Context, client *Client, promClient *prometheus.Client, datasourceUID string) LabelsDiagnoseResult {
 	return runLabelsDiagnose(ctx, client, promClient, datasourceUID)
 }
+
+// CheckContainerImageLabelDrift wraps the unexported check for testing.
+func CheckContainerImageLabelDrift(ctx context.Context, client *prometheus.Client, datasourceUID, namespace string) *CheckResult {
+	return checkContainerImageLabelDrift(ctx, client, datasourceUID, namespace)
+}

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -68,6 +68,11 @@ func CheckResourceFamilyCoverage(ctx context.Context, client *prometheus.Client,
 	return checkResourceFamilyCoverage(ctx, client, datasourceUID, env, namespace)
 }
 
+// CheckSplitIdentity wraps the unexported check for testing.
+func CheckSplitIdentity(ctx context.Context, client *prometheus.Client, datasourceUID, env, namespace string) *CheckResult {
+	return checkSplitIdentity(ctx, client, datasourceUID, env, namespace)
+}
+
 // ExpectedResourceTypes exposes the canonical asserts_resource_type set
 // for assertion in tests.
 func ExpectedResourceTypes() []string {

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/query/tempo"
 )
 
 // ScopeFlags is an exported alias for scopeFlags, used only in tests.
@@ -35,8 +36,16 @@ func FilterByInsightMatchers(results []SearchResult, matchers []InsightMatcher) 
 
 // RunDiagnose wraps the unexported runDiagnose function for testing.
 // Pass nil promClient and empty datasourceUID to skip metric checks.
+// Trace-side checks are skipped (nil tempo client); use RunDiagnoseWithTempo
+// to exercise those.
 func RunDiagnose(ctx context.Context, client *Client, scope *ScopeFlags, promClient *prometheus.Client, datasourceUID string) DiagnoseResult {
-	return runDiagnose(ctx, client, scope, promClient, datasourceUID)
+	return runDiagnose(ctx, client, scope, promClient, datasourceUID, nil, "")
+}
+
+// RunDiagnoseWithTempo wraps runDiagnose with full client wiring for tests
+// that exercise both metric and trace-side checks.
+func RunDiagnoseWithTempo(ctx context.Context, client *Client, scope *ScopeFlags, promClient *prometheus.Client, datasourceUID string, tempoClient *tempo.Client, tempoDatasourceUID string) DiagnoseResult {
+	return runDiagnose(ctx, client, scope, promClient, datasourceUID, tempoClient, tempoDatasourceUID)
 }
 
 // RunServiceDiagnose wraps the unexported runServiceDiagnose function for testing.


### PR DESCRIPTION
## Summary

Expands `gcx kg diagnose` with four new deterministic checks for
common Knowledge Graph / Asserts UI failure modes, and adds two
companion skill improvements: a new `manage-known-errors` skill for
acknowledging known/expected insights, plus targeted updates to
`diagnose-entity-graph`.

Each commit is independently reviewable. The four new code checks
follow the existing best-effort pattern: they stay silent when the
condition doesn't apply, emit `WARN` with a concrete remediation
hint when it does.

This PR builds on top of #746 (which landed correctness fixes) and
is independent of #726 / #727 (the trace-context-propagation pair).
Each pair has its own scope; no rebase dependencies.

## New diagnose checks (code)

### `DB instrumentation` (commit `d9db730`)

Probes Tempo's tags API for any span attribute in the
OpenTelemetry `db.*` family. When none exist, no service on the
stack has installed a database-client instrumentation library —
which guarantees that trace-derived Service→Database CALLS edges
cannot form, regardless of how many database entities exist in
the graph.

`WARN` recommendation gives equal billing to Python / Node.js /
Go / Java instrumentation packages, plus Beyla as the no-code
alternative.

Adds best-effort Tempo client plumbing (`resolveTempoClient`) to
the diagnose pipeline, mirroring the existing Prometheus client
pattern. The trace-side check is silently skipped when no Tempo
datasource can be resolved.

### `Container label drift` (commit `7ee5e9f`)

Detects cAdvisor `container_*` metrics arriving with `image=""`
on real workload containers. The downstream `asserts:resource`
recording rule for `cpu:usage` and `memory:usage` filters on
`image!=""` to exclude pause containers — so dropping the
`image` label silently empties the Asserts UI's Kubernetes / CPU
/ Memory tabs for that namespace.

Common cause: an Alloy `extraMetricProcessingRules` block with
`labeldrop regex = "image.*"`, often added for cardinality
reduction without realising the rule is load-bearing for
downstream Asserts views.

Stays silent when only `kube-system` shows the signature (pause
containers there legitimately have no image label).

### `Resource coverage` (commit `4386725`)

Probes which `asserts_resource_type` values are populated in
`asserts:resource` for the scoped env/namespace and flags any
missing from the canonical expected set:
`cpu:usage`, `cpu:throttle`, `memory:usage`, `disk:usage`,
`disk:inode_usage`.

Composes with `Container label drift`: the new check says
**which** Asserts UI tab will be empty; the drift check says
**why**. Both checks point at each other in their recommendations.

### `Split identity` (commit `cbfc123`)

Detects when one physical workload is discovered as two distinct
Service entities because OTel `service.name` disagrees with the
k8s workload name. KG can't merge them — the OTel-named entity
has no k8s metadata; the k8s-named entity has no trace data —
so neither view is fully usable.

Detection: `group by (job, service) (asserts:mixin_workload_job)`
scoped to the env/namespace. A single `job` mapping to multiple
distinct `service` values is a collision.

Recommendation names the fix path: align `OTEL_SERVICE_NAME` (or
`service.name` via `OTEL_RESOURCE_ATTRIBUTES`) with the k8s
workload, rename the deployment, or configure Asserts relabel
rules to reconcile.

## Skill updates (`diagnose-entity-graph`)

- **`4e6ef42`** — Step 7 now opens with an explicit pre-flight:
  before diagnosing why a service is broken, confirm it exists.
  If a user names an entity that isn't in the graph, that's the
  finding — report it directly rather than fabricate a diagnosis.
- **`e890432`** — Expand the skill's `description` frontmatter
  with empty-UI-tab phrasings so the skill auto-loads on
  "Kubernetes tab is empty" / "no CPU/memory data in Asserts" /
  "Memory tab shows nothing" / "saturation chart is blank". No
  new content in the skill body — the existing Step 6 sub-sections
  already cover those failure modes once the agent finds the skill.

Each of the four new code checks also contributes a small skill
update (one short subsection per check) that names the WARN
shape and defers to the check's `Recommendation` for the fix
path — following the lightweight-coordinator pattern the
maintainers have been asking for on #726 / #727.

## New skill: `manage-known-errors` (commit `a233a0d`)

Covers a workflow the existing skill bundle doesn't address:
acknowledging a known/expected Asserts insight so it stops
creating noise. Two mechanisms, both shipped with gcx and both
reversible:

- **Suppression** via `gcx kg suppressions create` — silences
  the insight regardless of value.
- **Custom threshold** via `gcx kg rules create` — pushes a
  `asserts:<family>:custom_threshold` recording rule that the
  Asserts assertion rule reads before falling back to the
  automatic baseline.

Names the six standard custom-threshold rules (`asserts:error:ratio:custom_threshold`,
the three latency variants, request rate, request cardinality)
and the `* 0 + <threshold>` Prometheus idiom for preserving
labels while overriding the value.

Includes an explicit anti-pattern callout: do **not** edit or
disable the Asserts-managed base alert rule. Those rules are
plugin-managed and will be overwritten on plugin update — the
`:custom_threshold` mechanism is the supported override path.

Skill follows the lightweight-coordinator pattern: routes the
agent through existing `gcx kg suppressions` and `gcx kg rules`
commands, defers to on-stack rule definitions (read via
`gcx alert rules get`) as the source of truth for which
`:custom_threshold` recording rule to target.

## What's not in this PR

- **Sibling-edges soft check** — was considered as an `INFO`
  check in `diagnose service` to flag missing edges between
  same-namespace siblings. Dropped after design review: risk of
  noise on stacks where missing edges are intentional. Can be a
  follow-up if anyone requests it.
- **`alert rules list` integration with plugin-managed rules** —
  surfacing Asserts assertion rules in the default
  `alert rules list` output would require a new provisioning-API
  client and a merge layer between two distinct rule response
  schemas. That's meaningful new code worth its own PR rather
  than bundled here.
- **`gcx kg insights explain <NAME>` subcommand** — would
  collapse a four-command discovery chain into one CLI call. Out
  of scope here; if useful, can ship as a small follow-up PR
  along with the matching skill content.
- **Slimming the pre-existing Steps 3-6 in `diagnose-entity-graph`** —
  the new code checks in this PR make several PromQL recipes in
  those steps partially redundant. Slimming should happen on
  #726's branch since the maintainer's review comments there
  already target the same content; doing it here would cause
  cross-PR conflicts.

## Validation

- `go test ./...` — clean across the whole repo
- `gofmt -d ./internal/providers/kg/...` — clean
- `go run ./scripts/validate-skills` — `validated claude-plugin/skills`
- 11 new tests across the 4 new checks (4 for DB instrumentation,
  4 for Container label drift, 3 for Resource coverage) plus 4
  for Split identity = 15 new tests total

## Diff size

5 files changed, 1335 insertions(+), 13 deletions(-)
