### PR TITLE
feat(login): guide users to create a Cloud API token at the prompt

### DIFF
--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -393,12 +393,10 @@ func askGrafanaAuth(opts *login.Options, existingToken string) error {
 		}
 	}
 
-	// Default to the first option in the menu. For Cloud targets, mTLS is not
-	// offered so we must not default to it even when TLS certs are present.
-	authMethod := "token"
-	if hasMTLS && opts.Target != login.TargetCloud {
-		authMethod = "mtls"
-	}
+	// Default to the first option in the menu: OAuth for Cloud, mTLS when certs
+	// are present (non-Cloud), token otherwise. Deriving from options[0] keeps
+	// the highlighted default in sync with the per-target menu order above.
+	authMethod := options[0].Value
 	// Single option: skip the menu and fall through directly.
 	if len(options) > 1 {
 		methodForm := huh.NewForm(huh.NewGroup(

--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -59,6 +59,22 @@ For on-premises instances, gcx defaults the organization ID to 1 if you do not s
 
 Commands under `gcx sm`, `gcx k6`, `gcx irm`, `gcx slo`, `gcx fleet`, and other Cloud product surfaces require a [Cloud Access Policy token](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/) in addition to Grafana auth.
 
+#### Where to create the token and which scopes to grant
+
+Create the token at **grafana.com → Administration → Cloud Access Policies → Create access policy** (`https://grafana.com/orgs/<your-org>/access-policies`). See [Create access policies](https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies/) for the step-by-step flow.
+
+Scope the access policy to what you manage. A good starting point:
+
+| Scope | Enables |
+|-------|---------|
+| `stacks:read` | Stack discovery (used to resolve the stack slug for most Cloud commands) |
+| `metrics:read`, `logs:read`, `traces:read`, `profiles:read` | Querying the corresponding signal stores (`gcx metrics`, `gcx logs`, `gcx traces`, `gcx profiles`) |
+| `set:alloy-data-write` | Fleet Management and Instrumentation Hub (`gcx fleet`, `gcx instrumentation`) |
+
+For product-specific surfaces (`gcx slo`, `gcx irm`, `gcx sm`, `gcx k6`), add the read/write scopes for that product. When in doubt, start narrow and widen the policy as commands report missing-scope errors — the token can be re-scoped without re-running `gcx login`.
+
+The interactive `gcx login` prompt links to this guidance when it asks for the Cloud Access Policy token.
+
 **Provide it at login:**
 
 ```bash

--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -68,15 +68,17 @@ Create the token in either place:
 
 See [Create access policies](https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies/) for the step-by-step flow.
 
-Scope the access policy to what you manage. A good starting point:
+Scope the access policy to what you manage. `stacks:read` is the required baseline — it resolves your stack and gates login/token validation. Then add the scopes for the products you use:
 
 | Scope | Enables |
 |-------|---------|
-| `stacks:read` | Stack discovery (used to resolve the stack slug for most Cloud commands) |
-| `metrics:read`, `logs:read`, `traces:read`, `profiles:read` | Querying the corresponding signal stores (`gcx metrics`, `gcx logs`, `gcx traces`, `gcx profiles`) |
-| `set:alloy-data-write` | Fleet Management and Instrumentation Hub (`gcx fleet`, `gcx instrumentation`) |
+| `stacks:read` | **Required.** Stack discovery (resolves the stack slug for all Cloud commands; also covers `gcx k6` reads) |
+| `metrics:write`, `logs:write`, `traces:write` | Synthetic Monitoring and k6 (`gcx sm`, `gcx k6`) — these write verbs are needed to mint the Synthetic Monitoring token |
+| `fleet-management:read` (and `fleet-management:write` for changes) | Fleet Management (`gcx fleet`) |
+| `stacks:write` | Creating or updating stacks |
+| `set:alloy-data-write` | Instrumentation Hub setup (`gcx instrumentation`) |
 
-For product-specific surfaces (`gcx slo`, `gcx irm`, `gcx sm`, `gcx k6`), add the read/write scopes for that product. When in doubt, start narrow and widen the policy as commands report missing-scope errors — the token can be re-scoped without re-running `gcx login`.
+The Cloud Access Policy token is for Grafana Cloud product APIs (GCOM stack management, Synthetic Monitoring, k6, Fleet, IRM, SLO). Signal queries (`gcx metrics`, `gcx logs`, `gcx traces`, `gcx profiles`) authenticate with your Grafana token (OAuth or service account), not this token. When in doubt, start narrow and widen the policy as commands report missing-scope errors — the token can be re-scoped without re-running `gcx login`.
 
 The interactive `gcx login` prompt links to this guidance when it asks for the Cloud Access Policy token.
 

--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -61,7 +61,12 @@ Commands under `gcx sm`, `gcx k6`, `gcx irm`, `gcx slo`, `gcx fleet`, and other 
 
 #### Where to create the token and which scopes to grant
 
-Create the token at **grafana.com → Administration → Cloud Access Policies → Create access policy** (`https://grafana.com/orgs/<your-org>/access-policies`). See [Create access policies](https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies/) for the step-by-step flow.
+Create the token in either place:
+
+- **In your stack** (deep-link the `gcx login` prompt offers): `https://<your-stack>.grafana.net/a/grafana-auth-app` → Access Policies → Create access policy.
+- **From grafana.com**: **Administration → Cloud Access Policies → Create access policy** (`https://grafana.com/orgs/<your-org>/access-policies`).
+
+See [Create access policies](https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies/) for the step-by-step flow.
 
 Scope the access policy to what you manage. A good starting point:
 

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -15,6 +15,19 @@ import (
 	"github.com/grafana/gcx/internal/httputils"
 )
 
+// cloudTokenHint is the guidance shown on the interactive Cloud Access Policy
+// (CAP) token prompt and in the ErrNeedInput hint: where to create a token,
+// which scopes to grant, and the skip affordance (issue #820). The org slug is
+// not resolvable at prompt time (resolving it needs the very token we are
+// asking for), so the management URL uses a literal <your-org> placeholder; the
+// docs link is always correct.
+const cloudTokenHint = "Create one at https://grafana.com/orgs/<your-org>/access-policies " +
+	"(Cloud Access Policies → Create access policy).\n" +
+	"Recommended scopes: stacks:read plus the product scopes for what you manage " +
+	"(e.g. metrics:read, logs:read, traces:read; SLO, IRM, Synthetic Monitoring).\n" +
+	"Docs: https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies\n" +
+	"Press Enter to skip (Cloud management features will be unavailable)."
+
 // Target identifies whether the login destination is Grafana Cloud or on-premises.
 type Target int
 
@@ -469,7 +482,7 @@ func resolveCloudAuth(opts Options, target Target) (*config.CloudConfig, error) 
 	return nil, &ErrNeedInput{
 		Fields:   []string{"cloud-token"},
 		Optional: true,
-		Hint:     "Provide a Grafana Cloud API token to enable Cloud management features, or press Enter to skip.",
+		Hint:     cloudTokenHint,
 	}
 }
 

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -30,8 +30,10 @@ func cloudTokenHint(server string) string {
 		create = "Create one at " + strings.TrimRight(server, "/") + "/a/grafana-auth-app"
 	}
 	return create + " (Access Policies → Create access policy).\n" +
-		"Recommended scopes: stacks:read plus the product scopes for what you manage " +
-		"(e.g. metrics:read, logs:read, traces:read; SLO, IRM, Synthetic Monitoring).\n" +
+		"Recommended scopes: stacks:read (required — resolves your stack). Then add per product:\n" +
+		"  metrics:write, logs:write, traces:write — Synthetic Monitoring & k6\n" +
+		"  fleet-management:read — Fleet\n" +
+		"  stacks:write — create or update stacks\n" +
 		"Docs: https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies\n" +
 		"Press Enter to skip (Cloud management features will be unavailable)."
 }

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -15,18 +15,26 @@ import (
 	"github.com/grafana/gcx/internal/httputils"
 )
 
-// cloudTokenHint is the guidance shown on the interactive Cloud Access Policy
-// (CAP) token prompt and in the ErrNeedInput hint: where to create a token,
-// which scopes to grant, and the skip affordance (issue #820). The org slug is
-// not resolvable at prompt time (resolving it needs the very token we are
-// asking for), so the management URL uses a literal <your-org> placeholder; the
-// docs link is always correct.
-const cloudTokenHint = "Create one at https://grafana.com/orgs/<your-org>/access-policies " +
-	"(Cloud Access Policies → Create access policy).\n" +
-	"Recommended scopes: stacks:read plus the product scopes for what you manage " +
-	"(e.g. metrics:read, logs:read, traces:read; SLO, IRM, Synthetic Monitoring).\n" +
-	"Docs: https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies\n" +
-	"Press Enter to skip (Cloud management features will be unavailable)."
+// cloudTokenHint returns the guidance shown on the interactive Cloud Access
+// Policy (CAP) token prompt and in the ErrNeedInput hint: where to create a
+// token, which scopes to grant, and the skip affordance (issue #820).
+//
+// When the stack server URL is known (always, at this prompt) it deep-links to
+// the in-stack Access Policies app at <server>/a/grafana-auth-app. Otherwise it
+// falls back to the org-level grafana.com page with a <your-org> placeholder
+// (the org slug is not resolvable here — resolving it needs the very token we
+// are asking for).
+func cloudTokenHint(server string) string {
+	create := "Create one at https://grafana.com/orgs/<your-org>/access-policies"
+	if server != "" {
+		create = "Create one at " + strings.TrimRight(server, "/") + "/a/grafana-auth-app"
+	}
+	return create + " (Access Policies → Create access policy).\n" +
+		"Recommended scopes: stacks:read plus the product scopes for what you manage " +
+		"(e.g. metrics:read, logs:read, traces:read; SLO, IRM, Synthetic Monitoring).\n" +
+		"Docs: https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies\n" +
+		"Press Enter to skip (Cloud management features will be unavailable)."
+}
 
 // Target identifies whether the login destination is Grafana Cloud or on-premises.
 type Target int
@@ -482,7 +490,7 @@ func resolveCloudAuth(opts Options, target Target) (*config.CloudConfig, error) 
 	return nil, &ErrNeedInput{
 		Fields:   []string{"cloud-token"},
 		Optional: true,
-		Hint:     cloudTokenHint,
+		Hint:     cloudTokenHint(opts.Server),
 	}
 }
 

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1247,8 +1247,9 @@ func TestRun_CloudTokenHintGuidance(t *testing.T) {
 	require.Equal(t, []string{"cloud-token"}, needInput.Fields)
 
 	hint := needInput.Hint
-	assert.Contains(t, hint, "access-policies", "hint must link to the access-policies page")
-	assert.Contains(t, hint, "grafana.com/orgs/", "hint must show the access-policies management URL")
+	assert.Contains(t, hint, "https://my-stack.grafana.net/a/grafana-auth-app",
+		"hint must deep-link to the in-stack Access Policies app for the known server")
+	assert.Contains(t, hint, "access-policies", "hint must link to the access-policies docs")
 	assert.Contains(t, hint, "stacks:read", "hint must name recommended scopes")
 	assert.Contains(t, strings.ToLower(hint), "skip", "hint must retain the skip affordance")
 }

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1208,3 +1208,47 @@ func TestRun_MTLSOnlyAuth(t *testing.T) {
 	require.NotNil(t, grafanaCfg.TLS, "TLS must be persisted")
 	assert.Contains(t, string(grafanaCfg.TLS.CertData), "cert-pem")
 }
+
+// TestRun_CloudTokenHintGuidance verifies that when a Cloud login needs a CAP
+// token, the ErrNeedInput hint guides the user to where a token is created and
+// which scopes are recommended (issue #820).
+func TestRun_CloudTokenHintGuidance(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "0")
+	agent.ResetForTesting()
+	t.Cleanup(func() { agent.ResetForTesting() })
+
+	dir := t.TempDir()
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server:   "https://my-stack.grafana.net",
+			UseOAuth: true,
+			Target:   login.TargetCloud,
+		},
+		Hooks: login.Hooks{
+			ConfigSource: configSource(dir),
+			NewAuthFlow: func(_ string, _ auth.Options) login.AuthFlow {
+				return &stubAuthFlow{result: &auth.Result{
+					Token:        "gat_test",
+					RefreshToken: "gar_test",
+					APIEndpoint:  "https://assistant.grafana.net/a/app/proxy",
+					ExpiresAt:    "2099-01-01T00:00:00Z",
+				}}
+			},
+			ValidateFn: func(_ context.Context, _ login.Options, _ config.NamespacedRESTConfig) (string, error) {
+				return "12.0.0", nil
+			},
+		},
+		RetryState: login.RetryState{StagedContext: &config.Context{}},
+	}
+
+	_, err := login.Run(context.Background(), &opts)
+	var needInput *login.ErrNeedInput
+	require.ErrorAs(t, err, &needInput, "must be ErrNeedInput")
+	require.Equal(t, []string{"cloud-token"}, needInput.Fields)
+
+	hint := needInput.Hint
+	assert.Contains(t, hint, "access-policies", "hint must link to the access-policies page")
+	assert.Contains(t, hint, "grafana.com/orgs/", "hint must show the access-policies management URL")
+	assert.Contains(t, hint, "stacks:read", "hint must name recommended scopes")
+	assert.Contains(t, strings.ToLower(hint), "skip", "hint must retain the skip affordance")
+}

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1250,6 +1250,9 @@ func TestRun_CloudTokenHintGuidance(t *testing.T) {
 	assert.Contains(t, hint, "https://my-stack.grafana.net/a/grafana-auth-app",
 		"hint must deep-link to the in-stack Access Policies app for the known server")
 	assert.Contains(t, hint, "access-policies", "hint must link to the access-policies docs")
-	assert.Contains(t, hint, "stacks:read", "hint must name recommended scopes")
+	assert.Contains(t, hint, "stacks:read", "hint must name stacks:read as the required baseline scope")
+	assert.Contains(t, hint, "metrics:write", "hint must name the Synthetic Monitoring & k6 write scopes")
+	assert.Contains(t, hint, "fleet-management:read", "hint must name the Fleet scope")
+	assert.Contains(t, hint, "stacks:write", "hint must name the stack-management scope")
 	assert.Contains(t, strings.ToLower(hint), "skip", "hint must retain the skip affordance")
 }


### PR DESCRIPTION
## Summary
- The interactive Cloud Access Policy (CAP) token prompt now tells users **where** to create a token and **which scopes** to grant — previously it only explained skip/keep semantics.
- The prompt **deep-links to the in-stack Access Policies app** (`<server>/a/grafana-auth-app`) using the known stack URL, fully satisfying AC#3.
- The auth-method menu now **defaults to the recommended first option** (OAuth on Cloud stacks) instead of always landing on the service-account-token row.
- Documents required scopes and both token-creation locations in `docs/reference/login.md`.

## Changes
- `internal/login/login.go` — `cloudTokenHint(server)` builds the prompt/`ErrNeedInput.Hint`: deep-links to `<server>/a/grafana-auth-app` when the server is known, falls back to `grafana.com/orgs/<your-org>/access-policies` otherwise; names recommended scopes; keeps the skip affordance.
- `cmd/gcx/login/command.go` — auth-method default derived from `options[0]` so the highlighted choice matches the per-target menu order (OAuth for Cloud, mTLS for non-Cloud-with-certs, token otherwise).
- `docs/reference/login.md` — "Where to create the token and which scopes to grant" subsection with a scope table and both creation locations (in-stack + grafana.com).
- `internal/login/login_test.go` — `TestRun_CloudTokenHintGuidance` asserts the hint deep-links to the in-stack app and names scopes + skip affordance.

## On AC#3 (deep-linking)
The **stack** server URL *is* known at the prompt, so the hint deep-links to the in-stack Access Policies app (`<server>/a/grafana-auth-app`). The org slug is not resolvable here (it needs the very token being requested), so the org-level `grafana.com/orgs/<your-org>` form is only a defensive fallback for the empty-server case.

## Test Plan
- [x] Tests pass locally (`GCX_AGENT_MODE=false mise run all`)
- [x] New test covers the change (`TestRun_CloudTokenHintGuidance`)
- [x] Lints clean (0 issues)
- [x] No reference-doc drift

Closes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)