### PR TITLE
fix(kg): list all insight categories in entities inspect help

### DIFF
--- a/docs/reference/cli/gcx_kg_entities_inspect.md
+++ b/docs/reference/cli/gcx_kg_entities_inspect.md
@@ -25,7 +25,7 @@ gcx kg entities inspect [Type--Name] [flags]
       --env string                         Environment scope (run 'gcx kg meta scopes' to see valid values)
       --from string                        Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                               help for inspect
-      --insight-categories strings         Filter insights by category (comma-separated, e.g. saturation,anomaly,failure); empty = all categories
+      --insight-categories strings         Filter insights by category (comma-separated, e.g. saturation,anomaly,failure,error,amend); empty = all categories
       --insight-hide-chronic-above int     Hide insights present more than this percent of the window (0-100); overrides --insight-hide-noise on this axis
       --insight-hide-noise                 Apply RCA Workbench noise filter: hide insights older than 48h or present >90% of the window
       --insight-hide-older-than duration   Hide insights older than a whole number of hours (e.g. 24h); overrides --insight-hide-noise on this axis

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1726,7 +1726,7 @@ func (o *inspectOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 	flags.BoolVar(&o.ShareLink, "share-link", false, "Print the RCA Workbench URL for this entity to stderr")
 	flags.BoolVar(&o.Open, "open", false, "Open the entity in the RCA Workbench in your browser")
-	flags.StringSliceVar(&o.InsightCategories, "insight-categories", nil, "Filter insights by category (comma-separated, e.g. saturation,anomaly,failure); empty = all categories")
+	flags.StringSliceVar(&o.InsightCategories, "insight-categories", nil, "Filter insights by category (comma-separated, e.g. saturation,anomaly,failure,error,amend); empty = all categories")
 	flags.BoolVar(&o.InsightHideNoise, "insight-hide-noise", false, "Apply RCA Workbench noise filter: hide insights older than 48h or present >90% of the window")
 	flags.DurationVar(&o.InsightHideOlderThan, "insight-hide-older-than", 0, "Hide insights older than a whole number of hours (e.g. 24h); overrides --insight-hide-noise on this axis")
 	flags.IntVar(&o.InsightHideChronicAbove, "insight-hide-chronic-above", 0, "Hide insights present more than this percent of the window (0-100); overrides --insight-hide-noise on this axis")


### PR DESCRIPTION
## Summary

The `--insight-categories` flag on `gcx kg entities inspect` had a help example listing only three of the five Asserts assertion categories. This adds `error` and `amend` so the example covers the full set.

**Before:**
```
--insight-categories strings    Filter insights by category (comma-separated, e.g. saturation,anomaly,failure); empty = all categories
```

**After:**
```
--insight-categories strings    Filter insights by category (comma-separated, e.g. saturation,anomaly,failure,error,amend); empty = all categories
```

## Changes
- `internal/providers/kg/commands.go` — flag help text
- `docs/reference/cli/gcx_kg_entities_inspect.md` — regenerated reference

## Testing
- `GCX_AGENT_MODE=false mise run all` — lint (0 issues), tests, build, docs all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)