### PR TITLE
add guidance for agents to avoid adding dependencies for small pieces of functionality

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -144,6 +144,9 @@ agent mode detection, behavior changes, and opt-out mechanisms.
 
 ## Dependency Rules
 
+- **Prefer stdlib over small dependencies.** Don't add a new `go.mod` dependency
+  when the used API surface is small enough to reimplement (~100 LOC or less).
+  See [docs/research/2026-05-26-dependency-audit.md](docs/research/2026-05-26-dependency-audit.md) for examples.
 - `cmd/` may import `internal/`; `internal/` may not import `cmd/`.
 - No circular dependencies between packages.
 - Provider implementations (`internal/providers/*/`) may import core resource types but not


### PR DESCRIPTION
Came up as a suggestion in https://github.com/grafana/gcx/pull/779

