### PR TITLE
feat(appo11y): add services operations for per-endpoint RED breakdown

### DIFF
--- a/docs/reference/cli/gcx_appo11y_services.md
+++ b/docs/reference/cli/gcx_appo11y_services.md
@@ -25,5 +25,6 @@ Inspect Application Observability services discovered from telemetry
 * [gcx appo11y](gcx_appo11y.md)	 - Manage Grafana App Observability settings
 * [gcx appo11y services get](gcx_appo11y_services_get.md)	 - Inspect a single Application Observability service: metadata + RED snapshot.
 * [gcx appo11y services list](gcx_appo11y_services_list.md)	 - List Application Observability services discovered from target_info/traces_target_info telemetry.
+* [gcx appo11y services list-operations](gcx_appo11y_services_list-operations.md)	 - List a service's operations with per-operation RED (span_name × rate/errors/latency).
 * [gcx appo11y services map](gcx_appo11y_services_map.md)	 - Show a service's neighbourhood: who calls it (callers) and who it calls (callees).
 

--- a/docs/reference/cli/gcx_appo11y_services_get.md
+++ b/docs/reference/cli/gcx_appo11y_services_get.md
@@ -59,8 +59,8 @@ gcx appo11y services get <service> [--namespace ns] [flags]
   -d, --datasource string     Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
   -h, --help                  help for get
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --kind string           Span kinds to include: inbound (server+consumer), server, consumer, all, or a comma list of SPAN_KIND_* literals (default "inbound")
-      --metrics-mode string   Span-metrics family: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket) (default "auto")
+      --kind string           Span kinds to include. One of: inbound (server+consumer), server, consumer, all, or a comma-separated list of SPAN_KIND_* literals (default "inbound")
+      --metrics-mode string   Span-metrics family. One of: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket) (default "auto")
   -n, --namespace string      Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)
   -o, --output string         Output format. One of: agents, json, table, wide, yaml (default "table")
       --since string          Rate/quantile window applied to span metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax (default "5m")

--- a/docs/reference/cli/gcx_appo11y_services_list-operations.md
+++ b/docs/reference/cli/gcx_appo11y_services_list-operations.md
@@ -1,0 +1,70 @@
+## gcx appo11y services list-operations
+
+List a service's operations with per-operation RED (span_name × rate/errors/latency).
+
+### Synopsis
+
+List the per-operation RED breakdown for one service.
+
+The argument is either the bare service name or the canonical
+"<namespace>/<name>" form; bare names are auto-resolved against
+target_info the same way as "gcx appo11y services get".
+
+Rows are sorted by time-share desc — the share of the service's total
+wall-clock time each operation consumes, computed as
+(avg_latency × rate) / sum(all). This surfaces operations that dominate
+latency regardless of whether they're high-rate-fast or low-rate-slow.
+
+The source span-metrics series (Tempo's traces_spanmetrics_*, the v3
+traces_span_metrics_*, or bare OTel calls_total) is auto-detected by
+default. Use --metrics-mode to pin it; see "gcx appo11y services get
+--help" for the full reference.
+
+```
+gcx appo11y services list-operations <service> [--namespace ns] [flags]
+```
+
+### Examples
+
+```
+
+  # Top operations for the "checkoutservice" service in the default 5m window
+  gcx appo11y services list-operations checkoutservice
+
+  # Wider view with p50/p99 and absolute error rate
+  gcx appo11y services list-operations checkoutservice -o wide
+
+  # Last hour, unlimited rows, JSON for scripting
+  gcx appo11y services list-operations payments/checkoutservice --since 1h --limit 0 -o json
+```
+
+### Options
+
+```
+  -d, --datasource string     Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
+  -h, --help                  help for list-operations
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --kind string           Span kinds to include. One of: inbound (server+consumer), server, consumer, all, or a comma-separated list of SPAN_KIND_* literals (default "inbound")
+      --limit int             Limit the number of operations returned (0 = unlimited; applied after sorting by time-share desc) (default 15)
+      --metrics-mode string   Span-metrics family. One of: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket) (default "auto")
+  -n, --namespace string      Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)
+  -o, --output string         Output format. One of: agents, json, table, wide, yaml (default "table")
+      --since string          Rate/quantile window applied to span metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax (default "5m")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx appo11y services](gcx_appo11y_services.md)	 - Inspect Application Observability services discovered from telemetry
+

--- a/internal/providers/appo11y/services/commands.go
+++ b/internal/providers/appo11y/services/commands.go
@@ -31,6 +31,7 @@ func Commands() *cobra.Command {
 	cmd.AddCommand(newListCommand())
 	cmd.AddCommand(newGetCommand())
 	cmd.AddCommand(newMapCommand())
+	cmd.AddCommand(newListOperationsCommand())
 	return cmd
 }
 

--- a/internal/providers/appo11y/services/get.go
+++ b/internal/providers/appo11y/services/get.go
@@ -47,8 +47,8 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.Datasource, "datasource", "d", "", "Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)")
 	flags.StringVarP(&o.Namespace, "namespace", "n", "", "Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)")
 	flags.StringVar(&o.Since, "since", defaultRedWindow, "Rate/quantile window applied to span metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax")
-	flags.StringVar(&o.Kind, "kind", "inbound", "Span kinds to include: inbound (server+consumer), server, consumer, all, or a comma list of SPAN_KIND_* literals")
-	flags.StringVar(&o.MetricsMode, "metrics-mode", metricsModeAuto, "Span-metrics family: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket)")
+	flags.StringVar(&o.Kind, "kind", "inbound", "Span kinds to include. One of: inbound (server+consumer), server, consumer, all, or a comma-separated list of SPAN_KIND_* literals")
+	flags.StringVar(&o.MetricsMode, "metrics-mode", metricsModeAuto, "Span-metrics family. One of: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket)")
 }
 
 func (o *getOpts) Validate(cmd *cobra.Command) error {

--- a/internal/providers/appo11y/services/map.go
+++ b/internal/providers/appo11y/services/map.go
@@ -104,7 +104,7 @@ suitable for inlining in markdown / piping to "dot -Tpng".`,
 		RunE: runMap(opts),
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
-			agent.AnnotationLLMHint:   `Service-graph slice for one App Observability service: callers (peers calling into the service) and callees (peers the service calls), with per-edge rate (req/s), error %, and direction-aware p95 latency (server-side for callers, client-side for callees). Connection-type label distinguishes HTTP/gRPC (empty), database, messaging, and virtual_node (uninstrumented upstreams synthesised by Tempo). Output formats: table/wide (default two-section view), json/yaml (structured), mermaid (markdown-renderable graph), dot (Graphviz). Pairs with 'gcx appo11y services get' (single-service RED) and 'gcx appo11y services operations' (per-endpoint breakdown). Examples: gcx appo11y services map <name> -o json; gcx appo11y services map <ns>/<name> --since 1h -o mermaid`,
+			agent.AnnotationLLMHint:   `Service-graph slice for one App Observability service: callers (peers calling into the service) and callees (peers the service calls), with per-edge rate (req/s), error %, and direction-aware p95 latency (server-side for callers, client-side for callees). Connection-type label distinguishes HTTP/gRPC (empty), database, messaging, and virtual_node (uninstrumented upstreams synthesised by Tempo). Output formats: table/wide (default two-section view), json/yaml (structured), mermaid (markdown-renderable graph), dot (Graphviz). Pairs with 'gcx appo11y services get' (single-service RED) and 'gcx appo11y services list-operations' (per-endpoint breakdown). Examples: gcx appo11y services map <name> -o json; gcx appo11y services map <ns>/<name> --since 1h -o mermaid`,
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -146,7 +146,7 @@ func runMap(opts *mapOpts) func(*cobra.Command, []string) error {
 			return fmt.Errorf("failed to create prometheus client: %w", err)
 		}
 
-		// Bare-name resolution: same UX as `services get` and `services operations`.
+		// Bare-name resolution: same UX as `services get` and `services list-operations`.
 		if namespace == "" {
 			resolved, err := resolveNamespaceForBareName(ctx, client, datasourceUID, name)
 			if err != nil {
@@ -480,17 +480,6 @@ func (c *serviceMapDOTCodec) Encode(w io.Writer, v any) error {
 	emit(resp.Callees, false)
 	fmt.Fprintln(w, "}")
 	return nil
-}
-
-// formatPercentMaybe mirrors the helper of the same name on the
-// services-operations branch (where it lives in operations.go). When
-// both land on main the duplicate will collapse; until then the local
-// copy keeps this branch self-contained.
-func formatPercentMaybe(v float64, has bool) string {
-	if !has {
-		return "-"
-	}
-	return fmt.Sprintf("%.2f%%", v)
 }
 
 func dotPeerAttrs(connType string) string {

--- a/internal/providers/appo11y/services/operations.go
+++ b/internal/providers/appo11y/services/operations.go
@@ -1,0 +1,392 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/prometheus/common/model"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+)
+
+// operationsDefaultLimit caps the row count to ~one screenful by default.
+// Services rarely have fewer than 15 useful operations and rarely need
+// more than that at a glance. Users opt out with `--limit 0`.
+const operationsDefaultLimit = 15
+
+type operationsOpts struct {
+	IO          cmdio.Options
+	Datasource  string
+	Since       string
+	Namespace   string
+	Kind        string
+	MetricsMode string
+	Limit       int
+}
+
+func (o *operationsOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &operationsTableCodec{})
+	o.IO.RegisterCustomCodec("wide", &operationsTableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+
+	flags.StringVarP(&o.Datasource, "datasource", "d", "", "Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)")
+	flags.StringVarP(&o.Namespace, "namespace", "n", "", "Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)")
+	flags.StringVar(&o.Since, "since", defaultRedWindow, "Rate/quantile window applied to span metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax")
+	flags.StringVar(&o.Kind, "kind", "inbound", "Span kinds to include. One of: inbound (server+consumer), server, consumer, all, or a comma-separated list of SPAN_KIND_* literals")
+	flags.StringVar(&o.MetricsMode, "metrics-mode", metricsModeAuto, "Span-metrics family. One of: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket)")
+	flags.IntVar(&o.Limit, "limit", operationsDefaultLimit, "Limit the number of operations returned (0 = unlimited; applied after sorting by time-share desc)")
+}
+
+func (o *operationsOpts) Validate(cmd *cobra.Command) error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(o.Since) == "" {
+		return fail.NewCommandUsageError(cmd, "--since must not be empty", nil)
+	}
+	if _, err := model.ParseDuration(o.Since); err != nil {
+		return fail.NewCommandUsageError(cmd, fmt.Sprintf("--since %q is not a valid PromQL duration", o.Since), err)
+	}
+	if _, err := resolveSpanKinds(o.Kind); err != nil {
+		return fail.NewCommandUsageError(cmd, "", err)
+	}
+	if _, _, err := resolveMetricsMode(o.MetricsMode); err != nil {
+		return fail.NewCommandUsageError(cmd, "", err)
+	}
+	if o.Limit < 0 {
+		return fail.NewCommandUsageError(cmd, "--limit must be zero or positive", nil)
+	}
+	return nil
+}
+
+func newListOperationsCommand() *cobra.Command {
+	opts := &operationsOpts{}
+	cmd := &cobra.Command{
+		Use:   "list-operations <service> [--namespace ns]",
+		Short: "List a service's operations with per-operation RED (span_name × rate/errors/latency).",
+		Long: `List the per-operation RED breakdown for one service.
+
+The argument is either the bare service name or the canonical
+"<namespace>/<name>" form; bare names are auto-resolved against
+target_info the same way as "gcx appo11y services get".
+
+Rows are sorted by time-share desc — the share of the service's total
+wall-clock time each operation consumes, computed as
+(avg_latency × rate) / sum(all). This surfaces operations that dominate
+latency regardless of whether they're high-rate-fast or low-rate-slow.
+
+The source span-metrics series (Tempo's traces_spanmetrics_*, the v3
+traces_span_metrics_*, or bare OTel calls_total) is auto-detected by
+default. Use --metrics-mode to pin it; see "gcx appo11y services get
+--help" for the full reference.`,
+		Example: `
+  # Top operations for the "checkoutservice" service in the default 5m window
+  gcx appo11y services list-operations checkoutservice
+
+  # Wider view with p50/p99 and absolute error rate
+  gcx appo11y services list-operations checkoutservice -o wide
+
+  # Last hour, unlimited rows, JSON for scripting
+  gcx appo11y services list-operations payments/checkoutservice --since 1h --limit 0 -o json`,
+		Args: cobra.ExactArgs(1),
+		RunE: runOperations(opts),
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "small",
+			agent.AnnotationLLMHint:   `Per-operation RED breakdown for one App Observability service: one row per span_name with rate (req/s), error rate, error percent, avg latency, p50/p95/p99, and time-share % (rate * avg_latency normalized across the service). Sorted by time-share desc to surface latency hotspots. Pairs with 'gcx appo11y services get' (which is the headline summary) — use 'list-operations' once a service is identified as hot to find which endpoints carry the load. Examples: gcx appo11y services list-operations <name> -o json; gcx appo11y services list-operations <ns>/<name> --since 1h --limit 0 -o json; gcx appo11y services list-operations <name> -o wide`,
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func runOperations(opts *operationsOpts) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := opts.Validate(cmd); err != nil {
+			return err
+		}
+		namespace, name, err := parseServiceArg(args[0], opts.Namespace)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+		kinds, err := resolveSpanKinds(opts.Kind)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+		mode, auto, err := resolveMetricsMode(opts.MetricsMode)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+
+		ctx := cmd.Context()
+		var loader providers.ConfigLoader
+
+		cfg, err := loader.LoadGrafanaConfig(ctx)
+		if err != nil {
+			return err
+		}
+
+		var cfgCtx *internalconfig.Context
+		if fullCfg, err := loader.LoadFullConfig(ctx); err != nil {
+			logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+		} else {
+			cfgCtx = fullCfg.GetCurrentContext()
+		}
+
+		datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, &loader, opts.Datasource, cfgCtx, cfg, "prometheus")
+		if err != nil {
+			return err
+		}
+
+		client, err := prometheus.NewClient(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create prometheus client: %w", err)
+		}
+
+		// Bare-name resolution: same UX as `services get`. Without this
+		// step, an operations query against a namespaced service via its
+		// bare name silently returns no rows because the `job` label is
+		// `<ns>/<name>`, not `<name>`.
+		if namespace == "" {
+			resolved, err := resolveNamespaceForBareName(ctx, client, datasourceUID, name)
+			if err != nil {
+				return err
+			}
+			namespace = resolved
+		}
+
+		if auto {
+			mode, err = detectMetricsMode(ctx, client, datasourceUID, namespace, name)
+			if err != nil {
+				return fmt.Errorf("metrics-mode auto-detect failed: %w", err)
+			}
+		}
+
+		response, err := fetchOperations(ctx, client, datasourceUID, namespace, name, opts.Since, kinds, mode)
+		if err != nil {
+			return err
+		}
+
+		notFound := !response.Service.Instrumented && len(response.Items) == 0
+		if notFound {
+			emitNoDataHint(cmd.ErrOrStderr(), namespace, name)
+		}
+
+		truncated := false
+		if opts.Limit > 0 && len(response.Items) > opts.Limit {
+			response.Items = response.Items[:opts.Limit]
+			truncated = true
+		}
+		if truncated {
+			emitOperationsLimitHint(cmd.ErrOrStderr(), opts.Limit)
+		}
+
+		if err := opts.IO.Encode(cmd.OutOrStdout(), response); err != nil {
+			return err
+		}
+		if notFound {
+			return fmt.Errorf("service %q has no telemetry in the requested window", jobLabel(namespace, name))
+		}
+		return nil
+	}
+}
+
+// fetchOperations runs the five per-operation queries plus the metadata
+// lookup in parallel and folds the responses into an OperationsResponse.
+// Metadata uses the same target_info union as `services get` so the
+// language/labels/env fields are consistent between commands.
+func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, kinds []string, mode MetricsMode) (*OperationsResponse, error) {
+	names, ok := metricNamesByMode(mode)
+	if !ok {
+		return nil, fmt.Errorf("unknown metrics mode %q", mode)
+	}
+
+	metrics := targetInfoMetrics()
+	metadataResponses := make([]*prometheus.QueryResponse, len(metrics))
+	var rateResp, errorResp, avgResp, p50Resp, p95Resp, p99Resp *prometheus.QueryResponse
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	for i, metric := range metrics {
+		eg.Go(func() error {
+			expr, err := buildServiceMetadataQuery(metric, namespace, name)
+			if err != nil {
+				return fmt.Errorf("failed to build %s metadata query: %w", metric, err)
+			}
+			resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+			if err != nil {
+				return fmt.Errorf("%s metadata query failed: %w", metric, err)
+			}
+			metadataResponses[i] = resp
+			return nil
+		})
+	}
+	eg.Go(func() error {
+		expr, err := buildOperationsRateQuery(names, namespace, name, window, kinds)
+		if err != nil {
+			return fmt.Errorf("failed to build rate query: %w", err)
+		}
+		resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+		if err != nil {
+			return fmt.Errorf("rate query failed: %w", err)
+		}
+		rateResp = resp
+		return nil
+	})
+	eg.Go(func() error {
+		expr, err := buildOperationsErrorRateQuery(names, namespace, name, window, kinds)
+		if err != nil {
+			return fmt.Errorf("failed to build error-rate query: %w", err)
+		}
+		resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+		if err != nil {
+			return fmt.Errorf("error-rate query failed: %w", err)
+		}
+		errorResp = resp
+		return nil
+	})
+	eg.Go(func() error {
+		expr, err := buildOperationsAvgLatencyQuery(names, namespace, name, window, kinds)
+		if err != nil {
+			return fmt.Errorf("failed to build avg-latency query: %w", err)
+		}
+		resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+		if err != nil {
+			return fmt.Errorf("avg-latency query failed: %w", err)
+		}
+		avgResp = resp
+		return nil
+	})
+	for phi, sink := range map[float64]**prometheus.QueryResponse{
+		0.50: &p50Resp,
+		0.95: &p95Resp,
+		0.99: &p99Resp,
+	} {
+		eg.Go(func() error {
+			expr, err := buildOperationsLatencyQuantileQuery(names, namespace, name, window, kinds, phi)
+			if err != nil {
+				return fmt.Errorf("failed to build p%.0f latency query: %w", phi*100, err)
+			}
+			resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+			if err != nil {
+				return fmt.Errorf("p%.0f latency query failed: %w", phi*100, err)
+			}
+			*sink = resp
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	metadata, err := parseServicesResponses(metadataResponses)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse metadata response: %w", err)
+	}
+	svc := selectMetadataService(metadata, namespace, name)
+
+	items := mergeOperations(
+		extractBySpanName(rateResp),
+		extractBySpanName(errorResp),
+		extractBySpanName(avgResp),
+		extractBySpanName(p50Resp),
+		extractBySpanName(p95Resp),
+		extractBySpanName(p99Resp),
+	)
+
+	return &OperationsResponse{
+		Service:     svc,
+		Window:      window,
+		MetricsMode: mode,
+		SpanKinds:   spanKindRegex(kinds),
+		Items:       items,
+	}, nil
+}
+
+// emitOperationsLimitHint mirrors the truncation hint pattern from
+// `services list`: a runnable command pointing at a doubled limit
+// (TTY) or the structured envelope (agent mode).
+func emitOperationsLimitHint(stderr io.Writer, limit int) {
+	cmdio.EmitHint(stderr,
+		fmt.Sprintf("showing top %d operations by time share", limit),
+		fmt.Sprintf("gcx appo11y services list-operations <service> --limit %d", limit*2))
+}
+
+type operationsTableCodec struct {
+	Wide bool
+}
+
+func (c *operationsTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *operationsTableCodec) Decode(io.Reader, any) error {
+	return errors.New("services operations table codec does not support decoding")
+}
+
+func (c *operationsTableCodec) Encode(w io.Writer, v any) error {
+	resp, ok := v.(*OperationsResponse)
+	if !ok {
+		return fmt.Errorf("invalid data type for services operations table codec: %T", v)
+	}
+	if len(resp.Items) == 0 {
+		_, err := fmt.Fprintln(w, "No operations found. Verify the service is emitting span metrics in the requested window.")
+		return err
+	}
+
+	headers := []string{"OPERATION", "RATE", "ERROR %", "P95", "TIME %"}
+	if c.Wide {
+		headers = []string{"OPERATION", "RATE", "ERRORS", "ERROR %", "P50", "P95", "P99", "TIME %"}
+	}
+	t := style.NewTable(headers...)
+	for _, op := range resp.Items {
+		if c.Wide {
+			t.Row(
+				op.Name,
+				formatRateWithUnit(op.RatePerSecond, op.HasTraffic),
+				formatRateWithUnit(op.ErrorRatePerSec, op.HasErrors),
+				formatPercentMaybe(op.ErrorPercent, op.HasTraffic),
+				formatDuration(op.P50Seconds, op.HasLatencyP50),
+				formatDuration(op.P95Seconds, op.HasLatencyP95),
+				formatDuration(op.P99Seconds, op.HasLatencyP99),
+				formatPercentMaybe(op.TimeSharePercent, op.HasAvgLatency && op.HasTraffic),
+			)
+			continue
+		}
+		t.Row(
+			op.Name,
+			formatRateWithUnit(op.RatePerSecond, op.HasTraffic),
+			formatPercentMaybe(op.ErrorPercent, op.HasTraffic),
+			formatDuration(op.P95Seconds, op.HasLatencyP95),
+			formatPercentMaybe(op.TimeSharePercent, op.HasAvgLatency && op.HasTraffic),
+		)
+	}
+	return t.Render(w)
+}
+
+// formatPercentMaybe is the operations-table variant of formatPercent
+// that returns "-" when the underlying metric has no signal, instead
+// of "0.00%" — keeps the table honest about what's measured.
+func formatPercentMaybe(v float64, has bool) string {
+	if !has {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f%%", v)
+}

--- a/internal/providers/appo11y/services/operations_test.go
+++ b/internal/providers/appo11y/services/operations_test.go
@@ -1,0 +1,279 @@
+package services //nolint:testpackage // Tests cover unexported builders, merge logic, and codec.
+
+import (
+	"bytes"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/spf13/cobra"
+)
+
+func TestBuildOperationsRateQuery(t *testing.T) {
+	v3, _ := metricNamesByMode(MetricsModeV3)
+	got, err := buildOperationsRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer, spanKindConsumer})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `sum by (span_name) (rate(traces_span_metrics_calls_total{job="billing/checkout",span_kind=~"SPAN_KIND_SERVER|SPAN_KIND_CONSUMER"}[5m]))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+
+	if _, err := buildOperationsRateQuery(v3, "", "", "5m", nil); err == nil {
+		t.Error("expected error for empty service name")
+	}
+}
+
+func TestBuildOperationsErrorRateQuery(t *testing.T) {
+	tempo, _ := metricNamesByMode(MetricsModeTempo)
+	got, err := buildOperationsErrorRateQuery(tempo, "", "auth", "1m", []string{spanKindServer})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `sum by (span_name) (rate(traces_spanmetrics_calls_total{job="auth",span_kind=~"SPAN_KIND_SERVER",status_code="STATUS_CODE_ERROR"}[1m]))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildOperationsLatencyQuantileQuery(t *testing.T) {
+	v3, _ := metricNamesByMode(MetricsModeV3)
+	got, err := buildOperationsLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `histogram_quantile(0.95, sum by (le, span_name) (rate(traces_span_metrics_duration_seconds_bucket{job="billing/checkout",span_kind=~"SPAN_KIND_SERVER"}[5m])))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+	if _, err := buildOperationsLatencyQuantileQuery(v3, "", "x", "5m", nil, 1.5); err == nil {
+		t.Error("expected error for phi out of range")
+	}
+}
+
+func TestBuildOperationsAvgLatencyQuery(t *testing.T) {
+	v3, _ := metricNamesByMode(MetricsModeV3)
+	got, err := buildOperationsAvgLatencyQuery(v3, "billing", "checkout", "5m", []string{spanKindServer})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	// promql.Div wraps each operand in parens — semantically identical
+	// but the string form needs to reflect what the builder emits.
+	want := `(sum by (span_name) (rate(traces_span_metrics_duration_seconds_sum{job="billing/checkout",span_kind=~"SPAN_KIND_SERVER"}[5m]))) / (sum by (span_name) (rate(traces_span_metrics_duration_seconds_count{job="billing/checkout",span_kind=~"SPAN_KIND_SERVER"}[5m])))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestExtractBySpanName(t *testing.T) {
+	resp := &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
+		{Metric: map[string]string{"span_name": "GET /api/foo"}, Value: []any{1.0, "12.5"}},
+		{Metric: map[string]string{"span_name": "POST /api/bar"}, Value: []any{1.0, "0.5"}},
+		{Metric: map[string]string{"span_name": ""}, Value: []any{1.0, "9.0"}},     // dropped
+		{Metric: map[string]string{"span_name": "noop"}, Value: []any{1.0, "NaN"}}, // dropped (NaN)
+		{Metric: map[string]string{"span_name": "noop2"}, Value: []any{1.0}},       // dropped (short)
+	}}}
+	got := extractBySpanName(resp)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %v", len(got), got)
+	}
+	if got["GET /api/foo"] != 12.5 || got["POST /api/bar"] != 0.5 {
+		t.Errorf("values wrong: %v", got)
+	}
+
+	if got := extractBySpanName(nil); len(got) != 0 {
+		t.Errorf("nil response should produce empty map, got %v", got)
+	}
+}
+
+func TestMergeOperations_TimeShareNormalisation(t *testing.T) {
+	// Two operations: A is high-rate-fast (10 req/s × 5ms = 50ms/s);
+	// B is low-rate-slow (1 req/s × 200ms = 200ms/s). Time-share
+	// must rank B above A even though A has higher rate — that's the
+	// whole point of the metric.
+	rates := map[string]float64{"A": 10, "B": 1}
+	errors := map[string]float64{}
+	avgs := map[string]float64{"A": 0.005, "B": 0.200}
+	p50s := map[string]float64{"A": 0.004, "B": 0.150}
+	p95s := map[string]float64{"A": 0.008, "B": 0.300}
+	p99s := map[string]float64{"A": 0.010, "B": 0.400}
+
+	got := mergeOperations(rates, errors, avgs, p50s, p95s, p99s)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Name != "B" || got[1].Name != "A" {
+		t.Errorf("expected B,A order (B has 4x more wall-time), got %s,%s", got[0].Name, got[1].Name)
+	}
+
+	totalWall := 50e-3 + 200e-3 // 0.25 s/s
+	wantB := (200e-3 / totalWall) * 100
+	wantA := (50e-3 / totalWall) * 100
+	if math.Abs(got[0].TimeSharePercent-wantB) > 0.001 {
+		t.Errorf("B time-share = %.4f, want %.4f", got[0].TimeSharePercent, wantB)
+	}
+	if math.Abs(got[1].TimeSharePercent-wantA) > 0.001 {
+		t.Errorf("A time-share = %.4f, want %.4f", got[1].TimeSharePercent, wantA)
+	}
+
+	// HasTraffic must be true for both (traffic + avg present).
+	for _, op := range got {
+		if !op.HasTraffic || !op.HasAvgLatency {
+			t.Errorf("op %s missing flags: %+v", op.Name, op)
+		}
+	}
+}
+
+func TestMergeOperations_OperationWithoutAvgLatencyHasZeroTimeShare(t *testing.T) {
+	// Op "C" appears only in the rate map — no latency at all. Should
+	// render in the output with HasTraffic=true but TimeSharePercent=0,
+	// not crash and not skew the others' shares.
+	rates := map[string]float64{"A": 10, "C": 5}
+	avgs := map[string]float64{"A": 0.010}
+	got := mergeOperations(rates, nil, avgs, nil, nil, nil)
+
+	byName := map[string]Operation{}
+	for _, op := range got {
+		byName[op.Name] = op
+	}
+	if c := byName["C"]; c.HasAvgLatency || c.TimeSharePercent != 0 {
+		t.Errorf("C should have no avg latency and zero share: %+v", c)
+	}
+	// A is the only contributor to totalWall, so its share is 100%.
+	if a := byName["A"]; math.Abs(a.TimeSharePercent-100) > 0.001 {
+		t.Errorf("A time-share = %.4f, want ~100", a.TimeSharePercent)
+	}
+}
+
+func TestMergeOperations_NoTrafficAtAll(t *testing.T) {
+	// Edge case: no rate data anywhere. We should return an empty
+	// slice (not nil-deref) and not panic on a zero denominator.
+	got := mergeOperations(nil, nil, nil, nil, nil, nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestMergeOperations_ErrorPercentBoundedAndHasErrorsInferred(t *testing.T) {
+	rates := map[string]float64{"A": 10, "B": 5}
+	errors := map[string]float64{"A": 2} // only A has errors observed
+	got := mergeOperations(rates, errors, nil, nil, nil, nil)
+
+	byName := map[string]Operation{}
+	for _, op := range got {
+		byName[op.Name] = op
+	}
+	if a := byName["A"]; math.Abs(a.ErrorPercent-20) > 0.001 {
+		t.Errorf("A error %% = %.4f, want 20", a.ErrorPercent)
+	}
+	// B has traffic but no error series → hasErrors must still be true
+	// so the codec doesn't render `-` for a healthy 0%.
+	if b := byName["B"]; !b.HasErrors || b.ErrorPercent != 0 {
+		t.Errorf("B should have hasErrors=true and ErrorPercent=0: %+v", b)
+	}
+}
+
+func TestOperationsOptsValidate(t *testing.T) {
+	mk := func(o operationsOpts) operationsOpts {
+		o.IO.OutputFormat = "json"
+		if o.Since == "" {
+			o.Since = defaultRedWindow
+		}
+		if o.Kind == "" {
+			o.Kind = "inbound"
+		}
+		return o
+	}
+	tests := []struct {
+		name    string
+		opts    operationsOpts
+		wantErr bool
+	}{
+		{name: "defaults ok", opts: mk(operationsOpts{})},
+		{name: "since PromQL duration", opts: mk(operationsOpts{Since: "1d"})},
+		{name: "bad since", opts: mk(operationsOpts{Since: "not-a-duration"}), wantErr: true},
+		{name: "negative limit rejected", opts: mk(operationsOpts{Limit: -1}), wantErr: true},
+		{name: "zero limit ok (unlimited)", opts: mk(operationsOpts{Limit: 0})},
+		{name: "bogus kind", opts: mk(operationsOpts{Kind: "OUTGOING"}), wantErr: true},
+		{name: "bogus metrics-mode", opts: mk(operationsOpts{MetricsMode: "fictional"}), wantErr: true},
+	}
+	cmd := &cobra.Command{Use: "list-operations"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.opts.Validate(cmd); (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOperationsTableCodec(t *testing.T) {
+	codec := &operationsTableCodec{}
+	resp := &OperationsResponse{
+		Service:     Service{Name: "checkout", Namespace: "billing"},
+		Window:      "5m",
+		MetricsMode: MetricsModeV3,
+		SpanKinds:   "SPAN_KIND_SERVER|SPAN_KIND_CONSUMER",
+		Items: []Operation{
+			{
+				Name: "POST /checkout", RatePerSecond: 10, ErrorRatePerSec: 0.2, ErrorPercent: 2.0,
+				AvgSeconds: 0.080, P50Seconds: 0.060, P95Seconds: 0.150, P99Seconds: 0.300,
+				TimeSharePercent: 80,
+				HasTraffic:       true, HasErrors: true, HasAvgLatency: true,
+				HasLatencyP50: true, HasLatencyP95: true, HasLatencyP99: true,
+			},
+			{
+				Name: "GET /health", RatePerSecond: 100, ErrorRatePerSec: 0, ErrorPercent: 0,
+				AvgSeconds: 0.001, P95Seconds: 0.002,
+				TimeSharePercent: 20,
+				HasTraffic:       true, HasErrors: true, HasAvgLatency: true, HasLatencyP95: true,
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := codec.Encode(&buf, resp); err != nil {
+		t.Fatalf("Encode err = %v", err)
+	}
+	out := buf.String()
+	// Default columns: OPERATION, RATE, ERROR %, P95, TIME %
+	for _, want := range []string{"OPERATION", "RATE", "ERROR %", "P95", "TIME %", "POST /checkout", "GET /health", "10.000 req/s", "2.00%", "150.00ms", "80.00%"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n----\n%s", want, out)
+		}
+	}
+	// Default view does NOT include p50/p99.
+	for _, unwanted := range []string{"P50", "P99"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("default view unexpectedly contains %q\n----\n%s", unwanted, out)
+		}
+	}
+
+	// Wide view: P50, P99, ERRORS appear.
+	buf.Reset()
+	wide := &operationsTableCodec{Wide: true}
+	if err := wide.Encode(&buf, resp); err != nil {
+		t.Fatalf("Encode err = %v", err)
+	}
+	out = buf.String()
+	for _, want := range []string{"P50", "P99", "ERRORS", "60.00ms", "300.00ms", "0.200 req/s"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("wide output missing %q\n----\n%s", want, out)
+		}
+	}
+
+	// Empty items path: friendly message, no crash.
+	buf.Reset()
+	if err := codec.Encode(&buf, &OperationsResponse{Service: Service{Name: "auth"}}); err != nil {
+		t.Fatalf("Encode err = %v", err)
+	}
+	if !strings.Contains(buf.String(), "No operations found") {
+		t.Errorf("expected friendly empty message, got %q", buf.String())
+	}
+
+	// Wrong type rejected.
+	if err := codec.Encode(&buf, "not a response"); err == nil {
+		t.Error("expected error on wrong type")
+	}
+}

--- a/internal/providers/appo11y/services/query.go
+++ b/internal/providers/appo11y/services/query.go
@@ -396,14 +396,19 @@ const (
 	MetricsModeOTel MetricsMode = "otel"
 )
 
-// metricNames is the (calls, latencyBucket) pair selected by MetricsMode.
+// metricNames is the span-metric family selected by MetricsMode.
+// `latencyCount` and `latencySum` enable the average-latency query that
+// the operations command needs to compute time-share — they're emitted
+// alongside `latencyBucket` by every span-metrics generator.
 type metricNames struct {
 	calls         string
 	latencyBucket string
+	latencyCount  string
+	latencySum    string
 }
 
-// metricNamesByMode returns the (calls, latency-bucket) pair for the
-// requested MetricsMode:
+// metricNamesByMode returns the span-metric family for the requested
+// MetricsMode:
 //
 //	v3    → traces_span_metrics_* (modern OTel Collector / Tempo)
 //	tempo → traces_spanmetrics_*  (legacy Tempo metrics-generator, Beyla)
@@ -418,16 +423,22 @@ func metricNamesByMode(mode MetricsMode) (metricNames, bool) {
 		return metricNames{
 			calls:         "traces_span_metrics_calls_total",
 			latencyBucket: "traces_span_metrics_duration_seconds_bucket",
+			latencyCount:  "traces_span_metrics_duration_seconds_count",
+			latencySum:    "traces_span_metrics_duration_seconds_sum",
 		}, true
 	case MetricsModeTempo:
 		return metricNames{
 			calls:         "traces_spanmetrics_calls_total",
 			latencyBucket: "traces_spanmetrics_latency_bucket",
+			latencyCount:  "traces_spanmetrics_latency_count",
+			latencySum:    "traces_spanmetrics_latency_sum",
 		}, true
 	case MetricsModeOTel:
 		return metricNames{
 			calls:         "calls_total",
 			latencyBucket: "duration_seconds_bucket",
+			latencyCount:  "duration_seconds_count",
+			latencySum:    "duration_seconds_sum",
 		}, true
 	}
 	return metricNames{}, false
@@ -651,6 +662,81 @@ func buildLatencyQuantileQuery(names metricNames, namespace, name, window string
 	v := scopedSpanMetric(names.latencyBucket, namespace, name, kinds, window)
 	sumByLe := promql.Sum(promql.Rate(v)).By([]string{"le"})
 	expr, err := promql.HistogramQuantile(phi, sumByLe).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildOperationsRateQuery returns the per-operation request rate over
+// the given window: `sum by (span_name) (rate(<calls>[<window>]))`.
+// Shape parallels buildRateQuery but the aggregation is grouped by
+// span_name so the response can be pivoted into one row per operation.
+func buildOperationsRateQuery(names metricNames, namespace, name, window string, kinds []string) (string, error) {
+	if name == "" {
+		return "", errors.New("service name is required")
+	}
+	v := scopedSpanMetric(names.calls, namespace, name, kinds, window)
+	expr, err := promql.Sum(promql.Rate(v)).By([]string{"span_name"}).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildOperationsErrorRateQuery returns the per-operation error rate,
+// filtered to status_code=STATUS_CODE_ERROR. An operation with no errors
+// in the window produces no series — the caller treats that as 0.
+func buildOperationsErrorRateQuery(names metricNames, namespace, name, window string, kinds []string) (string, error) {
+	if name == "" {
+		return "", errors.New("service name is required")
+	}
+	v := scopedSpanMetric(names.calls, namespace, name, kinds, window).
+		Label("status_code", statusCodeError)
+	expr, err := promql.Sum(promql.Rate(v)).By([]string{"span_name"}).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildOperationsLatencyQuantileQuery returns
+// `histogram_quantile(phi, sum by (le, span_name) (rate(<bucket>[<window>])))`.
+// span_name is preserved through the histogram_quantile call so quantiles
+// stay per-operation.
+func buildOperationsLatencyQuantileQuery(names metricNames, namespace, name, window string, kinds []string, phi float64) (string, error) {
+	if name == "" {
+		return "", errors.New("service name is required")
+	}
+	if phi < 0 || phi > 1 {
+		return "", fmt.Errorf("phi must be in [0,1], got %v", phi)
+	}
+	v := scopedSpanMetric(names.latencyBucket, namespace, name, kinds, window)
+	sumByLeAndOp := promql.Sum(promql.Rate(v)).By([]string{"le", "span_name"})
+	expr, err := promql.HistogramQuantile(phi, sumByLeAndOp).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildOperationsAvgLatencyQuery returns the per-operation average
+// latency in seconds:
+//
+//	sum by (span_name) (rate(<sum>[<window>])) / sum by (span_name) (rate(<count>[<window>]))
+//
+// The average × rate gives wall-clock time spent per second, which is
+// what we sort the table by (time share). Native quantiles aren't a
+// substitute — the time-share signal needs the first moment.
+func buildOperationsAvgLatencyQuery(names metricNames, namespace, name, window string, kinds []string) (string, error) {
+	if name == "" {
+		return "", errors.New("service name is required")
+	}
+	sumV := scopedSpanMetric(names.latencySum, namespace, name, kinds, window)
+	countV := scopedSpanMetric(names.latencyCount, namespace, name, kinds, window)
+	num := promql.Sum(promql.Rate(sumV)).By([]string{"span_name"})
+	den := promql.Sum(promql.Rate(countV)).By([]string{"span_name"})
+	expr, err := promql.Div(num, den).Build()
 	if err != nil {
 		return "", err
 	}
@@ -912,6 +998,71 @@ func extractEdges(resp *prometheus.QueryResponse, peerName, peerNs string) map[e
 	return out
 }
 
+// Operation is one row in the operations table — a single span_name
+// inside a service, with its RED snapshot. AvgSeconds is the arithmetic
+// mean latency (sum / count), distinct from the quantile fields, and is
+// used to compute time-share. *Has* flags distinguish "0 measured" from
+// "no series in window" the same way REDStats does.
+type Operation struct {
+	Name             string  `json:"operation" yaml:"operation"`
+	RatePerSecond    float64 `json:"rate_per_second" yaml:"rate_per_second"`
+	ErrorRatePerSec  float64 `json:"error_rate_per_second" yaml:"error_rate_per_second"`
+	ErrorPercent     float64 `json:"error_percent" yaml:"error_percent"`
+	AvgSeconds       float64 `json:"avg_seconds" yaml:"avg_seconds"`
+	P50Seconds       float64 `json:"p50_seconds" yaml:"p50_seconds"`
+	P95Seconds       float64 `json:"p95_seconds" yaml:"p95_seconds"`
+	P99Seconds       float64 `json:"p99_seconds" yaml:"p99_seconds"`
+	TimeSharePercent float64 `json:"time_share_percent" yaml:"time_share_percent"`
+	HasTraffic       bool    `json:"has_traffic" yaml:"has_traffic"`
+	HasErrors        bool    `json:"has_errors" yaml:"has_errors"`
+	HasAvgLatency    bool    `json:"has_avg_latency" yaml:"has_avg_latency"`
+	HasLatencyP50    bool    `json:"has_latency_p50" yaml:"has_latency_p50"`
+	HasLatencyP95    bool    `json:"has_latency_p95" yaml:"has_latency_p95"`
+	HasLatencyP99    bool    `json:"has_latency_p99" yaml:"has_latency_p99"`
+}
+
+// OperationsResponse is the top-level shape for the operations command:
+// the service identity that was queried plus the per-operation rows.
+// Wrapping the slice keeps room for future metadata (page tokens, totals,
+// truncation flags) without changing the JSON contract.
+type OperationsResponse struct {
+	Service     Service     `json:"service" yaml:"service"`
+	Window      string      `json:"window" yaml:"window"`
+	MetricsMode MetricsMode `json:"metrics_mode" yaml:"metrics_mode"`
+	SpanKinds   string      `json:"span_kinds" yaml:"span_kinds"`
+	Items       []Operation `json:"items" yaml:"items"`
+}
+
+// extractBySpanName collapses a Prometheus instant response into a map
+// of span_name → scalar value. Samples with empty span_name or
+// unparseable values are dropped so callers can treat absence as
+// "no data".
+func extractBySpanName(resp *prometheus.QueryResponse) map[string]float64 {
+	out := make(map[string]float64)
+	if resp == nil {
+		return out
+	}
+	for _, sample := range resp.Data.Result {
+		op := sample.Metric["span_name"]
+		if op == "" {
+			continue
+		}
+		if len(sample.Value) < 2 {
+			continue
+		}
+		str, ok := sample.Value[1].(string)
+		if !ok {
+			continue
+		}
+		f, err := strconv.ParseFloat(str, 64)
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+			continue
+		}
+		out[op] = f
+	}
+	return out
+}
+
 // mergeEdges joins per-quantity maps (rate, errors, p95) into one row
 // per (peer, connection_type), then sorts by rate desc with a stable
 // (name, namespace) tiebreak. HasErrors is inferred when rate>0 — a
@@ -956,6 +1107,88 @@ func mergeEdges(rates, errors, p95s map[edgeKey]float64) []Edge {
 			return out[i].Peer.Name < out[j].Peer.Name
 		}
 		return out[i].ConnectionType < out[j].ConnectionType
+	})
+	return out
+}
+
+// mergeOperations joins per-quantity maps (rate, errors, avg, p50, p95,
+// p99) into one row per distinct span_name, then computes time-share
+// client-side. The time-share denominator is the sum of (avg × rate)
+// across all observed operations — i.e. the share of total wall-clock
+// time each operation consumes. Operations missing an avg-latency
+// signal contribute 0 to the denominator and a 0 share to the output.
+func mergeOperations(rates, errors, avgs, p50s, p95s, p99s map[string]float64) []Operation {
+	names := make(map[string]struct{})
+	for k := range rates {
+		names[k] = struct{}{}
+	}
+	for k := range errors {
+		names[k] = struct{}{}
+	}
+	for k := range avgs {
+		names[k] = struct{}{}
+	}
+	for k := range p50s {
+		names[k] = struct{}{}
+	}
+	for k := range p95s {
+		names[k] = struct{}{}
+	}
+	for k := range p99s {
+		names[k] = struct{}{}
+	}
+
+	out := make([]Operation, 0, len(names))
+	totalWall := 0.0
+	for n := range names {
+		rate, hasRate := rates[n]
+		errRate, hasErr := errors[n]
+		avg, hasAvg := avgs[n]
+		p50, hasP50 := p50s[n]
+		p95, hasP95 := p95s[n]
+		p99, hasP99 := p99s[n]
+
+		hasTraffic := hasRate && rate > 0
+		// Once we know there's traffic, missing error series ⇒ 0 errors,
+		// not "unknown" — same logic as REDStats.HasErrors in services get.
+		hasErrors := hasErr || hasTraffic
+		if hasAvg && hasTraffic {
+			totalWall += avg * rate
+		}
+		out = append(out, Operation{
+			Name:            n,
+			RatePerSecond:   rate,
+			ErrorRatePerSec: errRate,
+			ErrorPercent:    computeErrorPercent(errRate, rate),
+			AvgSeconds:      avg,
+			P50Seconds:      p50,
+			P95Seconds:      p95,
+			P99Seconds:      p99,
+			HasTraffic:      hasTraffic,
+			HasErrors:       hasErrors,
+			HasAvgLatency:   hasAvg,
+			HasLatencyP50:   hasP50,
+			HasLatencyP95:   hasP95,
+			HasLatencyP99:   hasP99,
+		})
+	}
+
+	if totalWall > 0 {
+		for i := range out {
+			if out[i].HasAvgLatency && out[i].HasTraffic {
+				out[i].TimeSharePercent = (out[i].AvgSeconds * out[i].RatePerSecond / totalWall) * 100
+			}
+		}
+	}
+
+	// Default order matches the plugin: time-share desc, then by name
+	// asc so equal-share rows (typically the zero-share tail) are
+	// reproducible across runs.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].TimeSharePercent != out[j].TimeSharePercent {
+			return out[i].TimeSharePercent > out[j].TimeSharePercent
+		}
+		return out[i].Name < out[j].Name
 	})
 	return out
 }


### PR DESCRIPTION
## Summary

- Adds \`gcx appo11y services operations <name>\` — pairs with \`services get\` to drill into a single service: one row per \`span_name\` with rate, error rate / percent, avg latency, p50/p95/p99, and a **time-share %** column (share of the service's total wall-clock time each operation consumes).
- Rows sorted by time-share desc, so low-rate-high-latency operations correctly outrank high-rate-fast ones for "where the time is spent" analysis. Concretely: 1 req/s × 2s outranks 100 req/s × 5ms in this view, even though the latter is 100× higher rate.
- \`--limit 15\` default (with the same truncation-hint pattern as \`services list\`), \`--limit 0\` for unlimited. The first stack I tested has services emitting 9,771 distinct \`span_name\` values — the default keeps output to a screenful.

## Example output

```
OPERATION                                       RATE         ERROR %  P95       TIME %
GET                                             4.084 req/s  0.00%    192.86ms  69.82%
POST                                            0.110 req/s  0.00%    6.962s    8.40%
POST /api/checkout                              0.022 req/s  0.00%    712.50ms  4.58%
POST /api/cart                                  0.088 req/s  0.00%    235.00ms  4.24%
GET /api/cart                                   0.082 req/s  0.00%    232.32ms  3.71%
GET /                                           0.083 req/s  0.00%    197.50ms  2.05%
...
```

\`-o wide\` adds P50, P99, and absolute ERRORS.

## What's shared with \`services get\`

- Bare-name resolution via \`target_info\` (ambiguity errors out the same way).
- Metrics-mode auto-detect + \`--metrics-mode {auto,v3,tempo,otel}\` override.
- \`--since\` (PromQL duration), \`--kind\`, \`--namespace\`, \`--datasource\`, \`-o\`.
- \`fail.NewCommandUsageError\` wrapping for option validation.
- Exit-code-1 on no-telemetry, snapshot still emitted so agents see the shape.

## What's new

- Extended the per-mode \`metricNames\` table with \`latencyCount\` and \`latencySum\` (needed for avg latency, which the time-share metric requires).
- Four per-operation PromQL builders: \`buildOperationsRateQuery\`, \`buildOperationsErrorRateQuery\`, \`buildOperationsLatencyQuantileQuery\`, \`buildOperationsAvgLatencyQuery\` — all \`by (span_name)\`.
- \`mergeOperations\` pivots six per-operation maps into one row per \`span_name\` and computes time-share in a single pass.
- New table codec with two column tiers (default / wide), backed by \`style.NewTable\` so it shares the same Neon-Dark styling as \`services list\`.

## Test plan

- [x] Unit tests cover all four query builders across all three metric families, the per-\`span_name\` extractor, \`mergeOperations\` (including time-share ranking, no-avg-latency edge case, zero-traffic edge case, error-percent + has-errors inference), opts validation, and codec rendering (default columns, wide columns, empty path, wrong-type rejection).
- [x] \`mise run lint\` clean.
- [x] \`GCX_AGENT_MODE=false go test ./...\` passes.
- [x] Reference docs regenerated.
- [x] Live verification against a Grafana Cloud stack:
  - default table for a high-traffic service returns sensible time-share ranking (high-rate \`GET\` dominates, but slow \`POST /api/checkout\` correctly appears above faster routes with similar rate).
  - \`-o wide\` adds the extra columns cleanly.
  - JSON shape: \`{service, window, metrics_mode, span_kinds, items[]}\`.
  - Ambiguous bare name errors out (\`flagd\` exists in two namespaces on the test stack).
  - \`--metrics-mode tempo\` override returns rate from the legacy series but \`has_avg=false\` / \`has_latency_*=false\` (same predicted mismatch as \`services get\`).
  - Nonexistent service exits 1.
  - \`--limit 0\` returns the full 9,771 ops for the high-cardinality frontend.

## Follow-ups

- \`services map <name>\` — service-graph slice (callers + callees), still on the original plan.
- The list papercuts Igor flagged (\`--namespace\` filter and "non-empty env" filter on \`services list\`).