### PR TITLE
feat(login): acknowledge OAuth success before optional Cloud-token prompt

### DIFF
--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -461,6 +461,10 @@ func resolveGrafanaAuth(ctx context.Context, opts Options, target Target) (strin
 		grafanaCfg.ProxyEndpoint = result.APIEndpoint
 		grafanaCfg.AuthMethod = "oauth"
 		method = "oauth"
+		// Wrap up the OAuth step with a clear success line before any
+		// subsequent prompts (e.g. the optional Cloud API token). This runs
+		// once: retries hit the StagedContext cache above and skip OAuth.
+		announceOAuthLogin(w, result)
 
 	default:
 		return "", nil, &ErrNeedInput{Fields: []string{"grafana-auth"}}
@@ -513,11 +517,46 @@ func resolveCloudAuth(opts Options, target Target) (*config.CloudConfig, error) 
 		return nil, nil //nolint:nilnil // nil CloudConfig means "Cloud auth skipped"; valid non-error state.
 	}
 
+	// About to prompt for the optional Cloud API token: frame it as a distinct,
+	// skippable step so it doesn't read as a continuation of OAuth.
+	announceCloudTokenStep(opts.Writer)
 	return nil, &ErrNeedInput{
 		Fields:   []string{"cloud-token"},
 		Optional: true,
 		Hint:     cloudTokenHint(opts.Server),
 	}
+}
+
+// announceOAuthLogin surfaces a clear success message once the interactive OAuth
+// PKCE flow completes, before any subsequent prompts. It writes to w (the
+// caller-supplied progress writer); a nil writer discards, keeping
+// internal/login free of process streams (NC-001).
+func announceOAuthLogin(w io.Writer, result *auth.Result) {
+	if w == nil {
+		w = io.Discard
+	}
+	endpoint := result.InstanceEndpoint
+	if endpoint == "" {
+		endpoint = result.APIEndpoint
+	}
+	switch {
+	case endpoint != "" && result.Email != "":
+		fmt.Fprintf(w, "\n✔ Signed in to %s as %s\n", endpoint, result.Email)
+	case endpoint != "":
+		fmt.Fprintf(w, "\n✔ Signed in to %s\n", endpoint)
+	default:
+		fmt.Fprintln(w, "\n✔ Signed in")
+	}
+}
+
+// announceCloudTokenStep frames the upcoming optional Cloud API token prompt as
+// a separate, skippable step. It writes to w (the caller-supplied progress
+// writer); a nil writer discards (NC-001).
+func announceCloudTokenStep(w io.Writer) {
+	if w == nil {
+		w = io.Discard
+	}
+	fmt.Fprintln(w, "\nOptional: add a Grafana Cloud API token to enable Cloud management features.")
 }
 
 // warnCloudTokenUnvalidated surfaces a non-fatal advisory when a Cloud Access

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1347,3 +1347,86 @@ func TestRun_PersistsDiscoveredStackID(t *testing.T) {
 	require.NotNil(t, ctx.Grafana)
 	assert.Equal(t, int64(777), ctx.Grafana.StackID, "discovered stack id must be persisted to the saved context")
 }
+
+// TestRun_OAuthSuccess_AnnouncesSignInBeforeCloudTokenPrompt verifies that after
+// the interactive OAuth flow completes, Run writes a clear success line to the
+// progress Writer (wrapping up the OAuth step) and frames the upcoming optional
+// Cloud API token prompt — rather than jumping straight into the prompt.
+func TestRun_OAuthSuccess_AnnouncesSignInBeforeCloudTokenPrompt(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "0")
+	agent.ResetForTesting()
+
+	var buf bytes.Buffer
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server:   "https://mystack.grafana.net",
+			Target:   login.TargetCloud,
+			UseOAuth: true,
+			Writer:   &buf,
+		},
+		Hooks: login.Hooks{
+			ConfigSource: configSource(t.TempDir()),
+			NewAuthFlow: func(_ string, _ auth.Options) login.AuthFlow {
+				return &stubAuthFlow{result: &auth.Result{
+					Token:            "gat_test",
+					Email:            "you@example.com",
+					APIEndpoint:      "https://mystack.grafana.net/api",
+					InstanceEndpoint: "https://mystack.grafana.net",
+				}}
+			},
+			ValidateFn: noopValidate,
+		},
+		RetryState: login.RetryState{StagedContext: &config.Context{}},
+	}
+
+	// First call: OAuth runs, then step 5 returns ErrNeedInput for the optional
+	// Cloud token (interactive Cloud target, no token, not --yes/agent mode).
+	_, err := login.Run(context.Background(), &opts)
+	var needInput *login.ErrNeedInput
+	require.ErrorAs(t, err, &needInput)
+	require.Equal(t, []string{"cloud-token"}, needInput.Fields)
+
+	out := buf.String()
+	assert.Contains(t, out, "Signed in to https://mystack.grafana.net as you@example.com",
+		"OAuth completion must be acknowledged with identity and endpoint")
+	assert.Contains(t, out, "Grafana Cloud API token",
+		"the optional next step must be framed before the prompt appears")
+}
+
+// TestRun_OAuthSuccess_AnnouncesSignInWithoutEmail verifies the success line
+// degrades gracefully when the OAuth result carries no email.
+func TestRun_OAuthSuccess_AnnouncesSignInWithoutEmail(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "0")
+	agent.ResetForTesting()
+
+	var buf bytes.Buffer
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server:   "https://grafana.example.com",
+			Target:   login.TargetOnPrem,
+			UseOAuth: true,
+			Writer:   &buf,
+		},
+		Hooks: login.Hooks{
+			ConfigSource: configSource(t.TempDir()),
+			NewAuthFlow: func(_ string, _ auth.Options) login.AuthFlow {
+				return &stubAuthFlow{result: &auth.Result{
+					Token:            "gat_test",
+					APIEndpoint:      "https://grafana.example.com/api",
+					InstanceEndpoint: "https://grafana.example.com",
+				}}
+			},
+			ValidateFn: noopValidate,
+		},
+		RetryState: login.RetryState{StagedContext: &config.Context{}},
+	}
+
+	// On-prem OAuth: no cloud-token prompt, login completes.
+	_, err := login.Run(context.Background(), &opts)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "Signed in to https://grafana.example.com",
+		"OAuth completion must be acknowledged even without an email")
+	assert.NotContains(t, out, " as ", "no 'as <email>' clause when email is absent")
+}


### PR DESCRIPTION
## Summary
- After the interactive OAuth PKCE flow completed, login jumped straight into prompting for the **optional** Cloud API token with no acknowledgement that authentication had succeeded — the prompt read like a continuation of OAuth rather than a new, skippable step.
- This adds a clear success line wrapping up the OAuth step, plus a short frame for the optional Cloud-token step, so the flow has visible progress and clean step boundaries.

## Changes
- `internal/login/login.go`:
  - `announceOAuthLogin` — emits `✔ Signed in to <endpoint> as <email>` once OAuth completes (called from `resolveGrafanaAuth`). Fires exactly once: retries hit the `StagedContext` cache and skip OAuth. Degrades gracefully when the result has no email/endpoint.
  - `announceCloudTokenStep` — frames the upcoming Cloud API token prompt as a distinct, skippable step (called from `resolveCloudAuth`, gated to fire only when the prompt will actually appear: Cloud target, no token, interactive).
  - Both write to the caller-supplied progress `Writer`, matching the existing `warnCloudTokenUnvalidated` helper and keeping `internal/login` free of process streams (NC-001). No `internal/output` color import, consistent with the package convention.
- `internal/login/login_test.go`: two table-free tests covering the success line (with and without email) and the optional-step framing before the `ErrNeedInput{cloud-token}` sentinel.

### Flow, after
```
Waiting for authentication...

✔ Signed in to https://mystack.grafana.net as you@example.com

Optional: add a Grafana Cloud API token to enable Cloud management features.
? Grafana Cloud API token ›
```

## Test Plan
- [x] `GCX_AGENT_MODE=false mise run all` — lint 0 issues, linter-rules 42/42, full `go test ./...` clean, build OK
- [x] New tests cover the change (`TestRun_OAuthSuccess_*`)
- [x] Reference docs regenerated — no drift (change adds no flags/commands/config/env/linter rules)
- [x] No architecture-doc/package-map changes needed (two helpers in an existing file)
- [ ] `mkdocs` build not run locally (not installed) — CI covers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)