### PR TITLE
feat(aio11y): add `gcx aio11y login` to provision sigil credentials

### DIFF
--- a/docs/reference/cli/gcx_aio11y.md
+++ b/docs/reference/cli/gcx_aio11y.md
@@ -31,6 +31,7 @@ Manage Grafana AI Observability resources
 * [gcx aio11y generations](gcx_aio11y_generations.md)	 - Inspect individual LLM generations.
 * [gcx aio11y guards](gcx_aio11y_guards.md)	 - Manage synchronous policy guards (hook rules) that evaluate generations on the request path.
 * [gcx aio11y judge](gcx_aio11y_judge.md)	 - List LLM providers and models available for LLM-judge evaluators.
+* [gcx aio11y login](gcx_aio11y_login.md)	 - Provision sigil credentials for coding-agent plugins from the current context.
 * [gcx aio11y rules](gcx_aio11y_rules.md)	 - Manage rules that route generations to evaluators.
 * [gcx aio11y saved-conversations](gcx_aio11y_saved-conversations.md)	 - Bookmark live conversations as fixed inputs for evaluation runs.
 * [gcx aio11y scores](gcx_aio11y_scores.md)	 - View evaluation scores for generations.

--- a/docs/reference/cli/gcx_aio11y_login.md
+++ b/docs/reference/cli/gcx_aio11y_login.md
@@ -1,0 +1,72 @@
+## gcx aio11y login
+
+Provision sigil credentials for coding-agent plugins from the current context.
+
+### Synopsis
+
+Provision the shared sigil credentials file (~/.config/sigil/config.env) used by
+the Grafana AI Observability coding-agent plugins (Cursor, Claude Code, Codex,
+Copilot, OpenCode, pi).
+
+Endpoints and the tenant ID are resolved from the current gcx Grafana Cloud
+context:
+  - SIGIL_ENDPOINT                    the stack's GCOM regionSigilUrl
+  - SIGIL_AUTH_TENANT_ID              the Grafana Cloud stack instance ID
+  - SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT the GCOM OTLP gateway endpoint
+
+By default gcx mints a dedicated Cloud Access Policy token scoped to
+`sigil:write`, `metrics:write`, `traces:write` and writes it as
+SIGIL_AUTH_TOKEN. This requires the context's cloud token to have
+`accesspolicies:write`. If it doesn't, gcx falls back to writing the
+context token directly and tells you how to create a scoped one.
+
+Re-running reuses the access policy and rotates the token. Existing optional
+keys in config.env (e.g. SIGIL_TAGS) are preserved.
+
+```
+gcx aio11y login [flags]
+```
+
+### Examples
+
+```
+  gcx aio11y login
+  gcx aio11y login --content-capture-mode full
+  gcx aio11y login --no-provision          # write the context token as-is
+  gcx aio11y login --token glc_xxx         # use a token you created yourself
+  gcx aio11y login --dry-run
+```
+
+### Options
+
+```
+      --config-path string            Override the sigil config.env path (default: $XDG_CONFIG_HOME/sigil/config.env)
+      --content-capture-mode string   Set SIGIL_CONTENT_CAPTURE_MODE. One of: metadata_only, no_tool_content, full, full_with_metadata_spans
+      --dry-run                       Resolve and print the configuration without minting a token or writing config.env
+  -h, --help                          help for login
+      --json string                   Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --no-provision                  Don't mint a dedicated token; write the context's Cloud Access Policy token instead
+      --otlp-endpoint string          Override the OTLP gateway endpoint (SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT) instead of reading it from GCOM
+  -o, --output string                 Output format. One of: agents, json, text, yaml (default "text")
+      --sigil-endpoint string         Override the Sigil API endpoint (SIGIL_ENDPOINT) instead of reading it from GCOM
+      --token string                  Use this token as SIGIL_AUTH_TOKEN verbatim (skips automatic provisioning)
+      --token-expiry string           Expiry for the provisioned token (RFC3339, e.g. 2027-01-01T00:00:00Z); default: no expiry
+      --token-name string             Name for the provisioned token (default: sigil-<stack-slug>)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx aio11y](gcx_aio11y.md)	 - Manage Grafana AI Observability resources
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -454,6 +454,8 @@ var commandAnnotations = map[string]annotation{
 
 	"gcx aio11y generations get": {Cost: "medium", Hint: "<generation-id> -o json"},
 
+	"gcx aio11y login": {Cost: "small", Hint: "--dry-run -o json previews the resolved Sigil config without minting a token or writing ~/.config/sigil/config.env"},
+
 	"gcx aio11y guards create": {Cost: "small"},
 	"gcx aio11y guards delete": {Cost: "small"},
 	"gcx aio11y guards get":    {Cost: "small"},

--- a/internal/cloud/accesspolicy.go
+++ b/internal/cloud/accesspolicy.go
@@ -1,0 +1,179 @@
+package cloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Cloud Access Policies + Tokens API paths (grafana.com/api/v1/...).
+const (
+	accessPoliciesPath = "/api/v1/accesspolicies"
+	tokensPath         = "/api/v1/tokens"
+)
+
+// Realm scopes an access policy to a specific org or stack.
+type Realm struct {
+	// Type is "stack" or "org".
+	Type string `json:"type"`
+	// Identifier is the stack ID (for type "stack") or org ID (for type "org").
+	Identifier string `json:"identifier"`
+}
+
+// AccessPolicy is a Grafana Cloud access policy as returned by the GCOM
+// /v1/accesspolicies endpoints.
+type AccessPolicy struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	DisplayName string   `json:"displayName,omitempty"`
+	Scopes      []string `json:"scopes"`
+	Realms      []Realm  `json:"realms"`
+	Status      string   `json:"status,omitempty"`
+}
+
+// CreateAccessPolicyRequest is the body for POST /v1/accesspolicies.
+type CreateAccessPolicyRequest struct {
+	Name        string   `json:"name"`
+	DisplayName string   `json:"displayName,omitempty"`
+	Scopes      []string `json:"scopes"`
+	Realms      []Realm  `json:"realms"`
+}
+
+// Token is a Grafana Cloud access-policy token. The secret Token field is only
+// populated in the response to CreateToken.
+type Token struct {
+	ID             string `json:"id"`
+	AccessPolicyID string `json:"accessPolicyId"`
+	Name           string `json:"name"`
+	DisplayName    string `json:"displayName,omitempty"`
+	ExpiresAt      string `json:"expiresAt,omitempty"`
+	Token          string `json:"token,omitempty"`
+}
+
+// CreateTokenRequest is the body for POST /v1/tokens.
+type CreateTokenRequest struct {
+	AccessPolicyID string `json:"accessPolicyId"`
+	Name           string `json:"name"`
+	DisplayName    string `json:"displayName,omitempty"`
+	ExpiresAt      string `json:"expiresAt,omitempty"`
+}
+
+// CreateAccessPolicy creates an access policy in the given region. A 409
+// conflict (name already exists) surfaces as a *GCOMHTTPError so callers can
+// fall back to ListAccessPolicies.
+func (c *GCOMClient) CreateAccessPolicy(ctx context.Context, region string, req CreateAccessPolicyRequest) (AccessPolicy, error) {
+	var out AccessPolicy
+	q := url.Values{"region": {region}}
+	if err := c.doJSON(ctx, http.MethodPost, accessPoliciesPath, q, req, &out); err != nil {
+		return AccessPolicy{}, err
+	}
+	return out, nil
+}
+
+// ListAccessPolicies returns the access policies in the given region (first
+// page, up to the API default page size). Callers filter by name/realm
+// client-side because the list endpoint does not support a name filter.
+func (c *GCOMClient) ListAccessPolicies(ctx context.Context, region string) ([]AccessPolicy, error) {
+	var out struct {
+		Items []AccessPolicy `json:"items"`
+	}
+	q := url.Values{"region": {region}}
+	if err := c.doJSON(ctx, http.MethodGet, accessPoliciesPath, q, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Items, nil
+}
+
+// CreateToken creates a token for an access policy in the given region. The
+// returned Token.Token holds the secret and is only available here.
+func (c *GCOMClient) CreateToken(ctx context.Context, region string, req CreateTokenRequest) (Token, error) {
+	var out Token
+	q := url.Values{"region": {region}}
+	if err := c.doJSON(ctx, http.MethodPost, tokensPath, q, req, &out); err != nil {
+		return Token{}, err
+	}
+	return out, nil
+}
+
+// ListTokens returns tokens in the given region, optionally filtered by access
+// policy ID and token name (both server-side filters).
+func (c *GCOMClient) ListTokens(ctx context.Context, region, accessPolicyID, name string) ([]Token, error) {
+	var out struct {
+		Items []Token `json:"items"`
+	}
+	q := url.Values{"region": {region}}
+	if accessPolicyID != "" {
+		q.Set("accessPolicyId", accessPolicyID)
+	}
+	if name != "" {
+		q.Set("name", name)
+	}
+	if err := c.doJSON(ctx, http.MethodGet, tokensPath, q, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Items, nil
+}
+
+// DeleteToken deletes a token by ID in the given region.
+func (c *GCOMClient) DeleteToken(ctx context.Context, region, tokenID string) error {
+	q := url.Values{"region": {region}}
+	return c.doJSON(ctx, http.MethodDelete, tokensPath+"/"+url.PathEscape(tokenID), q, nil, nil)
+}
+
+// doJSON performs a GCOM request with an optional JSON body and optional query
+// params, decoding a 2xx response into out (when non-nil). Non-2xx responses
+// are returned as *GCOMHTTPError.
+func (c *GCOMClient) doJSON(ctx context.Context, method, rawPath string, q url.Values, body, out any) error {
+	endpoint, err := c.buildURL(rawPath)
+	if err != nil {
+		return err
+	}
+	if len(q) > 0 {
+		endpoint += "?" + q.Encode()
+	}
+
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("gcom client: marshal request: %w", err)
+		}
+		reader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	if err != nil {
+		return fmt.Errorf("gcom client: create request: %w", err)
+	}
+	c.setHeaders(req)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("gcom client: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("gcom client: read response body: %w", err)
+	}
+
+	if resp.StatusCode/100 != 2 {
+		return &GCOMHTTPError{Status: resp.StatusCode, Body: strings.TrimSpace(string(respBody))}
+	}
+
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("gcom client: decode response: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/cloud/accesspolicy.go
+++ b/internal/cloud/accesspolicy.go
@@ -14,7 +14,7 @@ import (
 // Cloud Access Policies + Tokens API paths (grafana.com/api/v1/...).
 const (
 	accessPoliciesPath = "/api/v1/accesspolicies"
-	tokensPath         = "/api/v1/tokens"
+	tokensPath         = "/api/v1/tokens" // #nosec G101 -- API resource path, not a credential.
 )
 
 // Realm scopes an access policy to a specific org or stack.

--- a/internal/cloud/accesspolicy_test.go
+++ b/internal/cloud/accesspolicy_test.go
@@ -1,0 +1,150 @@
+package cloud_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/cloud"
+)
+
+func TestGCOMClient_CreateAccessPolicy(t *testing.T) {
+	var gotRegion, gotMethod string
+	var gotBody cloud.CreateAccessPolicyRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRegion = r.URL.Query().Get("region")
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(cloud.AccessPolicy{ID: "pol-1", Name: gotBody.Name, Scopes: gotBody.Scopes, Realms: gotBody.Realms})
+	}))
+	defer srv.Close()
+
+	c, err := cloud.NewGCOMClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := c.CreateAccessPolicy(context.Background(), "us", cloud.CreateAccessPolicyRequest{
+		Name:   "sigil-mystack",
+		Scopes: []string{"sigil:write"},
+		Realms: []cloud.Realm{{Type: "stack", Identifier: "42"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateAccessPolicy: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if gotRegion != "us" {
+		t.Errorf("region query = %q, want us", gotRegion)
+	}
+	if got.ID != "pol-1" || got.Name != "sigil-mystack" {
+		t.Errorf("policy = %+v", got)
+	}
+}
+
+func TestGCOMClient_CreateAccessPolicy_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"message":"taken"}`))
+	}))
+	defer srv.Close()
+
+	c, _ := cloud.NewGCOMClient(srv.URL, "tok")
+	_, err := c.CreateAccessPolicy(context.Background(), "us", cloud.CreateAccessPolicyRequest{Name: "x"})
+
+	var httpErr *cloud.GCOMHTTPError
+	if !errors.As(err, &httpErr) || httpErr.Status != http.StatusConflict {
+		t.Fatalf("err = %v, want GCOMHTTPError 409", err)
+	}
+}
+
+func TestGCOMClient_ListAccessPolicies(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("region") != "eu" {
+			t.Errorf("region query = %q", r.URL.Query().Get("region"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []cloud.AccessPolicy{{ID: "a"}, {ID: "b"}},
+		})
+	}))
+	defer srv.Close()
+
+	c, _ := cloud.NewGCOMClient(srv.URL, "tok")
+	got, err := c.ListAccessPolicies(context.Background(), "eu")
+	if err != nil {
+		t.Fatalf("ListAccessPolicies: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+}
+
+func TestGCOMClient_CreateToken(t *testing.T) {
+	var gotBody cloud.CreateTokenRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(cloud.Token{ID: "tok-1", Name: gotBody.Name, Token: "glc_secret"})
+	}))
+	defer srv.Close()
+
+	c, _ := cloud.NewGCOMClient(srv.URL, "tok")
+	got, err := c.CreateToken(context.Background(), "us", cloud.CreateTokenRequest{AccessPolicyID: "pol-1", Name: "sigil-mystack"})
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+	if got.Token != "glc_secret" {
+		t.Errorf("token secret = %q", got.Token)
+	}
+	if gotBody.AccessPolicyID != "pol-1" {
+		t.Errorf("accessPolicyId = %q", gotBody.AccessPolicyID)
+	}
+}
+
+func TestGCOMClient_ListTokens_FiltersByPolicyAndName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("accessPolicyId") != "pol-1" || q.Get("name") != "sigil-mystack" {
+			t.Errorf("query = %v", q)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []cloud.Token{{ID: "t1", Name: "sigil-mystack"}}})
+	}))
+	defer srv.Close()
+
+	c, _ := cloud.NewGCOMClient(srv.URL, "tok")
+	got, err := c.ListTokens(context.Background(), "us", "pol-1", "sigil-mystack")
+	if err != nil {
+		t.Fatalf("ListTokens: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "t1" {
+		t.Errorf("tokens = %+v", got)
+	}
+}
+
+func TestGCOMClient_DeleteToken(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c, _ := cloud.NewGCOMClient(srv.URL, "tok")
+	if err := c.DeleteToken(context.Background(), "us", "tok-1"); err != nil {
+		t.Fatalf("DeleteToken: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %s, want DELETE", gotMethod)
+	}
+	if gotPath != "/api/v1/tokens/tok-1" {
+		t.Errorf("path = %s", gotPath)
+	}
+}

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -72,6 +72,34 @@ type StackInfo struct {
 	// Alertmanager
 	AMInstanceID  int    `json:"amInstanceId"`
 	AMInstanceURL string `json:"amInstanceUrl"`
+
+	// AI Observability (Sigil) — regional API endpoint for the stack
+	// (e.g. https://sigil-prod-eu-west-2.grafana.net). Used as SIGIL_ENDPOINT.
+	RegionSigilURL string `json:"regionSigilUrl,omitempty"`
+}
+
+// Connections holds an instance's connectivity information as returned by the
+// GCOM GET /api/instances/{id}/connections endpoint. Only the fields gcx
+// consumes are modelled; the upstream payload carries more.
+type Connections struct {
+	// OtlpHTTPURL is the OTLP HTTP gateway endpoint for the stack
+	// (e.g. https://otlp-gateway-prod-eu-west-2.grafana.net/otlp).
+	OtlpHTTPURL string `json:"otlpHttpUrl"`
+
+	// InfluxURL is the InfluxDB write endpoint, when provisioned.
+	InfluxURL string `json:"influxUrl"`
+
+	// OncallAPIURL is the Grafana OnCall API endpoint, when provisioned.
+	OncallAPIURL string `json:"oncallApiUrl"`
+
+	// AppPlatform carries the app platform (Grafana API server) connection
+	// details, when provisioned.
+	AppPlatform *AppPlatform `json:"appPlatform,omitempty"`
+}
+
+// AppPlatform holds the app platform connection details nested in Connections.
+type AppPlatform struct {
+	URL string `json:"url"`
 }
 
 // Region describes a Grafana Cloud stack region as returned by the GCOM API.
@@ -199,6 +227,47 @@ func (c *GCOMClient) GetStack(ctx context.Context, slug string) (StackInfo, erro
 	}
 
 	return info, nil
+}
+
+// GetConnections calls GET /api/instances/{slug}/connections on the GCOM API
+// and returns the instance's connectivity information (OTLP gateway, InfluxDB,
+// OnCall, app platform). It returns an error if the response status is not 200.
+func (c *GCOMClient) GetConnections(ctx context.Context, slug string) (Connections, error) {
+	endpoint, err := c.buildURL(instancesPath + url.PathEscape(slug) + "/connections")
+	if err != nil {
+		return Connections{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return Connections{}, fmt.Errorf("gcom client: create request: %w", err)
+	}
+	c.setHeaders(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return Connections{}, fmt.Errorf("gcom client: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return Connections{}, fmt.Errorf("gcom client: read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return Connections{}, &GCOMHTTPError{
+			Status: resp.StatusCode,
+			Body:   strings.TrimSpace(string(body)),
+		}
+	}
+
+	var conns Connections
+	if err := json.Unmarshal(body, &conns); err != nil {
+		return Connections{}, fmt.Errorf("gcom client: decode response: %w", err)
+	}
+
+	return conns, nil
 }
 
 // ListStacks calls GET /api/orgs/{orgSlug}/instances on the GCOM API and

--- a/internal/cloud/gcom_test.go
+++ b/internal/cloud/gcom_test.go
@@ -34,6 +34,7 @@ func TestGCOMClient_GetStack_Success(t *testing.T) {
 		AgentManagementInstanceURL: "https://fleet-management-prod-1.grafana.net",
 		AMInstanceID:               6001,
 		AMInstanceURL:              "https://alertmanager-prod-1.grafana.net",
+		RegionSigilURL:             "https://sigil-prod-us-central.grafana.net",
 	}
 
 	var capturedAuth string
@@ -78,6 +79,64 @@ func TestGCOMClient_GetStack_Success(t *testing.T) {
 	}
 	if got.HMInstancePromURL != want.HMInstancePromURL {
 		t.Errorf("HMInstancePromURL: got %q, want %q", got.HMInstancePromURL, want.HMInstancePromURL)
+	}
+	if got.RegionSigilURL != want.RegionSigilURL {
+		t.Errorf("RegionSigilURL: got %q, want %q", got.RegionSigilURL, want.RegionSigilURL)
+	}
+}
+
+func TestGCOMClient_GetConnections_Success(t *testing.T) {
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"otlpHttpUrl":  "https://otlp-gateway-prod-eu-west-2.grafana.net/otlp",
+			"influxUrl":    "https://influx-prod-eu-west-2.grafana.net",
+			"oncallApiUrl": "https://oncall-prod-eu-west-2.grafana.net",
+			"appPlatform":  map[string]any{"url": "https://mystack.grafana.net/apis"},
+		})
+	}))
+	defer srv.Close()
+
+	client, err := cloud.NewGCOMClient(srv.URL, "test-token")
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	got, err := client.GetConnections(context.Background(), "mystack")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedPath != "/api/instances/mystack/connections" {
+		t.Errorf("path: got %q, want /api/instances/mystack/connections", capturedPath)
+	}
+	if got.OtlpHTTPURL != "https://otlp-gateway-prod-eu-west-2.grafana.net/otlp" {
+		t.Errorf("OtlpHTTPURL: got %q", got.OtlpHTTPURL)
+	}
+	if got.AppPlatform == nil || got.AppPlatform.URL != "https://mystack.grafana.net/apis" {
+		t.Errorf("AppPlatform: got %+v", got.AppPlatform)
+	}
+}
+
+func TestGCOMClient_GetConnections_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+	}))
+	defer srv.Close()
+
+	client, err := cloud.NewGCOMClient(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	_, err = client.GetConnections(context.Background(), "mystack")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var httpErr *cloud.GCOMHTTPError
+	if !errors.As(err, &httpErr) || httpErr.Status != http.StatusForbidden {
+		t.Errorf("expected 403 GCOMHTTPError, got %v", err)
 	}
 }
 

--- a/internal/providers/aio11y/login/command.go
+++ b/internal/providers/aio11y/login/command.go
@@ -1,0 +1,374 @@
+// Package login implements `gcx aio11y login`, which provisions the shared
+// sigil dotenv (~/.config/sigil/config.env) from the current gcx Grafana Cloud
+// context. It resolves the Sigil API endpoint, OTLP gateway endpoint, and
+// tenant ID from GCOM and — by default — mints a dedicated, correctly-scoped
+// Cloud Access Policy token so coding-agent plugins (Cursor, Claude Code, …)
+// can send telemetry to Grafana AI Observability with a single command.
+package login
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/grafana/gcx/internal/cloud"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// contentCaptureModes are the values accepted by the sigil plugins for
+// SIGIL_CONTENT_CAPTURE_MODE.
+//
+//nolint:gochecknoglobals // constant-like lookup table.
+var contentCaptureModes = []string{
+	"metadata_only",
+	"no_tool_content",
+	"full",
+	"full_with_metadata_spans",
+}
+
+// sigilScopes are the Cloud Access Policy scopes the SIGIL_AUTH_TOKEN must
+// carry for AI Observability export to work. Also the scopes gcx requests when
+// provisioning a token automatically.
+//
+//nolint:gochecknoglobals // constant-like lookup table.
+var sigilScopes = []string{"sigil:write", "metrics:write", "traces:write"}
+
+// Token source labels (also surfaced in JSON output).
+const (
+	sourceProvisioned  = "provisioned"
+	sourceCloudContext = "cloud-context"
+	sourceFlag         = "flag"
+	sourceDryRun       = "provision (dry-run)"
+)
+
+type options struct {
+	IO                 cmdio.Options
+	SigilEndpoint      string
+	OTLPEndpoint       string
+	Token              string
+	NoProvision        bool
+	TokenName          string
+	TokenExpiry        string
+	ContentCaptureMode string
+	ConfigPath         string
+	DryRun             bool
+}
+
+func (o *options) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("text", &textCodec{})
+	o.IO.DefaultFormat("text")
+	o.IO.BindFlags(flags)
+
+	flags.StringVar(&o.Token, "token", "", "Use this token as SIGIL_AUTH_TOKEN verbatim (skips automatic provisioning)")
+	flags.BoolVar(&o.NoProvision, "no-provision", false, "Don't mint a dedicated token; write the context's Cloud Access Policy token instead")
+	flags.StringVar(&o.TokenName, "token-name", "", "Name for the provisioned token (default: sigil-<stack-slug>)")
+	flags.StringVar(&o.TokenExpiry, "token-expiry", "", "Expiry for the provisioned token (RFC3339, e.g. 2027-01-01T00:00:00Z); default: no expiry")
+	flags.StringVar(&o.ContentCaptureMode, "content-capture-mode", "", "Set SIGIL_CONTENT_CAPTURE_MODE. One of: "+joinStrings(contentCaptureModes))
+	flags.StringVar(&o.SigilEndpoint, "sigil-endpoint", "", "Override the Sigil API endpoint (SIGIL_ENDPOINT) instead of reading it from GCOM")
+	flags.StringVar(&o.OTLPEndpoint, "otlp-endpoint", "", "Override the OTLP gateway endpoint (SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT) instead of reading it from GCOM")
+	flags.StringVar(&o.ConfigPath, "config-path", "", "Override the sigil config.env path (default: $XDG_CONFIG_HOME/sigil/config.env)")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Resolve and print the configuration without minting a token or writing config.env")
+}
+
+func (o *options) validate() error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+	if o.ContentCaptureMode != "" && !slices.Contains(contentCaptureModes, o.ContentCaptureMode) {
+		return fmt.Errorf("invalid --content-capture-mode %q; valid values: %s", o.ContentCaptureMode, joinStrings(contentCaptureModes))
+	}
+	if o.TokenExpiry != "" {
+		if _, err := time.Parse(time.RFC3339, o.TokenExpiry); err != nil {
+			return fmt.Errorf("invalid --token-expiry %q (want RFC3339, e.g. 2027-01-01T00:00:00Z): %w", o.TokenExpiry, err)
+		}
+	}
+	if o.Token != "" && o.NoProvision {
+		return errors.New("--token and --no-provision are mutually exclusive")
+	}
+	return nil
+}
+
+// Command returns the `aio11y login` command.
+func Command(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &options{}
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Provision sigil credentials for coding-agent plugins from the current context.",
+		Long: `Provision the shared sigil credentials file (~/.config/sigil/config.env) used by
+the Grafana AI Observability coding-agent plugins (Cursor, Claude Code, Codex,
+Copilot, OpenCode, pi).
+
+Endpoints and the tenant ID are resolved from the current gcx Grafana Cloud
+context:
+  - SIGIL_ENDPOINT                    the stack's GCOM regionSigilUrl
+  - SIGIL_AUTH_TENANT_ID              the Grafana Cloud stack instance ID
+  - SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT the GCOM OTLP gateway endpoint
+
+By default gcx mints a dedicated Cloud Access Policy token scoped to
+` + "`sigil:write`, `metrics:write`, `traces:write`" + ` and writes it as
+SIGIL_AUTH_TOKEN. This requires the context's cloud token to have
+` + "`accesspolicies:write`" + `. If it doesn't, gcx falls back to writing the
+context token directly and tells you how to create a scoped one.
+
+Re-running reuses the access policy and rotates the token. Existing optional
+keys in config.env (e.g. SIGIL_TAGS) are preserved.`,
+		Example: `  gcx aio11y login
+  gcx aio11y login --content-capture-mode full
+  gcx aio11y login --no-provision          # write the context token as-is
+  gcx aio11y login --token glc_xxx         # use a token you created yourself
+  gcx aio11y login --dry-run`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.validate(); err != nil {
+				return err
+			}
+			return run(cmd, opts, loader)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func run(cmd *cobra.Command, opts *options, loader *providers.ConfigLoader) error {
+	ctx := cmd.Context()
+	ew := cmd.ErrOrStderr()
+
+	cloudCfg, conns, client, err := loader.LoadCloudConnections(ctx)
+	if err != nil {
+		return err
+	}
+
+	otlpEndpoint := opts.OTLPEndpoint
+	if otlpEndpoint == "" {
+		otlpEndpoint = conns.OtlpHTTPURL
+	}
+	if otlpEndpoint == "" {
+		return errors.New("GCOM did not return an OTLP gateway endpoint for this stack; pass --otlp-endpoint")
+	}
+
+	// Prefer the Sigil endpoint GCOM reports directly; fall back to deriving it
+	// from the OTLP gateway region for stacks that don't yet expose the field.
+	sigilEndpoint := opts.SigilEndpoint
+	if sigilEndpoint == "" {
+		sigilEndpoint = cloudCfg.Stack.RegionSigilURL
+	}
+	if sigilEndpoint == "" {
+		sigilEndpoint, err = sigilEndpointFromOTLP(otlpEndpoint)
+		if err != nil {
+			return fmt.Errorf("GCOM did not report a Sigil endpoint (regionSigilUrl) for this stack and it could not be derived: %w", err)
+		}
+	}
+
+	tenantID := strconv.Itoa(cloudCfg.Stack.ID)
+
+	token, tokenSource, outcome, err := resolveToken(ctx, ew, opts, cloudCfg, client)
+	if err != nil {
+		return err
+	}
+
+	res := &result{
+		ConfigPath:         "",
+		Endpoint:           sigilEndpoint,
+		TenantID:           tenantID,
+		OTLPEndpoint:       otlpEndpoint,
+		ContentCaptureMode: opts.ContentCaptureMode,
+		TokenConfigured:    token != "",
+		TokenSource:        tokenSource,
+	}
+	if outcome != nil {
+		res.AccessPolicy = outcome.PolicyName
+		res.TokenName = outcome.TokenName
+		res.TokenRotated = outcome.TokenRotated
+		res.PolicyReused = outcome.PolicyReused
+	}
+
+	path := opts.ConfigPath
+	if path == "" {
+		path, err = sigilConfigPath()
+		if err != nil {
+			return err
+		}
+	}
+	res.ConfigPath = path
+
+	if !opts.DryRun {
+		updates := map[string]string{
+			"SIGIL_ENDPOINT":                    sigilEndpoint,
+			"SIGIL_AUTH_TENANT_ID":              tenantID,
+			"SIGIL_AUTH_TOKEN":                  token,
+			"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": otlpEndpoint,
+		}
+		if opts.ContentCaptureMode != "" {
+			updates["SIGIL_CONTENT_CAPTURE_MODE"] = opts.ContentCaptureMode
+		}
+		if err := writeSigilConfig(path, updates); err != nil {
+			return err
+		}
+		res.Wrote = true
+	}
+
+	if !res.TokenConfigured && !opts.DryRun {
+		cmdio.Warning(ew, "No token was written. Provide one with --token or grant the cloud token accesspolicies:write.")
+	}
+
+	return opts.IO.Encode(cmd.OutOrStdout(), res)
+}
+
+// resolveToken decides which token to write as SIGIL_AUTH_TOKEN and how.
+//
+//   - --token:        use it verbatim.
+//   - --no-provision: use the context's cloud token.
+//   - --dry-run:      report the plan without minting (no side effects).
+//   - default:        mint a dedicated scoped token via GCOM, falling back to
+//     the context token (with guidance) when the cloud token can't provision.
+func resolveToken(ctx context.Context, ew io.Writer, opts *options, cloudCfg providers.CloudRESTConfig, client *cloud.GCOMClient) (string, string, *provisionOutcome, error) {
+	switch {
+	case opts.Token != "":
+		return opts.Token, sourceFlag, nil, nil
+	case opts.NoProvision:
+		return cloudCfg.Token, sourceCloudContext, nil, nil
+	case opts.DryRun:
+		return "", sourceDryRun, nil, nil
+	}
+
+	region := cloudCfg.Stack.RegionSlug
+	if region == "" {
+		cmdio.Warning(ew, "Could not determine the stack region; skipping token provisioning and using the cloud token as-is.")
+		return cloudCfg.Token, sourceCloudContext, nil, nil
+	}
+
+	slug := cloudCfg.Stack.Slug
+	if slug == "" {
+		slug = "stack"
+	}
+	tokenName := opts.TokenName
+	if tokenName == "" {
+		tokenName = "sigil-" + slug
+	}
+
+	outcome, err := provisionToken(ctx, client, provisionParams{
+		Region:      region,
+		StackID:     cloudCfg.Stack.ID,
+		StackSlug:   slug,
+		PolicyName:  "sigil-" + slug,
+		TokenName:   tokenName,
+		TokenExpiry: opts.TokenExpiry,
+		Scopes:      sigilScopes,
+	})
+	if err == nil {
+		return outcome.Token, sourceProvisioned, &outcome, nil
+	}
+	if isPermissionError(err) {
+		// Bootstrap token lacks accesspolicies:write — degrade gracefully so
+		// the user still gets a working-or-near-working config, with guidance.
+		cmdio.Warning(ew, "Could not mint a dedicated token: the cloud token lacks accesspolicies:write.")
+		cmdio.EmitNote(ew, "Wrote your cloud token as SIGIL_AUTH_TOKEN instead — it must have scopes: "+joinStrings(sigilScopes)+".")
+		cmdio.EmitNote(ew, "To auto-provision, use a cloud token with accesspolicies:write, or create a scoped token at "+accessPoliciesURL(cloudCfg.Stack.OrgSlug)+" and pass it with --token.")
+		return cloudCfg.Token, sourceCloudContext, nil, nil
+	}
+	return "", "", nil, err
+}
+
+// accessPoliciesURL returns the Cloud portal access-policies URL for an org.
+func accessPoliciesURL(orgSlug string) string {
+	if orgSlug == "" {
+		orgSlug = "<your-org>"
+	}
+	return "https://grafana.com/orgs/" + orgSlug + "/access-policies"
+}
+
+func joinStrings(s []string) string {
+	out := ""
+	for i, v := range s {
+		if i > 0 {
+			out += ", "
+		}
+		out += v
+	}
+	return out
+}
+
+// result is the structured outcome of `aio11y login`. The token secret is
+// never included — only how it was sourced.
+type result struct {
+	ConfigPath         string `json:"config_path" yaml:"config_path"`
+	Endpoint           string `json:"endpoint" yaml:"endpoint"`
+	TenantID           string `json:"tenant_id" yaml:"tenant_id"`
+	OTLPEndpoint       string `json:"otlp_endpoint" yaml:"otlp_endpoint"`
+	ContentCaptureMode string `json:"content_capture_mode,omitempty" yaml:"content_capture_mode,omitempty"`
+	TokenConfigured    bool   `json:"token_configured" yaml:"token_configured"`
+	TokenSource        string `json:"token_source" yaml:"token_source"`
+	AccessPolicy       string `json:"access_policy,omitempty" yaml:"access_policy,omitempty"`
+	TokenName          string `json:"token_name,omitempty" yaml:"token_name,omitempty"`
+	TokenRotated       bool   `json:"token_rotated,omitempty" yaml:"token_rotated,omitempty"`
+	PolicyReused       bool   `json:"policy_reused,omitempty" yaml:"policy_reused,omitempty"`
+	Wrote              bool   `json:"wrote" yaml:"wrote"`
+}
+
+// textCodec renders the human-facing summary for `aio11y login`.
+type textCodec struct{}
+
+func (c *textCodec) Format() format.Format { return "text" }
+
+func (c *textCodec) Encode(w io.Writer, v any) error {
+	res, ok := v.(*result)
+	if !ok {
+		return errors.New("invalid data type for text codec: expected *result")
+	}
+
+	switch {
+	case res.Wrote:
+		cmdio.Success(w, "Saved sigil credentials to %s", res.ConfigPath)
+	default:
+		cmdio.Info(w, "Dry run — nothing minted or written. Resolved configuration:")
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  SIGIL_ENDPOINT                    %s\n", res.Endpoint)
+	fmt.Fprintf(w, "  SIGIL_AUTH_TENANT_ID              %s\n", res.TenantID)
+	fmt.Fprintf(w, "  SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT %s\n", res.OTLPEndpoint)
+	if res.ContentCaptureMode != "" {
+		fmt.Fprintf(w, "  SIGIL_CONTENT_CAPTURE_MODE        %s\n", res.ContentCaptureMode)
+	}
+	fmt.Fprintf(w, "  SIGIL_AUTH_TOKEN                  %s\n", tokenDescription(res))
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Cursor setup:")
+	fmt.Fprintln(w, "  /add-plugin grafana/sigil-sdk")
+	return nil
+}
+
+func (c *textCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("text format does not support decoding")
+}
+
+// tokenDescription renders a human-readable summary of how the token was sourced.
+func tokenDescription(res *result) string {
+	switch res.TokenSource {
+	case sourceProvisioned:
+		verb := "minted"
+		if res.TokenRotated {
+			verb = "rotated"
+		}
+		policyState := "created"
+		if res.PolicyReused {
+			policyState = "reused"
+		}
+		return fmt.Sprintf("(%s token %q under %s access policy %q)", verb, res.TokenName, policyState, res.AccessPolicy)
+	case sourceFlag:
+		return "(set from --token)"
+	case sourceCloudContext:
+		return "(set from the context's cloud token)"
+	case sourceDryRun:
+		return "(would mint a dedicated access-policy token)"
+	default:
+		return "(missing)"
+	}
+}

--- a/internal/providers/aio11y/login/command.go
+++ b/internal/providers/aio11y/login/command.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/grafana/gcx/internal/cloud"
@@ -160,7 +161,7 @@ func run(cmd *cobra.Command, opts *options, loader *providers.ConfigLoader) erro
 		sigilEndpoint = cloudCfg.Stack.RegionSigilURL
 	}
 	if sigilEndpoint == "" {
-		sigilEndpoint, err = sigilEndpointFromOTLP(otlpEndpoint)
+		sigilEndpoint, err = SigilEndpointFromOTLP(otlpEndpoint)
 		if err != nil {
 			return fmt.Errorf("GCOM did not report a Sigil endpoint (regionSigilUrl) for this stack and it could not be derived: %w", err)
 		}
@@ -208,7 +209,7 @@ func run(cmd *cobra.Command, opts *options, loader *providers.ConfigLoader) erro
 		if opts.ContentCaptureMode != "" {
 			updates["SIGIL_CONTENT_CAPTURE_MODE"] = opts.ContentCaptureMode
 		}
-		if err := writeSigilConfig(path, updates); err != nil {
+		if err := WriteSigilConfig(path, updates); err != nil {
 			return err
 		}
 		res.Wrote = true
@@ -285,14 +286,7 @@ func accessPoliciesURL(orgSlug string) string {
 }
 
 func joinStrings(s []string) string {
-	out := ""
-	for i, v := range s {
-		if i > 0 {
-			out += ", "
-		}
-		out += v
-	}
-	return out
+	return strings.Join(s, ", ")
 }
 
 // result is the structured outcome of `aio11y login`. The token secret is

--- a/internal/providers/aio11y/login/command_test.go
+++ b/internal/providers/aio11y/login/command_test.go
@@ -1,0 +1,370 @@
+package login
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/grafana/gcx/internal/cloud"
+	"github.com/grafana/gcx/internal/providers"
+)
+
+// fakeGCOM is a configurable GCOM stand-in covering the endpoints aio11y login
+// touches: instance get/connections, access-policy create/list, token
+// create/list/delete.
+type fakeGCOM struct {
+	stack cloud.StackInfo
+	conns cloud.Connections
+
+	policyConflict   bool               // POST accesspolicies → 409, GET returns existingPolicy
+	permissionDenied bool               // POST accesspolicies → 403
+	tokenConflict    bool               // first POST tokens → 409 (forces rotation)
+	existingPolicy   cloud.AccessPolicy // returned by GET accesspolicies on conflict
+	existingToken    cloud.Token        // returned by GET tokens on rotation
+
+	mu             sync.Mutex
+	tokenPostCount int
+	deletedTokens  []string
+}
+
+func (f *fakeGCOM) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+
+		switch {
+		case strings.HasPrefix(path, "/api/instances/") && strings.HasSuffix(path, "/connections"):
+			writeJSON(t, w, f.conns)
+
+		case strings.HasPrefix(path, "/api/instances/"):
+			writeJSON(t, w, f.stack)
+
+		case path == "/api/v1/accesspolicies" && r.Method == http.MethodPost:
+			switch {
+			case f.permissionDenied:
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+			case f.policyConflict:
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"message":"name taken"}`))
+			default:
+				var req cloud.CreateAccessPolicyRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSON(t, w, cloud.AccessPolicy{ID: "pol-1", Name: req.Name, Scopes: req.Scopes, Realms: req.Realms})
+			}
+
+		case path == "/api/v1/accesspolicies" && r.Method == http.MethodGet:
+			writeJSON(t, w, map[string]any{"items": []cloud.AccessPolicy{f.existingPolicy}})
+
+		case path == "/api/v1/tokens" && r.Method == http.MethodPost:
+			f.mu.Lock()
+			first := f.tokenPostCount == 0
+			f.tokenPostCount++
+			f.mu.Unlock()
+			if f.tokenConflict && first {
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"message":"token name taken"}`))
+				return
+			}
+			var req cloud.CreateTokenRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			writeJSON(t, w, cloud.Token{ID: "tok-1", Name: req.Name, Token: "glc_minted"})
+
+		case path == "/api/v1/tokens" && r.Method == http.MethodGet:
+			writeJSON(t, w, map[string]any{"items": []cloud.Token{f.existingToken}})
+
+		case strings.HasPrefix(path, "/api/v1/tokens/") && r.Method == http.MethodDelete:
+			f.mu.Lock()
+			f.deletedTokens = append(f.deletedTokens, strings.TrimPrefix(path, "/api/v1/tokens/"))
+			f.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Errorf("encode: %v", err)
+	}
+}
+
+func writeCfg(t *testing.T, apiURL string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gcx.yaml")
+	content := `
+contexts:
+  default:
+    cloud:
+      token: "glc_test"
+      stack: "mystack"
+      api-url: "` + apiURL + `"
+current-context: default
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func newLoader(t *testing.T, apiURL string) *providers.ConfigLoader {
+	t.Helper()
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(writeCfg(t, apiURL))
+	loader.SetContextName("default")
+	return loader
+}
+
+func runLogin(t *testing.T, loader *providers.ConfigLoader, args ...string) (string, string, error) {
+	t.Helper()
+	cmd := Command(loader)
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), errBuf.String(), err
+}
+
+func TestLogin_ProvisionsTokenByDefault(t *testing.T) {
+	f := &fakeGCOM{
+		// regionSigilUrl is a different region than the OTLP host to prove the
+		// GCOM field is used verbatim rather than derived.
+		stack: cloud.StackInfo{ID: 42, Slug: "mystack", RegionSlug: "us", OrgSlug: "myorg", RegionSigilURL: "https://sigil-prod-us-east-0.grafana.net"},
+		conns: cloud.Connections{OtlpHTTPURL: "https://otlp-gateway-prod-eu-west-2.grafana.net/otlp"},
+	}
+	srv := f.server(t)
+	defer srv.Close()
+
+	loader := newLoader(t, srv.URL)
+	sigilPath := filepath.Join(t.TempDir(), "sigil", "config.env")
+
+	out, _, err := runLogin(t, loader, "--config-path", sigilPath, "--content-capture-mode", "full", "-o", "text")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	got := readEnv(t, sigilPath)
+	if got["SIGIL_ENDPOINT"] != "https://sigil-prod-us-east-0.grafana.net" {
+		t.Errorf("SIGIL_ENDPOINT = %q (expected GCOM regionSigilUrl)", got["SIGIL_ENDPOINT"])
+	}
+	if got["SIGIL_AUTH_TENANT_ID"] != "42" {
+		t.Errorf("SIGIL_AUTH_TENANT_ID = %q", got["SIGIL_AUTH_TENANT_ID"])
+	}
+	if got["SIGIL_AUTH_TOKEN"] != "glc_minted" {
+		t.Errorf("SIGIL_AUTH_TOKEN = %q (expected the minted token, not the cloud token)", got["SIGIL_AUTH_TOKEN"])
+	}
+	if got["SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT"] != "https://otlp-gateway-prod-eu-west-2.grafana.net/otlp" {
+		t.Errorf("SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT = %q", got["SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT"])
+	}
+	if got["SIGIL_CONTENT_CAPTURE_MODE"] != "full" {
+		t.Errorf("SIGIL_CONTENT_CAPTURE_MODE = %q", got["SIGIL_CONTENT_CAPTURE_MODE"])
+	}
+	if !strings.Contains(out, "/add-plugin grafana/sigil-sdk") {
+		t.Errorf("expected Cursor hint in output:\n%s", out)
+	}
+}
+
+func TestLogin_NoProvisionWritesContextToken(t *testing.T) {
+	f := &fakeGCOM{
+		stack: cloud.StackInfo{ID: 42, Slug: "mystack", RegionSlug: "us", RegionSigilURL: "https://sigil-prod-us-east-0.grafana.net"},
+		conns: cloud.Connections{OtlpHTTPURL: "https://otlp-gateway-prod-eu-west-2.grafana.net/otlp"},
+	}
+	srv := f.server(t)
+	defer srv.Close()
+
+	loader := newLoader(t, srv.URL)
+	sigilPath := filepath.Join(t.TempDir(), "config.env")
+
+	if _, _, err := runLogin(t, loader, "--config-path", sigilPath, "--no-provision", "-o", "text"); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	got := readEnv(t, sigilPath)
+	if got["SIGIL_AUTH_TOKEN"] != "glc_test" {
+		t.Errorf("SIGIL_AUTH_TOKEN = %q (expected the context cloud token)", got["SIGIL_AUTH_TOKEN"])
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.tokenPostCount != 0 {
+		t.Errorf("no-provision should not mint a token, got %d POSTs", f.tokenPostCount)
+	}
+}
+
+func TestLogin_FallsBackWhenProvisioningForbidden(t *testing.T) {
+	f := &fakeGCOM{
+		stack:            cloud.StackInfo{ID: 42, Slug: "mystack", RegionSlug: "us", OrgSlug: "myorg", RegionSigilURL: "https://sigil-prod-us-east-0.grafana.net"},
+		conns:            cloud.Connections{OtlpHTTPURL: "https://otlp-gateway-prod-eu-west-2.grafana.net/otlp"},
+		permissionDenied: true,
+	}
+	srv := f.server(t)
+	defer srv.Close()
+
+	loader := newLoader(t, srv.URL)
+	sigilPath := filepath.Join(t.TempDir(), "config.env")
+
+	out, errOut, err := runLogin(t, loader, "--config-path", sigilPath, "-o", "json")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	got := readEnv(t, sigilPath)
+	if got["SIGIL_AUTH_TOKEN"] != "glc_test" {
+		t.Errorf("SIGIL_AUTH_TOKEN = %q (expected fallback to context token)", got["SIGIL_AUTH_TOKEN"])
+	}
+	if !strings.Contains(errOut, "accesspolicies:write") {
+		t.Errorf("expected guidance about accesspolicies:write on stderr:\n%s", errOut)
+	}
+
+	var res result
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if res.TokenSource != sourceCloudContext {
+		t.Errorf("token_source = %q, want %q", res.TokenSource, sourceCloudContext)
+	}
+}
+
+func TestLogin_ReusesPolicyAndRotatesToken(t *testing.T) {
+	f := &fakeGCOM{
+		stack:          cloud.StackInfo{ID: 42, Slug: "mystack", RegionSlug: "us", RegionSigilURL: "https://sigil-prod-us-east-0.grafana.net"},
+		conns:          cloud.Connections{OtlpHTTPURL: "https://otlp-gateway-prod-eu-west-2.grafana.net/otlp"},
+		policyConflict: true,
+		tokenConflict:  true,
+		existingPolicy: cloud.AccessPolicy{
+			ID: "pol-existing", Name: "sigil-mystack",
+			Realms: []cloud.Realm{{Type: "stack", Identifier: "42"}},
+		},
+		existingToken: cloud.Token{ID: "old-tok", Name: "sigil-mystack"},
+	}
+	srv := f.server(t)
+	defer srv.Close()
+
+	loader := newLoader(t, srv.URL)
+	sigilPath := filepath.Join(t.TempDir(), "config.env")
+
+	out, _, err := runLogin(t, loader, "--config-path", sigilPath, "-o", "json")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	got := readEnv(t, sigilPath)
+	if got["SIGIL_AUTH_TOKEN"] != "glc_minted" {
+		t.Errorf("SIGIL_AUTH_TOKEN = %q", got["SIGIL_AUTH_TOKEN"])
+	}
+	f.mu.Lock()
+	deleted := append([]string(nil), f.deletedTokens...)
+	f.mu.Unlock()
+	if len(deleted) != 1 || deleted[0] != "old-tok" {
+		t.Errorf("expected old token to be deleted on rotation, got %v", deleted)
+	}
+
+	var res result
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !res.PolicyReused {
+		t.Error("policy_reused = false, want true")
+	}
+	if !res.TokenRotated {
+		t.Error("token_rotated = false, want true")
+	}
+}
+
+func TestLogin_DryRunMintsNothingAndWritesNothing(t *testing.T) {
+	f := &fakeGCOM{
+		stack: cloud.StackInfo{ID: 7, Slug: "mystack", RegionSlug: "us"},
+		conns: cloud.Connections{OtlpHTTPURL: "https://otlp-gateway-prod-us-east-0.grafana.net/otlp"},
+	}
+	srv := f.server(t)
+	defer srv.Close()
+
+	loader := newLoader(t, srv.URL)
+	sigilPath := filepath.Join(t.TempDir(), "sigil", "config.env")
+
+	out, _, err := runLogin(t, loader, "--config-path", sigilPath, "--dry-run", "-o", "text")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if _, statErr := os.Stat(sigilPath); !os.IsNotExist(statErr) {
+		t.Errorf("dry-run wrote a file (err=%v)", statErr)
+	}
+	if !strings.Contains(out, "sigil-prod-us-east-0") {
+		t.Errorf("expected derived endpoint in dry-run output:\n%s", out)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.tokenPostCount != 0 {
+		t.Errorf("dry-run must not mint a token, got %d POSTs", f.tokenPostCount)
+	}
+}
+
+func TestLogin_TokenFlagSkipsProvisioning(t *testing.T) {
+	f := &fakeGCOM{
+		stack: cloud.StackInfo{ID: 42, Slug: "mystack", RegionSlug: "us", RegionSigilURL: "https://sigil-prod-us-east-0.grafana.net"},
+		conns: cloud.Connections{OtlpHTTPURL: "https://otlp-gateway-prod-eu-west-2.grafana.net/otlp"},
+	}
+	srv := f.server(t)
+	defer srv.Close()
+
+	loader := newLoader(t, srv.URL)
+	sigilPath := filepath.Join(t.TempDir(), "config.env")
+
+	if _, _, err := runLogin(t, loader, "--config-path", sigilPath, "--token", "glc_byo", "-o", "text"); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	got := readEnv(t, sigilPath)
+	if got["SIGIL_AUTH_TOKEN"] != "glc_byo" {
+		t.Errorf("SIGIL_AUTH_TOKEN = %q, want glc_byo", got["SIGIL_AUTH_TOKEN"])
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.tokenPostCount != 0 {
+		t.Errorf("--token should skip provisioning, got %d POSTs", f.tokenPostCount)
+	}
+}
+
+func TestLogin_InvalidContentCaptureMode(t *testing.T) {
+	if _, _, err := runLogin(t, &providers.ConfigLoader{}, "--content-capture-mode", "bogus"); err == nil {
+		t.Fatal("expected error for invalid content-capture-mode")
+	}
+}
+
+func TestLogin_InvalidTokenExpiry(t *testing.T) {
+	if _, _, err := runLogin(t, &providers.ConfigLoader{}, "--token-expiry", "not-a-date"); err == nil {
+		t.Fatal("expected error for invalid token-expiry")
+	}
+}
+
+func TestLogin_TokenNotLeakedInJSON(t *testing.T) {
+	f := &fakeGCOM{
+		stack: cloud.StackInfo{ID: 99, Slug: "mystack", RegionSlug: "us", RegionSigilURL: "https://sigil-prod-us-east-0.grafana.net"},
+		conns: cloud.Connections{OtlpHTTPURL: "https://otlp-gateway-prod-eu-west-2.grafana.net/otlp"},
+	}
+	srv := f.server(t)
+	defer srv.Close()
+
+	loader := newLoader(t, srv.URL)
+	sigilPath := filepath.Join(t.TempDir(), "config.env")
+
+	out, _, err := runLogin(t, loader, "--config-path", sigilPath, "-o", "json")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if strings.Contains(out, "glc_minted") || strings.Contains(out, "glc_test") {
+		t.Errorf("token value leaked into JSON output:\n%s", out)
+	}
+}

--- a/internal/providers/aio11y/login/command_test.go
+++ b/internal/providers/aio11y/login/command_test.go
@@ -1,4 +1,4 @@
-package login
+package login_test
 
 import (
 	"bytes"
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/providers/aio11y/login"
 )
 
 // fakeGCOM is a configurable GCOM stand-in covering the endpoints aio11y login
@@ -128,7 +129,7 @@ func newLoader(t *testing.T, apiURL string) *providers.ConfigLoader {
 
 func runLogin(t *testing.T, loader *providers.ConfigLoader, args ...string) (string, string, error) {
 	t.Helper()
-	cmd := Command(loader)
+	cmd := login.Command(loader)
 	var out, errBuf bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&errBuf)
@@ -227,12 +228,14 @@ func TestLogin_FallsBackWhenProvisioningForbidden(t *testing.T) {
 		t.Errorf("expected guidance about accesspolicies:write on stderr:\n%s", errOut)
 	}
 
-	var res result
+	var res struct {
+		TokenSource string `json:"token_source"`
+	}
 	if err := json.Unmarshal([]byte(out), &res); err != nil {
 		t.Fatalf("unmarshal: %v\n%s", err, out)
 	}
-	if res.TokenSource != sourceCloudContext {
-		t.Errorf("token_source = %q, want %q", res.TokenSource, sourceCloudContext)
+	if res.TokenSource != "cloud-context" {
+		t.Errorf("token_source = %q, want cloud-context", res.TokenSource)
 	}
 }
 
@@ -270,7 +273,10 @@ func TestLogin_ReusesPolicyAndRotatesToken(t *testing.T) {
 		t.Errorf("expected old token to be deleted on rotation, got %v", deleted)
 	}
 
-	var res result
+	var res struct {
+		PolicyReused bool `json:"policy_reused"`
+		TokenRotated bool `json:"token_rotated"`
+	}
 	if err := json.Unmarshal([]byte(out), &res); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}

--- a/internal/providers/aio11y/login/endpoints.go
+++ b/internal/providers/aio11y/login/endpoints.go
@@ -1,0 +1,41 @@
+package login
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const otlpGatewayHostPrefix = "otlp-gateway-"
+
+// sigilEndpointFromOTLP derives the Sigil API endpoint from the OTLP gateway
+// URL exposed by GCOM. Both endpoints share the same regional cluster token:
+//
+//	https://otlp-gateway-prod-eu-west-2.grafana.net/otlp
+//	→ https://sigil-prod-eu-west-2.grafana.net
+//
+// It returns an error when the host does not match the expected gateway shape
+// so the caller can fall back to asking the user for an explicit
+// --sigil-endpoint instead of writing a guessed value.
+func sigilEndpointFromOTLP(otlpURL string) (string, error) {
+	trimmed := strings.TrimSpace(otlpURL)
+	if trimmed == "" {
+		return "", fmt.Errorf("OTLP endpoint is empty")
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("parse OTLP URL %q: %w", otlpURL, err)
+	}
+	host := u.Hostname()
+	if u.Scheme == "" || host == "" {
+		return "", fmt.Errorf("OTLP URL %q is not an absolute URL", otlpURL)
+	}
+	if !strings.HasPrefix(host, otlpGatewayHostPrefix) {
+		return "", fmt.Errorf(
+			"cannot derive Sigil endpoint from OTLP host %q (expected %q prefix); pass --sigil-endpoint",
+			host, otlpGatewayHostPrefix,
+		)
+	}
+	sigilHost := "sigil-" + strings.TrimPrefix(host, otlpGatewayHostPrefix)
+	return u.Scheme + "://" + sigilHost, nil
+}

--- a/internal/providers/aio11y/login/endpoints.go
+++ b/internal/providers/aio11y/login/endpoints.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -8,19 +9,19 @@ import (
 
 const otlpGatewayHostPrefix = "otlp-gateway-"
 
-// sigilEndpointFromOTLP derives the Sigil API endpoint from the OTLP gateway
+// SigilEndpointFromOTLP derives the Sigil API endpoint from the OTLP gateway
 // URL exposed by GCOM. Both endpoints share the same regional cluster token:
 //
 //	https://otlp-gateway-prod-eu-west-2.grafana.net/otlp
 //	→ https://sigil-prod-eu-west-2.grafana.net
 //
 // It returns an error when the host does not match the expected gateway shape
-// so the caller can fall back to asking the user for an explicit
-// --sigil-endpoint instead of writing a guessed value.
-func sigilEndpointFromOTLP(otlpURL string) (string, error) {
+// so the caller can ask the user for an explicit --sigil-endpoint instead of
+// writing a guessed value.
+func SigilEndpointFromOTLP(otlpURL string) (string, error) {
 	trimmed := strings.TrimSpace(otlpURL)
 	if trimmed == "" {
-		return "", fmt.Errorf("OTLP endpoint is empty")
+		return "", errors.New("OTLP endpoint is empty")
 	}
 	u, err := url.Parse(trimmed)
 	if err != nil {

--- a/internal/providers/aio11y/login/endpoints_test.go
+++ b/internal/providers/aio11y/login/endpoints_test.go
@@ -1,0 +1,61 @@
+package login
+
+import "testing"
+
+func TestSigilEndpointFromOTLP(t *testing.T) {
+	tests := []struct {
+		name    string
+		otlp    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "prod eu region",
+			otlp: "https://otlp-gateway-prod-eu-west-2.grafana.net/otlp",
+			want: "https://sigil-prod-eu-west-2.grafana.net",
+		},
+		{
+			name: "prod us region",
+			otlp: "https://otlp-gateway-prod-us-east-0.grafana.net/otlp",
+			want: "https://sigil-prod-us-east-0.grafana.net",
+		},
+		{
+			name: "no path suffix still derives host",
+			otlp: "https://otlp-gateway-prod-eu-west-2.grafana.net",
+			want: "https://sigil-prod-eu-west-2.grafana.net",
+		},
+		{
+			name:    "empty",
+			otlp:    "",
+			wantErr: true,
+		},
+		{
+			name:    "not a gateway host",
+			otlp:    "https://example.com/otlp",
+			wantErr: true,
+		},
+		{
+			name:    "relative url",
+			otlp:    "/otlp",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sigilEndpointFromOTLP(tt.otlp)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (got %q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/providers/aio11y/login/endpoints_test.go
+++ b/internal/providers/aio11y/login/endpoints_test.go
@@ -1,6 +1,10 @@
-package login
+package login_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/aio11y/login"
+)
 
 func TestSigilEndpointFromOTLP(t *testing.T) {
 	tests := []struct {
@@ -43,7 +47,7 @@ func TestSigilEndpointFromOTLP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := sigilEndpointFromOTLP(tt.otlp)
+			got, err := login.SigilEndpointFromOTLP(tt.otlp)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil (got %q)", got)

--- a/internal/providers/aio11y/login/provision.go
+++ b/internal/providers/aio11y/login/provision.go
@@ -1,0 +1,152 @@
+package login
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/grafana/gcx/internal/cloud"
+)
+
+// provisionParams holds the inputs for minting a dedicated sigil access-policy
+// token against GCOM.
+type provisionParams struct {
+	Region      string
+	StackID     int
+	StackSlug   string
+	PolicyName  string
+	TokenName   string
+	TokenExpiry string // RFC3339; empty means the token never expires
+	Scopes      []string
+}
+
+// provisionOutcome describes what provisionToken did, for reporting.
+type provisionOutcome struct {
+	PolicyName   string
+	TokenName    string
+	Token        string // the secret; only populated on success
+	PolicyReused bool   // an existing policy was reused instead of created
+	TokenRotated bool   // an existing token of the same name was replaced
+}
+
+// provisionToken finds or creates the sigil access policy for the stack and
+// mints a fresh token under it. If a token with the same name already exists it
+// is rotated (deleted and recreated) so exactly one active token remains.
+func provisionToken(ctx context.Context, client *cloud.GCOMClient, p provisionParams) (provisionOutcome, error) {
+	realm := cloud.Realm{Type: "stack", Identifier: strconv.Itoa(p.StackID)}
+
+	policy, reused, err := findOrCreatePolicy(ctx, client, p, realm)
+	if err != nil {
+		return provisionOutcome{}, err
+	}
+
+	tok, rotated, err := createOrRotateToken(ctx, client, p, policy.ID)
+	if err != nil {
+		return provisionOutcome{}, err
+	}
+
+	return provisionOutcome{
+		PolicyName:   policy.Name,
+		TokenName:    tok.Name,
+		Token:        tok.Token,
+		PolicyReused: reused,
+		TokenRotated: rotated,
+	}, nil
+}
+
+func findOrCreatePolicy(ctx context.Context, client *cloud.GCOMClient, p provisionParams, realm cloud.Realm) (cloud.AccessPolicy, bool, error) {
+	created, err := client.CreateAccessPolicy(ctx, p.Region, cloud.CreateAccessPolicyRequest{
+		Name:        p.PolicyName,
+		DisplayName: "Sigil (AI Observability) — " + p.StackSlug,
+		Scopes:      p.Scopes,
+		Realms:      []cloud.Realm{realm},
+	})
+	if err == nil {
+		return created, false, nil
+	}
+
+	// Name+org+region must be unique; on conflict, reuse the existing policy.
+	var httpErr *cloud.GCOMHTTPError
+	if errors.As(err, &httpErr) && httpErr.Status == http.StatusConflict {
+		existing, lerr := findPolicyByName(ctx, client, p.Region, p.PolicyName, realm)
+		if lerr != nil {
+			return cloud.AccessPolicy{}, false, lerr
+		}
+		if existing != nil {
+			return *existing, true, nil
+		}
+	}
+	return cloud.AccessPolicy{}, false, fmt.Errorf("create access policy %q: %w", p.PolicyName, err)
+}
+
+func findPolicyByName(ctx context.Context, client *cloud.GCOMClient, region, name string, realm cloud.Realm) (*cloud.AccessPolicy, error) {
+	policies, err := client.ListAccessPolicies(ctx, region)
+	if err != nil {
+		return nil, fmt.Errorf("list access policies: %w", err)
+	}
+	for i := range policies {
+		if policies[i].Name == name && realmMatches(policies[i].Realms, realm) {
+			return &policies[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func realmMatches(realms []cloud.Realm, want cloud.Realm) bool {
+	for _, r := range realms {
+		if r.Type == want.Type && r.Identifier == want.Identifier {
+			return true
+		}
+	}
+	return false
+}
+
+func createOrRotateToken(ctx context.Context, client *cloud.GCOMClient, p provisionParams, policyID string) (cloud.Token, bool, error) {
+	req := cloud.CreateTokenRequest{
+		AccessPolicyID: policyID,
+		Name:           p.TokenName,
+		DisplayName:    p.TokenName,
+		ExpiresAt:      p.TokenExpiry,
+	}
+
+	tok, err := client.CreateToken(ctx, p.Region, req)
+	if err == nil {
+		return tok, false, nil
+	}
+
+	// Token name is taken: rotate it so the freshly-minted secret is the only
+	// active one (we can't read back an existing token's secret).
+	var httpErr *cloud.GCOMHTTPError
+	if errors.As(err, &httpErr) && httpErr.Status == http.StatusConflict {
+		existing, lerr := client.ListTokens(ctx, p.Region, policyID, p.TokenName)
+		if lerr != nil {
+			return cloud.Token{}, false, fmt.Errorf("rotate token %q: list existing: %w", p.TokenName, lerr)
+		}
+		for _, t := range existing {
+			if t.Name != p.TokenName {
+				continue
+			}
+			if derr := client.DeleteToken(ctx, p.Region, t.ID); derr != nil {
+				return cloud.Token{}, false, fmt.Errorf("rotate token %q: delete existing: %w", p.TokenName, derr)
+			}
+		}
+		tok, err = client.CreateToken(ctx, p.Region, req)
+		if err != nil {
+			return cloud.Token{}, false, fmt.Errorf("create token %q after rotation: %w", p.TokenName, err)
+		}
+		return tok, true, nil
+	}
+	return cloud.Token{}, false, fmt.Errorf("create token %q: %w", p.TokenName, err)
+}
+
+// isPermissionError reports whether err is a GCOM 401/403, i.e. the bootstrap
+// token lacks the scopes required to provision (accesspolicies:write etc.).
+func isPermissionError(err error) bool {
+	var httpErr *cloud.GCOMHTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.Status == http.StatusUnauthorized || httpErr.Status == http.StatusForbidden
+	}
+	return false
+}

--- a/internal/providers/aio11y/login/provision.go
+++ b/internal/providers/aio11y/login/provision.go
@@ -70,28 +70,28 @@ func findOrCreatePolicy(ctx context.Context, client *cloud.GCOMClient, p provisi
 	// Name+org+region must be unique; on conflict, reuse the existing policy.
 	var httpErr *cloud.GCOMHTTPError
 	if errors.As(err, &httpErr) && httpErr.Status == http.StatusConflict {
-		existing, lerr := findPolicyByName(ctx, client, p.Region, p.PolicyName, realm)
+		existing, found, lerr := findPolicyByName(ctx, client, p.Region, p.PolicyName, realm)
 		if lerr != nil {
 			return cloud.AccessPolicy{}, false, lerr
 		}
-		if existing != nil {
-			return *existing, true, nil
+		if found {
+			return existing, true, nil
 		}
 	}
 	return cloud.AccessPolicy{}, false, fmt.Errorf("create access policy %q: %w", p.PolicyName, err)
 }
 
-func findPolicyByName(ctx context.Context, client *cloud.GCOMClient, region, name string, realm cloud.Realm) (*cloud.AccessPolicy, error) {
+func findPolicyByName(ctx context.Context, client *cloud.GCOMClient, region, name string, realm cloud.Realm) (cloud.AccessPolicy, bool, error) {
 	policies, err := client.ListAccessPolicies(ctx, region)
 	if err != nil {
-		return nil, fmt.Errorf("list access policies: %w", err)
+		return cloud.AccessPolicy{}, false, fmt.Errorf("list access policies: %w", err)
 	}
 	for i := range policies {
 		if policies[i].Name == name && realmMatches(policies[i].Realms, realm) {
-			return &policies[i], nil
+			return policies[i], true, nil
 		}
 	}
-	return nil, nil
+	return cloud.AccessPolicy{}, false, nil
 }
 
 func realmMatches(realms []cloud.Realm, want cloud.Realm) bool {

--- a/internal/providers/aio11y/login/sigilconfig.go
+++ b/internal/providers/aio11y/login/sigilconfig.go
@@ -1,0 +1,124 @@
+package login
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/grafana/gcx/internal/xdg"
+)
+
+// sigilConfigPath returns the default path to the shared sigil dotenv config:
+// $XDG_CONFIG_HOME/sigil/config.env, falling back to ~/.config/sigil/config.env.
+// This matches the path the sigil binary itself resolves.
+func sigilConfigPath() (string, error) {
+	home := xdg.ConfigHome()
+	if home == "" {
+		return "", errors.New("cannot resolve config home directory (set XDG_CONFIG_HOME or HOME)")
+	}
+	return filepath.Join(home, "sigil", "config.env"), nil
+}
+
+// writeSigilConfig merges updates into the dotenv file at path, preserving
+// unrelated lines, comments, and ordering. A key whose value is empty is
+// removed; a key not already present is appended. The write is atomic
+// (temp file + rename) and the file is created with 0600 permissions because
+// it holds credentials.
+func writeSigilConfig(path string, updates map[string]string) error {
+	var existing []string
+	if data, err := os.ReadFile(path); err == nil {
+		existing = strings.Split(string(data), "\n")
+		// Drop a single trailing empty element produced by a trailing newline
+		// so we don't accumulate blank lines on repeated writes.
+		if n := len(existing); n > 0 && existing[n-1] == "" {
+			existing = existing[:n-1]
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	applied := make(map[string]bool, len(updates))
+	out := make([]string, 0, len(existing)+len(updates))
+
+	for _, line := range existing {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			out = append(out, line)
+			continue
+		}
+		key := lineKey(trimmed)
+		val, ok := updates[key]
+		if !ok {
+			out = append(out, line)
+			continue
+		}
+		applied[key] = true
+		if strings.TrimSpace(val) == "" {
+			continue // empty value removes the key
+		}
+		out = append(out, key+"="+val)
+	}
+
+	for _, key := range sortedKeys(updates) {
+		if applied[key] || strings.TrimSpace(updates[key]) == "" {
+			continue
+		}
+		out = append(out, key+"="+updates[key])
+	}
+
+	content := strings.Join(out, "\n") + "\n"
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".config.env-*")
+	if err != nil {
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op after successful rename
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp file to %s: %w", path, err)
+	}
+	return nil
+}
+
+// lineKey extracts the KEY from a dotenv line of the form `KEY=value` or
+// `export KEY=value`. Returns "" when the line has no key.
+func lineKey(line string) string {
+	line = strings.TrimSpace(line)
+	if rest, ok := strings.CutPrefix(line, "export "); ok {
+		line = strings.TrimSpace(rest)
+	}
+	key, _, ok := strings.Cut(line, "=")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(key)
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/providers/aio11y/login/sigilconfig.go
+++ b/internal/providers/aio11y/login/sigilconfig.go
@@ -22,12 +22,12 @@ func sigilConfigPath() (string, error) {
 	return filepath.Join(home, "sigil", "config.env"), nil
 }
 
-// writeSigilConfig merges updates into the dotenv file at path, preserving
+// WriteSigilConfig merges updates into the dotenv file at path, preserving
 // unrelated lines, comments, and ordering. A key whose value is empty is
 // removed; a key not already present is appended. The write is atomic
 // (temp file + rename) and the file is created with 0600 permissions because
 // it holds credentials.
-func writeSigilConfig(path string, updates map[string]string) error {
+func WriteSigilConfig(path string, updates map[string]string) error {
 	var existing []string
 	if data, err := os.ReadFile(path); err == nil {
 		existing = strings.Split(string(data), "\n")

--- a/internal/providers/aio11y/login/sigilconfig_test.go
+++ b/internal/providers/aio11y/login/sigilconfig_test.go
@@ -1,0 +1,160 @@
+package login
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteSigilConfig_CreatesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sigil", "config.env")
+
+	err := writeSigilConfig(path, map[string]string{
+		"SIGIL_ENDPOINT":       "https://sigil-prod-eu-west-2.grafana.net",
+		"SIGIL_AUTH_TENANT_ID": "42",
+		"SIGIL_AUTH_TOKEN":     "glc_xxx",
+	})
+	if err != nil {
+		t.Fatalf("writeSigilConfig: %v", err)
+	}
+
+	got := readEnv(t, path)
+	if got["SIGIL_ENDPOINT"] != "https://sigil-prod-eu-west-2.grafana.net" {
+		t.Errorf("SIGIL_ENDPOINT = %q", got["SIGIL_ENDPOINT"])
+	}
+	if got["SIGIL_AUTH_TENANT_ID"] != "42" {
+		t.Errorf("SIGIL_AUTH_TENANT_ID = %q", got["SIGIL_AUTH_TENANT_ID"])
+	}
+	if got["SIGIL_AUTH_TOKEN"] != "glc_xxx" {
+		t.Errorf("SIGIL_AUTH_TOKEN = %q", got["SIGIL_AUTH_TOKEN"])
+	}
+
+	// File must be 0600 because it holds credentials.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("perm = %o, want 600", perm)
+	}
+}
+
+func TestWriteSigilConfig_PreservesUnrelatedAndComments(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.env")
+	seed := "# my config\n" +
+		"SIGIL_TAGS=team=infra\n" +
+		"SIGIL_ENDPOINT=https://old.example.com\n" +
+		"\n" +
+		"export SIGIL_CONTENT_CAPTURE_MODE=metadata_only\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := writeSigilConfig(path, map[string]string{
+		"SIGIL_ENDPOINT":   "https://new.example.com",
+		"SIGIL_AUTH_TOKEN": "glc_new",
+	})
+	if err != nil {
+		t.Fatalf("writeSigilConfig: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(raw)
+
+	got := readEnv(t, path)
+	if got["SIGIL_ENDPOINT"] != "https://new.example.com" {
+		t.Errorf("SIGIL_ENDPOINT not updated: %q", got["SIGIL_ENDPOINT"])
+	}
+	if got["SIGIL_AUTH_TOKEN"] != "glc_new" {
+		t.Errorf("SIGIL_AUTH_TOKEN not appended: %q", got["SIGIL_AUTH_TOKEN"])
+	}
+	// Unrelated keys and comments preserved.
+	if got["SIGIL_TAGS"] != "team=infra" {
+		t.Errorf("SIGIL_TAGS not preserved: %q", got["SIGIL_TAGS"])
+	}
+	if got["SIGIL_CONTENT_CAPTURE_MODE"] != "metadata_only" {
+		t.Errorf("SIGIL_CONTENT_CAPTURE_MODE not preserved: %q", got["SIGIL_CONTENT_CAPTURE_MODE"])
+	}
+	if !containsLine(content, "# my config") {
+		t.Errorf("comment line lost:\n%s", content)
+	}
+}
+
+func TestWriteSigilConfig_EmptyValueDeletes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.env")
+	if err := os.WriteFile(path, []byte("SIGIL_ENDPOINT=https://x\nSIGIL_OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := writeSigilConfig(path, map[string]string{
+		"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": "", // delete
+	})
+	if err != nil {
+		t.Fatalf("writeSigilConfig: %v", err)
+	}
+
+	got := readEnv(t, path)
+	if _, ok := got["SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT"]; ok {
+		t.Errorf("expected key to be deleted, still present")
+	}
+	if got["SIGIL_ENDPOINT"] != "https://x" {
+		t.Errorf("SIGIL_ENDPOINT clobbered: %q", got["SIGIL_ENDPOINT"])
+	}
+}
+
+// readEnv parses a dotenv file into a map for assertions.
+func readEnv(t *testing.T, path string) map[string]string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := map[string]string{}
+	for _, line := range splitLines(string(raw)) {
+		key := lineKey(line)
+		if key == "" {
+			continue
+		}
+		_, after, _ := cut(line, "=")
+		out[key] = after
+	}
+	return out
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	cur := ""
+	for _, r := range s {
+		if r == '\n' {
+			lines = append(lines, cur)
+			cur = ""
+			continue
+		}
+		cur += string(r)
+	}
+	if cur != "" {
+		lines = append(lines, cur)
+	}
+	return lines
+}
+
+func cut(s, sep string) (before, after string, found bool) {
+	for i := 0; i+len(sep) <= len(s); i++ {
+		if s[i:i+len(sep)] == sep {
+			return s[:i], s[i+len(sep):], true
+		}
+	}
+	return s, "", false
+}
+
+func containsLine(content, want string) bool {
+	for _, line := range splitLines(content) {
+		if line == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/aio11y/login/sigilconfig_test.go
+++ b/internal/providers/aio11y/login/sigilconfig_test.go
@@ -1,15 +1,19 @@
-package login
+package login_test
 
 import (
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
+
+	"github.com/grafana/gcx/internal/providers/aio11y/login"
 )
 
 func TestWriteSigilConfig_CreatesFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "sigil", "config.env")
 
-	err := writeSigilConfig(path, map[string]string{
+	err := login.WriteSigilConfig(path, map[string]string{
 		"SIGIL_ENDPOINT":       "https://sigil-prod-eu-west-2.grafana.net",
 		"SIGIL_AUTH_TENANT_ID": "42",
 		"SIGIL_AUTH_TOKEN":     "glc_xxx",
@@ -50,7 +54,7 @@ func TestWriteSigilConfig_PreservesUnrelatedAndComments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := writeSigilConfig(path, map[string]string{
+	err := login.WriteSigilConfig(path, map[string]string{
 		"SIGIL_ENDPOINT":   "https://new.example.com",
 		"SIGIL_AUTH_TOKEN": "glc_new",
 	})
@@ -89,7 +93,7 @@ func TestWriteSigilConfig_EmptyValueDeletes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := writeSigilConfig(path, map[string]string{
+	err := login.WriteSigilConfig(path, map[string]string{
 		"SIGIL_OTEL_EXPORTER_OTLP_ENDPOINT": "", // delete
 	})
 	if err != nil {
@@ -114,47 +118,30 @@ func readEnv(t *testing.T, path string) map[string]string {
 	}
 	out := map[string]string{}
 	for _, line := range splitLines(string(raw)) {
-		key := lineKey(line)
-		if key == "" {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
-		_, after, _ := cut(line, "=")
-		out[key] = after
+		if rest, ok := strings.CutPrefix(trimmed, "export "); ok {
+			trimmed = strings.TrimSpace(rest)
+		}
+		key, after, ok := strings.Cut(trimmed, "=")
+		if !ok {
+			continue
+		}
+		out[strings.TrimSpace(key)] = after
 	}
 	return out
 }
 
 func splitLines(s string) []string {
-	var lines []string
-	cur := ""
-	for _, r := range s {
-		if r == '\n' {
-			lines = append(lines, cur)
-			cur = ""
-			continue
-		}
-		cur += string(r)
+	s = strings.TrimSuffix(s, "\n")
+	if s == "" {
+		return nil
 	}
-	if cur != "" {
-		lines = append(lines, cur)
-	}
-	return lines
-}
-
-func cut(s, sep string) (before, after string, found bool) {
-	for i := 0; i+len(sep) <= len(s); i++ {
-		if s[i:i+len(sep)] == sep {
-			return s[:i], s[i+len(sep):], true
-		}
-	}
-	return s, "", false
+	return strings.Split(s, "\n")
 }
 
 func containsLine(content, want string) bool {
-	for _, line := range splitLines(content) {
-		if line == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(splitLines(content), want)
 }

--- a/internal/providers/aio11y/provider.go
+++ b/internal/providers/aio11y/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/savedconversations"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/templates"
 	"github.com/grafana/gcx/internal/providers/aio11y/generations"
+	"github.com/grafana/gcx/internal/providers/aio11y/login"
 	"github.com/grafana/gcx/internal/providers/aio11y/scores"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/spf13/cobra"
@@ -122,7 +123,13 @@ func (p *AIO11yProvider) Commands() []*cobra.Command {
 		agent.AnnotationLLMHint:   `gcx aio11y experiments list -o json; gcx aio11y experiments get <run-id> -o yaml; gcx aio11y experiments scores <run-id> -o json; gcx aio11y experiments report <run-id> -o json`,
 	}
 
-	aio11yCmd.AddCommand(convsCmd, agentsCmd, evaluatorsCmd, rulesCmd, guardsCmd, templatesCmd, generationsCmd, scoresCmd, judgeCmd, savedConvsCmd, collectionsCmd, experimentsCmd)
+	loginCmd := login.Command(loader)
+	loginCmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "low",
+		agent.AnnotationLLMHint:   `gcx aio11y login provisions ~/.config/sigil/config.env from the current Cloud context for coding-agent plugins. By default it mints a dedicated, scoped Cloud Access Policy token (needs accesspolicies:write on the context token; otherwise it falls back to the context token). Use --no-provision to write the context token as-is, --token to supply your own, or --dry-run -o json to preview without minting or writing.`,
+	}
+
+	aio11yCmd.AddCommand(convsCmd, agentsCmd, evaluatorsCmd, rulesCmd, guardsCmd, templatesCmd, generationsCmd, scoresCmd, judgeCmd, savedConvsCmd, collectionsCmd, experimentsCmd, loginCmd)
 
 	return []*cobra.Command{aio11yCmd}
 }

--- a/internal/providers/aio11y/provider.go
+++ b/internal/providers/aio11y/provider.go
@@ -124,10 +124,6 @@ func (p *AIO11yProvider) Commands() []*cobra.Command {
 	}
 
 	loginCmd := login.Command(loader)
-	loginCmd.Annotations = map[string]string{
-		agent.AnnotationTokenCost: "low",
-		agent.AnnotationLLMHint:   `gcx aio11y login provisions ~/.config/sigil/config.env from the current Cloud context for coding-agent plugins. By default it mints a dedicated, scoped Cloud Access Policy token (needs accesspolicies:write on the context token; otherwise it falls back to the context token). Use --no-provision to write the context token as-is, --token to supply your own, or --dry-run -o json to preview without minting or writing.`,
-	}
 
 	aio11yCmd.AddCommand(convsCmd, agentsCmd, evaluatorsCmd, rulesCmd, guardsCmd, templatesCmd, generationsCmd, scoresCmd, judgeCmd, savedConvsCmd, collectionsCmd, experimentsCmd, loginCmd)
 

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -313,6 +313,41 @@ func (l *ConfigLoader) LoadCloudConfig(ctx context.Context) (CloudRESTConfig, er
 	}, nil
 }
 
+// LoadCloudConnections loads Grafana Cloud configuration like LoadCloudConfig
+// and additionally fetches the stack's connectivity information (OTLP gateway,
+// etc.) from the GCOM connections endpoint. It also returns the authenticated
+// GCOM client so callers can perform follow-up operations (e.g. minting an
+// access-policy token in `aio11y login`). It is used by commands that need the
+// OTLP endpoint to derive downstream configuration.
+func (l *ConfigLoader) LoadCloudConnections(ctx context.Context) (CloudRESTConfig, cloud.Connections, *cloud.GCOMClient, error) {
+	base, err := l.loadCloudBase(ctx)
+	if err != nil {
+		return CloudRESTConfig{}, cloud.Connections{}, nil, err
+	}
+
+	slug := base.curCtx.ResolveStackSlug()
+	if slug == "" {
+		return CloudRESTConfig{}, cloud.Connections{}, nil, errors.New("cloud stack is not configured: set cloud.stack in config or GRAFANA_CLOUD_STACK env var")
+	}
+
+	stack, err := base.client.GetStack(ctx, slug)
+	if err != nil {
+		return CloudRESTConfig{}, cloud.Connections{}, nil, fmt.Errorf("failed to get stack info for %q: %w", slug, err)
+	}
+
+	conns, err := base.client.GetConnections(ctx, slug)
+	if err != nil {
+		return CloudRESTConfig{}, cloud.Connections{}, nil, fmt.Errorf("failed to get stack connections for %q: %w", slug, err)
+	}
+
+	return CloudRESTConfig{
+		Token:           base.token,
+		Stack:           stack,
+		Namespace:       "default",
+		ProviderConfigs: base.curCtx.Providers,
+	}, conns, base.client, nil
+}
+
 // configSource returns the config.Source to use for write-back operations.
 // Mirrors the resolution logic in config.LoadLayered.
 func (l *ConfigLoader) configSource() config.Source {


### PR DESCRIPTION
Adds a one-command setup for the Grafana AI Observability coding-agent plugins (Cursor, Claude Code, Codex, Copilot, OpenCode, pi). It resolves the Sigil endpoint, OTLP gateway, and tenant ID from the current Cloud context and writes `~/.config/sigil/config.env`.

By default it mints a dedicated, correctly-scoped Cloud Access Policy token (`sigil:write`, `metrics:write`, `traces:write`) realm-scoped to the stack, reusing the access policy and rotating the token on re-runs. When the context token lacks `accesspolicies:write` it falls back to writing the context token and prints guidance. Flags: `--no-provision`, `--token`, `--token-name`, `--token-expiry`, `--content-capture-mode`, `--dry-run`.

Adds GCOM access-policy/token client methods (`Create/List` access policies, `Create/List/Delete` tokens) and extends `LoadCloudConnections` to return the authenticated GCOM client.

### Reviewer notes

- Main behavior lives under `internal/providers/aio11y/login`; the Cloud changes are small GCOM access-policy/token client helpers.
- Token secrets are written only to `config.env`; command output reports the source/metadata and intentionally does not echo token values.
- Re-run behavior intentionally reuses the stack-scoped access policy and rotates a matching token name.
- The generated CLI reference page is included because this adds a new command.

### How to test / review

- Focused tests: `go test ./internal/providers/aio11y/login ./internal/cloud ./cmd/gcx/root`
- Full local gates: `GCX_AGENT_MODE=false mise run all` and `GCX_AGENT_MODE=false mise run reference-drift`
- Manual smoke: start with `gcx aio11y login --dry-run -o json`; use `--config-path <tmp>/config.env` for live testing so you do not touch your real sigil config.
