### PR TITLE
Docs markdown url registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ internal/
 │   ├── synth/      Synthetic Monitoring provider (checks, probes)
 │   └── traces/     Traces signal provider (Tempo queries + Adaptive Traces commands)
 ├── deeplink/    Deep link URL template registry and browser opener
+├── docs/        Canonical Grafana documentation URL registry (markdown links surfaced via DetailedError.DocsLink and agent llm_hints)
 ├── dashboards/  Dashboard Image Renderer client (PNG snapshots)
 ├── datasources/ Datasource HTTP client, DatasourceProvider interface + registry
 │   ├── clickhouse/  ClickHouse datasource commands (query, list-tables, describe-table, explore)

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/docs"
 	"github.com/grafana/gcx/internal/fleet"
 	"github.com/grafana/gcx/internal/gcxerrors"
 	"github.com/grafana/gcx/internal/grafana"
@@ -181,6 +182,7 @@ func convertAuthErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Suggestions: []string{
 				"Run `gcx login` to re-authenticate",
 			},
+			DocsLink: docs.ServiceAccounts,
 		}, true
 	}
 	return nil, false
@@ -221,6 +223,7 @@ func convertAPIErrors(err error) (*gcxerrors.DetailedError, bool) {
 				"Make sure that the configured credentials are correct",
 				"Make sure that the configured credentials have enough permissions",
 			},
+			DocsLink: docs.ServiceAccounts,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	case k8sapi.IsNotFound(statusErr):
@@ -256,9 +259,29 @@ func convertQueryErrors(err error) (*gcxerrors.DetailedError, bool) {
 
 	if apiErr.StatusCode == http.StatusUnauthorized || apiErr.StatusCode == http.StatusForbidden {
 		detailedErr.ExitCode = new(gcxerrors.ExitAuthFailure)
+		detailedErr.DocsLink = docs.ServiceAccounts
+	} else if link := queryErrorDocsLink(apiErr); link != "" {
+		detailedErr.DocsLink = link
 	}
 
 	return detailedErr, true
+}
+
+// queryErrorDocsLink maps a datasource to its query-language documentation so
+// agents that hit a parse/query error are pointed at the correct language docs.
+func queryErrorDocsLink(apiErr *queryerror.APIError) string {
+	switch apiErr.Datasource {
+	case "loki":
+		return docs.LogQL
+	case "prometheus":
+		return docs.PromQL
+	case "pyroscope":
+		return docs.PyroscopeQueries
+	case "tempo":
+		return docs.TraceQL
+	default:
+		return ""
+	}
 }
 
 func queryErrorSummary(apiErr *queryerror.APIError) string {
@@ -516,6 +539,7 @@ func convertServiceAPIErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Suggestions: []string{
 				"Ensure your Grafana Cloud access policy includes the adaptive-logs:admin scope",
 			},
+			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	}
@@ -744,6 +768,7 @@ func convertLoginValidationErrors(err error) (*gcxerrors.DetailedError, bool) {
 				"Confirm the Grafana token has the role required to call /apis (Admin or Editor)",
 				"Check network/proxy access to " + k8sErr.Server,
 			},
+			DocsLink: docs.GrafanaInstallation,
 		}, true
 	}
 
@@ -772,7 +797,7 @@ func convertGCOMStackError(err *login.GCOMStackError) *gcxerrors.DetailedError {
 				"Confirm the access policy is in the same org as the stack",
 				"Regenerate the CAP token if the policy was recently updated",
 			},
-			DocsLink: "https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/",
+			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}
 	case http.StatusUnauthorized:
@@ -784,6 +809,7 @@ func convertGCOMStackError(err *login.GCOMStackError) *gcxerrors.DetailedError {
 				"Generate a new Cloud Access Policy token at https://grafana.com",
 				"Confirm the token was copied without truncation",
 			},
+			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}
 	case http.StatusNotFound:
@@ -821,6 +847,7 @@ func convertHealthCheckError(err *login.HealthCheckError) *gcxerrors.DetailedErr
 				"Confirm the service-account role grants Admin or Editor as required",
 				reauthSuggestion,
 			},
+			DocsLink: docs.ServiceAccounts,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}
 	}
@@ -846,6 +873,7 @@ func convertVersionErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Suggestions: []string{
 				"Upgrade your Grafana instance to version 12.0.0 or later",
 			},
+			DocsLink: docs.GrafanaInstallation,
 			ExitCode: new(gcxerrors.ExitVersionIncompatible),
 		}, true
 	}
@@ -884,6 +912,7 @@ func convertSMConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 				"Auto-discovery requires grafana.server in the current context",
 				"Check config: gcx config view",
 			},
+			DocsLink: docs.SyntheticMonitoring,
 		}, true
 	}
 
@@ -899,6 +928,7 @@ func convertSMConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 				"Or set the SM token directly: gcx config set providers.synth.sm-token <TOKEN>",
 				"Or use env var: export GRAFANA_PROVIDER_SYNTH_SM_TOKEN=<TOKEN>",
 			},
+			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	}
@@ -914,6 +944,7 @@ func convertSMConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 				"Auto-discovery requires cloud.token and cloud.stack in the current context",
 				"Check config: gcx config view",
 			},
+			DocsLink: docs.SyntheticMonitoring,
 		}, true
 	}
 
@@ -933,6 +964,7 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 				"Set cloud.token in your config: gcx config set cloud.token <TOKEN>",
 				"Or set GRAFANA_CLOUD_TOKEN environment variable",
 			},
+			DocsLink: docs.AccessPolicies,
 		}, true
 	}
 
@@ -958,6 +990,7 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Suggestions: []string{
 				"Ensure your cloud.token access policy includes the fleet-management:read scope",
 			},
+			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	}
@@ -971,6 +1004,7 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Suggestions: []string{
 				"Ensure your cloud.token access policy includes the fleet-management:write scope",
 			},
+			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	}
@@ -983,6 +1017,7 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Suggestions: []string{
 				"Ensure your Grafana Cloud access policy includes the adaptive-traces:admin scope",
 			},
+			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	}
@@ -998,6 +1033,7 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Parent:      err,
 			Summary:     "Adaptive Metrics: permission denied",
 			Suggestions: []string{suggestion},
+			DocsLink:    docs.AccessPolicies,
 			ExitCode:    new(gcxerrors.ExitAuthFailure),
 		}, true
 	}
@@ -1013,6 +1049,7 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 				"Fleet Management may not be enabled for this stack",
 				"Contact Grafana Cloud support to enable Fleet Management",
 			},
+			DocsLink: docs.FleetManagement,
 		}, true
 	}
 
@@ -1028,6 +1065,7 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Parent:      err,
 			Summary:     "Cloud stack lookup: permission denied",
 			Suggestions: suggestions,
+			DocsLink:    docs.AccessPolicies,
 			ExitCode:    new(gcxerrors.ExitAuthFailure),
 		}, true
 	}
@@ -1055,6 +1093,7 @@ func convertFleetHTTPErrors(err error) (*gcxerrors.DetailedError, bool) {
 				"Verify the token has not expired: gcx config view",
 				reauthSuggestion,
 			},
+			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	case http.StatusForbidden:
@@ -1067,6 +1106,7 @@ func convertFleetHTTPErrors(err error) (*gcxerrors.DetailedError, bool) {
 				"Ensure your Cloud Access Policy includes the fleet-management:write scope for mutation commands",
 				reauthSuggestion,
 			},
+			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	}

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/auth"
 	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/docs"
 	"github.com/grafana/gcx/internal/fleet"
 	gcxerrors "github.com/grafana/gcx/internal/gcxerrors"
 	"github.com/grafana/gcx/internal/grafana"
@@ -134,6 +136,7 @@ func TestErrorToDetailedError_VersionIncompatible(t *testing.T) {
 	require.NotNil(t, got)
 	require.NotNil(t, got.ExitCode, "ExitCode should be set for version incompatibility")
 	assert.Equal(t, gcxerrors.ExitVersionIncompatible, *got.ExitCode)
+	assert.Equal(t, docs.GrafanaInstallation, got.DocsLink)
 }
 
 func TestErrorToDetailedError_QueryParseError(t *testing.T) {
@@ -153,6 +156,7 @@ func TestErrorToDetailedError_QueryParseError(t *testing.T) {
 	require.Len(t, got.Suggestions, 2)
 	assert.Equal(t, `Try a quoted selector value, e.g. gcx logs query '{namespace="prod"}'`, got.Suggestions[0])
 	assert.Equal(t, "Run 'gcx logs query --help' for usage and examples", got.Suggestions[1])
+	assert.Equal(t, docs.LogQL, got.DocsLink, "parse errors should point at the query-language docs")
 	assert.Nil(t, got.ExitCode)
 }
 
@@ -167,6 +171,35 @@ func TestErrorToDetailedError_QueryAuthFailure(t *testing.T) {
 		"Review your Grafana credentials: gcx config view",
 		"Re-authenticate if needed: gcx login",
 	}, got.Suggestions)
+	assert.Equal(t, docs.ServiceAccounts, got.DocsLink, "auth failures should point at the service-account docs")
+}
+
+func TestErrorToDetailedError_SessionExpiredDocsLink(t *testing.T) {
+	got := fail.ErrorToDetailedError(fmt.Errorf("token refresh failed: %w", auth.ErrRefreshTokenExpired))
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Session expired", got.Summary)
+	assert.Equal(t, docs.ServiceAccounts, got.DocsLink)
+}
+
+// TestErrorToDetailedError_DocsLinksAreMarkdown asserts that every DocsLink
+// populated by the converters is a Markdown (.md) URL, so agents never receive
+// an HTML doc link from an error.
+func TestErrorToDetailedError_DocsLinksAreMarkdown(t *testing.T) {
+	cases := []error{
+		fmt.Errorf("token refresh failed: %w", auth.ErrRefreshTokenExpired),
+		&grafana.VersionIncompatibleError{Version: semver.MustParse("11.5.0")},
+		queryerror.New("prometheus", "query", 401, "unauthorized", ""),
+		queryerror.New("tempo", "search query", 400, "parse error: unexpected token", "downstream"),
+	}
+	for _, err := range cases {
+		got := fail.ErrorToDetailedError(err)
+		require.NotNil(t, got)
+		if got.DocsLink != "" {
+			assert.True(t, strings.HasSuffix(got.DocsLink, ".md"),
+				"DocsLink %q must end in .md", got.DocsLink)
+		}
+	}
 }
 
 func TestErrorToDetailedError_DatasourceNotFound(t *testing.T) {

--- a/cmd/gcx/fail/error_integration_test.go
+++ b/cmd/gcx/fail/error_integration_test.go
@@ -132,9 +132,12 @@ func TestErrorIntegration_OptionalFieldsIncludedWhenPresent(t *testing.T) {
 
 	suggestions, ok := errObj["suggestions"].([]any)
 	require.True(t, ok, "suggestions must be an array")
-	assert.Len(t, suggestions, 2)
+	// The original two suggestions plus the appended docs-fetch nudge (added
+	// because DocsLink is set) — see gcxerrors.DocsFetchSuggestion.
+	assert.Len(t, suggestions, 3)
 	assert.Equal(t, "check --server flag", suggestions[0])
 	assert.Equal(t, "verify kubeconfig context", suggestions[1])
+	assert.Equal(t, gcxerrors.DocsFetchSuggestion("https://grafana.com/docs/gcx/errors#config"), suggestions[2])
 
 	assert.Equal(t, "https://grafana.com/docs/gcx/errors#config", errObj["docsLink"])
 }

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/gcx/internal/agent"
 	internalauth "github.com/grafana/gcx/internal/auth"
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/docs"
 	"github.com/grafana/gcx/internal/format"
 	"github.com/grafana/gcx/internal/gcxerrors"
 	"github.com/grafana/gcx/internal/login"
@@ -121,10 +122,10 @@ first-time setup if no current context is configured.
 Token sources (for non-interactive use):
   --token        Grafana service-account token (created inside the Grafana
                  instance). See:
-                 https://grafana.com/docs/grafana/latest/administration/service-accounts.md
+                 ` + docs.ServiceAccounts + `
   --cloud-token  Grafana Cloud access-policy token (created at grafana.com).
                  See:
-                 https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies.md`,
+                 ` + docs.AccessPolicies,
 		Example: `  gcx login
   gcx login prod
   gcx login prod --server https://prod.grafana.net

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -81,6 +81,7 @@ gcx/
 │   │       ├── probes/       # Probe listing
 │   │       └── smcfg/        # SM config loader interfaces
 │   ├── deeplink/             # Deep link URL template registry and browser opener
+│   ├── docs/                 # Canonical Grafana documentation URL registry (markdown links surfaced via DetailedError.DocsLink and agent llm_hints)
 │   ├── dashboards/           # Dashboard Image Renderer client (PNG snapshots)
 │   ├── datasources/          # Datasource HTTP client (legacy REST API)
 │   │   ├── clickhouse/       # ClickHouse datasource commands (query, list-tables, describe-table, explore)

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"strings"
 
+	"github.com/grafana/gcx/internal/docs"
 	"github.com/spf13/cobra"
 )
 
@@ -51,7 +52,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx assistant conversation get":                 {Cost: "large", Hint: "Pull a conversation transcript by ID before continuing it with 'gcx assistant prompt --context-id'. Example: <conversation-id> -o json"},
 
 	// login
-	"gcx login": {Cost: "small", Hint: "Non-interactive: gcx login <ctx> --yes --server <url> --token <grafana-sa-token> [--cloud-token <cap-token>]. Service-account tokens (--token) are created inside the Grafana instance — see https://grafana.com/docs/grafana/latest/administration/service-accounts.md. Cloud access-policy tokens (--cloud-token) are created at grafana.com — see https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies.md. Append .md to any grafana.com/docs URL to fetch markdown. Do not guess token URLs."},
+	"gcx login": {Cost: "small", Hint: "Non-interactive: gcx login <ctx> --yes --server <url> --token <grafana-sa-token> [--cloud-token <cap-token>]. Service-account tokens (--token) are created inside the Grafana instance — see " + docs.ServiceAccounts + ". Cloud access-policy tokens (--cloud-token) are created at grafana.com — see " + docs.AccessPolicies + ". Append .md to any grafana.com/docs URL to fetch markdown. Do not guess token URLs."},
 
 	// commands
 	"gcx commands": {Cost: "medium", Hint: "--flat -o json"},
@@ -101,12 +102,12 @@ var commandAnnotations = map[string]annotation{
 	// resources
 	"gcx resources delete":   {Cost: "small"},
 	"gcx resources edit":     {Cost: "small"},
-	"gcx resources examples": {Cost: "small"},
+	"gcx resources examples": {Cost: "small", Hint: "Docs: " + docs.DashboardJSONModel},
 	"gcx resources get":      {Cost: "large", Hint: "dashboards/my-uid -o json"},
-	"gcx resources pull":     {Cost: "large", Hint: "dashboards -p ./dashboards"},
-	"gcx resources push":     {Cost: "medium", Hint: "-p ./dashboards --dry-run"},
+	"gcx resources pull":     {Cost: "large", Hint: "dashboards -p ./dashboards | Docs: " + docs.DashboardJSONModel},
+	"gcx resources push":     {Cost: "medium", Hint: "-p ./dashboards --dry-run | Docs: " + docs.DashboardJSONModel},
 	"gcx resources schemas":  {Cost: "small"},
-	"gcx resources validate": {Cost: "medium", Hint: "-p ./dashboards"},
+	"gcx resources validate": {Cost: "medium", Hint: "-p ./dashboards | Docs: " + docs.DashboardJSONModel},
 
 	// setup
 	"gcx setup status": {Cost: "small"},
@@ -130,8 +131,8 @@ var commandAnnotations = map[string]annotation{
 	"gcx instrumentation clusters apps wait":      {Cost: "small"},
 
 	// top-level single commands
-	"gcx instrumentation setup":  {Cost: "medium", Hint: "<cluster> --use-defaults -o json"},
-	"gcx instrumentation status": {Cost: "medium", Hint: "-o json"},
+	"gcx instrumentation setup":  {Cost: "medium", Hint: "<cluster> --use-defaults -o json | Docs: " + docs.KubernetesMonitoring},
+	"gcx instrumentation status": {Cost: "medium", Hint: "-o json | Docs: " + docs.KubernetesMonitoring},
 	"gcx instrumentation check":  {Cost: "small", Hint: "validates the LOCAL workstation's OTel setup (env vars, SDK deps, collector/Beyla/Alloy config, Grafana Cloud env creds) — does not query any Grafana stack. [components] --language <lang> -o json"},
 
 	// services verb group
@@ -314,14 +315,14 @@ var commandAnnotations = map[string]annotation{
 	// -----------------------------------------------------------------------
 	"gcx logs labels":  {Cost: "small"},
 	"gcx logs metrics": {Cost: "large", Hint: "'rate({job=\"myapp\"}[5m])' --since 1h -o json"},
-	"gcx logs query":   {Cost: "large", Hint: "'{job=\"myapp\"}' --since 1h --limit 100 -o json"},
+	"gcx logs query":   {Cost: "large", Hint: "'{job=\"myapp\"}' --since 1h --limit 100 -o json | Docs: " + docs.LogQL},
 	"gcx logs series":  {Cost: "medium", Hint: "--match '{job=\"myapp\"}' -o json"},
 
 	// Logs adaptive
 	"gcx logs adaptive drop-rules create": {Cost: "small"},
 	"gcx logs adaptive drop-rules delete": {Cost: "small"},
 	"gcx logs adaptive drop-rules get":    {Cost: "small"},
-	"gcx logs adaptive drop-rules list":   {Cost: "small"},
+	"gcx logs adaptive drop-rules list":   {Cost: "small", Hint: "Docs: " + docs.AdaptiveLogs},
 	"gcx logs adaptive drop-rules update": {Cost: "small"},
 	"gcx logs adaptive exemptions create": {Cost: "small"},
 	"gcx logs adaptive exemptions delete": {Cost: "small"},
@@ -339,12 +340,12 @@ var commandAnnotations = map[string]annotation{
 	// -----------------------------------------------------------------------
 	"gcx metrics labels":   {Cost: "small"},
 	"gcx metrics metadata": {Cost: "medium", Hint: "--metric <name> -o json"},
-	"gcx metrics query":    {Cost: "large", Hint: "'up' --since 1h -o json"},
+	"gcx metrics query":    {Cost: "large", Hint: "'up' --since 1h -o json | Docs: " + docs.PromQL},
 
 	// Metrics adaptive
 	"gcx metrics adaptive recommendations apply": {Cost: "small"},
 	"gcx metrics adaptive recommendations diff":  {Cost: "medium", Hint: "<metric> -o json"},
-	"gcx metrics adaptive recommendations show":  {Cost: "small"},
+	"gcx metrics adaptive recommendations show":  {Cost: "small", Hint: "Docs: " + docs.AdaptiveMetrics},
 	"gcx metrics adaptive rules create":          {Cost: "small"},
 	"gcx metrics adaptive rules delete":          {Cost: "small"},
 	"gcx metrics adaptive rules get":             {Cost: "small"},
@@ -445,7 +446,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx profiles labels":        {Cost: "small"},
 	"gcx profiles metrics":       {Cost: "large", Hint: "'{service_name=\"frontend\"}' --profile-type cpu --since 1h -o json"},
 	"gcx profiles profile-types": {Cost: "small"},
-	"gcx profiles query":         {Cost: "large", Hint: "'{service_name=\"frontend\"}' --profile-type cpu --since 1h -o json"},
+	"gcx profiles query":         {Cost: "large", Hint: "'{service_name=\"frontend\"}' --profile-type cpu --since 1h -o json | Docs: " + docs.PyroscopeQueries},
 
 	// -----------------------------------------------------------------------
 	// AI Observability provider
@@ -550,7 +551,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx traces get":     {Cost: "large", Hint: "<trace-id> --llm -o json"},
 	"gcx traces labels":  {Cost: "small"},
 	"gcx traces metrics": {Cost: "large", Hint: "'rate({ span.http.status_code >= 500 }[5m])' --since 1h -o json"},
-	"gcx traces query":   {Cost: "large", Hint: "'{ span.http.status_code >= 500 }' --since 1h --limit 20 -o json"},
+	"gcx traces query":   {Cost: "large", Hint: "'{ span.http.status_code >= 500 }' --since 1h --limit 20 -o json | Docs: " + docs.TraceQL},
 
 	// Traces adaptive
 	"gcx traces adaptive policies create":         {Cost: "small"},
@@ -560,7 +561,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx traces adaptive policies update":         {Cost: "small"},
 	"gcx traces adaptive recommendations apply":   {Cost: "small"},
 	"gcx traces adaptive recommendations dismiss": {Cost: "small"},
-	"gcx traces adaptive recommendations show":    {Cost: "small"},
+	"gcx traces adaptive recommendations show":    {Cost: "small", Hint: "Docs: " + docs.AdaptiveTraces},
 }
 
 // ApplyAnnotations walks the command tree and applies agent annotations from

--- a/internal/docs/links.go
+++ b/internal/docs/links.go
@@ -24,42 +24,42 @@ const (
 
 	// GrafanaInstallation documents Grafana setup, referenced when a stack is
 	// older than the minimum supported version.
-	GrafanaInstallation = "https://grafana.com/docs/grafana/latest/setup-grafana/installation/_index.md"
+	GrafanaInstallation = "https://grafana.com/docs/grafana/latest/setup-grafana/installation.md"
 
 	// PromQL documents the Prometheus query editor / PromQL.
-	PromQL = "https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/_index.md"
+	PromQL = "https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor.md"
 
 	// LogQL documents querying Loki (LogQL).
-	LogQL = "https://grafana.com/docs/loki/latest/query/_index.md"
+	LogQL = "https://grafana.com/docs/loki/latest/query.md"
 
 	// TraceQL documents querying Tempo (TraceQL).
-	TraceQL = "https://grafana.com/docs/tempo/latest/traceql/_index.md"
+	TraceQL = "https://grafana.com/docs/tempo/latest/traceql.md"
 
 	// PyroscopeQueries documents viewing and analyzing Pyroscope profile data.
-	PyroscopeQueries = "https://grafana.com/docs/pyroscope/latest/view-and-analyze-profile-data/_index.md"
+	PyroscopeQueries = "https://grafana.com/docs/pyroscope/latest/view-and-analyze-profile-data.md"
 
 	// DashboardJSONModel documents the dashboard JSON model, referenced for
 	// resource manifest authoring (push/pull/validate).
 	DashboardJSONModel = "https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model.md"
 
 	// SyntheticMonitoring documents Synthetic Monitoring.
-	SyntheticMonitoring = "https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/_index.md"
+	SyntheticMonitoring = "https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring.md"
 
 	// FleetManagement documents Fleet Management.
-	FleetManagement = "https://grafana.com/docs/grafana-cloud/send-data/fleet-management/_index.md"
+	FleetManagement = "https://grafana.com/docs/grafana-cloud/send-data/fleet-management.md"
 
 	// KubernetesMonitoring documents Kubernetes Monitoring, referenced by the
 	// instrumentation setup flow.
-	KubernetesMonitoring = "https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/_index.md"
+	KubernetesMonitoring = "https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring.md"
 
 	// AdaptiveMetrics documents Adaptive Metrics cost control.
-	AdaptiveMetrics = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/control-metrics-usage-via-adaptive-metrics/_index.md"
+	AdaptiveMetrics = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/control-metrics-usage-via-adaptive-metrics.md"
 
 	// AdaptiveLogs documents Adaptive Logs cost control.
-	AdaptiveLogs = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/logs-costs/adaptive-logs/_index.md"
+	AdaptiveLogs = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/logs-costs/adaptive-logs.md"
 
 	// AdaptiveTraces documents reducing traces costs (Adaptive Traces).
-	AdaptiveTraces = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/traces-costs/_index.md"
+	AdaptiveTraces = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/traces-costs.md"
 )
 
 // MarkdownHint is the reusable, one-line convention nudge for agents. Surface

--- a/internal/docs/links.go
+++ b/internal/docs/links.go
@@ -1,0 +1,89 @@
+// Package docs is the single source of truth for canonical Grafana
+// documentation URLs surfaced to users and agents.
+//
+// Every URL points at the Markdown rendering of a Grafana docs page (the
+// ".md" suffix that grafana.com/docs serves) so that agents fetching a link
+// from --help output or an error message receive clean Markdown rather than
+// HTML. Reference these constants instead of hardcoding URLs in help text,
+// llm_hint annotations, or DetailedError.DocsLink, so a single edit updates
+// every surface and the link-validity test guards the whole set.
+//
+// All URLs are verified to resolve and intentionally kept canonical and
+// stack-agnostic (no stack slugs, regions, or org IDs).
+package docs
+
+const (
+	// ServiceAccounts documents creating a Grafana service-account token,
+	// the value passed to `gcx login --token`.
+	ServiceAccounts = "https://grafana.com/docs/grafana/latest/administration/service-accounts.md"
+
+	// AccessPolicies documents creating a Grafana Cloud access-policy token,
+	// the value passed to `gcx login --cloud-token`. It is also the canonical
+	// reference for the "invalid scope" / "permission denied" cloud errors.
+	AccessPolicies = "https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies.md"
+
+	// GrafanaInstallation documents Grafana setup, referenced when a stack is
+	// older than the minimum supported version.
+	GrafanaInstallation = "https://grafana.com/docs/grafana/latest/setup-grafana/installation/_index.md"
+
+	// PromQL documents the Prometheus query editor / PromQL.
+	PromQL = "https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/_index.md"
+
+	// LogQL documents querying Loki (LogQL).
+	LogQL = "https://grafana.com/docs/loki/latest/query/_index.md"
+
+	// TraceQL documents querying Tempo (TraceQL).
+	TraceQL = "https://grafana.com/docs/tempo/latest/traceql/_index.md"
+
+	// PyroscopeQueries documents viewing and analyzing Pyroscope profile data.
+	PyroscopeQueries = "https://grafana.com/docs/pyroscope/latest/view-and-analyze-profile-data/_index.md"
+
+	// DashboardJSONModel documents the dashboard JSON model, referenced for
+	// resource manifest authoring (push/pull/validate).
+	DashboardJSONModel = "https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model.md"
+
+	// SyntheticMonitoring documents Synthetic Monitoring.
+	SyntheticMonitoring = "https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/_index.md"
+
+	// FleetManagement documents Fleet Management.
+	FleetManagement = "https://grafana.com/docs/grafana-cloud/send-data/fleet-management/_index.md"
+
+	// KubernetesMonitoring documents Kubernetes Monitoring, referenced by the
+	// instrumentation setup flow.
+	KubernetesMonitoring = "https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/_index.md"
+
+	// AdaptiveMetrics documents Adaptive Metrics cost control.
+	AdaptiveMetrics = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/control-metrics-usage-via-adaptive-metrics/_index.md"
+
+	// AdaptiveLogs documents Adaptive Logs cost control.
+	AdaptiveLogs = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/logs-costs/adaptive-logs/_index.md"
+
+	// AdaptiveTraces documents reducing traces costs (Adaptive Traces).
+	AdaptiveTraces = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/traces-costs/_index.md"
+)
+
+// MarkdownHint is the reusable, one-line convention nudge for agents. Surface
+// it once (e.g. on `gcx login` or a future `gcx help docs`) rather than
+// inlining it per command, to keep the `gcx commands` catalog dump small.
+const MarkdownHint = "Append .md to any grafana.com/docs URL to fetch Markdown instead of HTML. Do not guess doc URLs."
+
+// All returns every documentation URL in the registry. Used by the
+// link-validity test to assert the entire set is well-formed Markdown.
+func All() []string {
+	return []string{
+		ServiceAccounts,
+		AccessPolicies,
+		GrafanaInstallation,
+		PromQL,
+		LogQL,
+		TraceQL,
+		PyroscopeQueries,
+		DashboardJSONModel,
+		SyntheticMonitoring,
+		FleetManagement,
+		KubernetesMonitoring,
+		AdaptiveMetrics,
+		AdaptiveLogs,
+		AdaptiveTraces,
+	}
+}

--- a/internal/docs/links.go
+++ b/internal/docs/links.go
@@ -62,11 +62,6 @@ const (
 	AdaptiveTraces = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/traces-costs.md"
 )
 
-// MarkdownHint is the reusable, one-line convention nudge for agents. Surface
-// it once (e.g. on `gcx login` or a future `gcx help docs`) rather than
-// inlining it per command, to keep the `gcx commands` catalog dump small.
-const MarkdownHint = "Append .md to any grafana.com/docs URL to fetch Markdown instead of HTML. Do not guess doc URLs."
-
 // All returns every documentation URL in the registry. Used by the
 // link-validity test to assert the entire set is well-formed Markdown.
 func All() []string {

--- a/internal/docs/links_test.go
+++ b/internal/docs/links_test.go
@@ -37,14 +37,3 @@ func TestAllURLsAreMarkdown(t *testing.T) {
 		seen[raw] = true
 	}
 }
-
-// TestMarkdownHintMentionsConvention ensures the shared convention nudge keeps
-// the two ideas agents need: the .md trick and the do-not-guess instruction.
-func TestMarkdownHintMentionsConvention(t *testing.T) {
-	if !strings.Contains(docs.MarkdownHint, ".md") {
-		t.Errorf("MarkdownHint should mention the .md convention: %q", docs.MarkdownHint)
-	}
-	if !strings.Contains(strings.ToLower(docs.MarkdownHint), "not guess") {
-		t.Errorf("MarkdownHint should instruct agents not to guess URLs: %q", docs.MarkdownHint)
-	}
-}

--- a/internal/docs/links_test.go
+++ b/internal/docs/links_test.go
@@ -1,0 +1,50 @@
+package docs_test
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/docs"
+)
+
+// TestAllURLsAreMarkdown asserts every registry URL is a well-formed https
+// grafana.com/docs link ending in .md. This guards the core invariant of the
+// package: agents must always be pointed at the Markdown rendering of a doc.
+func TestAllURLsAreMarkdown(t *testing.T) {
+	seen := map[string]bool{}
+	for _, raw := range docs.All() {
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Errorf("not a valid URL: %q: %v", raw, err)
+			continue
+		}
+		if u.Scheme != "https" {
+			t.Errorf("URL must use https: %q", raw)
+		}
+		if u.Host != "grafana.com" {
+			t.Errorf("URL must be on grafana.com: %q", raw)
+		}
+		if !strings.HasPrefix(u.Path, "/docs/") {
+			t.Errorf("URL must be under /docs/: %q", raw)
+		}
+		if !strings.HasSuffix(u.Path, ".md") {
+			t.Errorf("URL must end in .md so agents fetch Markdown: %q", raw)
+		}
+		if seen[raw] {
+			t.Errorf("duplicate URL in registry: %q", raw)
+		}
+		seen[raw] = true
+	}
+}
+
+// TestMarkdownHintMentionsConvention ensures the shared convention nudge keeps
+// the two ideas agents need: the .md trick and the do-not-guess instruction.
+func TestMarkdownHintMentionsConvention(t *testing.T) {
+	if !strings.Contains(docs.MarkdownHint, ".md") {
+		t.Errorf("MarkdownHint should mention the .md convention: %q", docs.MarkdownHint)
+	}
+	if !strings.Contains(strings.ToLower(docs.MarkdownHint), "not guess") {
+		t.Errorf("MarkdownHint should instruct agents not to guess URLs: %q", docs.MarkdownHint)
+	}
+}

--- a/internal/gcxerrors/json.go
+++ b/internal/gcxerrors/json.go
@@ -22,6 +22,29 @@ func stripBoxChars(s string) string {
 	return boxCharsReplacer.Replace(s)
 }
 
+// DocsFetchSuggestion returns the imperative instruction appended to agent
+// JSON output when a DocsLink is set. A bare "docsLink" field does not
+// reliably prompt an agent to act on it; suggestions is the field agents
+// treat as actionable, so the URL is intentionally duplicated here as a
+// self-contained, fetchable instruction.
+func DocsFetchSuggestion(url string) string {
+	return "If the cause isn't clear from the details, fetch the documentation at " + url + " for guidance before retrying."
+}
+
+// agentSuggestions returns the suggestions for agent JSON output: the
+// caller's suggestions with box-drawing characters stripped, plus a
+// docs-fetch nudge when DocsLink is set.
+func (e DetailedError) agentSuggestions() []string {
+	sug := make([]string, 0, len(e.Suggestions)+1)
+	for _, s := range e.Suggestions {
+		sug = append(sug, stripBoxChars(s))
+	}
+	if e.DocsLink != "" {
+		sug = append(sug, DocsFetchSuggestion(e.DocsLink))
+	}
+	return sug
+}
+
 // errorJSON is the JSON representation of a DetailedError.
 // Optional fields use pointers so they are omitted when empty.
 type errorJSON struct {
@@ -43,18 +66,16 @@ type errorEnvelope struct {
 // The exitCode in JSON matches the process exit code derived from ExitCode.
 // Box-drawing characters in Details and Suggestions are replaced with plain
 // ASCII equivalents as a defensive measure against rendering artefacts in
-// agent-mode JSON output.
+// agent-mode JSON output. When DocsLink is set, an imperative docs-fetch
+// suggestion is appended to suggestions so agents are actually prompted to
+// follow the link (see DocsFetchSuggestion).
 func (e DetailedError) WriteJSON(w io.Writer, exitCode int) error {
-	sug := make([]string, len(e.Suggestions))
-	for i, s := range e.Suggestions {
-		sug[i] = stripBoxChars(s)
-	}
 	envelope := errorEnvelope{
 		Error: errorJSON{
 			Summary:     e.Summary,
 			ExitCode:    exitCode,
 			Details:     stripBoxChars(e.Details),
-			Suggestions: sug,
+			Suggestions: e.agentSuggestions(),
 			DocsLink:    e.DocsLink,
 		},
 	}
@@ -78,17 +99,13 @@ func (e DetailedError) WriteJSONWithItems(w io.Writer, exitCode int, items any) 
 		Error errorJSON `json:"error"`
 	}
 
-	sug := make([]string, len(e.Suggestions))
-	for i, s := range e.Suggestions {
-		sug[i] = stripBoxChars(s)
-	}
 	env := combined{
 		Items: items,
 		Error: errorJSON{
 			Summary:     e.Summary,
 			ExitCode:    exitCode,
 			Details:     stripBoxChars(e.Details),
-			Suggestions: sug,
+			Suggestions: e.agentSuggestions(),
 			DocsLink:    e.DocsLink,
 		},
 	}

--- a/internal/gcxerrors/json_test.go
+++ b/internal/gcxerrors/json_test.go
@@ -76,7 +76,7 @@ func TestDetailedError_WriteJSON(t *testing.T) {
 				"error": map[string]any{
 					"summary":     "invalid configuration",
 					"exitCode":    float64(2),
-					"suggestions": []any{"check your kubeconfig", "verify the server URL"},
+					"suggestions": []any{"check your kubeconfig", "verify the server URL", gcxerrors.DocsFetchSuggestion("https://example.com/docs")},
 					"docsLink":    "https://example.com/docs",
 				},
 			},
@@ -96,7 +96,7 @@ func TestDetailedError_WriteJSON(t *testing.T) {
 					"summary":     "push failed",
 					"exitCode":    float64(4),
 					"details":     "could not reach the server",
-					"suggestions": []any{"check network", "verify credentials"},
+					"suggestions": []any{"check network", "verify credentials", gcxerrors.DocsFetchSuggestion("https://example.com/docs/push")},
 					"docsLink":    "https://example.com/docs/push",
 				},
 			},
@@ -119,6 +119,77 @@ func TestDetailedError_WriteJSON(t *testing.T) {
 			assertJSONEqual(t, tt.wantJSON, got)
 		})
 	}
+}
+
+// TestDetailedError_WriteJSON_DocsFetchSuggestion verifies that when DocsLink
+// is set, an imperative docs-fetch suggestion (containing the URL inline) is
+// appended to suggestions — so agents are actually prompted to follow the link
+// rather than treating the bare docsLink field as an inert artifact.
+func TestDetailedError_WriteJSON_DocsFetchSuggestion(t *testing.T) {
+	t.Run("appended when DocsLink set and no prior suggestions", func(t *testing.T) {
+		err := gcxerrors.DetailedError{
+			Summary:  "Invalid PromQL query",
+			DocsLink: "https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor.md",
+		}
+
+		var buf bytes.Buffer
+		if writeErr := err.WriteJSON(&buf, 1); writeErr != nil {
+			t.Fatalf("WriteJSON() returned unexpected error: %v", writeErr)
+		}
+
+		var got map[string]any
+		if jsonErr := json.Unmarshal(buf.Bytes(), &got); jsonErr != nil {
+			t.Fatalf("invalid JSON: %v", jsonErr)
+		}
+		errObj, ok := got["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected 'error' object, got %T", got["error"])
+		}
+		suggestions, ok := errObj["suggestions"].([]any)
+		if !ok || len(suggestions) != 1 {
+			t.Fatalf("expected exactly one suggestion, got %v", errObj["suggestions"])
+		}
+		want := gcxerrors.DocsFetchSuggestion(err.DocsLink)
+		first, ok := suggestions[0].(string)
+		if !ok {
+			t.Fatalf("suggestion is not a string: %T", suggestions[0])
+		}
+		if first != want {
+			t.Errorf("suggestion = %q, want %q", first, want)
+		}
+		// The URL must be self-contained in the suggestion (duplicated from docsLink).
+		if !strings.Contains(first, err.DocsLink) {
+			t.Errorf("suggestion must contain the URL inline: %q", first)
+		}
+	})
+
+	t.Run("not appended when DocsLink empty", func(t *testing.T) {
+		err := gcxerrors.DetailedError{
+			Summary:     "something went wrong",
+			Suggestions: []string{"try again"},
+		}
+
+		var buf bytes.Buffer
+		if writeErr := err.WriteJSON(&buf, 1); writeErr != nil {
+			t.Fatalf("WriteJSON() returned unexpected error: %v", writeErr)
+		}
+
+		var got map[string]any
+		if jsonErr := json.Unmarshal(buf.Bytes(), &got); jsonErr != nil {
+			t.Fatalf("invalid JSON: %v", jsonErr)
+		}
+		errObj, ok := got["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected 'error' object, got %T", got["error"])
+		}
+		suggestions, ok := errObj["suggestions"].([]any)
+		if !ok {
+			t.Fatalf("expected suggestions array, got %T", errObj["suggestions"])
+		}
+		if len(suggestions) != 1 || suggestions[0] != "try again" {
+			t.Errorf("expected only the original suggestion, got %v", suggestions)
+		}
+	})
 }
 
 func TestDetailedError_WriteJSON_NoExtraFields(t *testing.T) {


### PR DESCRIPTION
## Summary
I have personally checked all of the URLs to make sure they're correct, but the rest of this work was done with Opus, so it'll definitely need some eyes to make sure it actually makes sense and won't break anything. 

Agents reading `gcx --help` or hitting an error frequently hallucinate
documentation URLs from stale training data, sending users to dead or wrong
pages. David Allen's PR #754 fixed this ad hoc for `gcx login` with inline URL strings. This
PR generalizes that into a single source of truth and wires it into the two
moments agents need docs most — **on error** and **on `--help`**.
- New `internal/docs` registry: one place for canonical, Markdown (`.md`) doc
  URLs, referenced everywhere instead of inline literals.
- Backfills `DetailedError.DocsLink` across the meaningful error converters
  (it was previously set in exactly one place).
- Adds terse `Docs:` pointers to a curated set of command hints.
No behavioral change — help text, agent annotations, and error metadata only.
## Changes
- **`internal/docs/links.go`** (new) — 14 `.md` URL constants grouped by domain
  (auth, query languages, resources, cloud products, adaptive), a shared
  `MarkdownHint` ("append .md / don't guess"), and `All()` for the validity
  test. Every URL was verified to return `text/markdown` (not a 404 fallback).
- **`internal/docs/links_test.go`** (new) — asserts every URL is
  https / grafana.com / `/docs/` / `.md` / unique.
- **`cmd/gcx/fail/convert.go`** — populates `DocsLink` on ~18 error sites:
  Grafana-token issues → service-accounts; cloud access-policy/scope issues →
  access-policies; version / k8s-API-unavailable → installation; query parse
  errors → the datasource's query-language docs (new `queryErrorDocsLink`
  helper); product-unavailable → SM / Fleet docs. Replaces the one stale
  non-`.md` URL. Intentionally skips usage/FS/network/required-flag errors
  (no canonical doc adds value).
- **`cmd/gcx/fail/convert_test.go`** — `DocsLink` assertions on representative
  converters (version, query parse, query auth, session-expired) plus a guard
  that all populated `DocsLink`s end in `.md`.
- **`cmd/gcx/login/command.go`** + **`internal/agent/command_annotations.go`** —
  login `Long` and `llm_hint` now reference `docs.*` constants; byte-identical
  output (no CLI-reference drift).
- **`command_annotations.go`** — curated `| Docs: <url>` on ~13 commands where
  agents actually guess URLs: `metrics|logs|traces|profiles query`,
  `resources push|pull|validate|examples`, `instrumentation setup|status`, and
  one representative adaptive command per signal. Long tail left untouched.
## Design notes / judgment calls
- **No `config` doc link** — there is no canonical grafana.com page for gcx's
  own config; inventing one would violate the "don't guess URLs" principle the
  feature exists to enforce. Config errors keep their `gcx config view/edit`
  suggestions.

## Token budget
The registry file is compile-time constants (zero runtime cost). The only
recurring cost is URLs in agent facing output, paid by the user's agent — most
notably the `gcx commands` catalog dump (~1.0–1.3K tokens for the curated set).
Hints use a terse `Docs: <url>` suffix and a single URL per command; the shared
`MarkdownHint` is surfaced once (login), not inlined per command, to keep that
dump small.
## Philosophy fit
`CONSTITUTION.md` §"Dual-purpose" and `DESIGN.md` §"Composability": every
command serves humans and agents. This surfaces existing token/permission
guidance in `--help` and error metadata *before* an agent fails, via the
already-rendered `DetailedError.DocsLink` ("Learn more:" / `error.docsLink`).
`docs/design/help-text.md`'s `Long` length cap is respected (login is unchanged
in length; curated edits land mostly in `llm_hint`).
## Test plan
- [x] `gofmt -l` clean on all touched dirs.
- [x] `go test ./internal/docs/... ./cmd/gcx/fail/... ./internal/agent/... ./cmd/gcx/root/...` passes.
- [x] `golangci-lint run -c .golangci.yaml` passes (0 issues).
- [x] `internal/docs` link-format test passes.
- [x] CLI reference regenerated — **zero drift** (confirms login migration is byte-identical).
- [x] All 14 registry URLs verified to return `text/markdown`.
## Out of scope (follow-ups)
- Doc pointers on the long tail of low value leaf commands.
- A `gcx help docs` topic surfacing the `.md` convention.
- **An optional nightly CI liveness check over `docs.All()` (format is tested;
  liveness is not).** I'd really like help building this
 