### PR TITLE
chore(release): v0.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "gcx",
       "source": "./claude-plugin",
       "description": "Debug, explore, and instrument with Grafana using gcx CLI",
-      "version": "0.3.0"
+      "version": "0.4.1"
     }
   ]
 }

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,10 +1,14 @@
-- Added `gcx assistant conversation list` and `gcx assistant conversation get` to inspect Assistant conversations and transcripts.
-- Added support for continuing accessible non-CLI Assistant conversations by context ID, with a warning when the source is not CLI.
-- Added automatic migration of token-shaped config secrets into the OS keychain, with plaintext fallback when the keychain is unavailable.
-- **Breaking**: renamed `gcx kg rules` to `gcx kg prom-rules` to align with `model-rules` and `relabel-rules`.
-- Added read-only `gcx kg relabel-rules get` for prologue, epilogue, and generated rule groups.
-- Fixed `kg diagnose` verdicts so failing checks no longer report a healthy service, and reclassify scoped no-data checks as label-scope warnings when unscoped data exists.
-- Shared Grafana datasource query transport and dataframe wire types across ClickHouse, InfluxDB, and Infinity clients.
-- Hardened Claude GitHub Actions secret handling by scoping Vault outputs and restricting `@claude` triggers to trusted repository associations.
-- Improved agent guidance for dashboard workflows and Tempo trace analysis, including recommending `gcx traces get --llm -o json` for full-trace analysis.
-- Removed several small direct dependencies in favor of internal implementations.
+- **Breaking:** `--log-http-payload` has been renamed to `--insecure-log-http-payload`. The old flag name now exits with an error naming the replacement. Payload-dump behavior is unchanged — credentials, cookies, OAuth refresh tokens, and request bodies still appear in the dump when the flag is set. A startup warning is now printed to stderr when the flag is active.
+- **Breaking:** `gcx dev serve --address` now defaults to `127.0.0.1` (loopback) instead of `0.0.0.0`. Users who need LAN or remote access should pass `--address 0.0.0.0` explicitly. The WebSocket livereload endpoint now rejects cross-origin requests from hosts other than `localhost`, `127.0.0.1`, `[::1]`, or the configured listen address.
+- **Soft-breaking:** Custom Rego rules loaded via `gcx dev lint --rules` can no longer call `http.send`, any `net.*` builtin, or `opa.runtime`. No flag is provided to re-enable them. Bundled rules are unaffected.
+- Added `--jq` for inline JSON transformation and improved agent-mode hints.
+- Added OAuth login support for agent and non-interactive workflows.
+- Improved config performance with lazy keychain checks and StackID caching.
+- Moved stack management under the `gcx cloud stacks` command group.
+- Added App O11y service list, get, map, and operation breakdown commands.
+- Added Instrumentation Hub `gcx instrumentation check` diagnostics.
+- Expanded Assistant investigations with Lodestone v2 capability detection.
+- Expanded Knowledge Graph diagnose, meta metrics, and model-rules support.
+- Improved IRM incident filtering, paging, and OnCall escalation output.
+- Added metrics instant-query timestamps and richer Tempo tag-value output.
+- Hardened local debug surfaces and JSON error output for agent workflows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
 ## Unreleased
 
+## v0.4.1 (2026-06-23)
+
 - **Breaking:** `--log-http-payload` has been renamed to `--insecure-log-http-payload`. The old flag name now exits with an error naming the replacement. Payload-dump behavior is unchanged — credentials, cookies, OAuth refresh tokens, and request bodies still appear in the dump when the flag is set. A startup warning is now printed to stderr when the flag is active.
 - **Breaking:** `gcx dev serve --address` now defaults to `127.0.0.1` (loopback) instead of `0.0.0.0`. Users who need LAN or remote access should pass `--address 0.0.0.0` explicitly. The WebSocket livereload endpoint now rejects cross-origin requests from hosts other than `localhost`, `127.0.0.1`, `[::1]`, or the configured listen address.
 - **Soft-breaking:** Custom Rego rules loaded via `gcx dev lint --rules` can no longer call `http.send`, any `net.*` builtin, or `opa.runtime`. No flag is provided to re-enable them. Bundled rules are unaffected.
+- Added `--jq` for inline JSON transformation and improved agent-mode hints.
+- Added OAuth login support for agent and non-interactive workflows.
+- Improved config performance with lazy keychain checks and StackID caching.
+- Moved stack management under the `gcx cloud stacks` command group.
+- Added App O11y service list, get, map, and operation breakdown commands.
+- Added Instrumentation Hub `gcx instrumentation check` diagnostics.
+- Expanded Assistant investigations with Lodestone v2 capability detection.
+- Expanded Knowledge Graph diagnose, meta metrics, and model-rules support.
+- Improved IRM incident filtering, paging, and OnCall escalation output.
+- Added metrics instant-query timestamps and richer Tempo tag-value output.
+- Hardened local debug surfaces and JSON error output for agent workflows.
 
 ## v0.4.0 (2026-06-02)
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcx",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "description": "Debug, explore, and instrument with Grafana using gcx CLI",
   "keywords": ["grafana", "observability", "monitoring", "prometheus", "loki", "dashboards"],
   "author": {


### PR DESCRIPTION
Release v0.4.1.

## Changelog

- **Breaking:** `--log-http-payload` renamed to `--insecure-log-http-payload` (old name now errors; startup warning printed when active).
- **Breaking:** `gcx dev serve --address` now defaults to `127.0.0.1` (loopback); WebSocket livereload rejects cross-origin requests from non-local hosts.
- **Soft-breaking:** Custom Rego rules via `gcx dev lint --rules` can no longer call `http.send`, `net.*`, or `opa.runtime`.
- Added `--jq` for inline JSON transformation and improved agent-mode hints.
- Added OAuth login support for agent and non-interactive workflows.
- Improved config performance with lazy keychain checks and StackID caching.
- Moved stack management under the `gcx cloud stacks` command group.
- Added App O11y service list, get, map, and operation breakdown commands.
- Added Instrumentation Hub `gcx instrumentation check` diagnostics.
- Expanded Assistant investigations with Lodestone v2 capability detection.
- Expanded Knowledge Graph diagnose, meta metrics, and model-rules support.
- Improved IRM incident filtering, paging, and OnCall escalation output.
- Added metrics instant-query timestamps and richer Tempo tag-value output.
- Hardened local debug surfaces and JSON error output for agent workflows.

Bumps plugin manifests `0.3.0 → 0.4.1` (`plugin.json`, `marketplace.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)