### PR TITLE
chore(release): v0.3.0 changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "gcx",
       "source": "./claude-plugin",
       "description": "Debug, explore, and instrument with Grafana using gcx CLI",
-      "version": "0.2.16"
+      "version": "0.3.0"
     }
   ]
 }

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,10 +1,13 @@
-- Add `aio11y experiments` command group for managing evaluation experiments
-- Add `aio11y guards` subcommand for managing hook rules
-- Fix `kg insights` chart and sources request/response schemas
-- Fix `k6` token piping warning to reference the correct command
-- Centralize signal command wiring across metrics, logs, traces, and profiles
-- Consolidate error types into `internal/gcxerrors`, removing `fail` shims
-- Surface `diagnose-entity-graph` and document how skills get invoked
-- Mint Homebrew tap App token via broker in release workflow
-- Replace Dependabot with Renovate for dependency updates
-- Update Go module dependencies
+- Added ClickHouse, CloudWatch, and Infinity datasource providers.
+- Added richer IRM OnCall alert groups and SRE triage tooling.
+- Added a create-dashboard skill and dashboard list --limit flag.
+- Improved KG diagnosis for trace propagation and split environments.
+- Fixed KG rule list/get/delete calls to match the backend API.
+- Added dual k6 client support for OAuth and service-account tokens.
+- Fixed k6 provider support for OAuth login.
+- Made aio11y experiment cancellation require confirmation.
+- Warn when API responses return HTML instead of JSON.
+- Exit cleanly on Ctrl+C without noisy errors.
+- Normalized dashboard snapshot time ranges.
+- Removed target-valid-logql rule to restore go install compatibility.
+- Updated login help and Homebrew publishing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v0.3.0 (2026-05-26)
+
+- Added ClickHouse, CloudWatch, and Infinity datasource providers.
+- Added richer IRM OnCall alert groups and SRE triage tooling.
+- Added a create-dashboard skill and dashboard list --limit flag.
+- Improved KG diagnosis for trace propagation and split environments.
+- Fixed KG rule list/get/delete calls to match the backend API.
+- Added dual k6 client support for OAuth and service-account tokens.
+- Fixed k6 provider support for OAuth login.
+- Made aio11y experiment cancellation require confirmation.
+- Warn when API responses return HTML instead of JSON.
+- Exit cleanly on Ctrl+C without noisy errors.
+- Normalized dashboard snapshot time ranges.
+- Removed target-valid-logql rule to restore go install compatibility.
+- Updated login help and Homebrew publishing.
+
+
 ## v0.2.16 (2026-05-20)
 
 - Add `aio11y experiments` command group for managing evaluation experiments

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcx",
-  "version": "0.2.16",
+  "version": "0.3.0",
   "description": "Debug, explore, and instrument with Grafana using gcx CLI",
   "keywords": ["grafana", "observability", "monitoring", "prometheus", "loki", "dashboards"],
   "author": {


### PR DESCRIPTION
## v0.3.0 (2026-05-26)

- Added ClickHouse, CloudWatch, and Infinity datasource providers.
- Added richer IRM OnCall alert groups and SRE triage tooling.
- Added a create-dashboard skill and dashboard list --limit flag.
- Improved KG diagnosis for trace propagation and split environments.
- Fixed KG rule list/get/delete calls to match the backend API.
- Added dual k6 client support for OAuth and service-account tokens.
- Fixed k6 provider support for OAuth login.
- Made aio11y experiment cancellation require confirmation.
- Warn when API responses return HTML instead of JSON.
- Exit cleanly on Ctrl+C without noisy errors.
- Normalized dashboard snapshot time ranges.
- Removed target-valid-logql rule to restore go install compatibility.
- Updated login help and Homebrew publishing.
