### PR TITLE
perf(config): cut redundant config loads on write and diagnostics paths

### DIFF
--- a/cmd/gcx/main.go
+++ b/cmd/gcx/main.go
@@ -170,14 +170,15 @@ func collectSubCmds(cmd *cobra.Command) map[string]bool {
 }
 
 // loadDiagnosticsConfig reads diagnostics settings from the layered gcx config.
-// Any error (missing file, parse failure) returns a disabled config so the
-// caller is never affected by a config read failure.
+// It runs on every invocation, so it uses LoadDiagnostics, which reads only the
+// diagnostics block — no context parsing, no keychain probe, no config auto-
+// creation. A missing or malformed config simply yields a disabled config.
 func loadDiagnosticsConfig() agentlog.Config {
-	cfg, err := internalconfig.LoadLayered(context.Background(), "")
-	if err != nil || cfg.Diagnostics == nil || !cfg.Diagnostics.AgentInvocationLog {
+	d := internalconfig.LoadDiagnostics(context.Background())
+	if d == nil || !d.AgentInvocationLog {
 		return agentlog.Config{}
 	}
-	return agentlog.Config{Enabled: true, LogDir: cfg.Diagnostics.LogDir}
+	return agentlog.Config{Enabled: true, LogDir: d.LogDir}
 }
 
 func truncate(s string, n int) string {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -523,6 +523,13 @@ func LoadForWrite(ctx context.Context, explicitFile, fileType string) (Config, S
 				return cfg, src, err
 			}
 		}
+		// Fresh system (no config files yet): preserve LoadLayered's auto-create.
+		// LoadLayered only ever created the user layer, so --file user creates and
+		// returns it; other layer types have nothing to auto-create and still error.
+		if fileType == "user" && len(sources) == 0 {
+			cfg, err := Load(ctx, StandardLocation())
+			return cfg, StandardLocation(), err
+		}
 		return Config{}, nil, fmt.Errorf("no %s config file found", fileType)
 	}
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -504,11 +504,19 @@ func LoadForWrite(ctx context.Context, explicitFile, fileType string) (Config, S
 	}
 
 	if fileType != "" {
-		layered, err := LoadLayered(ctx, "")
+		// Selecting a layer by --file only needs the discovered source paths, not
+		// a full layered load+merge (which would parse every layer and resolve its
+		// keychain sentinels just to discard all but one). Honor the explicit-file
+		// env bypass exactly as LoadLayered does: when set, layering is bypassed
+		// and there is no named layer to select.
+		if os.Getenv(ConfigFileEnvVar) != "" {
+			return Config{}, nil, fmt.Errorf("no %s config file found", fileType)
+		}
+		sources, err := DiscoverSources()
 		if err != nil {
 			return Config{}, nil, err
 		}
-		for _, s := range layered.Sources {
+		for _, s := range sources {
 			if s.Type == fileType {
 				src := ExplicitConfigFile(s.Path)
 				cfg, err := Load(ctx, src)
@@ -549,6 +557,64 @@ func loadExplicit(ctx context.Context, path string, overrides ...Override) (Conf
 	}
 	cfg.Sources = []ConfigSource{{Path: path, Type: "explicit", ModTime: modTime}}
 	return cfg, nil
+}
+
+// LoadDiagnostics reads only the diagnostics settings from the layered config,
+// skipping context parsing and keychain resolution entirely. It runs on every
+// command invocation to configure agent logging, so unlike LoadLayered it never
+// builds the full Config, never probes the OS keychain, and never auto-creates a
+// config file. Returns nil when diagnostics are not configured in any layer.
+func LoadDiagnostics(ctx context.Context) *DiagnosticsConfig {
+	var result *DiagnosticsConfig
+	for _, path := range diagnosticsSourcePaths(ctx) {
+		d, err := readDiagnostics(path)
+		if err != nil || d == nil {
+			continue
+		}
+		if result == nil {
+			result = d
+			continue
+		}
+		merged := mergeDiagnosticsConfig(result, d)
+		result = &merged
+	}
+	return result
+}
+
+// diagnosticsSourcePaths returns config file paths in low→high precedence order,
+// honoring the GCX_CONFIG explicit-file bypass exactly as LoadLayered does.
+func diagnosticsSourcePaths(ctx context.Context) []string {
+	if envPath := os.Getenv(ConfigFileEnvVar); envPath != "" {
+		return []string{envPath}
+	}
+	sources, err := DiscoverSources()
+	if err != nil {
+		logging.FromContext(ctx).Debug("diagnostics: source discovery failed", "error", err.Error())
+		return nil
+	}
+	paths := make([]string, 0, len(sources))
+	for _, s := range sources {
+		paths = append(paths, s.Path)
+	}
+	return paths
+}
+
+// readDiagnostics decodes a config file and returns only its diagnostics block.
+// It parses into the full Config (the codec rejects unknown fields, so a partial
+// struct will not do) but deliberately skips keychain resolution, plaintext
+// migration, and the config auto-creation that Load performs. Missing or
+// malformed files yield (nil, err).
+func readDiagnostics(path string) (*DiagnosticsConfig, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg Config
+	codec := &format.YAMLCodec{BytesAsBase64: true}
+	if err := codec.Decode(bytes.NewBuffer(contents), &cfg); err != nil {
+		return nil, err
+	}
+	return cfg.Diagnostics, nil
 }
 
 func annotateErrorWithSource(filename string, contents []byte, err error) error {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -397,6 +397,35 @@ func TestLoadForWrite_singleSource_autoDetects(t *testing.T) {
 	require.Equal(t, "dev", cfg.CurrentContext)
 }
 
+func TestLoadDiagnostics_NoConfigReturnsNil(t *testing.T) {
+	isolatedLoaderEnv(t)
+	assert.Nil(t, config.LoadDiagnostics(t.Context()))
+}
+
+func TestLoadDiagnostics_ReadsEnabledFlag(t *testing.T) {
+	userDir, _ := isolatedLoaderEnv(t)
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
+		"diagnostics:\n  agent-invocation-log: true\n  log-dir: /user/logs\ncurrent-context: dev\ncontexts:\n  dev: {}\n")
+
+	d := config.LoadDiagnostics(t.Context())
+	require.NotNil(t, d)
+	assert.True(t, d.AgentInvocationLog)
+	assert.Equal(t, "/user/logs", d.LogDir)
+}
+
+func TestLoadDiagnostics_LayersLocalOverUser(t *testing.T) {
+	userDir, workDir := isolatedLoaderEnv(t)
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
+		"diagnostics:\n  agent-invocation-log: true\n  log-dir: /user/logs\n")
+	writeLoaderConfig(t, filepath.Join(workDir, ".gcx.yaml"),
+		"diagnostics:\n  log-dir: /local/logs\n")
+
+	d := config.LoadDiagnostics(t.Context())
+	require.NotNil(t, d)
+	assert.True(t, d.AgentInvocationLog, "feature stays enabled from the user layer")
+	assert.Equal(t, "/local/logs", d.LogDir, "local layer overrides log-dir")
+}
+
 func TestLoadForWrite_multipleSources_errors(t *testing.T) {
 	userDir, workDir := isolatedLoaderEnv(t)
 	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -387,6 +387,31 @@ func TestLoadForWrite_fileType_notFound_errors(t *testing.T) {
 	require.Contains(t, err.Error(), "no local config file found")
 }
 
+func TestLoadForWrite_fileType_user_freshSystem_autoCreates(t *testing.T) {
+	isolatedLoaderEnv(t)
+
+	// Fresh system: no config files exist anywhere. --file user must auto-create
+	// the user config (preserving the pre-perf LoadLayered behavior) rather than
+	// erroring with "no user config file found".
+	_, src, err := config.LoadForWrite(t.Context(), "", "user")
+	require.NoError(t, err)
+	require.NotNil(t, src)
+
+	filename, err := src()
+	require.NoError(t, err)
+	require.FileExists(t, filename)
+}
+
+func TestLoadForWrite_fileType_nonUser_freshSystem_errors(t *testing.T) {
+	isolatedLoaderEnv(t)
+
+	// Auto-create only ever applied to the user layer, so on a fresh system a
+	// non-user --file target still errors instead of conjuring a file.
+	_, _, err := config.LoadForWrite(t.Context(), "", "local")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no local config file found")
+}
+
 func TestLoadForWrite_singleSource_autoDetects(t *testing.T) {
 	userDir, _ := isolatedLoaderEnv(t)
 	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),


### PR DESCRIPTION
## Context

Fix 3 of 4 targeting bottlenecks on the code path shared by **most** gcx commands.

Two places did a full layered config load (read every layer + merge + resolve the current context's keychain sentinels) when far less was needed:

1. **`loadDiagnosticsConfig`** runs on **every** invocation (`main.go`, before the command's own config load) just to read one boolean. It called `LoadLayered`, which parses every context, resolves keychain sentinels, and even **auto-creates a config file** as a side effect.
2. **`LoadForWrite`'s `--file` branch** called `LoadLayered` (load + merge + per-layer keychain resolution) only to discover which file corresponds to the requested layer — then loaded that file *again*.

## Change

- Add **`LoadDiagnostics`**: reads only the `diagnostics` block from each layer, merging with the same precedence as `MergeConfigs`. No context resolution, **no keychain probe**, no config auto-creation. `loadDiagnosticsConfig` now uses it.
- **`LoadForWrite` `--file` branch** uses `DiscoverSources` (path lookup only) instead of a full `LoadLayered`, preserving the `GCX_CONFIG` explicit-file bypass exactly.

> `readDiagnostics` decodes into the full `Config` (the YAML codec rejects unknown fields, so a partial struct won't parse a real config) but skips Load's keychain resolution / migration / auto-create.

## Verification

- New tests: `TestLoadDiagnostics_{NoConfigReturnsNil,ReadsEnabledFlag,LayersLocalOverUser}`.
- Existing `TestLoadForWrite_fileType_*` continue to pass (cover the `--file` change behaviorally).
- `go test ./internal/config/... ./cmd/gcx/...` — pass
- `golangci-lint run ./internal/config/... ./cmd/gcx/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)