### PR TITLE
perf(config): lazy-open and memoize the OS keychain probe

### DIFF
--- a/internal/config/keychain.go
+++ b/internal/config/keychain.go
@@ -2,10 +2,35 @@ package config
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/grafana/gcx/internal/credentials"
 	"github.com/grafana/grafana-app-sdk/logging"
 )
+
+// lazyStore defers opening the keychain backend until the first Get/Set/Delete.
+// resolveSentinelsForContext only calls Get for fields that actually hold a
+// sentinel, and migratePlaintextSecrets only calls Set when plaintext secrets
+// are present, so a config whose current context has no keychain-backed secrets
+// never probes the OS keychain at all. Once opened, the backend is reused.
+type lazyStore struct {
+	once    sync.Once
+	open    func() credentials.Store
+	backend credentials.Store
+}
+
+func newLazyStore(open func() credentials.Store) *lazyStore {
+	return &lazyStore{open: open}
+}
+
+func (l *lazyStore) resolve() credentials.Store {
+	l.once.Do(func() { l.backend = l.open() })
+	return l.backend
+}
+
+func (l *lazyStore) Get(key string) (string, error) { return l.resolve().Get(key) }
+func (l *lazyStore) Set(key, value string) error    { return l.resolve().Set(key, value) }
+func (l *lazyStore) Delete(key string) error        { return l.resolve().Delete(key) }
 
 // keychainBacked tracks which (context, field) pairs were stored in the
 // keychain at load time. The map lives on Config as an unexported field; it is

--- a/internal/config/keychain_test.go
+++ b/internal/config/keychain_test.go
@@ -102,6 +102,55 @@ func writeYAML(t *testing.T, contents string) string {
 	return path
 }
 
+func TestLoad_NoSecretsDoesNotOpenKeychain(t *testing.T) {
+	var opens int
+	store := newFakeStore()
+	restore := config.SetKeychainStoreFnForTest(func() credentials.Store {
+		opens++
+		return store
+	})
+	t.Cleanup(restore)
+
+	path := writeYAML(t, `
+contexts:
+  default:
+    grafana:
+      server: https://example.invalid
+current-context: default
+`)
+
+	_, err := config.Load(t.Context(), config.ExplicitConfigFile(path))
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, opens, "keychain must not be opened when there are no secrets to resolve or migrate")
+}
+
+func TestLoad_SentinelOpensKeychain(t *testing.T) {
+	var opens int
+	store := newFakeStore()
+	require.NoError(t, store.Set(credentials.AccountKey("default", credentials.FieldGrafanaToken), "resolved-token"))
+	restore := config.SetKeychainStoreFnForTest(func() credentials.Store {
+		opens++
+		return store
+	})
+	t.Cleanup(restore)
+
+	path := writeYAML(t, `
+contexts:
+  default:
+    grafana:
+      server: https://example.invalid
+      token: keychain:gcx:default:grafana-token
+current-context: default
+`)
+
+	cfg, err := config.Load(t.Context(), config.ExplicitConfigFile(path))
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, opens, 1, "keychain must be opened to resolve a sentinel")
+	assert.Equal(t, "resolved-token", cfg.Contexts["default"].Grafana.APIToken)
+}
+
 func TestLoad_MigratesPlaintextSecretsIntoKeychain(t *testing.T) {
 	store := withFakeStore(t)
 	path := writeYAML(t, `

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -32,11 +33,23 @@ import (
 //nolint:gochecknoglobals // test injection seam for the keychain backend.
 var keychainStoreFn = defaultKeychainStore
 
+// openStoreOnce memoizes the OS-keychain probe (credentials.Open) for the
+// lifetime of the process. Open probes the backend with a syscall (a
+// /usr/bin/security subprocess on macOS); without memoization every Load — and
+// every layer of a layered load — repaid that probe.
+//
+//nolint:gochecknoglobals // process-wide memoization of the keychain probe.
+var (
+	openStoreOnce sync.Once
+	openedStore   credentials.Store
+)
+
 func defaultKeychainStore() credentials.Store {
 	if testing.Testing() {
 		return testingNoopStore{}
 	}
-	return credentials.Open()
+	openStoreOnce.Do(func() { openedStore = credentials.Open() })
+	return openedStore
 }
 
 type testingNoopStore struct{}
@@ -359,7 +372,10 @@ func Load(ctx context.Context, source Source, overrides ...Override) (Config, er
 	}
 
 	log := logging.FromContext(ctx)
-	store := keychainStoreFn()
+	// Defer opening the keychain until a sentinel actually needs resolving or a
+	// plaintext secret needs migrating; configs with no keychain-backed secrets
+	// then never probe the OS keychain.
+	store := newLazyStore(keychainStoreFn)
 	config.keychainStore = store
 
 	// Only resolve sentinels for the current context eagerly. Other contexts


### PR DESCRIPTION
## Context

Fix 2 of 4 targeting bottlenecks on the code path shared by **most** gcx commands.

Every config `Load()` called `credentials.Open()`, which probes the keychain backend with a syscall — a `/usr/bin/security` subprocess on macOS (~tens of ms). Worse:

- a **layered** load (system → user → local) repaid that probe **once per layer**, and
- the probe ran **even when the current context had no keychain-backed secrets** (e.g. OAuth-proxy contexts, env-var auth, anonymous).

## Change

Two changes, both behavior-preserving:

1. **Memoize `credentials.Open()`** via `sync.Once` in `defaultKeychainStore`, so the probe runs at most **once per process** instead of once per `Load`/layer.
2. **`lazyStore`** wrapper that defers opening the backend until the first `Get`/`Set`/`Delete`. Since `resolveSentinelsForContext` only calls `Get` for fields that actually hold a sentinel and `migratePlaintextSecrets` only calls `Set` when plaintext secrets are present, a config with **no keychain-backed secrets never probes the keychain at all**.

`Config.keychainStore` remains non-nil (the lazy wrapper), so on-demand `ResolveContext` for non-current contexts still works and only opens the backend if it actually finds a sentinel.

## Verification

- New tests: `TestLoad_NoSecretsDoesNotOpenKeychain` (asserts 0 opens) and `TestLoad_SentinelOpensKeychain` (asserts open + correct resolution).
- `go test ./internal/config/...` — pass
- `golangci-lint run ./internal/config/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)