### PR TITLE
fix(output): remove agent-mode hint banner that breaks JSON parsing

### DIFF
--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -40,11 +40,10 @@ type Options struct {
 	// ErrWriter is the writer for hints and diagnostics (defaults to os.Stderr).
 	ErrWriter io.Writer
 
-	customCodecs        map[string]format.Codec
-	defaultFormat       string
-	flags               *pflag.FlagSet
-	jsonFieldValidator  func(fields []string) error // optional; invoked before field extraction when --json is used
-	jsonFieldsHintShown bool
+	customCodecs       map[string]format.Codec
+	defaultFormat      string
+	flags              *pflag.FlagSet
+	jsonFieldValidator func(fields []string) error // optional; invoked before field extraction when --json is used
 }
 
 // SetJSONFieldValidator registers an optional validator invoked before field
@@ -167,29 +166,11 @@ func (opts *Options) Encode(dst io.Writer, value any) error {
 		return err
 	}
 
-	// Nudge toward --json field selection whenever the resolved codec is
-	// JSON-like (json or agents format) and the caller has not already
-	// requested field selection/discovery. Emitted once per invocation to
-	// stderr (never pollutes stdout). TTY: plain "hint:" line. Agent mode:
-	// JSONL {"class":"hint",...} — routed through emitHint/EmitHint so the
-	// hints framework handles codec & agent-mode compliance (FR-104).
-	isJSONLike := codec.Format() == format.JSON || codec.Format() == agentsFormat
-	if !opts.jsonFieldsHintShown && isJSONLike && len(opts.JSONFields) == 0 && !opts.JSONDiscovery {
-		opts.jsonFieldsHintShown = true
-		w := opts.ErrWriter
-		if w == nil {
-			w = os.Stderr
-		}
-		emitHint(w,
-			"use --json list to discover fields, --json field1,field2 to select — no external parsing needed",
-			"",
-		)
-	}
-
 	// Intercept JSON field discovery and field selection when the resolved
 	// codec is JSON-like. Commands that already check JSONFields/JSONDiscovery
 	// before calling Encode() will never reach here (they return early), so
 	// there is no double-application risk.
+	isJSONLike := codec.Format() == format.JSON || codec.Format() == agentsFormat
 	if isJSONLike {
 		if opts.JSONDiscovery {
 			return opts.encodeDiscovery(dst, value)

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -197,22 +197,18 @@ func TestJSONFlag_Parsing(t *testing.T) {
 }
 
 func TestEncode_AgentModeHint(t *testing.T) {
-	// The agent-mode hint banner has been removed (C.3c). No mode should emit it.
 	tests := []struct {
 		name      string
 		agentMode bool
 		jsonField string // if set, pass --json flag
-		wantHint  bool
 	}{
 		{
 			name:      "agent mode without --json: no hint",
 			agentMode: true,
-			wantHint:  false,
 		},
 		{
 			name:      "non-agent mode: no hint",
 			agentMode: false,
-			wantHint:  false,
 		},
 	}
 
@@ -221,7 +217,8 @@ func TestEncode_AgentModeHint(t *testing.T) {
 			agent.SetFlag(tc.agentMode)
 			t.Cleanup(func() { agent.SetFlag(false) })
 
-			opts := &cmdio.Options{}
+			var stderr bytes.Buffer
+			opts := &cmdio.Options{ErrWriter: &stderr}
 			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 			opts.BindFlags(flags)
 
@@ -231,11 +228,11 @@ func TestEncode_AgentModeHint(t *testing.T) {
 
 			require.NoError(t, opts.Validate())
 
-			var buf bytes.Buffer
-			require.NoError(t, opts.Encode(&buf, map[string]any{"name": "test"}))
+			var stdout bytes.Buffer
+			require.NoError(t, opts.Encode(&stdout, map[string]any{"name": "test"}))
 
-			// Encode writes to stdout (buf), not stderr. No hint should be emitted anywhere.
-			assert.NotContains(t, buf.String(), "--json list")
+			assert.NotContains(t, stdout.String(), "hint:", "hint must not appear on stdout")
+			assert.NotContains(t, stderr.String(), "hint:", "hint must not appear on stderr")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Remove the `hint: use --json list...` banner emitted to stderr in agent mode — it pollutes combined stdout+stderr in agent environments (Cursor, Claude Code, Copilot), breaking `jq` and `python3 -c json.load()` on every `-o json` response
- Drop the now-unused `agentHintShown` field from `Options` struct
- Fix `TestEncode_AgentModeHint` to capture stderr via `ErrWriter` and assert no hint on either stream (previously only checked stdout, so the leak was invisible)

Agents discover `--json list` via the `--help` tip, the gcx `SKILL.md` output flags table, and the `--json` flag description itself — the runtime hint was redundant.

## Test plan

- [x] `go test ./internal/output/...` passes
- [x] `golangci-lint run ./internal/output/...` clean (pre-existing prealloc warning only)
- [x] `GCX_AGENT_MODE=true bin/gcx providers list -o json 2>&1 | jq '.[0]'` returns valid JSON
- [x] `gofmt -l` reports no formatting issues

Made with [Cursor](https://cursor.com)