### PR TITLE
fix(output): make --json field-discovery hint pipe-aware

### DIFF
--- a/docs/design/agent-mode.md
+++ b/docs/design/agent-mode.md
@@ -48,11 +48,19 @@ The following are **not yet implemented**:
    contract via `IsPiped` is in place for when they are added)
 6. Confirmation prompts auto-approved ([safety.md § Agent Mode Auto-Approve](safety.md#33-agent-mode-auto-approve))
 
-**Note:** The `--json list` field-discovery hint fires whenever the resolved output codec
-is JSON-like (`-o json` or the `agents` default) and the caller has not already used
-`--json list` (field discovery) or `--json field1,field2` (field selection). In agent mode
-the hint is emitted as JSONL `{"class":"hint","summary":"..."}` on stderr. In TTY mode it is emitted as `hint: ...` text on stderr. The
-hint is emitted at most once per invocation.
+**Note:** The `--json list` field-discovery hint is **pipe-aware** — it is emitted only on
+an interactive TTY (stdout is a terminal) when the resolved output codec is JSON-like
+(`-o json`) and the caller has not already used `--json list` (field discovery) or
+`--json field1,field2` (field selection). On a TTY it is emitted as `hint: ...` text on
+stderr, at most once per invocation.
+
+When stdout is piped or **agent mode** is active, the hint is **suppressed entirely**.
+Those are exactly the programmatic cases where the field-selection convention is already
+documented in the gcx agent skill, and where a stderr line that merges into a tool's
+combined stdout+stderr capture would be mistaken for response data. (This replaces the
+earlier behavior of emitting a JSONL `{"class":"hint",...}` record on stderr in agent
+mode, which polluted combined-stream tool captures and caused agents to waste turns
+stripping it before parsing.)
 
 ### 6.2a Format choice vs non-format presentation properties
 

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -170,11 +170,20 @@ func (opts *Options) Encode(dst io.Writer, value any) error {
 	// Nudge toward --json field selection whenever the resolved codec is
 	// JSON-like (json or agents format) and the caller has not already
 	// requested field selection/discovery. Emitted once per invocation to
-	// stderr (never pollutes stdout). TTY: plain "hint:" line. Agent mode:
-	// JSONL {"class":"hint",...} — routed through emitHint/EmitHint so the
-	// hints framework handles codec & agent-mode compliance (FR-104).
+	// stderr as a plain "hint:" line.
+	//
+	// Pipe-aware (FR-005a): the hint is only emitted on an interactive TTY.
+	// When stdout is piped or agent mode is active, it is suppressed — those
+	// are exactly the programmatic cases where the field-selection convention
+	// is already covered by the gcx agent skill, and where a stderr line that
+	// merges into a tool's combined stdout+stderr capture causes the consumer
+	// to mistake it for response data. See docs/design/agent-mode.md.
+	// Read the live pipe state (set by terminal.Detect in PersistentPreRun)
+	// rather than opts.IsPiped, which is captured at BindFlags time — before
+	// detection runs — and is therefore stale here.
 	isJSONLike := codec.Format() == format.JSON || codec.Format() == agentsFormat
-	if !opts.jsonFieldsHintShown && isJSONLike && len(opts.JSONFields) == 0 && !opts.JSONDiscovery {
+	if !opts.jsonFieldsHintShown && isJSONLike && len(opts.JSONFields) == 0 && !opts.JSONDiscovery &&
+		!terminal.IsPiped() && !agent.IsAgentMode() {
 		opts.jsonFieldsHintShown = true
 		w := opts.ErrWriter
 		if w == nil {

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/terminal"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -196,22 +197,35 @@ func TestJSONFlag_Parsing(t *testing.T) {
 	}
 }
 
-func TestEncode_AgentModeHint(t *testing.T) {
-	// The agent-mode hint banner has been removed (C.3c). No mode should emit it.
+func TestEncode_JSONFieldsHint(t *testing.T) {
+	// The --json field-selection hint is pipe-aware: it is emitted to stderr
+	// only on an interactive TTY. When stdout is piped or agent mode is active
+	// it is suppressed, so it never contaminates a tool's merged stdout+stderr
+	// capture. See docs/design/agent-mode.md.
 	tests := []struct {
 		name      string
 		agentMode bool
+		piped     bool   // simulates non-TTY stdout
 		jsonField string // if set, pass --json flag
 		wantHint  bool
 	}{
 		{
-			name:      "agent mode without --json: no hint",
+			name:     "interactive TTY without --json: hint emitted",
+			wantHint: true,
+		},
+		{
+			name:     "piped stdout: no hint",
+			piped:    true,
+			wantHint: false,
+		},
+		{
+			name:      "agent mode: no hint",
 			agentMode: true,
 			wantHint:  false,
 		},
 		{
-			name:      "non-agent mode: no hint",
-			agentMode: false,
+			name:      "interactive TTY with --json field selection: no hint",
+			jsonField: "name",
 			wantHint:  false,
 		},
 	}
@@ -219,11 +233,18 @@ func TestEncode_AgentModeHint(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			agent.SetFlag(tc.agentMode)
-			t.Cleanup(func() { agent.SetFlag(false) })
+			terminal.SetPiped(tc.piped)
+			t.Cleanup(func() {
+				agent.SetFlag(false)
+				terminal.ResetForTesting()
+			})
 
 			opts := &cmdio.Options{}
 			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 			opts.BindFlags(flags)
+
+			var errBuf bytes.Buffer
+			opts.ErrWriter = &errBuf
 
 			if tc.jsonField != "" {
 				require.NoError(t, flags.Set("json", tc.jsonField))
@@ -234,8 +255,16 @@ func TestEncode_AgentModeHint(t *testing.T) {
 			var buf bytes.Buffer
 			require.NoError(t, opts.Encode(&buf, map[string]any{"name": "test"}))
 
-			// Encode writes to stdout (buf), not stderr. No hint should be emitted anywhere.
+			// The hint must never reach stdout regardless of mode.
 			assert.NotContains(t, buf.String(), "--json list")
+
+			if tc.wantHint {
+				assert.Contains(t, errBuf.String(), "--json list",
+					"interactive TTY should emit the field-selection hint to stderr")
+			} else {
+				assert.NotContains(t, errBuf.String(), "--json list",
+					"hint must be suppressed when piped, in agent mode, or when --json is already used")
+			}
 		})
 	}
 }


### PR DESCRIPTION
The field-discovery hint was emitted on stderr for every JSON-like response, including in agent mode (as a JSONL {"class":"hint",...} record). Tools that capture a command's combined stdout+stderr (e.g. Claude Code's Bash tool surface that line next to the JSON, so agents mistake it for response data and waste turns stripping it with sed before parsing.

Gate the hint on an interactive TTY only: suppress when stdout is piped or agent mode is active. Read the live terminal.IsPiped() (set by Detect() in PersistentPreRun) instead of the opts.IsPiped captured at BindFlags time, which is stale and previously leaked the hint on plain {
  "error": {
    "summary": "Unknown shorthand flag",
    "exitCode": 1,
    "details": "'o' in -o"
  }
} as well.

The nudge toward --json field selection is already documented in the gcx agent skill, so dropping the runtime hint for programmatic consumers loses nothing while keeping it for interactive users.

Replace TestEncode_AgentModeHint (which only asserted on stdout and so never caught the stderr emission) with TestEncode_JSONFieldsHint, which captures stderr across TTY/piped/agent/field-selection cases. Update docs/design/agent-mode.md to document the pipe-aware contract.