### PR TITLE
feat(output): default to NDJSON when stdout is not a TTY

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ internal/
 ├── testutils/   Shared test utilities
 ├── server/      Live dev server (Chi router, reverse proxy, websocket reload)
 ├── grafana/     OpenAPI client (health checks, version detection)
-├── output/      Output codec registry (json, yaml, text, wide, agents — field selection, discovery, k8s unstructured handling, temp-file spill)
+├── output/      Output codec registry (json, yaml, text, wide, agents, ndjson — ndjson is the non-TTY default with kind-tagged lines; field selection, discovery, k8s unstructured handling, temp-file spill)
 ├── format/      JSON/YAML codecs with format auto-detection
 ├── retry/       Retry transport (429, 502/503/504, transient connection errors — wraps all HTTP tiers)
 ├── httputils/   HTTP helpers (used by serve command's proxy)

--- a/claude-plugin/skills/debug-with-grafana/SKILL.md
+++ b/claude-plugin/skills/debug-with-grafana/SKILL.md
@@ -65,10 +65,15 @@ If no datasources appear, confirm the context is pointing at the correct
 Grafana instance. See `references/error-recovery.md` for auth and
 datasource-not-found recovery patterns.
 
-> **JSON output piping**: When piping gcx output through external tools, never
-> use `2>&1` — gcx writes hints to stderr that break JSON parsers. Use
-> `2>/dev/null` to suppress stderr, or use `--json field1,field2` to select
-> fields directly without piping:
+> **JSON output piping**: When stdout is piped, gcx defaults to **NDJSON** — one
+> JSON object per line. Data lines are `{"kind":"result","data":{...}}`; stderr
+> hints/warnings and the error envelope are also `kind`-tagged JSON lines, so a
+> `2>&1`-merged stream stays parseable line-by-line — demux by `kind`:
+> ```bash
+> gcx datasources list -t prometheus 2>&1 | jq -c 'select(.kind=="result").data'
+> ```
+> Use `2>/dev/null` if you want to drop diagnostics, `-o json` to force a single
+> JSON document, or `--json field1,field2` to select fields directly:
 > ```bash
 > gcx datasources list -t prometheus --json uid
 > gcx metrics query -d <prom-uid> 'up' --json metric,value

--- a/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
@@ -405,8 +405,11 @@ gcx metrics query -d <uid> 'up' -o json 2>/dev/null | \
   python3 -c "import json,sys; data=json.load(sys.stdin); print(len(data['data']['result']))"
 ```
 
-> **Piping caution**: Never use `2>&1` when piping gcx JSON output — gcx writes
-> hints to stderr that break JSON parsers. Use `2>/dev/null` instead.
+> **Piping note**: When stdout is piped, gcx defaults to NDJSON (one JSON object
+> per line, every line `kind`-tagged), so `2>&1` is safe — both data and stderr
+> diagnostics merge into a uniform stream you demux by `kind`
+> (`jq 'select(.kind=="result").data'`). Use `2>/dev/null` to drop diagnostics,
+> or `-o json` to force a single JSON document for tools that expect one.
 
 ## Scripting Patterns
 

--- a/cmd/gcx/main.go
+++ b/cmd/gcx/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/gcx/internal/agentlog"
 	internalconfig "github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/grafana/gcx/internal/terminal"
 	appversion "github.com/grafana/gcx/internal/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -111,9 +112,11 @@ func handleError(err error, boolFlags map[string]struct{}, subCmds map[string]bo
 		})
 	}
 
-	if agent.IsAgentMode() || root.IsJSONFlagActive() {
+	if agent.IsAgentMode() || root.IsJSONFlagActive() || terminal.IsPiped() {
 		// Machine consumers get JSON on stdout only — the human-formatted
-		// stderr error is noise for agents and scripts.
+		// stderr error is noise for agents and scripts. When stdout is non-TTY
+		// the error is a kind:"error" JSON line so a 2>&1-merged stream stays
+		// uniform with the NDJSON data/diagnostic lines.
 		if writeErr := detailedErr.WriteJSON(os.Stdout, exitCode); writeErr != nil {
 			fmt.Fprintln(os.Stderr, detailedErr.Error())
 		}

--- a/cmd/gcx/resources/get.go
+++ b/cmd/gcx/resources/get.go
@@ -308,9 +308,9 @@ func getCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			}
 
 			if res.PullSummary.IsTruncated() {
-				fmt.Fprintf(cmd.ErrOrStderr(),
-					"Showing first %d items per resource type. Use --limit=0 to fetch all.\n",
-					opts.Limit)
+				cmdio.EmitWarn(cmd.ErrOrStderr(), fmt.Sprintf(
+					"showing first %d items per resource type; use --limit=0 to fetch all",
+					opts.Limit))
 			}
 
 			if opts.OnError.FailOnErrors() && res.PullSummary.FailedCount() > 0 {

--- a/cmd/gcx/root/command_test.go
+++ b/cmd/gcx/root/command_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	claudeplugin "github.com/grafana/gcx/claude-plugin"
@@ -200,7 +201,9 @@ func TestSkillsInstallUpdate_EndToEndThroughRootCommand(t *testing.T) {
 	expected, err := fs.ReadFile(claudeplugin.SkillsFS(), path.Join(skillName, "SKILL.md"))
 	require.NoError(t, err)
 
-	stdout, stderr, err = executeRootCommandForTest("agent", "skills", "install", "--dir", installRoot, skillName)
+	// -o text exercises the human-facing summary codec. Test stdout is a pipe,
+	// so the implicit default is NDJSON; the explicit flag pins the text path.
+	stdout, stderr, err = executeRootCommandForTest("agent", "skills", "install", "--dir", installRoot, skillName, "-o", "text")
 	require.NoError(t, err, stderr)
 	require.Contains(t, stdout, "Installed 1 skill(s)")
 
@@ -214,13 +217,36 @@ func TestSkillsInstallUpdate_EndToEndThroughRootCommand(t *testing.T) {
 	require.NoError(t, os.Chmod(installedPath, 0o600))
 	require.NoError(t, os.WriteFile(installedPath, []byte("local-change"), 0o600))
 
-	stdout, stderr, err = executeRootCommandForTest("agent", "skills", "update", "--dir", installRoot, skillName)
+	stdout, stderr, err = executeRootCommandForTest("agent", "skills", "update", "--dir", installRoot, skillName, "-o", "text")
 	require.NoError(t, err, stderr)
 	require.Contains(t, stdout, "Updated 1 skill(s)")
 
 	updated, err := os.ReadFile(installedPath)
 	require.NoError(t, err)
 	require.Equal(t, expected, updated)
+}
+
+// TestNonTTYDefaultsToNDJSON_EndToEnd verifies that a command run through the
+// root command with no explicit -o defaults to NDJSON when stdout is non-TTY
+// (the test process pipe), with each data line wrapped as kind:"result".
+func TestNonTTYDefaultsToNDJSON_EndToEnd(t *testing.T) {
+	t.Setenv("GCX_NO_UPDATE_NOTIFIER", "1")
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
+
+	installRoot := filepath.Join(t.TempDir(), ".agents")
+
+	stdout, stderr, err := executeRootCommandForTest("agent", "skills", "list", "--dir", installRoot)
+	require.NoError(t, err, stderr)
+
+	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	require.NotEmpty(t, lines)
+	for _, line := range lines {
+		var obj map[string]any
+		require.NoErrorf(t, json.Unmarshal([]byte(line), &obj), "each line must be valid JSON: %s", line)
+		require.Equal(t, "result", obj["kind"], "non-TTY data lines must carry kind:result")
+		require.Contains(t, obj, "data")
+	}
 }
 
 func executeRootCommandForTest(args ...string) (string, string, error) {

--- a/docs/design/agent-mode.md
+++ b/docs/design/agent-mode.md
@@ -34,10 +34,16 @@ Reference: `internal/agent/agent.go`
 ### 6.2 Behavior Changes
 
 When agent mode is active:
-1. **Default output format** becomes `agents` for all commands (overrides
-   per-command `DefaultFormat()` in `io.Options.BindFlags()`). The `agents`
-   codec emits compact JSON when the payload is ≤ 100 KiB and spills to a
-   temp file otherwise — see [output.md § Agents Codec](output.md#111-agents-codec)
+1. **Default output format** becomes `ndjson` for all commands. Agent mode forces
+   pipe-aware behavior (`IsPiped=true`), and the non-TTY default is NDJSON —
+   resolved in `io.Options.Validate()`, overriding the per-command
+   `DefaultFormat()`. Each data line is wrapped `{"kind":"result","data":...}`;
+   oversized output still spills to a temp file (one `{"kind":"spill",...}` line).
+   See [output.md § NDJSON Codec](output.md#112-ndjson-codec). The single-object
+   `agents` codec remains available via explicit `-o agents`. NDJSON trades the
+   `agents` codec's maximal compactness (one document) for line-oriented
+   robustness: a `2>&1`-merged stream stays parseable, and large lists stream
+   line-by-line; spill still bounds truly oversized payloads.
 2. **Color** is disabled (`color.NoColor = true` in `PersistentPreRun`)
 3. **Pipe-aware behavior** is forced: `IsPiped=true`, `NoTruncate=true`
    regardless of actual TTY state (see [pipe-awareness.md § TTY Detection](pipe-awareness.md#51-tty-detection))
@@ -49,14 +55,15 @@ The following are **not yet implemented**:
 6. Confirmation prompts auto-approved ([safety.md § Agent Mode Auto-Approve](safety.md#33-agent-mode-auto-approve))
 
 **Note:** The `--json list` field-discovery hint fires whenever the resolved output codec
-is JSON-like (`-o json` or the `agents` default) and the caller has not already used
-`--json list` (field discovery) or `--json field1,field2` (field selection). In agent mode
-the hint is emitted as JSONL `{"class":"hint","summary":"..."}` on stderr. In TTY mode it is emitted as `hint: ...` text on stderr. The
+is JSON-like (`-o json`, the `ndjson` non-TTY default, or `-o agents`) and the caller has
+not already used `--json list` (field discovery) or `--json field1,field2` (field selection).
+When stdout is non-TTY (pipe or agent mode) the hint is emitted as JSONL
+`{"kind":"hint","summary":"..."}` on stderr. In TTY mode it is emitted as `hint: ...` text on stderr. The
 hint is emitted at most once per invocation.
 
 ### 6.2a Format choice vs non-format presentation properties
 
-**Format choice** (`-o text/wide/json/yaml`) is controlled by explicit flags. An explicit `-o wide` overrides the agent-mode JSON default — this is documented behavior.
+**Format choice** (`-o text/wide/json/yaml`) is controlled by explicit flags. An explicit `-o wide` overrides the agent-mode NDJSON default — this is documented behavior.
 
 **Non-format presentation properties** (color, truncation, box-drawing characters) are ALWAYS suppressed in agent mode, regardless of which format is active:
 - `-o wide` under agent mode: renders a wide table with no ANSI colors, no box chars.
@@ -65,10 +72,11 @@ hint is emitted at most once per invocation.
 ### 6.3 Opt-Out
 
 Explicit flags override agent mode defaults:
-- `-o json` forces full compact JSON to stdout (no spill)
-- `-o text` or `-o yaml` overrides the agents default
+- `-o json` forces a single pretty JSON document to stdout (no NDJSON line-wrapping)
+- `-o agents` forces the single-object compact-JSON-with-spill codec
+- `-o text` or `-o yaml` overrides the ndjson default
 - `-o wide` retains human table output even in agent mode (explicit-override semantics — the
-  operator has explicitly requested wide table format, so the JSON default is not applied)
+  operator has explicitly requested wide table format, so the NDJSON default is not applied)
 - `--agent=false` disables agent mode entirely (even when env vars are set)
 - `GCX_AGENT_MODE=0` disables agent mode regardless of other env vars
 - `GCX_AGENT_SPILL_BYTES=<n>` adjusts the spill threshold (bytes; default 102400)

--- a/docs/design/errors.md
+++ b/docs/design/errors.md
@@ -94,20 +94,24 @@ responses in `internal/providers/instrumentation/client.go`.
 
 ### 4.4 In-Band Error Reporting
 
-When agent mode is active and a command fails, a JSON error object is written
-to **stdout** in addition to the existing stderr `DetailedError` output
-(NC-003 — in-band JSON is additive, not a replacement).
+When stdout is non-TTY (any pipe/redirect, which agent mode also forces) and a
+command fails, a JSON error object is written to **stdout** in addition to the
+existing stderr `DetailedError` output (NC-003 — in-band JSON is additive, not a
+replacement). The top-level `kind:"error"` discriminator keeps the line uniform
+with the NDJSON data (`kind:"result"`) and diagnostic (`kind:"hint"`…) lines, so
+a `2>&1`-merged stream stays parseable line-by-line.
 
 **Error-only response** (command fails completely):
 
 ```json
-{"error": {"summary": "Resource not found - code 404", "exitCode": 1}}
+{"kind":"error","error": {"summary": "Resource not found - code 404", "exitCode": 1}}
 ```
 
 **Partial failure** (batch operation, some resources succeeded):
 
 ```json
 {
+  "kind": "error",
   "items": [...],
   "error": {"summary": "3 resources failed", "exitCode": 4, "details": "...", "suggestions": ["..."]}
 }
@@ -125,11 +129,13 @@ to **stdout** in addition to the existing stderr `DetailedError` output
 
 **Guarantees:**
 - On success, no `error` key appears in stdout JSON (NC-004).
-- When agent mode is NOT active, no error JSON is written to stdout.
+- When stdout is a TTY (and neither agent mode nor `--json` is active), no error
+  JSON is written to stdout — the human-formatted error goes to stderr only.
 - The JSON is always valid — partial writes cannot corrupt it (NC-004).
 
-**Implementation:** `cmd/gcx/fail/json.go` (`DetailedError.WriteJSON`).
-Invoked from `handleError` in `cmd/gcx/main.go` when `agent.IsAgentMode()` is true.
+**Implementation:** `internal/gcxerrors/json.go` (`DetailedError.WriteJSON`).
+Invoked from `handleError` in `cmd/gcx/main.go` when `agent.IsAgentMode()`,
+`--json` is active, or `terminal.IsPiped()` (non-TTY stdout).
 
 See [agent-mode.md](agent-mode.md) for the full agent mode specification.
 See [exit-codes.md](exit-codes.md) for exit code values referenced in `exitCode` fields.

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -85,7 +85,9 @@ document.
 ```
 
 - **Lists** (slices/arrays, or k8s lists with an `items` array) emit **one line
-  per element**. An empty list emits no data lines.
+  per element**. An empty list emits a single `{"kind":"empty"}` sentinel line so
+  a consumer can tell "0 results" apart from "no output". `select(.kind=="result")`
+  still yields zero records.
 - **Single objects** (and single-key wrapper maps like `{"datasources":[...]}`)
   emit **one line**. Wrapper maps are not unwrapped — the merged stream stays
   uniform regardless.
@@ -95,6 +97,7 @@ document.
 | `kind` | Stream | Meaning |
 |--------|--------|---------|
 | `result` | stdout | A data record; payload under `data` |
+| `empty` | stdout | A successful command whose collection had zero elements |
 | `spill` | stdout | Oversized output spilled to a temp file (see below) |
 | `error` | stdout | Error envelope (see [errors.md § 4.4](errors.md)) |
 | `hint` / `warning` / `note` | stderr | Diagnostics |

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -10,10 +10,12 @@ Reference alongside [cli-layer.md](../architecture/cli-layer.md) for command str
 
 ### 1.1 Built-in Codecs
 
-Every command gets `json`, `yaml`, and `agents` output for free via `io.Options`.
-The `json` and `yaml` codecs produce the full resource object as returned by
-the API — no envelope wrapping, no field filtering. This output is stable.
-The `agents` codec is described in [§ 1.1.1](#111-agents-codec) below.
+Every command gets `json`, `yaml`, `agents`, and `ndjson` output for free via
+`io.Options`. The `json` and `yaml` codecs produce the full resource object as
+returned by the API — no envelope wrapping, no field filtering. This output is
+stable. The `agents` codec is described in [§ 1.1.1](#111-agents-codec); the
+`ndjson` codec — the **default whenever stdout is not a TTY** — in
+[§ 1.1.2](#112-ndjson-codec).
 
 ```go
 ioOpts := &io.Options{}
@@ -61,6 +63,56 @@ mechanism because agents that need the full data can no longer retrieve it.
 
 **Implementation:** `internal/output/agents.go`
 
+#### 1.1.2 NDJSON Codec
+
+The `ndjson` codec emits **newline-delimited JSON**: one complete JSON object
+per line. It is the **implicit default whenever stdout is not a TTY** (any pipe
+or redirect, which agent mode also forces) and the user did not pass an explicit
+`-o`. An explicit `-o json/yaml/text/wide/agents` always wins; a real TTY keeps
+the command's own default (table/text).
+
+**Why it's the non-TTY default.** Diagnostics (hints/warnings/notes) go to
+stderr as JSONL, and the error envelope goes to stdout as JSON — all carrying a
+`kind` discriminator. A `2>&1`-merged stream is therefore *uniformly* NDJSON:
+every line is independently parseable and consumers demultiplex by `kind`. This
+removes the `2>&1` footgun where stderr lines corrupt a single stdout JSON
+document.
+
+**Data line shape** — each data line is wrapped:
+
+```json
+{"kind":"result","data":{"uid":"abc","name":"prom"}}
+```
+
+- **Lists** (slices/arrays, or k8s lists with an `items` array) emit **one line
+  per element**. An empty list emits no data lines.
+- **Single objects** (and single-key wrapper maps like `{"datasources":[...]}`)
+  emit **one line**. Wrapper maps are not unwrapped — the merged stream stays
+  uniform regardless.
+
+**Discriminator (`kind`) across the merged stream:**
+
+| `kind` | Stream | Meaning |
+|--------|--------|---------|
+| `result` | stdout | A data record; payload under `data` |
+| `spill` | stdout | Oversized output spilled to a temp file (see below) |
+| `error` | stdout | Error envelope (see [errors.md § 4.4](errors.md)) |
+| `hint` / `warning` / `note` | stderr | Diagnostics |
+
+Demux example: `gcx datasources list 2>&1 | jq -c 'select(.kind=="result").data'`
+
+**Spill** — the large-output guard is retained. When the full serialized payload
+exceeds the spill threshold (`GCX_AGENT_SPILL_BYTES`, default **100 KiB**), the
+payload is written to `$TMPDIR/gcx-results-<random>.json` and a single
+`{"kind":"spill",...}` line is emitted instead of the data lines (same envelope
+as the agents codec, plus `kind`).
+
+**Field selection** — `--json field1,field2` forces JSON output, so it overrides
+the NDJSON default: piping with `--json` yields field-selected JSON, not NDJSON.
+`--json ?` / `--json list` discovery is likewise unchanged.
+
+**Implementation:** `internal/output/ndjson.go`
+
 ### 1.2 Custom Codecs
 
 Commands register additional formats (e.g. `text`, `wide`, `graph`) via
@@ -83,10 +135,14 @@ JSON/YAML to silently omit fields. See Pattern 13 in `patterns.md`.
 
 | Command type | Default format | Rationale |
 |-------------|---------------|-----------|
-| `list`, `get` | `text` (with table codec) | Human-scannable |
-| `config view` | `yaml` | Config is YAML-native |
-| `push`, `pull`, `delete` | Status messages only | Operations, not data |
-| Agent mode ([agent-mode.md](agent-mode.md)) | `agents` | Token-efficient: compact JSON below 100 KiB, temp-file spill above (see [§ 1.1.1](#111-agents-codec)) |
+| `list`, `get` (real TTY) | `text` (with table codec) | Human-scannable |
+| `config view` (real TTY) | `yaml` | Config is YAML-native |
+| `push`, `pull`, `delete` (real TTY) | Status messages only | Operations, not data |
+| **Non-TTY (any pipe/redirect), incl. agent mode ([agent-mode.md](agent-mode.md))** | `ndjson` | Survives `2>&1` merging; stream-processable; uniform `kind` discriminator (see [§ 1.1.2](#112-ndjson-codec)) |
+
+The non-TTY default is resolved in `io.Options.Validate()` (which runs inside
+`RunE`, after `terminal.Detect()`), not in `BindFlags` — at `BindFlags` time the
+pipe state is not yet known.
 
 When building a new command: call `ioOpts.DefaultFormat("text")` for data
 display commands and register a table codec. Don't leave `json` as the default

--- a/docs/design/pipe-awareness.md
+++ b/docs/design/pipe-awareness.md
@@ -1,6 +1,6 @@
 # Pipe-Awareness
 
-> Describes TTY detection, automatic pipe behavior, --no-color, NO_COLOR environment variable support, and future auto-format switching.
+> Describes TTY detection, automatic pipe behavior (including the non-TTY NDJSON output default), --no-color, and NO_COLOR environment variable support.
 
 ---
 
@@ -15,6 +15,12 @@ a terminal. The result is stored as package-level state in `internal/terminal`.
 **Automatic behaviors when stdout is piped (not a TTY):**
 - Color is disabled (`color.NoColor = true`)
 - Table column truncation is suppressed (`NoTruncate = true`)
+- **Default output format becomes `ndjson`** (unless an explicit `-o` is given) —
+  one JSON object per line, so a `2>&1`-merged stream stays parseable. Resolved
+  in `io.Options.Validate()`, not `PersistentPreRun`. See
+  [output.md § NDJSON Codec](output.md#112-ndjson-codec). Diagnostics on stderr
+  (`hint`/`warning`/`note`) and the stdout error envelope (`error`) are likewise
+  emitted as `kind`-tagged JSON lines when stdout is non-TTY.
 
 **Override flags** (available on all commands):
 - `--no-truncate` — explicitly disables truncation regardless of TTY state
@@ -42,9 +48,12 @@ automated pipelines.
 `NoTruncate`, `SetPiped`, `SetNoTruncate`). Invoked from
 `cmd/gcx/root/command.go` (`PersistentPreRun`).
 
-Codecs read `terminal.IsPiped()` and `terminal.NoTruncate()` at encode time
-(via `io.Options.IsPiped` and `io.Options.NoTruncate` populated during
-`BindFlags`). Table codecs use `NoTruncate` to skip ellipsis truncation.
+Codecs read `terminal.IsPiped()` and `terminal.NoTruncate()` directly at encode
+time. (`io.Options.IsPiped`/`NoTruncate` are also populated in `BindFlags`, but
+note `BindFlags` runs at command-construction time — before `terminal.Detect()`
+in `PersistentPreRun` — so the pipe-dependent output default is resolved later,
+in `io.Options.Validate()`, which runs inside `RunE`.) Table codecs use
+`NoTruncate` to skip ellipsis truncation.
 
 ### 5.2 `--no-color` Flag
 

--- a/docs/reference/cli/gcx_agent_skills_install.md
+++ b/docs/reference/cli/gcx_agent_skills_install.md
@@ -29,7 +29,7 @@ gcx agent skills install [SKILL]... [flags]
       --force           Overwrite existing differing files managed by the gcx skills bundle
   -h, --help            help for install
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_agent_skills_list.md
+++ b/docs/reference/cli/gcx_agent_skills_list.md
@@ -23,7 +23,7 @@ gcx agent skills list [flags]
       --dir string      Root directory for the .agents installation (used to check installed status) (default "~/.agents")
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_agent_skills_uninstall.md
+++ b/docs/reference/cli/gcx_agent_skills_uninstall.md
@@ -27,7 +27,7 @@ gcx agent skills uninstall [SKILL]... [flags]
       --dry-run         Preview the uninstall without removing files
   -h, --help            help for uninstall
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
   -y, --yes             Auto-approve uninstalling all skills
 ```
 

--- a/docs/reference/cli/gcx_agent_skills_update.md
+++ b/docs/reference/cli/gcx_agent_skills_update.md
@@ -25,7 +25,7 @@ gcx agent skills update [SKILL]... [flags]
       --dry-run         Preview the update without writing files
   -h, --help            help for update
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_agents_get.md
+++ b/docs/reference/cli/gcx_aio11y_agents_get.md
@@ -15,7 +15,7 @@ gcx aio11y agents get <agent-name> [flags]
 ```
   -h, --help             help for get
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string    Output format. One of: agents, json, ndjson, yaml (default "yaml")
       --version string   Specific effective version to look up
 ```
 

--- a/docs/reference/cli/gcx_aio11y_agents_list.md
+++ b/docs/reference/cli/gcx_aio11y_agents_list.md
@@ -12,7 +12,7 @@ gcx aio11y agents list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of agents to return (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_agents_versions.md
+++ b/docs/reference/cli/gcx_aio11y_agents_versions.md
@@ -11,7 +11,7 @@ gcx aio11y agents versions <agent-name> [flags]
 ```
   -h, --help            help for versions
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_collections_conversations_list.md
+++ b/docs/reference/cli/gcx_aio11y_collections_conversations_list.md
@@ -12,7 +12,7 @@ gcx aio11y collections conversations list <collection-id> [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of saved conversations to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_collections_create.md
+++ b/docs/reference/cli/gcx_aio11y_collections_create.md
@@ -24,7 +24,7 @@ gcx aio11y collections create [flags]
   -h, --help                 help for create
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string          Collection name (required if --filename is not given)
-  -o, --output string        Output format. One of: agents, json, yaml (default "json")
+  -o, --output string        Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_collections_get.md
+++ b/docs/reference/cli/gcx_aio11y_collections_get.md
@@ -11,7 +11,7 @@ gcx aio11y collections get <collection-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_collections_list.md
+++ b/docs/reference/cli/gcx_aio11y_collections_list.md
@@ -12,7 +12,7 @@ gcx aio11y collections list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of collections to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_collections_update.md
+++ b/docs/reference/cli/gcx_aio11y_collections_update.md
@@ -13,7 +13,7 @@ gcx aio11y collections update <collection-id> [flags]
   -h, --help                 help for update
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string          New collection name
-  -o, --output string        Output format. One of: agents, json, yaml (default "json")
+  -o, --output string        Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_conversations_get.md
+++ b/docs/reference/cli/gcx_aio11y_conversations_get.md
@@ -11,7 +11,7 @@ gcx aio11y conversations get <conversation-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_conversations_list.md
+++ b/docs/reference/cli/gcx_aio11y_conversations_list.md
@@ -12,7 +12,7 @@ gcx aio11y conversations list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of conversations to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_conversations_search.md
+++ b/docs/reference/cli/gcx_aio11y_conversations_search.md
@@ -37,7 +37,7 @@ gcx aio11y conversations search [flags]
       --from string      Start of time range (RFC3339, e.g. 2026-01-01T00:00:00Z)
   -h, --help             help for search
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --page-size int    Number of results per page (default 50)
       --to string        End of time range (RFC3339, e.g. 2026-12-31T23:59:59Z)
 ```

--- a/docs/reference/cli/gcx_aio11y_evaluators_create.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_create.md
@@ -26,7 +26,7 @@ gcx aio11y evaluators create [flags]
   -f, --filename string   File containing the evaluator definition (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_evaluators_get.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_get.md
@@ -11,7 +11,7 @@ gcx aio11y evaluators get <evaluator-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_evaluators_list.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_list.md
@@ -12,7 +12,7 @@ gcx aio11y evaluators list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of evaluators to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_evaluators_test.md
+++ b/docs/reference/cli/gcx_aio11y_evaluators_test.md
@@ -28,7 +28,7 @@ gcx aio11y evaluators test [flags]
   -g, --generation string        Generation ID to evaluate
   -h, --help                     help for test
       --json string              Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string            Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string            Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_experiments_create.md
+++ b/docs/reference/cli/gcx_aio11y_experiments_create.md
@@ -22,7 +22,7 @@ gcx aio11y experiments create [flags]
   -f, --filename string   File containing the experiment create payload (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_experiments_get.md
+++ b/docs/reference/cli/gcx_aio11y_experiments_get.md
@@ -11,7 +11,7 @@ gcx aio11y experiments get <run-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_experiments_list.md
+++ b/docs/reference/cli/gcx_aio11y_experiments_list.md
@@ -12,7 +12,7 @@ gcx aio11y experiments list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of experiments to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_experiments_report.md
+++ b/docs/reference/cli/gcx_aio11y_experiments_report.md
@@ -11,7 +11,7 @@ gcx aio11y experiments report <run-id> [flags]
 ```
   -h, --help            help for report
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_experiments_scores.md
+++ b/docs/reference/cli/gcx_aio11y_experiments_scores.md
@@ -12,7 +12,7 @@ gcx aio11y experiments scores <run-id> [flags]
   -h, --help            help for scores
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of scores to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_experiments_update.md
+++ b/docs/reference/cli/gcx_aio11y_experiments_update.md
@@ -12,7 +12,7 @@ gcx aio11y experiments update <run-id> [flags]
   -h, --help            help for update
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string     New experiment name
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_generations_get.md
+++ b/docs/reference/cli/gcx_aio11y_generations_get.md
@@ -15,7 +15,7 @@ gcx aio11y generations get <generation-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_guards_create.md
+++ b/docs/reference/cli/gcx_aio11y_guards_create.md
@@ -25,7 +25,7 @@ gcx aio11y guards create [flags]
   -f, --filename string   File containing the hook rule definition (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_guards_get.md
+++ b/docs/reference/cli/gcx_aio11y_guards_get.md
@@ -11,7 +11,7 @@ gcx aio11y guards get <rule-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_guards_list.md
+++ b/docs/reference/cli/gcx_aio11y_guards_list.md
@@ -12,7 +12,7 @@ gcx aio11y guards list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of hook rules to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_guards_update.md
+++ b/docs/reference/cli/gcx_aio11y_guards_update.md
@@ -19,7 +19,7 @@ gcx aio11y guards update <rule-id> [flags]
   -f, --filename string   File containing the full hook rule definition (use - for stdin)
   -h, --help              help for update
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_judge_models.md
+++ b/docs/reference/cli/gcx_aio11y_judge_models.md
@@ -11,7 +11,7 @@ gcx aio11y judge models --provider <id> [flags]
 ```
   -h, --help              help for models
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string     Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --provider string   Provider ID (required, see 'judge providers')
 ```
 

--- a/docs/reference/cli/gcx_aio11y_judge_providers.md
+++ b/docs/reference/cli/gcx_aio11y_judge_providers.md
@@ -11,7 +11,7 @@ gcx aio11y judge providers [flags]
 ```
   -h, --help            help for providers
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_rules_create.md
+++ b/docs/reference/cli/gcx_aio11y_rules_create.md
@@ -25,7 +25,7 @@ gcx aio11y rules create [flags]
   -f, --filename string   File containing the rule definition (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_rules_get.md
+++ b/docs/reference/cli/gcx_aio11y_rules_get.md
@@ -11,7 +11,7 @@ gcx aio11y rules get <rule-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_rules_list.md
+++ b/docs/reference/cli/gcx_aio11y_rules_list.md
@@ -12,7 +12,7 @@ gcx aio11y rules list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of rules to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_rules_update.md
+++ b/docs/reference/cli/gcx_aio11y_rules_update.md
@@ -19,7 +19,7 @@ gcx aio11y rules update <rule-id> [flags]
   -f, --filename string   File containing the full rule definition (use - for stdin)
   -h, --help              help for update
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_collections.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_collections.md
@@ -11,7 +11,7 @@ gcx aio11y saved-conversations collections <saved-id> [flags]
 ```
   -h, --help            help for collections
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_get.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_get.md
@@ -11,7 +11,7 @@ gcx aio11y saved-conversations get <saved-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_list.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_list.md
@@ -12,7 +12,7 @@ gcx aio11y saved-conversations list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of saved conversations to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --source string   Filter by source (telemetry or manual)
 ```
 

--- a/docs/reference/cli/gcx_aio11y_saved-conversations_save.md
+++ b/docs/reference/cli/gcx_aio11y_saved-conversations_save.md
@@ -28,7 +28,7 @@ gcx aio11y saved-conversations save <conversation-id> [flags]
   -h, --help              help for save
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string       Human-readable name for the bookmark (required)
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
       --saved-id string   Bookmark ID; defaults to saved-<conversation-id>
       --tag stringArray   Tag in key=value form (repeatable)
 ```

--- a/docs/reference/cli/gcx_aio11y_scores_list.md
+++ b/docs/reference/cli/gcx_aio11y_scores_list.md
@@ -16,7 +16,7 @@ gcx aio11y scores list <generation-id> [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of scores to return (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_templates_get.md
+++ b/docs/reference/cli/gcx_aio11y_templates_get.md
@@ -26,7 +26,7 @@ gcx aio11y templates get <template-id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_aio11y_templates_list.md
+++ b/docs/reference/cli/gcx_aio11y_templates_list.md
@@ -22,7 +22,7 @@ gcx aio11y templates list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of templates to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --scope string    Filter by scope: "global" or "tenant"
 ```
 

--- a/docs/reference/cli/gcx_aio11y_templates_versions.md
+++ b/docs/reference/cli/gcx_aio11y_templates_versions.md
@@ -11,7 +11,7 @@ gcx aio11y templates versions <template-id> [flags]
 ```
   -h, --help            help for versions
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_contact-points_create.md
+++ b/docs/reference/cli/gcx_alert_contact-points_create.md
@@ -12,7 +12,7 @@ gcx alert contact-points create [flags]
   -f, --filename string   File containing the contact point definition (JSON/YAML, use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_contact-points_get.md
+++ b/docs/reference/cli/gcx_alert_contact-points_get.md
@@ -11,7 +11,7 @@ gcx alert contact-points get UID [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_contact-points_list.md
+++ b/docs/reference/cli/gcx_alert_contact-points_list.md
@@ -12,7 +12,7 @@ gcx alert contact-points list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_contact-points_update.md
+++ b/docs/reference/cli/gcx_alert_contact-points_update.md
@@ -12,7 +12,7 @@ gcx alert contact-points update UID [flags]
   -f, --filename string   File containing the contact point definition (JSON/YAML, use - for stdin)
   -h, --help              help for update
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_groups_get.md
+++ b/docs/reference/cli/gcx_alert_groups_get.md
@@ -11,7 +11,7 @@ gcx alert groups get NAME [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_groups_list.md
+++ b/docs/reference/cli/gcx_alert_groups_list.md
@@ -12,7 +12,7 @@ gcx alert groups list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_groups_status.md
+++ b/docs/reference/cli/gcx_alert_groups_status.md
@@ -11,7 +11,7 @@ gcx alert groups status [NAME] [flags]
 ```
   -h, --help            help for status
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_instances_list.md
+++ b/docs/reference/cli/gcx_alert_instances_list.md
@@ -15,7 +15,7 @@ gcx alert instances list [flags]
   -h, --help                help for list
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string         Filter by rule name (regex, e.g. 'Tempo.*')
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --rule string         Filter by rule UID
       --state string        Filter by alert instance state (firing, pending, inactive)
 ```

--- a/docs/reference/cli/gcx_alert_mute-timings_create.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_create.md
@@ -12,7 +12,7 @@ gcx alert mute-timings create [flags]
   -f, --filename string   File containing the mute timing definition (JSON/YAML, use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_mute-timings_get.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_get.md
@@ -11,7 +11,7 @@ gcx alert mute-timings get NAME [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_mute-timings_list.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_list.md
@@ -12,7 +12,7 @@ gcx alert mute-timings list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_mute-timings_update.md
+++ b/docs/reference/cli/gcx_alert_mute-timings_update.md
@@ -12,7 +12,7 @@ gcx alert mute-timings update NAME [flags]
   -f, --filename string   File containing the mute timing definition (JSON/YAML, use - for stdin)
   -h, --help              help for update
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_notification-policies_get.md
+++ b/docs/reference/cli/gcx_alert_notification-policies_get.md
@@ -11,7 +11,7 @@ gcx alert notification-policies get [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_rules_get.md
+++ b/docs/reference/cli/gcx_alert_rules_get.md
@@ -11,7 +11,7 @@ gcx alert rules get UID [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_rules_list.md
+++ b/docs/reference/cli/gcx_alert_rules_list.md
@@ -14,7 +14,7 @@ gcx alert rules list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --state string    Filter by rule state (firing, pending, inactive)
 ```
 

--- a/docs/reference/cli/gcx_alert_templates_get.md
+++ b/docs/reference/cli/gcx_alert_templates_get.md
@@ -11,7 +11,7 @@ gcx alert templates get NAME [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_templates_list.md
+++ b/docs/reference/cli/gcx_alert_templates_list.md
@@ -12,7 +12,7 @@ gcx alert templates list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_alert_templates_upsert.md
+++ b/docs/reference/cli/gcx_alert_templates_upsert.md
@@ -19,7 +19,7 @@ gcx alert templates upsert [flags]
   -f, --filename string   File containing the template definition (JSON/YAML, use - for stdin)
   -h, --help              help for upsert
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_appo11y_overrides_get.md
+++ b/docs/reference/cli/gcx_appo11y_overrides_get.md
@@ -11,7 +11,7 @@ gcx appo11y overrides get [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_appo11y_settings_get.md
+++ b/docs/reference/cli/gcx_appo11y_settings_get.md
@@ -11,7 +11,7 @@ gcx appo11y settings get [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_approvals.md
+++ b/docs/reference/cli/gcx_assistant_investigations_approvals.md
@@ -11,7 +11,7 @@ gcx assistant investigations approvals <id> [flags]
 ```
   -h, --help            help for approvals
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_cancel.md
+++ b/docs/reference/cli/gcx_assistant_investigations_cancel.md
@@ -11,7 +11,7 @@ gcx assistant investigations cancel <id> [flags]
 ```
   -h, --help            help for cancel
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_create.md
+++ b/docs/reference/cli/gcx_assistant_investigations_create.md
@@ -22,7 +22,7 @@ gcx assistant investigations create [flags]
       --description string   Investigation description
   -h, --help                 help for create
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string        Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string        Output format. One of: agents, json, ndjson, yaml (default "yaml")
       --title string         Investigation title (required)
 ```
 

--- a/docs/reference/cli/gcx_assistant_investigations_document.md
+++ b/docs/reference/cli/gcx_assistant_investigations_document.md
@@ -11,7 +11,7 @@ gcx assistant investigations document <investigation-id> <document-id> [flags]
 ```
   -h, --help            help for document
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_get.md
+++ b/docs/reference/cli/gcx_assistant_investigations_get.md
@@ -12,7 +12,7 @@ gcx assistant investigations get <id> [flags]
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open            Open the investigation in the default browser
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_list.md
+++ b/docs/reference/cli/gcx_assistant_investigations_list.md
@@ -17,7 +17,7 @@ gcx assistant investigations list [flags]
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of investigations to return (default 50)
       --offset int      Number of investigations to skip (for pagination)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --state string    Filter by investigation state (e.g. running, completed, cancelled)
 ```
 

--- a/docs/reference/cli/gcx_assistant_investigations_report.md
+++ b/docs/reference/cli/gcx_assistant_investigations_report.md
@@ -11,7 +11,7 @@ gcx assistant investigations report <id> [flags]
 ```
   -h, --help            help for report
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_timeline.md
+++ b/docs/reference/cli/gcx_assistant_investigations_timeline.md
@@ -11,7 +11,7 @@ gcx assistant investigations timeline <id> [flags]
 ```
   -h, --help            help for timeline
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_assistant_investigations_todos.md
+++ b/docs/reference/cli/gcx_assistant_investigations_todos.md
@@ -11,7 +11,7 @@ gcx assistant investigations todos <id> [flags]
 ```
   -h, --help            help for todos
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_commands.md
+++ b/docs/reference/cli/gcx_commands.md
@@ -24,7 +24,7 @@ gcx commands [flags]
   -h, --help             help for commands
       --include-hidden   Include hidden commands in the output
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: agents, json, text, yaml (default "json")
+  -o, --output string    Output format. One of: agents, json, ndjson, text, yaml (default "json")
       --validate         Validate catalog against a live Grafana instance (requires configured context)
 ```
 

--- a/docs/reference/cli/gcx_config_view.md
+++ b/docs/reference/cli/gcx_config_view.md
@@ -19,7 +19,7 @@ gcx config view [flags]
   -h, --help            help for view
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --minify          Remove all information not used by current-context from the output
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
       --raw             Display sensitive information
 ```
 

--- a/docs/reference/cli/gcx_dashboards_get.md
+++ b/docs/reference/cli/gcx_dashboards_get.md
@@ -18,7 +18,7 @@ gcx dashboards get <name> [flags]
       --api-version string   API version to use (e.g. dashboard.grafana.app/v1); defaults to server preferred version
   -h, --help                 help for get
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_dashboards_list.md
+++ b/docs/reference/cli/gcx_dashboards_list.md
@@ -13,7 +13,7 @@ gcx dashboards list [flags]
   -h, --help                 help for list
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int            Maximum number of dashboards to return in a single request (0 for no limit)
-  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_dashboards_search.md
+++ b/docs/reference/cli/gcx_dashboards_search.md
@@ -41,7 +41,7 @@ gcx dashboards search [query] [flags]
   -h, --help                 help for search
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int            Maximum number of results (0 for no limit) (default 50)
-  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --sort string          Sort key (e.g. name_sort)
       --tag stringArray      Filter by tag (repeatable)
 ```

--- a/docs/reference/cli/gcx_dashboards_versions_list.md
+++ b/docs/reference/cli/gcx_dashboards_versions_list.md
@@ -13,7 +13,7 @@ gcx dashboards versions list <name> [flags]
   -h, --help                 help for list
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int            Maximum number of revisions to return (0 = all)
-  -o, --output string        Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_clickhouse_describe-table.md
+++ b/docs/reference/cli/gcx_datasources_clickhouse_describe-table.md
@@ -31,7 +31,7 @@ gcx datasources clickhouse describe-table TABLE [flags]
   -d, --datasource string   Datasource UID (required unless datasources.clickhouse is configured)
   -h, --help                help for describe-table
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_clickhouse_list-tables.md
+++ b/docs/reference/cli/gcx_datasources_clickhouse_list-tables.md
@@ -33,7 +33,7 @@ gcx datasources clickhouse list-tables [flags]
   -d, --datasource string   Datasource UID (required unless datasources.clickhouse is configured)
   -h, --help                help for list-tables
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_clickhouse_query.md
+++ b/docs/reference/cli/gcx_datasources_clickhouse_query.md
@@ -46,7 +46,7 @@ gcx datasources clickhouse query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Max rows to return (0 disables enforcement) (default 100)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_cloudwatch_list-accounts.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_list-accounts.md
@@ -26,7 +26,7 @@ gcx datasources cloudwatch list-accounts [flags]
   -d, --datasource string   Datasource UID (required unless datasources.cloudwatch is configured)
   -h, --help                help for list-accounts
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --region string       AWS region (required)
 ```
 

--- a/docs/reference/cli/gcx_datasources_cloudwatch_list-dimensions.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_list-dimensions.md
@@ -27,7 +27,7 @@ gcx datasources cloudwatch list-dimensions [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --metric string       CloudWatch metric name (required)
       --namespace string    CloudWatch namespace (required)
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --region string       AWS region (required)
 ```
 

--- a/docs/reference/cli/gcx_datasources_cloudwatch_list-metrics.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_list-metrics.md
@@ -26,7 +26,7 @@ gcx datasources cloudwatch list-metrics [flags]
   -h, --help                help for list-metrics
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --namespace string    CloudWatch namespace (required)
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --region string       AWS region (required)
 ```
 

--- a/docs/reference/cli/gcx_datasources_cloudwatch_list-namespaces.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_list-namespaces.md
@@ -25,7 +25,7 @@ gcx datasources cloudwatch list-namespaces [flags]
   -d, --datasource string   Datasource UID (required unless datasources.cloudwatch is configured)
   -h, --help                help for list-namespaces
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --region string       AWS region (required)
 ```
 

--- a/docs/reference/cli/gcx_datasources_cloudwatch_list-regions.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_list-regions.md
@@ -24,7 +24,7 @@ gcx datasources cloudwatch list-regions [flags]
   -d, --datasource string   Datasource UID (required unless datasources.cloudwatch is configured)
   -h, --help                help for list-regions
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_cloudwatch_query.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_query.md
@@ -54,7 +54,7 @@ gcx datasources cloudwatch query [flags]
       --metric string               CloudWatch metric name, e.g. CPUUtilization (required)
       --namespace string            CloudWatch namespace, e.g. AWS/EC2 (required)
       --open                        Open the executed query in Grafana Explore
-  -o, --output string               Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string               Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --period string               Period in seconds (e.g. 60, 300) or "auto" to let CloudWatch pick a period that fits the time range (default "auto")
       --region string               AWS region, e.g. us-east-1 (required)
       --share-link                  Print the Grafana Explore URL for the executed query to stderr

--- a/docs/reference/cli/gcx_datasources_get.md
+++ b/docs/reference/cli/gcx_datasources_get.md
@@ -28,7 +28,7 @@ gcx datasources get UID [flags]
       --context string   Name of the context to use
   -h, --help             help for get
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string    Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_infinity_query.md
+++ b/docs/reference/cli/gcx_datasources_infinity_query.md
@@ -40,7 +40,7 @@ gcx datasources infinity query [EXPR] [flags]
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_datasources_influxdb_field-keys.md
+++ b/docs/reference/cli/gcx_datasources_influxdb_field-keys.md
@@ -31,7 +31,7 @@ gcx datasources influxdb field-keys [flags]
   -h, --help                 help for field-keys
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -m, --measurement string   Filter by measurement name
-  -o, --output string        Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_influxdb_measurements.md
+++ b/docs/reference/cli/gcx_datasources_influxdb_measurements.md
@@ -31,7 +31,7 @@ gcx datasources influxdb measurements [flags]
   -d, --datasource string   Datasource UID (required unless datasources.influxdb is configured)
   -h, --help                help for measurements
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_influxdb_query.md
+++ b/docs/reference/cli/gcx_datasources_influxdb_query.md
@@ -37,7 +37,7 @@ gcx datasources influxdb query [EXPR] [flags]
       --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_datasources_influxdb_tag-keys.md
+++ b/docs/reference/cli/gcx_datasources_influxdb_tag-keys.md
@@ -31,7 +31,7 @@ gcx datasources influxdb tag-keys [flags]
   -h, --help                 help for tag-keys
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -m, --measurement string   Filter by measurement name
-  -o, --output string        Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_influxdb_tag-values.md
+++ b/docs/reference/cli/gcx_datasources_influxdb_tag-values.md
@@ -32,7 +32,7 @@ gcx datasources influxdb tag-values [flags]
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -k, --key string           Tag key to get values for (required)
   -m, --measurement string   Filter by measurement name
-  -o, --output string        Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_list.md
+++ b/docs/reference/cli/gcx_datasources_list.md
@@ -32,7 +32,7 @@ gcx datasources list [flags]
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of datasources to return (default 50)
-  -o, --output string    Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, ndjson, table, yaml (default "table")
   -t, --type string      Filter by datasource type (e.g., prometheus, loki)
 ```
 

--- a/docs/reference/cli/gcx_datasources_loki_labels.md
+++ b/docs/reference/cli/gcx_datasources_loki_labels.md
@@ -31,7 +31,7 @@ gcx datasources loki labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_loki_metrics.md
+++ b/docs/reference/cli/gcx_datasources_loki_metrics.md
@@ -50,7 +50,7 @@ gcx datasources loki metrics [EXPR] [flags]
   -h, --help                help for metrics
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_loki_query.md
+++ b/docs/reference/cli/gcx_datasources_loki_query.md
@@ -50,7 +50,7 @@ gcx datasources loki query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of log lines to return (0 means no limit) (default 50)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, raw, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, raw, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_loki_series.md
+++ b/docs/reference/cli/gcx_datasources_loki_series.md
@@ -34,7 +34,7 @@ gcx datasources loki series [flags]
   -h, --help                help for series
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -M, --match stringArray   LogQL stream selector (required, e.g., '{job="varlogs"}')
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_prometheus_labels.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_labels.md
@@ -31,7 +31,7 @@ gcx datasources prometheus labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_prometheus_metadata.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_metadata.md
@@ -31,7 +31,7 @@ gcx datasources prometheus metadata [flags]
   -h, --help                help for metadata
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -m, --metric string       Filter by metric name
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_prometheus_query.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_query.md
@@ -45,7 +45,7 @@ gcx datasources prometheus query [EXPR] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_pyroscope_exemplars_profile.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_exemplars_profile.md
@@ -37,7 +37,7 @@ gcx datasources pyroscope exemplars profile [EXPR] [flags]
   -h, --help                    help for profile
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
-  -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string           Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
       --since string            Duration before --to (or now if omitted); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_pyroscope_exemplars_span.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_exemplars_span.md
@@ -37,7 +37,7 @@ gcx datasources pyroscope exemplars span [EXPR] [flags]
   -h, --help                    help for span
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
-  -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string           Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
       --since string            Duration before --to (or now if omitted); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_pyroscope_labels.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_labels.md
@@ -31,7 +31,7 @@ gcx datasources pyroscope labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_pyroscope_metrics.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_metrics.md
@@ -56,7 +56,7 @@ gcx datasources pyroscope metrics [EXPR] [flags]
   -h, --help                  help for metrics
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int             Maximum number of series to return (default 10)
-  -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string         Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_pyroscope_profile-types.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_profile-types.md
@@ -27,7 +27,7 @@ gcx datasources pyroscope profile-types [flags]
   -d, --datasource string   Datasource UID (required unless default-pyroscope-datasource is configured)
   -h, --help                help for profile-types
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -60,7 +60,7 @@ gcx datasources pyroscope query [EXPR] [flags]
   -h, --help                          help for query
       --json string                   Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-nodes int                 Maximum nodes in flame graph (default 0/unlimited for pprof output, 50000 for all other formats)
-  -o, --output string                 Output format. One of: agents, graph, json, pprof, table, wide, yaml (default "table")
+  -o, --output string                 Output format. One of: agents, graph, json, ndjson, pprof, table, wide, yaml (default "table")
       --pprof-overwrite               Overwrite the output file if it already exists (only with -o pprof)
       --pprof-path string             Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)

--- a/docs/reference/cli/gcx_datasources_query.md
+++ b/docs/reference/cli/gcx_datasources_query.md
@@ -43,7 +43,7 @@ gcx datasources query DATASOURCE_UID [EXPR] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int             Maximum number of log lines to return for loki queries (0 means no limit) (default 50)
       --max-nodes int         Maximum nodes in flame graph (pyroscope only) (default 1024)
-  -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string         Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --profile-type string   Profile type ID for pyroscope queries (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds')
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_tempo_get.md
+++ b/docs/reference/cli/gcx_datasources_tempo_get.md
@@ -45,7 +45,7 @@ gcx datasources tempo get TRACE_ID [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --llm                 Request LLM-friendly trace format
       --open                Open the retrieved trace in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_tempo_labels.md
+++ b/docs/reference/cli/gcx_datasources_tempo_labels.md
@@ -45,7 +45,7 @@ gcx datasources tempo labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)
 ```

--- a/docs/reference/cli/gcx_datasources_tempo_metrics.md
+++ b/docs/reference/cli/gcx_datasources_tempo_metrics.md
@@ -53,7 +53,7 @@ gcx datasources tempo metrics [TRACEQL] [flags]
       --instant             Run an instant query over the selected time range instead of a range query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_tempo_query.md
+++ b/docs/reference/cli/gcx_datasources_tempo_query.md
@@ -46,7 +46,7 @@ gcx datasources tempo query [TRACEQL] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of traces to return (0 means no limit) (default 20)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_dev_lint_rules.md
+++ b/docs/reference/cli/gcx_dev_lint_rules.md
@@ -29,7 +29,7 @@ gcx dev lint rules [flags]
 ```
   -h, --help                help for rules
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string       Output format. One of: agents, json, ndjson, yaml (default "yaml")
   -r, --rules stringArray   Path to custom rules.
 ```
 

--- a/docs/reference/cli/gcx_dev_lint_run.md
+++ b/docs/reference/cli/gcx_dev_lint_run.md
@@ -71,7 +71,7 @@ gcx dev lint run PATH... [flags]
   -h, --help                           help for run
       --json string                    Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-concurrent int             Maximum number of concurrent operations (default 10)
-  -o, --output string                  Output format. One of: agents, compact, json, pretty, yaml (default "pretty")
+  -o, --output string                  Output format. One of: agents, compact, json, ndjson, pretty, yaml (default "pretty")
   -r, --rules stringArray              Path to custom rules
 ```
 

--- a/docs/reference/cli/gcx_fleet_collectors_get.md
+++ b/docs/reference/cli/gcx_fleet_collectors_get.md
@@ -11,7 +11,7 @@ gcx fleet collectors get <id|name> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_fleet_collectors_list.md
+++ b/docs/reference/cli/gcx_fleet_collectors_list.md
@@ -12,7 +12,7 @@ gcx fleet collectors list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_fleet_pipelines_get.md
+++ b/docs/reference/cli/gcx_fleet_pipelines_get.md
@@ -11,7 +11,7 @@ gcx fleet pipelines get <id|name> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_fleet_pipelines_list.md
+++ b/docs/reference/cli/gcx_fleet_pipelines_list.md
@@ -12,7 +12,7 @@ gcx fleet pipelines list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_fleet_tenant_limits.md
+++ b/docs/reference/cli/gcx_fleet_tenant_limits.md
@@ -11,7 +11,7 @@ gcx fleet tenant limits [flags]
 ```
   -h, --help            help for limits
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_frontend_apps_get.md
+++ b/docs/reference/cli/gcx_frontend_apps_get.md
@@ -22,7 +22,7 @@ gcx frontend apps get [slug-id] [flags]
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string     Get Frontend Observability app by name instead of slug-id
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_frontend_apps_list.md
+++ b/docs/reference/cli/gcx_frontend_apps_list.md
@@ -12,7 +12,7 @@ gcx frontend apps list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for unlimited) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_frontend_apps_show-sourcemaps.md
+++ b/docs/reference/cli/gcx_frontend_apps_show-sourcemaps.md
@@ -25,7 +25,7 @@ gcx frontend apps show-sourcemaps <app-name> [flags]
   -h, --help            help for show-sourcemaps
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of sourcemaps to return (0 for all)
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_help-tree.md
+++ b/docs/reference/cli/gcx_help-tree.md
@@ -20,7 +20,7 @@ gcx help-tree [COMMAND...] [flags]
       --depth int       Maximum nesting depth (1 = root + direct children, 0 = unlimited)
   -h, --help            help for help-tree
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_instrumentation_clusters_apps_get.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_apps_get.md
@@ -20,7 +20,7 @@ gcx instrumentation clusters apps get <cluster> <namespace> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, wide, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, wide, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_instrumentation_clusters_apps_list.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_apps_list.md
@@ -19,7 +19,7 @@ gcx instrumentation clusters apps list <cluster> [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, wide, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, wide, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_instrumentation_clusters_get.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_get.md
@@ -31,7 +31,7 @@ gcx instrumentation clusters get <cluster> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_instrumentation_clusters_list.md
+++ b/docs/reference/cli/gcx_instrumentation_clusters_list.md
@@ -35,7 +35,7 @@ gcx instrumentation clusters list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_instrumentation_services_get.md
+++ b/docs/reference/cli/gcx_instrumentation_services_get.md
@@ -24,7 +24,7 @@ gcx instrumentation services get <cluster> <namespace> <service> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, wide, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, wide, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_instrumentation_services_list.md
+++ b/docs/reference/cli/gcx_instrumentation_services_list.md
@@ -38,7 +38,7 @@ gcx instrumentation services list [flags]
   -h, --help               help for list
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -n, --namespace string   Filter by Kubernetes namespace
-  -o, --output string      Output format. One of: agents, json, text, wide, yaml (default "text")
+  -o, --output string      Output format. One of: agents, json, ndjson, text, wide, yaml (default "text")
       --status string      Filter by instrumentation status (e.g. ERROR, INSTRUMENTED)
 ```
 

--- a/docs/reference/cli/gcx_instrumentation_status.md
+++ b/docs/reference/cli/gcx_instrumentation_status.md
@@ -25,7 +25,7 @@ gcx instrumentation status [flags]
   -h, --help               help for status
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --namespace string   Filter to a specific namespace; switches to workload-level view
-  -o, --output string      Output format. One of: agents, json, yaml (default "table")
+  -o, --output string      Output format. One of: agents, json, ndjson, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_incidents_activity_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_activity_list.md
@@ -12,7 +12,7 @@ gcx irm incidents activity list <incident-id> [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of activity items to return (default 50)
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_incidents_contexts_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_contexts_list.md
@@ -13,7 +13,7 @@ gcx irm incidents contexts list <incident-id> [flags]
   -h, --help                    help for list
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int               Maximum number of contexts to return (0 = server default)
-  -o, --output string           Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string           Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --status string           Filter by context status
       --type string             Filter by context type (e.g. genericURL, grafana.dashboard, code.github.pr). Note: alert-group links are encoded as genericURL contexts with alertGroupID set — use --alert-group-id to filter those.
 ```

--- a/docs/reference/cli/gcx_irm_incidents_create.md
+++ b/docs/reference/cli/gcx_irm_incidents_create.md
@@ -37,7 +37,7 @@ gcx irm incidents create [flags]
   -f, --filename string   File containing the incident manifest (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_incidents_get.md
+++ b/docs/reference/cli/gcx_irm_incidents_get.md
@@ -11,7 +11,7 @@ gcx irm incidents get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_incidents_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_list.md
@@ -14,7 +14,7 @@ gcx irm incidents list [flags]
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --labels strings   Filter by labels (key:value format, may be repeated)
       --limit int        Maximum number of incidents to return (default 50)
-  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --to string        End of time range (RFC3339, unix timestamp, or relative e.g. now)
 ```
 

--- a/docs/reference/cli/gcx_irm_incidents_severities_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_severities_list.md
@@ -11,7 +11,7 @@ gcx irm incidents severities list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_acknowledge.md
@@ -34,7 +34,7 @@ gcx irm oncall alert-groups acknowledge [<id>] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-age string        Filter: alert groups started within this duration (e.g. 1h, 24h, 7d)
       --mine                  Filter: limit to alert groups for the authenticated user
-  -o, --output string         Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string         Output format. One of: agents, json, ndjson, text, yaml (default "text")
       --state strings         Filter: state (firing|acknowledged|resolved|silenced; repeatable)
       --team strings          Filter: team PK (repeatable)
 ```

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_delete.md
@@ -33,7 +33,7 @@ gcx irm oncall alert-groups delete [<id>] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-age string        Filter: alert groups started within this duration (e.g. 1h, 24h, 7d)
       --mine                  Filter: limit to alert groups for the authenticated user
-  -o, --output string         Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string         Output format. One of: agents, json, ndjson, text, yaml (default "text")
       --state strings         Filter: state (firing|acknowledged|resolved|silenced; repeatable)
       --team strings          Filter: team PK (repeatable)
 ```

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_get.md
@@ -12,7 +12,7 @@ gcx irm oncall alert-groups get <id> [flags]
   -h, --help            help for get
       --include-raw     Include the unprocessed Alertmanager-shape payload under status.raw (hidden by default; the curated status.{target,links,...} blocks are the promoted view of the same data)
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_list-alerts.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_list-alerts.md
@@ -14,7 +14,7 @@ gcx irm oncall alert-groups list-alerts <alert-group-id> [flags]
       --include-raw     Include the unprocessed Alertmanager-shape payload under status.raw on each alert (hidden by default; status.{dimensions,links,...} are the promoted view of the same data)
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Cap on number of alerts retrieved (0 = no cap) (default 100)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --slim            Skip per-alert retrieval; emit only metadata + alert-group back-pointer
 ```
 

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_list.md
@@ -29,7 +29,7 @@ gcx irm oncall alert-groups list [flags]
       --limit int              Maximum number of alert groups to return (0 for all, capped by an internal safety limit) (default 50)
       --max-age string         Exclude groups older than this duration (e.g. 1h, 24h, 7d)
       --mine                   Limit to alert groups for the authenticated user
-  -o, --output string          Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string          Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --state strings          Filter by state (firing|acknowledged|resolved|silenced; repeatable, comma-separated). Default: firing,acknowledged,silenced
       --team strings           Filter by team PK (repeatable, comma-separated)
       --with-resolution-note   Limit to alert groups that have a resolution note

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_resolve.md
@@ -34,7 +34,7 @@ gcx irm oncall alert-groups resolve [<id>] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-age string        Filter: alert groups started within this duration (e.g. 1h, 24h, 7d)
       --mine                  Filter: limit to alert groups for the authenticated user
-  -o, --output string         Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string         Output format. One of: agents, json, ndjson, text, yaml (default "text")
       --state strings         Filter: state (firing|acknowledged|resolved|silenced; repeatable)
       --team strings          Filter: team PK (repeatable)
 ```

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_silence.md
@@ -35,7 +35,7 @@ gcx irm oncall alert-groups silence [<id>] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-age string        Filter: alert groups started within this duration (e.g. 1h, 24h, 7d)
       --mine                  Filter: limit to alert groups for the authenticated user
-  -o, --output string         Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string         Output format. One of: agents, json, ndjson, text, yaml (default "text")
       --state strings         Filter: state (firing|acknowledged|resolved|silenced; repeatable)
       --team strings          Filter: team PK (repeatable)
 ```

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unacknowledge.md
@@ -34,7 +34,7 @@ gcx irm oncall alert-groups unacknowledge [<id>] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-age string        Filter: alert groups started within this duration (e.g. 1h, 24h, 7d)
       --mine                  Filter: limit to alert groups for the authenticated user
-  -o, --output string         Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string         Output format. One of: agents, json, ndjson, text, yaml (default "text")
       --state strings         Filter: state (firing|acknowledged|resolved|silenced; repeatable)
       --team strings          Filter: team PK (repeatable)
 ```

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unresolve.md
@@ -34,7 +34,7 @@ gcx irm oncall alert-groups unresolve [<id>] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-age string        Filter: alert groups started within this duration (e.g. 1h, 24h, 7d)
       --mine                  Filter: limit to alert groups for the authenticated user
-  -o, --output string         Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string         Output format. One of: agents, json, ndjson, text, yaml (default "text")
       --state strings         Filter: state (firing|acknowledged|resolved|silenced; repeatable)
       --team strings          Filter: team PK (repeatable)
 ```

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_unsilence.md
@@ -34,7 +34,7 @@ gcx irm oncall alert-groups unsilence [<id>] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-age string        Filter: alert groups started within this duration (e.g. 1h, 24h, 7d)
       --mine                  Filter: limit to alert groups for the authenticated user
-  -o, --output string         Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string         Output format. One of: agents, json, ndjson, text, yaml (default "text")
       --state strings         Filter: state (firing|acknowledged|resolved|silenced; repeatable)
       --team strings          Filter: team PK (repeatable)
 ```

--- a/docs/reference/cli/gcx_irm_oncall_escalate.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalate.md
@@ -13,7 +13,7 @@ gcx irm oncall escalate [flags]
       --important          Mark as important
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --message string     Message for the escalation
-  -o, --output string      Output format. One of: agents, json, yaml (default "text")
+  -o, --output string      Output format. One of: agents, json, ndjson, yaml (default "text")
       --team string        Team ID
       --title string       Title of the escalation (required)
       --user-ids strings   User IDs (comma-separated)

--- a/docs/reference/cli/gcx_irm_oncall_escalation-chains_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-chains_get.md
@@ -11,7 +11,7 @@ gcx irm oncall escalation-chains get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_escalation-chains_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-chains_list.md
@@ -11,7 +11,7 @@ gcx irm oncall escalation-chains list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_escalation-policies_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-policies_get.md
@@ -11,7 +11,7 @@ gcx irm oncall escalation-policies get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_escalation-policies_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalation-policies_list.md
@@ -11,7 +11,7 @@ gcx irm oncall escalation-policies list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_integrations_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_integrations_get.md
@@ -11,7 +11,7 @@ gcx irm oncall integrations get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_integrations_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_integrations_list.md
@@ -11,7 +11,7 @@ gcx irm oncall integrations list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_organizations_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_organizations_get.md
@@ -11,7 +11,7 @@ gcx irm oncall organizations get [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_resolution-notes_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_resolution-notes_get.md
@@ -11,7 +11,7 @@ gcx irm oncall resolution-notes get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_resolution-notes_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_resolution-notes_list.md
@@ -11,7 +11,7 @@ gcx irm oncall resolution-notes list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_routes_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_routes_get.md
@@ -11,7 +11,7 @@ gcx irm oncall routes get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_routes_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_routes_list.md
@@ -11,7 +11,7 @@ gcx irm oncall routes list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_schedules_final-shifts.md
+++ b/docs/reference/cli/gcx_irm_oncall_schedules_final-shifts.md
@@ -12,7 +12,7 @@ gcx irm oncall schedules final-shifts <schedule-id> [flags]
       --end string      End date (YYYY-MM-DD) (default "YYYY-MM-DD")
   -h, --help            help for final-shifts
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --start string    Start date (YYYY-MM-DD) (default "YYYY-MM-DD")
 ```
 

--- a/docs/reference/cli/gcx_irm_oncall_schedules_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_schedules_get.md
@@ -11,7 +11,7 @@ gcx irm oncall schedules get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_schedules_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_schedules_list.md
@@ -11,7 +11,7 @@ gcx irm oncall schedules list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_shift-swaps_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_shift-swaps_get.md
@@ -11,7 +11,7 @@ gcx irm oncall shift-swaps get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_shift-swaps_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_shift-swaps_list.md
@@ -11,7 +11,7 @@ gcx irm oncall shift-swaps list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_shifts_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_shifts_get.md
@@ -11,7 +11,7 @@ gcx irm oncall shifts get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_shifts_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_shifts_list.md
@@ -11,7 +11,7 @@ gcx irm oncall shifts list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_slack-channels_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_slack-channels_list.md
@@ -11,7 +11,7 @@ gcx irm oncall slack-channels list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_teams_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_teams_get.md
@@ -11,7 +11,7 @@ gcx irm oncall teams get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_teams_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_teams_list.md
@@ -11,7 +11,7 @@ gcx irm oncall teams list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_user-groups_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_user-groups_list.md
@@ -11,7 +11,7 @@ gcx irm oncall user-groups list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_users_current.md
+++ b/docs/reference/cli/gcx_irm_oncall_users_current.md
@@ -11,7 +11,7 @@ gcx irm oncall users current [flags]
 ```
   -h, --help            help for current
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_users_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_users_get.md
@@ -11,7 +11,7 @@ gcx irm oncall users get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_users_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_users_list.md
@@ -11,7 +11,7 @@ gcx irm oncall users list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_webhooks_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_webhooks_get.md
@@ -11,7 +11,7 @@ gcx irm oncall webhooks get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_webhooks_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_webhooks_list.md
@@ -11,7 +11,7 @@ gcx irm oncall webhooks list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_env-vars_list.md
+++ b/docs/reference/cli/gcx_k6_env-vars_list.md
@@ -12,7 +12,7 @@ gcx k6 env-vars list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_load-tests_create.md
+++ b/docs/reference/cli/gcx_k6_load-tests_create.md
@@ -13,7 +13,7 @@ gcx k6 load-tests create [flags]
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string       Test name (required when --filename not used)
-  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "yaml")
       --project-id int    Project ID (required when --filename not used)
       --script string     Path to k6 script file (required when --filename not used)
 ```

--- a/docs/reference/cli/gcx_k6_load-tests_get.md
+++ b/docs/reference/cli/gcx_k6_load-tests_get.md
@@ -11,7 +11,7 @@ gcx k6 load-tests get <id-or-name> [flags]
 ```
   -h, --help             help for get
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string    Output format. One of: agents, json, ndjson, yaml (default "yaml")
       --project-id int   Project ID (required when looking up by name)
 ```
 

--- a/docs/reference/cli/gcx_k6_load-tests_list.md
+++ b/docs/reference/cli/gcx_k6_load-tests_list.md
@@ -12,7 +12,7 @@ gcx k6 load-tests list [flags]
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of items to return (0 for all) (default 50)
-  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --project-id int   Filter by project ID
 ```
 

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones_list.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-load-zones_list.md
@@ -11,7 +11,7 @@ gcx k6 load-zones allowed-load-zones list <project-id> [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_load-zones_allowed-projects_list.md
+++ b/docs/reference/cli/gcx_k6_load-zones_allowed-projects_list.md
@@ -11,7 +11,7 @@ gcx k6 load-zones allowed-projects list <load-zone-id> [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_load-zones_list.md
+++ b/docs/reference/cli/gcx_k6_load-zones_list.md
@@ -12,7 +12,7 @@ gcx k6 load-zones list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_projects_create.md
+++ b/docs/reference/cli/gcx_k6_projects_create.md
@@ -12,7 +12,7 @@ gcx k6 projects create [flags]
   -f, --filename string   File containing the project manifest (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_projects_get.md
+++ b/docs/reference/cli/gcx_k6_projects_get.md
@@ -11,7 +11,7 @@ gcx k6 projects get <id-or-name> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_projects_list.md
+++ b/docs/reference/cli/gcx_k6_projects_list.md
@@ -12,7 +12,7 @@ gcx k6 projects list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_runs_list.md
+++ b/docs/reference/cli/gcx_k6_runs_list.md
@@ -13,7 +13,7 @@ gcx k6 runs list [id-or-name] [flags]
       --id int           Load test ID (skip name lookup)
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of items to return (0 for all) (default 50)
-  -o, --output string    Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --project-id int   Project ID (required when looking up by name)
 ```
 

--- a/docs/reference/cli/gcx_k6_schedules_get.md
+++ b/docs/reference/cli/gcx_k6_schedules_get.md
@@ -11,7 +11,7 @@ gcx k6 schedules get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_schedules_list.md
+++ b/docs/reference/cli/gcx_k6_schedules_list.md
@@ -12,7 +12,7 @@ gcx k6 schedules list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_k6_test-run_runs_list.md
+++ b/docs/reference/cli/gcx_k6_test-run_runs_list.md
@@ -13,7 +13,7 @@ gcx k6 test-run runs list [test-name] [flags]
       --id int           Load test ID (skip name lookup)
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of items to return (0 for all) (default 50)
-  -o, --output string    Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --project-id int   k6 Cloud project ID (required when using name lookup)
 ```
 

--- a/docs/reference/cli/gcx_kg_diagnose.md
+++ b/docs/reference/cli/gcx_kg_diagnose.md
@@ -35,7 +35,7 @@ gcx kg diagnose [flags]
   -h, --help                help for diagnose
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --namespace string    Namespace scope
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --site string         Site scope
 ```
 

--- a/docs/reference/cli/gcx_kg_diagnose_labels.md
+++ b/docs/reference/cli/gcx_kg_diagnose_labels.md
@@ -27,7 +27,7 @@ gcx kg diagnose labels [flags]
   -d, --datasource string   Prometheus datasource UID (auto-discovered if omitted)
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_diagnose_service.md
+++ b/docs/reference/cli/gcx_kg_diagnose_service.md
@@ -28,7 +28,7 @@ gcx kg diagnose service NAME [flags]
   -h, --help                help for service
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --namespace string    Namespace scope
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --site string         Site scope
 ```
 

--- a/docs/reference/cli/gcx_kg_entities_inspect.md
+++ b/docs/reference/cli/gcx_kg_entities_inspect.md
@@ -20,7 +20,7 @@ gcx kg entities inspect [Type--Name] [flags]
       --name string                        Entity name
       --namespace string                   Namespace scope (run 'gcx kg meta scopes' to see valid values)
       --open                               Open the entity in the RCA Workbench in your browser
-  -o, --output string                      Output format. One of: agents, json, yaml (default "json")
+  -o, --output string                      Output format. One of: agents, json, ndjson, yaml (default "json")
       --share-link                         Print the RCA Workbench URL for this entity to stderr
       --since string                       Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
       --site string                        Site scope (run 'gcx kg meta scopes' to see valid values)

--- a/docs/reference/cli/gcx_kg_entities_list.md
+++ b/docs/reference/cli/gcx_kg_entities_list.md
@@ -26,7 +26,7 @@ gcx kg entities list [flags]
       --json string            Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int              Maximum number of items to return (0 for all; the backend may still page results — use --page to paginate) (default 50)
       --namespace string       Namespace scope (run 'gcx kg meta scopes' to see valid values)
-  -o, --output string          Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string          Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --page int               Page number (0-based)
       --property stringArray   Filter by property: name=value (exact) or name=~value (contains); repeatable (run 'gcx kg meta schema' to list property names)
       --since string           Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)

--- a/docs/reference/cli/gcx_kg_entities_query.md
+++ b/docs/reference/cli/gcx_kg_entities_query.md
@@ -47,7 +47,7 @@ gcx kg entities query <cypher-query> [flags]
   -h, --help            help for query
       --insights-only   Return only entities with active insights
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --page int        Page number (0-based)
       --since string    Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
       --to string       End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_kg_meta_all.md
+++ b/docs/reference/cli/gcx_kg_meta_all.md
@@ -12,7 +12,7 @@ gcx kg meta all [flags]
       --from string     Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help            help for all
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
       --since string    Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
       --to string       End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_kg_meta_logs.md
+++ b/docs/reference/cli/gcx_kg_meta_logs.md
@@ -11,7 +11,7 @@ gcx kg meta logs [flags]
 ```
   -h, --help            help for logs
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_meta_profiles.md
+++ b/docs/reference/cli/gcx_kg_meta_profiles.md
@@ -11,7 +11,7 @@ gcx kg meta profiles [flags]
 ```
   -h, --help            help for profiles
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_meta_schema.md
+++ b/docs/reference/cli/gcx_kg_meta_schema.md
@@ -12,7 +12,7 @@ gcx kg meta schema [flags]
       --from string     Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help            help for schema
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
       --since string    Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
       --to string       End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_kg_meta_scopes.md
+++ b/docs/reference/cli/gcx_kg_meta_scopes.md
@@ -11,7 +11,7 @@ gcx kg meta scopes [flags]
 ```
   -h, --help            help for scopes
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_meta_traces.md
+++ b/docs/reference/cli/gcx_kg_meta_traces.md
@@ -11,7 +11,7 @@ gcx kg meta traces [flags]
 ```
   -h, --help            help for traces
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_prom-rules_get.md
+++ b/docs/reference/cli/gcx_kg_prom-rules_get.md
@@ -11,7 +11,7 @@ gcx kg prom-rules get <name> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_prom-rules_list.md
+++ b/docs/reference/cli/gcx_kg_prom-rules_list.md
@@ -12,7 +12,7 @@ gcx kg prom-rules list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_status.md
+++ b/docs/reference/cli/gcx_kg_status.md
@@ -11,7 +11,7 @@ gcx kg status [flags]
 ```
   -h, --help            help for status
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_summary.md
+++ b/docs/reference/cli/gcx_kg_summary.md
@@ -14,7 +14,7 @@ gcx kg summary [flags]
   -h, --help               help for summary
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --namespace string   Namespace scope
-  -o, --output string      Output format. One of: agents, json, yaml (default "json")
+  -o, --output string      Output format. One of: agents, json, ndjson, yaml (default "json")
       --since string       Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
       --site string        Site scope
       --to string          End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_kg_suppressions_list.md
+++ b/docs/reference/cli/gcx_kg_suppressions_list.md
@@ -11,7 +11,7 @@ gcx kg suppressions list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_login.md
+++ b/docs/reference/cli/gcx_login.md
@@ -49,7 +49,7 @@ gcx login [CONTEXT_NAME] [flags]
       --json string               Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --oauth-callback-port int   Fixed local port for the OAuth callback server (default: auto-pick from 54321-54399). Useful when only specific ports are forwarded between a remote host and your browser
       --org-id int                Grafana organization ID (defaults to 1 for on-prem)
-  -o, --output string             Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string             Output format. One of: agents, json, ndjson, text, yaml (default "text")
       --server string             Grafana server URL (e.g. https://my-stack.grafana.net)
       --token string              Grafana service account token
       --yes                       Non-interactive: skip optional prompts and use defaults

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_create.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_create.md
@@ -18,7 +18,7 @@ gcx logs adaptive drop-rules create [flags]
   -f, --filename string   File containing the drop rule definition (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_get.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_get.md
@@ -17,7 +17,7 @@ gcx logs adaptive drop-rules get ID [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_list.md
@@ -13,7 +13,7 @@ gcx logs adaptive drop-rules list [flags]
   -h, --help                       help for list
       --json string                Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int                  Maximum number of drop rules to return (0 for no limit) (default 50)
-  -o, --output string              Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string              Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_drop-rules_update.md
+++ b/docs/reference/cli/gcx_logs_adaptive_drop-rules_update.md
@@ -18,7 +18,7 @@ gcx logs adaptive drop-rules update ID [flags]
   -f, --filename string   File containing the drop rule definition (use - for stdin)
   -h, --help              help for update
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions_create.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions_create.md
@@ -11,7 +11,7 @@ gcx logs adaptive exemptions create [flags]
 ```
   -h, --help                     help for create
       --json string              Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string            Output format. One of: agents, json, yaml (default "json")
+  -o, --output string            Output format. One of: agents, json, ndjson, yaml (default "json")
       --reason string            Reason for the exemption
       --stream-selector string   Log stream selector (required)
 ```

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions_list.md
@@ -12,7 +12,7 @@ gcx logs adaptive exemptions list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of exemptions to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_exemptions_update.md
+++ b/docs/reference/cli/gcx_logs_adaptive_exemptions_update.md
@@ -11,7 +11,7 @@ gcx logs adaptive exemptions update ID [flags]
 ```
   -h, --help                     help for update
       --json string              Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string            Output format. One of: agents, json, yaml (default "json")
+  -o, --output string            Output format. One of: agents, json, ndjson, yaml (default "json")
       --reason string            Reason for the exemption
       --stream-selector string   Log stream selector
 ```

--- a/docs/reference/cli/gcx_logs_adaptive_patterns_show.md
+++ b/docs/reference/cli/gcx_logs_adaptive_patterns_show.md
@@ -11,7 +11,7 @@ gcx logs adaptive patterns show [flags]
 ```
   -h, --help             help for show
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --segment string   Only include patterns for this segment (ID column from patterns stats, or API map key / selector)
       --top int          Table only: show top N patterns by volume; 0 shows all rows with no rollup (default 10)
 ```

--- a/docs/reference/cli/gcx_logs_adaptive_patterns_stats.md
+++ b/docs/reference/cli/gcx_logs_adaptive_patterns_stats.md
@@ -11,7 +11,7 @@ gcx logs adaptive patterns stats [flags]
 ```
   -h, --help            help for stats
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_segments_create.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments_create.md
@@ -13,7 +13,7 @@ gcx logs adaptive segments create [flags]
   -h, --help                  help for create
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string           Segment name (required)
-  -o, --output string         Output format. One of: agents, json, yaml (default "json")
+  -o, --output string         Output format. One of: agents, json, ndjson, yaml (default "json")
       --selector string       Log stream selector (required)
 ```
 

--- a/docs/reference/cli/gcx_logs_adaptive_segments_list.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments_list.md
@@ -12,7 +12,7 @@ gcx logs adaptive segments list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of segments to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_adaptive_segments_update.md
+++ b/docs/reference/cli/gcx_logs_adaptive_segments_update.md
@@ -13,7 +13,7 @@ gcx logs adaptive segments update ID [flags]
   -h, --help                  help for update
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string           Segment name
-  -o, --output string         Output format. One of: agents, json, yaml (default "json")
+  -o, --output string         Output format. One of: agents, json, ndjson, yaml (default "json")
       --selector string       Log stream selector
 ```
 

--- a/docs/reference/cli/gcx_logs_labels.md
+++ b/docs/reference/cli/gcx_logs_labels.md
@@ -31,7 +31,7 @@ gcx logs labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_logs_metrics.md
+++ b/docs/reference/cli/gcx_logs_metrics.md
@@ -44,7 +44,7 @@ gcx logs metrics [EXPR] [flags]
   -h, --help                help for metrics
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_logs_query.md
+++ b/docs/reference/cli/gcx_logs_query.md
@@ -50,7 +50,7 @@ gcx logs query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of log lines to return (0 means no limit) (default 50)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, raw, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, raw, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_logs_series.md
+++ b/docs/reference/cli/gcx_logs_series.md
@@ -31,7 +31,7 @@ gcx logs series [flags]
   -h, --help                help for series
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -M, --match stringArray   LogQL stream selector (required, e.g., '{job="varlogs"}')
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_create.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_create.md
@@ -17,7 +17,7 @@ gcx metrics adaptive exemptions create [flags]
       --managed-by string         Manager identifier
       --match-type string         Match type: exact, prefix, or suffix (default "exact")
       --metric string             Metric name or pattern
-  -o, --output string             Output format. One of: agents, json, yaml (default "json")
+  -o, --output string             Output format. One of: agents, json, ndjson, yaml (default "json")
       --reason string             Reason for the exemption
       --segment string            Segment ID
 ```

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_get.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_get.md
@@ -11,7 +11,7 @@ gcx metrics adaptive exemptions get <id> [flags]
 ```
   -h, --help             help for get
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "json")
+  -o, --output string    Output format. One of: agents, json, ndjson, table, wide, yaml (default "json")
       --segment string   Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_list.md
@@ -13,7 +13,7 @@ gcx metrics adaptive exemptions list [flags]
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of exemptions to return (0 for no limit)
-  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --segment string   Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_exemptions_update.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_exemptions_update.md
@@ -17,7 +17,7 @@ gcx metrics adaptive exemptions update <id> [flags]
       --managed-by string         Manager identifier
       --match-type string         Match type: exact, prefix, or suffix
       --metric string             Metric name or pattern
-  -o, --output string             Output format. One of: agents, json, yaml (default "json")
+  -o, --output string             Output format. One of: agents, json, ndjson, yaml (default "json")
       --reason string             Reason for the exemption
       --segment string            Segment ID
 ```

--- a/docs/reference/cli/gcx_metrics_adaptive_recommendations_diff.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_recommendations_diff.md
@@ -11,7 +11,7 @@ gcx metrics adaptive recommendations diff <metric>... [flags]
 ```
   -h, --help             help for diff
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --segment string   Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_recommendations_show.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_recommendations_show.md
@@ -12,7 +12,7 @@ gcx metrics adaptive recommendations show [flags]
       --action stringArray   Filter by action: add, update, remove, keep (repeatable)
   -h, --help                 help for show
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --reverse              Reverse the default sort order
       --segment string       Segment ID
       --sort string          Sort by: metric, savings, series-before, series-after, action (default "metric")

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_create.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_create.md
@@ -19,7 +19,7 @@ gcx metrics adaptive rules create [flags]
       --keep-labels strings           Labels to keep (comma-separated)
       --match-type string             Match type: exact, prefix, or suffix (default "exact")
       --metric string                 Metric name (required)
-  -o, --output string                 Output format. One of: agents, json, yaml (default "json")
+  -o, --output string                 Output format. One of: agents, json, ndjson, yaml (default "json")
       --segment string                Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_get.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_get.md
@@ -11,7 +11,7 @@ gcx metrics adaptive rules get <metric> [flags]
 ```
   -h, --help             help for get
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string    Output format. One of: agents, json, yaml (default "json")
+  -o, --output string    Output format. One of: agents, json, ndjson, yaml (default "json")
       --segment string   Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_list.md
@@ -12,7 +12,7 @@ gcx metrics adaptive rules list [flags]
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of rules to return (0 for no limit) (default 50)
-  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string    Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --segment string   Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_rules_update.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_rules_update.md
@@ -18,7 +18,7 @@ gcx metrics adaptive rules update <metric> [flags]
       --json string                   Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --keep-labels strings           Labels to keep (comma-separated)
       --match-type string             Match type: exact, prefix, or suffix
-  -o, --output string                 Output format. One of: agents, json, yaml (default "json")
+  -o, --output string                 Output format. One of: agents, json, ndjson, yaml (default "json")
       --segment string                Segment ID
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_create.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_create.md
@@ -14,7 +14,7 @@ gcx metrics adaptive segments create [flags]
   -h, --help                  help for create
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string           Segment name (required)
-  -o, --output string         Output format. One of: agents, json, yaml (default "json")
+  -o, --output string         Output format. One of: agents, json, ndjson, yaml (default "json")
       --selector string       PromQL label selector (required)
 ```
 

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_get.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_get.md
@@ -11,7 +11,7 @@ gcx metrics adaptive segments get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_list.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_list.md
@@ -12,7 +12,7 @@ gcx metrics adaptive segments list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of segments to return (0 for no limit)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_adaptive_segments_update.md
+++ b/docs/reference/cli/gcx_metrics_adaptive_segments_update.md
@@ -14,7 +14,7 @@ gcx metrics adaptive segments update <id> [flags]
   -h, --help                  help for update
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string           Segment name
-  -o, --output string         Output format. One of: agents, json, yaml (default "json")
+  -o, --output string         Output format. One of: agents, json, ndjson, yaml (default "json")
       --selector string       PromQL label selector
 ```
 

--- a/docs/reference/cli/gcx_metrics_billing_labels.md
+++ b/docs/reference/cli/gcx_metrics_billing_labels.md
@@ -31,7 +31,7 @@ gcx metrics billing labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_billing_query.md
+++ b/docs/reference/cli/gcx_metrics_billing_query.md
@@ -42,7 +42,7 @@ gcx metrics billing query [EXPR] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_metrics_billing_series.md
+++ b/docs/reference/cli/gcx_metrics_billing_series.md
@@ -35,7 +35,7 @@ gcx metrics billing series [SELECTOR] [flags]
   -h, --help                help for series
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --match stringArray   Additional series selector(s); repeatable
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_metrics_labels.md
+++ b/docs/reference/cli/gcx_metrics_labels.md
@@ -31,7 +31,7 @@ gcx metrics labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_metadata.md
+++ b/docs/reference/cli/gcx_metrics_metadata.md
@@ -31,7 +31,7 @@ gcx metrics metadata [flags]
   -h, --help                help for metadata
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -m, --metric string       Filter by metric name
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_metrics_query.md
+++ b/docs/reference/cli/gcx_metrics_query.md
@@ -45,7 +45,7 @@ gcx metrics query [EXPR] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_metrics_series.md
+++ b/docs/reference/cli/gcx_metrics_series.md
@@ -35,7 +35,7 @@ gcx metrics series [SELECTOR] [flags]
   -h, --help                help for series
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --match stringArray   Additional series selector(s); repeatable
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_profiles_exemplars_profile.md
+++ b/docs/reference/cli/gcx_profiles_exemplars_profile.md
@@ -37,7 +37,7 @@ gcx profiles exemplars profile [EXPR] [flags]
   -h, --help                    help for profile
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
-  -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string           Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
       --since string            Duration before --to (or now if omitted); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_profiles_exemplars_span.md
+++ b/docs/reference/cli/gcx_profiles_exemplars_span.md
@@ -37,7 +37,7 @@ gcx profiles exemplars span [EXPR] [flags]
   -h, --help                    help for span
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
-  -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string           Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
       --since string            Duration before --to (or now if omitted); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_profiles_labels.md
+++ b/docs/reference/cli/gcx_profiles_labels.md
@@ -31,7 +31,7 @@ gcx profiles labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_profiles_metrics.md
+++ b/docs/reference/cli/gcx_profiles_metrics.md
@@ -48,7 +48,7 @@ gcx profiles metrics [EXPR] [flags]
   -h, --help                  help for metrics
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int             Maximum number of series to return (default 10)
-  -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string         Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_profiles_profile-types.md
+++ b/docs/reference/cli/gcx_profiles_profile-types.md
@@ -27,7 +27,7 @@ gcx profiles profile-types [flags]
   -d, --datasource string   Datasource UID (required unless default-pyroscope-datasource is configured)
   -h, --help                help for profile-types
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -52,7 +52,7 @@ gcx profiles query [EXPR] [flags]
   -h, --help                          help for query
       --json string                   Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-nodes int                 Maximum nodes in flame graph (default 0/unlimited for pprof output, 50000 for all other formats)
-  -o, --output string                 Output format. One of: agents, graph, json, pprof, table, wide, yaml (default "table")
+  -o, --output string                 Output format. One of: agents, graph, json, ndjson, pprof, table, wide, yaml (default "table")
       --pprof-overwrite               Overwrite the output file if it already exists (only with -o pprof)
       --pprof-path string             Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)

--- a/docs/reference/cli/gcx_providers_list.md
+++ b/docs/reference/cli/gcx_providers_list.md
@@ -11,7 +11,7 @@ gcx providers list [flags]
 ```
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_resources_edit.md
+++ b/docs/reference/cli/gcx_resources_edit.md
@@ -38,7 +38,7 @@ gcx resources edit RESOURCE_SELECTOR [flags]
 ```
   -h, --help            help for edit
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_resources_examples.md
+++ b/docs/reference/cli/gcx_resources_examples.md
@@ -29,7 +29,7 @@ gcx resources examples [RESOURCE_SELECTOR] [flags]
 ```
   -h, --help            help for examples
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, wide, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, wide, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_resources_get.md
+++ b/docs/reference/cli/gcx_resources_get.md
@@ -79,7 +79,7 @@ gcx resources get [RESOURCE_SELECTOR]... [flags]
                             fail   — continue processing all resources and exit 1 if any failed (default)
                             abort  — stop on the first error and exit 1 (default "fail")
       --open              Open the resource in the default browser
-  -o, --output string     Output format. One of: agents, json, text, wide, yaml (default "text")
+  -o, --output string     Output format. One of: agents, json, ndjson, text, wide, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_resources_pull.md
+++ b/docs/reference/cli/gcx_resources_pull.md
@@ -69,7 +69,7 @@ gcx resources pull [RESOURCE_SELECTOR]... [flags]
                             ignore — continue processing all resources and exit 0
                             fail   — continue processing all resources and exit 1 if any failed (default)
                             abort  — stop on the first error and exit 1 (default "fail")
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "json")
   -p, --path string       Path on disk in which the resources will be written (default "./resources")
 ```
 

--- a/docs/reference/cli/gcx_resources_schemas.md
+++ b/docs/reference/cli/gcx_resources_schemas.md
@@ -30,7 +30,7 @@ gcx resources schemas [RESOURCE_SELECTOR] [flags]
   -h, --help            help for schemas
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --no-schema       Skip fetching OpenAPI spec schemas (faster, omits schema info and unlistable resource types)
-  -o, --output string   Output format. One of: agents, json, text, wide, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, wide, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_resources_validate.md
+++ b/docs/reference/cli/gcx_resources_validate.md
@@ -41,7 +41,7 @@ gcx resources validate [RESOURCE_SELECTOR]... [flags]
                                ignore — continue processing all resources and exit 0
                                fail   — continue processing all resources and exit 1 if any failed (default)
                                abort  — stop on the first error and exit 1 (default "fail")
-  -o, --output string        Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string        Output format. One of: agents, json, ndjson, text, yaml (default "text")
   -p, --path strings         Paths on disk from which to read the resources. (default [./resources])
 ```
 

--- a/docs/reference/cli/gcx_slo_definitions_get.md
+++ b/docs/reference/cli/gcx_slo_definitions_get.md
@@ -11,7 +11,7 @@ gcx slo definitions get UUID [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_definitions_list.md
+++ b/docs/reference/cli/gcx_slo_definitions_list.md
@@ -12,7 +12,7 @@ gcx slo definitions list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return after fetch (0 for all; use a positive value to trim output only)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_definitions_status.md
+++ b/docs/reference/cli/gcx_slo_definitions_status.md
@@ -38,7 +38,7 @@ gcx slo definitions status [UUID] [flags]
 ```
   -h, --help            help for status
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_definitions_timeline.md
+++ b/docs/reference/cli/gcx_slo_definitions_timeline.md
@@ -39,7 +39,7 @@ gcx slo definitions timeline [UUID] [flags]
       --from string     Start of the time range (e.g. now-7d, now-24h, RFC3339, Unix timestamp) (default "now-7d")
   -h, --help            help for timeline
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, graph, json, table, yaml (default "graph")
+  -o, --output string   Output format. One of: agents, graph, json, ndjson, table, yaml (default "graph")
       --since string    Duration before now (e.g. 1h, 7d). Equivalent to --from now-<since> --to now.
       --step string     Query step (e.g. 5m, 1h). Defaults to auto-computed value.
       --to string       End of the time range (e.g. now, RFC3339, Unix timestamp) (default "now")

--- a/docs/reference/cli/gcx_slo_reports_get.md
+++ b/docs/reference/cli/gcx_slo_reports_get.md
@@ -11,7 +11,7 @@ gcx slo reports get UUID [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_reports_list.md
+++ b/docs/reference/cli/gcx_slo_reports_list.md
@@ -12,7 +12,7 @@ gcx slo reports list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_reports_status.md
+++ b/docs/reference/cli/gcx_slo_reports_status.md
@@ -37,7 +37,7 @@ gcx slo reports status [UUID] [flags]
 ```
   -h, --help            help for status
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_slo_reports_timeline.md
+++ b/docs/reference/cli/gcx_slo_reports_timeline.md
@@ -40,7 +40,7 @@ gcx slo reports timeline [UUID] [flags]
       --from string     Start of the time range (e.g. now-7d, now-24h, RFC3339, Unix timestamp) (default "now-7d")
   -h, --help            help for timeline
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, graph, json, table, yaml (default "graph")
+  -o, --output string   Output format. One of: agents, graph, json, ndjson, table, yaml (default "graph")
       --since string    Duration before now (e.g. 1h, 7d). Equivalent to --from now-<since> --to now.
       --step string     Query step (e.g. 5m, 1h). Defaults to auto-computed value.
       --to string       End of the time range (e.g. now, RFC3339, Unix timestamp) (default "now")

--- a/docs/reference/cli/gcx_stacks_create.md
+++ b/docs/reference/cli/gcx_stacks_create.md
@@ -24,7 +24,7 @@ gcx stacks create [flags]
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --labels strings       Labels in key=value format (may be repeated)
       --name string          Stack name (required)
-  -o, --output string        Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string        Output format. One of: agents, json, ndjson, table, yaml (default "table")
       --region string        Region slug (e.g. us, eu). Use 'gcx stacks regions' to list.
       --slug string          Stack slug / subdomain (required)
       --url string           Custom domain URL

--- a/docs/reference/cli/gcx_stacks_get.md
+++ b/docs/reference/cli/gcx_stacks_get.md
@@ -11,7 +11,7 @@ gcx stacks get <stack-slug> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_stacks_list.md
+++ b/docs/reference/cli/gcx_stacks_list.md
@@ -12,7 +12,7 @@ gcx stacks list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --org string      Organisation slug (required)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_stacks_regions.md
+++ b/docs/reference/cli/gcx_stacks_regions.md
@@ -11,7 +11,7 @@ gcx stacks regions [flags]
 ```
   -h, --help            help for regions
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_stacks_update.md
+++ b/docs/reference/cli/gcx_stacks_update.md
@@ -25,7 +25,7 @@ gcx stacks update <stack-slug> [flags]
       --labels strings         Labels in key=value format (replaces all labels)
       --name string            New stack name
       --no-delete-protection   Disable delete protection
-  -o, --output string          Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string          Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_get.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_get.md
@@ -24,7 +24,7 @@ gcx synthetic-monitoring checks get NAME [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --show-status     Query and display the check's current execution status from Prometheus
 ```
 

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_list.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_list.md
@@ -27,7 +27,7 @@ gcx synthetic-monitoring checks list [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --label stringArray   Filter by label key=value (repeatable, e.g. --label env=prod)
       --limit int           Maximum number of items to return (0 for all) (default 50)
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_status.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_status.md
@@ -44,7 +44,7 @@ gcx synthetic-monitoring checks status [ID] [flags]
       --job string              Filter by job name glob pattern (e.g. --job 'shopk8s-*')
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --label stringArray       Filter by label key=value (repeatable, e.g. --label env=prod)
-  -o, --output string           Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string           Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --status string           Filter results by status: OK, FAILING, or NODATA
 ```
 

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_timeline.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_timeline.md
@@ -40,7 +40,7 @@ gcx synthetic-monitoring checks timeline ID [flags]
       --from string             Start of the time range (e.g. now-6h, now-24h, RFC3339, Unix timestamp)
   -h, --help                    help for timeline
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string           Output format. One of: agents, graph, json, table, yaml (default "graph")
+  -o, --output string           Output format. One of: agents, graph, json, ndjson, table, yaml (default "graph")
       --since string            Duration before now to display (e.g. 1h, 6h, 24h, 7d) (default "6h")
       --to string               End of the time range (e.g. now, RFC3339, Unix timestamp)
 ```

--- a/docs/reference/cli/gcx_synthetic-monitoring_probes_list.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_probes_list.md
@@ -12,7 +12,7 @@ gcx synthetic-monitoring probes list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of items to return (0 for all) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_adaptive_policies_create.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_create.md
@@ -12,7 +12,7 @@ gcx traces adaptive policies create [flags]
   -f, --filename string   File containing the policy definition (use - for stdin)
   -h, --help              help for create
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_adaptive_policies_get.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_get.md
@@ -11,7 +11,7 @@ gcx traces adaptive policies get <id> [flags]
 ```
   -h, --help            help for get
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string   Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_adaptive_policies_list.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_list.md
@@ -12,7 +12,7 @@ gcx traces adaptive policies list [flags]
   -h, --help            help for list
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int       Maximum number of policies to return (0 for no limit) (default 50)
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_adaptive_policies_update.md
+++ b/docs/reference/cli/gcx_traces_adaptive_policies_update.md
@@ -12,7 +12,7 @@ gcx traces adaptive policies update <id> [flags]
   -f, --filename string   File containing the policy definition (use - for stdin)
   -h, --help              help for update
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string     Output format. One of: agents, json, ndjson, yaml (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_adaptive_recommendations_show.md
+++ b/docs/reference/cli/gcx_traces_adaptive_recommendations_show.md
@@ -11,7 +11,7 @@ gcx traces adaptive recommendations show [flags]
 ```
   -h, --help            help for show
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string   Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_traces_get.md
+++ b/docs/reference/cli/gcx_traces_get.md
@@ -39,7 +39,7 @@ gcx traces get TRACE_ID [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --llm                 Request LLM-friendly trace format
       --open                Open the retrieved trace in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_traces_labels.md
+++ b/docs/reference/cli/gcx_traces_labels.md
@@ -33,7 +33,7 @@ gcx traces labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)
 ```

--- a/docs/reference/cli/gcx_traces_metrics.md
+++ b/docs/reference/cli/gcx_traces_metrics.md
@@ -44,7 +44,7 @@ gcx traces metrics [TRACEQL] [flags]
       --instant             Run an instant query over the selected time range instead of a range query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, graph, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_traces_query.md
+++ b/docs/reference/cli/gcx_traces_query.md
@@ -40,7 +40,7 @@ gcx traces query [TRACEQL] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of traces to return (0 means no limit) (default 20)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, ndjson, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to (or now if omitted); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_version.md
+++ b/docs/reference/cli/gcx_version.md
@@ -28,7 +28,7 @@ gcx version [flags]
 ```
   -h, --help            help for version
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string   Output format. One of: agents, json, ndjson, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/internal/gcxerrors/json.go
+++ b/internal/gcxerrors/json.go
@@ -32,8 +32,11 @@ type errorJSON struct {
 	DocsLink    string   `json:"docsLink,omitempty"`
 }
 
-// errorEnvelope is the top-level JSON object written to stdout on error.
+// errorEnvelope is the top-level JSON object written to stdout on error. The
+// kind:"error" discriminator keeps it uniform with NDJSON data/diagnostic lines
+// so a 2>&1-merged stream stays parseable line-by-line.
 type errorEnvelope struct {
+	Kind  string    `json:"kind"`
 	Error errorJSON `json:"error"`
 }
 
@@ -50,6 +53,7 @@ func (e DetailedError) WriteJSON(w io.Writer, exitCode int) error {
 		sug[i] = stripBoxChars(s)
 	}
 	envelope := errorEnvelope{
+		Kind: "error",
 		Error: errorJSON{
 			Summary:     e.Summary,
 			ExitCode:    exitCode,
@@ -74,6 +78,7 @@ func (e DetailedError) WriteJSON(w io.Writer, exitCode int) error {
 // the error context.
 func (e DetailedError) WriteJSONWithItems(w io.Writer, exitCode int, items any) error {
 	type combined struct {
+		Kind  string    `json:"kind"`
 		Items any       `json:"items"`
 		Error errorJSON `json:"error"`
 	}
@@ -83,6 +88,7 @@ func (e DetailedError) WriteJSONWithItems(w io.Writer, exitCode int, items any) 
 		sug[i] = stripBoxChars(s)
 	}
 	env := combined{
+		Kind:  "error",
 		Items: items,
 		Error: errorJSON{
 			Summary:     e.Summary,

--- a/internal/gcxerrors/json_test.go
+++ b/internal/gcxerrors/json_test.go
@@ -176,6 +176,41 @@ func TestWriteJSON_StripBoxCharsDefensive(t *testing.T) {
 	}
 }
 
+// TestWriteJSON_HasKindDiscriminator verifies both error envelopes carry the
+// top-level kind:"error" discriminator so a 2>&1-merged NDJSON stream stays
+// uniform and demuxable by kind.
+func TestWriteJSON_HasKindDiscriminator(t *testing.T) {
+	err := gcxerrors.DetailedError{Summary: "boom"}
+
+	t.Run("WriteJSON", func(t *testing.T) {
+		var buf bytes.Buffer
+		if writeErr := err.WriteJSON(&buf, 1); writeErr != nil {
+			t.Fatalf("WriteJSON() error: %v", writeErr)
+		}
+		var got map[string]any
+		if jsonErr := json.Unmarshal(buf.Bytes(), &got); jsonErr != nil {
+			t.Fatalf("invalid JSON: %v", jsonErr)
+		}
+		if got["kind"] != "error" {
+			t.Errorf("kind want %q, got %v", "error", got["kind"])
+		}
+	})
+
+	t.Run("WriteJSONWithItems", func(t *testing.T) {
+		var buf bytes.Buffer
+		if writeErr := err.WriteJSONWithItems(&buf, 4, []any{map[string]any{"ok": true}}); writeErr != nil {
+			t.Fatalf("WriteJSONWithItems() error: %v", writeErr)
+		}
+		var got map[string]any
+		if jsonErr := json.Unmarshal(buf.Bytes(), &got); jsonErr != nil {
+			t.Fatalf("invalid JSON: %v", jsonErr)
+		}
+		if got["kind"] != "error" {
+			t.Errorf("kind want %q, got %v", "error", got["kind"])
+		}
+	})
+}
+
 // assertJSONEqual compares two decoded JSON maps recursively.
 func assertJSONEqual(t *testing.T, want, got map[string]any) {
 	t.Helper()

--- a/internal/output/agents.go
+++ b/internal/output/agents.go
@@ -30,6 +30,7 @@ type agentsCodec struct {
 }
 
 type spillSummary struct {
+	Kind          string `json:"kind"`
 	SpilledTo     string `json:"spilled_to"`
 	Bytes         int    `json:"bytes"`
 	PreviewSample any    `json:"preview_sample"`
@@ -67,42 +68,63 @@ func (c *agentsCodec) Encode(dst io.Writer, value any) error {
 }
 
 func (c *agentsCodec) spill(dst io.Writer, value any, payload []byte) error {
+	s, err := spillPayload(c.errWriter, value, payload)
+	if err != nil {
+		return err
+	}
+
+	out := json.NewEncoder(dst)
+	out.SetEscapeHTML(false)
+	return out.Encode(s)
+}
+
+// writeSpillFile writes payload to a temp file matching SpillFilePattern and
+// returns its path. Shared by the agents and ndjson codecs.
+func writeSpillFile(payload []byte) (string, error) {
 	f, err := os.CreateTemp("", SpillFilePattern)
 	if err != nil {
-		return fmt.Errorf("create spill file: %w", err)
+		return "", fmt.Errorf("create spill file: %w", err)
 	}
 	if _, err := f.Write(payload); err != nil {
 		f.Close()
 		os.Remove(f.Name())
-		return fmt.Errorf("write spill file: %w", err)
+		return "", fmt.Errorf("write spill file: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		return fmt.Errorf("close spill file: %w", err)
+		return "", fmt.Errorf("close spill file: %w", err)
+	}
+	return f.Name(), nil
+}
+
+// spillPayload writes the full payload to a temp file, emits an oversized-output
+// hint to errWriter, and returns the summary describing the spill. Shared by the
+// agents and ndjson codecs so both produce identical spill files and summaries.
+func spillPayload(errWriter io.Writer, value any, payload []byte) (spillSummary, error) {
+	path, err := writeSpillFile(payload)
+	if err != nil {
+		return spillSummary{}, err
 	}
 
-	msg := fmt.Sprintf(
-		"Response too large for stdout (%d bytes). Full data written to %s. Read that file for complete results, or rerun with -o json to force inline output.",
-		len(payload), f.Name(),
-	)
-
 	s := spillSummary{
-		SpilledTo:     f.Name(),
+		Kind:          "spill",
+		SpilledTo:     path,
 		Bytes:         len(payload),
 		PreviewSample: previewOf(value),
-		Message:       msg,
+		Message: fmt.Sprintf(
+			"Response too large for stdout (%d bytes). Full data written to %s. Read that file for complete results, or rerun with -o json to force inline output.",
+			len(payload), path,
+		),
 	}
 	if n, ok := itemCount(value); ok {
 		s.TotalItems = &n
 	}
 
-	fmt.Fprintf(c.errWriter,
+	fmt.Fprintf(errWriter,
 		"hint: response too large for stdout (%d bytes) — read %s for full data, or use -o json to force inline\n",
-		len(payload), f.Name(),
+		len(payload), path,
 	)
 
-	out := json.NewEncoder(dst)
-	out.SetEscapeHTML(false)
-	return out.Encode(s)
+	return s, nil
 }
 
 func spillThreshold() int {
@@ -114,24 +136,36 @@ func spillThreshold() int {
 	return defaultSpillBytes
 }
 
-// itemCount returns the length of slice/array values and a true bool.
-// Also handles structs with an Items slice field (e.g. unstructured.UnstructuredList).
-func itemCount(value any) (int, bool) {
+// listValue resolves value to its list-shaped reflect.Value: the value itself
+// for slices/arrays, or its Items field for structs that have a slice/array Items
+// field (e.g. unstructured.UnstructuredList). The second return is false for any
+// other shape (including nil pointers/interfaces). Shared by itemCount, previewOf
+// (agents codec), and collectionElements (ndjson codec).
+func listValue(value any) (reflect.Value, bool) {
 	v := reflect.ValueOf(value)
 	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
 		if v.IsNil() {
-			return 0, false
+			return reflect.Value{}, false
 		}
 		v = v.Elem()
 	}
 	switch v.Kind() {
 	case reflect.Slice, reflect.Array:
-		return v.Len(), true
+		return v, true
 	case reflect.Struct:
 		items := v.FieldByName("Items")
 		if items.IsValid() && (items.Kind() == reflect.Slice || items.Kind() == reflect.Array) {
-			return items.Len(), true
+			return items, true
 		}
+	}
+	return reflect.Value{}, false
+}
+
+// itemCount returns the element count of list-shaped values (see listValue) and
+// a true bool, or 0/false for other shapes.
+func itemCount(value any) (int, bool) {
+	if list, ok := listValue(value); ok {
+		return list.Len(), true
 	}
 	return 0, false
 }
@@ -139,6 +173,11 @@ func itemCount(value any) (int, bool) {
 // previewOf returns the first spillPreviewItems elements for slices/lists,
 // the sorted top-level key names for map shapes, or nil for other shapes.
 func previewOf(value any) any {
+	if list, ok := listValue(value); ok {
+		n := min(list.Len(), spillPreviewItems)
+		return list.Slice(0, n).Interface()
+	}
+
 	v := reflect.ValueOf(value)
 	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
 		if v.IsNil() {
@@ -146,19 +185,7 @@ func previewOf(value any) any {
 		}
 		v = v.Elem()
 	}
-	take := func(slice reflect.Value) any {
-		n := min(slice.Len(), spillPreviewItems)
-		return slice.Slice(0, n).Interface()
-	}
-	switch v.Kind() {
-	case reflect.Slice, reflect.Array:
-		return take(v)
-	case reflect.Struct:
-		items := v.FieldByName("Items")
-		if items.IsValid() && (items.Kind() == reflect.Slice || items.Kind() == reflect.Array) {
-			return take(items)
-		}
-	case reflect.Map:
+	if v.Kind() == reflect.Map {
 		keys := v.MapKeys()
 		names := make([]string, 0, len(keys))
 		for _, k := range keys {

--- a/internal/output/agents_test.go
+++ b/internal/output/agents_test.go
@@ -48,6 +48,8 @@ func TestAgentsCodec_AboveThreshold_Spills(t *testing.T) {
 	var summary map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
 
+	assert.Equal(t, "spill", summary["kind"], "spill summary must carry kind:spill discriminator")
+
 	spillPath, ok := summary["spilled_to"].(string)
 	require.True(t, ok, "summary must contain spilled_to")
 	assert.True(t, strings.HasPrefix(spillPath, os.Getenv("TMPDIR")), "spill file should be in TMPDIR")

--- a/internal/output/export_test.go
+++ b/internal/output/export_test.go
@@ -16,3 +16,14 @@ func NewAgentsCodecForTesting() format.Codec {
 func NewAgentsCodecWithErrWriter(w io.Writer) format.Codec {
 	return newAgentsCodec(w)
 }
+
+// NewNDJSONCodecForTesting exposes the unexported ndjsonCodec for unit tests.
+// Uses os.Stderr as the error writer.
+func NewNDJSONCodecForTesting() format.Codec {
+	return newNDJSONCodec(nil)
+}
+
+// NewNDJSONCodecWithErrWriter exposes the ndjsonCodec with a custom errWriter for testing.
+func NewNDJSONCodecWithErrWriter(w io.Writer) format.Codec {
+	return newNDJSONCodec(w)
+}

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -76,11 +76,10 @@ func (opts *Options) BindFlags(flags *pflag.FlagSet) {
 		defaultFormat = opts.defaultFormat
 	}
 
-	// Agent mode: override any per-command default with the agents codec.
-	// Explicit -o flag from user still takes precedence (via cobra flag parsing).
-	if agent.IsAgentMode() {
-		defaultFormat = string(agentsFormat)
-	}
+	// The non-TTY default (NDJSON) cannot be resolved here: BindFlags runs at
+	// command-construction time, before root PersistentPreRun calls
+	// terminal.Detect(), so terminal.IsPiped() is not yet populated. It is
+	// resolved in Validate() instead, which runs inside RunE.
 
 	// Populate pipe/truncation state from package-level terminal detection.
 	// These are set by root PersistentPreRun via terminal.Detect() and
@@ -95,6 +94,18 @@ func (opts *Options) BindFlags(flags *pflag.FlagSet) {
 }
 
 func (opts *Options) Validate() error {
+	// Resolve the implicit non-TTY default now that terminal.Detect() and
+	// agent-mode pipe forcing (root PersistentPreRun) have run. When stdout is
+	// not a TTY (any pipe/redirect, which agent mode also forces) and the user
+	// did not explicitly pass -o, default to NDJSON so a 2>&1-merged stream
+	// stays uniformly parseable line-by-line. Explicit -o always wins.
+	if opts.flags != nil {
+		out := opts.flags.Lookup("output")
+		if (out == nil || !out.Changed) && terminal.IsPiped() {
+			opts.OutputFormat = string(ndjsonFormat)
+		}
+	}
+
 	codec := opts.codecFor(opts.OutputFormat)
 	if codec == nil {
 		return fmt.Errorf("unknown output format '%s'. Valid formats are: %s", opts.OutputFormat, strings.Join(opts.allowedCodecs(), ", "))
@@ -105,10 +116,10 @@ func (opts *Options) Validate() error {
 
 // applyJSONFlag processes the --json flag value. When -o/--output is explicitly
 // set to a non-JSON format, it returns an error because field selection only
-// works with JSON output. Combining -o json with --json is allowed since
-// there is no conflict. The agents format is intentionally excluded — in agent
-// mode the implicit default is agents, and users should pass only --json
-// (without an explicit -o) to combine field selection with the agents codec.
+// works with JSON output. Combining -o json with --json is allowed since there
+// is no conflict. --json forces JSON output, so it overrides the implicit
+// non-TTY NDJSON default: piping with --json field1,field2 yields field-selected
+// JSON, not NDJSON.
 func (opts *Options) applyJSONFlag() error {
 	if opts.flags == nil {
 		return nil
@@ -168,12 +179,12 @@ func (opts *Options) Encode(dst io.Writer, value any) error {
 	}
 
 	// Nudge toward --json field selection whenever the resolved codec is
-	// JSON-like (json or agents format) and the caller has not already
+	// JSON-like (json, agents, or ndjson format) and the caller has not already
 	// requested field selection/discovery. Emitted once per invocation to
-	// stderr (never pollutes stdout). TTY: plain "hint:" line. Agent mode:
-	// JSONL {"class":"hint",...} — routed through emitHint/EmitHint so the
-	// hints framework handles codec & agent-mode compliance (FR-104).
-	isJSONLike := codec.Format() == format.JSON || codec.Format() == agentsFormat
+	// stderr (never pollutes stdout). TTY: plain "hint:" line. Non-TTY:
+	// JSONL {"kind":"hint",...} — routed through emitHint/EmitHint so the
+	// hints framework handles codec & non-TTY compliance (FR-104).
+	isJSONLike := codec.Format() == format.JSON || codec.Format() == agentsFormat || codec.Format() == ndjsonFormat
 	if !opts.jsonFieldsHintShown && isJSONLike && len(opts.JSONFields) == 0 && !opts.JSONDiscovery {
 		opts.jsonFieldsHintShown = true
 		w := opts.ErrWriter
@@ -332,6 +343,7 @@ func (opts *Options) builtinCodecs() map[string]format.Codec {
 		"yaml":   format.NewYAMLCodec(),
 		"json":   format.NewJSONCodec(),
 		"agents": newAgentsCodec(errWriter),
+		"ndjson": newNDJSONCodec(errWriter),
 	}
 }
 
@@ -352,19 +364,33 @@ func (opts *Options) allowedCodecs() []string {
 	return allowedCodecs
 }
 
-// EmitHint writes a hint diagnostic to w. In agent mode the record is JSONL
-// with class:"hint" to match the FR-104 typed-class schema used by provider
-// commands. In TTY mode the line is "hint: <summary>" (with ": <command>"
+// diagnosticIsStructured reports whether diagnostics should be emitted as JSONL
+// records rather than human "prefix: text" lines. True when stdout is non-TTY
+// (any pipe) or agent mode (which forces piped behavior) so a 2>&1-merged stream
+// stays uniform with the NDJSON data lines.
+func diagnosticIsStructured() bool {
+	return agent.IsAgentMode() || terminal.IsPiped()
+}
+
+// emitStructured writes a single diagnostic JSONL record. command is omitted
+// when empty, so warn/note records (which never carry a command) match their
+// previous {"kind":...,"summary":...} shape exactly.
+func emitStructured(w io.Writer, kind, summary, command string) {
+	rec := struct {
+		Kind    string `json:"kind"`
+		Summary string `json:"summary"`
+		Command string `json:"command,omitempty"`
+	}{Kind: kind, Summary: summary, Command: command}
+	b, _ := json.Marshal(rec) //nolint:errchkjson
+	fmt.Fprintln(w, string(b))
+}
+
+// EmitHint writes a hint diagnostic to w. In structured mode the record is JSONL
+// with kind:"hint". In TTY mode the line is "hint: <summary>" (with ": <command>"
 // appended when command is non-empty). command may be empty.
 func EmitHint(w io.Writer, summary, command string) {
-	if agent.IsAgentMode() {
-		type hintEvent struct {
-			Class   string `json:"class"`
-			Summary string `json:"summary"`
-			Command string `json:"command,omitempty"`
-		}
-		b, _ := json.Marshal(hintEvent{Class: "hint", Summary: summary, Command: command}) //nolint:errchkjson
-		fmt.Fprintln(w, string(b))
+	if diagnosticIsStructured() {
+		emitStructured(w, "hint", summary, command)
 		return
 	}
 	if command != "" {
@@ -380,33 +406,21 @@ func emitHint(w io.Writer, summary, command string) {
 	EmitHint(w, summary, command)
 }
 
-// EmitWarn writes a warn-class diagnostic to w. In agent mode the record is
-// JSONL with class:"warning" to match the FR-104 typed-class schema used by
-// provider commands. In TTY mode the line is "warn: <summary>".
+// EmitWarn writes a warn diagnostic to w. In structured mode the record is JSONL
+// with kind:"warning". In TTY mode the line is "warn: <summary>".
 func EmitWarn(w io.Writer, summary string) {
-	if agent.IsAgentMode() {
-		type warnEvent struct {
-			Class   string `json:"class"`
-			Summary string `json:"summary"`
-		}
-		b, _ := json.Marshal(warnEvent{Class: "warning", Summary: summary}) //nolint:errchkjson
-		fmt.Fprintln(w, string(b))
+	if diagnosticIsStructured() {
+		emitStructured(w, "warning", summary, "")
 		return
 	}
 	fmt.Fprintf(w, "warn: %s\n", summary)
 }
 
-// EmitNote writes a note-class diagnostic to w. In agent mode the record is
-// JSONL with class:"note" to match the FR-104 typed-class schema used by
-// provider commands. In TTY mode the line is "note: <summary>".
+// EmitNote writes a note diagnostic to w. In structured mode the record is JSONL
+// with kind:"note". In TTY mode the line is "note: <summary>".
 func EmitNote(w io.Writer, summary string) {
-	if agent.IsAgentMode() {
-		type noteEvent struct {
-			Class   string `json:"class"`
-			Summary string `json:"summary"`
-		}
-		b, _ := json.Marshal(noteEvent{Class: "note", Summary: summary}) //nolint:errchkjson
-		fmt.Fprintln(w, string(b))
+	if diagnosticIsStructured() {
+		emitStructured(w, "note", summary, "")
 		return
 	}
 	fmt.Fprintf(w, "note: %s\n", summary)

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -8,62 +8,82 @@ import (
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/terminal"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBindFlags_AgentModeOverridesDefaultFormat(t *testing.T) {
+// TestValidate_NonTTYDefaultsToNDJSON verifies that the implicit output default
+// is resolved in Validate() (not BindFlags, which runs before terminal.Detect()).
+// When stdout is non-TTY (any pipe, which agent mode also forces) and no explicit
+// -o is given, the default becomes ndjson; an explicit -o always wins; a real TTY
+// keeps the command's default format.
+func TestValidate_NonTTYDefaultsToNDJSON(t *testing.T) {
 	tests := []struct {
 		name           string
-		agentMode      bool
+		piped          bool
 		defaultFormat  string
 		explicitOutput string // simulates -o flag; empty = use default
 		wantFormat     string
 	}{
 		{
-			name:       "agent mode forces agents when no command default set",
-			agentMode:  true,
-			wantFormat: "agents",
+			name:       "TTY with no command default uses json",
+			piped:      false,
+			wantFormat: "json",
 		},
 		{
-			name:          "agent mode forces agents when command sets text default",
-			agentMode:     true,
+			name:          "TTY with command default keeps that default",
+			piped:         false,
 			defaultFormat: "text",
-			wantFormat:    "agents",
+			wantFormat:    "text",
 		},
 		{
-			name:           "explicit -o yaml overrides agent mode agents default",
-			agentMode:      true,
+			name:       "non-TTY with no command default uses ndjson",
+			piped:      true,
+			wantFormat: "ndjson",
+		},
+		{
+			name:          "non-TTY overrides a command text default with ndjson",
+			piped:         true,
+			defaultFormat: "text",
+			wantFormat:    "ndjson",
+		},
+		{
+			name:           "explicit -o yaml wins over non-TTY ndjson default",
+			piped:          true,
 			defaultFormat:  "text",
 			explicitOutput: "yaml",
 			wantFormat:     "yaml",
 		},
 		{
-			name:          "no agent mode uses command default format",
-			agentMode:     false,
-			defaultFormat: "yaml",
-			wantFormat:    "yaml",
+			name:           "explicit -o agents wins over non-TTY ndjson default",
+			piped:          true,
+			explicitOutput: "agents",
+			wantFormat:     "agents",
 		},
 		{
-			name:       "no agent mode uses json when no command default set",
-			agentMode:  false,
-			wantFormat: "json",
+			name:           "explicit -o on a TTY keeps that format",
+			piped:          false,
+			defaultFormat:  "text",
+			explicitOutput: "yaml",
+			wantFormat:     "yaml",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			agent.SetFlag(tc.agentMode)
-			t.Cleanup(func() { agent.SetFlag(false) })
+			terminal.SetPiped(tc.piped)
+			t.Cleanup(terminal.ResetForTesting)
 
 			opts := &cmdio.Options{}
 			if tc.defaultFormat != "" {
 				opts.DefaultFormat(tc.defaultFormat)
 			}
 
-			// Register a dummy text codec so "text" is a valid format.
+			// Register dummy codecs so "text"/"yaml" are valid formats.
 			opts.RegisterCustomCodec("text", &dummyCodec{})
+			opts.RegisterCustomCodec("yaml", &dummyCodec{})
 
 			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 			opts.BindFlags(flags)
@@ -72,6 +92,7 @@ func TestBindFlags_AgentModeOverridesDefaultFormat(t *testing.T) {
 				require.NoError(t, flags.Set("output", tc.explicitOutput))
 			}
 
+			require.NoError(t, opts.Validate())
 			assert.Equal(t, tc.wantFormat, opts.OutputFormat)
 		})
 	}

--- a/internal/output/ndjson.go
+++ b/internal/output/ndjson.go
@@ -1,0 +1,94 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+
+	"github.com/grafana/gcx/internal/format"
+)
+
+const ndjsonFormat format.Format = "ndjson"
+
+// ndjsonCodec emits newline-delimited JSON: one complete JSON object per line.
+// Every data line is wrapped as {"kind":"result","data":<value>} so that a
+// stream merged with stderr diagnostics (2>&1) stays uniformly parseable
+// line-by-line, with each line distinguished by its "kind" field. This is the
+// default codec whenever stdout is not a TTY (see Options.Validate).
+type ndjsonCodec struct {
+	errWriter io.Writer
+}
+
+type ndjsonLine struct {
+	Kind string `json:"kind"`
+	Data any    `json:"data"`
+}
+
+func newNDJSONCodec(errWriter io.Writer) *ndjsonCodec {
+	if errWriter == nil {
+		errWriter = os.Stderr
+	}
+	return &ndjsonCodec{errWriter: errWriter}
+}
+
+func (c *ndjsonCodec) Format() format.Format { return ndjsonFormat }
+
+func (c *ndjsonCodec) Decode(io.Reader, any) error {
+	return errors.New("ndjson codec does not support decoding")
+}
+
+func (c *ndjsonCodec) Encode(dst io.Writer, value any) error {
+	// Measure the full payload once. Oversized output spills to a temp file and
+	// emits a single {"kind":"spill",...} line, matching the agents codec.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(value); err != nil {
+		return err
+	}
+
+	if buf.Len() > spillThreshold() {
+		s, err := spillPayload(c.errWriter, value, buf.Bytes())
+		if err != nil {
+			return err
+		}
+		return c.writeLine(dst, s)
+	}
+
+	if elems, ok := collectionElements(value); ok {
+		for _, elem := range elems {
+			if err := c.writeLine(dst, ndjsonLine{Kind: "result", Data: elem}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return c.writeLine(dst, ndjsonLine{Kind: "result", Data: value})
+}
+
+// writeLine encodes v as a single compact JSON line. encoding/json's Encode
+// already appends the trailing newline.
+func (c *ndjsonCodec) writeLine(dst io.Writer, v any) error {
+	enc := json.NewEncoder(dst)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}
+
+// collectionElements returns the elements of list-shaped values (slices, arrays,
+// or structs with an Items slice such as unstructured.UnstructuredList) so they
+// can be emitted one per line. Single objects and wrapper maps are not treated
+// as collections and emit as a single line.
+func collectionElements(value any) ([]any, bool) {
+	list, ok := listValue(value)
+	if !ok {
+		return nil, false
+	}
+	out := make([]any, list.Len())
+	for i := range out {
+		out[i] = list.Index(i).Interface()
+	}
+	return out, true
+}

--- a/internal/output/ndjson.go
+++ b/internal/output/ndjson.go
@@ -26,6 +26,14 @@ type ndjsonLine struct {
 	Data any    `json:"data"`
 }
 
+// emptyLine is emitted in place of data lines when a collection has zero
+// elements. Without it an empty list would emit nothing, leaving a consumer
+// unable to distinguish a successful empty result from a command that produced
+// no output. A select(.kind=="result") filter still yields zero records.
+type emptyLine struct {
+	Kind string `json:"kind"`
+}
+
 func newNDJSONCodec(errWriter io.Writer) *ndjsonCodec {
 	if errWriter == nil {
 		errWriter = os.Stderr
@@ -58,6 +66,9 @@ func (c *ndjsonCodec) Encode(dst io.Writer, value any) error {
 	}
 
 	if elems, ok := collectionElements(value); ok {
+		if len(elems) == 0 {
+			return c.writeLine(dst, emptyLine{Kind: "empty"})
+		}
 		for _, elem := range elems {
 			if err := c.writeLine(dst, ndjsonLine{Kind: "result", Data: elem}); err != nil {
 				return err

--- a/internal/output/ndjson_test.go
+++ b/internal/output/ndjson_test.go
@@ -95,13 +95,31 @@ func TestNDJSONCodec_WrapperMap_NotUnwrapped(t *testing.T) {
 	assert.Contains(t, lines[0]["data"], "datasources")
 }
 
-func TestNDJSONCodec_EmptySlice_NoLines(t *testing.T) {
+func TestNDJSONCodec_EmptySlice_EmptySentinel(t *testing.T) {
 	codec := cmdio.NewNDJSONCodecForTesting()
 
 	var buf bytes.Buffer
 	require.NoError(t, codec.Encode(&buf, []map[string]any{}))
 
-	assert.Empty(t, strings.TrimSpace(buf.String()), "empty collection emits no data lines")
+	lines := decodeLines(t, buf.Bytes())
+	require.Len(t, lines, 1, "empty collection emits a single sentinel line")
+	assert.Equal(t, "empty", lines[0]["kind"])
+	assert.NotContains(t, lines[0], "data", "sentinel carries no data field")
+}
+
+func TestNDJSONCodec_EmptyStructWithItems_EmptySentinel(t *testing.T) {
+	codec := cmdio.NewNDJSONCodecForTesting()
+
+	type listValue struct {
+		Items []map[string]any `json:"items"`
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, listValue{Items: []map[string]any{}}))
+
+	lines := decodeLines(t, buf.Bytes())
+	require.Len(t, lines, 1)
+	assert.Equal(t, "empty", lines[0]["kind"])
 }
 
 func TestNDJSONCodec_OverThreshold_SpillsOneLine(t *testing.T) {

--- a/internal/output/ndjson_test.go
+++ b/internal/output/ndjson_test.go
@@ -1,0 +1,144 @@
+package output_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// decodeLines splits NDJSON output into trimmed non-empty lines and asserts each
+// is independently parseable JSON, returning the decoded objects.
+func decodeLines(t *testing.T, b []byte) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for line := range strings.SplitSeq(strings.TrimRight(string(b), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var obj map[string]any
+		require.NoErrorf(t, json.Unmarshal([]byte(line), &obj), "line not valid JSON: %s", line)
+		out = append(out, obj)
+	}
+	return out
+}
+
+func TestNDJSONCodec_SingleObject_OneLine(t *testing.T) {
+	codec := cmdio.NewNDJSONCodecForTesting()
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, map[string]any{"uid": "abc", "name": "prom"}))
+
+	lines := decodeLines(t, buf.Bytes())
+	require.Len(t, lines, 1)
+	assert.Equal(t, "result", lines[0]["kind"])
+	assert.Equal(t, map[string]any{"uid": "abc", "name": "prom"}, lines[0]["data"])
+}
+
+func TestNDJSONCodec_Slice_OneLinePerElement(t *testing.T) {
+	codec := cmdio.NewNDJSONCodecForTesting()
+
+	data := []map[string]any{
+		{"uid": "a"}, {"uid": "b"}, {"uid": "c"},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	lines := decodeLines(t, buf.Bytes())
+	require.Len(t, lines, 3)
+	for i, want := range []string{"a", "b", "c"} {
+		assert.Equal(t, "result", lines[i]["kind"])
+		assert.Equal(t, map[string]any{"uid": want}, lines[i]["data"])
+	}
+}
+
+func TestNDJSONCodec_StructWithItems_OneLinePerItem(t *testing.T) {
+	codec := cmdio.NewNDJSONCodecForTesting()
+
+	type listValue struct {
+		Items []map[string]any
+	}
+	data := listValue{Items: []map[string]any{{"name": "alpha"}, {"name": "beta"}}}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	lines := decodeLines(t, buf.Bytes())
+	require.Len(t, lines, 2)
+	assert.Equal(t, map[string]any{"name": "alpha"}, lines[0]["data"])
+	assert.Equal(t, map[string]any{"name": "beta"}, lines[1]["data"])
+}
+
+func TestNDJSONCodec_WrapperMap_NotUnwrapped(t *testing.T) {
+	// A single-key wrapper map (the shape list commands pass for non-table
+	// formats) is NOT a collection — it emits as one line. The footgun is still
+	// fixed because the merged stream stays uniform NDJSON.
+	codec := cmdio.NewNDJSONCodecForTesting()
+
+	data := map[string]any{"datasources": []any{
+		map[string]any{"uid": "a"},
+		map[string]any{"uid": "b"},
+	}}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	lines := decodeLines(t, buf.Bytes())
+	require.Len(t, lines, 1)
+	assert.Equal(t, "result", lines[0]["kind"])
+	assert.Contains(t, lines[0]["data"], "datasources")
+}
+
+func TestNDJSONCodec_EmptySlice_NoLines(t *testing.T) {
+	codec := cmdio.NewNDJSONCodecForTesting()
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, []map[string]any{}))
+
+	assert.Empty(t, strings.TrimSpace(buf.String()), "empty collection emits no data lines")
+}
+
+func TestNDJSONCodec_OverThreshold_SpillsOneLine(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
+	t.Setenv("TMPDIR", t.TempDir())
+
+	var errBuf bytes.Buffer
+	codec := cmdio.NewNDJSONCodecWithErrWriter(&errBuf)
+
+	data := []map[string]any{{"name": "alpha"}, {"name": "beta"}, {"name": "gamma"}}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, data))
+
+	lines := decodeLines(t, buf.Bytes())
+	require.Len(t, lines, 1, "oversized output spills to a single summary line")
+	assert.Equal(t, "spill", lines[0]["kind"])
+	assert.EqualValues(t, len(data), lines[0]["total_items"])
+
+	spillPath, ok := lines[0]["spilled_to"].(string)
+	require.True(t, ok)
+	assert.True(t, strings.HasPrefix(spillPath, os.Getenv("TMPDIR")))
+	full, err := os.ReadFile(spillPath)
+	require.NoError(t, err)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(full, &got))
+	assert.Equal(t, data, got)
+
+	assert.NotEmpty(t, errBuf.String(), "spill emits a stderr hint")
+}
+
+func TestNDJSONCodec_Format(t *testing.T) {
+	codec := cmdio.NewNDJSONCodecForTesting()
+	assert.Equal(t, "ndjson", string(codec.Format()))
+}
+
+func TestNDJSONCodec_DecodeReturnsError(t *testing.T) {
+	codec := cmdio.NewNDJSONCodecForTesting()
+	require.Error(t, codec.Decode(strings.NewReader("{}"), &map[string]any{}))
+}

--- a/internal/providers/irm/oncall_actions.go
+++ b/internal/providers/irm/oncall_actions.go
@@ -176,18 +176,18 @@ func emitHint(stderr io.Writer, summary, command string) {
 	cmdio.EmitHint(stderr, summary, command)
 }
 
-// emitWarn writes a warn-class diagnostic to stderr. In agent mode the
-// record is JSONL with `class:"warning"`; in TTY mode the line is rendered
-// as `warn: <summary>`.
+// emitWarn writes a warn diagnostic to stderr. When stdout is non-TTY (pipe or
+// agent mode) the record is JSONL with `kind:"warning"`; in TTY mode the line is
+// rendered as `warn: <summary>`.
 // Delegates to output.EmitWarn — package-private alias kept for call-site
 // brevity and backward compat with white-box tests.
 func emitWarn(stderr io.Writer, summary string) {
 	cmdio.EmitWarn(stderr, summary)
 }
 
-// emitNote writes a note-class diagnostic to stderr. In agent mode the
-// record is JSONL with `class:"note"`; in TTY mode the line is rendered
-// as `note: <summary>`.
+// emitNote writes a note diagnostic to stderr. When stdout is non-TTY (pipe or
+// agent mode) the record is JSONL with `kind:"note"`; in TTY mode the line is
+// rendered as `note: <summary>`.
 // Delegates to output.EmitNote — package-private alias kept for call-site
 // brevity and backward compat with white-box tests.
 func emitNote(stderr io.Writer, summary string) {

--- a/internal/providers/irm/oncall_commands_extra.go
+++ b/internal/providers/irm/oncall_commands_extra.go
@@ -306,7 +306,7 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 // is a sensible next step that avoids committing to --limit 0):
 //
 //	TTY:    "hint: showing first N results: gcx irm oncall alert-groups list --limit M"
-//	agent:  {"class":"hint","summary":"showing first N results","command":"gcx irm oncall alert-groups list --limit M"}
+//	agent:  {"kind":"hint","summary":"showing first N results","command":"gcx irm oncall alert-groups list --limit M"}
 func emitAlertGroupListLimitHint(stderr io.Writer, limit int) {
 	suggested := limit * 2
 	emitHint(stderr,
@@ -394,7 +394,7 @@ func alertGroupListHasExplicitFilter(opts *alertGroupListOpts) bool {
 // line MUST contain a runnable gcx command):
 //
 //	TTY:    "hint: listing alert groups with filter <stringified>: gcx irm oncall alert-groups list --all"
-//	agent:  {"class":"hint","summary":"listing alert groups with filter <stringified>","command":"gcx irm oncall alert-groups list --all"}
+//	agent:  {"kind":"hint","summary":"listing alert groups with filter <stringified>","command":"gcx irm oncall alert-groups list --all"}
 //
 // Both TTY and agent-mode emissions go through the centralised emitHint
 // helper so the channel split is uniform across every
@@ -515,8 +515,8 @@ func listAlertGroupsLegacy(cmd *cobra.Command, opts *alertGroupListOpts, filters
 	}
 	if len(unsupported) > 0 {
 		// Centralised note emission. Agent mode renders
-		// JSONL with typed `class`; TTY renders dim plain text. Direct
-		// fmt.Fprintf is forbidden because it would bypass the class split.
+		// JSONL with typed `kind`; TTY renders dim plain text. Direct
+		// fmt.Fprintf is forbidden because it would bypass the kind split.
 		emitNote(cmd.ErrOrStderr(),
 			"SA-token mode uses the OnCall public API which does not honor: "+strings.Join(unsupported, ", "))
 	}
@@ -962,7 +962,7 @@ func newAlertGroupListAlertsCommand(loader OnCallConfigLoader) *cobra.Command {
 			}
 			if limit > 0 && total > len(ids) {
 				// Warn class on stderr; agent mode renders
-				// JSONL with typed `class`, TTY renders dim plain text.
+				// JSONL with typed `kind`, TTY renders dim plain text.
 				emitWarn(stderr,
 					fmt.Sprintf("retrieved %d of %d alerts; pass `--limit 0` to fetch all", len(ids), total))
 			}

--- a/internal/providers/irm/oncall_commands_extra_test.go
+++ b/internal/providers/irm/oncall_commands_extra_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/terminal"
 	"github.com/spf13/pflag"
 )
 
@@ -436,10 +437,12 @@ func TestAlertGroupGetRichOpts_DefaultsToTable(t *testing.T) {
 
 // TestEmitWarnEmitNote_Format pins the output contract for the
 // centralised diagnostic helpers: TTY plain-text with the prefixed class
-// name; agent mode JSONL with typed `class` field.
+// name; non-TTY (pipe/agent mode) JSONL with typed `kind` field.
 func TestEmitWarnEmitNote_Format(t *testing.T) {
 	t.Run("tty", func(t *testing.T) {
 		resetAgentMode(t)
+		terminal.SetPiped(false)
+		t.Cleanup(terminal.ResetForTesting)
 		var buf bytes.Buffer
 		emitWarn(&buf, "near the cap")
 		emitNote(&buf, "filter is in effect")
@@ -467,8 +470,8 @@ func TestEmitWarnEmitNote_Format(t *testing.T) {
 		if err := json.Unmarshal(warnBuf.Bytes(), &warnEv); err != nil {
 			t.Fatalf("emitWarn agent mode: expected valid JSON; got %q: %v", warnBuf.String(), err)
 		}
-		if got := warnEv["class"]; got != "warning" {
-			t.Errorf("emitWarn agent mode: class want %q, got %v", "warning", got)
+		if got := warnEv["kind"]; got != "warning" {
+			t.Errorf("emitWarn agent mode: kind want %q, got %v", "warning", got)
 		}
 		if got := warnEv["summary"]; got != "near the cap" {
 			t.Errorf("emitWarn agent mode: summary want %q, got %v", "near the cap", got)
@@ -479,8 +482,8 @@ func TestEmitWarnEmitNote_Format(t *testing.T) {
 		if err := json.Unmarshal(noteBuf.Bytes(), &noteEv); err != nil {
 			t.Fatalf("emitNote agent mode: expected valid JSON; got %q: %v", noteBuf.String(), err)
 		}
-		if got := noteEv["class"]; got != "note" {
-			t.Errorf("emitNote agent mode: class want %q, got %v", "note", got)
+		if got := noteEv["kind"]; got != "note" {
+			t.Errorf("emitNote agent mode: kind want %q, got %v", "note", got)
 		}
 		if got := noteEv["summary"]; got != "rate limited" {
 			t.Errorf("emitNote agent mode: summary want %q, got %v", "rate limited", got)


### PR DESCRIPTION
## Summary

Make **NDJSON** the implicit output default whenever stdout is **not a TTY** (any pipe/redirect; agent mode also forces this), so a `2>&1`-merged stream stays parseable. Explicit `-o` always wins; a real TTY keeps its table/text default.

Every emitted line is a self-describing envelope tagged by `kind`:

| `kind` | Stream | Meaning |
|--------|--------|---------|
| `result` | stdout | Data record (payload under `data`); one line per list element |
| `empty` | stdout | Successful command whose collection had zero elements |
| `spill` | stdout | Oversized output spilled to a temp file |
| `error` | stdout | Error envelope |
| `hint` / `warning` / `note` | stderr | Diagnostics (renamed from `class`) |

One filter — `select(.kind=="result")` — extracts data and ignores everything else. Closes the `2>&1` footgun (#796) where stderr JSONL corrupted a single stdout JSON document, and lets agents sample cheaply (`head -1` = one complete record).

## Design notes

- The non-TTY default can't resolve in `BindFlags` (runs before `terminal.Detect()`), so it resolves in `io.Options.Validate()`.
- Diagnostics and the error envelope are gated on `agent.IsAgentMode() || terminal.IsPiped()` so the merged stream is uniform for any non-agent pipe too.
- Large output still spills to a temp file with an inline preview.
- The single-object `agents` codec stays available via explicit `-o agents`.

## Test plan

- [x] `go build ./...`
- [x] `GCX_AGENT_MODE=false go test ./...`
- [x] `golangci-lint run` — 0 issues
- [x] Reference docs regenerated; `mkdocs build` succeeds
- [x] New tests: codec line shapes, empty sentinel, spill, non-TTY default resolution, e2e through root, `class`→`kind` rename, `kind:error` envelope

## Compliance

Presentation-only — data fetching stays format-agnostic (Pattern 13); all output goes through the codec system; explicit-flag override preserved; `class` fully removed (no compat alias).

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)