### PR TITLE
docs: recommend LLM trace output for agents

### DIFF
--- a/claude-plugin/skills/debug-with-grafana/SKILL.md
+++ b/claude-plugin/skills/debug-with-grafana/SKILL.md
@@ -278,11 +278,9 @@ gcx traces query -d <tempo-uid> \
   '{ resource.service.name = "<service-name>" && duration > 1s }' \
   --from now-1h --to now
 
-# Fetch a specific trace by ID (from search results or log trace IDs)
-gcx traces get -d <tempo-uid> <trace-id>
-
-# LLM-friendly trace output for analysis
-gcx traces get -d <tempo-uid> <trace-id> --llm
+# Fetch a specific trace by ID for analysis (from search results or log trace IDs)
+# Always use --llm so Tempo returns its token-efficient LLM trace encoding.
+gcx traces get -d <tempo-uid> <trace-id> --llm -o json
 ```
 
 **TraceQL attribute scoping**: Tempo requires scoped attribute names. Use
@@ -293,6 +291,10 @@ gcx traces get -d <tempo-uid> <trace-id> --llm
 Use `name` (unscoped) for the span name, `duration` for span duration,
 and `status` for span status. Use `trace:rootService` and `trace:rootName`
 for root span attributes (not `rootServiceName` or `rootTraceName`).
+
+When inspecting trace bodies, use `gcx traces get <trace-id> --llm -o json`. Do not fetch the
+OTLP-shaped default trace and manually compact it unless the user explicitly
+needs raw trace JSON for schema/debugging work.
 
 Discover available labels:
 ```bash

--- a/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
@@ -544,8 +544,8 @@ gcx logs query -d <loki-uid> \
 ```
 
 How to identify the backend services for a path:
-- Look at a representative trace with `gcx traces get <id> --llm` and pick the
-  service where the actual error (`status: error`) originates, plus its
+- Look at a representative trace with `gcx traces get <id> --llm -o json` and pick
+  the service where the actual error (`status: error`) originates, plus its
   immediate caller.
 - Or use `gcx logs labels -d <uid> -l job` to enumerate jobs, then exclude
   obvious gateway/proxy names (anything that just forwards — e.g. `webapp`,

--- a/claude-plugin/skills/debug-with-grafana/references/traceql-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/traceql-patterns.md
@@ -7,7 +7,7 @@ Workflow and query patterns for Tempo trace search using gcx.
 | Command | Purpose | Positional arg |
 |---------|---------|----------------|
 | `gcx traces query [TRACEQL]` | Search traces by TraceQL expression | TraceQL expression |
-| `gcx traces get TRACE_ID` | Fetch a single trace by ID | Trace ID (required) |
+| `gcx traces get TRACE_ID --llm -o json` | Fetch a single trace by ID in LLM-friendly format | Trace ID (required) |
 | `gcx traces labels` | List label names or values | None |
 
 All commands accept `-d <uid>` for the Tempo datasource UID. `search` is an
@@ -67,13 +67,16 @@ guessing further.
 
 ### 3. Get a specific trace
 
-Once you have a trace ID from search results or from a log `trace_id` field:
+Once you have a trace ID from search results or from a log `trace_id` field,
+use Tempo's LLM-friendly trace encoding for any agent analysis:
 
 ```bash
-gcx traces get -d <tempo-uid> <trace-id>
-gcx traces get -d <tempo-uid> <trace-id> --llm    # LLM-friendly format
-gcx traces get -d <tempo-uid> <trace-id> -o json
+gcx traces get -d <tempo-uid> <trace-id> --llm -o json
 ```
+
+Do not fetch the default OTLP-shaped trace and manually compact it for LLM
+consumption. Omit `--llm` only if the user explicitly needs raw trace JSON for
+schema debugging, export, or byte-for-byte comparison.
 
 The trace ID is a positional argument — do not use `--trace-id` (it doesn't
 exist).

--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -56,7 +56,7 @@ right group:
 | PromQL / Adaptive Metrics | `metrics` | `gcx metrics query -d <uid> 'up'` |
 | LogQL / Adaptive Logs | `logs` | `gcx logs query -d <uid> '{app="foo"}'` |
 | Profiling (Pyroscope) | `profiles` | `gcx profiles query` |
-| Tracing (Tempo) | `traces` | `gcx traces query -d <uid> '{ status = error }'` |
+| Tracing (Tempo) | `traces` | Search: `gcx traces query -d <uid> '{ status = error }'`; fetch for analysis: `gcx traces get -d <uid> <trace-id> --llm -o json` |
 | Datasource info and queries | `datasources` | `gcx datasources list` |
 | Fleet pipelines, collectors | `fleet` | `gcx fleet pipelines list` |
 | Knowledge Graph (Asserts) | `kg` | `gcx kg entities list` |
@@ -145,6 +145,23 @@ The `gcx datasources` group provides typed query interfaces:
 - `generic` — auto-detect datasource type
 
 Use `gcx datasources <type> --help` to discover type-specific flags.
+
+### Tempo trace bodies: use `--llm` for agent analysis
+
+When fetching a full Tempo trace for this agent to read, summarize, debug, or
+include in a prompt, **always use the LLM-friendly trace encoding**:
+
+```bash
+gcx traces get -d <tempo-uid> <trace-id> --llm -o json
+# equivalent legacy path:
+gcx datasources tempo get -d <tempo-uid> <trace-id> --llm -o json
+```
+
+Use `gcx traces query` to find trace IDs, then `gcx traces get --llm -o json` to inspect
+a selected trace. Do not fetch the default OTLP-shaped trace and manually compact
+or transform it for LLM consumption. Omit `--llm` only when the user explicitly
+needs raw OTLP/Tempo trace JSON for schema debugging, export, or byte-for-byte
+comparison.
 
 ## Grafana Assistant
 

--- a/docs/adrs/traces-get-table/001-tree-table-render-for-traces-get.md
+++ b/docs/adrs/traces-get-table/001-tree-table-render-for-traces-get.md
@@ -250,9 +250,6 @@ column. If users ask for it later, it's an additive flag.
   issues across all packages.
 - **Default flip.** Shipped in this PR — non-agent terminal default is
   `table`. Agent and pipe overrides remain in place via `cmdio.Options`.
-- **`--llm` flag content-type bug.** `Accept: application/vnd.grafana.llm`
-  causes the response to not be JSON, but the client unconditionally
-  `json.Unmarshal`s. Out of scope here; tracked as a separate item.
 - **Span events / links / attributes rendering.** Out of scope.
   `-o yaml` already renders attributes; events/links are rare enough to
   defer.

--- a/docs/reference/cli/gcx_datasources_tempo_get.md
+++ b/docs/reference/cli/gcx_datasources_tempo_get.md
@@ -20,20 +20,20 @@ gcx datasources tempo get TRACE_ID [flags]
 
 ```
 
-  # Get a trace using configured default datasource
-  gcx datasources tempo get abc123def456
+  # Get LLM-friendly output for agent analysis
+  gcx datasources tempo get abc123def456 --llm -o json
 
-  # Get a trace with explicit datasource UID
-  gcx datasources tempo get -d tempo-001 abc123def456
+  # Get LLM-friendly output with explicit datasource UID
+  gcx datasources tempo get -d tempo-001 abc123def456 --llm -o json
 
   # Print a Grafana Explore share link for the trace
   gcx datasources tempo get abc123def456 --share-link
 
-  # Get LLM-friendly output
-  gcx datasources tempo get abc123def456 --llm
+  # Get a human-readable trace table
+  gcx datasources tempo get abc123def456
 
-  # Get a trace within a time range
-  gcx datasources tempo get abc123def456 --since 1h
+  # Get LLM-friendly output within a time range
+  gcx datasources tempo get abc123def456 --since 1h --llm -o json
 ```
 
 ### Options

--- a/docs/reference/cli/gcx_traces_get.md
+++ b/docs/reference/cli/gcx_traces_get.md
@@ -20,13 +20,13 @@ gcx traces get TRACE_ID [flags]
 
 ```
 
-  # Fetch a trace by ID
-  gcx traces get -d UID <trace-id>
+  # Fetch a trace by ID for agent analysis
+  gcx traces get -d UID <trace-id> --llm -o json
 
   # Print a Grafana Explore share link for the trace
   gcx traces get -d UID <trace-id> --share-link
 
-  # Output as JSON
+  # Output raw OTLP-shaped JSON when explicitly needed
   gcx traces get -d UID <trace-id> -o json
 ```
 

--- a/internal/datasources/tempo/get.go
+++ b/internal/datasources/tempo/get.go
@@ -60,20 +60,20 @@ Use --share-link to print a Grafana Explore URL for the trace, or --open to
 open it in your browser after retrieval succeeds. Share links require an
 explicit time range via --since or --from/--to.`,
 		Example: `
-  # Get a trace using configured default datasource
-  gcx datasources tempo get abc123def456
+  # Get LLM-friendly output for agent analysis
+  gcx datasources tempo get abc123def456 --llm -o json
 
-  # Get a trace with explicit datasource UID
-  gcx datasources tempo get -d tempo-001 abc123def456
+  # Get LLM-friendly output with explicit datasource UID
+  gcx datasources tempo get -d tempo-001 abc123def456 --llm -o json
 
   # Print a Grafana Explore share link for the trace
   gcx datasources tempo get abc123def456 --share-link
 
-  # Get LLM-friendly output
-  gcx datasources tempo get abc123def456 --llm
+  # Get a human-readable trace table
+  gcx datasources tempo get abc123def456
 
-  # Get a trace within a time range
-  gcx datasources tempo get abc123def456 --since 1h`,
+  # Get LLM-friendly output within a time range
+  gcx datasources tempo get abc123def456 --since 1h --llm -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
@@ -152,7 +152,7 @@ explicit time range via --since or --from/--to.`,
 
 	cmd.Annotations = map[string]string{
 		agent.AnnotationTokenCost: "medium",
-		agent.AnnotationLLMHint:   "gcx datasources tempo get -d UID <trace-id> -o json",
+		agent.AnnotationLLMHint:   "gcx datasources tempo get -d UID <trace-id> --llm -o json",
 	}
 
 	opts.setup(cmd.Flags())

--- a/internal/providers/traces/provider.go
+++ b/internal/providers/traces/provider.go
@@ -38,15 +38,15 @@ func (p *Provider) descriptor() signals.Descriptor {
 			{
 				Build:     dstempo.GetCmd,
 				TokenCost: "medium",
-				LLMHint:   "gcx traces get -d abc123 <trace-id> -o json",
+				LLMHint:   "gcx traces get -d abc123 <trace-id> --llm -o json",
 				Example: `
-  # Fetch a trace by ID
-  gcx traces get -d UID <trace-id>
+  # Fetch a trace by ID for agent analysis
+  gcx traces get -d UID <trace-id> --llm -o json
 
   # Print a Grafana Explore share link for the trace
   gcx traces get -d UID <trace-id> --share-link
 
-  # Output as JSON
+  # Output raw OTLP-shaped JSON when explicitly needed
   gcx traces get -d UID <trace-id> -o json`,
 			},
 			{


### PR DESCRIPTION
The tempo LLM encoding has proved to be quite effective in token reduction. Around a 20% less tokens while keeping the data integrity. This PR updates agent-facing Tempo trace guidance to prefer `gcx traces get --llm -o json` for full-trace analysis.

