### PR TITLE
fix(irm): wire oncall escalate output through the codec system

### DIFF
--- a/docs/reference/cli/gcx_irm_oncall_escalate.md
+++ b/docs/reference/cli/gcx_irm_oncall_escalate.md
@@ -13,7 +13,7 @@ gcx irm oncall escalate [flags]
       --important          Mark as important
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --message string     Message for the escalation
-  -o, --output string      Output format. One of: agents, json, yaml (default "text")
+  -o, --output string      Output format. One of: agents, json, text, yaml (default "text")
       --team string        Team ID
       --title string       Title of the escalation (required)
       --user-ids strings   User IDs (comma-separated)

--- a/internal/providers/irm/oncall_commands_extra.go
+++ b/internal/providers/irm/oncall_commands_extra.go
@@ -1203,6 +1203,12 @@ type escalateOpts struct {
 }
 
 func (o *escalateOpts) setup(flags *pflag.FlagSet) {
+	// `text` is the human default but the global registry has no built-in text
+	// codec, so it must be registered explicitly — otherwise the default format
+	// fails IO.Validate(). yaml uses the stable-key-order codec to match the
+	// sibling oncall mutation commands; json/agents are built-in.
+	o.IO.RegisterCustomCodec("text", &escalationTextCodec{})
+	o.IO.RegisterCustomCodec("yaml", format.NewOrderedYAMLCodec())
 	o.IO.DefaultFormat("text")
 	o.IO.BindFlags(flags)
 	flags.StringVar(&o.Title, "title", "", "Title of the escalation (required)")
@@ -1259,12 +1265,44 @@ func newEscalateCommand(loader OnCallConfigLoader) *cobra.Command {
 				return err
 			}
 
-			cmdio.Success(cmd.OutOrStdout(), "Direct escalation created with alert group ID: %s", result.AlertGroupID)
-			return nil
+			// Emit through the codec system so json/yaml/agents modes get a
+			// structured document; the text codec renders the human one-liner.
+			res := escalationResult{
+				AlertGroupID: result.AlertGroupID,
+				Title:        opts.Title,
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), res)
 		},
 	}
 	opts.setup(cmd.Flags())
 	return cmd
+}
+
+// escalationResult is the structured output of `escalate`: the alert group ID
+// created by the direct paging call, plus the title for context. Emitted via
+// the codec system so json/yaml/agents modes produce a structured document.
+type escalationResult struct {
+	AlertGroupID string `json:"alertGroupId"`
+	Title        string `json:"title,omitempty"`
+}
+
+// escalationTextCodec renders escalationResult as the human one-line summary.
+// Registered as `-o text` (the default). Output-only: decoding is unsupported.
+type escalationTextCodec struct{}
+
+func (c *escalationTextCodec) Format() format.Format { return format.Format("text") }
+
+func (c *escalationTextCodec) Encode(w io.Writer, v any) error {
+	r, ok := v.(escalationResult)
+	if !ok {
+		return fmt.Errorf("text codec: unsupported value type %T (expected escalationResult)", v)
+	}
+	_, err := fmt.Fprintf(w, "Direct escalation created with alert group ID: %s\n", r.AlertGroupID)
+	return err
+}
+
+func (c *escalationTextCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("text format does not support decoding")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/providers/irm/oncall_commands_extra_test.go
+++ b/internal/providers/irm/oncall_commands_extra_test.go
@@ -434,6 +434,63 @@ func TestAlertGroupGetRichOpts_DefaultsToTable(t *testing.T) {
 	}
 }
 
+// TestEscalateOpts_DefaultFormatIsValid is the regression guard for #681: the
+// escalate command set DefaultFormat("text") without registering a text codec,
+// so in human/TTY mode IO.Validate() rejected its own default with "unknown
+// output format". Agent mode is forced off because BindFlags would otherwise
+// override the default with the (always-registered) agents codec and mask the
+// bug.
+func TestEscalateOpts_DefaultFormatIsValid(t *testing.T) {
+	resetAgentMode(t)
+	opts := &escalateOpts{}
+	opts.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
+
+	if got := opts.IO.OutputFormat; got != "text" {
+		t.Errorf("escalate default format want %q, got %q", "text", got)
+	}
+	if err := opts.IO.Validate(); err != nil {
+		t.Fatalf("IO.Validate() on default format returned error: %v", err)
+	}
+}
+
+// TestEscalationResult_Codecs pins escalate's output contract across modes:
+// the text codec renders the human one-liner, while json carries the
+// structured document with the alert group ID.
+func TestEscalationResult_Codecs(t *testing.T) {
+	t.Parallel()
+	res := escalationResult{AlertGroupID: "I123", Title: "DB down"}
+
+	t.Run("text", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		if err := (&escalationTextCodec{}).Encode(&buf, res); err != nil {
+			t.Fatalf("text encode: %v", err)
+		}
+		want := "Direct escalation created with alert group ID: I123\n"
+		if got := buf.String(); got != want {
+			t.Errorf("text codec output = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		t.Parallel()
+		b, err := json.Marshal(res)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if got := string(b); !strings.Contains(got, `"alertGroupId":"I123"`) {
+			t.Errorf("json must carry alertGroupId; got %s", got)
+		}
+	})
+
+	t.Run("text codec rejects foreign type", func(t *testing.T) {
+		t.Parallel()
+		if err := (&escalationTextCodec{}).Encode(&bytes.Buffer{}, struct{}{}); err == nil {
+			t.Error("text codec must reject non-escalationResult values")
+		}
+	})
+}
+
 // TestEmitWarnEmitNote_Format pins the output contract for the
 // centralised diagnostic helpers: TTY plain-text with the prefixed class
 // name; agent mode JSONL with typed `class` field.


### PR DESCRIPTION
## Summary
`gcx irm oncall escalate` set `DefaultFormat("text")` but never registered a `text` codec, so in human/TTY mode `IO.Validate()` rejected its own default with `unknown output format` and `--help` advertised an unreachable `(default "text")`. It also only printed prose via `cmdio.Success()` — never calling `Encode()` — so **agent mode emitted unstructured text** instead of a parseable document.

## Changes
- `internal/providers/irm/oncall_commands_extra.go`:
  - `escalateOpts.setup` registers an `escalationTextCodec` and the stable-key-order yaml codec, matching the sibling alert-group action verbs in `oncall_actions.go`.
  - `escalate` now emits a typed `escalationResult` through the codec system instead of `cmdio.Success()`. `json`/`yaml`/`agents` produce a structured `{"alertGroupId": ...}` document; `text` renders the same human one-liner as before.
- `internal/providers/irm/oncall_commands_extra_test.go`: regression test asserting the default format validates (with agent mode forced off so the agents-codec override can't mask the bug), plus text/json codec output contracts.
- `docs/reference/cli/gcx_irm_oncall_escalate.md`: regenerated — `-o` now correctly lists `text` as a valid format.

## Relationship to #712 / #681
This **supersedes the obsolete #712** (now closed). That PR targeted `alertGroupActionOpts`, a type that was removed when the alert-group action verbs were rewritten into `oncall_actions.go`. That rewrite already fixed the alert-group half of #681 by registering a real `text` codec (`mutationTextCodec`). `escalate` was the only command still carrying the bug — this PR closes that gap consistently with the established pattern.

Closes #681

## Test Plan
- [x] `go test -race -count=1 ./...` (full suite, green)
- [x] `GCX_AGENT_MODE=false mise run lint` (0 issues)
- [x] `GCX_AGENT_MODE=false` CLI reference regenerated — only `escalate` doc changed
- [x] New regression test fails when the `text` codec registration is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)