### PR TITLE
feat(prometheus): summarize query result shape on stderr

### DIFF
--- a/internal/datasources/prometheus/query.go
+++ b/internal/datasources/prometheus/query.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/gcx/internal/agent"
 	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/prometheus"
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -124,6 +125,11 @@ open it in your browser after the query succeeds.`,
 			if err != nil {
 				return fmt.Errorf("query failed: %w", err)
 			}
+
+			// Emit a one-line result-shape summary to stderr so empty/instant/range
+			// results are distinguishable at a glance. stdout stays byte-clean,
+			// preserving the machine-readable contract for piped consumers.
+			cmdio.EmitNote(cmd.ErrOrStderr(), prometheus.SummarizeResult(resp))
 
 			exploreURL := QueryExploreURL(cfg.GrafanaURL, dsquery.ExploreQuery{
 				DatasourceUID:  datasourceUID,

--- a/internal/query/prometheus/formatter.go
+++ b/internal/query/prometheus/formatter.go
@@ -16,7 +16,7 @@ import (
 // FormatWideTable to explode labels into individual columns.
 func FormatTable(w io.Writer, resp *QueryResponse) error {
 	if len(resp.Data.Result) == 0 {
-		fmt.Fprintln(w, "No data")
+		fmt.Fprintln(w, emptyResultMessage(resp.Data.ResultType))
 		return nil
 	}
 
@@ -37,7 +37,7 @@ func FormatTable(w io.Writer, resp *QueryResponse) error {
 // human-readable view.
 func FormatWideTable(w io.Writer, resp *QueryResponse) error {
 	if len(resp.Data.Result) == 0 {
-		fmt.Fprintln(w, "No data")
+		fmt.Fprintln(w, emptyResultMessage(resp.Data.ResultType))
 		return nil
 	}
 
@@ -50,6 +50,20 @@ func FormatWideTable(w io.Writer, resp *QueryResponse) error {
 		return formatScalarTable(w, resp)
 	default:
 		return fmt.Errorf("unsupported result type: %s", resp.Data.ResultType)
+	}
+}
+
+// emptyResultMessage describes an empty result in terms of the query type, so a
+// range query that legitimately matched no series is not mistaken for a degraded
+// instant query. Table output only; the JSON/YAML codecs carry resultType already.
+func emptyResultMessage(resultType string) string {
+	switch resultType {
+	case "matrix":
+		return "No data (empty matrix — range query matched no series)"
+	case "vector":
+		return "No data (empty vector — instant query matched no series)"
+	default:
+		return "No data"
 	}
 }
 

--- a/internal/query/prometheus/formatter_test.go
+++ b/internal/query/prometheus/formatter_test.go
@@ -11,6 +11,52 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFormatTableEmptyIsTypeAware(t *testing.T) {
+	tests := []struct {
+		name       string
+		resultType string
+		format     func(io.Writer, *prometheus.QueryResponse) error
+		want       string
+	}{
+		{
+			name:       "empty matrix names the range query",
+			resultType: "matrix",
+			format:     prometheus.FormatTable,
+			want:       "No data (empty matrix — range query matched no series)",
+		},
+		{
+			name:       "empty vector names the instant query",
+			resultType: "vector",
+			format:     prometheus.FormatTable,
+			want:       "No data (empty vector — instant query matched no series)",
+		},
+		{
+			name:       "wide table is also type-aware",
+			resultType: "matrix",
+			format:     prometheus.FormatWideTable,
+			want:       "No data (empty matrix — range query matched no series)",
+		},
+		{
+			name:       "unknown type falls back to plain message",
+			resultType: "scalar",
+			format:     prometheus.FormatTable,
+			want:       "No data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &prometheus.QueryResponse{
+				Status: "success",
+				Data:   prometheus.ResultData{ResultType: tt.resultType},
+			}
+			var buf bytes.Buffer
+			require.NoError(t, tt.format(&buf, resp))
+			assert.Equal(t, tt.want, strings.TrimSpace(buf.String()))
+		})
+	}
+}
+
 func TestFormatVectorTableVariants(t *testing.T) {
 	resp := &prometheus.QueryResponse{
 		Status: "success",

--- a/internal/query/prometheus/summarize.go
+++ b/internal/query/prometheus/summarize.go
@@ -1,0 +1,52 @@
+package prometheus
+
+import "fmt"
+
+// SummarizeResult returns a concise, one-line description of a query result's
+// shape (kind, series count, and points-per-series for ranges) so that
+// empty-but-ran, instant, and range results are distinguishable at a glance
+// without inspecting the JSON. It pairs with the request-intent result type:
+// an empty range reads as an empty matrix, never an empty vector.
+func SummarizeResult(resp *QueryResponse) string {
+	if resp == nil {
+		return ""
+	}
+
+	switch resp.Data.ResultType {
+	case "matrix":
+		return summarizeMatrix(resp.Data.Result)
+	case "vector":
+		if len(resp.Data.Result) == 0 {
+			return "vector: 0 series (empty instant result)"
+		}
+		return fmt.Sprintf("vector: %d series", len(resp.Data.Result))
+	case "scalar":
+		return "scalar"
+	default:
+		return resp.Data.ResultType
+	}
+}
+
+// summarizeMatrix reports series count and points-per-series, collapsing to a
+// single "N × P" figure when every series carries the same number of points and
+// falling back to a total when they differ.
+func summarizeMatrix(samples []Sample) string {
+	if len(samples) == 0 {
+		return "matrix: 0 series (empty range result)"
+	}
+
+	pointsPerSeries := len(samples[0].Values)
+	total := 0
+	uniform := true
+	for _, s := range samples {
+		total += len(s.Values)
+		if len(s.Values) != pointsPerSeries {
+			uniform = false
+		}
+	}
+
+	if uniform {
+		return fmt.Sprintf("matrix: %d series × %d points", len(samples), pointsPerSeries)
+	}
+	return fmt.Sprintf("matrix: %d series, %d points total", len(samples), total)
+}

--- a/internal/query/prometheus/summarize_test.go
+++ b/internal/query/prometheus/summarize_test.go
@@ -1,0 +1,84 @@
+package prometheus_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSummarizeResult(t *testing.T) {
+	matrixSample := func(points int) prometheus.Sample {
+		s := prometheus.Sample{Metric: map[string]string{"__name__": "up"}}
+		for i := range points {
+			s.Values = append(s.Values, []any{float64(i), "1"})
+		}
+		return s
+	}
+
+	tests := []struct {
+		name string
+		resp *prometheus.QueryResponse
+		want string
+	}{
+		{
+			name: "nil response",
+			resp: nil,
+			want: "",
+		},
+		{
+			name: "empty range result",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{ResultType: "matrix"}},
+			want: "matrix: 0 series (empty range result)",
+		},
+		{
+			name: "empty instant result",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{ResultType: "vector"}},
+			want: "vector: 0 series (empty instant result)",
+		},
+		{
+			name: "vector with series",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{
+				ResultType: "vector",
+				Result: []prometheus.Sample{
+					{Value: []any{1.0, "1"}},
+					{Value: []any{1.0, "2"}},
+					{Value: []any{1.0, "3"}},
+				},
+			}},
+			want: "vector: 3 series",
+		},
+		{
+			name: "uniform matrix",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{
+				ResultType: "matrix",
+				Result:     []prometheus.Sample{matrixSample(3), matrixSample(3)},
+			}},
+			want: "matrix: 2 series × 3 points",
+		},
+		{
+			name: "ragged matrix reports total",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{
+				ResultType: "matrix",
+				Result:     []prometheus.Sample{matrixSample(3), matrixSample(2)},
+			}},
+			want: "matrix: 2 series, 5 points total",
+		},
+		{
+			name: "scalar",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{ResultType: "scalar"}},
+			want: "scalar",
+		},
+		{
+			name: "unknown type falls back to type name",
+			resp: &prometheus.QueryResponse{Data: prometheus.ResultData{ResultType: "string"}},
+			want: "string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, prometheus.SummarizeResult(tt.resp))
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a concise, agent/human-legible result-shape summary so empty, instant, and range results are distinguishable without dropping to `jq`.

After a successful `gcx metrics query` / `gcx datasources prometheus query`, a one-line summary is emitted to **stderr** via `output.EmitNote`:

- `matrix: N series × P points` (uniform) · `matrix: N series, T points total` (ragged) · `matrix: 0 series (empty range result)`
- `vector: N series` · `vector: 0 series (empty instant result)`
- `scalar`

stdout stays byte-clean (JSON/table output unchanged), preserving the machine-readable contract for piped consumers; in agent mode the note is the FR-104 typed-class `{"class":"note","summary":…}` JSONL on stderr. The table/wide formatters also now describe an empty result by type — `No data (empty matrix — range query matched no series)` — instead of a bare `No data`.

Fixes Issue 4.

> The summary is most meaningful once range queries report `matrix` for empty results — see companion PR #839. Until that merges, an empty range still summarizes as an empty vector; this PR is otherwise independent and merges cleanly to `main`.

## Test plan

- New `internal/query/prometheus/summarize_test.go` (vector / matrix / scalar / empty, uniform vs ragged point counts); extended `formatter_test.go` for the type-aware empty messages.
- `go test ./...` green; build + lint clean.

End-to-end (requires a live Prometheus datasource):
```
GCX_AGENT_MODE=true gcx metrics query -d <ds> 'up' -o json 2>/tmp/err; cat /tmp/err
# {"class":"note","summary":"vector: N series"} on stderr; stdout JSON intact
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
