### PR TITLE
fix(login): consume GRAFANA_TOKEN/GRAFANA_CLOUD_TOKEN env vars

### DIFF
--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -168,6 +168,16 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 		!flags.Yes &&
 		!agent.IsAgentMode()
 
+	// Non-interactive callers (agent mode, --yes, piped stdin, CI) can't answer
+	// the auth prompt, so fall back to credentials already resolved into the
+	// source context. LoadConfigTolerant applies the GRAFANA_TOKEN /
+	// GRAFANA_CLOUD_TOKEN env overrides onto the current context, so this is what
+	// lets a headless `gcx login` consume those env vars the same way every other
+	// command does (and reuse a previously stored token on re-auth). Interactive
+	// callers keep the prompt flow — which offers "keep existing token" and
+	// auth-method switching — so we leave their flags untouched.
+	flags.Token, flags.CloudToken = resolveNonInteractiveTokens(flags.Token, flags.CloudToken, sourceCtx, isInteractive)
+
 	// Carry existing TLS settings into the login flow so that mTLS keeps
 	// working on re-auth without requiring the user to re-specify certs.
 	var existingTLS *config.TLS
@@ -532,9 +542,9 @@ func structuredMissingFieldsError(e *login.ErrNeedInput) error {
 		case "server":
 			suggestions = append(suggestions, "Pass --server <url> or set GRAFANA_SERVER")
 		case "grafana-auth":
-			suggestions = append(suggestions, "Pass --token <token> for a service account token, or configure TLS client certs for mTLS auth (GRAFANA_TLS_CERT_FILE / GRAFANA_TLS_KEY_FILE env vars, or gcx config set contexts.<ctx>.grafana.tls.cert-file ...)")
+			suggestions = append(suggestions, "Pass --token <token> (or set the GRAFANA_TOKEN env var) for a service account token, or configure TLS client certs for mTLS auth (GRAFANA_TLS_CERT_FILE / GRAFANA_TLS_KEY_FILE env vars, or gcx config set contexts.<ctx>.grafana.tls.cert-file ...)")
 		case "cloud-token":
-			suggestions = append(suggestions, "Pass --cloud-token <token> to enable Cloud features, or --yes to skip")
+			suggestions = append(suggestions, "Pass --cloud-token <token> (or set the GRAFANA_CLOUD_TOKEN env var) to enable Cloud features, or --yes to skip")
 		default:
 			suggestions = append(suggestions, "Provide --"+strings.ReplaceAll(f, "_", "-"))
 		}
@@ -602,6 +612,26 @@ func resolveSourceContext(cfg config.Config, contextName, server string) (*confi
 	default:
 		return cfg.GetCurrentContext(), cfg.CurrentContext
 	}
+}
+
+// resolveNonInteractiveTokens fills empty token flags from the (already
+// env-overridden) source context when the login is non-interactive, so that
+// `gcx login` honours GRAFANA_TOKEN / GRAFANA_CLOUD_TOKEN — and reuses a stored
+// token on re-auth — without an interactive prompt. Interactive logins are
+// returned unchanged: their prompt flow owns auth-method selection and already
+// offers a "keep existing token" affordance, so pre-filling here would skip the
+// menu. Explicitly-passed flags always win over the context value.
+func resolveNonInteractiveTokens(grafanaToken, cloudToken string, sourceCtx *config.Context, interactive bool) (string, string) {
+	if interactive || sourceCtx == nil {
+		return grafanaToken, cloudToken
+	}
+	if grafanaToken == "" && sourceCtx.Grafana != nil {
+		grafanaToken = sourceCtx.Grafana.APIToken
+	}
+	if cloudToken == "" && sourceCtx.Cloud != nil {
+		cloudToken = sourceCtx.Cloud.Token
+	}
+	return grafanaToken, cloudToken
 }
 
 // printModeHeader writes a one- or two-line status banner so the user

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -48,14 +48,14 @@ func TestStructuredMissingFieldsError(t *testing.T) {
 			err:            &internallogin.ErrNeedInput{Fields: []string{"grafana-auth"}},
 			wantSummary:    "Login requires additional input",
 			wantDetailSubs: []string{"grafana-auth"},
-			wantSuggestSub: []string{"--token"},
+			wantSuggestSub: []string{"--token", "GRAFANA_TOKEN"},
 		},
 		{
 			name:           "missing_cloud_token",
 			err:            &internallogin.ErrNeedInput{Fields: []string{"cloud-token"}},
 			wantSummary:    "Login requires additional input",
 			wantDetailSubs: []string{"cloud-token"},
-			wantSuggestSub: []string{"--cloud-token", "--yes"},
+			wantSuggestSub: []string{"--cloud-token", "GRAFANA_CLOUD_TOKEN", "--yes"},
 		},
 		{
 			name: "multiple_fields_with_hint",
@@ -94,6 +94,69 @@ func TestStructuredMissingFieldsError(t *testing.T) {
 			for _, sub := range tt.wantSuggestSub {
 				assert.Contains(t, joined, sub, "suggestions should mention %q", sub)
 			}
+		})
+	}
+}
+
+// TestResolveNonInteractiveTokens verifies the non-interactive credential
+// fallback: empty token flags are filled from the (env-overridden) source
+// context, explicit flags win, and interactive logins are left untouched.
+func TestResolveNonInteractiveTokens(t *testing.T) {
+	t.Parallel()
+
+	ctxWithTokens := &config.Context{
+		Grafana: &config.GrafanaConfig{APIToken: "glsa_env"},
+		Cloud:   &config.CloudConfig{Token: "glc_env"},
+	}
+
+	tests := []struct {
+		name           string
+		flagToken      string
+		flagCloud      string
+		sourceCtx      *config.Context
+		interactive    bool
+		wantToken      string
+		wantCloudToken string
+	}{
+		{
+			name:           "non_interactive_fills_from_context",
+			sourceCtx:      ctxWithTokens,
+			wantToken:      "glsa_env",
+			wantCloudToken: "glc_env",
+		},
+		{
+			name:        "interactive_leaves_flags_untouched",
+			sourceCtx:   ctxWithTokens,
+			interactive: true,
+		},
+		{
+			name:           "explicit_flags_win_over_context",
+			flagToken:      "glsa_flag",
+			flagCloud:      "glc_flag",
+			sourceCtx:      ctxWithTokens,
+			wantToken:      "glsa_flag",
+			wantCloudToken: "glc_flag",
+		},
+		{
+			name: "nil_source_context_is_noop",
+		},
+		{
+			name:      "oauth_context_without_api_token_stays_empty",
+			sourceCtx: &config.Context{Grafana: &config.GrafanaConfig{OAuthToken: "oauth"}},
+		},
+		{
+			name:      "fills_grafana_when_cloud_block_absent",
+			sourceCtx: &config.Context{Grafana: &config.GrafanaConfig{APIToken: "glsa_env"}},
+			wantToken: "glsa_env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotToken, gotCloud := resolveNonInteractiveTokens(tt.flagToken, tt.flagCloud, tt.sourceCtx, tt.interactive)
+			assert.Equal(t, tt.wantToken, gotToken, "grafana token mismatch")
+			assert.Equal(t, tt.wantCloudToken, gotCloud, "cloud token mismatch")
 		})
 	}
 }


### PR DESCRIPTION
## Problem

Non-interactive `gcx login` (agent mode, `--yes`, piped stdin, CI) reads the Grafana service-account and Cloud tokens **only** from the `--token` / `--cloud-token` flags. So a login with valid tokens already in `GRAFANA_TOKEN` / `GRAFANA_CLOUD_TOKEN` fails with:

```
Missing required fields: grafana-auth
```

…even though **every other gcx command** honours those env vars (`LoadConfigTolerant` → `ParseEnvIntoContext`), and `runLogin` already falls back `--server` to the env-overridden context. The token fields were the lone exception — an asymmetry, not an intentional design.

## Fix

Mirror the existing `--server` fallback for the token fields: when the login is **non-interactive**, fill empty token flags from the (already env-overridden) source context. This lets a headless `gcx login` consume `GRAFANA_TOKEN` / `GRAFANA_CLOUD_TOKEN` the same way it consumes `GRAFANA_SERVER`, and lets re-auth reuse a previously stored token.

**Interactive logins are intentionally left untouched** — their prompt flow owns auth-method selection and already offers a "keep existing token" affordance; pre-filling there would skip the menu (e.g. switching token → OAuth).

Also names the env vars in the non-interactive missing-input error, matching the server field's existing `or set GRAFANA_SERVER` suggestion.

## Testing

- New `TestResolveNonInteractiveTokens` table test (fills from context, explicit flags win, interactive untouched, nil/OAuth/cloud-absent edge cases).
- Updated `TestStructuredMissingFieldsError` to assert the env vars appear in suggestions.
- `GCX_AGENT_MODE=false mise run all` (lint + full `go test ./...` + reference regen; no reference drift). `mkdocs` not installed locally.

## Notes

First of three independent PRs from a login-failure investigation. The others cover (B) treating an optional CAP-token validation failure as non-fatal, and (C) environment-aware GCOM root + bare slug for ops/dev stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)