### PR TITLE
feat(instrumentation): add otel-checker

### DIFF
--- a/cmd/gcx/instrumentation/check/codec.go
+++ b/cmd/gcx/instrumentation/check/codec.go
@@ -1,0 +1,58 @@
+package check
+
+import (
+	"errors"
+	"io"
+
+	"github.com/grafana/gcx/internal/format"
+	"github.com/grafana/gcx/internal/style"
+	otelutils "github.com/grafana/otel-checker/checks/utils"
+)
+
+// CheckTableCodec renders otelutils.Results as a grouped status/component/
+// message table.
+//
+// Default columns: STATUS COMPONENT MESSAGE
+// Wide adds no extra columns today; the flag is reserved for future use
+// (e.g. raw severity codes) and accepted to satisfy the gcx output
+// convention of having distinct table/wide codecs.
+type CheckTableCodec struct {
+	Wide bool
+}
+
+var _ format.Codec = (*CheckTableCodec)(nil)
+
+func (c *CheckTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *CheckTableCodec) Encode(w io.Writer, v any) error {
+	results, ok := v.(otelutils.Results)
+	if !ok {
+		return errCheckTableCodecExpectedResults
+	}
+
+	t := style.NewTable("STATUS", "COMPONENT", "MESSAGE")
+	for _, r := range results.Errors {
+		t.Row("FAIL", r.Component, r.Message)
+	}
+	for _, r := range results.Warnings {
+		t.Row("WARN", r.Component, r.Message)
+	}
+	for _, r := range results.Checks {
+		t.Row("OK", r.Component, r.Message)
+	}
+	return t.Render(w)
+}
+
+func (c *CheckTableCodec) Decode(_ io.Reader, _ any) error {
+	return errCheckTableCodecNoDecode
+}
+
+var (
+	errCheckTableCodecExpectedResults = errors.New("CheckTableCodec: expected otelutils.Results")
+	errCheckTableCodecNoDecode        = errors.New("table format does not support decoding")
+)

--- a/cmd/gcx/instrumentation/check/command.go
+++ b/cmd/gcx/instrumentation/check/command.go
@@ -1,0 +1,186 @@
+// Package check implements the "gcx instrumentation check" command, a wrapper
+// around the otel-checker library that validates OpenTelemetry instrumentation
+// for an application: env vars, SDK config, collector config, Beyla/Alloy
+// config, and Grafana Cloud connectivity.
+package check
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	otelutils "github.com/grafana/otel-checker/checks/utils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type checkOpts struct {
+	IO                    cmdio.Options
+	Language              string
+	ManualInstrumentation bool
+	InstrumentationFile   string
+	PackageJSONPath       string
+	CollectorConfigPath   string
+	Debug                 bool
+
+	// Components is parsed from the positional argument; empty means "all".
+	Components []string
+}
+
+func (o *checkOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("table")
+	o.IO.RegisterCustomCodec("table", &CheckTableCodec{})
+	o.IO.RegisterCustomCodec("wide", &CheckTableCodec{Wide: true})
+	o.IO.SetJSONFieldValidator(cmdio.MakeFieldValidator(otelutils.Results{}))
+	o.IO.BindFlags(flags)
+
+	flags.StringVar(&o.Language, "language", "",
+		"Application language. Required for sdk, beyla, alloy, grafana-cloud. Possible values: "+
+			strings.Join(otelutils.SupportedLanguages, ", "))
+	flags.BoolVar(&o.ManualInstrumentation, "manual-instrumentation", false,
+		"Application is using manual instrumentation (JS only).")
+	flags.StringVar(&o.InstrumentationFile, "instrumentation-file", "",
+		"Path to the JS instrumentation file. Required when --language=js and --manual-instrumentation.")
+	flags.StringVar(&o.PackageJSONPath, "package-json-path", "",
+		"Path to package.json for JS dependency checks.")
+	flags.StringVar(&o.CollectorConfigPath, "collector-config-path", "",
+		"Path to the OpenTelemetry Collector config file.")
+	flags.BoolVar(&o.Debug, "debug", false,
+		"Print additional diagnostic output from the checker.")
+}
+
+// Validate finalizes opts after flag parsing and runs the otel-checker
+// library's own input validation. Pattern-matches Validate's typed/sentinel
+// errors so gcx can render its own UI rather than leaking the library's
+// error strings.
+func (o *checkOpts) Validate() error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+
+	cmd := o.toCommands()
+	err := otelutils.Validate(cmd)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, otelutils.ErrNoComponents):
+		return errors.New("at least one component is required")
+	case errors.Is(err, otelutils.ErrLanguageRequired):
+		return fmt.Errorf("--language is required for components: %s",
+			strings.Join(otelutils.LanguageRequiredFor, ", "))
+	case errors.Is(err, otelutils.ErrManualInstrumentationFile):
+		return errors.New("--instrumentation-file is required when --language=js and --manual-instrumentation are set")
+	}
+
+	var ule *otelutils.UnsupportedLanguageError
+	if errors.As(err, &ule) {
+		return fmt.Errorf("language %q is not supported. Possible values: %s",
+			ule.Language, strings.Join(otelutils.SupportedLanguages, ", "))
+	}
+	var uce *otelutils.UnsupportedComponentError
+	if errors.As(err, &uce) {
+		return fmt.Errorf("component %q is not supported. Possible values: %s",
+			uce.Component, strings.Join(otelutils.SupportedComponents, ", "))
+	}
+	return err
+}
+
+// toCommands maps the gcx-side opts into the otel-checker library's input
+// shape. When Components is empty, all SupportedComponents are checked.
+// WebServer/Listen/Format are intentionally left zero: gcx renders its own
+// way and never uses the library's web server.
+func (o *checkOpts) toCommands() otelutils.Commands {
+	components := o.Components
+	if len(components) == 0 {
+		components = append([]string(nil), otelutils.SupportedComponents...)
+	}
+	return otelutils.Commands{
+		Language:              o.Language,
+		Components:            components,
+		ManualInstrumentation: o.ManualInstrumentation,
+		InstrumentationFile:   o.InstrumentationFile,
+		PackageJsonPath:       o.PackageJSONPath,
+		CollectorConfigPath:   o.CollectorConfigPath,
+		Debug:                 o.Debug,
+	}
+}
+
+// Command returns the "gcx instrumentation check" cobra command.
+func Command() *cobra.Command {
+	opts := &checkOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "check [components]",
+		Short: "Validate OpenTelemetry instrumentation for an application",
+		Long: `Validate OpenTelemetry instrumentation configuration for an application
+running locally.
+
+Checks performed:
+  - Common OTEL_* environment variables (resource attributes, exporter, etc.)
+  - SDK setup and dependencies for the chosen language
+  - OpenTelemetry Collector config file (YAML schema, pipelines, exporters)
+  - Grafana Beyla configuration
+  - Grafana Alloy configuration
+  - Grafana Cloud connectivity (uses env vars for endpoint and credentials)
+
+Components is an optional comma-separated list — defaults to all when omitted.
+Supported components: ` + strings.Join(otelutils.SupportedComponents, ", ") + `.
+
+Powered by github.com/grafana/otel-checker.`,
+		Args: cobra.MaximumNArgs(1),
+		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return otelutils.SupportedComponents, cobra.ShellCompDirectiveNoFileComp
+		},
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Components = parseComponents(args)
+			if err := opts.Validate(); err != nil {
+				return fmt.Errorf("instrumentation check: %w", err)
+			}
+
+			results, err := run(cmd.Context(), opts.toCommands())
+			if err != nil {
+				return fmt.Errorf("instrumentation check: %w", err)
+			}
+
+			if err := opts.IO.Encode(cmd.OutOrStdout(), results); err != nil {
+				return fmt.Errorf("instrumentation check: %w", err)
+			}
+
+			if len(results.Errors) > 0 {
+				return fmt.Errorf("%d check(s) failed", len(results.Errors))
+			}
+			return nil
+		},
+	}
+
+	opts.setup(cmd.Flags())
+
+	if err := cmd.RegisterFlagCompletionFunc("language", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return otelutils.SupportedLanguages, cobra.ShellCompDirectiveNoFileComp
+	}); err != nil {
+		// RegisterFlagCompletionFunc only errors when the flag doesn't
+		// exist — impossible here since we just bound it.
+		panic(err)
+	}
+
+	return cmd
+}
+
+// parseComponents splits the single positional argument on commas and trims
+// surrounding whitespace. Returns nil for an empty/missing arg so callers can
+// distinguish "no components given" from "explicit empty list".
+func parseComponents(args []string) []string {
+	if len(args) == 0 || args[0] == "" {
+		return nil
+	}
+	parts := strings.Split(args[0], ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/cmd/gcx/instrumentation/check/run.go
+++ b/cmd/gcx/instrumentation/check/run.go
@@ -1,0 +1,37 @@
+package check
+
+import (
+	"context"
+
+	otelchecks "github.com/grafana/otel-checker/checks"
+	otelutils "github.com/grafana/otel-checker/checks/utils"
+)
+
+// checker is the minimal interface required to invoke the otel-checker
+// library. Tests substitute a fake; the real implementation is
+// otelchecks.Run.
+type checker func(ctx context.Context, cmd otelutils.Commands) *otelutils.Reporter
+
+// run executes the otel-checker library and returns the typed result
+// snapshot. Slices are normalized to non-nil for F-AGENT-01 compliance
+// (empty JSON arrays, not null).
+func run(ctx context.Context, cmd otelutils.Commands) (otelutils.Results, error) {
+	return runWith(ctx, cmd, otelchecks.Run)
+}
+
+// runWith is the testable seam for run; callers in tests pass a fake checker.
+func runWith(ctx context.Context, cmd otelutils.Commands, c checker) (otelutils.Results, error) {
+	reporter := c(ctx, cmd)
+	results := reporter.Results()
+
+	if results.Checks == nil {
+		results.Checks = []otelutils.ComponentResult{}
+	}
+	if results.Warnings == nil {
+		results.Warnings = []otelutils.ComponentResult{}
+	}
+	if results.Errors == nil {
+		results.Errors = []otelutils.ComponentResult{}
+	}
+	return results, nil
+}

--- a/cmd/gcx/instrumentation/check/run_test.go
+++ b/cmd/gcx/instrumentation/check/run_test.go
@@ -1,0 +1,263 @@
+//nolint:testpackage // white-box testing: accesses unexported run, opts, and codec.
+package check
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	otelutils "github.com/grafana/otel-checker/checks/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeReporter builds an otelutils.Reporter populated with the given
+// per-component messages.
+func fakeReporter(checks, warnings, errs map[string][]string) *otelutils.Reporter {
+	r := &otelutils.Reporter{}
+	for name, msgs := range checks {
+		c := r.Component(name)
+		for _, m := range msgs {
+			c.AddSuccessfulCheck(m)
+		}
+	}
+	for name, msgs := range warnings {
+		c := r.Component(name)
+		for _, m := range msgs {
+			c.AddWarning(m)
+		}
+	}
+	for name, msgs := range errs {
+		c := r.Component(name)
+		for _, m := range msgs {
+			c.AddError(m)
+		}
+	}
+	return r
+}
+
+// ─── parseComponents ─────────────────────────────────────────────────────────
+
+func TestParseComponents(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{"no args", nil, nil},
+		{"empty string", []string{""}, nil},
+		{"single component", []string{"sdk"}, []string{"sdk"}},
+		{"comma-separated", []string{"sdk,collector,beyla"}, []string{"sdk", "collector", "beyla"}},
+		{"trims whitespace", []string{" sdk , collector "}, []string{"sdk", "collector"}},
+		{"drops empties", []string{"sdk,,collector"}, []string{"sdk", "collector"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseComponents(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ─── opts.Validate ───────────────────────────────────────────────────────────
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name       string
+		components []string
+		language   string
+		manual     bool
+		instFile   string
+		wantErrSub string // substring of the expected error; "" means no error
+	}{
+		{
+			name:       "no components defaults to all (no error)",
+			components: nil,
+			language:   "go",
+			wantErrSub: "",
+		},
+		{
+			name:       "unsupported language",
+			components: []string{"sdk"},
+			language:   "rust",
+			wantErrSub: "language \"rust\" is not supported",
+		},
+		{
+			name:       "unsupported component",
+			components: []string{"sidecar"},
+			language:   "go",
+			wantErrSub: "component \"sidecar\" is not supported",
+		},
+		{
+			name:       "language required for sdk",
+			components: []string{"sdk"},
+			language:   "",
+			wantErrSub: "--language is required",
+		},
+		{
+			name:       "collector-only no language is fine",
+			components: []string{"collector"},
+			language:   "",
+			wantErrSub: "",
+		},
+		{
+			name:       "js manual without instrumentation file",
+			components: []string{"sdk"},
+			language:   "js",
+			manual:     true,
+			instFile:   "",
+			wantErrSub: "--instrumentation-file is required",
+		},
+		{
+			name:       "js manual with instrumentation file",
+			components: []string{"sdk"},
+			language:   "js",
+			manual:     true,
+			instFile:   "/tmp/instr.js",
+			wantErrSub: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &checkOpts{
+				Components:            tt.components,
+				Language:              tt.language,
+				ManualInstrumentation: tt.manual,
+				InstrumentationFile:   tt.instFile,
+			}
+			// Validate the otel-checker portion only; the IO portion needs a
+			// real cobra flag set bound via setup(), and isn't what these
+			// cases are exercising.
+			err := otelutils.Validate(o.toCommands())
+			if tt.wantErrSub == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			// Surface gcx's classified error rather than the library's
+			// raw message — go through the same switch the command uses.
+			gcxErr := classify(err)
+			assert.Contains(t, gcxErr.Error(), tt.wantErrSub)
+		})
+	}
+}
+
+// classify mirrors the error-classification switch in checkOpts.Validate so
+// tests can assert against the user-facing message without standing up a
+// full cobra command.
+func classify(err error) error {
+	o := &checkOpts{}
+	// Force the typed-error branch by simulating Validate's call shape: feed
+	// the same err through a copy of the switch via a temporary command.
+	// Simpler: just construct a checkOpts with no IO and run the same
+	// pattern-match.
+	_ = o
+	switch {
+	case errors.Is(err, otelutils.ErrNoComponents):
+		return errors.New("at least one component is required")
+	case errors.Is(err, otelutils.ErrLanguageRequired):
+		return errors.New("--language is required for components: sdk, beyla, alloy, grafana-cloud")
+	case errors.Is(err, otelutils.ErrManualInstrumentationFile):
+		return errors.New("--instrumentation-file is required when --language=js and --manual-instrumentation are set")
+	}
+	var ule *otelutils.UnsupportedLanguageError
+	if errors.As(err, &ule) {
+		return errors.New("language \"" + ule.Language + "\" is not supported")
+	}
+	var uce *otelutils.UnsupportedComponentError
+	if errors.As(err, &uce) {
+		return errors.New("component \"" + uce.Component + "\" is not supported")
+	}
+	return err
+}
+
+// ─── run / runWith ───────────────────────────────────────────────────────────
+
+func TestRunWith_ProducesTypedSnapshot(t *testing.T) {
+	want := fakeReporter(
+		map[string][]string{"SDK": {"OTEL_SERVICE_NAME is set"}},
+		map[string][]string{"Collector": {"exporter not specified"}},
+		map[string][]string{"Grafana Cloud": {"GRAFANA_CLOUD_INSTANCE_ID missing"}},
+	)
+	got, err := runWith(context.Background(), otelutils.Commands{Language: "go", Components: []string{"sdk"}},
+		func(_ context.Context, _ otelutils.Commands) *otelutils.Reporter { return want })
+	require.NoError(t, err)
+	require.Len(t, got.Checks, 1)
+	require.Len(t, got.Warnings, 1)
+	require.Len(t, got.Errors, 1)
+	assert.Equal(t, "SDK", got.Checks[0].Component)
+	assert.Equal(t, "Collector", got.Warnings[0].Component)
+	assert.Equal(t, "Grafana Cloud", got.Errors[0].Component)
+}
+
+func TestRunWith_EmptyReporterReturnsNonNilSlices(t *testing.T) {
+	got, err := runWith(context.Background(), otelutils.Commands{},
+		func(_ context.Context, _ otelutils.Commands) *otelutils.Reporter { return &otelutils.Reporter{} })
+	require.NoError(t, err)
+	// F-AGENT-01: empty slices, never nil.
+	assert.NotNil(t, got.Checks)
+	assert.NotNil(t, got.Warnings)
+	assert.NotNil(t, got.Errors)
+	assert.Empty(t, got.Checks)
+	assert.Empty(t, got.Warnings)
+	assert.Empty(t, got.Errors)
+}
+
+// ─── CheckTableCodec ─────────────────────────────────────────────────────────
+
+func TestCheckTableCodec_Encode(t *testing.T) {
+	codec := &CheckTableCodec{}
+	results := otelutils.Results{
+		Checks:   []otelutils.ComponentResult{{Component: "SDK", Message: "service.name set"}},
+		Warnings: []otelutils.ComponentResult{{Component: "Collector", Message: "missing receiver"}},
+		Errors:   []otelutils.ComponentResult{{Component: "Grafana Cloud", Message: "no instance id"}},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, results))
+
+	out := buf.String()
+	// All three rows present, in failure-first order.
+	assert.True(t, strings.Index(out, "FAIL") < strings.Index(out, "WARN"),
+		"FAIL row must precede WARN row, got:\n%s", out)
+	assert.True(t, strings.Index(out, "WARN") < strings.Index(out, "OK"),
+		"WARN row must precede OK row, got:\n%s", out)
+	assert.Contains(t, out, "Grafana Cloud")
+	assert.Contains(t, out, "no instance id")
+}
+
+func TestCheckTableCodec_WrongType(t *testing.T) {
+	codec := &CheckTableCodec{}
+	err := codec.Encode(&bytes.Buffer{}, "nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "otelutils.Results")
+}
+
+// ─── Command smoke test ──────────────────────────────────────────────────────
+//
+// Wire a Command() and exercise the validation error path end-to-end.
+// Avoids actually running otel-checker (which would touch real env vars).
+
+func TestCommand_RejectsUnsupportedLanguage(t *testing.T) {
+	cmd := Command()
+	cmd.SetArgs([]string{"sdk", "--language=rust"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "language \"rust\" is not supported")
+}
+
+func TestCommand_RejectsMissingLanguage(t *testing.T) {
+	cmd := Command()
+	cmd.SetArgs([]string{"sdk"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--language is required")
+}

--- a/cmd/gcx/instrumentation/check/run_test.go
+++ b/cmd/gcx/instrumentation/check/run_test.go
@@ -220,9 +220,9 @@ func TestCheckTableCodec_Encode(t *testing.T) {
 
 	out := buf.String()
 	// All three rows present, in failure-first order.
-	assert.True(t, strings.Index(out, "FAIL") < strings.Index(out, "WARN"),
+	assert.Less(t, strings.Index(out, "FAIL"), strings.Index(out, "WARN"),
 		"FAIL row must precede WARN row, got:\n%s", out)
-	assert.True(t, strings.Index(out, "WARN") < strings.Index(out, "OK"),
+	assert.Less(t, strings.Index(out, "WARN"), strings.Index(out, "OK"),
 		"WARN row must precede OK row, got:\n%s", out)
 	assert.Contains(t, out, "Grafana Cloud")
 	assert.Contains(t, out, "no instance id")

--- a/cmd/gcx/instrumentation/command.go
+++ b/cmd/gcx/instrumentation/command.go
@@ -6,6 +6,7 @@
 //	gcx instrumentation
 //	├── setup      — guided onboarding wizard
 //	├── status     — cross-cutting observed-state view
+//	├── check      — validate OTel instrumentation locally (otel-checker)
 //	├── clusters   — declared/observed state per cluster
 //	│   └── apps   — namespace-level RMW operations
 //	└── services   — workload-level observed state + overrides
@@ -16,6 +17,7 @@
 package instrumentation
 
 import (
+	"github.com/grafana/gcx/cmd/gcx/instrumentation/check"
 	"github.com/grafana/gcx/cmd/gcx/instrumentation/clusters"
 	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
 	"github.com/grafana/gcx/cmd/gcx/instrumentation/setup"
@@ -43,6 +45,10 @@ The instrumentation command tree provides:
   status     Cross-cutting observed state for clusters and namespaces
              (RunK8sMonitoring + ListPipelines merge).
 
+  check      Validate OpenTelemetry instrumentation for an application
+             running locally (env vars, SDK, collector, Beyla, Alloy,
+             Grafana Cloud connectivity).
+
   clusters   Declared and observed state per K8s cluster:
              list, get, configure, remove, wait.
              Sub-group "apps" manages namespace-level Beyla configuration.
@@ -57,6 +63,7 @@ The instrumentation command tree provides:
 	cmd.AddCommand(
 		setup.Command(loader),
 		status.Command(loader),
+		check.Command(),
 		clusters.Command(loader),
 		services.Command(loader),
 	)

--- a/docs/reference/cli/gcx_instrumentation.md
+++ b/docs/reference/cli/gcx_instrumentation.md
@@ -14,6 +14,10 @@ The instrumentation command tree provides:
   status     Cross-cutting observed state for clusters and namespaces
              (RunK8sMonitoring + ListPipelines merge).
 
+  check      Validate OpenTelemetry instrumentation for an application
+             running locally (env vars, SDK, collector, Beyla, Alloy,
+             Grafana Cloud connectivity).
+
   clusters   Declared and observed state per K8s cluster:
              list, get, configure, remove, wait.
              Sub-group "apps" manages namespace-level Beyla configuration.
@@ -42,6 +46,7 @@ The instrumentation command tree provides:
 ### SEE ALSO
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx instrumentation check](gcx_instrumentation_check.md)	 - Validate OpenTelemetry instrumentation for an application
 * [gcx instrumentation clusters](gcx_instrumentation_clusters.md)	 - Manage K8s monitoring configuration for clusters
 * [gcx instrumentation services](gcx_instrumentation_services.md)	 - Manage workload-level instrumentation across the fleet
 * [gcx instrumentation setup](gcx_instrumentation_setup.md)	 - Onboard a Kubernetes cluster for Grafana Instrumentation Hub

--- a/docs/reference/cli/gcx_instrumentation_check.md
+++ b/docs/reference/cli/gcx_instrumentation_check.md
@@ -1,0 +1,56 @@
+## gcx instrumentation check
+
+Validate OpenTelemetry instrumentation for an application
+
+### Synopsis
+
+Validate OpenTelemetry instrumentation configuration for an application
+running locally.
+
+Checks performed:
+  - Common OTEL_* environment variables (resource attributes, exporter, etc.)
+  - SDK setup and dependencies for the chosen language
+  - OpenTelemetry Collector config file (YAML schema, pipelines, exporters)
+  - Grafana Beyla configuration
+  - Grafana Alloy configuration
+  - Grafana Cloud connectivity (uses env vars for endpoint and credentials)
+
+Components is an optional comma-separated list — defaults to all when omitted.
+Supported components: sdk, beyla, alloy, collector, grafana-cloud.
+
+Powered by github.com/grafana/otel-checker.
+
+```
+gcx instrumentation check [components] [flags]
+```
+
+### Options
+
+```
+      --collector-config-path string   Path to the OpenTelemetry Collector config file.
+      --debug                          Print additional diagnostic output from the checker.
+  -h, --help                           help for check
+      --instrumentation-file string    Path to the JS instrumentation file. Required when --language=js and --manual-instrumentation.
+      --json string                    Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --language string                Application language. Required for sdk, beyla, alloy, grafana-cloud. Possible values: dotnet, go, java, js, python, ruby, php
+      --manual-instrumentation         Application is using manual instrumentation (JS only).
+  -o, --output string                  Output format. One of: agents, json, table, wide, yaml (default "table")
+      --package-json-path string       Path to package.json for JS dependency checks.
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx instrumentation](gcx_instrumentation.md)	 - Manage Grafana Instrumentation Hub
+

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 require (
 	github.com/go-openapi/runtime v0.29.5
 	github.com/gofrs/flock v0.13.0
+	github.com/grafana/otel-checker v0.2.0
 	github.com/zalando/go-keyring v0.2.8
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	sigs.k8s.io/yaml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae 
 github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae/go.mod h1:4WkWL9W7QMnRgRA1XrrSbZRg/UIoTx4x5ynx5RjJldU=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250903133002-4e28cba1c53a h1:+HkE1JQJUx6ocoZWZYGmX4JR7TsHcAXDJ/PK1Y3j53Q=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250903133002-4e28cba1c53a/go.mod h1:av5N0Naq+8VV9MLF7zAkihy/mVq5UbS2EvRSJukDHlY=
+github.com/grafana/otel-checker v0.2.0 h1:D0HGYeXI3oRzlhqAcvCD6Dl2SSDKWMGY21qFS/pbi/Y=
+github.com/grafana/otel-checker v0.2.0/go.mod h1:fD9UBbQ6JP6aDWkXh8JOVqojSWer9P8ZloJ3oHGj+lw=
 github.com/grafana/promql-builder/go v0.0.0-20250916111012-8fa9625b89a3 h1:B5SncfJyapaCmCM/r5007X4hjkKTgQ1XaOpA5VgrboU=
 github.com/grafana/promql-builder/go v0.0.0-20250916111012-8fa9625b89a3/go.mod h1:TsO1alA6DmSpsS8xh4lAknLlY2wLl4q3B/HFMlZvXaE=
 github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 h1:cLN4IBkmkYZNnk7EAJ0BHIethd+J6LqxFNw5mSiI2bM=

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -130,6 +130,7 @@ var commandAnnotations = map[string]annotation{
 	// top-level single commands
 	"gcx instrumentation setup":  {Cost: "medium", Hint: "<cluster> --use-defaults -o json"},
 	"gcx instrumentation status": {Cost: "medium", Hint: "-o json"},
+	"gcx instrumentation check":  {Cost: "small", Hint: "validates the LOCAL workstation's OTel setup (env vars, SDK deps, collector/Beyla/Alloy config, Grafana Cloud env creds) — does not query any Grafana stack. [components] --language <lang> -o json"},
 
 	// services verb group
 	"gcx instrumentation services list":    {Cost: "large", Hint: "K8s workloads discovered fleet-wide by the Beyla survey collector, for setting up instrumentation (distinct from 'gcx appo11y services', which lists telemetry-reporting services). --cluster <name> --namespace <ns> -o json"},


### PR DESCRIPTION
Add [Otel Checker](https://github.com/grafana/otel-checker) as a dependency, making it possible to run its commands from here. 
I added the commands under the existing `instrumentation` because I believe it was a good match, but if there is a better place or if it should be its own command, I'm happy to make the changes.

The OTel Checker also has a webserver option, but that was not included here, since it didn't quite fit with how GCX works.

Example for `gcx instrumentation check --language=js`:

<img width="967" height="492" alt="Screenshot 2026-06-09 at 9 18 41 AM" src="https://github.com/user-attachments/assets/bfc5c499-b6d8-4ea9-a209-a0a38cad9140" />
