### PR TITLE
fix(api): warn when response is text/html instead of JSON

### DIFF
--- a/cmd/gcx/api/command.go
+++ b/cmd/gcx/api/command.go
@@ -191,6 +191,22 @@ func outputResponse(cmd *cobra.Command, opts *apiOpts, resp *http.Response) erro
 		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
 
+	// HTML means we hit the Grafana frontend SPA, not an API endpoint.
+	if isHTMLResponse(resp) {
+		finalURL := ""
+		if resp.Request != nil && resp.Request.URL != nil {
+			finalURL = resp.Request.URL.String()
+		}
+		if finalURL != "" {
+			cmdio.Warning(cmd.ErrOrStderr(),
+				"Response is not JSON. Ensure the API path is valid (requested: %s).",
+				finalURL)
+		} else {
+			cmdio.Warning(cmd.ErrOrStderr(),
+				"Response is not JSON. Ensure the API path is valid.")
+		}
+	}
+
 	// Try to parse as JSON for structured output
 	var data any
 	if err := json.Unmarshal(respBody, &data); err != nil {
@@ -200,4 +216,17 @@ func outputResponse(cmd *cobra.Command, opts *apiOpts, resp *http.Response) erro
 	}
 
 	return opts.IO.Encode(cmd.OutOrStdout(), data)
+}
+
+// isHTMLResponse reports whether the response Content-Type indicates HTML.
+func isHTMLResponse(resp *http.Response) bool {
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		return false
+	}
+	// Strip parameters like `; charset=utf-8`.
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.EqualFold(strings.TrimSpace(ct), "text/html")
 }

--- a/cmd/gcx/api/command_test.go
+++ b/cmd/gcx/api/command_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -120,9 +121,10 @@ func TestOutputResponse_NonJSONRawOutput(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(htmlData)),
 	}
 
-	var output bytes.Buffer
+	var output, errOut bytes.Buffer
 	cmd := &cobra.Command{}
 	cmd.SetOut(&output)
+	cmd.SetErr(&errOut)
 
 	opts := &apiOpts{}
 	opts.IO.DefaultFormat("json")
@@ -130,6 +132,89 @@ func TestOutputResponse_NonJSONRawOutput(t *testing.T) {
 	err := outputResponse(cmd, opts, resp)
 	require.NoError(t, err)
 	assert.Equal(t, htmlData, output.String())
+	// No Content-Type set: must not emit a warning.
+	assert.Empty(t, errOut.String())
+}
+
+func TestOutputResponse_HTMLContentTypeWarns(t *testing.T) {
+	htmlData := `<!DOCTYPE html><html><body>Grafana SPA</body></html>`
+	reqURL, err := url.Parse("https://example.grafana.net/dashboards")
+	require.NoError(t, err)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+		Body:       io.NopCloser(strings.NewReader(htmlData)),
+		Request:    &http.Request{URL: reqURL},
+	}
+
+	var output, errOut bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+	cmd.SetErr(&errOut)
+
+	opts := &apiOpts{}
+	opts.IO.DefaultFormat("json")
+
+	err = outputResponse(cmd, opts, resp)
+	require.NoError(t, err)
+
+	// Body still written to stdout verbatim (no behavior change for pipes).
+	assert.Equal(t, htmlData, output.String())
+
+	// Warning written to stderr, includes the requested URL.
+	warn := errOut.String()
+	assert.Contains(t, warn, "Response is not JSON")
+	assert.Contains(t, warn, "https://example.grafana.net/dashboards")
+}
+
+func TestOutputResponse_HTMLContentTypeNoRequest(t *testing.T) {
+	// Defensive: a bare http.Response with no Request should still warn,
+	// just without the final URL.
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/html"}},
+		Body:       io.NopCloser(strings.NewReader("<html></html>")),
+	}
+
+	var output, errOut bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+	cmd.SetErr(&errOut)
+
+	opts := &apiOpts{}
+	opts.IO.DefaultFormat("json")
+
+	err := outputResponse(cmd, opts, resp)
+	require.NoError(t, err)
+	assert.Contains(t, errOut.String(), "Response is not JSON")
+	assert.NotContains(t, errOut.String(), "requested:")
+}
+
+func TestIsHTMLResponse(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		{name: "empty", contentType: "", want: false},
+		{name: "plain text/html", contentType: "text/html", want: true},
+		{name: "with charset", contentType: "text/html; charset=utf-8", want: true},
+		{name: "uppercase", contentType: "TEXT/HTML", want: true},
+		{name: "json", contentType: "application/json", want: false},
+		{name: "json with charset", contentType: "application/json; charset=utf-8", want: false},
+		{name: "plain text", contentType: "text/plain", want: false},
+		{name: "prometheus exposition", contentType: "text/plain; version=0.0.4", want: false},
+		{name: "protobuf", contentType: "application/x-protobuf", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{Header: http.Header{}}
+			if tt.contentType != "" {
+				resp.Header.Set("Content-Type", tt.contentType)
+			}
+			assert.Equal(t, tt.want, isHTMLResponse(resp))
+		})
+	}
 }
 
 func TestOutputResponse_ErrorWithBody(t *testing.T) {


### PR DESCRIPTION
`gcx api dashboards` (and any other path that resolves to a Grafana frontend route) silently dumps the React app's HTML shell to stdout, because Grafana returns HTTP 200 with `text/html` for SPA routes.

<img width="986" height="571" alt="image" src="https://github.com/user-attachments/assets/13fa60bc-5bfb-47f6-b6ba-bcb4a0d9dd6a" />


This change detects `text/html` responses and emits a stderr warning naming the final requested URL (post-redirect), so misrouted requests and login redirects are obvious. Body still goes to stdout verbatim and the exit code is unchanged, so existing pipelines that intentionally consume non-JSON aren't affected.

Example:

```
$ gcx api dashboards
⚠ Response is not JSON. Ensure the API path is valid (requested: https://my-stack.grafana.net/dashboards).
<!DOCTYPE html>
...
```

