### PR TITLE
feat(assistant): add integrations commands

### DIFF
--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -15,6 +15,7 @@ import (
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/assistant"
+	"github.com/grafana/gcx/internal/assistant/integrations"
 	"github.com/grafana/gcx/internal/assistant/investigations"
 	"github.com/grafana/gcx/internal/auth"
 	"github.com/grafana/gcx/internal/config"
@@ -99,6 +100,23 @@ Service account tokens are not supported.`,
 		return nil
 	}
 	cmd.AddCommand(invCmd)
+
+	// Wire integrations the same way.
+	intLoader := &providers.ConfigLoader{}
+	intCmd := integrations.Commands(intLoader)
+	intCmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		if err := cmd.PersistentPreRunE(c, args); err != nil {
+			return err
+		}
+		if configOpts.ConfigFile != "" {
+			intLoader.SetConfigFile(configOpts.ConfigFile)
+		}
+		if configOpts.Context != "" {
+			intLoader.SetContextName(configOpts.Context)
+		}
+		return nil
+	}
+	cmd.AddCommand(intCmd)
 	return cmd
 }
 

--- a/docs/reference/cli/gcx_assistant.md
+++ b/docs/reference/cli/gcx_assistant.md
@@ -31,6 +31,7 @@ Service account tokens are not supported.
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx assistant dashboard](gcx_assistant_dashboard.md)	 - Build a dashboard using the Grafana dashboarding agent
+* [gcx assistant integrations](gcx_assistant_integrations.md)	 - Manage Grafana Assistant integrations.
 * [gcx assistant investigations](gcx_assistant_investigations.md)	 - Manage Grafana Assistant investigations.
 * [gcx assistant prompt](gcx_assistant_prompt.md)	 - Send a single message to Grafana Assistant
 

--- a/docs/reference/cli/gcx_assistant_integrations.md
+++ b/docs/reference/cli/gcx_assistant_integrations.md
@@ -1,0 +1,32 @@
+## gcx assistant integrations
+
+Manage Grafana Assistant integrations.
+
+### Options
+
+```
+  -h, --help   help for integrations
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx assistant](gcx_assistant.md)	 - Interact with Grafana Assistant
+* [gcx assistant integrations create](gcx_assistant_integrations_create.md)	 - Create an integration.
+* [gcx assistant integrations delete](gcx_assistant_integrations_delete.md)	 - Delete an integration.
+* [gcx assistant integrations get](gcx_assistant_integrations_get.md)	 - Get integration detail.
+* [gcx assistant integrations list](gcx_assistant_integrations_list.md)	 - List integrations.
+* [gcx assistant integrations update](gcx_assistant_integrations_update.md)	 - Update an integration.
+* [gcx assistant integrations validate](gcx_assistant_integrations_validate.md)	 - Validate an integration.
+

--- a/docs/reference/cli/gcx_assistant_integrations_create.md
+++ b/docs/reference/cli/gcx_assistant_integrations_create.md
@@ -1,0 +1,53 @@
+## gcx assistant integrations create
+
+Create an integration.
+
+### Synopsis
+
+Create a new integration. Use --url for MCP server integrations or --configuration for custom JSON.
+
+```
+gcx assistant integrations create [flags]
+```
+
+### Examples
+
+```
+  gcx assistant integrations create --name="my-mcp" --scope=user --url="https://mcp.example.com"
+  gcx assistant integrations create --name="team-mcp" --scope=tenant --url="https://mcp.example.com" --applications=assistant
+  gcx assistant integrations create --name="custom" --scope=user --configuration='{"url":"https://mcp.example.com","socksProxyEnabled":true}'
+```
+
+### Options
+
+```
+      --applications strings    Target applications (assistant, loop, all) (default [all])
+      --configuration string    Integration configuration as JSON
+      --custom-header strings   Custom HTTP headers (key=value, repeatable)
+      --description string      Integration description
+      --enabled                 Whether the integration is enabled (default true)
+  -h, --help                    help for create
+      --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --name string             Integration name (required)
+  -o, --output string           Output format. One of: agents, json, yaml (default "yaml")
+      --scope string            Integration scope: user or tenant (required)
+      --type string             Integration type (default "mcp")
+      --url string              MCP server URL (shortcut for --configuration)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx assistant integrations](gcx_assistant_integrations.md)	 - Manage Grafana Assistant integrations.
+

--- a/docs/reference/cli/gcx_assistant_integrations_delete.md
+++ b/docs/reference/cli/gcx_assistant_integrations_delete.md
@@ -1,0 +1,42 @@
+## gcx assistant integrations delete
+
+Delete an integration.
+
+### Synopsis
+
+Delete an integration by ID. Prompts for confirmation unless --force is passed.
+
+```
+gcx assistant integrations delete <id> [flags]
+```
+
+### Examples
+
+```
+  gcx assistant integrations delete 550e8400-e29b-41d4-a716-446655440000
+  gcx assistant integrations delete 550e8400-e29b-41d4-a716-446655440000 --force
+```
+
+### Options
+
+```
+      --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx assistant integrations](gcx_assistant_integrations.md)	 - Manage Grafana Assistant integrations.
+

--- a/docs/reference/cli/gcx_assistant_integrations_get.md
+++ b/docs/reference/cli/gcx_assistant_integrations_get.md
@@ -1,0 +1,43 @@
+## gcx assistant integrations get
+
+Get integration detail.
+
+### Synopsis
+
+Get the full detail of a specific integration by ID.
+
+```
+gcx assistant integrations get <id> [flags]
+```
+
+### Examples
+
+```
+  gcx assistant integrations get 550e8400-e29b-41d4-a716-446655440000
+  gcx assistant integrations get 550e8400-e29b-41d4-a716-446655440000 -o json
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx assistant integrations](gcx_assistant_integrations.md)	 - Manage Grafana Assistant integrations.
+

--- a/docs/reference/cli/gcx_assistant_integrations_list.md
+++ b/docs/reference/cli/gcx_assistant_integrations_list.md
@@ -1,0 +1,49 @@
+## gcx assistant integrations list
+
+List integrations.
+
+### Synopsis
+
+List integrations with optional scope and status filters.
+
+```
+gcx assistant integrations list [flags]
+```
+
+### Examples
+
+```
+  gcx assistant integrations list
+  gcx assistant integrations list --scope=user
+  gcx assistant integrations list --enabled-only --limit=50
+  gcx assistant integrations list -o json
+```
+
+### Options
+
+```
+      --enabled-only    Only return enabled integrations
+  -h, --help            help for list
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of integrations to return (default 20)
+      --offset int      Number of integrations to skip (for pagination)
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+      --scope string    Filter by scope (user or tenant)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx assistant integrations](gcx_assistant_integrations.md)	 - Manage Grafana Assistant integrations.
+

--- a/docs/reference/cli/gcx_assistant_integrations_update.md
+++ b/docs/reference/cli/gcx_assistant_integrations_update.md
@@ -1,0 +1,51 @@
+## gcx assistant integrations update
+
+Update an integration.
+
+### Synopsis
+
+Update an existing integration. Fetches the current state and applies changes.
+
+```
+gcx assistant integrations update <id> [flags]
+```
+
+### Examples
+
+```
+  gcx assistant integrations update 550e8400-e29b-41d4-a716-446655440000 --name="renamed"
+  gcx assistant integrations update 550e8400-e29b-41d4-a716-446655440000 --enabled=false
+  gcx assistant integrations update 550e8400-e29b-41d4-a716-446655440000 --url="https://new-mcp.example.com"
+```
+
+### Options
+
+```
+      --applications strings    Target applications (assistant, loop, all)
+      --configuration string    Integration configuration as JSON
+      --custom-header strings   Custom HTTP headers (key=value, repeatable)
+      --description string      New description
+      --enabled                 Whether the integration is enabled (default true)
+  -h, --help                    help for update
+      --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --name string             New integration name
+  -o, --output string           Output format. One of: agents, json, yaml (default "yaml")
+      --url string              MCP server URL (shortcut for --configuration)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx assistant integrations](gcx_assistant_integrations.md)	 - Manage Grafana Assistant integrations.
+

--- a/docs/reference/cli/gcx_assistant_integrations_validate.md
+++ b/docs/reference/cli/gcx_assistant_integrations_validate.md
@@ -1,0 +1,43 @@
+## gcx assistant integrations validate
+
+Validate an integration.
+
+### Synopsis
+
+Test connectivity for an integration and list discovered MCP tools.
+
+```
+gcx assistant integrations validate <id> [flags]
+```
+
+### Examples
+
+```
+  gcx assistant integrations validate 550e8400-e29b-41d4-a716-446655440000
+  gcx assistant integrations validate 550e8400-e29b-41d4-a716-446655440000 -o yaml
+```
+
+### Options
+
+```
+  -h, --help            help for validate
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx assistant integrations](gcx_assistant_integrations.md)	 - Manage Grafana Assistant integrations.
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -38,6 +38,14 @@ var commandAnnotations = map[string]annotation{
 	"gcx assistant investigations timeline":  {Cost: "medium", Hint: "<id> -o json"},
 	"gcx assistant investigations todos":     {Cost: "medium", Hint: "<id> -o json"},
 
+	// assistant integrations
+	"gcx assistant integrations list":     {Cost: "small"},
+	"gcx assistant integrations get":      {Cost: "medium", Hint: "<id> -o json"},
+	"gcx assistant integrations create":   {Cost: "small"},
+	"gcx assistant integrations update":   {Cost: "small"},
+	"gcx assistant integrations delete":   {Cost: "small"},
+	"gcx assistant integrations validate": {Cost: "medium", Hint: "<id> -o json"},
+
 	// login
 	"gcx login": {Cost: "small", Hint: "Non-interactive: gcx login <ctx> --yes --server <url> --token <grafana-sa-token> [--cloud-token <cap-token>]. Service-account tokens (--token) are created inside the Grafana instance — see https://grafana.com/docs/grafana/latest/administration/service-accounts.md. Cloud access-policy tokens (--cloud-token) are created at grafana.com — see https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies.md. Append .md to any grafana.com/docs URL to fetch markdown. Do not guess token URLs."},
 

--- a/internal/assistant/assistanthttp/client.go
+++ b/internal/assistant/assistanthttp/client.go
@@ -34,9 +34,20 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 
 // DoRequest builds and executes an HTTP request against the Assistant plugin API.
 func (c *Client) DoRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	return c.DoRequestWithHeaders(ctx, method, path, body, nil)
+}
+
+// DoRequestWithHeaders builds and executes an HTTP request with additional headers.
+func (c *Client) DoRequestWithHeaders(ctx context.Context, method, path string, body io.Reader, headers http.Header) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, c.restConfig.Host+pluginBasePath+path, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	for k, vs := range headers {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
 	}
 
 	if body != nil {

--- a/internal/assistant/integrations/client.go
+++ b/internal/assistant/integrations/client.go
@@ -1,0 +1,195 @@
+package integrations
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/grafana/gcx/internal/assistant/assistanthttp"
+)
+
+type Client struct {
+	base *assistanthttp.Client
+}
+
+// NewClient creates a new integrations client.
+func NewClient(base *assistanthttp.Client) *Client {
+	return &Client{base: base}
+}
+
+// ListOptions holds optional parameters for listing integrations.
+type ListOptions struct {
+	Scope       string
+	EnabledOnly bool
+	Limit       int
+	Offset      int
+}
+
+// List returns integrations with optional filtering.
+func (c *Client) List(ctx context.Context, opts ListOptions) ([]Integration, *Pagination, error) {
+	params := url.Values{}
+	if opts.Scope != "" {
+		params.Set("scope", opts.Scope)
+	}
+	if opts.EnabledOnly {
+		params.Set("enabled_only", "true")
+	}
+	if opts.Limit > 0 {
+		params.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.Offset > 0 {
+		params.Set("offset", strconv.Itoa(opts.Offset))
+	}
+
+	path := "/integrations"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list integrations: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, assistanthttp.HandleErrorResponse(resp)
+	}
+
+	var envelope struct {
+		Data struct {
+			Integrations []Integration `json:"integrations"`
+			Pagination   Pagination    `json:"pagination"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, nil, fmt.Errorf("failed to decode integrations: %w", err)
+	}
+	if envelope.Data.Integrations == nil {
+		return []Integration{}, &envelope.Data.Pagination, nil
+	}
+	return envelope.Data.Integrations, &envelope.Data.Pagination, nil
+}
+
+// Get returns a single integration by ID.
+func (c *Client) Get(ctx context.Context, id string) (*Integration, error) {
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, "/integrations/"+url.PathEscape(id), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get integration %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, assistanthttp.HandleErrorResponse(resp)
+	}
+
+	var envelope struct {
+		Data Integration `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("failed to decode integration: %w", err)
+	}
+	return &envelope.Data, nil
+}
+
+// Create creates a new integration.
+func (c *Client) Create(ctx context.Context, req CreateRequest) (*Integration, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal create request: %w", err)
+	}
+
+	resp, err := c.base.DoRequest(ctx, http.MethodPost, "/integrations", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create integration: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, assistanthttp.HandleErrorResponse(resp)
+	}
+
+	var envelope struct {
+		Data Integration `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("failed to decode create response: %w", err)
+	}
+	return &envelope.Data, nil
+}
+
+// Update updates an existing integration.
+func (c *Client) Update(ctx context.Context, id string, req UpdateRequest) (*Integration, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal update request: %w", err)
+	}
+
+	resp, err := c.base.DoRequest(ctx, http.MethodPut, "/integrations/"+url.PathEscape(id), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to update integration %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, assistanthttp.HandleErrorResponse(resp)
+	}
+
+	var envelope struct {
+		Data Integration `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("failed to decode update response: %w", err)
+	}
+	return &envelope.Data, nil
+}
+
+// Delete fetches the integration to discover its scope (required by the
+// API's X-Resource-Scope header), then issues the DELETE.
+func (c *Client) Delete(ctx context.Context, id string) error {
+	integration, err := c.Get(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to fetch integration before delete: %w", err)
+	}
+
+	headers := http.Header{}
+	headers.Set("X-Resource-Scope", integration.Scope)
+
+	resp, err := c.base.DoRequestWithHeaders(ctx, http.MethodDelete, "/integrations/"+url.PathEscape(id), nil, headers)
+	if err != nil {
+		return fmt.Errorf("failed to delete integration %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return assistanthttp.HandleErrorResponse(resp)
+	}
+	return nil
+}
+
+// Validate tests connectivity for an integration and returns discovered tools.
+func (c *Client) Validate(ctx context.Context, id string) (*ValidationResult, error) {
+	resp, err := c.base.DoRequest(ctx, http.MethodGet, "/integrations/"+url.PathEscape(id)+"/validate", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to validate integration %s: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, assistanthttp.HandleErrorResponse(resp)
+	}
+
+	var envelope struct {
+		Data struct {
+			Result ValidationResult `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("failed to decode validation response: %w", err)
+	}
+	return &envelope.Data.Result, nil
+}

--- a/internal/assistant/integrations/client_test.go
+++ b/internal/assistant/integrations/client_test.go
@@ -1,0 +1,389 @@
+package integrations_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/assistant/assistanthttp"
+	"github.com/grafana/gcx/internal/assistant/integrations"
+	"github.com/grafana/gcx/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *integrations.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: server.URL},
+		Namespace: "default",
+	}
+	base, err := assistanthttp.NewClient(cfg)
+	require.NoError(t, err)
+	return integrations.NewClient(base)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		panic(err)
+	}
+}
+
+func boolPtr(b bool) *bool { return &b } //nolint:modernize // new(bool) gives *false, not a pointer to the given value.
+
+func TestList(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      integrations.ListOptions
+		handler   http.HandlerFunc
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name: "success",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/integrations")
+				writeJSON(w, map[string]any{
+					"data": map[string]any{
+						"integrations": []integrations.Integration{
+							{ID: "int-1", Name: "mcp-1", Type: "mcp", Scope: "user", Enabled: boolPtr(true)},    //nolint:modernize
+							{ID: "int-2", Name: "mcp-2", Type: "mcp", Scope: "tenant", Enabled: boolPtr(false)}, //nolint:modernize
+						},
+						"pagination": integrations.Pagination{Total: 2, Limit: 20, Offset: 0},
+					},
+				})
+			},
+			wantCount: 2,
+		},
+		{
+			name: "filter by scope",
+			opts: integrations.ListOptions{Scope: "user"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "user", r.URL.Query().Get("scope"))
+				writeJSON(w, map[string]any{
+					"data": map[string]any{
+						"integrations": []integrations.Integration{
+							{ID: "int-1", Name: "mcp-1", Type: "mcp", Scope: "user", Enabled: boolPtr(true)}, //nolint:modernize
+						},
+						"pagination": integrations.Pagination{Total: 1, Limit: 20, Offset: 0},
+					},
+				})
+			},
+			wantCount: 1,
+		},
+		{
+			name: "enabled only",
+			opts: integrations.ListOptions{EnabledOnly: true},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "true", r.URL.Query().Get("enabled_only"))
+				writeJSON(w, map[string]any{
+					"data": map[string]any{
+						"integrations": []integrations.Integration{},
+						"pagination":   integrations.Pagination{Total: 0, Limit: 20, Offset: 0},
+					},
+				})
+			},
+			wantCount: 0,
+		},
+		{
+			name: "pagination params",
+			opts: integrations.ListOptions{Limit: 10, Offset: 20},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "10", r.URL.Query().Get("limit"))
+				assert.Equal(t, "20", r.URL.Query().Get("offset"))
+				writeJSON(w, map[string]any{
+					"data": map[string]any{
+						"integrations": []integrations.Integration{},
+						"pagination":   integrations.Pagination{Total: 30, Limit: 10, Offset: 20},
+					},
+				})
+			},
+			wantCount: 0,
+		},
+		{
+			name: "null list",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, map[string]any{
+					"data": map[string]any{
+						"integrations": nil,
+						"pagination":   integrations.Pagination{Total: 0, Limit: 20, Offset: 0},
+					},
+				})
+			},
+			wantCount: 0,
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("internal error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, tt.handler)
+			items, _, err := client.List(t.Context(), tt.opts)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, items, tt.wantCount)
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name: "success",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/integrations/int-1")
+				writeJSON(w, map[string]any{
+					"data": integrations.Integration{
+						ID: "int-1", Name: "mcp-1", Type: "mcp", Scope: "user",
+						Enabled: boolPtr(true), CreatedBy: "admin", UpdatedBy: "admin", //nolint:modernize
+						CreatedAt: time.Now(), ModifiedAt: time.Now(),
+					},
+				})
+			},
+		},
+		{
+			name: "not found",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte("not found"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, tt.handler)
+			item, err := client.Get(t.Context(), "int-1")
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, "int-1", item.ID)
+			assert.Equal(t, "mcp-1", item.Name)
+		})
+	}
+}
+
+func TestCreate(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name: "success",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Contains(t, r.URL.Path, "/integrations")
+
+				body, _ := io.ReadAll(r.Body)
+				var req integrations.CreateRequest
+				assert.NoError(t, json.Unmarshal(body, &req))
+				assert.Equal(t, "test-mcp", req.Name)
+				assert.Equal(t, "mcp", req.Type)
+				assert.Equal(t, "user", req.Scope)
+
+				writeJSON(w, map[string]any{
+					"data": integrations.Integration{
+						ID: "int-new", Name: "test-mcp", Type: "mcp", Scope: "user",
+						Enabled: boolPtr(true), CreatedBy: "admin", UpdatedBy: "admin", //nolint:modernize
+						CreatedAt: time.Now(), ModifiedAt: time.Now(),
+					},
+				})
+			},
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("bad request"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, tt.handler)
+			enabled := true
+			resp, err := client.Create(t.Context(), integrations.CreateRequest{
+				Name:         "test-mcp",
+				Type:         "mcp",
+				Scope:        "user",
+				Enabled:      &enabled,
+				Applications: []string{"all"},
+			})
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, "int-new", resp.ID)
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Contains(t, r.URL.Path, "/integrations/int-1")
+
+		body, _ := io.ReadAll(r.Body)
+		var req integrations.UpdateRequest
+		assert.NoError(t, json.Unmarshal(body, &req))
+		assert.Equal(t, "user", req.Scope)
+		assert.Equal(t, "renamed", req.Name)
+
+		writeJSON(w, map[string]any{
+			"data": integrations.Integration{
+				ID: "int-1", Name: "renamed", Type: "mcp", Scope: "user",
+				Enabled: boolPtr(true), CreatedBy: "admin", UpdatedBy: "admin", //nolint:modernize
+				CreatedAt: time.Now(), ModifiedAt: time.Now(),
+			},
+		})
+	}))
+
+	resp, err := client.Update(t.Context(), "int-1", integrations.UpdateRequest{
+		Scope: "user",
+		Name:  "renamed",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", resp.Name)
+}
+
+func TestDelete(t *testing.T) {
+	callCount := 0
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			// First call: GET to discover scope
+			assert.Equal(t, http.MethodGet, r.Method)
+			writeJSON(w, map[string]any{
+				"data": integrations.Integration{
+					ID: "int-1", Name: "mcp-1", Type: "mcp", Scope: "tenant",
+					Enabled: boolPtr(true), CreatedBy: "admin", UpdatedBy: "admin", //nolint:modernize
+					CreatedAt: time.Now(), ModifiedAt: time.Now(),
+				},
+			})
+			return
+		}
+		// Second call: DELETE with scope header
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "tenant", r.Header.Get("X-Resource-Scope"))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	err := client.Delete(t.Context(), "int-1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name: "success with tools",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/integrations/int-1/validate")
+				writeJSON(w, map[string]any{
+					"data": map[string]any{
+						"result": integrations.ValidationResult{
+							Status:  "success",
+							Message: "Connected",
+							Tools: []integrations.MCPTool{
+								{Name: "search", Description: "Search for things"},
+								{Name: "create", Description: "Create things"},
+							},
+						},
+					},
+				})
+			},
+		},
+		{
+			name: "failed validation",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, map[string]any{
+					"data": map[string]any{
+						"result": integrations.ValidationResult{
+							Status: "failed",
+							Error:  "connection refused",
+						},
+					},
+				})
+			},
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("internal error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, tt.handler)
+			result, err := client.Validate(t.Context(), "int-1")
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotEmpty(t, result.Status)
+		})
+	}
+}
+
+func TestGet_InvalidJSON(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{invalid"))
+	}))
+
+	_, err := client.Get(t.Context(), "int-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode")
+}
+
+func TestList_InvalidJSON(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{invalid"))
+	}))
+
+	_, _, err := client.List(t.Context(), integrations.ListOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode")
+}

--- a/internal/assistant/integrations/commands.go
+++ b/internal/assistant/integrations/commands.go
@@ -1,0 +1,597 @@
+package integrations
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/grafana/gcx/internal/assistant/assistanthttp"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func newClient(cmd *cobra.Command, loader *providers.ConfigLoader) (*Client, error) {
+	cfg, err := loader.LoadGrafanaConfig(cmd.Context())
+	if err != nil {
+		return nil, err
+	}
+	base, err := assistanthttp.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(base), nil
+}
+
+// Commands returns the integrations command group.
+func Commands(loader *providers.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "integrations",
+		Short: "Manage Grafana Assistant integrations.",
+	}
+
+	cmd.AddCommand(
+		newListCommand(loader),
+		newGetCommand(loader),
+		newCreateCommand(loader),
+		newUpdateCommand(loader),
+		newDeleteCommand(loader),
+		newValidateCommand(loader),
+	)
+	return cmd
+}
+
+// --- list ---
+
+type listOpts struct {
+	IO          cmdio.Options
+	Scope       string
+	EnabledOnly bool
+	Limit       int
+	Offset      int
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ListTableCodec{})
+	o.IO.RegisterCustomCodec("wide", &ListTableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Scope, "scope", "", "Filter by scope (user or tenant)")
+	flags.BoolVar(&o.EnabledOnly, "enabled-only", false, "Only return enabled integrations")
+	flags.IntVar(&o.Limit, "limit", 20, "Maximum number of integrations to return")
+	flags.IntVar(&o.Offset, "offset", 0, "Number of integrations to skip (for pagination)")
+}
+
+func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List integrations.",
+		Long:  "List integrations with optional scope and status filters.",
+		Example: `  gcx assistant integrations list
+  gcx assistant integrations list --scope=user
+  gcx assistant integrations list --enabled-only --limit=50
+  gcx assistant integrations list -o json`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if opts.Scope != "" && opts.Scope != "user" && opts.Scope != "tenant" {
+				return fmt.Errorf("--scope must be user or tenant, got %q", opts.Scope)
+			}
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			integrations, _, err := client.List(cmd.Context(), ListOptions{
+				Scope:       opts.Scope,
+				EnabledOnly: opts.EnabledOnly,
+				Limit:       opts.Limit,
+				Offset:      opts.Offset,
+			})
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), integrations)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- get ---
+
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("yaml")
+	o.IO.BindFlags(flags)
+}
+
+func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get integration detail.",
+		Long:  "Get the full detail of a specific integration by ID.",
+		Example: `  gcx assistant integrations get 550e8400-e29b-41d4-a716-446655440000
+  gcx assistant integrations get 550e8400-e29b-41d4-a716-446655440000 -o json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			integration, err := client.Get(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), integration)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- create ---
+
+type createOpts struct {
+	IO            cmdio.Options
+	Name          string
+	Type          string
+	Scope         string
+	Enabled       bool
+	Applications  []string
+	Description   string
+	URL           string
+	Configuration string
+	CustomHeaders []string
+}
+
+func (o *createOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("yaml")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Name, "name", "", "Integration name (required)")
+	flags.StringVar(&o.Type, "type", "mcp", "Integration type")
+	flags.StringVar(&o.Scope, "scope", "", "Integration scope: user or tenant (required)")
+	flags.BoolVar(&o.Enabled, "enabled", true, "Whether the integration is enabled")
+	flags.StringSliceVar(&o.Applications, "applications", []string{"all"}, "Target applications (assistant, loop, all)")
+	flags.StringVar(&o.Description, "description", "", "Integration description")
+	flags.StringVar(&o.URL, "url", "", "MCP server URL (shortcut for --configuration)")
+	flags.StringVar(&o.Configuration, "configuration", "", "Integration configuration as JSON")
+	flags.StringSliceVar(&o.CustomHeaders, "custom-header", nil, "Custom HTTP headers (key=value, repeatable)")
+}
+
+func (o *createOpts) Validate() error {
+	if o.Name == "" {
+		return errors.New("--name is required")
+	}
+	if o.Scope == "" {
+		return errors.New("--scope is required (user or tenant)")
+	}
+	if o.Scope != "user" && o.Scope != "tenant" {
+		return fmt.Errorf("--scope must be user or tenant, got %q", o.Scope)
+	}
+	if o.URL != "" && o.Configuration != "" {
+		return errors.New("--url and --configuration are mutually exclusive")
+	}
+	return nil
+}
+
+func buildConfiguration(urlFlag, configFlag string) (json.RawMessage, error) {
+	if urlFlag != "" {
+		cfg := map[string]string{"url": urlFlag}
+		data, err := json.Marshal(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build configuration: %w", err)
+		}
+		return data, nil
+	}
+	if configFlag != "" {
+		raw := json.RawMessage(configFlag)
+		if !json.Valid(raw) {
+			return nil, errors.New("--configuration is not valid JSON")
+		}
+		return raw, nil
+	}
+	return nil, nil
+}
+
+func parseHeaders(headers []string) ([]Header, error) {
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	result := make([]Header, 0, len(headers))
+	for _, h := range headers {
+		key, value, ok := strings.Cut(h, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid header format %q, expected key=value", h)
+		}
+		result = append(result, Header{Key: key, Value: value})
+	}
+	return result, nil
+}
+
+func newCreateCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &createOpts{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an integration.",
+		Long:  "Create a new integration. Use --url for MCP server integrations or --configuration for custom JSON.",
+		Example: `  gcx assistant integrations create --name="my-mcp" --scope=user --url="https://mcp.example.com"
+  gcx assistant integrations create --name="team-mcp" --scope=tenant --url="https://mcp.example.com" --applications=assistant
+  gcx assistant integrations create --name="custom" --scope=user --configuration='{"url":"https://mcp.example.com","socksProxyEnabled":true}'`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			config, err := buildConfiguration(opts.URL, opts.Configuration)
+			if err != nil {
+				return err
+			}
+
+			headers, err := parseHeaders(opts.CustomHeaders)
+			if err != nil {
+				return err
+			}
+
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+
+			enabled := opts.Enabled
+			integration, err := client.Create(cmd.Context(), CreateRequest{
+				Name:          opts.Name,
+				Type:          opts.Type,
+				Scope:         opts.Scope,
+				Enabled:       &enabled,
+				Applications:  opts.Applications,
+				Description:   opts.Description,
+				Configuration: config,
+				CustomHeaders: headers,
+			})
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), integration)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- update ---
+
+type updateOpts struct {
+	IO            cmdio.Options
+	Name          string
+	Description   string
+	Applications  []string
+	URL           string
+	Configuration string
+	CustomHeaders []string
+}
+
+func (o *updateOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("yaml")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Name, "name", "", "New integration name")
+	flags.StringVar(&o.Description, "description", "", "New description")
+	// --enabled is not bound to a struct field; read via flags.Changed/GetBool
+	// so we can distinguish "not set" from "set to true" (the default).
+	flags.Bool("enabled", true, "Whether the integration is enabled")
+	flags.StringSliceVar(&o.Applications, "applications", nil, "Target applications (assistant, loop, all)")
+	flags.StringVar(&o.URL, "url", "", "MCP server URL (shortcut for --configuration)")
+	flags.StringVar(&o.Configuration, "configuration", "", "Integration configuration as JSON")
+	flags.StringSliceVar(&o.CustomHeaders, "custom-header", nil, "Custom HTTP headers (key=value, repeatable)")
+}
+
+func (o *updateOpts) Validate() error {
+	if o.URL != "" && o.Configuration != "" {
+		return errors.New("--url and --configuration are mutually exclusive")
+	}
+	return nil
+}
+
+func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &updateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update an integration.",
+		Long:  "Update an existing integration. Fetches the current state and applies changes.",
+		Example: `  gcx assistant integrations update 550e8400-e29b-41d4-a716-446655440000 --name="renamed"
+  gcx assistant integrations update 550e8400-e29b-41d4-a716-446655440000 --enabled=false
+  gcx assistant integrations update 550e8400-e29b-41d4-a716-446655440000 --url="https://new-mcp.example.com"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+
+			// Scope is immutable and required by the PUT endpoint.
+			existing, err := client.Get(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+
+			req := UpdateRequest{
+				Scope: existing.Scope,
+			}
+
+			if cmd.Flags().Changed("name") {
+				req.Name = opts.Name
+			}
+			if cmd.Flags().Changed("description") {
+				req.Description = &opts.Description
+			}
+			if cmd.Flags().Changed("enabled") {
+				val, _ := cmd.Flags().GetBool("enabled")
+				req.Enabled = &val
+			}
+			if cmd.Flags().Changed("applications") {
+				req.Applications = opts.Applications
+			}
+
+			config, err := buildConfiguration(opts.URL, opts.Configuration)
+			if err != nil {
+				return err
+			}
+			if config != nil {
+				req.Configuration = config
+			}
+
+			headers, err := parseHeaders(opts.CustomHeaders)
+			if err != nil {
+				return err
+			}
+			if headers != nil {
+				for i := range headers {
+					headers[i].Modified = true
+				}
+				req.CustomHeaders = headers
+			}
+
+			integration, err := client.Update(cmd.Context(), args[0], req)
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), integration)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- delete ---
+
+type deleteOpts struct {
+	Force bool
+}
+
+func (o *deleteOpts) setup(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
+}
+
+func newDeleteCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &deleteOpts{}
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete an integration.",
+		Long:  "Delete an integration by ID. Prompts for confirmation unless --force is passed.",
+		Example: `  gcx assistant integrations delete 550e8400-e29b-41d4-a716-446655440000
+  gcx assistant integrations delete 550e8400-e29b-41d4-a716-446655440000 --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.ErrOrStderr(), opts.Force,
+				fmt.Sprintf("Delete integration %s?", args[0]))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
+			}
+
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			if err := client.Delete(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			cmdio.Info(cmd.ErrOrStderr(), "Deleted integration %s", args[0])
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- validate ---
+
+type validateOpts struct {
+	IO cmdio.Options
+}
+
+func (o *validateOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ValidateTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newValidateCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &validateOpts{}
+	cmd := &cobra.Command{
+		Use:   "validate <id>",
+		Short: "Validate an integration.",
+		Long:  "Test connectivity for an integration and list discovered MCP tools.",
+		Example: `  gcx assistant integrations validate 550e8400-e29b-41d4-a716-446655440000
+  gcx assistant integrations validate 550e8400-e29b-41d4-a716-446655440000 -o yaml`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			result, err := client.Validate(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), result)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// --- table codecs ---
+
+// ListTableCodec renders []Integration as a table.
+type ListTableCodec struct {
+	Wide bool
+}
+
+func (c *ListTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *ListTableCodec) Encode(w io.Writer, v any) error {
+	integrations, ok := v.([]Integration)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []Integration")
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	if c.Wide {
+		fmt.Fprintln(tw, "NAME\tID\tTYPE\tSCOPE\tENABLED\tDESCRIPTION\tAPPLICATIONS\tCREATED BY\tMODIFIED")
+	} else {
+		fmt.Fprintln(tw, "NAME\tID\tTYPE\tSCOPE\tENABLED\tMODIFIED")
+	}
+
+	for _, i := range integrations {
+		name := truncate(i.Name, 40)
+		enabled := formatEnabled(i.Enabled)
+		modified := assistanthttp.FormatTime(i.ModifiedAt)
+
+		if c.Wide {
+			desc := truncate(i.Description, 30)
+			apps := strings.Join(i.Applications, ",")
+			if apps == "" {
+				apps = "-"
+			}
+			createdBy := i.CreatedBy
+			if createdBy == "" {
+				createdBy = "-"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				name, i.ID, i.Type, i.Scope, enabled, desc, apps, createdBy, modified)
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				name, i.ID, i.Type, i.Scope, enabled, modified)
+		}
+	}
+	return tw.Flush()
+}
+
+func (c *ListTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// ValidateTableCodec renders *ValidationResult as a table.
+type ValidateTableCodec struct{}
+
+func (c *ValidateTableCodec) Format() format.Format {
+	return "table"
+}
+
+func (c *ValidateTableCodec) Encode(w io.Writer, v any) error {
+	result, ok := v.(*ValidationResult)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected *ValidationResult")
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+
+	fmt.Fprintln(tw, "STATUS\tMESSAGE")
+	msg := result.Message
+	if msg == "" && result.Error != "" {
+		msg = result.Error
+	}
+	if msg == "" {
+		msg = "-"
+	}
+	fmt.Fprintf(tw, "%s\t%s\n", result.Status, msg)
+
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	if len(result.Tools) > 0 {
+		fmt.Fprintln(w)
+		tw = tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "TOOL\tDESCRIPTION")
+		for _, t := range result.Tools {
+			desc := truncate(t.Description, 60)
+			fmt.Fprintf(tw, "%s\t%s\n", t.Name, desc)
+		}
+		return tw.Flush()
+	}
+
+	return nil
+}
+
+func (c *ValidateTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+func formatEnabled(enabled *bool) string {
+	if enabled == nil {
+		return "-"
+	}
+	if *enabled {
+		return "Yes"
+	}
+	return "No"
+}
+
+func truncate(s string, maxLen int) string {
+	if s == "" {
+		return "-"
+	}
+	if len(s) <= maxLen {
+		return s
+	}
+	r := []rune(s)
+	if len(r) > maxLen {
+		return string(r[:maxLen-3]) + "..."
+	}
+	return s
+}

--- a/internal/assistant/integrations/commands_test.go
+++ b/internal/assistant/integrations/commands_test.go
@@ -1,0 +1,169 @@
+package integrations_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/assistant/integrations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListTableCodec_Encode(t *testing.T) {
+	items := []integrations.Integration{
+		{
+			ID:           "int-1",
+			Name:         "my-mcp-server",
+			Type:         "mcp",
+			Scope:        "user",
+			Enabled:      boolPtr(true), //nolint:modernize
+			Description:  "A test MCP server",
+			Applications: []string{"assistant"},
+			CreatedBy:    "admin",
+			ModifiedAt:   time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			ID:      "int-2",
+			Name:    "disabled-server",
+			Type:    "mcp",
+			Scope:   "tenant",
+			Enabled: boolPtr(false), //nolint:modernize
+		},
+	}
+
+	t.Run("table", func(t *testing.T) {
+		codec := &integrations.ListTableCodec{}
+		assert.Equal(t, "table", string(codec.Format()))
+
+		var buf bytes.Buffer
+		require.NoError(t, codec.Encode(&buf, items))
+		out := buf.String()
+		assert.Contains(t, out, "NAME")
+		assert.Contains(t, out, "ID")
+		assert.Contains(t, out, "TYPE")
+		assert.Contains(t, out, "SCOPE")
+		assert.Contains(t, out, "ENABLED")
+		assert.Contains(t, out, "MODIFIED")
+		assert.NotContains(t, out, "DESCRIPTION")
+		assert.Contains(t, out, "my-mcp-server")
+		assert.Contains(t, out, "Yes")
+		assert.Contains(t, out, "No")
+	})
+
+	t.Run("wide", func(t *testing.T) {
+		codec := &integrations.ListTableCodec{Wide: true}
+		assert.Equal(t, "wide", string(codec.Format()))
+
+		var buf bytes.Buffer
+		require.NoError(t, codec.Encode(&buf, items))
+		out := buf.String()
+		assert.Contains(t, out, "DESCRIPTION")
+		assert.Contains(t, out, "APPLICATIONS")
+		assert.Contains(t, out, "CREATED BY")
+		assert.Contains(t, out, "A test MCP server")
+		assert.Contains(t, out, "assistant")
+		assert.Contains(t, out, "admin")
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		codec := &integrations.ListTableCodec{}
+		err := codec.Encode(&bytes.Buffer{}, "wrong")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected []Integration")
+	})
+
+	t.Run("decode unsupported", func(t *testing.T) {
+		codec := &integrations.ListTableCodec{}
+		require.Error(t, codec.Decode(nil, nil))
+	})
+}
+
+func TestListTableCodec_NameTruncation(t *testing.T) {
+	items := []integrations.Integration{
+		{
+			ID:      "int-1",
+			Name:    "this-is-a-very-long-integration-name-that-should-be-truncated",
+			Type:    "mcp",
+			Scope:   "user",
+			Enabled: boolPtr(true), //nolint:modernize
+		},
+	}
+
+	var buf bytes.Buffer
+	codec := &integrations.ListTableCodec{}
+	require.NoError(t, codec.Encode(&buf, items))
+	assert.Contains(t, buf.String(), "...")
+}
+
+func TestListTableCodec_NilEnabled(t *testing.T) {
+	items := []integrations.Integration{
+		{
+			ID:    "int-1",
+			Name:  "test",
+			Type:  "mcp",
+			Scope: "user",
+		},
+	}
+
+	var buf bytes.Buffer
+	codec := &integrations.ListTableCodec{}
+	require.NoError(t, codec.Encode(&buf, items))
+	// nil enabled displays as "-"
+	assert.Contains(t, buf.String(), "-")
+}
+
+func TestValidateTableCodec_Encode(t *testing.T) {
+	t.Run("success with tools", func(t *testing.T) {
+		result := &integrations.ValidationResult{
+			Status:  "success",
+			Message: "Connected successfully",
+			Tools: []integrations.MCPTool{
+				{Name: "search", Description: "Search for items"},
+				{Name: "create", Description: "Create new items"},
+			},
+		}
+
+		codec := &integrations.ValidateTableCodec{}
+		assert.Equal(t, "table", string(codec.Format()))
+
+		var buf bytes.Buffer
+		require.NoError(t, codec.Encode(&buf, result))
+		out := buf.String()
+		assert.Contains(t, out, "STATUS")
+		assert.Contains(t, out, "MESSAGE")
+		assert.Contains(t, out, "success")
+		assert.Contains(t, out, "Connected successfully")
+		assert.Contains(t, out, "TOOL")
+		assert.Contains(t, out, "DESCRIPTION")
+		assert.Contains(t, out, "search")
+		assert.Contains(t, out, "create")
+	})
+
+	t.Run("failed without tools", func(t *testing.T) {
+		result := &integrations.ValidationResult{
+			Status: "failed",
+			Error:  "connection refused",
+		}
+
+		var buf bytes.Buffer
+		codec := &integrations.ValidateTableCodec{}
+		require.NoError(t, codec.Encode(&buf, result))
+		out := buf.String()
+		assert.Contains(t, out, "failed")
+		assert.Contains(t, out, "connection refused")
+		assert.NotContains(t, out, "TOOL")
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		codec := &integrations.ValidateTableCodec{}
+		err := codec.Encode(&bytes.Buffer{}, "wrong")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected *ValidationResult")
+	})
+
+	t.Run("decode unsupported", func(t *testing.T) {
+		codec := &integrations.ValidateTableCodec{}
+		require.Error(t, codec.Decode(nil, nil))
+	})
+}

--- a/internal/assistant/integrations/types.go
+++ b/internal/assistant/integrations/types.go
@@ -1,0 +1,87 @@
+package integrations
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Integration represents a Grafana Assistant integration (e.g. an MCP server).
+type Integration struct {
+	ID                   string          `json:"id"`
+	Name                 string          `json:"name"`
+	Type                 string          `json:"type"`
+	Scope                string          `json:"scope"`
+	Enabled              *bool           `json:"enabled"`
+	Description          string          `json:"description,omitempty"`
+	Applications         []string        `json:"applications,omitempty"`
+	Configuration        json.RawMessage `json:"configuration,omitempty"`
+	CustomHeaders        []Header        `json:"custom_headers,omitempty"`
+	AuthenticationFailed *bool           `json:"authenticationFailed,omitempty"`
+	DynamicClientID      string          `json:"dynamic_client_id,omitempty"`
+	UserID               string          `json:"userId,omitempty"`
+	CreatedAt            time.Time       `json:"created"`
+	ModifiedAt           time.Time       `json:"modified"`
+	CreatedBy            string          `json:"createdBy"`
+	UpdatedBy            string          `json:"updatedBy"`
+}
+
+// Header is a custom HTTP header attached to an integration.
+type Header struct {
+	Key      string `json:"key"`
+	Value    string `json:"value"`
+	Modified bool   `json:"modified,omitempty"`
+}
+
+// Pagination holds paging metadata from list responses.
+type Pagination struct {
+	Total  int64 `json:"total"`
+	Limit  int64 `json:"limit"`
+	Offset int64 `json:"offset"`
+}
+
+// CreateRequest is the body for POST /integrations.
+type CreateRequest struct {
+	Name          string          `json:"name"`
+	Type          string          `json:"type"`
+	Scope         string          `json:"scope"`
+	Enabled       *bool           `json:"enabled"`
+	Applications  []string        `json:"applications"`
+	Description   string          `json:"description,omitempty"`
+	Configuration json.RawMessage `json:"configuration,omitempty"`
+	CustomHeaders []Header        `json:"custom_headers,omitempty"`
+}
+
+// UpdateRequest is the body for PUT /integrations/{id}.
+type UpdateRequest struct {
+	Scope         string          `json:"scope"`
+	Name          string          `json:"name,omitempty"`
+	Description   *string         `json:"description,omitempty"`
+	Enabled       *bool           `json:"enabled,omitempty"`
+	Applications  []string        `json:"applications,omitempty"`
+	Configuration json.RawMessage `json:"configuration,omitempty"`
+	CustomHeaders []Header        `json:"custom_headers,omitempty"`
+}
+
+// ValidationResult is from GET /integrations/{id}/validate.
+type ValidationResult struct {
+	Status  string    `json:"status"`
+	Message string    `json:"message,omitempty"`
+	Error   string    `json:"error,omitempty"`
+	Tools   []MCPTool `json:"tools,omitempty"`
+}
+
+// MCPTool describes an MCP tool discovered during validation.
+type MCPTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Annotations *ToolAnnotation `json:"annotations,omitempty"`
+}
+
+// ToolAnnotation holds MCP tool annotation hints.
+type ToolAnnotation struct {
+	ReadOnlyHint    bool   `json:"readOnlyHint,omitempty"`
+	DestructiveHint bool   `json:"destructiveHint,omitempty"`
+	IdempotentHint  bool   `json:"idempotentHint,omitempty"`
+	OpenWorldHint   bool   `json:"openWorldHint,omitempty"`
+	Title           string `json:"title,omitempty"`
+}


### PR DESCRIPTION
## Summary

- add `gcx assistant integrations` command group with list, get, create, update, delete, and validate subcommands
- integrations are MCP server connections managed through the grafana-assistant-app plugin proxy
- add `DoRequestWithHeaders` to `assistanthttp.Client` to support custom HTTP headers (needed for DELETE's `X-Resource-Scope`)

## Design decisions

- **delete** uses GET-then-DELETE to auto-discover the integration's scope, avoiding a `--scope` flag
- **update** uses read-modify-write: fetches existing integration to get the immutable scope, merges user-provided flags
- **create** has `--url` as a shortcut for the common MCP server case (builds `{"url":"..."}` configuration internally), with `--configuration` as the advanced escape hatch
- **delete** uses `ConfirmDestructive` with `--force` for safety
- **validate** shows a status table + discovered MCP tools sub-table

## How to review this PR

- **commit 1**: the full implementation - types, HTTP client, cobra commands, table codecs, agent annotations, reference docs, and tests