### PR TITLE
feat(appo11y): add services get with auto-detected span-metrics

### DIFF
--- a/docs/reference/cli/gcx_appo11y_services.md
+++ b/docs/reference/cli/gcx_appo11y_services.md
@@ -23,5 +23,6 @@ Inspect Application Observability services discovered from telemetry
 ### SEE ALSO
 
 * [gcx appo11y](gcx_appo11y.md)	 - Manage Grafana App Observability settings
+* [gcx appo11y services get](gcx_appo11y_services_get.md)	 - Inspect a single Application Observability service: metadata + RED snapshot.
 * [gcx appo11y services list](gcx_appo11y_services_list.md)	 - List Application Observability services discovered from target_info/traces_target_info telemetry.
 

--- a/docs/reference/cli/gcx_appo11y_services_get.md
+++ b/docs/reference/cli/gcx_appo11y_services_get.md
@@ -15,17 +15,17 @@ can't accidentally target the wrong service. Pass --namespace or use the
 
 Metadata comes from the same target_info/traces_target_info union used by
 "gcx appo11y services list". RED numbers are computed from span metrics
-over --window (default 5m), restricted to inbound spans (SERVER + CONSUMER).
+over --since (default 5m), restricted to inbound spans (SERVER + CONSUMER).
 
 The span-metric family is selected by --metrics-mode:
   auto   probe each family for this service and pick the one with data
-         (default — prefers v3 > tempo > otel when a stack double-emits)
+         (prefers v3 > tempo > otel when a stack double-emits)
   v3     traces_span_metrics_calls_total / _duration_seconds_bucket
-         (modern Tempo / OTel Collector ≥ 1.0.9)
+         (OTel Collector >= 0.109, Grafana Alloy >= 1.5.0)
   tempo  traces_spanmetrics_calls_total  / _latency_bucket
-         (legacy Tempo metrics-generator, Beyla)
+         (Tempo metrics-generator — Grafana Cloud default — and Beyla)
   otel   calls_total / duration_seconds_bucket
-         (bare OTel Collector spanmetrics connector)
+         (OTel Collector 0.94–0.108, Alloy 1.0–1.4.3, Grafana Agent >= 0.40)
 The resolved mode is reported in the snapshot output so you can confirm
 which family produced the numbers.
 
@@ -41,7 +41,7 @@ gcx appo11y services get <service> [--namespace ns] [flags]
   gcx appo11y services get checkoutservice
 
   # Same service, explicit namespace (skips the lookup)
-  gcx appo11y services get payments/checkoutservice --window 1h
+  gcx appo11y services get payments/checkoutservice --since 1h
 
   # JSON for scripting
   gcx appo11y services get checkoutservice -o json
@@ -49,7 +49,7 @@ gcx appo11y services get <service> [--namespace ns] [flags]
   # Restrict to server-side traffic only
   gcx appo11y services get checkoutservice --kind server
 
-  # Stack still on the legacy Tempo metrics-generator
+  # Stack double-emits both families; force the Tempo metrics-generator numbers
   gcx appo11y services get checkoutservice --metrics-mode tempo
 ```
 
@@ -60,10 +60,10 @@ gcx appo11y services get <service> [--namespace ns] [flags]
   -h, --help                  help for get
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --kind string           Span kinds to include: inbound (server+consumer), server, consumer, all, or a comma list of SPAN_KIND_* literals (default "inbound")
-      --metrics-mode string   Span-metrics family: auto (default, probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket) (default "auto")
+      --metrics-mode string   Span-metrics family: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket) (default "auto")
   -n, --namespace string      Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)
   -o, --output string         Output format. One of: agents, json, table, wide, yaml (default "table")
-      --window string         Rate/quantile window (e.g. 1m, 5m, 1h) (default "5m")
+      --since string          Rate/quantile window applied to span metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax (default "5m")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_appo11y_services_get.md
+++ b/docs/reference/cli/gcx_appo11y_services_get.md
@@ -7,9 +7,11 @@ Inspect a single Application Observability service: metadata + RED snapshot.
 Show metadata and a rate/errors/duration snapshot for one service.
 
 The argument is either the bare service name (matching the OTel service.name
-resource attribute) or the canonical "<namespace>/<name>" form. When multiple
-namespaces have a service with the same name, either supply the namespace in
-the argument or pass --namespace.
+resource attribute) or the canonical "<namespace>/<name>" form. When a bare
+name is given, the namespace is resolved automatically from target_info;
+ambiguity (the same name in multiple namespaces) errors out so the snapshot
+can't accidentally target the wrong service. Pass --namespace or use the
+"<namespace>/<name>" form to disambiguate.
 
 Metadata comes from the same target_info/traces_target_info union used by
 "gcx appo11y services list". RED numbers are computed from span metrics
@@ -35,10 +37,10 @@ gcx appo11y services get <service> [--namespace ns] [flags]
 
 ```
 
-  # Bare service name, default 5m window
+  # Bare name — namespace is resolved from target_info
   gcx appo11y services get checkoutservice
 
-  # Namespaced service, longer window
+  # Same service, explicit namespace (skips the lookup)
   gcx appo11y services get payments/checkoutservice --window 1h
 
   # JSON for scripting

--- a/docs/reference/cli/gcx_appo11y_services_get.md
+++ b/docs/reference/cli/gcx_appo11y_services_get.md
@@ -1,0 +1,82 @@
+## gcx appo11y services get
+
+Inspect a single Application Observability service: metadata + RED snapshot.
+
+### Synopsis
+
+Show metadata and a rate/errors/duration snapshot for one service.
+
+The argument is either the bare service name (matching the OTel service.name
+resource attribute) or the canonical "<namespace>/<name>" form. When multiple
+namespaces have a service with the same name, either supply the namespace in
+the argument or pass --namespace.
+
+Metadata comes from the same target_info/traces_target_info union used by
+"gcx appo11y services list". RED numbers are computed from span metrics
+over --window (default 5m), restricted to inbound spans (SERVER + CONSUMER).
+
+The span-metric family is selected by --metrics-mode:
+  auto   probe each family for this service and pick the one with data
+         (default — prefers v3 > tempo > otel when a stack double-emits)
+  v3     traces_span_metrics_calls_total / _duration_seconds_bucket
+         (modern Tempo / OTel Collector ≥ 1.0.9)
+  tempo  traces_spanmetrics_calls_total  / _latency_bucket
+         (legacy Tempo metrics-generator, Beyla)
+  otel   calls_total / duration_seconds_bucket
+         (bare OTel Collector spanmetrics connector)
+The resolved mode is reported in the snapshot output so you can confirm
+which family produced the numbers.
+
+```
+gcx appo11y services get <service> [--namespace ns] [flags]
+```
+
+### Examples
+
+```
+
+  # Bare service name, default 5m window
+  gcx appo11y services get checkoutservice
+
+  # Namespaced service, longer window
+  gcx appo11y services get payments/checkoutservice --window 1h
+
+  # JSON for scripting
+  gcx appo11y services get checkoutservice -o json
+
+  # Restrict to server-side traffic only
+  gcx appo11y services get checkoutservice --kind server
+
+  # Stack still on the legacy Tempo metrics-generator
+  gcx appo11y services get checkoutservice --metrics-mode tempo
+```
+
+### Options
+
+```
+  -d, --datasource string     Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
+  -h, --help                  help for get
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --kind string           Span kinds to include: inbound (server+consumer), server, consumer, all, or a comma list of SPAN_KIND_* literals (default "inbound")
+      --metrics-mode string   Span-metrics family: auto (default, probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket) (default "auto")
+  -n, --namespace string      Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)
+  -o, --output string         Output format. One of: agents, json, table, wide, yaml (default "table")
+      --window string         Rate/quantile window (e.g. 1m, 5m, 1h) (default "5m")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx appo11y services](gcx_appo11y_services.md)	 - Inspect Application Observability services discovered from telemetry
+

--- a/internal/providers/appo11y/services/commands.go
+++ b/internal/providers/appo11y/services/commands.go
@@ -29,6 +29,7 @@ func Commands() *cobra.Command {
 		Short: "Inspect Application Observability services discovered from telemetry",
 	}
 	cmd.AddCommand(newListCommand())
+	cmd.AddCommand(newGetCommand())
 	return cmd
 }
 

--- a/internal/providers/appo11y/services/get.go
+++ b/internal/providers/appo11y/services/get.go
@@ -299,7 +299,15 @@ func resolveNamespaceForBareName(ctx context.Context, client *prometheus.Client,
 	case 1:
 		return namespaces[0], nil
 	}
-	return "", fmt.Errorf("service %q exists in multiple namespaces (%s); disambiguate with <namespace>/%s or --namespace", name, strings.Join(namespaces, ", "), name)
+	labels := make([]string, len(namespaces))
+	for i, ns := range namespaces {
+		if ns == "" {
+			labels[i] = "(none)"
+		} else {
+			labels[i] = ns
+		}
+	}
+	return "", fmt.Errorf("service %q exists in multiple namespaces (%s); disambiguate with <namespace>/%s or --namespace", name, strings.Join(labels, ", "), name)
 }
 
 // detectMetricsMode probes each metrics family in parallel for the given

--- a/internal/providers/appo11y/services/get.go
+++ b/internal/providers/appo11y/services/get.go
@@ -8,8 +8,8 @@ import (
 	"log/slog"
 	"strings"
 	"text/tabwriter"
-	"time"
 
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/agent"
 	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/prometheus"
 	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/prometheus/common/model"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
@@ -31,7 +32,7 @@ const defaultRedWindow = "5m"
 type getOpts struct {
 	IO          cmdio.Options
 	Datasource  string
-	Window      string
+	Since       string
 	Namespace   string
 	Kind        string
 	MetricsMode string
@@ -45,26 +46,26 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 
 	flags.StringVarP(&o.Datasource, "datasource", "d", "", "Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)")
 	flags.StringVarP(&o.Namespace, "namespace", "n", "", "Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)")
-	flags.StringVar(&o.Window, "window", defaultRedWindow, "Rate/quantile window (e.g. 1m, 5m, 1h)")
+	flags.StringVar(&o.Since, "since", defaultRedWindow, "Rate/quantile window applied to span metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax")
 	flags.StringVar(&o.Kind, "kind", "inbound", "Span kinds to include: inbound (server+consumer), server, consumer, all, or a comma list of SPAN_KIND_* literals")
-	flags.StringVar(&o.MetricsMode, "metrics-mode", metricsModeAuto, "Span-metrics family: auto (default, probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket)")
+	flags.StringVar(&o.MetricsMode, "metrics-mode", metricsModeAuto, "Span-metrics family: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket)")
 }
 
-func (o *getOpts) Validate() error {
+func (o *getOpts) Validate(cmd *cobra.Command) error {
 	if err := o.IO.Validate(); err != nil {
 		return err
 	}
-	if strings.TrimSpace(o.Window) == "" {
-		return errors.New("--window must not be empty")
+	if strings.TrimSpace(o.Since) == "" {
+		return fail.NewCommandUsageError(cmd, "--since must not be empty", nil)
 	}
-	if _, err := time.ParseDuration(o.Window); err != nil {
-		return fmt.Errorf("--window %q is not a valid duration: %w", o.Window, err)
+	if _, err := model.ParseDuration(o.Since); err != nil {
+		return fail.NewCommandUsageError(cmd, fmt.Sprintf("--since %q is not a valid PromQL duration", o.Since), err)
 	}
 	if _, err := resolveSpanKinds(o.Kind); err != nil {
-		return err
+		return fail.NewCommandUsageError(cmd, "", err)
 	}
 	if _, _, err := resolveMetricsMode(o.MetricsMode); err != nil {
-		return err
+		return fail.NewCommandUsageError(cmd, "", err)
 	}
 	return nil
 }
@@ -143,17 +144,17 @@ can't accidentally target the wrong service. Pass --namespace or use the
 
 Metadata comes from the same target_info/traces_target_info union used by
 "gcx appo11y services list". RED numbers are computed from span metrics
-over --window (default 5m), restricted to inbound spans (SERVER + CONSUMER).
+over --since (default 5m), restricted to inbound spans (SERVER + CONSUMER).
 
 The span-metric family is selected by --metrics-mode:
   auto   probe each family for this service and pick the one with data
-         (default — prefers v3 > tempo > otel when a stack double-emits)
+         (prefers v3 > tempo > otel when a stack double-emits)
   v3     traces_span_metrics_calls_total / _duration_seconds_bucket
-         (modern Tempo / OTel Collector ≥ 1.0.9)
+         (OTel Collector >= 0.109, Grafana Alloy >= 1.5.0)
   tempo  traces_spanmetrics_calls_total  / _latency_bucket
-         (legacy Tempo metrics-generator, Beyla)
+         (Tempo metrics-generator — Grafana Cloud default — and Beyla)
   otel   calls_total / duration_seconds_bucket
-         (bare OTel Collector spanmetrics connector)
+         (OTel Collector 0.94–0.108, Alloy 1.0–1.4.3, Grafana Agent >= 0.40)
 The resolved mode is reported in the snapshot output so you can confirm
 which family produced the numbers.`,
 		Example: `
@@ -161,7 +162,7 @@ which family produced the numbers.`,
   gcx appo11y services get checkoutservice
 
   # Same service, explicit namespace (skips the lookup)
-  gcx appo11y services get payments/checkoutservice --window 1h
+  gcx appo11y services get payments/checkoutservice --since 1h
 
   # JSON for scripting
   gcx appo11y services get checkoutservice -o json
@@ -169,13 +170,13 @@ which family produced the numbers.`,
   # Restrict to server-side traffic only
   gcx appo11y services get checkoutservice --kind server
 
-  # Stack still on the legacy Tempo metrics-generator
+  # Stack double-emits both families; force the Tempo metrics-generator numbers
   gcx appo11y services get checkoutservice --metrics-mode tempo`,
 		Args: cobra.ExactArgs(1),
 		RunE: runGet(opts),
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
-			agent.AnnotationLLMHint:   `Per-service RED snapshot from Tempo/OTel span metrics: rate (req/s), error rate, error percent, p50/p95/p99 latency (seconds) over --window (default 5m), scoped to inbound spans (SERVER+CONSUMER). --metrics-mode picks the family: v3 (default, traces_span_metrics_*), tempo (legacy traces_spanmetrics_*), otel (bare calls_total/duration_seconds_bucket). Pairs with 'gcx appo11y services list' to drill into a single row. Examples: gcx appo11y services get <name> -o json; gcx appo11y services get <ns>/<name> --window 1h -o json; gcx appo11y services get <name> --metrics-mode tempo -o json`,
+			agent.AnnotationLLMHint:   `Per-service RED snapshot from Tempo/OTel span metrics: rate (req/s), error rate, error percent, p50/p95/p99 latency (seconds) over --since (default 5m), scoped to inbound spans (SERVER+CONSUMER). --metrics-mode picks the family: auto (default, probes the stack), v3 (traces_span_metrics_*, OTel Collector >= 0.109 / Alloy >= 1.5), tempo (traces_spanmetrics_*, Tempo metrics-generator — Grafana Cloud default — and Beyla), otel (bare calls_total/duration_seconds_bucket, older Collector/Alloy/Agent). Pairs with 'gcx appo11y services list' to drill into a single row. Examples: gcx appo11y services get <name> -o json; gcx appo11y services get <ns>/<name> --since 1h -o json; gcx appo11y services get <name> --metrics-mode tempo -o json`,
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -184,20 +185,20 @@ which family produced the numbers.`,
 
 func runGet(opts *getOpts) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		if err := opts.Validate(); err != nil {
+		if err := opts.Validate(cmd); err != nil {
 			return err
 		}
 		namespace, name, err := parseServiceArg(args[0], opts.Namespace)
 		if err != nil {
-			return err
+			return fail.NewCommandUsageError(cmd, "", err)
 		}
 		kinds, err := resolveSpanKinds(opts.Kind)
 		if err != nil {
-			return err
+			return fail.NewCommandUsageError(cmd, "", err)
 		}
 		mode, auto, err := resolveMetricsMode(opts.MetricsMode)
 		if err != nil {
-			return err
+			return fail.NewCommandUsageError(cmd, "", err)
 		}
 
 		ctx := cmd.Context()
@@ -245,14 +246,24 @@ func runGet(opts *getOpts) func(*cobra.Command, []string) error {
 			}
 		}
 
-		detail, err := fetchServiceDetail(ctx, client, datasourceUID, namespace, name, opts.Window, kinds, mode)
+		detail, err := fetchServiceDetail(ctx, client, datasourceUID, namespace, name, opts.Since, kinds, mode)
 		if err != nil {
 			return err
 		}
-		if !detail.Service.Instrumented && !detail.RED.HasTraffic {
+		notFound := !detail.Service.Instrumented && !detail.RED.HasTraffic
+		if notFound {
 			emitNoDataHint(cmd.ErrOrStderr(), namespace, name)
 		}
-		return opts.IO.Encode(cmd.OutOrStdout(), detail)
+		if err := opts.IO.Encode(cmd.OutOrStdout(), detail); err != nil {
+			return err
+		}
+		if notFound {
+			// Align with other commands' "entity not-found" semantics:
+			// emit the snapshot (useful structure for agents) but signal
+			// failure via exit code so callers can branch on $?.
+			return fmt.Errorf("service %q has no telemetry in the requested window", jobLabel(namespace, name))
+		}
+		return nil
 	}
 }
 

--- a/internal/providers/appo11y/services/get.go
+++ b/internal/providers/appo11y/services/get.go
@@ -135,9 +135,11 @@ func newGetCommand() *cobra.Command {
 		Long: `Show metadata and a rate/errors/duration snapshot for one service.
 
 The argument is either the bare service name (matching the OTel service.name
-resource attribute) or the canonical "<namespace>/<name>" form. When multiple
-namespaces have a service with the same name, either supply the namespace in
-the argument or pass --namespace.
+resource attribute) or the canonical "<namespace>/<name>" form. When a bare
+name is given, the namespace is resolved automatically from target_info;
+ambiguity (the same name in multiple namespaces) errors out so the snapshot
+can't accidentally target the wrong service. Pass --namespace or use the
+"<namespace>/<name>" form to disambiguate.
 
 Metadata comes from the same target_info/traces_target_info union used by
 "gcx appo11y services list". RED numbers are computed from span metrics
@@ -155,10 +157,10 @@ The span-metric family is selected by --metrics-mode:
 The resolved mode is reported in the snapshot output so you can confirm
 which family produced the numbers.`,
 		Example: `
-  # Bare service name, default 5m window
+  # Bare name — namespace is resolved from target_info
   gcx appo11y services get checkoutservice
 
-  # Namespaced service, longer window
+  # Same service, explicit namespace (skips the lookup)
   gcx appo11y services get payments/checkoutservice --window 1h
 
   # JSON for scripting
@@ -223,6 +225,19 @@ func runGet(opts *getOpts) func(*cobra.Command, []string) error {
 			return fmt.Errorf("failed to create prometheus client: %w", err)
 		}
 
+		// Bare-name resolution: if the user passed just `<name>` (no
+		// namespace), look the service up in target_info to find the
+		// matching namespace. Without this step, a query for a namespaced
+		// service via its bare name silently returns no data because the
+		// `job` label is `<ns>/<name>`, not `<name>`.
+		if namespace == "" {
+			resolved, err := resolveNamespaceForBareName(ctx, client, datasourceUID, name)
+			if err != nil {
+				return err
+			}
+			namespace = resolved
+		}
+
 		if auto {
 			mode, err = detectMetricsMode(ctx, client, datasourceUID, namespace, name)
 			if err != nil {
@@ -239,6 +254,52 @@ func runGet(opts *getOpts) func(*cobra.Command, []string) error {
 		}
 		return opts.IO.Encode(cmd.OutOrStdout(), detail)
 	}
+}
+
+// resolveNamespaceForBareName queries the target_info union for any series
+// whose `job` is the bare name or some `<ns>/<name>`, then returns the
+// single matching namespace (or "" for a truly un-namespaced service).
+//
+// Returns:
+//   - "" with no error when nothing matched (caller proceeds with the bare
+//     name; the resulting snapshot will show no data and the standard hint
+//     will fire).
+//   - <ns> with no error when exactly one namespace matched (or only the
+//     bare-name shape did).
+//   - an error listing the candidates when multiple namespaces have a
+//     service with the requested name — ambiguity is something the user
+//     must resolve explicitly with `<ns>/<name>` or `--namespace`.
+func resolveNamespaceForBareName(ctx context.Context, client *prometheus.Client, datasourceUID, name string) (string, error) {
+	metrics := targetInfoMetrics()
+	responses := make([]*prometheus.QueryResponse, len(metrics))
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	for i, metric := range metrics {
+		eg.Go(func() error {
+			expr, err := buildBareNameLookupQuery(metric, name)
+			if err != nil {
+				return fmt.Errorf("failed to build %s lookup query: %w", metric, err)
+			}
+			resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+			if err != nil {
+				return fmt.Errorf("%s lookup query failed: %w", metric, err)
+			}
+			responses[i] = resp
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return "", err
+	}
+
+	namespaces := namespacesForName(extractJobsFromResponses(responses), name)
+	switch len(namespaces) {
+	case 0:
+		return "", nil
+	case 1:
+		return namespaces[0], nil
+	}
+	return "", fmt.Errorf("service %q exists in multiple namespaces (%s); disambiguate with <namespace>/%s or --namespace", name, strings.Join(namespaces, ", "), name)
 }
 
 // detectMetricsMode probes each metrics family in parallel for the given

--- a/internal/providers/appo11y/services/get.go
+++ b/internal/providers/appo11y/services/get.go
@@ -1,0 +1,526 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+)
+
+// defaultRedWindow is the rate/quantile window when --window isn't set.
+// 5m is a useful starting point: short enough to reflect current behaviour,
+// long enough that low-traffic services still produce histogram samples.
+const defaultRedWindow = "5m"
+
+type getOpts struct {
+	IO          cmdio.Options
+	Datasource  string
+	Window      string
+	Namespace   string
+	Kind        string
+	MetricsMode string
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &serviceDetailCodec{})
+	o.IO.RegisterCustomCodec("wide", &serviceDetailCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+
+	flags.StringVarP(&o.Datasource, "datasource", "d", "", "Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)")
+	flags.StringVarP(&o.Namespace, "namespace", "n", "", "Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)")
+	flags.StringVar(&o.Window, "window", defaultRedWindow, "Rate/quantile window (e.g. 1m, 5m, 1h)")
+	flags.StringVar(&o.Kind, "kind", "inbound", "Span kinds to include: inbound (server+consumer), server, consumer, all, or a comma list of SPAN_KIND_* literals")
+	flags.StringVar(&o.MetricsMode, "metrics-mode", metricsModeAuto, "Span-metrics family: auto (default, probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket)")
+}
+
+func (o *getOpts) Validate() error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(o.Window) == "" {
+		return errors.New("--window must not be empty")
+	}
+	if _, err := time.ParseDuration(o.Window); err != nil {
+		return fmt.Errorf("--window %q is not a valid duration: %w", o.Window, err)
+	}
+	if _, err := resolveSpanKinds(o.Kind); err != nil {
+		return err
+	}
+	if _, _, err := resolveMetricsMode(o.MetricsMode); err != nil {
+		return err
+	}
+	return nil
+}
+
+// resolveSpanKinds maps the `--kind` flag onto the literal SPAN_KIND_* values
+// that Tempo's spanmetrics emits. Aliases are case-insensitive; explicit
+// SPAN_KIND_* values are accepted verbatim (and case-corrected) so users can
+// pass a custom mix without learning a new vocabulary.
+func resolveSpanKinds(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultInboundSpanKinds(), nil
+	}
+	switch strings.ToLower(raw) {
+	case "inbound":
+		return defaultInboundSpanKinds(), nil
+	case "server":
+		return []string{spanKindServer}, nil
+	case "consumer":
+		return []string{spanKindConsumer}, nil
+	case "all":
+		return []string{"SPAN_KIND_SERVER", "SPAN_KIND_CONSUMER", "SPAN_KIND_CLIENT", "SPAN_KIND_PRODUCER", "SPAN_KIND_INTERNAL"}, nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(strings.ToUpper(p))
+		if p == "" {
+			continue
+		}
+		if !strings.HasPrefix(p, "SPAN_KIND_") {
+			return nil, fmt.Errorf("--kind %q is not a recognized alias (inbound, server, consumer, all) or a SPAN_KIND_* literal", raw)
+		}
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("--kind %q resolved to an empty set", raw)
+	}
+	return out, nil
+}
+
+// parseServiceArg splits a positional argument into (namespace, name).
+// Accepts "name" or "namespace/name"; an explicit --namespace flag wins
+// when the argument has no slash. If both are given and they disagree,
+// returns an error so the caller can't silently target a wrong service.
+func parseServiceArg(arg, flagNamespace string) (string, string, error) {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return "", "", errors.New("service name is required")
+	}
+	ns, name := parseJob(arg)
+	if ns == "" {
+		ns = flagNamespace
+	} else if flagNamespace != "" && flagNamespace != ns {
+		return "", "", fmt.Errorf("namespace %q in argument conflicts with --namespace %q", ns, flagNamespace)
+	}
+	if name == "" {
+		return "", "", fmt.Errorf("service name is empty (got %q)", arg)
+	}
+	return ns, name, nil
+}
+
+func newGetCommand() *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:   "get <service> [--namespace ns]",
+		Short: "Inspect a single Application Observability service: metadata + RED snapshot.",
+		Long: `Show metadata and a rate/errors/duration snapshot for one service.
+
+The argument is either the bare service name (matching the OTel service.name
+resource attribute) or the canonical "<namespace>/<name>" form. When multiple
+namespaces have a service with the same name, either supply the namespace in
+the argument or pass --namespace.
+
+Metadata comes from the same target_info/traces_target_info union used by
+"gcx appo11y services list". RED numbers are computed from span metrics
+over --window (default 5m), restricted to inbound spans (SERVER + CONSUMER).
+
+The span-metric family is selected by --metrics-mode:
+  auto   probe each family for this service and pick the one with data
+         (default — prefers v3 > tempo > otel when a stack double-emits)
+  v3     traces_span_metrics_calls_total / _duration_seconds_bucket
+         (modern Tempo / OTel Collector ≥ 1.0.9)
+  tempo  traces_spanmetrics_calls_total  / _latency_bucket
+         (legacy Tempo metrics-generator, Beyla)
+  otel   calls_total / duration_seconds_bucket
+         (bare OTel Collector spanmetrics connector)
+The resolved mode is reported in the snapshot output so you can confirm
+which family produced the numbers.`,
+		Example: `
+  # Bare service name, default 5m window
+  gcx appo11y services get checkoutservice
+
+  # Namespaced service, longer window
+  gcx appo11y services get payments/checkoutservice --window 1h
+
+  # JSON for scripting
+  gcx appo11y services get checkoutservice -o json
+
+  # Restrict to server-side traffic only
+  gcx appo11y services get checkoutservice --kind server
+
+  # Stack still on the legacy Tempo metrics-generator
+  gcx appo11y services get checkoutservice --metrics-mode tempo`,
+		Args: cobra.ExactArgs(1),
+		RunE: runGet(opts),
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "small",
+			agent.AnnotationLLMHint:   `Per-service RED snapshot from Tempo/OTel span metrics: rate (req/s), error rate, error percent, p50/p95/p99 latency (seconds) over --window (default 5m), scoped to inbound spans (SERVER+CONSUMER). --metrics-mode picks the family: v3 (default, traces_span_metrics_*), tempo (legacy traces_spanmetrics_*), otel (bare calls_total/duration_seconds_bucket). Pairs with 'gcx appo11y services list' to drill into a single row. Examples: gcx appo11y services get <name> -o json; gcx appo11y services get <ns>/<name> --window 1h -o json; gcx appo11y services get <name> --metrics-mode tempo -o json`,
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func runGet(opts *getOpts) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := opts.Validate(); err != nil {
+			return err
+		}
+		namespace, name, err := parseServiceArg(args[0], opts.Namespace)
+		if err != nil {
+			return err
+		}
+		kinds, err := resolveSpanKinds(opts.Kind)
+		if err != nil {
+			return err
+		}
+		mode, auto, err := resolveMetricsMode(opts.MetricsMode)
+		if err != nil {
+			return err
+		}
+
+		ctx := cmd.Context()
+		var loader providers.ConfigLoader
+
+		cfg, err := loader.LoadGrafanaConfig(ctx)
+		if err != nil {
+			return err
+		}
+
+		var cfgCtx *internalconfig.Context
+		if fullCfg, err := loader.LoadFullConfig(ctx); err != nil {
+			logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+		} else {
+			cfgCtx = fullCfg.GetCurrentContext()
+		}
+
+		datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, &loader, opts.Datasource, cfgCtx, cfg, "prometheus")
+		if err != nil {
+			return err
+		}
+
+		client, err := prometheus.NewClient(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create prometheus client: %w", err)
+		}
+
+		if auto {
+			mode, err = detectMetricsMode(ctx, client, datasourceUID, namespace, name)
+			if err != nil {
+				return fmt.Errorf("metrics-mode auto-detect failed: %w", err)
+			}
+		}
+
+		detail, err := fetchServiceDetail(ctx, client, datasourceUID, namespace, name, opts.Window, kinds, mode)
+		if err != nil {
+			return err
+		}
+		if !detail.Service.Instrumented && !detail.RED.HasTraffic {
+			emitNoDataHint(cmd.ErrOrStderr(), namespace, name)
+		}
+		return opts.IO.Encode(cmd.OutOrStdout(), detail)
+	}
+}
+
+// detectMetricsMode probes each metrics family in parallel for the given
+// service and returns the first one with data, biased toward modern names
+// (see metricsModePreference). When no family has data — uninstrumented
+// service, stale telemetry, wrong stack — it falls back to v3 so the RED
+// snapshot still renders (just with "no traffic") instead of erroring.
+func detectMetricsMode(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name string) (MetricsMode, error) {
+	preference := metricsModePreference()
+	found := make([]bool, len(preference))
+	job := jobLabel(namespace, name)
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	for i, m := range preference {
+		names, ok := metricNamesByMode(m)
+		if !ok {
+			return "", fmt.Errorf("unknown metrics mode %q", m)
+		}
+		eg.Go(func() error {
+			expr, err := buildModeProbeQuery(names.calls, job)
+			if err != nil {
+				return fmt.Errorf("failed to build %s probe query: %w", m, err)
+			}
+			resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+			if err != nil {
+				return fmt.Errorf("%s probe query failed: %w", m, err)
+			}
+			if v, ok := instantScalar(resp); ok && v > 0 {
+				found[i] = true
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return "", err
+	}
+	for i, m := range preference {
+		if found[i] {
+			return m, nil
+		}
+	}
+	return MetricsModeV3, nil
+}
+
+// fetchServiceDetail runs the metadata + RED queries in parallel and folds
+// the responses into one ServiceDetail. Latency and error queries return
+// zero with HasX=false when there's no series in the window; the table
+// codec renders those as `-`.
+func fetchServiceDetail(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, kinds []string, mode MetricsMode) (*ServiceDetail, error) {
+	names, ok := metricNamesByMode(mode)
+	if !ok {
+		return nil, fmt.Errorf("unknown metrics mode %q", mode)
+	}
+
+	metrics := targetInfoMetrics()
+	metadataResponses := make([]*prometheus.QueryResponse, len(metrics))
+	var rateResp, errorResp, p50Resp, p95Resp, p99Resp *prometheus.QueryResponse
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	for i, metric := range metrics {
+		eg.Go(func() error {
+			expr, err := buildServiceMetadataQuery(metric, namespace, name)
+			if err != nil {
+				return fmt.Errorf("failed to build %s metadata query: %w", metric, err)
+			}
+			resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+			if err != nil {
+				return fmt.Errorf("%s metadata query failed: %w", metric, err)
+			}
+			metadataResponses[i] = resp
+			return nil
+		})
+	}
+	eg.Go(func() error {
+		expr, err := buildRateQuery(names, namespace, name, window, kinds)
+		if err != nil {
+			return fmt.Errorf("failed to build rate query: %w", err)
+		}
+		resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+		if err != nil {
+			return fmt.Errorf("rate query failed: %w", err)
+		}
+		rateResp = resp
+		return nil
+	})
+	eg.Go(func() error {
+		expr, err := buildErrorRateQuery(names, namespace, name, window, kinds)
+		if err != nil {
+			return fmt.Errorf("failed to build error-rate query: %w", err)
+		}
+		resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+		if err != nil {
+			return fmt.Errorf("error-rate query failed: %w", err)
+		}
+		errorResp = resp
+		return nil
+	})
+	for phi, sink := range map[float64]**prometheus.QueryResponse{
+		0.50: &p50Resp,
+		0.95: &p95Resp,
+		0.99: &p99Resp,
+	} {
+		eg.Go(func() error {
+			expr, err := buildLatencyQuantileQuery(names, namespace, name, window, kinds, phi)
+			if err != nil {
+				return fmt.Errorf("failed to build p%.0f latency query: %w", phi*100, err)
+			}
+			resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+			if err != nil {
+				return fmt.Errorf("p%.0f latency query failed: %w", phi*100, err)
+			}
+			*sink = resp
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	metadata, err := parseServicesResponses(metadataResponses)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse metadata response: %w", err)
+	}
+
+	svc := selectMetadataService(metadata, namespace, name)
+	rate, hasRate := instantScalar(rateResp)
+	errRate, hasErr := instantScalar(errorResp)
+	p50, hasP50 := instantScalar(p50Resp)
+	p95, hasP95 := instantScalar(p95Resp)
+	p99, hasP99 := instantScalar(p99Resp)
+
+	return &ServiceDetail{
+		Service: svc,
+		RED: REDStats{
+			Window:          window,
+			MetricsMode:     mode,
+			SpanKinds:       spanKindRegex(kinds),
+			RatePerSecond:   rate,
+			ErrorRatePerSec: errRate,
+			ErrorPercent:    computeErrorPercent(errRate, rate),
+			P50Seconds:      p50,
+			P95Seconds:      p95,
+			P99Seconds:      p99,
+			HasTraffic:      hasRate && rate > 0,
+			// When there's traffic we know the error rate (it's 0 if no
+			// STATUS_CODE_ERROR series came back). Without this, a healthy
+			// service prints "-" for errors which reads as "no data" rather
+			// than the truthful "zero errors observed".
+			HasErrors:     hasErr || (hasRate && rate > 0),
+			HasLatencyP50: hasP50,
+			HasLatencyP95: hasP95,
+			HasLatencyP99: hasP99,
+		},
+	}, nil
+}
+
+// selectMetadataService picks the best metadata match from a list returned
+// by the filtered target_info query. The filter is already narrow (job
+// matches exactly), so 0 or 1 results are expected; on >1 we prefer an exact
+// (namespace, name) match, otherwise return the first row. When the query
+// returned nothing we synthesize a placeholder so the caller can still
+// render the requested identity (marked uninstrumented).
+func selectMetadataService(metadata []Service, namespace, name string) Service {
+	for _, s := range metadata {
+		if s.Namespace == namespace && s.Name == name {
+			return s
+		}
+	}
+	if len(metadata) > 0 {
+		return metadata[0]
+	}
+	return Service{Name: name, Namespace: namespace, Instrumented: false}
+}
+
+// emitNoDataHint surfaces a stderr line when neither target_info nor span
+// metrics returned anything for the requested service. TTY users get a
+// runnable suggestion; agent mode gets the structured hint envelope.
+func emitNoDataHint(stderr io.Writer, namespace, name string) {
+	label := name
+	if namespace != "" {
+		label = namespace + "/" + name
+	}
+	cmdio.EmitHint(stderr,
+		fmt.Sprintf("no telemetry found for %q in the requested window", label),
+		"gcx appo11y services list")
+}
+
+// serviceDetailCodec renders a ServiceDetail as a compact two-section
+// table: metadata header followed by a RED stats block. Wide adds the
+// extended target_info labels surfaced by `services list --output wide`.
+type serviceDetailCodec struct {
+	Wide bool
+}
+
+func (c *serviceDetailCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *serviceDetailCodec) Decode(io.Reader, any) error {
+	return errors.New("services get table codec does not support decoding")
+}
+
+func (c *serviceDetailCodec) Encode(w io.Writer, v any) error {
+	detail, ok := v.(*ServiceDetail)
+	if !ok {
+		return fmt.Errorf("invalid data type for services get table codec: %T", v)
+	}
+	if err := c.encodeMetadata(w, detail); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	return c.encodeRED(w, &detail.RED)
+}
+
+func (c *serviceDetailCodec) encodeMetadata(w io.Writer, d *ServiceDetail) error {
+	labels := defaultLabels()
+	if c.Wide {
+		labels = allTargetInfoLabels()
+	}
+	headers := []string{"FIELD", "VALUE"}
+	t := style.NewTable(headers...)
+	t.Row("name", orDash(d.Service.Name))
+	t.Row("namespace", orDash(d.Service.Namespace))
+	t.Row("language", orDash(d.Service.Language))
+	t.Row("status", instrumentationStatus(d.Service.Instrumented))
+	t.Row("environment", orDash(environmentValue(d.Service.Labels)))
+	for _, lbl := range labels {
+		if lbl == "deployment_environment" || lbl == "deployment_environment_name" {
+			continue // already surfaced as `environment`
+		}
+		t.Row(strings.ReplaceAll(lbl, "_", "."), orDash(d.Service.Labels[lbl]))
+	}
+	return t.Render(w)
+}
+
+func (c *serviceDetailCodec) encodeRED(w io.Writer, r *REDStats) error {
+	t := style.NewTable("METRIC", "VALUE")
+	t.Row("window", r.Window)
+	t.Row("metrics mode", string(r.MetricsMode))
+	t.Row("span kinds", r.SpanKinds)
+	t.Row("rate (req/s)", formatRate(r.RatePerSecond, r.HasTraffic))
+	t.Row("errors (req/s)", formatRate(r.ErrorRatePerSec, r.HasErrors))
+	t.Row("error %", formatPercent(r.ErrorPercent, r.HasTraffic))
+	t.Row("p50 latency", formatDuration(r.P50Seconds, r.HasLatencyP50))
+	t.Row("p95 latency", formatDuration(r.P95Seconds, r.HasLatencyP95))
+	t.Row("p99 latency", formatDuration(r.P99Seconds, r.HasLatencyP99))
+	return t.Render(w)
+}
+
+func formatRate(v float64, has bool) string {
+	if !has {
+		return "-"
+	}
+	return fmt.Sprintf("%.3f", v)
+}
+
+func formatPercent(v float64, has bool) string {
+	if !has {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f%%", v)
+}
+
+// formatDuration prints a latency value with units that scale to the
+// magnitude — sub-millisecond stays in µs, sub-second stays in ms, anything
+// larger is shown in seconds. Keeps the table readable across services that
+// answer in 200µs and ones that answer in 2s without flipping precision.
+func formatDuration(seconds float64, has bool) string {
+	if !has {
+		return "-"
+	}
+	switch {
+	case seconds < 0.001:
+		return fmt.Sprintf("%.0fµs", seconds*1_000_000)
+	case seconds < 1:
+		return fmt.Sprintf("%.2fms", seconds*1000)
+	default:
+		return fmt.Sprintf("%.3fs", seconds)
+	}
+}

--- a/internal/providers/appo11y/services/get.go
+++ b/internal/providers/appo11y/services/get.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
@@ -16,7 +17,6 @@ import (
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/prometheus"
-	"github.com/grafana/gcx/internal/style"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -299,15 +299,34 @@ func resolveNamespaceForBareName(ctx context.Context, client *prometheus.Client,
 	case 1:
 		return namespaces[0], nil
 	}
-	labels := make([]string, len(namespaces))
-	for i, ns := range namespaces {
+	return "", fmt.Errorf("service %q exists in %d namespaces (%s); disambiguate with <namespace>/%s or --namespace",
+		name, len(namespaces), summarizeNamespaces(namespaces, 5), name)
+}
+
+// summarizeNamespaces formats a namespace list for the ambiguity error.
+// At most `max` entries are listed verbatim — with 30+ candidates (services
+// deployed per-region) the full list would push the rest of the error off
+// screen and bury the hint. Empty namespaces render as `(none)` so users
+// can tell the bare-job shape apart from the namespaced ones.
+func summarizeNamespaces(namespaces []string, limit int) string {
+	render := func(ns string) string {
 		if ns == "" {
-			labels[i] = "(none)"
-		} else {
-			labels[i] = ns
+			return "(none)"
 		}
+		return ns
 	}
-	return "", fmt.Errorf("service %q exists in multiple namespaces (%s); disambiguate with <namespace>/%s or --namespace", name, strings.Join(labels, ", "), name)
+	if len(namespaces) <= limit {
+		out := make([]string, len(namespaces))
+		for i, ns := range namespaces {
+			out[i] = render(ns)
+		}
+		return strings.Join(out, ", ")
+	}
+	head := make([]string, limit)
+	for i := range limit {
+		head[i] = render(namespaces[i])
+	}
+	return fmt.Sprintf("%s, ... and %d more", strings.Join(head, ", "), len(namespaces)-limit)
 }
 
 // detectMetricsMode probes each metrics family in parallel for the given
@@ -518,62 +537,78 @@ func (c *serviceDetailCodec) Encode(w io.Writer, v any) error {
 	if !ok {
 		return fmt.Errorf("invalid data type for services get table codec: %T", v)
 	}
-	if err := c.encodeMetadata(w, detail); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintln(w); err != nil {
-		return err
-	}
-	return c.encodeRED(w, &detail.RED)
-}
+	// kubectl-describe-style key:value block, not a bordered table.
+	// A single resource doesn't tabulate well: the value column gets
+	// stretched to terminal width and the borders dominate ~20 short
+	// rows, so we drop the tabular renderer in favour of aligned text
+	// with section spacing.
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
 
-func (c *serviceDetailCodec) encodeMetadata(w io.Writer, d *ServiceDetail) error {
+	writeRow := func(label, value string) {
+		fmt.Fprintf(tw, "%s:\t%s\n", label, value)
+	}
+
+	d := &detail.Service
+	writeRow("Name", orDash(d.Name))
+	writeRow("Namespace", orDash(d.Namespace))
+	writeRow("Language", orDash(d.Language))
+	writeRow("Status", instrumentationStatus(d.Instrumented))
+	writeRow("Environment", orDash(environmentValue(d.Labels)))
+
 	labels := defaultLabels()
 	if c.Wide {
 		labels = allTargetInfoLabels()
 	}
-	headers := []string{"FIELD", "VALUE"}
-	t := style.NewTable(headers...)
-	t.Row("name", orDash(d.Service.Name))
-	t.Row("namespace", orDash(d.Service.Namespace))
-	t.Row("language", orDash(d.Service.Language))
-	t.Row("status", instrumentationStatus(d.Service.Instrumented))
-	t.Row("environment", orDash(environmentValue(d.Service.Labels)))
+	wroteLabelHeader := false
 	for _, lbl := range labels {
 		if lbl == "deployment_environment" || lbl == "deployment_environment_name" {
-			continue // already surfaced as `environment`
+			continue // already surfaced as `Environment`
 		}
-		t.Row(strings.ReplaceAll(lbl, "_", "."), orDash(d.Service.Labels[lbl]))
+		value := d.Labels[lbl]
+		if value == "" {
+			continue
+		}
+		if !wroteLabelHeader {
+			fmt.Fprintln(tw, "Labels:")
+			wroteLabelHeader = true
+		}
+		fmt.Fprintf(tw, "  %s:\t%s\n", strings.ReplaceAll(lbl, "_", "."), value)
 	}
-	return t.Render(w)
+
+	fmt.Fprintln(tw)
+
+	r := &detail.RED
+	writeRow("Window", r.Window)
+	writeRow("Metrics mode", string(r.MetricsMode))
+	writeRow("Span kinds", r.SpanKinds)
+	writeRow("Rate", formatRateWithUnit(r.RatePerSecond, r.HasTraffic))
+	writeRow("Errors", formatErrors(r.ErrorRatePerSec, r.ErrorPercent, r.HasErrors, r.HasTraffic))
+	fmt.Fprintln(tw, "Latency:")
+	fmt.Fprintf(tw, "  p50:\t%s\n", formatDuration(r.P50Seconds, r.HasLatencyP50))
+	fmt.Fprintf(tw, "  p95:\t%s\n", formatDuration(r.P95Seconds, r.HasLatencyP95))
+	fmt.Fprintf(tw, "  p99:\t%s\n", formatDuration(r.P99Seconds, r.HasLatencyP99))
+
+	return tw.Flush()
 }
 
-func (c *serviceDetailCodec) encodeRED(w io.Writer, r *REDStats) error {
-	t := style.NewTable("METRIC", "VALUE")
-	t.Row("window", r.Window)
-	t.Row("metrics mode", string(r.MetricsMode))
-	t.Row("span kinds", r.SpanKinds)
-	t.Row("rate (req/s)", formatRate(r.RatePerSecond, r.HasTraffic))
-	t.Row("errors (req/s)", formatRate(r.ErrorRatePerSec, r.HasErrors))
-	t.Row("error %", formatPercent(r.ErrorPercent, r.HasTraffic))
-	t.Row("p50 latency", formatDuration(r.P50Seconds, r.HasLatencyP50))
-	t.Row("p95 latency", formatDuration(r.P95Seconds, r.HasLatencyP95))
-	t.Row("p99 latency", formatDuration(r.P99Seconds, r.HasLatencyP99))
-	return t.Render(w)
-}
-
-func formatRate(v float64, has bool) string {
+func formatRateWithUnit(v float64, has bool) string {
 	if !has {
 		return "-"
 	}
-	return fmt.Sprintf("%.3f", v)
+	return fmt.Sprintf("%.3f req/s", v)
 }
 
-func formatPercent(v float64, has bool) string {
-	if !has {
+// formatErrors combines the absolute error rate with the percentage so the
+// describe view shows both on one line. When there's no traffic, no error
+// signal exists either.
+func formatErrors(rate, pct float64, hasErrors, hasTraffic bool) string {
+	if !hasErrors {
 		return "-"
 	}
-	return fmt.Sprintf("%.2f%%", v)
+	if !hasTraffic {
+		return fmt.Sprintf("%.3f req/s", rate)
+	}
+	return fmt.Sprintf("%.3f req/s (%.2f%%)", rate, pct)
 }
 
 // formatDuration prints a latency value with units that scale to the

--- a/internal/providers/appo11y/services/get_test.go
+++ b/internal/providers/appo11y/services/get_test.go
@@ -230,6 +230,98 @@ func TestResolveMetricsMode(t *testing.T) {
 	}
 }
 
+func TestBuildBareNameLookupQuery(t *testing.T) {
+	got, err := buildBareNameLookupQuery("target_info", "checkoutservice")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `group by (job) (target_info{job=~"(.+/)?checkoutservice"})`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+
+	// Regex metachars in the name are escaped so a service named "v1.api"
+	// doesn't accidentally match "v1Xapi" via the literal `.`.
+	got, err = buildBareNameLookupQuery("traces_target_info", "v1.api")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want = `group by (job) (traces_target_info{job=~"(.+/)?v1\\.api"})`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+
+	if _, err := buildBareNameLookupQuery("target_info", ""); err == nil {
+		t.Error("expected error for empty name")
+	}
+}
+
+func TestExtractJobsFromResponses(t *testing.T) {
+	r1 := &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
+		{Metric: map[string]string{"job": "payments/checkout"}},
+		{Metric: map[string]string{"job": "shipping/checkout"}},
+		{Metric: map[string]string{"job": ""}}, // dropped
+	}}}
+	r2 := &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
+		{Metric: map[string]string{"job": "payments/checkout"}}, // duplicate across responses → dedup
+		{Metric: map[string]string{"job": "checkout"}},          // bare-name shape
+	}}}
+	got := extractJobsFromResponses([]*prometheus.QueryResponse{r1, nil, r2})
+	want := []string{"checkout", "payments/checkout", "shipping/checkout"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("[%d] got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestNamespacesForName(t *testing.T) {
+	tests := []struct {
+		name string
+		jobs []string
+		svc  string
+		want []string
+	}{
+		{name: "empty", jobs: nil, svc: "checkout", want: []string{}},
+		{name: "bare only", jobs: []string{"checkout"}, svc: "checkout", want: []string{""}},
+		{name: "single namespace", jobs: []string{"payments/checkout"}, svc: "checkout", want: []string{"payments"}},
+		{
+			name: "mixed bare + namespaced (both real possibilities)",
+			jobs: []string{"checkout", "payments/checkout"},
+			svc:  "checkout",
+			want: []string{"", "payments"},
+		},
+		{
+			name: "multiple namespaces sorted",
+			jobs: []string{"shipping/checkout", "payments/checkout", "billing/checkout"},
+			svc:  "checkout",
+			want: []string{"billing", "payments", "shipping"},
+		},
+		{
+			name: "regex over-match dropped if suffix doesn't end in /<name>",
+			jobs: []string{"checkout-internal"}, // would match `(.+/)?checkout` regex without the suffix guard
+			svc:  "checkout",
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := namespacesForName(tt.jobs, tt.svc)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestBuildModeProbeQuery(t *testing.T) {
 	got, err := buildModeProbeQuery("traces_span_metrics_calls_total", "billing/checkout")
 	if err != nil {

--- a/internal/providers/appo11y/services/get_test.go
+++ b/internal/providers/appo11y/services/get_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/spf13/cobra"
 )
 
 func TestResolveSpanKinds(t *testing.T) {
@@ -481,8 +482,8 @@ func TestFormatDuration(t *testing.T) {
 func TestGetOptsValidate(t *testing.T) {
 	mk := func(o getOpts) getOpts {
 		o.IO.OutputFormat = "json"
-		if o.Window == "" {
-			o.Window = defaultRedWindow
+		if o.Since == "" {
+			o.Since = defaultRedWindow
 		}
 		if o.Kind == "" {
 			o.Kind = "inbound"
@@ -495,18 +496,23 @@ func TestGetOptsValidate(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "defaults ok", opts: mk(getOpts{})},
-		{name: "custom window", opts: mk(getOpts{Window: "1h"})},
-		{name: "bad window", opts: mk(getOpts{Window: "not-a-duration"}), wantErr: true},
-		{name: "empty window", opts: mk(getOpts{Window: "  "}), wantErr: true},
+		{name: "custom since (hours)", opts: mk(getOpts{Since: "1h"})},
+		{name: "PromQL day duration accepted (Go ParseDuration rejects this)", opts: mk(getOpts{Since: "1d"})},
+		{name: "PromQL week duration accepted", opts: mk(getOpts{Since: "1w"})},
+		{name: "bad since", opts: mk(getOpts{Since: "not-a-duration"}), wantErr: true},
+		{name: "empty since", opts: mk(getOpts{Since: "  "}), wantErr: true},
 		{name: "bogus kind", opts: mk(getOpts{Kind: "OUTGOING"}), wantErr: true},
 		{name: "comma kinds ok", opts: mk(getOpts{Kind: "SPAN_KIND_SERVER,SPAN_KIND_CLIENT"})},
 		{name: "default metrics-mode (empty) ok", opts: mk(getOpts{MetricsMode: ""})},
 		{name: "explicit tempo mode", opts: mk(getOpts{MetricsMode: "tempo"})},
 		{name: "bogus metrics-mode rejected", opts: mk(getOpts{MetricsMode: "fictional"}), wantErr: true},
 	}
+	// Validate's UsageError wraps require a *cobra.Command for the help
+	// suggestion; a bare instance is enough — we only check error-vs-nil.
+	cmd := &cobra.Command{Use: "get"}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.opts.Validate(); (err != nil) != tt.wantErr {
+			if err := tt.opts.Validate(cmd); (err != nil) != tt.wantErr {
 				t.Errorf("err = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/providers/appo11y/services/get_test.go
+++ b/internal/providers/appo11y/services/get_test.go
@@ -537,13 +537,29 @@ func TestServiceDetailCodec(t *testing.T) {
 		t.Fatalf("Encode err = %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{"checkout", "billing", "go", "instrumented", "production", "5m", "12.500", "2.00%", "10.00ms", "150.00ms", "450.00ms"} {
+	// Describe-style block: kubectl-like "Field: value" lines, single
+	// section break between identity and RED, latency under a sub-heading.
+	for _, want := range []string{
+		"Name:", "checkout",
+		"Namespace:", "billing",
+		"Language:", "go",
+		"Status:", "instrumented",
+		"Environment:", "production",
+		"Window:", "5m",
+		"Rate:", "12.500 req/s",
+		"Errors:", "0.250 req/s (2.00%)",
+		"Latency:",
+		"p50:", "10.00ms",
+		"p95:", "150.00ms",
+		"p99:", "450.00ms",
+	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q\n----\n%s", want, out)
 		}
 	}
 
-	// no-data path renders dashes for unmeasured fields.
+	// no-data path: every measured row prints "-", but the structural
+	// labels still appear so the user can tell what's missing.
 	d2 := &ServiceDetail{
 		Service: Service{Name: "auth"},
 		RED:     REDStats{Window: "5m", SpanKinds: "SPAN_KIND_SERVER"},
@@ -553,11 +569,12 @@ func TestServiceDetailCodec(t *testing.T) {
 		t.Fatalf("Encode err = %v", err)
 	}
 	out = buf.String()
-	if !strings.Contains(out, "auth") {
-		t.Errorf("output missing service name: %s", out)
+	for _, want := range []string{"Name:", "auth", "Rate:", "Errors:", "Latency:", "p50:", "p95:", "p99:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("no-data output missing %q\n----\n%s", want, out)
+		}
 	}
-	// Each unmeasured RED row should print "-".
-	if !strings.Contains(out, "rate (req/s)") || strings.Count(out, "-") < 6 {
+	if strings.Count(out, "-") < 6 {
 		t.Errorf("expected several dash rows for no-data, got:\n%s", out)
 	}
 

--- a/internal/providers/appo11y/services/get_test.go
+++ b/internal/providers/appo11y/services/get_test.go
@@ -1,0 +1,475 @@
+package services //nolint:testpackage // Tests cover unexported builders and helpers.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/prometheus"
+)
+
+func TestResolveSpanKinds(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    []string
+		wantErr bool
+	}{
+		{name: "default empty", in: "", want: []string{spanKindServer, spanKindConsumer}},
+		{name: "inbound alias", in: "inbound", want: []string{spanKindServer, spanKindConsumer}},
+		{name: "server alias", in: "server", want: []string{spanKindServer}},
+		{name: "consumer alias", in: "consumer", want: []string{spanKindConsumer}},
+		{name: "all alias is sorted as written", in: "all"}, // length-checked below
+		{name: "explicit single literal", in: "SPAN_KIND_CLIENT", want: []string{"SPAN_KIND_CLIENT"}},
+		{name: "explicit comma list", in: "SPAN_KIND_SERVER,SPAN_KIND_CLIENT", want: []string{"SPAN_KIND_SERVER", "SPAN_KIND_CLIENT"}},
+		{name: "case-insensitive literal", in: "span_kind_server", want: []string{spanKindServer}},
+		{name: "comma list with spaces", in: " SPAN_KIND_SERVER , SPAN_KIND_CONSUMER ", want: []string{spanKindServer, spanKindConsumer}},
+		{name: "bogus literal rejected", in: "MYTHICAL_KIND", wantErr: true},
+		{name: "comma list with empty entries collapses to non-empty", in: "SPAN_KIND_SERVER,,SPAN_KIND_CONSUMER", want: []string{spanKindServer, spanKindConsumer}},
+		{name: "comma list of only empty rejected", in: ",,,", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveSpanKinds(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if tt.in == "all" {
+				// The "all" alias intentionally includes every defined kind;
+				// length check is enough to detect accidental drift.
+				if len(got) != 5 {
+					t.Errorf("len(all) = %d, want 5: %v", len(got), got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d (%v)", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseServiceArg(t *testing.T) {
+	tests := []struct {
+		name, arg, flagNs string
+		wantNs, wantName  string
+		wantErr           bool
+	}{
+		{name: "bare name", arg: "checkout", wantName: "checkout"},
+		{name: "namespace/name", arg: "billing/checkout", wantNs: "billing", wantName: "checkout"},
+		{name: "flag namespace fills in", arg: "checkout", flagNs: "billing", wantNs: "billing", wantName: "checkout"},
+		{name: "arg namespace overrides empty flag", arg: "billing/checkout", flagNs: "", wantNs: "billing", wantName: "checkout"},
+		{name: "flag matches arg namespace", arg: "billing/checkout", flagNs: "billing", wantNs: "billing", wantName: "checkout"},
+		{name: "conflict between arg and flag", arg: "billing/checkout", flagNs: "shipping", wantErr: true},
+		{name: "empty arg", arg: "", wantErr: true},
+		{name: "whitespace arg", arg: "   ", wantErr: true},
+		{name: "leading slash treated as empty namespace", arg: "/checkout", wantName: "checkout"},
+		{name: "trailing slash is empty name", arg: "billing/", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns, name, err := parseServiceArg(tt.arg, tt.flagNs)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if ns != tt.wantNs || name != tt.wantName {
+				t.Errorf("got (%q, %q), want (%q, %q)", ns, name, tt.wantNs, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestBuildServiceMetadataQuery(t *testing.T) {
+	tests := []struct {
+		name, metric, ns, svc string
+		wantContains          []string
+		wantErr               bool
+	}{
+		{
+			name:   "namespaced",
+			metric: "target_info", ns: "billing", svc: "checkout",
+			wantContains: []string{`target_info{job="billing/checkout"}`, "group by (telemetry_sdk_language, job"},
+		},
+		{
+			name:   "bare name",
+			metric: "traces_target_info", ns: "", svc: "auth",
+			wantContains: []string{`traces_target_info{job="auth"}`},
+		},
+		{name: "empty name rejected", metric: "target_info", ns: "x", svc: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildServiceMetadataQuery(tt.metric, tt.ns, tt.svc)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			for _, s := range tt.wantContains {
+				if !strings.Contains(got, s) {
+					t.Errorf("query missing %q: %s", s, got)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildRateQuery(t *testing.T) {
+	v3, _ := metricNamesByMode(MetricsModeV3)
+	got, err := buildRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer, spanKindConsumer})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `sum(rate(traces_span_metrics_calls_total{job="billing/checkout",span_kind=~"SPAN_KIND_SERVER|SPAN_KIND_CONSUMER"}[5m]))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+
+	// Tempo (legacy) mode swaps to traces_spanmetrics_* without changing the job/kind filters.
+	tempo, _ := metricNamesByMode(MetricsModeTempo)
+	got, err = buildRateQuery(tempo, "", "auth", "1m", []string{spanKindServer})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want = `sum(rate(traces_spanmetrics_calls_total{job="auth",span_kind=~"SPAN_KIND_SERVER"}[1m]))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+
+	if _, err := buildRateQuery(v3, "", "", "5m", nil); err == nil {
+		t.Error("expected error for empty service name")
+	}
+}
+
+func TestBuildErrorRateQuery(t *testing.T) {
+	v3, _ := metricNamesByMode(MetricsModeV3)
+	got, err := buildErrorRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `sum(rate(traces_span_metrics_calls_total{job="billing/checkout",span_kind=~"SPAN_KIND_SERVER",status_code="STATUS_CODE_ERROR"}[5m]))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildLatencyQuantileQuery(t *testing.T) {
+	v3, _ := metricNamesByMode(MetricsModeV3)
+	got, err := buildLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `histogram_quantile(0.95, sum by (le) (rate(traces_span_metrics_duration_seconds_bucket{job="billing/checkout",span_kind=~"SPAN_KIND_SERVER"}[5m])))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+
+	// OTel mode uses the bare names (no traces_ prefix).
+	otel, _ := metricNamesByMode(MetricsModeOTel)
+	got, err = buildLatencyQuantileQuery(otel, "billing", "checkout", "5m", []string{spanKindServer}, 0.95)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want = `histogram_quantile(0.95, sum by (le) (rate(duration_seconds_bucket{job="billing/checkout",span_kind=~"SPAN_KIND_SERVER"}[5m])))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+
+	if _, err := buildLatencyQuantileQuery(v3, "", "x", "5m", nil, 1.5); err == nil {
+		t.Error("expected error for phi out of range")
+	}
+}
+
+func TestResolveMetricsMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantMode MetricsMode
+		wantAuto bool
+		wantErr  bool
+	}{
+		{name: "empty defaults to auto", in: "", wantAuto: true},
+		{name: "explicit auto", in: "auto", wantAuto: true},
+		{name: "v3", in: "v3", wantMode: MetricsModeV3},
+		{name: "otel-109 alias", in: "otel-109", wantMode: MetricsModeV3},
+		{name: "tempo", in: "tempo", wantMode: MetricsModeTempo},
+		{name: "legacy alias for tempo", in: "legacy", wantMode: MetricsModeTempo},
+		{name: "beyla alias for tempo", in: "beyla", wantMode: MetricsModeTempo},
+		{name: "otel", in: "otel", wantMode: MetricsModeOTel},
+		{name: "case-insensitive", in: "TEMPO", wantMode: MetricsModeTempo},
+		{name: "unknown rejected", in: "fictional-mode", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mode, auto, err := resolveMetricsMode(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if auto != tt.wantAuto {
+				t.Errorf("auto = %v, want %v", auto, tt.wantAuto)
+			}
+			if !auto && mode != tt.wantMode {
+				t.Errorf("mode = %q, want %q", mode, tt.wantMode)
+			}
+		})
+	}
+}
+
+func TestBuildModeProbeQuery(t *testing.T) {
+	got, err := buildModeProbeQuery("traces_span_metrics_calls_total", "billing/checkout")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `count(traces_span_metrics_calls_total{job="billing/checkout"})`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+
+	if _, err := buildModeProbeQuery("", "x"); err == nil {
+		t.Error("expected error for empty metric")
+	}
+	if _, err := buildModeProbeQuery("metric", ""); err == nil {
+		t.Error("expected error for empty job")
+	}
+}
+
+func TestJobLabel(t *testing.T) {
+	cases := map[string]struct{ ns, name, want string }{
+		"namespaced": {ns: "billing", name: "checkout", want: "billing/checkout"},
+		"bare":       {ns: "", name: "auth", want: "auth"},
+	}
+	for label, tc := range cases {
+		t.Run(label, func(t *testing.T) {
+			if got := jobLabel(tc.ns, tc.name); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInstantScalar(t *testing.T) {
+	tests := []struct {
+		name    string
+		resp    *prometheus.QueryResponse
+		wantVal float64
+		wantHas bool
+	}{
+		{name: "nil response", resp: nil, wantHas: false},
+		{name: "empty result", resp: &prometheus.QueryResponse{}, wantHas: false},
+		{
+			name: "single sample",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
+				{Value: []any{1.0, "12.345"}},
+			}}},
+			wantVal: 12.345, wantHas: true,
+		},
+		{
+			name: "NaN treated as no data",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
+				{Value: []any{1.0, "NaN"}},
+			}}},
+			wantHas: false,
+		},
+		{
+			name: "+Inf treated as no data",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
+				{Value: []any{1.0, "+Inf"}},
+			}}},
+			wantHas: false,
+		},
+		{
+			name: "non-string value",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
+				{Value: []any{1.0, 12.34}},
+			}}},
+			wantHas: false,
+		},
+		{
+			name: "short value array",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
+				{Value: []any{1.0}},
+			}}},
+			wantHas: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVal, gotHas := instantScalar(tt.resp)
+			if gotHas != tt.wantHas {
+				t.Errorf("has = %v, want %v", gotHas, tt.wantHas)
+			}
+			if tt.wantHas && gotVal != tt.wantVal {
+				t.Errorf("val = %v, want %v", gotVal, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestComputeErrorPercent(t *testing.T) {
+	tests := []struct {
+		name        string
+		errs, total float64
+		want        float64
+	}{
+		{name: "zero total stays zero (no division)", total: 0, errs: 5, want: 0},
+		{name: "normal", total: 100, errs: 5, want: 5},
+		{name: "100%", total: 7, errs: 7, want: 100},
+		{name: "clamps above 100", total: 1, errs: 3, want: 100},
+		{name: "clamps negative to zero", total: 1, errs: -2, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := computeErrorPercent(tt.errs, tt.total); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectMetadataService(t *testing.T) {
+	rows := []Service{
+		{Name: "checkout", Namespace: "billing", Language: "go", Instrumented: true},
+		{Name: "checkout", Namespace: "shipping", Language: "java", Instrumented: true},
+	}
+	got := selectMetadataService(rows, "shipping", "checkout")
+	if got.Namespace != "shipping" || got.Language != "java" {
+		t.Errorf("exact match lost: %+v", got)
+	}
+
+	// No exact match → first row wins.
+	got = selectMetadataService(rows, "unknown", "checkout")
+	if got.Namespace != "billing" {
+		t.Errorf("fallback should pick first row, got %+v", got)
+	}
+
+	// Empty list → synthesized uninstrumented placeholder.
+	got = selectMetadataService(nil, "billing", "checkout")
+	if got.Instrumented || got.Name != "checkout" || got.Namespace != "billing" {
+		t.Errorf("placeholder wrong: %+v", got)
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		s    float64
+		has  bool
+		want string
+	}{
+		{name: "no data", s: 0.5, has: false, want: "-"},
+		{name: "microseconds", s: 0.0001, has: true, want: "100µs"},
+		{name: "milliseconds", s: 0.025, has: true, want: "25.00ms"},
+		{name: "seconds", s: 1.5, has: true, want: "1.500s"},
+		{name: "zero with has=true is microseconds", s: 0, has: true, want: "0µs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatDuration(tt.s, tt.has); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetOptsValidate(t *testing.T) {
+	mk := func(o getOpts) getOpts {
+		o.IO.OutputFormat = "json"
+		if o.Window == "" {
+			o.Window = defaultRedWindow
+		}
+		if o.Kind == "" {
+			o.Kind = "inbound"
+		}
+		return o
+	}
+	tests := []struct {
+		name    string
+		opts    getOpts
+		wantErr bool
+	}{
+		{name: "defaults ok", opts: mk(getOpts{})},
+		{name: "custom window", opts: mk(getOpts{Window: "1h"})},
+		{name: "bad window", opts: mk(getOpts{Window: "not-a-duration"}), wantErr: true},
+		{name: "empty window", opts: mk(getOpts{Window: "  "}), wantErr: true},
+		{name: "bogus kind", opts: mk(getOpts{Kind: "OUTGOING"}), wantErr: true},
+		{name: "comma kinds ok", opts: mk(getOpts{Kind: "SPAN_KIND_SERVER,SPAN_KIND_CLIENT"})},
+		{name: "default metrics-mode (empty) ok", opts: mk(getOpts{MetricsMode: ""})},
+		{name: "explicit tempo mode", opts: mk(getOpts{MetricsMode: "tempo"})},
+		{name: "bogus metrics-mode rejected", opts: mk(getOpts{MetricsMode: "fictional"}), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.opts.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestServiceDetailCodec(t *testing.T) {
+	codec := &serviceDetailCodec{}
+	d := &ServiceDetail{
+		Service: Service{
+			Name: "checkout", Namespace: "billing", Language: "go",
+			Instrumented: true,
+			Labels: map[string]string{
+				"deployment_environment": "production",
+				"k8s_namespace_name":     "prod",
+			},
+		},
+		RED: REDStats{
+			Window: "5m", SpanKinds: "SPAN_KIND_SERVER|SPAN_KIND_CONSUMER",
+			RatePerSecond: 12.5, ErrorRatePerSec: 0.25, ErrorPercent: 2.0,
+			P50Seconds: 0.010, P95Seconds: 0.150, P99Seconds: 0.450,
+			HasTraffic: true, HasErrors: true,
+			HasLatencyP50: true, HasLatencyP95: true, HasLatencyP99: true,
+		},
+	}
+	var buf bytes.Buffer
+	if err := codec.Encode(&buf, d); err != nil {
+		t.Fatalf("Encode err = %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"checkout", "billing", "go", "instrumented", "production", "5m", "12.500", "2.00%", "10.00ms", "150.00ms", "450.00ms"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n----\n%s", want, out)
+		}
+	}
+
+	// no-data path renders dashes for unmeasured fields.
+	d2 := &ServiceDetail{
+		Service: Service{Name: "auth"},
+		RED:     REDStats{Window: "5m", SpanKinds: "SPAN_KIND_SERVER"},
+	}
+	buf.Reset()
+	if err := codec.Encode(&buf, d2); err != nil {
+		t.Fatalf("Encode err = %v", err)
+	}
+	out = buf.String()
+	if !strings.Contains(out, "auth") {
+		t.Errorf("output missing service name: %s", out)
+	}
+	// Each unmeasured RED row should print "-".
+	if !strings.Contains(out, "rate (req/s)") || strings.Count(out, "-") < 6 {
+		t.Errorf("expected several dash rows for no-data, got:\n%s", out)
+	}
+
+	if err := codec.Encode(&buf, "not a *ServiceDetail"); err == nil {
+		t.Error("expected error on wrong type")
+	}
+}

--- a/internal/providers/appo11y/services/query.go
+++ b/internal/providers/appo11y/services/query.go
@@ -8,8 +8,10 @@ package services
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/grafana/gcx/internal/query/prometheus"
@@ -363,4 +365,301 @@ func mergeServiceSets(display, baseline, graph []Service) []Service {
 	out = append(out, uninstrumentedFromGraph(baseline, graph)...)
 	sortServices(out)
 	return out
+}
+
+// OTel proto-style label values emitted by all metrics-generator variants;
+// the metric names themselves differ between modes (see MetricsMode below).
+const (
+	statusCodeError  = "STATUS_CODE_ERROR"
+	spanKindServer   = "SPAN_KIND_SERVER"
+	spanKindConsumer = "SPAN_KIND_CONSUMER"
+)
+
+// MetricsMode identifies which family of Tempo/OTel span-metric names a
+// stack emits. Three distinct name sets cover the modes a Grafana Cloud
+// stack typically configures (legacy Tempo metrics-generator / Beyla
+// share names with each other; modern OTel Collector emits a v3 family;
+// the bare OTel Collector connector emits without the `traces_` prefix).
+// The active mode is normally a stack-level setting; the CLI exposes it
+// as `--metrics-mode` so a user can override the auto-probe.
+type MetricsMode string
+
+const (
+	// MetricsModeV3 is the modern Tempo/OTel-Collector-≥1.0.9 family.
+	// Default — matches what new Grafana Cloud stacks emit.
+	MetricsModeV3 MetricsMode = "v3"
+	// MetricsModeTempo is the legacy Tempo metrics-generator family
+	// (also used by Beyla; sometimes labelled "legacy").
+	MetricsModeTempo MetricsMode = "tempo"
+	// MetricsModeOTel is the bare OTel Collector spanmetrics connector
+	// family (no `traces_` prefix).
+	MetricsModeOTel MetricsMode = "otel"
+)
+
+// metricNames is the (calls, latencyBucket) pair selected by MetricsMode.
+type metricNames struct {
+	calls         string
+	latencyBucket string
+}
+
+// metricNamesByMode returns the (calls, latency-bucket) pair for the
+// requested MetricsMode:
+//
+//	v3    → traces_span_metrics_* (modern OTel Collector / Tempo)
+//	tempo → traces_spanmetrics_*  (legacy Tempo metrics-generator, Beyla)
+//	otel  → bare calls_total / duration_seconds_bucket (OTel Collector
+//	        spanmetrics connector, no `traces_` prefix)
+//
+// Constructed on demand rather than as a package global to keep the table
+// inside the type's behaviour and satisfy gochecknoglobals.
+func metricNamesByMode(mode MetricsMode) (metricNames, bool) {
+	switch mode {
+	case MetricsModeV3:
+		return metricNames{
+			calls:         "traces_span_metrics_calls_total",
+			latencyBucket: "traces_span_metrics_duration_seconds_bucket",
+		}, true
+	case MetricsModeTempo:
+		return metricNames{
+			calls:         "traces_spanmetrics_calls_total",
+			latencyBucket: "traces_spanmetrics_latency_bucket",
+		}, true
+	case MetricsModeOTel:
+		return metricNames{
+			calls:         "calls_total",
+			latencyBucket: "duration_seconds_bucket",
+		}, true
+	}
+	return metricNames{}, false
+}
+
+// metricsModeAuto is the flag value that triggers automatic detection.
+// It is NOT a MetricsMode value — it resolves to one at runtime by
+// probing the stack.
+const metricsModeAuto = "auto"
+
+// metricsModePreference orders the modes for auto-detection: when multiple
+// families return data (common during a stack's v2→v3 migration), prefer
+// the modern names so the snapshot reflects the current canonical family.
+func metricsModePreference() []MetricsMode {
+	return []MetricsMode{MetricsModeV3, MetricsModeTempo, MetricsModeOTel}
+}
+
+// resolveMetricsMode maps the --metrics-mode flag value onto a canonical
+// MetricsMode or returns ("", true) when the user wants auto-detection.
+// A few alternative names are accepted (legacy, beyla, otel-109) so users
+// don't have to remember which short label maps to which family. Empty
+// input defaults to auto so the common case "just works" without a flag.
+func resolveMetricsMode(raw string) (MetricsMode, bool, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "auto":
+		return "", true, nil
+	case "v3", "otel-109", "otel109", "otelcollector109":
+		return MetricsModeV3, false, nil
+	case "tempo", "tempo-metrics-gen", "tempometricsgen", "beyla", "beyla-metrics-gen", "legacy":
+		return MetricsModeTempo, false, nil
+	case "otel", "otel-collector", "otelcollector":
+		return MetricsModeOTel, false, nil
+	}
+	return "", false, fmt.Errorf("--metrics-mode %q is not one of: auto, v3, tempo, otel", raw)
+}
+
+// buildModeProbeQuery returns a cheap PromQL expression that yields a
+// single scalar when the named calls metric has any series for the
+// requested job, and empty otherwise. Used by auto-detection to pick a
+// MetricsMode without running the full RED query against every family.
+func buildModeProbeQuery(metric, job string) (string, error) {
+	if metric == "" || job == "" {
+		return "", errors.New("metric and job are required")
+	}
+	v := promql.Vector(metric).Label("job", escapePromqlValue(job))
+	expr, err := promql.Count(v).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// jobLabel returns the PromQL `job` label value for a (namespace, name)
+// pair, matching the `<namespace>/<service>` encoding target_info uses
+// throughout this package.
+func jobLabel(namespace, name string) string {
+	if namespace == "" {
+		return name
+	}
+	return namespace + "/" + name
+}
+
+// defaultInboundSpanKinds captures the two span kinds that represent
+// incoming traffic for RED purposes: SERVER (HTTP/gRPC handlers) and
+// CONSUMER (message-queue consumers). CLIENT/PRODUCER are outbound and
+// would double-count if mixed in.
+func defaultInboundSpanKinds() []string {
+	return []string{spanKindServer, spanKindConsumer}
+}
+
+// spanKindRegex turns a kind list into a PromQL regex value. The result is
+// always anchored to the literal kinds — no user input flows in.
+func spanKindRegex(kinds []string) string {
+	if len(kinds) == 0 {
+		return spanKindServer
+	}
+	return strings.Join(kinds, "|")
+}
+
+// buildServiceMetadataQuery filters the target_info union by a single
+// (namespace, name). When namespace is empty the matcher uses the bare name
+// to catch the `job="auth"` shape; otherwise it matches the canonical
+// `<namespace>/<name>` encoding. metric must be one of `target_info` or
+// `traces_target_info`.
+func buildServiceMetadataQuery(metric, namespace, name string) (string, error) {
+	if name == "" {
+		return "", errors.New("service name is required")
+	}
+	job := name
+	if namespace != "" {
+		job = namespace + "/" + name
+	}
+	v := promql.Vector(metric).Label("job", escapePromqlValue(job))
+	expr, err := promql.Group(v).By(groupByLabels(nil)).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildRateQuery returns the PromQL for the headline request rate (per
+// second) over the given window, scoped to the service and span kinds.
+func buildRateQuery(names metricNames, namespace, name, window string, kinds []string) (string, error) {
+	if name == "" {
+		return "", errors.New("service name is required")
+	}
+	v := scopedSpanMetric(names.calls, namespace, name, kinds, window)
+	expr, err := promql.Sum(promql.Rate(v)).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildErrorRateQuery returns the PromQL for the error rate (per second)
+// over the given window, scoped to status_code=STATUS_CODE_ERROR.
+func buildErrorRateQuery(names metricNames, namespace, name, window string, kinds []string) (string, error) {
+	if name == "" {
+		return "", errors.New("service name is required")
+	}
+	v := scopedSpanMetric(names.calls, namespace, name, kinds, window).
+		Label("status_code", statusCodeError)
+	expr, err := promql.Sum(promql.Rate(v)).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildLatencyQuantileQuery returns the PromQL for `histogram_quantile(phi,
+// sum by (le) (rate(... [window]))) `. phi must be in [0, 1].
+func buildLatencyQuantileQuery(names metricNames, namespace, name, window string, kinds []string, phi float64) (string, error) {
+	if name == "" {
+		return "", errors.New("service name is required")
+	}
+	if phi < 0 || phi > 1 {
+		return "", fmt.Errorf("phi must be in [0,1], got %v", phi)
+	}
+	v := scopedSpanMetric(names.latencyBucket, namespace, name, kinds, window)
+	sumByLe := promql.Sum(promql.Rate(v)).By([]string{"le"})
+	expr, err := promql.HistogramQuantile(phi, sumByLe).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// scopedSpanMetric returns a vector selector for `metric` filtered by a
+// single `job="<ns>/<name>"` (or bare `job="<name>"`) label plus a
+// span_kind regex. Range is applied so the caller can wrap in `rate()`.
+//
+// We keep `service` + `service_namespace` out of the selector on purpose:
+// not every metric family emits them. Newer stacks emit both, but the
+// legacy Tempo `traces_spanmetrics_*` family and the OTel Collector
+// variant only emit `job`. Filtering on `job` alone keeps the query
+// portable across every metrics-mode this command supports.
+func scopedSpanMetric(metric, namespace, name string, kinds []string, window string) *promql.VectorExprBuilder {
+	return promql.Vector(metric).
+		Label("job", escapePromqlValue(jobLabel(namespace, name))).
+		LabelMatchRegexp("span_kind", spanKindRegex(kinds)).
+		Range(window)
+}
+
+// instantScalar pulls the first sample's value out of a Prometheus instant
+// response and parses it as float64. The second return is false when there
+// is no series (empty result), when the value is NaN/Inf, or when it can't
+// be parsed — in all three cases the caller should treat the metric as
+// "no data" rather than zero so the table can render `-` instead of `0.00`.
+func instantScalar(resp *prometheus.QueryResponse) (float64, bool) {
+	if resp == nil || len(resp.Data.Result) == 0 {
+		return 0, false
+	}
+	sample := resp.Data.Result[0]
+	if len(sample.Value) < 2 {
+		return 0, false
+	}
+	str, ok := sample.Value[1].(string)
+	if !ok {
+		return 0, false
+	}
+	f, err := strconv.ParseFloat(str, 64)
+	if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, false
+	}
+	return f, true
+}
+
+// REDStats holds the rate / errors / duration snapshot for one service over
+// a time window. Latency fields are seconds; *HasData* flags distinguish
+// "0.0 measured" from "no series in window". MetricsMode records which
+// span-metric family fed the numbers, so a no-data result can be diagnosed
+// (wrong mode? service really has no traffic?).
+type REDStats struct {
+	Window          string      `json:"window" yaml:"window"`
+	MetricsMode     MetricsMode `json:"metrics_mode" yaml:"metrics_mode"`
+	SpanKinds       string      `json:"span_kinds" yaml:"span_kinds"`
+	RatePerSecond   float64     `json:"rate_per_second" yaml:"rate_per_second"`
+	ErrorRatePerSec float64     `json:"error_rate_per_second" yaml:"error_rate_per_second"`
+	ErrorPercent    float64     `json:"error_percent" yaml:"error_percent"`
+	P50Seconds      float64     `json:"p50_seconds" yaml:"p50_seconds"`
+	P95Seconds      float64     `json:"p95_seconds" yaml:"p95_seconds"`
+	P99Seconds      float64     `json:"p99_seconds" yaml:"p99_seconds"`
+	HasTraffic      bool        `json:"has_traffic" yaml:"has_traffic"`
+	HasErrors       bool        `json:"has_errors" yaml:"has_errors"`
+	HasLatencyP50   bool        `json:"has_latency_p50" yaml:"has_latency_p50"`
+	HasLatencyP95   bool        `json:"has_latency_p95" yaml:"has_latency_p95"`
+	HasLatencyP99   bool        `json:"has_latency_p99" yaml:"has_latency_p99"`
+}
+
+// ServiceDetail is the get-command response: inventory metadata plus a RED
+// snapshot. Service.Instrumented=false plus !RED.HasTraffic means we found
+// the service only via the service graph and it has no Tempo spanmetrics
+// emitting on its behalf.
+type ServiceDetail struct {
+	Service Service  `json:"service" yaml:"service"`
+	RED     REDStats `json:"red" yaml:"red"`
+}
+
+// computeErrorPercent reports errors/total as a percentage (0..100), or 0
+// when there's no traffic. A non-zero error rate with zero total rate
+// shouldn't happen in practice but we collapse it to 0 rather than +Inf so
+// the table never prints `+Inf%`.
+func computeErrorPercent(errors, total float64) float64 {
+	if total <= 0 {
+		return 0
+	}
+	pct := (errors / total) * 100
+	if pct < 0 {
+		return 0
+	}
+	if pct > 100 {
+		return 100
+	}
+	return pct
 }

--- a/internal/providers/appo11y/services/query.go
+++ b/internal/providers/appo11y/services/query.go
@@ -528,6 +528,88 @@ func buildServiceMetadataQuery(metric, namespace, name string) (string, error) {
 	return expr.String(), nil
 }
 
+// buildBareNameLookupQuery searches the target_info union for any series
+// whose `job` is either the bare `<name>` or some `<namespace>/<name>`.
+// Used to auto-resolve the namespace when the user passes only a bare
+// service name (the alternative is silent no-data for namespaced services).
+// metric must be one of `target_info` or `traces_target_info`.
+func buildBareNameLookupQuery(metric, name string) (string, error) {
+	if name == "" {
+		return "", errors.New("service name is required")
+	}
+	// `(.+/)?<escaped name>` matches both bare `<name>` and any
+	// `<ns>/<name>` shape. PromQL regexes are RE2 — anchoring is implicit
+	// for full-match, so we don't need ^/$ markers.
+	pattern := "(.+/)?" + regexp.QuoteMeta(name)
+	v := promql.Vector(metric).LabelMatchRegexp("job", escapePromqlValue(pattern))
+	expr, err := promql.Group(v).By([]string{"job"}).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// extractJobsFromResponses returns the deduplicated set of `job` label
+// values present in the provided Prometheus responses. Empty jobs are
+// dropped.
+func extractJobsFromResponses(responses []*prometheus.QueryResponse) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(responses))
+	for _, resp := range responses {
+		if resp == nil {
+			continue
+		}
+		for _, sample := range resp.Data.Result {
+			job := sample.Metric["job"]
+			if job == "" {
+				continue
+			}
+			if _, dup := seen[job]; dup {
+				continue
+			}
+			seen[job] = struct{}{}
+			out = append(out, job)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// namespacesForName parses a slice of job labels (as returned by
+// buildBareNameLookupQuery) and returns the distinct namespaces that the
+// requested service appears under. A job equal to the bare name is treated
+// as the empty-namespace case; jobs of the shape `<ns>/<name>` contribute
+// `<ns>`; jobs that end with `/<name>` but with extra slashes (rare) are
+// preserved as the full prefix so the caller can still target them via
+// --namespace.
+func namespacesForName(jobs []string, name string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(jobs))
+	for _, job := range jobs {
+		if job == name {
+			if _, dup := seen[""]; dup {
+				continue
+			}
+			seen[""] = struct{}{}
+			out = append(out, "")
+			continue
+		}
+		if !strings.HasSuffix(job, "/"+name) {
+			// Regex matched but the suffix doesn't actually end with /<name>
+			// (defensive: shouldn't happen with our pattern).
+			continue
+		}
+		ns := strings.TrimSuffix(job, "/"+name)
+		if _, dup := seen[ns]; dup {
+			continue
+		}
+		seen[ns] = struct{}{}
+		out = append(out, ns)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // buildRateQuery returns the PromQL for the headline request rate (per
 // second) over the given window, scoped to the service and span kinds.
 func buildRateQuery(names metricNames, namespace, name, window string, kinds []string) (string, error) {


### PR DESCRIPTION
## Summary

- Adds `gcx appo11y services get <name>` — drills into a single service from `services list`, returning metadata (language, env, k8s labels) plus a RED snapshot (rate, error rate, error %, p50/p95/p99 latency) over a configurable window.
- Auto-detects the span-metrics family for the requested service (probes `traces_span_metrics_*`, `traces_spanmetrics_*`, and bare `calls_total` in parallel; prefers the modern family when a stack double-emits during a v2→v3 migration).
- Manual override via `--metrics-mode {auto,v3,tempo,otel}` (plus aliases `legacy`, `beyla`, `otel-109`). The resolved mode is reported on the RED block so the source of the numbers is always visible.
- Service identity uses `job="<ns>/<name>"` — matches the canonical encoding already used by `target_info` discovery, so the query is portable across every metrics-mode this command supports.

## Why this shape

- `job=` is the canonical label filter across all metrics-modes. Using `service` + `service_namespace` instead would have broken on the legacy Tempo and bare OTel families, which don't emit those labels.
- The active span-metrics family is normally a stack-level setting. Since the CLI has no direct read on that setting, auto-detection probes the stack instead — it picks the family that has data for *this* service, with a stable preference order for double-emitting stacks.

## Flags

- `--window` (default `5m`)
- `--kind`: `inbound` (default: SERVER+CONSUMER), `server`, `consumer`, `all`, or a comma list of `SPAN_KIND_*` literals
- `--metrics-mode`: `auto` (default), `v3`, `tempo`, `otel`
- `--namespace`/`-n`, `--datasource`/`-d`, `--output`/`-o`

## Test plan

- [x] Unit tests cover the kind resolver, arg parser, metrics-mode resolver, all three query builders across all three families, the mode probe builder, instant scalar extraction, error-percent math, metadata selection, opts validation, and codec output.
- [x] `mise run lint` clean.
- [x] `GCX_AGENT_MODE=false go test ./...` passes.
- [x] Reference docs regenerated (`mise run reference`).
- [x] Live verification against a Grafana Cloud stack:
  - **auto** picks the modern family on a v3 stack and returns rate + p50/p95/p99 latency for an instrumented service.
  - **`--metrics-mode tempo` (override)** demonstrates the mismatch case: rate returns from the legacy `_calls_total` series, but latency is empty because the legacy `_latency_bucket` family isn't emitted on the same stack — exactly the scenario the help text predicts.
  - **nonexistent / uninstrumented service in auto** returns a clean no-data snapshot plus a stderr hint pointing at `services list`, no crash.

## Follow-ups

- `services operations <name>` — span-name × RED breakdown.
- `services map <name>` — service-graph slice (callers + callees).