### PR TITLE
feat(traces): add adaptive config show/set commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ gcx provides dedicated commands for each Grafana Cloud product:
 | **Assistant** | `gcx assistant` | `assistant prompt`, `assistant investigations list`, `assistant investigations report` |
 | **Adaptive Metrics** | `gcx metrics adaptive` | `metrics adaptive recommendations show`, `metrics adaptive rules list` |
 | **Adaptive Logs** | `gcx logs adaptive` | `logs adaptive patterns show`, `logs adaptive drop-rules list` |
-| **Adaptive Traces** | `gcx traces adaptive` | `traces adaptive recommendations show`, `traces adaptive policies list` |
+| **Adaptive Traces** | `gcx traces adaptive` | `traces adaptive recommendations show`, `traces adaptive policies list`, `traces adaptive config show` |
 | **Profiles (Pyroscope)** | `gcx profiles` | `profiles query`, `profiles labels` |
 | **Traces (Tempo)** | `gcx traces` | `traces query`, `traces get`, `traces labels` |
 

--- a/docs/reference/cli/gcx_traces_adaptive_config.md
+++ b/docs/reference/cli/gcx_traces_adaptive_config.md
@@ -1,11 +1,11 @@
-## gcx traces adaptive
+## gcx traces adaptive config
 
-Manage Adaptive Traces resources
+Manage the Adaptive Traces tenant configuration.
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+  -h, --help   help for config
 ```
 
 ### Options inherited from parent commands
@@ -22,8 +22,7 @@ Manage Adaptive Traces resources
 
 ### SEE ALSO
 
-* [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces
-* [gcx traces adaptive config](gcx_traces_adaptive_config.md)	 - Manage the Adaptive Traces tenant configuration.
-* [gcx traces adaptive policies](gcx_traces_adaptive_policies.md)	 - Manage Adaptive Traces sampling policies.
-* [gcx traces adaptive recommendations](gcx_traces_adaptive_recommendations.md)	 - Manage Adaptive Traces recommendations.
+* [gcx traces adaptive](gcx_traces_adaptive.md)	 - Manage Adaptive Traces resources
+* [gcx traces adaptive config set](gcx_traces_adaptive_config_set.md)	 - Replace the Adaptive Traces tenant configuration.
+* [gcx traces adaptive config show](gcx_traces_adaptive_config_show.md)	 - Show the Adaptive Traces tenant configuration.
 

--- a/docs/reference/cli/gcx_traces_adaptive_config_set.md
+++ b/docs/reference/cli/gcx_traces_adaptive_config_set.md
@@ -1,11 +1,23 @@
-## gcx traces adaptive
+## gcx traces adaptive config set
 
-Manage Adaptive Traces resources
+Replace the Adaptive Traces tenant configuration.
+
+### Synopsis
+
+Replace the Adaptive Traces tenant configuration with the contents of the supplied file. The API does not support partial patches — the entire payload is required and the existing document is overwritten.
+
+```
+gcx traces adaptive config set [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+  -f, --filename string   File containing the full configuration payload (use - for stdin)
+      --force             Skip confirmation prompt
+  -h, --help              help for set
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands
@@ -22,8 +34,5 @@ Manage Adaptive Traces resources
 
 ### SEE ALSO
 
-* [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces
 * [gcx traces adaptive config](gcx_traces_adaptive_config.md)	 - Manage the Adaptive Traces tenant configuration.
-* [gcx traces adaptive policies](gcx_traces_adaptive_policies.md)	 - Manage Adaptive Traces sampling policies.
-* [gcx traces adaptive recommendations](gcx_traces_adaptive_recommendations.md)	 - Manage Adaptive Traces recommendations.
 

--- a/docs/reference/cli/gcx_traces_adaptive_config_set.md
+++ b/docs/reference/cli/gcx_traces_adaptive_config_set.md
@@ -6,6 +6,8 @@ Replace the Adaptive Traces tenant configuration.
 
 Replace the Adaptive Traces tenant configuration with the contents of the supplied file. The API does not support partial patches — the entire payload is required and the existing document is overwritten.
 
+To avoid clobbering fields you did not intend to change, run `gcx traces adaptive config show` first, edit the returned document, and pass the full result back to `set`. Any field omitted from the payload is dropped, not preserved.
+
 ```
 gcx traces adaptive config set [flags]
 ```

--- a/docs/reference/cli/gcx_traces_adaptive_config_show.md
+++ b/docs/reference/cli/gcx_traces_adaptive_config_show.md
@@ -1,11 +1,17 @@
-## gcx traces adaptive
+## gcx traces adaptive config show
 
-Manage Adaptive Traces resources
+Show the Adaptive Traces tenant configuration.
+
+```
+gcx traces adaptive config show [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for adaptive
+  -h, --help            help for show
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands
@@ -22,8 +28,5 @@ Manage Adaptive Traces resources
 
 ### SEE ALSO
 
-* [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces
 * [gcx traces adaptive config](gcx_traces_adaptive_config.md)	 - Manage the Adaptive Traces tenant configuration.
-* [gcx traces adaptive policies](gcx_traces_adaptive_policies.md)	 - Manage Adaptive Traces sampling policies.
-* [gcx traces adaptive recommendations](gcx_traces_adaptive_recommendations.md)	 - Manage Adaptive Traces recommendations.
 

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -562,6 +562,8 @@ var commandAnnotations = map[string]annotation{
 	"gcx traces adaptive recommendations apply":   {Cost: "small"},
 	"gcx traces adaptive recommendations dismiss": {Cost: "small"},
 	"gcx traces adaptive recommendations show":    {Cost: "small", Hint: "Docs: " + docs.AdaptiveTraces},
+	"gcx traces adaptive config show":             {Cost: "small"},
+	"gcx traces adaptive config set":              {Cost: "small"},
 }
 
 // ApplyAnnotations walks the command tree and applies agent annotations from

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -563,7 +563,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx traces adaptive recommendations dismiss": {Cost: "small"},
 	"gcx traces adaptive recommendations show":    {Cost: "small", Hint: "Docs: " + docs.AdaptiveTraces},
 	"gcx traces adaptive config show":             {Cost: "small"},
-	"gcx traces adaptive config set":              {Cost: "small"},
+	"gcx traces adaptive config set":              {Cost: "small", Hint: "Run `gcx traces adaptive config show` first, edit the returned document, then pass the full result back via -f. The API replaces the entire payload — fields omitted from the set body are dropped, not preserved."},
 }
 
 // ApplyAnnotations walks the command tree and applies agent annotations from

--- a/internal/providers/traces/adaptive/client.go
+++ b/internal/providers/traces/adaptive/client.go
@@ -18,6 +18,7 @@ const (
 	recommendationsPath      = "/adaptive-traces/api/v1/recommendations"
 	recommendationApplyFmt   = recommendationsPath + "/%s/apply"
 	recommendationDismissFmt = recommendationsPath + "/%s/dismiss"
+	configPath               = "/adaptive-traces/api/v1/config"
 )
 
 // Client is an HTTP client for the Adaptive Traces API.
@@ -199,6 +200,60 @@ func (c *Client) DismissRecommendation(ctx context.Context, id string) error {
 	}
 
 	return nil
+}
+
+// GetConfig returns the Adaptive Traces tenant configuration.
+func (c *Client) GetConfig(ctx context.Context) (Config, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, configPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("getting config: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("adaptive-traces: get config: %w", handleErrorResponse(resp))
+	}
+
+	var cfg Config
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("decoding config: %w", err)
+	}
+	if cfg == nil {
+		cfg = Config{}
+	}
+	return cfg, nil
+}
+
+// UpdateConfig replaces the Adaptive Traces tenant configuration. The API does
+// not support partial patches — the entire payload is required on every call.
+func (c *Client) UpdateConfig(ctx context.Context, cfg Config) (Config, error) {
+	body, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling config: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, http.MethodPut, configPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("updating config: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return nil, fmt.Errorf("adaptive-traces: update config: %w", handleErrorResponse(resp))
+	}
+
+	if resp.StatusCode == http.StatusNoContent {
+		return cfg, nil
+	}
+
+	var updated Config
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		return nil, fmt.Errorf("decoding updated config: %w", err)
+	}
+	if updated == nil {
+		updated = Config{}
+	}
+	return updated, nil
 }
 
 func (c *Client) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {

--- a/internal/providers/traces/adaptive/client_test.go
+++ b/internal/providers/traces/adaptive/client_test.go
@@ -3,6 +3,7 @@ package traces_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -413,6 +414,140 @@ func TestClient_ApplyRecommendation(t *testing.T) {
 // ---------------------------------------------------------------------------
 // DismissRecommendation
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// GetConfig
+// ---------------------------------------------------------------------------
+
+func TestClient_GetConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    traces.Config
+		wantErr bool
+	}{
+		{
+			name: "success",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/adaptive-traces/api/v1/config", r.URL.Path)
+				assert.Equal(t, "Basic NDI6dGVzdC10b2tlbg==", r.Header.Get("Authorization"))
+				writeJSON(w, map[string]any{
+					"default_sampling_percentage": 10.0,
+					"feature_flags":               map[string]any{"recommendations_enabled": true},
+				})
+			},
+			want: traces.Config{
+				"default_sampling_percentage": 10.0,
+				"feature_flags":               map[string]any{"recommendations_enabled": true},
+			},
+		},
+		{
+			name: "null body returns empty config",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("null"))
+			},
+			want: traces.Config{},
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				writeJSON(w, map[string]string{"error": "boom"})
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			client := newTestClient(srv)
+			got, err := client.GetConfig(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateConfig
+// ---------------------------------------------------------------------------
+
+func TestClient_UpdateConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   traces.Config
+		handler http.HandlerFunc
+		want    traces.Config
+		wantErr bool
+	}{
+		{
+			name:  "success sends full payload via PUT",
+			input: traces.Config{"default_sampling_percentage": 25.0},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPut, r.Method)
+				assert.Equal(t, "/adaptive-traces/api/v1/config", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				var sent map[string]any
+				assert.NoError(t, json.Unmarshal(body, &sent))
+				assert.Equal(t, map[string]any{"default_sampling_percentage": 25.0}, sent)
+				writeJSON(w, sent)
+			},
+			want: traces.Config{"default_sampling_percentage": 25.0},
+		},
+		{
+			name:  "204 no content echoes input",
+			input: traces.Config{"default_sampling_percentage": 7.5},
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			},
+			want: traces.Config{"default_sampling_percentage": 7.5},
+		},
+		{
+			name:  "null body returns empty config",
+			input: traces.Config{"default_sampling_percentage": 1.0},
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("null"))
+			},
+			want: traces.Config{},
+		},
+		{
+			name:  "server error",
+			input: traces.Config{},
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				writeJSON(w, map[string]string{"error": "invalid"})
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			client := newTestClient(srv)
+			got, err := client.UpdateConfig(context.Background(), tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
 
 //nolint:dupl // Similar test pattern for similar API, acceptable duplication.
 func TestClient_DismissRecommendation(t *testing.T) {

--- a/internal/providers/traces/adaptive/commands.go
+++ b/internal/providers/traces/adaptive/commands.go
@@ -744,8 +744,11 @@ func (h *tracesHelper) configSetCommand() *cobra.Command {
 	return cmd
 }
 
-// maxConfigFileSize is the maximum size of a config file (10 MB).
-const maxConfigFileSize = 10 << 20
+// maxConfigFileSize is the maximum size of a config file (512 KB). The config
+// document holds a sampling percentage, feature flags, and a list of
+// user-defined condition rules — generous headroom for ~1.5k–2k condition
+// entries while still rejecting accidentally-piped large payloads early.
+const maxConfigFileSize = 512 << 10
 
 func readConfigFromFile(filePath string, stdin io.Reader) (Config, error) {
 	var reader io.Reader

--- a/internal/providers/traces/adaptive/commands.go
+++ b/internal/providers/traces/adaptive/commands.go
@@ -28,6 +28,7 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 	h := &tracesHelper{loader: loader}
 	cmd.AddCommand(h.policiesCommand())
 	cmd.AddCommand(h.recommendationsCommand())
+	cmd.AddCommand(h.configCommand())
 	return cmd
 }
 
@@ -604,4 +605,179 @@ func ReadPolicyFromReader(reader io.Reader) (*Policy, error) {
 	}
 
 	return &policy, nil
+}
+
+// ===========================================================================
+// config (singleton)
+// ===========================================================================
+
+func (h *tracesHelper) configCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage the Adaptive Traces tenant configuration.",
+	}
+	cmd.AddCommand(
+		h.configShowCommand(),
+		h.configSetCommand(),
+	)
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// config show
+// ---------------------------------------------------------------------------
+
+type configShowOpts struct {
+	IO cmdio.Options
+}
+
+func (o *configShowOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("yaml")
+	o.IO.BindFlags(flags)
+}
+
+func (h *tracesHelper) configShowCommand() *cobra.Command {
+	opts := &configShowOpts{}
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show the Adaptive Traces tenant configuration.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			cfg, err := client.GetConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), cfg)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// config set
+// ---------------------------------------------------------------------------
+
+type configSetOpts struct {
+	IO    cmdio.Options
+	File  string
+	Force bool
+}
+
+func (o *configSetOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("yaml")
+	o.IO.BindFlags(flags)
+	flags.StringVarP(&o.File, "filename", "f", "", "File containing the full configuration payload (use - for stdin)")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
+}
+
+func (o *configSetOpts) Validate() error {
+	if o.File == "" {
+		return errors.New("--filename/-f is required")
+	}
+	return nil
+}
+
+func (h *tracesHelper) configSetCommand() *cobra.Command {
+	opts := &configSetOpts{}
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Replace the Adaptive Traces tenant configuration.",
+		Long: "Replace the Adaptive Traces tenant configuration with the contents of the " +
+			"supplied file. The API does not support partial patches — the entire payload is " +
+			"required and the existing document is overwritten.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			cfg, err := readConfigFromFile(opts.File, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.ErrOrStderr(), opts.Force,
+				"Replace the Adaptive Traces tenant configuration? This overwrites the entire existing document.")
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
+			}
+
+			ctx := cmd.Context()
+
+			client, err := h.newClient(ctx)
+			if err != nil {
+				return err
+			}
+
+			updated, err := client.UpdateConfig(ctx, cfg)
+			if err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.ErrOrStderr(), "Replaced Adaptive Traces tenant configuration")
+			return opts.IO.Encode(cmd.OutOrStdout(), updated)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// maxConfigFileSize is the maximum size of a config file (10 MB).
+const maxConfigFileSize = 10 << 20
+
+func readConfigFromFile(filePath string, stdin io.Reader) (Config, error) {
+	var reader io.Reader
+	if filePath == "-" {
+		reader = stdin
+	} else {
+		f, err := os.Open(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("opening file %s: %w", filePath, err)
+		}
+		defer f.Close()
+		reader = f
+	}
+
+	return ReadConfigFromReader(reader)
+}
+
+// ReadConfigFromReader decodes a Config from an io.Reader (YAML or JSON). Exported for testing.
+func ReadConfigFromReader(reader io.Reader) (Config, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, maxConfigFileSize))
+	if err != nil {
+		return nil, fmt.Errorf("reading input: %w", err)
+	}
+
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil, errors.New("config payload is empty")
+	}
+
+	var cfg Config
+	yamlCodec := format.NewYAMLCodec()
+	if err := yamlCodec.Decode(strings.NewReader(string(data)), &cfg); err != nil {
+		return nil, fmt.Errorf("decoding input: %w", err)
+	}
+	if cfg == nil {
+		cfg = Config{}
+	}
+	return cfg, nil
 }

--- a/internal/providers/traces/adaptive/commands.go
+++ b/internal/providers/traces/adaptive/commands.go
@@ -697,7 +697,10 @@ func (h *tracesHelper) configSetCommand() *cobra.Command {
 		Short: "Replace the Adaptive Traces tenant configuration.",
 		Long: "Replace the Adaptive Traces tenant configuration with the contents of the " +
 			"supplied file. The API does not support partial patches — the entire payload is " +
-			"required and the existing document is overwritten.",
+			"required and the existing document is overwritten.\n\n" +
+			"To avoid clobbering fields you did not intend to change, run `gcx traces adaptive " +
+			"config show` first, edit the returned document, and pass the full result back to " +
+			"`set`. Any field omitted from the payload is dropped, not preserved.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.Validate(); err != nil {

--- a/internal/providers/traces/adaptive/commands_test.go
+++ b/internal/providers/traces/adaptive/commands_test.go
@@ -169,6 +169,105 @@ func TestPoliciesCreate_Integration(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// ReadConfigFromReader
+// ---------------------------------------------------------------------------
+
+func TestReadConfigFromReader(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    traces.Config
+		wantErr bool
+	}{
+		{
+			name:  "json",
+			input: `{"default_sampling_percentage":10,"feature_flags":{"recommendations_enabled":true}}`,
+			want: traces.Config{
+				"default_sampling_percentage": uint64(10),
+				"feature_flags":               map[string]any{"recommendations_enabled": true},
+			},
+		},
+		{
+			name: "yaml",
+			input: `default_sampling_percentage: 25
+feature_flags:
+  recommendations_enabled: false
+`,
+			want: traces.Config{
+				"default_sampling_percentage": uint64(25),
+				"feature_flags":               map[string]any{"recommendations_enabled": false},
+			},
+		},
+		{
+			name:    "empty input is rejected",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid input",
+			input:   "<<<not valid>>>",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := traces.ReadConfigFromReader(strings.NewReader(tc.input))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration-style: config show + set via test server
+// ---------------------------------------------------------------------------
+
+func TestConfig_Integration(t *testing.T) {
+	stored := traces.Config{"default_sampling_percentage": 10.0}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/adaptive-traces/api/v1/config", r.URL.Path)
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(stored)
+		case http.MethodPut:
+			var next traces.Config
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&next))
+			stored = next
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(stored)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	client := traces.NewClient(srv.URL, 42, "test-token", srv.Client())
+
+	got, err := client.GetConfig(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, traces.Config{"default_sampling_percentage": 10.0}, got)
+
+	updated, err := client.UpdateConfig(t.Context(), traces.Config{
+		"default_sampling_percentage": 50.0,
+		"feature_flags":               map[string]any{"recommendations_enabled": true},
+	})
+	require.NoError(t, err)
+	assert.InDelta(t, 50.0, updated["default_sampling_percentage"], 1e-9)
+
+	// Confirm round-trip — fetched value reflects the update.
+	got, err = client.GetConfig(t.Context())
+	require.NoError(t, err)
+	assert.InDelta(t, 50.0, got["default_sampling_percentage"], 1e-9)
+}
+
+// ---------------------------------------------------------------------------
 // Integration-style: policies delete via test server
 // ---------------------------------------------------------------------------
 

--- a/internal/providers/traces/adaptive/types.go
+++ b/internal/providers/traces/adaptive/types.go
@@ -50,6 +50,18 @@ type RecommendationAction struct {
 	Seed                 *PolicySeed `json:"seed,omitempty"`
 }
 
+// Config is the Adaptive Traces tenant configuration document.
+//
+// The schema is intentionally flexible: Adaptive Traces makes no backwards
+// compatibility guarantees about config fields, and the set of supported keys
+// changes as features are enabled or disabled server-side. Modeling the
+// document as a generic map lets new and removed fields flow through
+// round-trips unchanged without requiring CLI releases.
+//
+// Updates always replace the entire document — the API does not support
+// partial patches today.
+type Config map[string]any
+
 // Recommendation represents an adaptive traces sampling recommendation.
 type Recommendation struct {
 	ID          string                 `json:"id"`

--- a/internal/providers/traces/adaptive/types.go
+++ b/internal/providers/traces/adaptive/types.go
@@ -59,7 +59,9 @@ type RecommendationAction struct {
 // round-trips unchanged without requiring CLI releases.
 //
 // Updates always replace the entire document — the API does not support
-// partial patches today.
+// partial patches today. Callers should `show` the current config, mutate
+// the returned map, then `set` it back; any field omitted from the set
+// payload is dropped, not preserved.
 type Config map[string]any
 
 // Recommendation represents an adaptive traces sampling recommendation.


### PR DESCRIPTION
## Summary

- Adds `gcx traces adaptive config show` and `gcx traces adaptive config set` against the singleton `/adaptive-traces/api/v1/config` endpoint.
- `set` replaces the entire payload via PUT — the API doesn't support partial patches, mirroring the `notification-policies set` precedent.
- The endpoint isn't registered as a typed adapter (no list/create/delete semantics); per CONSTITUTION's provider-only rules the commands use the allowed alternative verbs `show` and `set` rather than `get`/`update`.
- Payload modeled as opaque `Config map[string]any` so server-introduced fields round-trip without CLI changes.

## Test plan

- [x] `go test ./internal/providers/traces/...` — new client and command tests pass (table-driven + a GET/PUT/GET round-trip integration test)
- [x] `go test ./cmd/gcx/root/` — `TestConsistency_AllLeafCommandsHaveTokenCost` still green after adding annotations for the two new leaves
- [x] `go test ./...` (with `GCX_AGENT_MODE=false` to avoid agent-mode auto-detection tripping pre-existing destructive-prompt tests)
- [x] Manual: `gcx traces adaptive config show` and `gcx traces adaptive config set -f config.yaml` against a real tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)