### PR TITLE
fix(cloud): derive GCOM root and stack slug per environment

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -199,12 +199,13 @@ func (context *Context) ResolveStackSlug() string {
 //
 //nolint:gochecknoglobals // constant-like lookup table; no mutable state.
 var grafanaCloudStackSuffixes = []struct {
-	suffix string
-	envTag string // appended to the slug for non-prod Grafana-run environments
+	suffix   string
+	envTag   string // appended to the context NAME (not the slug) for non-prod environments
+	gcomRoot string // GCOM (grafana.com) API root that manages stacks in this environment
 }{
-	{".grafana.net", ""},
-	{".grafana-dev.net", "-dev"},
-	{".grafana-ops.net", "-ops"},
+	{".grafana.net", "", "https://grafana.com"},
+	{".grafana-dev.net", "-dev", "https://grafana-dev.com"},
+	{".grafana-ops.net", "-ops", "https://grafana-ops.com"},
 }
 
 // grafanaCloudRootSuffixes are the Grafana-run root domains used by probes
@@ -237,46 +238,64 @@ func IsGrafanaCloudHost(host string) bool {
 	return false
 }
 
-// StackSlugFromServerURL attempts to extract a Grafana Cloud stack slug from
-// a server URL. It returns the slug and true for *.grafana.net,
-// *.grafana-dev.net, and *.grafana-ops.net URLs, or ("", false) for anything else.
-// For non-prod Grafana-run environments, an env suffix is appended to the slug
-// to prevent context-name collisions: "-dev" for *.grafana-dev.net, "-ops" for
-// *.grafana-ops.net. *.grafana.net (prod) is returned unchanged.
-func StackSlugFromServerURL(serverURL string) (string, bool) {
+// matchGrafanaCloudStack matches a server URL against the known Grafana-run
+// stack suffixes. It returns, in order: the bare stack slug; the context-name
+// env tag ("-dev"/"-ops", empty for prod); the GCOM API root for that
+// environment; and a bool that is false for non-Grafana-Cloud or custom-domain
+// URLs. Regional subdomains ("mystack.us.grafana.net") collapse to their first
+// component ("mystack").
+func matchGrafanaCloudStack(serverURL string) (string, string, string, bool) {
 	parsed, err := url.Parse(serverURL)
 	if err != nil {
-		return "", false
+		return "", "", "", false
 	}
 
 	host := parsed.Hostname()
 	for _, entry := range grafanaCloudStackSuffixes {
-		slug, ok := strings.CutSuffix(host, entry.suffix)
-		if !ok {
+		s, found := strings.CutSuffix(host, entry.suffix)
+		if !found {
 			continue
 		}
-		// For regional subdomains like "mystack.us.grafana.net",
-		// CutSuffix returns "mystack.us". Take only the first component.
-		if i := strings.Index(slug, "."); i >= 0 {
-			slug = slug[:i]
+		if i := strings.Index(s, "."); i >= 0 {
+			s = s[:i]
 		}
-		if slug == "" {
+		if s == "" {
 			continue
 		}
-		return slug + entry.envTag, true
+		return s, entry.envTag, entry.gcomRoot, true
 	}
 
-	return "", false
+	return "", "", "", false
+}
+
+// StackSlugFromServerURL extracts the Grafana Cloud stack slug from a server URL.
+// It returns the slug and true for *.grafana.net, *.grafana-dev.net, and
+// *.grafana-ops.net URLs, or ("", false) for anything else. The slug is the real
+// stack slug used by the GCOM and stack-scoped APIs — the per-environment naming
+// suffix ("-dev"/"-ops") is NOT included here; that lives in ContextNameFromServerURL.
+func StackSlugFromServerURL(serverURL string) (string, bool) {
+	slug, _, _, ok := matchGrafanaCloudStack(serverURL)
+	return slug, ok
+}
+
+// GCOMRootFromServerURL returns the GCOM (grafana.com) API root that manages the
+// stack at serverURL: grafana.com for *.grafana.net, grafana-dev.com for
+// *.grafana-dev.net, grafana-ops.com for *.grafana-ops.net. ok is false for
+// non-Grafana-Cloud or custom-domain URLs.
+func GCOMRootFromServerURL(serverURL string) (string, bool) {
+	_, _, gcomRoot, ok := matchGrafanaCloudStack(serverURL)
+	return gcomRoot, ok
 }
 
 // ContextNameFromServerURL derives a context name from a Grafana server URL.
-// For Grafana Cloud URLs, it returns the stack slug (with env suffix for
-// -dev/-ops). For other URLs, dots in the hostname are replaced with hyphens
-// to keep the name shell-friendly. Returns DefaultContextName if the URL
-// cannot be parsed.
+// For Grafana Cloud URLs, it returns the stack slug with the per-environment
+// suffix ("-dev"/"-ops") appended to prevent collisions between same-named
+// stacks across environments. For other URLs, dots in the hostname are replaced
+// with hyphens to keep the name shell-friendly. Returns DefaultContextName if
+// the URL cannot be parsed.
 func ContextNameFromServerURL(serverURL string) string {
-	if slug, ok := StackSlugFromServerURL(serverURL); ok {
-		return slug
+	if slug, envTag, _, ok := matchGrafanaCloudStack(serverURL); ok {
+		return slug + envTag
 	}
 
 	parsed, err := url.Parse(serverURL)
@@ -288,8 +307,12 @@ func ContextNameFromServerURL(serverURL string) string {
 }
 
 // ResolveGCOMURL returns the Grafana Cloud API (GCOM) base URL for this context.
-// If Cloud.APIUrl is set, it is returned prefixed with "https://".
-// Otherwise, "https://grafana.com" is returned.
+// Resolution order:
+//  1. An explicit Cloud.APIUrl, prefixed with "https://" if it has no scheme.
+//  2. The GCOM root derived from the stack server URL's environment, so that an
+//     ops stack (*.grafana-ops.net) resolves to grafana-ops.com and a dev stack
+//     to grafana-dev.com instead of prod grafana.com.
+//  3. "https://grafana.com" as the default (prod, or non-Grafana-Cloud hosts).
 func (context *Context) ResolveGCOMURL() string {
 	if context.Cloud != nil && context.Cloud.APIUrl != "" {
 		apiURL := context.Cloud.APIUrl
@@ -300,6 +323,12 @@ func (context *Context) ResolveGCOMURL() string {
 			slog.Warn("GCOM API URL uses http:// — cloud tokens may be sent unencrypted", "url", apiURL)
 		}
 		return apiURL
+	}
+
+	if context.Grafana != nil {
+		if root, ok := GCOMRootFromServerURL(context.Grafana.Server); ok {
+			return root
+		}
 	}
 
 	return "https://grafana.com"

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -287,6 +287,13 @@ func TestContext_ResolveStackSlug(t *testing.T) {
 			expected: "mystack",
 		},
 		{
+			name: "ops stack derivation is the bare slug (no -ops naming suffix)",
+			ctx: config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-ops.net"},
+			},
+			expected: "mystack",
+		},
+		{
 			name: "non-grafana.net server returns empty string",
 			ctx: config.Context{
 				Grafana: &config.GrafanaConfig{Server: "https://grafana.mycompany.com"},
@@ -503,6 +510,42 @@ func TestContext_ResolveGCOMURL(t *testing.T) {
 			expected: "https://grafana.com",
 		},
 		{
+			name: "prod stack server derives grafana.com",
+			ctx: config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana.net"},
+			},
+			expected: "https://grafana.com",
+		},
+		{
+			name: "ops stack server derives grafana-ops.com",
+			ctx: config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-ops.net"},
+			},
+			expected: "https://grafana-ops.com",
+		},
+		{
+			name: "dev stack server derives grafana-dev.com",
+			ctx: config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-dev.net"},
+			},
+			expected: "https://grafana-dev.com",
+		},
+		{
+			name: "explicit cloud.api-url wins over server-derived root",
+			ctx: config.Context{
+				Cloud:   &config.CloudConfig{APIUrl: "https://grafana.com"},
+				Grafana: &config.GrafanaConfig{Server: "https://mystack.grafana-ops.net"},
+			},
+			expected: "https://grafana.com",
+		},
+		{
+			name: "non-cloud server falls back to grafana.com",
+			ctx: config.Context{
+				Grafana: &config.GrafanaConfig{Server: "https://grafana.example.com"},
+			},
+			expected: "https://grafana.com",
+		},
+		{
 			name: "custom cloud.api-url is prefixed with https://",
 			ctx: config.Context{
 				Cloud: &config.CloudConfig{APIUrl: "grafana-dev.com"},
@@ -589,7 +632,9 @@ func TestGrafanaConfig_InferredAuthMethod(t *testing.T) {
 	}
 }
 
-func TestStackSlugFromServerURL_AppendsEnvSuffix(t *testing.T) {
+func TestStackSlugFromServerURL(t *testing.T) {
+	// The slug is the real GCOM/stack-API identifier: the per-environment naming
+	// suffix ("-dev"/"-ops") is NOT part of it (that lives in the context name).
 	cases := []struct {
 		name     string
 		url      string
@@ -598,8 +643,8 @@ func TestStackSlugFromServerURL_AppendsEnvSuffix(t *testing.T) {
 	}{
 		{"prod bare", "https://mystack.grafana.net", "mystack", true},
 		{"prod regional", "https://mystack.us.grafana.net", "mystack", true},
-		{"dev appends -dev", "https://mystack.grafana-dev.net", "mystack-dev", true},
-		{"ops appends -ops", "https://mystack.grafana-ops.net", "mystack-ops", true},
+		{"dev is bare (no -dev suffix)", "https://mystack.grafana-dev.net", "mystack", true},
+		{"ops is bare (no -ops suffix)", "https://mystack.grafana-ops.net", "mystack", true},
 		{"custom domain no match", "https://grafana.example.com", "", false},
 		{"empty slug rejected", "https://.grafana-dev.net", "", false},
 	}
@@ -608,6 +653,29 @@ func TestStackSlugFromServerURL_AppendsEnvSuffix(t *testing.T) {
 			slug, ok := config.StackSlugFromServerURL(tc.url)
 			if slug != tc.wantSlug || ok != tc.wantOK {
 				t.Fatalf("got (%q, %v), want (%q, %v)", slug, ok, tc.wantSlug, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestGCOMRootFromServerURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		url      string
+		wantRoot string
+		wantOK   bool
+	}{
+		{"prod", "https://mystack.grafana.net", "https://grafana.com", true},
+		{"prod regional", "https://mystack.us.grafana.net", "https://grafana.com", true},
+		{"dev", "https://mystack.grafana-dev.net", "https://grafana-dev.com", true},
+		{"ops", "https://mystack.grafana-ops.net", "https://grafana-ops.com", true},
+		{"custom domain no match", "https://grafana.example.com", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, ok := config.GCOMRootFromServerURL(tc.url)
+			if root != tc.wantRoot || ok != tc.wantOK {
+				t.Fatalf("got (%q, %v), want (%q, %v)", root, ok, tc.wantRoot, tc.wantOK)
 			}
 		})
 	}

--- a/internal/login/validate.go
+++ b/internal/login/validate.go
@@ -146,11 +146,16 @@ func Validate(ctx context.Context, opts Options, restCfg config.NamespacedRESTCo
 	}
 
 	if opts.Target == TargetCloud && opts.CloudToken != "" {
-		gcomBaseURL := opts.CloudAPIURL
-		if gcomBaseURL == "" {
-			gcomBaseURL = "https://grafana.com"
+		// Resolve the GCOM root the same way runtime cloud commands do: an
+		// explicit --cloud-api-url wins, otherwise it is derived from the stack
+		// server URL's environment (ops/dev stacks → grafana-ops.com /
+		// grafana-dev.com), falling back to grafana.com. Validating an ops/dev
+		// CAP token against prod grafana.com otherwise 401s.
+		gcomCtx := &config.Context{
+			Grafana: &config.GrafanaConfig{Server: opts.Server},
+			Cloud:   &config.CloudConfig{APIUrl: opts.CloudAPIURL},
 		}
-		gcomC, err := cloud.NewGCOMClient(gcomBaseURL, opts.CloudToken)
+		gcomC, err := cloud.NewGCOMClient(gcomCtx.ResolveGCOMURL(), opts.CloudToken)
 		if err != nil {
 			return "", fmt.Errorf("connectivity validation: invalid GCOM URL: %w", err)
 		}


### PR DESCRIPTION
## Problem

Cloud Access Policy (CAP) token validation — and every GCOM-backed cloud command — resolved the GCOM API root to a hardcoded `https://grafana.com`, and used the env-tagged context slug (`mystack-ops`) as the stack identifier.

For **ops/dev** stacks (`*.grafana-ops.net`, `*.grafana-dev.net`) this means:
- a valid **ops** CAP token is validated against **prod** `grafana.com` → **401**, and
- the slug sent is `mystack-ops`, which grafana.com can't resolve → **409 `Value must be id or slug`**.

So `gcx login --cloud-token …` (and cloud-management commands) fail against non-prod stacks **even with a valid token**. Observed end-to-end: logging into `ops.grafana-ops.net` 401'd against `grafana.com`; pointing at `grafana-ops.com` turned it into a 409 about the slug `ops-ops`.

## Fix

Two related changes in `internal/config`, both keyed off the existing stack-suffix table (now carrying a `gcomRoot` per environment):

1. **`ResolveGCOMURL`** derives the GCOM root from the stack server URL's environment when `cloud.api-url` is unset — `grafana-ops.com` for `*.grafana-ops.net`, `grafana-dev.com` for `*.grafana-dev.net`, `grafana.com` for prod/unknown. An explicit `cloud.api-url` still wins.
2. The `-dev`/`-ops` suffix was always a **context-name** disambiguator, never part of the real stack slug. `StackSlugFromServerURL` (and thus `ResolveStackSlug` — used by GCOM `GetStack`, datasource resolution, and provider config) now returns the **bare** slug; the suffix moved into `ContextNameFromServerURL`, so **context names are unchanged**.

login's `Validate` now builds the GCOM client via `ResolveGCOMURL`, matching runtime cloud commands instead of duplicating a hardcoded default.

**Prod stacks are unaffected**: their env tag is empty and their root was already `grafana.com`, so slugs, context names, and GCOM roots are identical to before.

## Testing

- `TestStackSlugFromServerURL`: dev/ops now return bare slugs (was the `_AppendsEnvSuffix` test).
- New `TestGCOMRootFromServerURL` + new `ResolveGCOMURL` cases (prod/dev/ops derivation, explicit-override precedence, non-cloud fallback) + a bare-slug `ResolveStackSlug` ops case.
- `TestContextNameFromServerURL` unchanged and still green (names keep their suffix).
- Full suite green in a CI-equivalent env.
- **Live**: `gcx login` against `*.grafana-ops.net` now succeeds (`hasCloudToken: true`, `stackSlug: "ops"`), where it previously 401/409'd.

## Notes

Third of three independent PRs from a login-failure investigation (#859 env-token consumption, #860 non-fatal optional CAP). This one stands alone and benefits all GCOM cloud commands, not just login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)