### PR TITLE
feat(athena): add Athena datasource provider support

### DIFF
--- a/docs/reference/cli/gcx_datasources.md
+++ b/docs/reference/cli/gcx_datasources.md
@@ -26,6 +26,7 @@ List, inspect, and query Grafana datasources. Use top-level signal commands (met
 ### SEE ALSO
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx datasources athena](gcx_datasources_athena.md)	 - Query Amazon Athena datasources
 * [gcx datasources clickhouse](gcx_datasources_clickhouse.md)	 - Query ClickHouse datasources
 * [gcx datasources cloudwatch](gcx_datasources_cloudwatch.md)	 - Query AWS CloudWatch datasources
 * [gcx datasources get](gcx_datasources_get.md)	 - Get details of a specific datasource

--- a/docs/reference/cli/gcx_datasources_athena.md
+++ b/docs/reference/cli/gcx_datasources_athena.md
@@ -12,12 +12,12 @@ Query Amazon Athena datasources
 ### Options inherited from parent commands
 
 ```
-      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --context string     Name of the context to use (overrides current-context in config)
-      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
-      --no-color           Disable color output
-      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO

--- a/docs/reference/cli/gcx_datasources_athena.md
+++ b/docs/reference/cli/gcx_datasources_athena.md
@@ -1,0 +1,31 @@
+## gcx datasources athena
+
+Query Amazon Athena datasources
+
+### Options
+
+```
+      --config string   Path to the configuration file to use
+  -h, --help            help for athena
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources](gcx_datasources.md)	 - Manage and query Grafana datasources
+* [gcx datasources athena describe-table](gcx_datasources_athena_describe-table.md)	 - Show column schema for an Athena table
+* [gcx datasources athena list-catalogs](gcx_datasources_athena_list-catalogs.md)	 - List available Athena data catalogs
+* [gcx datasources athena list-databases](gcx_datasources_athena_list-databases.md)	 - List databases in an Athena data catalog
+* [gcx datasources athena list-tables](gcx_datasources_athena_list-tables.md)	 - List tables in an Athena database
+* [gcx datasources athena query](gcx_datasources_athena_query.md)	 - Execute a SQL query against an Athena datasource
+

--- a/docs/reference/cli/gcx_datasources_athena_describe-table.md
+++ b/docs/reference/cli/gcx_datasources_athena_describe-table.md
@@ -31,6 +31,7 @@ gcx datasources athena describe-table TABLE [flags]
       --database string     Database name
   -d, --datasource string   Datasource UID (required unless datasources.athena is configured)
   -h, --help                help for describe-table
+      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --region string       AWS region override
@@ -39,13 +40,13 @@ gcx datasources athena describe-table TABLE [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --config string      Path to the configuration file to use
-      --context string     Name of the context to use (overrides current-context in config)
-      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
-      --no-color           Disable color output
-      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO

--- a/docs/reference/cli/gcx_datasources_athena_describe-table.md
+++ b/docs/reference/cli/gcx_datasources_athena_describe-table.md
@@ -1,0 +1,54 @@
+## gcx datasources athena describe-table
+
+Show column schema for an Athena table
+
+### Synopsis
+
+Show column details including name and type for each column in the specified table.
+
+```
+gcx datasources athena describe-table TABLE [flags]
+```
+
+### Examples
+
+```
+
+  # Describe a table
+  gcx datasources athena describe-table my_table -d UID --database mydb
+
+  # With catalog and region
+  gcx datasources athena describe-table my_table -d UID --catalog AwsDataCatalog --database mydb --region us-east-1
+
+  # Output as JSON
+  gcx datasources athena describe-table my_table -d UID --database mydb -o json
+```
+
+### Options
+
+```
+      --catalog string      Data catalog
+      --database string     Database name
+  -d, --datasource string   Datasource UID (required unless datasources.athena is configured)
+  -h, --help                help for describe-table
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --region string       AWS region override
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources athena](gcx_datasources_athena.md)	 - Query Amazon Athena datasources
+

--- a/docs/reference/cli/gcx_datasources_athena_list-catalogs.md
+++ b/docs/reference/cli/gcx_datasources_athena_list-catalogs.md
@@ -22,6 +22,7 @@ gcx datasources athena list-catalogs [flags]
 ```
   -d, --datasource string   Datasource UID (required unless datasources.athena is configured)
   -h, --help                help for list-catalogs
+      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --region string       AWS region override
@@ -30,13 +31,13 @@ gcx datasources athena list-catalogs [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --config string      Path to the configuration file to use
-      --context string     Name of the context to use (overrides current-context in config)
-      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
-      --no-color           Disable color output
-      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO

--- a/docs/reference/cli/gcx_datasources_athena_list-catalogs.md
+++ b/docs/reference/cli/gcx_datasources_athena_list-catalogs.md
@@ -1,0 +1,45 @@
+## gcx datasources athena list-catalogs
+
+List available Athena data catalogs
+
+```
+gcx datasources athena list-catalogs [flags]
+```
+
+### Examples
+
+```
+
+  # List all catalogs
+  gcx datasources athena list-catalogs
+
+  # With explicit datasource and region
+  gcx datasources athena list-catalogs -d UID --region us-east-1
+```
+
+### Options
+
+```
+  -d, --datasource string   Datasource UID (required unless datasources.athena is configured)
+  -h, --help                help for list-catalogs
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --region string       AWS region override
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources athena](gcx_datasources_athena.md)	 - Query Amazon Athena datasources
+

--- a/docs/reference/cli/gcx_datasources_athena_list-databases.md
+++ b/docs/reference/cli/gcx_datasources_athena_list-databases.md
@@ -23,6 +23,7 @@ gcx datasources athena list-databases [flags]
       --catalog string      Data catalog to query
   -d, --datasource string   Datasource UID (required unless datasources.athena is configured)
   -h, --help                help for list-databases
+      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --region string       AWS region override
@@ -31,13 +32,13 @@ gcx datasources athena list-databases [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --config string      Path to the configuration file to use
-      --context string     Name of the context to use (overrides current-context in config)
-      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
-      --no-color           Disable color output
-      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO

--- a/docs/reference/cli/gcx_datasources_athena_list-databases.md
+++ b/docs/reference/cli/gcx_datasources_athena_list-databases.md
@@ -1,0 +1,46 @@
+## gcx datasources athena list-databases
+
+List databases in an Athena data catalog
+
+```
+gcx datasources athena list-databases [flags]
+```
+
+### Examples
+
+```
+
+  # List databases in the default catalog
+  gcx datasources athena list-databases -d UID --catalog AwsDataCatalog
+
+  # With region override
+  gcx datasources athena list-databases -d UID --catalog AwsDataCatalog --region us-east-1
+```
+
+### Options
+
+```
+      --catalog string      Data catalog to query
+  -d, --datasource string   Datasource UID (required unless datasources.athena is configured)
+  -h, --help                help for list-databases
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --region string       AWS region override
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources athena](gcx_datasources_athena.md)	 - Query Amazon Athena datasources
+

--- a/docs/reference/cli/gcx_datasources_athena_list-tables.md
+++ b/docs/reference/cli/gcx_datasources_athena_list-tables.md
@@ -1,0 +1,50 @@
+## gcx datasources athena list-tables
+
+List tables in an Athena database
+
+```
+gcx datasources athena list-tables [flags]
+```
+
+### Examples
+
+```
+
+  # List tables in a database
+  gcx datasources athena list-tables -d UID --database mydb
+
+  # With catalog and region
+  gcx datasources athena list-tables -d UID --catalog AwsDataCatalog --database mydb --region us-east-1
+
+  # Output as JSON
+  gcx datasources athena list-tables -d UID --database mydb -o json
+```
+
+### Options
+
+```
+      --catalog string      Data catalog to query
+      --database string     Database to query
+  -d, --datasource string   Datasource UID (required unless datasources.athena is configured)
+  -h, --help                help for list-tables
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --region string       AWS region override
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources athena](gcx_datasources_athena.md)	 - Query Amazon Athena datasources
+

--- a/docs/reference/cli/gcx_datasources_athena_list-tables.md
+++ b/docs/reference/cli/gcx_datasources_athena_list-tables.md
@@ -27,6 +27,7 @@ gcx datasources athena list-tables [flags]
       --database string     Database to query
   -d, --datasource string   Datasource UID (required unless datasources.athena is configured)
   -h, --help                help for list-tables
+      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --region string       AWS region override
@@ -35,13 +36,13 @@ gcx datasources athena list-tables [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --config string      Path to the configuration file to use
-      --context string     Name of the context to use (overrides current-context in config)
-      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
-      --no-color           Disable color output
-      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO

--- a/docs/reference/cli/gcx_datasources_athena_query.md
+++ b/docs/reference/cli/gcx_datasources_athena_query.md
@@ -1,0 +1,76 @@
+## gcx datasources athena query
+
+Execute a SQL query against an Athena datasource
+
+### Synopsis
+
+Execute a SQL query against an Amazon Athena datasource.
+
+EXPR is the SQL query to execute, passed as a positional argument or via --expr.
+Datasource is resolved from -d flag or datasources.athena in your context.
+Server-side macros ($__timeFilter, $__dateFilter, etc.) are supported.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.
+
+```
+gcx datasources athena query [EXPR] [flags]
+```
+
+### Examples
+
+```
+
+  # Simple query
+  gcx datasources athena query 'SELECT count(*) FROM events'
+
+  # With time macro and explicit datasource
+  gcx datasources athena query -d UID 'SELECT * FROM logs WHERE $__timeFilter(event_time)' --since 1h
+
+  # With connection overrides
+  gcx datasources athena query -d UID 'SELECT 1' --region us-west-2 --database analytics
+
+  # Enable result reuse (Athena engine v3)
+  gcx datasources athena query -d UID 'SELECT count(*) FROM events' --result-reuse --ttl-minutes 60
+
+  # Disable limit enforcement
+  gcx datasources athena query 'SELECT * FROM big_table' --limit 0
+```
+
+### Options
+
+```
+      --catalog string      Data catalog override
+      --database string     Database override
+  -d, --datasource string   Datasource UID (required unless datasources.athena is configured)
+      --expr string         Query expression (alternative to positional argument)
+      --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
+  -h, --help                help for query
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int           Max rows to return (0 disables enforcement) (default 100)
+      --open                Open the executed query in Grafana Explore
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --region string       AWS region override
+      --result-reuse        Enable Athena query result reuse (engine v3)
+      --share-link          Print the Grafana Explore URL for the executed query to stderr
+      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --step string         Query step (e.g., '15s', '1m')
+      --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
+      --ttl-minutes int     Cache TTL in minutes for result reuse; 0 disables (default 60)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources athena](gcx_datasources_athena.md)	 - Query Amazon Athena datasources
+

--- a/docs/reference/cli/gcx_datasources_athena_query.md
+++ b/docs/reference/cli/gcx_datasources_athena_query.md
@@ -45,6 +45,7 @@ gcx datasources athena query [EXPR] [flags]
       --expr string         Query expression (alternative to positional argument)
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for query
+      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Max rows to return (0 disables enforcement) (default 100)
       --open                Open the executed query in Grafana Explore
@@ -52,7 +53,7 @@ gcx datasources athena query [EXPR] [flags]
       --region string       AWS region override
       --result-reuse        Enable Athena query result reuse (engine v3)
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
       --ttl-minutes int     Cache TTL in minutes for result reuse; 0 disables (default 60)
@@ -61,13 +62,13 @@ gcx datasources athena query [EXPR] [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --config string      Path to the configuration file to use
-      --context string     Name of the context to use (overrides current-context in config)
-      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
-      --no-color           Disable color output
-      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -78,6 +78,13 @@ var commandAnnotations = map[string]annotation{
 	"gcx datasources clickhouse list-tables":    {Cost: "small"},
 	"gcx datasources clickhouse describe-table": {Cost: "small", Hint: "TABLE -d UID --database default -o json"},
 
+	// datasources athena
+	"gcx datasources athena query":          {Cost: "medium", Hint: "-d UID 'SELECT count(*) FROM events' -o json"},
+	"gcx datasources athena list-catalogs":  {Cost: "small", Hint: "-d UID -o json"},
+	"gcx datasources athena list-databases": {Cost: "small", Hint: "-d UID --catalog AwsDataCatalog -o json"},
+	"gcx datasources athena list-tables":    {Cost: "small", Hint: "-d UID --catalog AwsDataCatalog --database mydb -o json"},
+	"gcx datasources athena describe-table": {Cost: "small", Hint: "TABLE -d UID --catalog AwsDataCatalog --database mydb -o json"},
+
 	// datasources cloudwatch
 	"gcx datasources cloudwatch query":           {Cost: "large", Hint: "gcx datasources cloudwatch query -d UID --region us-east-1 --namespace AWS/EC2 --metric CPUUtilization --since 1h -o json"},
 	"gcx datasources cloudwatch list-namespaces": {Cost: "small", Hint: "gcx datasources cloudwatch list-namespaces -d UID --region us-east-1 -o json"},

--- a/internal/datasources/athena/describe_table.go
+++ b/internal/datasources/athena/describe_table.go
@@ -1,0 +1,124 @@
+package athena
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/athena"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type describeTableOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	Region     string
+	Catalog    string
+	Database   string
+}
+
+func (opts *describeTableOpts) setup(flags *pflag.FlagSet) {
+	dsquery.RegisterCodecs(&opts.IO, false)
+	opts.IO.BindFlags(flags)
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.athena is configured)")
+	flags.StringVar(&opts.Region, "region", "", "AWS region override")
+	flags.StringVar(&opts.Catalog, "catalog", "", "Data catalog")
+	flags.StringVar(&opts.Database, "database", "", "Database name")
+}
+
+func (opts *describeTableOpts) Validate() error {
+	return opts.IO.Validate()
+}
+
+// DescribeTableCmd returns the `describe-table` subcommand for an Athena datasource parent.
+func DescribeTableCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &describeTableOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "describe-table TABLE",
+		Short: "Show column schema for an Athena table",
+		Long:  `Show column details including name and type for each column in the specified table.`,
+		Example: `
+  # Describe a table
+  gcx datasources athena describe-table my_table -d UID --database mydb
+
+  # With catalog and region
+  gcx datasources athena describe-table my_table -d UID --catalog AwsDataCatalog --database mydb --region us-east-1
+
+  # Output as JSON
+  gcx datasources athena describe-table my_table -d UID --database mydb -o json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			table := args[0]
+			ctx := cmd.Context()
+
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
+			datasourceUID, _, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "athena")
+			if err != nil {
+				return err
+			}
+
+			client, err := athena.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			body := map[string]string{
+				"table": table,
+			}
+			if opts.Region != "" {
+				body["region"] = opts.Region
+			}
+			if opts.Catalog != "" {
+				body["catalog"] = opts.Catalog
+			}
+			if opts.Database != "" {
+				body["database"] = opts.Database
+			}
+
+			data, err := client.Resource(ctx, datasourceUID, "/columns", body)
+			if err != nil {
+				return err
+			}
+
+			var columns []string
+			if err := json.Unmarshal(data, &columns); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), athena.StringList{Items: columns, Header: "COLUMN"})
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+		agent.AnnotationLLMHint:   `gcx datasources athena describe-table TABLE -d UID --catalog AwsDataCatalog --database mydb -o json`,
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/datasources/athena/explore.go
+++ b/internal/datasources/athena/explore.go
@@ -1,0 +1,26 @@
+package athena
+
+import (
+	"strings"
+
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+)
+
+// QueryExploreURL builds a Grafana Explore URL for an Athena SQL query.
+func QueryExploreURL(host string, query dsquery.ExploreQuery) string {
+	if strings.TrimSpace(host) == "" || query.DatasourceUID == "" || strings.TrimSpace(query.Expr) == "" {
+		return ""
+	}
+
+	from, to := dsquery.ExploreRange(query.From, query.To, false)
+
+	q := map[string]any{
+		"refId":      "A",
+		"rawSQL":     query.Expr,
+		"editorMode": "code",
+		"format":     1,
+		"datasource": dsquery.ExploreDatasource(query.DatasourceType, query.DatasourceUID),
+	}
+
+	return dsquery.BuildExploreURL(host, query.OrgID, dsquery.SinglePane(query.DatasourceUID, []any{q}, from, to, nil), nil)
+}

--- a/internal/datasources/athena/explore_test.go
+++ b/internal/datasources/athena/explore_test.go
@@ -1,0 +1,60 @@
+package athena_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/grafana/gcx/internal/datasources/athena"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryExploreURL(t *testing.T) {
+	t.Run("builds explore link", func(t *testing.T) {
+		got := athena.QueryExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{
+			DatasourceUID:  "athena-uid",
+			DatasourceType: "grafana-athena-datasource",
+			Expr:           "SELECT count(*) FROM events",
+			OrgID:          1,
+		})
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Equal(t, "1", params.Get("schemaVersion"))
+		assert.Equal(t, "1", params.Get("orgId"))
+		assert.Contains(t, params.Get("panes"), `"datasource":"athena-uid"`)
+		assert.Contains(t, params.Get("panes"), `"rawSQL":"SELECT count(*) FROM events"`)
+		assert.Contains(t, params.Get("panes"), `"editorMode":"code"`)
+		assert.Contains(t, params.Get("panes"), `"from":"now-1h"`)
+		assert.Contains(t, params.Get("panes"), `"to":"now"`)
+	})
+
+	t.Run("includes explicit time range", func(t *testing.T) {
+		got := athena.QueryExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{
+			DatasourceUID:  "athena-uid",
+			DatasourceType: "grafana-athena-datasource",
+			Expr:           "SELECT 1",
+			From:           "2026-05-10T10:00:00Z",
+			To:             "2026-05-10T11:00:00Z",
+		})
+
+		require.NotEmpty(t, got)
+		params := mustParseURL(t, got).Query()
+		assert.Contains(t, params.Get("panes"), `"from":"2026-05-10T10:00:00Z"`)
+		assert.Contains(t, params.Get("panes"), `"to":"2026-05-10T11:00:00Z"`)
+	})
+
+	t.Run("returns empty for missing required fields", func(t *testing.T) {
+		assert.Empty(t, athena.QueryExploreURL("", dsquery.ExploreQuery{DatasourceUID: "athena-uid", Expr: "SELECT 1"}))
+		assert.Empty(t, athena.QueryExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{Expr: "SELECT 1"}))
+		assert.Empty(t, athena.QueryExploreURL("https://mystack.grafana.net", dsquery.ExploreQuery{DatasourceUID: "athena-uid"}))
+	})
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}

--- a/internal/datasources/athena/list_catalogs.go
+++ b/internal/datasources/athena/list_catalogs.go
@@ -1,0 +1,106 @@
+package athena
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/athena"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type listCatalogsOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	Region     string
+}
+
+func (opts *listCatalogsOpts) setup(flags *pflag.FlagSet) {
+	dsquery.RegisterCodecs(&opts.IO, false)
+	opts.IO.BindFlags(flags)
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.athena is configured)")
+	flags.StringVar(&opts.Region, "region", "", "AWS region override")
+}
+
+func (opts *listCatalogsOpts) Validate() error {
+	return opts.IO.Validate()
+}
+
+// ListCatalogsCmd returns the `list-catalogs` subcommand for an Athena datasource parent.
+func ListCatalogsCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listCatalogsOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "list-catalogs",
+		Short: "List available Athena data catalogs",
+		Example: `
+  # List all catalogs
+  gcx datasources athena list-catalogs
+
+  # With explicit datasource and region
+  gcx datasources athena list-catalogs -d UID --region us-east-1`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
+			datasourceUID, _, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "athena")
+			if err != nil {
+				return err
+			}
+
+			client, err := athena.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			body := map[string]string{}
+			if opts.Region != "" {
+				body["region"] = opts.Region
+			}
+
+			data, err := client.Resource(ctx, datasourceUID, "/catalogs", body)
+			if err != nil {
+				return err
+			}
+
+			var catalogs []string
+			if err := json.Unmarshal(data, &catalogs); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), athena.StringList{Items: catalogs, Header: "CATALOG"})
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+		agent.AnnotationLLMHint:   `gcx datasources athena list-catalogs -d UID -o json`,
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/datasources/athena/list_databases.go
+++ b/internal/datasources/athena/list_databases.go
@@ -1,0 +1,111 @@
+package athena
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/athena"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type listDatabasesOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	Region     string
+	Catalog    string
+}
+
+func (opts *listDatabasesOpts) setup(flags *pflag.FlagSet) {
+	dsquery.RegisterCodecs(&opts.IO, false)
+	opts.IO.BindFlags(flags)
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.athena is configured)")
+	flags.StringVar(&opts.Region, "region", "", "AWS region override")
+	flags.StringVar(&opts.Catalog, "catalog", "", "Data catalog to query")
+}
+
+func (opts *listDatabasesOpts) Validate() error {
+	return opts.IO.Validate()
+}
+
+// ListDatabasesCmd returns the `list-databases` subcommand for an Athena datasource parent.
+func ListDatabasesCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listDatabasesOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "list-databases",
+		Short: "List databases in an Athena data catalog",
+		Example: `
+  # List databases in the default catalog
+  gcx datasources athena list-databases -d UID --catalog AwsDataCatalog
+
+  # With region override
+  gcx datasources athena list-databases -d UID --catalog AwsDataCatalog --region us-east-1`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
+			datasourceUID, _, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "athena")
+			if err != nil {
+				return err
+			}
+
+			client, err := athena.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			body := map[string]string{}
+			if opts.Region != "" {
+				body["region"] = opts.Region
+			}
+			if opts.Catalog != "" {
+				body["catalog"] = opts.Catalog
+			}
+
+			data, err := client.Resource(ctx, datasourceUID, "/databases", body)
+			if err != nil {
+				return err
+			}
+
+			var databases []string
+			if err := json.Unmarshal(data, &databases); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), athena.StringList{Items: databases, Header: "DATABASE"})
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+		agent.AnnotationLLMHint:   `gcx datasources athena list-databases -d UID --catalog AwsDataCatalog -o json`,
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/datasources/athena/list_tables.go
+++ b/internal/datasources/athena/list_tables.go
@@ -1,0 +1,119 @@
+package athena
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/athena"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type listTablesOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	Region     string
+	Catalog    string
+	Database   string
+}
+
+func (opts *listTablesOpts) setup(flags *pflag.FlagSet) {
+	dsquery.RegisterCodecs(&opts.IO, false)
+	opts.IO.BindFlags(flags)
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.athena is configured)")
+	flags.StringVar(&opts.Region, "region", "", "AWS region override")
+	flags.StringVar(&opts.Catalog, "catalog", "", "Data catalog to query")
+	flags.StringVar(&opts.Database, "database", "", "Database to query")
+}
+
+func (opts *listTablesOpts) Validate() error {
+	return opts.IO.Validate()
+}
+
+// ListTablesCmd returns the `list-tables` subcommand for an Athena datasource parent.
+func ListTablesCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listTablesOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "list-tables",
+		Short: "List tables in an Athena database",
+		Example: `
+  # List tables in a database
+  gcx datasources athena list-tables -d UID --database mydb
+
+  # With catalog and region
+  gcx datasources athena list-tables -d UID --catalog AwsDataCatalog --database mydb --region us-east-1
+
+  # Output as JSON
+  gcx datasources athena list-tables -d UID --database mydb -o json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
+			datasourceUID, _, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "athena")
+			if err != nil {
+				return err
+			}
+
+			client, err := athena.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			body := map[string]string{}
+			if opts.Region != "" {
+				body["region"] = opts.Region
+			}
+			if opts.Catalog != "" {
+				body["catalog"] = opts.Catalog
+			}
+			if opts.Database != "" {
+				body["database"] = opts.Database
+			}
+
+			data, err := client.Resource(ctx, datasourceUID, "/tables", body)
+			if err != nil {
+				return err
+			}
+
+			var tables []string
+			if err := json.Unmarshal(data, &tables); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), athena.StringList{Items: tables, Header: "TABLE"})
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+		agent.AnnotationLLMHint:   `gcx datasources athena list-tables -d UID --catalog AwsDataCatalog --database mydb -o json`,
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/datasources/athena/query.go
+++ b/internal/datasources/athena/query.go
@@ -1,0 +1,152 @@
+package athena
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/athena"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultLimit = 100
+	maxLimit     = 1000
+)
+
+// QueryCmd returns the `query` subcommand for an Athena datasource parent.
+func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
+	shared := &dsquery.SharedOpts{}
+	share := &dsquery.ExploreLinkOpts{}
+	var datasource string
+	var limit int
+	var region, catalog, database string
+	var resultReuse bool
+	var ttlMinutes int
+
+	cmd := &cobra.Command{
+		Use:   "query [EXPR]",
+		Short: "Execute a SQL query against an Athena datasource",
+		Long: `Execute a SQL query against an Amazon Athena datasource.
+
+EXPR is the SQL query to execute, passed as a positional argument or via --expr.
+Datasource is resolved from -d flag or datasources.athena in your context.
+Server-side macros ($__timeFilter, $__dateFilter, etc.) are supported.
+Use --share-link to print the equivalent Grafana Explore URL, or --open to
+open it in your browser after the query succeeds.`,
+		Example: `
+  # Simple query
+  gcx datasources athena query 'SELECT count(*) FROM events'
+
+  # With time macro and explicit datasource
+  gcx datasources athena query -d UID 'SELECT * FROM logs WHERE $__timeFilter(event_time)' --since 1h
+
+  # With connection overrides
+  gcx datasources athena query -d UID 'SELECT 1' --region us-west-2 --database analytics
+
+  # Enable result reuse (Athena engine v3)
+  gcx datasources athena query -d UID 'SELECT count(*) FROM events' --result-reuse --ttl-minutes 60
+
+  # Disable limit enforcement
+  gcx datasources athena query 'SELECT * FROM big_table' --limit 0`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := shared.Validate(); err != nil {
+				return err
+			}
+
+			expr, err := shared.ResolveExpr(args, 0)
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			var cfgCtx *internalconfig.Context
+			fullCfg, err := loader.LoadFullConfig(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+			} else {
+				cfgCtx = fullCfg.GetCurrentContext()
+			}
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
+			datasourceUID, dsType, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, datasource, cfgCtx, cfg, "athena")
+			if err != nil {
+				return err
+			}
+
+			sql := athena.EnforceLimit(expr, limit, maxLimit)
+
+			now := time.Now()
+			start, end, _, err := shared.ParseTimes(now)
+			if err != nil {
+				return err
+			}
+
+			client, err := athena.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			resp, err := client.Query(ctx, datasourceUID, athena.QueryRequest{
+				RawSQL:                     sql,
+				Start:                      start,
+				End:                        end,
+				Region:                     region,
+				Catalog:                    catalog,
+				Database:                   database,
+				ResultReuseEnabled:         resultReuse,
+				ResultReuseMaxAgeInMinutes: ttlMinutes,
+			})
+			if err != nil {
+				return fmt.Errorf("query failed: %w", err)
+			}
+
+			exploreURL := QueryExploreURL(cfg.GrafanaURL, dsquery.ExploreQuery{
+				DatasourceUID:  datasourceUID,
+				DatasourceType: dsType,
+				Expr:           sql,
+				From:           shared.From,
+				To:             shared.To,
+				OrgID:          dsquery.OrgID(cfgCtx),
+			})
+			unavailableMsg, failedOpenMsg := dsquery.ExploreMessages("query")
+
+			return dsquery.EncodeAndHandleExplore(cmd, func() error {
+				return shared.IO.Encode(cmd.OutOrStdout(), resp)
+			}, *share, dsquery.ExploreLink{
+				URL:            exploreURL,
+				UnavailableMsg: unavailableMsg,
+				FailedOpenMsg:  failedOpenMsg,
+			})
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "medium",
+		agent.AnnotationLLMHint:   `gcx datasources athena query -d UID 'SELECT count(*) FROM events' -o json`,
+	}
+
+	shared.Setup(cmd.Flags(), false)
+	cmd.Flags().StringVarP(&datasource, "datasource", "d", "", "Datasource UID (required unless datasources.athena is configured)")
+	cmd.Flags().IntVar(&limit, "limit", defaultLimit, "Max rows to return (0 disables enforcement)")
+	cmd.Flags().StringVar(&region, "region", "", "AWS region override")
+	cmd.Flags().StringVar(&catalog, "catalog", "", "Data catalog override")
+	cmd.Flags().StringVar(&database, "database", "", "Database override")
+	cmd.Flags().BoolVar(&resultReuse, "result-reuse", false, "Enable Athena query result reuse (engine v3)")
+	cmd.Flags().IntVar(&ttlMinutes, "ttl-minutes", 60, "Cache TTL in minutes for result reuse; 0 disables")
+	share.Setup(cmd.Flags(), "executed query")
+
+	return cmd
+}

--- a/internal/datasources/providers/athena.go
+++ b/internal/datasources/providers/athena.go
@@ -1,0 +1,30 @@
+package providers
+
+import (
+	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/datasources/athena"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+)
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	datasources.RegisterProvider(&athenaDSProvider{})
+}
+
+type athenaDSProvider struct{}
+
+func (p *athenaDSProvider) Kind() string      { return "athena" }
+func (p *athenaDSProvider) ShortDesc() string { return "Query Amazon Athena datasources" }
+
+func (p *athenaDSProvider) QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
+	return athena.QueryCmd(loader)
+}
+
+func (p *athenaDSProvider) ExtraCommands(loader *providers.ConfigLoader) []*cobra.Command {
+	return []*cobra.Command{
+		athena.ListCatalogsCmd(loader),
+		athena.ListDatabasesCmd(loader),
+		athena.ListTablesCmd(loader),
+		athena.DescribeTableCmd(loader),
+	}
+}

--- a/internal/datasources/query/codecs.go
+++ b/internal/datasources/query/codecs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/gcx/internal/query/loki"
 	"github.com/grafana/gcx/internal/query/prometheus"
 	"github.com/grafana/gcx/internal/query/pyroscope"
+	querysql "github.com/grafana/gcx/internal/query/sql"
 	"github.com/grafana/gcx/internal/query/tempo"
 )
 
@@ -44,14 +45,12 @@ func (c *queryTableCodec) Encode(w io.Writer, data any) error {
 		return influxdb.FormatQueryTable(w, resp)
 	case *tempo.GetTraceResponse:
 		return tempo.FormatTraceTable(w, resp)
-	case *clickhouse.QueryResponse:
-		return clickhouse.FormatTable(w, resp)
+	case *querysql.QueryResponse:
+		return querysql.FormatTable(w, resp)
 	case []clickhouse.TableInfo:
 		return clickhouse.FormatListTablesTable(w, resp)
 	case []clickhouse.ColumnInfo:
 		return clickhouse.FormatDescribeTableTable(w, resp)
-	case *athena.QueryResponse:
-		return athena.FormatTable(w, resp)
 	case athena.StringList:
 		return athena.FormatStringList(w, resp.Items, resp.Header)
 	case *cloudwatch.QueryResponse:
@@ -83,10 +82,8 @@ func (c *queryWideCodec) Encode(w io.Writer, data any) error {
 		return infinity.FormatTable(w, resp)
 	case *tempo.GetTraceResponse:
 		return tempo.FormatTraceWide(w, resp)
-	case *clickhouse.QueryResponse:
-		return clickhouse.FormatWideTable(w, resp)
-	case *athena.QueryResponse:
-		return athena.FormatWideTable(w, resp)
+	case *querysql.QueryResponse:
+		return querysql.FormatWideTable(w, resp)
 	case athena.StringList:
 		return athena.FormatStringList(w, resp.Items, resp.Header)
 	case *cloudwatch.QueryResponse:
@@ -147,14 +144,12 @@ func (c *queryGraphCodec) Encode(w io.Writer, data any) error {
 		if err != nil {
 			return err
 		}
-	case *clickhouse.QueryResponse:
-		return errors.New("graph output is not supported for ClickHouse queries; use -o table/json/yaml")
+	case *querysql.QueryResponse:
+		return errors.New("graph output is not supported for SQL datasource queries; use -o table/json/yaml")
 	case []clickhouse.TableInfo:
 		return errors.New("graph output is not supported for ClickHouse list-tables; use -o table/json/yaml")
 	case []clickhouse.ColumnInfo:
 		return errors.New("graph output is not supported for ClickHouse describe-table; use -o table/json/yaml")
-	case *athena.QueryResponse:
-		return errors.New("graph output is not supported for Athena queries; use -o table/json/yaml")
 	case athena.StringList:
 		return errors.New("graph output is not supported for Athena discovery; use -o table/json/yaml")
 	default:

--- a/internal/datasources/query/codecs.go
+++ b/internal/datasources/query/codecs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/gcx/internal/format"
 	"github.com/grafana/gcx/internal/graph"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/query/athena"
 	"github.com/grafana/gcx/internal/query/clickhouse"
 	"github.com/grafana/gcx/internal/query/cloudwatch"
 	"github.com/grafana/gcx/internal/query/infinity"
@@ -49,6 +50,10 @@ func (c *queryTableCodec) Encode(w io.Writer, data any) error {
 		return clickhouse.FormatListTablesTable(w, resp)
 	case []clickhouse.ColumnInfo:
 		return clickhouse.FormatDescribeTableTable(w, resp)
+	case *athena.QueryResponse:
+		return athena.FormatTable(w, resp)
+	case athena.StringList:
+		return athena.FormatStringList(w, resp.Items, resp.Header)
 	case *cloudwatch.QueryResponse:
 		return cloudwatch.FormatTable(w, resp)
 	default:
@@ -80,6 +85,10 @@ func (c *queryWideCodec) Encode(w io.Writer, data any) error {
 		return tempo.FormatTraceWide(w, resp)
 	case *clickhouse.QueryResponse:
 		return clickhouse.FormatWideTable(w, resp)
+	case *athena.QueryResponse:
+		return athena.FormatWideTable(w, resp)
+	case athena.StringList:
+		return athena.FormatStringList(w, resp.Items, resp.Header)
 	case *cloudwatch.QueryResponse:
 		return cloudwatch.FormatWide(w, resp)
 	default:
@@ -144,6 +153,10 @@ func (c *queryGraphCodec) Encode(w io.Writer, data any) error {
 		return errors.New("graph output is not supported for ClickHouse list-tables; use -o table/json/yaml")
 	case []clickhouse.ColumnInfo:
 		return errors.New("graph output is not supported for ClickHouse describe-table; use -o table/json/yaml")
+	case *athena.QueryResponse:
+		return errors.New("graph output is not supported for Athena queries; use -o table/json/yaml")
+	case athena.StringList:
+		return errors.New("graph output is not supported for Athena discovery; use -o table/json/yaml")
 	default:
 		return errors.New("invalid data type for graph codec")
 	}

--- a/internal/datasources/query/resolve.go
+++ b/internal/datasources/query/resolve.go
@@ -158,6 +158,8 @@ func NormalizeKind(pluginID string) string {
 		return "pyroscope"
 	case "grafana-clickhouse-datasource":
 		return "clickhouse"
+	case "grafana-athena-datasource":
+		return "athena"
 	case "yesoreyeram-infinity-datasource":
 		return "infinity"
 	case "synthetic-monitoring-datasource":

--- a/internal/query/athena/client.go
+++ b/internal/query/athena/client.go
@@ -1,0 +1,215 @@
+package athena
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/queryerror"
+	"k8s.io/client-go/rest"
+)
+
+const maxResponseBytes = 50 << 20 // 50 MB
+
+// Client executes queries and resource requests against an Athena datasource via Grafana.
+type Client struct {
+	restConfig config.NamespacedRESTConfig
+	httpClient *http.Client
+}
+
+// NewClient creates a new Athena query client.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	httpClient, err := rest.HTTPClientFor(&cfg.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+	return &Client{
+		restConfig: cfg,
+		httpClient: httpClient,
+	}, nil
+}
+
+// Resource makes a POST request to the Athena plugin's resource API for schema discovery.
+func (c *Client) Resource(ctx context.Context, datasourceUID string, path string, body map[string]string) ([]byte, error) {
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal resource request: %w", err)
+	}
+
+	resourceURL := fmt.Sprintf("%s/api/datasources/uid/%s/resources%s", c.restConfig.Host, url.PathEscape(datasourceUID), path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resourceURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, queryerror.FromBody("athena", "resource"+path, resp.StatusCode, respBody)
+	}
+
+	return respBody, nil
+}
+
+// Query executes a SQL query against the specified Athena datasource.
+func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryRequest) (*QueryResponse, error) {
+	from := strconv.FormatInt(req.Start.UnixMilli(), 10)
+	to := strconv.FormatInt(req.End.UnixMilli(), 10)
+	if req.Start.IsZero() || req.End.IsZero() {
+		now := time.Now()
+		from = strconv.FormatInt(now.Add(-1*time.Hour).UnixMilli(), 10)
+		to = strconv.FormatInt(now.UnixMilli(), 10)
+	}
+
+	connectionArgs := map[string]any{}
+	if req.Region != "" {
+		connectionArgs["region"] = req.Region
+	}
+	if req.Catalog != "" {
+		connectionArgs["catalog"] = req.Catalog
+	}
+	if req.Database != "" {
+		connectionArgs["database"] = req.Database
+	}
+	if req.ResultReuseEnabled {
+		connectionArgs["resultReuseEnabled"] = true
+		if req.ResultReuseMaxAgeInMinutes > 0 {
+			connectionArgs["resultReuseMaxAgeInMinutes"] = req.ResultReuseMaxAgeInMinutes
+		}
+	}
+
+	queryMap := map[string]any{
+		"refId":      "A",
+		"datasource": map[string]any{"type": DatasourceType, "uid": datasourceUID},
+		"rawSql":     req.RawSQL,
+		"format":     QueryFormatTable,
+	}
+	if len(connectionArgs) > 0 {
+		queryMap["connectionArgs"] = connectionArgs
+	}
+
+	bodyMap := map[string]any{
+		"queries": []any{queryMap},
+		"from":    from,
+		"to":      to,
+	}
+
+	body, err := json.Marshal(bodyMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	apiPath := c.buildQueryPath()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Fall back to legacy /api/ds/query if K8s query API doesn't exist.
+	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
+		apiPath = "/api/ds/query"
+		httpReq, err = http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		resp, err = c.httpClient.Do(httpReq)
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute query: %w", err)
+		}
+		defer resp.Body.Close()
+		respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, queryerror.FromBody("athena", "query", resp.StatusCode, respBody)
+	}
+
+	return parseResponse(respBody)
+}
+
+func parseResponse(respBody []byte) (*QueryResponse, error) {
+	var raw GrafanaQueryResponse
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	result, ok := raw.Results["A"]
+	if !ok {
+		return &QueryResponse{}, nil
+	}
+	if result.Error != "" {
+		status := result.Status
+		if status == 0 {
+			status = http.StatusBadRequest
+		}
+		return nil, queryerror.New("athena", "query", status, result.Error, result.ErrorSource)
+	}
+
+	resp := &QueryResponse{}
+
+	// Athena uses grafana/sqlds which returns exactly one frame per query result set.
+	// See: github.com/grafana/sqlds/blob/5b4920612a218a63954c7f9f34947c63d2bff19b/query.go#L252
+	// Ref: github.com/grafana/athena-datasource/blob/e0876565e2a37d28b3ecc2c1d213fb1c5fa66f3b/pkg/athena/datasource.go#L21
+	if len(result.Frames) == 0 {
+		return resp, nil
+	}
+	frame := result.Frames[0]
+
+	for _, f := range frame.Schema.Fields {
+		resp.Columns = append(resp.Columns, Column(f))
+	}
+
+	if len(frame.Data.Values) == 0 || len(frame.Data.Values[0]) == 0 {
+		return resp, nil
+	}
+	numRows := len(frame.Data.Values[0])
+	for rowIdx := range numRows {
+		row := make([]any, len(frame.Data.Values))
+		for colIdx := range frame.Data.Values {
+			if rowIdx < len(frame.Data.Values[colIdx]) {
+				row[colIdx] = frame.Data.Values[colIdx][rowIdx]
+			}
+		}
+		resp.Rows = append(resp.Rows, row)
+	}
+	return resp, nil
+}
+
+func (c *Client) buildQueryPath() string {
+	return fmt.Sprintf("/apis/query.grafana.app/v0alpha1/namespaces/%s/query",
+		c.restConfig.Namespace)
+}

--- a/internal/query/athena/client.go
+++ b/internal/query/athena/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/query/grafanaquery"
+	querysql "github.com/grafana/gcx/internal/query/sql"
 	"github.com/grafana/gcx/internal/queryerror"
 	"k8s.io/client-go/rest"
 )
@@ -70,7 +71,7 @@ func (c *Client) Resource(ctx context.Context, datasourceUID string, path string
 }
 
 // Query executes a SQL query against the specified Athena datasource.
-func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryRequest) (*QueryResponse, error) {
+func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryRequest) (*querysql.QueryResponse, error) {
 	from := strconv.FormatInt(req.Start.UnixMilli(), 10)
 	to := strconv.FormatInt(req.End.UnixMilli(), 10)
 	if req.Start.IsZero() || req.End.IsZero() {
@@ -122,53 +123,5 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		return nil, err
 	}
 
-	return parseResponse(respBody)
-}
-
-func parseResponse(respBody []byte) (*QueryResponse, error) {
-	var raw GrafanaQueryResponse
-	if err := json.Unmarshal(respBody, &raw); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	result, ok := raw.Results["A"]
-	if !ok {
-		return &QueryResponse{}, nil
-	}
-	if result.Error != "" {
-		status := result.Status
-		if status == 0 {
-			status = http.StatusBadRequest
-		}
-		return nil, queryerror.New("athena", "query", status, result.Error, result.ErrorSource)
-	}
-
-	resp := &QueryResponse{}
-
-	// Athena uses grafana/sqlds which returns exactly one frame per query result set.
-	// See: github.com/grafana/sqlds/blob/5b4920612a218a63954c7f9f34947c63d2bff19b/query.go#L252
-	// Ref: github.com/grafana/athena-datasource/blob/e0876565e2a37d28b3ecc2c1d213fb1c5fa66f3b/pkg/athena/datasource.go#L21
-	if len(result.Frames) == 0 {
-		return resp, nil
-	}
-	frame := result.Frames[0]
-
-	for _, f := range frame.Schema.Fields {
-		resp.Columns = append(resp.Columns, Column{Name: f.Name, Type: f.Type})
-	}
-
-	if len(frame.Data.Values) == 0 || len(frame.Data.Values[0]) == 0 {
-		return resp, nil
-	}
-	numRows := len(frame.Data.Values[0])
-	for rowIdx := range numRows {
-		row := make([]any, len(frame.Data.Values))
-		for colIdx := range frame.Data.Values {
-			if rowIdx < len(frame.Data.Values[colIdx]) {
-				row[colIdx] = frame.Data.Values[colIdx][rowIdx]
-			}
-		}
-		resp.Rows = append(resp.Rows, row)
-	}
-	return resp, nil
+	return querysql.ParseResponse(respBody, "athena")
 }

--- a/internal/query/athena/client.go
+++ b/internal/query/athena/client.go
@@ -5,23 +5,23 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
+	"github.com/grafana/gcx/internal/query/grafanaquery"
 	"github.com/grafana/gcx/internal/queryerror"
 	"k8s.io/client-go/rest"
 )
 
-const maxResponseBytes = 50 << 20 // 50 MB
-
 // Client executes queries and resource requests against an Athena datasource via Grafana.
 type Client struct {
-	restConfig config.NamespacedRESTConfig
-	httpClient *http.Client
+	host        string
+	httpClient  *http.Client
+	queryClient *grafanaquery.Client
 }
 
 // NewClient creates a new Athena query client.
@@ -31,8 +31,9 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 	return &Client{
-		restConfig: cfg,
-		httpClient: httpClient,
+		host:        cfg.Host,
+		httpClient:  httpClient,
+		queryClient: grafanaquery.NewClientWithHTTPClient(cfg, httpClient),
 	}, nil
 }
 
@@ -43,7 +44,7 @@ func (c *Client) Resource(ctx context.Context, datasourceUID string, path string
 		return nil, fmt.Errorf("failed to marshal resource request: %w", err)
 	}
 
-	resourceURL := fmt.Sprintf("%s/api/datasources/uid/%s/resources%s", c.restConfig.Host, url.PathEscape(datasourceUID), path)
+	resourceURL := fmt.Sprintf("%s/api/datasources/uid/%s/resources%s", c.host, url.PathEscape(datasourceUID), path)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resourceURL, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -56,7 +57,7 @@ func (c *Client) Resource(ctx context.Context, datasourceUID string, path string
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -116,46 +117,9 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	apiPath := c.buildQueryPath()
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
+	respBody, err := c.queryClient.Execute(ctx, body, "athena", "query")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute query: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	// Fall back to legacy /api/ds/query if K8s query API doesn't exist.
-	if resp.StatusCode == http.StatusNotFound {
-		resp.Body.Close()
-		apiPath = "/api/ds/query"
-		httpReq, err = http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create request: %w", err)
-		}
-		httpReq.Header.Set("Content-Type", "application/json")
-		resp, err = c.httpClient.Do(httpReq)
-		if err != nil {
-			return nil, fmt.Errorf("failed to execute query: %w", err)
-		}
-		defer resp.Body.Close()
-		respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
-		if err != nil {
-			return nil, fmt.Errorf("failed to read response: %w", err)
-		}
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, queryerror.FromBody("athena", "query", resp.StatusCode, respBody)
+		return nil, err
 	}
 
 	return parseResponse(respBody)
@@ -190,7 +154,7 @@ func parseResponse(respBody []byte) (*QueryResponse, error) {
 	frame := result.Frames[0]
 
 	for _, f := range frame.Schema.Fields {
-		resp.Columns = append(resp.Columns, Column(f))
+		resp.Columns = append(resp.Columns, Column{Name: f.Name, Type: f.Type})
 	}
 
 	if len(frame.Data.Values) == 0 || len(frame.Data.Values[0]) == 0 {
@@ -207,9 +171,4 @@ func parseResponse(respBody []byte) (*QueryResponse, error) {
 		resp.Rows = append(resp.Rows, row)
 	}
 	return resp, nil
-}
-
-func (c *Client) buildQueryPath() string {
-	return fmt.Sprintf("/apis/query.grafana.app/v0alpha1/namespaces/%s/query",
-		c.restConfig.Namespace)
 }

--- a/internal/query/athena/client_test.go
+++ b/internal/query/athena/client_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/query/athena"
+	querysql "github.com/grafana/gcx/internal/query/sql"
 	"github.com/grafana/gcx/internal/queryerror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ func TestQuery(t *testing.T) {
 	tests := []struct {
 		name       string
 		handler    http.HandlerFunc
-		assertResp func(t *testing.T, resp *athena.QueryResponse)
+		assertResp func(t *testing.T, resp *querysql.QueryResponse)
 	}{
 		{
 			name: "parses columnar response",
@@ -38,7 +39,7 @@ func TestQuery(t *testing.T) {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"id","type":"number"},{"name":"name","type":"string"}]},"data":{"values":[[1,2],["alice","bob"]]}}]}}}`))
 			}),
-			assertResp: func(t *testing.T, resp *athena.QueryResponse) {
+			assertResp: func(t *testing.T, resp *querysql.QueryResponse) {
 				t.Helper()
 				assert.Len(t, resp.Columns, 2)
 				assert.Equal(t, "id", resp.Columns[0].Name)
@@ -54,7 +55,7 @@ func TestQuery(t *testing.T) {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"x","type":"string"}]},"data":{"values":[[]]}}]}}}`))
 			}),
-			assertResp: func(t *testing.T, resp *athena.QueryResponse) {
+			assertResp: func(t *testing.T, resp *querysql.QueryResponse) {
 				t.Helper()
 				assert.Len(t, resp.Columns, 1)
 				assert.Empty(t, resp.Rows)
@@ -66,7 +67,7 @@ func TestQuery(t *testing.T) {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"name","type":"string"},{"name":"count","type":"number"}]},"data":{"values":[["t1","t2"],[100,null]]}}]}}}`))
 			}),
-			assertResp: func(t *testing.T, resp *athena.QueryResponse) {
+			assertResp: func(t *testing.T, resp *querysql.QueryResponse) {
 				t.Helper()
 				assert.Len(t, resp.Rows, 2)
 				assert.Nil(t, resp.Rows[1][1])

--- a/internal/query/athena/client_test.go
+++ b/internal/query/athena/client_test.go
@@ -1,0 +1,190 @@
+package athena_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/query/athena"
+	"github.com/grafana/gcx/internal/queryerror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newTestClient(t *testing.T, srvURL string) *athena.Client {
+	t.Helper()
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: srvURL},
+		Namespace: "default",
+	}
+	c, err := athena.NewClient(cfg)
+	require.NoError(t, err)
+	return c
+}
+
+func TestQuery(t *testing.T) {
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		assertResp func(t *testing.T, resp *athena.QueryResponse)
+	}{
+		{
+			name: "parses columnar response",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"id","type":"number"},{"name":"name","type":"string"}]},"data":{"values":[[1,2],["alice","bob"]]}}]}}}`))
+			}),
+			assertResp: func(t *testing.T, resp *athena.QueryResponse) {
+				t.Helper()
+				assert.Len(t, resp.Columns, 2)
+				assert.Equal(t, "id", resp.Columns[0].Name)
+				assert.Equal(t, "name", resp.Columns[1].Name)
+				assert.Len(t, resp.Rows, 2)
+				assert.Equal(t, "alice", resp.Rows[0][1])
+				assert.Equal(t, "bob", resp.Rows[1][1])
+			},
+		},
+		{
+			name: "empty result",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"x","type":"string"}]},"data":{"values":[[]]}}]}}}`))
+			}),
+			assertResp: func(t *testing.T, resp *athena.QueryResponse) {
+				t.Helper()
+				assert.Len(t, resp.Columns, 1)
+				assert.Empty(t, resp.Rows)
+			},
+		},
+		{
+			name: "nullable values",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"name","type":"string"},{"name":"count","type":"number"}]},"data":{"values":[["t1","t2"],[100,null]]}}]}}}`))
+			}),
+			assertResp: func(t *testing.T, resp *athena.QueryResponse) {
+				t.Helper()
+				assert.Len(t, resp.Rows, 2)
+				assert.Nil(t, resp.Rows[1][1])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server.URL)
+			resp, err := client.Query(context.Background(), "test-uid", athena.QueryRequest{
+				RawSQL: "SELECT 1",
+				Start:  time.Now().Add(-1 * time.Hour),
+				End:    time.Now(),
+			})
+			require.NoError(t, err)
+			tt.assertResp(t, resp)
+		})
+	}
+}
+
+func TestQuery_RequestConstruction(t *testing.T) {
+	var capturedPath string
+	var capturedMethod string
+	var capturedContentType string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedMethod = r.Method
+		capturedContentType = r.Header.Get("Content-Type")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"v","type":"number"}]},"data":{"values":[[1]]}}]}}}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	_, err := client.Query(context.Background(), "test-uid", athena.QueryRequest{
+		RawSQL: "SELECT 1",
+		Start:  time.Now().Add(-1 * time.Hour),
+		End:    time.Now(),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, capturedMethod)
+	assert.Equal(t, "/apis/query.grafana.app/v0alpha1/namespaces/default/query", capturedPath)
+	assert.Equal(t, "application/json", capturedContentType)
+}
+
+func TestQuery_ReturnsTypedAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":{"A":{"error":"SYNTAX_ERROR: line 1:8: mismatched input","errorSource":"downstream","status":400}}}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	_, err := client.Query(context.Background(), "test-uid", athena.QueryRequest{
+		RawSQL: "SELECT ???",
+		Start:  time.Now().Add(-1 * time.Hour),
+		End:    time.Now(),
+	})
+	require.Error(t, err)
+
+	var apiErr *queryerror.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, "athena", apiErr.Datasource)
+	assert.Equal(t, "query", apiErr.Operation)
+	assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+	assert.Contains(t, apiErr.Message, "SYNTAX_ERROR")
+	assert.Equal(t, "downstream", apiErr.ErrorSource)
+}
+
+func TestQuery_FallsBackOn404(t *testing.T) {
+	callCount := 0
+	var capturedPaths []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		capturedPaths = append(capturedPaths, r.URL.Path)
+		if callCount == 1 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"n","type":"number"}]},"data":{"values":[[42]]}}]}}}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	resp, err := client.Query(context.Background(), "test-uid", athena.QueryRequest{
+		RawSQL: "SELECT 42",
+		Start:  time.Now().Add(-1 * time.Hour),
+		End:    time.Now(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount, "expected 2 HTTP calls (K8s + fallback)")
+	assert.Equal(t, "/apis/query.grafana.app/v0alpha1/namespaces/default/query", capturedPaths[0])
+	assert.Equal(t, "/api/ds/query", capturedPaths[1])
+	require.Len(t, resp.Rows, 1)
+	assert.InDelta(t, float64(42), resp.Rows[0][0], 0.001)
+}
+
+func TestResource(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/datasources/uid/test-uid/resources/catalogs", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`["AwsDataCatalog","IcebergCatalog"]`))
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	data, err := c.Resource(context.Background(), "test-uid", "/catalogs", map[string]string{})
+	require.NoError(t, err)
+	assert.Equal(t, `["AwsDataCatalog","IcebergCatalog"]`, string(data))
+}

--- a/internal/query/athena/export_test.go
+++ b/internal/query/athena/export_test.go
@@ -1,6 +1,0 @@
-package athena
-
-// ParseResponse exposes parseResponse for testing.
-func ParseResponse(body []byte) (*QueryResponse, error) {
-	return parseResponse(body)
-}

--- a/internal/query/athena/export_test.go
+++ b/internal/query/athena/export_test.go
@@ -1,0 +1,6 @@
+package athena
+
+// ParseResponse exposes parseResponse for testing.
+func ParseResponse(body []byte) (*QueryResponse, error) {
+	return parseResponse(body)
+}

--- a/internal/query/athena/formatter.go
+++ b/internal/query/athena/formatter.go
@@ -3,49 +3,9 @@ package athena
 import (
 	"fmt"
 	"io"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/grafana/gcx/internal/style"
 )
-
-// FormatTable formats a QueryResponse as a human-readable table.
-func FormatTable(w io.Writer, resp *QueryResponse) error {
-	if len(resp.Rows) == 0 {
-		fmt.Fprintln(w, "No data")
-		return nil
-	}
-
-	timeColumns := make(map[int]bool, len(resp.Columns))
-	headers := make([]string, len(resp.Columns))
-	for i, col := range resp.Columns {
-		headers[i] = strings.ToUpper(col.Name)
-		if col.Type == "time" {
-			timeColumns[i] = true
-		}
-	}
-
-	t := style.NewTable(headers...)
-	for _, row := range resp.Rows {
-		vals := make([]string, len(row))
-		for i, v := range row {
-			if timeColumns[i] {
-				vals[i] = formatTimestamp(v)
-			} else {
-				vals[i] = formatValue(v)
-			}
-		}
-		t.Row(vals...)
-	}
-	return t.Render(w)
-}
-
-// FormatWideTable formats a QueryResponse as a wide table.
-// Athena results are inherently flat, so this delegates to FormatTable.
-func FormatWideTable(w io.Writer, resp *QueryResponse) error {
-	return FormatTable(w, resp)
-}
 
 // FormatStringList formats a []string as a single-column table with the given header.
 func FormatStringList(w io.Writer, items []string, header string) error {
@@ -58,36 +18,4 @@ func FormatStringList(w io.Writer, items []string, header string) error {
 		t.Row(item)
 	}
 	return t.Render(w)
-}
-
-func formatTimestamp(v any) string {
-	switch ts := v.(type) {
-	case float64:
-		return time.UnixMilli(int64(ts)).UTC().Format(time.RFC3339)
-	case string:
-		ms, err := strconv.ParseInt(ts, 10, 64)
-		if err != nil {
-			return ts
-		}
-		return time.UnixMilli(ms).UTC().Format(time.RFC3339)
-	default:
-		return fmt.Sprintf("%v", v)
-	}
-}
-
-func formatValue(v any) string {
-	if v == nil {
-		return "-"
-	}
-	switch val := v.(type) {
-	case float64:
-		if val == float64(int64(val)) {
-			return strconv.FormatInt(int64(val), 10)
-		}
-		return fmt.Sprintf("%g", val)
-	case string:
-		return val
-	default:
-		return fmt.Sprintf("%v", val)
-	}
 }

--- a/internal/query/athena/formatter.go
+++ b/internal/query/athena/formatter.go
@@ -1,0 +1,93 @@
+package athena
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/gcx/internal/style"
+)
+
+// FormatTable formats a QueryResponse as a human-readable table.
+func FormatTable(w io.Writer, resp *QueryResponse) error {
+	if len(resp.Rows) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+
+	timeColumns := make(map[int]bool, len(resp.Columns))
+	headers := make([]string, len(resp.Columns))
+	for i, col := range resp.Columns {
+		headers[i] = strings.ToUpper(col.Name)
+		if col.Type == "time" {
+			timeColumns[i] = true
+		}
+	}
+
+	t := style.NewTable(headers...)
+	for _, row := range resp.Rows {
+		vals := make([]string, len(row))
+		for i, v := range row {
+			if timeColumns[i] {
+				vals[i] = formatTimestamp(v)
+			} else {
+				vals[i] = formatValue(v)
+			}
+		}
+		t.Row(vals...)
+	}
+	return t.Render(w)
+}
+
+// FormatWideTable formats a QueryResponse as a wide table.
+// Athena results are inherently flat, so this delegates to FormatTable.
+func FormatWideTable(w io.Writer, resp *QueryResponse) error {
+	return FormatTable(w, resp)
+}
+
+// FormatStringList formats a []string as a single-column table with the given header.
+func FormatStringList(w io.Writer, items []string, header string) error {
+	if len(items) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+	t := style.NewTable(header)
+	for _, item := range items {
+		t.Row(item)
+	}
+	return t.Render(w)
+}
+
+func formatTimestamp(v any) string {
+	switch ts := v.(type) {
+	case float64:
+		return time.UnixMilli(int64(ts)).UTC().Format(time.RFC3339)
+	case string:
+		ms, err := strconv.ParseInt(ts, 10, 64)
+		if err != nil {
+			return ts
+		}
+		return time.UnixMilli(ms).UTC().Format(time.RFC3339)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func formatValue(v any) string {
+	if v == nil {
+		return "-"
+	}
+	switch val := v.(type) {
+	case float64:
+		if val == float64(int64(val)) {
+			return strconv.FormatInt(int64(val), 10)
+		}
+		return fmt.Sprintf("%g", val)
+	case string:
+		return val
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}

--- a/internal/query/athena/formatter_test.go
+++ b/internal/query/athena/formatter_test.go
@@ -9,44 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFormatTable(t *testing.T) {
-	t.Run("renders columns and rows", func(t *testing.T) {
-		resp := &athena.QueryResponse{
-			Columns: []athena.Column{{Name: "id", Type: "number"}, {Name: "name", Type: "string"}},
-			Rows:    [][]any{{float64(1), "alice"}, {float64(2), "bob"}},
-		}
-		var buf bytes.Buffer
-		err := athena.FormatTable(&buf, resp)
-		require.NoError(t, err)
-		out := buf.String()
-		assert.Contains(t, out, "ID")
-		assert.Contains(t, out, "NAME")
-		assert.Contains(t, out, "alice")
-		assert.Contains(t, out, "bob")
-	})
-
-	t.Run("formats time columns as RFC3339", func(t *testing.T) {
-		resp := &athena.QueryResponse{
-			Columns: []athena.Column{{Name: "timestamp", Type: "time"}, {Name: "service", Type: "string"}},
-			Rows:    [][]any{{float64(1778601661000), "frontend"}, {float64(1778601721000), "backend"}},
-		}
-		var buf bytes.Buffer
-		err := athena.FormatTable(&buf, resp)
-		require.NoError(t, err)
-		out := buf.String()
-		assert.Contains(t, out, "2026-05-12T")
-		assert.NotContains(t, out, "1778601661000")
-	})
-
-	t.Run("empty result", func(t *testing.T) {
-		resp := &athena.QueryResponse{}
-		var buf bytes.Buffer
-		err := athena.FormatTable(&buf, resp)
-		require.NoError(t, err)
-		assert.Contains(t, buf.String(), "No data")
-	})
-}
-
 func TestFormatStringList(t *testing.T) {
 	t.Run("renders items", func(t *testing.T) {
 		var buf bytes.Buffer

--- a/internal/query/athena/formatter_test.go
+++ b/internal/query/athena/formatter_test.go
@@ -1,0 +1,67 @@
+package athena_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/athena"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatTable(t *testing.T) {
+	t.Run("renders columns and rows", func(t *testing.T) {
+		resp := &athena.QueryResponse{
+			Columns: []athena.Column{{Name: "id", Type: "number"}, {Name: "name", Type: "string"}},
+			Rows:    [][]any{{float64(1), "alice"}, {float64(2), "bob"}},
+		}
+		var buf bytes.Buffer
+		err := athena.FormatTable(&buf, resp)
+		require.NoError(t, err)
+		out := buf.String()
+		assert.Contains(t, out, "ID")
+		assert.Contains(t, out, "NAME")
+		assert.Contains(t, out, "alice")
+		assert.Contains(t, out, "bob")
+	})
+
+	t.Run("formats time columns as RFC3339", func(t *testing.T) {
+		resp := &athena.QueryResponse{
+			Columns: []athena.Column{{Name: "timestamp", Type: "time"}, {Name: "service", Type: "string"}},
+			Rows:    [][]any{{float64(1778601661000), "frontend"}, {float64(1778601721000), "backend"}},
+		}
+		var buf bytes.Buffer
+		err := athena.FormatTable(&buf, resp)
+		require.NoError(t, err)
+		out := buf.String()
+		assert.Contains(t, out, "2026-05-12T")
+		assert.NotContains(t, out, "1778601661000")
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		resp := &athena.QueryResponse{}
+		var buf bytes.Buffer
+		err := athena.FormatTable(&buf, resp)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "No data")
+	})
+}
+
+func TestFormatStringList(t *testing.T) {
+	t.Run("renders items", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := athena.FormatStringList(&buf, []string{"alpha", "beta", "gamma"}, "CATALOG")
+		require.NoError(t, err)
+		out := buf.String()
+		assert.Contains(t, out, "CATALOG")
+		assert.Contains(t, out, "alpha")
+		assert.Contains(t, out, "gamma")
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := athena.FormatStringList(&buf, []string{}, "EMPTY")
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "No data")
+	})
+}

--- a/internal/query/athena/types.go
+++ b/internal/query/athena/types.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/grafana/gcx/internal/query/dataframe"
 )
 
 const (
@@ -39,35 +41,23 @@ type StringList struct {
 	Header string   `json:"-"`
 }
 
-// GrafanaQueryResponse is the top-level wire format from Grafana's query API.
-type GrafanaQueryResponse struct {
-	Results map[string]GrafanaResult `json:"results"`
-}
+// GrafanaQueryResponse is the top-level Grafana datasource query response.
+type GrafanaQueryResponse = dataframe.Response
 
-type GrafanaResult struct {
-	Frames      []DataFrame `json:"frames"`
-	Error       string      `json:"error,omitempty"`
-	ErrorSource string      `json:"errorSource,omitempty"`
-	Status      int         `json:"status,omitempty"`
-}
+// GrafanaResult represents a single Grafana datasource query result.
+type GrafanaResult = dataframe.Result
 
-type DataFrame struct {
-	Schema DataFrameSchema `json:"schema"`
-	Data   DataFrameData   `json:"data"`
-}
+// DataFrame represents a Grafana data frame.
+type DataFrame = dataframe.Frame
 
-type DataFrameSchema struct {
-	Fields []DataFrameField `json:"fields"`
-}
+// DataFrameSchema describes the structure of a Grafana data frame.
+type DataFrameSchema = dataframe.Schema
 
-type DataFrameField struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
-}
+// DataFrameField describes a field in a Grafana data frame.
+type DataFrameField = dataframe.Field
 
-type DataFrameData struct {
-	Values [][]any `json:"values"`
-}
+// DataFrameData contains column-oriented Grafana data frame values.
+type DataFrameData = dataframe.Data
 
 var (
 	limitClauseRe = regexp.MustCompile(`(?i)\bLIMIT\s+(\d+)\s*$`)

--- a/internal/query/athena/types.go
+++ b/internal/query/athena/types.go
@@ -1,0 +1,111 @@
+package athena
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	DatasourceType   = "grafana-athena-datasource"
+	QueryFormatTable = 1
+)
+
+type QueryRequest struct {
+	RawSQL                     string
+	Start                      time.Time
+	End                        time.Time
+	Region                     string
+	Catalog                    string
+	Database                   string
+	ResultReuseEnabled         bool
+	ResultReuseMaxAgeInMinutes int
+}
+
+type QueryResponse struct {
+	Columns []Column `json:"columns"`
+	Rows    [][]any  `json:"rows"`
+}
+
+type Column struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// StringList wraps a []string discovery result with a header for table formatting.
+type StringList struct {
+	Items  []string `json:"items"`
+	Header string   `json:"-"`
+}
+
+// GrafanaQueryResponse is the top-level wire format from Grafana's query API.
+type GrafanaQueryResponse struct {
+	Results map[string]GrafanaResult `json:"results"`
+}
+
+type GrafanaResult struct {
+	Frames      []DataFrame `json:"frames"`
+	Error       string      `json:"error,omitempty"`
+	ErrorSource string      `json:"errorSource,omitempty"`
+	Status      int         `json:"status,omitempty"`
+}
+
+type DataFrame struct {
+	Schema DataFrameSchema `json:"schema"`
+	Data   DataFrameData   `json:"data"`
+}
+
+type DataFrameSchema struct {
+	Fields []DataFrameField `json:"fields"`
+}
+
+type DataFrameField struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type DataFrameData struct {
+	Values [][]any `json:"values"`
+}
+
+var (
+	limitClauseRe = regexp.MustCompile(`(?i)\bLIMIT\s+(\d+)\s*$`)
+	limitBailRe   = regexp.MustCompile(`(?i)(\bLIMIT\s+(\d+|ALL)\s+OFFSET\b)`)
+)
+
+// EnforceLimit ensures the SQL has a LIMIT clause within bounds.
+// If limit is 0, enforcement is disabled (pass-through).
+// Athena SQL's dialect is simpler than ClickHouse — it lacks LIMIT BY,
+// FORMAT, SETTINGS, etc. Only SHOW, DESCRIBE, and OFFSET need to be skipped.
+func EnforceLimit(sql string, limit, maxLimit int) string {
+	if limit == 0 {
+		return sql
+	}
+
+	trimmed := strings.TrimSpace(sql)
+	upper := strings.ToUpper(trimmed)
+	if strings.HasPrefix(upper, "SHOW") || strings.HasPrefix(upper, "DESCRIBE") || strings.HasPrefix(upper, "EXPLAIN") {
+		return sql
+	}
+
+	suffix := sql[len(strings.TrimRight(sql, "; \t\n")):]
+	trimmedNoSuffix := strings.TrimRight(sql, "; \t\n")
+
+	if limitBailRe.MatchString(trimmedNoSuffix) {
+		return sql
+	}
+
+	if m := limitClauseRe.FindStringSubmatchIndex(trimmedNoSuffix); m != nil {
+		existing, _ := strconv.Atoi(trimmedNoSuffix[m[2]:m[3]])
+		if existing > maxLimit {
+			return trimmedNoSuffix[:m[2]] + strconv.Itoa(maxLimit) + trimmedNoSuffix[m[3]:] + suffix
+		}
+		return sql
+	}
+
+	if limit > maxLimit {
+		limit = maxLimit
+	}
+	return trimmedNoSuffix + " LIMIT " + strconv.Itoa(limit) + suffix
+}

--- a/internal/query/athena/types.go
+++ b/internal/query/athena/types.go
@@ -2,11 +2,10 @@ package athena
 
 import (
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/grafana/gcx/internal/query/dataframe"
+	querysql "github.com/grafana/gcx/internal/query/sql"
 )
 
 const (
@@ -25,77 +24,26 @@ type QueryRequest struct {
 	ResultReuseMaxAgeInMinutes int
 }
 
-type QueryResponse struct {
-	Columns []Column `json:"columns"`
-	Rows    [][]any  `json:"rows"`
-}
-
-type Column struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
-}
-
 // StringList wraps a []string discovery result with a header for table formatting.
 type StringList struct {
 	Items  []string `json:"items"`
 	Header string   `json:"-"`
 }
 
-// GrafanaQueryResponse is the top-level Grafana datasource query response.
-type GrafanaQueryResponse = dataframe.Response
-
-// GrafanaResult represents a single Grafana datasource query result.
-type GrafanaResult = dataframe.Result
-
-// DataFrame represents a Grafana data frame.
-type DataFrame = dataframe.Frame
-
-// DataFrameSchema describes the structure of a Grafana data frame.
-type DataFrameSchema = dataframe.Schema
-
-// DataFrameField describes a field in a Grafana data frame.
-type DataFrameField = dataframe.Field
-
-// DataFrameData contains column-oriented Grafana data frame values.
-type DataFrameData = dataframe.Data
-
-var (
-	limitClauseRe = regexp.MustCompile(`(?i)\bLIMIT\s+(\d+)\s*$`)
-	limitBailRe   = regexp.MustCompile(`(?i)(\bLIMIT\s+(\d+|ALL)\s+OFFSET\b)`)
-)
+var limitBailRe = regexp.MustCompile(`(?i)(\bLIMIT\s+(\d+|ALL)\s+OFFSET\b)`)
 
 // EnforceLimit ensures the SQL has a LIMIT clause within bounds.
 // If limit is 0, enforcement is disabled (pass-through).
 // Athena SQL's dialect is simpler than ClickHouse — it lacks LIMIT BY,
-// FORMAT, SETTINGS, etc. Only SHOW, DESCRIBE, and OFFSET need to be skipped.
+// FORMAT, SETTINGS, etc. Only SHOW, DESCRIBE, EXPLAIN, and OFFSET are skipped.
 func EnforceLimit(sql string, limit, maxLimit int) string {
-	if limit == 0 {
-		return sql
-	}
+	return querysql.EnforceLimit(sql, limit, maxLimit, athenaBail)
+}
 
-	trimmed := strings.TrimSpace(sql)
-	upper := strings.ToUpper(trimmed)
+func athenaBail(sql string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(sql))
 	if strings.HasPrefix(upper, "SHOW") || strings.HasPrefix(upper, "DESCRIBE") || strings.HasPrefix(upper, "EXPLAIN") {
-		return sql
+		return true
 	}
-
-	suffix := sql[len(strings.TrimRight(sql, "; \t\n")):]
-	trimmedNoSuffix := strings.TrimRight(sql, "; \t\n")
-
-	if limitBailRe.MatchString(trimmedNoSuffix) {
-		return sql
-	}
-
-	if m := limitClauseRe.FindStringSubmatchIndex(trimmedNoSuffix); m != nil {
-		existing, _ := strconv.Atoi(trimmedNoSuffix[m[2]:m[3]])
-		if existing > maxLimit {
-			return trimmedNoSuffix[:m[2]] + strconv.Itoa(maxLimit) + trimmedNoSuffix[m[3]:] + suffix
-		}
-		return sql
-	}
-
-	if limit > maxLimit {
-		limit = maxLimit
-	}
-	return trimmedNoSuffix + " LIMIT " + strconv.Itoa(limit) + suffix
+	return limitBailRe.MatchString(strings.TrimRight(sql, "; \t\n"))
 }

--- a/internal/query/athena/types_test.go
+++ b/internal/query/athena/types_test.go
@@ -1,0 +1,39 @@
+package athena_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/athena"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnforceLimit(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		limit    int
+		maxLimit int
+		want     string
+	}{
+		{name: "appends default limit", sql: "SELECT * FROM events", limit: 100, maxLimit: 1000, want: "SELECT * FROM events LIMIT 100"},
+		{name: "caps existing limit", sql: "SELECT * FROM events LIMIT 5000", limit: 100, maxLimit: 1000, want: "SELECT * FROM events LIMIT 1000"},
+		{name: "preserves small limit", sql: "SELECT * FROM events LIMIT 50", limit: 100, maxLimit: 1000, want: "SELECT * FROM events LIMIT 50"},
+		{name: "skips SHOW", sql: "SHOW DATABASES", limit: 100, maxLimit: 1000, want: "SHOW DATABASES"},
+		{name: "skips DESCRIBE", sql: "DESCRIBE my_table", limit: 100, maxLimit: 1000, want: "DESCRIBE my_table"},
+		{name: "skips show lowercase", sql: "show tables", limit: 100, maxLimit: 1000, want: "show tables"},
+		{name: "bails on LIMIT OFFSET", sql: "SELECT * FROM events LIMIT 100 OFFSET 10", limit: 100, maxLimit: 1000, want: "SELECT * FROM events LIMIT 100 OFFSET 10"},
+		{name: "bails on LIMIT ALL OFFSET", sql: "SELECT * FROM events LIMIT ALL OFFSET 5", limit: 100, maxLimit: 1000, want: "SELECT * FROM events LIMIT ALL OFFSET 5"},
+		{name: "case insensitive limit detection", sql: "SELECT * FROM events limit 50", limit: 100, maxLimit: 1000, want: "SELECT * FROM events limit 50"},
+		{name: "bails on EXPLAIN", sql: "EXPLAIN SELECT * FROM events", limit: 100, maxLimit: 1000, want: "EXPLAIN SELECT * FROM events"},
+		{name: "bails on EXPLAIN ANALYZE", sql: "EXPLAIN ANALYZE SELECT * FROM events", limit: 100, maxLimit: 1000, want: "EXPLAIN ANALYZE SELECT * FROM events"},
+		{name: "bails on lowercase explain", sql: "explain select * from events", limit: 100, maxLimit: 1000, want: "explain select * from events"},
+		{name: "disabled when zero", sql: "SELECT * FROM events", limit: 0, maxLimit: 1000, want: "SELECT * FROM events"},
+		{name: "strips trailing semicolon", sql: "SELECT * FROM events;", limit: 100, maxLimit: 1000, want: "SELECT * FROM events LIMIT 100;"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := athena.EnforceLimit(tt.sql, tt.limit, tt.maxLimit)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/query/clickhouse/client.go
+++ b/internal/query/clickhouse/client.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/query/grafanaquery"
-	"github.com/grafana/gcx/internal/queryerror"
+	querysql "github.com/grafana/gcx/internal/query/sql"
 )
 
 // Client is a client for executing ClickHouse queries via Grafana's datasource API.
@@ -29,7 +28,7 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 }
 
 // Query executes a ClickHouse query against the specified datasource.
-func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryRequest) (*QueryResponse, error) {
+func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryRequest) (*querysql.QueryResponse, error) {
 	intervalMs := req.IntervalMs
 	if intervalMs == 0 {
 		intervalMs = 60000
@@ -67,54 +66,5 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		return nil, err
 	}
 
-	return parseResponse(respBody)
-}
-
-func parseResponse(respBody []byte) (*QueryResponse, error) {
-	var raw GrafanaQueryResponse
-	if err := json.Unmarshal(respBody, &raw); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	result, ok := raw.Results["A"]
-	if !ok {
-		return &QueryResponse{}, nil
-	}
-	if result.Error != "" {
-		status := result.Status
-		if status == 0 {
-			status = http.StatusBadRequest
-		}
-		return nil, queryerror.New("clickhouse", "query", status, result.Error, result.ErrorSource)
-	}
-
-	resp := &QueryResponse{}
-
-	// ClickHouse with FormatOptionTable (format=1) produces exactly one frame per
-	// result set. Only the first frame is used.
-	// See: github.com/grafana/clickhouse-datasource/blob/c56e3af64308ffc4cf304c8f4dd9ce545d6b2063/pkg/plugin/driver.go#L448-L453
-	// Ref: github.com/grafana/mcp-grafana/blob/9517bc0fc86b4d4f8a5978f28498bf376dc51d65/tools/clickhouse.go#L326-L349
-	if len(result.Frames) == 0 {
-		return resp, nil
-	}
-	frame := result.Frames[0]
-
-	for _, f := range frame.Schema.Fields {
-		resp.Columns = append(resp.Columns, Column{Name: f.Name, Type: f.Type})
-	}
-
-	if len(frame.Data.Values) == 0 || len(frame.Data.Values[0]) == 0 {
-		return resp, nil
-	}
-	numRows := len(frame.Data.Values[0])
-	for rowIdx := range numRows {
-		row := make([]any, len(frame.Data.Values))
-		for colIdx := range frame.Data.Values {
-			if rowIdx < len(frame.Data.Values[colIdx]) {
-				row[colIdx] = frame.Data.Values[colIdx][rowIdx]
-			}
-		}
-		resp.Rows = append(resp.Rows, row)
-	}
-	return resp, nil
+	return querysql.ParseResponse(respBody, "clickhouse")
 }

--- a/internal/query/clickhouse/client_test.go
+++ b/internal/query/clickhouse/client_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/query/clickhouse"
+	querysql "github.com/grafana/gcx/internal/query/sql"
 	"github.com/grafana/gcx/internal/queryerror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,7 @@ func TestQuery(t *testing.T) {
 	tests := []struct {
 		name       string
 		handler    http.HandlerFunc
-		assertResp func(t *testing.T, resp *clickhouse.QueryResponse)
+		assertResp func(t *testing.T, resp *querysql.QueryResponse)
 	}{
 		{
 			name: "parses columnar response",
@@ -38,7 +39,7 @@ func TestQuery(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"col1","type":"string"},{"name":"col2","type":"number"}]},"data":{"values":[["a","b"],[1,2]]}}],"status":200}}}`))
 			}),
-			assertResp: func(t *testing.T, resp *clickhouse.QueryResponse) {
+			assertResp: func(t *testing.T, resp *querysql.QueryResponse) {
 				t.Helper()
 				assert.Len(t, resp.Columns, 2)
 				assert.Equal(t, "col1", resp.Columns[0].Name)
@@ -55,7 +56,7 @@ func TestQuery(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"x","type":"string"}]},"data":{"values":[[]]}}],"status":200}}}`))
 			}),
-			assertResp: func(t *testing.T, resp *clickhouse.QueryResponse) {
+			assertResp: func(t *testing.T, resp *querysql.QueryResponse) {
 				t.Helper()
 				assert.Len(t, resp.Columns, 1)
 				assert.Empty(t, resp.Rows)
@@ -68,7 +69,7 @@ func TestQuery(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"name","type":"string"},{"name":"total_rows","type":"number"}]},"data":{"values":[["t1","t2"],[100,null]]}}],"status":200}}}`))
 			}),
-			assertResp: func(t *testing.T, resp *clickhouse.QueryResponse) {
+			assertResp: func(t *testing.T, resp *querysql.QueryResponse) {
 				t.Helper()
 				assert.Len(t, resp.Rows, 2)
 				assert.Nil(t, resp.Rows[1][1])

--- a/internal/query/clickhouse/export_test.go
+++ b/internal/query/clickhouse/export_test.go
@@ -1,8 +1,0 @@
-package clickhouse
-
-// Test helpers — expose internal functions for external test package.
-
-// ParseResponse exposes parseResponse for testing.
-func ParseResponse(body []byte) (*QueryResponse, error) {
-	return parseResponse(body)
-}

--- a/internal/query/clickhouse/formatter.go
+++ b/internal/query/clickhouse/formatter.go
@@ -4,48 +4,9 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
-	"time"
 
 	"github.com/grafana/gcx/internal/style"
 )
-
-// FormatTable formats a QueryResponse as a human-readable table.
-func FormatTable(w io.Writer, resp *QueryResponse) error {
-	if len(resp.Rows) == 0 {
-		fmt.Fprintln(w, "No data")
-		return nil
-	}
-
-	timeColumns := make(map[int]bool, len(resp.Columns))
-	headers := make([]string, len(resp.Columns))
-	for i, col := range resp.Columns {
-		headers[i] = strings.ToUpper(col.Name)
-		if col.Type == "time" {
-			timeColumns[i] = true
-		}
-	}
-
-	t := style.NewTable(headers...)
-	for _, row := range resp.Rows {
-		vals := make([]string, len(row))
-		for i, v := range row {
-			if timeColumns[i] {
-				vals[i] = formatTimestamp(v)
-			} else {
-				vals[i] = formatValue(v)
-			}
-		}
-		t.Row(vals...)
-	}
-	return t.Render(w)
-}
-
-// FormatWideTable formats a QueryResponse as a wide table. ClickHouse results
-// are inherently flat, so this delegates to FormatTable.
-func FormatWideTable(w io.Writer, resp *QueryResponse) error {
-	return FormatTable(w, resp)
-}
 
 // FormatListTablesTable formats a slice of TableInfo as a human-readable table.
 func FormatListTablesTable(w io.Writer, tables []TableInfo) error {
@@ -71,38 +32,6 @@ func FormatDescribeTableTable(w io.Writer, cols []ColumnInfo) error {
 		t.Row(c.Name, c.Type, c.DefaultType, c.DefaultExpression, c.Comment)
 	}
 	return t.Render(w)
-}
-
-func formatTimestamp(v any) string {
-	switch ts := v.(type) {
-	case float64:
-		return time.UnixMilli(int64(ts)).UTC().Format(time.RFC3339)
-	case string:
-		ms, err := strconv.ParseInt(ts, 10, 64)
-		if err != nil {
-			return ts
-		}
-		return time.UnixMilli(ms).UTC().Format(time.RFC3339)
-	default:
-		return fmt.Sprintf("%v", v)
-	}
-}
-
-func formatValue(v any) string {
-	if v == nil {
-		return "-"
-	}
-	switch val := v.(type) {
-	case float64:
-		if val == float64(int64(val)) {
-			return strconv.FormatInt(int64(val), 10)
-		}
-		return fmt.Sprintf("%g", val)
-	case string:
-		return val
-	default:
-		return fmt.Sprintf("%v", val)
-	}
 }
 
 func formatNullableUint64(v *uint64) string {

--- a/internal/query/clickhouse/formatter_test.go
+++ b/internal/query/clickhouse/formatter_test.go
@@ -9,47 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFormatTable(t *testing.T) {
-	t.Run("renders columns and rows", func(t *testing.T) {
-		resp := &clickhouse.QueryResponse{
-			Columns: []clickhouse.Column{{Name: "id", Type: "number"}, {Name: "name", Type: "string"}},
-			Rows:    [][]any{{float64(1), "alice"}, {float64(2), "bob"}},
-		}
-		var buf bytes.Buffer
-		err := clickhouse.FormatTable(&buf, resp)
-		require.NoError(t, err)
-		out := buf.String()
-		assert.Contains(t, out, "ID")
-		assert.Contains(t, out, "NAME")
-		assert.Contains(t, out, "alice")
-		assert.Contains(t, out, "bob")
-	})
-
-	t.Run("formats time columns as RFC3339", func(t *testing.T) {
-		resp := &clickhouse.QueryResponse{
-			Columns: []clickhouse.Column{{Name: "timestamp", Type: "time"}, {Name: "service", Type: "string"}},
-			Rows:    [][]any{{float64(1778601661000), "frontend"}, {float64(1778601721000), "backend"}},
-		}
-		var buf bytes.Buffer
-		err := clickhouse.FormatTable(&buf, resp)
-		require.NoError(t, err)
-		out := buf.String()
-		assert.Contains(t, out, "2026-05-12T")
-		assert.NotContains(t, out, "1778601661000")
-	})
-
-	t.Run("empty result", func(t *testing.T) {
-		resp := &clickhouse.QueryResponse{
-			Columns: []clickhouse.Column{{Name: "x", Type: "string"}},
-			Rows:    nil,
-		}
-		var buf bytes.Buffer
-		err := clickhouse.FormatTable(&buf, resp)
-		require.NoError(t, err)
-		assert.Contains(t, buf.String(), "No data")
-	})
-}
-
 func TestFormatListTablesTable(t *testing.T) {
 	totalRows := uint64(1000)
 	totalBytes := uint64(4096)

--- a/internal/query/clickhouse/types.go
+++ b/internal/query/clickhouse/types.go
@@ -3,30 +3,11 @@ package clickhouse
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/grafana/gcx/internal/query/dataframe"
+	querysql "github.com/grafana/gcx/internal/query/sql"
 )
-
-// GrafanaQueryResponse is the top-level Grafana datasource query response.
-type GrafanaQueryResponse = dataframe.Response
-
-// GrafanaResult represents a single Grafana datasource query result.
-type GrafanaResult = dataframe.Result
-
-// DataFrame represents a Grafana data frame.
-type DataFrame = dataframe.Frame
-
-// DataFrameSchema describes the structure of a Grafana data frame.
-type DataFrameSchema = dataframe.Schema
-
-// DataFrameField describes a field in a Grafana data frame.
-type DataFrameField = dataframe.Field
-
-// DataFrameData contains column-oriented Grafana data frame values.
-type DataFrameData = dataframe.Data
 
 // EscapeSQLString escapes single quotes for use in SQL string literals.
 // Matches the ClickHouse plugin's own escapeSQLString implementation.
@@ -47,38 +28,14 @@ func ValidateIdentifier(name, field string) error {
 	return nil
 }
 
-var (
-	limitClauseRe = regexp.MustCompile(`(?i)\bLIMIT\s+(\d+)\s*$`)
-	limitBailRe   = regexp.MustCompile(`(?im)(\bLIMIT\s+\d+\s+BY\b|\bLIMIT\s+\d+\s+OFFSET\b|\bLIMIT\s+\d+\s*,|\bFORMAT\b|\bSETTINGS\b|^\s*EXPLAIN\b|^\s*DESC(RIBE)?\b|^\s*SHOW\s+CREATE\b|^\s*EXISTS\b|^\s*CHECK\b)`)
-)
+var limitBailRe = regexp.MustCompile(`(?im)(\bLIMIT\s+\d+\s+BY\b|\bLIMIT\s+\d+\s+OFFSET\b|\bLIMIT\s+\d+\s*,|\bFORMAT\b|\bSETTINGS\b|^\s*EXPLAIN\b|^\s*DESC(RIBE)?\b|^\s*SHOW\s+CREATE\b|^\s*EXISTS\b|^\s*CHECK\b)`)
 
 // EnforceLimit ensures the SQL has a LIMIT clause within bounds.
 // If limit is 0, enforcement is disabled (pass-through).
-// If the SQL contains LIMIT BY, FORMAT, or SETTINGS, it bails out (pass-through).
+// If the SQL contains LIMIT BY, FORMAT, SETTINGS, or a metadata statement
+// (EXPLAIN/DESCRIBE/SHOW CREATE/EXISTS/CHECK), it bails out (pass-through).
 func EnforceLimit(sql string, limit, maxLimit int) string {
-	if limit == 0 {
-		return sql
-	}
-
-	if limitBailRe.MatchString(sql) {
-		return sql
-	}
-
-	trimmed := strings.TrimRight(sql, "; \t\n")
-	suffix := sql[len(trimmed):]
-
-	if m := limitClauseRe.FindStringSubmatchIndex(trimmed); m != nil {
-		existing, _ := strconv.Atoi(trimmed[m[2]:m[3]])
-		if existing > maxLimit {
-			return trimmed[:m[2]] + strconv.Itoa(maxLimit) + trimmed[m[3]:] + suffix
-		}
-		return sql
-	}
-
-	if limit > maxLimit {
-		limit = maxLimit
-	}
-	return trimmed + " LIMIT " + strconv.Itoa(limit) + suffix
+	return querysql.EnforceLimit(sql, limit, maxLimit, limitBailRe.MatchString)
 }
 
 // QueryRequest represents a ClickHouse query request.
@@ -87,18 +44,6 @@ type QueryRequest struct {
 	Start      time.Time
 	End        time.Time
 	IntervalMs int64
-}
-
-// QueryResponse holds the parsed row-oriented result of a ClickHouse query.
-type QueryResponse struct {
-	Columns []Column `json:"columns"`
-	Rows    [][]any  `json:"rows"`
-}
-
-// Column describes a result column.
-type Column struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
 }
 
 // TableInfo represents a row from system.tables.
@@ -120,7 +65,7 @@ type ColumnInfo struct {
 }
 
 // ParseTableInfoRows converts a QueryResponse from the system.tables query into typed TableInfo.
-func ParseTableInfoRows(resp *QueryResponse) []TableInfo {
+func ParseTableInfoRows(resp *querysql.QueryResponse) []TableInfo {
 	tables := make([]TableInfo, 0, len(resp.Rows))
 	for _, row := range resp.Rows {
 		if len(row) < 5 {
@@ -147,7 +92,7 @@ func ParseTableInfoRows(resp *QueryResponse) []TableInfo {
 }
 
 // ParseColumnInfoRows converts a QueryResponse from the system.columns query into typed ColumnInfo.
-func ParseColumnInfoRows(resp *QueryResponse) []ColumnInfo {
+func ParseColumnInfoRows(resp *querysql.QueryResponse) []ColumnInfo {
 	cols := make([]ColumnInfo, 0, len(resp.Rows))
 	for _, row := range resp.Rows {
 		if len(row) < 5 {

--- a/internal/query/sql/formatter.go
+++ b/internal/query/sql/formatter.go
@@ -1,0 +1,80 @@
+package sql
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/gcx/internal/style"
+)
+
+// FormatTable formats a QueryResponse as a human-readable table.
+func FormatTable(w io.Writer, resp *QueryResponse) error {
+	if len(resp.Rows) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+
+	timeColumns := make(map[int]bool, len(resp.Columns))
+	headers := make([]string, len(resp.Columns))
+	for i, col := range resp.Columns {
+		headers[i] = strings.ToUpper(col.Name)
+		if col.Type == "time" {
+			timeColumns[i] = true
+		}
+	}
+
+	t := style.NewTable(headers...)
+	for _, row := range resp.Rows {
+		vals := make([]string, len(row))
+		for i, v := range row {
+			if timeColumns[i] {
+				vals[i] = formatTimestamp(v)
+			} else {
+				vals[i] = formatValue(v)
+			}
+		}
+		t.Row(vals...)
+	}
+	return t.Render(w)
+}
+
+// FormatWideTable formats a QueryResponse as a wide table. SQL datasource
+// results are inherently flat, so this delegates to FormatTable.
+func FormatWideTable(w io.Writer, resp *QueryResponse) error {
+	return FormatTable(w, resp)
+}
+
+func formatTimestamp(v any) string {
+	switch ts := v.(type) {
+	case float64:
+		return time.UnixMilli(int64(ts)).UTC().Format(time.RFC3339)
+	case string:
+		ms, err := strconv.ParseInt(ts, 10, 64)
+		if err != nil {
+			return ts
+		}
+		return time.UnixMilli(ms).UTC().Format(time.RFC3339)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func formatValue(v any) string {
+	if v == nil {
+		return "-"
+	}
+	switch val := v.(type) {
+	case float64:
+		if val == float64(int64(val)) {
+			return strconv.FormatInt(int64(val), 10)
+		}
+		return fmt.Sprintf("%g", val)
+	case string:
+		return val
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}

--- a/internal/query/sql/formatter_test.go
+++ b/internal/query/sql/formatter_test.go
@@ -1,0 +1,59 @@
+package sql_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/sql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatTable(t *testing.T) {
+	t.Run("renders columns and rows", func(t *testing.T) {
+		resp := &sql.QueryResponse{
+			Columns: []sql.Column{{Name: "id", Type: "number"}, {Name: "name", Type: "string"}},
+			Rows:    [][]any{{float64(1), "alice"}, {float64(2), "bob"}},
+		}
+		var buf bytes.Buffer
+		err := sql.FormatTable(&buf, resp)
+		require.NoError(t, err)
+		out := buf.String()
+		assert.Contains(t, out, "ID")
+		assert.Contains(t, out, "NAME")
+		assert.Contains(t, out, "alice")
+		assert.Contains(t, out, "bob")
+	})
+
+	t.Run("formats time columns as RFC3339", func(t *testing.T) {
+		resp := &sql.QueryResponse{
+			Columns: []sql.Column{{Name: "timestamp", Type: "time"}, {Name: "service", Type: "string"}},
+			Rows:    [][]any{{float64(1778601661000), "frontend"}, {float64(1778601721000), "backend"}},
+		}
+		var buf bytes.Buffer
+		err := sql.FormatTable(&buf, resp)
+		require.NoError(t, err)
+		out := buf.String()
+		assert.Contains(t, out, "2026-05-12T")
+		assert.NotContains(t, out, "1778601661000")
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		resp := &sql.QueryResponse{}
+		var buf bytes.Buffer
+		err := sql.FormatTable(&buf, resp)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "No data")
+	})
+}
+
+func TestFormatWideTable(t *testing.T) {
+	resp := &sql.QueryResponse{
+		Columns: []sql.Column{{Name: "id", Type: "number"}},
+		Rows:    [][]any{{float64(1)}},
+	}
+	var buf bytes.Buffer
+	err := sql.FormatWideTable(&buf, resp)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "ID")
+}

--- a/internal/query/sql/parse.go
+++ b/internal/query/sql/parse.go
@@ -1,0 +1,60 @@
+package sql
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/grafana/gcx/internal/query/dataframe"
+	"github.com/grafana/gcx/internal/queryerror"
+)
+
+// ParseResponse parses a Grafana datasource query response (refId "A") into a
+// row-oriented QueryResponse. product names the datasource in error messages
+// (e.g. "clickhouse", "athena").
+//
+// SQL datasources backed by grafana/sqlds return exactly one frame per result
+// set, so only the first frame is used.
+func ParseResponse(respBody []byte, product string) (*QueryResponse, error) {
+	var raw dataframe.Response
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	result, ok := raw.Results["A"]
+	if !ok {
+		return &QueryResponse{}, nil
+	}
+	if result.Error != "" {
+		status := result.Status
+		if status == 0 {
+			status = http.StatusBadRequest
+		}
+		return nil, queryerror.New(product, "query", status, result.Error, result.ErrorSource)
+	}
+
+	resp := &QueryResponse{}
+	if len(result.Frames) == 0 {
+		return resp, nil
+	}
+	frame := result.Frames[0]
+
+	for _, f := range frame.Schema.Fields {
+		resp.Columns = append(resp.Columns, Column{Name: f.Name, Type: f.Type})
+	}
+
+	if len(frame.Data.Values) == 0 || len(frame.Data.Values[0]) == 0 {
+		return resp, nil
+	}
+	numRows := len(frame.Data.Values[0])
+	for rowIdx := range numRows {
+		row := make([]any, len(frame.Data.Values))
+		for colIdx := range frame.Data.Values {
+			if rowIdx < len(frame.Data.Values[colIdx]) {
+				row[colIdx] = frame.Data.Values[colIdx][rowIdx]
+			}
+		}
+		resp.Rows = append(resp.Rows, row)
+	}
+	return resp, nil
+}

--- a/internal/query/sql/parse_test.go
+++ b/internal/query/sql/parse_test.go
@@ -1,27 +1,28 @@
-package clickhouse_test
+package sql_test
 
 import (
 	"encoding/json"
 	"testing"
 
-	"github.com/grafana/gcx/internal/query/clickhouse"
+	"github.com/grafana/gcx/internal/query/dataframe"
+	"github.com/grafana/gcx/internal/query/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseResponse_SingleFrame(t *testing.T) {
-	raw := clickhouse.GrafanaQueryResponse{
-		Results: map[string]clickhouse.GrafanaResult{
+	raw := dataframe.Response{
+		Results: map[string]dataframe.Result{
 			"A": {
-				Frames: []clickhouse.DataFrame{
+				Frames: []dataframe.Frame{
 					{
-						Schema: clickhouse.DataFrameSchema{
-							Fields: []clickhouse.DataFrameField{
+						Schema: dataframe.Schema{
+							Fields: []dataframe.Field{
 								{Name: "id", Type: "number"},
 								{Name: "name", Type: "string"},
 							},
 						},
-						Data: clickhouse.DataFrameData{
+						Data: dataframe.Data{
 							Values: [][]any{
 								{float64(1), float64(2)},
 								{"alice", "bob"},
@@ -37,10 +38,10 @@ func TestParseResponse_SingleFrame(t *testing.T) {
 	body, err := json.Marshal(raw)
 	require.NoError(t, err)
 
-	resp, err := clickhouse.ParseResponse(body)
+	resp, err := sql.ParseResponse(body, "clickhouse")
 	require.NoError(t, err)
 
-	assert.Equal(t, []clickhouse.Column{{Name: "id", Type: "number"}, {Name: "name", Type: "string"}}, resp.Columns)
+	assert.Equal(t, []sql.Column{{Name: "id", Type: "number"}, {Name: "name", Type: "string"}}, resp.Columns)
 	require.Len(t, resp.Rows, 2)
 	assert.InDelta(t, 1, resp.Rows[0][0], 0)
 	assert.Equal(t, "alice", resp.Rows[0][1])
@@ -49,23 +50,23 @@ func TestParseResponse_SingleFrame(t *testing.T) {
 }
 
 func TestParseResponse_UsesOnlyFirstFrame(t *testing.T) {
-	raw := clickhouse.GrafanaQueryResponse{
-		Results: map[string]clickhouse.GrafanaResult{
+	raw := dataframe.Response{
+		Results: map[string]dataframe.Result{
 			"A": {
-				Frames: []clickhouse.DataFrame{
+				Frames: []dataframe.Frame{
 					{
-						Schema: clickhouse.DataFrameSchema{
-							Fields: []clickhouse.DataFrameField{{Name: "v", Type: "number"}},
+						Schema: dataframe.Schema{
+							Fields: []dataframe.Field{{Name: "v", Type: "number"}},
 						},
-						Data: clickhouse.DataFrameData{
+						Data: dataframe.Data{
 							Values: [][]any{{float64(1), float64(2)}},
 						},
 					},
 					{
-						Schema: clickhouse.DataFrameSchema{
-							Fields: []clickhouse.DataFrameField{{Name: "v", Type: "number"}},
+						Schema: dataframe.Schema{
+							Fields: []dataframe.Field{{Name: "v", Type: "number"}},
 						},
-						Data: clickhouse.DataFrameData{
+						Data: dataframe.Data{
 							Values: [][]any{{float64(3)}},
 						},
 					},
@@ -78,7 +79,7 @@ func TestParseResponse_UsesOnlyFirstFrame(t *testing.T) {
 	body, err := json.Marshal(raw)
 	require.NoError(t, err)
 
-	resp, err := clickhouse.ParseResponse(body)
+	resp, err := sql.ParseResponse(body, "clickhouse")
 	require.NoError(t, err)
 
 	require.Len(t, resp.Rows, 2)
@@ -87,23 +88,23 @@ func TestParseResponse_UsesOnlyFirstFrame(t *testing.T) {
 }
 
 func TestParseResponse_MismatchedFrameSkipped(t *testing.T) {
-	raw := clickhouse.GrafanaQueryResponse{
-		Results: map[string]clickhouse.GrafanaResult{
+	raw := dataframe.Response{
+		Results: map[string]dataframe.Result{
 			"A": {
-				Frames: []clickhouse.DataFrame{
+				Frames: []dataframe.Frame{
 					{
-						Schema: clickhouse.DataFrameSchema{
-							Fields: []clickhouse.DataFrameField{{Name: "a", Type: "string"}},
+						Schema: dataframe.Schema{
+							Fields: []dataframe.Field{{Name: "a", Type: "string"}},
 						},
-						Data: clickhouse.DataFrameData{
+						Data: dataframe.Data{
 							Values: [][]any{{"x"}},
 						},
 					},
 					{
-						Schema: clickhouse.DataFrameSchema{
-							Fields: []clickhouse.DataFrameField{{Name: "b", Type: "number"}},
+						Schema: dataframe.Schema{
+							Fields: []dataframe.Field{{Name: "b", Type: "number"}},
 						},
-						Data: clickhouse.DataFrameData{
+						Data: dataframe.Data{
 							Values: [][]any{{float64(99)}},
 						},
 					},
@@ -116,17 +117,17 @@ func TestParseResponse_MismatchedFrameSkipped(t *testing.T) {
 	body, err := json.Marshal(raw)
 	require.NoError(t, err)
 
-	resp, err := clickhouse.ParseResponse(body)
+	resp, err := sql.ParseResponse(body, "clickhouse")
 	require.NoError(t, err)
 
-	assert.Equal(t, []clickhouse.Column{{Name: "a", Type: "string"}}, resp.Columns)
+	assert.Equal(t, []sql.Column{{Name: "a", Type: "string"}}, resp.Columns)
 	require.Len(t, resp.Rows, 1)
 	assert.Equal(t, "x", resp.Rows[0][0])
 }
 
 func TestParseResponse_ErrorInResult(t *testing.T) {
-	raw := clickhouse.GrafanaQueryResponse{
-		Results: map[string]clickhouse.GrafanaResult{
+	raw := dataframe.Response{
+		Results: map[string]dataframe.Result{
 			"A": {
 				Error:       "Code: 62. DB::Exception: Syntax error",
 				ErrorSource: "downstream",
@@ -138,21 +139,21 @@ func TestParseResponse_ErrorInResult(t *testing.T) {
 	body, err := json.Marshal(raw)
 	require.NoError(t, err)
 
-	_, err = clickhouse.ParseResponse(body)
+	_, err = sql.ParseResponse(body, "clickhouse")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Syntax error")
 }
 
 func TestParseResponse_EmptyResult(t *testing.T) {
-	raw := clickhouse.GrafanaQueryResponse{
-		Results: map[string]clickhouse.GrafanaResult{
+	raw := dataframe.Response{
+		Results: map[string]dataframe.Result{
 			"A": {
-				Frames: []clickhouse.DataFrame{
+				Frames: []dataframe.Frame{
 					{
-						Schema: clickhouse.DataFrameSchema{
-							Fields: []clickhouse.DataFrameField{{Name: "x", Type: "string"}},
+						Schema: dataframe.Schema{
+							Fields: []dataframe.Field{{Name: "x", Type: "string"}},
 						},
-						Data: clickhouse.DataFrameData{
+						Data: dataframe.Data{
 							Values: [][]any{{}},
 						},
 					},
@@ -165,23 +166,23 @@ func TestParseResponse_EmptyResult(t *testing.T) {
 	body, err := json.Marshal(raw)
 	require.NoError(t, err)
 
-	resp, err := clickhouse.ParseResponse(body)
+	resp, err := sql.ParseResponse(body, "clickhouse")
 	require.NoError(t, err)
 
-	assert.Equal(t, []clickhouse.Column{{Name: "x", Type: "string"}}, resp.Columns)
+	assert.Equal(t, []sql.Column{{Name: "x", Type: "string"}}, resp.Columns)
 	assert.Empty(t, resp.Rows)
 }
 
 func TestParseResponse_MissingRefID(t *testing.T) {
-	raw := clickhouse.GrafanaQueryResponse{
-		Results: map[string]clickhouse.GrafanaResult{
+	raw := dataframe.Response{
+		Results: map[string]dataframe.Result{
 			"B": {
-				Frames: []clickhouse.DataFrame{
+				Frames: []dataframe.Frame{
 					{
-						Schema: clickhouse.DataFrameSchema{
-							Fields: []clickhouse.DataFrameField{{Name: "v", Type: "number"}},
+						Schema: dataframe.Schema{
+							Fields: []dataframe.Field{{Name: "v", Type: "number"}},
 						},
-						Data: clickhouse.DataFrameData{
+						Data: dataframe.Data{
 							Values: [][]any{{float64(1)}},
 						},
 					},
@@ -194,7 +195,7 @@ func TestParseResponse_MissingRefID(t *testing.T) {
 	body, err := json.Marshal(raw)
 	require.NoError(t, err)
 
-	resp, err := clickhouse.ParseResponse(body)
+	resp, err := sql.ParseResponse(body, "clickhouse")
 	require.NoError(t, err)
 
 	assert.Empty(t, resp.Columns)

--- a/internal/query/sql/types.go
+++ b/internal/query/sql/types.go
@@ -1,0 +1,56 @@
+// Package sql holds the shared building blocks for SQL-style Grafana datasources
+// (ClickHouse, Athena, …) that query via Grafana's unified datasource query API
+// and render row-oriented results. Dialect packages keep their own request
+// construction, schema discovery, and LIMIT bail rules; the common response
+// shape, table formatting, response parsing, and LIMIT clamping live here.
+package sql
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// QueryResponse holds the parsed row-oriented result of a SQL datasource query.
+type QueryResponse struct {
+	Columns []Column `json:"columns"`
+	Rows    [][]any  `json:"rows"`
+}
+
+// Column describes a result column.
+type Column struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+var limitClauseRe = regexp.MustCompile(`(?i)\bLIMIT\s+(\d+)\s*$`)
+
+// EnforceLimit ensures the SQL has a trailing LIMIT clause within bounds.
+// If limit is 0, enforcement is disabled (pass-through). The bail predicate
+// lets each dialect opt out for statements where appending a LIMIT is invalid
+// or unwanted (SHOW/DESCRIBE/EXPLAIN, LIMIT … OFFSET, dialect-specific clauses).
+func EnforceLimit(sql string, limit, maxLimit int, bail func(string) bool) string {
+	if limit == 0 {
+		return sql
+	}
+
+	if bail != nil && bail(sql) {
+		return sql
+	}
+
+	trimmed := strings.TrimRight(sql, "; \t\n")
+	suffix := sql[len(trimmed):]
+
+	if m := limitClauseRe.FindStringSubmatchIndex(trimmed); m != nil {
+		existing, _ := strconv.Atoi(trimmed[m[2]:m[3]])
+		if existing > maxLimit {
+			return trimmed[:m[2]] + strconv.Itoa(maxLimit) + trimmed[m[3]:] + suffix
+		}
+		return sql
+	}
+
+	if limit > maxLimit {
+		limit = maxLimit
+	}
+	return trimmed + " LIMIT " + strconv.Itoa(limit) + suffix
+}

--- a/internal/query/sql/types_test.go
+++ b/internal/query/sql/types_test.go
@@ -1,0 +1,39 @@
+package sql_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/sql"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnforceLimit(t *testing.T) {
+	// bail mimics a dialect that opts out of EXPLAIN statements.
+	bail := func(s string) bool {
+		return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(s)), "EXPLAIN")
+	}
+
+	tests := []struct {
+		name     string
+		sql      string
+		limit    int
+		maxLimit int
+		bail     func(string) bool
+		want     string
+	}{
+		{name: "appends default limit", sql: "SELECT 1", limit: 100, maxLimit: 1000, want: "SELECT 1 LIMIT 100"},
+		{name: "caps existing limit", sql: "SELECT 1 LIMIT 5000", limit: 100, maxLimit: 1000, want: "SELECT 1 LIMIT 1000"},
+		{name: "preserves small limit", sql: "SELECT 1 LIMIT 50", limit: 100, maxLimit: 1000, want: "SELECT 1 LIMIT 50"},
+		{name: "strips trailing semicolon", sql: "SELECT 1;", limit: 100, maxLimit: 1000, want: "SELECT 1 LIMIT 100;"},
+		{name: "disabled when zero", sql: "SELECT 1", limit: 0, maxLimit: 1000, want: "SELECT 1"},
+		{name: "nil bail is allowed", sql: "SELECT 1", limit: 100, maxLimit: 1000, bail: func(string) bool { return false }, want: "SELECT 1 LIMIT 100"},
+		{name: "bail passes through", sql: "EXPLAIN SELECT 1", limit: 100, maxLimit: 1000, bail: bail, want: "EXPLAIN SELECT 1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sql.EnforceLimit(tt.sql, tt.limit, tt.maxLimit, tt.bail)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Closes #773

## What

Add a full Athena datasource provider to gcx, following the same pattern as the existing ClickHouse provider. This gives both humans and agents the ability to query Athena datasources and explore their schema directly from the CLI. Supports server-side macros, result reuse (engine v3), LIMIT enforcement with bail-outs for OFFSET/EXPLAIN, and Explore URL generation.

## Commands

| Command | Description |
|---------|-------------|
| `gcx datasources athena query` | Execute SQL queries against Athena |
| `gcx datasources athena list-catalogs` | List available data catalogs |
| `gcx datasources athena list-databases` | List databases in a catalog |
| `gcx datasources athena list-tables` | List tables in a database |
| `gcx datasources athena describe-table` | Show column schema for a table |

## Design decisions

- Result reuse TTL is exposed as `--ttl-minutes` (not `--result-reuse-max-age`) — the unit is always minutes (matching the Grafana UI's "TTL (mins)"), and in the context of `athena query` there's only one thing with a TTL

## Test plan

- [x] Unit tests for query client (happy path, empty result, nulls, error handling, request construction, 404 fallback)
- [x] Unit tests for `EnforceLimit` (append, cap, preserve, bail cases including EXPLAIN and OFFSET)
- [x] Unit tests for formatter (table rendering, time column RFC3339 formatting, string list, empty results)
- [x] Unit tests for explore URL generation (full link, explicit time range, missing required fields)
- [x] Tested against a real Athena datasource: list-catalogs, list-databases, list-tables, describe-table, query, DESCRIBE SQL, share-link

🤖 Generated with [Claude Code](https://claude.com/claude-code)