### PR TITLE
feat(irm): add status, severity and query filters to incidents list

### DIFF
--- a/docs/reference/cli/gcx_irm_incidents_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_list.md
@@ -12,7 +12,7 @@ gcx irm incidents list [flags]
       --from string       Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)
   -h, --help              help for list
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --labels strings    Filter by label text or key:value (may be repeated; matched client-side)
+      --labels strings    Filter by label text or key:value, e.g. squad:mimir (may be repeated)
       --limit int         Maximum number of incidents to return (default 50)
   -o, --output string     Output format. One of: agents, json, table, wide, yaml (default "table")
       --query string      Raw incident query string, e.g. "isdrill:true"; cannot be combined with --labels, --status, or --severity

--- a/docs/reference/cli/gcx_irm_incidents_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_list.md
@@ -2,6 +2,17 @@
 
 List incidents.
 
+### Synopsis
+
+List incidents, most recent first.
+
+--status and --severity are applied server-side. --labels and --from/--to are
+applied client-side, one page at a time, so a highly selective --labels filter
+can page through the full incident history before collecting --limit incidents.
+
+--query is a raw query-string escape hatch and cannot be combined with the
+structured --labels, --status, or --severity filters.
+
 ```
 gcx irm incidents list [flags]
 ```

--- a/docs/reference/cli/gcx_irm_incidents_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_list.md
@@ -12,7 +12,7 @@ gcx irm incidents list [flags]
       --from string       Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)
   -h, --help              help for list
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --labels strings    Filter by labels (label text or key:value, may be repeated)
+      --labels strings    Filter by label text or key:value (may be repeated; matched client-side)
       --limit int         Maximum number of incidents to return (default 50)
   -o, --output string     Output format. One of: agents, json, table, wide, yaml (default "table")
       --query string      Raw incident query string, e.g. "isdrill:true"; cannot be combined with --labels, --status, or --severity

--- a/docs/reference/cli/gcx_irm_incidents_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_list.md
@@ -15,7 +15,7 @@ gcx irm incidents list [flags]
       --labels strings    Filter by labels (label text or key:value, may be repeated)
       --limit int         Maximum number of incidents to return (default 50)
   -o, --output string     Output format. One of: agents, json, table, wide, yaml (default "table")
-      --query string      Raw incident query string, e.g. "isdrill:true"; cannot be combined with the other filter flags
+      --query string      Raw incident query string, e.g. "isdrill:true"; cannot be combined with --labels, --status, or --severity
       --severity string   Filter by severity label, e.g. major (see: gcx irm incidents severities list)
       --status strings    Filter by status (active|resolved; repeatable, comma-separated)
       --to string         End of time range (RFC3339, unix timestamp, or relative e.g. now)

--- a/docs/reference/cli/gcx_irm_incidents_list.md
+++ b/docs/reference/cli/gcx_irm_incidents_list.md
@@ -9,13 +9,16 @@ gcx irm incidents list [flags]
 ### Options
 
 ```
-      --from string      Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)
-  -h, --help             help for list
-      --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --labels strings   Filter by labels (label text or key:value, may be repeated)
-      --limit int        Maximum number of incidents to return (default 50)
-  -o, --output string    Output format. One of: agents, json, table, wide, yaml (default "table")
-      --to string        End of time range (RFC3339, unix timestamp, or relative e.g. now)
+      --from string       Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)
+  -h, --help              help for list
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --labels strings    Filter by labels (label text or key:value, may be repeated)
+      --limit int         Maximum number of incidents to return (default 50)
+  -o, --output string     Output format. One of: agents, json, table, wide, yaml (default "table")
+      --query string      Raw incident query string, e.g. "isdrill:true"; cannot be combined with the other filter flags
+      --severity string   Filter by severity label, e.g. major (see: gcx irm incidents severities list)
+      --status strings    Filter by status (active|resolved; repeatable, comma-separated)
+      --to string         End of time range (RFC3339, unix timestamp, or relative e.g. now)
 ```
 
 ### Options inherited from parent commands

--- a/internal/providers/irm/export_test.go
+++ b/internal/providers/irm/export_test.go
@@ -4,15 +4,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewTestListCommand creates a list command for testing validation.
-// Labels and date strings are injected after flag setup so they go through Validate().
-func NewTestListCommand(labels []string, dateFrom, dateTo string) *cobra.Command {
+// NewTestListCommand creates a list command for testing validation. Flag
+// values are injected after flag setup so they go through Validate().
+func NewTestListCommand(labels, statuses []string, severity, query, dateFrom, dateTo string) *cobra.Command {
 	opts := &incidentListOpts{}
 	cmd := &cobra.Command{
 		Use:          "list",
 		SilenceUsage: true,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			opts.Labels = labels
+			opts.Statuses = statuses
+			opts.Severity = severity
+			opts.Query = query
 			opts.DateFrom = dateFrom
 			opts.DateTo = dateTo
 			return opts.Validate()

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -68,14 +68,37 @@ func quoteIncidentQueryValue(v string) string {
 	return `"` + v + `"`
 }
 
-// buildLabelsQueryString translates label filters into query-string terms.
-// Juxtaposed label terms AND together, which matches the behaviour of the
-// structured incidentLabels filter on the deprecated QueryIncidents endpoint
-// (verified live: identical result sets).
-func buildLabelsQueryString(labels []string) string {
-	terms := make([]string, len(labels))
-	for i, l := range labels {
-		terms[i] = "label:" + quoteIncidentQueryValue(l)
+// buildIncidentQueryString compiles the structured filters into a single
+// incident query-string-language expression. A non-empty query.QueryString is
+// used verbatim (raw escape hatch) and the structured filters are ignored.
+//
+// Terms are juxtaposed, which the language treats as AND; values within the
+// multi-valued statuses filter are ORed with or(...) so that two statuses
+// match either, not both at once. Verified live against QueryIncidentPreviews.
+func buildIncidentQueryString(query IncidentQuery) string {
+	if query.QueryString != "" {
+		return query.QueryString
+	}
+
+	var terms []string
+	for _, l := range query.IncidentLabels {
+		terms = append(terms, "label:"+quoteIncidentQueryValue(l))
+	}
+	if len(query.Statuses) > 0 {
+		statusTerms := make([]string, len(query.Statuses))
+		for i, s := range query.Statuses {
+			statusTerms[i] = "status:" + s
+		}
+		if len(statusTerms) == 1 {
+			terms = append(terms, statusTerms[0])
+		} else {
+			// or(...) — match any of the statuses; juxtaposition would AND
+			// them and match nothing.
+			terms = append(terms, "or("+strings.Join(statusTerms, " ")+")")
+		}
+	}
+	if query.Severity != "" {
+		terms = append(terms, "severity:"+quoteIncidentQueryValue(query.Severity))
 	}
 	return strings.Join(terms, " ")
 }
@@ -84,15 +107,18 @@ func buildLabelsQueryString(labels []string) string {
 // response cursor until query.Limit incidents are collected or the server
 // reports no more pages. A non-positive query.Limit defaults to 100.
 //
-// QueryIncidentPreviews has no structured filter fields: label filters are
-// translated into the query-string language, and date bounds — which even
-// the deprecated QueryIncidents endpoint ignored server-side — are enforced
-// here on createdTime, dateFrom inclusive and dateTo exclusive.
+// QueryIncidentPreviews has no structured filter fields: labels, statuses and
+// severity are compiled into the query-string language, and date bounds —
+// which even the deprecated QueryIncidents endpoint ignored server-side — are
+// enforced here on createdTime, dateFrom inclusive and dateTo exclusive.
 func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incident, error) {
 	for _, l := range query.IncidentLabels {
 		if strings.Contains(l, `"`) {
 			return nil, fmt.Errorf("incidents: invalid label %q: the incident query-string language cannot express values containing double quotes", l)
 		}
+	}
+	if strings.Contains(query.Severity, `"`) {
+		return nil, fmt.Errorf("incidents: invalid severity %q: the incident query-string language cannot express values containing double quotes", query.Severity)
 	}
 
 	if query.Limit <= 0 {
@@ -108,7 +134,7 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 	wire := incidentPreviewsQuery{
 		OrderDirection: query.OrderDirection,
 		OrderField:     query.OrderField,
-		QueryString:    buildLabelsQueryString(query.IncidentLabels),
+		QueryString:    buildIncidentQueryString(query),
 	}
 
 	var from, to time.Time

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -129,6 +129,61 @@ func buildIncidentQueryString(query IncidentQuery) string {
 	return strings.Join(terms, " ")
 }
 
+// validateIncidentQuery rejects filter values the incident query-string
+// language cannot express: a status outside the supported enum, or a severity
+// containing a double quote (it cannot appear inside the single-quoted server
+// value).
+func validateIncidentQuery(query IncidentQuery) error {
+	for _, s := range query.Statuses {
+		if !isIncidentStatusFilter(s) {
+			return fmt.Errorf("incidents: invalid status %q: must be active or resolved", s)
+		}
+	}
+	if strings.Contains(query.Severity, `"`) {
+		return fmt.Errorf("incidents: invalid severity %q: the incident query-string language cannot express values containing double quotes", query.Severity)
+	}
+	return nil
+}
+
+// incidentPreviewFilter enforces the bounds QueryIncidentPreviews has no fields
+// for: the createdTime window (dateFrom inclusive, dateTo exclusive) and label
+// matching. A zero from/to disables that side of the window; empty labels
+// disables label matching.
+type incidentPreviewFilter struct {
+	from, to    time.Time
+	newestFirst bool
+	labels      []string
+}
+
+// classify reports whether a preview should be kept (first result) and whether
+// paging can stop early because the newest-first crawl has passed the
+// from-bound (second result); when stop is true, keep is always false.
+func (f incidentPreviewFilter) classify(p IncidentPreview) (bool, bool) {
+	created := time.Time(p.CreatedTime)
+	if created.IsZero() {
+		// A preview without a createdTime cannot be placed in the requested
+		// window, so date-bounded queries exclude it.
+		if !f.from.IsZero() || !f.to.IsZero() {
+			return false, false
+		}
+		return f.matchesLabels(p), false
+	}
+	if !f.from.IsZero() && created.Before(f.from) {
+		return false, f.newestFirst
+	}
+	if !f.to.IsZero() && !created.Before(f.to) {
+		return false, false
+	}
+	return f.matchesLabels(p), false
+}
+
+func (f incidentPreviewFilter) matchesLabels(p IncidentPreview) bool {
+	if len(f.labels) == 0 {
+		return true
+	}
+	return incidentMatchesLabels(p.Labels, f.labels)
+}
+
 // List queries incident previews with the given parameters, following the
 // response cursor until query.Limit incidents are collected or the server
 // reports no more pages. A non-positive query.Limit defaults to 100.
@@ -141,13 +196,8 @@ func buildIncidentQueryString(query IncidentQuery) string {
 // label or date filter can page through the full history before collecting
 // query.Limit results.
 func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incident, error) {
-	for _, s := range query.Statuses {
-		if !isIncidentStatusFilter(s) {
-			return nil, fmt.Errorf("incidents: invalid status %q: must be active or resolved", s)
-		}
-	}
-	if strings.Contains(query.Severity, `"`) {
-		return nil, fmt.Errorf("incidents: invalid severity %q: the incident query-string language cannot express values containing double quotes", query.Severity)
+	if err := validateIncidentQuery(query); err != nil {
+		return nil, err
 	}
 
 	if query.Limit <= 0 {
@@ -173,12 +223,19 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 	if query.DateTo != nil {
 		to = time.Time(*query.DateTo)
 	}
-	dateBounded := !from.IsZero() || !to.IsZero()
 	labelFiltered := query.QueryString == "" && len(query.IncidentLabels) > 0
-	clientFiltered := dateBounded || labelFiltered
-	// With the default createdTime-descending order, every incident after the
-	// first one older than `from` is older too, so paging can stop early.
-	newestFirst := query.OrderDirection == "DESC" && query.OrderField == "createdTime"
+	filter := incidentPreviewFilter{
+		from: from,
+		to:   to,
+		// With the default createdTime-descending order, every incident after
+		// the first one older than `from` is older too, so paging can stop
+		// early.
+		newestFirst: query.OrderDirection == "DESC" && query.OrderField == "createdTime",
+	}
+	if labelFiltered {
+		filter.labels = query.IncidentLabels
+	}
+	clientFiltered := !from.IsZero() || !to.IsZero() || labelFiltered
 
 	limit := query.Limit
 	var (
@@ -202,34 +259,16 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 		}
 
 		for _, preview := range resp.IncidentPreviews {
-			created := time.Time(preview.CreatedTime)
-			if created.IsZero() {
-				// A preview without a createdTime cannot be placed in the
-				// requested window, so date-bounded queries exclude it.
-				if from.IsZero() && to.IsZero() {
-					inc := preview.ToIncident()
-					if labelFiltered && !incidentMatchesLabels(inc.Labels, query.IncidentLabels) {
-						continue
-					}
-					all = append(all, inc)
-				}
-				continue
+			keep, stop := filter.classify(preview)
+			if stop {
+				// Newest-first crawl passed the from-bound; no later preview
+				// can fall in range.
+				pastFrom = true
+				break
 			}
-			if !from.IsZero() && created.Before(from) {
-				if newestFirst {
-					pastFrom = true
-					break
-				}
-				continue
+			if keep {
+				all = append(all, preview.ToIncident())
 			}
-			if !to.IsZero() && !created.Before(to) {
-				continue
-			}
-			inc := preview.ToIncident()
-			if labelFiltered && !incidentMatchesLabels(inc.Labels, query.IncidentLabels) {
-				continue
-			}
-			all = append(all, inc)
 		}
 
 		if len(all) >= limit {

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -137,7 +137,9 @@ func buildIncidentQueryString(query IncidentQuery) string {
 // are compiled into the query-string language. Label and date bounds are
 // enforced here against returned previews: labels are matched as either plain
 // label text or key:value pairs, and createdTime uses dateFrom inclusive and
-// dateTo exclusive.
+// dateTo exclusive. Because that matching is client-side, a highly selective
+// label or date filter can page through the full history before collecting
+// query.Limit results.
 func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incident, error) {
 	for _, s := range query.Statuses {
 		if !isIncidentStatusFilter(s) {

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -131,9 +131,12 @@ func buildIncidentQueryString(query IncidentQuery) string {
 
 // validateIncidentQuery rejects filter values the incident query-string
 // language cannot express: a status outside the supported enum, or a severity
-// containing a double quote (it cannot appear inside the single-quoted server
-// value).
+// containing a double quote. A raw query string is the complete server-side
+// expression, so structured fields are ignored and not validated.
 func validateIncidentQuery(query IncidentQuery) error {
+	if query.QueryString != "" {
+		return nil
+	}
 	for _, s := range query.Statuses {
 		if !isIncidentStatusFilter(s) {
 			return fmt.Errorf("incidents: invalid status %q: must be active or resolved", s)

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -68,6 +68,10 @@ func quoteIncidentQueryValue(v string) string {
 	return `"` + v + `"`
 }
 
+func isIncidentStatusFilter(s string) bool {
+	return s == "active" || s == "resolved"
+}
+
 // buildIncidentQueryString compiles the structured filters into a single
 // incident query-string-language expression. A non-empty query.QueryString is
 // used verbatim (raw escape hatch) and the structured filters are ignored.
@@ -115,6 +119,11 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 	for _, l := range query.IncidentLabels {
 		if strings.Contains(l, `"`) {
 			return nil, fmt.Errorf("incidents: invalid label %q: the incident query-string language cannot express values containing double quotes", l)
+		}
+	}
+	for _, s := range query.Statuses {
+		if !isIncidentStatusFilter(s) {
+			return nil, fmt.Errorf("incidents: invalid status %q: must be active or resolved", s)
 		}
 	}
 	if strings.Contains(query.Severity, `"`) {

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -58,18 +58,43 @@ func NewIncidentClient(cfg config.NamespacedRESTConfig) (*IncidentClient, error)
 const incidentsMaxPageSize = 100
 
 // quoteIncidentQueryValue wraps a value for the incident query-string
-// language, which requires quoting for values containing spaces or colons.
-// Double-quoted values match both Tags-key label text and keyed key:value
-// composites and may themselves contain single quotes. The reverse does not
-// hold — the server rejects double quotes inside single-quoted values — so
-// values containing a double quote cannot be expressed in the language and
-// are rejected by List and by the list command's validation.
+// language, which requires quoting for values containing spaces.
 func quoteIncidentQueryValue(v string) string {
 	return `"` + v + `"`
 }
 
 func isIncidentStatusFilter(s string) bool {
 	return s == "active" || s == "resolved"
+}
+
+func incidentLabelValue(l IncidentLabel) string {
+	if l.Label != "" {
+		return l.Label
+	}
+	return l.Value
+}
+
+func incidentMatchesLabel(labels []IncidentLabel, filter string) bool {
+	key, value, keyed := strings.Cut(filter, ":")
+	for _, l := range labels {
+		labelValue := incidentLabelValue(l)
+		if labelValue == filter {
+			return true
+		}
+		if keyed && key != "" && value != "" && l.Key == key && labelValue == value {
+			return true
+		}
+	}
+	return false
+}
+
+func incidentMatchesLabels(labels []IncidentLabel, filters []string) bool {
+	for _, f := range filters {
+		if !incidentMatchesLabel(labels, f) {
+			return false
+		}
+	}
+	return true
 }
 
 // buildIncidentQueryString compiles the structured filters into a single
@@ -85,9 +110,6 @@ func buildIncidentQueryString(query IncidentQuery) string {
 	}
 
 	var terms []string
-	for _, l := range query.IncidentLabels {
-		terms = append(terms, "label:"+quoteIncidentQueryValue(l))
-	}
 	if len(query.Statuses) > 0 {
 		statusTerms := make([]string, len(query.Statuses))
 		for i, s := range query.Statuses {
@@ -111,16 +133,12 @@ func buildIncidentQueryString(query IncidentQuery) string {
 // response cursor until query.Limit incidents are collected or the server
 // reports no more pages. A non-positive query.Limit defaults to 100.
 //
-// QueryIncidentPreviews has no structured filter fields: labels, statuses and
-// severity are compiled into the query-string language, and date bounds —
-// which even the deprecated QueryIncidents endpoint ignored server-side — are
-// enforced here on createdTime, dateFrom inclusive and dateTo exclusive.
+// QueryIncidentPreviews has no structured filter fields: statuses and severity
+// are compiled into the query-string language. Label and date bounds are
+// enforced here against returned previews: labels are matched as either plain
+// label text or key:value pairs, and createdTime uses dateFrom inclusive and
+// dateTo exclusive.
 func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incident, error) {
-	for _, l := range query.IncidentLabels {
-		if strings.Contains(l, `"`) {
-			return nil, fmt.Errorf("incidents: invalid label %q: the incident query-string language cannot express values containing double quotes", l)
-		}
-	}
 	for _, s := range query.Statuses {
 		if !isIncidentStatusFilter(s) {
 			return nil, fmt.Errorf("incidents: invalid status %q: must be active or resolved", s)
@@ -154,6 +172,8 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 		to = time.Time(*query.DateTo)
 	}
 	dateBounded := !from.IsZero() || !to.IsZero()
+	labelFiltered := query.QueryString == "" && len(query.IncidentLabels) > 0
+	clientFiltered := dateBounded || labelFiltered
 	// With the default createdTime-descending order, every incident after the
 	// first one older than `from` is older too, so paging can stop early.
 	newestFirst := query.OrderDirection == "DESC" && query.OrderField == "createdTime"
@@ -165,11 +185,11 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 		pastFrom bool
 	)
 	for {
-		if dateBounded {
-			// Date filtering happens client-side, so a page can contribute
-			// anywhere from zero to all of its previews. Fetch full pages to
-			// keep the crawl towards the bounds short; the result is
-			// truncated to limit below.
+		if clientFiltered {
+			// Client-side filters can discard any number of previews, so a
+			// page can contribute anywhere from zero to all of its previews.
+			// Fetch full pages to keep the crawl towards the bounds short;
+			// the result is truncated to limit below.
 			wire.Limit = incidentsMaxPageSize
 		} else {
 			wire.Limit = min(limit-len(all), incidentsMaxPageSize)
@@ -185,7 +205,11 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 				// A preview without a createdTime cannot be placed in the
 				// requested window, so date-bounded queries exclude it.
 				if from.IsZero() && to.IsZero() {
-					all = append(all, preview.ToIncident())
+					inc := preview.ToIncident()
+					if labelFiltered && !incidentMatchesLabels(inc.Labels, query.IncidentLabels) {
+						continue
+					}
+					all = append(all, inc)
 				}
 				continue
 			}
@@ -199,7 +223,11 @@ func (c *IncidentClient) List(ctx context.Context, query IncidentQuery) ([]Incid
 			if !to.IsZero() && !created.Before(to) {
 				continue
 			}
-			all = append(all, preview.ToIncident())
+			inc := preview.ToIncident()
+			if labelFiltered && !incidentMatchesLabels(inc.Labels, query.IncidentLabels) {
+				continue
+			}
+			all = append(all, inc)
 		}
 
 		if len(all) >= limit {

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -498,6 +498,19 @@ func TestClient_List_CombinedAndSeverityFilters(t *testing.T) {
 			wantCalls: 1,
 		},
 		{
+			name:  "raw query string skips structured filter validation",
+			query: irm.IncidentQuery{Limit: 10, QueryString: "isdrill:true", Statuses: []string{"not-a-status"}, Severity: `the "big" sev`},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					assert.Equal(t, "isdrill:true", (*calls)[0].Query["queryString"])
+					writeJSON(w, previewsPage("p1", 1, false, ""))
+				}
+			},
+			wantLen:   1,
+			wantCalls: 1,
+		},
+		{
 			name:  "rejects severity containing a double quote",
 			query: irm.IncidentQuery{Limit: 10, Severity: `the "big" sev`},
 			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -249,38 +249,112 @@ func TestClient_List(t *testing.T) {
 }
 
 // TestClient_List_Filters covers the filter translation the migration to
-// QueryIncidentPreviews introduced: labels become query-string terms and the
-// date bounds are enforced client-side (the endpoint has no date fields).
+// QueryIncidentPreviews introduced: labels and date bounds are enforced
+// client-side (the endpoint has no structured fields for either), while status
+// and severity still compile into query-string terms.
 func TestClient_List_Filters(t *testing.T) {
 	tests := []clientListCase{
 		{
-			name:  "translates labels into quoted query-string terms",
-			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{"security", "PIR not needed", "service_name:checkout", "team's"}},
+			name:  "matches keyed and legacy labels client-side",
+			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{"squad:mimir"}},
 			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
 				t.Helper()
 				return func(w http.ResponseWriter, _ *http.Request) {
 					req := (*calls)[0]
-					assert.Equal(t, `label:"security" label:"PIR not needed" label:"service_name:checkout" label:"team's"`, req.Query["queryString"])
+					assert.NotContains(t, req.Query, "queryString")
 					assert.NotContains(t, req.Query, "incidentLabels")
 					assert.Equal(t, "DESC", req.Query["orderDirection"])
 					assert.True(t, req.IncludeCustomFieldValues)
 					assert.True(t, req.IncludeIncidentChannels)
-					writeJSON(w, previewsPage("p1", 1, false, ""))
+					writeJSON(w, map[string]any{
+						"incidentPreviews": []map[string]any{
+							{
+								"incidentID": "inc-keyed",
+								"title":      "Keyed squad",
+								"status":     "active",
+								"labels":     []map[string]any{{"key": "squad", "label": "mimir"}},
+							},
+							{
+								"incidentID": "inc-legacy",
+								"title":      "Legacy tag",
+								"status":     "active",
+								"labels":     []map[string]any{{"key": "Tags", "label": "squad:mimir"}},
+							},
+							{
+								"incidentID": "inc-other",
+								"title":      "Other squad",
+								"status":     "active",
+								"labels":     []map[string]any{{"key": "squad", "label": "tempo"}},
+							},
+						},
+						"cursor": map[string]any{"hasMore": false},
+					})
 				}
 			},
-			wantLen:   1,
+			wantIDs:   []string{"inc-keyed", "inc-legacy"},
 			wantCalls: 1,
 		},
 		{
-			name:  "rejects labels containing a double quote",
+			name:  "labels with double quotes are matched client-side",
 			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{`the "big" outage`}},
-			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
 				t.Helper()
-				return func(_ http.ResponseWriter, _ *http.Request) {
-					t.Error("API must not be called for an inexpressible label")
+				return func(w http.ResponseWriter, _ *http.Request) {
+					assert.NotContains(t, (*calls)[0].Query, "queryString")
+					writeJSON(w, map[string]any{
+						"incidentPreviews": []map[string]any{
+							{
+								"incidentID": "inc-quoted",
+								"title":      "Quoted label",
+								"status":     "active",
+								"labels":     []map[string]any{{"key": "Tags", "label": `the "big" outage`}},
+							},
+						},
+						"cursor": map[string]any{"hasMore": false},
+					})
 				}
 			},
-			wantErr: "cannot express values containing double quotes",
+			wantIDs:   []string{"inc-quoted"},
+			wantCalls: 1,
+		},
+		{
+			name:  "keeps paging until enough client-side label matches are found",
+			query: irm.IncidentQuery{Limit: 1, IncidentLabels: []string{"component:warpstream"}},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					req := (*calls)[len(*calls)-1]
+					assert.InDelta(t, 100, req.Query["limit"], 0)
+					switch len(*calls) {
+					case 1:
+						writeJSON(w, map[string]any{
+							"incidentPreviews": []map[string]any{
+								{
+									"incidentID": "inc-nonmatching",
+									"title":      "Other incident",
+									"status":     "active",
+									"labels":     []map[string]any{{"key": "component", "label": "database"}},
+								},
+							},
+							"cursor": map[string]any{"hasMore": true, "nextValue": "cursor-1"},
+						})
+					default:
+						writeJSON(w, map[string]any{
+							"incidentPreviews": []map[string]any{
+								{
+									"incidentID": "inc-warpstream",
+									"title":      "WarpStream incident",
+									"status":     "active",
+									"labels":     []map[string]any{{"key": "component", "label": "warpstream"}},
+								},
+							},
+							"cursor": map[string]any{"hasMore": false},
+						})
+					}
+				}
+			},
+			wantIDs:   []string{"inc-warpstream"},
+			wantCalls: 2,
 		},
 		{
 			name:  "single status becomes a bare status term",
@@ -326,11 +400,29 @@ func TestClient_List_Filters(t *testing.T) {
 			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
 				t.Helper()
 				return func(w http.ResponseWriter, _ *http.Request) {
-					assert.Equal(t, `label:"security" status:active severity:"major"`, (*calls)[0].Query["queryString"])
-					writeJSON(w, previewsPage("p1", 1, false, ""))
+					assert.Equal(t, `status:active severity:"major"`, (*calls)[0].Query["queryString"])
+					writeJSON(w, map[string]any{
+						"incidentPreviews": []map[string]any{
+							{
+								"incidentID":    "inc-security",
+								"title":         "Security incident",
+								"status":        "active",
+								"severityLabel": "Major",
+								"labels":        []map[string]any{{"key": "Tags", "label": "security"}},
+							},
+							{
+								"incidentID":    "inc-other",
+								"title":         "Other incident",
+								"status":        "active",
+								"severityLabel": "Major",
+								"labels":        []map[string]any{{"key": "Tags", "label": "other"}},
+							},
+						},
+						"cursor": map[string]any{"hasMore": false},
+					})
 				}
 			},
-			wantLen:   1,
+			wantIDs:   []string{"inc-security"},
 			wantCalls: 1,
 		},
 		{

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -248,11 +248,10 @@ func TestClient_List(t *testing.T) {
 	}
 }
 
-// TestClient_List_Filters covers the filter translation the migration to
-// QueryIncidentPreviews introduced: labels and date bounds are enforced
-// client-side (the endpoint has no structured fields for either), while status
-// and severity still compile into query-string terms.
-func TestClient_List_Filters(t *testing.T) {
+// TestClient_List_LabelFilters covers client-side label matching: keyed vs
+// legacy labels, labels carried in `value` rather than `label`, double quotes,
+// and paging until enough matches accumulate.
+func TestClient_List_LabelFilters(t *testing.T) {
 	tests := []clientListCase{
 		{
 			name:  "matches keyed and legacy labels client-side",
@@ -392,6 +391,18 @@ func TestClient_List_Filters(t *testing.T) {
 			wantIDs:   []string{"inc-warpstream"},
 			wantCalls: 2,
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { runClientListCase(t, tt) })
+	}
+}
+
+// TestClient_List_StatusFilters covers the status filter compiling into
+// query-string terms: a single bare status, multiple statuses ORed together,
+// and rejection of a status outside the supported enum.
+func TestClient_List_StatusFilters(t *testing.T) {
+	tests := []clientListCase{
 		{
 			name:  "single status becomes a bare status term",
 			query: irm.IncidentQuery{Limit: 10, Statuses: []string{"active"}},
@@ -430,6 +441,18 @@ func TestClient_List_Filters(t *testing.T) {
 			},
 			wantErr: "must be active or resolved",
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { runClientListCase(t, tt) })
+	}
+}
+
+// TestClient_List_CombinedAndSeverityFilters covers filters composing into one
+// query string: labels, status and severity ANDed together, a raw query string
+// overriding the structured filters, and rejection of an inexpressible severity.
+func TestClient_List_CombinedAndSeverityFilters(t *testing.T) {
+	tests := []clientListCase{
 		{
 			name:  "labels, status and severity AND together",
 			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{"security"}, Statuses: []string{"active"}, Severity: "major"},
@@ -485,6 +508,19 @@ func TestClient_List_Filters(t *testing.T) {
 			},
 			wantErr: "cannot express values containing double quotes",
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { runClientListCase(t, tt) })
+	}
+}
+
+// TestClient_List_DateFiltersAndErrors covers the client-side date window (the
+// endpoint has no date fields): full-page fetches, the from/to bounds, missing
+// createdTime, early stop under newest-first order — plus surfacing an in-band
+// response error.
+func TestClient_List_DateFiltersAndErrors(t *testing.T) {
+	tests := []clientListCase{
 		{
 			name: "fetches full pages while date filtering",
 			query: irm.IncidentQuery{

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -310,6 +310,17 @@ func TestClient_List_Filters(t *testing.T) {
 			wantCalls: 1,
 		},
 		{
+			name:  "rejects status outside the supported enum",
+			query: irm.IncidentQuery{Limit: 10, Statuses: []string{`active status:resolved`}},
+			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(_ http.ResponseWriter, _ *http.Request) {
+					t.Error("API must not be called for an invalid status")
+				}
+			},
+			wantErr: "must be active or resolved",
+		},
+		{
 			name:  "labels, status and severity AND together",
 			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{"security"}, Statuses: []string{"active"}, Severity: "major"},
 			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -283,6 +283,70 @@ func TestClient_List_Filters(t *testing.T) {
 			wantErr: "cannot express values containing double quotes",
 		},
 		{
+			name:  "single status becomes a bare status term",
+			query: irm.IncidentQuery{Limit: 10, Statuses: []string{"active"}},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					assert.Equal(t, "status:active", (*calls)[0].Query["queryString"])
+					writeJSON(w, previewsPage("p1", 1, false, ""))
+				}
+			},
+			wantLen:   1,
+			wantCalls: 1,
+		},
+		{
+			name:  "multiple statuses are ORed, not ANDed",
+			query: irm.IncidentQuery{Limit: 10, Statuses: []string{"active", "resolved"}},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					// Juxtaposition would AND the statuses and match nothing.
+					assert.Equal(t, "or(status:active status:resolved)", (*calls)[0].Query["queryString"])
+					writeJSON(w, previewsPage("p1", 1, false, ""))
+				}
+			},
+			wantLen:   1,
+			wantCalls: 1,
+		},
+		{
+			name:  "labels, status and severity AND together",
+			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{"security"}, Statuses: []string{"active"}, Severity: "major"},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					assert.Equal(t, `label:"security" status:active severity:"major"`, (*calls)[0].Query["queryString"])
+					writeJSON(w, previewsPage("p1", 1, false, ""))
+				}
+			},
+			wantLen:   1,
+			wantCalls: 1,
+		},
+		{
+			name:  "raw query string is used verbatim and overrides structured filters",
+			query: irm.IncidentQuery{Limit: 10, QueryString: "isdrill:true", IncidentLabels: []string{"ignored"}, Statuses: []string{"active"}},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					assert.Equal(t, "isdrill:true", (*calls)[0].Query["queryString"])
+					writeJSON(w, previewsPage("p1", 1, false, ""))
+				}
+			},
+			wantLen:   1,
+			wantCalls: 1,
+		},
+		{
+			name:  "rejects severity containing a double quote",
+			query: irm.IncidentQuery{Limit: 10, Severity: `the "big" sev`},
+			handler: func(t *testing.T, _ *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(_ http.ResponseWriter, _ *http.Request) {
+					t.Error("API must not be called for an inexpressible severity")
+				}
+			},
+			wantErr: "cannot express values containing double quotes",
+		},
+		{
 			name: "fetches full pages while date filtering",
 			query: irm.IncidentQuery{
 				Limit:  2,

--- a/internal/providers/irm/incidents_client_test.go
+++ b/internal/providers/irm/incidents_client_test.go
@@ -295,6 +295,42 @@ func TestClient_List_Filters(t *testing.T) {
 			wantCalls: 1,
 		},
 		{
+			// QueryIncidentPreviews can carry a label's text in `value`
+			// rather than `label`; incidentLabelValue falls back to it, so
+			// value-only labels must match both key:value filters (keyed
+			// branch) and bare label-text filters (direct branch).
+			name:  "matches labels carrying value instead of label",
+			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{"squad:mimir", "security"}},
+			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {
+				t.Helper()
+				return func(w http.ResponseWriter, _ *http.Request) {
+					assert.NotContains(t, (*calls)[0].Query, "queryString")
+					writeJSON(w, map[string]any{
+						"incidentPreviews": []map[string]any{
+							{
+								"incidentID": "inc-value",
+								"title":      "Value-only labels",
+								"status":     "active",
+								"labels": []map[string]any{
+									{"key": "squad", "value": "mimir"},
+									{"key": "Tags", "value": "security"},
+								},
+							},
+							{
+								"incidentID": "inc-partial",
+								"title":      "Missing security",
+								"status":     "active",
+								"labels":     []map[string]any{{"key": "squad", "value": "mimir"}},
+							},
+						},
+						"cursor": map[string]any{"hasMore": false},
+					})
+				}
+			},
+			wantIDs:   []string{"inc-value"},
+			wantCalls: 1,
+		},
+		{
 			name:  "labels with double quotes are matched client-side",
 			query: irm.IncidentQuery{Limit: 10, IncidentLabels: []string{`the "big" outage`}},
 			handler: func(t *testing.T, calls *[]listRequest) http.HandlerFunc {

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -94,11 +94,21 @@ func (o *incidentListOpts) Validate() error {
 	return nil
 }
 
+const incidentListLong = `List incidents, most recent first.
+
+--status and --severity are applied server-side. --labels and --from/--to are
+applied client-side, one page at a time, so a highly selective --labels filter
+can page through the full incident history before collecting --limit incidents.
+
+--query is a raw query-string escape hatch and cannot be combined with the
+structured --labels, --status, or --severity filters.`
+
 func NewListCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &incidentListOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List incidents.",
+		Long:  incidentListLong,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -41,7 +41,7 @@ func (o *incidentListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
 	flags.IntVar(&o.Limit, "limit", 50, "Maximum number of incidents to return")
-	flags.StringSliceVar(&o.Labels, "labels", nil, "Filter by label text or key:value (may be repeated; matched client-side)")
+	flags.StringSliceVar(&o.Labels, "labels", nil, "Filter by label text or key:value, e.g. squad:mimir (may be repeated)")
 	flags.StringVar(&o.DateFrom, "from", "", "Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)")
 	flags.StringVar(&o.DateTo, "to", "", "End of time range (RFC3339, unix timestamp, or relative e.g. now)")
 	flags.StringSliceVar(&o.Statuses, "status", nil, "Filter by status (active|resolved; repeatable, comma-separated)")

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -46,7 +46,7 @@ func (o *incidentListOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVar(&o.DateTo, "to", "", "End of time range (RFC3339, unix timestamp, or relative e.g. now)")
 	flags.StringSliceVar(&o.Statuses, "status", nil, "Filter by status (active|resolved; repeatable, comma-separated)")
 	flags.StringVar(&o.Severity, "severity", "", "Filter by severity label, e.g. major (see: gcx irm incidents severities list)")
-	flags.StringVar(&o.Query, "query", "", "Raw incident query string, e.g. \"isdrill:true\"; cannot be combined with the other filter flags")
+	flags.StringVar(&o.Query, "query", "", "Raw incident query string, e.g. \"isdrill:true\"; cannot be combined with --labels, --status, or --severity")
 }
 
 func (o *incidentListOpts) Validate() error {
@@ -76,7 +76,7 @@ func (o *incidentListOpts) Validate() error {
 		}
 	}
 	for _, s := range o.Statuses {
-		if s != "active" && s != "resolved" {
+		if !isIncidentStatusFilter(s) {
 			return fmt.Errorf("invalid --status value %q: must be active or resolved", s)
 		}
 	}

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -30,6 +30,9 @@ type incidentListOpts struct {
 	Labels   []string
 	DateFrom string
 	DateTo   string
+	Statuses []string
+	Severity string
+	Query    string
 }
 
 func (o *incidentListOpts) setup(flags *pflag.FlagSet) {
@@ -41,6 +44,9 @@ func (o *incidentListOpts) setup(flags *pflag.FlagSet) {
 	flags.StringSliceVar(&o.Labels, "labels", nil, "Filter by labels (label text or key:value, may be repeated)")
 	flags.StringVar(&o.DateFrom, "from", "", "Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)")
 	flags.StringVar(&o.DateTo, "to", "", "End of time range (RFC3339, unix timestamp, or relative e.g. now)")
+	flags.StringSliceVar(&o.Statuses, "status", nil, "Filter by status (active|resolved; repeatable, comma-separated)")
+	flags.StringVar(&o.Severity, "severity", "", "Filter by severity label, e.g. major (see: gcx irm incidents severities list)")
+	flags.StringVar(&o.Query, "query", "", "Raw incident query string, e.g. \"isdrill:true\"; cannot be combined with the other filter flags")
 }
 
 func (o *incidentListOpts) Validate() error {
@@ -49,6 +55,13 @@ func (o *incidentListOpts) Validate() error {
 	}
 	if o.Limit < 1 {
 		return fmt.Errorf("invalid --limit value %d: must be at least 1", o.Limit)
+	}
+	if o.Query != "" && (len(o.Labels) > 0 || len(o.Statuses) > 0 || o.Severity != "") {
+		// --query is a raw escape hatch: the user writes the whole
+		// query-string expression. The structured flags also compile into
+		// query-string terms, so combining them would be ambiguous
+		// (e.g. --status active --query status:resolved).
+		return errors.New("--query cannot be combined with --labels, --status, or --severity")
 	}
 	// Labels match plain label text for the default Tags key and key:value
 	// composites for keyed labels; values are passed through as given and
@@ -61,6 +74,16 @@ func (o *incidentListOpts) Validate() error {
 		if strings.Contains(l, `"`) {
 			return fmt.Errorf("invalid --labels value %q: cannot contain double quotes", l)
 		}
+	}
+	for _, s := range o.Statuses {
+		if s != "active" && s != "resolved" {
+			return fmt.Errorf("invalid --status value %q: must be active or resolved", s)
+		}
+	}
+	// Severity is also double-quoted into the query-string language, which
+	// cannot express a value containing a double quote.
+	if strings.Contains(o.Severity, `"`) {
+		return fmt.Errorf("invalid --severity value %q: cannot contain double quotes", o.Severity)
 	}
 	now := time.Now()
 	if o.DateFrom != "" {
@@ -91,6 +114,9 @@ func NewListCommand(loader GrafanaConfigLoader) *cobra.Command {
 			q := IncidentQuery{
 				Limit:          opts.Limit,
 				IncidentLabels: opts.Labels,
+				Statuses:       opts.Statuses,
+				Severity:       opts.Severity,
+				QueryString:    opts.Query,
 			}
 			now := time.Now()
 			if opts.DateFrom != "" {

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -41,7 +41,7 @@ func (o *incidentListOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
 	flags.IntVar(&o.Limit, "limit", 50, "Maximum number of incidents to return")
-	flags.StringSliceVar(&o.Labels, "labels", nil, "Filter by labels (label text or key:value, may be repeated)")
+	flags.StringSliceVar(&o.Labels, "labels", nil, "Filter by label text or key:value (may be repeated; matched client-side)")
 	flags.StringVar(&o.DateFrom, "from", "", "Start of time range (RFC3339, unix timestamp, or relative e.g. now-7d)")
 	flags.StringVar(&o.DateTo, "to", "", "End of time range (RFC3339, unix timestamp, or relative e.g. now)")
 	flags.StringSliceVar(&o.Statuses, "status", nil, "Filter by status (active|resolved; repeatable, comma-separated)")
@@ -63,16 +63,11 @@ func (o *incidentListOpts) Validate() error {
 		// (e.g. --status active --query status:resolved).
 		return errors.New("--query cannot be combined with --labels, --status, or --severity")
 	}
-	// Labels match plain label text for the default Tags key and key:value
-	// composites for keyed labels; values are passed through as given and
-	// double-quoted into the incident query-string language by the client.
-	// That language cannot express a value containing a double quote.
+	// Labels are matched client-side against preview label objects as either
+	// plain label text or key:value pairs.
 	for _, l := range o.Labels {
 		if strings.TrimSpace(l) == "" {
 			return errors.New("invalid --labels value: label must not be empty")
-		}
-		if strings.Contains(l, `"`) {
-			return fmt.Errorf("invalid --labels value %q: cannot contain double quotes", l)
 		}
 	}
 	for _, s := range o.Statuses {

--- a/internal/providers/irm/incidents_commands_test.go
+++ b/internal/providers/irm/incidents_commands_test.go
@@ -315,7 +315,64 @@ func TestListOpts_LabelValidation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := irm.NewTestListCommand(tt.labels, "", "")
+			cmd := irm.NewTestListCommand(tt.labels, nil, "", "", "", "")
+			cmd.SetArgs([]string{})
+			err := cmd.Execute()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestListOpts_FilterValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		statuses []string
+		severity string
+		query    string
+		labels   []string
+		wantErr  string
+	}{
+		{name: "valid status", statuses: []string{"active"}},
+		{name: "both statuses", statuses: []string{"active", "resolved"}},
+		{name: "valid severity", severity: "major"},
+		{name: "query alone", query: "isdrill:true"},
+		{
+			name:     "unknown status",
+			statuses: []string{"pending"},
+			wantErr:  "must be active or resolved",
+		},
+		{
+			name:     "severity with a double quote",
+			severity: `the "big" sev`,
+			wantErr:  "cannot contain double quotes",
+		},
+		{
+			name:    "query combined with labels",
+			query:   "isdrill:true",
+			labels:  []string{"security"},
+			wantErr: "--query cannot be combined",
+		},
+		{
+			name:     "query combined with status",
+			query:    "isdrill:true",
+			statuses: []string{"active"},
+			wantErr:  "--query cannot be combined",
+		},
+		{
+			name:     "query combined with severity",
+			query:    "isdrill:true",
+			severity: "major",
+			wantErr:  "--query cannot be combined",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := irm.NewTestListCommand(tt.labels, tt.statuses, tt.severity, tt.query, "", "")
 			cmd.SetArgs([]string{})
 			err := cmd.Execute()
 			if tt.wantErr != "" {
@@ -375,13 +432,15 @@ func TestIncidentsListCommand_BuildsQuery(t *testing.T) {
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{
 		"--labels", "security,PIR not needed",
+		"--status", "active",
+		"--severity", "major",
 		"--from", "2024-06-01T00:00:00Z",
 		"--to", "2024-06-15T00:00:00Z",
 		"--limit", "10",
 	})
 	require.NoError(t, cmd.Execute())
 
-	assert.Equal(t, `label:"security" label:"PIR not needed"`, query["queryString"])
+	assert.Equal(t, `label:"security" label:"PIR not needed" status:active severity:"major"`, query["queryString"])
 	assert.NotContains(t, query, "incidentLabels")
 	assert.NotContains(t, query, "dateFrom")
 	assert.NotContains(t, query, "dateTo")
@@ -455,7 +514,7 @@ func TestListOpts_DateValidation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := irm.NewTestListCommand(nil, tt.dateFrom, tt.dateTo)
+			cmd := irm.NewTestListCommand(nil, nil, "", "", tt.dateFrom, tt.dateTo)
 			cmd.SetArgs([]string{})
 			err := cmd.Execute()
 			if tt.wantErr != "" {

--- a/internal/providers/irm/incidents_commands_test.go
+++ b/internal/providers/irm/incidents_commands_test.go
@@ -291,7 +291,7 @@ func TestListOpts_LabelValidation(t *testing.T) {
 		},
 		{
 			// Keyed labels are matched by their key:value composite.
-			name:   "key:value text passes through verbatim",
+			name:   "key:value text passes",
 			labels: []string{"team:platform"},
 		},
 		{
@@ -300,12 +300,8 @@ func TestListOpts_LabelValidation(t *testing.T) {
 			wantErr: "label must not be empty",
 		},
 		{
-			// The query-string language rejects double quotes inside
-			// single-quoted values, so a label containing a double quote
-			// cannot be expressed at all.
-			name:    "label with a double quote fails",
-			labels:  []string{`the "big" outage`},
-			wantErr: "cannot contain double quotes",
+			name:   "label with a double quote passes",
+			labels: []string{`the "big" outage`},
 		},
 		{
 			// Apostrophes are fine: double-quoted values may contain them.
@@ -396,8 +392,8 @@ func (l fakeGrafanaConfigLoader) LoadGrafanaConfig(context.Context) (config.Name
 
 // TestIncidentsListCommand_BuildsQuery runs the real list command against a
 // fake API and asserts the flags land in a QueryIncidentPreviews request:
-// labels become quoted query-string terms, and the date flags never reach
-// the wire (the endpoint has no date fields) but are enforced client-side.
+// labels and date flags never reach the wire (the endpoint has no structured
+// fields for them) but are enforced client-side.
 func TestIncidentsListCommand_BuildsQuery(t *testing.T) {
 	t.Setenv("GCX_AGENT_MODE", "false")
 	agent.ResetForTesting()
@@ -412,8 +408,31 @@ func TestIncidentsListCommand_BuildsQuery(t *testing.T) {
 		query = body.Query
 		writeJSON(w, map[string]any{
 			"incidentPreviews": []map[string]any{
-				{"incidentID": "inc-1", "title": "Security incident", "status": "active", "severityLabel": "Major", "createdTime": "2024-06-10T12:00:00Z"},
-				{"incidentID": "inc-2", "title": "Too old", "status": "resolved", "createdTime": "2024-05-01T12:00:00Z"},
+				{
+					"incidentID":    "inc-1",
+					"title":         "Security incident",
+					"status":        "active",
+					"severityLabel": "Major",
+					"createdTime":   "2024-06-10T12:00:00Z",
+					"labels": []map[string]any{
+						{"key": "Tags", "label": "security"},
+						{"key": "Tags", "label": "PIR not needed"},
+					},
+				},
+				{
+					"incidentID":  "inc-2",
+					"title":       "Too old",
+					"status":      "resolved",
+					"createdTime": "2024-05-01T12:00:00Z",
+					"labels":      []map[string]any{{"key": "Tags", "label": "security"}},
+				},
+				{
+					"incidentID":  "inc-3",
+					"title":       "Wrong label",
+					"status":      "active",
+					"createdTime": "2024-06-10T12:00:00Z",
+					"labels":      []map[string]any{{"key": "Tags", "label": "security"}},
+				},
 			},
 			"cursor": map[string]any{"hasMore": false},
 		})
@@ -440,7 +459,7 @@ func TestIncidentsListCommand_BuildsQuery(t *testing.T) {
 	})
 	require.NoError(t, cmd.Execute())
 
-	assert.Equal(t, `label:"security" label:"PIR not needed" status:active severity:"major"`, query["queryString"])
+	assert.Equal(t, `status:active severity:"major"`, query["queryString"])
 	assert.NotContains(t, query, "incidentLabels")
 	assert.NotContains(t, query, "dateFrom")
 	assert.NotContains(t, query, "dateTo")
@@ -453,6 +472,7 @@ func TestIncidentsListCommand_BuildsQuery(t *testing.T) {
 	assert.Contains(t, out, "Security incident")
 	assert.Contains(t, out, "Major", "severityLabel must surface in the SEVERITY column")
 	assert.NotContains(t, out, "inc-2", "incidents outside --from/--to must be filtered client-side")
+	assert.NotContains(t, out, "inc-3", "incidents missing one --labels value must be filtered client-side")
 }
 
 func TestIncidentsListCommand_RejectsNonPositiveLimit(t *testing.T) {

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -165,6 +165,7 @@ type IncidentLabel struct {
 	Key         string `json:"key"`
 	KeyUUID     string `json:"keyUUID,omitempty"`
 	Label       string `json:"label,omitempty"`
+	Value       string `json:"value,omitempty"`
 	LabelUUID   string `json:"labelUUID,omitempty"`
 	ColorHex    string `json:"colorHex,omitempty"`
 	Description string `json:"description,omitempty"`

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -190,6 +190,15 @@ type IncidentQuery struct {
 	DateFrom       *FlexTime
 	DateTo         *FlexTime
 	IncidentLabels []string
+	// Statuses filters by incident status (active/resolved). Multiple values
+	// are ORed together.
+	Statuses []string
+	// Severity filters by severity label (e.g. "major").
+	Severity string
+	// QueryString is a raw incident query-string-language expression. When
+	// set it is used verbatim and the structured filters above are ignored;
+	// the list command rejects combining them.
+	QueryString string
 }
 
 // incidentPreviewsQuery is the documented IncidentPreviewsQuery wire type.


### PR DESCRIPTION
## What

Adds three filter flags to `gcx irm incidents list`, building on the `QueryIncidentPreviews` migration (#833).

`QueryIncidentPreviews` has no structured filter fields, so the filters split two ways — some compile into its query-string language, the rest are enforced client-side:

| Flag | How | Notes |
|---|---|---|
| `--status` | query-string `status:active` | `active`/`resolved`, repeatable/comma-separated; multiple values are ORed (see below) |
| `--severity` | query-string `severity:"major"` | severity label; the server matches it case-insensitively |
| `--query` | query-string *(verbatim)* | raw escape hatch |
| `--labels` | client-side | matched against each preview's labels as plain text (legacy `Tags`) or `key:value` (keyed); multiple labels AND |

`--from`/`--to` stay client-side as in #833. Within the query string, status and severity AND together by juxtaposition.

### Labels are matched client-side, not via the query string

Compiling labels to a `label:"…"` query-string term didn't match keyed `key:value` labels, so labels are now filtered client-side against the returned previews, matching either legacy `Tags` text or `key:value` (a preview may carry its text in `label` or `value`; both are handled). Because label and date filtering run client-side, a highly selective `--labels` filter can page through the full incident history before collecting `--limit` incidents.

### Multi-value status must OR, not AND

Juxtaposition is AND in this language, so `--status active,resolved` naively compiling to `status:active status:resolved` matches **nothing** (no incident is both). Multiple statuses are wrapped: `or(status:active status:resolved)`.

### `--query` is mutually exclusive with the structured filters

`--query` is a raw escape hatch — the user writes the whole expression, and it's used verbatim in place of the structured filters. Combining it with `--labels`/`--status`/`--severity` (e.g. `--status active --query status:resolved`) is rejected rather than silently ignoring one.

### Double quotes

`--severity` is double-quoted into the query string, and the language can't express a value containing a double quote (it rejects `"` inside single-quoted strings), so such a `--severity` value is rejected up front. `--labels`, matched client-side, accepts any text.

## Scope

The three new filters plus the keyed-label-matching fix. No fetch-all, `--limit` cap, or output changes. The query-string syntax (`status:`, `severity:`, `or(...)` — the public docs' `any(...)` returns HTTP 400 — and AND-by-juxtaposition) was verified live against `QueryIncidentPreviews`.

## Tests

- **Client** (`List`): status query-string assembly (single term, multi-status `or()`), severity term, raw-query override, and severity double-quote rejection; client-side label matching (keyed vs legacy, value-only labels, double-quoted labels, paging until enough matches accumulate); plus the date-window and paging cases.
- **Command**: flag validation (status enum, severity double-quote, `--query` exclusivity) and end-to-end that status/severity land in the request `queryString` while labels and dates are enforced client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
