### PR TITLE
feat(appo11y): add services map for the service-graph slice

### DIFF
--- a/docs/reference/cli/gcx_appo11y_services.md
+++ b/docs/reference/cli/gcx_appo11y_services.md
@@ -25,4 +25,5 @@ Inspect Application Observability services discovered from telemetry
 * [gcx appo11y](gcx_appo11y.md)	 - Manage Grafana App Observability settings
 * [gcx appo11y services get](gcx_appo11y_services_get.md)	 - Inspect a single Application Observability service: metadata + RED snapshot.
 * [gcx appo11y services list](gcx_appo11y_services_list.md)	 - List Application Observability services discovered from target_info/traces_target_info telemetry.
+* [gcx appo11y services map](gcx_appo11y_services_map.md)	 - Show a service's neighbourhood: who calls it (callers) and who it calls (callees).
 

--- a/docs/reference/cli/gcx_appo11y_services_map.md
+++ b/docs/reference/cli/gcx_appo11y_services_map.md
@@ -1,0 +1,80 @@
+## gcx appo11y services map
+
+Show a service's neighbourhood: who calls it (callers) and who it calls (callees).
+
+### Synopsis
+
+Render the service-graph slice for one service: a callers list (services
+calling into this one) and a callees list (services this one calls).
+
+Data comes from Tempo's service-graph metric family
+(traces_service_graph_request_*), which is consistent across every
+metrics-mode — so there's no --metrics-mode flag here.
+
+The argument is either the bare service name or the canonical
+"<namespace>/<name>" form; bare names are auto-resolved against
+target_info the same way "gcx appo11y services get" does.
+
+Latency is direction-aware: callers see the server-side p95
+(how long this service took to respond), callees see the client-side
+p95 (how long this service waited on the peer).
+
+Connection type is empty for HTTP/gRPC peers; "database",
+"messaging", or "virtual_node" for typed edges. Virtual-node peers
+are uninstrumented callers Tempo synthesises from orphan spans.
+
+Beyond --output table/wide/json/yaml, --output mermaid and
+--output dot render the map as a Mermaid or Graphviz graph,
+suitable for inlining in markdown / piping to "dot -Tpng".
+
+```
+gcx appo11y services map <service> [--namespace ns] [flags]
+```
+
+### Examples
+
+```
+
+  # Default two-section table
+  gcx appo11y services map checkoutservice
+
+  # Mermaid graph — paste into a markdown doc or a PR comment
+  gcx appo11y services map checkoutservice -o mermaid
+
+  # Graphviz DOT — pipe to dot for an image
+  gcx appo11y services map checkoutservice -o dot | dot -Tpng -o map.png
+
+  # Wide table with p95 / connection-type, last hour
+  gcx appo11y services map payments/checkoutservice --since 1h -o wide
+
+  # JSON for scripting
+  gcx appo11y services map checkoutservice -o json
+```
+
+### Options
+
+```
+  -d, --datasource string   Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
+  -h, --help                help for map
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -n, --namespace string    Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)
+  -o, --output string       Output format. One of: agents, dot, json, mermaid, table, wide, yaml (default "table")
+      --since string        Rate/quantile window applied to service-graph metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax (default "5m")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx appo11y services](gcx_appo11y_services.md)	 - Inspect Application Observability services discovered from telemetry
+

--- a/internal/providers/appo11y/services/commands.go
+++ b/internal/providers/appo11y/services/commands.go
@@ -30,6 +30,7 @@ func Commands() *cobra.Command {
 	}
 	cmd.AddCommand(newListCommand())
 	cmd.AddCommand(newGetCommand())
+	cmd.AddCommand(newMapCommand())
 	return cmd
 }
 

--- a/internal/providers/appo11y/services/map.go
+++ b/internal/providers/appo11y/services/map.go
@@ -1,0 +1,507 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/prometheus/common/model"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+)
+
+type mapOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	Since      string
+	Namespace  string
+}
+
+func (o *mapOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &serviceMapTableCodec{})
+	o.IO.RegisterCustomCodec("wide", &serviceMapTableCodec{Wide: true})
+	o.IO.RegisterCustomCodec("mermaid", &serviceMapMermaidCodec{})
+	o.IO.RegisterCustomCodec("dot", &serviceMapDOTCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+
+	flags.StringVarP(&o.Datasource, "datasource", "d", "", "Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)")
+	flags.StringVarP(&o.Namespace, "namespace", "n", "", "Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)")
+	flags.StringVar(&o.Since, "since", defaultRedWindow, "Rate/quantile window applied to service-graph metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax")
+}
+
+func (o *mapOpts) Validate(cmd *cobra.Command) error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(o.Since) == "" {
+		return fail.NewCommandUsageError(cmd, "--since must not be empty", nil)
+	}
+	if _, err := model.ParseDuration(o.Since); err != nil {
+		return fail.NewCommandUsageError(cmd, fmt.Sprintf("--since %q is not a valid PromQL duration", o.Since), err)
+	}
+	return nil
+}
+
+func newMapCommand() *cobra.Command {
+	opts := &mapOpts{}
+	cmd := &cobra.Command{
+		Use:   "map <service> [--namespace ns]",
+		Short: "Show a service's neighbourhood: who calls it (callers) and who it calls (callees).",
+		Long: `Render the service-graph slice for one service: a callers list (services
+calling into this one) and a callees list (services this one calls).
+
+Data comes from Tempo's service-graph metric family
+(traces_service_graph_request_*), which is consistent across every
+metrics-mode — so there's no --metrics-mode flag here.
+
+The argument is either the bare service name or the canonical
+"<namespace>/<name>" form; bare names are auto-resolved against
+target_info the same way "gcx appo11y services get" does.
+
+Latency is direction-aware: callers see the server-side p95
+(how long this service took to respond), callees see the client-side
+p95 (how long this service waited on the peer).
+
+Connection type is empty for HTTP/gRPC peers; "database",
+"messaging", or "virtual_node" for typed edges. Virtual-node peers
+are uninstrumented callers Tempo synthesises from orphan spans.
+
+Beyond --output table/wide/json/yaml, --output mermaid and
+--output dot render the map as a Mermaid or Graphviz graph,
+suitable for inlining in markdown / piping to "dot -Tpng".`,
+		Example: `
+  # Default two-section table
+  gcx appo11y services map checkoutservice
+
+  # Mermaid graph — paste into a markdown doc or a PR comment
+  gcx appo11y services map checkoutservice -o mermaid
+
+  # Graphviz DOT — pipe to dot for an image
+  gcx appo11y services map checkoutservice -o dot | dot -Tpng -o map.png
+
+  # Wide table with p95 / connection-type, last hour
+  gcx appo11y services map payments/checkoutservice --since 1h -o wide
+
+  # JSON for scripting
+  gcx appo11y services map checkoutservice -o json`,
+		Args: cobra.ExactArgs(1),
+		RunE: runMap(opts),
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "small",
+			agent.AnnotationLLMHint:   `Service-graph slice for one App Observability service: callers (peers calling into the service) and callees (peers the service calls), with per-edge rate (req/s), error %, and direction-aware p95 latency (server-side for callers, client-side for callees). Connection-type label distinguishes HTTP/gRPC (empty), database, messaging, and virtual_node (uninstrumented upstreams synthesised by Tempo). Output formats: table/wide (default two-section view), json/yaml (structured), mermaid (markdown-renderable graph), dot (Graphviz). Pairs with 'gcx appo11y services get' (single-service RED) and 'gcx appo11y services operations' (per-endpoint breakdown). Examples: gcx appo11y services map <name> -o json; gcx appo11y services map <ns>/<name> --since 1h -o mermaid`,
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func runMap(opts *mapOpts) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := opts.Validate(cmd); err != nil {
+			return err
+		}
+		namespace, name, err := parseServiceArg(args[0], opts.Namespace)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+
+		ctx := cmd.Context()
+		var loader providers.ConfigLoader
+
+		cfg, err := loader.LoadGrafanaConfig(ctx)
+		if err != nil {
+			return err
+		}
+
+		var cfgCtx *internalconfig.Context
+		if fullCfg, err := loader.LoadFullConfig(ctx); err != nil {
+			logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+		} else {
+			cfgCtx = fullCfg.GetCurrentContext()
+		}
+
+		datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, &loader, opts.Datasource, cfgCtx, cfg, "prometheus")
+		if err != nil {
+			return err
+		}
+
+		client, err := prometheus.NewClient(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create prometheus client: %w", err)
+		}
+
+		// Bare-name resolution: same UX as `services get` and `services operations`.
+		if namespace == "" {
+			resolved, err := resolveNamespaceForBareName(ctx, client, datasourceUID, name)
+			if err != nil {
+				return err
+			}
+			namespace = resolved
+		}
+
+		result, err := fetchServiceMap(ctx, client, datasourceUID, namespace, name, opts.Since)
+		if err != nil {
+			return err
+		}
+
+		notFound := len(result.Callers) == 0 && len(result.Callees) == 0
+		if notFound {
+			emitNoDataHint(cmd.ErrOrStderr(), namespace, name)
+		}
+		if err := opts.IO.Encode(cmd.OutOrStdout(), result); err != nil {
+			return err
+		}
+		if notFound {
+			return fmt.Errorf("service %q has no service-graph edges in the requested window", jobLabel(namespace, name))
+		}
+		return nil
+	}
+}
+
+// fetchServiceMap runs both direction × {rate, errors, p95} = 6 queries
+// in parallel and folds them into a ServiceMap. Each direction's edges
+// are independently parsed and merged, then sorted by rate desc.
+func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string) (*ServiceMap, error) {
+	type edgeQuerySet struct {
+		rate, errors, p95 *prometheus.QueryResponse
+	}
+	var callerSet, calleeSet edgeQuerySet
+
+	directions := []struct {
+		dir mapDirection
+		set *edgeQuerySet
+	}{
+		{callersDirection, &callerSet},
+		{calleesDirection, &calleeSet},
+	}
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	for _, d := range directions {
+		eg.Go(func() error {
+			expr, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, d.dir, namespace, name, window)
+			if err != nil {
+				return fmt.Errorf("failed to build %s rate query: %w", directionLabel(d.dir), err)
+			}
+			resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+			if err != nil {
+				return fmt.Errorf("%s rate query failed: %w", directionLabel(d.dir), err)
+			}
+			d.set.rate = resp
+			return nil
+		})
+		eg.Go(func() error {
+			expr, err := buildServiceMapEdgeQuery(serviceGraphRequestFailedTotalMetric, d.dir, namespace, name, window)
+			if err != nil {
+				return fmt.Errorf("failed to build %s error-rate query: %w", directionLabel(d.dir), err)
+			}
+			resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+			if err != nil {
+				return fmt.Errorf("%s error-rate query failed: %w", directionLabel(d.dir), err)
+			}
+			d.set.errors = resp
+			return nil
+		})
+		eg.Go(func() error {
+			expr, err := buildServiceMapLatencyQuery(d.dir, namespace, name, window, 0.95)
+			if err != nil {
+				return fmt.Errorf("failed to build %s p95 latency query: %w", directionLabel(d.dir), err)
+			}
+			resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+			if err != nil {
+				return fmt.Errorf("%s p95 latency query failed: %w", directionLabel(d.dir), err)
+			}
+			d.set.p95 = resp
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	parseEdges := func(set edgeQuerySet, dir mapDirection) []Edge {
+		peerName, peerNs := dir.peerLabels()
+		return mergeEdges(
+			extractEdges(set.rate, peerName, peerNs),
+			extractEdges(set.errors, peerName, peerNs),
+			extractEdges(set.p95, peerName, peerNs),
+		)
+	}
+
+	return &ServiceMap{
+		Service: Service{Name: name, Namespace: namespace},
+		Window:  window,
+		Callers: parseEdges(callerSet, callersDirection),
+		Callees: parseEdges(calleeSet, calleesDirection),
+	}, nil
+}
+
+func directionLabel(d mapDirection) string {
+	if d == callersDirection {
+		return "callers"
+	}
+	return "callees"
+}
+
+// formatPeer renders a peer for table / graph output. Virtual nodes
+// have no real namespace, so collapse "virtual:peer" to just "peer";
+// otherwise show "name (namespace)" when namespace is non-empty.
+func formatPeer(e Edge) string {
+	if e.Peer.Namespace == "" {
+		return e.Peer.Name
+	}
+	return fmt.Sprintf("%s (%s)", e.Peer.Name, e.Peer.Namespace)
+}
+
+func orDashConnType(t string) string {
+	if t == "" {
+		return "-"
+	}
+	return t
+}
+
+// serviceMapTableCodec renders a two-section table: callers above,
+// callees below, separated by a blank line. Default columns:
+// PEER, RATE, ERROR %, P95, TYPE. --output wide is identical for now
+// (kept for codec symmetry with other commands).
+type serviceMapTableCodec struct {
+	Wide bool
+}
+
+func (c *serviceMapTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *serviceMapTableCodec) Decode(io.Reader, any) error {
+	return errors.New("services map table codec does not support decoding")
+}
+
+func (c *serviceMapTableCodec) Encode(w io.Writer, v any) error {
+	resp, ok := v.(*ServiceMap)
+	if !ok {
+		return fmt.Errorf("invalid data type for services map table codec: %T", v)
+	}
+	if err := c.encodeSection(w, "CALLERS", resp.Callers); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	return c.encodeSection(w, "CALLEES", resp.Callees)
+}
+
+func (c *serviceMapTableCodec) encodeSection(w io.Writer, label string, edges []Edge) error {
+	if len(edges) == 0 {
+		_, err := fmt.Fprintf(w, "%s: (none)\n", label)
+		return err
+	}
+	headers := []string{label, "RATE", "ERROR %", "P95", "TYPE"}
+	t := style.NewTable(headers...)
+	for _, e := range edges {
+		t.Row(
+			formatPeer(e),
+			formatRateWithUnit(e.RatePerSecond, e.RatePerSecond > 0),
+			formatPercentMaybe(e.ErrorPercent, e.RatePerSecond > 0),
+			formatDuration(e.P95Seconds, e.HasLatency),
+			orDashConnType(e.ConnectionType),
+		)
+	}
+	return t.Render(w)
+}
+
+// mermaidNodeID sanitises a peer identity into a Mermaid-safe node ID.
+// Mermaid IDs must be alphanumeric plus underscores; everything else
+// is folded into underscores. Namespace is folded in to keep IDs
+// unique across same-name peers from different namespaces. The node
+// label remains human-readable via the [text] / ((text)) etc. forms
+// emitted by mermaidNode.
+func mermaidNodeID(name, namespace string) string {
+	combined := name
+	if namespace != "" {
+		combined = namespace + "_" + name
+	}
+	var b strings.Builder
+	for _, r := range combined {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "node"
+	}
+	return out
+}
+
+// mermaidNode renders a node declaration with the right shape per
+// connection type:
+//
+//	default                  → rectangle  ["label"]
+//	database peer            → cylinder   [("label")]
+//	messaging_system peer    → queue      [/"label"\]
+//	virtual_node             → rounded    ("label")
+//
+// The center node (the queried service) uses a hex-shape {{label}} so
+// it stands out from the peers. connection_type label values come from
+// Tempo's service-graph processor — see the connType constants below.
+func mermaidNode(id, label, connType string, center bool) string {
+	escaped := strings.ReplaceAll(label, `"`, `&quot;`)
+	if center {
+		return fmt.Sprintf("%s{{%q}}", id, escaped)
+	}
+	switch connType {
+	case connTypeDatabase:
+		return fmt.Sprintf("%s[(%q)]", id, escaped)
+	case connTypeMessagingSystem:
+		return fmt.Sprintf("%s[/%q\\]", id, escaped)
+	case connTypeVirtualNode:
+		return fmt.Sprintf("%s(%q)", id, escaped)
+	default:
+		return fmt.Sprintf("%s[%q]", id, escaped)
+	}
+}
+
+// connType* are the literal `connection_type` label values Tempo's
+// service-graph processor emits. Empty means HTTP/gRPC (no special
+// classification). Centralising the constants keeps the table and
+// graph codecs in sync.
+const (
+	connTypeDatabase        = "database"
+	connTypeMessagingSystem = "messaging_system"
+	connTypeVirtualNode     = "virtual_node"
+)
+
+// serviceMapMermaidCodec emits a Mermaid `graph LR` block — renders
+// inline in GitHub, Slack, Claude, and any markdown viewer.
+type serviceMapMermaidCodec struct{}
+
+func (c *serviceMapMermaidCodec) Format() format.Format { return "mermaid" }
+func (c *serviceMapMermaidCodec) Decode(io.Reader, any) error {
+	return errors.New("services map mermaid codec does not support decoding")
+}
+
+func (c *serviceMapMermaidCodec) Encode(w io.Writer, v any) error {
+	resp, ok := v.(*ServiceMap)
+	if !ok {
+		return fmt.Errorf("invalid data type for services map mermaid codec: %T", v)
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
+	fmt.Fprintln(tw, "graph LR")
+	centerID := mermaidNodeID(resp.Service.Name, resp.Service.Namespace)
+	centerLabel := resp.Service.Name
+	if resp.Service.Namespace != "" {
+		centerLabel = resp.Service.Namespace + "/" + resp.Service.Name
+	}
+	fmt.Fprintf(tw, "  %s\n", mermaidNode(centerID, centerLabel, "", true))
+
+	emitEdges := func(edges []Edge, into bool) {
+		for _, e := range edges {
+			peerID := mermaidNodeID(e.Peer.Name, e.Peer.Namespace)
+			fmt.Fprintf(tw, "  %s\n", mermaidNode(peerID, formatPeer(e), e.ConnectionType, false))
+			label := formatMermaidEdgeLabel(e)
+			if into {
+				fmt.Fprintf(tw, "  %s -->|%s| %s\n", peerID, label, centerID)
+			} else {
+				fmt.Fprintf(tw, "  %s -->|%s| %s\n", centerID, label, peerID)
+			}
+		}
+	}
+	emitEdges(resp.Callers, true)
+	emitEdges(resp.Callees, false)
+	return tw.Flush()
+}
+
+func formatMermaidEdgeLabel(e Edge) string {
+	rate := formatRateWithUnit(e.RatePerSecond, e.RatePerSecond > 0)
+	// Mermaid edge labels can't contain pipes or backticks; rate
+	// strings don't use either, but keep the helper defensively.
+	rate = strings.ReplaceAll(rate, "|", "/")
+	return rate
+}
+
+// serviceMapDOTCodec emits a Graphviz `digraph` block. Same node-shape
+// vocabulary as Mermaid (cylinder/queue/rounded/box). Pipe to
+// `dot -Tpng` or `dot -Tsvg` for a rendered image.
+type serviceMapDOTCodec struct{}
+
+func (c *serviceMapDOTCodec) Format() format.Format { return "dot" }
+func (c *serviceMapDOTCodec) Decode(io.Reader, any) error {
+	return errors.New("services map dot codec does not support decoding")
+}
+
+func (c *serviceMapDOTCodec) Encode(w io.Writer, v any) error {
+	resp, ok := v.(*ServiceMap)
+	if !ok {
+		return fmt.Errorf("invalid data type for services map dot codec: %T", v)
+	}
+	fmt.Fprintln(w, "digraph G {")
+	fmt.Fprintln(w, "  rankdir=LR;")
+
+	centerLabel := resp.Service.Name
+	if resp.Service.Namespace != "" {
+		centerLabel = resp.Service.Namespace + "/" + resp.Service.Name
+	}
+	fmt.Fprintf(w, "  %q [shape=box, style=\"filled,bold\", fillcolor=lightblue];\n", centerLabel)
+
+	emit := func(edges []Edge, into bool) {
+		for _, e := range edges {
+			peerLabel := formatPeer(e)
+			fmt.Fprintf(w, "  %q [%s];\n", peerLabel, dotPeerAttrs(e.ConnectionType))
+			edgeLabel := formatRateWithUnit(e.RatePerSecond, e.RatePerSecond > 0)
+			if into {
+				fmt.Fprintf(w, "  %q -> %q [label=%q];\n", peerLabel, centerLabel, edgeLabel)
+			} else {
+				fmt.Fprintf(w, "  %q -> %q [label=%q];\n", centerLabel, peerLabel, edgeLabel)
+			}
+		}
+	}
+	emit(resp.Callers, true)
+	emit(resp.Callees, false)
+	fmt.Fprintln(w, "}")
+	return nil
+}
+
+// formatPercentMaybe mirrors the helper of the same name on the
+// services-operations branch (where it lives in operations.go). When
+// both land on main the duplicate will collapse; until then the local
+// copy keeps this branch self-contained.
+func formatPercentMaybe(v float64, has bool) string {
+	if !has {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f%%", v)
+}
+
+func dotPeerAttrs(connType string) string {
+	switch connType {
+	case connTypeDatabase:
+		return `shape=cylinder, style=filled, fillcolor="#fef3c7"`
+	case connTypeMessagingSystem:
+		return `shape=parallelogram, style=filled, fillcolor="#fde68a"`
+	case connTypeVirtualNode:
+		return `shape=ellipse, style="filled,dashed", fillcolor="#e5e7eb"`
+	default:
+		return `shape=box`
+	}
+}

--- a/internal/providers/appo11y/services/map_test.go
+++ b/internal/providers/appo11y/services/map_test.go
@@ -1,0 +1,306 @@
+package services //nolint:testpackage // Tests cover unexported builders, merge logic, and codecs.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/spf13/cobra"
+)
+
+func TestBuildServiceMapEdgeQuery_Callers(t *testing.T) {
+	got, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "billing", "checkout", "5m")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	// Callers: X is the server; group by the client side + connection_type.
+	want := `sum by (client, client_service_namespace, connection_type) (rate(traces_service_graph_request_total{server="checkout",server_service_namespace="billing"}[5m]))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildServiceMapEdgeQuery_Callees(t *testing.T) {
+	got, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, calleesDirection, "billing", "checkout", "5m")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	// Callees: X is the client; group by the server side + connection_type.
+	want := `sum by (server, server_service_namespace, connection_type) (rate(traces_service_graph_request_total{client="checkout",client_service_namespace="billing"}[5m]))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildServiceMapEdgeQuery_BareName(t *testing.T) {
+	got, err := buildServiceMapEdgeQuery(serviceGraphRequestFailedTotalMetric, callersDirection, "", "auth", "1m")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `sum by (client, client_service_namespace, connection_type) (rate(traces_service_graph_request_failed_total{server="auth"}[1m]))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+
+	if _, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "", "", "5m"); err == nil {
+		t.Error("expected error for empty service name")
+	}
+	if _, err := buildServiceMapEdgeQuery("", callersDirection, "", "auth", "5m"); err == nil {
+		t.Error("expected error for empty metric")
+	}
+}
+
+func TestBuildServiceMapLatencyQuery_DirectionPicksHistogram(t *testing.T) {
+	// Callers should query the server_seconds bucket (how long X took to respond).
+	got, err := buildServiceMapLatencyQuery(callersDirection, "billing", "checkout", "5m", 0.95)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `histogram_quantile(0.95, sum by (le, client, client_service_namespace, connection_type) (rate(traces_service_graph_request_server_seconds_bucket{server="checkout",server_service_namespace="billing"}[5m])))`
+	if got != want {
+		t.Errorf("callers latency query wrong\ngot %q\nwant %q", got, want)
+	}
+
+	// Callees should query the client_seconds bucket (how long X waited on the peer).
+	got, err = buildServiceMapLatencyQuery(calleesDirection, "billing", "checkout", "5m", 0.95)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want = `histogram_quantile(0.95, sum by (le, server, server_service_namespace, connection_type) (rate(traces_service_graph_request_client_seconds_bucket{client="checkout",client_service_namespace="billing"}[5m])))`
+	if got != want {
+		t.Errorf("callees latency query wrong\ngot %q\nwant %q", got, want)
+	}
+
+	if _, err := buildServiceMapLatencyQuery(callersDirection, "", "x", "5m", 1.5); err == nil {
+		t.Error("expected error for phi out of range")
+	}
+}
+
+func TestExtractEdges(t *testing.T) {
+	// Two peers, one with namespace + connection_type, one bare. Empty
+	// peer name dropped; NaN value dropped; short value array dropped.
+	resp := &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
+		{Metric: map[string]string{"client": "frontend", "client_service_namespace": "oteldemo01", "connection_type": ""}, Value: []any{1.0, "0.5"}},
+		{Metric: map[string]string{"client": "postgres", "connection_type": "database"}, Value: []any{1.0, "0.044"}},
+		{Metric: map[string]string{"client": "", "connection_type": ""}, Value: []any{1.0, "9.0"}},                 // dropped
+		{Metric: map[string]string{"client": "user", "connection_type": "virtual_node"}, Value: []any{1.0, "NaN"}}, // dropped
+		{Metric: map[string]string{"client": "noop"}, Value: []any{1.0}},                                           // dropped (short)
+	}}}
+	got := extractEdges(resp, "client", "client_service_namespace")
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %v", len(got), got)
+	}
+	if got[edgeKey{name: "frontend", namespace: "oteldemo01", connType: ""}] != 0.5 {
+		t.Errorf("frontend value wrong: %v", got)
+	}
+	if got[edgeKey{name: "postgres", namespace: "", connType: "database"}] != 0.044 {
+		t.Errorf("postgres value wrong: %v", got)
+	}
+
+	if got := extractEdges(nil, "client", "client_service_namespace"); len(got) != 0 {
+		t.Errorf("nil response should produce empty map, got %v", got)
+	}
+}
+
+func TestMergeEdges(t *testing.T) {
+	rates := map[edgeKey]float64{
+		{name: "A", namespace: "ns"}:             1.0,
+		{name: "B", namespace: "ns"}:             5.0,
+		{name: "postgres", connType: "database"}: 0.5,
+	}
+	errors := map[edgeKey]float64{
+		{name: "A", namespace: "ns"}: 0.1, // 10% error
+	}
+	p95s := map[edgeKey]float64{
+		{name: "B", namespace: "ns"}: 0.020,
+	}
+	got := mergeEdges(rates, errors, p95s)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	// Sorted by rate desc: B (5) > A (1) > postgres (0.5).
+	if got[0].Peer.Name != "B" || got[1].Peer.Name != "A" || got[2].Peer.Name != "postgres" {
+		t.Errorf("unexpected order: %v %v %v", got[0].Peer.Name, got[1].Peer.Name, got[2].Peer.Name)
+	}
+
+	byName := map[string]Edge{}
+	for _, e := range got {
+		byName[e.Peer.Name] = e
+	}
+	// A: has errors observed → 10%.
+	if a := byName["A"]; a.ErrorPercent != 10 || !a.HasErrors {
+		t.Errorf("A wrong: %+v", a)
+	}
+	// B: has traffic but no error series → HasErrors should still be true (healthy 0%).
+	if b := byName["B"]; b.ErrorPercent != 0 || !b.HasErrors {
+		t.Errorf("B wrong: %+v", b)
+	}
+	// postgres: connType preserved; no latency observed.
+	if pg := byName["postgres"]; pg.ConnectionType != "database" || pg.HasLatency {
+		t.Errorf("postgres wrong: %+v", pg)
+	}
+}
+
+func TestMergeEdges_Empty(t *testing.T) {
+	if got := mergeEdges(nil, nil, nil); len(got) != 0 {
+		t.Errorf("expected empty slice, got %v", got)
+	}
+}
+
+func TestMapOptsValidate(t *testing.T) {
+	mk := func(o mapOpts) mapOpts {
+		o.IO.OutputFormat = "json"
+		if o.Since == "" {
+			o.Since = defaultRedWindow
+		}
+		return o
+	}
+	tests := []struct {
+		name    string
+		opts    mapOpts
+		wantErr bool
+	}{
+		{name: "defaults ok", opts: mk(mapOpts{})},
+		{name: "PromQL day", opts: mk(mapOpts{Since: "1d"})},
+		{name: "bad since", opts: mk(mapOpts{Since: "not-a-duration"}), wantErr: true},
+		{name: "empty since", opts: mk(mapOpts{Since: "  "}), wantErr: true},
+	}
+	cmd := &cobra.Command{Use: "map"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.opts.Validate(cmd); (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestServiceMapTableCodec(t *testing.T) {
+	codec := &serviceMapTableCodec{}
+	resp := &ServiceMap{
+		Service: Service{Name: "checkout", Namespace: "billing"},
+		Window:  "5m",
+		Callers: []Edge{
+			{Peer: Service{Name: "frontend", Namespace: "billing"}, RatePerSecond: 0.5, ErrorPercent: 0, P95Seconds: 0.072, HasErrors: true, HasLatency: true},
+		},
+		Callees: []Edge{
+			{Peer: Service{Name: "cartservice", Namespace: "billing"}, RatePerSecond: 0.044, ErrorPercent: 0, P95Seconds: 0.025, HasErrors: true, HasLatency: true},
+			{Peer: Service{Name: "postgres"}, ConnectionType: "database", RatePerSecond: 0.044, HasErrors: true},
+		},
+	}
+	var buf bytes.Buffer
+	if err := codec.Encode(&buf, resp); err != nil {
+		t.Fatalf("Encode err = %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"CALLERS", "CALLEES", "frontend (billing)", "cartservice (billing)", "postgres", "0.500 req/s", "0.044 req/s", "database", "72.00ms"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n----\n%s", want, out)
+		}
+	}
+
+	// Empty section renders "(none)" instead of an empty table.
+	buf.Reset()
+	if err := codec.Encode(&buf, &ServiceMap{Service: Service{Name: "lonely"}}); err != nil {
+		t.Fatalf("Encode err = %v", err)
+	}
+	if out := buf.String(); !strings.Contains(out, "CALLERS: (none)") || !strings.Contains(out, "CALLEES: (none)") {
+		t.Errorf("expected `(none)` placeholders, got:\n%s", out)
+	}
+
+	if err := codec.Encode(&buf, "not a response"); err == nil {
+		t.Error("expected error on wrong type")
+	}
+}
+
+func TestServiceMapMermaidCodec(t *testing.T) {
+	codec := &serviceMapMermaidCodec{}
+	resp := &ServiceMap{
+		Service: Service{Name: "checkout", Namespace: "billing"},
+		Window:  "5m",
+		Callers: []Edge{
+			{Peer: Service{Name: "frontend", Namespace: "billing"}, RatePerSecond: 0.5},
+		},
+		Callees: []Edge{
+			{Peer: Service{Name: "postgres"}, ConnectionType: connTypeDatabase, RatePerSecond: 0.044},
+			{Peer: Service{Name: "kafka"}, ConnectionType: connTypeMessagingSystem, RatePerSecond: 0.022},
+			{Peer: Service{Name: "user"}, ConnectionType: connTypeVirtualNode, RatePerSecond: 0.01},
+		},
+	}
+	var buf bytes.Buffer
+	if err := codec.Encode(&buf, resp); err != nil {
+		t.Fatalf("Encode err = %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"graph LR",
+		`{{"billing/checkout"}}`, // center hex-shape
+		`["frontend (billing)"]`, // regular peer rectangle
+		`[("postgres")]`,         // database cylinder
+		`[/"kafka"\]`,            // messaging_system queue
+		`("user")`,               // virtual_node rounded
+		"-->|0.500 req/s|",       // edge label
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("mermaid output missing %q\n----\n%s", want, out)
+		}
+	}
+}
+
+func TestMermaidNodeID(t *testing.T) {
+	tests := []struct{ name, ns, want string }{
+		{name: "checkout", ns: "billing", want: "billing_checkout"},
+		{name: "checkout-service", ns: "billing.prod", want: "billing_prod_checkout_service"}, // dots/hyphens folded
+		{name: "auth", ns: "", want: "auth"},
+		{name: "", ns: "", want: "node"}, // fallback so we never emit an empty ID
+	}
+	for _, tt := range tests {
+		if got := mermaidNodeID(tt.name, tt.ns); got != tt.want {
+			t.Errorf("mermaidNodeID(%q, %q) = %q, want %q", tt.name, tt.ns, got, tt.want)
+		}
+	}
+}
+
+func TestServiceMapDOTCodec(t *testing.T) {
+	codec := &serviceMapDOTCodec{}
+	resp := &ServiceMap{
+		Service: Service{Name: "checkout", Namespace: "billing"},
+		Callers: []Edge{
+			{Peer: Service{Name: "frontend", Namespace: "billing"}, RatePerSecond: 0.5},
+		},
+		Callees: []Edge{
+			{Peer: Service{Name: "postgres"}, ConnectionType: connTypeDatabase, RatePerSecond: 0.044},
+			{Peer: Service{Name: "kafka"}, ConnectionType: connTypeMessagingSystem, RatePerSecond: 0.02},
+		},
+	}
+	var buf bytes.Buffer
+	if err := codec.Encode(&buf, resp); err != nil {
+		t.Fatalf("Encode err = %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"digraph G {",
+		"rankdir=LR",
+		`"billing/checkout"`,  // center node
+		"fillcolor=lightblue", // center styling
+		`"frontend (billing)" -> "billing/checkout"`, // caller edge
+		`"billing/checkout" -> "postgres"`,           // callee edge
+		"shape=cylinder",                             // database shape
+		"shape=parallelogram",                        // messaging_system shape
+		`label="0.500 req/s"`,                        // rate label
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dot output missing %q\n----\n%s", want, out)
+		}
+	}
+}
+
+func TestDirectionLatencyBucketMetric(t *testing.T) {
+	if callersDirection.latencyBucketMetric() != serviceGraphRequestServerBucketMetric {
+		t.Errorf("callers should use server_seconds_bucket")
+	}
+	if calleesDirection.latencyBucketMetric() != serviceGraphRequestClientBucketMetric {
+		t.Errorf("callees should use client_seconds_bucket")
+	}
+}

--- a/internal/providers/appo11y/services/query.go
+++ b/internal/providers/appo11y/services/query.go
@@ -728,6 +728,238 @@ type ServiceDetail struct {
 	RED     REDStats `json:"red" yaml:"red"`
 }
 
+// Service-graph metric names. These are emitted by Tempo's
+// metrics-generator and are consistent across all metrics-modes —
+// unlike the spanmetrics family, only the histogram bucket may vary
+// (we use the seconds-prefixed variant, which is the modern emission).
+const (
+	serviceGraphRequestTotalMetric        = "traces_service_graph_request_total"
+	serviceGraphRequestFailedTotalMetric  = "traces_service_graph_request_failed_total"
+	serviceGraphRequestServerBucketMetric = "traces_service_graph_request_server_seconds_bucket"
+	serviceGraphRequestClientBucketMetric = "traces_service_graph_request_client_seconds_bucket"
+)
+
+// mapDirection picks which side of the edge the queried service sits on.
+// callersDirection: X is the `server`, peers are `client`/`client_service_namespace`.
+// calleesDirection: X is the `client`, peers are `server`/`server_service_namespace`.
+// The direction also picks which latency histogram is meaningful —
+// callers see X's response time (server_seconds), callees see how long
+// X waited on the peer (client_seconds).
+type mapDirection int
+
+const (
+	callersDirection mapDirection = iota
+	calleesDirection
+)
+
+// peerLabels returns the (name, namespace) label pair to group by for
+// this direction. Always returned in (nameLabel, namespaceLabel) order.
+func (d mapDirection) peerLabels() (string, string) {
+	if d == callersDirection {
+		return "client", "client_service_namespace"
+	}
+	return "server", "server_service_namespace"
+}
+
+// selfLabels returns the (name, namespace) labels that filter the
+// queried service down. These are always the *opposite* of peerLabels:
+// for callers we filter by server="X" (we want edges *into* X), for
+// callees by client="X" (edges *out of* X).
+func (d mapDirection) selfLabels() (string, string) {
+	if d == callersDirection {
+		return "server", "server_service_namespace"
+	}
+	return "client", "client_service_namespace"
+}
+
+// latencyBucketMetric picks the histogram that matches the latency
+// the queried service is responsible for or waiting on. For inbound
+// callers we want server-side (how long X took to respond); for
+// outbound callees we want client-side (how long X waited).
+func (d mapDirection) latencyBucketMetric() string {
+	if d == callersDirection {
+		return serviceGraphRequestServerBucketMetric
+	}
+	return serviceGraphRequestClientBucketMetric
+}
+
+// buildServiceMapEdgeQuery returns a `sum by (peer_name, peer_namespace,
+// connection_type) (rate(metric{self_labels}[window]))` expression that
+// aggregates a service-graph counter to one row per peer per
+// connection-type. metric is one of the service-graph counter metrics
+// (request_total, request_failed_total).
+func buildServiceMapEdgeQuery(metric string, dir mapDirection, namespace, name, window string) (string, error) {
+	if name == "" {
+		return "", errors.New("service name is required")
+	}
+	if metric == "" {
+		return "", errors.New("metric name is required")
+	}
+	selfName, selfNs := dir.selfLabels()
+	peerName, peerNs := dir.peerLabels()
+
+	v := promql.Vector(metric).Label(selfName, escapePromqlValue(name))
+	if namespace != "" {
+		v = v.Label(selfNs, escapePromqlValue(namespace))
+	}
+	v = v.Range(window)
+
+	expr, err := promql.Sum(promql.Rate(v)).
+		By([]string{peerName, peerNs, "connection_type"}).
+		Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildServiceMapLatencyQuery returns
+//
+//	histogram_quantile(phi, sum by (le, peer_name, peer_namespace, connection_type) (rate(<bucket>[window])))
+//
+// with the bucket metric picked by `dir.latencyBucketMetric()`.
+func buildServiceMapLatencyQuery(dir mapDirection, namespace, name, window string, phi float64) (string, error) {
+	if name == "" {
+		return "", errors.New("service name is required")
+	}
+	if phi < 0 || phi > 1 {
+		return "", fmt.Errorf("phi must be in [0,1], got %v", phi)
+	}
+	selfName, selfNs := dir.selfLabels()
+	peerName, peerNs := dir.peerLabels()
+
+	v := promql.Vector(dir.latencyBucketMetric()).Label(selfName, escapePromqlValue(name))
+	if namespace != "" {
+		v = v.Label(selfNs, escapePromqlValue(namespace))
+	}
+	v = v.Range(window)
+
+	sumByLe := promql.Sum(promql.Rate(v)).By([]string{"le", peerName, peerNs, "connection_type"})
+	expr, err := promql.HistogramQuantile(phi, sumByLe).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// Edge is one row in the callers or callees list — a peer of the
+// queried service plus the rate/error/latency observed for that edge.
+// Connection type is empty for HTTP/gRPC peers; `database` / `messaging`
+// / `virtual_node` for typed edges.
+type Edge struct {
+	Peer            Service `json:"peer" yaml:"peer"`
+	ConnectionType  string  `json:"connection_type,omitempty" yaml:"connection_type,omitempty"`
+	RatePerSecond   float64 `json:"rate_per_second" yaml:"rate_per_second"`
+	ErrorRatePerSec float64 `json:"error_rate_per_second" yaml:"error_rate_per_second"`
+	ErrorPercent    float64 `json:"error_percent" yaml:"error_percent"`
+	P95Seconds      float64 `json:"p95_seconds" yaml:"p95_seconds"`
+	HasErrors       bool    `json:"has_errors" yaml:"has_errors"`
+	HasLatency      bool    `json:"has_latency" yaml:"has_latency"`
+}
+
+// ServiceMap is the response shape for `services map`: the queried
+// service plus its inbound (callers) and outbound (callees) edges from
+// the Tempo service-graph metric. Each direction is independently
+// sorted by rate desc.
+type ServiceMap struct {
+	Service Service `json:"service" yaml:"service"`
+	Window  string  `json:"window" yaml:"window"`
+	Callers []Edge  `json:"callers" yaml:"callers"`
+	Callees []Edge  `json:"callees" yaml:"callees"`
+}
+
+// edgeKey identifies an edge for the purpose of joining the rate /
+// error / latency responses. The same peer reached over two different
+// connection types is two distinct edges in the service graph.
+type edgeKey struct {
+	name      string
+	namespace string
+	connType  string
+}
+
+// extractEdges flattens a Prometheus instant response into a map keyed
+// by (peer name, peer namespace, connection_type). Samples with empty
+// peer name or unparseable values are dropped so callers can treat
+// absence as "no data". peerName / peerNs name which labels to read.
+func extractEdges(resp *prometheus.QueryResponse, peerName, peerNs string) map[edgeKey]float64 {
+	out := make(map[edgeKey]float64)
+	if resp == nil {
+		return out
+	}
+	for _, sample := range resp.Data.Result {
+		n := sample.Metric[peerName]
+		if n == "" {
+			continue
+		}
+		if len(sample.Value) < 2 {
+			continue
+		}
+		str, ok := sample.Value[1].(string)
+		if !ok {
+			continue
+		}
+		f, err := strconv.ParseFloat(str, 64)
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+			continue
+		}
+		key := edgeKey{
+			name:      n,
+			namespace: sample.Metric[peerNs],
+			connType:  sample.Metric["connection_type"],
+		}
+		out[key] = f
+	}
+	return out
+}
+
+// mergeEdges joins per-quantity maps (rate, errors, p95) into one row
+// per (peer, connection_type), then sorts by rate desc with a stable
+// (name, namespace) tiebreak. HasErrors is inferred when rate>0 — a
+// healthy edge with no STATUS_CODE_ERROR series prints 0% rather than
+// "no data". Matches the convention from REDStats / Operation.
+func mergeEdges(rates, errors, p95s map[edgeKey]float64) []Edge {
+	keys := make(map[edgeKey]struct{})
+	for k := range rates {
+		keys[k] = struct{}{}
+	}
+	for k := range errors {
+		keys[k] = struct{}{}
+	}
+	for k := range p95s {
+		keys[k] = struct{}{}
+	}
+	out := make([]Edge, 0, len(keys))
+	for k := range keys {
+		rate, hasRate := rates[k]
+		errRate, hasErr := errors[k]
+		p95, hasP95 := p95s[k]
+		hasTraffic := hasRate && rate > 0
+		out = append(out, Edge{
+			Peer:            Service{Name: k.name, Namespace: k.namespace},
+			ConnectionType:  k.connType,
+			RatePerSecond:   rate,
+			ErrorRatePerSec: errRate,
+			ErrorPercent:    computeErrorPercent(errRate, rate),
+			P95Seconds:      p95,
+			HasErrors:       hasErr || hasTraffic,
+			HasLatency:      hasP95,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].RatePerSecond != out[j].RatePerSecond {
+			return out[i].RatePerSecond > out[j].RatePerSecond
+		}
+		if out[i].Peer.Namespace != out[j].Peer.Namespace {
+			return out[i].Peer.Namespace < out[j].Peer.Namespace
+		}
+		if out[i].Peer.Name != out[j].Peer.Name {
+			return out[i].Peer.Name < out[j].Peer.Name
+		}
+		return out[i].ConnectionType < out[j].ConnectionType
+	})
+	return out
+}
+
 // computeErrorPercent reports errors/total as a percentage (0..100), or 0
 // when there's no traffic. A non-zero error rate with zero total rate
 // shouldn't happen in practice but we collapse it to 0 rather than +Inf so


### PR DESCRIPTION
## Summary

- Adds \`gcx appo11y services map <name>\` — completes the \`services list → get → operations → map\` drill-down trilogy.
- Returns the queried service's neighbourhood from Tempo's service-graph metric family (\`traces_service_graph_request_*\`): callers (who calls this service) + callees (who this service calls), each with rate, error %, direction-aware p95 latency, and the \`connection_type\` label.
- Four output codecs: \`table\` / \`wide\` / \`json\` / \`yaml\` *plus* \`mermaid\` and \`dot\` graph codecs so the map can be inlined in markdown or piped through Graphviz.
- No \`--metrics-mode\` flag here — the service-graph metric family is consistent across every metrics-mode the other commands target.

## Example output

```
CALLERS                RATE         ERROR %  P95       TYPE
frontend (oteldemo01)  0.049 req/s  0.00%    637.50ms  -

CALLEES                             RATE         ERROR %  P95       TYPE
unknown                             0.262 req/s  0.00%    126.05ms  virtual_node
cartservice (oteldemo01)            0.098 req/s  0.00%    239.62ms  -
shippingservice (oteldemo01)        0.087 req/s  0.00%    55.00ms   -
productcatalogservice (oteldemo01)  0.049 req/s  0.00%    69.37ms   -
emailservice (oteldemo01)           0.044 req/s  0.00%    46.67ms   -
paymentservice (oteldemo01)         0.043 req/s  0.00%    186.99ms  -
frauddetectionservice (oteldemo01)  0.033 req/s  0.00%    4.75ms    messaging_system
kafka                               0.021 req/s  0.00%    4.75ms    virtual_node
currencyservice (oteldemo01)        0.011 req/s  0.00%    9.75ms    -
```

Same service rendered as Mermaid (renders inline in this PR description):

```mermaid
graph LR
  oteldemo01_checkoutservice{{"oteldemo01/checkoutservice"}}
  oteldemo01_frontend["frontend (oteldemo01)"]
  oteldemo01_frontend -->|0.049 req/s| oteldemo01_checkoutservice
  unknown("unknown")
  oteldemo01_checkoutservice -->|0.262 req/s| unknown
  oteldemo01_cartservice["cartservice (oteldemo01)"]
  oteldemo01_checkoutservice -->|0.098 req/s| oteldemo01_cartservice
  oteldemo01_frauddetectionservice[/"frauddetectionservice (oteldemo01)"\]
  oteldemo01_checkoutservice -->|0.033 req/s| oteldemo01_frauddetectionservice
  kafka("kafka")
  oteldemo01_checkoutservice -->|0.021 req/s| kafka
```

## Node-shape vocabulary

| connection_type | Mermaid | Graphviz |
|---|---|---|
| (empty: HTTP/gRPC) | rectangle | box |
| \`database\` | cylinder | cylinder |
| \`messaging_system\` | queue | parallelogram |
| \`virtual_node\` (orphan span) | rounded | dashed ellipse |
| center (queried service) | hex | bold blue box |

## Direction-aware latency

For each direction, we query the histogram that matters from the queried service's point of view:

- **Callers** → \`server_seconds_bucket\` (how long *this* service took to respond)
- **Callees** → \`client_seconds_bucket\` (how long *this* service waited on the peer)

## What's shared with \`services get\` / \`services operations\`

- Bare-name resolution via \`target_info\` (with the same ambiguity error).
- \`--since\` (PromQL duration), \`--namespace\`, \`--datasource\`, \`-o\`.
- \`fail.NewCommandUsageError\` wrapping for option validation.
- Exit-code-1 on no-edges, response still emitted so agents see the empty shape.

## Test plan

- [x] Unit tests cover the per-direction builders (callers vs callees, server_seconds vs client_seconds bucket), the failed-total error builder, edge extraction (including dropped NaN / empty / short-value samples), \`mergeEdges\` (rate-desc sort, has-errors inference, connection_type preservation), opts validation, mermaid node-ID sanitisation (alphanumeric + underscore), and all three codecs (table, mermaid, dot) including connection-type-specific shapes.
- [x] \`mise run lint\` clean.
- [x] \`GCX_AGENT_MODE=false go test ./...\` passes.
- [x] Reference docs regenerated.
- [x] Live verification against a Grafana Cloud stack:
  - Table view returns 1 caller + 9 callees for \`oteldemo01/checkoutservice\` with realistic rates / p95.
  - One real bug surfaced and fixed during live verification: Tempo's \`connection_type\` label uses \`messaging_system\` (not \`messaging\`), so the initial codec mapping missed the queue shape. Centralised the three valid values as \`connType*\` constants.
  - Mermaid renders correctly in this PR description (see above) — database / messaging / virtual_node shapes all distinct.
  - DOT pipes cleanly to \`dot -Tpng\`.
  - JSON shape: \`{service, window, callers[], callees[]}\` with per-edge \`peer\` / \`connection_type\` / \`rate_per_second\` / \`error_*\` / \`p95_seconds\`.
  - Nonexistent service exits 1.

## Note on duplication

\`formatPercentMaybe\` exists on both this branch and the open \`services operations\` PR (#842). It's annotated with a comment and will collapse to a single definition when both land. No functional concern.

## Follow-ups

This closes the original three-step plan (\`get\` → \`operations\` → \`map\`). Open items from the broader review:

- Igor's \`services list\` papercuts: \`--namespace\` filter and a way to require non-empty namespace / env.
- An optional global \`operations\` view (top operations across the whole stack, no service arg) — flagged previously, not yet requested.