### PR TITLE
feat(login): add --oauth flag so OAuth works in agent/non-interactive mode

### DIFF
--- a/claude-plugin/skills/setup-gcx/SKILL.md
+++ b/claude-plugin/skills/setup-gcx/SKILL.md
@@ -63,7 +63,21 @@ gcx config set contexts.cloud.grafana.server https://myorg.grafana.net
 Replace `cloud` with any name you prefer for this context (e.g., `prod`,
 `myorg-cloud`). Replace the server URL with your Grafana Cloud URL.
 
-### Step 2: Set the API token
+### Step 2: Authenticate
+
+**Option A-1: Browser OAuth (recommended for Grafana Cloud)**
+
+```bash
+gcx login cloud --server https://myorg.grafana.net --oauth
+```
+
+Opens a browser for the user to approve. This works non-interactively and in
+agent mode — the agent issues the command, the browser opens, and the user
+approves. No token to create or paste. `gcx login` also sets the context as
+current and verifies connectivity, so Steps 1, 3, and 4 are handled for you;
+skip them when using this option.
+
+**Option A-2: Service account token**
 
 ```bash
 gcx config set contexts.cloud.grafana.token glsa_XXXXXXXXXXXXXXXX

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -193,6 +193,12 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 	// auth-method switching — so we leave their flags untouched.
 	flags.Token, flags.CloudToken = resolveNonInteractiveTokens(flags.Token, flags.CloudToken, sourceCtx, isInteractive)
 
+	// Re-auth default: a non-interactive `gcx login <ctx>` on a context that
+	// previously authenticated via OAuth defaults to OAuth instead of failing
+	// for missing grafana-auth. Runs after token resolution so a stored token
+	// still takes precedence.
+	flags.OAuth = defaultOAuthFromContext(flags.OAuth, flags.Token, sourceCtx, isInteractive)
+
 	// Carry existing TLS settings into the login flow so that mTLS keeps
 	// working on re-auth without requiring the user to re-specify certs.
 	var existingTLS *config.TLS
@@ -650,6 +656,21 @@ func resolveNonInteractiveTokens(grafanaToken, cloudToken string, sourceCtx *con
 		cloudToken = sourceCtx.Cloud.Token
 	}
 	return grafanaToken, cloudToken
+}
+
+// defaultOAuthFromContext decides whether to default to OAuth when re-authing
+// an existing context that previously used OAuth. Like resolveNonInteractiveTokens,
+// it only applies to non-interactive logins: a bare `gcx login <oauth-ctx>` in
+// agent mode / CI would otherwise fail with a "missing grafana-auth" error, since
+// OAuth credentials aren't reusable as a token. Interactive logins keep their
+// auth-method menu (where OAuth is already the default for Cloud), and an
+// explicit --oauth/--token always wins.
+func defaultOAuthFromContext(useOAuth bool, grafanaToken string, sourceCtx *config.Context, interactive bool) bool {
+	if useOAuth || interactive || grafanaToken != "" ||
+		sourceCtx == nil || sourceCtx.Grafana == nil {
+		return useOAuth
+	}
+	return sourceCtx.Grafana.AuthMethod == "oauth"
 }
 
 // printModeHeader writes a one- or two-line status banner so the user

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -45,6 +45,7 @@ type loginOpts struct {
 	Token               string
 	CloudToken          string
 	CloudAPIURL         string
+	OAuth               bool
 	Cloud               bool
 	Yes                 bool
 	AllowServerOverride bool
@@ -65,6 +66,7 @@ func (opts *loginOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.Token, "token", "", "Grafana service account token")
 	flags.StringVar(&opts.CloudToken, "cloud-token", "", "Grafana Cloud API token (enables Cloud management features)")
 	flags.StringVar(&opts.CloudAPIURL, "cloud-api-url", "", "Override Grafana Cloud API URL")
+	flags.BoolVar(&opts.OAuth, "oauth", false, "Authenticate via browser-based OAuth (recommended for Grafana Cloud). Works non-interactively and in agent mode: opens a browser for the user to approve.")
 	flags.BoolVar(&opts.Cloud, "cloud", false, "Force Grafana Cloud target (skip auto-detection)")
 	flags.BoolVar(&opts.Yes, "yes", false, "Non-interactive: skip optional prompts and use defaults")
 	flags.BoolVar(&opts.AllowServerOverride, "allow-server-override", false, "Allow re-pointing an existing context at a different server URL")
@@ -86,6 +88,15 @@ func (opts *loginOpts) Validate(args []string) error {
 			),
 			Suggestions: []string{
 				"Drop --context and use the positional form: gcx login " + args[0],
+			},
+		}
+	}
+	if opts.OAuth && opts.Token != "" {
+		return gcxerrors.DetailedError{
+			Summary: "conflicting authentication methods",
+			Details: "--oauth and --token are mutually exclusive. OAuth authenticates via browser; --token uses a service account token.",
+			Suggestions: []string{
+				"Use --oauth for browser-based login, or --token <token> for a service account token",
 			},
 		}
 	}
@@ -119,7 +130,9 @@ Pass CONTEXT_NAME to target a specific context:
 Without CONTEXT_NAME, re-authenticates the current context, or starts a
 first-time setup if no current context is configured.
 
-Token sources (for non-interactive use):
+Auth sources (for non-interactive use):
+  --oauth        Browser-based OAuth (recommended for Grafana Cloud). Opens a
+                 browser for the user to approve; works in agent mode.
   --token        Grafana service-account token (created inside the Grafana
                  instance). See:
                  ` + docs.ServiceAccounts + `
@@ -129,6 +142,7 @@ Token sources (for non-interactive use):
 		Example: `  gcx login
   gcx login prod
   gcx login prod --server https://prod.grafana.net
+  gcx login prod --server https://prod.grafana.net --oauth
   gcx login --yes prod --token glsa_xxx
   gcx login --yes --server https://localhost:3000 --token glsa_xxx`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -205,6 +219,7 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 			GrafanaToken:      flags.Token,
 			CloudToken:        flags.CloudToken,
 			CloudAPIURL:       flags.CloudAPIURL,
+			UseOAuth:          flags.OAuth,
 			OAuthCallbackPort: flags.OAuthCallbackPort,
 			Yes:               flags.Yes,
 			OrgID:             flags.OrgID,
@@ -543,7 +558,9 @@ func structuredMissingFieldsError(e *login.ErrNeedInput) error {
 		case "server":
 			suggestions = append(suggestions, "Pass --server <url> or set GRAFANA_SERVER")
 		case "grafana-auth":
-			suggestions = append(suggestions, "Pass --token <token> (or set the GRAFANA_TOKEN env var) for a service account token, or configure TLS client certs for mTLS auth (GRAFANA_TLS_CERT_FILE / GRAFANA_TLS_KEY_FILE env vars, or gcx config set contexts.<ctx>.grafana.tls.cert-file ...)")
+			suggestions = append(suggestions,
+				"Pass --oauth to authenticate via browser (recommended for Grafana Cloud; opens a browser for the user to approve, works in agent mode)",
+				"Pass --token <token> (or set the GRAFANA_TOKEN env var) for a service account token, or configure TLS client certs for mTLS auth (GRAFANA_TLS_CERT_FILE / GRAFANA_TLS_KEY_FILE env vars, or gcx config set contexts.<ctx>.grafana.tls.cert-file ...)")
 		case "cloud-token":
 			suggestions = append(suggestions, "Pass --cloud-token <token> (or set the GRAFANA_CLOUD_TOKEN env var) to enable Cloud features, or --yes to skip")
 		default:
@@ -705,13 +722,15 @@ func printResult(cmd *cobra.Command, ioOpts *cmdio.Options, server string, resul
 	ew := cmd.ErrOrStderr()
 	if ioOpts.OutputFormat == "text" {
 		fmt.Fprintln(ew)
-		fmt.Fprintln(ew, "Next: gcx config check")
+		fmt.Fprintln(ew, "Verify access anytime with: gcx config check")
 	}
 	if result.IsCloud && !result.HasCloudToken {
 		fmt.Fprintln(ew)
-		fmt.Fprintln(ew, "Note: Cloud API commands require a Cloud Access Policy (CAP) token.")
+		fmt.Fprintln(ew, "You're authenticated for the Grafana API (dashboards, datasources, queries, alerts, folders).")
+		fmt.Fprintln(ew, "Grafana Cloud product management (SLOs, Synthetic Monitoring, Fleet, k6, IRM, Adaptive telemetry)")
+		fmt.Fprintln(ew, "additionally requires a Cloud Access Policy (CAP) token.")
 		fmt.Fprintln(ew, "See: https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/")
-		fmt.Fprintf(ew, "Run 'gcx login --context %s --cloud-token <token>' to add one.\n", result.ContextName)
+		fmt.Fprintf(ew, "Add one with: gcx login --context %s --cloud-token <token>\n", result.ContextName)
 	}
 	return nil
 }

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -161,6 +161,66 @@ func TestResolveNonInteractiveTokens(t *testing.T) {
 	}
 }
 
+// TestDefaultOAuthFromContext verifies that a non-interactive re-auth of an
+// existing OAuth context defaults to OAuth, while interactive logins, explicit
+// flags, stored tokens, and non-OAuth contexts are left untouched (issue #854).
+func TestDefaultOAuthFromContext(t *testing.T) {
+	t.Parallel()
+
+	oauthCtx := &config.Context{Grafana: &config.GrafanaConfig{AuthMethod: "oauth"}}
+	tokenCtx := &config.Context{Grafana: &config.GrafanaConfig{AuthMethod: "token"}}
+
+	tests := []struct {
+		name         string
+		useOAuth     bool
+		grafanaToken string
+		sourceCtx    *config.Context
+		interactive  bool
+		want         bool
+	}{
+		{
+			name:      "non_interactive_oauth_context_defaults_oauth",
+			sourceCtx: oauthCtx,
+			want:      true,
+		},
+		{
+			name:        "interactive_oauth_context_unchanged",
+			sourceCtx:   oauthCtx,
+			interactive: true,
+			want:        false,
+		},
+		{
+			name:      "token_context_not_defaulted",
+			sourceCtx: tokenCtx,
+			want:      false,
+		},
+		{
+			name:         "stored_token_wins_over_oauth_default",
+			grafanaToken: "glsa_env",
+			sourceCtx:    oauthCtx,
+			want:         false,
+		},
+		{
+			name:      "explicit_oauth_flag_preserved",
+			useOAuth:  true,
+			sourceCtx: tokenCtx,
+			want:      true,
+		},
+		{
+			name: "nil_source_context",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := defaultOAuthFromContext(tt.useOAuth, tt.grafanaToken, tt.sourceCtx, tt.interactive)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // TestStructuredClarificationError verifies that structuredClarificationError
 // returns the right DetailedError variant for each Field ("allow-override",
 // "save-unvalidated", ambiguous target).

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -384,18 +384,35 @@ func TestLoginOptsValidate(t *testing.T) {
 func TestOAuthFlagParses(t *testing.T) {
 	t.Parallel()
 
-	opts := &loginOpts{}
-	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	opts.setup(flags)
+	tests := []struct {
+		name      string
+		args      []string
+		wantOAuth bool
+	}{
+		{
+			name:      "oauth_flag_set",
+			args:      []string{"--server", "https://example.grafana.net", "--oauth"},
+			wantOAuth: true,
+		},
+		{
+			name:      "oauth_flag_absent",
+			args:      []string{"--server", "https://example.grafana.net"},
+			wantOAuth: false,
+		},
+	}
 
-	require.NoError(t, flags.Parse([]string{"--server", "https://example.grafana.net", "--oauth"}))
-	assert.True(t, opts.OAuth, "--oauth should set loginOpts.OAuth")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	opts2 := &loginOpts{}
-	flags2 := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	opts2.setup(flags2)
-	require.NoError(t, flags2.Parse([]string{"--server", "https://example.grafana.net"}))
-	assert.False(t, opts2.OAuth, "OAuth should default to false")
+			opts := &loginOpts{}
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			opts.setup(flags)
+
+			require.NoError(t, flags.Parse(tt.args))
+			assert.Equal(t, tt.wantOAuth, opts.OAuth)
+		})
+	}
 }
 
 // TestPrintResult_TextCodec is a golden comparison that confirms the text

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -48,7 +48,7 @@ func TestStructuredMissingFieldsError(t *testing.T) {
 			err:            &internallogin.ErrNeedInput{Fields: []string{"grafana-auth"}},
 			wantSummary:    "Login requires additional input",
 			wantDetailSubs: []string{"grafana-auth"},
-			wantSuggestSub: []string{"--token", "GRAFANA_TOKEN"},
+			wantSuggestSub: []string{"--oauth", "--token", "GRAFANA_TOKEN"},
 		},
 		{
 			name:           "missing_cloud_token",
@@ -239,6 +239,8 @@ func TestLoginOptsValidate(t *testing.T) {
 		name          string
 		args          []string
 		contextFlag   string
+		oauthFlag     bool
+		tokenFlag     string
 		wantErr       bool
 		wantErrSubstr string
 	}{
@@ -267,6 +269,26 @@ func TestLoginOptsValidate(t *testing.T) {
 			contextFlag: "",
 			wantErr:     false,
 		},
+		{
+			name:          "conflict_oauth_and_token",
+			args:          []string{},
+			oauthFlag:     true,
+			tokenFlag:     "glsa_xxx",
+			wantErr:       true,
+			wantErrSubstr: "conflicting authentication methods",
+		},
+		{
+			name:      "oauth_alone",
+			args:      []string{},
+			oauthFlag: true,
+			wantErr:   false,
+		},
+		{
+			name:      "token_alone",
+			args:      []string{},
+			tokenFlag: "glsa_xxx",
+			wantErr:   false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -275,6 +297,8 @@ func TestLoginOptsValidate(t *testing.T) {
 
 			opts := &loginOpts{
 				Config: configcmd.Options{Context: tt.contextFlag},
+				OAuth:  tt.oauthFlag,
+				Token:  tt.tokenFlag,
 			}
 			// Bind flags into a throwaway FlagSet so IO.Validate() has a
 			// populated flag set to inspect (otherwise --json handling is
@@ -292,6 +316,26 @@ func TestLoginOptsValidate(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestOAuthFlagParses confirms setup() registers the --oauth flag and that it
+// parses into loginOpts.OAuth, which runLogin maps to login.Inputs.UseOAuth so
+// OAuth is reachable non-interactively (issue #854).
+func TestOAuthFlagParses(t *testing.T) {
+	t.Parallel()
+
+	opts := &loginOpts{}
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.setup(flags)
+
+	require.NoError(t, flags.Parse([]string{"--server", "https://example.grafana.net", "--oauth"}))
+	assert.True(t, opts.OAuth, "--oauth should set loginOpts.OAuth")
+
+	opts2 := &loginOpts{}
+	flags2 := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts2.setup(flags2)
+	require.NoError(t, flags2.Parse([]string{"--server", "https://example.grafana.net"}))
+	assert.False(t, opts2.OAuth, "OAuth should default to false")
 }
 
 // TestPrintResult_TextCodec is a golden comparison that confirms the text
@@ -331,7 +375,7 @@ func TestPrintResult_TextCodec(t *testing.T) {
   Stack:       mystack
 `,
 			wantStderrSubs: []string{
-				"Next: gcx config check",
+				"Verify access anytime with: gcx config check",
 			},
 		},
 		{
@@ -351,8 +395,9 @@ func TestPrintResult_TextCodec(t *testing.T) {
   Stack:       stack
 `,
 			wantStderrSubs: []string{
-				"Next: gcx config check",
-				"Note: Cloud API commands require a Cloud Access Policy (CAP) token.",
+				"Verify access anytime with: gcx config check",
+				"authenticated for the Grafana API",
+				"requires a Cloud Access Policy (CAP) token.",
 				"grafana.com/docs/grafana-cloud/security-and-account-management",
 				"gcx login --context stack --cloud-token",
 			},
@@ -373,7 +418,7 @@ func TestPrintResult_TextCodec(t *testing.T) {
   Grafana Cloud: no
 `,
 			wantStderrSubs: []string{
-				"Next: gcx config check",
+				"Verify access anytime with: gcx config check",
 			},
 		},
 		{
@@ -390,7 +435,7 @@ func TestPrintResult_TextCodec(t *testing.T) {
   Grafana Cloud: no
 `,
 			wantStderrSubs: []string{
-				"Next: gcx config check",
+				"Verify access anytime with: gcx config check",
 			},
 		},
 	}

--- a/docs/reference/cli/gcx_login.md
+++ b/docs/reference/cli/gcx_login.md
@@ -14,7 +14,9 @@ Pass CONTEXT_NAME to target a specific context:
 Without CONTEXT_NAME, re-authenticates the current context, or starts a
 first-time setup if no current context is configured.
 
-Token sources (for non-interactive use):
+Auth sources (for non-interactive use):
+  --oauth        Browser-based OAuth (recommended for Grafana Cloud). Opens a
+                 browser for the user to approve; works in agent mode.
   --token        Grafana service-account token (created inside the Grafana
                  instance). See:
                  https://grafana.com/docs/grafana/latest/administration/service-accounts.md
@@ -32,6 +34,7 @@ gcx login [CONTEXT_NAME] [flags]
   gcx login
   gcx login prod
   gcx login prod --server https://prod.grafana.net
+  gcx login prod --server https://prod.grafana.net --oauth
   gcx login --yes prod --token glsa_xxx
   gcx login --yes --server https://localhost:3000 --token glsa_xxx
 ```
@@ -47,6 +50,7 @@ gcx login [CONTEXT_NAME] [flags]
       --context string            Name of the context to use
   -h, --help                      help for login
       --json string               Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --oauth                     Authenticate via browser-based OAuth (recommended for Grafana Cloud). Works non-interactively and in agent mode: opens a browser for the user to approve.
       --oauth-callback-port int   Fixed local port for the OAuth callback server (default: auto-pick from 54321-54399). Useful when only specific ports are forwarded between a remote host and your browser
       --org-id int                Grafana organization ID (defaults to 1 for on-prem)
   -o, --output string             Output format. One of: agents, json, text, yaml (default "text")

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -52,7 +52,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx assistant conversation get":                 {Cost: "large", Hint: "Pull a conversation transcript by ID before continuing it with 'gcx assistant prompt --context-id'. Example: <conversation-id> -o json"},
 
 	// login
-	"gcx login": {Cost: "small", Hint: "Non-interactive: gcx login <ctx> --yes --server <url> --token <grafana-sa-token> [--cloud-token <cap-token>]. Service-account tokens (--token) are created inside the Grafana instance — see " + docs.ServiceAccounts + ". Cloud access-policy tokens (--cloud-token) are created at grafana.com — see " + docs.AccessPolicies + ". Append .md to any grafana.com/docs URL to fetch markdown. Do not guess token URLs."},
+	"gcx login": {Cost: "small", Hint: "Browser OAuth (recommended for Grafana Cloud): gcx login <ctx> --server <url> --oauth — opens a browser for the user to approve; works in agent mode. Non-interactive token: gcx login <ctx> --yes --server <url> --token <grafana-sa-token> [--cloud-token <cap-token>]. Service-account tokens (--token) are created inside the Grafana instance — see " + docs.ServiceAccounts + ". Cloud access-policy tokens (--cloud-token) are created at grafana.com — see " + docs.AccessPolicies + ". Append .md to any grafana.com/docs URL to fetch markdown. Do not guess token URLs."},
 
 	// commands
 	"gcx commands": {Cost: "medium", Hint: "--flat -o json"},


### PR DESCRIPTION
## Summary
- Adds an explicit `--oauth` flag to `gcx login` so browser-based OAuth is reachable in **any** mode, including agent mode and other non-interactive contexts.
- Fixes the root cause of #854: OAuth was only reachable through the interactive auth-method menu, which agent mode disables — and the agent command hint only ever documented `--token`, so an agent could neither discover nor trigger OAuth. This violated the CONSTITUTION invariant that *"agent mode switches defaults but does not change available functionality."*
- Defaults to OAuth when re-authenticating an existing OAuth context, so a bare `gcx login <ctx>` refreshes non-interactively instead of erroring.
- Clarifies the post-login advisory messaging (the vague `Next:` line and the generic "Cloud API commands" CAP-token note).

## Changes
- `cmd/gcx/login/command.go`
  - New `--oauth` flag (→ `login.Inputs.UseOAuth`); `Validate` rejects `--oauth` + `--token` as mutually exclusive.
  - `defaultOAuthFromContext` helper: a **non-interactive** `gcx login <ctx>` on a context with stored `auth-method: oauth` defaults to OAuth (mirrors the existing `resolveNonInteractiveTokens` gating; explicit flags / stored tokens still win; interactive keeps its menu).
  - `--oauth` added to the non-interactive `grafana-auth` error suggestions and to the command `Long`/`Example` help; reworded post-login advisory (what works now vs. what needs a CAP token).
- `internal/agent/command_annotations.go` — `gcx login` agent hint now leads with the browser-OAuth path so agents discover it.
- `claude-plugin/skills/setup-gcx/SKILL.md` — documents the OAuth option for the Grafana Cloud setup path.
- `cmd/gcx/login/command_test.go` — tests for the Validate conflict, `--oauth` flag parsing, `defaultOAuthFromContext`, updated `grafana-auth` suggestions, and updated post-login golden stderr text.
- `docs/reference/cli/gcx_login.md` — regenerated CLI reference.

With `--server` but no auth flag in agent mode (new context), login returns a structured error that now suggests `--oauth`/`--token` — OAuth is not auto-triggered for a brand-new context (no surprise browser). For an existing OAuth context, a bare re-auth defaults to OAuth.

## Test Plan
- [x] Tests pass locally (`GCX_AGENT_MODE=false mise run all`)
- [x] New tests cover the `--oauth` flag, mutual-exclusion validation, OAuth re-auth defaulting, and the reworded advisory
- [x] Lints clean; CLI reference regenerated; `reference-drift` clean
- [x] **Live-verified against a real Grafana Cloud stack (agent mode):**
  - Bare `gcx login <new-ctx> --server <cloud-url>` → structured error suggesting `--oauth` (no hang, no browser, nothing persisted)
  - `gcx login <ctx> --oauth` → full browser PKCE flow completes, context refreshed
  - Bare `gcx login <existing-oauth-ctx>` → now defaults to OAuth and completes (previously errored)

Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)