### PR TITLE
ci: harden Claude workflows' Vault usage (export_env: false + author guard)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,6 +32,9 @@ jobs:
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
+          # Keep the secret on the step output instead of exporting it into
+          # $GITHUB_ENV for every later step (incl. claude-code-action).
+          export_env: false
           repo_secrets: |
             ANTHROPIC_API_KEY=anthropic-api-key:api_key
 
@@ -39,7 +42,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1
         with:
-          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ fromJSON(steps.get-secrets.outputs.secrets).ANTHROPIC_API_KEY }}
           use_sticky_comment: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   claude:
+    # Only trusted repo actors (OWNER/MEMBER/COLLABORATOR) may trigger Claude.
+    # gcx is a public repo, so without this guard any commenter could mint a
+    # Vault secret and run Claude with write scopes. The @claude body/title
+    # checks are preserved; each event branch uses its own association field.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -34,6 +38,9 @@ jobs:
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
+          # Keep the secret on the step output instead of exporting it into
+          # $GITHUB_ENV for every later step (incl. claude-code-action).
+          export_env: false
           repo_secrets: |
             ANTHROPIC_API_KEY=anthropic-api-key:api_key
 
@@ -41,6 +48,6 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1
         with:
-          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ fromJSON(steps.get-secrets.outputs.secrets).ANTHROPIC_API_KEY }}
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary

Two CI-only hardening changes to the two workflows that pull secrets from Vault via `grafana/shared-workflows/actions/get-vault-secrets` (`claude.yml`, `claude-code-review.yml`):

- **`export_env: false`** on every `get-vault-secrets` call. The action defaults to `export_env: true`, which writes each fetched secret into `$GITHUB_ENV` so it's readable by *every* later step in the job (including the third-party `anthropics/claude-code-action`). Both workflows now read the secret from the step output via `fromJSON(steps.get-secrets.outputs.secrets).ANTHROPIC_API_KEY` instead of `${{ env.ANTHROPIC_API_KEY }}`, so the global env export is no longer needed — this removes it and keeps the secret scoped to the step output.
- **`author_association` guard** (`OWNER`/`MEMBER`/`COLLABORATOR`) on the comment/review/issue-triggered workflow that fetches Vault secrets *and* runs Claude: `claude.yml`. It fires on four event types, so each branch is guarded with its own association field (`comment`/`comment`/`review`/`issue`). The existing `@claude` body/title checks (including this repo's issue-title check) are preserved.

## Why

`get-vault-secrets` defaulting to `export_env: true` widens every fetched secret's blast radius to the whole job; scoping it to the step output is least-privilege with no functional change.

`claude.yml` previously gated only on the comment/issue *body* (e.g. `contains(comment.body, '@claude')`), so **any commenter** could trigger a job that mints a Vault secret and runs Claude with `contents`/`pull-requests`/`issues: write`. The guard restricts that to trusted repo associations. **`grafana/gcx` is a public repo**, so this matters here: the guard is transparent for org members / collaborators and only blocks bots, non-members, and former contributors.

`claude-code-review.yml` is triggered by `pull_request` (no `pull_request_target`). GitHub does not pass secrets to `pull_request` runs from forks and Vault OIDC rejects fork refs, so an untrusted fork PR cannot fetch the secret anyway — it gets only the `export_env: false` change, and keeps its existing `user.type != 'Bot'` + `draft == false` guards.

Applies the pattern from grafana/grafana-assistant-app#7020. Part of grafana/grafana-assistant-app#6947 (Security Hardening Week — GitHub Actions guardrails; the scope list includes `grafana/gcx`).

## Test plan

- [x] `actionlint` (1.7.12) clean on both edited workflows. The only repo-wide finding is a pre-existing, info-level shellcheck note in the untouched `publish-homebrew-formula.yml` — unrelated.
- [ ] **`export_env: false` — post-merge:** as a member, `@claude …` on an issue/PR and confirm Claude still authenticates, validating the secret resolves via `fromJSON(steps.get-secrets.outputs.secrets)` with the env export removed. For `claude-code-review.yml`, open/ready a non-draft PR and confirm the review still runs and authenticates.
- [ ] **Guard — post-merge:** `issue_comment`/`issues` definitions load from the default branch, so after merge, comment `@claude …` as a member and confirm the job runs (not skipped); confirm a non-member/external `@claude` comment is skipped.
- [ ] No behavior change for members; the guard only blocks non-/former-members and bots.

## Scope / follow-ups

CI config only — no product code. Fork-PR guards are intentionally deferred: Vault OIDC already rejects fork `pull_request` events, and `issue_comment` runs in base-repo context (a fork guard wouldn't cover the comment path anyway).

> Note: replaces the no-op #795 (its branch was accidentally fast-forwarded to `main`, so GitHub auto-closed it as merged with an empty diff — nothing actually landed on `main`). This PR carries the real change as a single GitHub-signed commit so it satisfies the `required_signatures` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
