### PR TITLE
feat: add create-dashboard skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Query production. Investigate alerts. Let the Assistant root-cause issues. Ship 
 
 gcx is a CLI for Grafana. It gives you and your AI coding agent structured access to your Grafana instance: dashboards, alerts, SLOs, metrics, logs, traces, and more.
 
-gcx works with any agentic coding tool. It ships with a suite of agent skills for common workflows like alert investigation, dashboard GitOps, SLO management, and observability setup - ready to use out of the box.
+gcx works with any agentic coding tool. It ships with a suite of agent skills for common workflows like alert investigation, dashboard creation and GitOps, SLO management, and observability setup - ready to use out of the box.
 
 > [!WARNING]
 > **Public preview** — gcx is under active development. Bugs are handled by Engineering; on-call support and SLAs are not available. See [release life cycle](https://grafana.com/docs/release-life-cycle/).
@@ -243,8 +243,8 @@ gcx traces query '{.cluster="dev-us-central-0"}' --since 1h
 
 ## Install Agent Skills
 
-gcx ships a portable Agent Skills bundle for setup, dashboard GitOps,
-datasource exploration, alert investigation, structured debugging, SLO
+gcx ships a portable Agent Skills bundle for setup, dashboard creation and
+GitOps, datasource exploration, alert investigation, structured debugging, SLO
 management, Synthetic Monitoring workflows, Knowledge Graph diagnosis,
 project scaffolding, resource generation and import, and end-to-end
 observability rollout.
@@ -267,12 +267,11 @@ For example: OpenAI Codex, OpenCode, and Pi. View the skills shipped in the bund
 
 ```sh
 gcx agent skills list
-20 skill(s) bundled with gcx
+22 skill(s) bundled with gcx
 
 SKILL                      INSTALLED    DESCRIPTION
-diagnose-entity-graph      no           Diagnose Knowledge Graph problems: missing entities, missing edges, ...
+create-dashboard           yes          Design and create dashboards with datasource discovery and snapshot-based visual iteration.
 explore-datasources        yes          Discover what datasources, metrics, labels, and log streams are available in a Grafana instance.
-gcx-observability          yes          (Experimental) End-to-end observability setup for Grafana Cloud.
 ....
 ```
 

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -72,7 +72,8 @@ canonical portable skill bundle.
 | `scaffold-project` | Scaffold a new gcx resources-as-code project |
 | `generate-resource-stubs` | Generate typed Grafana resource stubs as Go code |
 | `import-dashboards` | Import existing Grafana dashboards into Go builder code |
-| `manage-dashboards` | Pull, validate, create, push, and promote dashboards |
+| `create-dashboard` | Design and create dashboards with datasource discovery and snapshot-based visual iteration |
+| `manage-dashboards` | Operate existing dashboards: list, search, pull, push, validate, promote, restore, delete, and snapshot |
 | `explore-datasources` | Discover datasources, metrics, labels, and log streams |
 | `investigate-alert` | Investigate why a Grafana alert is firing and what it impacts |
 | `debug-with-grafana` | Run a structured diagnostic workflow across metrics, logs, and dashboards |
@@ -119,6 +120,14 @@ claude-plugin/
 Claude will invoke `grafana-debugger`, run the `debug-with-grafana` skill,
 query Prometheus for latency metrics, correlate with Loki error logs, and
 return a root-cause analysis with the exact query commands used.
+
+**Dashboard creation workflow:**
+> "Create a checkout service triage dashboard in the SRE folder."
+
+Claude will invoke `create-dashboard`, verify the target context/folder,
+discover datasources and metric labels, author the dashboard, push it, render a
+PNG with `gcx dashboards snapshot`, inspect the image, and iterate on layout or
+queries before reporting the result.
 
 **Dashboard GitOps workflow:**
 > "Pull all dashboards from staging, validate them, and push to production."

--- a/claude-plugin/skills/create-dashboard/SKILL.md
+++ b/claude-plugin/skills/create-dashboard/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: create-dashboard
+description: >
+  Use when the user wants to create a new Grafana dashboard, design dashboard
+  panels, variables, queries, or layout, or make a material visual redesign of
+  an existing dashboard. This skill uses gcx plus `gcx dashboards snapshot` as
+  a visual feedback loop. Triggers on "create dashboard", "new dashboard",
+  "build dashboard", "dashboard for <service>", "improve this dashboard", or
+  "iterate on a dashboard".
+---
+
+# Create Dashboard
+
+Create dashboards as an iterative product workflow, not as a one-shot manifest
+write. The loop is:
+
+```text
+understand goal → discover data → author dashboard → validate/push → snapshot → inspect → revise
+```
+
+A dashboard creation task is not complete after `push` succeeds. It is complete
+only after the dashboard has been visually checked, or after you report exactly
+why the snapshot step is blocked.
+
+For pure operations on existing dashboards — list, search, pull, push, promote,
+restore, delete, or one-off snapshot — use `manage-dashboards` instead.
+
+## Hard Rules
+
+- Do not create dashboards in an arbitrary/default folder. If the target
+  context or folder is ambiguous and the operation will write to Grafana, ask
+  one concise question.
+- If the user gives a context, folder, datasource, or dashboard title, proceed
+  with stated assumptions instead of running a long clarification round.
+- Verify the active gcx context before writes.
+- Verify datasources, metrics, labels, and log fields before adding panels. Do
+  not invent PromQL, LogQL, datasource UIDs, label names, or folder UIDs.
+- Prefer existing project conventions. If the repo already has
+  grafana-foundation-sdk builders, generated manifests, or a dashboards
+  registry, follow that pattern.
+- Use `gcx dashboards snapshot` for visual feedback. After rendering a PNG,
+  inspect the image with the available image/read tool; do not only report the
+  file path.
+- Iterate at least once after the first snapshot when there are obvious visual
+  or data problems: login page, wrong variables, empty prime panels, title
+  truncation, broken layout, unreadable legends, or poor top-screen triage.
+- Prefer dedicated gcx commands over `gcx api`. Use raw API only when a needed
+  operation has no dedicated command.
+
+## Inputs to Establish
+
+Collect only the missing inputs needed to start:
+
+| Input | Needed for | Default if user is vague |
+|-------|------------|--------------------------|
+| Grafana context | Any read/write | Active gcx context after `gcx config current-context` |
+| Folder | Dashboard creation | Ask; do not default to General silently |
+| Audience | Dashboard shape | On-call/SRE triage audience |
+| Entity scope | Queries/variables | Service/team/namespace from the user request |
+| Datasource(s) | Panel queries | Infer from similar dashboards, then verify |
+| Time range | Snapshot and query tests | `--since 6h` for operational dashboards |
+| Storage path | Local files | Existing repo convention, else `./resources/dashboards/<name>.yaml` |
+
+## Workflow
+
+### 1. Verify context and permissions
+
+```bash
+gcx config current-context
+gcx config check
+gcx config list-contexts
+```
+
+Use `--context <name>` on subsequent commands when the user named a context and
+you do not want to mutate global state.
+
+Classify failures before continuing:
+
+- config/connectivity failure → use `setup-gcx` first
+- read 401/403 → missing dashboard/datasource read permissions
+- write 403 → token lacks dashboard write permissions
+- folder-specific write failure → wrong folder UID or folder permissions
+
+### 2. Resolve folder and find local/live conventions
+
+Find the target folder and similar dashboards before authoring.
+
+```bash
+# Folder/resource inventory. Use JSON for exact UIDs.
+gcx resources get folders -o json
+
+# Similar live dashboards are better than generic examples for variables,
+# datasource UIDs, tags, units, and team conventions.
+gcx dashboards search "<service-or-team-keyword>" -o json
+gcx dashboards get <similar-dashboard-uid> -o json > /tmp/similar-dashboard.json
+```
+
+Extract useful patterns:
+
+```bash
+jq -r '.. | objects | select(.expr?) | .expr' /tmp/similar-dashboard.json | sort -u
+jq '.spec.templating.list[]? | {name,type,query,current}' /tmp/similar-dashboard.json
+jq '.spec.panels[]? | {id,title,type,gridPos}' /tmp/similar-dashboard.json
+```
+
+If local repository scans are appropriate under project rules, look for existing
+dashboard builders/manifests and follow their style instead of creating a new
+parallel convention.
+
+### 3. Discover data before panels
+
+Use the `explore-datasources` skill when datasource choice or metric inventory is
+unclear. Minimum discovery for Prometheus/Loki dashboards:
+
+```bash
+gcx datasources list -o json
+
+# Prometheus: prove metric and label availability over the intended scope.
+gcx datasources prometheus query -d <prom_uid> '<promql>' --since 5m -o json
+
+# Loki: sample log streams and parsed fields before adding log panels.
+gcx datasources loki query -d <loki_uid> '<logql>' --since 1h -o raw
+```
+
+Check units, histogram buckets, status labels, route/operation labels, cluster
+or namespace labels, and cardinality. Prefer `topk()` or aggregations for high
+cardinality dimensions.
+
+### 4. Design the dashboard story
+
+Dashboards should answer a diagnostic question. Prefer a top-to-bottom story:
+
+```text
+Context and health → user impact → traffic/errors/latency → dependency path → resources → logs/traces links
+```
+
+Panel rules:
+
+- Put the most actionable row in the first screen.
+- Use variables for the entity scope users will actually change: cluster,
+  namespace, service, route, tenant, datasource.
+- Give every panel a clear title, unit, legend, and short description.
+- Use thresholds only where they encode an operational decision.
+- Collapse deep-dive/noisy rows by default.
+- Avoid panels that are empty by design in the normal case unless the panel
+  title/description says that empty is healthy.
+- Add drilldown links when a panel naturally leads to logs, traces, or another
+  dashboard.
+
+Dashboard quality checklist, distilled from Grafana dashboard best practices:
+
+- Define the dashboard's job before adding panels. If a panel does not support
+  that job, remove it or move it to a collapsed deep-dive row.
+- Prefer fewer, decision-oriented panels over metric inventory. The top row
+  should answer "is there a problem and where should I look next?"
+- Use consistent units, decimals, color semantics, thresholds, and legend names
+  across panels.
+- Keep variables useful but limited. Too many variables make snapshots and
+  debugging ambiguous.
+- Avoid unbounded/high-cardinality queries in default panels. Use aggregation,
+  `topk()`, scoped variables, and sensible time ranges.
+- Tune refresh and time ranges for the use case. Do not make expensive panels
+  auto-refresh faster than the data or the user decision requires.
+- Make empty states intentional: either empty means healthy and the description
+  says so, or the panel should be fixed/removed.
+- Validate readability at the expected viewport, not only the JSON structure.
+
+### 5. Author the dashboard
+
+Choose one authoring mode.
+
+#### Mode A: Existing resources-as-code project
+
+Follow the repo's established pattern. If a typed stub is needed, use the
+`generate-resource-stubs` skill or:
+
+```bash
+gcx dev generate dashboards/<dashboard_file>.go
+```
+
+Then edit the generated builder and any registry/all-files required by the
+project. Run the project's normal generation/build command before pushing.
+
+#### Mode B: Standalone resource manifest
+
+Start from the live schema instead of guessing fields:
+
+```bash
+gcx resources schemas dashboards -o json > /tmp/dashboard-schema.json
+```
+
+`gcx resources examples` is useful for resource types that ship examples, but
+current dashboard authoring should not depend on an example being available.
+
+Create a manifest such as `./resources/dashboards/<dashboard-name>.yaml`.
+Use a stable slug-like `metadata.name` for the dashboard resource name/UID and a
+human-readable `spec.title` for the displayed title.
+
+```yaml
+apiVersion: dashboard.grafana.app/v1beta1
+kind: Dashboard
+metadata:
+  name: <stable-dashboard-slug>
+spec:
+  title: "<Human readable dashboard title>"
+  tags: [gcx]
+  timezone: browser
+  schemaVersion: 36
+  # folderUID: <folder-uid>
+  templating:
+    list: []
+  panels: []
+```
+
+Fill in panels, variables, links, and layout using patterns discovered above.
+
+### 6. Validate, dry-run, push, and verify
+
+```bash
+gcx resources validate -p <dashboard-path-or-dir> -o json
+gcx resources push -p <dashboard-path-or-dir> --dry-run
+gcx resources push -p <dashboard-path-or-dir>
+
+# Verify the stored object. <name> is metadata.name.
+gcx resources get dashboards/<name> -o json
+```
+
+If pushing into a directory that also contains folders, gcx orders folders before
+dashboards automatically. If an existing dashboard is protected by a different
+manager annotation, stop and explain; only use `--include-managed` when the user
+explicitly wants gcx to take ownership.
+
+### 7. Snapshot, inspect, and iterate
+
+Render a full-dashboard snapshot with the same variables and time range a user
+would use. Replace or omit the `--var` examples below so they match variables
+actually defined in the dashboard.
+
+```bash
+mkdir -p ./snapshots
+GCX_AGENT_MODE=true gcx dashboards snapshot <dashboard-name> \
+  --output-dir ./snapshots \
+  --since 6h \
+  --var cluster=<cluster> \
+  --var namespace=<namespace> \
+  --width 1920 \
+  --theme dark
+```
+
+Then read/open the PNG returned in `file_path`. Inspect for:
+
+- login/error page instead of the dashboard
+- wrong dashboard, wrong folder, wrong time range, or wrong variables
+- empty top-row panels caused by bad queries or labels
+- title truncation or legends consuming the panel
+- overlapping panels, gaps, or poor row order
+- unreadable high-cardinality series
+- missing units/thresholds/descriptions
+- too much chrome; consider a larger width or kiosk-style settings if available
+
+Render individual panels when a panel is suspect:
+
+```bash
+GCX_AGENT_MODE=true gcx dashboards snapshot <dashboard-name> --panel <panel-id> \
+  --output-dir ./snapshots --since 6h --width 1200 --height 700
+```
+
+If the snapshot reveals issues, edit the source, validate, push, and snapshot
+again. Keep the loop short but real; one good visual correction is better than a
+successful push with an unusable dashboard.
+
+### 8. Final response
+
+Report only the useful operational facts:
+
+- assumptions made
+- Grafana context and folder
+- dashboard title and resource name/UID
+- local source path
+- validation/push result
+- snapshot path(s) and what you observed
+- iterations performed
+- remaining issues or blockers
+
+If snapshot failed, include the exact failure class: missing image renderer,
+auth/RBAC, bad variables, rendering timeout, or command error. Do not claim the
+dashboard was visually reviewed when it was not.

--- a/claude-plugin/skills/generate-resource-stubs/SKILL.md
+++ b/claude-plugin/skills/generate-resource-stubs/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: generate-resource-stubs
 description: >
-  Use when the user wants to create new Grafana dashboard or alert rule Go
-  files from scratch, generate typed stubs, add a new dashboard to a project,
-  or write grafana-foundation-sdk builder code. Triggers on "new dashboard",
-  "generate dashboard", "add dashboard", "create alert rule", "generate stub",
-  "foundation-sdk builder", "dashboard as code from scratch".
+  Use when the user explicitly wants typed Go stub files, generated resource
+  skeletons, or grafana-foundation-sdk builder boilerplate for dashboards or
+  alert rules. This is scaffolding only; for designing or creating a usable
+  dashboard with datasource discovery and snapshot iteration, use the
+  create-dashboard skill instead. Triggers on "generate stub", "dashboard
+  stub", "create alert rule stub", "foundation-sdk builder", or "builder
+  boilerplate".
 ---
 
 # Generate Typed Resource Stubs
@@ -13,6 +15,10 @@ description: >
 Generate ready-to-edit Go files for dashboards and alert rules using
 `gcx dev generate`. The generated code uses the grafana-foundation-sdk
 builder pattern and compiles without modification.
+
+This skill stops at scaffolding. If the task is to decide which dashboard
+panels, variables, queries, and layout should exist, use `create-dashboard`
+after generating the stub.
 
 ## Quick Start
 

--- a/claude-plugin/skills/manage-dashboards/SKILL.md
+++ b/claude-plugin/skills/manage-dashboards/SKILL.md
@@ -1,665 +1,194 @@
 ---
 name: manage-dashboards
 description: >
-  Use this skill when the user wants to list, get, create, update, delete,
-  or search dashboards imperatively; inspect or restore a dashboard version;
-  pull dashboards from Grafana to local files, push local dashboard files to
-  Grafana, create a new dashboard from scratch, validate dashboard files
-  against the Grafana API schema, promote dashboards across environments
-  (dev, staging, production), manage Grafana folders and their associated
-  dashboards, or capture visual snapshots (screenshots/PNG images) of
-  dashboards or individual panels. Also use this skill when the user asks
-  about editing, deleting, or diffing dashboards, about the live development
-  server for iterative dashboard authoring, or wants to render/export a
-  dashboard image.
+  Use for operational management of existing Grafana dashboards: list, get,
+  search, create or update from an already-authored manifest, delete, inspect
+  and restore versions, pull/push/validate/promote dashboard resource files,
+  manage dashboard folders, or render PNG snapshots. For designing or creating
+  a new dashboard, or for material visual/dashboard UX changes, use the
+  create-dashboard skill instead.
 ---
 
 # Manage Dashboards
 
-gcx exposes **two paths** for dashboard management:
+This skill is for dashboard operations, not dashboard design. If the user wants
+an agent to design a new dashboard, choose queries, arrange panels, or iterate
+visually, use `create-dashboard`.
 
-1. **Imperative commands** (`gcx dashboards …`) — CRUD, search, and version
-   history. Best for interactive work, scripting, and agent-driven operations.
-2. **Declarative resource pipeline** (`gcx resources push/pull …`) — bulk
-   GitOps-style synchronization of local files with Grafana. Best for
-   infrastructure-as-code and CI/CD promotion across environments.
+Use `gcx` dedicated commands first. Only use `gcx api` when a dedicated command
+cannot perform the requested operation.
 
-Both paths remain fully supported and use the same Kubernetes-compatible API.
+## Routing
 
----
+| User intent | Use |
+|-------------|-----|
+| Build a new dashboard from an idea, service, SLO, incident, or set of metrics | `create-dashboard` |
+| Redesign layout, choose panels/queries, or visually iterate dashboard quality | `create-dashboard` |
+| Generate a Go builder skeleton only | `generate-resource-stubs` |
+| Convert an existing live dashboard to Go code | `import-dashboards` |
+| List, search, inspect, delete, restore, pull, push, validate, promote, or snapshot existing dashboards | this skill |
+| Configure gcx/auth first | `setup-gcx` |
 
-## Workflow 0: Imperative CRUD, search, and version history
+## Preflight for Mutations
 
-Use the `gcx dashboards` subcommands when you want to inspect or modify a
-single dashboard without maintaining local files.
-
-### List and inspect dashboards
-
-```bash
-# List all dashboards (table view)
-gcx dashboards list
-
-# Wide view — adds PANELS and URL columns
-gcx dashboards list -o wide
-
-# Get a specific dashboard by name (metadata.name == legacy Dashboard UID)
-gcx dashboards get my-dashboard-name
-
-# Output as YAML or JSON
-gcx dashboards get my-dashboard-name -o yaml
-gcx dashboards get my-dashboard-name -o json
-```
-
-### Create and update dashboards
+Before any create/update/delete/push/restore operation:
 
 ```bash
-# Create a dashboard from a YAML/JSON manifest
-gcx dashboards create -f dashboard.yaml
-
-# Update an existing dashboard (name must match metadata.name)
-gcx dashboards update my-dashboard-name -f dashboard.yaml
-
-# Read manifest from stdin
-gcx dashboards create -f -
-```
-
-### Delete a dashboard
-
-```bash
-# Delete with confirmation prompt
-gcx dashboards delete my-dashboard-name
-
-# Skip confirmation
-gcx dashboards delete my-dashboard-name --yes
-gcx dashboards delete my-dashboard-name -y
-```
-
-### Search dashboards
-
-`gcx dashboards search` uses the Grafana full-text search API (pinned to
-`v0alpha1`). It supports filtering by title, tag, and folder.
-
-> **`list` vs `search --folder`**: `gcx dashboards list` does NOT support
-> a `--folder` flag because folder membership is stored as an annotation
-> (`grafana.app/folder`), not as a label selector the API can filter on.
-> To filter by folder, use `gcx dashboards search --folder <folder-name>`.
-
-```bash
-# Search by title keyword
-gcx dashboards search "my dashboard"
-
-# Filter by folder (use the folder's metadata.name)
-gcx dashboards search --folder my-folder-name
-
-# Multiple folders
-gcx dashboards search --folder folder-a --folder folder-b
-
-# Filter by tag
-gcx dashboards search --tag prod
-
-# Combine query + tag + folder
-gcx dashboards search "latency" --tag slo --folder platform
-
-# Limit results
-gcx dashboards search "metrics" --limit 10
-
-# Output as YAML or JSON (K8s DashboardSearchResultList envelope)
-gcx dashboards search "metrics" -o yaml
-
-# Include recently deleted dashboards
-gcx dashboards search "old-dashboard" --deleted
-```
-
-Search results are client-side filtered to `resource == "dashboards"` only
-(folder hits returned by the server are dropped automatically).
-
-### Version history and restore
-
-```bash
-# List version history for a dashboard
-gcx dashboards versions list my-dashboard-name
-
-# Limit to last 5 revisions
-gcx dashboards versions list my-dashboard-name --limit 5
-
-# Restore to a specific version (shows the VERSION column from versions list)
-gcx dashboards versions restore my-dashboard-name 3
-
-# Restore with a custom commit message
-gcx dashboards versions restore my-dashboard-name 3 --message "Revert accidental panel deletion"
-
-# Skip confirmation prompt
-gcx dashboards versions restore my-dashboard-name 3 --yes
-```
-
-Restore executes a compound LIST → GET → PUT sequence: it fetches the
-historical spec, carries the current `metadata.resourceVersion` forward
-(optimistic concurrency), and writes a `grafana.app/message` annotation on
-the new revision. A HTTP 409 conflict exits non-zero.
-
----
-
-## Prerequisites
-
-gcx must be installed and configured with a working context pointing to
-your Grafana instance. If gcx is not configured, use the
-`setup-gcx` skill first.
-
-```bash
-# Verify configuration and connectivity
+gcx config current-context
 gcx config check
 ```
 
-## Workflow 1: Pull Dashboards from Grafana
+Use `--context <name>` when the user named a target environment. Do not switch
+the global context unless the user asked for it.
 
-Pull downloads resources from Grafana and writes them as local JSON or YAML
-files. Use pull to create a local working copy, back up dashboards, or
-bootstrap a GitOps repository.
-
-### Pull all dashboards
+For writes, read current state first and preserve folder/manager intent:
 
 ```bash
-# Pull all dashboards into ./resources (JSON, default)
-gcx resources pull dashboards
-
-# Pull as YAML
-gcx resources pull dashboards -o yaml
-
-# Pull to a custom directory
-gcx resources pull dashboards -p ./my-dashboards
+gcx dashboards get <dashboard-name> -o json
+gcx resources get folders -o json
 ```
 
-### Pull folders and dashboards together
+Manager boundary: gcx protects resources managed by another tool. If a push
+fails because of `grafana.app/managed-by`, stop and ask/confirm before using
+`--include-managed`.
 
-Pulling folders alongside dashboards preserves the folder hierarchy on disk.
-Always pull both when you intend to push them to another environment later.
+## Fast Operation Map
+
+Use JSON/YAML for programmatic work and table/wide output for human summaries.
+
+| Operation | Command pattern |
+|-----------|-----------------|
+| List dashboards | `gcx dashboards list -o wide` |
+| Search by text/tag/folder | `gcx dashboards search "<query>" --tag <tag> --folder <folder-name> -o json` |
+| Get one dashboard | `gcx dashboards get <dashboard-name> -o json` |
+| Create from finished file | `gcx dashboards create -f <dashboard.yaml>` |
+| Update from finished file | `gcx dashboards update <dashboard-name> -f <dashboard.yaml>` |
+| Delete with confirmation | `gcx dashboards delete <dashboard-name>` |
+| Delete non-interactively | `gcx dashboards delete <dashboard-name> --yes` |
+| Version history | `gcx dashboards versions list <dashboard-name>` |
+| Restore version | `gcx dashboards versions restore <dashboard-name> <version> --message "<why>"` |
+| Pull dashboards/folders | `gcx resources pull dashboards folders -p <dir> -o yaml` |
+| Pull one dashboard | `gcx resources pull dashboards/<dashboard-name> -p <dir> -o yaml` |
+| Validate local files | `gcx resources validate -p <path> -o json` |
+| Preview push | `gcx resources push -p <path> --dry-run` |
+| Push local files | `gcx resources push -p <path>` |
+| Delete by selector | `gcx resources delete dashboards/<dashboard-name>` |
+| Edit in `$EDITOR` | `gcx resources edit dashboards/<dashboard-name> -o yaml` |
+| List resource kinds | `gcx resources schemas` |
+
+`<dashboard-name>` is the dashboard resource name (`metadata.name`), which is
+also the value accepted by `gcx dashboards snapshot`.
+
+## GitOps Pull/Push Workflow
+
+Use this for backups, local edits, and promotion across environments.
 
 ```bash
-gcx resources pull dashboards folders
-gcx resources pull dashboards folders -p ./resources -o yaml
+# Pull source state. Include folders when folder placement matters.
+gcx resources pull --context <source> dashboards folders -p ./dashboards-work -o yaml
+
+# Validate locally before any write.
+gcx resources validate -p ./dashboards-work -o json
+
+# Preview target changes.
+gcx resources push --context <target> -p ./dashboards-work --dry-run
+
+# Apply after review.
+gcx resources push --context <target> -p ./dashboards-work
 ```
 
-### Pull a specific dashboard
+Notes:
+
+- Pull output directories may include API version/group in their path. Use the
+  paths printed by gcx; do not assume a fixed `dashboards/` directory shape.
+- When a directory contains folders and dashboards, gcx pushes folders first.
+- Use `--on-error abort` when later resources depend on earlier ones and partial
+  progress would be confusing.
+- Dry-run before writing to production unless the user explicitly opts out.
+
+## Folder-Specific Work
+
+Folder membership is stored on dashboard resources; listing dashboards is not a
+folder filter. Use search for folder-filtered dashboard discovery:
 
 ```bash
-# Pull by UID
-gcx resources pull dashboards/my-dashboard-uid
-
-# Pull multiple specific dashboards
-gcx resources pull dashboards/uid-a dashboards/uid-b
-
-# Pull dashboards matching a glob pattern
-gcx resources pull dashboards/prod-*
+gcx dashboards search --folder <folder-name> -o json
 ```
 
-### Pull dashboards managed by other tools
-
-By default, pull only fetches dashboards managed by gcx. To include
-dashboards created via the UI, Terraform, or other tools:
+When authoring or reviewing files, look for folder references in the dashboard
+spec and verify the folder exists:
 
 ```bash
-gcx resources pull dashboards --include-managed
+gcx resources get folders/<folder-name> -o json
+gcx resources get dashboards/<dashboard-name> -o json
 ```
 
-### Inspect pulled resources
+## Snapshots for Existing Dashboards
 
-After pulling, files appear in the target directory structured by kind:
-
-```
-./resources/
-  dashboards/
-    my-dashboard.json
-    another-dashboard.yaml
-  folders/
-    my-folder.json
-```
-
-Use `gcx resources get` to inspect resources without writing files:
+Use snapshots to inspect an existing dashboard or confirm a finished change. For
+new dashboard creation, hand off to `create-dashboard`, which includes the full
+visual iteration loop.
 
 ```bash
-gcx resources get dashboards -o json
-gcx resources get dashboards/my-uid -o yaml
+# Full dashboard PNG. Force agent-mode JSON so file_path is machine-readable.
+GCX_AGENT_MODE=true gcx dashboards snapshot <dashboard-name> --output-dir ./snapshots --since 6h
+
+# With variables.
+GCX_AGENT_MODE=true gcx dashboards snapshot <dashboard-name> --output-dir ./snapshots \
+  --since 6h --var cluster=prod --var datasource=grafanacloud-prom
+
+# One panel.
+GCX_AGENT_MODE=true gcx dashboards snapshot <dashboard-name> --panel <panel-id> \
+  --output-dir ./snapshots --width 1200 --height 700
 ```
 
----
+If the user needs visual assessment, read/open the PNG from the returned
+`file_path` and summarize what you see. Do not just paste the snapshot path.
 
-## Workflow 2: Push Dashboards to Grafana
+Troubleshooting:
 
-Push reads local resource files and writes them to Grafana. gcx handles
-folder ordering automatically and protects resources managed by other tools.
+- `plugin not found` / renderer 500: Grafana Image Renderer is unavailable.
+- Wrong data: inspect template variables and rerun with `--var` overrides.
+- Cropped image: increase `--height`, `--width`, or render individual panels.
+- Auth/RBAC errors: check `gcx config check` and dashboard/folder permissions.
 
-### Topological sort: folders are pushed before dashboards
-
-When pushing a directory that contains both folders and dashboards, gcx
-automatically pushes folders first (level by level) before pushing dashboards.
-Dashboards reference their parent folder via `spec.folderUID`; the folder must
-exist before the dashboard can be created or updated. **You do not need to
-split the push into two separate commands** — gcx's topological sort
-handles ordering automatically.
+Inspect variables before rendering:
 
 ```bash
-# Push everything under ./resources — folders created before dashboards
-gcx resources push
-
-# Push from a specific directory
-gcx resources push -p ./my-resources
-
-# Explicitly include both kinds (still sorted automatically)
-gcx resources push dashboards folders
+gcx resources get dashboards/<dashboard-name> -o json \
+  | jq '.spec.templating.list[]? | {name, type, current: .current.value}'
 ```
 
-### Manager metadata
+## Version Restore Safety
 
-When gcx pushes a resource, it sets this annotation automatically:
-
-```yaml
-metadata:
-  annotations:
-    grafana.app/managed-by: gcx
-```
-
-Resources that carry a **different** `grafana.app/managed-by` value (set by
-the Grafana UI, Terraform, or another tool) are **protected by default**.
-gcx refuses to overwrite them unless you pass `--include-managed`.
+Restore performs a read of historical content and writes a new current revision.
+Always include a message and verify afterwards:
 
 ```bash
-# Override protection — only when you deliberately want to take ownership
-gcx resources push --include-managed
+gcx dashboards versions list <dashboard-name> --limit 10
+gcx dashboards versions restore <dashboard-name> <version> \
+  --message "Restore known-good dashboard after <reason>"
+gcx dashboards get <dashboard-name> -o json
 ```
 
-### Dry run before pushing to production
-
-Always dry-run before pushing to production environments to preview what will
-change:
-
-```bash
-gcx resources push --dry-run
-gcx resources push -p ./my-resources --dry-run
-```
-
-### Push specific kinds or UIDs
-
-```bash
-# Push only dashboards (folders must already exist in Grafana)
-gcx resources push dashboards
-
-# Push a single dashboard file
-gcx resources push -p ./resources/dashboards/my-dashboard.json
-```
-
-### Error handling during push
-
-```bash
-# Stop on first error (useful when later resources depend on earlier ones)
-gcx resources push --on-error abort
-
-# Continue past errors, report all failures at the end (default)
-gcx resources push --on-error fail
-
-# Ignore per-resource errors entirely (CI pipelines with partial success)
-gcx resources push --on-error ignore
-```
-
----
-
-## Workflow 3: Create a New Dashboard
-
-Creating a new dashboard with gcx involves authoring a resource file
-locally and then pushing it to Grafana.
-
-### Step 1: Get an existing dashboard as a template
-
-Pull a similar dashboard to use as a starting point:
-
-```bash
-gcx resources pull dashboards/existing-uid -p ./templates -o yaml
-```
-
-Or list available dashboards to find a suitable one:
-
-```bash
-gcx resources get dashboards -o wide
-```
-
-### Step 2: Author the resource file
-
-Create a new YAML or JSON file. Set `metadata.name` to a human-readable name;
-leave `metadata.uid` empty (gcx assigns a UID on first push) or set it
-explicitly to a value you choose.
-
-Minimal dashboard resource structure:
-
-```yaml
-apiVersion: dashboard.grafana.app/v1alpha1
-kind: Dashboard
-metadata:
-  name: my-new-dashboard
-  # uid: leave empty for auto-assignment, or set explicitly
-spec:
-  title: "My New Dashboard"
-  tags: []
-  panels: []
-  # Optional: place in a folder
-  # folderUID: <folder-uid>
-```
-
-### Step 3: Validate before pushing
-
-```bash
-# Validate the file against Grafana's API schema
-gcx resources validate -p ./my-new-dashboard.yaml
-```
-
-Resolve any validation errors before proceeding.
-
-### Step 4: Push the new dashboard
-
-```bash
-gcx resources push -p ./my-new-dashboard.yaml
-```
-
-gcx assigns a UID and sets `grafana.app/managed-by: gcx`
-automatically. Pull the dashboard after pushing to capture the assigned UID:
-
-```bash
-gcx resources pull dashboards/<assigned-uid>
-```
-
-### Step 5: Iterate with the live dev server
-
-For iterative panel authoring, use `serve` to get instant browser previews on
-every file save:
-
-```bash
-gcx dev serve ./dashboards
-```
-
-See the `serve` command reference in
-[`references/resource-operations.md`](references/resource-operations.md) for
-full flag details and the hot-reload workflow.
-
----
-
-## Workflow 4: Validate Dashboard Files
-
-Validate checks local resource files against the Grafana API schema without
-writing anything to Grafana. Use this in CI/CD pipelines and before pushing to
-production.
-
-### Validate default directory
-
-```bash
-gcx resources validate
-```
-
-### Validate a specific path
-
-```bash
-gcx resources validate -p ./dashboards
-gcx resources validate -p ./resources/dashboards/my-dashboard.yaml
-```
-
-### Validate multiple directories
-
-```bash
-gcx resources validate -p ./dashboards -p ./folders
-```
-
-### Validate and output as JSON (CI/CD)
-
-```bash
-gcx resources validate -o json
-```
-
-Expected output structure (field names, not fabricated values):
-
-```json
-{
-  "results": [
-    {
-      "file": "<path>",
-      "kind": "Dashboard",
-      "name": "<name>",
-      "uid": "<uid>",
-      "valid": true,
-      "errors": []
-    }
-  ],
-  "summary": {
-    "total": "<count>",
-    "valid": "<count>",
-    "invalid": "<count>"
-  }
-}
-```
-
-A non-zero exit code indicates at least one resource failed validation.
-
----
-
-## Workflow 5: Promote Dashboards Across Environments
-
-Promoting dashboards means pulling them from a source environment (e.g.,
-staging) and pushing them to a target environment (e.g., production). This
-uses gcx's multi-context support.
-
-### Prerequisites: one context per environment
-
-Each environment needs a named context in your gcx configuration. If
-you have not set up multi-context configuration, use the `setup-gcx`
-skill to create contexts for staging and production.
-
-```bash
-# Verify your contexts
-gcx config view
-
-# Example: switch active context
-gcx config use-context staging
-gcx config use-context production
-```
-
-### Option A: use --context flag (no active-context switch)
-
-The `--context` flag targets a specific context for a single command without
-changing the active context globally. This is the safest pattern for promotion
-scripts.
-
-```bash
-# Step 1: Pull dashboards from staging
-gcx resources pull --context staging dashboards folders -p ./promote
-
-# Step 2: Review what was pulled
-gcx resources validate -p ./promote
-
-# Step 3: Dry-run push to production
-gcx resources push --context production -p ./promote --dry-run
-
-# Step 4: Push to production
-gcx resources push --context production -p ./promote
-```
-
-### Option B: switch active context with use-context
-
-```bash
-# Pull from staging
-gcx config use-context staging
-gcx resources pull dashboards folders -p ./promote
-
-# Push to production
-gcx config use-context production
-gcx resources push -p ./promote
-```
-
-### Folder ordering during promotion
-
-Because the promote directory contains both folders and dashboards, gcx
-automatically pushes folders before dashboards in the target environment. You
-do not need to run separate commands for folders and dashboards.
-
-### Handling manager metadata during promotion
-
-Dashboards pulled from staging carry `grafana.app/managed-by: gcx`.
-When you push them to production, gcx recognizes the annotation and
-allows the push without `--include-managed`. If the production environment
-already has dashboards managed by another tool (UI, Terraform), add
-`--include-managed` to take ownership:
-
-```bash
-gcx resources push --context production -p ./promote --include-managed
-```
-
-### Full promotion script pattern
-
-```bash
-#!/bin/bash
-set -e
-SOURCE_CTX=staging
-TARGET_CTX=production
-WORK_DIR=$(mktemp -d)
-
-# Pull from source
-gcx resources pull --context "$SOURCE_CTX" dashboards folders -p "$WORK_DIR"
-
-# Validate
-gcx resources validate -p "$WORK_DIR"
-
-# Dry run on target
-gcx resources push --context "$TARGET_CTX" -p "$WORK_DIR" --dry-run
-
-# Apply
-gcx resources push --context "$TARGET_CTX" -p "$WORK_DIR"
-```
-
----
-
-## Workflow 6: Capture Dashboard Snapshots
-
-Render a Grafana dashboard or individual panel to a PNG image using the Grafana
-Image Renderer. Requires the `grafana-image-renderer` plugin on the Grafana
-instance.
-
-> **If stuck**, run `gcx dashboards snapshot --help` for the full flag
-> reference, or `gcx dashboards --help` to see available subcommands.
-
-### Step 1: Find the dashboard UID
-
-```bash
-# List all dashboards to find UIDs
-gcx resources get dashboards
-
-# Get a specific dashboard by name substring (use -ojson for programmatic access)
-gcx resources get dashboards -ojson | jq '.items[] | {uid: .metadata.name, title: .spec.title}'
-```
-
-### Step 2: Discover template variables (if the dashboard uses them)
-
-Most dashboards have template variables (cluster, datasource, job, etc.) that
-control what data is displayed. To render a meaningful snapshot, you should set
-these to the values relevant to the user's context.
-
-```bash
-# Inspect the dashboard's template variables
-gcx resources get dashboards/<uid> -ojson | jq '.spec.templating.list[] | {name, type, current: .current.value}'
-```
-
-This shows each variable's name and its current default value. Use `--var` to
-override any of these during rendering.
-
-### Step 3: Render the snapshot
-
-```bash
-# Basic: full dashboard, current directory
-gcx dashboards snapshot <uid>
-
-# With output directory
-gcx dashboards snapshot <uid> --output-dir ./snapshots
-
-# With template variable overrides (match the dashboard's variable names)
-gcx dashboards snapshot <uid> --var cluster=prod --var datasource=grafanacloud-prom
-
-# With time range
-gcx dashboards snapshot <uid> --since 6h --var cluster=prod
-gcx dashboards snapshot <uid> --from now-1h --to now --tz UTC
-
-# Single panel (find panel IDs from the dashboard JSON: .spec.panels[].id)
-gcx dashboards snapshot <uid> --panel 42
-
-# Custom dimensions and theme
-gcx dashboards snapshot <uid> --width 1280 --height 720 --theme light
-
-# Multiple dashboards concurrently
-gcx dashboards snapshot uid-a uid-b uid-c --output-dir ./snapshots
-```
-
-### Output
-
-**Agent mode** (auto-detected): JSON array to stdout with file paths and metadata:
-
-```json
-[{"uid": "<uid>", "panel_id": null, "file_path": "/abs/path/<uid>.png", "width": 1920, "height": -1, "theme": "dark", "rendered_at": "<RFC3339>"}]
-```
-
-**Human mode**: table with columns UID, Panel, File, Size.
-
-Files are named `{uid}.png` (full dashboard) or `{uid}-panel-{panelId}.png` (single panel).
-
-### Troubleshooting
-
-```bash
-# If rendering fails with 500 or "plugin not found":
-# → The grafana-image-renderer plugin is likely not installed on the Grafana instance
-
-# If the snapshot shows default/wrong variable values:
-# → Inspect variables and pass the right ones with --var
-gcx resources get dashboards/<uid> -ojson | jq '.spec.templating.list[] | {name, current: .current.value}'
-
-# If the snapshot is cut off or too small:
-# → Default height is -1 (full page). Override with --height if needed.
-# → For panels, default is 800x600. Override with --width/--height.
-
-# Full flag reference:
-gcx dashboards snapshot --help
-```
-
----
-
-## Common Operations
-
-### Delete a dashboard
-
-```bash
-# Delete a specific dashboard
-gcx resources delete dashboards/my-uid
-
-# Dry-run before bulk delete
-gcx resources delete dashboards/temp-* --dry-run
-gcx resources delete dashboards/temp-* -y
-```
-
-### Edit a dashboard in-place
-
-Opens the resource in `$EDITOR`, then pushes the updated version:
-
-```bash
-gcx resources edit dashboards/my-uid
-gcx resources edit dashboards/my-uid -o yaml
-```
-
-### List available resource kinds
-
-```bash
-gcx resources schemas
-```
-
----
+A conflict or 409 means someone changed the dashboard concurrently. Re-fetch,
+review the newest version, and retry only if the restore is still correct.
+
+## Common Failure Handling
+
+| Symptom | Action |
+|---------|--------|
+| `gcx config check` fails | Use `setup-gcx` before dashboard operations |
+| Dashboard not found | Search first; confirm `metadata.name`, not just title |
+| Folder filter does not work with list | Use `gcx dashboards search --folder <folder-name>` |
+| Push blocked by manager metadata | Ask before `--include-managed` |
+| Validation fails | Fix local file; do not push invalid resources |
+| Snapshot returns wrong variables | Inspect templating and pass `--var name=value` |
+| Snapshot unavailable | Report renderer/auth blocker; do not claim visual review |
 
 ## References
 
 - [`references/resource-operations.md`](references/resource-operations.md) —
-  Full flag reference for all `gcx resources` subcommands, selector
-  syntax, and `serve` workflow details.
-
-- [`references/resource-model.md`](references/resource-model.md) —
-  Kubernetes-style resource structure, manager metadata behavior, dependency
-  rules (folders before dashboards), push ordering phases, and resource
-  lifecycle (create, read, update, delete).
+  selector syntax, pull/push/validate flags, and `gcx dev serve` details.
+- [`references/resource-model.md`](references/resource-model.md) — resource
+  structure, manager metadata, folder ordering, and lifecycle behavior.

--- a/docs/sources/overview.md
+++ b/docs/sources/overview.md
@@ -17,7 +17,7 @@ The Grafana CLI `gcx` is available in [public preview](https://grafana.com/docs/
 
 `gcx` is a single CLI that allows you and your AI coding agent structured access to both Grafana (dashboards, folders, alert rules, data sources) and Grafana Cloud products such as Synthetic Monitoring, K6, Fleet Management, Incidents, or Adaptive Telemetry.
 
-`gcx` ships with a suite of agent skills for common workflows like alert investigation, root-cause analysis, dashboard GitOps, SLO management, and observability setup. It natively supports agentic workflows and it's integrated with Grafana Assistant, combining the previously fragmented user experience into one single tool.
+`gcx` ships with a suite of agent skills for common workflows like alert investigation, root-cause analysis, dashboard creation and GitOps, SLO management, and observability setup. It natively supports agentic workflows and it's integrated with Grafana Assistant, combining the previously fragmented user experience into one single tool.
 
 ## Benefits of `gcx`
 


### PR DESCRIPTION
## What this PR does

The manage-dashboard is a pretty generic/low value skill. I have been working lately creating dashboards and we can use the snapshot tool as part of the dashboard creation/enhancement cycle. 

So the creation of dashboards has been extracted to a new skill and the manage-dashboard references it.

