### PR TITLE
fix: agent-mode JSON errors omit details from fallback-wrapped errors

### DIFF
--- a/cmd/gcx/fail/json_test.go
+++ b/cmd/gcx/fail/json_test.go
@@ -1,6 +1,8 @@
 package fail_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -38,5 +40,36 @@ func TestWriteJSON_NoBoxChars(t *testing.T) {
 	// Verify the actual content is preserved, not lost.
 	if !strings.Contains(output, "cluster not found") {
 		t.Errorf("WriteJSON output missing summary:\n%s", output)
+	}
+}
+
+// TestWriteJSON_FallbackErrorIncludesDetails verifies that when an unrecognised
+// wrapped error falls through to fallbackDetailedError, the inner error message
+// appears in the JSON "details" field via Parent folding.
+func TestWriteJSON_FallbackErrorIncludesDetails(t *testing.T) {
+	inner := fmt.Errorf("response body exceeds 50 MB limit; try narrowing your query or adding filters")
+	err := fmt.Errorf("search failed: %w", inner)
+
+	converted := fail.ErrorToDetailedError(err)
+
+	var buf strings.Builder
+	_ = converted.WriteJSON(&buf, 1)
+
+	var got map[string]any
+	if jsonErr := json.Unmarshal([]byte(buf.String()), &got); jsonErr != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", jsonErr, buf.String())
+	}
+
+	errObj, ok := got["error"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'error' key in JSON output")
+	}
+
+	details, _ := errObj["details"].(string)
+	if details == "" {
+		t.Errorf("expected non-empty 'details' in JSON, got: %s", buf.String())
+	}
+	if !strings.Contains(details, "50 MB limit") {
+		t.Errorf("expected details to contain inner error message, got: %q", details)
 	}
 }

--- a/cmd/gcx/fail/json_test.go
+++ b/cmd/gcx/fail/json_test.go
@@ -2,6 +2,7 @@ package fail_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -47,7 +48,7 @@ func TestWriteJSON_NoBoxChars(t *testing.T) {
 // wrapped error falls through to fallbackDetailedError, the inner error message
 // appears in the JSON "details" field via Parent folding.
 func TestWriteJSON_FallbackErrorIncludesDetails(t *testing.T) {
-	inner := fmt.Errorf("response body exceeds 50 MB limit; try narrowing your query or adding filters")
+	inner := errors.New("response body exceeds 50 MB limit; try narrowing your query or adding filters")
 	err := fmt.Errorf("search failed: %w", inner)
 
 	converted := fail.ErrorToDetailedError(err)

--- a/internal/gcxerrors/json.go
+++ b/internal/gcxerrors/json.go
@@ -45,6 +45,19 @@ func (e DetailedError) agentSuggestions() []string {
 	return sug
 }
 
+// resolvedDetails returns Details if non-empty, otherwise falls back to
+// Parent.Error() so that wrapped errors surfaced via fallbackDetailedError
+// still carry context in the JSON output.
+func (e DetailedError) resolvedDetails() string {
+	if e.Details != "" {
+		return e.Details
+	}
+	if e.Parent != nil {
+		return e.Parent.Error()
+	}
+	return ""
+}
+
 // errorJSON is the JSON representation of a DetailedError.
 // Optional fields use pointers so they are omitted when empty.
 type errorJSON struct {
@@ -74,7 +87,7 @@ func (e DetailedError) WriteJSON(w io.Writer, exitCode int) error {
 		Error: errorJSON{
 			Summary:     e.Summary,
 			ExitCode:    exitCode,
-			Details:     stripBoxChars(e.Details),
+			Details:     stripBoxChars(e.resolvedDetails()),
 			Suggestions: e.agentSuggestions(),
 			DocsLink:    e.DocsLink,
 		},
@@ -104,7 +117,7 @@ func (e DetailedError) WriteJSONWithItems(w io.Writer, exitCode int, items any) 
 		Error: errorJSON{
 			Summary:     e.Summary,
 			ExitCode:    exitCode,
-			Details:     stripBoxChars(e.Details),
+			Details:     stripBoxChars(e.resolvedDetails()),
 			Suggestions: e.agentSuggestions(),
 			DocsLink:    e.DocsLink,
 		},

--- a/internal/gcxerrors/json_test.go
+++ b/internal/gcxerrors/json_test.go
@@ -3,6 +3,7 @@ package gcxerrors_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -98,6 +99,37 @@ func TestDetailedError_WriteJSON(t *testing.T) {
 					"details":     "could not reach the server",
 					"suggestions": []any{"check network", "verify credentials", gcxerrors.DocsFetchSuggestion("https://example.com/docs/push")},
 					"docsLink":    "https://example.com/docs/push",
+				},
+			},
+		},
+		{
+			name: "parent folded into details when details is empty",
+			err: gcxerrors.DetailedError{
+				Summary: "Search failed",
+				Parent:  errors.New("response body exceeds 50 MB limit; try narrowing your query or adding filters"),
+			},
+			exitCode: 1,
+			wantJSON: map[string]any{
+				"error": map[string]any{
+					"summary":  "Search failed",
+					"exitCode": float64(1),
+					"details":  "response body exceeds 50 MB limit; try narrowing your query or adding filters",
+				},
+			},
+		},
+		{
+			name: "parent NOT folded when details is already set",
+			err: gcxerrors.DetailedError{
+				Summary: "Search failed",
+				Details: "explicit details here",
+				Parent:  errors.New("this should not appear in details"),
+			},
+			exitCode: 1,
+			wantJSON: map[string]any{
+				"error": map[string]any{
+					"summary":  "Search failed",
+					"exitCode": float64(1),
+					"details":  "explicit details here",
 				},
 			},
 		},


### PR DESCRIPTION
closes #855

## Summary

- `WriteJSON` now folds `DetailedError.Parent` into the `details` JSON field when `Details` is empty, matching how the TTY renderer already handles this case.
- adds `resolvedDetails()` helper on `DetailedError` used by both `WriteJSON` and `WriteJSONWithItems`.

**Before** - wrapped errors that fall through to `fallbackDetailedError` produce:

```json
{"error":{"summary":"Query failed","exitCode":1}}
```

**After**:

```json
{"error":{"summary":"Query failed","exitCode":1,"details":"response body exceeds 0 MB limit; use a narrower time range or add filters to reduce data volume"}}
```

TTY output was already correct:

```
Error: Query failed
│
├─ Details:
│
│ response body exceeds 0 MB limit; use a narrower time range or add filters to reduce data volume
│
└─
```