### PR TITLE
fix(login): don't let an optional CAP-token failure block login

### DIFF
--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -304,13 +304,30 @@ func Run(ctx context.Context, opts *Options) (Result, error) {
 			validateFn = Validate
 		}
 		v, err := validateFn(ctx, *opts, restCfg)
-		if err != nil {
+		var capErr *GCOMStackError
+		switch {
+		case err == nil:
+			grafanaVersion = v
+
+		case errors.As(err, &capErr):
+			// The Cloud Access Policy (CAP) token is optional: its absence does
+			// not block login (resolveCloudAuth skips it under --yes/agent mode),
+			// so a present-but-rejected token must not block login either. A
+			// GCOMStackError means every earlier Validate step (health, K8s
+			// discovery, version) passed — the Grafana auth is sound and only the
+			// CAP check failed. Warn and continue, persisting the token anyway:
+			// the CAP validation itself can be wrong for non-prod stacks (GCOM
+			// root / slug derivation), and the user can re-run with a corrected
+			// token without losing core access in the meantime.
+			warnCloudTokenUnvalidated(opts.Writer, capErr)
+
+		case opts.Yes || agent.IsAgentMode():
 			// Non-interactive callers with --yes get a hard fail — they did not
 			// opt in to "save anyway". The debug prompt is an interactive-only
 			// escape hatch that requires explicit confirmation.
-			if opts.Yes || agent.IsAgentMode() {
-				return Result{}, err
-			}
+			return Result{}, err
+
+		default:
 			return Result{}, &ErrNeedClarification{
 				Field: "save-unvalidated",
 				Question: fmt.Sprintf(
@@ -320,7 +337,6 @@ func Run(ctx context.Context, opts *Options) (Result, error) {
 				Choices: []string{"yes", "no"},
 			}
 		}
-		grafanaVersion = v
 	}
 
 	// Step 7: Persist to config (write only after all validation passes)
@@ -494,6 +510,22 @@ func resolveCloudAuth(opts Options, target Target) (*config.CloudConfig, error) 
 		Optional: true,
 		Hint:     cloudTokenHint(opts.Server),
 	}
+}
+
+// warnCloudTokenUnvalidated surfaces a non-fatal advisory when a Cloud Access
+// Policy (CAP) token is present but its GCOM validation failed. Because the CAP
+// token is optional, login proceeds; this explains why Cloud management features
+// may not work. It writes to w (the caller-supplied progress writer); a nil
+// writer discards, keeping internal/login free of process streams (NC-001).
+func warnCloudTokenUnvalidated(w io.Writer, e *GCOMStackError) {
+	if w == nil {
+		w = io.Discard
+	}
+	msg := fmt.Sprintf("Warning: Cloud Access Policy token could not be validated for stack %q", e.Slug)
+	if e.Status != 0 {
+		msg += fmt.Sprintf(" (GCOM returned %d)", e.Status)
+	}
+	fmt.Fprintln(w, msg+". Logging in anyway; Cloud management features may be unavailable until a working token is provided.")
 }
 
 // persistContext loads the existing config (tolerating ErrNotExist), upserts the

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1,6 +1,7 @@
 package login_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"path/filepath"
@@ -906,6 +907,50 @@ func TestRun_ValidationFailure_EmitsSaveUnvalidatedClarification(t *testing.T) {
 	if _, err := config.Load(context.Background(), configSource(dir)); err == nil {
 		t.Errorf("config written despite validation failure + no ForceSave")
 	}
+}
+
+// TestRun_OptionalCloudTokenRejected_WarnsAndPersists verifies that a rejected
+// Cloud Access Policy (CAP) token does not block login: Run warns, persists the
+// context (including the token), and returns no error. Other validation failures
+// still hard-fail / prompt (covered by the save-unvalidated test above).
+func TestRun_OptionalCloudTokenRejected_WarnsAndPersists(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "0")
+	agent.ResetForTesting()
+
+	dir := t.TempDir()
+	var warnBuf bytes.Buffer
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server:       "https://mystack.grafana.net",
+			ContextName:  "mystack",
+			Target:       login.TargetCloud,
+			GrafanaToken: "glsa_test",
+			CloudToken:   "glc_bad",
+			Writer:       &warnBuf,
+		},
+		Hooks: login.Hooks{
+			ConfigSource: configSource(dir),
+			ValidateFn: func(_ context.Context, _ login.Options, _ config.NamespacedRESTConfig) (string, error) {
+				return "", &login.GCOMStackError{Slug: "mystack", Status: 401, Cause: errors.New("unauthorized")}
+			},
+		},
+		RetryState: login.RetryState{
+			StagedContext: &config.Context{},
+		},
+	}
+
+	result, err := login.Run(context.Background(), &opts)
+	require.NoError(t, err, "an optional CAP-token rejection must not fail login")
+	assert.True(t, result.HasCloudToken, "the CAP token should still be persisted")
+	assert.Contains(t, warnBuf.String(), "Cloud Access Policy token could not be validated")
+	assert.Contains(t, warnBuf.String(), "401")
+
+	// The context must have been written despite the CAP validation failure.
+	cfg, err := config.Load(context.Background(), configSource(dir))
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Contexts["mystack"])
+	require.NotNil(t, cfg.Contexts["mystack"].Cloud)
+	assert.Equal(t, "glc_bad", cfg.Contexts["mystack"].Cloud.Token)
 }
 
 func TestRun_ForceSave_BypassesValidation(t *testing.T) {


### PR DESCRIPTION
## Problem

When a Cloud Access Policy (CAP) token is present but rejected by GCOM, `gcx login` hard-fails the **entire** login (exit 3) — even when the Grafana service-account auth is valid:

```
{"error":{"summary":"Grafana Cloud token rejected","exitCode":3,"details":"GCOM returned 401 for stack \"…\""}}
```

But the CAP token is **optional by design** — `resolveCloudAuth` skips it entirely under `--yes`/agent mode, and login proceeds fine without one. So a *bad* CAP token shouldn't be more fatal than a *missing* one.

## Fix

`Validate` returns the first failing step, so a `*GCOMStackError` uniquely means health + K8s discovery + version all passed — the Grafana auth is sound and only the optional CAP check failed. Treat that one case as **non-fatal**: warn (naming the stack and GCOM status) and continue, persisting the token anyway.

Persisting the (rejected) token is deliberate: the CAP validation itself can be wrong for non-prod stacks (GCOM root / slug derivation — addressed in a separate PR), so discarding a possibly-valid token would be worse than keeping it with a warning. The user keeps core access and can re-run with a corrected token.

All other validation failures (health, discovery, version) keep their existing hard-fail / `save-unvalidated` prompt behaviour.

## Testing

- New `TestRun_OptionalCloudTokenRejected_WarnsAndPersists`: a `GCOMStackError` from `ValidateFn` → no error, context persisted (incl. token), warning emitted with the GCOM status.
- Existing `TestRun_ValidationFailure_EmitsSaveUnvalidatedClarification` still asserts non-CAP failures prompt/hard-fail.
- Full suite green in a CI-equivalent env (`GRAFANA_*` unset, agent-mode neutralized).

## Notes

Second of three independent PRs from a login-failure investigation (see also #859). Contained entirely to `internal/login`. The `GCOMStackError` → exit-3 mapping in `cmd/gcx/fail` becomes effectively unreachable from login but is left in place as defensive code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)