### PR TITLE
fix(aio11y): properly send and return tags and descriptions for Experiments

### DIFF
--- a/docs/reference/cli/gcx_aio11y_experiments_update.md
+++ b/docs/reference/cli/gcx_aio11y_experiments_update.md
@@ -9,11 +9,11 @@ gcx aio11y experiments update <run-id> [flags]
 ### Options
 
 ```
-      --description string   New experiment description; pass an empty string to clear
   -h, --help                 help for update
+  -o, --output string        Output format. One of: agents, json, yaml (default "json")
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --name string          New experiment name
-  -o, --output string        Output format. One of: agents, json, yaml (default "json")
+      --description string   New experiment description; pass an empty string to clear
       --tag strings          Experiment tag (repeatable or comma-separated; replaces all tags)
 ```
 

--- a/docs/reference/cli/gcx_aio11y_experiments_update.md
+++ b/docs/reference/cli/gcx_aio11y_experiments_update.md
@@ -9,10 +9,12 @@ gcx aio11y experiments update <run-id> [flags]
 ### Options
 
 ```
-  -h, --help            help for update
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --name string     New experiment name
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+      --description string   New experiment description; pass an empty string to clear
+  -h, --help                 help for update
+      --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --name string          New experiment name
+  -o, --output string        Output format. One of: agents, json, yaml (default "json")
+      --tag strings          Experiment tag (repeatable or comma-separated; replaces all tags)
 ```
 
 ### Options inherited from parent commands

--- a/internal/providers/aio11y/eval/experiments/client_test.go
+++ b/internal/providers/aio11y/eval/experiments/client_test.go
@@ -116,24 +116,31 @@ func TestClient_Create(t *testing.T) {
 		var raw map[string]any
 		assert.NoError(t, json.Unmarshal(body, &raw))
 		assert.Equal(t, "exp-1", raw["name"])
+		assert.Equal(t, "Nightly", raw["description"])
 		assert.Equal(t, "external", raw["source"])
+		assert.Equal(t, []any{"support", "prompt-v2"}, raw["tags"])
 
 		w.WriteHeader(http.StatusCreated)
 		writeJSON(w, experiments.Experiment{
-			RunID:  "r-99",
-			Name:   "exp-1",
-			Source: "external",
-			Status: "pending",
+			RunID:       "r-99",
+			Name:        "exp-1",
+			Description: "Nightly",
+			Tags:        []string{"support", "prompt-v2"},
+			Source:      "external",
+			Status:      "pending",
 		})
 	}))
 
 	exp, err := client.Create(context.Background(), &experiments.Experiment{
-		Name:   "exp-1",
-		Source: "external",
+		Name:        "exp-1",
+		Description: "Nightly",
+		Tags:        []string{"support", "prompt-v2"},
+		Source:      "external",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "r-99", exp.RunID)
 	assert.Equal(t, "pending", exp.Status)
+	assert.Equal(t, []string{"support", "prompt-v2"}, exp.Tags)
 }
 
 func TestClient_Create_TransportError(t *testing.T) {
@@ -154,15 +161,21 @@ func TestClient_Update_PATCH(t *testing.T) {
 		var raw map[string]any
 		assert.NoError(t, json.Unmarshal(body, &raw))
 		assert.Equal(t, "renamed", raw["name"])
+		assert.Equal(t, "Updated notes", raw["description"])
+		assert.Equal(t, []any{"support", "release"}, raw["tags"])
 
 		w.WriteHeader(http.StatusOK)
-		writeJSON(w, experiments.Experiment{RunID: "r-1", Name: "renamed"})
+		writeJSON(w, experiments.Experiment{RunID: "r-1", Name: "renamed", Description: "Updated notes", Tags: []string{"support", "release"}})
 	}))
 
 	name := "renamed"
-	exp, err := client.Update(context.Background(), "r-1", &experiments.UpdateRequest{Name: &name})
+	description := "Updated notes"
+	tags := []string{"support", "release"}
+	exp, err := client.Update(context.Background(), "r-1", &experiments.UpdateRequest{Name: &name, Description: &description, Tags: &tags})
 	require.NoError(t, err)
 	assert.Equal(t, "renamed", exp.Name)
+	assert.Equal(t, "Updated notes", exp.Description)
+	assert.Equal(t, []string{"support", "release"}, exp.Tags)
 }
 
 func TestClient_Update_NotFound(t *testing.T) {

--- a/internal/providers/aio11y/eval/experiments/commands.go
+++ b/internal/providers/aio11y/eval/experiments/commands.go
@@ -285,7 +285,10 @@ func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
 			return opts.IO.Encode(cmd.OutOrStdout(), updated)
 		},
 	}
-	opts.setup(cmd.Flags())
+	cmd.InitDefaultHelpFlag()
+	flags := cmd.Flags()
+	flags.SortFlags = false
+	opts.setup(flags)
 	return cmd
 }
 

--- a/internal/providers/aio11y/eval/experiments/commands.go
+++ b/internal/providers/aio11y/eval/experiments/commands.go
@@ -226,21 +226,25 @@ func newCreateCommand(loader *providers.ConfigLoader) *cobra.Command {
 // --- update ---
 
 type updateOpts struct {
-	IO   cmdio.Options
-	Name string
+	IO          cmdio.Options
+	Name        string
+	Description string
+	Tags        []string
 }
 
 func (o *updateOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("json")
 	o.IO.BindFlags(flags)
 	flags.StringVar(&o.Name, "name", "", "New experiment name")
+	flags.StringVar(&o.Description, "description", "", "New experiment description; pass an empty string to clear")
+	flags.StringSliceVar(&o.Tags, "tag", nil, "Experiment tag (repeatable or comma-separated; replaces all tags)")
 }
 
 // newUpdateCommand sends a true partial PATCH using pointer fields gated by
-// cmd.Flags().Changed(...). Only fields the user explicitly sets are sent on
-// the wire. Status and error are intentionally not exposed — they are
-// server-managed lifecycle fields; use `cancel` for the one user-driven
-// transition.
+// cmd.Flags().Changed(...). Only fields the user explicitly sets are sent on the
+// wire. Tags replace the full tag set when --tag is present; pass --tag "" to
+// clear tags. Status and error are intentionally not exposed — they are
+// server-managed lifecycle fields; use `cancel` for the one user-driven transition.
 func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &updateOpts{}
 	cmd := &cobra.Command{
@@ -257,8 +261,16 @@ func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
 				name := opts.Name
 				req.Name = &name
 			}
-			if req.Name == nil {
-				return errors.New("--name is required")
+			if cmd.Flags().Changed("description") {
+				description := opts.Description
+				req.Description = &description
+			}
+			if cmd.Flags().Changed("tag") {
+				tags := opts.Tags
+				req.Tags = &tags
+			}
+			if req.Name == nil && req.Description == nil && req.Tags == nil {
+				return errors.New("--name, --description, or --tag is required")
 			}
 
 			client, err := newClient(cmd, loader)
@@ -419,9 +431,9 @@ func (c *TableCodec) Encode(w io.Writer, v any) error {
 
 	var t *style.TableBuilder
 	if c.Wide {
-		t = style.NewTable("RUN-ID", "NAME", "STATUS", "SOURCE", "COLLECTION", "SCORES", "CREATED", "COMPLETED", "ERROR")
+		t = style.NewTable("RUN-ID", "NAME", "STATUS", "SOURCE", "COLLECTION-ID", "TAGS", "SCORES", "CREATED", "COMPLETED", "DESCRIPTION", "ERROR")
 	} else {
-		t = style.NewTable("RUN-ID", "NAME", "STATUS", "SOURCE", "COLLECTION", "SCORES", "CREATED")
+		t = style.NewTable("RUN-ID", "NAME", "STATUS", "SOURCE", "COLLECTION-ID", "TAGS", "SCORES", "CREATED")
 	}
 
 	for _, exp := range items {
@@ -438,17 +450,25 @@ func (c *TableCodec) Encode(w io.Writer, v any) error {
 		if source == "" {
 			source = "-"
 		}
+		tags := formatTags(exp.Tags)
 		if c.Wide {
 			completed := "-"
 			if exp.CompletedAt != nil {
 				completed = aio11yhttp.FormatTime(*exp.CompletedAt)
 			}
-			t.Row(exp.RunID, exp.Name, status, source, collection, scores, aio11yhttp.FormatTime(exp.CreatedAt), completed, aio11yhttp.Truncate(exp.Error, 40))
+			t.Row(exp.RunID, exp.Name, status, source, collection, tags, scores, aio11yhttp.FormatTime(exp.CreatedAt), completed, aio11yhttp.Truncate(exp.Description, 40), aio11yhttp.Truncate(exp.Error, 40))
 		} else {
-			t.Row(exp.RunID, exp.Name, status, source, collection, scores, aio11yhttp.FormatTime(exp.CreatedAt))
+			t.Row(exp.RunID, exp.Name, status, source, collection, tags, scores, aio11yhttp.FormatTime(exp.CreatedAt))
 		}
 	}
 	return t.Render(w)
+}
+
+func formatTags(tags []string) string {
+	if len(tags) == 0 {
+		return "-"
+	}
+	return strings.Join(tags, ", ")
 }
 
 func (c *TableCodec) Decode(_ io.Reader, _ any) error {

--- a/internal/providers/aio11y/eval/experiments/commands_test.go
+++ b/internal/providers/aio11y/eval/experiments/commands_test.go
@@ -36,7 +36,7 @@ func TestCreateCommand_RequiresFilename(t *testing.T) {
 	assert.Contains(t, err.Error(), "--filename/-f is required")
 }
 
-func TestUpdateCommand_RequiresName(t *testing.T) {
+func TestUpdateCommand_RequiresMutableField(t *testing.T) {
 	cmd := experiments.Commands(nil)
 	cmd.SetArgs([]string{"update", "r-1"})
 
@@ -46,7 +46,7 @@ func TestUpdateCommand_RequiresName(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--name is required")
+	assert.Contains(t, err.Error(), "--name, --description, or --tag is required")
 }
 
 func TestUpdateCommand_RejectsRemovedStatusAndErrorFlags(t *testing.T) {
@@ -154,6 +154,8 @@ func TestTableCodec_Encode(t *testing.T) {
 			Status:       "running",
 			Source:       "external",
 			CollectionID: "c-1",
+			Tags:         []string{"support", "prompt-v2"},
+			Description:  "Nightly regression run",
 			ScoreCount:   5,
 			CreatedAt:    time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
 			CompletedAt:  &completed,
@@ -170,12 +172,12 @@ func TestTableCodec_Encode(t *testing.T) {
 		{
 			name: "table format",
 			wide: false,
-			want: []string{"RUN-ID", "NAME", "STATUS", "r-1", "exp-1", "running"},
+			want: []string{"RUN-ID", "NAME", "STATUS", "COLLECTION-ID", "TAGS", "r-1", "exp-1", "running", "c-1", "support, prompt-v2"},
 		},
 		{
-			name: "wide adds ERROR and COMPLETED",
+			name: "wide adds ERROR, COMPLETED, and DESCRIPTION",
 			wide: true,
-			want: []string{"ERROR", "COMPLETED", "something", "2026-04-02 12:00"},
+			want: []string{"ERROR", "COMPLETED", "DESCRIPTION", "something", "Nightly regression run", "2026-04-02 12:00"},
 		},
 	}
 

--- a/internal/providers/aio11y/eval/experiments/types.go
+++ b/internal/providers/aio11y/eval/experiments/types.go
@@ -10,6 +10,8 @@ import (
 type Experiment struct {
 	// User-provided fields (spec).
 	Name         string                `json:"name"`
+	Description  string                `json:"description,omitempty"`
+	Tags         []string              `json:"tags,omitempty"`
 	Source       string                `json:"source,omitempty"`
 	CollectionID string                `json:"collection_id,omitempty"`
 	Evaluators   []ExperimentEvaluator `json:"evaluators,omitempty"`
@@ -43,7 +45,9 @@ type ExperimentEvaluator struct {
 // via Cancel, and the server owns the error message. Metadata is not
 // patchable through the CLI yet; add a field here when wiring it up.
 type UpdateRequest struct {
-	Name *string `json:"name,omitempty"`
+	Name        *string   `json:"name,omitempty"`
+	Description *string   `json:"description,omitempty"`
+	Tags        *[]string `json:"tags,omitempty"`
 }
 
 // ScoreItem is one score record produced by an evaluator during an experiment.

--- a/internal/providers/aio11y/provider.go
+++ b/internal/providers/aio11y/provider.go
@@ -119,7 +119,7 @@ func (p *AIO11yProvider) Commands() []*cobra.Command {
 	experimentsCmd := experiments.Commands(loader)
 	experimentsCmd.Annotations = map[string]string{
 		agent.AnnotationTokenCost: "medium",
-		agent.AnnotationLLMHint:   `gcx aio11y experiments list -o json; gcx aio11y experiments get <run-id> -o yaml; gcx aio11y experiments scores <run-id> -o json; gcx aio11y experiments report <run-id> -o json`,
+		agent.AnnotationLLMHint:   `gcx aio11y experiments list -o json; gcx aio11y experiments get <run-id> -o yaml; gcx aio11y experiments update <run-id> --description '...' --tag nightly --tag support -o json; gcx aio11y experiments scores <run-id> -o json; gcx aio11y experiments report <run-id> -o json`,
 	}
 
 	aio11yCmd.AddCommand(convsCmd, agentsCmd, evaluatorsCmd, rulesCmd, guardsCmd, templatesCmd, generationsCmd, scoresCmd, judgeCmd, savedConvsCmd, collectionsCmd, experimentsCmd)


### PR DESCRIPTION
## Notes

We added `Tags` and `Description` to Experiments in AI o11y so this PR updates `gcx` to return those values and accept them in the API nicely.

## Testing

Ran locally in gcx:
```
➜  gcx git:(jgordley/gcx-aio11y-experiments-tags-update) /Users/jgordley/Documents/projects/aio11y/gcx/bin/gcx aio11y experiments list --limit 1
```
| RUN-ID                 | NAME                           | STATUS    | SOURCE   | … | TAGS                                      | S… | CREATED          |
|------------------------|--------------------------------|-----------|----------|---|-------------------------------------------|----|------------------|
| sir-alex-fpl-26936188-223-1 | Sir Alex FPL eval (claude-haiku-4-5-20251001) | succeeded | external | - | sir-alex-fpl, smoke, claude-haiku-4-5-20251001 | 30 | 2026-06-04 06:59 |