### PR TITLE
feat(assistant): add conversation list/get and relax context resume

### DIFF
--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -78,6 +78,7 @@ Service account tokens are not supported.`,
 	configOpts.BindFlags(cmd.PersistentFlags())
 	cmd.AddCommand(promptCommand(configOpts))
 	cmd.AddCommand(dashboardCommand(configOpts))
+	cmd.AddCommand(conversationCommand(configOpts))
 
 	// Create a ConfigLoader for investigations that shares the same --config/--context
 	// flags already bound by configOpts. Wire the values via PersistentPreRunE so that
@@ -260,11 +261,15 @@ func runPrompt(cmd *cobra.Command, message string, opts *promptOpts, configOpts 
 
 	// Validate context ID if provided
 	if contextID != "" {
-		if err := c.ValidateCLIContext(ctx, contextID); err != nil {
+		notice, err := c.ValidateCLIContext(ctx, contextID)
+		if err != nil {
 			if opts.jsonOut {
 				return jsonError(err)
 			}
 			return err
+		}
+		if notice != "" && !opts.jsonOut {
+			cmdio.Info(errW, "%s", notice)
 		}
 	}
 

--- a/cmd/gcx/assistant/conversation.go
+++ b/cmd/gcx/assistant/conversation.go
@@ -1,0 +1,149 @@
+package assistant
+
+import (
+	"fmt"
+
+	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/internal/assistant"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func conversationCommand(configOpts *cmdconfig.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "conversation",
+		Short: "Read Grafana Assistant conversations",
+		Long:  "Fetch conversation metadata and message history without sending a new prompt.",
+	}
+
+	cmd.AddCommand(conversationListCommand(configOpts))
+	cmd.AddCommand(conversationGetCommand(configOpts))
+	return cmd
+}
+
+type conversationListOpts struct {
+	IO              cmdio.Options
+	source          string
+	limit           int
+	offset          int
+	includeArchived bool
+	archivedOnly    bool
+	timeout         int
+}
+
+func (o *conversationListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &assistant.ConversationListCodec{})
+	o.IO.RegisterCustomCodec("wide", &assistant.ConversationListCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.source, "source", assistant.DefaultConversationSources, `Filter by conversation source. Use "all" for every source, or a comma-separated list (e.g. "assistant,cli").`)
+	flags.IntVar(&o.limit, "limit", 15, "Maximum number of conversations to return")
+	flags.IntVar(&o.offset, "offset", 0, "Number of conversations to skip (for pagination)")
+	flags.BoolVar(&o.includeArchived, "include-archived", false, "Include archived conversations")
+	flags.BoolVar(&o.archivedOnly, "archived-only", false, "Show only archived conversations")
+	flags.IntVar(&o.timeout, "timeout", 60, "HTTP timeout in seconds")
+}
+
+func conversationListCommand(configOpts *cmdconfig.Options) *cobra.Command {
+	opts := &conversationListOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Grafana Assistant conversations",
+		Long: `List the conversations you can access, most recently updated first.
+
+Use this to discover conversation IDs, then pull a transcript with
+'gcx assistant conversation get' or continue one with
+'gcx assistant prompt --context-id'.`,
+		Args: cobra.NoArgs,
+		Example: `  gcx assistant conversation list
+  gcx assistant conversation list --source assistant --limit 25
+  gcx assistant conversation list -o json`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			clientOpts, err := resolveAssistantClientOptions(cmd.Context(), configOpts, opts.timeout, assistant.DefaultAgentID)
+			if err != nil {
+				return err
+			}
+			client := assistant.New(clientOpts)
+
+			chats, err := client.ListChats(cmd.Context(), assistant.ListChatsOptions{
+				Source:          opts.source,
+				Limit:           opts.limit,
+				Offset:          opts.offset,
+				IncludeArchived: opts.includeArchived,
+				ArchivedOnly:    opts.archivedOnly,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to list conversations: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), chats)
+		},
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type conversationGetOpts struct {
+	IO      cmdio.Options
+	timeout int
+}
+
+func (o *conversationGetOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("text", &assistant.ConversationTextCodec{})
+	o.IO.DefaultFormat("text")
+	o.IO.BindFlags(flags)
+	flags.IntVar(&o.timeout, "timeout", 60, "HTTP timeout in seconds")
+}
+
+func conversationGetCommand(configOpts *cmdconfig.Options) *cobra.Command {
+	opts := &conversationGetOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "get <conversation-id>",
+		Short: "Get a conversation transcript",
+		Long: `Fetch conversation metadata and message history for a conversation ID.
+
+Use this to pull a web Assistant chat into a coding agent before continuing it
+with 'gcx assistant prompt --context-id'.`,
+		Args: cobra.ExactArgs(1),
+		Example: `  gcx assistant conversation get 295a674f-3a3d-44e8-9166-3f8054409f65
+  gcx assistant conversation get 295a674f-3a3d-44e8-9166-3f8054409f65 -o json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			clientOpts, err := resolveAssistantClientOptions(cmd.Context(), configOpts, opts.timeout, assistant.DefaultAgentID)
+			if err != nil {
+				return err
+			}
+			client := assistant.New(clientOpts)
+
+			chatID := args[0]
+			chat, err := client.GetChat(cmd.Context(), chatID)
+			if err != nil {
+				return fmt.Errorf("failed to fetch conversation: %w", err)
+			}
+
+			messages, err := client.GetChatMessages(cmd.Context(), chatID)
+			if err != nil {
+				return fmt.Errorf("failed to fetch conversation messages: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), assistant.ConversationTranscript{
+				Chat:     *chat,
+				Messages: messages,
+			})
+		},
+	}
+
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/cmd/gcx/assistant/conversation.go
+++ b/cmd/gcx/assistant/conversation.go
@@ -1,6 +1,7 @@
 package assistant
 
 import (
+	"errors"
 	"fmt"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
@@ -32,6 +33,25 @@ type conversationListOpts struct {
 	timeout         int
 }
 
+func (o *conversationListOpts) Validate() error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+	if o.timeout <= 0 {
+		return errors.New("--timeout must be positive")
+	}
+	if o.limit < 0 {
+		return errors.New("--limit must not be negative")
+	}
+	if o.offset < 0 {
+		return errors.New("--offset must not be negative")
+	}
+	if o.includeArchived && o.archivedOnly {
+		return errors.New("cannot use both --include-archived and --archived-only flags")
+	}
+	return nil
+}
+
 func (o *conversationListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("table", &assistant.ConversationListCodec{})
 	o.IO.RegisterCustomCodec("wide", &assistant.ConversationListCodec{Wide: true})
@@ -61,7 +81,7 @@ Use this to discover conversation IDs, then pull a transcript with
   gcx assistant conversation list --source assistant --limit 25
   gcx assistant conversation list -o json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := opts.IO.Validate(); err != nil {
+			if err := opts.Validate(); err != nil {
 				return err
 			}
 
@@ -95,6 +115,16 @@ type conversationGetOpts struct {
 	timeout int
 }
 
+func (o *conversationGetOpts) Validate() error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+	if o.timeout <= 0 {
+		return errors.New("--timeout must be positive")
+	}
+	return nil
+}
+
 func (o *conversationGetOpts) setup(flags *pflag.FlagSet) {
 	o.IO.RegisterCustomCodec("text", &assistant.ConversationTextCodec{})
 	o.IO.DefaultFormat("text")
@@ -116,7 +146,7 @@ with 'gcx assistant prompt --context-id'.`,
 		Example: `  gcx assistant conversation get 295a674f-3a3d-44e8-9166-3f8054409f65
   gcx assistant conversation get 295a674f-3a3d-44e8-9166-3f8054409f65 -o json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.IO.Validate(); err != nil {
+			if err := opts.Validate(); err != nil {
 				return err
 			}
 

--- a/cmd/gcx/assistant/conversation_test.go
+++ b/cmd/gcx/assistant/conversation_test.go
@@ -120,6 +120,58 @@ func TestConversationListCommand_TableOutput(t *testing.T) {
 	require.Contains(t, out, "Disk pressure")
 }
 
+func TestConversationCommand_Validation(t *testing.T) {
+	cfgPath := writeAssistantTestConfig(t, "http://127.0.0.1:0")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "list negative limit",
+			args:    []string{"conversation", "list", "--config", cfgPath, "--limit", "-1"},
+			wantErr: "--limit must not be negative",
+		},
+		{
+			name:    "list negative offset",
+			args:    []string{"conversation", "list", "--config", cfgPath, "--offset", "-1"},
+			wantErr: "--offset must not be negative",
+		},
+		{
+			name:    "list conflicting archive flags",
+			args:    []string{"conversation", "list", "--config", cfgPath, "--include-archived", "--archived-only"},
+			wantErr: "cannot use both --include-archived and --archived-only flags",
+		},
+		{
+			name:    "list non-positive timeout",
+			args:    []string{"conversation", "list", "--config", cfgPath, "--timeout", "0"},
+			wantErr: "--timeout must be positive",
+		},
+		{
+			name:    "get non-positive timeout",
+			args:    []string{"conversation", "get", "chat-1", "--config", cfgPath, "--timeout", "0"},
+			wantErr: "--timeout must be positive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := assistantcmd.Command()
+			root.SetContext(context.Background())
+			root.SilenceUsage = true
+			root.SilenceErrors = true
+			root.SetOut(&bytes.Buffer{})
+			root.SetErr(&bytes.Buffer{})
+			root.SetArgs(tt.args)
+
+			err := root.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestConversationCommand_Registered(t *testing.T) {
 	root := assistantcmd.Command()
 

--- a/cmd/gcx/assistant/conversation_test.go
+++ b/cmd/gcx/assistant/conversation_test.go
@@ -12,6 +12,7 @@ import (
 
 	assistantcmd "github.com/grafana/gcx/cmd/gcx/assistant"
 	"github.com/grafana/gcx/internal/assistant"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,8 +73,8 @@ func TestConversationListCommand_TableOutput(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		require.Equal(t, "all", r.URL.Query().Get("source"))
-		require.Equal(t, "25", r.URL.Query().Get("limit"))
+		assert.Equal(t, "all", r.URL.Query().Get("source"))
+		assert.Equal(t, "25", r.URL.Query().Get("limit"))
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{

--- a/cmd/gcx/assistant/conversation_test.go
+++ b/cmd/gcx/assistant/conversation_test.go
@@ -1,0 +1,147 @@
+package assistant_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	assistantcmd "github.com/grafana/gcx/cmd/gcx/assistant"
+	"github.com/grafana/gcx/internal/assistant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConversationGetCommand_TextOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/plugins/grafana-assistant-app/resources/api/v1/chats/chat-1":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": assistant.Chat{
+					ID:     "chat-1",
+					Name:   "Checkout latency",
+					Source: "assistant",
+				},
+			})
+		case "/api/plugins/grafana-assistant-app/resources/api/v1/chats/chat-1/all-messages":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"messages": []assistant.ChatMessage{
+						{
+							Role: "user",
+							Content: assistant.ContentJSON{
+								{Type: "text", Text: "Why is checkout slow?"},
+							},
+						},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cfgPath := writeAssistantTestConfig(t, server.URL)
+
+	root := assistantcmd.Command()
+	root.SetContext(context.Background())
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"conversation", "get", "chat-1", "--config", cfgPath, "--output", "text"})
+
+	require.NoError(t, root.Execute())
+
+	out := stdout.String()
+	require.Contains(t, out, "Conversation: Checkout latency")
+	require.Contains(t, out, "Why is checkout slow?")
+}
+
+func TestConversationListCommand_TableOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/plugins/grafana-assistant-app/resources/api/v1/chats" {
+			http.NotFound(w, r)
+			return
+		}
+		require.Equal(t, "all", r.URL.Query().Get("source"))
+		require.Equal(t, "25", r.URL.Query().Get("limit"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"items": []assistant.Chat{
+					{
+						ID:        "chat-1",
+						Name:      "Checkout latency",
+						Source:    "assistant",
+						UpdatedAt: "2026-05-30T12:00:00Z",
+					},
+					{
+						ID:     "chat-2",
+						Name:   "Disk pressure",
+						Source: "cli",
+					},
+				},
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	cfgPath := writeAssistantTestConfig(t, server.URL)
+
+	root := assistantcmd.Command()
+	root.SetContext(context.Background())
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"conversation", "list", "--config", cfgPath, "--source", "all", "--limit", "25", "--output", "table"})
+
+	require.NoError(t, root.Execute())
+
+	out := stdout.String()
+	require.Contains(t, out, "ID")
+	require.Contains(t, out, "TITLE")
+	require.Contains(t, out, "chat-1")
+	require.Contains(t, out, "Checkout latency")
+	require.Contains(t, out, "2026-05-30 12:00")
+	require.Contains(t, out, "chat-2")
+	require.Contains(t, out, "Disk pressure")
+}
+
+func TestConversationCommand_Registered(t *testing.T) {
+	root := assistantcmd.Command()
+
+	for _, sub := range []string{"get", "list"} {
+		cmd, _, err := root.Find([]string{"conversation", sub})
+		require.NoError(t, err)
+		require.Equal(t, sub, cmd.Name())
+	}
+}
+
+func writeAssistantTestConfig(t *testing.T, grafanaURL string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	content := `current-context: test
+contexts:
+  test:
+    grafana:
+      server: ` + grafanaURL + `
+      stack-id: 12345
+      token: test-token
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(content), 0o600))
+	return cfgPath
+}

--- a/docs/reference/cli/gcx_assistant.md
+++ b/docs/reference/cli/gcx_assistant.md
@@ -30,6 +30,7 @@ Service account tokens are not supported.
 ### SEE ALSO
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx assistant conversation](gcx_assistant_conversation.md)	 - Read Grafana Assistant conversations
 * [gcx assistant dashboard](gcx_assistant_dashboard.md)	 - Build a dashboard using the Grafana dashboarding agent
 * [gcx assistant investigations](gcx_assistant_investigations.md)	 - Manage Grafana Assistant investigations.
 * [gcx assistant prompt](gcx_assistant_prompt.md)	 - Send a single message to Grafana Assistant

--- a/docs/reference/cli/gcx_assistant_conversation.md
+++ b/docs/reference/cli/gcx_assistant_conversation.md
@@ -1,0 +1,32 @@
+## gcx assistant conversation
+
+Read Grafana Assistant conversations
+
+### Synopsis
+
+Fetch conversation metadata and message history without sending a new prompt.
+
+### Options
+
+```
+  -h, --help   help for conversation
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx assistant](gcx_assistant.md)	 - Interact with Grafana Assistant
+* [gcx assistant conversation get](gcx_assistant_conversation_get.md)	 - Get a conversation transcript
+* [gcx assistant conversation list](gcx_assistant_conversation_list.md)	 - List Grafana Assistant conversations
+

--- a/docs/reference/cli/gcx_assistant_conversation_get.md
+++ b/docs/reference/cli/gcx_assistant_conversation_get.md
@@ -1,0 +1,47 @@
+## gcx assistant conversation get
+
+Get a conversation transcript
+
+### Synopsis
+
+Fetch conversation metadata and message history for a conversation ID.
+
+Use this to pull a web Assistant chat into a coding agent before continuing it
+with 'gcx assistant prompt --context-id'.
+
+```
+gcx assistant conversation get <conversation-id> [flags]
+```
+
+### Examples
+
+```
+  gcx assistant conversation get 295a674f-3a3d-44e8-9166-3f8054409f65
+  gcx assistant conversation get 295a674f-3a3d-44e8-9166-3f8054409f65 -o json
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+      --timeout int     HTTP timeout in seconds (default 60)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx assistant conversation](gcx_assistant_conversation.md)	 - Read Grafana Assistant conversations
+

--- a/docs/reference/cli/gcx_assistant_conversation_list.md
+++ b/docs/reference/cli/gcx_assistant_conversation_list.md
@@ -1,0 +1,54 @@
+## gcx assistant conversation list
+
+List Grafana Assistant conversations
+
+### Synopsis
+
+List the conversations you can access, most recently updated first.
+
+Use this to discover conversation IDs, then pull a transcript with
+'gcx assistant conversation get' or continue one with
+'gcx assistant prompt --context-id'.
+
+```
+gcx assistant conversation list [flags]
+```
+
+### Examples
+
+```
+  gcx assistant conversation list
+  gcx assistant conversation list --source assistant --limit 25
+  gcx assistant conversation list -o json
+```
+
+### Options
+
+```
+      --archived-only      Show only archived conversations
+  -h, --help               help for list
+      --include-archived   Include archived conversations
+      --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int          Maximum number of conversations to return (default 15)
+      --offset int         Number of conversations to skip (for pagination)
+  -o, --output string      Output format. One of: agents, json, table, wide, yaml (default "table")
+      --source string      Filter by conversation source. Use "all" for every source, or a comma-separated list (e.g. "assistant,cli"). (default "assistant,slack,cli")
+      --timeout int        HTTP timeout in seconds (default 60)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string      Path to the configuration file to use
+      --context string     Name of the context to use
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx assistant conversation](gcx_assistant_conversation.md)	 - Read Grafana Assistant conversations
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -37,6 +37,8 @@ var commandAnnotations = map[string]annotation{
 	"gcx assistant investigations report":    {Cost: "medium", Hint: "<id> -o json"},
 	"gcx assistant investigations timeline":  {Cost: "medium", Hint: "<id> -o json"},
 	"gcx assistant investigations todos":     {Cost: "medium", Hint: "<id> -o json"},
+	"gcx assistant conversation list":        {Cost: "small", Hint: "Discover conversation IDs. --source assistant,slack,cli (default), --limit, --offset, -o json"},
+	"gcx assistant conversation get":         {Cost: "large", Hint: "Pull a conversation transcript by ID before continuing it with 'gcx assistant prompt --context-id'. Example: <conversation-id> -o json"},
 
 	// login
 	"gcx login": {Cost: "small", Hint: "Non-interactive: gcx login <ctx> --yes --server <url> --token <grafana-sa-token> [--cloud-token <cap-token>]. Service-account tokens (--token) are created inside the Grafana instance — see https://grafana.com/docs/grafana/latest/administration/service-accounts.md. Cloud access-policy tokens (--cloud-token) are created at grafana.com — see https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies.md. Append .md to any grafana.com/docs URL to fetch markdown. Do not guess token URLs."},

--- a/internal/assistant/api.go
+++ b/internal/assistant/api.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -92,6 +94,101 @@ func FetchChat(ctx context.Context, baseURL, token, chatID string, httpClient *h
 
 	return &response.Data, nil
 }
+
+// ListChatsOptions controls filtering and pagination for FetchChats.
+type ListChatsOptions struct {
+	// Source filters chats by origin. Supports a single value ("assistant"),
+	// comma-separated values ("assistant,cli"), or "all" for every source.
+	// When empty the backend defaults to "assistant".
+	Source string
+	// Limit caps the number of chats returned. Zero uses the backend default.
+	Limit int
+	// Offset skips the first N chats for pagination.
+	Offset int
+	// IncludeArchived also returns archived chats.
+	IncludeArchived bool
+	// ArchivedOnly returns only archived chats (overrides IncludeArchived).
+	ArchivedOnly bool
+}
+
+// FetchChats lists the caller's chats from the REST API.
+func FetchChats(ctx context.Context, baseURL, token string, opts ListChatsOptions, httpClient *http.Client) ([]Chat, error) {
+	endpoints := GetChatEndpoints(baseURL)
+
+	query := url.Values{}
+	if opts.Source != "" {
+		query.Set("source", opts.Source)
+	}
+	if opts.Limit > 0 {
+		query.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.Offset > 0 {
+		query.Set("offset", strconv.Itoa(opts.Offset))
+	}
+	if opts.IncludeArchived {
+		query.Set("includeArchived", "true")
+	}
+	if opts.ArchivedOnly {
+		query.Set("archivedOnly", "true")
+	}
+
+	endpoint := endpoints.Chats()
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-App-Source", "cli")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to list chats: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var response struct {
+		Data struct {
+			Items []Chat `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	// Inline-assistant chats are ephemeral inline-generation artifacts, not
+	// conversations worth listing or continuing, so drop them regardless of
+	// the requested source filter.
+	chats := make([]Chat, 0, len(response.Data.Items))
+	for _, chat := range response.Data.Items {
+		if chat.Source == inlineAssistantSource {
+			continue
+		}
+		chats = append(chats, chat)
+	}
+
+	return chats, nil
+}
+
+// inlineAssistantSource is the chat source used by the inline (in-editor)
+// assistant for short, single-shot generations.
+const inlineAssistantSource = "inline-assistant"
+
+// DefaultConversationSources is the source allowlist 'gcx assistant
+// conversation list' requests by default, covering the conversation kinds a
+// user typically wants to resume. Filtering happens server-side, keeping
+// --limit/--offset honest. Ephemeral inline-assistant chats are excluded.
+const DefaultConversationSources = "assistant,slack,cli"
 
 // FetchChatMessages fetches messages for a chat from the REST API.
 func FetchChatMessages(ctx context.Context, baseURL, token, chatID string, httpClient *http.Client) ([]ChatMessage, error) {

--- a/internal/assistant/api.go
+++ b/internal/assistant/api.go
@@ -100,6 +100,12 @@ type ListChatsOptions struct {
 	// Source filters chats by origin. Supports a single value ("assistant"),
 	// comma-separated values ("assistant,cli"), or "all" for every source.
 	// When empty the backend defaults to "assistant".
+	//
+	// Filtering happens server-side, so --limit/--offset are honest for the
+	// default and explicit comma-separated sources. For "all", ephemeral
+	// inline-assistant chats are stripped client-side after the server
+	// applies limit/offset, so a page may return fewer rows than --limit;
+	// pagination is best-effort for that case (see FetchChats).
 	Source string
 	// Limit caps the number of chats returned. Zero uses the backend default.
 	Limit int
@@ -169,6 +175,15 @@ func FetchChats(ctx context.Context, baseURL, token string, opts ListChatsOption
 	// Inline-assistant chats are ephemeral inline-generation artifacts, not
 	// conversations worth listing or continuing, so drop them regardless of
 	// the requested source filter.
+	//
+	// For the default and explicit comma-separated sources, inline-assistant
+	// is never requested, so this loop is purely a safety net and pagination
+	// stays honest. For Source == "all" the backend applies limit/offset
+	// before we strip inline chats here, so a page can return fewer rows than
+	// --limit even when more non-inline chats exist at later offsets. We
+	// accept that best-effort behavior for "all" (a power-user/debug path)
+	// rather than couple gcx to a backend excludeSource param or hard-code a
+	// non-inline source allowlist that would silently hide future sources.
 	chats := make([]Chat, 0, len(response.Data.Items))
 	for _, chat := range response.Data.Items {
 		if chat.Source == inlineAssistantSource {

--- a/internal/assistant/api_test.go
+++ b/internal/assistant/api_test.go
@@ -1,0 +1,174 @@
+package assistant_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/assistant"
+)
+
+func TestFetchChatMessages(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/api/plugins/grafana-assistant-app/resources/api/v1/chats/chat-1/all-messages" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"messages": []assistant.ChatMessage{
+					{
+						ID:   "m1",
+						Role: "user",
+						Content: assistant.ContentJSON{
+							{Type: "text", Text: "Why is checkout slow?"},
+						},
+					},
+					{
+						ID:   "m2",
+						Role: "assistant",
+						Content: assistant.ContentJSON{
+							{Type: "text", Text: "p99 latency is elevated."},
+						},
+					},
+				},
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	messages, err := assistant.FetchChatMessages(
+		context.Background(),
+		server.URL+"/api/plugins/grafana-assistant-app/resources/api/v1",
+		"test-token",
+		"chat-1",
+		server.Client(),
+	)
+	if err != nil {
+		t.Fatalf("FetchChatMessages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("got %d messages, want 2", len(messages))
+	}
+	if messages[0].ExtractText() != "Why is checkout slow?" {
+		t.Fatalf("message 0 text = %q", messages[0].ExtractText())
+	}
+}
+
+func TestFetchChats(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/api/plugins/grafana-assistant-app/resources/api/v1/chats" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("source"); got != "assistant,cli" {
+			t.Errorf("source query = %q, want %q", got, "assistant,cli")
+		}
+		if got := r.URL.Query().Get("limit"); got != "10" {
+			t.Errorf("limit query = %q, want %q", got, "10")
+		}
+		if got := r.URL.Query().Get("includeArchived"); got != "true" {
+			t.Errorf("includeArchived query = %q, want %q", got, "true")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"items": []assistant.Chat{
+					{ID: "chat-1", Name: "Checkout latency", Source: "assistant", UpdatedAt: "2026-05-30T12:00:00Z"},
+					{ID: "chat-2", Name: "Disk pressure", Source: "cli"},
+					{ID: "chat-3", Name: "Inline edit", Source: "inline-assistant"},
+				},
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	chats, err := assistant.FetchChats(
+		context.Background(),
+		server.URL+"/api/plugins/grafana-assistant-app/resources/api/v1",
+		"test-token",
+		assistant.ListChatsOptions{Source: "assistant,cli", Limit: 10, IncludeArchived: true},
+		server.Client(),
+	)
+	if err != nil {
+		t.Fatalf("FetchChats: %v", err)
+	}
+	// chat-3 is an inline-assistant chat and must be filtered out.
+	if len(chats) != 2 {
+		t.Fatalf("got %d chats, want 2", len(chats))
+	}
+	if chats[0].ID != "chat-1" || chats[0].Name != "Checkout latency" {
+		t.Fatalf("chat 0 = %+v", chats[0])
+	}
+	for _, c := range chats {
+		if c.Source == "inline-assistant" {
+			t.Fatalf("inline-assistant chat %s was not filtered out", c.ID)
+		}
+	}
+}
+
+func TestConversationTranscript_FormatText(t *testing.T) {
+	t.Parallel()
+
+	transcript := assistant.ConversationTranscript{
+		Chat: assistant.Chat{
+			ID:     "chat-1",
+			Name:   "Checkout latency",
+			Source: "assistant",
+		},
+		Messages: []assistant.ChatMessage{
+			{
+				Role: "user",
+				Content: assistant.ContentJSON{
+					{Type: "text", Text: "Why is checkout slow?"},
+				},
+			},
+			{
+				Role:    "internal",
+				Content: assistant.ContentJSON{{Type: "text", Text: "hidden system"}},
+			},
+			{
+				Role: "assistant",
+				Content: assistant.ContentJSON{
+					{Type: "text", Text: "p99 latency is elevated."},
+				},
+			},
+		},
+	}
+
+	out := transcript.FormatText()
+	for _, want := range []string{
+		"Conversation: Checkout latency",
+		"ID: chat-1",
+		"Source: assistant",
+		"USER:",
+		"Why is checkout slow?",
+		"ASSISTANT:",
+		"p99 latency is elevated.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("FormatText() missing %q\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "hidden system") {
+		t.Fatalf("FormatText() should omit internal messages\n%s", out)
+	}
+}

--- a/internal/assistant/client.go
+++ b/internal/assistant/client.go
@@ -78,16 +78,38 @@ func (c *Client) GetChat(ctx context.Context, chatID string) (*Chat, error) {
 	return FetchChat(ctx, c.baseURL, c.freshToken(), chatID, c.httpClient)
 }
 
-// ValidateCLIContext validates that a context ID belongs to a CLI-created chat.
-func (c *Client) ValidateCLIContext(ctx context.Context, contextID string) error {
+// GetChatMessages fetches all messages for a chat.
+func (c *Client) GetChatMessages(ctx context.Context, chatID string) ([]ChatMessage, error) {
+	return FetchChatMessages(ctx, c.baseURL, c.freshToken(), chatID, c.httpClient)
+}
+
+// ListChats lists the caller's chats, with optional filtering and pagination.
+func (c *Client) ListChats(ctx context.Context, opts ListChatsOptions) ([]Chat, error) {
+	return FetchChats(ctx, c.baseURL, c.freshToken(), opts, c.httpClient)
+}
+
+// ValidateCLIContext validates that contextID refers to an existing chat the caller can access.
+// It returns an optional notice when continuing a conversation not started from the CLI.
+func (c *Client) ValidateCLIContext(ctx context.Context, contextID string) (notice string, err error) {
 	chat, err := c.GetChat(ctx, contextID)
 	if err != nil {
-		return fmt.Errorf("failed to validate context: %w", err)
+		return "", fmt.Errorf("failed to validate context: %w", err)
 	}
-	if chat.Source != "cli" {
-		return fmt.Errorf("context %s was not created by CLI (source: %s). Use a CLI-created context or start a new conversation", contextID, chat.Source)
+	return ValidateResumableChatSource(contextID, chat)
+}
+
+func ValidateResumableChatSource(contextID string, chat *Chat) (notice string, err error) {
+	if chat == nil {
+		return "", fmt.Errorf("context %s not found or not accessible", contextID)
 	}
-	return nil
+	if chat.Source != "" && chat.Source != "cli" {
+		notice = fmt.Sprintf(
+			"Continuing a %s conversation (id: %s). Message history is shared; agent behavior may differ from the CLI assistant.",
+			chat.Source,
+			contextID,
+		)
+	}
+	return notice, nil
 }
 
 // GetBaseURL returns the computed base URL for API requests.

--- a/internal/assistant/client.go
+++ b/internal/assistant/client.go
@@ -90,7 +90,7 @@ func (c *Client) ListChats(ctx context.Context, opts ListChatsOptions) ([]Chat, 
 
 // ValidateCLIContext validates that contextID refers to an existing chat the caller can access.
 // It returns an optional notice when continuing a conversation not started from the CLI.
-func (c *Client) ValidateCLIContext(ctx context.Context, contextID string) (notice string, err error) {
+func (c *Client) ValidateCLIContext(ctx context.Context, contextID string) (string, error) {
 	chat, err := c.GetChat(ctx, contextID)
 	if err != nil {
 		return "", fmt.Errorf("failed to validate context: %w", err)
@@ -98,18 +98,20 @@ func (c *Client) ValidateCLIContext(ctx context.Context, contextID string) (noti
 	return ValidateResumableChatSource(contextID, chat)
 }
 
-func ValidateResumableChatSource(contextID string, chat *Chat) (notice string, err error) {
+// ValidateResumableChatSource reports whether chat can be resumed and returns an
+// optional notice when continuing a conversation not started from the CLI.
+func ValidateResumableChatSource(contextID string, chat *Chat) (string, error) {
 	if chat == nil {
 		return "", fmt.Errorf("context %s not found or not accessible", contextID)
 	}
 	if chat.Source != "" && chat.Source != "cli" {
-		notice = fmt.Sprintf(
+		return fmt.Sprintf(
 			"Continuing a %s conversation (id: %s). Message history is shared; agent behavior may differ from the CLI assistant.",
 			chat.Source,
 			contextID,
-		)
+		), nil
 	}
-	return notice, nil
+	return "", nil
 }
 
 // GetBaseURL returns the computed base URL for API requests.

--- a/internal/assistant/context_validation_test.go
+++ b/internal/assistant/context_validation_test.go
@@ -1,0 +1,106 @@
+package assistant_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/assistant"
+)
+
+func TestValidateResumableChatSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		source     string
+		wantNotice bool
+		wantErr    bool
+	}{
+		{name: "cli", source: "cli"},
+		{name: "assistant", source: "assistant", wantNotice: true},
+		{name: "a2a", source: "a2a", wantNotice: true},
+		{name: "slack", source: "slack", wantNotice: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			notice, err := assistant.ValidateResumableChatSource("chat-id", &assistant.Chat{
+				ID:     "chat-id",
+				Source: tt.source,
+			})
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNotice && notice == "" {
+				t.Fatal("expected notice for non-cli source")
+			}
+			if !tt.wantNotice && notice != "" {
+				t.Fatalf("expected empty notice, got %q", notice)
+			}
+		})
+	}
+}
+
+func TestValidateCLIContext_ResumesWebChat(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/plugins/grafana-assistant-app/resources/api/v1/chats/web-chat-id" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": assistant.Chat{
+				ID:     "web-chat-id",
+				Source: "assistant",
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client := assistant.New(assistant.ClientOptions{
+		GrafanaURL: server.URL,
+		Token:      "test-token",
+	})
+
+	notice, err := client.ValidateCLIContext(context.Background(), "web-chat-id")
+	if err != nil {
+		t.Fatalf("ValidateCLIContext() error = %v", err)
+	}
+	if notice == "" {
+		t.Fatal("expected notice for web conversation")
+	}
+}
+
+func TestValidateCLIContext_RejectsMissingChat(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	client := assistant.New(assistant.ClientOptions{
+		GrafanaURL: server.URL,
+		Token:      "test-token",
+	})
+
+	_, err := client.ValidateCLIContext(context.Background(), "missing-chat-id")
+	if err == nil {
+		t.Fatal("expected error when chat does not exist")
+	}
+}

--- a/internal/assistant/conversation_list_codec.go
+++ b/internal/assistant/conversation_list_codec.go
@@ -1,6 +1,7 @@
 package assistant
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"text/tabwriter"
@@ -59,7 +60,7 @@ func (c *ConversationListCodec) Encode(dst io.Writer, value any) error {
 }
 
 func (c *ConversationListCodec) Decode(_ io.Reader, _ any) error {
-	return fmt.Errorf("decode not supported for table format")
+	return errors.New("decode not supported for table format")
 }
 
 // formatChatTime renders an RFC3339 timestamp string for table display.

--- a/internal/assistant/conversation_list_codec.go
+++ b/internal/assistant/conversation_list_codec.go
@@ -1,0 +1,75 @@
+package assistant
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/grafana/gcx/internal/format"
+)
+
+// ConversationListCodec renders []Chat as a table.
+type ConversationListCodec struct {
+	Wide bool
+}
+
+func (c *ConversationListCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *ConversationListCodec) Encode(dst io.Writer, value any) error {
+	chats, ok := value.([]Chat)
+	if !ok {
+		return fmt.Errorf("expected []Chat, got %T", value)
+	}
+
+	tw := tabwriter.NewWriter(dst, 0, 4, 2, ' ', 0)
+	if c.Wide {
+		fmt.Fprintln(tw, "ID\tTITLE\tSOURCE\tCATEGORY\tUPDATED")
+	} else {
+		fmt.Fprintln(tw, "ID\tTITLE\tSOURCE\tUPDATED")
+	}
+
+	for _, chat := range chats {
+		title := truncate(chat.Name, 50)
+		if title == "" {
+			title = "-"
+		}
+		source := chat.Source
+		if source == "" {
+			source = "-"
+		}
+		updated := formatChatTime(chat.UpdatedAt)
+
+		if c.Wide {
+			category := chat.Category
+			if category == "" {
+				category = "-"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", chat.ID, title, source, category, updated)
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", chat.ID, title, source, updated)
+		}
+	}
+	return tw.Flush()
+}
+
+func (c *ConversationListCodec) Decode(_ io.Reader, _ any) error {
+	return fmt.Errorf("decode not supported for table format")
+}
+
+// formatChatTime renders an RFC3339 timestamp string for table display.
+func formatChatTime(value string) string {
+	if value == "" {
+		return "-"
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return value
+	}
+	return t.UTC().Format("2006-01-02 15:04")
+}

--- a/internal/assistant/transcript.go
+++ b/internal/assistant/transcript.go
@@ -1,0 +1,64 @@
+package assistant
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConversationTranscript is a chat and its message history.
+type ConversationTranscript struct {
+	Chat     Chat          `json:"chat"`
+	Messages []ChatMessage `json:"messages"`
+}
+
+// VisibleMessages returns user/assistant messages with extractable text, in API order.
+func (t ConversationTranscript) VisibleMessages() []ChatMessage {
+	if len(t.Messages) == 0 {
+		return nil
+	}
+	visible := make([]ChatMessage, 0, len(t.Messages))
+	for _, m := range t.Messages {
+		if m.Hidden {
+			continue
+		}
+		if m.Role != "user" && m.Role != "assistant" {
+			continue
+		}
+		if strings.TrimSpace(m.ExtractText()) == "" {
+			continue
+		}
+		visible = append(visible, m)
+	}
+	return visible
+}
+
+// FormatText renders a human-readable transcript for coding agents and terminals.
+func (t ConversationTranscript) FormatText() string {
+	var b strings.Builder
+
+	title := strings.TrimSpace(t.Chat.Name)
+	if title == "" {
+		title = "(untitled)"
+	}
+	fmt.Fprintf(&b, "Conversation: %s\n", title)
+	fmt.Fprintf(&b, "ID: %s\n", t.Chat.ID)
+	if t.Chat.Source != "" {
+		fmt.Fprintf(&b, "Source: %s\n", t.Chat.Source)
+	}
+
+	visible := t.VisibleMessages()
+	if len(visible) == 0 {
+		b.WriteString("\n(no user/assistant messages)\n")
+		return b.String()
+	}
+
+	for _, m := range visible {
+		role := strings.ToUpper(m.Role)
+		b.WriteByte('\n')
+		fmt.Fprintf(&b, "%s:\n", role)
+		b.WriteString(m.ExtractText())
+		b.WriteByte('\n')
+	}
+
+	return strings.TrimRight(b.String(), "\n") + "\n"
+}

--- a/internal/assistant/transcript_codec.go
+++ b/internal/assistant/transcript_codec.go
@@ -1,0 +1,28 @@
+package assistant
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/format"
+)
+
+// ConversationTextCodec encodes a ConversationTranscript as plain text.
+type ConversationTextCodec struct{}
+
+func (c *ConversationTextCodec) Format() format.Format {
+	return "text"
+}
+
+func (c *ConversationTextCodec) Encode(dst io.Writer, value any) error {
+	transcript, ok := value.(ConversationTranscript)
+	if !ok {
+		return fmt.Errorf("expected ConversationTranscript, got %T", value)
+	}
+	_, err := io.WriteString(dst, transcript.FormatText())
+	return err
+}
+
+func (c *ConversationTextCodec) Decode(_ io.Reader, _ any) error {
+	return fmt.Errorf("decode not supported for text format")
+}

--- a/internal/assistant/transcript_codec.go
+++ b/internal/assistant/transcript_codec.go
@@ -1,6 +1,7 @@
 package assistant
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -24,5 +25,5 @@ func (c *ConversationTextCodec) Encode(dst io.Writer, value any) error {
 }
 
 func (c *ConversationTextCodec) Decode(_ io.Reader, _ any) error {
-	return fmt.Errorf("decode not supported for text format")
+	return errors.New("decode not supported for text format")
 }

--- a/internal/assistant/types.go
+++ b/internal/assistant/types.go
@@ -255,10 +255,11 @@ func (NopLogger) Warning(string) {}
 
 // Chat represents a chat conversation.
 type Chat struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Category string `json:"category,omitempty"`
-	Source   string `json:"source"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Category  string `json:"category,omitempty"`
+	Source    string `json:"source"`
+	UpdatedAt string `json:"modified,omitempty"`
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Makes it easy to hand off a Grafana Assistant web conversation to a coding agent (or continue it in gcx):

- **`gcx assistant conversation list`** — discover conversation IDs. Defaults `--source` to `assistant,slack,cli` (filtered server-side, so `--limit`/`--offset` stay honest), with `all`/comma-list, pagination, and archived filters. Output: table (default), wide, or json.
- **`gcx assistant conversation get <id>`** — pull a conversation transcript as plain text (or json) to paste into a coding agent before continuing.
- **Relaxed `--context-id` resume** — instead of rejecting chats not created by the CLI, gcx now resumes any accessible chat and prints a soft notice for non-CLI sources, matching backend behavior (the backend never filtered on source).
- Ephemeral `inline-assistant` chats are excluded from listings.

## Why

Previously gcx defensively blocked resuming non-CLI chats even though the backend allowed it, and there was no way to discover conversation IDs or pull a transcript from the CLI. This rounds out the web → CLI/coding-agent handoff workflow.

## Test plan

- [x] `go test ./internal/assistant/... ./cmd/gcx/assistant/...` passes
- [x] `go build ./cmd/gcx/` succeeds
- [ ] Manual: `gcx assistant conversation list` shows the same conversations as the web sidebar
- [ ] Manual: `gcx assistant conversation get <id>` renders a readable transcript
- [ ] Manual: `gcx assistant prompt --context-id <web-uuid>` resumes a web chat with a notice