### PR TITLE
feat(tempo): add LLM tag values output

### DIFF
--- a/claude-plugin/skills/create-dashboard/SKILL.md
+++ b/claude-plugin/skills/create-dashboard/SKILL.md
@@ -121,7 +121,7 @@ gcx datasources list -o json
 |------|-----------|---------------------------|
 | Prometheus | `gcx datasources prometheus labels -d <uid> --label __name__` | `gcx datasources prometheus labels -d <uid> --label <label>` |
 | Loki | `gcx datasources loki labels -d <uid>` | `gcx datasources loki labels -d <uid> --label <label>` |
-| Tempo | `gcx datasources tempo labels -d <uid>` | `gcx datasources tempo labels -d <uid> -l <attr> [--scope span\|resource] [-q '<traceql>']` |
+| Tempo | `gcx datasources tempo labels -d <uid>` | `gcx datasources tempo labels -d <uid> -l <attr> --llm -o json [--scope span\|resource] [-q '<traceql>']` |
 | Pyroscope | `gcx datasources pyroscope profile-types -d <uid>` then `labels -d <uid>` | `gcx datasources pyroscope labels -d <uid> --label <label>` |
 
 Prometheus also has `gcx datasources prometheus metadata -d <uid>` for metric type and help text.

--- a/claude-plugin/skills/debug-with-grafana/SKILL.md
+++ b/claude-plugin/skills/debug-with-grafana/SKILL.md
@@ -296,10 +296,11 @@ When inspecting trace bodies, use `gcx traces get <trace-id> --llm -o json`. Do 
 OTLP-shaped default trace and manually compact it unless the user explicitly
 needs raw trace JSON for schema/debugging work.
 
-Discover available labels:
+Discover available labels and values:
 ```bash
 gcx traces labels -d <tempo-uid>
-gcx traces labels -d <tempo-uid> -l resource.service.name
+# For agent workflows, request Tempo's compact LLM label-value encoding.
+gcx traces tags -d <tempo-uid> -l resource.service.name --llm -o json
 ```
 
 > **Common mistake**: `gcx traces labels -l service.name` will fail — Tempo

--- a/claude-plugin/skills/debug-with-grafana/references/traceql-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/traceql-patterns.md
@@ -8,7 +8,8 @@ Workflow and query patterns for Tempo trace search using gcx.
 |---------|---------|----------------|
 | `gcx traces query [TRACEQL]` | Search traces by TraceQL expression | TraceQL expression |
 | `gcx traces get TRACE_ID --llm -o json` | Fetch a single trace by ID in LLM-friendly format | Trace ID (required) |
-| `gcx traces labels` | List label names or values | None |
+| `gcx traces labels` | List label names | None |
+| `gcx traces tags -l TAG --llm -o json` | List tag values in compact LLM-friendly format | None |
 
 All commands accept `-d <uid>` for the Tempo datasource UID. `search` is an
 alias for `query`. There are no `--tag` or `--service` flags — use TraceQL
@@ -22,8 +23,9 @@ Start by listing tags, then inspect values for the ones that scope the problem.
 
 ```bash
 gcx traces labels -d <tempo-uid>
-gcx traces labels -d <tempo-uid> -l resource.service.name
-gcx traces labels -d <tempo-uid> -l span.http.status_code
+# For agent workflows, prefer compact LLM-friendly tag-value output.
+gcx traces tags -d <tempo-uid> -l resource.service.name --llm -o json
+gcx traces tags -d <tempo-uid> -l span.http.status_code --llm -o json
 ```
 
 > **Common mistake**: `-l service.name` will fail — Tempo parses the dot as an
@@ -75,7 +77,7 @@ gcx traces get -d <tempo-uid> <trace-id> --llm -o json
 ```
 
 Do not fetch the default OTLP-shaped trace and manually compact it for LLM
-consumption. Omit `--llm` only if the user explicitly needs raw trace JSON for
+consumption. Omit `--llm` only if the user explicitly needs raw OTLP/Tempo trace JSON for
 schema debugging, export, or byte-for-byte comparison.
 
 The trace ID is a positional argument — do not use `--trace-id` (it doesn't

--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -56,7 +56,7 @@ right group:
 | PromQL / Adaptive Metrics | `metrics` | `gcx metrics query -d <uid> 'up'` |
 | LogQL / Adaptive Logs | `logs` | `gcx logs query -d <uid> '{app="foo"}'` |
 | Profiling (Pyroscope) | `profiles` | `gcx profiles query` |
-| Tracing (Tempo) | `traces` | Search: `gcx traces query -d <uid> '{ status = error }'`; fetch for analysis: `gcx traces get -d <uid> <trace-id> --llm -o json` |
+| Tracing (Tempo) | `traces` | Search: `gcx traces query -d <uid> '{ status = error }'`; values: `gcx traces tags -d <uid> -l resource.service.name --llm -o json`; trace: `gcx traces get -d <uid> <trace-id> --llm -o json` |
 | Datasource info and queries | `datasources` | `gcx datasources list` |
 | Fleet pipelines, collectors | `fleet` | `gcx fleet pipelines list` |
 | Knowledge Graph (Asserts) | `kg` | `gcx kg entities list` |
@@ -146,22 +146,26 @@ The `gcx datasources` group provides typed query interfaces:
 
 Use `gcx datasources <type> --help` to discover type-specific flags.
 
-### Tempo trace bodies: use `--llm` for agent analysis
+### Tempo LLM-friendly output for agents
 
-When fetching a full Tempo trace for this agent to read, summarize, debug, or
-include in a prompt, **always use the LLM-friendly trace encoding**:
+When fetching Tempo tag values or full trace bodies for this agent to inspect,
+summarize, debug, or include in a prompt, prefer Tempo's compact LLM-friendly
+encoding:
 
 ```bash
+# Attribute values grouped by type instead of repeated {type,value} objects.
+gcx traces tags -d <tempo-uid> -l resource.service.name --llm -o json
+
+# Full trace body in Tempo's LLM-friendly trace encoding.
 gcx traces get -d <tempo-uid> <trace-id> --llm -o json
 # equivalent legacy path:
 gcx datasources tempo get -d <tempo-uid> <trace-id> --llm -o json
 ```
 
-Use `gcx traces query` to find trace IDs, then `gcx traces get --llm -o json` to inspect
-a selected trace. Do not fetch the default OTLP-shaped trace and manually compact
-or transform it for LLM consumption. Omit `--llm` only when the user explicitly
-needs raw OTLP/Tempo trace JSON for schema debugging, export, or byte-for-byte
-comparison.
+Use `gcx traces labels -d <tempo-uid>` to discover attribute names first. Use
+`gcx traces query` to find trace IDs, then `gcx traces get --llm -o json` to inspect
+a selected trace. Omit `--llm` only when the user explicitly needs raw Tempo/OTLP
+JSON or the standard `tagValues: [{type, value}]` shape for schema/debugging work.
 
 ## Grafana Assistant
 

--- a/claude-plugin/skills/manage-dashboards/SKILL.md
+++ b/claude-plugin/skills/manage-dashboards/SKILL.md
@@ -70,7 +70,7 @@ Use JSON/YAML for programmatic work and table/wide output for human summaries.
 | Loki label names | `gcx datasources loki labels -d <uid>` |
 | Loki label values | `gcx datasources loki labels -d <uid> --label <label>` |
 | Tempo attribute names | `gcx datasources tempo labels -d <uid>` |
-| Tempo attribute values | `gcx datasources tempo labels -d <uid> -l service.name` |
+| Tempo attribute values | `gcx datasources tempo labels -d <uid> -l resource.service.name --llm -o json` |
 | Pyroscope profile types | `gcx datasources pyroscope profile-types -d <uid>` |
 | Pyroscope label values | `gcx datasources pyroscope labels -d <uid> --label service_name` |
 | Other datasource types | Check `gcx datasources <type> --help` for dedicated subcommands before using `gcx api` |

--- a/docs/reference/cli/gcx_datasources_tempo_labels.md
+++ b/docs/reference/cli/gcx_datasources_tempo_labels.md
@@ -25,6 +25,9 @@ gcx datasources tempo labels [flags]
   # Get values for a specific label
   gcx datasources tempo labels -d UID -l service.name
 
+  # Get LLM-friendly values for a specific label
+  gcx datasources tempo labels -d UID -l service.name --llm -o json
+
   # Using the tags alias
   gcx datasources tempo tags -d UID -l service.name
 
@@ -45,6 +48,7 @@ gcx datasources tempo labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
+      --llm                 Request LLM-friendly label values format (requires --label)
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)

--- a/docs/reference/cli/gcx_traces_labels.md
+++ b/docs/reference/cli/gcx_traces_labels.md
@@ -22,6 +22,9 @@ gcx traces labels [flags]
   # List all labels
   gcx traces labels -d UID
 
+  # Get LLM-friendly values for a label
+  gcx traces tags -d UID -l resource.service.name --llm -o json
+
   # Output as JSON
   gcx traces labels -d UID -o json
 ```
@@ -33,6 +36,7 @@ gcx traces labels [flags]
   -h, --help                help for labels
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
+      --llm                 Request LLM-friendly label values format (requires --label)
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)

--- a/internal/datasources/tempo/tags.go
+++ b/internal/datasources/tempo/tags.go
@@ -24,6 +24,7 @@ type labelsOpts struct {
 	Label      string
 	Scope      string
 	Query      string
+	LLM        bool
 }
 
 func (opts *labelsOpts) setup(flags *pflag.FlagSet) {
@@ -35,11 +36,15 @@ func (opts *labelsOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&opts.Label, "label", "l", "", "Get values for this label (omit to list all labels)")
 	flags.StringVar(&opts.Scope, "scope", "", "Tag scope filter (resource, span, event, link, instrumentation)")
 	flags.StringVarP(&opts.Query, "query", "q", "", "TraceQL query to filter labels")
+	flags.BoolVar(&opts.LLM, "llm", false, "Request LLM-friendly label values format (requires --label)")
 }
 
 func (opts *labelsOpts) Validate() error {
 	if err := opts.IO.Validate(); err != nil {
 		return err
+	}
+	if opts.LLM && opts.Label == "" {
+		return errors.New("--llm requires --label")
 	}
 	return tempo.ValidateTagScope(opts.Scope)
 }
@@ -65,6 +70,9 @@ Datasource is resolved from -d flag or datasources.tempo in your context.`,
 
   # Get values for a specific label
   gcx datasources tempo labels -d UID -l service.name
+
+  # Get LLM-friendly values for a specific label
+  gcx datasources tempo labels -d UID -l service.name --llm -o json
 
   # Using the tags alias
   gcx datasources tempo tags -d UID -l service.name
@@ -112,9 +120,10 @@ Datasource is resolved from -d flag or datasources.tempo in your context.`,
 			// When -l is set, get values for that label; otherwise list all labels.
 			if opts.Label != "" {
 				resp, err := client.TagValues(ctx, datasourceUID, tempo.TagValuesRequest{
-					Tag:   opts.Label,
-					Scope: opts.Scope,
-					Query: opts.Query,
+					Tag:       opts.Label,
+					Scope:     opts.Scope,
+					Query:     opts.Query,
+					LLMFormat: opts.LLM,
 				})
 				if err != nil {
 					return fmt.Errorf("failed to get label values: %w", err)

--- a/internal/datasources/tempo/tags_test.go
+++ b/internal/datasources/tempo/tags_test.go
@@ -1,0 +1,70 @@
+package tempo_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cmdtempo "github.com/grafana/gcx/internal/datasources/tempo"
+	"github.com/grafana/gcx/internal/providers"
+	querytempo "github.com/grafana/gcx/internal/query/tempo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabelsCmd_TagValuesLLM(t *testing.T) {
+	var valuesCalls int
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/bootdata":
+			http.Error(w, `{"message":"not a cloud stack"}`, http.StatusNotFound)
+		case "/api/datasources/proxy/uid/tempo-uid/api/v2/search/tag/resource.service.name/values":
+			valuesCalls++
+			assert.Equal(t, querytempo.AcceptLLM, r.Header.Get("Accept"))
+			w.Header().Set("Content-Type", "application/vnd.grafana.llm+json")
+			_, err := w.Write([]byte(`{"tagValues":{"string":["frontend","backend"]},"metrics":{"inspectedBytes":123}}`))
+			assert.NoError(t, err)
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfgFile := writeTempoTestConfig(t, `
+contexts:
+  default:
+    grafana:
+      server: "`+srv.URL+`"
+      token: "test-token"
+      org-id: 1
+      tls:
+        insecure-skip-verify: true
+    datasources:
+      tempo: tempo-uid
+current-context: default
+`)
+
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(cfgFile)
+
+	cmd := cmdtempo.LabelsCmd(loader)
+	root := &cobra.Command{Use: "test"}
+	root.AddCommand(cmd)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"tags", "-l", "service.name", "--scope", "resource", "--llm", "-o", "json"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.Equal(t, 1, valuesCalls)
+	assert.Contains(t, stdout.String(), `"tagValues": {`)
+	assert.Contains(t, stdout.String(), `"string": [`)
+	assert.Contains(t, stdout.String(), `"frontend"`)
+	assert.Empty(t, stderr.String())
+}

--- a/internal/providers/traces/provider.go
+++ b/internal/providers/traces/provider.go
@@ -57,6 +57,9 @@ func (p *Provider) descriptor() signals.Descriptor {
   # List all labels
   gcx traces labels -d UID
 
+  # Get LLM-friendly values for a label
+  gcx traces tags -d UID -l resource.service.name --llm -o json
+
   # Output as JSON
   gcx traces labels -d UID -o json`,
 			},

--- a/internal/query/tempo/client.go
+++ b/internal/query/tempo/client.go
@@ -183,6 +183,10 @@ func (c *Client) TagValues(ctx context.Context, datasourceUID string, req TagVal
 	}
 	httpReq.URL.RawQuery = q.Encode()
 
+	if req.LLMFormat {
+		httpReq.Header.Set("Accept", AcceptLLM)
+	}
+
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tag values: %w", err)
@@ -198,12 +202,14 @@ func (c *Client) TagValues(ctx context.Context, datasourceUID string, req TagVal
 		return nil, queryerror.FromBody("tempo", "tag values query", resp.StatusCode, respBody)
 	}
 
-	var result TagValuesResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
+	llmContentType := isLLMContentType(resp.Header.Get("Content-Type"))
+	result, err := decodeTagValuesResponse(respBody, llmContentType)
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
+	result.LLMFormat = req.LLMFormat || llmContentType
 
-	return &result, nil
+	return result, nil
 }
 
 // MetricsRange executes a TraceQL metrics range query.
@@ -298,6 +304,21 @@ func (c *Client) MetricsInstant(ctx context.Context, datasourceUID string, req M
 func (c *Client) buildResourcePath(datasourceUID, resourcePath string) string {
 	return fmt.Sprintf("/api/datasources/proxy/uid/%s/%s",
 		datasourceUID, resourcePath)
+}
+
+func decodeTagValuesResponse(data []byte, llmContentType bool) (*TagValuesResponse, error) {
+	if llmContentType {
+		return decodeLLMTagValuesResponse(data)
+	}
+	return decodeStandardTagValuesResponse(data)
+}
+
+func isLLMContentType(contentType string) bool {
+	mediaType := strings.TrimSpace(strings.ToLower(contentType))
+	if i := strings.IndexByte(mediaType, ';'); i >= 0 {
+		mediaType = strings.TrimSpace(mediaType[:i])
+	}
+	return mediaType == AcceptLLM || mediaType == AcceptLLM+"+json"
 }
 
 // traceQLIdentifier constructs a fully-qualified TraceQL identifier.

--- a/internal/query/tempo/client_test.go
+++ b/internal/query/tempo/client_test.go
@@ -235,10 +235,13 @@ func TestTags(t *testing.T) {
 
 func TestTagValues(t *testing.T) {
 	tests := []struct {
-		name    string
-		req     tempo.TagValuesRequest
-		handler http.HandlerFunc
-		wantErr bool
+		name        string
+		req         tempo.TagValuesRequest
+		handler     http.HandlerFunc
+		wantErr     bool
+		wantLLM     bool
+		wantByType  bool
+		wantMetrics bool
 	}{
 		{
 			name: "tag with scope prepended",
@@ -279,6 +282,46 @@ func TestTagValues(t *testing.T) {
 			},
 		},
 		{
+			name:        "LLM format sets accept header and parses compact response",
+			req:         tempo.TagValuesRequest{Tag: "service.name", Scope: "resource", LLMFormat: true},
+			wantLLM:     true,
+			wantByType:  true,
+			wantMetrics: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tempo.AcceptLLM, r.Header.Get("Accept"))
+				assert.Contains(t, r.URL.Path, "/api/v2/search/tag/resource.service.name/values")
+				w.Header().Set("Content-Type", "application/vnd.grafana.llm+json")
+				_, err := w.Write([]byte(`{"tagValues":{"string":["frontend","backend"],"int":[500]},"metrics":{"inspectedBytes":123}}`))
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name:        "LLM content type marks response as LLM format",
+			req:         tempo.TagValuesRequest{Tag: "service.name", Scope: "resource"},
+			wantLLM:     true,
+			wantByType:  true,
+			wantMetrics: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Empty(t, r.Header.Get("Accept"))
+				assert.Contains(t, r.URL.Path, "/api/v2/search/tag/resource.service.name/values")
+				w.Header().Set("Content-Type", "application/vnd.grafana.llm+json; charset=utf-8")
+				_, err := w.Write([]byte(`{"tagValues":{"string":["frontend","backend"]},"metrics":{"inspectedBytes":123}}`))
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name:    "LLM request with standard response keeps compact output preference",
+			req:     tempo.TagValuesRequest{Tag: "service.name", Scope: "resource", LLMFormat: true},
+			wantLLM: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tempo.AcceptLLM, r.Header.Get("Accept"))
+				assert.Contains(t, r.URL.Path, "/api/v2/search/tag/resource.service.name/values")
+				writeJSON(t, w, tempo.TagValuesResponse{
+					TagValues: []tempo.TagValue{{Type: "string", Value: "frontend"}},
+				})
+			},
+		},
+		{
 			name: "server error",
 			req:  tempo.TagValuesRequest{Tag: "bad"},
 			handler: func(w http.ResponseWriter, _ *http.Request) {
@@ -299,8 +342,36 @@ func TestTagValues(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.NotEmpty(t, resp.TagValues)
+			if tc.wantLLM {
+				assert.True(t, resp.LLMFormat)
+				if tc.wantByType {
+					assert.NotEmpty(t, resp.TagValuesByType)
+				}
+				if tc.wantMetrics {
+					assert.EqualValues(t, 123, resp.Metrics["inspectedBytes"])
+				}
+
+				encoded, err := json.Marshal(resp)
+				require.NoError(t, err)
+				assert.Contains(t, string(encoded), `"tagValues":{"`)
+			}
 		})
 	}
+}
+
+func TestTagValuesResponseMarshalJSON_LLMCompactsStandardValues(t *testing.T) {
+	resp := tempo.TagValuesResponse{
+		LLMFormat: true,
+		TagValues: []tempo.TagValue{
+			{Type: "string", Value: "frontend"},
+			{Type: "string", Value: "backend"},
+			{Type: "int", Value: 500},
+		},
+	}
+
+	encoded, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"tagValues":{"int":[500],"string":["frontend","backend"]}}`, string(encoded))
 }
 
 func TestMetricsRange(t *testing.T) {

--- a/internal/query/tempo/types.go
+++ b/internal/query/tempo/types.go
@@ -1,12 +1,13 @@
 package tempo
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"time"
 )
 
-// AcceptLLM is the Accept header value for LLM-friendly trace responses.
+// AcceptLLM is the Accept header value for Tempo LLM-friendly responses.
 const AcceptLLM = "application/vnd.grafana.llm"
 
 // tagScopes lists the valid Tempo tag scopes.
@@ -80,20 +81,109 @@ type TagScope struct {
 
 // TagValuesRequest represents a request for values of a specific trace tag.
 type TagValuesRequest struct {
-	Tag   string
-	Scope string
-	Query string
+	Tag       string
+	Scope     string
+	Query     string
+	LLMFormat bool
 }
 
 // TagValuesResponse represents the response from the Tempo tag-values API.
 type TagValuesResponse struct {
-	TagValues []TagValue `json:"tagValues"`
+	TagValues       []TagValue       `json:"-"`
+	TagValuesByType map[string][]any `json:"-"`
+	Metrics         map[string]any   `json:"-"`
+	LLMFormat       bool             `json:"-"`
 }
 
 // TagValue represents a typed value for a trace tag.
 type TagValue struct {
 	Type  string `json:"type"`
 	Value any    `json:"value"`
+}
+
+type standardTagValuesResponse struct {
+	TagValues []TagValue     `json:"tagValues"`
+	Metrics   map[string]any `json:"metrics,omitempty"`
+}
+
+type llmTagValuesResponse struct {
+	TagValues map[string][]any `json:"tagValues"`
+	Metrics   map[string]any   `json:"metrics,omitempty"`
+}
+
+// MarshalJSON preserves the LLM-friendly tag-values shape when the response
+// was requested with AcceptLLM. The default shape remains unchanged.
+func (r TagValuesResponse) MarshalJSON() ([]byte, error) {
+	if r.LLMFormat {
+		return json.Marshal(llmTagValuesResponse{
+			TagValues: r.llmTagValues(),
+			Metrics:   r.Metrics,
+		})
+	}
+
+	return json.Marshal(standardTagValuesResponse{
+		TagValues: r.TagValues,
+		Metrics:   r.Metrics,
+	})
+}
+
+func decodeStandardTagValuesResponse(data []byte) (*TagValuesResponse, error) {
+	var wire standardTagValuesResponse
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, err
+	}
+	return &TagValuesResponse{
+		TagValues: wire.TagValues,
+		Metrics:   wire.Metrics,
+	}, nil
+}
+
+func decodeLLMTagValuesResponse(data []byte) (*TagValuesResponse, error) {
+	var wire llmTagValuesResponse
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, err
+	}
+	return &TagValuesResponse{
+		TagValues:       flattenTagValues(wire.TagValues),
+		TagValuesByType: wire.TagValues,
+		Metrics:         wire.Metrics,
+		LLMFormat:       true,
+	}, nil
+}
+
+func (r TagValuesResponse) llmTagValues() map[string][]any {
+	if r.TagValuesByType != nil {
+		return r.TagValuesByType
+	}
+	return groupTagValues(r.TagValues)
+}
+
+func groupTagValues(values []TagValue) map[string][]any {
+	byType := make(map[string][]any)
+	for _, value := range values {
+		byType[value.Type] = append(byType[value.Type], value.Value)
+	}
+	return byType
+}
+
+func flattenTagValues(byType map[string][]any) []TagValue {
+	if len(byType) == 0 {
+		return nil
+	}
+
+	types := make([]string, 0, len(byType))
+	for typ := range byType {
+		types = append(types, typ)
+	}
+	slices.Sort(types)
+
+	values := make([]TagValue, 0)
+	for _, typ := range types {
+		for _, value := range byType[typ] {
+			values = append(values, TagValue{Type: typ, Value: value})
+		}
+	}
+	return values
 }
 
 // MetricsRequest represents a Tempo TraceQL metrics query request.


### PR DESCRIPTION
When using the header` Accept: application/vnd.grafana.llm` Tempo returns a simplified JSON format optimized for LLM consumption. 

This is around ~49.8% smaller than regular response:

 ```json
   {
     "tagValues": [
       {
         "type": "string",
         "value": "gme-ingester"
       },
       {
         "type": "string",
         "value": "grafana-security-docs"
       },
       {
         "type": "string",
         "value": "cloudconfig.grafana.app"
       }
     ]
   }
 ```

 With --llm:

 ```json
   {
     "metrics": {
       "inspectedBytes": 485118972
     },
     "tagValues": {
       "string": [
         "gme-ingester",
         "grafana-security-docs",
         "cloudconfig.grafana.app"
       ]
     }
   }
```

This PR enables the --llm command in the same way we already do for the traces get command. It also improves existing skills to favor it in agentic workflows