### PR TITLE
oauth flow for `gcx cloud login`

### DIFF
--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -508,7 +508,7 @@ func buildTokenRefresher(ctx context.Context, configOpts *cmdconfig.Options, ctx
 		}
 
 		// Do the refresh
-		rr, err := auth.DoRefresh(ctx, proxyEndpoint, refreshToken)
+		rr, err := auth.ProxyRefresh(ctx, proxyEndpoint, refreshToken)
 		if err != nil {
 			return token, err // return stale token on failure
 		}

--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -181,8 +181,12 @@ func saveCloudConfig(ctx context.Context, configOpts *cmdconfig.Options, cloud *
 		cfg.SetContext(contextName, true, config.Context{})
 	}
 	curCtx := cfg.Contexts[contextName]
-	// replace the entire cloud config - clears any stale OAuth fields
-	// when switching from OAuth to SA token or vice versa
+	// Replace the entire cloud config to clear any stale OAuth/token fields
+	// when switching from OAuth to SA token or vice versa, but preserve the
+	// non-auth Stack selection so re-authenticating doesn't drop it.
+	if curCtx.Cloud != nil {
+		cloud.Stack = curCtx.Cloud.Stack
+	}
 	curCtx.Cloud = cloud
 
 	if err := config.Write(ctx, source, cfg); err != nil {

--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -57,12 +57,9 @@ directly via --cloud-token.
 
 Two endpoints can be configured independently, both defaulting to
 https://grafana.com: --oauth-url is used only for the login flow here, while
---api-url is used by every command that talks to the Grafana Cloud API. In
-production neither needs setting; against a dev environment where the two
-differ (e.g. a private API endpoint), set both.`,
+--api-url is used by every command that talks to the Grafana Cloud API.`,
 		Example: `  gcx cloud login
-  gcx cloud login --cloud-token glsa_abc123
-  gcx cloud login --oauth-url https://grafana.example.com --api-url https://api.internal.example.com`,
+  gcx cloud login --cloud-token glsa_abc123`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Endpoint URLs are sticky across re-auth: when not passed
 			// explicitly, carry over whatever the current context already has so

--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -3,6 +3,16 @@
 package cloud
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/internal/auth"
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/gcxerrors"
 	"github.com/grafana/gcx/internal/providers/stacks"
 	"github.com/spf13/cobra"
 )
@@ -15,6 +25,185 @@ func Command() *cobra.Command {
 	}
 
 	cmd.AddCommand(stacks.NewCommand())
+	cmd.AddCommand(loginCmd())
 
 	return cmd
+}
+
+const defaultClientID = "gcx"
+
+func loginCmd() *cobra.Command {
+	configOpts := &cmdconfig.Options{}
+	var (
+		oauthURL   string
+		apiURL     string
+		scopes     []string
+		cloudToken string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate with the Grafana Cloud API (GCOM)",
+		Long: `Authenticate with the Grafana Cloud API and store the token in the gcx config.
+
+This is different from "gcx login", which authenticates to a specific
+Grafana stack instance. "gcx cloud login" authenticates against the
+Grafana Cloud platform API (grafana.com), enabling commands that manage
+Cloud resources like stacks and access policies.
+
+By default, opens a browser for interactive OAuth2 authentication.
+
+For non-interactive use (CI/CD, scripts), pass a Cloud Access Policy token
+directly via --cloud-token.
+
+Two endpoints can be configured independently, both defaulting to
+https://grafana.com: --oauth-url is used only for the login flow here, while
+--api-url is used by every command that talks to the Grafana Cloud API. In
+production neither needs setting; against a dev environment where the two
+differ (e.g. a private API endpoint), set both.`,
+		Example: `  gcx cloud login
+  gcx cloud login --cloud-token glsa_abc123
+  gcx cloud login --oauth-url https://grafana.example.com --api-url https://api.internal.example.com`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Endpoint URLs are sticky across re-auth: when not passed
+			// explicitly, carry over whatever the current context already has so
+			// a plain `gcx cloud login` doesn't wipe a previously set value.
+			cur := currentCloudContext(cmd.Context(), configOpts)
+			if !cmd.Flags().Changed("oauth-url") && cur != nil && cur.Cloud != nil && cur.Cloud.OAuthUrl != "" {
+				oauthURL = cur.Cloud.OAuthUrl
+			}
+			if !cmd.Flags().Changed("api-url") && cur != nil && cur.Cloud != nil && cur.Cloud.APIUrl != "" {
+				apiURL = cur.Cloud.APIUrl
+			}
+			// Normalize whichever values won (flag, carry-over, or default)
+			// so a bare host (e.g. "grafana.example.com") gets an https:// scheme
+			// before it reaches the OAuth flow or is saved to config.
+			oauthURL = config.NormalizeCloudURL(oauthURL)
+			apiURL = config.NormalizeCloudURL(apiURL)
+			if cloudToken != "" {
+				return runTokenLogin(cmd.Context(), configOpts, cloudToken, oauthURL, apiURL)
+			}
+			return runOAuthLogin(cmd.Context(), configOpts, oauthURL, apiURL, scopes)
+		},
+	}
+
+	configOpts.BindFlags(cmd.Flags())
+	cmd.Flags().StringVar(&cloudToken, "cloud-token", "", "Cloud Access Policy token (skips interactive OAuth flow)")
+	cmd.Flags().StringVar(&oauthURL, "oauth-url", "https://grafana.com", "Base URL for the OAuth login flow (used only by this command)")
+	cmd.Flags().StringVar(&apiURL, "api-url", "https://grafana.com", "Base URL for Grafana Cloud API resource calls (stacks etc.)")
+	cmd.Flags().StringSliceVar(&scopes, "scope", []string{
+		"stacks:read", "stacks:write", "stacks:delete",
+		"accesspolicies:read", "accesspolicies:write", "accesspolicies:delete",
+	}, "OAuth2 scopes to request")
+
+	return cmd
+}
+
+// currentCloudContext loads the config and returns the current context, or nil
+// if config can't be loaded or the context doesn't exist yet.
+func currentCloudContext(ctx context.Context, configOpts *cmdconfig.Options) *config.Context {
+	cfg, err := config.Load(ctx, configOpts.ConfigSource())
+	if err != nil {
+		return nil
+	}
+	ctxName := cfg.CurrentContext
+	if ctxName == "" {
+		ctxName = config.DefaultContextName
+	}
+	return cfg.Contexts[ctxName]
+}
+
+func runTokenLogin(ctx context.Context, configOpts *cmdconfig.Options, token, oauthURL, apiURL string) error {
+	cloud := &config.CloudConfig{
+		Token:    token,
+		OAuthUrl: oauthURL,
+		APIUrl:   apiURL,
+	}
+	if err := saveCloudConfig(ctx, configOpts, cloud); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "Cloud token saved.")
+	return nil
+}
+
+func runOAuthLogin(ctx context.Context, configOpts *cmdconfig.Options, oauthURL, apiURL string, scopes []string) error {
+	flow := auth.NewGCOMFlow(auth.GCOMOptions{
+		ClientID: defaultClientID,
+		GCOMURL:  oauthURL,
+		Scopes:   scopes,
+		Writer:   os.Stderr,
+	})
+
+	result, err := flow.Run(ctx)
+	if err != nil {
+		return &gcxerrors.DetailedError{
+			Summary: "Authentication failed",
+			Parent:  err,
+			Suggestions: []string{
+				"Check that the OAuth login URL is correct",
+				"Ensure you are logged in to Grafana Cloud in your browser",
+				"Try again with: gcx cloud login --oauth-url <url>",
+			},
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Authenticated as %s (%s)\n", result.Info.Login, result.Info.Email)
+	fmt.Fprintf(os.Stderr, "Scopes: %s\n", result.Scope)
+
+	cloud := &config.CloudConfig{
+		Token:          result.AccessToken,
+		TokenExpiresAt: time.Now().Add(time.Duration(result.ExpiresIn) * time.Second).Format(time.RFC3339),
+		OAuthUrl:       oauthURL,
+		APIUrl:         apiURL,
+	}
+	return saveCloudConfig(ctx, configOpts, cloud)
+}
+
+func saveCloudConfig(ctx context.Context, configOpts *cmdconfig.Options, cloud *config.CloudConfig) error {
+	source := configOpts.ConfigSource()
+	if source == nil {
+		source = config.StandardLocation()
+	}
+
+	cfg, err := config.Load(ctx, source)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return &gcxerrors.DetailedError{
+			Summary: "Failed to load config",
+			Parent:  err,
+			Suggestions: []string{
+				"Check your config file syntax: gcx config edit",
+				"Or reset with: rm ~/.config/gcx/config.yaml && gcx cloud login",
+			},
+		}
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		cfg = config.Config{}
+	}
+
+	contextName := cfg.CurrentContext
+	if contextName == "" {
+		contextName = config.DefaultContextName
+	}
+
+	if !cfg.HasContext(contextName) {
+		cfg.SetContext(contextName, true, config.Context{})
+	}
+	curCtx := cfg.Contexts[contextName]
+	// replace the entire cloud config - clears any stale OAuth fields
+	// when switching from OAuth to SA token or vice versa
+	curCtx.Cloud = cloud
+
+	if err := config.Write(ctx, source, cfg); err != nil {
+		return &gcxerrors.DetailedError{
+			Summary: "Failed to save config",
+			Parent:  err,
+			Suggestions: []string{
+				"Check file permissions on the config file",
+				"Try: gcx config edit",
+			},
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Token saved to context %q\n", contextName)
+	return nil
 }

--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
 	"github.com/grafana/gcx/internal/auth"
@@ -151,19 +150,15 @@ func runOAuthLogin(ctx context.Context, configOpts *cmdconfig.Options, oauthURL,
 	fmt.Fprintf(os.Stderr, "Scopes: %s\n", result.Scope)
 
 	cloud := &config.CloudConfig{
-		Token:          result.AccessToken,
-		TokenExpiresAt: time.Now().Add(time.Duration(result.ExpiresIn) * time.Second).Format(time.RFC3339),
-		OAuthUrl:       oauthURL,
-		APIUrl:         apiURL,
+		Token:    result.AccessToken,
+		OAuthUrl: oauthURL,
+		APIUrl:   apiURL,
 	}
 	return saveCloudConfig(ctx, configOpts, cloud)
 }
 
 func saveCloudConfig(ctx context.Context, configOpts *cmdconfig.Options, cloud *config.CloudConfig) error {
 	source := configOpts.ConfigSource()
-	if source == nil {
-		source = config.StandardLocation()
-	}
 
 	cfg, err := config.Load(ctx, source)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/gcx/internal/gcxerrors"
 	"github.com/grafana/gcx/internal/providers/stacks"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type loginOpts struct {
@@ -21,6 +22,16 @@ type loginOpts struct {
 	apiURL     string
 	scopes     []string
 	cloudToken string
+}
+
+func (opts *loginOpts) bindFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&opts.cloudToken, "cloud-token", "", "Cloud Access Policy token (skips interactive OAuth flow)")
+	flags.StringVar(&opts.oauthURL, "oauth-url", "https://grafana.com", "Base URL for the OAuth login flow (used only by this command)")
+	flags.StringVar(&opts.apiURL, "api-url", "https://grafana.com", "Base URL for Grafana Cloud API resource calls (stacks etc.)")
+	flags.StringSliceVar(&opts.scopes, "scope", []string{
+		"stacks:read", "stacks:write", "stacks:delete",
+		"accesspolicies:read", "accesspolicies:write", "accesspolicies:delete",
+	}, "OAuth2 scopes to request")
 }
 
 func (opts *loginOpts) Validate() error {
@@ -102,13 +113,7 @@ https://grafana.com: --oauth-url is used only for the login flow here, while
 	}
 
 	configOpts.BindFlags(cmd.Flags())
-	cmd.Flags().StringVar(&opts.cloudToken, "cloud-token", "", "Cloud Access Policy token (skips interactive OAuth flow)")
-	cmd.Flags().StringVar(&opts.oauthURL, "oauth-url", "https://grafana.com", "Base URL for the OAuth login flow (used only by this command)")
-	cmd.Flags().StringVar(&opts.apiURL, "api-url", "https://grafana.com", "Base URL for Grafana Cloud API resource calls (stacks etc.)")
-	cmd.Flags().StringSliceVar(&opts.scopes, "scope", []string{
-		"stacks:read", "stacks:write", "stacks:delete",
-		"accesspolicies:read", "accesspolicies:write", "accesspolicies:delete",
-	}, "OAuth2 scopes to request")
+	opts.bindFlags(cmd.Flags())
 
 	return cmd
 }

--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -16,6 +16,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type loginOpts struct {
+	oauthURL   string
+	apiURL     string
+	scopes     []string
+	cloudToken string
+}
+
+func (opts *loginOpts) Validate() error {
+	if opts.oauthURL == "" {
+		return errors.New("--oauth-url must not be empty")
+	}
+	if opts.apiURL == "" {
+		return errors.New("--api-url must not be empty")
+	}
+	if opts.cloudToken == "" && len(opts.scopes) == 0 {
+		return errors.New("--scope must not be empty for interactive OAuth login")
+	}
+	return nil
+}
+
 // Command returns the top-level "cloud" cobra command with all subcommands.
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
@@ -33,12 +53,7 @@ const defaultClientID = "gcx"
 
 func loginCmd() *cobra.Command {
 	configOpts := &cmdconfig.Options{}
-	var (
-		oauthURL   string
-		apiURL     string
-		scopes     []string
-		cloudToken string
-	)
+	opts := &loginOpts{}
 
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -66,28 +81,31 @@ https://grafana.com: --oauth-url is used only for the login flow here, while
 			// a plain `gcx cloud login` doesn't wipe a previously set value.
 			cur := currentCloudContext(cmd.Context(), configOpts)
 			if !cmd.Flags().Changed("oauth-url") && cur != nil && cur.Cloud != nil && cur.Cloud.OAuthUrl != "" {
-				oauthURL = cur.Cloud.OAuthUrl
+				opts.oauthURL = cur.Cloud.OAuthUrl
 			}
 			if !cmd.Flags().Changed("api-url") && cur != nil && cur.Cloud != nil && cur.Cloud.APIUrl != "" {
-				apiURL = cur.Cloud.APIUrl
+				opts.apiURL = cur.Cloud.APIUrl
 			}
 			// Normalize whichever values won (flag, carry-over, or default)
 			// so a bare host (e.g. "grafana.example.com") gets an https:// scheme
 			// before it reaches the OAuth flow or is saved to config.
-			oauthURL = config.NormalizeCloudURL(oauthURL)
-			apiURL = config.NormalizeCloudURL(apiURL)
-			if cloudToken != "" {
-				return runTokenLogin(cmd.Context(), configOpts, cloudToken, oauthURL, apiURL)
+			opts.oauthURL = config.NormalizeCloudURL(opts.oauthURL)
+			opts.apiURL = config.NormalizeCloudURL(opts.apiURL)
+			if err := opts.Validate(); err != nil {
+				return err
 			}
-			return runOAuthLogin(cmd.Context(), configOpts, oauthURL, apiURL, scopes)
+			if opts.cloudToken != "" {
+				return runTokenLogin(cmd.Context(), configOpts, opts)
+			}
+			return runOAuthLogin(cmd.Context(), configOpts, opts)
 		},
 	}
 
 	configOpts.BindFlags(cmd.Flags())
-	cmd.Flags().StringVar(&cloudToken, "cloud-token", "", "Cloud Access Policy token (skips interactive OAuth flow)")
-	cmd.Flags().StringVar(&oauthURL, "oauth-url", "https://grafana.com", "Base URL for the OAuth login flow (used only by this command)")
-	cmd.Flags().StringVar(&apiURL, "api-url", "https://grafana.com", "Base URL for Grafana Cloud API resource calls (stacks etc.)")
-	cmd.Flags().StringSliceVar(&scopes, "scope", []string{
+	cmd.Flags().StringVar(&opts.cloudToken, "cloud-token", "", "Cloud Access Policy token (skips interactive OAuth flow)")
+	cmd.Flags().StringVar(&opts.oauthURL, "oauth-url", "https://grafana.com", "Base URL for the OAuth login flow (used only by this command)")
+	cmd.Flags().StringVar(&opts.apiURL, "api-url", "https://grafana.com", "Base URL for Grafana Cloud API resource calls (stacks etc.)")
+	cmd.Flags().StringSliceVar(&opts.scopes, "scope", []string{
 		"stacks:read", "stacks:write", "stacks:delete",
 		"accesspolicies:read", "accesspolicies:write", "accesspolicies:delete",
 	}, "OAuth2 scopes to request")
@@ -109,11 +127,11 @@ func currentCloudContext(ctx context.Context, configOpts *cmdconfig.Options) *co
 	return cfg.Contexts[ctxName]
 }
 
-func runTokenLogin(ctx context.Context, configOpts *cmdconfig.Options, token, oauthURL, apiURL string) error {
+func runTokenLogin(ctx context.Context, configOpts *cmdconfig.Options, opts *loginOpts) error {
 	cloud := &config.CloudConfig{
-		Token:    token,
-		OAuthUrl: oauthURL,
-		APIUrl:   apiURL,
+		Token:    opts.cloudToken,
+		OAuthUrl: opts.oauthURL,
+		APIUrl:   opts.apiURL,
 	}
 	if err := saveCloudConfig(ctx, configOpts, cloud); err != nil {
 		return err
@@ -122,11 +140,11 @@ func runTokenLogin(ctx context.Context, configOpts *cmdconfig.Options, token, oa
 	return nil
 }
 
-func runOAuthLogin(ctx context.Context, configOpts *cmdconfig.Options, oauthURL, apiURL string, scopes []string) error {
+func runOAuthLogin(ctx context.Context, configOpts *cmdconfig.Options, opts *loginOpts) error {
 	flow := auth.NewGCOMFlow(auth.GCOMOptions{
 		ClientID: defaultClientID,
-		GCOMURL:  oauthURL,
-		Scopes:   scopes,
+		GCOMURL:  opts.oauthURL,
+		Scopes:   opts.scopes,
 		Writer:   os.Stderr,
 	})
 
@@ -148,8 +166,8 @@ func runOAuthLogin(ctx context.Context, configOpts *cmdconfig.Options, oauthURL,
 
 	cloud := &config.CloudConfig{
 		Token:    result.AccessToken,
-		OAuthUrl: oauthURL,
-		APIUrl:   apiURL,
+		OAuthUrl: opts.oauthURL,
+		APIUrl:   opts.apiURL,
 	}
 	return saveCloudConfig(ctx, configOpts, cloud)
 }

--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -125,20 +125,7 @@ func currentCloudContext(ctx context.Context, configOpts *cmdconfig.Options) *co
 	if err != nil {
 		return nil
 	}
-	return cfg.Contexts[targetContextName(configOpts, cfg)]
-}
-
-// targetContextName resolves which context login should read from and write to:
-// the explicit --context flag when set, otherwise the config's current context,
-// falling back to the default.
-func targetContextName(configOpts *cmdconfig.Options, cfg config.Config) string {
-	if configOpts.Context != "" {
-		return configOpts.Context
-	}
-	if cfg.CurrentContext != "" {
-		return cfg.CurrentContext
-	}
-	return config.DefaultContextName
+	return cfg.Contexts[config.ResolveContextName(configOpts.Context, cfg)]
 }
 
 func runTokenLogin(ctx context.Context, configOpts *cmdconfig.Options, opts *loginOpts) error {
@@ -147,9 +134,11 @@ func runTokenLogin(ctx context.Context, configOpts *cmdconfig.Options, opts *log
 		OAuthUrl: opts.oauthURL,
 		APIUrl:   opts.apiURL,
 	}
-	if err := saveCloudConfig(ctx, configOpts, cloud); err != nil {
+	contextName, err := config.SaveCloudConfig(ctx, configOpts.ConfigSource(), configOpts.Context, cloud)
+	if err != nil {
 		return err
 	}
+	fmt.Fprintf(os.Stderr, "Token saved to context %q\n", contextName)
 	fmt.Fprintln(os.Stderr, "Cloud token saved.")
 	return nil
 }
@@ -183,52 +172,10 @@ func runOAuthLogin(ctx context.Context, configOpts *cmdconfig.Options, opts *log
 		OAuthUrl: opts.oauthURL,
 		APIUrl:   opts.apiURL,
 	}
-	return saveCloudConfig(ctx, configOpts, cloud)
-}
-
-func saveCloudConfig(ctx context.Context, configOpts *cmdconfig.Options, cloud *config.CloudConfig) error {
-	source := configOpts.ConfigSource()
-
-	cfg, err := config.Load(ctx, source)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return &gcxerrors.DetailedError{
-			Summary: "Failed to load config",
-			Parent:  err,
-			Suggestions: []string{
-				"Check your config file syntax: gcx config edit",
-				"Or reset with: rm ~/.config/gcx/config.yaml && gcx cloud login",
-			},
-		}
+	contextName, err := config.SaveCloudConfig(ctx, configOpts.ConfigSource(), configOpts.Context, cloud)
+	if err != nil {
+		return err
 	}
-	if errors.Is(err, os.ErrNotExist) {
-		cfg = config.Config{}
-	}
-
-	contextName := targetContextName(configOpts, cfg)
-
-	if !cfg.HasContext(contextName) {
-		cfg.SetContext(contextName, true, config.Context{})
-	}
-	curCtx := cfg.Contexts[contextName]
-	// Replace the entire cloud config to clear any stale OAuth/token fields
-	// when switching from OAuth to SA token or vice versa, but preserve the
-	// non-auth Stack selection so re-authenticating doesn't drop it.
-	if curCtx.Cloud != nil {
-		cloud.Stack = curCtx.Cloud.Stack
-	}
-	curCtx.Cloud = cloud
-
-	if err := config.Write(ctx, source, cfg); err != nil {
-		return &gcxerrors.DetailedError{
-			Summary: "Failed to save config",
-			Parent:  err,
-			Suggestions: []string{
-				"Check file permissions on the config file",
-				"Try: gcx config edit",
-			},
-		}
-	}
-
 	fmt.Fprintf(os.Stderr, "Token saved to context %q\n", contextName)
 	return nil
 }

--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -113,18 +113,27 @@ https://grafana.com: --oauth-url is used only for the login flow here, while
 	return cmd
 }
 
-// currentCloudContext loads the config and returns the current context, or nil
+// currentCloudContext loads the config and returns the target context, or nil
 // if config can't be loaded or the context doesn't exist yet.
 func currentCloudContext(ctx context.Context, configOpts *cmdconfig.Options) *config.Context {
 	cfg, err := config.Load(ctx, configOpts.ConfigSource())
 	if err != nil {
 		return nil
 	}
-	ctxName := cfg.CurrentContext
-	if ctxName == "" {
-		ctxName = config.DefaultContextName
+	return cfg.Contexts[targetContextName(configOpts, cfg)]
+}
+
+// targetContextName resolves which context login should read from and write to:
+// the explicit --context flag when set, otherwise the config's current context,
+// falling back to the default.
+func targetContextName(configOpts *cmdconfig.Options, cfg config.Config) string {
+	if configOpts.Context != "" {
+		return configOpts.Context
 	}
-	return cfg.Contexts[ctxName]
+	if cfg.CurrentContext != "" {
+		return cfg.CurrentContext
+	}
+	return config.DefaultContextName
 }
 
 func runTokenLogin(ctx context.Context, configOpts *cmdconfig.Options, opts *loginOpts) error {
@@ -190,10 +199,7 @@ func saveCloudConfig(ctx context.Context, configOpts *cmdconfig.Options, cloud *
 		cfg = config.Config{}
 	}
 
-	contextName := cfg.CurrentContext
-	if contextName == "" {
-		contextName = config.DefaultContextName
-	}
+	contextName := targetContextName(configOpts, cfg)
 
 	if !cfg.HasContext(contextName) {
 		cfg.SetContext(contextName, true, config.Context{})

--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -28,9 +28,13 @@ func (opts *loginOpts) bindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.cloudToken, "cloud-token", "", "Cloud Access Policy token (skips interactive OAuth flow)")
 	flags.StringVar(&opts.oauthURL, "oauth-url", "https://grafana.com", "Base URL for the OAuth login flow (used only by this command)")
 	flags.StringVar(&opts.apiURL, "api-url", "https://grafana.com", "Base URL for Grafana Cloud API resource calls (stacks etc.)")
+	// Only stacks:* is grantable through the interactive OAuth flow (the gcx OAuth
+	// client's registered allowlist). The product scopes gcx also uses
+	// (metrics:*, logs:*, traces:*, fleet-management:*, set:alloy-data-write) are
+	// Cloud Access Policy scopes: they can't be obtained here, only on a token
+	// created in the Access Policies UI and passed via --cloud-token.
 	flags.StringSliceVar(&opts.scopes, "scope", []string{
 		"stacks:read", "stacks:write", "stacks:delete",
-		"accesspolicies:read", "accesspolicies:write", "accesspolicies:delete",
 	}, "OAuth2 scopes to request")
 }
 

--- a/cmd/gcx/cloud/command_test.go
+++ b/cmd/gcx/cloud/command_test.go
@@ -1,0 +1,53 @@
+package cloud
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/internal/config"
+)
+
+// TestSaveCloudConfigPreservesStack verifies that re-authenticating (which
+// writes a fresh CloudConfig with only auth fields) does not drop a previously
+// configured non-auth Stack selection.
+func TestSaveCloudConfigPreservesStack(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	source := config.ExplicitConfigFile(path)
+
+	seed := config.Config{}
+	seed.SetContext(config.DefaultContextName, true, config.Context{
+		Cloud: &config.CloudConfig{
+			Token:    "old-token",
+			Stack:    "mystack",
+			OAuthUrl: "https://old.example",
+		},
+	})
+	if err := config.Write(ctx, source, seed); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	configOpts := &cmdconfig.Options{ConfigFile: path}
+	newCloud := &config.CloudConfig{
+		Token:    "new-token",
+		OAuthUrl: "https://grafana.com",
+		APIUrl:   "https://grafana.com",
+	}
+	if err := saveCloudConfig(ctx, configOpts, newCloud); err != nil {
+		t.Fatalf("saveCloudConfig: %v", err)
+	}
+
+	got, err := config.Load(ctx, source)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	cloud := got.Contexts[config.DefaultContextName].Cloud
+	if cloud.Stack != "mystack" {
+		t.Errorf("Stack not preserved: got %q, want %q", cloud.Stack, "mystack")
+	}
+	if cloud.Token != "new-token" {
+		t.Errorf("Token not updated: got %q, want %q", cloud.Token, "new-token")
+	}
+}

--- a/cmd/gcx/cloud/command_test.go
+++ b/cmd/gcx/cloud/command_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage // white-box testing: accesses unexported saveCloudConfig.
 package cloud
 
 import (

--- a/docs/reference/cli/gcx_cloud.md
+++ b/docs/reference/cli/gcx_cloud.md
@@ -22,5 +22,6 @@ Manage your Grafana Cloud resources
 ### SEE ALSO
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx cloud login](gcx_cloud_login.md)	 - Authenticate with the Grafana Cloud API (GCOM)
 * [gcx cloud stacks](gcx_cloud_stacks.md)	 - Manage Grafana Cloud stacks (list, create, update, delete)
 

--- a/docs/reference/cli/gcx_cloud_login.md
+++ b/docs/reference/cli/gcx_cloud_login.md
@@ -18,9 +18,7 @@ directly via --cloud-token.
 
 Two endpoints can be configured independently, both defaulting to
 https://grafana.com: --oauth-url is used only for the login flow here, while
---api-url is used by every command that talks to the Grafana Cloud API. In
-production neither needs setting; against a dev environment where the two
-differ (e.g. a private API endpoint), set both.
+--api-url is used by every command that talks to the Grafana Cloud API.
 
 ```
 gcx cloud login [flags]
@@ -31,7 +29,6 @@ gcx cloud login [flags]
 ```
   gcx cloud login
   gcx cloud login --cloud-token glsa_abc123
-  gcx cloud login --oauth-url https://grafana.example.com --api-url https://api.internal.example.com
 ```
 
 ### Options

--- a/docs/reference/cli/gcx_cloud_login.md
+++ b/docs/reference/cli/gcx_cloud_login.md
@@ -1,0 +1,62 @@
+## gcx cloud login
+
+Authenticate with the Grafana Cloud API (GCOM)
+
+### Synopsis
+
+Authenticate with the Grafana Cloud API and store the token in the gcx config.
+
+This is different from "gcx login", which authenticates to a specific
+Grafana stack instance. "gcx cloud login" authenticates against the
+Grafana Cloud platform API (grafana.com), enabling commands that manage
+Cloud resources like stacks and access policies.
+
+By default, opens a browser for interactive OAuth2 authentication.
+
+For non-interactive use (CI/CD, scripts), pass a Cloud Access Policy token
+directly via --cloud-token.
+
+Two endpoints can be configured independently, both defaulting to
+https://grafana.com: --oauth-url is used only for the login flow here, while
+--api-url is used by every command that talks to the Grafana Cloud API. In
+production neither needs setting; against a dev environment where the two
+differ (e.g. a private API endpoint), set both.
+
+```
+gcx cloud login [flags]
+```
+
+### Examples
+
+```
+  gcx cloud login
+  gcx cloud login --cloud-token glsa_abc123
+  gcx cloud login --oauth-url https://grafana.example.com --api-url https://api.internal.example.com
+```
+
+### Options
+
+```
+      --api-url string       Base URL for Grafana Cloud API resource calls (stacks etc.) (default "https://grafana.com")
+      --cloud-token string   Cloud Access Policy token (skips interactive OAuth flow)
+      --config string        Path to the configuration file to use
+      --context string       Name of the context to use
+  -h, --help                 help for login
+      --oauth-url string     Base URL for the OAuth login flow (used only by this command) (default "https://grafana.com")
+      --scope strings        OAuth2 scopes to request (default [stacks:read,stacks:write,stacks:delete,accesspolicies:read,accesspolicies:write,accesspolicies:delete])
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx cloud](gcx_cloud.md)	 - Manage your Grafana Cloud resources
+

--- a/docs/reference/cli/gcx_cloud_login.md
+++ b/docs/reference/cli/gcx_cloud_login.md
@@ -40,7 +40,7 @@ gcx cloud login [flags]
       --context string       Name of the context to use
   -h, --help                 help for login
       --oauth-url string     Base URL for the OAuth login flow (used only by this command) (default "https://grafana.com")
-      --scope strings        OAuth2 scopes to request (default [stacks:read,stacks:write,stacks:delete,accesspolicies:read,accesspolicies:write,accesspolicies:delete])
+      --scope strings        OAuth2 scopes to request (default [stacks:read,stacks:write,stacks:delete])
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -96,11 +96,19 @@ contexts:
       # CloudConfig holds Grafana Cloud platform credentials and configuration.
       # Token is a Grafana Cloud API token used to authenticate against GCOM.
       token: string
+      # TokenExpiresAt is the token expiration time in RFC3339 format.
+      # Only set for OAuth tokens obtained via `gcx cloud login`.
+      token-expires-at: string
       # Stack is the Grafana Cloud stack slug (e.g. "mystack").
       # Optional: if not set, the slug may be derived from Grafana.Server.
       stack: string
-      # APIUrl is the base URL of the Grafana Cloud API (GCOM).
-      # Optional: defaults to "https://grafana.com".
+      # OAuthUrl is the base URL for the OAuth login flow run by `gcx cloud
+      # login`. It is used only during login. Optional: defaults to
+      # "https://grafana.com".
+      oauth-url: string
+      # APIUrl is the base URL for all Grafana Cloud API (GCOM) resource calls
+      # (stacks, regions, access policies, etc.). Every client talking to GCOM
+      # uses it. Optional: defaults to "https://grafana.com".
       api-url: string
     # DefaultPrometheusDatasource is the UID of the default Prometheus datasource to use for queries.
     default-prometheus-datasource: string

--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -96,9 +96,6 @@ contexts:
       # CloudConfig holds Grafana Cloud platform credentials and configuration.
       # Token is a Grafana Cloud API token used to authenticate against GCOM.
       token: string
-      # TokenExpiresAt is the token expiration time in RFC3339 format.
-      # Only set for OAuth tokens obtained via `gcx cloud login`.
-      token-expires-at: string
       # Stack is the Grafana Cloud stack slug (e.g. "mystack").
       # Optional: if not set, the slug may be derived from Grafana.Server.
       stack: string

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -13,8 +13,15 @@ disables the notifier (NO_COLOR convention).
 
 ## `GRAFANA_CLOUD_API_URL`
 
-APIUrl is the base URL of the Grafana Cloud API (GCOM).
-Optional: defaults to "https://grafana.com".
+APIUrl is the base URL for all Grafana Cloud API (GCOM) resource calls
+(stacks, regions, access policies, etc.). Every client talking to GCOM
+uses it. Optional: defaults to "https://grafana.com".
+
+## `GRAFANA_CLOUD_OAUTH_URL`
+
+OAuthUrl is the base URL for the OAuth login flow run by `gcx cloud
+login`. It is used only during login. Optional: defaults to
+"https://grafana.com".
 
 ## `GRAFANA_CLOUD_STACK`
 

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -52,7 +52,8 @@ var commandAnnotations = map[string]annotation{
 	"gcx assistant conversation get":                 {Cost: "large", Hint: "Pull a conversation transcript by ID before continuing it with 'gcx assistant prompt --context-id'. Example: <conversation-id> -o json"},
 
 	// login
-	"gcx login": {Cost: "small", Hint: "Browser OAuth (recommended for Grafana Cloud): gcx login <ctx> --server <url> --oauth — opens a browser for the user to approve; works in agent mode. Non-interactive token: gcx login <ctx> --yes --server <url> --token <grafana-sa-token> [--cloud-token <cap-token>]. Service-account tokens (--token) are created inside the Grafana instance — see " + docs.ServiceAccounts + ". Cloud access-policy tokens (--cloud-token) are created at grafana.com — see " + docs.AccessPolicies + ". Append .md to any grafana.com/docs URL to fetch markdown. Do not guess token URLs."},
+	"gcx login":       {Cost: "small", Hint: "Browser OAuth (recommended for Grafana Cloud): gcx login <ctx> --server <url> --oauth — opens a browser for the user to approve; works in agent mode. Non-interactive token: gcx login <ctx> --yes --server <url> --token <grafana-sa-token> [--cloud-token <cap-token>]. Service-account tokens (--token) are created inside the Grafana instance — see " + docs.ServiceAccounts + ". Cloud access-policy tokens (--cloud-token) are created at grafana.com — see " + docs.AccessPolicies + ". Append .md to any grafana.com/docs URL to fetch markdown. Do not guess token URLs."},
+	"gcx cloud login": {Cost: "small", Hint: "Authenticate to the Grafana Cloud platform API (grafana.com) for managing stacks and access policies, distinct from 'gcx login' which targets a single stack. Browser OAuth by default; non-interactive: gcx cloud login --cloud-token <cap-token>. Cloud access-policy tokens are created at grafana.com, see " + docs.AccessPolicies + "."},
 
 	// commands
 	"gcx commands": {Cost: "medium", Hint: "--flat -o json"},

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -177,80 +177,88 @@ func (f *Flow) Run(ctx context.Context) (*Result, error) {
 }
 
 func (f *Flow) startCallbackServer(ctx context.Context, listener net.Listener, expectedState, codeVerifier string, resultCh chan<- *Result, errCh chan<- error) *http.Server {
+	return newCallbackServer(listener, errCh, func(w http.ResponseWriter, r *http.Request) {
+		state := r.URL.Query().Get("state")
+		if state != expectedState {
+			errCh <- errors.New("invalid state - possible CSRF attack")
+			renderErrorPage(w, "Invalid state parameter")
+			return
+		}
+
+		if errMsg := r.URL.Query().Get("error"); errMsg != "" {
+			errMsg = StripControlChars(errMsg)
+			errCh <- fmt.Errorf("authentication denied: %s", errMsg)
+			renderErrorPage(w, errMsg)
+			return
+		}
+
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			errCh <- errors.New("no authorization code received")
+			renderErrorPage(w, "No authorization code received")
+			return
+		}
+
+		endpoint := r.URL.Query().Get("endpoint")
+		if endpoint == "" {
+			errCh <- errors.New("no API endpoint received")
+			renderErrorPage(w, "No API endpoint received")
+			return
+		}
+		if err := ValidateEndpointURL(endpoint); err != nil {
+			errCh <- fmt.Errorf("invalid API endpoint: %w", err)
+			renderErrorPage(w, "Invalid API endpoint")
+			return
+		}
+
+		exchangeResult, err := exchangeCodeForToken(ctx, endpoint, code, codeVerifier)
+		if err != nil {
+			errCh <- fmt.Errorf("token exchange failed: %w", err)
+			renderErrorPage(w, "Token exchange failed")
+			return
+		}
+
+		instanceEndpoint := r.URL.Query().Get("instanceEndpoint")
+		instanceEndpointUrl, err := url.Parse(instanceEndpoint)
+		if err != nil {
+			errCh <- fmt.Errorf("invalid endpoint url: %w", err)
+			renderErrorPage(w, "Invalid instance endpoint passed")
+			return
+		}
+		if instanceEndpointUrl.Scheme != "https" {
+			errCh <- fmt.Errorf("invalid endpoint scheme: expected 'https', got '%s'", instanceEndpointUrl.Scheme)
+			renderErrorPage(w, "Invalid instance endpoint: needs to be an HTTPS URL")
+			return
+		}
+
+		result := &Result{
+			Token:            exchangeResult.Data.Token,
+			Email:            exchangeResult.Data.Email,
+			DeviceName:       r.URL.Query().Get("device"),
+			APIEndpoint:      exchangeResult.Data.APIEndpoint,
+			ExpiresAt:        exchangeResult.Data.ExpiresAt,
+			RefreshToken:     exchangeResult.Data.RefreshToken,
+			RefreshExpiresAt: exchangeResult.Data.RefreshExpiresAt,
+			InstanceEndpoint: instanceEndpoint,
+		}
+
+		resultCh <- result
+		renderSuccessPage(w)
+	})
+}
+
+// newCallbackServer binds a single-use /callback handler to listener and starts
+// serving in a goroutine. handle runs at most once; replayed callbacks get 410
+// Gone. Serve errors are reported on errCh.
+func newCallbackServer(listener net.Listener, errCh chan<- error, handle http.HandlerFunc) *http.Server {
 	var once sync.Once
 
 	mux := http.NewServeMux()
-
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
 		handled := false
 		once.Do(func() {
 			handled = true
-			state := r.URL.Query().Get("state")
-			if state != expectedState {
-				errCh <- errors.New("invalid state - possible CSRF attack")
-				renderErrorPage(w, "Invalid state parameter")
-				return
-			}
-
-			if errMsg := r.URL.Query().Get("error"); errMsg != "" {
-				errMsg = StripControlChars(errMsg)
-				errCh <- fmt.Errorf("authentication denied: %s", errMsg)
-				renderErrorPage(w, errMsg)
-				return
-			}
-
-			code := r.URL.Query().Get("code")
-			if code == "" {
-				errCh <- errors.New("no authorization code received")
-				renderErrorPage(w, "No authorization code received")
-				return
-			}
-
-			endpoint := r.URL.Query().Get("endpoint")
-			if endpoint == "" {
-				errCh <- errors.New("no API endpoint received")
-				renderErrorPage(w, "No API endpoint received")
-				return
-			}
-			if err := ValidateEndpointURL(endpoint); err != nil {
-				errCh <- fmt.Errorf("invalid API endpoint: %w", err)
-				renderErrorPage(w, "Invalid API endpoint")
-				return
-			}
-
-			exchangeResult, err := exchangeCodeForToken(ctx, endpoint, code, codeVerifier)
-			if err != nil {
-				errCh <- fmt.Errorf("token exchange failed: %w", err)
-				renderErrorPage(w, "Token exchange failed")
-				return
-			}
-
-			instanceEndpoint := r.URL.Query().Get("instanceEndpoint")
-			instanceEndpointUrl, err := url.Parse(instanceEndpoint)
-			if err != nil {
-				errCh <- fmt.Errorf("invalid endpoint url: %w", err)
-				renderErrorPage(w, "Invalid instance endpoint passed")
-				return
-			}
-			if instanceEndpointUrl.Scheme != "https" {
-				errCh <- fmt.Errorf("invalid endpoint scheme: expected 'https', got '%s'", instanceEndpointUrl.Scheme)
-				renderErrorPage(w, "Invalid instance endpoint: needs to be an HTTPS URL")
-				return
-			}
-
-			result := &Result{
-				Token:            exchangeResult.Data.Token,
-				Email:            exchangeResult.Data.Email,
-				DeviceName:       r.URL.Query().Get("device"),
-				APIEndpoint:      exchangeResult.Data.APIEndpoint,
-				ExpiresAt:        exchangeResult.Data.ExpiresAt,
-				RefreshToken:     exchangeResult.Data.RefreshToken,
-				RefreshExpiresAt: exchangeResult.Data.RefreshExpiresAt,
-				InstanceEndpoint: instanceEndpoint,
-			}
-
-			resultCh <- result
-			renderSuccessPage(w)
+			handle(w, r)
 		})
 		if !handled {
 			http.Error(w, "Authentication already processed", http.StatusGone)

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -305,6 +306,42 @@ func ValidateEndpointURL(endpoint string) error {
 	}
 
 	return fmt.Errorf("endpoint host %q is not a trusted Grafana domain", hostname)
+}
+
+var allowedGCOMHosts = []string{ //nolint:gochecknoglobals
+	"grafana.com",
+	"grafana-dev.com",
+	"grafana-ops.com",
+}
+
+// validateGCOMURL checks that the given URL points at a trusted Grafana Cloud
+// platform (GCOM) domain or a local address. Unlike ValidateEndpointURL, which
+// guards per-stack *.grafana.net endpoints, this validates the grafana.com
+// family used by the cloud login flow. Returns an error if the URL is untrusted.
+func validateGCOMURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("malformed URL: %w", err)
+	}
+	if u.Host == "" {
+		return errors.New("URL has no host")
+	}
+
+	hostname := u.Hostname()
+
+	if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1" {
+		return nil
+	}
+
+	if u.Scheme != "https" {
+		return fmt.Errorf("URL must use HTTPS, got %q", u.Scheme)
+	}
+
+	if slices.Contains(allowedGCOMHosts, hostname) {
+		return nil
+	}
+
+	return fmt.Errorf("URL host %q is not a trusted Grafana Cloud domain", hostname)
 }
 
 type exchangeResponse struct {

--- a/internal/auth/flow_test.go
+++ b/internal/auth/flow_test.go
@@ -51,6 +51,39 @@ func TestValidateEndpointURL_RejectsUntrustedDomains(t *testing.T) {
 	}
 }
 
+func TestGCOMFlowRun_RejectsUntrustedURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		gcomURL string
+	}{
+		{"random domain", "https://evil.example.com"},
+		{"http non-local", "http://grafana.com"},
+		{"stack endpoint", "https://mystack.grafana.net"},
+		{"subdomain bypass", "https://grafana.com.attacker.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var writer bytes.Buffer
+			flow := auth.NewGCOMFlow(auth.GCOMOptions{
+				GCOMURL: tt.gcomURL,
+				Writer:  &writer,
+			})
+
+			_, err := flow.Run(context.Background())
+			if err == nil {
+				t.Fatalf("expected %q to be rejected", tt.gcomURL)
+			}
+			if !strings.Contains(err.Error(), "invalid GCOM URL") {
+				t.Fatalf("expected invalid GCOM URL error, got %v", err)
+			}
+			if writer.Len() != 0 {
+				t.Fatalf("expected no browser instructions before validation failure, got %q", writer.String())
+			}
+		})
+	}
+}
+
 func TestFlowRun_FailsBeforeBrowserOutputWhenFixedPortUnavailable(t *testing.T) {
 	var lc net.ListenConfig
 	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/grafana/gcx/internal/deeplink"
 )
 
 // GCOMResult contains the result of a GCOM OAuth2 PKCE authentication flow.
@@ -110,7 +112,7 @@ func (f *GCOMFlow) Run(ctx context.Context) (*GCOMResult, error) {
 	fmt.Fprintln(f.writer, "Opening browser to authenticate with Grafana Cloud...")
 	fmt.Fprintf(f.writer, "If browser doesn't open, visit:\n  %s\n\n", authURL)
 
-	if err := openBrowser(ctx, authURL); err != nil {
+	if err := deeplink.Open(authURL); err != nil {
 		fmt.Fprintln(f.writer, "(Could not open browser automatically)")
 	}
 

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -20,10 +20,7 @@ import (
 type GCOMResult struct {
 	AccessToken string
 	Scope       string
-	ExpiresIn   int
-	UserID      int
 	Info        struct {
-		Name  string `json:"name"`
 		Email string `json:"email"`
 		Login string `json:"login"`
 	}
@@ -40,12 +37,6 @@ type GCOMOptions struct {
 	// Scopes is the list of OAuth2 scopes to request.
 	Scopes []string
 
-	// Port specifies a fixed port for the callback server. 0 = auto.
-	Port int
-
-	// BindAddress for the callback server. Defaults to "127.0.0.1".
-	BindAddress string
-
 	// Writer for user-facing messages. Defaults to os.Stderr.
 	Writer io.Writer
 }
@@ -58,9 +49,6 @@ type GCOMFlow struct {
 
 // NewGCOMFlow creates a new GCOM OAuth2 PKCE flow.
 func NewGCOMFlow(opts GCOMOptions) *GCOMFlow {
-	if opts.BindAddress == "" {
-		opts.BindAddress = "127.0.0.1"
-	}
 	if opts.GCOMURL == "" {
 		opts.GCOMURL = "https://grafana.com"
 	}
@@ -73,7 +61,7 @@ func NewGCOMFlow(opts GCOMOptions) *GCOMFlow {
 
 // Run executes the GCOM OAuth2 PKCE flow.
 func (f *GCOMFlow) Run(ctx context.Context) (*GCOMResult, error) {
-	listener, port, err := listenOnCallbackPort(ctx, f.opts.BindAddress, f.opts.Port)
+	listener, port, err := listenOnCallbackPort(ctx, "127.0.0.1", 0)
 	if err != nil {
 		return nil, fmt.Errorf("no available port: %w", err)
 	}
@@ -199,12 +187,8 @@ func (f *GCOMFlow) startGCOMCallbackServer(ctx context.Context, listener net.Lis
 
 type gcomTokenResponse struct {
 	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_in"`
 	Scope       string `json:"scope"`
-	UID         int    `json:"uid"`
 	Info        struct {
-		Name  string `json:"name"`
 		Email string `json:"email"`
 		Login string `json:"login"`
 	} `json:"info"`
@@ -271,8 +255,6 @@ func (f *GCOMFlow) exchangeGCOMToken(ctx context.Context, code, codeVerifier, re
 	return &GCOMResult{
 		AccessToken: tokenResp.AccessToken,
 		Scope:       tokenResp.Scope,
-		ExpiresIn:   tokenResp.ExpiresIn,
-		UserID:      tokenResp.UID,
 		Info:        tokenResp.Info,
 	}, nil
 }

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -234,7 +234,17 @@ func (f *GCOMFlow) exchangeGCOMToken(ctx context.Context, code, codeVerifier, re
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			redirectEndpoint := req.URL.Scheme + "://" + req.URL.Host
+			if err := ValidateEndpointURL(redirectEndpoint); err != nil {
+				return fmt.Errorf("redirect to untrusted URL blocked: %w", err)
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("token request failed: %w", err)
 	}

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -246,7 +246,7 @@ func (f *GCOMFlow) exchangeGCOMToken(ctx context.Context, code, codeVerifier, re
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("token exchange returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("token exchange returned status %d", resp.StatusCode)
 	}
 
 	var tokenResp gcomTokenResponse

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -1,0 +1,268 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// GCOMResult contains the result of a GCOM OAuth2 PKCE authentication flow.
+type GCOMResult struct {
+	AccessToken string
+	Scope       string
+	ExpiresIn   int
+	UserID      int
+	Info        struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+		Login string `json:"login"`
+	}
+}
+
+// GCOMOptions configures the GCOM OAuth2 PKCE flow.
+type GCOMOptions struct {
+	// ClientID is the OAuth2 client ID registered in GCOM.
+	ClientID string
+
+	// GCOMURL is the base URL of the GCOM API (e.g. "https://grafana.com").
+	GCOMURL string
+
+	// Scopes is the list of OAuth2 scopes to request.
+	Scopes []string
+
+	// Port specifies a fixed port for the callback server. 0 = auto.
+	Port int
+
+	// BindAddress for the callback server. Defaults to "127.0.0.1".
+	BindAddress string
+
+	// Writer for user-facing messages. Defaults to os.Stderr.
+	Writer io.Writer
+}
+
+// GCOMFlow manages a direct GCOM OAuth2 PKCE authentication flow.
+type GCOMFlow struct {
+	opts   GCOMOptions
+	writer io.Writer
+}
+
+// NewGCOMFlow creates a new GCOM OAuth2 PKCE flow.
+func NewGCOMFlow(opts GCOMOptions) *GCOMFlow {
+	if opts.BindAddress == "" {
+		opts.BindAddress = "127.0.0.1"
+	}
+	if opts.GCOMURL == "" {
+		opts.GCOMURL = "https://grafana.com"
+	}
+	w := opts.Writer
+	if w == nil {
+		w = os.Stderr
+	}
+	return &GCOMFlow{opts: opts, writer: w}
+}
+
+// Run executes the GCOM OAuth2 PKCE flow.
+func (f *GCOMFlow) Run(ctx context.Context) (*GCOMResult, error) {
+	listener, port, err := listenOnCallbackPort(ctx, f.opts.BindAddress, f.opts.Port)
+	if err != nil {
+		return nil, fmt.Errorf("no available port: %w", err)
+	}
+
+	state, err := generateState()
+	if err != nil {
+		_ = listener.Close()
+		return nil, fmt.Errorf("failed to generate state: %w", err)
+	}
+
+	codeVerifier, err := generateCodeVerifier()
+	if err != nil {
+		_ = listener.Close()
+		return nil, fmt.Errorf("failed to generate PKCE code verifier: %w", err)
+	}
+	codeChallenge := generateCodeChallenge(codeVerifier)
+
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+
+	resultCh := make(chan *GCOMResult, 1)
+	errCh := make(chan error, 1)
+	server := f.startGCOMCallbackServer(ctx, listener, state, codeVerifier, redirectURI, resultCh, errCh)
+
+	// A fresh context is intentional: the request context may already be
+	// cancelled by the time we shut down, and graceful shutdown needs its own
+	// timeout.
+	//nolint:contextcheck // shutdown must not inherit the (possibly cancelled) request context
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	gcomURL := strings.TrimSuffix(f.opts.GCOMURL, "/")
+	scope := strings.Join(f.opts.Scopes, " ")
+
+	authURL := fmt.Sprintf("%s/oauth2/authorize?client_id=%s&redirect_uri=%s&scope=%s&code_challenge=%s&code_challenge_method=S256&state=%s&response_type=code",
+		gcomURL,
+		url.QueryEscape(f.opts.ClientID),
+		url.QueryEscape(redirectURI),
+		url.QueryEscape(scope),
+		url.QueryEscape(codeChallenge),
+		url.QueryEscape(state),
+	)
+
+	fmt.Fprintln(f.writer, "Opening browser to authenticate with Grafana Cloud...")
+	fmt.Fprintf(f.writer, "If browser doesn't open, visit:\n  %s\n\n", authURL)
+
+	if err := openBrowser(ctx, authURL); err != nil {
+		fmt.Fprintln(f.writer, "(Could not open browser automatically)")
+	}
+
+	fmt.Fprintln(f.writer, "Waiting for authentication...")
+
+	select {
+	case result := <-resultCh:
+		return result, nil
+	case err := <-errCh:
+		return nil, err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (f *GCOMFlow) startGCOMCallbackServer(ctx context.Context, listener net.Listener, expectedState, codeVerifier, redirectURI string, resultCh chan<- *GCOMResult, errCh chan<- error) *http.Server {
+	var once sync.Once
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		handled := false
+		once.Do(func() {
+			handled = true
+			state := r.URL.Query().Get("state")
+			if state != expectedState {
+				errCh <- errors.New("invalid state - possible CSRF attack")
+				renderErrorPage(w, "Invalid state parameter")
+				return
+			}
+
+			if errMsg := r.URL.Query().Get("error"); errMsg != "" {
+				errCh <- fmt.Errorf("authentication denied: %s", StripControlChars(errMsg))
+				renderErrorPage(w, StripControlChars(errMsg))
+				return
+			}
+
+			code := r.URL.Query().Get("code")
+			if code == "" {
+				errCh <- errors.New("no authorization code received")
+				renderErrorPage(w, "No authorization code received")
+				return
+			}
+
+			result, err := f.exchangeGCOMToken(ctx, code, codeVerifier, redirectURI)
+			if err != nil {
+				errCh <- fmt.Errorf("token exchange failed: %w", err)
+				renderErrorPage(w, "Token exchange failed")
+				return
+			}
+
+			resultCh <- result
+			renderSuccessPage(w)
+		})
+		if !handled {
+			http.Error(w, "Authentication already processed", http.StatusGone)
+		}
+	})
+
+	server := &http.Server{
+		Addr:              listener.Addr().String(),
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- fmt.Errorf("callback server error: %w", err)
+		}
+	}()
+
+	return server
+}
+
+type gcomTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope"`
+	UID         int    `json:"uid"`
+	Info        struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+		Login string `json:"login"`
+	} `json:"info"`
+}
+
+func (f *GCOMFlow) exchangeGCOMToken(ctx context.Context, code, codeVerifier, redirectURI string) (*GCOMResult, error) {
+	gcomURL := strings.TrimSuffix(f.opts.GCOMURL, "/")
+	tokenURL := gcomURL + "/api/oauth2/token"
+
+	body, err := json.Marshal(map[string]string{
+		"grant_type":    "authorization_code",
+		"client_id":     f.opts.ClientID,
+		"code":          code,
+		"code_verifier": codeVerifier,
+		"redirect_uri":  redirectURI,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal token request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token exchange returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var tokenResp gcomTokenResponse
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, errors.New("token response missing access_token")
+	}
+
+	return &GCOMResult{
+		AccessToken: tokenResp.AccessToken,
+		Scope:       tokenResp.Scope,
+		ExpiresIn:   tokenResp.ExpiresIn,
+		UserID:      tokenResp.UID,
+		Info:        tokenResp.Info,
+	}, nil
+}

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -63,6 +63,10 @@ func NewGCOMFlow(opts GCOMOptions) *GCOMFlow {
 
 // Run executes the GCOM OAuth2 PKCE flow.
 func (f *GCOMFlow) Run(ctx context.Context) (*GCOMResult, error) {
+	if err := validateGCOMURL(f.opts.GCOMURL); err != nil {
+		return nil, fmt.Errorf("invalid GCOM URL: %w", err)
+	}
+
 	listener, port, err := listenOnCallbackPort(ctx, "127.0.0.1", 0)
 	if err != nil {
 		return nil, fmt.Errorf("no available port: %w", err)

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/grafana/gcx/internal/deeplink"
@@ -133,62 +132,37 @@ func (f *GCOMFlow) Run(ctx context.Context) (*GCOMResult, error) {
 }
 
 func (f *GCOMFlow) startGCOMCallbackServer(ctx context.Context, listener net.Listener, expectedState, codeVerifier, redirectURI string, resultCh chan<- *GCOMResult, errCh chan<- error) *http.Server {
-	var once sync.Once
-
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-		handled := false
-		once.Do(func() {
-			handled = true
-			state := r.URL.Query().Get("state")
-			if state != expectedState {
-				errCh <- errors.New("invalid state - possible CSRF attack")
-				renderErrorPage(w, "Invalid state parameter")
-				return
-			}
-
-			if errMsg := r.URL.Query().Get("error"); errMsg != "" {
-				errCh <- fmt.Errorf("authentication denied: %s", StripControlChars(errMsg))
-				renderErrorPage(w, StripControlChars(errMsg))
-				return
-			}
-
-			code := r.URL.Query().Get("code")
-			if code == "" {
-				errCh <- errors.New("no authorization code received")
-				renderErrorPage(w, "No authorization code received")
-				return
-			}
-
-			result, err := f.exchangeGCOMToken(ctx, code, codeVerifier, redirectURI)
-			if err != nil {
-				errCh <- fmt.Errorf("token exchange failed: %w", err)
-				renderErrorPage(w, "Token exchange failed")
-				return
-			}
-
-			resultCh <- result
-			renderSuccessPage(w)
-		})
-		if !handled {
-			http.Error(w, "Authentication already processed", http.StatusGone)
+	return newCallbackServer(listener, errCh, func(w http.ResponseWriter, r *http.Request) {
+		state := r.URL.Query().Get("state")
+		if state != expectedState {
+			errCh <- errors.New("invalid state - possible CSRF attack")
+			renderErrorPage(w, "Invalid state parameter")
+			return
 		}
+
+		if errMsg := r.URL.Query().Get("error"); errMsg != "" {
+			errCh <- fmt.Errorf("authentication denied: %s", StripControlChars(errMsg))
+			renderErrorPage(w, StripControlChars(errMsg))
+			return
+		}
+
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			errCh <- errors.New("no authorization code received")
+			renderErrorPage(w, "No authorization code received")
+			return
+		}
+
+		result, err := f.exchangeGCOMToken(ctx, code, codeVerifier, redirectURI)
+		if err != nil {
+			errCh <- fmt.Errorf("token exchange failed: %w", err)
+			renderErrorPage(w, "Token exchange failed")
+			return
+		}
+
+		resultCh <- result
+		renderSuccessPage(w)
 	})
-
-	server := &http.Server{
-		Addr:              listener.Addr().String(),
-		Handler:           mux,
-		ReadHeaderTimeout: 10 * time.Second,
-	}
-
-	go func() {
-		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errCh <- fmt.Errorf("callback server error: %w", err)
-		}
-	}()
-
-	return server
 }
 
 type gcomTokenResponse struct {

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/grafana/gcx/internal/deeplink"
+	"github.com/grafana/gcx/internal/httputils"
 )
 
 // GCOMResult contains the result of a GCOM OAuth2 PKCE authentication flow.
@@ -198,15 +199,17 @@ func (f *GCOMFlow) exchangeGCOMToken(ctx context.Context, code, codeVerifier, re
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+	// NewClient (not NewDefaultClient): NewDefaultClient logs payloads from ctx,
+	// which would dump the OAuth code/code_verifier secrets.
+	client := httputils.NewClient(httputils.ClientOpts{
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
 			redirectEndpoint := req.URL.Scheme + "://" + req.URL.Host
 			if err := ValidateEndpointURL(redirectEndpoint); err != nil {
 				return fmt.Errorf("redirect to untrusted URL blocked: %w", err)
 			}
 			return nil
 		},
-	}
+	})
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -180,7 +180,7 @@ func (t *RefreshTransport) maybeRefresh(req *http.Request) error {
 	defer cancel()
 
 	// Network call happens outside the in-process mutex.
-	result, err := t.doRefresh(refreshCtx, refreshToken)
+	result, err := t.doProxyRefresh(refreshCtx, refreshToken)
 	if err != nil {
 		return err
 	}
@@ -189,13 +189,13 @@ func (t *RefreshTransport) maybeRefresh(req *http.Request) error {
 	// already consumed the old refresh token and rotated it, so discarding
 	// the response would leave the client with an invalid refresh token.
 	t.mu.Lock()
-	t.Token = result.Data.Token
-	if result.Data.RefreshToken != "" {
-		t.RefreshToken = result.Data.RefreshToken
+	t.Token = result.Token
+	if result.RefreshToken != "" {
+		t.RefreshToken = result.RefreshToken
 	}
 	// Unparseable expiry falls back to zero time so the next request re-refreshes.
-	t.ExpiresAt, _ = time.Parse(time.RFC3339, result.Data.ExpiresAt)
-	if rp, err := time.Parse(time.RFC3339, result.Data.RefreshExpiresAt); err == nil {
+	t.ExpiresAt, _ = time.Parse(time.RFC3339, result.ExpiresAt)
+	if rp, err := time.Parse(time.RFC3339, result.RefreshExpiresAt); err == nil {
 		t.RefreshExpiresAt = rp
 	}
 	storedRefresh := t.RefreshToken
@@ -204,10 +204,10 @@ func (t *RefreshTransport) maybeRefresh(req *http.Request) error {
 
 	if onRefresh != nil {
 		if err := onRefresh(
-			result.Data.Token,
+			result.Token,
 			storedRefresh,
-			result.Data.ExpiresAt,
-			result.Data.RefreshExpiresAt,
+			result.ExpiresAt,
+			result.RefreshExpiresAt,
 		); err != nil {
 			return fmt.Errorf("failed to persist refreshed tokens: %w", err)
 		}
@@ -216,7 +216,7 @@ func (t *RefreshTransport) maybeRefresh(req *http.Request) error {
 	return nil
 }
 
-type refreshResponse struct {
+type proxyRefreshResponse struct {
 	Data struct {
 		Token            string `json:"token"`
 		ExpiresAt        string `json:"expires_at"`
@@ -225,42 +225,49 @@ type refreshResponse struct {
 	} `json:"data"`
 }
 
-func (t *RefreshTransport) doRefresh(ctx context.Context, refreshToken string) (*refreshResponse, error) {
+func (t *RefreshTransport) doProxyRefresh(ctx context.Context, refreshToken string) (RefreshResult, error) {
 	body, err := json.Marshal(map[string]string{
 		"refresh_token": refreshToken,
 	})
 	if err != nil {
-		return nil, err
+		return RefreshResult{}, err
 	}
 
 	refreshURL := t.ProxyEndpoint + "/api/cli/v1/auth/refresh"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, refreshURL, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("failed to build refresh request: %w", err)
+		return RefreshResult{}, fmt.Errorf("failed to build refresh request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := t.base().RoundTrip(req)
 	if err != nil {
-		return nil, fmt.Errorf("refresh request failed: %w", err)
+		return RefreshResult{}, fmt.Errorf("refresh request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	limitedBody := io.LimitReader(resp.Body, maxResponseBytes)
 
+	// The response body is not included in errors: a refresh endpoint can echo
+	// tokens or other credentials in its body, which must not leak into logs.
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("oauth refresh failed: status %d from %s: %w", resp.StatusCode, req.URL.Path, ErrRefreshTokenExpired)
+		return RefreshResult{}, fmt.Errorf("oauth refresh failed: status %d: %w", resp.StatusCode, ErrRefreshTokenExpired)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("oauth refresh failed: status %d from %s", resp.StatusCode, req.URL.Path)
+		return RefreshResult{}, fmt.Errorf("oauth refresh failed: status %d", resp.StatusCode)
 	}
 
-	var result refreshResponse
+	var result proxyRefreshResponse
 	if err := json.NewDecoder(limitedBody).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to parse refresh response: %w", err)
+		return RefreshResult{}, fmt.Errorf("failed to parse refresh response: %w", err)
 	}
 
-	return &result, nil
+	return RefreshResult{
+		Token:            result.Data.Token,
+		RefreshToken:     result.Data.RefreshToken,
+		ExpiresAt:        result.Data.ExpiresAt,
+		RefreshExpiresAt: result.Data.RefreshExpiresAt,
+	}, nil
 }
 
 // RefreshResult holds the token credentials returned by a successful refresh.
@@ -271,19 +278,10 @@ type RefreshResult struct {
 	RefreshExpiresAt string
 }
 
-// DoRefresh calls the proxy refresh endpoint and returns new token credentials.
+// ProxyRefresh calls the proxy refresh endpoint and returns new token credentials.
 // This is used by the assistant command's token refresher, which needs to refresh
 // tokens outside of an HTTP round-trip context.
-func DoRefresh(ctx context.Context, proxyEndpoint, refreshTok string) (RefreshResult, error) {
+func ProxyRefresh(ctx context.Context, proxyEndpoint, refreshTok string) (RefreshResult, error) {
 	t := &RefreshTransport{ProxyEndpoint: proxyEndpoint}
-	result, err := t.doRefresh(ctx, refreshTok)
-	if err != nil {
-		return RefreshResult{}, err
-	}
-	return RefreshResult{
-		Token:            result.Data.Token,
-		RefreshToken:     result.Data.RefreshToken,
-		ExpiresAt:        result.Data.ExpiresAt,
-		RefreshExpiresAt: result.Data.RefreshExpiresAt,
-	}, nil
+	return t.doProxyRefresh(ctx, refreshTok)
 }

--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -279,8 +279,6 @@ type RefreshResult struct {
 }
 
 // ProxyRefresh calls the proxy refresh endpoint and returns new token credentials.
-// This is used by the assistant command's token refresher, which needs to refresh
-// tokens outside of an HTTP round-trip context.
 func ProxyRefresh(ctx context.Context, proxyEndpoint, refreshTok string) (RefreshResult, error) {
 	t := &RefreshTransport{ProxyEndpoint: proxyEndpoint}
 	return t.doProxyRefresh(ctx, refreshTok)

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -90,7 +90,6 @@ type Region struct {
 type CreateStackRequest struct {
 	Name             string            `json:"name"`
 	Slug             string            `json:"slug"`
-	Org              string            `json:"org,omitempty"`
 	URL              string            `json:"url,omitempty"`
 	Region           string            `json:"region,omitempty"`
 	Description      string            `json:"description,omitempty"`
@@ -143,11 +142,9 @@ func NewGCOMClient(baseURL, token string) (*GCOMClient, error) {
 		return nil, fmt.Errorf("gcom client: base URL must use HTTPS (got %q)", parsedBase.Scheme)
 	}
 
-	transport := http.RoundTripper(&httputils.UserAgentTransport{Base: &retry.Transport{}})
-
 	httpClient := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: transport,
+		Transport: &httputils.UserAgentTransport{Base: &retry.Transport{}},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if req.URL.Host != parsedBase.Host {
 				return fmt.Errorf("gcom client: refusing cross-domain redirect to %s (configured base: %s)",

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -132,13 +132,6 @@ type GCOMClient struct {
 // The client uses a 30-second timeout and will not follow HTTP redirects to a
 // different domain than baseURL.
 func NewGCOMClient(baseURL, token string) (*GCOMClient, error) {
-	return NewGCOMClientWithTransport(baseURL, token, nil)
-}
-
-// NewGCOMClientWithTransport is like NewGCOMClient but allows injecting a
-// custom http.RoundTripper that wraps the default transport stack. When
-// transport is nil, the default UserAgent + retry stack is used directly.
-func NewGCOMClientWithTransport(baseURL, token string, transport http.RoundTripper) (*GCOMClient, error) {
 	baseURL = strings.TrimRight(baseURL, "/")
 
 	parsedBase, err := url.Parse(baseURL)
@@ -150,9 +143,7 @@ func NewGCOMClientWithTransport(baseURL, token string, transport http.RoundTripp
 		return nil, fmt.Errorf("gcom client: base URL must use HTTPS (got %q)", parsedBase.Scheme)
 	}
 
-	if transport == nil {
-		transport = &httputils.UserAgentTransport{Base: &retry.Transport{}}
-	}
+	transport := http.RoundTripper(&httputils.UserAgentTransport{Base: &retry.Transport{}})
 
 	httpClient := &http.Client{
 		Timeout:   30 * time.Second,

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -90,6 +90,7 @@ type Region struct {
 type CreateStackRequest struct {
 	Name             string            `json:"name"`
 	Slug             string            `json:"slug"`
+	Org              string            `json:"org,omitempty"`
 	URL              string            `json:"url,omitempty"`
 	Region           string            `json:"region,omitempty"`
 	Description      string            `json:"description,omitempty"`
@@ -131,6 +132,13 @@ type GCOMClient struct {
 // The client uses a 30-second timeout and will not follow HTTP redirects to a
 // different domain than baseURL.
 func NewGCOMClient(baseURL, token string) (*GCOMClient, error) {
+	return NewGCOMClientWithTransport(baseURL, token, nil)
+}
+
+// NewGCOMClientWithTransport is like NewGCOMClient but allows injecting a
+// custom http.RoundTripper that wraps the default transport stack. When
+// transport is nil, the default UserAgent + retry stack is used directly.
+func NewGCOMClientWithTransport(baseURL, token string, transport http.RoundTripper) (*GCOMClient, error) {
 	baseURL = strings.TrimRight(baseURL, "/")
 
 	parsedBase, err := url.Parse(baseURL)
@@ -142,9 +150,13 @@ func NewGCOMClient(baseURL, token string) (*GCOMClient, error) {
 		return nil, fmt.Errorf("gcom client: base URL must use HTTPS (got %q)", parsedBase.Scheme)
 	}
 
+	if transport == nil {
+		transport = &httputils.UserAgentTransport{Base: &retry.Transport{}}
+	}
+
 	httpClient := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: &httputils.UserAgentTransport{Base: &retry.Transport{}},
+		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if req.URL.Host != parsedBase.Host {
 				return fmt.Errorf("gcom client: refusing cross-domain redirect to %s (configured base: %s)",

--- a/internal/config/cloud_login.go
+++ b/internal/config/cloud_login.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/grafana/gcx/internal/gcxerrors"
+)
+
+// MergeCloudInto applies non-empty fields from incoming onto existing,
+// allocating existing if nil. It returns the merged config.
+func MergeCloudInto(existing, incoming *CloudConfig) *CloudConfig {
+	if existing == nil {
+		existing = &CloudConfig{}
+	}
+	if incoming.Token != "" {
+		existing.Token = incoming.Token
+	}
+	if incoming.OAuthUrl != "" {
+		existing.OAuthUrl = incoming.OAuthUrl
+	}
+	if incoming.APIUrl != "" {
+		existing.APIUrl = incoming.APIUrl
+	}
+	if incoming.Stack != "" {
+		existing.Stack = incoming.Stack
+	}
+	return existing
+}
+
+// ResolveContextName picks the context to operate on: the explicit override when
+// set, otherwise the config's current context, falling back to the default.
+func ResolveContextName(override string, cfg Config) string {
+	if override != "" {
+		return override
+	}
+	if cfg.CurrentContext != "" {
+		return cfg.CurrentContext
+	}
+	return DefaultContextName
+}
+
+// SaveCloudConfig writes cloud credentials into the resolved context (see
+// ResolveContextName), creating the context if it doesn't exist and preserving
+// any existing Stack selection so re-authenticating doesn't drop it. It returns
+// the name of the context that was written.
+func SaveCloudConfig(ctx context.Context, source Source, contextOverride string, cloud *CloudConfig) (string, error) {
+	cfg, err := Load(ctx, source)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", &gcxerrors.DetailedError{
+			Summary: "Failed to load config",
+			Parent:  err,
+			Suggestions: []string{
+				"Check your config file syntax: gcx config edit",
+				"Or reset with: rm ~/.config/gcx/config.yaml && gcx cloud login",
+			},
+		}
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		cfg = Config{}
+	}
+
+	contextName := ResolveContextName(contextOverride, cfg)
+
+	if !cfg.HasContext(contextName) {
+		cfg.SetContext(contextName, true, Context{})
+	}
+	curCtx := cfg.Contexts[contextName]
+	// Merge the incoming auth fields onto the existing cloud config so
+	// re-authenticating refreshes credentials without dropping the non-auth
+	// Stack selection.
+	curCtx.Cloud = MergeCloudInto(curCtx.Cloud, cloud)
+
+	if err := Write(ctx, source, cfg); err != nil {
+		return "", &gcxerrors.DetailedError{
+			Summary: "Failed to save config",
+			Parent:  err,
+			Suggestions: []string{
+				"Check file permissions on the config file",
+				"Try: gcx config edit",
+			},
+		}
+	}
+
+	return contextName, nil
+}

--- a/internal/config/cloud_login_test.go
+++ b/internal/config/cloud_login_test.go
@@ -1,12 +1,10 @@
-//nolint:testpackage // white-box testing: accesses unexported saveCloudConfig.
-package cloud
+package config_test
 
 import (
 	"context"
 	"path/filepath"
 	"testing"
 
-	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
 	"github.com/grafana/gcx/internal/config"
 )
 
@@ -30,14 +28,13 @@ func TestSaveCloudConfigPreservesStack(t *testing.T) {
 		t.Fatalf("seed write: %v", err)
 	}
 
-	configOpts := &cmdconfig.Options{ConfigFile: path}
 	newCloud := &config.CloudConfig{
 		Token:    "new-token",
 		OAuthUrl: "https://grafana.com",
 		APIUrl:   "https://grafana.com",
 	}
-	if err := saveCloudConfig(ctx, configOpts, newCloud); err != nil {
-		t.Fatalf("saveCloudConfig: %v", err)
+	if _, err := config.SaveCloudConfig(ctx, source, "", newCloud); err != nil {
+		t.Fatalf("SaveCloudConfig: %v", err)
 	}
 
 	got, err := config.Load(ctx, source)

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -175,6 +175,9 @@ func mergeCloudConfig(base, over *CloudConfig) CloudConfig {
 	if over.Stack != "" {
 		result.Stack = over.Stack
 	}
+	if over.OAuthUrl != "" {
+		result.OAuthUrl = over.OAuthUrl
+	}
 	if over.APIUrl != "" {
 		result.APIUrl = over.APIUrl
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -128,12 +128,22 @@ type CloudConfig struct {
 	// Token is a Grafana Cloud API token used to authenticate against GCOM.
 	Token string `datapolicy:"secret" env:"GRAFANA_CLOUD_TOKEN" json:"token,omitempty" yaml:"token,omitempty"`
 
+	// TokenExpiresAt is the token expiration time in RFC3339 format.
+	// Only set for OAuth tokens obtained via `gcx cloud login`.
+	TokenExpiresAt string `json:"token-expires-at,omitempty" yaml:"token-expires-at,omitempty"`
+
 	// Stack is the Grafana Cloud stack slug (e.g. "mystack").
 	// Optional: if not set, the slug may be derived from Grafana.Server.
 	Stack string `env:"GRAFANA_CLOUD_STACK" json:"stack,omitempty" yaml:"stack,omitempty"`
 
-	// APIUrl is the base URL of the Grafana Cloud API (GCOM).
-	// Optional: defaults to "https://grafana.com".
+	// OAuthUrl is the base URL for the OAuth login flow run by `gcx cloud
+	// login`. It is used only during login. Optional: defaults to
+	// "https://grafana.com".
+	OAuthUrl string `env:"GRAFANA_CLOUD_OAUTH_URL" json:"oauth-url,omitempty" yaml:"oauth-url,omitempty"`
+
+	// APIUrl is the base URL for all Grafana Cloud API (GCOM) resource calls
+	// (stacks, regions, access policies, etc.). Every client talking to GCOM
+	// uses it. Optional: defaults to "https://grafana.com".
 	APIUrl string `env:"GRAFANA_CLOUD_API_URL" json:"api-url,omitempty" yaml:"api-url,omitempty"`
 }
 
@@ -343,23 +353,17 @@ func ContextNameFromServerURL(serverURL string) string {
 	return strings.ReplaceAll(parsed.Hostname(), ".", "-")
 }
 
-// ResolveGCOMURL returns the Grafana Cloud API (GCOM) base URL for this context.
-// Resolution order:
+// ResolveCloudAPIURL returns the base URL for Grafana Cloud API (GCOM) resource
+// calls (stacks, regions, access policies, etc.). Every client talking to GCOM
+// uses it. Resolution order:
 //  1. An explicit Cloud.APIUrl, prefixed with "https://" if it has no scheme.
 //  2. The GCOM root derived from the stack server URL's environment, so that an
 //     ops stack (*.grafana-ops.net) resolves to grafana-ops.com and a dev stack
 //     to grafana-dev.com instead of prod grafana.com.
 //  3. "https://grafana.com" as the default (prod, or non-Grafana-Cloud hosts).
-func (context *Context) ResolveGCOMURL() string {
+func (context *Context) ResolveCloudAPIURL() string {
 	if context.Cloud != nil && context.Cloud.APIUrl != "" {
-		apiURL := context.Cloud.APIUrl
-		if !strings.HasPrefix(apiURL, "https://") && !strings.HasPrefix(apiURL, "http://") {
-			apiURL = "https://" + apiURL
-		}
-		if strings.HasPrefix(apiURL, "http://") {
-			slog.Warn("GCOM API URL uses http:// — cloud tokens may be sent unencrypted", "url", apiURL)
-		}
-		return apiURL
+		return NormalizeCloudURL(context.Cloud.APIUrl)
 	}
 
 	if context.Grafana != nil {
@@ -369,6 +373,28 @@ func (context *Context) ResolveGCOMURL() string {
 	}
 
 	return "https://grafana.com"
+}
+
+// ResolveOAuthURL returns the base URL for the OAuth login flow run by
+// `gcx cloud login`. It returns the normalized Cloud.OAuthUrl, or
+// "https://grafana.com" when unset. Used only during login.
+func (context *Context) ResolveOAuthURL() string {
+	if context.Cloud != nil && context.Cloud.OAuthUrl != "" {
+		return NormalizeCloudURL(context.Cloud.OAuthUrl)
+	}
+	return "https://grafana.com"
+}
+
+// NormalizeCloudURL prefixes a Grafana Cloud URL with "https://" when no scheme
+// is present, and warns when an insecure http:// scheme is used.
+func NormalizeCloudURL(raw string) string {
+	if !strings.HasPrefix(raw, "https://") && !strings.HasPrefix(raw, "http://") {
+		raw = "https://" + raw
+	}
+	if strings.HasPrefix(raw, "http://") {
+		slog.Warn("Grafana Cloud URL uses http:// - credentials may be sent unencrypted", "url", raw)
+	}
+	return raw
 }
 
 type GrafanaConfig struct {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -128,10 +128,6 @@ type CloudConfig struct {
 	// Token is a Grafana Cloud API token used to authenticate against GCOM.
 	Token string `datapolicy:"secret" env:"GRAFANA_CLOUD_TOKEN" json:"token,omitempty" yaml:"token,omitempty"`
 
-	// TokenExpiresAt is the token expiration time in RFC3339 format.
-	// Only set for OAuth tokens obtained via `gcx cloud login`.
-	TokenExpiresAt string `json:"token-expires-at,omitempty" yaml:"token-expires-at,omitempty"`
-
 	// Stack is the Grafana Cloud stack slug (e.g. "mystack").
 	// Optional: if not set, the slug may be derived from Grafana.Server.
 	Stack string `env:"GRAFANA_CLOUD_STACK" json:"stack,omitempty" yaml:"stack,omitempty"`
@@ -372,16 +368,6 @@ func (context *Context) ResolveCloudAPIURL() string {
 		}
 	}
 
-	return "https://grafana.com"
-}
-
-// ResolveOAuthURL returns the base URL for the OAuth login flow run by
-// `gcx cloud login`. It returns the normalized Cloud.OAuthUrl, or
-// "https://grafana.com" when unset. Used only during login.
-func (context *Context) ResolveOAuthURL() string {
-	if context.Cloud != nil && context.Cloud.OAuthUrl != "" {
-		return NormalizeCloudURL(context.Cloud.OAuthUrl)
-	}
 	return "https://grafana.com"
 }
 

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -583,55 +583,6 @@ func TestContext_ResolveCloudAPIURL(t *testing.T) {
 	}
 }
 
-func TestContext_ResolveOAuthURL(t *testing.T) {
-	testCases := []struct {
-		name     string
-		ctx      config.Context
-		expected string
-	}{
-		{
-			name:     "no cloud config returns default grafana.com URL",
-			ctx:      config.Context{},
-			expected: "https://grafana.com",
-		},
-		{
-			name: "empty cloud.oauth-url returns default grafana.com URL",
-			ctx: config.Context{
-				Cloud: &config.CloudConfig{},
-			},
-			expected: "https://grafana.com",
-		},
-		{
-			name: "custom cloud.oauth-url is prefixed with https://",
-			ctx: config.Context{
-				Cloud: &config.CloudConfig{OAuthUrl: "grafana-dev.com"},
-			},
-			expected: "https://grafana-dev.com",
-		},
-		{
-			name: "cloud.api-url does not affect the OAuth URL",
-			ctx: config.Context{
-				Cloud: &config.CloudConfig{APIUrl: "https://grafana-dev.com"},
-			},
-			expected: "https://grafana.com",
-		},
-		{
-			name: "stack server env does not affect the OAuth URL",
-			ctx: config.Context{
-				Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-ops.net"},
-			},
-			expected: "https://grafana.com",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			req := require.New(t)
-			req.Equal(tc.expected, tc.ctx.ResolveOAuthURL())
-		})
-	}
-}
-
 func TestGrafanaConfig_InferredAuthMethod(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -491,7 +491,7 @@ func TestContextNameFromServerURL_DotsToHyphens(t *testing.T) {
 	}
 }
 
-func TestContext_ResolveGCOMURL(t *testing.T) {
+func TestContext_ResolveCloudAPIURL(t *testing.T) {
 	testCases := []struct {
 		name     string
 		ctx      config.Context
@@ -500,6 +500,13 @@ func TestContext_ResolveGCOMURL(t *testing.T) {
 		{
 			name:     "no cloud config returns default grafana.com URL",
 			ctx:      config.Context{},
+			expected: "https://grafana.com",
+		},
+		{
+			name: "cloud.oauth-url does not affect the API URL",
+			ctx: config.Context{
+				Cloud: &config.CloudConfig{OAuthUrl: "https://grafana-dev.com"},
+			},
 			expected: "https://grafana.com",
 		},
 		{
@@ -571,7 +578,56 @@ func TestContext_ResolveGCOMURL(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := require.New(t)
-			req.Equal(tc.expected, tc.ctx.ResolveGCOMURL())
+			req.Equal(tc.expected, tc.ctx.ResolveCloudAPIURL())
+		})
+	}
+}
+
+func TestContext_ResolveOAuthURL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ctx      config.Context
+		expected string
+	}{
+		{
+			name:     "no cloud config returns default grafana.com URL",
+			ctx:      config.Context{},
+			expected: "https://grafana.com",
+		},
+		{
+			name: "empty cloud.oauth-url returns default grafana.com URL",
+			ctx: config.Context{
+				Cloud: &config.CloudConfig{},
+			},
+			expected: "https://grafana.com",
+		},
+		{
+			name: "custom cloud.oauth-url is prefixed with https://",
+			ctx: config.Context{
+				Cloud: &config.CloudConfig{OAuthUrl: "grafana-dev.com"},
+			},
+			expected: "https://grafana-dev.com",
+		},
+		{
+			name: "cloud.api-url does not affect the OAuth URL",
+			ctx: config.Context{
+				Cloud: &config.CloudConfig{APIUrl: "https://grafana-dev.com"},
+			},
+			expected: "https://grafana.com",
+		},
+		{
+			name: "stack server env does not affect the OAuth URL",
+			ctx: config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-ops.net"},
+			},
+			expected: "https://grafana.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := require.New(t)
+			req.Equal(tc.expected, tc.ctx.ResolveOAuthURL())
 		})
 	}
 }

--- a/internal/httputils/client.go
+++ b/internal/httputils/client.go
@@ -28,6 +28,9 @@ type ClientOpts struct {
 	TLSConfig   *tls.Config
 	Timeout     time.Duration // default: 60s
 	Middlewares []Middleware  // default: []Middleware{LoggingMiddleware}
+	// CheckRedirect, if non-nil, is set on the returned client to gate redirects
+	// (see http.Client.CheckRedirect).
+	CheckRedirect func(req *http.Request, via []*http.Request) error
 }
 
 // NewClient returns a configured *http.Client.
@@ -49,7 +52,7 @@ func NewClient(opts ClientOpts) *http.Client {
 	// Outermost layers: User-Agent injection, then retry for rate limiting (429) and transient errors.
 	rt = &retry.Transport{Base: rt}
 	rt = &UserAgentTransport{Base: rt}
-	return &http.Client{Timeout: timeout, Transport: rt}
+	return &http.Client{Timeout: timeout, Transport: rt, CheckRedirect: opts.CheckRedirect}
 }
 
 // NewDefaultClient returns an *http.Client with LoggingRoundTripper, 60s timeout,

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -673,17 +673,27 @@ func mergeAuthIntoExisting(existing *config.Context, incoming config.Context, ex
 
 	// Update Cloud config if present in the incoming context.
 	if incoming.Cloud != nil {
-		if existing.Cloud == nil {
-			existing.Cloud = &config.CloudConfig{}
-		}
-		if incoming.Cloud.Token != "" {
-			existing.Cloud.Token = incoming.Cloud.Token
-		}
-		if incoming.Cloud.APIUrl != "" {
-			existing.Cloud.APIUrl = incoming.Cloud.APIUrl
-		}
-		if incoming.Cloud.Stack != "" {
-			existing.Cloud.Stack = incoming.Cloud.Stack
-		}
+		existing.Cloud = mergeCloudInto(existing.Cloud, incoming.Cloud)
 	}
+}
+
+// mergeCloudInto applies non-empty fields from incoming onto existing,
+// allocating existing if nil. It returns the merged config.
+func mergeCloudInto(existing, incoming *config.CloudConfig) *config.CloudConfig {
+	if existing == nil {
+		existing = &config.CloudConfig{}
+	}
+	if incoming.Token != "" {
+		existing.Token = incoming.Token
+	}
+	if incoming.OAuthUrl != "" {
+		existing.OAuthUrl = incoming.OAuthUrl
+	}
+	if incoming.APIUrl != "" {
+		existing.APIUrl = incoming.APIUrl
+	}
+	if incoming.Stack != "" {
+		existing.Stack = incoming.Stack
+	}
+	return existing
 }

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -673,27 +673,6 @@ func mergeAuthIntoExisting(existing *config.Context, incoming config.Context, ex
 
 	// Update Cloud config if present in the incoming context.
 	if incoming.Cloud != nil {
-		existing.Cloud = mergeCloudInto(existing.Cloud, incoming.Cloud)
+		existing.Cloud = config.MergeCloudInto(existing.Cloud, incoming.Cloud)
 	}
-}
-
-// mergeCloudInto applies non-empty fields from incoming onto existing,
-// allocating existing if nil. It returns the merged config.
-func mergeCloudInto(existing, incoming *config.CloudConfig) *config.CloudConfig {
-	if existing == nil {
-		existing = &config.CloudConfig{}
-	}
-	if incoming.Token != "" {
-		existing.Token = incoming.Token
-	}
-	if incoming.OAuthUrl != "" {
-		existing.OAuthUrl = incoming.OAuthUrl
-	}
-	if incoming.APIUrl != "" {
-		existing.APIUrl = incoming.APIUrl
-	}
-	if incoming.Stack != "" {
-		existing.Stack = incoming.Stack
-	}
-	return existing
 }

--- a/internal/login/validate.go
+++ b/internal/login/validate.go
@@ -155,7 +155,7 @@ func Validate(ctx context.Context, opts Options, restCfg config.NamespacedRESTCo
 			Grafana: &config.GrafanaConfig{Server: opts.Server},
 			Cloud:   &config.CloudConfig{APIUrl: opts.CloudAPIURL},
 		}
-		gcomC, err := cloud.NewGCOMClient(gcomCtx.ResolveGCOMURL(), opts.CloudToken)
+		gcomC, err := cloud.NewGCOMClient(gcomCtx.ResolveCloudAPIURL(), opts.CloudToken)
 		if err != nil {
 			return "", fmt.Errorf("connectivity validation: invalid GCOM URL: %w", err)
 		}

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -236,8 +236,9 @@ func (l *ConfigLoader) loadCloudBase(ctx context.Context) (cloudBase, error) {
 	}
 
 	token := curCtx.Cloud.Token
-	gcomURL := curCtx.ResolveGCOMURL()
-	client, err := cloud.NewGCOMClient(gcomURL, token)
+	apiURL := curCtx.ResolveCloudAPIURL()
+
+	client, err := cloud.NewGCOMClient(apiURL, token)
 	if err != nil {
 		return cloudBase{}, fmt.Errorf("failed to create GCOM client: %w", err)
 	}

--- a/internal/providers/configloader_test.go
+++ b/internal/providers/configloader_test.go
@@ -96,7 +96,7 @@ current-context: default
 // cloud section.
 func TestConfigLoader_LoadCloudConfig_EnvVars(t *testing.T) {
 	// Config file has api-url pointing at our test server (the scheme is supplied
-	// by ResolveGCOMURL as "https://", so we can't use the test server's plain
+	// by ResolveCloudAPIURL as "https://", so we can't use the test server's plain
 	// HTTP URL here — but we still verify that env vars are parsed and validation
 	// passes by checking the error is a network error, not a validation error).
 	cfgFile := writeConfigFile(t, `
@@ -126,8 +126,8 @@ func TestConfigLoader_LoadCloudConfig_GCOMCallAttempted(t *testing.T) {
 	srv := newMockGCOMServer(t, cloud.StackInfo{ID: 42, Slug: "mystack"})
 	defer srv.Close()
 
-	// ResolveGCOMURL prepends "https://"; our test server is HTTP only. We
-	// write api-url without the scheme so ResolveGCOMURL adds "https://".
+	// ResolveCloudAPIURL prepends "https://"; our test server is HTTP only. We
+	// write api-url without the scheme so ResolveCloudAPIURL adds "https://".
 	// This means the connection will fail at TLS, proving the GCOM call
 	// was attempted (rather than a validation failure).
 	cfgFile := writeConfigFile(t, `
@@ -692,7 +692,7 @@ func TestConfigLoader_LoadCloudConfig_FullRoundTrip(t *testing.T) {
 	srv := newMockGCOMServer(t, wantStack)
 	defer srv.Close()
 
-	// Use the full http:// URL — ResolveGCOMURL now preserves existing schemes.
+	// Use the full http:// URL — ResolveCloudAPIURL now preserves existing schemes.
 	cfgFile := writeConfigFile(t, `
 contexts:
   default:


### PR DESCRIPTION
Part of https://github.com/grafana/gcx-internal/issues/13

Followup to https://github.com/grafana/gcx/pull/698 with fewer features: no refresh tokens or org selection

## Summary

Adds `gcx cloud login`, which authenticates against the Grafana Cloud platform API (grafana.com) for managing Cloud resources like stacks and access policies. This is distinct from `gcx login`, which targets a single Grafana stack instance.

- Interactive browser OAuth2 (PKCE) by default; `--cloud-token` for non-interactive use (CI/scripts)
- Two endpoints, configured independently, each defaulting to `https://grafana.com`:
  - `oauth-url` (`GRAFANA_CLOUD_OAUTH_URL`): used only by the login flow
  - `api-url` (`GRAFANA_CLOUD_API_URL`): used by every client that talks to the Cloud API
- Strict separation, no cross-fallback: production sets neither; an environment whose OAuth host and API host differ can set both. URLs missing a scheme are normalized to `https://`.
- Hardens the proxy token-refresh path so the response body (which can echo tokens) is no longer included in error messages.

## How to test

build with `mise run build`, then validate against an internal instance: follow instructions in https://github.com/grafana/deployment_tools/pull/632434 (dev)

Then run `gcx cloud stacks list --org <org>` to use it (give yourself stacks:read permissions at least)

## blockers

- [x] Wait for https://github.com/grafana/deployment_tools/pull/632405 to be merged
