### PR TITLE
fix(kg): drop empty rcaPatterns field from entities inspect output

### DIFF
--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1671,6 +1671,12 @@ narrow to one entity), which is cheaper and returns those fields directly.`,
 				}
 				return err
 			}
+			// The llm-summary endpoint echoes an empty "rcaPatterns" array (we
+			// request IncludeRcaPatterns: false). Drop it when empty so inspect
+			// output doesn't carry a permanently-empty field.
+			if p, ok := result["rcaPatterns"].([]any); ok && len(p) == 0 {
+				delete(result, "rcaPatterns")
+			}
 			if isEmptyLLMResult(result) {
 				scopeDesc := ""
 				if len(scope) > 0 {


### PR DESCRIPTION
## Summary

`gcx kg entities inspect` always surfaced an empty `rcaPatterns` field in its output. The llm-summary endpoint echoes an empty `rcaPatterns` array because inspect requests `IncludeRcaPatterns: false`, so the field was always present and always empty.

This strips `rcaPatterns` from the result when it's an empty array. A populated array (should the request ever change) passes through untouched.

## Testing

- `GCX_AGENT_MODE=false mise run all` — lint (0 issues), tests, build, docs all pass
- Verified against a live stack: `gcx kg entities inspect Service--redis` no longer emits `rcaPatterns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)