### PR TITLE
fix: add ReadResponseBody helper to detect oversized responses

### DIFF
--- a/internal/datasources/client.go
+++ b/internal/datasources/client.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
 	"k8s.io/client-go/rest"
 )
 
@@ -69,7 +69,7 @@ func (c *Client) List(ctx context.Context) ([]*Datasource, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	body, err := httputils.ReadResponseBody(resp.Body, maxResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -108,7 +108,7 @@ func (c *Client) get(ctx context.Context, path, identifier string) (*Datasource,
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	body, err := httputils.ReadResponseBody(resp.Body, maxResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/internal/httputils/read.go
+++ b/internal/httputils/read.go
@@ -1,0 +1,26 @@
+package httputils
+
+import (
+	"fmt"
+	"io"
+)
+
+// DefaultResponseLimit is the standard response body size cap (50 MB).
+// Individual callers may pass a smaller limit for resource-listing endpoints.
+const DefaultResponseLimit int64 = 50 << 20
+
+// ReadResponseBody reads up to limit bytes from r. If the response exceeds the
+// limit, it returns an error instead of silently truncating.
+func ReadResponseBody(r io.Reader, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		if limit >= 1<<20 {
+			return nil, fmt.Errorf("response body exceeds %d MB limit; try narrowing your query or adding filters", limit>>20)
+		}
+		return nil, fmt.Errorf("response body exceeds %d bytes limit; try narrowing your query or adding filters", limit)
+	}
+	return data, nil
+}

--- a/internal/httputils/read_test.go
+++ b/internal/httputils/read_test.go
@@ -1,0 +1,87 @@
+package httputils_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/httputils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadResponseBody(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		limit     int64
+		wantData  string
+		wantErr   string
+		readerErr error
+	}{
+		{
+			name:     "within limit",
+			input:    "hello world",
+			limit:    100,
+			wantData: "hello world",
+		},
+		{
+			name:     "at exactly the limit",
+			input:    strings.Repeat("x", 50),
+			limit:    50,
+			wantData: strings.Repeat("x", 50),
+		},
+		{
+			name:    "exceeds limit by one byte",
+			input:   strings.Repeat("x", 51),
+			limit:   50,
+			wantErr: "response body exceeds 50 bytes limit",
+		},
+		{
+			name:    "exceeds limit at MB scale",
+			input:   strings.Repeat("x", (1<<20)+1),
+			limit:   1 << 20,
+			wantErr: "response body exceeds 1 MB limit",
+		},
+		{
+			name:      "propagates reader error",
+			limit:     100,
+			readerErr: io.ErrUnexpectedEOF,
+			wantErr:   "unexpected EOF",
+		},
+		{
+			name:     "empty body",
+			input:    "",
+			limit:    100,
+			wantData: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r io.Reader
+			if tt.readerErr != nil {
+				r = &errReader{err: tt.readerErr}
+			} else {
+				r = strings.NewReader(tt.input)
+			}
+
+			data, err := httputils.ReadResponseBody(r, tt.limit)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantData, string(data))
+		})
+	}
+}
+
+type errReader struct {
+	err error
+}
+
+func (r *errReader) Read([]byte) (int, error) {
+	return 0, r.err
+}

--- a/internal/query/cloudwatch/client.go
+++ b/internal/query/cloudwatch/client.go
@@ -5,20 +5,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/queryerror"
 	"k8s.io/client-go/rest"
 )
 
-const (
-	maxQueryResponseBytes    = 50 << 20 // 50 MB
-	maxResourceResponseBytes = 1 << 20  // 1 MB
-)
+const maxResourceResponseBytes = 1 << 20 // 1 MB
 
 // Client is an HTTP client for CloudWatch queries and resource listing via Grafana's proxy.
 type Client struct {
@@ -199,7 +196,7 @@ func (c *Client) getResource(ctx context.Context, dsUID, resource string, params
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResourceResponseBytes))
+	body, err := httputils.ReadResponseBody(resp.Body, maxResourceResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -224,7 +221,7 @@ func (c *Client) post(ctx context.Context, apiPath string, body []byte) ([]byte,
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxQueryResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, resp.StatusCode, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/internal/query/grafanaquery/client.go
+++ b/internal/query/grafanaquery/client.go
@@ -4,15 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/queryerror"
 	"k8s.io/client-go/rest"
 )
-
-const defaultMaxResponseBytes int64 = 50 << 20 // 50 MB
 
 // Client executes Grafana datasource query API requests.
 type Client struct {
@@ -42,7 +40,7 @@ func NewClientWithHTTPClient(cfg config.NamespacedRESTConfig, httpClient *http.C
 		host:             cfg.Host,
 		namespace:        cfg.Namespace,
 		httpClient:       httpClient,
-		maxResponseBytes: defaultMaxResponseBytes,
+		maxResponseBytes: httputils.DefaultResponseLimit,
 	}
 }
 
@@ -82,7 +80,7 @@ func (c *Client) post(ctx context.Context, path string, body []byte) (int, []byt
 	}
 	defer resp.Body.Close()
 
-	respBody, err := c.readLimited(resp.Body)
+	respBody, err := httputils.ReadResponseBody(resp.Body, c.maxResponseBytes)
 	if err != nil {
 		return resp.StatusCode, nil, err
 	}
@@ -92,15 +90,4 @@ func (c *Client) post(ctx context.Context, path string, body []byte) (int, []byt
 
 func (c *Client) k8sQueryPath() string {
 	return fmt.Sprintf("/apis/query.grafana.app/v0alpha1/namespaces/%s/query", c.namespace)
-}
-
-func (c *Client) readLimited(r io.Reader) ([]byte, error) {
-	data, err := io.ReadAll(io.LimitReader(r, c.maxResponseBytes+1))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-	if int64(len(data)) > c.maxResponseBytes {
-		return nil, fmt.Errorf("response body exceeds %d MB limit; use a narrower time range or add filters to reduce data volume", c.maxResponseBytes>>20)
-	}
-	return data, nil
 }

--- a/internal/query/loki/client.go
+++ b/internal/query/loki/client.go
@@ -5,17 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/queryerror"
 	"k8s.io/client-go/rest"
 )
-
-const maxResponseBytes = 50 << 20 // 50 MB
 
 type Client struct {
 	restConfig config.NamespacedRESTConfig
@@ -88,7 +86,7 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -107,7 +105,7 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 			return nil, fmt.Errorf("failed to execute query: %w", err)
 		}
 		defer resp.Body.Close()
-		respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+		respBody, err = httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
@@ -187,7 +185,7 @@ func (c *Client) MetricQuery(ctx context.Context, datasourceUID string, req Quer
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -206,7 +204,7 @@ func (c *Client) MetricQuery(ctx context.Context, datasourceUID string, req Quer
 			return nil, fmt.Errorf("failed to execute query: %w", err)
 		}
 		defer resp.Body.Close()
-		respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+		respBody, err = httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
@@ -248,7 +246,7 @@ func (c *Client) Labels(ctx context.Context, datasourceUID string) (*LabelsRespo
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -279,7 +277,7 @@ func (c *Client) LabelValues(ctx context.Context, datasourceUID, labelName strin
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -318,7 +316,7 @@ func (c *Client) Series(ctx context.Context, datasourceUID string, matchers []st
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/internal/query/prometheus/client.go
+++ b/internal/query/prometheus/client.go
@@ -5,17 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/queryerror"
 	"k8s.io/client-go/rest"
 )
-
-const maxResponseBytes = 50 << 20 // 50 MB
 
 // Client is a client for executing Prometheus queries via Grafana's datasource API.
 type Client struct {
@@ -97,7 +95,7 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -116,7 +114,7 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 			return nil, fmt.Errorf("failed to execute query: %w", err)
 		}
 		defer resp.Body.Close()
-		respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+		respBody, err = httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
@@ -162,7 +160,7 @@ func (c *Client) Labels(ctx context.Context, datasourceUID string) (*LabelsRespo
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -194,7 +192,7 @@ func (c *Client) LabelValues(ctx context.Context, datasourceUID, labelName strin
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -232,7 +230,7 @@ func (c *Client) Metadata(ctx context.Context, datasourceUID string, metric stri
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/internal/query/prometheus/series.go
+++ b/internal/query/prometheus/series.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/grafana/gcx/internal/httputils"
 )
 
 // SeriesResponse represents the response from a /api/v1/series query.
@@ -45,7 +46,7 @@ func (c *Client) Series(ctx context.Context, datasourceUID string, match []strin
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/internal/query/pyroscope/client.go
+++ b/internal/query/pyroscope/client.go
@@ -6,19 +6,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/queryerror"
 	"google.golang.org/protobuf/encoding/protowire"
 	"k8s.io/client-go/rest"
 )
-
-const maxResponseBytes = 50 << 20 // 50 MB
 
 // Client is a client for executing Pyroscope queries via Grafana's datasource API.
 type Client struct {
@@ -81,7 +79,7 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -127,7 +125,7 @@ func (c *Client) ProfileTypes(ctx context.Context, datasourceUID string, req Pro
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -176,7 +174,7 @@ func (c *Client) LabelNames(ctx context.Context, datasourceUID string, req Label
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -226,7 +224,7 @@ func (c *Client) LabelValues(ctx context.Context, datasourceUID string, req Labe
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -290,7 +288,7 @@ func (c *Client) SelectSeries(ctx context.Context, datasourceUID string, req Sel
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -353,7 +351,7 @@ func (c *Client) SelectHeatmap(ctx context.Context, datasourceUID string, req Se
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -412,13 +410,9 @@ func (c *Client) Pprof(ctx context.Context, datasourceUID string, req PprofReque
 	}
 	defer resp.Body.Close()
 
-	// Read one byte beyond the limit to detect truncation before gzipping.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	body, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-	if int64(len(body)) > maxResponseBytes {
-		return nil, fmt.Errorf("pprof response exceeds %d bytes", maxResponseBytes)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/query/tempo/client.go
+++ b/internal/query/tempo/client.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/queryerror"
 	"k8s.io/client-go/rest"
 )
@@ -64,7 +64,7 @@ func (c *Client) Search(ctx context.Context, datasourceUID string, req SearchReq
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -109,7 +109,7 @@ func (c *Client) GetTrace(ctx context.Context, datasourceUID string, req GetTrac
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -150,7 +150,7 @@ func (c *Client) Tags(ctx context.Context, datasourceUID string, req TagsRequest
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -193,7 +193,7 @@ func (c *Client) TagValues(ctx context.Context, datasourceUID string, req TagVal
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -240,7 +240,7 @@ func (c *Client) MetricsRange(ctx context.Context, datasourceUID string, req Met
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -283,7 +283,7 @@ func (c *Client) MetricsInstant(ctx context.Context, datasourceUID string, req M
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}


### PR DESCRIPTION
@javiermolinar as [promised](https://github.com/grafana/gcx/pull/733#discussion_r3270870432), here is the PR to handle "response too large" for all datasources.

## Summary

Add `httputils.ReadResponseBody` helper that detects oversized responses instead of silently truncating. Wired into all query clients and the datasources client.

- Replaces `io.ReadAll(io.LimitReader(...))` with overflow detection
- Consolidates duplicated `maxResponseBytes` constants into `httputils.DefaultResponseLimit`
- Adds 50 MB limit to Tempo (previously unbounded)
- Removes InfluxDB's local `readLimited` and Infinity/Pyroscope inline overflow checks

Same pattern as [mcp-grafana#884](https://github.com/grafana/mcp-grafana/pull/884).

## Test plan

- [x] `httputils.ReadResponseBody` unit tests (within limit, at limit, overflow, reader error, empty body)
- [x] All query client tests pass
- [x] Lint clean
- [x] Manual verification: overflow error renders correctly in CLI