### PR TITLE
feat(aio11y): gate experiments cancel on --force + confirmation

### DIFF
--- a/docs/reference/cli/gcx_aio11y_experiments_cancel.md
+++ b/docs/reference/cli/gcx_aio11y_experiments_cancel.md
@@ -9,7 +9,8 @@ gcx aio11y experiments cancel <run-id> [flags]
 ### Options
 
 ```
-  -h, --help   help for cancel
+      --force   Skip confirmation prompt
+  -h, --help    help for cancel
 ```
 
 ### Options inherited from parent commands

--- a/internal/providers/aio11y/eval/experiments/commands.go
+++ b/internal/providers/aio11y/eval/experiments/commands.go
@@ -279,12 +279,30 @@ func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
 
 // --- cancel ---
 
+type cancelOpts struct {
+	Force bool
+}
+
+func (o *cancelOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
+}
+
 func newCancelCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &cancelOpts{}
 	cmd := &cobra.Command{
 		Use:   "cancel <run-id>",
 		Short: "Cancel a running experiment.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.ErrOrStderr(), opts.Force,
+				fmt.Sprintf("Cancel experiment %s?", args[0]))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
+			}
+
 			client, err := newClient(cmd, loader)
 			if err != nil {
 				return err
@@ -296,6 +314,7 @@ func newCancelCommand(loader *providers.ConfigLoader) *cobra.Command {
 			return nil
 		},
 	}
+	opts.setup(cmd.Flags())
 	return cmd
 }
 

--- a/internal/providers/aio11y/eval/experiments/commands_test.go
+++ b/internal/providers/aio11y/eval/experiments/commands_test.go
@@ -2,6 +2,7 @@ package experiments_test
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,6 +92,26 @@ func TestCancelCommand_RequiresArg(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "accepts 1 arg")
+}
+
+func TestCancelCommand_AbortsWithoutForce(t *testing.T) {
+	// Without --force, the confirmation gate must run before any client call,
+	// so an unconfigured loader (nil) never trips a network/auth path. A "n"
+	// on stdin aborts; non-TTY stdin without --force errors with "use --force".
+	cmd := experiments.Commands(nil)
+	cmd.SetArgs([]string{"cancel", "r-1"})
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetIn(strings.NewReader("n\n"))
+
+	err := cmd.Execute()
+	if err != nil {
+		assert.Contains(t, err.Error(), "use --force")
+	} else {
+		assert.Contains(t, stderr.String(), "Aborted")
+	}
 }
 
 func TestScoresCommand_RequiresArg(t *testing.T) {


### PR DESCRIPTION
Follow-up for https://github.com/grafana/gcx/pull/732

`experiments cancel` discards a partially-run experiment. Align it with the rest of the `aio11y` changing commands which all gate destructive operations with an explicit `--force` flag.