### PR TITLE
fix(prometheus): report query result type from request intent, not data shape

### DIFF
--- a/internal/query/prometheus/client.go
+++ b/internal/query/prometheus/client.go
@@ -143,8 +143,10 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		}
 	}
 
-	// Convert to Prometheus-style response
-	return convertGrafanaResponse(&grafanaResp), nil
+	// Convert to Prometheus-style response. Pass the request intent so the result
+	// type reflects what was asked (range -> matrix, instant -> vector), not the
+	// shape of the data that came back.
+	return convertGrafanaResponse(&grafanaResp, req.IsRange()), nil
 }
 
 // Labels returns all label names.

--- a/internal/query/prometheus/export_test.go
+++ b/internal/query/prometheus/export_test.go
@@ -17,3 +17,8 @@ func (c *Client) BuildMetadataPath(datasourceUID string) string {
 func (c *Client) BuildSeriesPath(datasourceUID string) string {
 	return c.buildSeriesPath(datasourceUID)
 }
+
+// ConvertGrafanaResponse exposes the unexported converter for the external test package.
+func ConvertGrafanaResponse(grafanaResp *GrafanaQueryResponse, isRange bool) *QueryResponse {
+	return convertGrafanaResponse(grafanaResp, isRange)
+}

--- a/internal/query/prometheus/types.go
+++ b/internal/query/prometheus/types.go
@@ -96,12 +96,20 @@ type DataFrameData struct {
 	Values [][]any `json:"values,omitempty"`
 }
 
-// convertGrafanaResponse converts a Grafana query response to the Prometheus-style format.
-func convertGrafanaResponse(grafanaResp *GrafanaQueryResponse) *QueryResponse {
+// convertGrafanaResponse converts a Grafana query response to the Prometheus-style
+// format. The result type reflects the request intent, not the shape of the data
+// that came back: a range query is always a matrix (matching the Prometheus
+// query_range contract, even when empty), an instant query a vector. Deriving it
+// from the data would make an empty range indistinguishable from an empty instant.
+func convertGrafanaResponse(grafanaResp *GrafanaQueryResponse, isRange bool) *QueryResponse {
+	resultType := "vector"
+	if isRange {
+		resultType = "matrix"
+	}
 	result := &QueryResponse{
 		Status: "success",
 		Data: ResultData{
-			ResultType: "vector",
+			ResultType: resultType,
 			Result:     []Sample{},
 		},
 	}
@@ -146,9 +154,10 @@ func convertGrafanaResponse(grafanaResp *GrafanaQueryResponse) *QueryResponse {
 			Metric: labels,
 		}
 
-		// Check if this is a range query (multiple values) or instant query (single value)
-		if len(timeValues) > 1 {
-			result.Data.ResultType = "matrix"
+		// Shape the sample by request intent, not point count: a range sample
+		// always uses Values (even a single point), so a one-point range is not
+		// mistyped as an instant value.
+		if isRange {
 			sample.Values = make([][]any, len(timeValues))
 			for i := range timeValues {
 				// Convert milliseconds to seconds for Prometheus compatibility

--- a/internal/query/prometheus/types_test.go
+++ b/internal/query/prometheus/types_test.go
@@ -1,0 +1,115 @@
+package prometheus_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// frameWith builds a single-series Grafana data frame with a time column and a
+// number column, the shape Grafana returns for Prometheus queries.
+func frameWith(timestampsMs []any, values []any) prometheus.DataFrame {
+	return prometheus.DataFrame{
+		Schema: prometheus.DataFrameSchema{
+			Fields: []prometheus.Field{
+				{Name: "Time", Type: "time"},
+				{Name: "Value", Type: "number", Labels: map[string]string{"__name__": "up"}},
+			},
+		},
+		Data: prometheus.DataFrameData{
+			Values: [][]any{timestampsMs, values},
+		},
+	}
+}
+
+func grafanaResp(frames ...prometheus.DataFrame) *prometheus.GrafanaQueryResponse {
+	return &prometheus.GrafanaQueryResponse{
+		Results: map[string]prometheus.GrafanaResult{"A": {Frames: frames}},
+	}
+}
+
+func TestConvertGrafanaResponse_ResultTypeReflectsIntent(t *testing.T) {
+	tests := []struct {
+		name           string
+		resp           *prometheus.GrafanaQueryResponse
+		isRange        bool
+		wantResultType string
+		wantSamples    int
+		// assertSample runs against the first sample when wantSamples > 0.
+		assertSample func(t *testing.T, s prometheus.Sample)
+	}{
+		{
+			name:           "empty range reports matrix",
+			resp:           grafanaResp(),
+			isRange:        true,
+			wantResultType: "matrix",
+			wantSamples:    0,
+		},
+		{
+			name:           "empty instant reports vector",
+			resp:           grafanaResp(),
+			isRange:        false,
+			wantResultType: "vector",
+			wantSamples:    0,
+		},
+		{
+			name:           "multi-point range is matrix with Values",
+			resp:           grafanaResp(frameWith([]any{1000.0, 2000.0, 3000.0}, []any{1.0, 2.0, 3.0})),
+			isRange:        true,
+			wantResultType: "matrix",
+			wantSamples:    1,
+			assertSample: func(t *testing.T, s prometheus.Sample) {
+				t.Helper()
+				assert.Nil(t, s.Value)
+				require.Len(t, s.Values, 3)
+				// Milliseconds are converted to Prometheus seconds.
+				assert.InDelta(t, 1.0, s.Values[0][0], 1e-9)
+				assert.Equal(t, "1", s.Values[0][1])
+			},
+		},
+		{
+			// Issue 2 regression guard: a one-point range must still be a matrix.
+			name:           "single-point range is matrix with Values",
+			resp:           grafanaResp(frameWith([]any{1000.0}, []any{5.0})),
+			isRange:        true,
+			wantResultType: "matrix",
+			wantSamples:    1,
+			assertSample: func(t *testing.T, s prometheus.Sample) {
+				t.Helper()
+				assert.Nil(t, s.Value)
+				require.Len(t, s.Values, 1)
+				assert.InDelta(t, 1.0, s.Values[0][0], 1e-9)
+				assert.Equal(t, "5", s.Values[0][1])
+			},
+		},
+		{
+			name:           "single-point instant is vector with Value",
+			resp:           grafanaResp(frameWith([]any{1700000000000.0}, []any{1.0})),
+			isRange:        false,
+			wantResultType: "vector",
+			wantSamples:    1,
+			assertSample: func(t *testing.T, s prometheus.Sample) {
+				t.Helper()
+				assert.Nil(t, s.Values)
+				require.Len(t, s.Value, 2)
+				assert.InDelta(t, 1700000000.0, s.Value[0], 1e-9)
+				assert.Equal(t, "1", s.Value[1])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prometheus.ConvertGrafanaResponse(tt.resp, tt.isRange)
+
+			assert.Equal(t, "success", got.Status)
+			assert.Equal(t, tt.wantResultType, got.Data.ResultType)
+			require.Len(t, got.Data.Result, tt.wantSamples)
+			if tt.wantSamples > 0 && tt.assertSample != nil {
+				tt.assertSample(t, got.Data.Result[0])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`gcx metrics query` (and the identical `gcx datasources prometheus query`) goes through Grafana's datasource query API, which returns Grafana dataframes, then **reconstructs** the Prometheus `resultType` from the *shape* of the returned data — defaulting to `vector` and only upgrading to `matrix` when it sees a multi-point series. An empty range query therefore reported `resultType: vector` with an empty result, making "ran fine, matched nothing" byte-for-byte identical to "did not run as a range" — a success-shaped wrong answer for a tool used non-interactively.

This threads the request intent (`QueryRequest.IsRange()`, already known at the only call site) into `convertGrafanaResponse`, so the type reflects **what was asked**, not what came back:

- range query → `resultType: matrix`, matching the Prometheus `query_range` contract **even when the result is empty**
- instant query → `vector`
- single-point range series → `matrix` with `Values` (previously could fall through to the instant `Value` branch — the Issue 2 guard)

The public `Client.Query` signature is unchanged, so every other caller (`slo`, `kg`, `appo11y`, `synth`, legacy datasources query) gets correct typing with no edits. Verified that range-query consumers (SLO timeline, synth timeline) read `Sample.Values`.

Fixes Issues 1 & 2 from the result-type / duration UX analysis.

## Test plan

- New `internal/query/prometheus/types_test.go`: empty range → matrix (empty), empty instant → vector (empty), multi-point range → matrix/`Values`, **single-point range → matrix/`Values`** (Issue 2 regression guard), single-point instant → vector/`Value`.
- `go test ./...` green; build + lint clean.

End-to-end (requires a live Prometheus datasource):
```
gcx metrics query -d <ds> 'metric{tenant="nomatch"}' --since 6h --step 1h -o json | jq .data.resultType   # matrix (was: vector)
gcx metrics query -d <ds> 'up' -o json | jq .data.resultType                                              # vector (unchanged)
```

Companion PR #841 adds an at-a-glance result-shape summary that builds on this correct typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
