### PR TITLE
fix(aio11y): preserve min_idle_seconds for conversation rules

### DIFF
--- a/internal/providers/aio11y/eval/rules/client_test.go
+++ b/internal/providers/aio11y/eval/rules/client_test.go
@@ -134,14 +134,15 @@ func TestClient_Create_ConversationRule(t *testing.T) {
 		// otherwise the backend rejects conversation rules. This is the bug
 		// being guarded: gcx previously dropped the field entirely.
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		assert.Contains(t, string(body), `"min_idle_seconds":10`)
 
 		var def eval.RuleDefinition
-		require.NoError(t, json.Unmarshal(body, &def))
+		assert.NoError(t, json.Unmarshal(body, &def))
 		assert.Equal(t, "conversation", def.Selector)
-		require.NotNil(t, def.MinIdleSeconds)
-		assert.Equal(t, 10, *def.MinIdleSeconds)
+		if assert.NotNil(t, def.MinIdleSeconds) {
+			assert.Equal(t, 10, *def.MinIdleSeconds)
+		}
 
 		w.WriteHeader(http.StatusCreated)
 		writeJSON(w, def)

--- a/internal/providers/aio11y/eval/rules/client_test.go
+++ b/internal/providers/aio11y/eval/rules/client_test.go
@@ -3,6 +3,7 @@ package rules_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -121,6 +122,42 @@ func TestClient_Create(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "new-rule", created.RuleID)
 	assert.True(t, created.Enabled)
+}
+
+func TestClient_Create_ConversationRule(t *testing.T) {
+	idle := 10
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/rules")
+
+		// The body the backend actually receives must carry min_idle_seconds,
+		// otherwise the backend rejects conversation rules. This is the bug
+		// being guarded: gcx previously dropped the field entirely.
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), `"min_idle_seconds":10`)
+
+		var def eval.RuleDefinition
+		require.NoError(t, json.Unmarshal(body, &def))
+		assert.Equal(t, "conversation", def.Selector)
+		require.NotNil(t, def.MinIdleSeconds)
+		assert.Equal(t, 10, *def.MinIdleSeconds)
+
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(w, def)
+	}))
+
+	created, err := client.Create(context.Background(), &eval.RuleDefinition{
+		RuleID:         "online.conversation.report_compiler.response_quality",
+		Enabled:        true,
+		Selector:       "conversation",
+		MinIdleSeconds: &idle,
+		SampleRate:     1.0,
+		EvaluatorIDs:   []string{"custom.response_quality.v1"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created.MinIdleSeconds)
+	assert.Equal(t, 10, *created.MinIdleSeconds)
 }
 
 func TestClient_Update(t *testing.T) {

--- a/internal/providers/aio11y/eval/rules/read_test.go
+++ b/internal/providers/aio11y/eval/rules/read_test.go
@@ -35,4 +35,28 @@ evaluator_ids:
 	require.NoError(t, err)
 	assert.Equal(t, "my-rule", def.RuleID)
 	assert.True(t, def.Enabled)
+	// Generation-level rules carry no min_idle_seconds.
+	assert.Nil(t, def.MinIdleSeconds)
+}
+
+func Test_readRuleFile_ConversationRuleMinIdleSeconds(t *testing.T) {
+	content := `rule_id: online.conversation.report_compiler.response_quality
+enabled: true
+selector: conversation
+min_idle_seconds: 10
+match:
+  agent_name:
+    - Report Compiler
+sample_rate: 1.0
+evaluator_ids:
+  - custom.response_quality.v1
+`
+	path := filepath.Join(t.TempDir(), "conversation-rule.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	def, err := rules.ReadRuleFile(path, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "conversation", def.Selector)
+	require.NotNil(t, def.MinIdleSeconds)
+	assert.Equal(t, 10, *def.MinIdleSeconds)
 }

--- a/internal/providers/aio11y/eval/types.go
+++ b/internal/providers/aio11y/eval/types.go
@@ -51,11 +51,15 @@ type RuleDefinition struct {
 	// User-provided fields (spec)
 	RuleID        string         `json:"rule_id"`
 	Enabled       bool           `json:"enabled"`
-	Selector      string         `json:"selector"` // user_visible_turn, all_assistant_generations, etc.
+	Selector      string         `json:"selector"` // user_visible_turn, all_assistant_generations, conversation, etc.
 	Match         map[string]any `json:"match,omitempty"`
 	SampleRate    float64        `json:"sample_rate"`
 	EvaluatorIDs  []string       `json:"evaluator_ids"`
 	AlertRuleUIDs []string       `json:"alert_rule_uids,omitempty"`
+	// MinIdleSeconds is required by the backend when Selector is "conversation":
+	// it is the idle period after which a conversation is considered complete and
+	// eligible for evaluation. A pointer so it is omitted for non-conversation rules.
+	MinIdleSeconds *int `json:"min_idle_seconds,omitempty"`
 
 	// Server-generated fields (stripped on push)
 	TenantID  string     `json:"tenant_id,omitempty"`

--- a/internal/providers/aio11y/eval/types_test.go
+++ b/internal/providers/aio11y/eval/types_test.go
@@ -1,11 +1,13 @@
 package eval_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/aio11y/eval"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResourceIdentity(t *testing.T) {
@@ -49,4 +51,45 @@ func TestResourceIdentity(t *testing.T) {
 			assert.Equal(t, tc.updated, tc.identity.GetResourceName())
 		})
 	}
+}
+
+// TestRuleDefinition_MinIdleSeconds verifies that min_idle_seconds is serialized
+// into the request body for conversation rules and omitted otherwise. This is the
+// exact body the rule client sends on create/update.
+func TestRuleDefinition_MinIdleSeconds(t *testing.T) {
+	idle := 10
+
+	t.Run("conversation rule includes min_idle_seconds", func(t *testing.T) {
+		rule := eval.RuleDefinition{
+			RuleID:         "online.conversation.report_compiler.response_quality",
+			Enabled:        true,
+			Selector:       "conversation",
+			MinIdleSeconds: &idle,
+			SampleRate:     1.0,
+			EvaluatorIDs:   []string{"custom.response_quality.v1"},
+		}
+
+		body, err := json.Marshal(rule)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), `"min_idle_seconds":10`)
+
+		var decoded eval.RuleDefinition
+		require.NoError(t, json.Unmarshal(body, &decoded))
+		require.NotNil(t, decoded.MinIdleSeconds)
+		assert.Equal(t, 10, *decoded.MinIdleSeconds)
+	})
+
+	t.Run("generation rule omits min_idle_seconds", func(t *testing.T) {
+		rule := eval.RuleDefinition{
+			RuleID:       "rule-1",
+			Enabled:      true,
+			Selector:     "user_visible_turn",
+			SampleRate:   1.0,
+			EvaluatorIDs: []string{"eval-1"},
+		}
+
+		body, err := json.Marshal(rule)
+		require.NoError(t, err)
+		assert.NotContains(t, string(body), "min_idle_seconds")
+	})
 }


### PR DESCRIPTION
## Problem

Creating a conversation-scope eval rule via `gcx` failed even though the equivalent direct API call succeeded:

```bash
gcx aio11y rules create -f conversation-rule.yaml --agent
# Backend: min_idle_seconds is required when selector is "conversation"
```

`gcx` was **silently dropping** `min_idle_seconds`. The `RuleDefinition` struct had no corresponding field, so the value was lost when parsing YAML/JSON and never serialized into the create/update request body. The backend then rejected the (incomplete) conversation rule.

## Fix

Add the missing field to `RuleDefinition` (`internal/providers/aio11y/eval/types.go`):

```go
MinIdleSeconds *int `json:"min_idle_seconds,omitempty"`
```

- **Pointer + `omitempty`** so the field is omitted for non-conversation rules (no behavior change) and round-trips for conversation rules.
- The entire rules CRUD flow marshals/unmarshals this single struct — the HTTP client (`client.go`), the generic `TypedCRUD` adapter, and `specToUnstructured` (where `min_idle_seconds` is **not** in `ruleStripFields`). So one field fixes **create, get, list, and update** at once.

No client-side validation of the `selector`/`min_idle_seconds` coupling is added — consistent with the provider's pattern of delegating spec validation to the backend (selectors are unvalidated free-form strings in gcx).

## Note on the feature toggle

Conversation rules are gated by a **backend feature toggle**. This change is orthogonal to the toggle: it only ensures `gcx` serializes the field correctly. With the toggle off the backend rejects the rule regardless (as it did before this fix); with the toggle on, `gcx` now works end-to-end instead of failing on its own.

## Tests

Regression tests at three layers:
- `read_test.go` — YAML `selector: conversation` + `min_idle_seconds: 10` parses into the struct; generation rules carry `nil`.
- `types_test.go` — `json.Marshal` includes `"min_idle_seconds":10` for conversation rules and omits it otherwise.
- `client_test.go` — the **outgoing HTTP request body** received by the server carries `min_idle_seconds` (the exact path the bug broke).

Verified these fail without the fix (build error / field undefined) and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)