### PR TITLE
refactor: move stacks under cloud command group

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ cmd/gcx/
   datasources/  Datasource commands (list, get, query, per-type subcommands via DatasourceProvider)
   providers/    Provider list command
   assistant/    Assistant commands (AI-powered investigations)
+  cloud/        Cloud platform command group (mounts gcx cloud stacks)
   api/          Raw API passthrough
   linter/       Linting (mounted under dev lint)
   commands/     Commands catalog (agent metadata)

--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -1,0 +1,20 @@
+// Package cloud provides the top-level "gcx cloud" command group for managing
+// Grafana Cloud platform resources (stacks, orgs, etc.).
+package cloud
+
+import (
+	"github.com/grafana/gcx/internal/providers/stacks"
+	"github.com/spf13/cobra"
+)
+
+// Command returns the top-level "cloud" cobra command with all subcommands.
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cloud",
+		Short: "Manage your Grafana Cloud resources",
+	}
+
+	cmd.AddCommand(stacks.NewCommand())
+
+	return cmd
+}

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -1332,8 +1332,8 @@ func convertStacksErrors(err error) (*gcxerrors.DetailedError, bool) {
 				Details: msg,
 				Parent:  err,
 				Suggestions: []string{
-					"Disable delete protection first: gcx stacks update <slug> --no-delete-protection",
-					"Then retry: gcx stacks delete <slug>",
+					"Disable delete protection first: gcx cloud stacks update <slug> --no-delete-protection",
+					"Then retry: gcx cloud stacks delete <slug>",
 				},
 			}, true
 		}
@@ -1343,7 +1343,7 @@ func convertStacksErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Parent:  err,
 			Suggestions: []string{
 				"Choose a different slug with --slug",
-				"List existing stacks: gcx stacks list --org <org-slug>",
+				"List existing stacks: gcx cloud stacks list --org <org-slug>",
 			},
 		}, true
 	case http.StatusForbidden:

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -14,6 +14,7 @@ import (
 	agentcmd "github.com/grafana/gcx/cmd/gcx/agent"
 	"github.com/grafana/gcx/cmd/gcx/api"
 	assistantcmd "github.com/grafana/gcx/cmd/gcx/assistant"
+	cloudcmd "github.com/grafana/gcx/cmd/gcx/cloud"
 	"github.com/grafana/gcx/cmd/gcx/commands"
 	"github.com/grafana/gcx/cmd/gcx/config"
 	"github.com/grafana/gcx/cmd/gcx/datasources"
@@ -247,6 +248,7 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 	rootCmd.AddCommand(agentcmd.Command())
 	rootCmd.AddCommand(api.Command())
 	rootCmd.AddCommand(assistantcmd.Command())
+	rootCmd.AddCommand(cloudcmd.Command())
 	rootCmd.AddCommand(logincmd.Command())
 	rootCmd.AddCommand(config.Command())
 	rootCmd.AddCommand(dev.Command())

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -28,6 +28,7 @@ Run 'gcx agent skills list' to see bundled Agent Skills with task-specific guida
 * [gcx api](gcx_api.md)	 - Make direct HTTP requests to the Grafana API
 * [gcx appo11y](gcx_appo11y.md)	 - Manage Grafana App Observability settings
 * [gcx assistant](gcx_assistant.md)	 - Interact with Grafana Assistant
+* [gcx cloud](gcx_cloud.md)	 - Manage your Grafana Cloud resources
 * [gcx commands](gcx_commands.md)	 - List all commands with rich metadata for agent consumption
 * [gcx completion](gcx_completion.md)	 - Generate the autocompletion script for the specified shell
 * [gcx config](gcx_config.md)	 - View or manipulate configuration settings
@@ -49,7 +50,6 @@ Run 'gcx agent skills list' to see bundled Agent Skills with task-specific guida
 * [gcx resources](gcx_resources.md)	 - Manipulate Grafana resources
 * [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
 * [gcx slo](gcx_slo.md)	 - Manage Grafana SLO definitions and reports
-* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
 * [gcx synthetic-monitoring](gcx_synthetic-monitoring.md)	 - Manage Grafana Synthetic Monitoring checks and probes
 * [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces
 * [gcx version](gcx_version.md)	 - Print version information.

--- a/docs/reference/cli/gcx_cloud.md
+++ b/docs/reference/cli/gcx_cloud.md
@@ -1,0 +1,26 @@
+## gcx cloud
+
+Manage your Grafana Cloud resources
+
+### Options
+
+```
+  -h, --help   help for cloud
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx cloud stacks](gcx_cloud_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+

--- a/docs/reference/cli/gcx_cloud.md
+++ b/docs/reference/cli/gcx_cloud.md
@@ -11,12 +11,12 @@ Manage your Grafana Cloud resources
 ### Options inherited from parent commands
 
 ```
-      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --context string     Name of the context to use (overrides current-context in config)
-      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
-      --no-color           Disable color output
-      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO

--- a/docs/reference/cli/gcx_cloud_stacks.md
+++ b/docs/reference/cli/gcx_cloud_stacks.md
@@ -1,25 +1,18 @@
-## gcx stacks list
+## gcx cloud stacks
 
-List stacks in an organisation.
-
-```
-gcx stacks list [flags]
-```
+Manage Grafana Cloud stacks (list, create, update, delete)
 
 ### Options
 
 ```
-  -h, --help            help for list
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --org string      Organisation slug (required)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+      --config string   Path to the configuration file to use
+  -h, --help            help for stacks
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --config string               Path to the configuration file to use
       --context string              Name of the context to use (overrides current-context in config)
       --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
       --no-color                    Disable color output
@@ -29,5 +22,11 @@ gcx stacks list [flags]
 
 ### SEE ALSO
 
-* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+* [gcx cloud](gcx_cloud.md)	 - Manage your Grafana Cloud resources
+* [gcx cloud stacks create](gcx_cloud_stacks_create.md)	 - Create a new Grafana Cloud stack.
+* [gcx cloud stacks delete](gcx_cloud_stacks_delete.md)	 - Delete a Grafana Cloud stack.
+* [gcx cloud stacks get](gcx_cloud_stacks_get.md)	 - Get details of a single stack.
+* [gcx cloud stacks list](gcx_cloud_stacks_list.md)	 - List stacks in an organisation.
+* [gcx cloud stacks regions](gcx_cloud_stacks_regions.md)	 - List available regions for stack creation.
+* [gcx cloud stacks update](gcx_cloud_stacks_update.md)	 - Update a Grafana Cloud stack.
 

--- a/docs/reference/cli/gcx_cloud_stacks_create.md
+++ b/docs/reference/cli/gcx_cloud_stacks_create.md
@@ -1,4 +1,4 @@
-## gcx stacks create
+## gcx cloud stacks create
 
 Create a new Grafana Cloud stack.
 
@@ -6,12 +6,12 @@ Create a new Grafana Cloud stack.
 
 Create a new Grafana Cloud stack.
 
-This command creates a new Grafana Cloud stack, which provisions infrastructure
-and may incur costs. Always confirm the stack name, slug, and region with the
-user before executing. Prefer --dry-run first.
+This provisions new infrastructure and may incur costs. The stack name, slug,
+and region cannot be changed after creation - double-check before running.
+Use --dry-run to preview the request first.
 
 ```
-gcx stacks create [flags]
+gcx cloud stacks create [flags]
 ```
 
 ### Options
@@ -25,7 +25,7 @@ gcx stacks create [flags]
       --labels strings       Labels in key=value format (may be repeated)
       --name string          Stack name (required)
   -o, --output string        Output format. One of: agents, json, table, yaml (default "table")
-      --region string        Region slug (e.g. us, eu). Use 'gcx stacks regions' to list.
+      --region string        Region slug (e.g. us, eu). Use 'gcx cloud stacks regions' to list.
       --slug string          Stack slug / subdomain (required)
       --url string           Custom domain URL
 ```
@@ -44,5 +44,5 @@ gcx stacks create [flags]
 
 ### SEE ALSO
 
-* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+* [gcx cloud stacks](gcx_cloud_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
 

--- a/docs/reference/cli/gcx_cloud_stacks_delete.md
+++ b/docs/reference/cli/gcx_cloud_stacks_delete.md
@@ -1,4 +1,4 @@
-## gcx stacks delete
+## gcx cloud stacks delete
 
 Delete a Grafana Cloud stack.
 
@@ -6,13 +6,12 @@ Delete a Grafana Cloud stack.
 
 Delete a Grafana Cloud stack.
 
-This command permanently deletes a Grafana Cloud stack and ALL its data
-(dashboards, alerts, datasources, metrics, logs, traces). This action is
-IRREVERSIBLE. Always confirm with the user by name before executing. Prefer
---dry-run first. Never run this command without explicit user confirmation.
+This permanently deletes a stack and all its data (dashboards, alerts,
+datasources, metrics, logs, traces). This cannot be undone.
+Use --dry-run to preview the operation first.
 
 ```
-gcx stacks delete <stack-slug> [flags]
+gcx cloud stacks delete <stack-slug> [flags]
 ```
 
 ### Options
@@ -37,5 +36,5 @@ gcx stacks delete <stack-slug> [flags]
 
 ### SEE ALSO
 
-* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+* [gcx cloud stacks](gcx_cloud_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
 

--- a/docs/reference/cli/gcx_cloud_stacks_get.md
+++ b/docs/reference/cli/gcx_cloud_stacks_get.md
@@ -1,18 +1,24 @@
-## gcx stacks
+## gcx cloud stacks get
 
-Manage Grafana Cloud stacks (list, create, update, delete)
+Get details of a single stack.
+
+```
+gcx cloud stacks get <stack-slug> [flags]
+```
 
 ### Options
 
 ```
-      --config string   Path to the configuration file to use
-  -h, --help            help for stacks
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
       --context string              Name of the context to use (overrides current-context in config)
       --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
       --no-color                    Disable color output
@@ -22,11 +28,5 @@ Manage Grafana Cloud stacks (list, create, update, delete)
 
 ### SEE ALSO
 
-* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
-* [gcx stacks create](gcx_stacks_create.md)	 - Create a new Grafana Cloud stack.
-* [gcx stacks delete](gcx_stacks_delete.md)	 - Delete a Grafana Cloud stack.
-* [gcx stacks get](gcx_stacks_get.md)	 - Get details of a single stack.
-* [gcx stacks list](gcx_stacks_list.md)	 - List stacks in an organisation.
-* [gcx stacks regions](gcx_stacks_regions.md)	 - List available regions for stack creation.
-* [gcx stacks update](gcx_stacks_update.md)	 - Update a Grafana Cloud stack.
+* [gcx cloud stacks](gcx_cloud_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
 

--- a/docs/reference/cli/gcx_cloud_stacks_get.md
+++ b/docs/reference/cli/gcx_cloud_stacks_get.md
@@ -11,7 +11,7 @@ gcx cloud stacks get <stack-slug> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_cloud_stacks_list.md
+++ b/docs/reference/cli/gcx_cloud_stacks_list.md
@@ -1,16 +1,17 @@
-## gcx stacks get
+## gcx cloud stacks list
 
-Get details of a single stack.
+List stacks in an organisation.
 
 ```
-gcx stacks get <stack-slug> [flags]
+gcx cloud stacks list [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for get
+  -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --org string      Organisation slug (required)
   -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
@@ -28,5 +29,5 @@ gcx stacks get <stack-slug> [flags]
 
 ### SEE ALSO
 
-* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+* [gcx cloud stacks](gcx_cloud_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
 

--- a/docs/reference/cli/gcx_cloud_stacks_regions.md
+++ b/docs/reference/cli/gcx_cloud_stacks_regions.md
@@ -1,9 +1,9 @@
-## gcx stacks regions
+## gcx cloud stacks regions
 
 List available regions for stack creation.
 
 ```
-gcx stacks regions [flags]
+gcx cloud stacks regions [flags]
 ```
 
 ### Options
@@ -28,5 +28,5 @@ gcx stacks regions [flags]
 
 ### SEE ALSO
 
-* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+* [gcx cloud stacks](gcx_cloud_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
 

--- a/docs/reference/cli/gcx_cloud_stacks_update.md
+++ b/docs/reference/cli/gcx_cloud_stacks_update.md
@@ -1,4 +1,4 @@
-## gcx stacks update
+## gcx cloud stacks update
 
 Update a Grafana Cloud stack.
 
@@ -6,12 +6,11 @@ Update a Grafana Cloud stack.
 
 Update a Grafana Cloud stack.
 
-This command modifies a live Grafana Cloud stack. Changing the name or disabling
-delete protection can have downstream effects. Always confirm the intended
-changes with the user and prefer --dry-run first.
+This modifies a live stack. Note that the slug and region cannot be changed.
+Use --dry-run to preview the request first.
 
 ```
-gcx stacks update <stack-slug> [flags]
+gcx cloud stacks update <stack-slug> [flags]
 ```
 
 ### Options
@@ -42,5 +41,5 @@ gcx stacks update <stack-slug> [flags]
 
 ### SEE ALSO
 
-* [gcx stacks](gcx_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
+* [gcx cloud stacks](gcx_cloud_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
 

--- a/internal/providers/stacks/commands.go
+++ b/internal/providers/stacks/commands.go
@@ -141,7 +141,7 @@ func (o *createOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 	flags.StringVar(&o.Name, "name", "", "Stack name (required)")
 	flags.StringVar(&o.Slug, "slug", "", "Stack slug / subdomain (required)")
-	flags.StringVar(&o.Region, "region", "", "Region slug (e.g. us, eu). Use 'gcx stacks regions' to list.")
+	flags.StringVar(&o.Region, "region", "", "Region slug (e.g. us, eu). Use 'gcx cloud stacks regions' to list.")
 	flags.StringVar(&o.Description, "description", "", "Short description")
 	flags.StringSliceVar(&o.Labels, "labels", nil, "Labels in key=value format (may be repeated)")
 	flags.StringVar(&o.URL, "url", "", "Custom domain URL")
@@ -156,9 +156,9 @@ func newCreateCommand(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "Create a new Grafana Cloud stack.",
 		Long: `Create a new Grafana Cloud stack.
 
-This command creates a new Grafana Cloud stack, which provisions infrastructure
-and may incur costs. Always confirm the stack name, slug, and region with the
-user before executing. Prefer --dry-run first.`,
+This provisions new infrastructure and may incur costs. The stack name, slug,
+and region cannot be changed after creation - double-check before running.
+Use --dry-run to preview the request first.`,
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:write",
 			agent.AnnotationTokenCost:     "small",
@@ -248,9 +248,8 @@ func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "Update a Grafana Cloud stack.",
 		Long: `Update a Grafana Cloud stack.
 
-This command modifies a live Grafana Cloud stack. Changing the name or disabling
-delete protection can have downstream effects. Always confirm the intended
-changes with the user and prefer --dry-run first.`,
+This modifies a live stack. Note that the slug and region cannot be changed.
+Use --dry-run to preview the request first.`,
 		Args: cobra.ExactArgs(1),
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:write",
@@ -332,10 +331,9 @@ func newDeleteCommand(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "Delete a Grafana Cloud stack.",
 		Long: `Delete a Grafana Cloud stack.
 
-This command permanently deletes a Grafana Cloud stack and ALL its data
-(dashboards, alerts, datasources, metrics, logs, traces). This action is
-IRREVERSIBLE. Always confirm with the user by name before executing. Prefer
---dry-run first. Never run this command without explicit user confirmation.`,
+This permanently deletes a stack and all its data (dashboards, alerts,
+datasources, metrics, logs, traces). This cannot be undone.
+Use --dry-run to preview the operation first.`,
 		Args: cobra.ExactArgs(1),
 		Annotations: map[string]string{
 			agent.AnnotationRequiredScope: "stacks:delete",

--- a/internal/providers/stacks/commands.go
+++ b/internal/providers/stacks/commands.go
@@ -82,7 +82,7 @@ type getOpts struct {
 func (o *getOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &stackTableCodec{})
 	o.IO.RegisterCustomCodec("wide", &stackTableCodec{Wide: true})
-	o.IO.DefaultFormat("table")
+	o.IO.DefaultFormat("yaml")
 	o.IO.BindFlags(flags)
 }
 

--- a/internal/providers/stacks/commands_test.go
+++ b/internal/providers/stacks/commands_test.go
@@ -3,9 +3,14 @@ package stacks_test
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/grafana/gcx/internal/cloud"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/stacks"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -276,6 +281,48 @@ func TestGetCommand_RequiresArg(t *testing.T) {
 	_, err := runCmd(t, stacks.NewTestGetCommand(), []string{"get"}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "accepts 1 arg")
+}
+
+func TestGetCommand_DefaultFormat_YAML(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+
+	want := cloud.StackInfo{
+		ID:   42,
+		Slug: "mystack",
+		Name: "My Stack",
+		URL:  "https://mystack.grafana.net",
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(want); err != nil {
+			t.Errorf("mock server: encode: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	cfgFile, err := os.CreateTemp(t.TempDir(), "gcx-config-*.yaml")
+	require.NoError(t, err)
+	_, err = cfgFile.WriteString(`
+contexts:
+  default:
+    cloud:
+      token: "test-token"
+      api-url: "` + srv.URL + `"
+current-context: default
+`)
+	require.NoError(t, err)
+	require.NoError(t, cfgFile.Close())
+
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(cfgFile.Name())
+
+	out, err := runCmd(t, stacks.NewTestGetCommandWithLoader(loader), []string{"get", "mystack"}, "")
+	require.NoError(t, err)
+
+	// Default format for a singular get should be YAML, not a table.
+	assert.Contains(t, out, "slug: mystack")
+	assert.NotContains(t, out, "SLUG", "table header should not appear in default yaml output")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/providers/stacks/commands_test.go
+++ b/internal/providers/stacks/commands_test.go
@@ -282,20 +282,21 @@ func TestGetCommand_RequiresArg(t *testing.T) {
 // provider registration
 // ---------------------------------------------------------------------------
 
-func TestStacksProvider_Commands(t *testing.T) {
+func TestStacksProvider_Commands_ReturnsNil(t *testing.T) {
 	p := &stacks.StacksProvider{}
 
 	assert.Equal(t, "stacks", p.Name())
 	assert.NotEmpty(t, p.ShortDesc())
+	assert.Nil(t, p.Commands(), "Commands() should return nil — stacks is wired via cmd/gcx/cloud")
+}
 
-	cmds := p.Commands()
-	require.Len(t, cmds, 1, "should return one top-level 'stacks' command")
+func TestNewCommand(t *testing.T) {
+	cmd := stacks.NewCommand()
 
-	stacksCmd := cmds[0]
-	assert.Equal(t, "stacks", stacksCmd.Use)
+	assert.Equal(t, "stacks", cmd.Use)
 
-	subNames := make([]string, 0, len(stacksCmd.Commands()))
-	for _, sub := range stacksCmd.Commands() {
+	subNames := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
 		subNames = append(subNames, sub.Name())
 	}
 	assert.ElementsMatch(t, []string{"list", "get", "create", "update", "delete", "regions"}, subNames)

--- a/internal/providers/stacks/commands_test.go
+++ b/internal/providers/stacks/commands_test.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/stacks"
+	"github.com/grafana/gcx/internal/testutils"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -301,21 +301,17 @@ func TestGetCommand_DefaultFormat_YAML(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	cfgFile, err := os.CreateTemp(t.TempDir(), "gcx-config-*.yaml")
-	require.NoError(t, err)
-	_, err = cfgFile.WriteString(`
+	cfgPath := testutils.CreateTempFile(t, `
 contexts:
   default:
     cloud:
       token: "test-token"
-      api-url: "` + srv.URL + `"
+      api-url: "`+srv.URL+`"
 current-context: default
 `)
-	require.NoError(t, err)
-	require.NoError(t, cfgFile.Close())
 
 	loader := &providers.ConfigLoader{}
-	loader.SetConfigFile(cfgFile.Name())
+	loader.SetConfigFile(cfgPath)
 
 	out, err := runCmd(t, stacks.NewTestGetCommandWithLoader(loader), []string{"get", "mystack"}, "")
 	require.NoError(t, err)

--- a/internal/providers/stacks/export_test.go
+++ b/internal/providers/stacks/export_test.go
@@ -15,6 +15,11 @@ func NewTestListCommand() *cobra.Command { return newListCommand(&providers.Conf
 // NewTestGetCommand creates a get command for external tests.
 func NewTestGetCommand() *cobra.Command { return newGetCommand(&providers.ConfigLoader{}) }
 
+// NewTestGetCommandWithLoader creates a get command with a custom ConfigLoader for external tests.
+func NewTestGetCommandWithLoader(loader *providers.ConfigLoader) *cobra.Command {
+	return newGetCommand(loader)
+}
+
 // NewTestCreateCommand creates a create command for external tests.
 func NewTestCreateCommand() *cobra.Command { return newCreateCommand(&providers.ConfigLoader{}) }
 

--- a/internal/providers/stacks/export_test.go
+++ b/internal/providers/stacks/export_test.go
@@ -15,7 +15,6 @@ func NewTestListCommand() *cobra.Command { return newListCommand(&providers.Conf
 // NewTestGetCommand creates a get command for external tests.
 func NewTestGetCommand() *cobra.Command { return newGetCommand(&providers.ConfigLoader{}) }
 
-// NewTestGetCommandWithLoader creates a get command with a custom ConfigLoader for external tests.
 func NewTestGetCommandWithLoader(loader *providers.ConfigLoader) *cobra.Command {
 	return newGetCommand(loader)
 }

--- a/internal/providers/stacks/provider.go
+++ b/internal/providers/stacks/provider.go
@@ -21,12 +21,19 @@ func (p *StacksProvider) ShortDesc() string {
 	return "Manage Grafana Cloud stacks (list, create, update, delete)"
 }
 
-func (p *StacksProvider) Commands() []*cobra.Command {
+// Commands returns nil because the stacks command tree is wired via
+// cmd/gcx/cloud (as "gcx cloud stacks"). The provider is still registered
+// so it appears in "gcx providers list".
+func (p *StacksProvider) Commands() []*cobra.Command { return nil }
+
+// NewCommand returns the "stacks" cobra command with all subcommands registered.
+// Called by cmd/gcx/cloud to mount stacks under the cloud command group.
+func NewCommand() *cobra.Command {
 	loader := &providers.ConfigLoader{}
 
 	stacksCmd := &cobra.Command{
 		Use:   "stacks",
-		Short: p.ShortDesc(),
+		Short: "Manage Grafana Cloud stacks (list, create, update, delete)",
 	}
 
 	loader.BindFlags(stacksCmd.PersistentFlags())
@@ -40,7 +47,7 @@ func (p *StacksProvider) Commands() []*cobra.Command {
 		newRegionsCommand(loader),
 	)
 
-	return []*cobra.Command{stacksCmd}
+	return stacksCmd
 }
 
 func (p *StacksProvider) Validate(_ map[string]string) error { return nil }


### PR DESCRIPTION
`gcx stacks ...` -> `gcx cloud stacks ...`

- introduce `gcx cloud` command group for Grafana Cloud platform resources. 
- move `gcx stacks` to `gcx cloud stacks` (stacks is the only subcommand for now)
- update error suggestions and flag help to reference new command path

also some iteration on the docs for the commands:
- rewrite help text to be human-facing rather than agent-directed

also, fix the formatting on `gcx cloud stacks get`: singular things should return yaml by default, so now it does:

```
./bin/gcx cloud stacks get dafyddt
agentManagementInstanceId: 12345
agentManagementInstanceUrl: https://fleet-management-prod-001.grafana.net
amInstanceId: 678910
...
```
