### PR TITLE
feat(faro): add play-replay-session command with local rrweb-player

### DIFF
--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -239,6 +239,7 @@
  "gcx frontend apps list-sourcemaps": "finite",
  "gcx frontend apps inspect-replay-session": "finite",
  "gcx frontend apps inspect-replay-segment": "finite",
+ "gcx frontend apps play-replay-session": "finite",
  "gcx frontend apps update": "finite",
  "gcx help": "prose",
  "gcx help-tree": "finite",

--- a/docs/reference/cli/gcx_frontend_apps.md
+++ b/docs/reference/cli/gcx_frontend_apps.md
@@ -33,5 +33,6 @@ Manage Frontend Observability apps.
 * [gcx frontend apps list](gcx_frontend_apps_list.md)	 - List Frontend Observability apps.
 * [gcx frontend apps list-replay-sessions](gcx_frontend_apps_list-replay-sessions.md)	 - List Frontend Observability sessions that have replay recordings.
 * [gcx frontend apps list-sourcemaps](gcx_frontend_apps_list-sourcemaps.md)	 - List sourcemaps for a Frontend Observability app.
+* [gcx frontend apps play-replay-session](gcx_frontend_apps_play-replay-session.md)	 - Download and play a session replay locally.
 * [gcx frontend apps update](gcx_frontend_apps_update.md)	 - Update a Frontend Observability app from a file.
 

--- a/docs/reference/cli/gcx_frontend_apps_play-replay-session.md
+++ b/docs/reference/cli/gcx_frontend_apps_play-replay-session.md
@@ -1,0 +1,50 @@
+## gcx frontend apps play-replay-session
+
+Download and play a session replay locally.
+
+### Synopsis
+
+Downloads all segments for a session replay and serves a local rrweb-player. Provides a control API for agent-driven playback via WebSocket.
+
+```
+gcx frontend apps play-replay-session <app-name> <session-id> [flags]
+```
+
+### Examples
+
+```
+  # Play a session replay (prints local URL).
+  gcx frontend apps play-replay-session my-web-app-42 abc-session-123
+
+  # Open browser automatically.
+  gcx frontend apps play-replay-session my-web-app-42 abc-session-123 --open
+
+  # Use a specific port.
+  gcx frontend apps play-replay-session my-web-app-42 abc-session-123 --port 8080
+```
+
+### Options
+
+```
+  -h, --help                    help for play-replay-session
+      --open                    Open a browser automatically
+      --player-version string   rrweb-player version to load from CDN (default "2.0.0-alpha.17")
+      --port int                Port to serve on (0 = random available port)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx frontend apps](gcx_frontend_apps.md)	 - Manage Frontend Observability apps.
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -227,6 +227,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx frontend apps list-replay-sessions":   {Cost: "medium", Hint: "<app-name> [--since 24h] [-d <loki-uid>] -o json"},
 	"gcx frontend apps inspect-replay-session": {Cost: "small", Hint: "<app-name> <session-id> [--limit N] -o json"},
 	"gcx frontend apps inspect-replay-segment": {Cost: "small", Hint: "<app-name> <session-id> <segment-id> [--recording-id <recording-id>] [--save events.json] [-o json]"},
+	"gcx frontend apps play-replay-session":    {Cost: "medium", Hint: "<app-name> <session-id> [--port 8080] [--open]"},
 	"gcx frontend apps update":                 {Cost: "small"},
 
 	// -----------------------------------------------------------------------

--- a/internal/providers/faro/provider.go
+++ b/internal/providers/faro/provider.go
@@ -63,6 +63,7 @@ func (p *FaroProvider) Commands() []*cobra.Command {
 		newListReplaySessionsCommand(loader),
 		newInspectReplaySessionCommand(loader),
 		newInspectReplaySegmentCommand(loader),
+		newPlayReplaySessionCommand(loader),
 	)
 
 	faroCmd.AddCommand(appsCmd)

--- a/internal/providers/faro/session_player.go
+++ b/internal/providers/faro/session_player.go
@@ -1,0 +1,361 @@
+package faro
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+)
+
+//go:embed session_player.html
+var sessionPlayerHTMLTemplate string
+
+// ValidateEventStream checks that events start with Meta (4) followed by
+// FullSnapshot (2). Writes warnings to w.
+func ValidateEventStream(events []RRWebEvent, w io.Writer) {
+	if len(events) == 0 {
+		_, _ = fmt.Fprintln(w, "Warning: event stream is empty.")
+		return
+	}
+	if events[0].Type != 4 {
+		_, _ = fmt.Fprintln(w, "Warning: event stream does not start with a Meta event (type 4). Replay may render a blank page.")
+	}
+	hasFullSnapshot := false
+	for _, e := range events {
+		if e.Type == 2 {
+			hasFullSnapshot = true
+			break
+		}
+	}
+	if !hasFullSnapshot {
+		_, _ = fmt.Fprintln(w, "Warning: event stream contains no FullSnapshot event (type 2). Replay may render a blank page.")
+	}
+}
+
+// playerState holds the last known player state reported by the browser.
+type playerState struct {
+	mu    sync.RWMutex
+	state json.RawMessage
+}
+
+func (ps *playerState) set(data json.RawMessage) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	ps.state = data
+}
+
+func (ps *playerState) get() json.RawMessage {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	if ps.state == nil {
+		return json.RawMessage(`{"timestamp":0,"playing":false,"duration":0}`)
+	}
+	return ps.state
+}
+
+//nolint:gochecknoglobals // Stateless upgrader reused across WebSocket connections.
+var wsUpgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return true
+		}
+		return strings.HasPrefix(origin, "http://localhost:") || strings.HasPrefix(origin, "http://127.0.0.1:")
+	},
+}
+
+// SessionPlayerServer manages the local replay server.
+type SessionPlayerServer struct {
+	events    json.RawMessage
+	indexHTML []byte
+	state     *playerState
+	wsMu      sync.Mutex
+	wsConn    *websocket.Conn
+}
+
+// NewSessionPlayerServer creates a session player server with the given events JSON.
+func NewSessionPlayerServer(eventsJSON json.RawMessage, playerVersion string) (*SessionPlayerServer, error) {
+	tmpl, err := template.New("player").Parse(sessionPlayerHTMLTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("parsing player template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, map[string]string{"PlayerVersion": playerVersion}); err != nil {
+		return nil, fmt.Errorf("rendering player template: %w", err)
+	}
+	return &SessionPlayerServer{
+		events:    eventsJSON,
+		indexHTML: buf.Bytes(),
+		state:     &playerState{},
+	}, nil
+}
+
+func (s *SessionPlayerServer) handleIndex(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write(s.indexHTML)
+}
+
+func (s *SessionPlayerServer) handleEvents(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(s.events)
+}
+
+func (s *SessionPlayerServer) handleState(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(s.state.get())
+}
+
+func (s *SessionPlayerServer) handleControl(action string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var msg struct {
+			Timestamp int64 `json:"timestamp,omitempty"`
+		}
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&msg)
+		}
+		cmd := map[string]any{"action": action}
+		if action == "goto" {
+			cmd["timestamp"] = msg.Timestamp
+		}
+		data, err := json.Marshal(cmd)
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		s.wsMu.Lock()
+		conn := s.wsConn
+		if conn != nil {
+			_ = conn.WriteMessage(websocket.TextMessage, data)
+		}
+		s.wsMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}
+}
+
+func (s *SessionPlayerServer) handleWS(w http.ResponseWriter, r *http.Request) {
+	conn, err := wsUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	s.wsMu.Lock()
+	s.wsConn = conn
+	s.wsMu.Unlock()
+	defer func() {
+		s.wsMu.Lock()
+		if s.wsConn == conn {
+			s.wsConn = nil
+		}
+		s.wsMu.Unlock()
+		_ = conn.Close()
+	}()
+	for {
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		s.state.set(message)
+	}
+}
+
+// Handler returns the HTTP handler for the session player server.
+func (s *SessionPlayerServer) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", s.handleIndex)
+	mux.HandleFunc("GET /api/events", s.handleEvents)
+	mux.HandleFunc("GET /api/state", s.handleState)
+	mux.HandleFunc("POST /api/goto", s.handleControl("goto"))
+	mux.HandleFunc("POST /api/play", s.handleControl("play"))
+	mux.HandleFunc("POST /api/pause", s.handleControl("pause"))
+	mux.HandleFunc("GET /ws", s.handleWS)
+	return mux
+}
+
+// ---------------------------------------------------------------------------
+// play-replay-session command
+// ---------------------------------------------------------------------------
+
+type playReplaySessionOpts struct {
+	Port          int
+	Open          bool
+	PlayerVersion string
+}
+
+func (o *playReplaySessionOpts) setup(flags *pflag.FlagSet) {
+	flags.IntVar(&o.Port, "port", 0, "Port to serve on (0 = random available port)")
+	flags.BoolVar(&o.Open, "open", false, "Open a browser automatically")
+	flags.StringVar(&o.PlayerVersion, "player-version", "2.0.0-alpha.17", "rrweb-player version to load from CDN")
+}
+
+func (o *playReplaySessionOpts) Validate() error {
+	if o.Port < 0 || o.Port > 65535 {
+		return errors.New("--port must be 0 or a valid TCP port (1-65535)")
+	}
+	if strings.TrimSpace(o.PlayerVersion) == "" {
+		return errors.New("--player-version must not be empty")
+	}
+	return nil
+}
+
+func newPlayReplaySessionCommand(loader RESTConfigLoader) *cobra.Command {
+	opts := &playReplaySessionOpts{}
+	cmd := &cobra.Command{
+		Use:   "play-replay-session <app-name> <session-id>",
+		Short: "Download and play a session replay locally.",
+		Long:  "Downloads all segments for a session replay and serves a local rrweb-player. Provides a control API for agent-driven playback via WebSocket.",
+		Example: `  # Play a session replay (prints local URL).
+  gcx frontend apps play-replay-session my-web-app-42 abc-session-123
+
+  # Open browser automatically.
+  gcx frontend apps play-replay-session my-web-app-42 abc-session-123 --open
+
+  # Use a specific port.
+  gcx frontend apps play-replay-session my-web-app-42 abc-session-123 --port 8080`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			stderr := cmd.ErrOrStderr()
+
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(cfg)
+			if err != nil {
+				return err
+			}
+
+			appID := resolveAppID(args[0])
+			sessionID := args[1]
+
+			recordingID, err := resolveFirstRecordingID(ctx, client, appID, sessionID)
+			if err != nil {
+				return err
+			}
+			cmdio.Info(stderr, "Using recording %s", recordingID)
+
+			manifest, err := client.GetManifest(ctx, appID, sessionID, recordingID)
+			if err != nil {
+				return err
+			}
+			if len(manifest.Segments) == 0 {
+				return fmt.Errorf("recording %s has no segments", recordingID)
+			}
+
+			cmdio.Info(stderr, "Downloading %d segments...", len(manifest.Segments))
+
+			allSegments := make([]*RecordingSegmentResponse, len(manifest.Segments))
+			g, gctx := errgroup.WithContext(ctx)
+			g.SetLimit(10)
+
+			for i, seg := range manifest.Segments {
+				g.Go(func() error {
+					segResp, err := client.GetSegment(gctx, appID, sessionID, recordingID, strconv.FormatInt(seg.ID, 10))
+					if err != nil {
+						return fmt.Errorf("downloading segment %d: %w", seg.ID, err)
+					}
+					allSegments[i] = segResp
+					return nil
+				})
+			}
+			if err := g.Wait(); err != nil {
+				return err
+			}
+
+			var allEvents []RRWebEvent
+			for _, seg := range allSegments {
+				allEvents = append(allEvents, seg.Events...)
+			}
+
+			ValidateEventStream(allEvents, stderr)
+
+			eventsJSON, err := json.Marshal(allEvents)
+			if err != nil {
+				return fmt.Errorf("marshaling events: %w", err)
+			}
+
+			srv, err := NewSessionPlayerServer(eventsJSON, opts.PlayerVersion)
+			if err != nil {
+				return err
+			}
+
+			var lc net.ListenConfig
+			listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf("127.0.0.1:%d", opts.Port))
+			if err != nil {
+				return fmt.Errorf("starting server: %w", err)
+			}
+
+			addr, ok := listener.Addr().(*net.TCPAddr)
+			if !ok {
+				return fmt.Errorf("unexpected listener address type: %T", listener.Addr())
+			}
+			localURL := fmt.Sprintf("http://localhost:%d", addr.Port)
+			cmdio.Success(stderr, "Serving session replay at %s", localURL)
+			cmdio.Info(stderr, "Press Ctrl-C to stop.")
+
+			if opts.Open {
+				openBrowser(localURL)
+			}
+
+			httpServer := &http.Server{
+				Handler:           srv.Handler(),
+				ReadHeaderTimeout: 10 * time.Second,
+			}
+
+			sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt)
+			defer stop()
+
+			go func() {
+				<-sigCtx.Done()
+				_ = httpServer.Close()
+			}()
+
+			log := logging.FromContext(ctx)
+			if err := httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+				log.Error("Server error", "error", err)
+				return err
+			}
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.CommandContext(context.Background(), "open", url)
+	case "windows":
+		cmd = exec.CommandContext(context.Background(), "cmd", "/c", "start", url)
+	default:
+		cmd = exec.CommandContext(context.Background(), "xdg-open", url)
+	}
+	_ = cmd.Start()
+}

--- a/internal/providers/faro/session_player.html
+++ b/internal/providers/faro/session_player.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Session Replay — gcx</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/rrweb-player@{{.PlayerVersion}}/dist/style.min.css">
+  <style>
+    body { margin: 0; background: #111217; display: flex; justify-content: center; align-items: center; min-height: 100vh; font-family: system-ui, sans-serif; color: #ccc; }
+    #loading { text-align: center; }
+    #error { color: #f55; text-align: center; display: none; }
+  </style>
+</head>
+<body>
+  <div id="loading">Loading session replay…</div>
+  <div id="error"></div>
+  <div id="player"></div>
+
+  <script type="module">
+    import Player from 'https://cdn.jsdelivr.net/npm/rrweb-player@{{.PlayerVersion}}/dist/rrweb-player.js';
+
+    (async function() {
+      const loadingEl = document.getElementById('loading');
+      const errorEl = document.getElementById('error');
+      const playerEl = document.getElementById('player');
+
+      let replayer = null;
+      let isPlaying = false;
+
+      try {
+        const resp = await fetch('/api/events');
+        if (!resp.ok) throw new Error(`Failed to load events: ${resp.status}`);
+        const events = await resp.json();
+
+        if (events.length === 0) {
+          throw new Error('No events in session');
+        }
+
+        loadingEl.style.display = 'none';
+        replayer = new Player({
+          target: playerEl,
+          props: { events, showController: true, autoPlay: false },
+        });
+      } catch (e) {
+        loadingEl.style.display = 'none';
+        errorEl.style.display = 'block';
+        errorEl.textContent = e.message;
+        return;
+      }
+
+      // WebSocket control channel
+      const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const ws = new WebSocket(`${wsProto}//${location.host}/ws`);
+
+      function sendState() {
+        if (!replayer || ws.readyState !== WebSocket.OPEN) return;
+        const r = replayer.getReplayer();
+        const meta = r.getMetaData();
+        const state = {
+          type: 'state',
+          timestamp: r.getCurrentTime() + (meta ? meta.startTime : 0),
+          playing: isPlaying,
+          duration: meta ? meta.totalTime : 0,
+        };
+        ws.send(JSON.stringify(state));
+      }
+
+      ws.onmessage = function(event) {
+        if (!replayer) return;
+        const r = replayer.getReplayer();
+        const msg = JSON.parse(event.data);
+        switch (msg.action) {
+          case 'goto':
+            r.pause(msg.timestamp);
+            break;
+          case 'play':
+            r.play();
+            isPlaying = true;
+            break;
+          case 'pause':
+            r.pause();
+            isPlaying = false;
+            break;
+        }
+        setTimeout(sendState, 100);
+      };
+
+      // Send state periodically
+      setInterval(sendState, 500);
+    })();
+  </script>
+</body>
+</html>

--- a/internal/providers/faro/session_player_test.go
+++ b/internal/providers/faro/session_player_test.go
@@ -1,0 +1,162 @@
+package faro_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	faro "github.com/grafana/gcx/internal/providers/faro"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestPlayerServer(t *testing.T, eventsJSON json.RawMessage) *faro.SessionPlayerServer {
+	t.Helper()
+	srv, err := faro.NewSessionPlayerServer(eventsJSON, "2.0.0-alpha.17")
+	require.NoError(t, err)
+	return srv
+}
+
+func TestValidateEventStream_Valid(t *testing.T) {
+	events := []faro.RRWebEvent{
+		{Type: 4, Timestamp: 1000, Data: json.RawMessage(`{}`)},
+		{Type: 2, Timestamp: 1001, Data: json.RawMessage(`{}`)},
+		{Type: 3, Timestamp: 1002, Data: json.RawMessage(`{}`)},
+	}
+	var buf bytes.Buffer
+	faro.ValidateEventStream(events, &buf)
+	assert.Empty(t, buf.String())
+}
+
+func TestValidateEventStream_MissingMeta(t *testing.T) {
+	events := []faro.RRWebEvent{
+		{Type: 2, Timestamp: 1000, Data: json.RawMessage(`{}`)},
+	}
+	var buf bytes.Buffer
+	faro.ValidateEventStream(events, &buf)
+	assert.Contains(t, buf.String(), "Meta")
+}
+
+func TestValidateEventStream_MissingFullSnapshot(t *testing.T) {
+	events := []faro.RRWebEvent{
+		{Type: 4, Timestamp: 1000, Data: json.RawMessage(`{}`)},
+		{Type: 3, Timestamp: 1001, Data: json.RawMessage(`{}`)},
+	}
+	var buf bytes.Buffer
+	faro.ValidateEventStream(events, &buf)
+	assert.Contains(t, buf.String(), "FullSnapshot")
+}
+
+func TestValidateEventStream_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	faro.ValidateEventStream(nil, &buf)
+	assert.Contains(t, buf.String(), "empty")
+}
+
+func TestSessionPlayerServer_Events(t *testing.T) {
+	events := []faro.RRWebEvent{{Type: 4, Timestamp: 1000, Data: json.RawMessage(`{}`)}}
+	eventsJSON, err := json.Marshal(events)
+	require.NoError(t, err)
+
+	srv := newTestPlayerServer(t, eventsJSON)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+"/api/events", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	var got []faro.RRWebEvent
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Len(t, got, 1)
+	assert.Equal(t, 4, got[0].Type)
+}
+
+func TestSessionPlayerServer_State(t *testing.T) {
+	srv := newTestPlayerServer(t, json.RawMessage(`[]`))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+"/api/state", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var state map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&state))
+	assert.Contains(t, state, "timestamp")
+}
+
+func TestSessionPlayerServer_Control(t *testing.T) {
+	srv := newTestPlayerServer(t, json.RawMessage(`[]`))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+	ws, wsResp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer ws.Close()
+	if wsResp != nil {
+		wsResp.Body.Close()
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL+"/api/play", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.NoError(t, ws.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, msg, err := ws.ReadMessage()
+	require.NoError(t, err)
+
+	var cmd map[string]any
+	require.NoError(t, json.Unmarshal(msg, &cmd))
+	assert.Equal(t, "play", cmd["action"])
+}
+
+func TestPlayReplaySessionCommandRegistered(t *testing.T) {
+	p := &faro.FaroProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+
+	frontendCmd := cmds[0]
+	appsCmd, _, err := frontendCmd.Find([]string{"apps"})
+	require.NoError(t, err)
+
+	found := false
+	for _, sub := range appsCmd.Commands() {
+		if sub.Name() == "play-replay-session" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "play-replay-session command should be registered under apps")
+}
+
+func TestPlayReplaySessionRejectsInvalidPort(t *testing.T) {
+	err := executeFaroCommand(t, "apps", "play-replay-session", "my-web-app-42", "sess-1", "--port", "70000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--port must be 0 or a valid TCP port")
+}
+
+func TestPlayReplaySessionRejectsEmptyPlayerVersion(t *testing.T) {
+	err := executeFaroCommand(t, "apps", "play-replay-session", "my-web-app-42", "sess-1", "--player-version", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--player-version must not be empty")
+}


### PR DESCRIPTION
## Summary

- Adds `play-session` command under `gcx frontend apps` that downloads all segments and serves a local rrweb-player
- WebSocket control API enables agent-driven playback (play/pause/goto)
- Loads rrweb-player from CDN with configurable `--player-version` flag

**Depends on #823** (session replay inspection commands).

### Security hardening

- Server binds to `127.0.0.1` only (not all interfaces)
- WebSocket `CheckOrigin` restricted to localhost origins
- WebSocket write race fixed (hold mutex through `WriteMessage`)
- `--player-version` flag wired into HTML template via `html/template`
- Cross-platform browser opening (`open`/`xdg-open`/`cmd /c start`)

### Open questions for review

- CDN-loaded rrweb-player JS has same-origin access to `/api/events` — should we vendor/embed the player assets instead?
- Should `--recording-id` be added here too (currently auto-selects first recording)?

## Test plan

- [x] `go test ./internal/providers/faro/... -race` passes
- [x] `golangci-lint` clean
- [ ] Manual test: `gcx frontend apps play-session <app> <session-id>` opens player
- [ ] Manual test: `gcx frontend apps play-session <app> <session-id> --open` launches browser
- [ ] Manual test: WebSocket control API responds to play/pause/goto
- [ ] Verify server only reachable from localhost