### PR TITLE
feat: default pyroscope metrics step from datasource

### DIFF
--- a/docs/reference/cli/gcx_datasources_pyroscope_metrics.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_metrics.md
@@ -60,7 +60,7 @@ gcx datasources pyroscope metrics [EXPR] [flags]
   -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
-      --step string           Query step (e.g., '15s', '1m')
+      --step string           Query step (e.g., '15s', '1m'); defaults to the Pyroscope datasource minStep (or 15s) when omitted
       --to string             End time (RFC3339, Unix timestamp, or relative like 'now')
       --top                   Aggregate into a ranked leaderboard (equivalent to profilecli query top)
 ```

--- a/docs/reference/cli/gcx_profiles_metrics.md
+++ b/docs/reference/cli/gcx_profiles_metrics.md
@@ -52,7 +52,7 @@ gcx profiles metrics [EXPR] [flags]
   -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --profile-type string   Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds') (required)
       --since string          Duration before --to (or now if omitted); mutually exclusive with --from
-      --step string           Query step (e.g., '15s', '1m')
+      --step string           Query step (e.g., '15s', '1m'); defaults to the Pyroscope datasource minStep (or 15s) when omitted
       --to string             End time (RFC3339, Unix timestamp, or relative like 'now')
       --top                   Aggregate into a ranked leaderboard (equivalent to profilecli query top)
 ```

--- a/internal/datasources/pyroscope/series.go
+++ b/internal/datasources/pyroscope/series.go
@@ -150,7 +150,12 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 				groupBy = []string{"service_name"}
 			}
 
-			stepSeconds, start, end, err := resolveMetricsStepSeconds(ctx, cfg, datasourceUID, opts.Top, start, end, step)
+			// --top mode queries the full range to get one bucket per series.
+			if opts.Top && (start.IsZero() || end.IsZero()) {
+				start, end = pyroscope.DefaultTimeRange(start, end)
+			}
+
+			stepSeconds, err := resolveMetricsStepSeconds(ctx, cfg, datasourceUID, opts.Top, start, end, step)
 			if err != nil {
 				return err
 			}
@@ -194,26 +199,21 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 	return cmd
 }
 
-func resolveMetricsStepSeconds(ctx context.Context, cfg internalconfig.NamespacedRESTConfig, datasourceUID string, top bool, start, end time.Time, step time.Duration) (float64, time.Time, time.Time, error) {
-	// --top mode: set step to full range to get one bucket per series.
-	if top {
-		if start.IsZero() || end.IsZero() {
-			s, e := pyroscope.DefaultTimeRange(start, end)
-			start, end = s, e
+func resolveMetricsStepSeconds(ctx context.Context, cfg internalconfig.NamespacedRESTConfig, datasourceUID string, top bool, start, end time.Time, step time.Duration) (float64, error) {
+	switch {
+	case top:
+		// One bucket per series across the (already-defaulted) full range.
+		return end.Sub(start).Seconds(), nil
+	case step > 0:
+		// Explicit --step wins over the datasource minStep.
+		return step.Seconds(), nil
+	default:
+		minStep, err := dsquery.GetPyroscopeMinStep(ctx, cfg, datasourceUID)
+		if err != nil {
+			return 0, err
 		}
-		return end.Sub(start).Seconds(), start, end, nil
+		return minStep.Seconds(), nil
 	}
-
-	// Explicit --step wins over the datasource minStep.
-	if step > 0 {
-		return step.Seconds(), start, end, nil
-	}
-
-	pyroscopeCfg, err := dsquery.GetPyroscopeConfig(ctx, cfg, datasourceUID)
-	if err != nil {
-		return 0, start, end, err
-	}
-	return pyroscopeCfg.MinStep.Seconds(), start, end, nil
 }
 
 // pyroscopeSeriesTableCodec renders SelectSeriesResponse or TopSeriesResponse as a table.

--- a/internal/datasources/pyroscope/series.go
+++ b/internal/datasources/pyroscope/series.go
@@ -1,6 +1,7 @@
 package pyroscope
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -39,7 +40,7 @@ func (opts *pyroscopeMetricsOpts) setup(flags *pflag.FlagSet) {
 
 	flags.StringVar(&opts.shared.From, "from", "", "Start time (RFC3339, Unix timestamp, or relative like 'now-1h')")
 	flags.StringVar(&opts.shared.To, "to", "", "End time (RFC3339, Unix timestamp, or relative like 'now')")
-	flags.StringVar(&opts.shared.Step, "step", "", "Query step (e.g., '15s', '1m')")
+	flags.StringVar(&opts.shared.Step, "step", "", "Query step (e.g., '15s', '1m'); defaults to the Pyroscope datasource minStep (or 15s) when omitted")
 	flags.StringVar(&opts.shared.Since, "since", "", "Duration before --to (or now if omitted); mutually exclusive with --from")
 
 	opts.shared.SetupExprFlag(flags)
@@ -149,16 +150,9 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 				groupBy = []string{"service_name"}
 			}
 
-			// --top mode: set step to full range to get one bucket per series.
-			var stepSeconds float64
-			if opts.Top {
-				if start.IsZero() || end.IsZero() {
-					s, e := pyroscope.DefaultTimeRange(start, end)
-					start, end = s, e
-				}
-				stepSeconds = end.Sub(start).Seconds()
-			} else if step > 0 {
-				stepSeconds = step.Seconds()
+			stepSeconds, start, end, err := resolveMetricsStepSeconds(ctx, cfg, datasourceUID, opts.Top, start, end, step)
+			if err != nil {
+				return err
 			}
 
 			client, err := pyroscope.NewClient(cfg)
@@ -198,6 +192,28 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 
 	opts.setup(cmd.Flags())
 	return cmd
+}
+
+func resolveMetricsStepSeconds(ctx context.Context, cfg internalconfig.NamespacedRESTConfig, datasourceUID string, top bool, start, end time.Time, step time.Duration) (float64, time.Time, time.Time, error) {
+	// --top mode: set step to full range to get one bucket per series.
+	if top {
+		if start.IsZero() || end.IsZero() {
+			s, e := pyroscope.DefaultTimeRange(start, end)
+			start, end = s, e
+		}
+		return end.Sub(start).Seconds(), start, end, nil
+	}
+
+	// Explicit --step wins over the datasource minStep.
+	if step > 0 {
+		return step.Seconds(), start, end, nil
+	}
+
+	pyroscopeCfg, err := dsquery.GetPyroscopeConfig(ctx, cfg, datasourceUID)
+	if err != nil {
+		return 0, start, end, err
+	}
+	return pyroscopeCfg.MinStep.Seconds(), start, end, nil
 }
 
 // pyroscopeSeriesTableCodec renders SelectSeriesResponse or TopSeriesResponse as a table.

--- a/internal/datasources/pyroscope/series_test.go
+++ b/internal/datasources/pyroscope/series_test.go
@@ -1,0 +1,81 @@
+package pyroscope
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestResolveMetricsStepSeconds(t *testing.T) {
+	start := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	end := start.Add(2 * time.Hour)
+
+	t.Run("uses datasource minStep when step omitted", func(t *testing.T) {
+		restCfg, calls := pyroscopeMinStepRESTConfig(t, "1m")
+
+		step, gotStart, gotEnd, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", false, start, end, 0)
+
+		require.NoError(t, err)
+		assert.Equal(t, 60.0, step)
+		assert.Equal(t, start, gotStart)
+		assert.Equal(t, end, gotEnd)
+		assert.Equal(t, 1, *calls)
+	})
+
+	t.Run("explicit step wins over datasource minStep", func(t *testing.T) {
+		restCfg, calls := pyroscopeMinStepRESTConfig(t, "1m")
+
+		step, gotStart, gotEnd, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", false, start, end, 15*time.Second)
+
+		require.NoError(t, err)
+		assert.Equal(t, 15.0, step)
+		assert.Equal(t, start, gotStart)
+		assert.Equal(t, end, gotEnd)
+		assert.Equal(t, 0, *calls)
+	})
+
+	t.Run("top uses full range and does not fetch datasource config", func(t *testing.T) {
+		restCfg, calls := pyroscopeMinStepRESTConfig(t, "1m")
+
+		step, gotStart, gotEnd, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", true, start, end, 0)
+
+		require.NoError(t, err)
+		assert.Equal(t, 7200.0, step)
+		assert.Equal(t, start, gotStart)
+		assert.Equal(t, end, gotEnd)
+		assert.Equal(t, 0, *calls)
+	})
+}
+
+func pyroscopeMinStepRESTConfig(t *testing.T, minStep string) (config.NamespacedRESTConfig, *int) {
+	t.Helper()
+
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/datasources/uid/pyro-1", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"uid":  "pyro-1",
+			"type": "grafana-pyroscope-datasource",
+			"jsonData": map[string]any{
+				"minStep": minStep,
+			},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	return config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: srv.URL},
+		Namespace: "default",
+	}, &calls
+}

--- a/internal/datasources/pyroscope/series_test.go
+++ b/internal/datasources/pyroscope/series_test.go
@@ -21,36 +21,30 @@ func TestResolveMetricsStepSeconds(t *testing.T) {
 	t.Run("uses datasource minStep when step omitted", func(t *testing.T) {
 		restCfg, calls := pyroscopeMinStepRESTConfig(t, "1m")
 
-		step, gotStart, gotEnd, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", false, start, end, 0)
+		step, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", false, start, end, 0)
 
 		require.NoError(t, err)
 		assert.InDelta(t, 60.0, step, 1e-9)
-		assert.Equal(t, start, gotStart)
-		assert.Equal(t, end, gotEnd)
 		assert.Equal(t, 1, *calls)
 	})
 
 	t.Run("explicit step wins over datasource minStep", func(t *testing.T) {
 		restCfg, calls := pyroscopeMinStepRESTConfig(t, "1m")
 
-		step, gotStart, gotEnd, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", false, start, end, 15*time.Second)
+		step, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", false, start, end, 15*time.Second)
 
 		require.NoError(t, err)
 		assert.InDelta(t, 15.0, step, 1e-9)
-		assert.Equal(t, start, gotStart)
-		assert.Equal(t, end, gotEnd)
 		assert.Equal(t, 0, *calls)
 	})
 
 	t.Run("top uses full range and does not fetch datasource config", func(t *testing.T) {
 		restCfg, calls := pyroscopeMinStepRESTConfig(t, "1m")
 
-		step, gotStart, gotEnd, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", true, start, end, 0)
+		step, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", true, start, end, 0)
 
 		require.NoError(t, err)
 		assert.InDelta(t, 7200.0, step, 1e-9)
-		assert.Equal(t, start, gotStart)
-		assert.Equal(t, end, gotEnd)
 		assert.Equal(t, 0, *calls)
 	})
 }

--- a/internal/datasources/pyroscope/series_test.go
+++ b/internal/datasources/pyroscope/series_test.go
@@ -1,4 +1,4 @@
-package pyroscope
+package pyroscope //nolint:testpackage // white-box test of unexported resolveMetricsStepSeconds
 
 import (
 	"context"
@@ -24,7 +24,7 @@ func TestResolveMetricsStepSeconds(t *testing.T) {
 		step, gotStart, gotEnd, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", false, start, end, 0)
 
 		require.NoError(t, err)
-		assert.Equal(t, 60.0, step)
+		assert.InDelta(t, 60.0, step, 1e-9)
 		assert.Equal(t, start, gotStart)
 		assert.Equal(t, end, gotEnd)
 		assert.Equal(t, 1, *calls)
@@ -36,7 +36,7 @@ func TestResolveMetricsStepSeconds(t *testing.T) {
 		step, gotStart, gotEnd, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", false, start, end, 15*time.Second)
 
 		require.NoError(t, err)
-		assert.Equal(t, 15.0, step)
+		assert.InDelta(t, 15.0, step, 1e-9)
 		assert.Equal(t, start, gotStart)
 		assert.Equal(t, end, gotEnd)
 		assert.Equal(t, 0, *calls)
@@ -48,7 +48,7 @@ func TestResolveMetricsStepSeconds(t *testing.T) {
 		step, gotStart, gotEnd, err := resolveMetricsStepSeconds(context.Background(), restCfg, "pyro-1", true, start, end, 0)
 
 		require.NoError(t, err)
-		assert.Equal(t, 7200.0, step)
+		assert.InDelta(t, 7200.0, step, 1e-9)
 		assert.Equal(t, start, gotStart)
 		assert.Equal(t, end, gotEnd)
 		assert.Equal(t, 0, *calls)

--- a/internal/datasources/query/pyroscope_config.go
+++ b/internal/datasources/query/pyroscope_config.go
@@ -1,0 +1,56 @@
+package query
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/grafana-app-sdk/logging"
+)
+
+const defaultPyroscopeMinStep = 15 * time.Second
+
+// PyroscopeConfig holds query-related settings from a Pyroscope datasource's jsonData.
+type PyroscopeConfig struct {
+	MinStep time.Duration
+}
+
+// GetPyroscopeConfig fetches the datasource by UID and reads jsonData.minStep.
+// minStep defaults to 15s when unset or invalid, matching Grafana's Pyroscope backend.
+func GetPyroscopeConfig(ctx context.Context, cfg config.NamespacedRESTConfig, uid string) (PyroscopeConfig, error) {
+	dsClient, err := datasources.NewClient(cfg)
+	if err != nil {
+		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, fmt.Errorf("failed to create datasource client: %w", err)
+	}
+
+	ds, err := dsClient.GetByUID(ctx, uid)
+	if err != nil {
+		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, fmt.Errorf("failed to get datasource %q: %w", uid, err)
+	}
+
+	jsonData, ok := ds.JSONData.(map[string]any)
+	if !ok || jsonData == nil {
+		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, nil
+	}
+
+	minStep, _ := jsonData["minStep"].(string)
+	if minStep == "" {
+		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, nil
+	}
+
+	parsed, err := ParseDuration(minStep)
+	if err != nil || parsed <= 0 {
+		logging.FromContext(ctx).Warn(
+			"invalid Pyroscope datasource minStep; using default",
+			slog.String("datasource_uid", uid),
+			slog.String("min_step", minStep),
+			slog.Duration("default_min_step", defaultPyroscopeMinStep),
+		)
+		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, nil
+	}
+
+	return PyroscopeConfig{MinStep: parsed}, nil
+}

--- a/internal/datasources/query/pyroscope_config.go
+++ b/internal/datasources/query/pyroscope_config.go
@@ -41,8 +41,8 @@ func GetPyroscopeConfig(ctx context.Context, cfg config.NamespacedRESTConfig, ui
 		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, nil
 	}
 
-	parsed, parseErr := ParseDuration(minStep)
-	if parseErr != nil || parsed <= 0 {
+	parsed, _ := ParseDuration(minStep) //nolint:errcheck // invalid minStep falls back to default; parse error is intentionally ignored
+	if parsed <= 0 {
 		logging.FromContext(ctx).Warn(
 			"invalid Pyroscope datasource minStep; using default",
 			slog.String("datasource_uid", uid),

--- a/internal/datasources/query/pyroscope_config.go
+++ b/internal/datasources/query/pyroscope_config.go
@@ -41,8 +41,8 @@ func GetPyroscopeConfig(ctx context.Context, cfg config.NamespacedRESTConfig, ui
 		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, nil
 	}
 
-	parsed, err := ParseDuration(minStep)
-	if err != nil || parsed <= 0 {
+	parsed, parseErr := ParseDuration(minStep)
+	if parseErr != nil || parsed <= 0 {
 		logging.FromContext(ctx).Warn(
 			"invalid Pyroscope datasource minStep; using default",
 			slog.String("datasource_uid", uid),

--- a/internal/datasources/query/pyroscope_config.go
+++ b/internal/datasources/query/pyroscope_config.go
@@ -13,32 +13,27 @@ import (
 
 const defaultPyroscopeMinStep = 15 * time.Second
 
-// PyroscopeConfig holds query-related settings from a Pyroscope datasource's jsonData.
-type PyroscopeConfig struct {
-	MinStep time.Duration
-}
-
-// GetPyroscopeConfig fetches the datasource by UID and reads jsonData.minStep.
-// minStep defaults to 15s when unset or invalid, matching Grafana's Pyroscope backend.
-func GetPyroscopeConfig(ctx context.Context, cfg config.NamespacedRESTConfig, uid string) (PyroscopeConfig, error) {
+// GetPyroscopeMinStep fetches the datasource by UID and reads jsonData.minStep.
+// It defaults to 15s when unset or invalid, matching Grafana's Pyroscope backend.
+func GetPyroscopeMinStep(ctx context.Context, cfg config.NamespacedRESTConfig, uid string) (time.Duration, error) {
 	dsClient, err := datasources.NewClient(cfg)
 	if err != nil {
-		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, fmt.Errorf("failed to create datasource client: %w", err)
+		return 0, fmt.Errorf("failed to create datasource client: %w", err)
 	}
 
 	ds, err := dsClient.GetByUID(ctx, uid)
 	if err != nil {
-		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, fmt.Errorf("failed to get datasource %q: %w", uid, err)
+		return 0, fmt.Errorf("failed to get datasource %q: %w", uid, err)
 	}
 
 	jsonData, ok := ds.JSONData.(map[string]any)
 	if !ok || jsonData == nil {
-		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, nil
+		return defaultPyroscopeMinStep, nil
 	}
 
 	minStep, _ := jsonData["minStep"].(string)
 	if minStep == "" {
-		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, nil
+		return defaultPyroscopeMinStep, nil
 	}
 
 	parsed, _ := ParseDuration(minStep)
@@ -49,8 +44,8 @@ func GetPyroscopeConfig(ctx context.Context, cfg config.NamespacedRESTConfig, ui
 			slog.String("min_step", minStep),
 			slog.Duration("default_min_step", defaultPyroscopeMinStep),
 		)
-		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, nil
+		return defaultPyroscopeMinStep, nil
 	}
 
-	return PyroscopeConfig{MinStep: parsed}, nil
+	return parsed, nil
 }

--- a/internal/datasources/query/pyroscope_config.go
+++ b/internal/datasources/query/pyroscope_config.go
@@ -41,7 +41,7 @@ func GetPyroscopeConfig(ctx context.Context, cfg config.NamespacedRESTConfig, ui
 		return PyroscopeConfig{MinStep: defaultPyroscopeMinStep}, nil
 	}
 
-	parsed, _ := ParseDuration(minStep) //nolint:errcheck // invalid minStep falls back to default; parse error is intentionally ignored
+	parsed, _ := ParseDuration(minStep)
 	if parsed <= 0 {
 		logging.FromContext(ctx).Warn(
 			"invalid Pyroscope datasource minStep; using default",

--- a/internal/datasources/query/pyroscope_config_test.go
+++ b/internal/datasources/query/pyroscope_config_test.go
@@ -1,0 +1,82 @@
+package query_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestGetPyroscopeConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonData map[string]any
+		want     time.Duration
+	}{
+		{
+			name:     "minStep from datasource jsonData",
+			jsonData: map[string]any{"minStep": "1m"},
+			want:     time.Minute,
+		},
+		{
+			name:     "extended minStep unit",
+			jsonData: map[string]any{"minStep": "7d"},
+			want:     7 * 24 * time.Hour,
+		},
+		{
+			name:     "missing minStep defaults to 15s",
+			jsonData: map[string]any{},
+			want:     15 * time.Second,
+		},
+		{
+			name:     "invalid minStep defaults to 15s",
+			jsonData: map[string]any{"minStep": "not-a-duration"},
+			want:     15 * time.Second,
+		},
+		{
+			name:     "zero minStep defaults to 15s",
+			jsonData: map[string]any{"minStep": "0s"},
+			want:     15 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restCfg := pyroscopeDatasourceRESTConfig(t, tt.jsonData)
+
+			cfg, err := dsquery.GetPyroscopeConfig(context.Background(), restCfg, "pyro-1")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cfg.MinStep)
+		})
+	}
+}
+
+func pyroscopeDatasourceRESTConfig(t *testing.T, jsonData map[string]any) config.NamespacedRESTConfig {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/datasources/uid/pyro-1", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"uid":      "pyro-1",
+			"name":     "profiles",
+			"type":     "grafana-pyroscope-datasource",
+			"jsonData": jsonData,
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	return config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: srv.URL},
+		Namespace: "default",
+	}
+}

--- a/internal/datasources/query/pyroscope_config_test.go
+++ b/internal/datasources/query/pyroscope_config_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func TestGetPyroscopeConfig(t *testing.T) {
+func TestGetPyroscopeMinStep(t *testing.T) {
 	tests := []struct {
 		name     string
 		jsonData map[string]any
@@ -52,9 +52,9 @@ func TestGetPyroscopeConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			restCfg := pyroscopeDatasourceRESTConfig(t, tt.jsonData)
 
-			cfg, err := dsquery.GetPyroscopeConfig(context.Background(), restCfg, "pyro-1")
+			minStep, err := dsquery.GetPyroscopeMinStep(context.Background(), restCfg, "pyro-1")
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, cfg.MinStep)
+			assert.Equal(t, tt.want, minStep)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

When `--step` is omitted from `gcx profiles metrics`, the query step now defaults to the Pyroscope datasource's configured `minStep` (read from `jsonData.minStep`), falling back to 15s if unset or invalid — matching Grafana's own Pyroscope backend behaviour.

Previously, omitting `--step` sent `stepSeconds=0` to the API, which could produce unexpected results.

## Changes

- **`internal/datasources/query/pyroscope_config.go`** — new `GetPyroscopeConfig` helper that fetches a Pyroscope datasource by UID and parses `jsonData.minStep` (default 15s).
- **`internal/datasources/pyroscope/series.go`** — extracts `resolveMetricsStepSeconds` to centralise step resolution: `--top` full-range → explicit `--step` → datasource minStep → 15s fallback. Updates `--step` flag description to document the default.
- Tests for both new units.

## Testing

```bash
go test ./internal/datasources/pyroscope/... ./internal/datasources/query/...
```