### PR TITLE
feat(irm): migrate incidents queries to QueryIncidentPreviews (v1 API)

### DIFF
--- a/.claude/skills/migrate-provider/gcx-provider-recipe.md
+++ b/.claude/skills/migrate-provider/gcx-provider-recipe.md
@@ -387,9 +387,14 @@ that only surfaced during smoke testing:
 
 ### gRPC-style POST APIs (Incidents/IRM)
 
-- The IRM API uses gRPC-style POST endpoints (`IncidentsService.QueryIncidents`,
-  `IncidentsService.GetIncident`, etc.) — all operations are POST with JSON bodies,
-  not REST-style GET/POST/PUT/DELETE. The `doRequest` helper always uses POST.
+- The IRM API uses gRPC-style POST endpoints (`IncidentsService.QueryIncidentPreviews`,
+  `IncidentsService.GetIncident`, etc.) under the versioned `/resources/api/v1/`
+  base path — all operations are POST with JSON bodies, not REST-style
+  GET/POST/PUT/DELETE. The `doRequest` helper always uses POST.
+  (`QueryIncidents` is deprecated upstream; gcx queries previews and filters
+  via the query-string language, e.g. `label:"security"`. Undocumented
+  services like `SeveritiesService` and `IncidentContextService` 404 under
+  `/v1` and stay on the unversioned base path.)
 - gcx's `GetIncident` fetches all incidents (limit 100) and filters client-side.
   The actual API has a `GetIncident` endpoint — use it directly for O(1) lookups.
 - The IRM API only supports status updates via `UpdateStatus` — there is no

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -58,11 +58,11 @@ func NewIncidentClient(cfg config.NamespacedRESTConfig) (*IncidentClient, error)
 const incidentsMaxPageSize = 100
 
 // quoteIncidentQueryValue wraps a value for the incident query-string
-// language. Double quotes are required for values containing spaces or
-// colons and match both Tags-key label text and keyed key:value composites
-// (verified live); values containing a double quote fall back to single
-// quotes. Values containing both quote characters are rejected upstream by
-// the list command's validation.
+// language, which requires quoting for values containing spaces or colons.
+// Quoted values match both Tags-key label text and keyed key:value
+// composites. Double quotes are the default; values containing a double
+// quote fall back to single quotes, and values containing both quote
+// characters are rejected upstream by the list command's validation.
 func quoteIncidentQueryValue(v string) string {
 	if strings.Contains(v, `"`) {
 		return "'" + v + "'"
@@ -133,17 +133,23 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 
 		for _, preview := range resp.IncidentPreviews {
 			created := time.Time(preview.CreatedTime)
-			if !created.IsZero() {
-				if !from.IsZero() && created.Before(from) {
-					if newestFirst {
-						pastFrom = true
-						break
-					}
-					continue
+			if created.IsZero() {
+				// A preview without a createdTime cannot be placed in the
+				// requested window, so date-bounded queries exclude it.
+				if from.IsZero() && to.IsZero() {
+					all = append(all, preview.ToIncident())
 				}
-				if !to.IsZero() && !created.Before(to) {
-					continue
+				continue
+			}
+			if !from.IsZero() && created.Before(from) {
+				if newestFirst {
+					pastFrom = true
+					break
 				}
+				continue
+			}
+			if !to.IsZero() && !created.Before(to) {
+				continue
 			}
 			all = append(all, preview.ToIncident())
 		}

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -59,14 +59,12 @@ const incidentsMaxPageSize = 100
 
 // quoteIncidentQueryValue wraps a value for the incident query-string
 // language, which requires quoting for values containing spaces or colons.
-// Quoted values match both Tags-key label text and keyed key:value
-// composites. Double quotes are the default; values containing a double
-// quote fall back to single quotes, and values containing both quote
-// characters are rejected upstream by the list command's validation.
+// Double-quoted values match both Tags-key label text and keyed key:value
+// composites and may themselves contain single quotes. The reverse does not
+// hold — the server rejects double quotes inside single-quoted values — so
+// values containing a double quote cannot be expressed in the language and
+// are rejected by List and by the list command's validation.
 func quoteIncidentQueryValue(v string) string {
-	if strings.Contains(v, `"`) {
-		return "'" + v + "'"
-	}
 	return `"` + v + `"`
 }
 
@@ -91,6 +89,12 @@ func buildLabelsQueryString(labels []string) string {
 // the deprecated QueryIncidents endpoint ignored server-side — are enforced
 // here on createdTime, dateFrom inclusive and dateTo exclusive.
 func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incident, error) {
+	for _, l := range query.IncidentLabels {
+		if strings.Contains(l, `"`) {
+			return nil, fmt.Errorf("incidents: invalid label %q: the incident query-string language cannot express values containing double quotes", l)
+		}
+	}
+
 	if query.Limit <= 0 {
 		query.Limit = 100
 	}
@@ -114,6 +118,7 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 	if query.DateTo != nil {
 		to = time.Time(*query.DateTo)
 	}
+	dateBounded := !from.IsZero() || !to.IsZero()
 	// With the default createdTime-descending order, every incident after the
 	// first one older than `from` is older too, so paging can stop early.
 	newestFirst := query.OrderDirection == "DESC" && query.OrderField == "createdTime"
@@ -125,7 +130,15 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 		pastFrom bool
 	)
 	for {
-		wire.Limit = min(limit-len(all), incidentsMaxPageSize)
+		if dateBounded {
+			// Date filtering happens client-side, so a page can contribute
+			// anywhere from zero to all of its previews. Fetch full pages to
+			// keep the crawl towards the bounds short; the result is
+			// truncated to limit below.
+			wire.Limit = incidentsMaxPageSize
+		} else {
+			wire.Limit = min(limit-len(all), incidentsMaxPageSize)
+		}
 		resp, err := c.queryIncidentPreviews(ctx, wire, cursor)
 		if err != nil {
 			return nil, err

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/resources/adapter"
@@ -19,16 +21,22 @@ import (
 var ErrNotFound = fmt.Errorf("incident: %w", adapter.ErrNotFound)
 
 const (
-	incidentBasePath = "/api/plugins/grafana-irm-app/resources/api"
+	// incidentBasePath is the documented versioned base path of the IRM
+	// Incident API (IncidentsService, ActivityService).
+	incidentBasePath = "/api/plugins/grafana-irm-app/resources/api/v1"
+	// incidentLegacyBasePath is the unversioned base path. SeveritiesService
+	// and IncidentContextService are not part of the documented v1 API and
+	// 404 under the /v1 prefix — they only respond here.
+	incidentLegacyBasePath = "/api/plugins/grafana-irm-app/resources/api"
 
 	incGetPath        = incidentBasePath + "/IncidentsService.GetIncident"
 	incCreatePath     = incidentBasePath + "/IncidentsService.CreateIncident"
 	incUpdateStatPath = incidentBasePath + "/IncidentsService.UpdateStatus"
-	incQueryPath      = incidentBasePath + "/IncidentsService.QueryIncidents"
+	incQueryPath      = incidentBasePath + "/IncidentsService.QueryIncidentPreviews"
 	actQueryPath      = incidentBasePath + "/ActivityService.QueryActivity"
 	actAddPath        = incidentBasePath + "/ActivityService.AddActivity"
-	sevGetPath        = incidentBasePath + "/SeveritiesService.GetOrgSeverities"
-	ctxQueryPath      = incidentBasePath + "/IncidentContextService.QueryIncidentContext"
+	sevGetPath        = incidentLegacyBasePath + "/SeveritiesService.GetOrgSeverities"
+	ctxQueryPath      = incidentLegacyBasePath + "/IncidentContextService.QueryIncidentContext"
 )
 
 // Client is an HTTP client for the Grafana IRM Incidents API.
@@ -46,12 +54,42 @@ func NewIncidentClient(cfg config.NamespacedRESTConfig) (*IncidentClient, error)
 	return &IncidentClient{httpClient: httpClient, host: cfg.Host}, nil
 }
 
-// incidentsMaxPageSize is the documented maximum for IncidentsQuery.limit.
+// incidentsMaxPageSize is the documented maximum for IncidentPreviewsQuery.limit.
 const incidentsMaxPageSize = 100
 
-// List queries incidents with the given parameters, following the response
-// cursor until query.Limit incidents are collected or the server reports no
-// more pages. A non-positive query.Limit defaults to 100.
+// quoteIncidentQueryValue wraps a value for the incident query-string
+// language. Double quotes are required for values containing spaces or
+// colons and match both Tags-key label text and keyed key:value composites
+// (verified live); values containing a double quote fall back to single
+// quotes. Values containing both quote characters are rejected upstream by
+// the list command's validation.
+func quoteIncidentQueryValue(v string) string {
+	if strings.Contains(v, `"`) {
+		return "'" + v + "'"
+	}
+	return `"` + v + `"`
+}
+
+// buildLabelsQueryString translates label filters into query-string terms.
+// Juxtaposed label terms AND together, which matches the behaviour of the
+// structured incidentLabels filter on the deprecated QueryIncidents endpoint
+// (verified live: identical result sets).
+func buildLabelsQueryString(labels []string) string {
+	terms := make([]string, len(labels))
+	for i, l := range labels {
+		terms[i] = "label:" + quoteIncidentQueryValue(l)
+	}
+	return strings.Join(terms, " ")
+}
+
+// List queries incident previews with the given parameters, following the
+// response cursor until query.Limit incidents are collected or the server
+// reports no more pages. A non-positive query.Limit defaults to 100.
+//
+// QueryIncidentPreviews has no structured filter fields: label filters are
+// translated into the query-string language, and date bounds — which even
+// the deprecated QueryIncidents endpoint ignored server-side — are enforced
+// here on createdTime, dateFrom inclusive and dateTo exclusive.
 func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incident, error) {
 	if query.Limit <= 0 {
 		query.Limit = 100
@@ -63,25 +101,60 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 		query.OrderField = "createdTime"
 	}
 
+	wire := incidentPreviewsQuery{
+		OrderDirection: query.OrderDirection,
+		OrderField:     query.OrderField,
+		QueryString:    buildLabelsQueryString(query.IncidentLabels),
+	}
+
+	var from, to time.Time
+	if query.DateFrom != nil {
+		from = time.Time(*query.DateFrom)
+	}
+	if query.DateTo != nil {
+		to = time.Time(*query.DateTo)
+	}
+	// With the default createdTime-descending order, every incident after the
+	// first one older than `from` is older too, so paging can stop early.
+	newestFirst := query.OrderDirection == "DESC" && query.OrderField == "createdTime"
+
 	limit := query.Limit
 	var (
-		all    []Incident
-		cursor *IncidentCursor
+		all      []Incident
+		cursor   *IncidentCursor
+		pastFrom bool
 	)
 	for {
-		query.Limit = min(limit-len(all), incidentsMaxPageSize)
-		resp, err := c.queryIncidents(ctx, query, cursor)
+		wire.Limit = min(limit-len(all), incidentsMaxPageSize)
+		resp, err := c.queryIncidentPreviews(ctx, wire, cursor)
 		if err != nil {
 			return nil, err
 		}
-		all = append(all, resp.Incidents...)
+
+		for _, preview := range resp.IncidentPreviews {
+			created := time.Time(preview.CreatedTime)
+			if !created.IsZero() {
+				if !from.IsZero() && created.Before(from) {
+					if newestFirst {
+						pastFrom = true
+						break
+					}
+					continue
+				}
+				if !to.IsZero() && !created.Before(to) {
+					continue
+				}
+			}
+			all = append(all, preview.ToIncident())
+		}
+
 		if len(all) >= limit {
 			return all[:limit], nil
 		}
-		// Also stop on an empty page or an empty cursor value: both mean the
-		// server cannot make progress, and looping on them would re-fetch
-		// the same page forever.
-		if !resp.Cursor.HasMore || resp.Cursor.NextValue == "" || len(resp.Incidents) == 0 {
+		// Stop when no further page can add results: the from-bound was
+		// crossed, the server reports no more pages, or it returns an empty
+		// page or cursor value (looping on those would re-fetch forever).
+		if pastFrom || !resp.Cursor.HasMore || resp.Cursor.NextValue == "" || len(resp.IncidentPreviews) == 0 {
 			return all, nil
 		}
 		// The API contract is to pass previously returned cursor values back
@@ -314,10 +387,17 @@ func (c *IncidentClient) GetSeverities(ctx context.Context) ([]Severity, error) 
 	return result.Severities, nil
 }
 
-// queryIncidents fetches a single page. cursor is nil for the first page and
-// the previously returned cursor for subsequent pages.
-func (c *IncidentClient) queryIncidents(ctx context.Context, query IncidentQuery, cursor *IncidentCursor) (*queryIncidentsResponse, error) {
-	body, err := json.Marshal(queryIncidentsRequest{Query: query, Cursor: cursor})
+// queryIncidentPreviews fetches a single page. cursor is nil for the first
+// page and the previously returned cursor for subsequent pages. Custom field
+// values and incident channels are always requested so previews carry the
+// same optional data the full incidents used to.
+func (c *IncidentClient) queryIncidentPreviews(ctx context.Context, query incidentPreviewsQuery, cursor *IncidentCursor) (*queryIncidentPreviewsResponse, error) {
+	body, err := json.Marshal(queryIncidentPreviewsRequest{
+		Query:                    query,
+		Cursor:                   cursor,
+		IncludeCustomFieldValues: true,
+		IncludeIncidentChannels:  true,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("incidents: marshal query request: %w", err)
 	}
@@ -332,9 +412,13 @@ func (c *IncidentClient) queryIncidents(ctx context.Context, query IncidentQuery
 		return nil, handleIncidentErrorResponse(resp)
 	}
 
-	var result queryIncidentsResponse
+	var result queryIncidentPreviewsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("incidents: decode query response: %w", err)
+	}
+	// The API can report failure in-band on a 200 response.
+	if result.Error != "" {
+		return nil, fmt.Errorf("incidents: query: %s", result.Error)
 	}
 
 	return &result, nil

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -297,6 +297,29 @@ func TestClient_List_Filters(t *testing.T) {
 			wantCalls: 1,
 		},
 		{
+			name: "excludes previews without a createdTime when a bound is set",
+			query: irm.IncidentQuery{
+				Limit:    50,
+				DateFrom: flexTimePtr(time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)),
+			},
+			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					// inc-2 has no createdTime and cannot be placed in the
+					// window, so it must not leak into the results.
+					writeJSON(w, map[string]any{
+						"incidentPreviews": []map[string]any{
+							{"incidentID": "inc-1", "title": "Outage", "status": "active", "createdTime": "2026-06-11T10:00:00Z"},
+							{"incidentID": "inc-2", "title": "No created time", "status": "active"},
+						},
+						"cursor": map[string]any{"hasMore": false},
+					})
+				}
+			},
+			wantIDs:   []string{"inc-1"},
+			wantCalls: 1,
+		},
+		{
 			name: "applies the to bound client-side and keeps paging",
 			query: irm.IncidentQuery{
 				Limit:  50,

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -3,9 +3,12 @@ package irm_test
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers/irm"
@@ -25,43 +28,102 @@ func newTestClient(t *testing.T, server *httptest.Server) *irm.IncidentClient {
 	return c
 }
 
-// listRequest mirrors the QueryIncidents request body for assertions.
+// listRequest mirrors the QueryIncidentPreviews request body for assertions.
 type listRequest struct {
-	Query  map[string]any  `json:"query"`
-	Cursor *map[string]any `json:"cursor"`
+	Query                    map[string]any  `json:"query"`
+	Cursor                   *map[string]any `json:"cursor"`
+	IncludeCustomFieldValues bool            `json:"includeCustomFieldValues"`
+	IncludeIncidentChannels  bool            `json:"includeIncidentChannels"`
 }
 
-// incidentPage builds a one-page response with n incidents named after page.
-func incidentPage(page string, n int, hasMore bool, nextValue string) map[string]any {
-	incs := make([]map[string]any, n)
-	for i := range incs {
-		incs[i] = map[string]any{"incidentID": fmt.Sprintf("inc-%s-%d", page, i), "title": "Outage " + page, "status": "active"}
+// previewsPage builds a one-page response with n previews named after page.
+func previewsPage(page string, n int, hasMore bool, nextValue string) map[string]any {
+	previews := make([]map[string]any, n)
+	for i := range previews {
+		previews[i] = map[string]any{"incidentID": fmt.Sprintf("inc-%s-%d", page, i), "title": "Outage " + page, "status": "active"}
 	}
 	return map[string]any{
-		"incidents": incs,
-		"cursor":    map[string]any{"hasMore": hasMore, "nextValue": nextValue},
-		"query":     map[string]any{},
+		"incidentPreviews": previews,
+		"cursor":           map[string]any{"hasMore": hasMore, "nextValue": nextValue},
 	}
+}
+
+// datedPage builds a one-page response from incidentID → createdTime pairs.
+func datedPage(created map[string]string, hasMore bool, nextValue string) map[string]any {
+	previews := make([]map[string]any, 0, len(created))
+	for _, id := range slices.Sorted(maps.Keys(created)) {
+		previews = append(previews, map[string]any{"incidentID": id, "title": "Outage " + id, "status": "active", "createdTime": created[id]})
+	}
+	return map[string]any{
+		"incidentPreviews": previews,
+		"cursor":           map[string]any{"hasMore": hasMore, "nextValue": nextValue},
+	}
+}
+
+func flexTimePtr(t time.Time) *irm.FlexTime {
+	ft := irm.FlexTime(t)
+	return &ft
+}
+
+// clientListCase is one List scenario: a query, a scripted server, and the
+// expected outcome.
+type clientListCase struct {
+	name      string
+	query     irm.IncidentQuery
+	handler   func(t *testing.T, calls *[]listRequest) http.HandlerFunc
+	wantIDs   []string
+	wantLen   int
+	wantCalls int
+	wantErr   string
+}
+
+// runClientListCase records every request body, serves tt.handler, runs
+// List, and checks the outcome against the case expectations.
+func runClientListCase(t *testing.T, tt clientListCase) {
+	t.Helper()
+	var calls []listRequest
+	inner := tt.handler(t, &calls)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req listRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		calls = append(calls, req)
+		inner(w, r)
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server)
+	result, err := c.List(t.Context(), tt.query)
+
+	if tt.wantErr != "" {
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), tt.wantErr)
+		return
+	}
+
+	require.NoError(t, err)
+	if tt.wantIDs != nil {
+		ids := make([]string, len(result))
+		for i, inc := range result {
+			ids[i] = inc.IncidentID
+		}
+		assert.Equal(t, tt.wantIDs, ids)
+	} else {
+		assert.Len(t, result, tt.wantLen)
+	}
+	assert.Len(t, calls, tt.wantCalls)
 }
 
 func TestClient_List(t *testing.T) {
-	tests := []struct {
-		name      string
-		query     irm.IncidentQuery
-		handler   func(t *testing.T, calls *[]listRequest) http.HandlerFunc
-		wantLen   int
-		wantCalls int
-		wantErr   string
-	}{
+	tests := []clientListCase{
 		{
-			name:  "returns incidents",
+			name:  "returns incidents from the previews endpoint",
 			query: irm.IncidentQuery{Limit: 50},
 			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
 				t.Helper()
 				return func(w http.ResponseWriter, r *http.Request) {
 					assert.Equal(t, http.MethodPost, r.Method)
-					assert.Contains(t, r.URL.Path, "IncidentsService.QueryIncidents")
-					writeJSON(w, incidentPage("a", 2, false, ""))
+					assert.Contains(t, r.URL.Path, "/api/v1/IncidentsService.QueryIncidentPreviews")
+					writeJSON(w, previewsPage("a", 2, false, ""))
 				}
 			},
 			wantLen:   2,
@@ -75,7 +137,7 @@ func TestClient_List(t *testing.T) {
 				return func(w http.ResponseWriter, _ *http.Request) {
 					switch len(*calls) {
 					case 1:
-						writeJSON(w, incidentPage("p1", 1, true, "cursor-1"))
+						writeJSON(w, previewsPage("p1", 1, true, "cursor-1"))
 					default:
 						req := (*calls)[1]
 						if assert.NotNil(t, req.Cursor, "second request must carry the cursor next to the query") {
@@ -83,8 +145,7 @@ func TestClient_List(t *testing.T) {
 							assert.Equal(t, "cursor-1", (*req.Cursor)["nextValue"])
 							assert.Equal(t, true, (*req.Cursor)["hasMore"])
 						}
-						assert.NotContains(t, req.Query, "contextPayload")
-						writeJSON(w, incidentPage("p2", 1, false, ""))
+						writeJSON(w, previewsPage("p2", 1, false, ""))
 					}
 				}
 			},
@@ -101,15 +162,15 @@ func TestClient_List(t *testing.T) {
 					assert.LessOrEqual(t, req.Query["limit"], float64(100), "per-page limit must not exceed the documented maximum")
 					switch len(*calls) {
 					case 1:
-						writeJSON(w, incidentPage("p1", 100, true, "cursor-1"))
+						writeJSON(w, previewsPage("p1", 100, true, "cursor-1"))
 					case 2:
 						// 150 remain wanted; the page request must ask for 100.
 						assert.InDelta(t, 100, req.Query["limit"], 0)
-						writeJSON(w, incidentPage("p2", 100, true, "cursor-2"))
+						writeJSON(w, previewsPage("p2", 100, true, "cursor-2"))
 					default:
 						// 50 remain wanted; the page request must shrink.
 						assert.InDelta(t, 50, req.Query["limit"], 0)
-						writeJSON(w, incidentPage("p3", 50, false, ""))
+						writeJSON(w, previewsPage("p3", 50, false, ""))
 					}
 				}
 			},
@@ -122,7 +183,7 @@ func TestClient_List(t *testing.T) {
 			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
 				t.Helper()
 				return func(w http.ResponseWriter, _ *http.Request) {
-					writeJSON(w, incidentPage("p1", 1, true, "cursor-1"))
+					writeJSON(w, previewsPage("p1", 1, true, "cursor-1"))
 				}
 			},
 			wantLen:   1,
@@ -134,7 +195,7 @@ func TestClient_List(t *testing.T) {
 			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
 				t.Helper()
 				return func(w http.ResponseWriter, _ *http.Request) {
-					writeJSON(w, incidentPage("p1", 5, false, ""))
+					writeJSON(w, previewsPage("p1", 5, false, ""))
 				}
 			},
 			wantLen:   3,
@@ -148,7 +209,7 @@ func TestClient_List(t *testing.T) {
 				return func(w http.ResponseWriter, _ *http.Request) {
 					// A misbehaving server claims more pages but provides no
 					// cursor to fetch them; the client must not loop forever.
-					writeJSON(w, incidentPage("p1", 1, true, ""))
+					writeJSON(w, previewsPage("p1", 1, true, ""))
 				}
 			},
 			wantLen:   1,
@@ -162,25 +223,10 @@ func TestClient_List(t *testing.T) {
 				return func(w http.ResponseWriter, _ *http.Request) {
 					req := (*calls)[0]
 					assert.InDelta(t, 100, req.Query["limit"], 0)
-					writeJSON(w, incidentPage("p1", 100, true, "cursor-1"))
+					writeJSON(w, previewsPage("p1", 100, true, "cursor-1"))
 				}
 			},
 			wantLen:   100,
-			wantCalls: 1,
-		},
-		{
-			name:  "forwards filters in the query",
-			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{"security"}},
-			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
-				t.Helper()
-				return func(w http.ResponseWriter, _ *http.Request) {
-					q := (*calls)[0].Query
-					assert.Equal(t, []any{"security"}, q["incidentLabels"])
-					assert.Equal(t, "DESC", q["orderDirection"])
-					writeJSON(w, incidentPage("p1", 1, false, ""))
-				}
-			},
-			wantLen:   1,
 			wantCalls: 1,
 		},
 		{
@@ -198,31 +244,121 @@ func TestClient_List(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var calls []listRequest
-			inner := tt.handler(t, &calls)
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var req listRequest
-				assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-				calls = append(calls, req)
-				inner(w, r)
-			}))
-			defer server.Close()
-
-			c := newTestClient(t, server)
-			result, err := c.List(t.Context(), tt.query)
-
-			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Len(t, result, tt.wantLen)
-			assert.Len(t, calls, tt.wantCalls)
-		})
+		t.Run(tt.name, func(t *testing.T) { runClientListCase(t, tt) })
 	}
+}
+
+// TestClient_List_Filters covers the filter translation the migration to
+// QueryIncidentPreviews introduced: labels become query-string terms and the
+// date bounds are enforced client-side (the endpoint has no date fields).
+func TestClient_List_Filters(t *testing.T) {
+	tests := []clientListCase{
+		{
+			name:  "translates labels into quoted query-string terms",
+			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{"security", "PIR not needed", "service_name:checkout"}},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					req := (*calls)[0]
+					assert.Equal(t, `label:"security" label:"PIR not needed" label:"service_name:checkout"`, req.Query["queryString"])
+					assert.NotContains(t, req.Query, "incidentLabels")
+					assert.Equal(t, "DESC", req.Query["orderDirection"])
+					assert.True(t, req.IncludeCustomFieldValues)
+					assert.True(t, req.IncludeIncidentChannels)
+					writeJSON(w, previewsPage("p1", 1, false, ""))
+				}
+			},
+			wantLen:   1,
+			wantCalls: 1,
+		},
+		{
+			name: "applies the from bound client-side and stops early",
+			query: irm.IncidentQuery{
+				Limit:    50,
+				DateFrom: flexTimePtr(time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)),
+			},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					// No date fields exist on the wire; the bound must be
+					// enforced client-side. Descending createdTime order
+					// means everything past inc-2 is older still, so the
+					// client must filter and stop after one call.
+					req := (*calls)[0]
+					assert.NotContains(t, req.Query, "dateFrom")
+					writeJSON(w, datedPage(map[string]string{
+						"inc-1": "2026-06-11T10:00:00Z",
+						"inc-2": "2026-06-10T09:00:00Z",
+						"inc-3": "2026-06-09T08:00:00Z",
+					}, true, "cursor-1"))
+				}
+			},
+			wantIDs:   []string{"inc-1", "inc-2"},
+			wantCalls: 1,
+		},
+		{
+			name: "applies the to bound client-side and keeps paging",
+			query: irm.IncidentQuery{
+				Limit:  50,
+				DateTo: flexTimePtr(time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)),
+			},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					// Page one is entirely newer than the to bound (exclusive);
+					// the matching incidents are on page two.
+					if len(*calls) == 1 {
+						writeJSON(w, datedPage(map[string]string{
+							"inc-1": "2026-06-11T10:00:00Z",
+							"inc-2": "2026-06-10T00:00:00Z",
+						}, true, "cursor-1"))
+					} else {
+						writeJSON(w, datedPage(map[string]string{
+							"inc-3": "2026-06-09T08:00:00Z",
+						}, false, ""))
+					}
+				}
+			},
+			wantIDs:   []string{"inc-3"},
+			wantCalls: 2,
+		},
+		{
+			name:  "surfaces in-band response error",
+			query: irm.IncidentQuery{Limit: 10},
+			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					writeJSON(w, map[string]any{"incidentPreviews": []map[string]any{}, "cursor": map[string]any{}, "error": "Invalid query string"})
+				}
+			},
+			wantErr: "Invalid query string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { runClientListCase(t, tt) })
+	}
+}
+
+// TestClient_List_MapsSeverityLabel pins the preview→Incident conversion:
+// previews carry severityLabel where full incidents carried severity.
+func TestClient_List_MapsSeverityLabel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"incidentPreviews": []map[string]any{
+				{"incidentID": "inc-1", "title": "Outage", "status": "active", "severityLabel": "Major", "severityID": "sev-2"},
+			},
+			"cursor": map[string]any{"hasMore": false},
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server)
+	result, err := c.List(t.Context(), irm.IncidentQuery{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "Major", result[0].Severity)
+	assert.Equal(t, "sev-2", result[0].SeverityID)
 }
 
 func TestClient_Get(t *testing.T) {
@@ -405,6 +541,7 @@ func TestClient_QueryIncidentContext(t *testing.T) {
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Contains(t, r.URL.Path, "IncidentContextService.QueryIncidentContext")
+				assert.NotContains(t, r.URL.Path, "/v1/", "IncidentContextService 404s under the v1 prefix")
 				var body map[string]any
 				_ = json.NewDecoder(r.Body).Decode(&body)
 				query, _ := body["query"].(map[string]any)
@@ -529,6 +666,7 @@ func TestClient_GetSeverities(t *testing.T) {
 			name: "returns severities",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				assert.Contains(t, r.URL.Path, "SeveritiesService.GetOrgSeverities")
+				assert.NotContains(t, r.URL.Path, "/v1/", "SeveritiesService 404s under the v1 prefix")
 				writeJSON(w, map[string]any{
 					"severities": []map[string]any{
 						{"severityID": "sev-1", "displayLabel": "Critical", "level": 1, "color": "#FF0000"},

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -255,12 +255,12 @@ func TestClient_List_Filters(t *testing.T) {
 	tests := []clientListCase{
 		{
 			name:  "translates labels into quoted query-string terms",
-			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{"security", "PIR not needed", "service_name:checkout"}},
+			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{"security", "PIR not needed", "service_name:checkout", "team's"}},
 			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
 				t.Helper()
 				return func(w http.ResponseWriter, _ *http.Request) {
 					req := (*calls)[0]
-					assert.Equal(t, `label:"security" label:"PIR not needed" label:"service_name:checkout"`, req.Query["queryString"])
+					assert.Equal(t, `label:"security" label:"PIR not needed" label:"service_name:checkout" label:"team's"`, req.Query["queryString"])
 					assert.NotContains(t, req.Query, "incidentLabels")
 					assert.Equal(t, "DESC", req.Query["orderDirection"])
 					assert.True(t, req.IncludeCustomFieldValues)
@@ -269,6 +269,41 @@ func TestClient_List_Filters(t *testing.T) {
 				}
 			},
 			wantLen:   1,
+			wantCalls: 1,
+		},
+		{
+			name:  "rejects labels containing a double quote",
+			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{`the "big" outage`}},
+			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(_ http.ResponseWriter, _ *http.Request) {
+					t.Error("API must not be called for an inexpressible label")
+				}
+			},
+			wantErr: "cannot express values containing double quotes",
+		},
+		{
+			name: "fetches full pages while date filtering",
+			query: irm.IncidentQuery{
+				Limit:  2,
+				DateTo: flexTimePtr(time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)),
+			},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					// Client-side filtering can discard any number of
+					// previews, so the page request must not shrink to the
+					// remaining limit.
+					req := (*calls)[0]
+					assert.InDelta(t, 100, req.Query["limit"], 0)
+					writeJSON(w, datedPage(map[string]string{
+						"inc-1": "2026-06-11T10:00:00Z",
+						"inc-2": "2026-06-09T09:00:00Z",
+						"inc-3": "2026-06-08T08:00:00Z",
+					}, false, ""))
+				}
+			},
+			wantIDs:   []string{"inc-2", "inc-3"},
 			wantCalls: 1,
 		},
 		{

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -52,14 +52,14 @@ func (o *incidentListOpts) Validate() error {
 	}
 	// Labels match plain label text for the default Tags key and key:value
 	// composites for keyed labels; values are passed through as given and
-	// quoted into the incident query-string language by the client. A value
-	// containing both quote characters cannot be quoted in that language.
+	// double-quoted into the incident query-string language by the client.
+	// That language cannot express a value containing a double quote.
 	for _, l := range o.Labels {
 		if strings.TrimSpace(l) == "" {
 			return errors.New("invalid --labels value: label must not be empty")
 		}
-		if strings.Contains(l, `"`) && strings.Contains(l, "'") {
-			return fmt.Errorf("invalid --labels value %q: cannot contain both single and double quotes", l)
+		if strings.Contains(l, `"`) {
+			return fmt.Errorf("invalid --labels value %q: cannot contain double quotes", l)
 		}
 	}
 	now := time.Now()

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -50,13 +50,16 @@ func (o *incidentListOpts) Validate() error {
 	if o.Limit < 1 {
 		return fmt.Errorf("invalid --limit value %d: must be at least 1", o.Limit)
 	}
-	// The API's incidentLabels field matches plain label text for labels
-	// under the default Tags key and key:value composites for keyed labels,
-	// so any non-empty string is a valid filter — pass values through as
-	// given.
+	// Labels match plain label text for the default Tags key and key:value
+	// composites for keyed labels; values are passed through as given and
+	// quoted into the incident query-string language by the client. A value
+	// containing both quote characters cannot be quoted in that language.
 	for _, l := range o.Labels {
 		if strings.TrimSpace(l) == "" {
 			return errors.New("invalid --labels value: label must not be empty")
+		}
+		if strings.Contains(l, `"`) && strings.Contains(l, "'") {
+			return fmt.Errorf("invalid --labels value %q: cannot contain both single and double quotes", l)
 		}
 	}
 	now := time.Now()

--- a/internal/providers/irm/incidents_commands_test.go
+++ b/internal/providers/irm/incidents_commands_test.go
@@ -299,6 +299,13 @@ func TestListOpts_LabelValidation(t *testing.T) {
 			labels:  []string{"security", ""},
 			wantErr: "label must not be empty",
 		},
+		{
+			// The query-string language has no escape for a value holding
+			// both quote characters, so it cannot be expressed.
+			name:    "label with both quote characters fails",
+			labels:  []string{`it's a "label"`},
+			wantErr: "cannot contain both single and double quotes",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -325,8 +332,9 @@ func (l fakeGrafanaConfigLoader) LoadGrafanaConfig(context.Context) (config.Name
 }
 
 // TestIncidentsListCommand_BuildsQuery runs the real list command against a
-// fake API and asserts the filters land in the request as the API documents
-// them: plain label text in incidentLabels and RFC3339 dates.
+// fake API and asserts the flags land in a QueryIncidentPreviews request:
+// labels become quoted query-string terms, and the date flags never reach
+// the wire (the endpoint has no date fields) but are enforced client-side.
 func TestIncidentsListCommand_BuildsQuery(t *testing.T) {
 	t.Setenv("GCX_AGENT_MODE", "false")
 	agent.ResetForTesting()
@@ -340,8 +348,9 @@ func TestIncidentsListCommand_BuildsQuery(t *testing.T) {
 		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		query = body.Query
 		writeJSON(w, map[string]any{
-			"incidents": []map[string]any{
-				{"incidentID": "inc-1", "title": "Security incident", "status": "active"},
+			"incidentPreviews": []map[string]any{
+				{"incidentID": "inc-1", "title": "Security incident", "status": "active", "severityLabel": "Major", "createdTime": "2024-06-10T12:00:00Z"},
+				{"incidentID": "inc-2", "title": "Too old", "status": "resolved", "createdTime": "2024-05-01T12:00:00Z"},
 			},
 			"cursor": map[string]any{"hasMore": false},
 		})
@@ -359,20 +368,24 @@ func TestIncidentsListCommand_BuildsQuery(t *testing.T) {
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{
-		"--labels", "security,important",
+		"--labels", "security,PIR not needed",
 		"--from", "2024-06-01T00:00:00Z",
 		"--to", "2024-06-15T00:00:00Z",
 		"--limit", "10",
 	})
 	require.NoError(t, cmd.Execute())
 
-	assert.Equal(t, []any{"security", "important"}, query["incidentLabels"])
-	assert.Equal(t, "2024-06-01T00:00:00Z", query["dateFrom"])
-	assert.Equal(t, "2024-06-15T00:00:00Z", query["dateTo"])
+	assert.Equal(t, `label:"security" label:"PIR not needed"`, query["queryString"])
+	assert.NotContains(t, query, "incidentLabels")
+	assert.NotContains(t, query, "dateFrom")
+	assert.NotContains(t, query, "dateTo")
 	assert.InDelta(t, 10, query["limit"], 0)
 
-	assert.Contains(t, stdout.String(), "inc-1")
-	assert.Contains(t, stdout.String(), "Security incident")
+	out := stdout.String()
+	assert.Contains(t, out, "inc-1")
+	assert.Contains(t, out, "Security incident")
+	assert.Contains(t, out, "Major", "severityLabel must surface in the SEVERITY column")
+	assert.NotContains(t, out, "inc-2", "incidents outside --from/--to must be filtered client-side")
 }
 
 func TestIncidentsListCommand_RejectsNonPositiveLimit(t *testing.T) {

--- a/internal/providers/irm/incidents_commands_test.go
+++ b/internal/providers/irm/incidents_commands_test.go
@@ -300,11 +300,17 @@ func TestListOpts_LabelValidation(t *testing.T) {
 			wantErr: "label must not be empty",
 		},
 		{
-			// The query-string language has no escape for a value holding
-			// both quote characters, so it cannot be expressed.
-			name:    "label with both quote characters fails",
-			labels:  []string{`it's a "label"`},
-			wantErr: "cannot contain both single and double quotes",
+			// The query-string language rejects double quotes inside
+			// single-quoted values, so a label containing a double quote
+			// cannot be expressed at all.
+			name:    "label with a double quote fails",
+			labels:  []string{`the "big" outage`},
+			wantErr: "cannot contain double quotes",
+		},
+		{
+			// Apostrophes are fine: double-quoted values may contain them.
+			name:   "label with a single quote passes",
+			labels: []string{"team's incident"},
 		},
 	}
 	for _, tt := range tests {
@@ -379,7 +385,9 @@ func TestIncidentsListCommand_BuildsQuery(t *testing.T) {
 	assert.NotContains(t, query, "incidentLabels")
 	assert.NotContains(t, query, "dateFrom")
 	assert.NotContains(t, query, "dateTo")
-	assert.InDelta(t, 10, query["limit"], 0)
+	// With date bounds the client fetches full pages and filters down to
+	// --limit itself, so the wire limit is the page maximum, not 10.
+	assert.InDelta(t, 100, query["limit"], 0)
 
 	out := stdout.String()
 	assert.Contains(t, out, "inc-1")

--- a/internal/providers/irm/incidents_resource_adapter_test.go
+++ b/internal/providers/irm/incidents_resource_adapter_test.go
@@ -76,7 +76,6 @@ func TestResourceAdapter_List(t *testing.T) {
 						{"incidentID": "inc-2", "title": "Outage 2", "status": "resolved"},
 					},
 					"cursor": map[string]any{"hasMore": false},
-					"query":  map[string]any{},
 				})
 			},
 			wantLen:       2,
@@ -91,7 +90,6 @@ func TestResourceAdapter_List(t *testing.T) {
 				writeJSON(w, map[string]any{
 					"incidentPreviews": []map[string]any{},
 					"cursor":           map[string]any{"hasMore": false},
-					"query":            map[string]any{},
 				})
 			},
 			wantLen: 0,
@@ -295,7 +293,6 @@ func TestResourceAdapter_ListPopulatesMetadata(t *testing.T) {
 				{"incidentID": "meta-inc", "title": "Metadata Inc", "status": "active"},
 			},
 			"cursor": map[string]any{"hasMore": false},
-			"query":  map[string]any{},
 		})
 	}))
 	defer server.Close()

--- a/internal/providers/irm/incidents_resource_adapter_test.go
+++ b/internal/providers/irm/incidents_resource_adapter_test.go
@@ -71,7 +71,7 @@ func TestResourceAdapter_List(t *testing.T) {
 			namespace: "stack-123",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				writeJSON(w, map[string]any{
-					"incidents": []map[string]any{
+					"incidentPreviews": []map[string]any{
 						{"incidentID": "inc-1", "title": "Outage 1", "status": "active"},
 						{"incidentID": "inc-2", "title": "Outage 2", "status": "resolved"},
 					},
@@ -89,9 +89,9 @@ func TestResourceAdapter_List(t *testing.T) {
 			namespace: "stack-123",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				writeJSON(w, map[string]any{
-					"incidents": []map[string]any{},
-					"cursor":    map[string]any{"hasMore": false},
-					"query":     map[string]any{},
+					"incidentPreviews": []map[string]any{},
+					"cursor":           map[string]any{"hasMore": false},
+					"query":            map[string]any{},
 				})
 			},
 			wantLen: 0,
@@ -291,7 +291,7 @@ func TestResourceAdapter_RoundTrip(t *testing.T) {
 func TestResourceAdapter_ListPopulatesMetadata(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, map[string]any{
-			"incidents": []map[string]any{
+			"incidentPreviews": []map[string]any{
 				{"incidentID": "meta-inc", "title": "Metadata Inc", "status": "active"},
 			},
 			"cursor": map[string]any{"hasMore": false},

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -176,10 +176,13 @@ type IncidentCursor struct {
 	NextValue string `json:"nextValue"`
 }
 
-// IncidentQuery describes an incidents List call. Since the migration to
-// QueryIncidentPreviews it is gcx's caller-facing options struct, not a wire
-// type: labels are translated into the incident query-string language and
-// date bounds are enforced client-side (see IncidentClient.List).
+// QueryIncidentPreviews: severity arrives as severityLabel, and the rest of
+// a full Incident's fields are absent — the structured children (taskList,
+// incidentMembership, incidentHookRuns, refs) as well as overviewURL,
+// durationSeconds, prefix, state, statusID, fieldGroupUUID, descriptionUser,
+// descriptionModifiedTime, statusModifiedByUser and statusModifiedTime. The
+// opt-in membership preview (includeMembershipPreview) is not requested:
+// its important-assignments-only shape does not map onto IncidentMembership.
 type IncidentQuery struct {
 	Limit          int
 	OrderDirection string

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -176,35 +176,97 @@ type IncidentCursor struct {
 	NextValue string `json:"nextValue"`
 }
 
-// IncidentQuery represents a query for incidents.
+// IncidentQuery describes an incidents List call. Since the migration to
+// QueryIncidentPreviews it is gcx's caller-facing options struct, not a wire
+// type: labels are translated into the incident query-string language and
+// date bounds are enforced client-side (see IncidentClient.List).
 type IncidentQuery struct {
-	Limit           int       `json:"limit"`
-	OrderDirection  string    `json:"orderDirection"`
-	OrderField      string    `json:"orderField"`
-	QueryString     string    `json:"queryString"`
-	DateFrom        *FlexTime `json:"dateFrom,omitempty"`
-	DateTo          *FlexTime `json:"dateTo,omitempty"`
-	Severity        string    `json:"severity,omitempty"`
-	OnlyDrills      bool      `json:"onlyDrills,omitempty"`
-	IncludeStatuses []string  `json:"includeStatuses,omitempty"`
-	ExcludeStatuses []string  `json:"excludeStatuses,omitempty"`
-	IncidentLabels  []string  `json:"incidentLabels,omitempty"`
-	IncidentRoles   []string  `json:"incidentRoles,omitempty"`
+	Limit          int
+	OrderDirection string
+	OrderField     string
+	DateFrom       *FlexTime
+	DateTo         *FlexTime
+	IncidentLabels []string
 }
 
-// queryIncidentsRequest is the request body for querying incidents. The
-// cursor rides next to the query, not inside it: pass the cursor returned by
-// the previous page to fetch the next one.
-type queryIncidentsRequest struct {
-	Query  IncidentQuery   `json:"query"`
-	Cursor *IncidentCursor `json:"cursor,omitempty"`
+// incidentPreviewsQuery is the documented IncidentPreviewsQuery wire type.
+type incidentPreviewsQuery struct {
+	Limit          int    `json:"limit"`
+	OrderDirection string `json:"orderDirection"`
+	OrderField     string `json:"orderField,omitempty"`
+	QueryString    string `json:"queryString,omitempty"`
 }
 
-// queryIncidentsResponse is the response from querying incidents.
-type queryIncidentsResponse struct {
-	Incidents []Incident     `json:"incidents"`
-	Cursor    IncidentCursor `json:"cursor"`
-	Query     IncidentQuery  `json:"query"`
+// queryIncidentPreviewsRequest is the request body for QueryIncidentPreviews.
+// The cursor rides next to the query, not inside it: pass the cursor
+// returned by the previous page to fetch the next one.
+type queryIncidentPreviewsRequest struct {
+	Query                    incidentPreviewsQuery `json:"query"`
+	Cursor                   *IncidentCursor       `json:"cursor,omitempty"`
+	IncludeCustomFieldValues bool                  `json:"includeCustomFieldValues"`
+	IncludeIncidentChannels  bool                  `json:"includeIncidentChannels"`
+}
+
+// queryIncidentPreviewsResponse is the response from QueryIncidentPreviews.
+type queryIncidentPreviewsResponse struct {
+	IncidentPreviews []IncidentPreview `json:"incidentPreviews"`
+	Cursor           IncidentCursor    `json:"cursor"`
+	Error            string            `json:"error,omitempty"`
+}
+
+// IncidentPreview is the reduced incident shape returned by
+// QueryIncidentPreviews: severity arrives as severityLabel, and the
+// structured children of a full Incident (taskList, membership, hook runs,
+// refs) are absent.
+type IncidentPreview struct {
+	IncidentID       string               `json:"incidentID"`
+	Title            string               `json:"title"`
+	Slug             string               `json:"slug,omitempty"`
+	Status           string               `json:"status"`
+	SeverityID       string               `json:"severityID,omitempty"`
+	SeverityLabel    string               `json:"severityLabel,omitempty"`
+	IsDrill          bool                 `json:"isDrill"`
+	IncidentType     string               `json:"incidentType,omitempty"`
+	Description      string               `json:"description,omitempty"`
+	Summary          string               `json:"summary,omitempty"`
+	Version          int                  `json:"version,omitempty"`
+	Labels           []IncidentLabel      `json:"labels,omitempty"`
+	FieldValues      []IncidentFieldValue `json:"fieldValues,omitempty"`
+	IncidentChannels []any                `json:"incidentChannels,omitempty"`
+	CreatedByUser    *IncidentUser        `json:"createdByUser,omitempty"`
+	CreatedTime      FlexTime             `json:"createdTime,omitzero"`
+	ModifiedTime     FlexTime             `json:"modifiedTime,omitzero"`
+	ClosedTime       FlexTime             `json:"closedTime,omitzero"`
+	IncidentStart    FlexTime             `json:"incidentStart,omitzero"`
+	IncidentEnd      FlexTime             `json:"incidentEnd,omitzero"`
+}
+
+// ToIncident maps the preview onto the Incident shape used across the
+// provider; severityLabel populates Severity, matching the field
+// QueryIncidents used to return, and fields previews do not carry stay zero.
+func (p IncidentPreview) ToIncident() Incident {
+	return Incident{
+		IncidentID:       p.IncidentID,
+		Title:            p.Title,
+		Slug:             p.Slug,
+		Status:           p.Status,
+		Severity:         p.SeverityLabel,
+		SeverityID:       p.SeverityID,
+		IsDrill:          p.IsDrill,
+		IncidentType:     p.IncidentType,
+		Description:      p.Description,
+		Summary:          p.Summary,
+		Version:          p.Version,
+		Labels:           p.Labels,
+		FieldValues:      p.FieldValues,
+		IncidentChannels: p.IncidentChannels,
+		CreatedByUser:    p.CreatedByUser,
+		CreatedTime:      p.CreatedTime,
+		ModifiedTime:     p.ModifiedTime,
+		ClosedTime:       p.ClosedTime,
+		IncidentStart:    p.IncidentStart,
+		IncidentEnd:      p.IncidentEnd,
+	}
 }
 
 // createIncidentRequest is the request body for creating an incident.


### PR DESCRIPTION
Migrates `gcx irm incidents list` off the deprecated `IncidentsService.QueryIncidents` endpoint onto `QueryIncidentPreviews` on the documented `/v1` base path. No new flags and no CLI surface change: flags, validation, output columns, and the K8s envelope all stay as they are.

Fixes #832.

### Why migrate?

The upstream rationale (grafana/incident#5410, May 2024) gives three reasons:

1. **Previews are the purpose-built listing shape.** Full `Incident` objects force the server to assemble structured children (task list, membership, …) for every row of every page; `IncidentPreview` is "a minimal preview of a full Incident … meant for lightweight listings", with the heavier data opt-in per request.
2. **The query-string language replaced structured filter fields as the filter model.** Quoting the PR: "the query was simplified to rely exclusively on the QueryString parameter, which is more flexible (it supports logical operators) and makes it easier to add extra filter parameters." New filter capabilities land only there.
3. **Grafana's own UI moved to previews in the same PR.** The homepage and All Incidents page were refactored onto `QueryIncidentPreviews` — meaning Grafana itself stopped calling `QueryIncidents` in May 2024.

Point 3 is visible in practice: the old endpoint's documented `dateFrom`/`dateTo` filters silently don't filter and newer response data such as `incidentChannels` is never populated on it. gcx was building on an endpoint whose filters Grafana stopped exercising two years ago.

### Filter translation

`IncidentPreviewsQuery` has no structured filter fields, only a query string:

- **`--labels`** values become quoted query-string terms (`label:"security" label:"PIR not needed"`), ANDed together. Live tests return exactly the same incidents as the old structured filter. Values containing a double quote cannot be expressed in the language (live probing showed the server rejects them inside single-quoted strings) and are rejected up front; apostrophes work.
- **`--from`/`--to`** are enforced client-side on `createdTime` — the previews endpoint has no date fields, and the old endpoint ignored its own (see *Why migrate*) — so the date flags now actually filter.

### Response mapping

Previews carry `severityLabel` where full incidents carried `severity`; `IncidentPreview.ToIncident` maps it back, so the SEVERITY column and the `severity` field in `-o json|yaml` envelopes are unchanged. Custom field values and incident channels are always requested. The structured children only full incidents carried (`taskList`, `incidentMembership`, `incidentHookRuns`, `refs`) are absent from **list** output — `incidents get` still returns the full object via `GetIncident`.

### Path versioning

`IncidentsService.*` and `ActivityService.*` move to the documented `/resources/api/v1` base path (list, get, and activity checked against a live stack). One discovery: `SeveritiesService` and `IncidentContextService` are not part of the documented v1 API and **404 under the `/v1` prefix** — they stay on the unversioned path, and tests guard the split.

Also per #832: the undocumented `orderField` is no longer sent to the deprecated endpoint (the previews query documents `orderField`, where it is still used), and `IncidentQuery` is no longer serialized into requests at all — it now just holds the options callers pass to `List`, while the request body is built from a separate struct matching the documented `IncidentPreviewsQuery`.

## Tests

The client suite checks exactly what each request contains: previews path, quoted query-string translation (and that `incidentLabels`/`dateFrom`/`dateTo` no longer appear in requests), top-level cursor echo, page-size clamping, stop conditions, `severityLabel` mapping, both client-side date bounds, and in-band error surfacing. Command-level tests confirm the flags behave exactly as before, against a fake API.

The change was also exercised end to end against a live Grafana Cloud stack: label filters returned the same incidents as the pre-migration endpoint for Tags, keyed, and spaced labels; date windows isolated the expected incidents; fetching 150 incidents returned 150 unique results across pages; and `get`, `activity list`, `severities list`, and `contexts list` all work on their respective paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



