### PR TITLE
refactor(output): address PR #720 review feedback

### DIFF
--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -30,10 +30,6 @@ type Options struct {
 	JSONFields    []string
 	JSONDiscovery bool
 
-	// JQExpression is the raw --jq flag value, retained for diagnostics.
-	// The compiled query lives in jqQuery and is populated by Validate().
-	JQExpression string
-
 	// IsPiped reports whether stdout is not connected to a terminal.
 	// Populated from terminal.IsPiped() during BindFlags.
 	IsPiped bool
@@ -189,13 +185,11 @@ func (opts *Options) applyJQFlag() error {
 		return fmt.Errorf("--jq requires JSON output, but -o %s was specified", outputFlag.Value.String())
 	}
 
-	expr := jqFlag.Value.String()
-	query, err := gojq.Parse(expr)
+	query, err := gojq.Parse(jqFlag.Value.String())
 	if err != nil {
 		return fmt.Errorf("invalid --jq expression: %w", err)
 	}
 
-	opts.JQExpression = expr
 	opts.jqQuery = query
 	opts.OutputFormat = "json"
 	return nil

--- a/internal/output/jq.go
+++ b/internal/output/jq.go
@@ -17,14 +17,15 @@ import (
 // a caller using --jq wants the transformed results in-stream, not a "spilled
 // to /tmp" summary.
 type JQCodec struct {
-	query *gojq.Query
+	query   *gojq.Query
+	decoder *format.JSONCodec
 }
 
 // NewJQCodec returns a JQCodec that runs the given compiled query.
 // Callers should obtain the query via gojq.Parse so syntax errors surface
 // during flag validation, not encoding.
 func NewJQCodec(query *gojq.Query) *JQCodec {
-	return &JQCodec{query: query}
+	return &JQCodec{query: query, decoder: format.NewJSONCodec()}
 }
 
 func (c *JQCodec) Format() format.Format {
@@ -56,7 +57,7 @@ func (c *JQCodec) Encode(dst io.Writer, value any) error {
 }
 
 func (c *JQCodec) Decode(src io.Reader, value any) error {
-	return format.NewJSONCodec().Decode(src, value)
+	return c.decoder.Decode(src, value)
 }
 
 // toJQInput converts an arbitrary Go value into the generic JSON primitives


### PR DESCRIPTION
## Summary

Follow-up to #720 (already merged) addressing the two inline review comments @radiohead left during approval.

## Changes

- **`internal/output/format.go`** — remove the unused `Options.JQExpression` field. It was assigned in `applyJQFlag()` but never read anywhere ([review comment](https://github.com/grafana/gcx/pull/720#discussion_r-format)). The compiled query in `jqQuery` is the only `--jq` state actually consumed (used in `Encode()` and the agent-hint suppression).
- **`internal/output/jq.go`** — `JQCodec` now holds a single `*format.JSONCodec` created in `NewJQCodec`, instead of allocating a fresh `format.NewJSONCodec()` on every `Decode` call ([review comment](https://github.com/grafana/gcx/pull/720#discussion_r-jq)).

No behavior change — pure cleanup.

## Test Plan

- [x] `go test ./internal/output/...` passes
- [x] `git grep JQExpression` returns nothing (field fully removed)
- [x] `GCX_AGENT_MODE=false mise run all` — lint, tests, build, validate-skills, and reference regeneration all green (no reference-doc drift); only the `docs` mkdocs step skipped locally (tool not installed, runs in CI)

Refs #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)