### PR TITLE
feat(k6): dual-client (OAuth + SA token) with cross-invocation cache

### DIFF
--- a/internal/providers/k6/api.go
+++ b/internal/providers/k6/api.go
@@ -7,9 +7,9 @@ import "context"
 //   - ProxyClient: routes through the grafana-k6-app plugin proxy (OAuth).
 //   - DirectClient: talks to api.k6.io directly with an SA-token-exchanged v3 token.
 //
-//nolint:interfacebloat // single source of truth for both client implementations;
-// the alternative is two parallel call sites everywhere.
-type API interface {
+// The interface is intentionally broad — it is the single source of truth for
+// both client implementations; the alternative is two parallel call sites everywhere.
+type API interface { //nolint:interfacebloat
 	// Identity
 	Token(ctx context.Context) (string, error)
 

--- a/internal/providers/k6/api.go
+++ b/internal/providers/k6/api.go
@@ -1,0 +1,62 @@
+package k6
+
+import "context"
+
+// API is the union of all k6 client operations consumed by gcx commands
+// and resource adapters. Implementations:
+//   - ProxyClient: routes through the grafana-k6-app plugin proxy (OAuth).
+//   - DirectClient: talks to api.k6.io directly with an SA-token-exchanged v3 token.
+//
+//nolint:interfacebloat // single source of truth for both client implementations;
+// the alternative is two parallel call sites everywhere.
+type API interface {
+	// Identity
+	Token(ctx context.Context) (string, error)
+
+	// Projects
+	ListProjects(ctx context.Context) ([]Project, error)
+	GetProject(ctx context.Context, id int) (*Project, error)
+	CreateProject(ctx context.Context, name string) (*Project, error)
+	UpdateProject(ctx context.Context, id int, name string) error
+	DeleteProject(ctx context.Context, id int) error
+	GetProjectByName(ctx context.Context, name string) (*Project, error)
+
+	// Load tests
+	ListLoadTests(ctx context.Context) ([]LoadTest, error)
+	ListLoadTestsByProject(ctx context.Context, projectID int) ([]LoadTest, error)
+	ListLoadTestsWithLimit(ctx context.Context, limit int) ([]LoadTest, error)
+	GetLoadTest(ctx context.Context, id int) (*LoadTest, error)
+	GetLoadTestByName(ctx context.Context, projectID int, name string) (*LoadTest, error)
+	CreateLoadTest(ctx context.Context, name string, projectID int, script string) (*LoadTest, error)
+	UpdateLoadTest(ctx context.Context, id int, name, script string) error
+	UpdateLoadTestScript(ctx context.Context, id int, script string) error
+	GetLoadTestScript(ctx context.Context, id int) (string, error)
+	DeleteLoadTest(ctx context.Context, id int) error
+
+	// Test runs
+	ListTestRuns(ctx context.Context, loadTestID int) ([]TestRunStatus, error)
+
+	// Env vars
+	ListEnvVars(ctx context.Context) ([]EnvVar, error)
+	CreateEnvVar(ctx context.Context, name, value, description string) (*EnvVar, error)
+	UpdateEnvVar(ctx context.Context, id int, name, value, description string) error
+	DeleteEnvVar(ctx context.Context, id int) error
+
+	// Schedules
+	ListSchedules(ctx context.Context) ([]Schedule, error)
+	GetSchedule(ctx context.Context, id int) (*Schedule, error)
+	CreateSchedule(ctx context.Context, loadTestID int, req ScheduleRequest) (*Schedule, error)
+	UpdateScheduleByID(ctx context.Context, id int, req ScheduleRequest) (*Schedule, error)
+	DeleteScheduleByLoadTest(ctx context.Context, loadTestID int) error
+
+	// Load zones
+	ListLoadZones(ctx context.Context) ([]LoadZone, error)
+	CreateLoadZone(ctx context.Context, req PLZCreateRequest) (*PLZCreateResponse, error)
+	DeleteLoadZone(ctx context.Context, name string) error
+
+	// Allowed projects / load zones
+	ListAllowedProjects(ctx context.Context, loadZoneID int) ([]AllowedProject, error)
+	UpdateAllowedProjects(ctx context.Context, loadZoneID int, projectIDs []int) error
+	ListAllowedLoadZones(ctx context.Context, projectID int) ([]AllowedLoadZone, error)
+	UpdateAllowedLoadZones(ctx context.Context, projectID int, loadZoneIDs []int) error
+}

--- a/internal/providers/k6/cache.go
+++ b/internal/providers/k6/cache.go
@@ -1,0 +1,65 @@
+package k6
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+)
+
+// Provider config keys used for cross-invocation auth caching in DirectClient mode.
+// These are persisted to the gcx config file so subsequent invocations can skip
+// the /v3/account/grafana-app/start round-trip. The cache is keyed by stack ID;
+// any mismatch invalidates the entry.
+const (
+	keyCachedToken   = "cached-token"
+	keyCachedOrgID   = "cached-org-id"
+	keyCachedStackID = "cached-stack-id"
+)
+
+// cacheStore is the persistence sink for the SA-token cache. It is satisfied
+// by providers.ConfigLoader; declared locally to keep the cache code
+// decoupled from the heavier CloudConfigLoader interface.
+type cacheStore interface {
+	SaveProviderConfig(ctx context.Context, providerName, key, value string) error
+}
+
+// loadCache returns the cached k6 credentials if the cache is bound to the
+// current stack ID. A mismatch (stack changed) is treated as a miss; callers
+// should fall back to a fresh exchange, which will overwrite the stale entry.
+func loadCache(providerCfg map[string]string, currentStackID int) (string, int, bool) {
+	if providerCfg == nil {
+		return "", 0, false
+	}
+	tok := providerCfg[keyCachedToken]
+	cachedStack, errStack := strconv.Atoi(providerCfg[keyCachedStackID])
+	cachedOrg, errOrg := strconv.Atoi(providerCfg[keyCachedOrgID])
+	if tok == "" || errStack != nil || errOrg != nil || cachedStack != currentStackID {
+		return "", 0, false
+	}
+	return tok, cachedOrg, true
+}
+
+// persistCache writes the cached fields back to the config under
+// providers.k6.* so subsequent invocations skip the /start round-trip.
+// Save failures are non-fatal: the in-memory client still works for this run.
+func persistCache(ctx context.Context, store cacheStore, token string, orgID, stackID int) {
+	saves := []struct{ key, val string }{
+		{keyCachedToken, token},
+		{keyCachedOrgID, strconv.Itoa(orgID)},
+		{keyCachedStackID, strconv.Itoa(stackID)},
+	}
+	for _, s := range saves {
+		if err := store.SaveProviderConfig(ctx, "k6", s.key, s.val); err != nil {
+			slog.DebugContext(ctx, "k6: failed to persist cached auth", "key", s.key, "error", err)
+		}
+	}
+}
+
+// clearCache wipes the persisted cache. Called when a cached token is rejected.
+func clearCache(ctx context.Context, store cacheStore) {
+	for _, key := range []string{keyCachedToken, keyCachedOrgID, keyCachedStackID} {
+		if err := store.SaveProviderConfig(ctx, "k6", key, ""); err != nil {
+			slog.DebugContext(ctx, "k6: failed to clear cached auth", "key", key, "error", err)
+		}
+	}
+}

--- a/internal/providers/k6/cache_test.go
+++ b/internal/providers/k6/cache_test.go
@@ -9,17 +9,19 @@ import (
 )
 
 type fakeStore struct {
-	saved   map[string]string
-	saveErr error
+	saved    map[string]string
+	provider string
+	saveErr  error
 }
 
-func (f *fakeStore) SaveProviderConfig(_ context.Context, _, key, value string) error {
+func (f *fakeStore) SaveProviderConfig(_ context.Context, providerName, key, value string) error {
 	if f.saveErr != nil {
 		return f.saveErr
 	}
 	if f.saved == nil {
 		f.saved = make(map[string]string)
 	}
+	f.provider = providerName
 	f.saved[key] = value
 	return nil
 }
@@ -88,6 +90,7 @@ func TestPersistCache_SavesAllThreeKeys(t *testing.T) {
 	assert.Equal(t, "tok-xyz", store.saved[keyCachedToken])
 	assert.Equal(t, "42", store.saved[keyCachedOrgID])
 	assert.Equal(t, "999", store.saved[keyCachedStackID])
+	assert.Equal(t, "k6", store.provider)
 }
 
 func TestPersistCache_SaveErrorIsNonFatal(t *testing.T) {
@@ -100,7 +103,9 @@ func TestPersistCache_SaveErrorIsNonFatal(t *testing.T) {
 func TestClearCache_ClearsAllThreeKeys(t *testing.T) {
 	store := &fakeStore{}
 	clearCache(context.Background(), store)
+	assert.Len(t, store.saved, 3)
 	assert.Empty(t, store.saved[keyCachedToken])
 	assert.Empty(t, store.saved[keyCachedOrgID])
 	assert.Empty(t, store.saved[keyCachedStackID])
+	assert.Equal(t, "k6", store.provider)
 }

--- a/internal/providers/k6/cache_test.go
+++ b/internal/providers/k6/cache_test.go
@@ -1,0 +1,106 @@
+package k6 //nolint:testpackage // tests exercise unexported cache helpers.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeStore struct {
+	saved   map[string]string
+	saveErr error
+}
+
+func (f *fakeStore) SaveProviderConfig(_ context.Context, _, key, value string) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	if f.saved == nil {
+		f.saved = make(map[string]string)
+	}
+	f.saved[key] = value
+	return nil
+}
+
+func TestLoadCache(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            map[string]string
+		currentStackID int
+		wantOk         bool
+		wantToken      string
+		wantOrgID      int
+	}{
+		{
+			name: "hit: all fields match stack",
+			cfg: map[string]string{
+				keyCachedToken: "tok", keyCachedOrgID: "42", keyCachedStackID: "999",
+			},
+			currentStackID: 999, wantOk: true, wantToken: "tok", wantOrgID: 42,
+		},
+		{name: "miss: nil map", cfg: nil, currentStackID: 999, wantOk: false},
+		{
+			name: "miss: empty token",
+			cfg: map[string]string{
+				keyCachedToken: "", keyCachedOrgID: "42", keyCachedStackID: "999",
+			},
+			currentStackID: 999, wantOk: false,
+		},
+		{
+			name: "miss: stack mismatch",
+			cfg: map[string]string{
+				keyCachedToken: "tok", keyCachedOrgID: "42", keyCachedStackID: "888",
+			},
+			currentStackID: 999, wantOk: false,
+		},
+		{
+			name: "miss: non-numeric org",
+			cfg: map[string]string{
+				keyCachedToken: "tok", keyCachedOrgID: "bad", keyCachedStackID: "999",
+			},
+			currentStackID: 999, wantOk: false,
+		},
+		{
+			name: "miss: non-numeric stack",
+			cfg: map[string]string{
+				keyCachedToken: "tok", keyCachedOrgID: "42", keyCachedStackID: "bad",
+			},
+			currentStackID: 999, wantOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tok, org, ok := loadCache(tt.cfg, tt.currentStackID)
+			assert.Equal(t, tt.wantOk, ok)
+			if tt.wantOk {
+				assert.Equal(t, tt.wantToken, tok)
+				assert.Equal(t, tt.wantOrgID, org)
+			}
+		})
+	}
+}
+
+func TestPersistCache_SavesAllThreeKeys(t *testing.T) {
+	store := &fakeStore{}
+	persistCache(context.Background(), store, "tok-xyz", 42, 999)
+	assert.Equal(t, "tok-xyz", store.saved[keyCachedToken])
+	assert.Equal(t, "42", store.saved[keyCachedOrgID])
+	assert.Equal(t, "999", store.saved[keyCachedStackID])
+}
+
+func TestPersistCache_SaveErrorIsNonFatal(t *testing.T) {
+	store := &fakeStore{saveErr: errors.New("disk full")}
+	// Must not panic; must not return anything (signature is void by design).
+	persistCache(context.Background(), store, "tok", 42, 999)
+	assert.Empty(t, store.saved)
+}
+
+func TestClearCache_ClearsAllThreeKeys(t *testing.T) {
+	store := &fakeStore{}
+	clearCache(context.Background(), store)
+	assert.Empty(t, store.saved[keyCachedToken])
+	assert.Empty(t, store.saved[keyCachedOrgID])
+	assert.Empty(t, store.saved[keyCachedStackID])
+}

--- a/internal/providers/k6/commands.go
+++ b/internal/providers/k6/commands.go
@@ -27,7 +27,7 @@ import (
 // ---------------------------------------------------------------------------
 
 // resolveProject resolves a <id-or-name> argument to a project ID.
-func resolveProject(cmd *cobra.Command, client *Client, arg string) (int, error) {
+func resolveProject(cmd *cobra.Command, client *ProxyClient, arg string) (int, error) {
 	id, err := strconv.Atoi(arg)
 	if err == nil {
 		return id, nil
@@ -41,7 +41,7 @@ func resolveProject(cmd *cobra.Command, client *Client, arg string) (int, error)
 }
 
 // resolveLoadTest resolves a load test by ID flag or by name+project-id.
-func resolveLoadTest(cmd *cobra.Command, client *Client, idFlag, projectID int, nameArg string) (*LoadTest, error) {
+func resolveLoadTest(cmd *cobra.Command, client *ProxyClient, idFlag, projectID int, nameArg string) (*LoadTest, error) {
 	ctx := cmd.Context()
 	if idFlag != 0 {
 		return client.GetLoadTest(ctx, idFlag)
@@ -66,7 +66,7 @@ func resolveLoadTest(cmd *cobra.Command, client *Client, idFlag, projectID int, 
 }
 
 // resolveLoadTestArg resolves a <id-or-name> argument to a LoadTest.
-func resolveLoadTestArg(cmd *cobra.Command, client *Client, arg string, projectID int) (*LoadTest, error) {
+func resolveLoadTestArg(cmd *cobra.Command, client *ProxyClient, arg string, projectID int) (*LoadTest, error) {
 	id, err := strconv.Atoi(arg)
 	if err == nil {
 		return client.GetLoadTest(cmd.Context(), id)

--- a/internal/providers/k6/commands.go
+++ b/internal/providers/k6/commands.go
@@ -27,7 +27,7 @@ import (
 // ---------------------------------------------------------------------------
 
 // resolveProject resolves a <id-or-name> argument to a project ID.
-func resolveProject(cmd *cobra.Command, client *ProxyClient, arg string) (int, error) {
+func resolveProject(cmd *cobra.Command, client API, arg string) (int, error) {
 	id, err := strconv.Atoi(arg)
 	if err == nil {
 		return id, nil
@@ -41,7 +41,7 @@ func resolveProject(cmd *cobra.Command, client *ProxyClient, arg string) (int, e
 }
 
 // resolveLoadTest resolves a load test by ID flag or by name+project-id.
-func resolveLoadTest(cmd *cobra.Command, client *ProxyClient, idFlag, projectID int, nameArg string) (*LoadTest, error) {
+func resolveLoadTest(cmd *cobra.Command, client API, idFlag, projectID int, nameArg string) (*LoadTest, error) {
 	ctx := cmd.Context()
 	if idFlag != 0 {
 		return client.GetLoadTest(ctx, idFlag)
@@ -66,7 +66,7 @@ func resolveLoadTest(cmd *cobra.Command, client *ProxyClient, idFlag, projectID 
 }
 
 // resolveLoadTestArg resolves a <id-or-name> argument to a LoadTest.
-func resolveLoadTestArg(cmd *cobra.Command, client *ProxyClient, arg string, projectID int) (*LoadTest, error) {
+func resolveLoadTestArg(cmd *cobra.Command, client API, arg string, projectID int) (*LoadTest, error) {
 	id, err := strconv.Atoi(arg)
 	if err == nil {
 		return client.GetLoadTest(cmd.Context(), id)

--- a/internal/providers/k6/direct_client.go
+++ b/internal/providers/k6/direct_client.go
@@ -1,12 +1,15 @@
 package k6
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -34,8 +37,7 @@ type DirectClient struct {
 	stackID   int
 	token     string
 	http      *http.Client
-	//nolint:unused // wired in Task 6 (SetReauth / doWithReauth)
-	reauth ReauthFunc
+	reauth    ReauthFunc
 }
 
 // NewDirectClient creates a DirectClient. If apiDomain is empty, DefaultAPIDomain
@@ -113,8 +115,6 @@ func (c *DirectClient) Token(_ context.Context) (string, error) {
 
 // orgIDValue returns the cached organization ID, used internally by EnvVar methods.
 // The plural form (orgID()) is reserved for ProxyClient's lazy variant.
-//
-//nolint:unused // called by resource methods added in Task 6
 func (c *DirectClient) orgIDValue() int { return c.orgID }
 
 // authResponse is the JSON body returned by PUT /v3/account/grafana-app/start.
@@ -122,3 +122,791 @@ type authResponse struct {
 	OrgID          string `json:"organization_id"`
 	V3GrafanaToken string `json:"v3_grafana_token"`
 }
+
+// ---------------------------------------------------------------------------
+// Auth management helpers
+// ---------------------------------------------------------------------------
+
+// SetReauth registers a callback used to refresh credentials when a request is
+// rejected with 401. Without it, 401s propagate to the caller as-is. The
+// callback is invoked at most once per request — after a successful retry,
+// subsequent 401s on the same request are NOT retried.
+func (c *DirectClient) SetReauth(fn ReauthFunc) { c.reauth = fn }
+
+// SetCachedAuth populates the client with previously-exchanged credentials,
+// skipping the /v3/account/grafana-app/start round-trip. The caller is
+// responsible for wiring SetReauth to refresh on 401 if these credentials
+// turn out to be stale.
+func (c *DirectClient) SetCachedAuth(token string, orgID, stackID int) {
+	c.token = token
+	c.orgID = orgID
+	c.stackID = stackID
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+// doJSON marshals body to JSON, builds the request via the build closure (so
+// the retry path can rebuild it with fresh credentials), and executes it via
+// doWithReauth.
+func (c *DirectClient) doJSON(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	var bodyBytes []byte
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("k6: marshal request body: %w", err)
+		}
+		bodyBytes = b
+	}
+	build := func() (*http.Request, error) {
+		var br io.Reader
+		if bodyBytes != nil {
+			br = bytes.NewReader(bodyBytes)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, c.apiDomain+path, br)
+		if err != nil {
+			return nil, fmt.Errorf("k6: create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("X-Stack-Id", strconv.Itoa(c.stackID))
+		return req, nil
+	}
+	return c.doWithReauth(ctx, build)
+}
+
+// doRaw issues a multipart/form-data or application/octet-stream request,
+// buffering the body so the retry path can replay it.
+func (c *DirectClient) doRaw(ctx context.Context, method, path, contentType string, body io.Reader) (int, []byte, error) {
+	var bodyBytes []byte
+	if body != nil {
+		buf, err := io.ReadAll(body)
+		if err != nil {
+			return 0, nil, fmt.Errorf("k6: buffer raw request body: %w", err)
+		}
+		bodyBytes = buf
+	}
+	build := func() (*http.Request, error) {
+		var br io.Reader
+		if bodyBytes != nil {
+			br = bytes.NewReader(bodyBytes)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, c.apiDomain+path, br)
+		if err != nil {
+			return nil, fmt.Errorf("k6: create raw request: %w", err)
+		}
+		if contentType != "" {
+			req.Header.Set("Content-Type", contentType)
+		}
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("X-Stack-Id", strconv.Itoa(c.stackID))
+		return req, nil
+	}
+	resp, err := c.doWithReauth(ctx, build)
+	if err != nil {
+		return 0, nil, fmt.Errorf("k6: raw request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("k6: read raw response: %w", err)
+	}
+	return resp.StatusCode, respBody, nil
+}
+
+// doWithReauth runs the request; if it 401s and a reauth callback is wired,
+// invokes the callback once and retries with refreshed credentials. The
+// request is rebuilt for the retry so headers (including Authorization)
+// pick up the new token and the body reader is reset.
+func (c *DirectClient) doWithReauth(ctx context.Context, build func() (*http.Request, error)) (*http.Response, error) {
+	req, err := build()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil || resp.StatusCode != http.StatusUnauthorized || c.reauth == nil {
+		return resp, err
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	token, orgID, err := c.reauth(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("k6: reauth after 401: %w", err)
+	}
+	c.token = token
+	c.orgID = orgID
+
+	req2, err := build()
+	if err != nil {
+		return nil, err
+	}
+	return c.http.Do(req2)
+}
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
+// ListProjects retrieves all projects for the stack.
+func (c *DirectClient) ListProjects(ctx context.Context) ([]Project, error) {
+	resp, err := c.doJSON(ctx, http.MethodGet, projectsPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("k6: list projects: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("k6: list projects: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+
+	result, err := decodeJSON[projectsResponse](resp)
+	if err != nil {
+		return nil, err
+	}
+	return result.Value, nil
+}
+
+// GetProject retrieves a single project by ID.
+func (c *DirectClient) GetProject(ctx context.Context, id int) (*Project, error) {
+	resp, err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf(projectsPath+"/%d", id), nil)
+	if err != nil {
+		return nil, fmt.Errorf("k6: get project: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("k6: project %d not found", id)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("k6: get project %d: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+	}
+
+	project, err := decodeJSON[Project](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &project, nil
+}
+
+// CreateProject creates a new project.
+func (c *DirectClient) CreateProject(ctx context.Context, name string) (*Project, error) {
+	resp, err := c.doJSON(ctx, http.MethodPost, projectsPath, struct {
+		Name string `json:"name"`
+	}{Name: name})
+	if err != nil {
+		return nil, fmt.Errorf("k6: create project: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("k6: create project: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+
+	project, err := decodeJSON[Project](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &project, nil
+}
+
+// UpdateProject updates an existing project's name.
+func (c *DirectClient) UpdateProject(ctx context.Context, id int, name string) error {
+	resp, err := c.doJSON(ctx, http.MethodPatch, fmt.Sprintf(projectsPath+"/%d", id), struct {
+		Name string `json:"name"`
+	}{Name: name})
+	if err != nil {
+		return fmt.Errorf("k6: update project: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("k6: update project %d: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+	}
+	return nil
+}
+
+// DeleteProject deletes a project by ID.
+func (c *DirectClient) DeleteProject(ctx context.Context, id int) error {
+	resp, err := c.doJSON(ctx, http.MethodDelete, fmt.Sprintf(projectsPath+"/%d", id), nil)
+	if err != nil {
+		return fmt.Errorf("k6: delete project: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("k6: delete project %d: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+	}
+	return nil
+}
+
+// GetProjectByName finds a project by name.
+func (c *DirectClient) GetProjectByName(ctx context.Context, name string) (*Project, error) {
+	projects, err := c.ListProjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range projects {
+		if p.Name == name {
+			return &p, nil
+		}
+	}
+	return nil, fmt.Errorf("k6: project %q not found", name)
+}
+
+// ---------------------------------------------------------------------------
+// Load Tests
+// ---------------------------------------------------------------------------
+
+// ListLoadTestsByProject retrieves load tests filtered by project ID.
+// Uses the server-side project_id query parameter to avoid fetching all tests.
+func (c *DirectClient) ListLoadTestsByProject(ctx context.Context, projectID int) ([]LoadTest, error) {
+	path := fmt.Sprintf(loadTestsPath+"?project_id=%d", projectID)
+	return c.listLoadTests(ctx, path, 0)
+}
+
+// ListLoadTests retrieves all load tests across all projects, handling pagination.
+func (c *DirectClient) ListLoadTests(ctx context.Context) ([]LoadTest, error) {
+	return c.listLoadTests(ctx, loadTestsPath, 0)
+}
+
+// ListLoadTestsWithLimit retrieves load tests with a server-side limit on the
+// number of results. Pass 0 for no limit (fetches all).
+func (c *DirectClient) ListLoadTestsWithLimit(ctx context.Context, limit int) ([]LoadTest, error) {
+	return c.listLoadTests(ctx, loadTestsPath, limit)
+}
+
+// listLoadTests fetches load tests from the given path, paginating through all pages.
+// The k6 v6 API uses OData-style pagination with $skip/$top parameters and @count.
+// If limit > 0, at most limit items are fetched by setting $top accordingly.
+func (c *DirectClient) listLoadTests(ctx context.Context, path string, limit int) ([]LoadTest, error) {
+	const defaultPageSize = 100
+	var all []LoadTest
+
+	for {
+		pageSize := defaultPageSize
+		if limit > 0 {
+			if remaining := limit - len(all); remaining < pageSize {
+				pageSize = remaining
+			}
+		}
+
+		sep := "?"
+		if strings.Contains(path, "?") {
+			sep = "&"
+		}
+		pagePath := fmt.Sprintf("%s%s$skip=%d&$top=%d", path, sep, len(all), pageSize)
+
+		resp, err := c.doJSON(ctx, http.MethodGet, pagePath, nil)
+		if err != nil {
+			return nil, fmt.Errorf("k6: list load tests: %w", err)
+		}
+
+		if resp.StatusCode >= 400 {
+			body := readErrorBody(resp)
+			resp.Body.Close()
+			return nil, fmt.Errorf("k6: list load tests: status %d: %s", resp.StatusCode, body)
+		}
+
+		result, err := decodeJSON[loadTestsResponse](resp)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, result.Value...)
+
+		// Stop if limit reached.
+		if limit > 0 && len(all) >= limit {
+			all = all[:limit]
+			break
+		}
+
+		// Stop if we got fewer results than page size or have fetched all (per @count).
+		if len(result.Value) < pageSize || (result.Count > 0 && len(all) >= result.Count) {
+			break
+		}
+	}
+	return all, nil
+}
+
+// GetLoadTest retrieves a single load test by ID.
+func (c *DirectClient) GetLoadTest(ctx context.Context, id int) (*LoadTest, error) {
+	resp, err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf(loadTestsPath+"/%d", id), nil)
+	if err != nil {
+		return nil, fmt.Errorf("k6: get load test: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("k6: load test %d not found", id)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("k6: get load test %d: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+	}
+
+	test, err := decodeJSON[LoadTest](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &test, nil
+}
+
+// DeleteLoadTest deletes a load test by ID.
+func (c *DirectClient) DeleteLoadTest(ctx context.Context, id int) error {
+	resp, err := c.doJSON(ctx, http.MethodDelete, fmt.Sprintf(loadTestsPath+"/%d", id), nil)
+	if err != nil {
+		return fmt.Errorf("k6: delete load test: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("k6: delete load test %d: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+	}
+	return nil
+}
+
+// CreateLoadTest creates a new load test via multipart/form-data upload.
+//
+//nolint:dupl // identical multipart construction; ProxyClient and DirectClient are parallel implementations
+func (c *DirectClient) CreateLoadTest(ctx context.Context, name string, projectID int, script string) (*LoadTest, error) {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	if err := writer.WriteField("name", name); err != nil {
+		return nil, fmt.Errorf("k6: write name field: %w", err)
+	}
+	part, err := writer.CreateFormFile("script", "script.js")
+	if err != nil {
+		return nil, fmt.Errorf("k6: create script form file: %w", err)
+	}
+	if _, err := io.WriteString(part, script); err != nil {
+		return nil, fmt.Errorf("k6: write script content: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("k6: close multipart writer: %w", err)
+	}
+
+	path := fmt.Sprintf(projectsPath+"/%d/load_tests", projectID)
+	status, respBody, err := c.doRaw(ctx, http.MethodPost, path, writer.FormDataContentType(), &buf)
+	if err != nil {
+		return nil, fmt.Errorf("k6: create load test: %w", err)
+	}
+	if status != http.StatusCreated && status != http.StatusOK {
+		return nil, fmt.Errorf("k6: create load test: status %d: %s", status, string(respBody))
+	}
+
+	var lt LoadTest
+	if err := json.Unmarshal(respBody, &lt); err != nil {
+		return nil, fmt.Errorf("k6: decode created load test: %w", err)
+	}
+	return &lt, nil
+}
+
+// UpdateLoadTest updates an existing load test's metadata and optionally its script.
+func (c *DirectClient) UpdateLoadTest(ctx context.Context, id int, name, script string) error {
+	resp, err := c.doJSON(ctx, http.MethodPatch, fmt.Sprintf(loadTestsPath+"/%d", id), struct {
+		Name string `json:"name,omitempty"`
+	}{Name: name})
+	if err != nil {
+		return fmt.Errorf("k6: update load test: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("k6: update load test %d: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+	}
+
+	if script != "" {
+		return c.UpdateLoadTestScript(ctx, id, script)
+	}
+	return nil
+}
+
+// UpdateLoadTestScript updates only the script of a load test.
+func (c *DirectClient) UpdateLoadTestScript(ctx context.Context, id int, script string) error {
+	path := fmt.Sprintf(loadTestsPath+"/%d/script", id)
+	status, respBody, err := c.doRaw(ctx, http.MethodPut, path, "application/octet-stream", strings.NewReader(script))
+	if err != nil {
+		return fmt.Errorf("k6: update load test script: %w", err)
+	}
+	if status != http.StatusNoContent && status != http.StatusOK {
+		return fmt.Errorf("k6: update load test script %d: status %d: %s", id, status, string(respBody))
+	}
+	return nil
+}
+
+// GetLoadTestScript fetches the script content of a load test.
+func (c *DirectClient) GetLoadTestScript(ctx context.Context, id int) (string, error) {
+	path := fmt.Sprintf(loadTestsPath+"/%d/script", id)
+	status, body, err := c.doRaw(ctx, http.MethodGet, path, "", nil)
+	if err != nil {
+		return "", fmt.Errorf("k6: get load test script: %w", err)
+	}
+	if status >= 400 {
+		return "", fmt.Errorf("k6: get load test script %d: status %d: %s", id, status, string(body))
+	}
+	return string(body), nil
+}
+
+// GetLoadTestByName finds a load test by name within a project.
+func (c *DirectClient) GetLoadTestByName(ctx context.Context, projectID int, name string) (*LoadTest, error) {
+	tests, err := c.ListLoadTestsByProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	for _, t := range tests {
+		if t.Name == name {
+			return &t, nil
+		}
+	}
+	return nil, fmt.Errorf("k6: load test %q not found in project %d", name, projectID)
+}
+
+// ---------------------------------------------------------------------------
+// Test Runs
+// ---------------------------------------------------------------------------
+
+// ListTestRuns retrieves all test runs for a load test.
+func (c *DirectClient) ListTestRuns(ctx context.Context, loadTestID int) ([]TestRunStatus, error) {
+	path := fmt.Sprintf(loadTestsPath+"/%d/test_runs", loadTestID)
+	resp, err := c.doJSON(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("k6: list test runs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("k6: list test runs for %d: status %d: %s", loadTestID, resp.StatusCode, readErrorBody(resp))
+	}
+
+	result, err := decodeJSON[testRunsResponse](resp)
+	if err != nil {
+		return nil, err
+	}
+	return result.Value, nil
+}
+
+// ---------------------------------------------------------------------------
+// Environment Variables
+// ---------------------------------------------------------------------------
+
+// ListEnvVars retrieves all environment variables for the organization.
+func (c *DirectClient) ListEnvVars(ctx context.Context) ([]EnvVar, error) {
+	id := c.orgIDValue()
+
+	path := fmt.Sprintf(envVarsPathFmt, id)
+	resp, err := c.doJSON(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("k6: list env vars: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("k6: list env vars: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+
+	result, err := decodeJSON[envVarsResponse](resp)
+	if err != nil {
+		return nil, err
+	}
+	return result.EnvVars, nil
+}
+
+// CreateEnvVar creates a new environment variable.
+func (c *DirectClient) CreateEnvVar(ctx context.Context, name, value, description string) (*EnvVar, error) {
+	id := c.orgIDValue()
+
+	path := fmt.Sprintf(envVarsPathFmt, id)
+	resp, err := c.doJSON(ctx, http.MethodPost, path, envVarRequest{Name: name, Value: value, Description: description})
+	if err != nil {
+		return nil, fmt.Errorf("k6: create env var: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("k6: create env var: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+
+	result, err := decodeJSON[envVarResponse](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &result.EnvVar, nil
+}
+
+// UpdateEnvVar updates an existing environment variable.
+func (c *DirectClient) UpdateEnvVar(ctx context.Context, id int, name, value, description string) error {
+	orgID := c.orgIDValue()
+
+	path := fmt.Sprintf(envVarsPathFmt+"/%d", orgID, id)
+	resp, err := c.doJSON(ctx, http.MethodPatch, path, envVarRequest{Name: name, Value: value, Description: description})
+	if err != nil {
+		return fmt.Errorf("k6: update env var: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("k6: update env var %d: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+	}
+	return nil
+}
+
+// DeleteEnvVar deletes an environment variable by ID.
+func (c *DirectClient) DeleteEnvVar(ctx context.Context, id int) error {
+	orgID := c.orgIDValue()
+
+	path := fmt.Sprintf(envVarsPathFmt+"/%d", orgID, id)
+	resp, err := c.doJSON(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return fmt.Errorf("k6: delete env var: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("k6: delete env var %d: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Schedules
+// ---------------------------------------------------------------------------
+
+// ListSchedules retrieves all schedules.
+func (c *DirectClient) ListSchedules(ctx context.Context) ([]Schedule, error) {
+	resp, err := c.doJSON(ctx, http.MethodGet, schedulesPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("k6: list schedules: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("k6: list schedules: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+
+	result, err := decodeJSON[schedulesResponse](resp)
+	if err != nil {
+		return nil, err
+	}
+	return result.Value, nil
+}
+
+// GetSchedule retrieves a schedule by ID.
+func (c *DirectClient) GetSchedule(ctx context.Context, id int) (*Schedule, error) {
+	resp, err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf(schedulesPath+"/%d", id), nil)
+	if err != nil {
+		return nil, fmt.Errorf("k6: get schedule: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("k6: schedule %d not found", id)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("k6: get schedule %d: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+	}
+
+	s, err := decodeJSON[Schedule](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// CreateSchedule creates a schedule for a load test.
+func (c *DirectClient) CreateSchedule(ctx context.Context, loadTestID int, req ScheduleRequest) (*Schedule, error) {
+	path := fmt.Sprintf(loadTestsPath+"/%d/schedule", loadTestID)
+	resp, err := c.doJSON(ctx, http.MethodPost, path, req)
+	if err != nil {
+		return nil, fmt.Errorf("k6: create schedule: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("k6: create schedule: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+
+	s, err := decodeJSON[Schedule](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// UpdateScheduleByID updates a schedule by its ID.
+func (c *DirectClient) UpdateScheduleByID(ctx context.Context, id int, req ScheduleRequest) (*Schedule, error) {
+	resp, err := c.doJSON(ctx, http.MethodPut, fmt.Sprintf(schedulesPath+"/%d", id), req)
+	if err != nil {
+		return nil, fmt.Errorf("k6: update schedule: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return nil, fmt.Errorf("k6: update schedule %d: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+	}
+
+	if resp.StatusCode == http.StatusNoContent {
+		return c.GetSchedule(ctx, id)
+	}
+
+	s, err := decodeJSON[Schedule](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// DeleteScheduleByLoadTest deletes the schedule for a load test.
+func (c *DirectClient) DeleteScheduleByLoadTest(ctx context.Context, loadTestID int) error {
+	path := fmt.Sprintf(loadTestsPath+"/%d/schedule", loadTestID)
+	resp, err := c.doJSON(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return fmt.Errorf("k6: delete schedule: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("k6: delete schedule for load test %d: status %d: %s", loadTestID, resp.StatusCode, readErrorBody(resp))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Load Zones
+// ---------------------------------------------------------------------------
+
+// ListLoadZones retrieves all load zones for the stack.
+func (c *DirectClient) ListLoadZones(ctx context.Context) ([]LoadZone, error) {
+	resp, err := c.doJSON(ctx, http.MethodGet, loadZonesPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("k6: list load zones: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("k6: list load zones: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+
+	result, err := decodeJSON[loadZonesResponse](resp)
+	if err != nil {
+		return nil, err
+	}
+	return result.Value, nil
+}
+
+// CreateLoadZone registers a Private Load Zone.
+func (c *DirectClient) CreateLoadZone(ctx context.Context, req PLZCreateRequest) (*PLZCreateResponse, error) {
+	resp, err := c.doJSON(ctx, http.MethodPost, plzPath, req)
+	if err != nil {
+		return nil, fmt.Errorf("k6: create load zone: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("k6: create load zone: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+
+	result, err := decodeJSON[PLZCreateResponse](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteLoadZone deregisters a Private Load Zone by name.
+func (c *DirectClient) DeleteLoadZone(ctx context.Context, name string) error {
+	resp, err := c.doJSON(ctx, http.MethodDelete, plzPath+"/"+url.PathEscape(name), nil)
+	if err != nil {
+		return fmt.Errorf("k6: delete load zone: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("k6: delete load zone %q: status %d: %s", name, resp.StatusCode, readErrorBody(resp))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Allowed Projects / Load Zones
+// ---------------------------------------------------------------------------
+
+// ListAllowedProjects lists the projects allowed to use a load zone.
+func (c *DirectClient) ListAllowedProjects(ctx context.Context, loadZoneID int) ([]AllowedProject, error) {
+	path := fmt.Sprintf(loadZonesPath+"/%d/allowed_projects", loadZoneID)
+	resp, err := c.doJSON(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("k6: list allowed projects: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("k6: list allowed projects: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+
+	result, err := decodeJSON[allowedProjectsResponse](resp)
+	if err != nil {
+		return nil, err
+	}
+	return result.Value, nil
+}
+
+// UpdateAllowedProjects sets the projects allowed to use a load zone.
+func (c *DirectClient) UpdateAllowedProjects(ctx context.Context, loadZoneID int, projectIDs []int) error {
+	path := fmt.Sprintf(loadZonesPath+"/%d/allowed_projects", loadZoneID)
+	body := struct {
+		ProjectIDs []int `json:"project_ids"`
+	}{ProjectIDs: projectIDs}
+	resp, err := c.doJSON(ctx, http.MethodPut, path, body)
+	if err != nil {
+		return fmt.Errorf("k6: update allowed projects: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("k6: update allowed projects: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+	return nil
+}
+
+// ListAllowedLoadZones lists the load zones allowed for a project.
+func (c *DirectClient) ListAllowedLoadZones(ctx context.Context, projectID int) ([]AllowedLoadZone, error) {
+	path := fmt.Sprintf(projectsPath+"/%d/allowed_load_zones", projectID)
+	resp, err := c.doJSON(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("k6: list allowed load zones: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("k6: list allowed load zones: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+
+	result, err := decodeJSON[allowedLoadZonesResponse](resp)
+	if err != nil {
+		return nil, err
+	}
+	return result.Value, nil
+}
+
+// UpdateAllowedLoadZones sets the load zones allowed for a project.
+func (c *DirectClient) UpdateAllowedLoadZones(ctx context.Context, projectID int, loadZoneIDs []int) error {
+	path := fmt.Sprintf(projectsPath+"/%d/allowed_load_zones", projectID)
+	body := struct {
+		LoadZoneIDs []int `json:"load_zone_ids"`
+	}{LoadZoneIDs: loadZoneIDs}
+	resp, err := c.doJSON(ctx, http.MethodPut, path, body)
+	if err != nil {
+		return fmt.Errorf("k6: update allowed load zones: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("k6: update allowed load zones: status %d: %s", resp.StatusCode, readErrorBody(resp))
+	}
+	return nil
+}
+
+// Compile-time assertion: DirectClient must implement API.
+var _ API = (*DirectClient)(nil)

--- a/internal/providers/k6/direct_client.go
+++ b/internal/providers/k6/direct_client.go
@@ -1,7 +1,6 @@
 package k6
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -64,11 +63,7 @@ func NewDirectClient(ctx context.Context, apiDomain string, httpClient *http.Cli
 func (c *DirectClient) Authenticate(ctx context.Context, saToken string, stackID int) error {
 	stackStr := strconv.Itoa(stackID)
 
-	body, err := json.Marshal(struct{}{})
-	if err != nil {
-		return fmt.Errorf("k6: marshal auth request: %w", err)
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.apiDomain+authPath, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.apiDomain+authPath, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("k6: create auth request: %w", err)
 	}

--- a/internal/providers/k6/direct_client.go
+++ b/internal/providers/k6/direct_client.go
@@ -1,0 +1,129 @@
+package k6
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/gcx/internal/httputils"
+)
+
+const (
+	// DefaultAPIDomain is the canonical k6 Cloud API endpoint.
+	DefaultAPIDomain = "https://api.k6.io"
+
+	authPath = "/v3/account/grafana-app/start"
+)
+
+// ReauthFunc refreshes the k6 auth credentials when a cached token is rejected.
+// It must perform a fresh /start exchange, persist the new credentials, and
+// return them so the caller can update the client's in-memory state.
+type ReauthFunc func(ctx context.Context) (token string, orgID int, err error)
+
+// DirectClient talks to api.k6.io directly using an SA-token-exchanged v3 token.
+// It does NOT route through the grafana-k6-app plugin proxy — this path exists
+// for stacks that cannot use OAuth (CI service accounts, headless automation).
+type DirectClient struct {
+	apiDomain string
+	orgID     int
+	stackID   int
+	token     string
+	http      *http.Client
+	//nolint:unused // wired in Task 6 (SetReauth / doWithReauth)
+	reauth ReauthFunc
+}
+
+// NewDirectClient creates a DirectClient. If apiDomain is empty, DefaultAPIDomain
+// is used. If httpClient is nil, a default httputils client is created.
+//
+// The returned client is not authenticated until Authenticate or SetCachedAuth
+// is called. Both Bearer + X-Stack-Id are injected on every subsequent request.
+func NewDirectClient(ctx context.Context, apiDomain string, httpClient *http.Client) *DirectClient {
+	if apiDomain == "" {
+		apiDomain = DefaultAPIDomain
+	}
+	if httpClient == nil {
+		httpClient = httputils.NewDefaultClient(ctx)
+	}
+	return &DirectClient{
+		apiDomain: strings.TrimRight(apiDomain, "/"),
+		http:      httpClient,
+	}
+}
+
+// Authenticate exchanges a Grafana SA token (glsa_*) for a k6 v3 token by
+// calling PUT /v3/account/grafana-app/start. The exchange uses
+// X-Grafana-Service-Token; the CAP token does NOT work here (k6 backend
+// rejects any header value longer than ~100 chars).
+func (c *DirectClient) Authenticate(ctx context.Context, saToken string, stackID int) error {
+	stackStr := strconv.Itoa(stackID)
+
+	body, err := json.Marshal(struct{}{})
+	if err != nil {
+		return fmt.Errorf("k6: marshal auth request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.apiDomain+authPath, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("k6: create auth request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Grafana-Service-Token", saToken)
+	req.Header.Set("X-Stack-Id", stackStr)
+	req.Header.Set("X-Grafana-User", "admin")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("k6: auth request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("k6: token exchange failed (PUT %s, status %d): %s", authPath, resp.StatusCode, string(respBody))
+	}
+
+	var ar authResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ar); err != nil {
+		return fmt.Errorf("k6: decode auth response: %w", err)
+	}
+
+	orgID, err := strconv.Atoi(ar.OrgID)
+	if err != nil {
+		return fmt.Errorf("k6: parse organization_id %q: %w", ar.OrgID, err)
+	}
+
+	c.orgID = orgID
+	c.stackID = stackID
+	c.token = ar.V3GrafanaToken
+	return nil
+}
+
+// Token returns the v3 k6 token previously obtained via Authenticate or
+// SetCachedAuth. The signature returns an error to satisfy the API interface
+// (ProxyClient.Token is lazy and can fail); DirectClient.Token never errors
+// in practice but returns errors.New(...) if the client has not been
+// authenticated yet, to give callers a clear failure mode.
+func (c *DirectClient) Token(_ context.Context) (string, error) {
+	if c.token == "" {
+		return "", errors.New("k6: DirectClient not authenticated (call Authenticate or SetCachedAuth first)")
+	}
+	return c.token, nil
+}
+
+// orgIDValue returns the cached organization ID, used internally by EnvVar methods.
+// The plural form (orgID()) is reserved for ProxyClient's lazy variant.
+//
+//nolint:unused // called by resource methods added in Task 6
+func (c *DirectClient) orgIDValue() int { return c.orgID }
+
+// authResponse is the JSON body returned by PUT /v3/account/grafana-app/start.
+type authResponse struct {
+	OrgID          string `json:"organization_id"`
+	V3GrafanaToken string `json:"v3_grafana_token"`
+}

--- a/internal/providers/k6/direct_client.go
+++ b/internal/providers/k6/direct_client.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/grafana/gcx/internal/httputils"
 )
@@ -38,6 +39,7 @@ type DirectClient struct {
 	token     string
 	http      *http.Client
 	reauth    ReauthFunc
+	mu        sync.Mutex // guards token, orgID, stackID across reauth races
 }
 
 // NewDirectClient creates a DirectClient. If apiDomain is empty, DefaultAPIDomain
@@ -95,9 +97,11 @@ func (c *DirectClient) Authenticate(ctx context.Context, saToken string, stackID
 		return fmt.Errorf("k6: parse organization_id %q: %w", ar.OrgID, err)
 	}
 
+	c.mu.Lock()
 	c.orgID = orgID
 	c.stackID = stackID
 	c.token = ar.V3GrafanaToken
+	c.mu.Unlock()
 	return nil
 }
 
@@ -107,15 +111,22 @@ func (c *DirectClient) Authenticate(ctx context.Context, saToken string, stackID
 // in practice but returns errors.New(...) if the client has not been
 // authenticated yet, to give callers a clear failure mode.
 func (c *DirectClient) Token(_ context.Context) (string, error) {
-	if c.token == "" {
+	c.mu.Lock()
+	tok := c.token
+	c.mu.Unlock()
+	if tok == "" {
 		return "", errors.New("k6: DirectClient not authenticated (call Authenticate or SetCachedAuth first)")
 	}
-	return c.token, nil
+	return tok, nil
 }
 
 // orgIDValue returns the cached organization ID, used internally by EnvVar methods.
 // The plural form (orgID()) is reserved for ProxyClient's lazy variant.
-func (c *DirectClient) orgIDValue() int { return c.orgID }
+func (c *DirectClient) orgIDValue() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.orgID
+}
 
 // authResponse is the JSON body returned by PUT /v3/account/grafana-app/start.
 type authResponse struct {
@@ -138,6 +149,8 @@ func (c *DirectClient) SetReauth(fn ReauthFunc) { c.reauth = fn }
 // responsible for wiring SetReauth to refresh on 401 if these credentials
 // turn out to be stale.
 func (c *DirectClient) SetCachedAuth(token string, orgID, stackID int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.token = token
 	c.orgID = orgID
 	c.stackID = stackID
@@ -160,6 +173,10 @@ func (c *DirectClient) doJSON(ctx context.Context, method, path string, body any
 		bodyBytes = b
 	}
 	build := func() (*http.Request, error) {
+		c.mu.Lock()
+		token := c.token
+		stackID := c.stackID
+		c.mu.Unlock()
 		var br io.Reader
 		if bodyBytes != nil {
 			br = bytes.NewReader(bodyBytes)
@@ -169,8 +186,8 @@ func (c *DirectClient) doJSON(ctx context.Context, method, path string, body any
 			return nil, fmt.Errorf("k6: create request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+c.token)
-		req.Header.Set("X-Stack-Id", strconv.Itoa(c.stackID))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("X-Stack-Id", strconv.Itoa(stackID))
 		return req, nil
 	}
 	return c.doWithReauth(ctx, build)
@@ -188,6 +205,10 @@ func (c *DirectClient) doRaw(ctx context.Context, method, path, contentType stri
 		bodyBytes = buf
 	}
 	build := func() (*http.Request, error) {
+		c.mu.Lock()
+		token := c.token
+		stackID := c.stackID
+		c.mu.Unlock()
 		var br io.Reader
 		if bodyBytes != nil {
 			br = bytes.NewReader(bodyBytes)
@@ -199,8 +220,8 @@ func (c *DirectClient) doRaw(ctx context.Context, method, path, contentType stri
 		if contentType != "" {
 			req.Header.Set("Content-Type", contentType)
 		}
-		req.Header.Set("Authorization", "Bearer "+c.token)
-		req.Header.Set("X-Stack-Id", strconv.Itoa(c.stackID))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("X-Stack-Id", strconv.Itoa(stackID))
 		return req, nil
 	}
 	resp, err := c.doWithReauth(ctx, build)
@@ -235,8 +256,10 @@ func (c *DirectClient) doWithReauth(ctx context.Context, build func() (*http.Req
 	if err != nil {
 		return nil, fmt.Errorf("k6: reauth after 401: %w", err)
 	}
+	c.mu.Lock()
 	c.token = token
 	c.orgID = orgID
+	c.mu.Unlock()
 
 	req2, err := build()
 	if err != nil {
@@ -594,6 +617,9 @@ func (c *DirectClient) ListTestRuns(ctx context.Context, loadTestID int) ([]Test
 // ListEnvVars retrieves all environment variables for the organization.
 func (c *DirectClient) ListEnvVars(ctx context.Context) ([]EnvVar, error) {
 	id := c.orgIDValue()
+	if id == 0 {
+		return nil, errors.New("k6: DirectClient not authenticated (call Authenticate or SetCachedAuth first)")
+	}
 
 	path := fmt.Sprintf(envVarsPathFmt, id)
 	resp, err := c.doJSON(ctx, http.MethodGet, path, nil)
@@ -616,6 +642,9 @@ func (c *DirectClient) ListEnvVars(ctx context.Context) ([]EnvVar, error) {
 // CreateEnvVar creates a new environment variable.
 func (c *DirectClient) CreateEnvVar(ctx context.Context, name, value, description string) (*EnvVar, error) {
 	id := c.orgIDValue()
+	if id == 0 {
+		return nil, errors.New("k6: DirectClient not authenticated (call Authenticate or SetCachedAuth first)")
+	}
 
 	path := fmt.Sprintf(envVarsPathFmt, id)
 	resp, err := c.doJSON(ctx, http.MethodPost, path, envVarRequest{Name: name, Value: value, Description: description})
@@ -638,6 +667,9 @@ func (c *DirectClient) CreateEnvVar(ctx context.Context, name, value, descriptio
 // UpdateEnvVar updates an existing environment variable.
 func (c *DirectClient) UpdateEnvVar(ctx context.Context, id int, name, value, description string) error {
 	orgID := c.orgIDValue()
+	if orgID == 0 {
+		return errors.New("k6: DirectClient not authenticated (call Authenticate or SetCachedAuth first)")
+	}
 
 	path := fmt.Sprintf(envVarsPathFmt+"/%d", orgID, id)
 	resp, err := c.doJSON(ctx, http.MethodPatch, path, envVarRequest{Name: name, Value: value, Description: description})
@@ -655,6 +687,9 @@ func (c *DirectClient) UpdateEnvVar(ctx context.Context, id int, name, value, de
 // DeleteEnvVar deletes an environment variable by ID.
 func (c *DirectClient) DeleteEnvVar(ctx context.Context, id int) error {
 	orgID := c.orgIDValue()
+	if orgID == 0 {
+		return errors.New("k6: DirectClient not authenticated (call Authenticate or SetCachedAuth first)")
+	}
 
 	path := fmt.Sprintf(envVarsPathFmt+"/%d", orgID, id)
 	resp, err := c.doJSON(ctx, http.MethodDelete, path, nil)

--- a/internal/providers/k6/direct_client_test.go
+++ b/internal/providers/k6/direct_client_test.go
@@ -12,6 +12,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDirectClient_ListProjects_SendsBearerAndStackID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3/account/grafana-app/start" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"organization_id": "42", "v3_grafana_token": "v3-tok",
+			})
+			return
+		}
+		assert.Equal(t, "/cloud/v6/projects", r.URL.Path)
+		assert.Equal(t, "Bearer v3-tok", r.Header.Get("Authorization"))
+		assert.Equal(t, "999", r.Header.Get("X-Stack-Id"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"value": []map[string]any{{"id": 1, "name": "p1"}},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := k6.NewDirectClient(context.Background(), srv.URL, nil)
+	require.NoError(t, client.Authenticate(t.Context(), "glsa_test", 999))
+	projects, err := client.ListProjects(t.Context())
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+	assert.Equal(t, "p1", projects[0].Name)
+}
+
 func TestDirectClient_AuthenticateAndToken(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut && r.URL.Path == "/v3/account/grafana-app/start" {

--- a/internal/providers/k6/direct_client_test.go
+++ b/internal/providers/k6/direct_client_test.go
@@ -3,8 +3,10 @@ package k6_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/k6"
@@ -84,4 +86,138 @@ func TestDirectClient_EnvVars_RequireAuth(t *testing.T) {
 	err = client.DeleteEnvVar(t.Context(), 1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not authenticated")
+}
+
+func TestDirectClient_401WithReauthRetries(t *testing.T) {
+	var apiCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3/account/grafana-app/start" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"organization_id": "42", "v3_grafana_token": "old",
+			})
+			return
+		}
+		call := apiCalls.Add(1)
+		if call == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		assert.Equal(t, "Bearer new", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": []any{}})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := k6.NewDirectClient(context.Background(), srv.URL, nil)
+	require.NoError(t, client.Authenticate(t.Context(), "glsa_test", 999))
+	client.SetReauth(func(_ context.Context) (string, int, error) {
+		return "new", 42, nil
+	})
+	_, err := client.ListProjects(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), apiCalls.Load())
+	tok, _ := client.Token(t.Context())
+	assert.Equal(t, "new", tok)
+}
+
+func TestDirectClient_401WithReauthFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3/account/grafana-app/start" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"organization_id": "42", "v3_grafana_token": "tok",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := k6.NewDirectClient(context.Background(), srv.URL, nil)
+	require.NoError(t, client.Authenticate(t.Context(), "glsa_test", 999))
+	client.SetReauth(func(_ context.Context) (string, int, error) {
+		return "", 0, errors.New("credential expired")
+	})
+	_, err := client.ListProjects(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "k6: reauth after 401:")
+	assert.Contains(t, err.Error(), "credential expired")
+}
+
+func TestDirectClient_401WithoutReauthPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3/account/grafana-app/start" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"organization_id": "42", "v3_grafana_token": "tok",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := k6.NewDirectClient(context.Background(), srv.URL, nil)
+	require.NoError(t, client.Authenticate(t.Context(), "glsa_test", 999))
+	_, err := client.ListProjects(t.Context())
+	require.Error(t, err)
+}
+
+func TestDirectClient_SetCachedAuth_SkipsExchange(t *testing.T) {
+	var capturedAuth, capturedStackID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3/account/grafana-app/start" {
+			t.Fatalf("unexpected exchange call when cache was provided")
+		}
+		capturedAuth = r.Header.Get("Authorization")
+		capturedStackID = r.Header.Get("X-Stack-Id")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": []any{}})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := k6.NewDirectClient(context.Background(), srv.URL, nil)
+	client.SetCachedAuth("cached-v3", 42, 999)
+	tok, err := client.Token(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "cached-v3", tok)
+	_, err = client.ListProjects(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer cached-v3", capturedAuth)
+	assert.Equal(t, "999", capturedStackID)
+}
+
+func TestDirectClient_doRaw_401WithReauthRetries(t *testing.T) {
+	var scriptCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3/account/grafana-app/start" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"organization_id": "42", "v3_grafana_token": "old",
+			})
+			return
+		}
+		if r.Method == http.MethodPut && r.URL.Path == "/cloud/v6/load_tests/5/script" {
+			call := scriptCalls.Add(1)
+			if call == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			assert.Equal(t, "Bearer new", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := k6.NewDirectClient(context.Background(), srv.URL, nil)
+	require.NoError(t, client.Authenticate(t.Context(), "glsa_test", 999))
+	client.SetReauth(func(_ context.Context) (string, int, error) {
+		return "new", 42, nil
+	})
+	err := client.UpdateLoadTestScript(t.Context(), 5, "export default function() {}")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), scriptCalls.Load())
 }

--- a/internal/providers/k6/direct_client_test.go
+++ b/internal/providers/k6/direct_client_test.go
@@ -17,6 +17,7 @@ func TestDirectClient_AuthenticateAndToken(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == "/v3/account/grafana-app/start" {
 			assert.Equal(t, "glsa_test", r.Header.Get("X-Grafana-Service-Token"))
 			assert.Equal(t, "999", r.Header.Get("X-Stack-Id"))
+			assert.Equal(t, "admin", r.Header.Get("X-Grafana-User"))
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]string{
 				"organization_id":  "42",

--- a/internal/providers/k6/direct_client_test.go
+++ b/internal/providers/k6/direct_client_test.go
@@ -1,0 +1,38 @@
+package k6_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/k6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectClient_AuthenticateAndToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && r.URL.Path == "/v3/account/grafana-app/start" {
+			assert.Equal(t, "glsa_test", r.Header.Get("X-Grafana-Service-Token"))
+			assert.Equal(t, "999", r.Header.Get("X-Stack-Id"))
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"organization_id":  "42",
+				"v3_grafana_token": "fresh-v3-token",
+			})
+			return
+		}
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := k6.NewDirectClient(context.Background(), srv.URL, nil)
+	err := client.Authenticate(t.Context(), "glsa_test", 999)
+	require.NoError(t, err)
+
+	tok, err := client.Token(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "fresh-v3-token", tok)
+}

--- a/internal/providers/k6/direct_client_test.go
+++ b/internal/providers/k6/direct_client_test.go
@@ -64,3 +64,24 @@ func TestDirectClient_AuthenticateAndToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "fresh-v3-token", tok)
 }
+
+func TestDirectClient_EnvVars_RequireAuth(t *testing.T) {
+	// Fresh client, never authenticated.
+	client := k6.NewDirectClient(context.Background(), "http://unused", nil)
+
+	_, err := client.ListEnvVars(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not authenticated")
+
+	_, err = client.CreateEnvVar(t.Context(), "X", "y", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not authenticated")
+
+	err = client.UpdateEnvVar(t.Context(), 1, "X", "y", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not authenticated")
+
+	err = client.DeleteEnvVar(t.Context(), 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not authenticated")
+}

--- a/internal/providers/k6/provider.go
+++ b/internal/providers/k6/provider.go
@@ -56,8 +56,20 @@ func (p *K6Provider) Validate(cfg map[string]string) error {
 }
 
 // ConfigKeys returns the configuration keys used by this provider.
+// The cached-* keys are populated lazily in DirectClient mode (SA-token auth)
+// to skip the /v3/account/grafana-app/start round-trip on subsequent invocations.
+// They are not used in OAuth/plugin-proxy mode.
 func (p *K6Provider) ConfigKeys() []providers.ConfigKey {
-	return nil
+	return []providers.ConfigKey{
+		// Cached auth from /v3/account/grafana-app/start (DirectClient / SA-token mode only).
+		// Populated lazily on first run, reused on subsequent invocations to skip the
+		// round-trip. Invalidated on 401 from any k6 API call. Bound to a specific
+		// stack via cached-stack-id; cache is dropped if the stack changes.
+		// Not used in OAuth/plugin-proxy mode.
+		{Name: keyCachedToken, Secret: true},
+		{Name: keyCachedOrgID},
+		{Name: keyCachedStackID},
+	}
 }
 
 // TypedRegistrations returns adapter registrations for k6 resource types.

--- a/internal/providers/k6/proxy_client.go
+++ b/internal/providers/k6/proxy_client.go
@@ -30,9 +30,9 @@ const (
 	plzPath        = "/cloud-resources/v1/load-zones"
 )
 
-// Client is an HTTP client for the k6 Cloud API.
+// ProxyClient is an HTTP client for the k6 Cloud API.
 // It routes every k6 API call through the grafana-k6-app plugin proxy.
-type Client struct {
+type ProxyClient struct {
 	host      string
 	proxyBase string
 	http      *http.Client
@@ -42,17 +42,17 @@ type Client struct {
 	cachedOrgID int    // memoized result of /organization, used only by env var methods
 }
 
-// NewClient creates a Client that routes every k6 API call through the
+// NewProxyClient creates a ProxyClient that routes every k6 API call through the
 // grafana-k6-app plugin proxy on host. authClient must carry the
 // Grafana auth — typically a client built from a rest.Config wrapped with
 // RefreshTransport, so the OAuth bearer is injected (and refreshed before
 // expiry) on every request.
-func NewClient(ctx context.Context, host string, authClient *http.Client) *Client {
+func NewProxyClient(ctx context.Context, host string, authClient *http.Client) *ProxyClient {
 	if authClient == nil {
 		authClient = httputils.NewDefaultClient(ctx)
 	}
 	base := strings.TrimRight(host, "/")
-	return &Client{
+	return &ProxyClient{
 		host:      base,
 		proxyBase: base + pluginProxyBasePath,
 		http:      authClient,
@@ -61,7 +61,7 @@ func NewClient(ctx context.Context, host string, authClient *http.Client) *Clien
 
 // orgID hits /organization on the plugin to discover the k6 organization ID
 // for legacy APIs. The result is memoised for the life of the client.
-func (c *Client) orgID(ctx context.Context) (int, error) {
+func (c *ProxyClient) orgID(ctx context.Context) (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.cachedOrgID != 0 {
@@ -97,7 +97,7 @@ func (c *Client) orgID(ctx context.Context) (int, error) {
 
 // Token returns the user's k6 Personal API token. It is fetched on demand from
 // /v3/account/me through the proxy and memoised for the life of the client.
-func (c *Client) Token(ctx context.Context) (string, error) {
+func (c *ProxyClient) Token(ctx context.Context) (string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.cachedToken != "" {
@@ -134,7 +134,7 @@ func (c *Client) Token(ctx context.Context) (string, error) {
 // HTTP helpers
 // ---------------------------------------------------------------------------
 
-func (c *Client) doJSON(ctx context.Context, method, path string, body any) (*http.Response, error) {
+func (c *ProxyClient) doJSON(ctx context.Context, method, path string, body any) (*http.Response, error) {
 	var bodyReader io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -169,7 +169,7 @@ func readErrorBody(resp *http.Response) string {
 
 // doRaw performs a raw HTTP request through the plugin proxy.
 // Used for multipart/form-data and application/octet-stream requests.
-func (c *Client) doRaw(ctx context.Context, method, path, contentType string, body io.Reader) (int, []byte, error) {
+func (c *ProxyClient) doRaw(ctx context.Context, method, path, contentType string, body io.Reader) (int, []byte, error) {
 	req, err := http.NewRequestWithContext(ctx, method, c.proxyBase+path, body)
 	if err != nil {
 		return 0, nil, fmt.Errorf("k6: create raw request: %w", err)
@@ -197,7 +197,7 @@ func (c *Client) doRaw(ctx context.Context, method, path, contentType string, bo
 // ---------------------------------------------------------------------------
 
 // ListProjects retrieves all projects for the stack.
-func (c *Client) ListProjects(ctx context.Context) ([]Project, error) {
+func (c *ProxyClient) ListProjects(ctx context.Context) ([]Project, error) {
 	resp, err := c.doJSON(ctx, http.MethodGet, projectsPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("k6: list projects: %w", err)
@@ -216,7 +216,7 @@ func (c *Client) ListProjects(ctx context.Context) ([]Project, error) {
 }
 
 // GetProject retrieves a single project by ID.
-func (c *Client) GetProject(ctx context.Context, id int) (*Project, error) {
+func (c *ProxyClient) GetProject(ctx context.Context, id int) (*Project, error) {
 	resp, err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf(projectsPath+"/%d", id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("k6: get project: %w", err)
@@ -238,7 +238,7 @@ func (c *Client) GetProject(ctx context.Context, id int) (*Project, error) {
 }
 
 // CreateProject creates a new project.
-func (c *Client) CreateProject(ctx context.Context, name string) (*Project, error) {
+func (c *ProxyClient) CreateProject(ctx context.Context, name string) (*Project, error) {
 	resp, err := c.doJSON(ctx, http.MethodPost, projectsPath, struct {
 		Name string `json:"name"`
 	}{Name: name})
@@ -259,7 +259,7 @@ func (c *Client) CreateProject(ctx context.Context, name string) (*Project, erro
 }
 
 // UpdateProject updates an existing project's name.
-func (c *Client) UpdateProject(ctx context.Context, id int, name string) error {
+func (c *ProxyClient) UpdateProject(ctx context.Context, id int, name string) error {
 	resp, err := c.doJSON(ctx, http.MethodPatch, fmt.Sprintf(projectsPath+"/%d", id), struct {
 		Name string `json:"name"`
 	}{Name: name})
@@ -275,7 +275,7 @@ func (c *Client) UpdateProject(ctx context.Context, id int, name string) error {
 }
 
 // DeleteProject deletes a project by ID.
-func (c *Client) DeleteProject(ctx context.Context, id int) error {
+func (c *ProxyClient) DeleteProject(ctx context.Context, id int) error {
 	resp, err := c.doJSON(ctx, http.MethodDelete, fmt.Sprintf(projectsPath+"/%d", id), nil)
 	if err != nil {
 		return fmt.Errorf("k6: delete project: %w", err)
@@ -289,7 +289,7 @@ func (c *Client) DeleteProject(ctx context.Context, id int) error {
 }
 
 // GetProjectByName finds a project by name.
-func (c *Client) GetProjectByName(ctx context.Context, name string) (*Project, error) {
+func (c *ProxyClient) GetProjectByName(ctx context.Context, name string) (*Project, error) {
 	projects, err := c.ListProjects(ctx)
 	if err != nil {
 		return nil, err
@@ -308,26 +308,26 @@ func (c *Client) GetProjectByName(ctx context.Context, name string) (*Project, e
 
 // ListLoadTestsByProject retrieves load tests filtered by project ID.
 // Uses the server-side project_id query parameter to avoid fetching all tests.
-func (c *Client) ListLoadTestsByProject(ctx context.Context, projectID int) ([]LoadTest, error) {
+func (c *ProxyClient) ListLoadTestsByProject(ctx context.Context, projectID int) ([]LoadTest, error) {
 	path := fmt.Sprintf(loadTestsPath+"?project_id=%d", projectID)
 	return c.listLoadTests(ctx, path, 0)
 }
 
 // ListLoadTests retrieves all load tests across all projects, handling pagination.
-func (c *Client) ListLoadTests(ctx context.Context) ([]LoadTest, error) {
+func (c *ProxyClient) ListLoadTests(ctx context.Context) ([]LoadTest, error) {
 	return c.listLoadTests(ctx, loadTestsPath, 0)
 }
 
 // ListLoadTestsWithLimit retrieves load tests with a server-side limit on the
 // number of results. Pass 0 for no limit (fetches all).
-func (c *Client) ListLoadTestsWithLimit(ctx context.Context, limit int) ([]LoadTest, error) {
+func (c *ProxyClient) ListLoadTestsWithLimit(ctx context.Context, limit int) ([]LoadTest, error) {
 	return c.listLoadTests(ctx, loadTestsPath, limit)
 }
 
 // listLoadTests fetches load tests from the given path, paginating through all pages.
 // The k6 v6 API uses OData-style pagination with $skip/$top parameters and @count.
 // If limit > 0, at most limit items are fetched by setting $top accordingly.
-func (c *Client) listLoadTests(ctx context.Context, path string, limit int) ([]LoadTest, error) {
+func (c *ProxyClient) listLoadTests(ctx context.Context, path string, limit int) ([]LoadTest, error) {
 	const defaultPageSize = 100
 	var all []LoadTest
 
@@ -379,7 +379,7 @@ func (c *Client) listLoadTests(ctx context.Context, path string, limit int) ([]L
 }
 
 // GetLoadTest retrieves a single load test by ID.
-func (c *Client) GetLoadTest(ctx context.Context, id int) (*LoadTest, error) {
+func (c *ProxyClient) GetLoadTest(ctx context.Context, id int) (*LoadTest, error) {
 	resp, err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf(loadTestsPath+"/%d", id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("k6: get load test: %w", err)
@@ -401,7 +401,7 @@ func (c *Client) GetLoadTest(ctx context.Context, id int) (*LoadTest, error) {
 }
 
 // DeleteLoadTest deletes a load test by ID.
-func (c *Client) DeleteLoadTest(ctx context.Context, id int) error {
+func (c *ProxyClient) DeleteLoadTest(ctx context.Context, id int) error {
 	resp, err := c.doJSON(ctx, http.MethodDelete, fmt.Sprintf(loadTestsPath+"/%d", id), nil)
 	if err != nil {
 		return fmt.Errorf("k6: delete load test: %w", err)
@@ -415,7 +415,7 @@ func (c *Client) DeleteLoadTest(ctx context.Context, id int) error {
 }
 
 // CreateLoadTest creates a new load test via multipart/form-data upload.
-func (c *Client) CreateLoadTest(ctx context.Context, name string, projectID int, script string) (*LoadTest, error) {
+func (c *ProxyClient) CreateLoadTest(ctx context.Context, name string, projectID int, script string) (*LoadTest, error) {
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 	if err := writer.WriteField("name", name); err != nil {
@@ -449,7 +449,7 @@ func (c *Client) CreateLoadTest(ctx context.Context, name string, projectID int,
 }
 
 // UpdateLoadTest updates an existing load test's metadata and optionally its script.
-func (c *Client) UpdateLoadTest(ctx context.Context, id int, name, script string) error {
+func (c *ProxyClient) UpdateLoadTest(ctx context.Context, id int, name, script string) error {
 	resp, err := c.doJSON(ctx, http.MethodPatch, fmt.Sprintf(loadTestsPath+"/%d", id), struct {
 		Name string `json:"name,omitempty"`
 	}{Name: name})
@@ -469,7 +469,7 @@ func (c *Client) UpdateLoadTest(ctx context.Context, id int, name, script string
 }
 
 // UpdateLoadTestScript updates only the script of a load test.
-func (c *Client) UpdateLoadTestScript(ctx context.Context, id int, script string) error {
+func (c *ProxyClient) UpdateLoadTestScript(ctx context.Context, id int, script string) error {
 	path := fmt.Sprintf(loadTestsPath+"/%d/script", id)
 	status, respBody, err := c.doRaw(ctx, http.MethodPut, path, "application/octet-stream", strings.NewReader(script))
 	if err != nil {
@@ -482,7 +482,7 @@ func (c *Client) UpdateLoadTestScript(ctx context.Context, id int, script string
 }
 
 // GetLoadTestScript fetches the script content of a load test.
-func (c *Client) GetLoadTestScript(ctx context.Context, id int) (string, error) {
+func (c *ProxyClient) GetLoadTestScript(ctx context.Context, id int) (string, error) {
 	path := fmt.Sprintf(loadTestsPath+"/%d/script", id)
 	status, body, err := c.doRaw(ctx, http.MethodGet, path, "", nil)
 	if err != nil {
@@ -495,7 +495,7 @@ func (c *Client) GetLoadTestScript(ctx context.Context, id int) (string, error) 
 }
 
 // GetLoadTestByName finds a load test by name within a project.
-func (c *Client) GetLoadTestByName(ctx context.Context, projectID int, name string) (*LoadTest, error) {
+func (c *ProxyClient) GetLoadTestByName(ctx context.Context, projectID int, name string) (*LoadTest, error) {
 	tests, err := c.ListLoadTestsByProject(ctx, projectID)
 	if err != nil {
 		return nil, err
@@ -513,7 +513,7 @@ func (c *Client) GetLoadTestByName(ctx context.Context, projectID int, name stri
 // ---------------------------------------------------------------------------
 
 // ListTestRuns retrieves all test runs for a load test.
-func (c *Client) ListTestRuns(ctx context.Context, loadTestID int) ([]TestRunStatus, error) {
+func (c *ProxyClient) ListTestRuns(ctx context.Context, loadTestID int) ([]TestRunStatus, error) {
 	path := fmt.Sprintf(loadTestsPath+"/%d/test_runs", loadTestID)
 	resp, err := c.doJSON(ctx, http.MethodGet, path, nil)
 	if err != nil {
@@ -537,7 +537,7 @@ func (c *Client) ListTestRuns(ctx context.Context, loadTestID int) ([]TestRunSta
 // ---------------------------------------------------------------------------
 
 // ListEnvVars retrieves all environment variables for the organization.
-func (c *Client) ListEnvVars(ctx context.Context) ([]EnvVar, error) {
+func (c *ProxyClient) ListEnvVars(ctx context.Context) ([]EnvVar, error) {
 	id, err := c.orgID(ctx)
 	if err != nil {
 		return nil, err
@@ -562,7 +562,7 @@ func (c *Client) ListEnvVars(ctx context.Context) ([]EnvVar, error) {
 }
 
 // CreateEnvVar creates a new environment variable.
-func (c *Client) CreateEnvVar(ctx context.Context, name, value, description string) (*EnvVar, error) {
+func (c *ProxyClient) CreateEnvVar(ctx context.Context, name, value, description string) (*EnvVar, error) {
 	id, err := c.orgID(ctx)
 	if err != nil {
 		return nil, err
@@ -587,7 +587,7 @@ func (c *Client) CreateEnvVar(ctx context.Context, name, value, description stri
 }
 
 // UpdateEnvVar updates an existing environment variable.
-func (c *Client) UpdateEnvVar(ctx context.Context, id int, name, value, description string) error {
+func (c *ProxyClient) UpdateEnvVar(ctx context.Context, id int, name, value, description string) error {
 	orgID, err := c.orgID(ctx)
 	if err != nil {
 		return err
@@ -607,7 +607,7 @@ func (c *Client) UpdateEnvVar(ctx context.Context, id int, name, value, descript
 }
 
 // DeleteEnvVar deletes an environment variable by ID.
-func (c *Client) DeleteEnvVar(ctx context.Context, id int) error {
+func (c *ProxyClient) DeleteEnvVar(ctx context.Context, id int) error {
 	orgID, err := c.orgID(ctx)
 	if err != nil {
 		return err
@@ -631,7 +631,7 @@ func (c *Client) DeleteEnvVar(ctx context.Context, id int) error {
 // ---------------------------------------------------------------------------
 
 // ListSchedules retrieves all schedules.
-func (c *Client) ListSchedules(ctx context.Context) ([]Schedule, error) {
+func (c *ProxyClient) ListSchedules(ctx context.Context) ([]Schedule, error) {
 	resp, err := c.doJSON(ctx, http.MethodGet, schedulesPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("k6: list schedules: %w", err)
@@ -650,7 +650,7 @@ func (c *Client) ListSchedules(ctx context.Context) ([]Schedule, error) {
 }
 
 // GetSchedule retrieves a schedule by ID.
-func (c *Client) GetSchedule(ctx context.Context, id int) (*Schedule, error) {
+func (c *ProxyClient) GetSchedule(ctx context.Context, id int) (*Schedule, error) {
 	resp, err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf(schedulesPath+"/%d", id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("k6: get schedule: %w", err)
@@ -672,7 +672,7 @@ func (c *Client) GetSchedule(ctx context.Context, id int) (*Schedule, error) {
 }
 
 // CreateSchedule creates a schedule for a load test.
-func (c *Client) CreateSchedule(ctx context.Context, loadTestID int, req ScheduleRequest) (*Schedule, error) {
+func (c *ProxyClient) CreateSchedule(ctx context.Context, loadTestID int, req ScheduleRequest) (*Schedule, error) {
 	path := fmt.Sprintf(loadTestsPath+"/%d/schedule", loadTestID)
 	resp, err := c.doJSON(ctx, http.MethodPost, path, req)
 	if err != nil {
@@ -692,7 +692,7 @@ func (c *Client) CreateSchedule(ctx context.Context, loadTestID int, req Schedul
 }
 
 // UpdateScheduleByID updates a schedule by its ID.
-func (c *Client) UpdateScheduleByID(ctx context.Context, id int, req ScheduleRequest) (*Schedule, error) {
+func (c *ProxyClient) UpdateScheduleByID(ctx context.Context, id int, req ScheduleRequest) (*Schedule, error) {
 	resp, err := c.doJSON(ctx, http.MethodPut, fmt.Sprintf(schedulesPath+"/%d", id), req)
 	if err != nil {
 		return nil, fmt.Errorf("k6: update schedule: %w", err)
@@ -715,7 +715,7 @@ func (c *Client) UpdateScheduleByID(ctx context.Context, id int, req ScheduleReq
 }
 
 // DeleteScheduleByLoadTest deletes the schedule for a load test.
-func (c *Client) DeleteScheduleByLoadTest(ctx context.Context, loadTestID int) error {
+func (c *ProxyClient) DeleteScheduleByLoadTest(ctx context.Context, loadTestID int) error {
 	path := fmt.Sprintf(loadTestsPath+"/%d/schedule", loadTestID)
 	resp, err := c.doJSON(ctx, http.MethodDelete, path, nil)
 	if err != nil {
@@ -734,7 +734,7 @@ func (c *Client) DeleteScheduleByLoadTest(ctx context.Context, loadTestID int) e
 // ---------------------------------------------------------------------------
 
 // ListLoadZones retrieves all load zones for the stack.
-func (c *Client) ListLoadZones(ctx context.Context) ([]LoadZone, error) {
+func (c *ProxyClient) ListLoadZones(ctx context.Context) ([]LoadZone, error) {
 	resp, err := c.doJSON(ctx, http.MethodGet, loadZonesPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("k6: list load zones: %w", err)
@@ -753,7 +753,7 @@ func (c *Client) ListLoadZones(ctx context.Context) ([]LoadZone, error) {
 }
 
 // CreateLoadZone registers a Private Load Zone.
-func (c *Client) CreateLoadZone(ctx context.Context, req PLZCreateRequest) (*PLZCreateResponse, error) {
+func (c *ProxyClient) CreateLoadZone(ctx context.Context, req PLZCreateRequest) (*PLZCreateResponse, error) {
 	resp, err := c.doJSON(ctx, http.MethodPost, plzPath, req)
 	if err != nil {
 		return nil, fmt.Errorf("k6: create load zone: %w", err)
@@ -772,7 +772,7 @@ func (c *Client) CreateLoadZone(ctx context.Context, req PLZCreateRequest) (*PLZ
 }
 
 // DeleteLoadZone deregisters a Private Load Zone by name.
-func (c *Client) DeleteLoadZone(ctx context.Context, name string) error {
+func (c *ProxyClient) DeleteLoadZone(ctx context.Context, name string) error {
 	resp, err := c.doJSON(ctx, http.MethodDelete, plzPath+"/"+url.PathEscape(name), nil)
 	if err != nil {
 		return fmt.Errorf("k6: delete load zone: %w", err)
@@ -790,7 +790,7 @@ func (c *Client) DeleteLoadZone(ctx context.Context, name string) error {
 // ---------------------------------------------------------------------------
 
 // ListAllowedProjects lists the projects allowed to use a load zone.
-func (c *Client) ListAllowedProjects(ctx context.Context, loadZoneID int) ([]AllowedProject, error) {
+func (c *ProxyClient) ListAllowedProjects(ctx context.Context, loadZoneID int) ([]AllowedProject, error) {
 	path := fmt.Sprintf(loadZonesPath+"/%d/allowed_projects", loadZoneID)
 	resp, err := c.doJSON(ctx, http.MethodGet, path, nil)
 	if err != nil {
@@ -810,7 +810,7 @@ func (c *Client) ListAllowedProjects(ctx context.Context, loadZoneID int) ([]All
 }
 
 // UpdateAllowedProjects sets the projects allowed to use a load zone.
-func (c *Client) UpdateAllowedProjects(ctx context.Context, loadZoneID int, projectIDs []int) error {
+func (c *ProxyClient) UpdateAllowedProjects(ctx context.Context, loadZoneID int, projectIDs []int) error {
 	path := fmt.Sprintf(loadZonesPath+"/%d/allowed_projects", loadZoneID)
 	body := struct {
 		ProjectIDs []int `json:"project_ids"`
@@ -828,7 +828,7 @@ func (c *Client) UpdateAllowedProjects(ctx context.Context, loadZoneID int, proj
 }
 
 // ListAllowedLoadZones lists the load zones allowed for a project.
-func (c *Client) ListAllowedLoadZones(ctx context.Context, projectID int) ([]AllowedLoadZone, error) {
+func (c *ProxyClient) ListAllowedLoadZones(ctx context.Context, projectID int) ([]AllowedLoadZone, error) {
 	path := fmt.Sprintf(projectsPath+"/%d/allowed_load_zones", projectID)
 	resp, err := c.doJSON(ctx, http.MethodGet, path, nil)
 	if err != nil {
@@ -848,7 +848,7 @@ func (c *Client) ListAllowedLoadZones(ctx context.Context, projectID int) ([]All
 }
 
 // UpdateAllowedLoadZones sets the load zones allowed for a project.
-func (c *Client) UpdateAllowedLoadZones(ctx context.Context, projectID int, loadZoneIDs []int) error {
+func (c *ProxyClient) UpdateAllowedLoadZones(ctx context.Context, projectID int, loadZoneIDs []int) error {
 	path := fmt.Sprintf(projectsPath+"/%d/allowed_load_zones", projectID)
 	body := struct {
 		LoadZoneIDs []int `json:"load_zone_ids"`
@@ -864,3 +864,6 @@ func (c *Client) UpdateAllowedLoadZones(ctx context.Context, projectID int, load
 	}
 	return nil
 }
+
+// Compile-time assertion: ProxyClient must implement API.
+var _ API = (*ProxyClient)(nil)

--- a/internal/providers/k6/proxy_client.go
+++ b/internal/providers/k6/proxy_client.go
@@ -415,6 +415,8 @@ func (c *ProxyClient) DeleteLoadTest(ctx context.Context, id int) error {
 }
 
 // CreateLoadTest creates a new load test via multipart/form-data upload.
+//
+//nolint:dupl // identical multipart construction; ProxyClient and DirectClient are parallel implementations
 func (c *ProxyClient) CreateLoadTest(ctx context.Context, name string, projectID int, script string) (*LoadTest, error) {
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)

--- a/internal/providers/k6/proxy_client_test.go
+++ b/internal/providers/k6/proxy_client_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newAuthenticatedClient creates a k6 client pointed at a test server.
+// newAuthenticatedProxyClient creates a k6 client pointed at a test server.
 // The server responds to the plugin /organization endpoint with orgID=42
 // (lazily fetched by env var methods) and forwards cloud calls under the
 // plugin /cloud prefix to the supplied handler.
-func newAuthenticatedClient(t *testing.T, handler http.Handler) *k6.ProxyClient {
+func newAuthenticatedProxyClient(t *testing.T, handler http.Handler) *k6.ProxyClient {
 	t.Helper()
 
 	const proxyPrefix = "/api/plugins/k6-app/resources/cloud"
@@ -67,11 +67,11 @@ func (b *bearerInjector) RoundTrip(req *http.Request) (*http.Response, error) {
 	return base.RoundTrip(clone)
 }
 
-// TestClient_Token_FetchesFromAccountMe verifies that Token in OAuth
+// TestProxyClient_Token_FetchesFromAccountMe verifies that Token in OAuth
 // proxy mode resolves to /v3/account/me .token.key, routing the call through
 // the plugin proxy without Bearer / X-Stack-Id headers (the auth client's
 // transport injects auth, the plugin resolves the stack).
-func TestClient_Token_FetchesFromAccountMe(t *testing.T) {
+func TestProxyClient_Token_FetchesFromAccountMe(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/plugins/k6-app/resources/cloud/v3/account/me", r.URL.Path)
@@ -91,9 +91,9 @@ func TestClient_Token_FetchesFromAccountMe(t *testing.T) {
 	assert.Equal(t, "k6-v3-from-me", token)
 }
 
-// TestClient_Token_Memoised confirms that repeated Token calls in proxy
+// TestProxyClient_Token_Memoised confirms that repeated Token calls in proxy
 // mode hit /v3/account/me only once.
-func TestClient_Token_Memoised(t *testing.T) {
+func TestProxyClient_Token_Memoised(t *testing.T) {
 	var calls int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		calls++
@@ -110,10 +110,10 @@ func TestClient_Token_Memoised(t *testing.T) {
 	assert.Equal(t, 1, calls, "expected /v3/account/me to be called once, got %d", calls)
 }
 
-// TestClient_Token_EmptyKey surfaces an error when /v3/account/me
+// TestProxyClient_Token_EmptyKey surfaces an error when /v3/account/me
 // returns a successful response with no token.key, rather than letting
 // callers print an empty token.
-func TestClient_Token_EmptyKey(t *testing.T) {
+func TestProxyClient_Token_EmptyKey(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(t, w, map[string]any{"token": map[string]any{"key": ""}})
@@ -125,11 +125,11 @@ func TestClient_Token_EmptyKey(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestClient_RoutesResourceCallsThroughProxy verifies that regular API
+// TestProxyClient_RoutesResourceCallsThroughProxy verifies that regular API
 // calls hit the plugin proxy path (not api.k6.io) and omit Bearer +
 // X-Stack-Id — relying entirely on the auth client's transport for
 // credential injection.
-func TestClient_RoutesResourceCallsThroughProxy(t *testing.T) {
+func TestProxyClient_RoutesResourceCallsThroughProxy(t *testing.T) {
 	var listRecorded struct {
 		path string
 		auth string
@@ -164,7 +164,7 @@ func TestClient_RoutesResourceCallsThroughProxy(t *testing.T) {
 	assert.Empty(t, listRecorded.stk, "X-Stack-Id must be omitted in proxy mode")
 }
 
-func TestClient_ListProjects(t *testing.T) {
+func TestProxyClient_ListProjects(t *testing.T) {
 	tests := []struct {
 		name    string
 		handler http.HandlerFunc
@@ -207,7 +207,7 @@ func TestClient_ListProjects(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := newAuthenticatedClient(t, tt.handler)
+			client := newAuthenticatedProxyClient(t, tt.handler)
 			projects, err := client.ListProjects(t.Context())
 
 			if tt.wantErr {
@@ -221,7 +221,7 @@ func TestClient_ListProjects(t *testing.T) {
 	}
 }
 
-func TestClient_GetProject(t *testing.T) {
+func TestProxyClient_GetProject(t *testing.T) {
 	tests := []struct {
 		name     string
 		id       int
@@ -252,7 +252,7 @@ func TestClient_GetProject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := newAuthenticatedClient(t, tt.handler)
+			client := newAuthenticatedProxyClient(t, tt.handler)
 			p, err := client.GetProject(t.Context(), tt.id)
 
 			if tt.wantErr {
@@ -266,7 +266,7 @@ func TestClient_GetProject(t *testing.T) {
 	}
 }
 
-func TestClient_CreateProject(t *testing.T) {
+func TestProxyClient_CreateProject(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/cloud/v6/projects", r.URL.Path)
@@ -278,26 +278,26 @@ func TestClient_CreateProject(t *testing.T) {
 		writeJSON(t, w, map[string]any{"id": 10, "name": "New Project"})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	p, err := client.CreateProject(t.Context(), "New Project")
 	require.NoError(t, err)
 	assert.Equal(t, 10, p.ID)
 	assert.Equal(t, "New Project", p.Name)
 }
 
-func TestClient_DeleteProject(t *testing.T) {
+func TestProxyClient_DeleteProject(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
 		assert.Equal(t, "/cloud/v6/projects/10", r.URL.Path)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	err := client.DeleteProject(t.Context(), 10)
 	require.NoError(t, err)
 }
 
-func TestClient_ListLoadTests(t *testing.T) {
+func TestProxyClient_ListLoadTests(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/cloud/v6/load_tests", r.URL.Path)
@@ -310,14 +310,14 @@ func TestClient_ListLoadTests(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	tests, err := client.ListLoadTests(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, tests, 2)
 	assert.Equal(t, "My Test", tests[0].Name)
 }
 
-func TestClient_ListLoadTests_WithLimit(t *testing.T) {
+func TestProxyClient_ListLoadTests_WithLimit(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		// When limit=5 is passed, $top should be 5 instead of the default 100
@@ -332,13 +332,13 @@ func TestClient_ListLoadTests_WithLimit(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	tests, err := client.ListLoadTestsWithLimit(t.Context(), 5)
 	require.NoError(t, err)
 	assert.Len(t, tests, 2)
 }
 
-func TestClient_GetLoadTest(t *testing.T) {
+func TestProxyClient_GetLoadTest(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/cloud/v6/load_tests/6", r.URL.Path)
@@ -346,14 +346,14 @@ func TestClient_GetLoadTest(t *testing.T) {
 		writeJSON(t, w, map[string]any{"id": 6, "name": "my-load-test", "project_id": 1})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	test, err := client.GetLoadTest(t.Context(), 6)
 	require.NoError(t, err)
 	assert.Equal(t, "my-load-test", test.Name)
 	assert.Equal(t, 1, test.ProjectID)
 }
 
-func TestClient_ListTestRuns(t *testing.T) {
+func TestProxyClient_ListTestRuns(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/cloud/v6/load_tests/6/test_runs", r.URL.Path)
@@ -365,7 +365,7 @@ func TestClient_ListTestRuns(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	runs, err := client.ListTestRuns(t.Context(), 6)
 	require.NoError(t, err)
 	assert.Len(t, runs, 1)
@@ -373,7 +373,7 @@ func TestClient_ListTestRuns(t *testing.T) {
 	assert.Equal(t, 1, runs[0].ResultStatus)
 }
 
-func TestClient_ListEnvVars(t *testing.T) {
+func TestProxyClient_ListEnvVars(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/v3/organizations/42/envvars", r.URL.Path)
@@ -385,14 +385,14 @@ func TestClient_ListEnvVars(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	envVars, err := client.ListEnvVars(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, envVars, 1)
 	assert.Equal(t, "MY_VAR", envVars[0].Name)
 }
 
-func TestClient_CreateEnvVar(t *testing.T) {
+func TestProxyClient_CreateEnvVar(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/v3/organizations/42/envvars", r.URL.Path)
@@ -407,38 +407,38 @@ func TestClient_CreateEnvVar(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	ev, err := client.CreateEnvVar(t.Context(), "NEW_VAR", "world", "")
 	require.NoError(t, err)
 	assert.Equal(t, 4, ev.ID)
 	assert.Equal(t, "NEW_VAR", ev.Name)
 }
 
-func TestClient_UpdateEnvVar(t *testing.T) {
+func TestProxyClient_UpdateEnvVar(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
 		assert.Equal(t, "/v3/organizations/42/envvars/3", r.URL.Path)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	err := client.UpdateEnvVar(t.Context(), 3, "MY_VAR", "updated", "")
 	require.NoError(t, err)
 }
 
-func TestClient_DeleteEnvVar(t *testing.T) {
+func TestProxyClient_DeleteEnvVar(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
 		assert.Equal(t, "/v3/organizations/42/envvars/3", r.URL.Path)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	err := client.DeleteEnvVar(t.Context(), 3)
 	require.NoError(t, err)
 }
 
-func TestClient_GetProjectByName(t *testing.T) {
+func TestProxyClient_GetProjectByName(t *testing.T) {
 	projectListHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(t, w, map[string]any{
@@ -449,7 +449,7 @@ func TestClient_GetProjectByName(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, projectListHandler)
+	client := newAuthenticatedProxyClient(t, projectListHandler)
 
 	// Found by name.
 	p, err := client.GetProjectByName(t.Context(), "My Project")
@@ -463,7 +463,7 @@ func TestClient_GetProjectByName(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
-func TestClient_ListLoadTestsByProject(t *testing.T) {
+func TestProxyClient_ListLoadTestsByProject(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify server-side filtering is requested
 		assert.Equal(t, "1", r.URL.Query().Get("project_id"))
@@ -477,7 +477,7 @@ func TestClient_ListLoadTestsByProject(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	tests, err := client.ListLoadTestsByProject(t.Context(), 1)
 	require.NoError(t, err)
 	assert.Len(t, tests, 2)
@@ -485,7 +485,7 @@ func TestClient_ListLoadTestsByProject(t *testing.T) {
 	assert.Equal(t, "Test C", tests[1].Name)
 }
 
-func TestClient_CreateLoadTest(t *testing.T) {
+func TestProxyClient_CreateLoadTest(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/cloud/v6/projects/1/load_tests", r.URL.Path)
@@ -494,14 +494,14 @@ func TestClient_CreateLoadTest(t *testing.T) {
 		writeJSON(t, w, map[string]any{"id": 10, "name": "New Test", "project_id": 1})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	lt, err := client.CreateLoadTest(t.Context(), "New Test", 1, "export default function() {}")
 	require.NoError(t, err)
 	assert.Equal(t, 10, lt.ID)
 	assert.Equal(t, "New Test", lt.Name)
 }
 
-func TestClient_UpdateLoadTest(t *testing.T) {
+func TestProxyClient_UpdateLoadTest(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {
 			assert.Equal(t, "/cloud/v6/load_tests/5", r.URL.Path)
@@ -511,12 +511,12 @@ func TestClient_UpdateLoadTest(t *testing.T) {
 		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	err := client.UpdateLoadTest(t.Context(), 5, "Updated Name", "")
 	require.NoError(t, err)
 }
 
-func TestClient_UpdateLoadTestScript(t *testing.T) {
+func TestProxyClient_UpdateLoadTestScript(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Equal(t, "/cloud/v6/load_tests/5/script", r.URL.Path)
@@ -524,12 +524,12 @@ func TestClient_UpdateLoadTestScript(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	err := client.UpdateLoadTestScript(t.Context(), 5, "export default function() { console.log('hi'); }")
 	require.NoError(t, err)
 }
 
-func TestClient_GetLoadTestScript(t *testing.T) {
+func TestProxyClient_GetLoadTestScript(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/cloud/v6/load_tests/5/script", r.URL.Path)
@@ -537,13 +537,13 @@ func TestClient_GetLoadTestScript(t *testing.T) {
 		_, _ = w.Write([]byte("export default function() {}"))
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	script, err := client.GetLoadTestScript(t.Context(), 5)
 	require.NoError(t, err)
 	assert.Equal(t, "export default function() {}", script)
 }
 
-func TestClient_GetLoadTestByName(t *testing.T) {
+func TestProxyClient_GetLoadTestByName(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(t, w, map[string]any{
@@ -554,7 +554,7 @@ func TestClient_GetLoadTestByName(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 
 	lt, err := client.GetLoadTestByName(t.Context(), 1, "beta")
 	require.NoError(t, err)
@@ -566,7 +566,7 @@ func TestClient_GetLoadTestByName(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
-func TestClient_ListSchedules(t *testing.T) {
+func TestProxyClient_ListSchedules(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/cloud/v6/schedules", r.URL.Path)
@@ -578,7 +578,7 @@ func TestClient_ListSchedules(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	schedules, err := client.ListSchedules(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, schedules, 1)
@@ -586,7 +586,7 @@ func TestClient_ListSchedules(t *testing.T) {
 	assert.Equal(t, 5, schedules[0].LoadTestID)
 }
 
-func TestClient_GetSchedule(t *testing.T) {
+func TestProxyClient_GetSchedule(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/cloud/v6/schedules/10", r.URL.Path)
@@ -596,13 +596,13 @@ func TestClient_GetSchedule(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	s, err := client.GetSchedule(t.Context(), 10)
 	require.NoError(t, err)
 	assert.Equal(t, 10, s.ID)
 }
 
-func TestClient_CreateSchedule(t *testing.T) {
+func TestProxyClient_CreateSchedule(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/cloud/v6/load_tests/5/schedule", r.URL.Path)
@@ -612,7 +612,7 @@ func TestClient_CreateSchedule(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	s, err := client.CreateSchedule(t.Context(), 5, k6.ScheduleRequest{
 		Starts: "2026-06-01T10:00:00Z",
 	})
@@ -620,7 +620,7 @@ func TestClient_CreateSchedule(t *testing.T) {
 	assert.Equal(t, 10, s.ID)
 }
 
-func TestClient_UpdateScheduleByID(t *testing.T) {
+func TestProxyClient_UpdateScheduleByID(t *testing.T) {
 	t.Run("200 OK with body", func(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPut, r.Method)
@@ -630,7 +630,7 @@ func TestClient_UpdateScheduleByID(t *testing.T) {
 			})
 		})
 
-		client := newAuthenticatedClient(t, handler)
+		client := newAuthenticatedProxyClient(t, handler)
 		s, err := client.UpdateScheduleByID(t.Context(), 10, k6.ScheduleRequest{
 			Starts: "2026-07-01T12:00:00Z",
 		})
@@ -655,7 +655,7 @@ func TestClient_UpdateScheduleByID(t *testing.T) {
 			})
 		})
 
-		client := newAuthenticatedClient(t, handler)
+		client := newAuthenticatedProxyClient(t, handler)
 		s, err := client.UpdateScheduleByID(t.Context(), 10, k6.ScheduleRequest{
 			Starts: "2026-07-01T12:00:00Z",
 		})
@@ -666,19 +666,19 @@ func TestClient_UpdateScheduleByID(t *testing.T) {
 	})
 }
 
-func TestClient_DeleteScheduleByLoadTest(t *testing.T) {
+func TestProxyClient_DeleteScheduleByLoadTest(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
 		assert.Equal(t, "/cloud/v6/load_tests/5/schedule", r.URL.Path)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	err := client.DeleteScheduleByLoadTest(t.Context(), 5)
 	require.NoError(t, err)
 }
 
-func TestClient_ListLoadZones(t *testing.T) {
+func TestProxyClient_ListLoadZones(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/cloud/v6/load_zones", r.URL.Path)
@@ -690,14 +690,14 @@ func TestClient_ListLoadZones(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	zones, err := client.ListLoadZones(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, zones, 1)
 	assert.Equal(t, "my-plz", zones[0].Name)
 }
 
-func TestClient_CreateLoadZone(t *testing.T) {
+func TestProxyClient_CreateLoadZone(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/cloud-resources/v1/load-zones", r.URL.Path)
@@ -707,7 +707,7 @@ func TestClient_CreateLoadZone(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	resp, err := client.CreateLoadZone(t.Context(), k6.PLZCreateRequest{
 		K6LoadZoneID: "k6-plz-123",
 		ProviderID:   "aws",
@@ -717,19 +717,19 @@ func TestClient_CreateLoadZone(t *testing.T) {
 	assert.Equal(t, "my-plz", resp.Name)
 }
 
-func TestClient_DeleteLoadZone(t *testing.T) {
+func TestProxyClient_DeleteLoadZone(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
 		assert.Equal(t, "/cloud-resources/v1/load-zones/my-plz", r.URL.Path)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	err := client.DeleteLoadZone(t.Context(), "my-plz")
 	require.NoError(t, err)
 }
 
-func TestClient_ListAllowedProjects(t *testing.T) {
+func TestProxyClient_ListAllowedProjects(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/cloud/v6/load_zones/1/allowed_projects", r.URL.Path)
@@ -739,14 +739,14 @@ func TestClient_ListAllowedProjects(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	projects, err := client.ListAllowedProjects(t.Context(), 1)
 	require.NoError(t, err)
 	assert.Len(t, projects, 1)
 	assert.Equal(t, 10, projects[0].ID)
 }
 
-func TestClient_UpdateAllowedProjects(t *testing.T) {
+func TestProxyClient_UpdateAllowedProjects(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Equal(t, "/cloud/v6/load_zones/1/allowed_projects", r.URL.Path)
@@ -756,12 +756,12 @@ func TestClient_UpdateAllowedProjects(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	err := client.UpdateAllowedProjects(t.Context(), 1, []int{10, 20})
 	require.NoError(t, err)
 }
 
-func TestClient_ListAllowedLoadZones(t *testing.T) {
+func TestProxyClient_ListAllowedLoadZones(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/cloud/v6/projects/1/allowed_load_zones", r.URL.Path)
@@ -771,14 +771,14 @@ func TestClient_ListAllowedLoadZones(t *testing.T) {
 		})
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	zones, err := client.ListAllowedLoadZones(t.Context(), 1)
 	require.NoError(t, err)
 	assert.Len(t, zones, 1)
 	assert.Equal(t, 100, zones[0].ID)
 }
 
-func TestClient_UpdateAllowedLoadZones(t *testing.T) {
+func TestProxyClient_UpdateAllowedLoadZones(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Equal(t, "/cloud/v6/projects/1/allowed_load_zones", r.URL.Path)
@@ -788,7 +788,7 @@ func TestClient_UpdateAllowedLoadZones(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	client := newAuthenticatedClient(t, handler)
+	client := newAuthenticatedProxyClient(t, handler)
 	err := client.UpdateAllowedLoadZones(t.Context(), 1, []int{100, 200})
 	require.NoError(t, err)
 }

--- a/internal/providers/k6/proxy_client_test.go
+++ b/internal/providers/k6/proxy_client_test.go
@@ -17,7 +17,7 @@ import (
 // The server responds to the plugin /organization endpoint with orgID=42
 // (lazily fetched by env var methods) and forwards cloud calls under the
 // plugin /cloud prefix to the supplied handler.
-func newAuthenticatedClient(t *testing.T, handler http.Handler) *k6.Client {
+func newAuthenticatedClient(t *testing.T, handler http.Handler) *k6.ProxyClient {
 	t.Helper()
 
 	const proxyPrefix = "/api/plugins/k6-app/resources/cloud"
@@ -47,7 +47,7 @@ func newAuthenticatedClient(t *testing.T, handler http.Handler) *k6.Client {
 	t.Cleanup(srv.Close)
 
 	authClient := &http.Client{Transport: &bearerInjector{token: "test-k6-token"}}
-	return k6.NewClient(context.Background(), srv.URL, authClient)
+	return k6.NewProxyClient(context.Background(), srv.URL, authClient)
 }
 
 // bearerInjector is a RoundTripper that injects a Bearer Authorization
@@ -85,7 +85,7 @@ func TestClient_Token_FetchesFromAccountMe(t *testing.T) {
 	defer srv.Close()
 
 	authClient := &http.Client{Transport: &bearerInjector{token: "gat_test-oauth-token"}}
-	client := k6.NewClient(context.Background(), srv.URL, authClient)
+	client := k6.NewProxyClient(context.Background(), srv.URL, authClient)
 	token, err := client.Token(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "k6-v3-from-me", token)
@@ -102,7 +102,7 @@ func TestClient_Token_Memoised(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := k6.NewClient(context.Background(), srv.URL, &http.Client{Transport: &bearerInjector{token: "tok"}})
+	client := k6.NewProxyClient(context.Background(), srv.URL, &http.Client{Transport: &bearerInjector{token: "tok"}})
 	for range 3 {
 		_, err := client.Token(t.Context())
 		require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestClient_Token_EmptyKey(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := k6.NewClient(context.Background(), srv.URL, &http.Client{Transport: &bearerInjector{token: "tok"}})
+	client := k6.NewProxyClient(context.Background(), srv.URL, &http.Client{Transport: &bearerInjector{token: "tok"}})
 	_, err := client.Token(t.Context())
 	require.Error(t, err)
 }
@@ -152,7 +152,7 @@ func TestClient_RoutesResourceCallsThroughProxy(t *testing.T) {
 	defer srv.Close()
 
 	authClient := &http.Client{Transport: &bearerInjector{token: "gat_test-oauth-token"}}
-	client := k6.NewClient(context.Background(), srv.URL, authClient)
+	client := k6.NewProxyClient(context.Background(), srv.URL, authClient)
 
 	projects, err := client.ListProjects(t.Context())
 	require.NoError(t, err)

--- a/internal/providers/k6/resource_adapter.go
+++ b/internal/providers/k6/resource_adapter.go
@@ -62,7 +62,7 @@ type CloudConfigLoader interface {
 	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
 }
 
-func authenticatedClient(ctx context.Context, loader CloudConfigLoader) (*Client, string, error) {
+func authenticatedClient(ctx context.Context, loader CloudConfigLoader) (*ProxyClient, string, error) {
 	restCfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
 		return nil, "", err
@@ -78,7 +78,7 @@ func authenticatedClient(ctx context.Context, loader CloudConfigLoader) (*Client
 	if _, err := authlib.ParseNamespace(restCfg.Namespace); err != nil {
 		return nil, "", err
 	}
-	return NewClient(ctx, restCfg.Host, authClient), restCfg.Namespace, nil
+	return NewProxyClient(ctx, restCfg.Host, authClient), restCfg.Namespace, nil
 }
 
 // newSubResourceFactory returns a lazy adapter.Factory for a specific k6 resource.
@@ -120,7 +120,7 @@ func newSubResourceFactory(loader CloudConfigLoader, rd resourceDef) adapter.Fac
 // TypedCRUD constructors
 // ---------------------------------------------------------------------------
 
-func newProjectCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
+func newProjectCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[Project]{
 		ListFn: adapter.LimitedListFn(c.ListProjects),
 		GetFn: func(ctx context.Context, name string) (*Project, error) {
@@ -157,7 +157,7 @@ func newProjectCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Res
 	return crud.AsAdapter()
 }
 
-func newLoadTestCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
+func newLoadTestCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[LoadTest]{
 		ListFn: adapter.LimitedListFn(c.ListLoadTests),
 		GetFn: func(ctx context.Context, name string) (*LoadTest, error) {
@@ -194,7 +194,7 @@ func newLoadTestCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Re
 	return crud.AsAdapter()
 }
 
-func newScheduleCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
+func newScheduleCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[Schedule]{
 		ListFn: adapter.LimitedListFn(c.ListSchedules),
 		GetFn: func(ctx context.Context, name string) (*Schedule, error) {
@@ -241,7 +241,7 @@ func newScheduleCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Re
 	return crud.AsAdapter()
 }
 
-func newEnvVarCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
+func newEnvVarCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[EnvVar]{
 		ListFn: adapter.LimitedListFn(c.ListEnvVars),
 		GetFn: func(ctx context.Context, name string) (*EnvVar, error) {
@@ -298,7 +298,7 @@ func newEnvVarCRUD(c *Client, ns string, desc resources.Descriptor) adapter.Reso
 	return crud.AsAdapter()
 }
 
-func newLoadZoneCRUD(c *Client, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
+func newLoadZoneCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[LoadZone]{
 		ListFn: adapter.LimitedListFn(c.ListLoadZones),
 		GetFn: func(ctx context.Context, name string) (*LoadZone, error) {

--- a/internal/providers/k6/resource_adapter.go
+++ b/internal/providers/k6/resource_adapter.go
@@ -62,7 +62,7 @@ type CloudConfigLoader interface {
 	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
 }
 
-func authenticatedClient(ctx context.Context, loader CloudConfigLoader) (*ProxyClient, string, error) {
+func authenticatedClient(ctx context.Context, loader CloudConfigLoader) (API, string, error) {
 	restCfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
 		return nil, "", err
@@ -120,7 +120,7 @@ func newSubResourceFactory(loader CloudConfigLoader, rd resourceDef) adapter.Fac
 // TypedCRUD constructors
 // ---------------------------------------------------------------------------
 
-func newProjectCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
+func newProjectCRUD(c API, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[Project]{
 		ListFn: adapter.LimitedListFn(c.ListProjects),
 		GetFn: func(ctx context.Context, name string) (*Project, error) {
@@ -157,7 +157,7 @@ func newProjectCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapte
 	return crud.AsAdapter()
 }
 
-func newLoadTestCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
+func newLoadTestCRUD(c API, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[LoadTest]{
 		ListFn: adapter.LimitedListFn(c.ListLoadTests),
 		GetFn: func(ctx context.Context, name string) (*LoadTest, error) {
@@ -194,7 +194,7 @@ func newLoadTestCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapt
 	return crud.AsAdapter()
 }
 
-func newScheduleCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
+func newScheduleCRUD(c API, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[Schedule]{
 		ListFn: adapter.LimitedListFn(c.ListSchedules),
 		GetFn: func(ctx context.Context, name string) (*Schedule, error) {
@@ -241,7 +241,7 @@ func newScheduleCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapt
 	return crud.AsAdapter()
 }
 
-func newEnvVarCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
+func newEnvVarCRUD(c API, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[EnvVar]{
 		ListFn: adapter.LimitedListFn(c.ListEnvVars),
 		GetFn: func(ctx context.Context, name string) (*EnvVar, error) {
@@ -298,7 +298,7 @@ func newEnvVarCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapter
 	return crud.AsAdapter()
 }
 
-func newLoadZoneCRUD(c *ProxyClient, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
+func newLoadZoneCRUD(c API, ns string, desc resources.Descriptor) adapter.ResourceAdapter {
 	crud := &adapter.TypedCRUD[LoadZone]{
 		ListFn: adapter.LimitedListFn(c.ListLoadZones),
 		GetFn: func(ctx context.Context, name string) (*LoadZone, error) {

--- a/internal/providers/k6/resource_adapter.go
+++ b/internal/providers/k6/resource_adapter.go
@@ -9,6 +9,8 @@ import (
 
 	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -58,8 +60,16 @@ func allResources() []resourceDef {
 	}
 }
 
+// CloudConfigLoader is the subset of providers.ConfigLoader the k6 provider
+// consumes. The methods needed depend on the auth mode:
+//   - OAuth (plugin proxy): LoadGrafanaConfig only.
+//   - SA token (direct API): all four (LoadCloudConfig for stack ID,
+//     LoadProviderConfig + SaveProviderConfig for the cache).
 type CloudConfigLoader interface {
 	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
+	LoadCloudConfig(ctx context.Context) (providers.CloudRESTConfig, error)
+	LoadProviderConfig(ctx context.Context, providerName string) (map[string]string, string, error)
+	SaveProviderConfig(ctx context.Context, providerName, key, value string) error
 }
 
 func authenticatedClient(ctx context.Context, loader CloudConfigLoader) (API, string, error) {
@@ -67,18 +77,60 @@ func authenticatedClient(ctx context.Context, loader CloudConfigLoader) (API, st
 	if err != nil {
 		return nil, "", err
 	}
-	if !restCfg.IsOAuthProxy() {
-		return nil, "", errors.New("k6 provider requires OAuth authentication -- run `gcx login` and select OAuth mode")
+
+	if restCfg.IsOAuthProxy() {
+		authClient, err := rest.HTTPClientFor(&restCfg.Config)
+		if err != nil {
+			return nil, "", err
+		}
+		if _, err := authlib.ParseNamespace(restCfg.Namespace); err != nil {
+			return nil, "", err
+		}
+		return NewProxyClient(ctx, restCfg.Host, authClient), restCfg.Namespace, nil
 	}
 
-	authClient, err := rest.HTTPClientFor(&restCfg.Config)
+	// SA-token path: direct api.k6.io with /start exchange + cross-invocation cache.
+	cloudCfg, err := loader.LoadCloudConfig(ctx)
 	if err != nil {
+		return nil, "", fmt.Errorf("k6: load cloud config: %w", err)
+	}
+	providerCfg, _, _ := loader.LoadProviderConfig(ctx, "k6")
+	domain := DefaultAPIDomain
+	if d := providerCfg["api-domain"]; d != "" {
+		domain = d
+	}
+	client := NewDirectClient(ctx, domain, httputils.NewDefaultClient(ctx))
+
+	exchange := func(ctx context.Context) (string, int, error) {
+		grafanaCfg, err := loader.LoadGrafanaConfig(ctx)
+		if err != nil {
+			return "", 0, fmt.Errorf("k6: load grafana config: %w", err)
+		}
+		if grafanaCfg.BearerToken == "" {
+			return "", 0, errors.New("k6: grafana.token is required (must be a glsa_* service-account token)")
+		}
+		if err := client.Authenticate(ctx, grafanaCfg.BearerToken, cloudCfg.Stack.ID); err != nil {
+			return "", 0, fmt.Errorf("k6 auth failed (PUT %s): %w -- ensure your token has k6 scopes", authPath, err)
+		}
+		tok, _ := client.Token(ctx)
+		persistCache(ctx, loader, tok, client.orgIDValue(), cloudCfg.Stack.ID)
+		return tok, client.orgIDValue(), nil
+	}
+
+	client.SetReauth(func(ctx context.Context) (string, int, error) {
+		clearCache(ctx, loader)
+		return exchange(ctx)
+	})
+
+	if cachedTok, cachedOrg, ok := loadCache(providerCfg, cloudCfg.Stack.ID); ok {
+		client.SetCachedAuth(cachedTok, cachedOrg, cloudCfg.Stack.ID)
+		return client, cloudCfg.Namespace, nil
+	}
+
+	if _, _, err := exchange(ctx); err != nil {
 		return nil, "", err
 	}
-	if _, err := authlib.ParseNamespace(restCfg.Namespace); err != nil {
-		return nil, "", err
-	}
-	return NewProxyClient(ctx, restCfg.Host, authClient), restCfg.Namespace, nil
+	return client, cloudCfg.Namespace, nil
 }
 
 // newSubResourceFactory returns a lazy adapter.Factory for a specific k6 resource.

--- a/internal/providers/k6/resource_adapter.go
+++ b/internal/providers/k6/resource_adapter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	authlib "github.com/grafana/authlib/types"
@@ -94,7 +95,10 @@ func authenticatedClient(ctx context.Context, loader CloudConfigLoader) (API, st
 	if err != nil {
 		return nil, "", fmt.Errorf("k6: load cloud config: %w", err)
 	}
-	providerCfg, _, _ := loader.LoadProviderConfig(ctx, "k6")
+	providerCfg, _, providerCfgErr := loader.LoadProviderConfig(ctx, "k6")
+	if providerCfgErr != nil {
+		slog.DebugContext(ctx, "k6: could not load provider config, proceeding without cache", "error", providerCfgErr)
+	}
 	domain := DefaultAPIDomain
 	if d := providerCfg["api-domain"]; d != "" {
 		domain = d
@@ -110,7 +114,7 @@ func authenticatedClient(ctx context.Context, loader CloudConfigLoader) (API, st
 			return "", 0, errors.New("k6: grafana.token is required (must be a glsa_* service-account token)")
 		}
 		if err := client.Authenticate(ctx, grafanaCfg.BearerToken, cloudCfg.Stack.ID); err != nil {
-			return "", 0, fmt.Errorf("k6 auth failed (PUT %s): %w -- ensure your token has k6 scopes", authPath, err)
+			return "", 0, fmt.Errorf("k6: auth failed (PUT %s): %w -- ensure your token has k6 scopes", authPath, err)
 		}
 		tok, _ := client.Token(ctx)
 		persistCache(ctx, loader, tok, client.orgIDValue(), cloudCfg.Stack.ID)

--- a/internal/providers/k6/resource_adapter_internal_test.go
+++ b/internal/providers/k6/resource_adapter_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/grafana/gcx/internal/cloud"
@@ -109,4 +110,76 @@ func TestAuthenticatedClient_SATokenMissingBearer(t *testing.T) {
 	_, _, err := authenticatedClient(context.Background(), loader)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "grafana.token is required")
+}
+
+// TestAuthenticatedClient_SATokenReauthOn401Chain verifies the end-to-end
+// integration of the reauth callback wired in authenticatedClient:
+// stale cache hit -> 401 from API call -> clearCache -> fresh exchange ->
+// persistCache -> retry succeeds with new token.
+func TestAuthenticatedClient_SATokenReauthOn401Chain(t *testing.T) {
+	var apiCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3/account/grafana-app/start" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"organization_id": "55", "v3_grafana_token": "fresh-after-401",
+			})
+			return
+		}
+		if r.URL.Path == "/cloud/v6/projects" {
+			call := apiCalls.Add(1)
+			if call == 1 {
+				// First call uses the stale cached token: server rejects.
+				assert.Equal(t, "Bearer stale-cached", r.Header.Get("Authorization"))
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			// Retry uses the freshly-exchanged token.
+			assert.Equal(t, "Bearer fresh-after-401", r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"value": []any{}})
+			return
+		}
+		t.Fatalf("unexpected: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(srv.Close)
+
+	loader := &mockLoader{
+		cloudCfg: providers.CloudRESTConfig{
+			Stack:     cloud.StackInfo{ID: 999},
+			Namespace: "stack-999",
+		},
+		grafanaCfg: config.NamespacedRESTConfig{
+			Config: rest.Config{BearerToken: "glsa_test"},
+		},
+		providerCfg: map[string]string{
+			"api-domain":     srv.URL,
+			keyCachedToken:   "stale-cached",
+			keyCachedOrgID:   "42",
+			keyCachedStackID: "999",
+		},
+	}
+
+	client, _, err := authenticatedClient(context.Background(), loader)
+	require.NoError(t, err)
+
+	// Issue an API call; the stale token triggers 401, reauth runs the chain.
+	require.NoError(t, callListProjects(t, client))
+
+	// Two API calls happened (401 then retry).
+	assert.Equal(t, int32(2), apiCalls.Load())
+
+	// loader.saved must reflect a fresh persistCache call with the new credentials.
+	assert.Equal(t, "fresh-after-401", loader.saved[keyCachedToken])
+	assert.Equal(t, "55", loader.saved[keyCachedOrgID])
+	assert.Equal(t, "999", loader.saved[keyCachedStackID])
+}
+
+// callListProjects is a tiny helper so the integration test doesn't need to
+// know about the API interface methods beyond ListProjects.
+func callListProjects(t *testing.T, client API) error {
+	t.Helper()
+	_, err := client.ListProjects(context.Background())
+	return err
 }

--- a/internal/providers/k6/resource_adapter_internal_test.go
+++ b/internal/providers/k6/resource_adapter_internal_test.go
@@ -1,0 +1,112 @@
+// Package k6 internal tests exercise unexported helpers (authenticatedClient, cache keys).
+package k6
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/cloud"
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+type mockLoader struct {
+	cloudCfg    providers.CloudRESTConfig
+	grafanaCfg  config.NamespacedRESTConfig
+	providerCfg map[string]string
+	saved       map[string]string
+}
+
+func (m *mockLoader) LoadCloudConfig(_ context.Context) (providers.CloudRESTConfig, error) {
+	return m.cloudCfg, nil
+}
+
+func (m *mockLoader) LoadGrafanaConfig(_ context.Context) (config.NamespacedRESTConfig, error) {
+	return m.grafanaCfg, nil
+}
+
+func (m *mockLoader) LoadProviderConfig(_ context.Context, _ string) (map[string]string, string, error) {
+	return m.providerCfg, "", nil
+}
+
+func (m *mockLoader) SaveProviderConfig(_ context.Context, _, key, value string) error {
+	if m.saved == nil {
+		m.saved = make(map[string]string)
+	}
+	m.saved[key] = value
+	return nil
+}
+
+func TestAuthenticatedClient_SATokenColdPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3/account/grafana-app/start" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"organization_id": "42", "v3_grafana_token": "fresh-tok",
+			})
+			return
+		}
+		t.Fatalf("unexpected: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(srv.Close)
+
+	loader := &mockLoader{
+		cloudCfg: providers.CloudRESTConfig{
+			Stack:     cloud.StackInfo{ID: 999},
+			Namespace: "stack-999",
+		},
+		grafanaCfg: config.NamespacedRESTConfig{
+			Config: rest.Config{BearerToken: "glsa_test"},
+		},
+		providerCfg: map[string]string{"api-domain": srv.URL},
+	}
+
+	client, ns, err := authenticatedClient(context.Background(), loader)
+	require.NoError(t, err)
+	assert.Equal(t, "stack-999", ns)
+	tok, _ := client.Token(context.Background())
+	assert.Equal(t, "fresh-tok", tok)
+	assert.Equal(t, "fresh-tok", loader.saved[keyCachedToken])
+	assert.Equal(t, "999", loader.saved[keyCachedStackID])
+}
+
+func TestAuthenticatedClient_SATokenCachePath(t *testing.T) {
+	loader := &mockLoader{
+		cloudCfg: providers.CloudRESTConfig{
+			Stack:     cloud.StackInfo{ID: 999},
+			Namespace: "stack-999",
+		},
+		grafanaCfg: config.NamespacedRESTConfig{
+			Config: rest.Config{BearerToken: "glsa_test"},
+		},
+		providerCfg: map[string]string{
+			"api-domain":     "http://unused-because-cache-hit",
+			keyCachedToken:   "cached-v3",
+			keyCachedOrgID:   "42",
+			keyCachedStackID: "999",
+		},
+	}
+
+	client, _, err := authenticatedClient(context.Background(), loader)
+	require.NoError(t, err)
+	tok, _ := client.Token(context.Background())
+	assert.Equal(t, "cached-v3", tok)
+	// No exchange should have happened — SaveProviderConfig must not have been called.
+	assert.Empty(t, loader.saved)
+}
+
+func TestAuthenticatedClient_SATokenMissingBearer(t *testing.T) {
+	loader := &mockLoader{
+		cloudCfg:   providers.CloudRESTConfig{Stack: cloud.StackInfo{ID: 999}},
+		grafanaCfg: config.NamespacedRESTConfig{}, // empty BearerToken
+	}
+	_, _, err := authenticatedClient(context.Background(), loader)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "grafana.token is required")
+}


### PR DESCRIPTION
## What

Splits the k6 provider into two concrete clients sharing a single `k6.API` interface:

- **`ProxyClient`** (renamed from #642's `Client`) — routes through `grafana-k6-app` plugin proxy with the OAuth bearer; **unchanged from #642**.
- **`DirectClient`** (new) — talks to `api.k6.io` directly with an SA-token-exchanged v3 token. Caches the v3 token under `providers.k6.cached-*` so subsequent invocations skip the `/v3/account/grafana-app/start` exchange, and retries once on 401 by clearing the cache and re-exchanging.

`authenticatedClient` selects the right client based on `restCfg.IsOAuthProxy()`.

## Why

PR #642 reworked the k6 path to OAuth via the plugin proxy and explicitly removed SA-token support. This PR restores SA tokens — required for CI / service-account / headless flows where OAuth login isn't viable. The cache fix from #766 carries forward: the exchange now uses `grafana.token` (a `glsa_*` SA token) instead of the rejected CAP token in `cloud.token`.

Closes #766 (superseded — the original branch's flat-client approach was incompatible with #642's plugin-proxy architecture).

## How it was tested

- [x] `mise run all` — lint + tests + build + docs all pass
- [ ] Smoke tests against a Grafana Cloud stack

---
**Generated by Claude Code**