### PR TITLE
fix(irm): correct incidents list paging, label filter format, and page size

### DIFF
--- a/.claude/skills/migrate-provider/gcx-provider-recipe.md
+++ b/.claude/skills/migrate-provider/gcx-provider-recipe.md
@@ -399,8 +399,10 @@ that only surfaced during smoke testing:
   optional time fields instead of null. The `omitzero` tag (Go 1.24+) replaces
   `omitempty` for struct-typed fields to satisfy the modernize linter.
 - Delete is not supported — the IRM API has no delete endpoint.
-- Cursor-based pagination: the `contextPayload` field carries the cursor value
-  between pages, not a separate cursor parameter.
+- Cursor-based pagination: the cursor is a top-level request field next to
+  `query` (`{"query": {...}, "cursor": {"nextValue": "..."}}`) — pass the
+  previously returned cursor back verbatim to fetch the next page. It is not
+  a field inside the query object. Page `limit` is capped at 100 by the API.
 
 ### Token Exchange Auth (k6)
 

--- a/docs/reference/cli/gcx_irm_incidents_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_list.md
@@ -12,7 +12,7 @@ gcx irm incidents list [flags]
       --from string      Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --labels strings   Filter by label: plain text for default Tags labels (e.g. security), key:value for keyed labels (e.g. team:platform); repeatable, comma-separated
+      --labels strings   Filter by labels (label text or key:value, may be repeated)
       --limit int        Maximum number of incidents to return (default 50)
   -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
       --to string        End of time range (RFC3339, unix timestamp, or relative e.g. now)

--- a/docs/reference/cli/gcx_irm_incidents_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_list.md
@@ -12,7 +12,7 @@ gcx irm incidents list [flags]
       --from string      Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --labels strings   Filter by label text, e.g. security (repeatable, comma-separated)
+      --labels strings   Filter by label: plain text for default Tags labels (e.g. security), key:value for keyed labels (e.g. team:platform); repeatable, comma-separated
       --limit int        Maximum number of incidents to return (default 50)
   -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
       --to string        End of time range (RFC3339, unix timestamp, or relative e.g. now)

--- a/docs/reference/cli/gcx_irm_incidents_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_list.md
@@ -12,7 +12,7 @@ gcx irm incidents list [flags]
       --from string      Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)
   -h, --help             help for list
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --labels strings   Filter by labels (key:value format, may be repeated)
+      --labels strings   Filter by label text, e.g. security (repeatable, comma-separated)
       --limit int        Maximum number of incidents to return (default 50)
   -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
       --to string        End of time range (RFC3339, unix timestamp, or relative e.g. now)

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -46,9 +46,14 @@ func NewIncidentClient(cfg config.NamespacedRESTConfig) (*IncidentClient, error)
 	return &IncidentClient{httpClient: httpClient, host: cfg.Host}, nil
 }
 
-// List queries incidents with the given parameters and handles pagination.
+// incidentsMaxPageSize is the documented maximum for IncidentsQuery.limit.
+const incidentsMaxPageSize = 100
+
+// List queries incidents with the given parameters, following the response
+// cursor until query.Limit incidents are collected or the server reports no
+// more pages. A non-positive query.Limit defaults to 100.
 func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incident, error) {
-	if query.Limit == 0 {
+	if query.Limit <= 0 {
 		query.Limit = 100
 	}
 	if query.OrderDirection == "" {
@@ -59,22 +64,28 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 	}
 
 	limit := query.Limit
-	var all []Incident
+	var (
+		all    []Incident
+		cursor *IncidentCursor
+	)
 	for {
-		resp, err := c.queryIncidents(ctx, query)
+		query.Limit = min(limit-len(all), incidentsMaxPageSize)
+		resp, err := c.queryIncidents(ctx, query, cursor)
 		if err != nil {
 			return nil, err
 		}
 		all = append(all, resp.Incidents...)
-		if len(all) >= limit || !resp.Cursor.HasMore {
-			break
+		if len(all) >= limit {
+			return all[:limit], nil
 		}
-		query.ContextPayload = resp.Cursor.NextValue
+		// Also stop on an empty page or an empty cursor value: both mean the
+		// server cannot make progress, and looping on them would re-fetch
+		// the same page forever.
+		if !resp.Cursor.HasMore || resp.Cursor.NextValue == "" || len(resp.Incidents) == 0 {
+			return all, nil
+		}
+		cursor = &IncidentCursor{NextValue: resp.Cursor.NextValue}
 	}
-	if len(all) > limit {
-		all = all[:limit]
-	}
-	return all, nil
 }
 
 // Get returns a single incident by ID.
@@ -301,9 +312,10 @@ func (c *IncidentClient) GetSeverities(ctx context.Context) ([]Severity, error) 
 	return result.Severities, nil
 }
 
-// queryIncidents performs a single paginated query.
-func (c *IncidentClient) queryIncidents(ctx context.Context, query IncidentQuery) (*queryIncidentsResponse, error) {
-	body, err := json.Marshal(queryIncidentsRequest{Query: query})
+// queryIncidents fetches a single page. cursor is nil for the first page and
+// the previously returned cursor for subsequent pages.
+func (c *IncidentClient) queryIncidents(ctx context.Context, query IncidentQuery, cursor *IncidentCursor) (*queryIncidentsResponse, error) {
+	body, err := json.Marshal(queryIncidentsRequest{Query: query, Cursor: cursor})
 	if err != nil {
 		return nil, fmt.Errorf("incidents: marshal query request: %w", err)
 	}

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -84,7 +84,9 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 		if !resp.Cursor.HasMore || resp.Cursor.NextValue == "" || len(resp.Incidents) == 0 {
 			return all, nil
 		}
-		cursor = &IncidentCursor{NextValue: resp.Cursor.NextValue}
+		// The API contract is to pass previously returned cursor values back
+		// as-is.
+		cursor = &resp.Cursor
 	}
 }
 

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -79,7 +79,9 @@ func TestClient_List(t *testing.T) {
 					default:
 						req := (*calls)[1]
 						if assert.NotNil(t, req.Cursor, "second request must carry the cursor next to the query") {
+							// The previously returned cursor is echoed back verbatim.
 							assert.Equal(t, "cursor-1", (*req.Cursor)["nextValue"])
+							assert.Equal(t, true, (*req.Cursor)["hasMore"])
 						}
 						assert.NotContains(t, req.Query, "contextPayload")
 						writeJSON(w, incidentPage("p2", 1, false, ""))

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -2,6 +2,7 @@ package irm_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -24,81 +25,200 @@ func newTestClient(t *testing.T, server *httptest.Server) *irm.IncidentClient {
 	return c
 }
 
+// listRequest mirrors the QueryIncidents request body for assertions.
+type listRequest struct {
+	Query  map[string]any  `json:"query"`
+	Cursor *map[string]any `json:"cursor"`
+}
+
+// incidentPage builds a one-page response with n incidents named after page.
+func incidentPage(page string, n int, hasMore bool, nextValue string) map[string]any {
+	incs := make([]map[string]any, n)
+	for i := range incs {
+		incs[i] = map[string]any{"incidentID": fmt.Sprintf("inc-%s-%d", page, i), "title": "Outage " + page, "status": "active"}
+	}
+	return map[string]any{
+		"incidents": incs,
+		"cursor":    map[string]any{"hasMore": hasMore, "nextValue": nextValue},
+		"query":     map[string]any{},
+	}
+}
+
 func TestClient_List(t *testing.T) {
 	tests := []struct {
-		name    string
-		handler http.HandlerFunc
-		wantLen int
-		wantErr bool
+		name      string
+		query     irm.IncidentQuery
+		handler   func(t *testing.T, calls *[]listRequest) http.HandlerFunc
+		wantLen   int
+		wantCalls int
+		wantErr   string
 	}{
 		{
-			name: "returns incidents",
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, http.MethodPost, r.Method)
-				assert.Contains(t, r.URL.Path, "IncidentsService.QueryIncidents")
-				writeJSON(w, map[string]any{
-					"incidents": []map[string]any{
-						{"incidentID": "inc-1", "title": "Outage 1", "status": "active"},
-						{"incidentID": "inc-2", "title": "Outage 2", "status": "resolved"},
-					},
-					"cursor": map[string]any{"hasMore": false},
-					"query":  map[string]any{},
-				})
+			name:  "returns incidents",
+			query: irm.IncidentQuery{Limit: 50},
+			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, http.MethodPost, r.Method)
+					assert.Contains(t, r.URL.Path, "IncidentsService.QueryIncidents")
+					writeJSON(w, incidentPage("a", 2, false, ""))
+				}
 			},
-			wantLen: 2,
+			wantLen:   2,
+			wantCalls: 1,
 		},
 		{
-			name: "handles pagination",
-			handler: func() http.HandlerFunc {
-				call := 0
+			name:  "pages with top-level cursor",
+			query: irm.IncidentQuery{Limit: 50},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
 				return func(w http.ResponseWriter, _ *http.Request) {
-					call++
-					if call == 1 {
-						writeJSON(w, map[string]any{
-							"incidents": []map[string]any{
-								{"incidentID": "inc-1", "title": "Page 1", "status": "active"},
-							},
-							"cursor": map[string]any{"hasMore": true, "nextValue": "cursor-1"},
-							"query":  map[string]any{},
-						})
-					} else {
-						writeJSON(w, map[string]any{
-							"incidents": []map[string]any{
-								{"incidentID": "inc-2", "title": "Page 2", "status": "active"},
-							},
-							"cursor": map[string]any{"hasMore": false},
-							"query":  map[string]any{},
-						})
+					switch len(*calls) {
+					case 1:
+						writeJSON(w, incidentPage("p1", 1, true, "cursor-1"))
+					default:
+						req := (*calls)[1]
+						if assert.NotNil(t, req.Cursor, "second request must carry the cursor next to the query") {
+							assert.Equal(t, "cursor-1", (*req.Cursor)["nextValue"])
+						}
+						assert.NotContains(t, req.Query, "contextPayload")
+						writeJSON(w, incidentPage("p2", 1, false, ""))
 					}
 				}
-			}(),
-			wantLen: 2,
+			},
+			wantLen:   2,
+			wantCalls: 2,
 		},
 		{
-			name: "propagates error",
-			handler: func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusInternalServerError)
-				writeJSON(w, map[string]string{"error": "internal error"})
+			name:  "clamps page size to API maximum",
+			query: irm.IncidentQuery{Limit: 250},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					req := (*calls)[len(*calls)-1]
+					assert.LessOrEqual(t, req.Query["limit"], float64(100), "per-page limit must not exceed the documented maximum")
+					switch len(*calls) {
+					case 1:
+						writeJSON(w, incidentPage("p1", 100, true, "cursor-1"))
+					case 2:
+						// 150 remain wanted; the page request must ask for 100.
+						assert.InDelta(t, 100, req.Query["limit"], 0)
+						writeJSON(w, incidentPage("p2", 100, true, "cursor-2"))
+					default:
+						// 50 remain wanted; the page request must shrink.
+						assert.InDelta(t, 50, req.Query["limit"], 0)
+						writeJSON(w, incidentPage("p3", 50, false, ""))
+					}
+				}
 			},
-			wantErr: true,
+			wantLen:   250,
+			wantCalls: 3,
+		},
+		{
+			name:  "stops at limit when the server has more",
+			query: irm.IncidentQuery{Limit: 1},
+			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					writeJSON(w, incidentPage("p1", 1, true, "cursor-1"))
+				}
+			},
+			wantLen:   1,
+			wantCalls: 1,
+		},
+		{
+			name:  "truncates when the server over-returns",
+			query: irm.IncidentQuery{Limit: 3},
+			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					writeJSON(w, incidentPage("p1", 5, false, ""))
+				}
+			},
+			wantLen:   3,
+			wantCalls: 1,
+		},
+		{
+			name:  "stops on hasMore with empty cursor value",
+			query: irm.IncidentQuery{Limit: 50},
+			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					// A misbehaving server claims more pages but provides no
+					// cursor to fetch them; the client must not loop forever.
+					writeJSON(w, incidentPage("p1", 1, true, ""))
+				}
+			},
+			wantLen:   1,
+			wantCalls: 1,
+		},
+		{
+			name:  "limit zero defaults to one full page",
+			query: irm.IncidentQuery{},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					req := (*calls)[0]
+					assert.InDelta(t, 100, req.Query["limit"], 0)
+					writeJSON(w, incidentPage("p1", 100, true, "cursor-1"))
+				}
+			},
+			wantLen:   100,
+			wantCalls: 1,
+		},
+		{
+			name:  "forwards filters in the query",
+			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{"security"}},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					q := (*calls)[0].Query
+					assert.Equal(t, []any{"security"}, q["incidentLabels"])
+					assert.Equal(t, "DESC", q["orderDirection"])
+					writeJSON(w, incidentPage("p1", 1, false, ""))
+				}
+			},
+			wantLen:   1,
+			wantCalls: 1,
+		},
+		{
+			name:  "propagates error",
+			query: irm.IncidentQuery{Limit: 10},
+			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+					writeJSON(w, map[string]string{"error": "internal error"})
+				}
+			},
+			wantErr: "internal error",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(tt.handler)
+			var calls []listRequest
+			inner := tt.handler(t, &calls)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req listRequest
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+				calls = append(calls, req)
+				inner(w, r)
+			}))
 			defer server.Close()
 
 			c := newTestClient(t, server)
-			result, err := c.List(t.Context(), irm.IncidentQuery{})
+			result, err := c.List(t.Context(), tt.query)
 
-			if tt.wantErr {
+			if tt.wantErr != "" {
 				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
 
 			require.NoError(t, err)
 			assert.Len(t, result, tt.wantLen)
+			assert.Len(t, calls, tt.wantCalls)
 		})
 	}
 }

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -38,7 +38,7 @@ func (o *incidentListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
 	flags.IntVar(&o.Limit, "limit", 50, "Maximum number of incidents to return")
-	flags.StringSliceVar(&o.Labels, "labels", nil, "Filter by labels (key:value format, may be repeated)")
+	flags.StringSliceVar(&o.Labels, "labels", nil, "Filter by label text, e.g. security (repeatable, comma-separated)")
 	flags.StringVar(&o.DateFrom, "from", "", "Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)")
 	flags.StringVar(&o.DateTo, "to", "", "End of time range (RFC3339, unix timestamp, or relative e.g. now)")
 }
@@ -47,9 +47,11 @@ func (o *incidentListOpts) Validate() error {
 	if err := o.IO.Validate(); err != nil {
 		return err
 	}
+	// The API's incidentLabels field matches on plain label text (e.g.
+	// "security"), not key:value pairs — pass values through as given.
 	for _, l := range o.Labels {
-		if !strings.Contains(l, ":") {
-			return fmt.Errorf("invalid label %q: must be in key:value format", l)
+		if strings.TrimSpace(l) == "" {
+			return errors.New("invalid --labels value: label must not be empty")
 		}
 	}
 	now := time.Now()
@@ -64,20 +66,6 @@ func (o *incidentListOpts) Validate() error {
 		}
 	}
 	return nil
-}
-
-// BuildQueryString converts --labels values into the IRM query string format.
-// Each label is formatted as field:Tags:'key:value' and multiple labels are
-// separated by a space.
-func BuildQueryString(labels []string) string {
-	if len(labels) == 0 {
-		return ""
-	}
-	parts := make([]string, len(labels))
-	for i, l := range labels {
-		parts[i] = "field:Tags:'" + l + "'"
-	}
-	return strings.Join(parts, " ")
 }
 
 func NewListCommand(loader GrafanaConfigLoader) *cobra.Command {

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -38,7 +38,7 @@ func (o *incidentListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
 	flags.IntVar(&o.Limit, "limit", 50, "Maximum number of incidents to return")
-	flags.StringSliceVar(&o.Labels, "labels", nil, "Filter by label: plain text for default Tags labels (e.g. security), key:value for keyed labels (e.g. team:platform); repeatable, comma-separated")
+	flags.StringSliceVar(&o.Labels, "labels", nil, "Filter by labels (label text or key:value, may be repeated)")
 	flags.StringVar(&o.DateFrom, "from", "", "Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)")
 	flags.StringVar(&o.DateTo, "to", "", "End of time range (RFC3339, unix timestamp, or relative e.g. now)")
 }

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -38,7 +38,7 @@ func (o *incidentListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
 	flags.IntVar(&o.Limit, "limit", 50, "Maximum number of incidents to return")
-	flags.StringSliceVar(&o.Labels, "labels", nil, "Filter by label text, e.g. security (repeatable, comma-separated)")
+	flags.StringSliceVar(&o.Labels, "labels", nil, "Filter by label: plain text for default Tags labels (e.g. security), key:value for keyed labels (e.g. team:platform); repeatable, comma-separated")
 	flags.StringVar(&o.DateFrom, "from", "", "Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)")
 	flags.StringVar(&o.DateTo, "to", "", "End of time range (RFC3339, unix timestamp, or relative e.g. now)")
 }
@@ -47,8 +47,10 @@ func (o *incidentListOpts) Validate() error {
 	if err := o.IO.Validate(); err != nil {
 		return err
 	}
-	// The API's incidentLabels field matches on plain label text (e.g.
-	// "security"), not key:value pairs — pass values through as given.
+	// The API's incidentLabels field matches plain label text for labels
+	// under the default Tags key and key:value composites for keyed labels,
+	// so any non-empty string is a valid filter — pass values through as
+	// given.
 	for _, l := range o.Labels {
 		if strings.TrimSpace(l) == "" {
 			return errors.New("invalid --labels value: label must not be empty")

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -47,6 +47,9 @@ func (o *incidentListOpts) Validate() error {
 	if err := o.IO.Validate(); err != nil {
 		return err
 	}
+	if o.Limit < 1 {
+		return fmt.Errorf("invalid --limit value %d: must be at least 1", o.Limit)
+	}
 	// The API's incidentLabels field matches plain label text for labels
 	// under the default Tags key and key:value composites for keyed labels,
 	// so any non-empty string is a valid filter — pass values through as

--- a/internal/providers/irm/incidents_commands_test.go
+++ b/internal/providers/irm/incidents_commands_test.go
@@ -2,13 +2,20 @@ package irm_test
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers/irm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
 
 // ---------------------------------------------------------------------------
@@ -277,13 +284,19 @@ func TestListOpts_LabelValidation(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:   "valid labels pass",
-			labels: []string{"team:platform", "env:prod"},
+			// The API's incidentLabels field matches plain label text, so
+			// values without a colon are valid.
+			name:   "plain label text passes",
+			labels: []string{"security", "customersaffected"},
 		},
 		{
-			name:    "missing colon fails",
-			labels:  []string{"nocolon"},
-			wantErr: "must be in key:value format",
+			name:   "colon-separated text passes through verbatim",
+			labels: []string{"team:platform"},
+		},
+		{
+			name:    "empty label fails",
+			labels:  []string{"security", ""},
+			wantErr: "label must not be empty",
 		},
 	}
 	for _, tt := range tests {
@@ -294,9 +307,71 @@ func TestListOpts_LabelValidation(t *testing.T) {
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}
+}
+
+// fakeGrafanaConfigLoader implements irm.GrafanaConfigLoader for command tests.
+type fakeGrafanaConfigLoader struct {
+	cfg config.NamespacedRESTConfig
+}
+
+func (l fakeGrafanaConfigLoader) LoadGrafanaConfig(context.Context) (config.NamespacedRESTConfig, error) {
+	return l.cfg, nil
+}
+
+// TestIncidentsListCommand_BuildsQuery runs the real list command against a
+// fake API and asserts the filters land in the request as the API documents
+// them: plain label text in incidentLabels and RFC3339 dates.
+func TestIncidentsListCommand_BuildsQuery(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	var query map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Query map[string]any `json:"query"`
+		}
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		query = body.Query
+		writeJSON(w, map[string]any{
+			"incidents": []map[string]any{
+				{"incidentID": "inc-1", "title": "Security incident", "status": "active"},
+			},
+			"cursor": map[string]any{"hasMore": false},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	loader := fakeGrafanaConfigLoader{cfg: config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: server.URL},
+		Namespace: "stack-123",
+	}}
+
+	cmd := irm.NewListCommand(loader)
+	cmd.SilenceUsage = true
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--labels", "security,important",
+		"--from", "2024-06-01T00:00:00Z",
+		"--to", "2024-06-15T00:00:00Z",
+		"--limit", "10",
+	})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, []any{"security", "important"}, query["incidentLabels"])
+	assert.Equal(t, "2024-06-01T00:00:00Z", query["dateFrom"])
+	assert.Equal(t, "2024-06-15T00:00:00Z", query["dateTo"])
+	assert.InDelta(t, 10, query["limit"], 0)
+
+	assert.Contains(t, stdout.String(), "inc-1")
+	assert.Contains(t, stdout.String(), "Security incident")
 }
 
 func TestListOpts_DateValidation(t *testing.T) {

--- a/internal/providers/irm/incidents_commands_test.go
+++ b/internal/providers/irm/incidents_commands_test.go
@@ -375,6 +375,29 @@ func TestIncidentsListCommand_BuildsQuery(t *testing.T) {
 	assert.Contains(t, stdout.String(), "Security incident")
 }
 
+func TestIncidentsListCommand_RejectsNonPositiveLimit(t *testing.T) {
+	for _, limit := range []string{"0", "-5"} {
+		t.Run("limit "+limit, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				t.Error("API must not be called when validation fails")
+			}))
+			t.Cleanup(server.Close)
+
+			cmd := irm.NewListCommand(fakeGrafanaConfigLoader{cfg: config.NamespacedRESTConfig{
+				Config: rest.Config{Host: server.URL},
+			}})
+			cmd.SilenceUsage = true
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{"--limit", limit})
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "must be at least 1")
+		})
+	}
+}
+
 func TestListOpts_DateValidation(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/providers/irm/incidents_commands_test.go
+++ b/internal/providers/irm/incidents_commands_test.go
@@ -284,13 +284,14 @@ func TestListOpts_LabelValidation(t *testing.T) {
 		wantErr string
 	}{
 		{
-			// The API's incidentLabels field matches plain label text, so
-			// values without a colon are valid.
+			// Labels under the default Tags key are matched by plain text,
+			// so values without a colon are valid.
 			name:   "plain label text passes",
-			labels: []string{"security", "customersaffected"},
+			labels: []string{"security", "PIR not needed"},
 		},
 		{
-			name:   "colon-separated text passes through verbatim",
+			// Keyed labels are matched by their key:value composite.
+			name:   "key:value text passes through verbatim",
 			labels: []string{"team:platform"},
 		},
 		{

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -182,7 +182,6 @@ type IncidentQuery struct {
 	OrderDirection  string    `json:"orderDirection"`
 	OrderField      string    `json:"orderField"`
 	QueryString     string    `json:"queryString"`
-	ContextPayload  string    `json:"contextPayload,omitempty"`
 	DateFrom        *FlexTime `json:"dateFrom,omitempty"`
 	DateTo          *FlexTime `json:"dateTo,omitempty"`
 	Severity        string    `json:"severity,omitempty"`
@@ -193,9 +192,12 @@ type IncidentQuery struct {
 	IncidentRoles   []string  `json:"incidentRoles,omitempty"`
 }
 
-// queryIncidentsRequest is the request body for querying incidents.
+// queryIncidentsRequest is the request body for querying incidents. The
+// cursor rides next to the query, not inside it: pass the cursor returned by
+// the previous page to fetch the next one.
 type queryIncidentsRequest struct {
-	Query IncidentQuery `json:"query"`
+	Query  IncidentQuery   `json:"query"`
+	Cursor *IncidentCursor `json:"cursor,omitempty"`
 }
 
 // queryIncidentsResponse is the response from querying incidents.


### PR DESCRIPTION
## What

Three bug fixes for `gcx irm incidents list`, found by checking the implementation against the [Grafana Incident API reference](https://grafana.com/docs/grafana-cloud/alerting-and-irm/irm/reference/incident-api/reference/). No new flags or behavior beyond the fixes.

### 1. Pagination never advanced past the first page

The pagination cursor was sent as a `contextPayload` field **inside** the query object — a field that does not exist in the API. The server ignored it and returned the same first page on every request, so any list spanning multiple pages was padded with duplicates of page one.

Per the API reference, `QueryIncidentsRequest` takes the cursor as a **top-level field next to the query** (`{"query": {...}, "cursor": {"nextValue": "..."}}`). The client now sends it there, and also stops paging when the server cannot make progress (no `hasMore`, empty `nextValue`, or an empty page) instead of looping forever on a misbehaving response.

### 2. `--labels` rejected valid labels

The flag required `key:value` format, but that rejects real labels. Verified against a live stack, the API's `incidentLabels` field matches:

- **plain label text** for labels under the default `Tags` key (e.g. `security`, matching the docs example `["security", "customersaffected"]`) — the old validation hard-errored on these client-side;
- **`key:value` composites** for keyed labels (e.g. `team:platform`) — these worked before and still produce byte-identical requests.

Both forms are valid inputs, so values are now passed through verbatim and only empty values are rejected; the help text documents both forms. Also removes the unused `BuildQueryString` helper that encoded a query syntax matching nothing in the API.

### 3. `--limit` ignored the documented per-page maximum

`IncidentsQuery.limit` has a documented maximum of 100 per page, but the user's `--limit` was forwarded unchanged. The per-page request is now clamped to 100 and paging continues until the requested total is collected (e.g. `--limit 250` fetches pages of 100, 100, 50).

## Tests

`TestClient_List` asserts the request wire shape: cursor placement on page two (and absence of `contextPayload`), per-page clamping across a three-page fetch, stop conditions (limit reached, server over-returns, `hasMore` with an empty cursor), and filter forwarding. A new command-level test runs the real command against a fake API and verifies label text and RFC3339 dates land in the request as documented.

**Verified live** against a Grafana Cloud stack: `--limit 150` returns 150 unique incidents across two pages (previously duplicates), a no-colon `Tags` label and a `key:value` keyed label both match, and a bare keyed-label value without its key correctly matches nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)