### PR TITLE
feat(skills): add 'gcx agent skills get' and surface bundled skills in help/hints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ cmd/gcx/
   helptree/     Help tree for agent context
   setup/        Onboarding (gcx setup status)
   instrumentation/  Instrumentation Hub commands (clusters, services, setup wizard, status)
-  skills/       Portable Agent Skills installer for .agents-compatible tools
+  skills/       Portable Agent Skills installer for .agents-compatible tools (install/update/list/get/uninstall; get reads bundled SKILL.md or references without installing)
   dev/          Developer tools (import, scaffold, generate, lint, serve)
   fail/         Structured error conversion
 

--- a/cmd/gcx/commands/command.go
+++ b/cmd/gcx/commands/command.go
@@ -27,6 +27,7 @@ type CommandInfo struct {
 	RequiredScope  string        `json:"required_scope,omitempty"`
 	RequiredRole   string        `json:"required_role,omitempty"`
 	RequiredAction string        `json:"required_action,omitempty"`
+	Skill          string        `json:"skill,omitempty"`
 	Args           string        `json:"args,omitempty"`
 	Flags          []FlagInfo    `json:"flags,omitempty"`
 	Subcommands    []CommandInfo `json:"subcommands,omitempty"`
@@ -162,6 +163,7 @@ func walkCommandWithOptions(cmd *cobra.Command, parentPath string, includeHidden
 		RequiredScope:  cmd.Annotations[agent.AnnotationRequiredScope],
 		RequiredRole:   cmd.Annotations[agent.AnnotationRequiredRole],
 		RequiredAction: cmd.Annotations[agent.AnnotationRequiredAction],
+		Skill:          cmd.Annotations[agent.AnnotationSkill],
 		Args:           extractArgs(cmd.Use),
 	}
 

--- a/cmd/gcx/helptree/command.go
+++ b/cmd/gcx/helptree/command.go
@@ -36,6 +36,7 @@ type treeNode struct {
 	Short    string      `json:"short,omitempty"`
 	Args     string      `json:"args,omitempty"`
 	Hint     string      `json:"hint,omitempty"`
+	Skill    string      `json:"skill,omitempty"`
 	Children []*treeNode `json:"children,omitempty"`
 }
 
@@ -47,6 +48,9 @@ func buildTreeNode(cmd *cobra.Command, depth int, opts RenderOptions) *treeNode 
 	}
 	if hint := cmd.Annotations[agent.AnnotationLLMHint]; hint != "" {
 		node.Hint = hint
+	}
+	if skill := cmd.Annotations[agent.AnnotationSkill]; skill != "" {
+		node.Skill = skill
 	}
 	if opts.MaxDepth > 0 && depth >= opts.MaxDepth {
 		return node

--- a/cmd/gcx/helptree/render.go
+++ b/cmd/gcx/helptree/render.go
@@ -57,6 +57,11 @@ func renderNode(buf *strings.Builder, cmd *cobra.Command, depth int, opts Render
 		line += "  # hint: " + hint
 	}
 
+	// Append related-skill annotation.
+	if skill := cmd.Annotations[agent.AnnotationSkill]; skill != "" {
+		line += "  # skill: " + strings.ReplaceAll(skill, ",", ", ")
+	}
+
 	fmt.Fprintln(buf, line)
 
 	// Recurse into subcommands if depth allows.

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -151,7 +151,7 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:           path.Base(os.Args[0]),
 		Short:         "Control plane for Grafana Cloud operations",
-		Long:          "gcx is a unified CLI for managing Grafana resources, dashboards, datasources, alerting, and Cloud product APIs (SLO, IRM, Synthetic Monitoring, Fleet, k6, and more).",
+		Long:          "gcx is a unified CLI for managing Grafana resources, dashboards, datasources, alerting, and Cloud product APIs (SLO, IRM, Synthetic Monitoring, Fleet, k6, and more).\n\nRun 'gcx agent skills list' to see bundled Agent Skills with task-specific guidance.",
 		SilenceUsage:  true,
 		SilenceErrors: true, // We want to print errors ourselves
 		Version:       version,

--- a/cmd/gcx/root/consistency_test.go
+++ b/cmd/gcx/root/consistency_test.go
@@ -113,6 +113,7 @@ func TestConsistency_OnlyKnownAnnotationKeys(t *testing.T) {
 		agent.AnnotationRequiredScope:      true,
 		agent.AnnotationRequiredRole:       true,
 		agent.AnnotationRequiredAction:     true,
+		agent.AnnotationSkill:              true,
 		cobra.BashCompOneRequiredFlag:      true,
 		cobra.BashCompCustom:               true,
 		cobra.BashCompFilenameExt:          true,
@@ -149,6 +150,25 @@ func TestConsistency_NoOrphanedRegistryEntries(t *testing.T) {
 		t.Run(regPath, func(t *testing.T) {
 			if !paths[regPath] {
 				t.Errorf("registry entry %q does not match any command in the tree", regPath)
+			}
+		})
+	}
+}
+
+// TestConsistency_SkillMappingResolvesToCommands verifies every key in the
+// command-area-to-skill registry matches an actual command in the tree.
+func TestConsistency_SkillMappingResolvesToCommands(t *testing.T) {
+	rootCmd := buildRootCmd()
+
+	paths := make(map[string]bool)
+	agent.WalkCommands(rootCmd, func(cmd *cobra.Command) {
+		paths[cmd.CommandPath()] = true
+	})
+
+	for _, skillPath := range agent.CommandSkillPaths() {
+		t.Run(skillPath, func(t *testing.T) {
+			if !paths[skillPath] {
+				t.Errorf("skill mapping key %q does not match any command in the tree", skillPath)
 			}
 		})
 	}

--- a/cmd/gcx/skills/command.go
+++ b/cmd/gcx/skills/command.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -34,6 +35,7 @@ func Command() *cobra.Command {
 	cmd.AddCommand(newInstallCommand(claudeplugin.SkillsFS()))
 	cmd.AddCommand(newUpdateCommand(claudeplugin.SkillsFS()))
 	cmd.AddCommand(newListCommand(claudeplugin.SkillsFS()))
+	cmd.AddCommand(newGetCommand(claudeplugin.SkillsFS()))
 	cmd.AddCommand(newUninstallCommand(claudeplugin.SkillsFS()))
 
 	return cmd
@@ -495,6 +497,209 @@ func renderSkillsTable(dst goio.Writer, skills []skillInfo) error {
 
 func installSkills(source fs.FS, root string, filter map[string]struct{}, force bool, dryRun bool) (installResult, error) {
 	return skillops.Install(source, root, filter, force, dryRun)
+}
+
+type getOpts struct {
+	Source fs.FS
+	IO     cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("text")
+	o.IO.RegisterCustomCodec("text", &getTextCodec{})
+	o.IO.BindFlags(flags)
+}
+
+func (o *getOpts) Validate(args []string) error {
+	if o.Source == nil {
+		return errors.New("skills source is not configured")
+	}
+	if len(args) == 0 {
+		return errors.New("provide a skill name")
+	}
+	if len(args) > 2 {
+		return errors.New("provide a skill name and at most one reference path")
+	}
+	return o.IO.Validate()
+}
+
+func newGetCommand(source fs.FS) *cobra.Command {
+	opts := &getOpts{Source: source}
+
+	cmd := &cobra.Command{
+		Use:   "get SKILL [REFERENCE]",
+		Short: "Print a bundled skill's content without installing it",
+		Long: `Print the content of a bundled gcx Agent Skill straight from the embedded bundle, without writing anything to ~/.agents.
+
+By default the skill's SKILL.md body is printed. Pass a reference path (e.g. references/query-patterns.md) to print a single bundled reference file instead.`,
+		Example: `  gcx agent skills get create-dashboard
+  gcx agent skills get create-dashboard -o json
+  gcx agent skills get debug-with-grafana references/query-patterns.md`,
+		Args: cobra.RangeArgs(1, 2),
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			names, err := skillops.BundledSkillNames(source)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+			return names, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(args); err != nil {
+				return err
+			}
+
+			name := args[0]
+			reference := ""
+			if len(args) == 2 {
+				reference = args[1]
+			}
+
+			result, err := getBundledSkill(opts.Source, name, reference)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), result)
+		},
+	}
+
+	opts.setup(cmd.Flags())
+
+	return cmd
+}
+
+type getResult struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Path        string   `json:"path"`
+	Body        string   `json:"body"`
+	References  []string `json:"references"`
+}
+
+type getTextCodec struct{}
+
+func (c *getTextCodec) Format() format.Format { return "text" }
+
+func (c *getTextCodec) Encode(dst goio.Writer, value any) error {
+	var result getResult
+	switch v := value.(type) {
+	case getResult:
+		result = v
+	case *getResult:
+		if v == nil {
+			return errors.New("nil get result")
+		}
+		result = *v
+	default:
+		return fmt.Errorf("get text codec: unsupported value %T", value)
+	}
+
+	_, err := goio.WriteString(dst, result.Body)
+	return err
+}
+
+func (c *getTextCodec) Decode(_ goio.Reader, _ any) error {
+	return errors.New("get text codec does not support decoding")
+}
+
+// resolveReferencePath cleans a user-supplied reference path and rejects any
+// path that would escape the skill directory.
+func resolveReferencePath(reference string) (string, error) {
+	if path.IsAbs(reference) {
+		return "", fmt.Errorf("invalid reference path %q: must be relative to the skill directory", reference)
+	}
+
+	cleaned := path.Clean(reference)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("invalid reference path %q: must not escape the skill directory", reference)
+	}
+
+	return cleaned, nil
+}
+
+func getBundledSkill(source fs.FS, name string, reference string) (getResult, error) {
+	if err := validateSkillName(name); err != nil {
+		return getResult{}, err
+	}
+
+	bundled, err := skillops.BundledSkillNames(source)
+	if err != nil {
+		return getResult{}, err
+	}
+	if !slices.Contains(bundled, name) {
+		return getResult{}, fmt.Errorf("unknown skill %q (use 'gcx agent skills list' to see available skills)", name)
+	}
+
+	relPath := "SKILL.md"
+	if strings.TrimSpace(reference) != "" {
+		relPath, err = resolveReferencePath(reference)
+		if err != nil {
+			return getResult{}, err
+		}
+	}
+
+	filePath := path.Join(name, relPath)
+	body, err := fs.ReadFile(source, filePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return getResult{}, fmt.Errorf("file %q not found in skill %q", relPath, name)
+		}
+		return getResult{}, err
+	}
+
+	references, err := listSkillReferences(source, name)
+	if err != nil {
+		return getResult{}, err
+	}
+
+	skillDoc := body
+	if relPath != "SKILL.md" {
+		skillDoc, err = fs.ReadFile(source, path.Join(name, "SKILL.md"))
+		if err != nil {
+			skillDoc = nil
+		}
+	}
+	description := extractSkillShortDescription(skillDoc)
+
+	return getResult{
+		Name:        name,
+		Description: description,
+		Path:        relPath,
+		Body:        string(body),
+		References:  references,
+	}, nil
+}
+
+// listSkillReferences returns the bundled reference file paths for a skill,
+// relative to the skill directory (e.g. "references/query-patterns.md").
+func listSkillReferences(source fs.FS, name string) ([]string, error) {
+	refsDir := path.Join(name, "references")
+	var refs []string
+	err := fs.WalkDir(source, refsDir, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if errors.Is(walkErr, fs.ErrNotExist) {
+				return fs.SkipDir
+			}
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(name, p)
+		if err != nil {
+			return err
+		}
+		refs = append(refs, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(refs)
+	return refs, nil
 }
 
 type uninstallOpts struct {

--- a/cmd/gcx/skills/command.go
+++ b/cmd/gcx/skills/command.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v3"
 )
 
 // Command returns the top-level skills command group.
@@ -403,7 +402,7 @@ func listBundledSkills(source fs.FS, installRoot string) (listResult, error) {
 
 		result.Skills = append(result.Skills, skillInfo{
 			Name:             entry.Name(),
-			ShortDescription: extractSkillShortDescription(data),
+			ShortDescription: skillops.ShortDescriptionFromBytes(data),
 			Installed:        installed,
 		})
 	}
@@ -418,69 +417,6 @@ func listBundledSkills(source fs.FS, installRoot string) (listResult, error) {
 
 func installedBundledSkillNames(source fs.FS, root string) ([]string, error) {
 	return skillops.InstalledBundledSkillNames(source, root)
-}
-
-type skillFrontMatter struct {
-	Description string `yaml:"description"`
-}
-
-func extractSkillShortDescription(data []byte) string {
-	description, err := extractSkillDescriptionFromMarkdown(data)
-	if err != nil {
-		return normalizeDescription(fallbackSkillDescription(data))
-	}
-
-	return normalizeDescription(description)
-}
-
-func extractSkillDescriptionFromMarkdown(data []byte) (string, error) {
-	content := strings.ReplaceAll(string(data), "\r\n", "\n")
-	lines := strings.Split(content, "\n")
-	if len(lines) < 3 || strings.TrimSpace(lines[0]) != "---" {
-		return "", errors.New("missing front matter")
-	}
-
-	end := -1
-	for i := 1; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) == "---" {
-			end = i
-			break
-		}
-	}
-	if end < 0 {
-		return "", errors.New("unterminated front matter")
-	}
-
-	var meta skillFrontMatter
-	if err := yaml.Unmarshal([]byte(strings.Join(lines[1:end], "\n")), &meta); err != nil {
-		return "", err
-	}
-
-	return meta.Description, nil
-}
-
-func normalizeDescription(description string) string {
-	normalized := strings.Join(strings.Fields(description), " ")
-	return normalized
-}
-
-func fallbackSkillDescription(data []byte) string {
-	content := strings.ReplaceAll(string(data), "\r\n", "\n")
-	for line := range strings.SplitSeq(content, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			continue
-		}
-		if strings.HasPrefix(trimmed, "#") {
-			continue
-		}
-		if strings.HasPrefix(trimmed, "---") {
-			continue
-		}
-		return trimmed
-	}
-
-	return ""
 }
 
 func renderSkillsTable(dst goio.Writer, skills []skillInfo) error {
@@ -662,7 +598,7 @@ func getBundledSkill(source fs.FS, name string, reference string) (getResult, er
 			skillDoc = nil
 		}
 	}
-	description := extractSkillShortDescription(skillDoc)
+	description := skillops.ShortDescriptionFromBytes(skillDoc)
 
 	return getResult{
 		Name:        name,

--- a/cmd/gcx/skills/command_test.go
+++ b/cmd/gcx/skills/command_test.go
@@ -330,21 +330,6 @@ func TestListBundledSkills_ShowsInstalledStatus(t *testing.T) {
 	require.False(t, result.Skills[1].Installed)
 }
 
-func TestExtractSkillShortDescription_ParsesFrontMatter(t *testing.T) {
-	t.Parallel()
-
-	data := []byte(`---
-name: sample
-description: >
-  Use this skill to do an example operation in a concise way.
----
-
-# Sample
-`)
-	desc := extractSkillShortDescription(data)
-	require.Equal(t, "Use this skill to do an example operation in a concise way.", desc)
-}
-
 func TestListCommand_JSONIncludesShortDescription(t *testing.T) {
 	source := fstest.MapFS{
 		"alpha/SKILL.md": {

--- a/cmd/gcx/skills/command_test.go
+++ b/cmd/gcx/skills/command_test.go
@@ -369,6 +369,137 @@ description: alpha skill description
 	require.Contains(t, stdout.String(), `"short_description": "alpha skill description"`)
 }
 
+func TestGetBundledSkill_ReturnsSkillBody(t *testing.T) {
+	t.Parallel()
+
+	result, err := getBundledSkill(testSkillsFS(), "alpha", "")
+	require.NoError(t, err)
+	require.Equal(t, "alpha", result.Name)
+	require.Equal(t, "SKILL.md", result.Path)
+	require.Equal(t, "alpha-skill", result.Body)
+	require.Equal(t, []string{"references/guide.md"}, result.References)
+}
+
+func TestGetBundledSkill_ReturnsReferenceBody(t *testing.T) {
+	t.Parallel()
+
+	result, err := getBundledSkill(testSkillsFS(), "alpha", "references/guide.md")
+	require.NoError(t, err)
+	require.Equal(t, "references/guide.md", result.Path)
+	require.Equal(t, "alpha-guide", result.Body)
+}
+
+func TestGetBundledSkill_ExtractsDescriptionFromFrontMatter(t *testing.T) {
+	t.Parallel()
+
+	source := fstest.MapFS{
+		"alpha/SKILL.md": {Data: []byte("---\nname: alpha\ndescription: alpha skill description\n---\n\nbody\n")},
+	}
+
+	result, err := getBundledSkill(source, "alpha", "")
+	require.NoError(t, err)
+	require.Equal(t, "alpha skill description", result.Description)
+}
+
+func TestGetBundledSkill_UnknownSkill(t *testing.T) {
+	t.Parallel()
+
+	_, err := getBundledSkill(testSkillsFS(), "nonexistent", "")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unknown skill")
+	require.ErrorContains(t, err, "gcx agent skills list")
+}
+
+func TestGetBundledSkill_MissingReference(t *testing.T) {
+	t.Parallel()
+
+	_, err := getBundledSkill(testSkillsFS(), "alpha", "references/missing.md")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestGetBundledSkill_RejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		reference string
+	}{
+		{name: "parent escape", reference: "../beta/SKILL.md"},
+		{name: "nested parent escape", reference: "references/../../beta/SKILL.md"},
+		{name: "absolute path", reference: "/etc/passwd"},
+		{name: "bare parent", reference: ".."},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := getBundledSkill(testSkillsFS(), "alpha", tc.reference)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "invalid reference path")
+		})
+	}
+}
+
+func TestGetCommand_TextPrintsBody(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
+
+	cmd := newGetCommand(testSkillsFS())
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"alpha"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Equal(t, "alpha-skill", stdout.String())
+}
+
+func TestGetCommand_JSONIncludesFields(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
+
+	source := fstest.MapFS{
+		"alpha/SKILL.md":            {Data: []byte("---\nname: alpha\ndescription: alpha skill description\n---\nbody\n")},
+		"alpha/references/guide.md": {Data: []byte("alpha-guide")},
+	}
+
+	cmd := newGetCommand(source)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"alpha", "-o", "json"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	out := stdout.String()
+	require.Contains(t, out, `"name": "alpha"`)
+	require.Contains(t, out, `"description": "alpha skill description"`)
+	require.Contains(t, out, `"path": "SKILL.md"`)
+	require.Contains(t, out, `"references": [`)
+	require.Contains(t, out, `"references/guide.md"`)
+}
+
+func TestGetCommand_UnknownSkillErrors(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
+
+	cmd := newGetCommand(testSkillsFS())
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"not-a-bundled-skill"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unknown skill")
+}
+
 func TestUninstallSkills_RemovesRequestedSkills(t *testing.T) {
 	t.Parallel()
 

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -6,6 +6,8 @@ Control plane for Grafana Cloud operations
 
 gcx is a unified CLI for managing Grafana resources, dashboards, datasources, alerting, and Cloud product APIs (SLO, IRM, Synthetic Monitoring, Fleet, k6, and more).
 
+Run 'gcx agent skills list' to see bundled Agent Skills with task-specific guidance.
+
 ### Options
 
 ```

--- a/docs/reference/cli/gcx_agent_skills.md
+++ b/docs/reference/cli/gcx_agent_skills.md
@@ -26,6 +26,7 @@ Install the canonical portable gcx Agent Skills bundle for .agents-compatible ag
 ### SEE ALSO
 
 * [gcx agent](gcx_agent.md)	 - Agent mode utilities
+* [gcx agent skills get](gcx_agent_skills_get.md)	 - Print a bundled skill's content without installing it
 * [gcx agent skills install](gcx_agent_skills_install.md)	 - Install bundled gcx skills into ~/.agents/skills
 * [gcx agent skills list](gcx_agent_skills_list.md)	 - List skills bundled with the gcx binary
 * [gcx agent skills uninstall](gcx_agent_skills_uninstall.md)	 - Uninstall gcx-managed skills from ~/.agents/skills

--- a/docs/reference/cli/gcx_agent_skills_get.md
+++ b/docs/reference/cli/gcx_agent_skills_get.md
@@ -1,0 +1,45 @@
+## gcx agent skills get
+
+Print a bundled skill's content without installing it
+
+### Synopsis
+
+Print the content of a bundled gcx Agent Skill straight from the embedded bundle, without writing anything to ~/.agents.
+
+By default the skill's SKILL.md body is printed. Pass a reference path (e.g. references/query-patterns.md) to print a single bundled reference file instead.
+
+```
+gcx agent skills get SKILL [REFERENCE] [flags]
+```
+
+### Examples
+
+```
+  gcx agent skills get create-dashboard
+  gcx agent skills get create-dashboard -o json
+  gcx agent skills get debug-with-grafana references/query-patterns.md
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string     Name of the context to use (overrides current-context in config)
+      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
+      --no-color           Disable color output
+      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx agent skills](gcx_agent_skills.md)	 - Manage portable gcx Agent Skills
+

--- a/docs/reference/cli/gcx_agent_skills_get.md
+++ b/docs/reference/cli/gcx_agent_skills_get.md
@@ -31,12 +31,12 @@ gcx agent skills get SKILL [REFERENCE] [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent              Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
-      --context string     Name of the context to use (overrides current-context in config)
-      --log-http-payload   Log full HTTP request/response bodies (includes headers — may expose tokens)
-      --no-color           Disable color output
-      --no-truncate        Disable table column truncation (auto-enabled when stdout is piped)
-  -v, --verbose count      Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
 ```
 
 ### SEE ALSO

--- a/internal/agent/annotations.go
+++ b/internal/agent/annotations.go
@@ -7,4 +7,5 @@ const (
 	AnnotationRequiredScope  = "agent.required_scope"  // required auth scope
 	AnnotationRequiredRole   = "agent.required_role"   // required role
 	AnnotationRequiredAction = "agent.required_action" // required action
+	AnnotationSkill          = "agent.skill"           // comma-joined related Agent Skill names
 )

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
@@ -133,6 +135,7 @@ var commandAnnotations = map[string]annotation{
 	// skills
 	"gcx agent skills install":   {Cost: "small"},
 	"gcx agent skills list":      {Cost: "small"},
+	"gcx agent skills get":       {Cost: "small", Hint: "<name> -o text"},
 	"gcx agent skills update":    {Cost: "small"},
 	"gcx agent skills uninstall": {Cost: "small"},
 
@@ -569,6 +572,20 @@ func ApplyAnnotations(root *cobra.Command) {
 		}
 		if _, exists := cmd.Annotations[AnnotationLLMHint]; !exists && a.Hint != "" {
 			cmd.Annotations[AnnotationLLMHint] = a.Hint
+		}
+	})
+
+	// Set the related-skill annotation on each mapped area node.
+	WalkCommands(root, func(cmd *cobra.Command) {
+		skills, ok := commandSkills[cmd.CommandPath()]
+		if !ok || len(skills) == 0 {
+			return
+		}
+		if cmd.Annotations == nil {
+			cmd.Annotations = make(map[string]string)
+		}
+		if _, exists := cmd.Annotations[AnnotationSkill]; !exists {
+			cmd.Annotations[AnnotationSkill] = strings.Join(skills, ",")
 		}
 	})
 }

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -135,7 +135,7 @@ var commandAnnotations = map[string]annotation{
 	// skills
 	"gcx agent skills install":   {Cost: "small"},
 	"gcx agent skills list":      {Cost: "small"},
-	"gcx agent skills get":       {Cost: "small", Hint: "<name> -o text"},
+	"gcx agent skills get":       {Cost: "small (medium for large skills)", Hint: "<name> [references/<file>]"},
 	"gcx agent skills update":    {Cost: "small"},
 	"gcx agent skills uninstall": {Cost: "small"},
 

--- a/internal/agent/command_skills.go
+++ b/internal/agent/command_skills.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// commandSkills maps command-area paths to the bundled Agent Skills that are
+// most relevant when working in that area. The mapping is intentionally kept at
+// area granularity (not per-leaf) to keep the table small and avoid per-command
+// churn; the same static-registry pattern as commandAnnotations and
+// KnownResources. A drift test verifies every mapped skill name exists in the
+// bundle and every key resolves to a real command.
+//
+//nolint:gochecknoglobals // centralized skill registry, accessed via SkillsForCommand
+var commandSkills = map[string][]string{
+	"gcx dashboards":           {"create-dashboard", "manage-dashboards"},
+	"gcx resources":            {"generate-resource-stubs", "import-dashboards", "scaffold-project"},
+	"gcx slo":                  {"slo-manage", "slo-investigate", "slo-optimize", "slo-check-status"},
+	"gcx synthetic-monitoring": {"synth-manage-checks", "synth-investigate-check", "synth-check-status"},
+	"gcx alert":                {"investigate-alert"},
+	"gcx irm":                  {"oncall-triage"},
+	"gcx logs":                 {"debug-with-grafana"},
+	"gcx metrics":              {"debug-with-grafana"},
+	"gcx traces":               {"debug-with-grafana"},
+	"gcx profiles":             {"debug-with-grafana"},
+	"gcx datasources":          {"explore-datasources"},
+	"gcx kg":                   {"diagnose-entity-graph"},
+	"gcx aio11y":               {"aio11y"},
+	"gcx setup":                {"setup-gcx"},
+	"gcx login":                {"setup-gcx"},
+}
+
+// SkillsForCommand returns the bundled skill names mapped to the nearest mapped
+// ancestor of cmd (including cmd itself). It returns nil when no ancestor is
+// mapped.
+func SkillsForCommand(cmd *cobra.Command) []string {
+	for c := cmd; c != nil; c = c.Parent() {
+		if skills, ok := commandSkills[c.CommandPath()]; ok {
+			return skills
+		}
+	}
+	return nil
+}
+
+// CommandSkillPaths returns all command-area paths in the skill registry. Used
+// by consistency tests to detect entries that don't resolve to a real command.
+func CommandSkillPaths() []string {
+	paths := make([]string, 0, len(commandSkills))
+	for p := range commandSkills {
+		paths = append(paths, p)
+	}
+	return paths
+}

--- a/internal/agent/command_skills_test.go
+++ b/internal/agent/command_skills_test.go
@@ -1,0 +1,59 @@
+package agent //nolint:testpackage // drift test inspects the unexported commandSkills registry directly
+
+import (
+	"io/fs"
+	"testing"
+
+	claudeplugin "github.com/grafana/gcx/claude-plugin"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkillsForCommand_NearestAncestor(t *testing.T) {
+	t.Parallel()
+
+	root := &cobra.Command{Use: "gcx"}
+	dashboards := &cobra.Command{Use: "dashboards"}
+	get := &cobra.Command{Use: "get"}
+	dashboards.AddCommand(get)
+	root.AddCommand(dashboards)
+
+	unmapped := &cobra.Command{Use: "providers"}
+	list := &cobra.Command{Use: "list"}
+	unmapped.AddCommand(list)
+	root.AddCommand(unmapped)
+
+	cases := []struct {
+		name string
+		cmd  *cobra.Command
+		want []string
+	}{
+		{name: "mapped area node", cmd: dashboards, want: []string{"create-dashboard", "manage-dashboards"}},
+		{name: "leaf inherits from area ancestor", cmd: get, want: []string{"create-dashboard", "manage-dashboards"}},
+		{name: "unmapped area", cmd: unmapped, want: nil},
+		{name: "unmapped leaf", cmd: list, want: nil},
+		{name: "root", cmd: root, want: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, SkillsForCommand(tc.cmd))
+		})
+	}
+}
+
+func TestCommandSkills_AllSkillsExistInBundle(t *testing.T) {
+	t.Parallel()
+
+	source := claudeplugin.SkillsFS()
+	for area, skills := range commandSkills {
+		for _, skill := range skills {
+			t.Run(area+"/"+skill, func(t *testing.T) {
+				t.Parallel()
+				_, err := fs.Stat(source, skill+"/SKILL.md")
+				require.NoErrorf(t, err, "mapped skill %q for %q must exist in the bundle", skill, area)
+			})
+		}
+	}
+}

--- a/internal/skills/describe.go
+++ b/internal/skills/describe.go
@@ -1,0 +1,83 @@
+package skills
+
+import (
+	"errors"
+	"io/fs"
+	"path"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type skillFrontMatter struct {
+	Description string `yaml:"description"`
+}
+
+// ShortDescription reads the normalized one-line description from a bundled
+// skill's SKILL.md front matter. It returns "" when the skill is missing or has
+// no usable description.
+func ShortDescription(source fs.FS, name string) string {
+	data, err := fs.ReadFile(source, path.Join(name, "SKILL.md"))
+	if err != nil {
+		return ""
+	}
+	return ShortDescriptionFromBytes(data)
+}
+
+// ShortDescriptionFromBytes extracts the normalized one-line description from
+// SKILL.md content, falling back to the first non-heading body line when the
+// front matter has no description.
+func ShortDescriptionFromBytes(data []byte) string {
+	description, err := descriptionFromFrontMatter(data)
+	if err != nil {
+		return normalizeDescription(fallbackDescription(data))
+	}
+	return normalizeDescription(description)
+}
+
+func descriptionFromFrontMatter(data []byte) (string, error) {
+	content := strings.ReplaceAll(string(data), "\r\n", "\n")
+	lines := strings.Split(content, "\n")
+	if len(lines) < 3 || strings.TrimSpace(lines[0]) != "---" {
+		return "", errors.New("missing front matter")
+	}
+
+	end := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			end = i
+			break
+		}
+	}
+	if end < 0 {
+		return "", errors.New("unterminated front matter")
+	}
+
+	var meta skillFrontMatter
+	if err := yaml.Unmarshal([]byte(strings.Join(lines[1:end], "\n")), &meta); err != nil {
+		return "", err
+	}
+	return meta.Description, nil
+}
+
+func normalizeDescription(description string) string {
+	return strings.Join(strings.Fields(description), " ")
+}
+
+func fallbackDescription(data []byte) string {
+	content := strings.ReplaceAll(string(data), "\r\n", "\n")
+	for line := range strings.SplitSeq(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "---") {
+			continue
+		}
+		return trimmed
+	}
+	return ""
+}

--- a/internal/skills/describe_test.go
+++ b/internal/skills/describe_test.go
@@ -1,0 +1,58 @@
+package skills_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/grafana/gcx/internal/skills"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShortDescriptionFromBytes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "folded front matter description",
+			data: "---\nname: sample\ndescription: >\n  Use this skill to do an example operation\n  in a concise way.\n---\n\n# Sample\n",
+			want: "Use this skill to do an example operation in a concise way.",
+		},
+		{
+			name: "plain front matter description",
+			data: "---\nname: alpha\ndescription: alpha skill description\n---\n",
+			want: "alpha skill description",
+		},
+		{
+			name: "front matter present but no description key yields empty",
+			data: "---\nname: beta\n---\n\n# Heading\n\nFirst real line here.\n",
+			want: "",
+		},
+		{
+			name: "no front matter falls back to first body line",
+			data: "# Title\n\nBody sentence.\n",
+			want: "Body sentence.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, skills.ShortDescriptionFromBytes([]byte(tc.data)))
+		})
+	}
+}
+
+func TestShortDescription_ReadsFromFS(t *testing.T) {
+	t.Parallel()
+
+	source := fstest.MapFS{
+		"alpha/SKILL.md": {Data: []byte("---\nname: alpha\ndescription: alpha skill description\n---\n")},
+	}
+
+	require.Equal(t, "alpha skill description", skills.ShortDescription(source, "alpha"))
+	require.Empty(t, skills.ShortDescription(source, "missing"))
+}

--- a/internal/style/help.go
+++ b/internal/style/help.go
@@ -5,11 +5,26 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/spf13/cobra"
 )
 
 // jsonDiscoveryTip is the help text shown for commands that support --json field selection.
 const jsonDiscoveryTip = "Use --json list to discover available fields, --json field1,field2 to select specific fields."
+
+// relatedSkillFooter returns the "Related skill" footer lines for a command, or
+// nil when no skill is mapped to the command or its ancestors.
+func relatedSkillFooter(cmd *cobra.Command) []string {
+	skills := agent.SkillsForCommand(cmd)
+	if len(skills) == 0 {
+		return nil
+	}
+	lines := []string{"Related skill(s): " + strings.Join(skills, ", ")}
+	for _, name := range skills {
+		lines = append(lines, "  Load with: gcx agent skills get "+name)
+	}
+	return lines
+}
 
 // HelpFunc returns a custom Cobra help function that renders Long descriptions
 // and Examples through glamour markdown rendering when styling is enabled.
@@ -18,12 +33,18 @@ func HelpFunc(defaultHelp func(*cobra.Command, []string)) func(*cobra.Command, [
 	return func(cmd *cobra.Command, args []string) {
 		if !IsStylingEnabled() {
 			defaultHelp(cmd, args)
+			w := cmd.OutOrStdout()
 			// Append JSON discovery tip for commands that support --json.
 			if f := cmd.Flags().Lookup("json"); f != nil {
-				w := cmd.OutOrStdout()
 				fmt.Fprintln(w)
 				fmt.Fprintln(w, "Tip:")
 				fmt.Fprintln(w, "  "+jsonDiscoveryTip)
+			}
+			if footer := relatedSkillFooter(cmd); footer != nil {
+				fmt.Fprintln(w)
+				for _, line := range footer {
+					fmt.Fprintln(w, line)
+				}
 			}
 			return
 		}
@@ -113,6 +134,14 @@ func HelpFunc(defaultHelp func(*cobra.Command, []string)) func(*cobra.Command, [
 		if f := cmd.Flags().Lookup("json"); f != nil {
 			fmt.Fprintln(w, "Tip:")
 			fmt.Fprintln(w, "  "+jsonDiscoveryTip)
+			fmt.Fprintln(w)
+		}
+
+		// --- Related skill footer ---
+		if footer := relatedSkillFooter(cmd); footer != nil {
+			for _, line := range footer {
+				fmt.Fprintln(w, line)
+			}
 			fmt.Fprintln(w)
 		}
 

--- a/internal/style/help.go
+++ b/internal/style/help.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/glamour"
+	claudeplugin "github.com/grafana/gcx/claude-plugin"
 	"github.com/grafana/gcx/internal/agent"
+	skillops "github.com/grafana/gcx/internal/skills"
 	"github.com/spf13/cobra"
 )
 
@@ -19,10 +21,15 @@ func relatedSkillFooter(cmd *cobra.Command) []string {
 	if len(skills) == 0 {
 		return nil
 	}
-	lines := []string{"Related skill(s): " + strings.Join(skills, ", ")}
+	lines := []string{"Related skill(s):"}
 	for _, name := range skills {
-		lines = append(lines, "  Load with: gcx agent skills get "+name)
+		if desc := skillops.ShortDescription(claudeplugin.SkillsFS(), name); desc != "" {
+			lines = append(lines, "  "+name+" — "+desc)
+		} else {
+			lines = append(lines, "  "+name)
+		}
 	}
+	lines = append(lines, "Read a skill only if it fits your task: gcx agent skills get <name>")
 	return lines
 }
 

--- a/internal/style/help.go
+++ b/internal/style/help.go
@@ -29,7 +29,12 @@ func relatedSkillFooter(cmd *cobra.Command) []string {
 			lines = append(lines, "  "+name)
 		}
 	}
-	lines = append(lines, "Read a skill only if it fits your task: gcx agent skills get <name>")
+	lines = append(
+		lines,
+		"Read a skill only if it fits your task",
+		"These skills are bundled — no install needed",
+		"gcx agent skills get <name> -otext",
+	)
 	return lines
 }
 


### PR DESCRIPTION
When `gcx` is used without installed skills, agents need to figure out how to use it. They can check `help` and examples, but we also already have useful skills that could be used too.

This PR adds a `gcx agent skills get <name>` command that prints a bundled `SKILL.md` without installing it, and show the available skills through the help banner, command catalog, and agent hint annotations. With this the agent while, for example, listing the dashboards, gets a hint that the dashboard-related skills can be retrieved and does so when needed.