### PR TITLE
feat(kg): kg diagnose orientation block

### DIFF
--- a/claude-plugin/skills/diagnose-entity-graph/SKILL.md
+++ b/claude-plugin/skills/diagnose-entity-graph/SKILL.md
@@ -16,6 +16,22 @@ Systematic diagnosis of Entity Graph problems using gcx commands. Follow the
 steps in order — each step narrows the cause. Be direct and report findings
 concisely.
 
+## Start here: read the Orientation block
+
+`gcx kg diagnose` prints an Orientation block above its check table. Read it
+first. It tells you which (if any) of the five common Entity Graph scenarios
+the run matches:
+
+- "I see no entities at all"
+- "Some expected entities are missing"
+- "I see entities with no edges"
+- "I see disconnected clusters of entities"
+- "I can't filter to the entities I want"
+
+When the Orientation block names a matched scenario, follow its `Next:`
+commands. The per-step playbook below is the fallback for runs where no
+scenario matched or the matched scenario's hints didn't resolve the issue.
+
 ## Reading Diagnose Output
 
 Treat `gcx kg diagnose`'s verdicts as authoritative for the queries it

--- a/internal/providers/kg/diagnose.go
+++ b/internal/providers/kg/diagnose.go
@@ -49,7 +49,14 @@ type CheckResult struct {
 
 // DiagnoseResult is the full output of the diagnose command.
 type DiagnoseResult struct {
-	Env     string        `json:"env,omitempty"`
+	Env string `json:"env,omitempty"`
+
+	// Orientation is the top-of-output summary that anchors the user in
+	// one of the five Entity Graph scenarios. Computed from the same data
+	// the per-check goroutines collect; no extra API calls. Omitted from
+	// JSON when nil (e.g. legacy callers that bypass the runner).
+	Orientation *Orientation `json:"orientation,omitempty"`
+
 	Checks  []CheckResult `json:"checks"`
 	Summary struct {
 		Total  int `json:"total"`
@@ -283,24 +290,39 @@ func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promCli
 		mu.Unlock()
 	}
 
+	// Raw data shared with the Orientation block. Each contributing
+	// goroutine fills its own field; computeOrientation reads the
+	// composed struct after g.Wait() returns. Series counts default to
+	// zero, which is the safe value for absence in the detectors.
+	var orientationInput OrientationInput
+
 	// Check 1: Stack status + sanity checks.
 	g.Go(func() error {
-		checks := checkStackStatus(ctx, client)
+		checks, enabled := checkStackStatus(ctx, client)
 		mu.Lock()
 		result.Checks = append(result.Checks, checks...)
+		orientationInput.StackEnabled = enabled
 		mu.Unlock()
 		return nil
 	})
 
 	// Check 2: Entity counts.
 	g.Go(func() error {
-		addCheck(checkEntityCounts(ctx, client))
+		c, counts := checkEntityCounts(ctx, client)
+		mu.Lock()
+		result.Checks = append(result.Checks, c)
+		orientationInput.EntityCounts = counts
+		mu.Unlock()
 		return nil
 	})
 
 	// Check 3: Scope values.
 	g.Go(func() error {
-		addCheck(checkScopeValues(ctx, client))
+		c, scopes := checkScopeValues(ctx, client)
+		mu.Lock()
+		result.Checks = append(result.Checks, c)
+		orientationInput.Scopes = scopes
+		mu.Unlock()
 		return nil
 	})
 
@@ -317,7 +339,20 @@ func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promCli
 	if promClient != nil && datasourceUID != "" {
 		for _, mc := range metricChecks(scope.env, scope.namespace) {
 			g.Go(func() error {
-				addCheck(checkMetric(ctx, promClient, datasourceUID, mc))
+				c, series := checkMetric(ctx, promClient, datasourceUID, mc)
+				mu.Lock()
+				result.Checks = append(result.Checks, c)
+				// Capture series counts the Orientation detectors need.
+				// metricChecks emits these in a fixed order; match by name.
+				switch mc.Name {
+				case "Metric: traces_target_info":
+					orientationInput.TracesTargetInfoSeries = series
+				case "Metric: asserts:relation:calls":
+					orientationInput.AssertsRelationCallsSeries = series
+				case "Metric: asserts:mixin_workload_job":
+					orientationInput.AssertsMixinWorkloadJobSeries = series
+				}
+				mu.Unlock()
 				return nil
 			})
 		}
@@ -351,7 +386,33 @@ func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promCli
 	})
 
 	result.computeSummary()
+
+	// Build the Orientation block from the data collected above.
+	orient := computeOrientation(orientationInput, scope)
+	orient.PipelineHealth = pipelineHealthFromSummary(result.Summary)
+	result.Orientation = &orient
+
 	return result
+}
+
+// pipelineHealthFromSummary derives the Orientation health verdict from
+// the existing pass/warn/fail counts the per-check goroutines produce.
+// Kept here (not in orientation.go) because it depends on the
+// DiagnoseResult.Summary shape.
+func pipelineHealthFromSummary(s struct {
+	Total  int `json:"total"`
+	Passed int `json:"passed"`
+	Failed int `json:"failed"`
+	Warned int `json:"warned"`
+}) PipelineHealth {
+	switch {
+	case s.Failed > 0:
+		return PipelineFailed
+	case s.Warned > 0:
+		return PipelineDegraded
+	default:
+		return PipelineHealthy
+	}
 }
 
 // checkOrder returns a sort key for deterministic output ordering.
@@ -391,7 +452,7 @@ func checkOrder(name string) int {
 // Individual checks
 // ---------------------------------------------------------------------------
 
-func checkStackStatus(ctx context.Context, client *Client) []CheckResult {
+func checkStackStatus(ctx context.Context, client *Client) ([]CheckResult, bool) {
 	status, err := client.GetStatus(ctx)
 	if err != nil {
 		return []CheckResult{{
@@ -399,10 +460,11 @@ func checkStackStatus(ctx context.Context, client *Client) []CheckResult {
 			Status:         CheckFail,
 			Detail:         fmt.Sprintf("API error: %v", err),
 			Recommendation: "Verify the Grafana instance is reachable and the Asserts plugin is installed.",
-		}}
+		}}, false
 	}
 
 	var results []CheckResult
+	enabled := status.Enabled && status.Status == "complete"
 
 	// Main status check.
 	if status.Enabled && status.Status == "complete" {
@@ -452,10 +514,13 @@ func checkStackStatus(ctx context.Context, client *Client) []CheckResult {
 		results = append(results, c)
 	}
 
-	return results
+	return results, enabled
 }
 
-func checkEntityCounts(ctx context.Context, client *Client) CheckResult {
+// checkEntityCounts returns the user-facing check result plus the raw
+// per-type count map so the Orientation block can compute entity totals
+// without a second API call. counts is nil on API error.
+func checkEntityCounts(ctx context.Context, client *Client) (CheckResult, map[string]int64) {
 	now := time.Now()
 	counts, err := client.CountEntityTypes(ctx, now.Add(-1*time.Hour).UnixMilli(), now.UnixMilli(), nil)
 	if err != nil {
@@ -464,7 +529,7 @@ func checkEntityCounts(ctx context.Context, client *Client) CheckResult {
 			Status:         CheckFail,
 			Detail:         fmt.Sprintf("API error: %v", err),
 			Recommendation: "Failed to retrieve entity counts. Check connectivity to the Asserts API.",
-		}
+		}, nil
 	}
 
 	if len(counts) == 0 {
@@ -473,7 +538,7 @@ func checkEntityCounts(ctx context.Context, client *Client) CheckResult {
 			Status:         CheckFail,
 			Detail:         "no entity types found",
 			Recommendation: "No entities discovered. Verify that traces_target_info or asserts:mixin_workload_job metrics are being produced.",
-		}
+		}, counts
 	}
 
 	var total int64
@@ -496,17 +561,20 @@ func checkEntityCounts(ctx context.Context, client *Client) CheckResult {
 			Status:         CheckFail,
 			Detail:         "all entity type counts are 0",
 			Recommendation: "Entity types exist but have no instances. Check that recording rules are producing data and the graph ingestion pipeline is running.",
-		}
+		}, counts
 	}
 
 	return CheckResult{
 		Name:   "Entity counts",
 		Status: CheckPass,
 		Detail: fmt.Sprintf("%d total (%s)", total, strings.Join(parts, ", ")),
-	}
+	}, counts
 }
 
-func checkScopeValues(ctx context.Context, client *Client) CheckResult {
+// checkScopeValues returns the user-facing check result plus the raw
+// scopes map so the Orientation block can detect known/unknown scope
+// values without a second API call. scopes is nil on API error.
+func checkScopeValues(ctx context.Context, client *Client) (CheckResult, map[string][]string) {
 	scopes, err := client.ListEntityScopes(ctx)
 	if err != nil {
 		return CheckResult{
@@ -514,7 +582,7 @@ func checkScopeValues(ctx context.Context, client *Client) CheckResult {
 			Status:         CheckFail,
 			Detail:         fmt.Sprintf("API error: %v", err),
 			Recommendation: "Failed to retrieve scope values. Check connectivity to the Asserts API.",
-		}
+		}, nil
 	}
 
 	if len(scopes) == 0 {
@@ -523,7 +591,7 @@ func checkScopeValues(ctx context.Context, client *Client) CheckResult {
 			Status:         CheckWarn,
 			Detail:         "no scope dimensions returned",
 			Recommendation: "No env/site/namespace values found. Entities may exist without scope labels.",
-		}
+		}, scopes
 	}
 
 	var parts []string
@@ -539,14 +607,14 @@ func checkScopeValues(ctx context.Context, client *Client) CheckResult {
 			Status:         CheckWarn,
 			Detail:         "scope dimensions present but env/site/namespace are empty",
 			Recommendation: "The asserts_env label may not be set. Verify that deployment_environment is configured in your OTel SDK and that Mimir relabeling rules map it to asserts_env.",
-		}
+		}, scopes
 	}
 
 	return CheckResult{
 		Name:   "Scope values",
 		Status: CheckPass,
 		Detail: strings.Join(parts, "; "),
-	}
+	}, scopes
 }
 
 func checkTelemetryConfigs(ctx context.Context, client *Client) []CheckResult {
@@ -863,7 +931,11 @@ func checkEdgeSourceGap(ctx context.Context, client *prometheus.Client, datasour
 // under a different env label value (e.g. the raw metric carries
 // deployment_environment with one value while asserts_env is derived
 // from a different source label downstream).
-func checkMetric(ctx context.Context, client *prometheus.Client, datasourceUID string, def metricCheckDef) CheckResult {
+//
+// The second return value is the parsed series count (0 on error or
+// no-data). Callers that don't need it can discard it; the Orientation
+// block uses it as one of its detector inputs.
+func checkMetric(ctx context.Context, client *prometheus.Client, datasourceUID string, def metricCheckDef) (CheckResult, int64) {
 	resp, err := client.Query(ctx, datasourceUID, prometheus.QueryRequest{
 		Query: def.Query,
 	})
@@ -873,7 +945,7 @@ func checkMetric(ctx context.Context, client *prometheus.Client, datasourceUID s
 			Status:         CheckWarn,
 			Detail:         fmt.Sprintf("query error: %v", err),
 			Recommendation: "Could not execute PromQL query. Check Prometheus datasource connectivity.",
-		}
+		}, 0
 	}
 
 	if len(resp.Data.Result) == 0 {
@@ -898,7 +970,7 @@ func checkMetric(ctx context.Context, client *prometheus.Client, datasourceUID s
 						"label (e.g. cluster or namespace) than the raw metric's deployment_environment. " +
 						"Run: gcx metrics labels --label deployment_environment ; gcx metrics labels --label asserts_env " +
 						"and cross-reference to identify which value the data actually carries.",
-				}
+				}, 0
 			}
 		}
 		return CheckResult{
@@ -906,16 +978,17 @@ func checkMetric(ctx context.Context, client *prometheus.Client, datasourceUID s
 			Status:         CheckFail,
 			Detail:         "no data",
 			Recommendation: def.Recommendation,
-		}
+		}, 0
 	}
 
 	// Extract the count value from the instant query result.
 	count := extractInstantValue(resp.Data.Result[0])
+	series, _ := strconv.ParseInt(count, 10, 64)
 	return CheckResult{
 		Name:   def.Name,
 		Status: CheckPass,
 		Detail: count + " series",
-	}
+	}, series
 }
 
 // extractInstantValue pulls the scalar value from an instant query sample.
@@ -1030,6 +1103,11 @@ func (c *DiagnoseTableCodec) Encode(w io.Writer, v any) error {
 		return errors.New("invalid data type for table codec: expected DiagnoseResult")
 	}
 
+	// Orientation block goes above the per-check table.
+	if result.Orientation != nil {
+		renderOrientation(w, *result.Orientation, result.Env)
+	}
+
 	t := style.NewTable("CHECK", "STATUS", "DETAIL")
 	for _, check := range result.Checks {
 		t.Row(check.Name, strings.ToUpper(string(check.Status)), check.Detail)
@@ -1068,4 +1146,103 @@ func (c *DiagnoseTableCodec) Encode(w io.Writer, v any) error {
 
 func (c *DiagnoseTableCodec) Decode(_ io.Reader, _ any) error {
 	return errors.New("table format does not support decoding")
+}
+
+// renderOrientation writes the Orientation block above the per-check table.
+// Layout, in order:
+//   - One-line pipeline health verdict and scope hint.
+//   - Entity overview: total entities (excluding meta types) and the
+//     traced-services-over-total ratio.
+//   - Scope overview: env list (with "none" called out when present) and
+//     namespace count.
+//   - Matched scenarios — one block per scenario, naming it verbatim,
+//     with reasoning and concrete next commands.
+//   - Starting points (only when no scope flag was set): three ways to
+//     scope further, with runtime-substituted context.
+//   - When scenario 4 is not detected at stack level, a "see also" hint
+//     points the user at the per-env comparison workflow.
+//
+// All numeric values come from the live OrientationInput. No authored
+// thresholds.
+func renderOrientation(w io.Writer, o Orientation, env string) {
+	// Header: one-line stack health verdict and scope.
+	scopeHint := "(unscoped: --env / --namespace / --site not set)"
+	if o.Scope.FilterSet {
+		scopeHint = fmt.Sprintf("(env=%s)", env)
+	}
+	fmt.Fprintf(w, "Pipeline health: %s  %s\n", o.PipelineHealth, scopeHint)
+
+	// Entity overview.
+	fmt.Fprintf(w, "Entity overview: %d entities", o.EntityOverview.Total)
+	if o.EntityOverview.TotalServiceCount > 0 {
+		fmt.Fprintf(w, " — %d Service entities, of which %d emit traces",
+			o.EntityOverview.TotalServiceCount,
+			o.EntityOverview.TracedServiceCount)
+	}
+	fmt.Fprintln(w, ".")
+
+	// Scope overview.
+	if len(o.Scope.EnvsKnown) > 0 {
+		fmt.Fprintf(w, "Scope: %d env(s) known", len(o.Scope.EnvsKnown))
+		if o.Scope.NoneBucketPresent {
+			fmt.Fprint(w, " (one is the \"none\" bucket — entities with no asserts_env)")
+		}
+		if n := len(o.Scope.NamespacesKnown); n > 0 {
+			fmt.Fprintf(w, "; %d namespace(s) known", n)
+		}
+		fmt.Fprintln(w, ".")
+	}
+
+	// Matched scenarios (already ordered high → medium by computeOrientation).
+	if len(o.MatchedScenarios) > 0 {
+		fmt.Fprintln(w)
+		for _, s := range o.MatchedScenarios {
+			fmt.Fprintf(w, "→ Scenario matched: %q (%s confidence)\n", s.Label, s.Confidence)
+			if s.Reasoning != "" {
+				fmt.Fprintf(w, "  %s\n", s.Reasoning)
+			}
+			if len(s.NextCommands) > 0 {
+				fmt.Fprintln(w, "  Next:")
+				for _, cmd := range s.NextCommands {
+					fmt.Fprintf(w, "    %s\n", cmd)
+				}
+			}
+		}
+	} else {
+		// No scenario matched. Tailor the "no match" line to pipeline health
+		// — don't say "looks healthy" when checks below the orientation are
+		// failing.
+		fmt.Fprintln(w)
+		switch o.PipelineHealth {
+		case PipelineHealthy:
+			fmt.Fprintln(w, "→ Stack looks healthy. For per-service investigation:")
+			fmt.Fprintln(w, "    gcx kg diagnose service NAME --env ENV")
+		case PipelineDegraded:
+			fmt.Fprintln(w, "→ No top-level scenario matched, but some checks reported warnings.")
+			fmt.Fprintln(w, "  See the table below for details, or run:")
+			fmt.Fprintln(w, "    gcx kg diagnose service NAME --env ENV")
+		case PipelineFailed:
+			fmt.Fprintln(w, "→ No top-level scenario matched, but some checks failed.")
+			fmt.Fprintln(w, "  See the table and recommendations below for details.")
+		}
+	}
+
+	// Starting points (only shown when no scope flag is set).
+	if len(o.StartingPoints) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Ways to scope this further:")
+		for _, p := range o.StartingPoints {
+			if p.Context != "" {
+				fmt.Fprintf(w, "  • %s (%s):\n      %s\n", p.Label, p.Context, p.Command)
+			} else {
+				fmt.Fprintf(w, "  • %s:\n      %s\n", p.Label, p.Command)
+			}
+		}
+	}
+
+	// Scenario 4 "see also" hint (deferred detector).
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "See also: to detect disconnected clusters across environments,")
+	fmt.Fprintln(w, "re-run scoped to each --env separately and compare.")
+	fmt.Fprintln(w)
 }

--- a/internal/providers/kg/diagnose.go
+++ b/internal/providers/kg/diagnose.go
@@ -47,6 +47,17 @@ type CheckResult struct {
 	Recommendation string      `json:"recommendation,omitempty"`
 }
 
+// DiagnoseSummary is the per-check pass/fail tally for a diagnose run.
+// Named so functions that derive verdicts from it (e.g.
+// pipelineHealthFromSummary) can take it by type rather than coupling to
+// an inline anonymous struct.
+type DiagnoseSummary struct {
+	Total  int `json:"total"`
+	Passed int `json:"passed"`
+	Failed int `json:"failed"`
+	Warned int `json:"warned"`
+}
+
 // DiagnoseResult is the full output of the diagnose command.
 type DiagnoseResult struct {
 	Env       string `json:"env,omitempty"`
@@ -59,13 +70,8 @@ type DiagnoseResult struct {
 	// JSON when nil (e.g. legacy callers that bypass the runner).
 	Orientation *Orientation `json:"orientation,omitempty"`
 
-	Checks  []CheckResult `json:"checks"`
-	Summary struct {
-		Total  int `json:"total"`
-		Passed int `json:"passed"`
-		Failed int `json:"failed"`
-		Warned int `json:"warned"`
-	} `json:"summary"`
+	Checks  []CheckResult   `json:"checks"`
+	Summary DiagnoseSummary `json:"summary"`
 }
 
 func (r *DiagnoseResult) computeSummary() {
@@ -403,14 +409,9 @@ func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promCli
 
 // pipelineHealthFromSummary derives the Orientation health verdict from
 // the existing pass/warn/fail counts the per-check goroutines produce.
-// Kept here (not in orientation.go) because it depends on the
-// DiagnoseResult.Summary shape.
-func pipelineHealthFromSummary(s struct {
-	Total  int `json:"total"`
-	Passed int `json:"passed"`
-	Failed int `json:"failed"`
-	Warned int `json:"warned"`
-}) PipelineHealth {
+// Kept here (not in orientation.go) because it consumes the DiagnoseSummary
+// type defined alongside DiagnoseResult.
+func pipelineHealthFromSummary(s DiagnoseSummary) PipelineHealth {
 	switch {
 	case s.Failed > 0:
 		return PipelineFailed

--- a/internal/providers/kg/diagnose.go
+++ b/internal/providers/kg/diagnose.go
@@ -1212,12 +1212,11 @@ func renderOrientation(w io.Writer, o Orientation, env, namespace, site string) 
 		fmt.Fprintln(w, ".")
 	}
 
-	// Scope overview.
+	// Scope overview. (The NoneBucketPresent callout that previously rendered
+	// here was removed alongside the inert NoneBucketHasEntities producer;
+	// see ScopeSummary doc.)
 	if len(o.Scope.EnvsKnown) > 0 {
 		fmt.Fprintf(w, "Scope: %d env(s) known", len(o.Scope.EnvsKnown))
-		if o.Scope.NoneBucketPresent {
-			fmt.Fprint(w, " (one is the \"none\" bucket — entities with no asserts_env)")
-		}
 		if n := len(o.Scope.NamespacesKnown); n > 0 {
 			fmt.Fprintf(w, "; %d namespace(s) known", n)
 		}

--- a/internal/providers/kg/diagnose.go
+++ b/internal/providers/kg/diagnose.go
@@ -49,7 +49,9 @@ type CheckResult struct {
 
 // DiagnoseResult is the full output of the diagnose command.
 type DiagnoseResult struct {
-	Env string `json:"env,omitempty"`
+	Env       string `json:"env,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Site      string `json:"site,omitempty"`
 
 	// Orientation is the top-of-output summary that anchors the user in
 	// one of the five Entity Graph scenarios. Computed from the same data
@@ -278,7 +280,11 @@ func resolvePromClient(ctx context.Context, loader *providers.ConfigLoader, cfg 
 // ---------------------------------------------------------------------------
 
 func runDiagnose(ctx context.Context, client *Client, scope *scopeFlags, promClient *prometheus.Client, datasourceUID string) DiagnoseResult {
-	result := DiagnoseResult{Env: scope.env}
+	result := DiagnoseResult{
+		Env:       scope.env,
+		Namespace: scope.namespace,
+		Site:      scope.site,
+	}
 
 	var (
 		mu sync.Mutex
@@ -1105,7 +1111,7 @@ func (c *DiagnoseTableCodec) Encode(w io.Writer, v any) error {
 
 	// Orientation block goes above the per-check table.
 	if result.Orientation != nil {
-		renderOrientation(w, *result.Orientation, result.Env)
+		renderOrientation(w, *result.Orientation, result.Env, result.Namespace, result.Site)
 	}
 
 	t := style.NewTable("CHECK", "STATUS", "DETAIL")
@@ -1164,22 +1170,46 @@ func (c *DiagnoseTableCodec) Decode(_ io.Reader, _ any) error {
 //
 // All numeric values come from the live OrientationInput. No authored
 // thresholds.
-func renderOrientation(w io.Writer, o Orientation, env string) {
-	// Header: one-line stack health verdict and scope.
+func renderOrientation(w io.Writer, o Orientation, env, namespace, site string) {
+	// Header: one-line stack health verdict and scope. Build the scope hint
+	// from whichever dimensions are actually set (not just env) so multi-
+	// dimension filters (--namespace foo without --env) render correctly.
 	scopeHint := "(unscoped: --env / --namespace / --site not set)"
 	if o.Scope.FilterSet {
-		scopeHint = fmt.Sprintf("(env=%s)", env)
+		var parts []string
+		if env != "" {
+			parts = append(parts, "env="+env)
+		}
+		if namespace != "" {
+			parts = append(parts, "namespace="+namespace)
+		}
+		if site != "" {
+			parts = append(parts, "site="+site)
+		}
+		scopeHint = "(" + strings.Join(parts, ", ") + ")"
 	}
 	fmt.Fprintf(w, "Pipeline health: %s  %s\n", o.PipelineHealth, scopeHint)
 
-	// Entity overview.
-	fmt.Fprintf(w, "Entity overview: %d entities", o.EntityOverview.Total)
-	if o.EntityOverview.TotalServiceCount > 0 {
-		fmt.Fprintf(w, " — %d Service entities, of which %d emit traces",
-			o.EntityOverview.TotalServiceCount,
-			o.EntityOverview.TracedServiceCount)
+	// Entity overview. Entity counts (Total, TotalServiceCount) come from
+	// the stack-wide CountEntityTypes call; TracedServiceCount comes from a
+	// scope-filtered metric check. When a scope filter is set we label the
+	// stack-wide numbers as such and put the scoped trace count on its own
+	// clause so the two scopes can't be misread as a single ratio.
+	if o.Scope.FilterSet {
+		fmt.Fprintf(w, "Entity overview (stack-wide): %d entities", o.EntityOverview.Total)
+		if o.EntityOverview.TotalServiceCount > 0 {
+			fmt.Fprintf(w, " — %d Service entities", o.EntityOverview.TotalServiceCount)
+		}
+		fmt.Fprintf(w, ". Tracing in scope: %d service(s) emit traces.\n", o.EntityOverview.TracedServiceCount)
+	} else {
+		fmt.Fprintf(w, "Entity overview: %d entities", o.EntityOverview.Total)
+		if o.EntityOverview.TotalServiceCount > 0 {
+			fmt.Fprintf(w, " — %d Service entities, of which %d emit traces",
+				o.EntityOverview.TotalServiceCount,
+				o.EntityOverview.TracedServiceCount)
+		}
+		fmt.Fprintln(w, ".")
 	}
-	fmt.Fprintln(w, ".")
 
 	// Scope overview.
 	if len(o.Scope.EnvsKnown) > 0 {

--- a/internal/providers/kg/diagnose_service.go
+++ b/internal/providers/kg/diagnose_service.go
@@ -287,7 +287,7 @@ func runServiceMetricChecks(ctx context.Context, promClient *prometheus.Client, 
 
 	for _, def := range checks {
 		g.Go(func() error {
-			c := checkMetric(ctx, promClient, datasourceUID, def)
+			c, _ := checkMetric(ctx, promClient, datasourceUID, def)
 			mu.Lock()
 			results = append(results, c)
 			mu.Unlock()

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -58,3 +58,45 @@ func ComputeServiceSummary(r *ServiceDiagnoseResult) {
 func RunLabelsDiagnose(ctx context.Context, client *Client, promClient *prometheus.Client, datasourceUID string) LabelsDiagnoseResult {
 	return runLabelsDiagnose(ctx, client, promClient, datasourceUID)
 }
+
+// --- Orientation test entry points ---
+
+// ComputeOrientation wraps the unexported computeOrientation function for testing.
+func ComputeOrientation(in OrientationInput, scope *ScopeFlags) Orientation {
+	return computeOrientation(in, scope)
+}
+
+// BuildEntityOverview wraps the unexported buildEntityOverview function for testing.
+func BuildEntityOverview(in OrientationInput) EntityOverview {
+	return buildEntityOverview(in)
+}
+
+// BuildScopeSummary wraps the unexported buildScopeSummary function for testing.
+func BuildScopeSummary(in OrientationInput, scope *ScopeFlags) ScopeSummary {
+	return buildScopeSummary(in, scope)
+}
+
+// DetectNoEntities wraps the unexported detectNoEntities function for testing.
+func DetectNoEntities(in OrientationInput, overview EntityOverview) *MatchedScenario {
+	return detectNoEntities(in, overview)
+}
+
+// DetectEntitiesNoEdges wraps the unexported detectEntitiesNoEdges function for testing.
+func DetectEntitiesNoEdges(in OrientationInput, overview EntityOverview, scope *ScopeFlags) *MatchedScenario {
+	return detectEntitiesNoEdges(in, overview, scope)
+}
+
+// DetectCantFilter wraps the unexported detectCantFilter function for testing.
+func DetectCantFilter(in OrientationInput, scope *ScopeFlags) *MatchedScenario {
+	return detectCantFilter(in, scope)
+}
+
+// DetectMissingEntities wraps the unexported detectMissingEntities function for testing.
+func DetectMissingEntities(in OrientationInput, scope *ScopeFlags) *MatchedScenario {
+	return detectMissingEntities(in, scope)
+}
+
+// BuildStartingPoints wraps the unexported buildStartingPoints function for testing.
+func BuildStartingPoints(scope ScopeSummary) []StartingPoint {
+	return buildStartingPoints(scope)
+}

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -100,3 +100,9 @@ func DetectMissingEntities(in OrientationInput, scope *ScopeFlags) *MatchedScena
 func BuildStartingPoints(scope ScopeSummary) []StartingPoint {
 	return buildStartingPoints(scope)
 }
+
+// PipelineHealthFromSummary wraps the unexported pipelineHealthFromSummary
+// function for testing.
+func PipelineHealthFromSummary(s DiagnoseSummary) PipelineHealth {
+	return pipelineHealthFromSummary(s)
+}

--- a/internal/providers/kg/orientation.go
+++ b/internal/providers/kg/orientation.go
@@ -100,9 +100,11 @@ type ScopeSummary struct {
 	// by namespace.
 	NamespacesKnown []string `json:"namespacesKnown,omitempty"`
 
-	// NoneBucketPresent is true when the EnvsKnown list contains a "none"
-	// value that has non-empty entities behind it — the signature for
-	// scenario 5 ("I can't filter to the entities I want").
+	// NoneBucketPresent is reserved for a future detector that distinguishes
+	// a "none" env value backed by entities from bare presence in the scope
+	// list. Producing it truthfully requires a scoped CountEntityTypes(
+	// env="none") call (not currently issued by runDiagnose), so this field
+	// is left at its zero value until that producer is wired.
 	NoneBucketPresent bool `json:"noneBucketPresent"`
 }
 
@@ -222,9 +224,12 @@ type OrientationInput struct {
 	// unscoped bucket.
 	Scopes map[string][]string
 
-	// NoneBucketHasEntities indicates that the "none" env value is
-	// present in Scopes AND has entities behind it. Detected by
-	// runDiagnose at the API boundary and passed in here.
+	// NoneBucketHasEntities is reserved for a future detector that
+	// distinguishes a "none" env value backed by entities from bare
+	// presence in the scope list. Producing it truthfully requires a
+	// scoped CountEntityTypes(env="none") call that runDiagnose does not
+	// currently issue, so this field is left at its zero value until
+	// that producer is wired.
 	NoneBucketHasEntities bool
 
 	// TracesTargetInfoSeries is the count of traces_target_info series
@@ -318,8 +323,9 @@ func buildEntityOverview(in OrientationInput) EntityOverview {
 }
 
 // buildScopeSummary captures the scope state for the run. NoneBucketPresent
-// is true only when the "none" value appears in env scopes AND has
-// entities behind it — bare presence in the scope list isn't enough.
+// is propagated from OrientationInput.NoneBucketHasEntities, which is
+// reserved for a future detector (see field doc); today it is always
+// zero in production.
 func buildScopeSummary(in OrientationInput, scope *scopeFlags) ScopeSummary {
 	out := ScopeSummary{
 		FilterSet:         scope.env != "" || scope.namespace != "" || scope.site != "",
@@ -393,23 +399,21 @@ func detectEntitiesNoEdges(in OrientationInput, _ EntityOverview, scope *scopeFl
 }
 
 // detectCantFilter → scenario 5, "I can't filter to the entities I want".
-// Two triggers:
-//   - the "none" bucket has non-empty entities (some workloads have no
-//     asserts_env at all), OR
-//   - the user supplied a scope value that doesn't match any known scope.
+// Triggers when the user supplied a scope value that doesn't match any
+// known scope.
+//
+// A second trigger (the "none" env bucket backed by entities) is reserved
+// for a future detector; see OrientationInput.NoneBucketHasEntities. Until
+// that producer is wired, this detector relies on scopeValueUnknown alone.
 func detectCantFilter(in OrientationInput, scope *scopeFlags) *MatchedScenario {
-	if !in.NoneBucketHasEntities && !scopeValueUnknown(in, scope) {
+	if !scopeValueUnknown(in, scope) {
 		return nil
-	}
-	reasoning := "Some entities have no asserts_env label set (the \"none\" scope bucket)."
-	if scopeValueUnknown(in, scope) {
-		reasoning = "The scope value you provided does not match any value the stack knows about."
 	}
 	return &MatchedScenario{
 		ID:         ScenarioCantFilter,
 		Label:      "I can't filter to the entities I want",
 		Confidence: ConfidenceHigh,
-		Reasoning:  reasoning,
+		Reasoning:  "The scope value you provided does not match any value the stack knows about.",
 		NextCommands: []string{
 			"gcx kg meta scopes",
 			"gcx kg diagnose labels",

--- a/internal/providers/kg/orientation.go
+++ b/internal/providers/kg/orientation.go
@@ -349,10 +349,16 @@ func detectNoEntities(in OrientationInput, overview EntityOverview) *MatchedScen
 }
 
 // detectEntitiesNoEdges → scenario 3, "I see entities with no edges".
-// Triggers when Service entities exist for the scope but
-// asserts:relation:calls has zero series.
-func detectEntitiesNoEdges(in OrientationInput, overview EntityOverview, scope *scopeFlags) *MatchedScenario {
-	if overview.TotalServiceCount == 0 {
+// Triggers when workload entities exist for the scope (scoped signal:
+// asserts:mixin_workload_job > 0) but asserts:relation:calls has zero
+// series for the same scope. Both signals share scope so a --env/--namespace
+// filter pointed at an empty scope no longer false-positives against
+// stack-wide service counts.
+func detectEntitiesNoEdges(in OrientationInput, _ EntityOverview, scope *scopeFlags) *MatchedScenario {
+	// Workload signal is scoped (metricChecks(scope.env, scope.namespace)).
+	// No workloads in scope → defer to detectMissingEntities; this detector
+	// must not fire on stack-wide service counts.
+	if in.AssertsMixinWorkloadJobSeries == 0 {
 		return nil
 	}
 	if in.AssertsRelationCallsSeries > 0 {
@@ -366,7 +372,7 @@ func detectEntitiesNoEdges(in OrientationInput, overview EntityOverview, scope *
 		ID:         ScenarioEntitiesNoEdges,
 		Label:      "I see entities with no edges",
 		Confidence: ConfidenceHigh,
-		Reasoning:  "Service entities are discovered for " + scopeHint + " but asserts:relation:calls has no series.",
+		Reasoning:  "Workload entities are discovered for " + scopeHint + " but asserts:relation:calls has no series.",
 		NextCommands: []string{
 			"gcx kg diagnose labels",
 			"gcx kg diagnose service <name>",

--- a/internal/providers/kg/orientation.go
+++ b/internal/providers/kg/orientation.go
@@ -3,6 +3,7 @@ package kg
 import (
 	"fmt"
 	"slices"
+	"strings"
 )
 
 // Orientation summarizes a stack's Entity Graph state in terms a user can
@@ -249,10 +250,11 @@ type OrientationInput struct {
 // API data and the scope flags. It runs after the per-check goroutines
 // complete; it adds no new API calls of its own.
 //
-// Scenario ordering in the output: high-confidence detectors first
-// (no-entities, entities-no-edges, cant-filter), then medium-confidence
-// (missing-entities). Within a tier, ScenarioID alphabetical order is
-// stable for testability.
+// Scenario ordering in the output is explicit: high-confidence entries
+// come before medium-confidence; within a confidence tier, ScenarioID
+// alphabetical order is the tiebreaker. The sort is applied after all
+// detectors run so adding or reordering detector calls cannot change
+// the user-visible order.
 func computeOrientation(in OrientationInput, scope *scopeFlags) Orientation {
 	overview := buildEntityOverview(in)
 	scopeSummary := buildScopeSummary(in, scope)
@@ -270,6 +272,16 @@ func computeOrientation(in OrientationInput, scope *scopeFlags) Orientation {
 	if s := detectMissingEntities(in, scope); s != nil {
 		matched = append(matched, *s)
 	}
+	slices.SortStableFunc(matched, func(a, b MatchedScenario) int {
+		if a.Confidence != b.Confidence {
+			// high before medium
+			if a.Confidence == ConfidenceHigh {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(string(a.ID), string(b.ID))
+	})
 
 	var startingPoints []StartingPoint
 	if !scopeSummary.FilterSet {

--- a/internal/providers/kg/orientation.go
+++ b/internal/providers/kg/orientation.go
@@ -1,0 +1,481 @@
+package kg
+
+import (
+	"fmt"
+	"slices"
+)
+
+// Orientation summarizes a stack's Entity Graph state in terms a user can
+// orient against: which of the five common scenarios their run matches, what
+// the entity / scope shape looks like, and where to start scoping if the
+// stack is unfamiliar.
+//
+// It is computed from the data already collected by runDiagnose and adds no
+// new API calls. The text codec renders it above the per-check table; the
+// JSON codec exposes it as a structured `orientation` field on
+// DiagnoseResult.
+//
+// Design rules (carried from maintainer feedback on prior PRs):
+//   - Numbers printed in this block are runtime data computed from the
+//     user's DiagnoseResult — never authored thresholds.
+//   - Scenario detection conditions are binary, not threshold-based.
+//   - Scenarios are named verbatim every time; never referenced by index.
+type Orientation struct {
+	// PipelineHealth is a one-word summary of the overall check pass/fail
+	// state. Maps to the existing summary counts:
+	//   "healthy"  — all checks PASS
+	//   "degraded" — at least one WARN, no FAIL
+	//   "failed"   — at least one FAIL
+	PipelineHealth PipelineHealth `json:"pipelineHealth"`
+
+	// EntityOverview describes the entity inventory the run discovered.
+	EntityOverview EntityOverview `json:"entityOverview"`
+
+	// Scope describes the scope dimensions in play for this run.
+	Scope ScopeSummary `json:"scope"`
+
+	// MatchedScenarios lists the original five Entity Graph scenarios that
+	// this run's data matches. Multiple may match simultaneously; ordering
+	// is by confidence (high first). Empty when none match.
+	MatchedScenarios []MatchedScenario `json:"matchedScenarios,omitempty"`
+
+	// StartingPoints suggests ways to scope further when the user has not
+	// set any --env / --namespace / --site filter. Omitted (nil) when any
+	// scope flag was set.
+	StartingPoints []StartingPoint `json:"startingPoints,omitempty"`
+}
+
+// PipelineHealth is a coarse one-word verdict on the existing per-check
+// pass/fail counts. Distinct type so the text codec and JSON consumers can
+// pattern-match without parsing the verb string.
+type PipelineHealth string
+
+const (
+	PipelineHealthy  PipelineHealth = "healthy"
+	PipelineDegraded PipelineHealth = "degraded"
+	PipelineFailed   PipelineHealth = "failed"
+)
+
+// EntityOverview is the user-facing summary of how many entities exist and
+// how many of them are emitting traces. All numbers are computed from the
+// existing entity-count and metric-check responses in DiagnoseResult.
+type EntityOverview struct {
+	// Total entities across all types, EXCLUDING catalog meta types
+	// (EntityType, Schema, Env). Those types describe the catalog itself,
+	// not the user's workloads, and inflate the count without informational
+	// value.
+	Total int64 `json:"total"`
+
+	// ByType is the per-type breakdown that drove Total. Same exclusion
+	// applied. Sorted output is the codec's concern, not this struct's.
+	ByType map[string]int64 `json:"byType"`
+
+	// TracedServiceCount is the number of Tempo-traced services for the
+	// scope being examined. Derived from the traces_target_info series
+	// count returned by the existing metric check.
+	TracedServiceCount int64 `json:"tracedServiceCount"`
+
+	// TotalServiceCount is the total Service-typed entity count, from
+	// ByType["Service"]. Surfaced separately so the codec can render
+	// "M of N services emit traces" without a separate lookup.
+	TotalServiceCount int64 `json:"totalServiceCount"`
+}
+
+// ScopeSummary captures what scope dimensions are known to the stack and
+// what the user filtered on for this run.
+type ScopeSummary struct {
+	// FilterSet is true if the user supplied any of --env / --namespace /
+	// --site. The starting-points block in Orientation is suppressed when
+	// this is true — the user has already expressed a preference.
+	FilterSet bool `json:"filterSet"`
+
+	// EnvsKnown is the list of env scope values the Asserts API reports.
+	// Includes the "none" bucket as a literal value when present; the
+	// codec calls it out so the user doesn't mistake it for a real env.
+	EnvsKnown []string `json:"envsKnown,omitempty"`
+
+	// NamespacesKnown is the list of namespace scope values the Asserts
+	// API reports. Used by the starting-points block to suggest scoping
+	// by namespace.
+	NamespacesKnown []string `json:"namespacesKnown,omitempty"`
+
+	// NoneBucketPresent is true when the EnvsKnown list contains a "none"
+	// value that has non-empty entities behind it — the signature for
+	// scenario 5 ("I can't filter to the entities I want").
+	NoneBucketPresent bool `json:"noneBucketPresent"`
+}
+
+// MatchedScenario describes one of the five original Entity Graph scenarios
+// that this run's data matches. Names appear verbatim — never referenced
+// by index — so the agent and the user have a stable string to align on.
+type MatchedScenario struct {
+	// ID is a stable machine-readable identifier for agents.
+	ID ScenarioID `json:"id"`
+
+	// Label is the user-facing scenario name, quoted verbatim from the
+	// founding troubleshooting guide. Example: "I see no entities at all".
+	Label string `json:"label"`
+
+	// Confidence is how strongly the detector matches. Sort order in
+	// MatchedScenarios uses this field (high before medium).
+	Confidence Confidence `json:"confidence"`
+
+	// Reasoning is a one-line explanation of why the detector triggered,
+	// using only data the user can verify by re-running diagnose or
+	// running an adjacent gcx command. No hard-coded thresholds.
+	Reasoning string `json:"reasoning"`
+
+	// NextCommands are concrete gcx commands the user (or agent) can run
+	// next. Each must be a real, current gcx command — no aspirational
+	// flags or subcommands.
+	NextCommands []string `json:"nextCommands,omitempty"`
+}
+
+// ScenarioID is a stable identifier for one of the five scenarios.
+// Scenario 4 ("disconnected clusters") is deferred to a follow-up PR
+// (needs per-env comparison we don't currently do at stack level), so it
+// has an ID reserved here but no detector yet.
+type ScenarioID string
+
+const (
+	ScenarioNoEntities           ScenarioID = "no-entities"
+	ScenarioMissingEntities      ScenarioID = "missing-entities"
+	ScenarioEntitiesNoEdges      ScenarioID = "entities-no-edges"
+	ScenarioDisconnectedClusters ScenarioID = "disconnected-clusters" // reserved; not yet detected
+	ScenarioCantFilter           ScenarioID = "cant-filter"
+)
+
+// Confidence is the strength of a scenario match. Only two levels — keeping
+// the vocabulary small avoids judgment-call boundaries.
+type Confidence string
+
+const (
+	ConfidenceHigh   Confidence = "high"
+	ConfidenceMedium Confidence = "medium"
+)
+
+// StartingPoint is one suggested way to scope an unscoped run. Each
+// starting point has a one-line context (using runtime data from this run,
+// e.g. "you have N namespaces") and a concrete gcx command.
+type StartingPoint struct {
+	// ID is a stable machine-readable identifier.
+	ID StartingPointID `json:"id"`
+
+	// Label is the user-facing description of this scoping mode.
+	Label string `json:"label"`
+
+	// Context is runtime-substituted detail using only data from the
+	// current DiagnoseResult — e.g. "you have N namespaces on this stack".
+	// No judgment about whether a count is "too many".
+	Context string `json:"context,omitempty"`
+
+	// Command is the gcx command the user runs to act on this starting
+	// point. Must be a real, current gcx command.
+	Command string `json:"command"`
+}
+
+// StartingPointID is a stable identifier for one of the starting-point
+// modes: namespace, name-pattern, or single-service-and-neighbors.
+type StartingPointID string
+
+const (
+	StartingPointByNamespace     StartingPointID = "by-namespace"
+	StartingPointByNamePattern   StartingPointID = "by-name-pattern"
+	StartingPointBySingleService StartingPointID = "by-single-service"
+)
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+// isMetaEntityType reports whether the given entity type is a catalog-level
+// type that describes the Entity Graph schema itself rather than user
+// workloads. These inflate entity counts without informational value; the
+// EntityOverview excludes them.
+func isMetaEntityType(t string) bool {
+	switch t {
+	case "EntityType", "Schema", "Env":
+		return true
+	default:
+		return false
+	}
+}
+
+// OrientationInput is the raw data the detectors need. It is populated by
+// runDiagnose from the same API responses that drive the per-check table,
+// then passed to computeOrientation. Separating the input from the
+// detection logic keeps the detectors pure and table-testable.
+type OrientationInput struct {
+	// StackEnabled is true when the Asserts plugin reports
+	// status="complete" and enabled=true. False signals scenario 1
+	// directly (the stack isn't ready).
+	StackEnabled bool
+
+	// EntityCounts is the raw per-type count map returned by
+	// CountEntityTypes. Includes meta types; the detector filters them
+	// out when computing the user-facing total.
+	EntityCounts map[string]int64
+
+	// Scopes is the ListEntityScopes response (env / site / namespace
+	// dimension values). May include "none" as a literal value for the
+	// unscoped bucket.
+	Scopes map[string][]string
+
+	// NoneBucketHasEntities indicates that the "none" env value is
+	// present in Scopes AND has entities behind it. Detected by
+	// runDiagnose at the API boundary and passed in here.
+	NoneBucketHasEntities bool
+
+	// TracesTargetInfoSeries is the count of traces_target_info series
+	// returned by the existing metric check, scoped to the current
+	// --env / --namespace filter (or unscoped if none set). Used to
+	// compute TracedServiceCount.
+	TracesTargetInfoSeries int64
+
+	// AssertsRelationCallsSeries is the count of asserts:relation:calls
+	// series for the scope. Zero with non-empty services signals
+	// scenario 3 ("entities with no edges").
+	AssertsRelationCallsSeries int64
+
+	// AssertsMixinWorkloadJobSeries is the count of
+	// asserts:mixin_workload_job series for the scope. Used to detect
+	// scenario 2 ("some expected entities are missing") when the user
+	// has set a scope filter but the scoped metric checks returned
+	// nothing.
+	AssertsMixinWorkloadJobSeries int64
+}
+
+// computeOrientation produces the user-facing Orientation block from raw
+// API data and the scope flags. It runs after the per-check goroutines
+// complete; it adds no new API calls of its own.
+//
+// Scenario ordering in the output: high-confidence detectors first
+// (no-entities, entities-no-edges, cant-filter), then medium-confidence
+// (missing-entities). Within a tier, ScenarioID alphabetical order is
+// stable for testability.
+func computeOrientation(in OrientationInput, scope *scopeFlags) Orientation {
+	overview := buildEntityOverview(in)
+	scopeSummary := buildScopeSummary(in, scope)
+
+	var matched []MatchedScenario
+	if s := detectNoEntities(in, overview); s != nil {
+		matched = append(matched, *s)
+	}
+	if s := detectEntitiesNoEdges(in, overview, scope); s != nil {
+		matched = append(matched, *s)
+	}
+	if s := detectCantFilter(in, scope); s != nil {
+		matched = append(matched, *s)
+	}
+	if s := detectMissingEntities(in, scope); s != nil {
+		matched = append(matched, *s)
+	}
+
+	var startingPoints []StartingPoint
+	if !scopeSummary.FilterSet {
+		startingPoints = buildStartingPoints(scopeSummary)
+	}
+
+	return Orientation{
+		PipelineHealth:   PipelineHealthy, // overwritten by runDiagnose after check summary
+		EntityOverview:   overview,
+		Scope:            scopeSummary,
+		MatchedScenarios: matched,
+		StartingPoints:   startingPoints,
+	}
+}
+
+// buildEntityOverview filters meta types out of EntityCounts and computes
+// the totals the user-facing block needs.
+func buildEntityOverview(in OrientationInput) EntityOverview {
+	out := EntityOverview{
+		ByType:             make(map[string]int64, len(in.EntityCounts)),
+		TracedServiceCount: in.TracesTargetInfoSeries,
+	}
+	for t, n := range in.EntityCounts {
+		if isMetaEntityType(t) {
+			continue
+		}
+		out.ByType[t] = n
+		out.Total += n
+		if t == "Service" {
+			out.TotalServiceCount = n
+		}
+	}
+	return out
+}
+
+// buildScopeSummary captures the scope state for the run. NoneBucketPresent
+// is true only when the "none" value appears in env scopes AND has
+// entities behind it — bare presence in the scope list isn't enough.
+func buildScopeSummary(in OrientationInput, scope *scopeFlags) ScopeSummary {
+	out := ScopeSummary{
+		FilterSet:         scope.env != "" || scope.namespace != "" || scope.site != "",
+		NoneBucketPresent: in.NoneBucketHasEntities,
+	}
+	if envs, ok := in.Scopes["env"]; ok {
+		out.EnvsKnown = append(out.EnvsKnown, envs...)
+	}
+	if ns, ok := in.Scopes["namespace"]; ok {
+		out.NamespacesKnown = append(out.NamespacesKnown, ns...)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Scenario detectors (binary conditions only — no thresholds)
+// ---------------------------------------------------------------------------
+
+// detectNoEntities → scenario 1, "I see no entities at all".
+// Triggers when the stack is disabled OR the non-meta entity total is zero.
+func detectNoEntities(in OrientationInput, overview EntityOverview) *MatchedScenario {
+	if in.StackEnabled && overview.Total > 0 {
+		return nil
+	}
+	reasoning := "No workload entities are discovered on this stack."
+	if !in.StackEnabled {
+		reasoning = "The Asserts plugin reports the stack is not fully enabled."
+	}
+	return &MatchedScenario{
+		ID:         ScenarioNoEntities,
+		Label:      "I see no entities at all",
+		Confidence: ConfidenceHigh,
+		Reasoning:  reasoning,
+		NextCommands: []string{
+			"gcx kg status",
+			"gcx kg diagnose --env <env>",
+		},
+	}
+}
+
+// detectEntitiesNoEdges → scenario 3, "I see entities with no edges".
+// Triggers when Service entities exist for the scope but
+// asserts:relation:calls has zero series.
+func detectEntitiesNoEdges(in OrientationInput, overview EntityOverview, scope *scopeFlags) *MatchedScenario {
+	if overview.TotalServiceCount == 0 {
+		return nil
+	}
+	if in.AssertsRelationCallsSeries > 0 {
+		return nil
+	}
+	scopeHint := "this stack"
+	if scope.env != "" {
+		scopeHint = "env=" + scope.env
+	}
+	return &MatchedScenario{
+		ID:         ScenarioEntitiesNoEdges,
+		Label:      "I see entities with no edges",
+		Confidence: ConfidenceHigh,
+		Reasoning:  "Service entities are discovered for " + scopeHint + " but asserts:relation:calls has no series.",
+		NextCommands: []string{
+			"gcx kg diagnose labels",
+			"gcx kg diagnose service <name>",
+		},
+	}
+}
+
+// detectCantFilter → scenario 5, "I can't filter to the entities I want".
+// Two triggers:
+//   - the "none" bucket has non-empty entities (some workloads have no
+//     asserts_env at all), OR
+//   - the user supplied a scope value that doesn't match any known scope.
+func detectCantFilter(in OrientationInput, scope *scopeFlags) *MatchedScenario {
+	if !in.NoneBucketHasEntities && !scopeValueUnknown(in, scope) {
+		return nil
+	}
+	reasoning := "Some entities have no asserts_env label set (the \"none\" scope bucket)."
+	if scopeValueUnknown(in, scope) {
+		reasoning = "The scope value you provided does not match any value the stack knows about."
+	}
+	return &MatchedScenario{
+		ID:         ScenarioCantFilter,
+		Label:      "I can't filter to the entities I want",
+		Confidence: ConfidenceHigh,
+		Reasoning:  reasoning,
+		NextCommands: []string{
+			"gcx kg meta scopes",
+			"gcx kg diagnose labels",
+		},
+	}
+}
+
+// detectMissingEntities → scenario 2, "Some expected entities are missing".
+// Triggers when the user supplied a scope filter AND the scoped
+// asserts:mixin_workload_job check returned zero series (no workloads
+// discovered in scope). Medium confidence — also fires when a scope is
+// genuinely empty, which is a legitimate state, hence the lower confidence
+// vs. scenarios 1 and 3.
+func detectMissingEntities(in OrientationInput, scope *scopeFlags) *MatchedScenario {
+	filterSet := scope.env != "" || scope.namespace != "" || scope.site != ""
+	if !filterSet {
+		return nil
+	}
+	if in.AssertsMixinWorkloadJobSeries > 0 {
+		return nil
+	}
+	return &MatchedScenario{
+		ID:         ScenarioMissingEntities,
+		Label:      "Some expected entities are missing",
+		Confidence: ConfidenceMedium,
+		Reasoning:  "The scope filter you applied returned no workload entities — either the scope is genuinely empty or the asserts_env mapping does not cover it.",
+		NextCommands: []string{
+			"gcx kg diagnose labels",
+			"gcx kg entities query \"MATCH (n) WHERE n.name CONTAINS 'X' RETURN n LIMIT 10\"",
+		},
+	}
+}
+
+// scopeValueUnknown reports whether any user-supplied scope filter value
+// (--env / --namespace / --site) is missing from the corresponding scope
+// dimension returned by the Asserts API. Best-effort: if a dimension is
+// missing from Scopes entirely we treat it as not-unknown so we don't
+// false-positive on stacks that don't populate every dimension.
+func scopeValueUnknown(in OrientationInput, scope *scopeFlags) bool {
+	checks := []struct {
+		value, dim string
+	}{
+		{scope.env, "env"},
+		{scope.namespace, "namespace"},
+		{scope.site, "site"},
+	}
+	for _, c := range checks {
+		if c.value == "" {
+			continue
+		}
+		known, ok := in.Scopes[c.dim]
+		if !ok {
+			continue
+		}
+		if !slices.Contains(known, c.value) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildStartingPoints emits the three scoping suggestions. The codec is
+// responsible for rendering — this function just produces the structured
+// data with runtime-substituted context values.
+func buildStartingPoints(scope ScopeSummary) []StartingPoint {
+	points := []StartingPoint{
+		{
+			ID:      StartingPointByNamespace,
+			Label:   "By namespace",
+			Command: "gcx kg diagnose --namespace NS",
+		},
+		{
+			ID:      StartingPointByNamePattern,
+			Label:   "By service name pattern",
+			Command: "gcx kg entities query \"MATCH (s:Service) WHERE s.name CONTAINS 'X' RETURN s LIMIT 20\"",
+		},
+		{
+			ID:      StartingPointBySingleService,
+			Label:   "By single service + neighbors",
+			Command: "gcx kg diagnose service NAME",
+		},
+	}
+	if n := len(scope.NamespacesKnown); n > 0 {
+		points[0].Context = fmt.Sprintf("you have %d namespace(s) on this stack", n)
+	}
+	return points
+}

--- a/internal/providers/kg/orientation_test.go
+++ b/internal/providers/kg/orientation_test.go
@@ -441,3 +441,46 @@ func TestBuildStartingPoints_NoNamespacesKnown_NoContextSet(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// PipelineHealthFromSummary
+// ---------------------------------------------------------------------------
+
+func TestPipelineHealthFromSummary(t *testing.T) {
+	tests := []struct {
+		name string
+		s    kg.DiagnoseSummary
+		want kg.PipelineHealth
+	}{
+		{
+			name: "all passed",
+			s:    kg.DiagnoseSummary{Total: 5, Passed: 5},
+			want: kg.PipelineHealthy,
+		},
+		{
+			name: "warned, no failed",
+			s:    kg.DiagnoseSummary{Total: 5, Passed: 3, Warned: 2},
+			want: kg.PipelineDegraded,
+		},
+		{
+			name: "any failed dominates warned",
+			s:    kg.DiagnoseSummary{Total: 5, Passed: 2, Warned: 2, Failed: 1},
+			want: kg.PipelineFailed,
+		},
+		{
+			name: "any failed dominates passed",
+			s:    kg.DiagnoseSummary{Total: 5, Passed: 4, Failed: 1},
+			want: kg.PipelineFailed,
+		},
+		{
+			name: "zero checks → healthy",
+			s:    kg.DiagnoseSummary{},
+			want: kg.PipelineHealthy,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, kg.PipelineHealthFromSummary(tt.s))
+		})
+	}
+}

--- a/internal/providers/kg/orientation_test.go
+++ b/internal/providers/kg/orientation_test.go
@@ -143,32 +143,54 @@ func TestDetectEntitiesNoEdges(t *testing.T) {
 		wantMatch bool
 	}{
 		{
-			name:      "services exist, calls = 0",
-			in:        kg.OrientationInput{AssertsRelationCallsSeries: 0},
-			overview:  kg.EntityOverview{TotalServiceCount: 100},
+			name: "workloads in scope, calls = 0",
+			in: kg.OrientationInput{
+				AssertsMixinWorkloadJobSeries: 100,
+				AssertsRelationCallsSeries:    0,
+			},
 			scope:     kg.NewTestScopeFlags("", "", ""),
 			wantMatch: true,
 		},
 		{
-			name:      "services exist, calls > 0",
-			in:        kg.OrientationInput{AssertsRelationCallsSeries: 20},
-			overview:  kg.EntityOverview{TotalServiceCount: 100},
+			name: "workloads in scope, calls > 0",
+			in: kg.OrientationInput{
+				AssertsMixinWorkloadJobSeries: 100,
+				AssertsRelationCallsSeries:    20,
+			},
 			scope:     kg.NewTestScopeFlags("", "", ""),
 			wantMatch: false,
 		},
 		{
-			name:      "no services — detector silent",
-			in:        kg.OrientationInput{AssertsRelationCallsSeries: 0},
-			overview:  kg.EntityOverview{TotalServiceCount: 0},
+			name: "no workloads in scope — detector silent",
+			in: kg.OrientationInput{
+				AssertsMixinWorkloadJobSeries: 0,
+				AssertsRelationCallsSeries:    0,
+			},
 			scope:     kg.NewTestScopeFlags("", "", ""),
 			wantMatch: false,
 		},
 		{
-			name:      "env scope echoed in reasoning",
-			in:        kg.OrientationInput{AssertsRelationCallsSeries: 0},
-			overview:  kg.EntityOverview{TotalServiceCount: 100},
+			name: "env scope echoed in reasoning",
+			in: kg.OrientationInput{
+				AssertsMixinWorkloadJobSeries: 100,
+				AssertsRelationCallsSeries:    0,
+			},
 			scope:     kg.NewTestScopeFlags("production", "", ""),
 			wantMatch: true,
+		},
+		{
+			// Regression: previously this fired HIGH-confidence on an
+			// empty scope because the gate was the stack-wide
+			// TotalServiceCount. With the scoped workload gate, an
+			// empty scope must defer to detectMissingEntities.
+			name: "scope with stack-wide services but no scoped workloads — silent",
+			in: kg.OrientationInput{
+				AssertsMixinWorkloadJobSeries: 0,
+				AssertsRelationCallsSeries:    0,
+			},
+			overview:  kg.EntityOverview{TotalServiceCount: 6427},
+			scope:     kg.NewTestScopeFlags("azure-westeurope-1", "", ""),
+			wantMatch: false,
 		},
 	}
 
@@ -323,18 +345,18 @@ func TestComputeOrientation_FilterSet_SuppressesStartingPoints(t *testing.T) {
 }
 
 func TestComputeOrientation_MultipleScenarios_OrderByConfidence(t *testing.T) {
-	// Simulates: scope filter applied, services exist but no edges,
-	// AND the scoped workload-job series is empty.
-	// Expect: entities-no-edges (high) and missing-entities (medium) both
-	// match, with high-confidence first.
+	// Simulates: user supplied an env value the stack does not know about.
+	// Expect: cant-filter (high, via scopeValueUnknown) AND missing-entities
+	// (medium, via filter-set with zero scoped workloads) both match, with
+	// high-confidence first.
 	in := kg.OrientationInput{
 		StackEnabled:                  true,
 		EntityCounts:                  map[string]int64{"Service": 100},
-		Scopes:                        map[string][]string{"env": {"prod"}},
+		Scopes:                        map[string][]string{"env": {"prod", "staging"}},
 		AssertsRelationCallsSeries:    0,
 		AssertsMixinWorkloadJobSeries: 0,
 	}
-	scope := kg.NewTestScopeFlags("prod", "", "")
+	scope := kg.NewTestScopeFlags("doesnotexist", "", "")
 
 	got := kg.ComputeOrientation(in, &scope)
 

--- a/internal/providers/kg/orientation_test.go
+++ b/internal/providers/kg/orientation_test.go
@@ -67,16 +67,11 @@ func TestBuildScopeSummary(t *testing.T) {
 			wantFilterSet: true,
 			wantNoneBkt:   false,
 		},
-		{
-			name:  "none bucket present and populated",
-			scope: kg.NewTestScopeFlags("", "", ""),
-			in: kg.OrientationInput{
-				Scopes:                map[string][]string{"env": {"prod", "none"}},
-				NoneBucketHasEntities: true,
-			},
-			wantFilterSet: false,
-			wantNoneBkt:   true,
-		},
+		// NOTE: a "none bucket present and populated" case used to live here
+		// and set OrientationInput.NoneBucketHasEntities directly. It was
+		// removed because runDiagnose does not populate that field today
+		// (the producer requires a scoped CountEntityTypes(env="none") call).
+		// Restore the case when the producer is wired.
 	}
 
 	for _, tt := range tests {
@@ -216,12 +211,11 @@ func TestDetectCantFilter(t *testing.T) {
 		scope     kg.ScopeFlags
 		wantMatch bool
 	}{
-		{
-			name:      "none bucket has entities",
-			in:        kg.OrientationInput{NoneBucketHasEntities: true},
-			scope:     kg.NewTestScopeFlags("", "", ""),
-			wantMatch: true,
-		},
+		// NOTE: a "none bucket has entities" case used to live here and set
+		// OrientationInput.NoneBucketHasEntities directly. It was removed
+		// because runDiagnose does not populate that field today (the producer
+		// requires a scoped CountEntityTypes(env="none") call). Restore the
+		// case when the producer is wired.
 		{
 			name: "user gave bogus env",
 			in: kg.OrientationInput{

--- a/internal/providers/kg/orientation_test.go
+++ b/internal/providers/kg/orientation_test.go
@@ -1,0 +1,421 @@
+package kg_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/kg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// EntityOverview / ScopeSummary builders
+// ---------------------------------------------------------------------------
+
+func TestBuildEntityOverview_ExcludesMetaTypes(t *testing.T) {
+	in := kg.OrientationInput{
+		EntityCounts: map[string]int64{
+			"Service":    10,
+			"Pod":        50,
+			"EntityType": 18, // meta — excluded
+			"Schema":     30, // meta — excluded
+			"Env":        3,  // meta — excluded
+		},
+		TracesTargetInfoSeries: 4,
+	}
+
+	overview := kg.BuildEntityOverview(in)
+
+	assert.Equal(t, int64(60), overview.Total,
+		"Total should exclude meta types (10 + 50, not 10+50+18+30+3)")
+	assert.Equal(t, int64(10), overview.TotalServiceCount)
+	assert.Equal(t, int64(4), overview.TracedServiceCount)
+	assert.NotContains(t, overview.ByType, "EntityType")
+	assert.NotContains(t, overview.ByType, "Schema")
+	assert.NotContains(t, overview.ByType, "Env")
+	assert.Contains(t, overview.ByType, "Service")
+	assert.Contains(t, overview.ByType, "Pod")
+}
+
+func TestBuildScopeSummary(t *testing.T) {
+	tests := []struct {
+		name          string
+		scope         kg.ScopeFlags
+		in            kg.OrientationInput
+		wantFilterSet bool
+		wantNoneBkt   bool
+	}{
+		{
+			name:          "no filter, no none bucket",
+			scope:         kg.NewTestScopeFlags("", "", ""),
+			in:            kg.OrientationInput{Scopes: map[string][]string{"env": {"prod", "staging"}}},
+			wantFilterSet: false,
+			wantNoneBkt:   false,
+		},
+		{
+			name:          "env filter set",
+			scope:         kg.NewTestScopeFlags("prod", "", ""),
+			in:            kg.OrientationInput{Scopes: map[string][]string{"env": {"prod"}}},
+			wantFilterSet: true,
+			wantNoneBkt:   false,
+		},
+		{
+			name:          "namespace filter set",
+			scope:         kg.NewTestScopeFlags("", "", "team-a"),
+			in:            kg.OrientationInput{Scopes: map[string][]string{"namespace": {"team-a"}}},
+			wantFilterSet: true,
+			wantNoneBkt:   false,
+		},
+		{
+			name:  "none bucket present and populated",
+			scope: kg.NewTestScopeFlags("", "", ""),
+			in: kg.OrientationInput{
+				Scopes:                map[string][]string{"env": {"prod", "none"}},
+				NoneBucketHasEntities: true,
+			},
+			wantFilterSet: false,
+			wantNoneBkt:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kg.BuildScopeSummary(tt.in, &tt.scope)
+			assert.Equal(t, tt.wantFilterSet, got.FilterSet, "FilterSet mismatch")
+			assert.Equal(t, tt.wantNoneBkt, got.NoneBucketPresent, "NoneBucketPresent mismatch")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario detectors
+// ---------------------------------------------------------------------------
+
+func TestDetectNoEntities(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        kg.OrientationInput
+		overview  kg.EntityOverview
+		wantMatch bool
+	}{
+		{
+			name:      "stack disabled",
+			in:        kg.OrientationInput{StackEnabled: false, EntityCounts: map[string]int64{"Service": 5}},
+			overview:  kg.EntityOverview{Total: 5},
+			wantMatch: true,
+		},
+		{
+			name:      "stack enabled, zero entities",
+			in:        kg.OrientationInput{StackEnabled: true, EntityCounts: map[string]int64{}},
+			overview:  kg.EntityOverview{Total: 0},
+			wantMatch: true,
+		},
+		{
+			name:      "stack enabled, entities present",
+			in:        kg.OrientationInput{StackEnabled: true, EntityCounts: map[string]int64{"Service": 5}},
+			overview:  kg.EntityOverview{Total: 5},
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kg.DetectNoEntities(tt.in, tt.overview)
+			if tt.wantMatch {
+				require.NotNil(t, got, "expected scenario match")
+				assert.Equal(t, kg.ScenarioNoEntities, got.ID)
+				assert.Equal(t, "I see no entities at all", got.Label)
+				assert.Equal(t, kg.ConfidenceHigh, got.Confidence)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
+
+func TestDetectEntitiesNoEdges(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        kg.OrientationInput
+		overview  kg.EntityOverview
+		scope     kg.ScopeFlags
+		wantMatch bool
+	}{
+		{
+			name:      "services exist, calls = 0",
+			in:        kg.OrientationInput{AssertsRelationCallsSeries: 0},
+			overview:  kg.EntityOverview{TotalServiceCount: 100},
+			scope:     kg.NewTestScopeFlags("", "", ""),
+			wantMatch: true,
+		},
+		{
+			name:      "services exist, calls > 0",
+			in:        kg.OrientationInput{AssertsRelationCallsSeries: 20},
+			overview:  kg.EntityOverview{TotalServiceCount: 100},
+			scope:     kg.NewTestScopeFlags("", "", ""),
+			wantMatch: false,
+		},
+		{
+			name:      "no services — detector silent",
+			in:        kg.OrientationInput{AssertsRelationCallsSeries: 0},
+			overview:  kg.EntityOverview{TotalServiceCount: 0},
+			scope:     kg.NewTestScopeFlags("", "", ""),
+			wantMatch: false,
+		},
+		{
+			name:      "env scope echoed in reasoning",
+			in:        kg.OrientationInput{AssertsRelationCallsSeries: 0},
+			overview:  kg.EntityOverview{TotalServiceCount: 100},
+			scope:     kg.NewTestScopeFlags("production", "", ""),
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kg.DetectEntitiesNoEdges(tt.in, tt.overview, &tt.scope)
+			if tt.wantMatch {
+				require.NotNil(t, got, "expected scenario match")
+				assert.Equal(t, kg.ScenarioEntitiesNoEdges, got.ID)
+				assert.Equal(t, "I see entities with no edges", got.Label)
+				assert.Equal(t, kg.ConfidenceHigh, got.Confidence)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
+
+func TestDetectCantFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        kg.OrientationInput
+		scope     kg.ScopeFlags
+		wantMatch bool
+	}{
+		{
+			name:      "none bucket has entities",
+			in:        kg.OrientationInput{NoneBucketHasEntities: true},
+			scope:     kg.NewTestScopeFlags("", "", ""),
+			wantMatch: true,
+		},
+		{
+			name: "user gave bogus env",
+			in: kg.OrientationInput{
+				Scopes: map[string][]string{"env": {"prod", "staging"}},
+			},
+			scope:     kg.NewTestScopeFlags("doesnotexist", "", ""),
+			wantMatch: true,
+		},
+		{
+			name: "user gave valid env, no none bucket",
+			in: kg.OrientationInput{
+				Scopes: map[string][]string{"env": {"prod", "staging"}},
+			},
+			scope:     kg.NewTestScopeFlags("prod", "", ""),
+			wantMatch: false,
+		},
+		{
+			name:      "no filter, no none bucket — silent",
+			in:        kg.OrientationInput{},
+			scope:     kg.NewTestScopeFlags("", "", ""),
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kg.DetectCantFilter(tt.in, &tt.scope)
+			if tt.wantMatch {
+				require.NotNil(t, got, "expected scenario match")
+				assert.Equal(t, kg.ScenarioCantFilter, got.ID)
+				assert.Equal(t, "I can't filter to the entities I want", got.Label)
+				assert.Equal(t, kg.ConfidenceHigh, got.Confidence)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
+
+func TestDetectMissingEntities(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        kg.OrientationInput
+		scope     kg.ScopeFlags
+		wantMatch bool
+	}{
+		{
+			name:      "no filter — silent regardless of data",
+			in:        kg.OrientationInput{AssertsMixinWorkloadJobSeries: 0},
+			scope:     kg.NewTestScopeFlags("", "", ""),
+			wantMatch: false,
+		},
+		{
+			name:      "filter set, no workloads in scope",
+			in:        kg.OrientationInput{AssertsMixinWorkloadJobSeries: 0},
+			scope:     kg.NewTestScopeFlags("prod", "", ""),
+			wantMatch: true,
+		},
+		{
+			name:      "filter set, workloads present",
+			in:        kg.OrientationInput{AssertsMixinWorkloadJobSeries: 100},
+			scope:     kg.NewTestScopeFlags("prod", "", ""),
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kg.DetectMissingEntities(tt.in, &tt.scope)
+			if tt.wantMatch {
+				require.NotNil(t, got, "expected scenario match")
+				assert.Equal(t, kg.ScenarioMissingEntities, got.ID)
+				assert.Equal(t, "Some expected entities are missing", got.Label)
+				assert.Equal(t, kg.ConfidenceMedium, got.Confidence)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ComputeOrientation — end-to-end composition
+// ---------------------------------------------------------------------------
+
+func TestComputeOrientation_HealthyUnscoped(t *testing.T) {
+	in := kg.OrientationInput{
+		StackEnabled:                  true,
+		EntityCounts:                  map[string]int64{"Service": 100, "Pod": 200, "EntityType": 18, "Schema": 30, "Env": 3},
+		Scopes:                        map[string][]string{"env": {"prod"}, "namespace": {"team-a", "team-b"}},
+		TracesTargetInfoSeries:        20,
+		AssertsRelationCallsSeries:    20,
+		AssertsMixinWorkloadJobSeries: 100,
+	}
+	scope := kg.NewTestScopeFlags("", "", "")
+
+	got := kg.ComputeOrientation(in, &scope)
+
+	assert.Empty(t, got.MatchedScenarios, "healthy stack should match no scenarios")
+	assert.NotEmpty(t, got.StartingPoints, "unscoped run should suggest starting points")
+	assert.Len(t, got.StartingPoints, 3)
+	assert.Equal(t, int64(300), got.EntityOverview.Total, "total excludes meta types")
+	assert.Equal(t, int64(20), got.EntityOverview.TracedServiceCount)
+	assert.False(t, got.Scope.FilterSet)
+}
+
+func TestComputeOrientation_FilterSet_SuppressesStartingPoints(t *testing.T) {
+	in := kg.OrientationInput{
+		StackEnabled:                  true,
+		EntityCounts:                  map[string]int64{"Service": 10},
+		Scopes:                        map[string][]string{"env": {"prod"}},
+		AssertsRelationCallsSeries:    5,
+		AssertsMixinWorkloadJobSeries: 10,
+	}
+	scope := kg.NewTestScopeFlags("prod", "", "")
+
+	got := kg.ComputeOrientation(in, &scope)
+
+	assert.Empty(t, got.StartingPoints, "starting points must be suppressed when any scope flag is set")
+	assert.True(t, got.Scope.FilterSet)
+}
+
+func TestComputeOrientation_MultipleScenarios_OrderByConfidence(t *testing.T) {
+	// Simulates: scope filter applied, services exist but no edges,
+	// AND the scoped workload-job series is empty.
+	// Expect: entities-no-edges (high) and missing-entities (medium) both
+	// match, with high-confidence first.
+	in := kg.OrientationInput{
+		StackEnabled:                  true,
+		EntityCounts:                  map[string]int64{"Service": 100},
+		Scopes:                        map[string][]string{"env": {"prod"}},
+		AssertsRelationCallsSeries:    0,
+		AssertsMixinWorkloadJobSeries: 0,
+	}
+	scope := kg.NewTestScopeFlags("prod", "", "")
+
+	got := kg.ComputeOrientation(in, &scope)
+
+	require.GreaterOrEqual(t, len(got.MatchedScenarios), 2,
+		"expected both entities-no-edges and missing-entities to match")
+
+	// First match must be high-confidence.
+	assert.Equal(t, kg.ConfidenceHigh, got.MatchedScenarios[0].Confidence,
+		"high-confidence scenarios should appear first")
+
+	// All high-confidence entries must come before any medium-confidence ones.
+	seenMedium := false
+	for _, s := range got.MatchedScenarios {
+		if s.Confidence == kg.ConfidenceMedium {
+			seenMedium = true
+		}
+		if seenMedium {
+			assert.NotEqual(t, kg.ConfidenceHigh, s.Confidence,
+				"no high-confidence entry may follow a medium-confidence entry")
+		}
+	}
+}
+
+func TestComputeOrientation_NoEntities_StackDisabled(t *testing.T) {
+	in := kg.OrientationInput{
+		StackEnabled: false,
+		EntityCounts: map[string]int64{},
+	}
+	scope := kg.NewTestScopeFlags("", "", "")
+
+	got := kg.ComputeOrientation(in, &scope)
+
+	require.Len(t, got.MatchedScenarios, 1)
+	assert.Equal(t, kg.ScenarioNoEntities, got.MatchedScenarios[0].ID)
+}
+
+// ---------------------------------------------------------------------------
+// Starting points
+// ---------------------------------------------------------------------------
+
+func TestBuildStartingPoints_AlwaysThreeModes(t *testing.T) {
+	scope := kg.ScopeSummary{NamespacesKnown: []string{"a", "b", "c"}}
+	got := kg.BuildStartingPoints(scope)
+
+	require.Len(t, got, 3)
+	ids := []string{string(got[0].ID), string(got[1].ID), string(got[2].ID)}
+	sort.Strings(ids)
+	assert.Equal(t, []string{
+		string(kg.StartingPointByNamePattern),
+		string(kg.StartingPointByNamespace),
+		string(kg.StartingPointBySingleService),
+	}, ids)
+}
+
+func TestBuildStartingPoints_NamespaceContextUsesRuntimeCount(t *testing.T) {
+	scope := kg.ScopeSummary{NamespacesKnown: []string{"a", "b", "c", "d"}}
+	got := kg.BuildStartingPoints(scope)
+
+	var nsPoint kg.StartingPoint
+	for _, p := range got {
+		if p.ID == kg.StartingPointByNamespace {
+			nsPoint = p
+		}
+	}
+	require.Equal(t, kg.StartingPointByNamespace, nsPoint.ID,
+		"by-namespace starting point must be present")
+	assert.Contains(t, nsPoint.Context, "4 namespace",
+		"namespace context should report the actual count")
+	// Context must NOT make a judgment about whether the count is too many.
+	assert.NotContains(t, nsPoint.Context, "many")
+	assert.NotContains(t, nsPoint.Context, "too")
+}
+
+func TestBuildStartingPoints_NoNamespacesKnown_NoContextSet(t *testing.T) {
+	scope := kg.ScopeSummary{}
+	got := kg.BuildStartingPoints(scope)
+
+	for _, p := range got {
+		if p.ID == kg.StartingPointByNamespace {
+			assert.Empty(t, p.Context,
+				"namespace context should be empty when no namespaces are known")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a top-level **Orientation block** to `gcx kg diagnose` output that
surfaces which of the five original Entity Graph scenarios a user's run
matches:

1. "I see no entities at all"
2. "Some expected entities are missing"
3. "I see entities with no edges"
4. "I see disconnected clusters of entities" *(detector deferred; v1 emits a "see also" hint)*
5. "I can't filter to the entities I want"

These scenarios were the founding product framing for `kg diagnose` but had
drifted out of the user-visible output as we layered on sub-checks. This PR
restores the top-level orientation so the user (or their AI agent) doesn't
have to infer the scenario from a 10-line check table.

## Commits

| Commit | Adds |
|---|---|
| `fef190d` | Orientation types, four scenario detectors, 14 table-driven tests |
| `8b122fe` | Wires Orientation into `runDiagnose`; both text and JSON codecs surface it |
| `eb514ff` | Skill gains a 16-line "Start here" pointer at the Orientation block |
| `fac5ff8` | **Round 2:** scope-aware `detectEntitiesNoEdges` (no more false-HIGH on empty scopes) |
| `fbfff82` | **Round 2:** label stack-wide vs scoped numbers in the codec header; multi-dimension scope hint |
| `761e90f` | **Round 2:** explicit `slices.SortStableFunc` on matched scenarios (was relying on call order) |
| `5639f6f` | **Round 2:** extract `DiagnoseSummary` named type + direct unit test on `pipelineHealthFromSummary` |
| `3cef4e9` | **Round 2:** mark none-bucket detection inert until producer is wired; drop dead codec/test paths |

## Round 2 review notes (resolved)

Round 2 review from @radiohead surfaced two correctness issues + three
minors + a test-coverage gap. All addressed:

- **M2 — `detectEntitiesNoEdges` mixed stack-wide and scoped signals.**
  Gate is now `AssertsMixinWorkloadJobSeries` (scoped). Regression test
  added with the live numbers from the review.
- **M3 + m1 — codec amplified the scope mismatch and hard-coded `(env=)`.**
  Stack-wide numbers labeled `(stack-wide)`, scoped trace count on its own
  clause. Multi-dimension scope hint built from whichever of
  env/namespace/site is set.
- **m2 — accidental scenario ordering.** Replaced with explicit
  `slices.SortStableFunc` by `(Confidence, ScenarioID)`.
- **m3 — anonymous-struct param.** Extracted `DiagnoseSummary` (JSON shape
  unchanged); added direct unit test.
- **M1 + T1 — `NoneBucketHasEntities` was never produced.** Producing it
  truthfully needs a new `CountEntityTypes(env="none")` API call. Marked
  the field reserved, removed the dead codec branch and detector operand,
  dropped the two test cases that exercised the unreachable path. NOTE
  comments mark where to restore them when the producer is wired (a
  separate follow-up).

## Design rules followed

Direct response to boundary feedback from #726/#745/#748:

- **Skill/code boundary.** All detection logic in Go. The skill addition is
  16 lines — names the five scenarios verbatim and tells the agent to read
  the Orientation block first.
- **Numbers are runtime data, not authored thresholds.** Everything printed
  comes from the current `DiagnoseResult`. No constants like `total > N`.
- **Detection is binary.** No knobs, no severity scoring, no judgment phrasing.
- **Scenarios named verbatim every time.** Skill, JSON `label`, text codec —
  all use the same strings so an agent can match by exact string.
- **Cost-aware.** Zero new API calls. `computeOrientation` reads data the
  existing per-check goroutines already collected. (M1 deferred precisely
  because wiring it would add a new API call.)
- **No new file size in `diagnose.go`.** The new detector code lives in
  `orientation.go`.

## Deliberately out of scope

- **Preflight check** for the 5-confidently-wrong "no data" verdicts
  failure mode — still under investigation.
- **Scenario 4 detector** (disconnected clusters) — needs per-env
  comparison the stack-level run doesn't currently do. Text codec emits a
  "See also" hint pointing at the per-env comparison workflow.
- **Four checks proposed in #748** — kept out per the size pushback there.
- **None-bucket producer** — see M1 above; needs a new API call.
