### PR TITLE
perf(config): skip stack-ID /bootdata call when StackID is configured + persist it on login

### DIFF
--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
-	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/gcx/internal/auth"
 	"github.com/grafana/gcx/internal/httputils"
 	"github.com/grafana/gcx/internal/retry"
@@ -256,20 +255,7 @@ func NewNamespacedRESTConfig(ctx context.Context, cfg Context) (NamespacedRESTCo
 	}
 
 	// Namespace
-	var namespace string
-
-	discoveredStackID, err := DiscoverStackID(ctx, *cfg.Grafana)
-
-	if err == nil {
-		// even if cfg.Grafana.OrgID was set - we ignore it, discoveredStackID takes precedent
-		namespace = authlib.CloudNamespaceFormatter(discoveredStackID)
-	} else {
-		if cfg.Grafana.OrgID != 0 {
-			namespace = authlib.OrgNamespaceFormatter(cfg.Grafana.OrgID)
-		} else {
-			namespace = authlib.CloudNamespaceFormatter(cfg.Grafana.StackID)
-		}
-	}
+	namespace := resolveNamespace(ctx, *cfg.Grafana)
 
 	// Wrap transport with debug logging so `-vvv` shows every HTTP request.
 	// When --insecure-log-http-payload is set, also add full request/response body dumps.

--- a/internal/config/rest_test.go
+++ b/internal/config/rest_test.go
@@ -91,8 +91,10 @@ func TestNewNamespacedRESTConfig_NilTLSLeavesDefaults(t *testing.T) {
 	}
 }
 
-func TestNewNamespacedRESTConfig_UsesBootdataStack(t *testing.T) {
+func TestNewNamespacedRESTConfig_ConfiguredStackIDSkipsBootdata(t *testing.T) {
+	var hits int
 	bootdataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"settings": map[string]any{
 				"namespace": "stacks-98765",
@@ -110,12 +112,43 @@ func TestNewNamespacedRESTConfig_UsesBootdataStack(t *testing.T) {
 
 	restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), ctx)
 
-	if got, want := restCfg.Namespace, authlib.CloudNamespaceFormatter(98765); got != want {
+	// A configured StackID is authoritative: no /bootdata round-trip is made and
+	// the namespace reflects the configured stack, not the server's response.
+	if hits != 0 {
+		t.Fatalf("expected no bootdata requests, got %d", hits)
+	}
+	if got, want := restCfg.Namespace, authlib.CloudNamespaceFormatter(12345); got != want {
 		t.Fatalf("expected namespace %s, got %s", want, got)
 	}
+}
 
-	if ctx.Grafana.StackID != 12345 {
-		t.Fatalf("expected original stack ID to remain unchanged, got %d", ctx.Grafana.StackID)
+func TestNewNamespacedRESTConfig_DiscoversAndCachesStackID(t *testing.T) {
+	var hits int
+	bootdataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"settings": map[string]any{
+				"namespace": "stacks-77777",
+			},
+		})
+	}))
+	defer bootdataServer.Close()
+
+	// No StackID/OrgID configured: the stack ID is discovered via /bootdata.
+	ctx := config.Context{
+		Grafana: &config.GrafanaConfig{Server: bootdataServer.URL},
+	}
+
+	for i := range 2 {
+		restCfg, _ := config.NewNamespacedRESTConfig(t.Context(), ctx)
+		if got, want := restCfg.Namespace, authlib.CloudNamespaceFormatter(77777); got != want {
+			t.Fatalf("call %d: expected namespace %s, got %s", i, want, got)
+		}
+	}
+
+	// The second build reuses the cached discovery instead of hitting the server.
+	if hits != 1 {
+		t.Fatalf("expected exactly 1 bootdata request (cached thereafter), got %d", hits)
 	}
 }
 

--- a/internal/config/rest_test.go
+++ b/internal/config/rest_test.go
@@ -122,6 +122,25 @@ func TestNewNamespacedRESTConfig_ConfiguredStackIDSkipsBootdata(t *testing.T) {
 	}
 }
 
+func TestNamespacedRESTConfig_StackID(t *testing.T) {
+	cases := []struct {
+		namespace string
+		want      int64
+	}{
+		{"stacks-12345", 12345},
+		{"org-5", 0},   // on-prem org namespace: not a stack
+		{"default", 0}, // org-1
+		{"", 0},        // unresolved
+		{"garbage", 0},
+	}
+	for _, tc := range cases {
+		rc := config.NamespacedRESTConfig{Namespace: tc.namespace}
+		if got := rc.StackID(); got != tc.want {
+			t.Errorf("StackID() for namespace %q = %d, want %d", tc.namespace, got, tc.want)
+		}
+	}
+}
+
 func TestNewNamespacedRESTConfig_DiscoversAndCachesStackID(t *testing.T) {
 	var hits int
 	bootdataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/config/stack_id.go
+++ b/internal/config/stack_id.go
@@ -26,6 +26,18 @@ var (
 	stackIDCache   = map[string]int64{}
 )
 
+// StackID returns the Grafana Cloud stack ID encoded in the resolved namespace
+// (e.g. "stacks-12345" -> 12345), or 0 when the namespace is not a cloud stack
+// namespace (on-prem org namespaces, or an unresolved/empty namespace). It lets
+// callers recover the discovered stack ID without a second /bootdata round-trip.
+func (n *NamespacedRESTConfig) StackID() int64 {
+	info, err := authlib.ParseNamespace(n.Namespace)
+	if err != nil {
+		return 0
+	}
+	return info.StackID
+}
+
 // resolveNamespace returns the Kubernetes namespace for a Grafana context.
 // A configured StackID is authoritative and resolves locally with no network
 // call. Otherwise the cloud stack ID is discovered via /bootdata (memoized per

--- a/internal/config/stack_id.go
+++ b/internal/config/stack_id.go
@@ -8,12 +8,70 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	authlib "github.com/grafana/authlib/types"
 )
 
 var errBootdataNonOK = errors.New("bootdata request failed")
+
+// stackIDCache memoizes successful /bootdata stack-ID discoveries per server for
+// the lifetime of the process, so repeated REST-config builds in a single
+// invocation don't repay the network round-trip.
+//
+//nolint:gochecknoglobals // process-wide positive cache; only successes stored.
+var (
+	stackIDCacheMu sync.Mutex
+	stackIDCache   = map[string]int64{}
+)
+
+// resolveNamespace returns the Kubernetes namespace for a Grafana context.
+// A configured StackID is authoritative and resolves locally with no network
+// call. Otherwise the cloud stack ID is discovered via /bootdata (memoized per
+// server), with OrgID as the on-prem fallback when discovery fails.
+func resolveNamespace(ctx context.Context, cfg GrafanaConfig) string {
+	// A configured StackID is authoritative; Validate already guards mismatches
+	// against discovery, so trust it here and skip the network round-trip.
+	if cfg.StackID != 0 {
+		return authlib.CloudNamespaceFormatter(cfg.StackID)
+	}
+
+	// No StackID configured: discover it (cached). Discovery takes precedence
+	// over OrgID, matching prior behavior.
+	if discoveredStackID, err := discoverStackIDCached(ctx, cfg); err == nil {
+		return authlib.CloudNamespaceFormatter(discoveredStackID)
+	}
+
+	if cfg.OrgID != 0 {
+		return authlib.OrgNamespaceFormatter(cfg.OrgID)
+	}
+	return authlib.CloudNamespaceFormatter(cfg.StackID)
+}
+
+// discoverStackIDCached wraps DiscoverStackID with a process-lifetime positive
+// cache keyed by server URL. Failures are not cached so a transient error does
+// not pin a missing stack ID for the rest of the process.
+func discoverStackIDCached(ctx context.Context, cfg GrafanaConfig) (int64, error) {
+	key := strings.TrimSuffix(cfg.Server, "/")
+
+	stackIDCacheMu.Lock()
+	cached, ok := stackIDCache[key]
+	stackIDCacheMu.Unlock()
+	if ok {
+		return cached, nil
+	}
+
+	id, err := DiscoverStackID(ctx, cfg)
+	if err != nil {
+		return 0, err
+	}
+
+	stackIDCacheMu.Lock()
+	stackIDCache[key] = id
+	stackIDCacheMu.Unlock()
+	return id, nil
+}
 
 // DiscoverStackID attempts to discover a Grafana Cloud stack namespace via the /bootdata endpoint.
 // It returns the parsed stack ID when the response matches the expected format.

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -297,6 +297,14 @@ func Run(ctx context.Context, opts *Options) (Result, error) {
 		return Result{}, fmt.Errorf("TLS configuration: %w", err)
 	}
 
+	// Persist the cloud stack ID discovered while building the REST config so
+	// subsequent commands resolve the namespace locally and skip the /bootdata
+	// round-trip. On-prem (org) namespaces yield 0 and are left unset. Done
+	// before validation so it also applies on the --force save-anyway path.
+	if sid := restCfg.StackID(); sid != 0 {
+		tempCtx.Grafana.StackID = sid
+	}
+
 	var grafanaVersion string
 	if !opts.ForceSave {
 		validateFn := opts.ValidateFn
@@ -608,6 +616,12 @@ func mergeAuthIntoExisting(existing *config.Context, incoming config.Context, ex
 	g.OAuthTokenExpiresAt = src.OAuthTokenExpiresAt
 	g.OAuthRefreshExpiresAt = src.OAuthRefreshExpiresAt
 	g.ProxyEndpoint = src.ProxyEndpoint
+
+	// Carry the freshly discovered cloud stack ID through re-auth so re-logins
+	// keep it current. Left untouched when discovery yielded nothing (0).
+	if src.StackID != 0 {
+		g.StackID = src.StackID
+	}
 
 	if explicitOrgID != 0 {
 		g.OrgID = int64(explicitOrgID)

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -3,7 +3,10 @@ package login_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1300,4 +1303,47 @@ func TestRun_CloudTokenHintGuidance(t *testing.T) {
 	assert.Contains(t, hint, "fleet-management:read", "hint must name the Fleet scope")
 	assert.Contains(t, hint, "stacks:write", "hint must name the stack-management scope")
 	assert.Contains(t, strings.ToLower(hint), "skip", "hint must retain the skip affordance")
+}
+
+// TestRun_PersistsDiscoveredStackID verifies that the cloud stack ID discovered
+// while building the REST config (via /bootdata) is written to the saved
+// context, so later commands skip the discovery round-trip.
+func TestRun_PersistsDiscoveredStackID(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/bootdata" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"settings": map[string]any{"namespace": "stacks-777"},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	src := configSource(dir)
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server:       srv.URL,
+			Target:       login.TargetCloud,
+			GrafanaToken: "glsa_test", // token auth keeps Server == srv.URL (no OAuth override)
+			Yes:          true,
+		},
+		Hooks: login.Hooks{
+			ConfigSource: src,
+			ValidateFn:   noopValidate,
+		},
+	}
+
+	result, err := login.Run(context.Background(), &opts)
+	require.NoError(t, err)
+
+	cfg, err := config.Load(context.Background(), src)
+	require.NoError(t, err)
+	ctx := cfg.Contexts[result.ContextName]
+	require.NotNil(t, ctx)
+	require.NotNil(t, ctx.Grafana)
+	assert.Equal(t, int64(777), ctx.Grafana.StackID, "discovered stack id must be persisted to the saved context")
 }


### PR DESCRIPTION
## Context

Part of a series targeting performance bottlenecks on the path shared by **most** gcx commands. This PR has two complementary halves: stop paying for stack-ID discovery when it's avoidable, and make logins record the stack ID so the skip actually applies.

## 1. Skip `/bootdata` when `StackID` is configured (+ cache)

`NewNamespacedRESTConfig` — on the path shared by nearly every resource/provider command — called `DiscoverStackID()` **unconditionally**: fresh `http.Transport`, synchronous `GET <server>/bootdata`, 5s timeout, no caching, and it **ignored an already-configured `StackID`**.

- `resolveNamespace`: a configured `StackID` resolves the namespace locally with **no network call**; otherwise discovery runs, then falls back to `OrgID`/zero (discovery still precedes `OrgID`, as before).
- Successful discoveries are memoized per server for the process lifetime; failures are not cached.

**Behavior change:** discovery no longer overrides a configured `StackID` (`Context.Validate()` already guards mismatches). The old `UsesBootdataStack` test is rewritten; new tests assert no `/bootdata` request when `StackID` is set, plus the caching path.

**Measured:** `/bootdata` to a live cloud stack ≈ **140 ms**; `resources get` median **702 ms → 564 ms (−138 ms)** once `stack-id` is set.

## 2. Persist the discovered stack ID on login

The skip above was dormant because **no login ever wrote `grafana.stack-id`** — yet login already discovers it while building the REST config for validation, then discarded it.

- New `NamespacedRESTConfig.StackID()` recovers the ID from the resolved namespace (`stacks-<id>`) — **no extra network call**.
- `login.Run` sets `tempCtx.Grafana.StackID` from it before persisting (also on the `--force` path); `mergeAuthIntoExisting` carries it through re-auth. Cloud-only — on-prem org namespaces yield 0.

**Verified live (wbkprez):** the resolved namespace is `stacks-1631916` and `StackID()` returns `1631916`, i.e. the saved context now records `grafana.stack-id: 1631916`. (A full interactive OAuth login can't be driven headlessly; covered by `TestRun_PersistsDiscoveredStackID` with an httptest `/bootdata`.)

## Verification

- `go test ./internal/config/... ./internal/login/...` — pass
- `golangci-lint run ./internal/config/... ./internal/login/...` — 0 issues

> Note: a stale local (gitignored) `vendor/` forces `-mod=vendor`; synced locally with `go mod vendor`. origin/main does not vendor, so CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)