### PR TITLE
feat(dashboards): add --limit flag to dashboards list

### DIFF
--- a/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
@@ -521,6 +521,46 @@ gcx logs query -d <loki-uid> 'topk(10, sum by(pod) (rate({job="app"} [5m])))'
 
 Rule of thumb: if your query uses `rate()`, `count_over_time()`, or `bytes_over_time()`, wrap it with `sum()`, `sum by(label)`, or `topk()`.
 
+### Counting requests across distributed services
+
+A single HTTP request typically produces one log line at *every* service it
+traverses (gateway, upstream, backend). Using a label selector that matches
+all of them double- or triple-counts the same request.
+
+**Symptom**: counts look ~2-3x what the rest of the evidence (dashboards,
+metrics, traces) suggests.
+
+**Wrong** (counts every hop):
+```bash
+gcx logs query -d <loki-uid> \
+  'sum(count_over_time({job=~".+"} | json | path="/api/<endpoint>" | status >= 500 [6h]))'
+```
+
+**Right** — scope the label selector to the *backend services that own the
+request*, not the gateway / proxy / load balancer:
+```bash
+gcx logs query -d <loki-uid> \
+  'sum(count_over_time({job=~"<backend-svc-a>|<backend-svc-b>"} | json | __error__="" | path="/api/<endpoint>" | status >= 500 [6h]))'
+```
+
+How to identify the backend services for a path:
+- Look at a representative trace with `gcx traces get <id> --llm` and pick the
+  service where the actual error (`status: error`) originates, plus its
+  immediate caller.
+- Or use `gcx logs labels -d <uid> -l job` to enumerate jobs, then exclude
+  obvious gateway/proxy names (anything that just forwards — e.g. `webapp`,
+  `api-gateway`, `envoy`, `nginx`).
+
+Alternative: deduplicate by `trace_id` if the logs contain it:
+```bash
+gcx logs query -d <loki-uid> \
+  'count(count by (trace_id) (rate({job=~".+"} | json | path="/api/<endpoint>" | status >= 500 [6h])))'
+```
+
+Always include `| __error__=""` after `| json` to drop lines that failed to
+parse, otherwise the parser stage silently keeps them and they pollute the
+count.
+
 ### Stream Labels vs Extracted Labels
 
 Loki has two kinds of labels — confusing them causes silent failures:

--- a/docs/reference/cli/gcx_dashboards_list.md
+++ b/docs/reference/cli/gcx_dashboards_list.md
@@ -12,6 +12,7 @@ gcx dashboards list [flags]
       --api-version string   API version to use (e.g. dashboard.grafana.app/v1); defaults to server preferred version
   -h, --help                 help for list
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int            Maximum number of dashboards to return in a single request (0 for no limit)
   -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 

--- a/internal/providers/dashboards/crud.go
+++ b/internal/providers/dashboards/crud.go
@@ -34,6 +34,7 @@ type GrafanaConfigLoader interface {
 type listOpts struct {
 	IO         cmdio.Options
 	APIVersion string
+	Limit      int64
 }
 
 func (o *listOpts) setup(flags *pflag.FlagSet) {
@@ -43,9 +44,13 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 
 	flags.StringVar(&o.APIVersion, "api-version", "", "API version to use (e.g. dashboard.grafana.app/v1); defaults to server preferred version")
+	flags.Int64Var(&o.Limit, "limit", 0, "Maximum number of dashboards to return in a single request (0 for no limit)")
 }
 
 func (o *listOpts) Validate() error {
+	if o.Limit < 0 {
+		return fmt.Errorf("--limit must be >= 0, got %d", o.Limit)
+	}
 	return o.IO.Validate()
 }
 
@@ -78,7 +83,7 @@ func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
 				return err
 			}
 
-			list, err := client.List(ctx, desc, metav1.ListOptions{})
+			list, err := client.List(ctx, desc, metav1.ListOptions{Limit: opts.Limit})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## What

Add a `--limit` flag to `gcx dashboards list` that caps a single request to the App Platform API.

```
gcx dashboards list --limit 50
```

Default is `0` (no limit), preserving current behavior.

