### PR TITLE
fix(query): accept calendar durations (d/w/y) on --since and --step

### DIFF
--- a/docs/reference/cli/gcx_datasources_clickhouse_query.md
+++ b/docs/reference/cli/gcx_datasources_clickhouse_query.md
@@ -48,7 +48,7 @@ gcx datasources clickhouse query [EXPR] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_datasources_cloudwatch_query.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_query.md
@@ -58,7 +58,7 @@ gcx datasources cloudwatch query [flags]
       --period string               Period in seconds (e.g. 60, 300) or "auto" to let CloudWatch pick a period that fits the time range (default "auto")
       --region string               AWS region, e.g. us-east-1 (required)
       --share-link                  Print the Grafana Explore URL for the executed query to stderr
-      --since string                Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string                Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --statistic string            Statistic: Average, Sum, Maximum, Minimum, SampleCount, or a percentile/trimmed-mean (e.g. p95, p99, tm99) (default "Average")
       --to string                   End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_datasources_infinity_query.md
+++ b/docs/reference/cli/gcx_datasources_infinity_query.md
@@ -41,7 +41,7 @@ gcx datasources infinity query [EXPR] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 

--- a/docs/reference/cli/gcx_datasources_influxdb_query.md
+++ b/docs/reference/cli/gcx_datasources_influxdb_query.md
@@ -38,7 +38,7 @@ gcx datasources influxdb query [EXPR] [flags]
   -h, --help                help for query
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 

--- a/docs/reference/cli/gcx_datasources_loki_metrics.md
+++ b/docs/reference/cli/gcx_datasources_loki_metrics.md
@@ -52,7 +52,7 @@ gcx datasources loki metrics [EXPR] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_datasources_loki_query.md
+++ b/docs/reference/cli/gcx_datasources_loki_query.md
@@ -52,7 +52,7 @@ gcx datasources loki query [EXPR] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, json, raw, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_datasources_prometheus_query.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_query.md
@@ -50,7 +50,7 @@ gcx datasources prometheus query [EXPR] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --time string         Evaluation time for an instant query (RFC3339, Unix timestamp, or relative like 'now-5m'). Mutually exclusive with --from/--to/--since
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_pyroscope_exemplars_profile.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_exemplars_profile.md
@@ -39,7 +39,7 @@ gcx datasources pyroscope exemplars profile [EXPR] [flags]
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
   -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
-      --since string            Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string            Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')
       --top-n int               Maximum number of exemplars to return (default 100)
 ```

--- a/docs/reference/cli/gcx_datasources_pyroscope_exemplars_span.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_exemplars_span.md
@@ -39,7 +39,7 @@ gcx datasources pyroscope exemplars span [EXPR] [flags]
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
   -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
-      --since string            Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string            Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')
       --top-n int               Maximum number of exemplars to return (default 100)
 ```

--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -65,7 +65,7 @@ gcx datasources pyroscope query [EXPR] [flags]
       --pprof-path string             Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)
       --profile-type string           Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
-      --since string                  Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string                  Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --stacktrace-selector strings   Only query locations with these function names, starting from the root (repeatable)
       --step string                   Query step (e.g., '15s', '1m')
       --to string                     End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_query.md
+++ b/docs/reference/cli/gcx_datasources_query.md
@@ -45,7 +45,7 @@ gcx datasources query DATASOURCE_UID [EXPR] [flags]
       --max-nodes int         Maximum nodes in flame graph (pyroscope only) (default 1024)
   -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --profile-type string   Profile type ID for pyroscope queries (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds')
-      --since string          Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string          Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')
       --to string             End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_datasources_tempo_get.md
+++ b/docs/reference/cli/gcx_datasources_tempo_get.md
@@ -47,7 +47,7 @@ gcx datasources tempo get TRACE_ID [flags]
       --open                Open the retrieved trace in Grafana Explore
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 

--- a/docs/reference/cli/gcx_datasources_tempo_metrics.md
+++ b/docs/reference/cli/gcx_datasources_tempo_metrics.md
@@ -55,7 +55,7 @@ gcx datasources tempo metrics [TRACEQL] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_datasources_tempo_query.md
+++ b/docs/reference/cli/gcx_datasources_tempo_query.md
@@ -48,7 +48,7 @@ gcx datasources tempo query [TRACEQL] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_logs_metrics.md
+++ b/docs/reference/cli/gcx_logs_metrics.md
@@ -46,7 +46,7 @@ gcx logs metrics [EXPR] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_logs_query.md
+++ b/docs/reference/cli/gcx_logs_query.md
@@ -52,7 +52,7 @@ gcx logs query [EXPR] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, json, raw, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_metrics_billing_query.md
+++ b/docs/reference/cli/gcx_metrics_billing_query.md
@@ -44,7 +44,7 @@ gcx metrics billing query [EXPR] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --time string         Evaluation time for an instant query (RFC3339, Unix timestamp, or relative like 'now-5m'). Mutually exclusive with --from/--to/--since
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_metrics_billing_series.md
+++ b/docs/reference/cli/gcx_metrics_billing_series.md
@@ -36,7 +36,7 @@ gcx metrics billing series [SELECTOR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --match stringArray   Additional series selector(s); repeatable
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 

--- a/docs/reference/cli/gcx_metrics_query.md
+++ b/docs/reference/cli/gcx_metrics_query.md
@@ -50,7 +50,7 @@ gcx metrics query [EXPR] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --time string         Evaluation time for an instant query (RFC3339, Unix timestamp, or relative like 'now-5m'). Mutually exclusive with --from/--to/--since
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_metrics_series.md
+++ b/docs/reference/cli/gcx_metrics_series.md
@@ -36,7 +36,7 @@ gcx metrics series [SELECTOR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --match stringArray   Additional series selector(s); repeatable
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 

--- a/docs/reference/cli/gcx_profiles_exemplars_profile.md
+++ b/docs/reference/cli/gcx_profiles_exemplars_profile.md
@@ -39,7 +39,7 @@ gcx profiles exemplars profile [EXPR] [flags]
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
   -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
-      --since string            Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string            Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')
       --top-n int               Maximum number of exemplars to return (default 100)
 ```

--- a/docs/reference/cli/gcx_profiles_exemplars_span.md
+++ b/docs/reference/cli/gcx_profiles_exemplars_span.md
@@ -39,7 +39,7 @@ gcx profiles exemplars span [EXPR] [flags]
       --max-label-columns int   Max label columns in table output (0 hides label columns) (default 3)
   -o, --output string           Output format. One of: agents, json, table, yaml (default "table")
       --profile-type string     Profile type ID (default "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
-      --since string            Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string            Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string               End time (RFC3339, Unix timestamp, or relative like 'now')
       --top-n int               Maximum number of exemplars to return (default 100)
 ```

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -57,7 +57,7 @@ gcx profiles query [EXPR] [flags]
       --pprof-path string             Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)
       --profile-type string           Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
-      --since string                  Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string                  Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --stacktrace-selector strings   Only query locations with these function names, starting from the root (repeatable)
       --step string                   Query step (e.g., '15s', '1m')
       --to string                     End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_traces_get.md
+++ b/docs/reference/cli/gcx_traces_get.md
@@ -41,7 +41,7 @@ gcx traces get TRACE_ID [flags]
       --open                Open the retrieved trace in Grafana Explore
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 

--- a/docs/reference/cli/gcx_traces_metrics.md
+++ b/docs/reference/cli/gcx_traces_metrics.md
@@ -46,7 +46,7 @@ gcx traces metrics [TRACEQL] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_traces_query.md
+++ b/docs/reference/cli/gcx_traces_query.md
@@ -42,7 +42,7 @@ gcx traces query [TRACEQL] [flags]
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
-      --since string        Duration before --to (or now if omitted); mutually exclusive with --from
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/go-openapi/runtime v0.29.5
 	github.com/gofrs/flock v0.13.0
 	github.com/grafana/otel-checker v0.2.0
+	github.com/prometheus/common v0.67.5
 	github.com/zalando/go-keyring v0.2.8
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	sigs.k8s.io/yaml v1.6.0
@@ -146,7 +147,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/datasources/query/opts.go
+++ b/internal/datasources/query/opts.go
@@ -23,7 +23,7 @@ type TimeRangeOpts struct {
 func (opts *TimeRangeOpts) SetupTimeFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.From, "from", "", "Start time (RFC3339, Unix timestamp, or relative like 'now-1h')")
 	flags.StringVar(&opts.To, "to", "", "End time (RFC3339, Unix timestamp, or relative like 'now')")
-	flags.StringVar(&opts.Since, "since", "", "Duration before --to (or now if omitted); mutually exclusive with --from")
+	flags.StringVar(&opts.Since, "since", "", "Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from")
 }
 
 // SetupInstantFlag registers the --time flag for instant queries at a specific timestamp.

--- a/internal/datasources/query/opts_test.go
+++ b/internal/datasources/query/opts_test.go
@@ -92,6 +92,18 @@ func TestSharedOptsValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "since accepts calendar durations like 7d",
+			setup: func(opts *dsquery.SharedOpts) {
+				opts.Since = "7d"
+			},
+			assert: func(t *testing.T, opts *dsquery.SharedOpts) {
+				t.Helper()
+				require.NotEmpty(t, opts.From)
+				require.NotEmpty(t, opts.To)
+				assertRange(t, opts.From, opts.To, 7*24*time.Hour)
+			},
+		},
+		{
 			name: "time flag is valid (instant at specific time)",
 			setup: func(opts *dsquery.SharedOpts) {
 				opts.Time = "2026-01-01T12:00:00Z"

--- a/internal/datasources/query/time_test.go
+++ b/internal/datasources/query/time_test.go
@@ -111,6 +111,21 @@ func TestParseDuration(t *testing.T) {
 			expected: 90 * time.Minute,
 		},
 		{
+			name:     "7d",
+			input:    "7d",
+			expected: 7 * 24 * time.Hour,
+		},
+		{
+			name:     "2w",
+			input:    "2w",
+			expected: 2 * 7 * 24 * time.Hour,
+		},
+		{
+			name:     "1y",
+			input:    "1y",
+			expected: 365 * 24 * time.Hour,
+		},
+		{
 			name:    "invalid",
 			input:   "invalid",
 			wantErr: true,

--- a/internal/shared/dates.go
+++ b/internal/shared/dates.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/prometheus/common/model"
 )
 
 var relativeTimeRegex = regexp.MustCompile(`^now(?:([+-])(\d+)([smhdwMy]))?$`)
@@ -83,13 +85,20 @@ func parseRelativeTime(s string, now time.Time) (time.Time, error) {
 	return now.Add(duration), nil
 }
 
-// ParseDuration parses a duration string that can be:
-// - Go duration (e.g., "1h30m", "5m").
-// - Prometheus-style duration (e.g., "1h", "30m", "5s").
+// ParseDuration parses a Prometheus-style duration string. It accepts the units
+// ms, s, m, h, d, w, and y, optionally compounded from larger to smaller units
+// (e.g. "30m", "1h30m", "7d", "2w", "1y"), matching Prometheus and the Grafana
+// Explore UI. Unlike Go's time.ParseDuration it understands d/w/y, but it does
+// not accept fractional values ("1.5h") or units in reversed order ("30m1h").
+// An empty string parses to 0.
 func ParseDuration(s string) (time.Duration, error) {
 	if s == "" {
 		return 0, nil
 	}
 
-	return time.ParseDuration(s)
+	d, err := model.ParseDurationAllowNegative(s)
+	if err != nil {
+		return 0, fmt.Errorf("%w (valid units: s, m, h, d, w, y; e.g. 30m, 1h30m, 7d)", err)
+	}
+	return time.Duration(d), nil
 }

--- a/internal/shared/dates_test.go
+++ b/internal/shared/dates_test.go
@@ -1,0 +1,45 @@
+package shared_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/shared"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+		wantErr  string
+	}{
+		{name: "empty string parses to zero", input: "", expected: 0},
+		{name: "go-style hours", input: "1h", expected: time.Hour},
+		{name: "compound big to small", input: "1h30m", expected: 90 * time.Minute},
+		{name: "calendar days", input: "7d", expected: 7 * 24 * time.Hour},
+		{name: "calendar weeks", input: "2w", expected: 2 * 7 * 24 * time.Hour},
+		{name: "calendar years", input: "1y", expected: 365 * 24 * time.Hour},
+		{name: "compound days and hours", input: "1d12h", expected: 36 * time.Hour},
+		{name: "negative preserved", input: "-1h", expected: -time.Hour},
+		{name: "zero without unit", input: "0", expected: 0},
+		{name: "fractional rejected", input: "1.5h", wantErr: "valid units"},
+		{name: "reversed order rejected", input: "30m1h", wantErr: "valid units"},
+		{name: "unparseable reports accepted units", input: "tomorrow", wantErr: "valid units: s, m, h, d, w, y"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := shared.ParseDuration(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## What

`--since 7d` (and `2w`, `1y`, `1d12h`) were rejected because `shared.ParseDuration` used Go's `time.ParseDuration`, which only understands `s`/`m`/`h`. Prometheus durations and the Grafana Explore UI both accept `d`/`w`/`y`, so `7d` is the natural thing to type and what users copy from elsewhere.

`ParseDuration` now uses the already-vendored `prometheus/common/model.ParseDurationAllowNegative` (promoted from indirect to direct in `go.mod` — no new dependency):

- accepts `ms, s, m, h, d, w, y` and compounds ordered large→small (`1h30m`, `1d12h`)
- preserves negative durations, so the existing `--since must be greater than 0` guard still fires (no test churn)
- accepts `0`
- parse failures now name the accepted units, e.g. `--since tomorrow` → `… (valid units: s, m, h, d, w, y; e.g. 30m, 1h30m, 7d)`

The misleading doc comment and the `--since` flag help are corrected to describe the real syntax. The flag is shared across all signal/datasource query commands (`metrics`, `logs`, `traces`, `profiles`, datasource `query` subcommands…), so each gains calendar durations; CLI reference docs regenerated accordingly.

Fixes Issue 3.

## Test plan

- New `internal/shared/dates_test.go`; extended `internal/datasources/query/{time,opts}_test.go`: `7d`/`2w`/`1y`/`1d12h` parse; empty→0; `0` and `-1h` still rejected by the range guard; fractional (`1.5h`) and reversed-order (`30m1h`) rejected; invalid input reports accepted units; `--since 7d` resolves a range.
- `go test ./...` green; build + lint clean; `GCX_AGENT_MODE=false` CLI reference regeneration drift-free (diff is exactly the `--since` help line).

End-to-end (requires a live Prometheus datasource):
```
gcx metrics query -d <ds> 'vector(1)' --since 7d --step 1h    # succeeds (was: "Invalid --since duration")
gcx metrics query -d <ds> 'vector(1)' --since tomorrow        # errors, now naming the accepted units
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
