### PR TITLE
feat(irm): notification compliance rules + doctor

### DIFF
--- a/docs/reference/cli/gcx_irm_doctor.md
+++ b/docs/reference/cli/gcx_irm_doctor.md
@@ -1,0 +1,37 @@
+## gcx irm doctor
+
+Check whether your OnCall notification setup meets the org's compliance rules.
+
+```
+gcx irm doctor [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for doctor
+      --instance-id string    TEST-ONLY: X-Grafana-Instance-ID for direct transport. Defaults to $INSTANCE_ID.
+      --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --oncall-token string   TEST-ONLY: OnCall API token for direct transport. Defaults to $ONCALL_TOKEN.
+      --oncall-url string     TEST-ONLY: OnCall engine base URL (e.g. http://host:8084); bypasses the plugin proxy. Defaults to $ONCALL_URL.
+  -o, --output string         Output format. One of: agents, json, text, yaml (default "text")
+      --user string           OnCall user ID to check (defaults to the current user)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx irm](gcx_irm.md)	 - Manage Grafana IRM (OnCall + Incidents)
+

--- a/docs/reference/cli/gcx_irm_oncall.md
+++ b/docs/reference/cli/gcx_irm_oncall.md
@@ -24,6 +24,7 @@ Manage Grafana OnCall resources.
 
 * [gcx irm](gcx_irm.md)	 - Manage Grafana IRM (OnCall + Incidents)
 * [gcx irm oncall alert-groups](gcx_irm_oncall_alert-groups.md)	 - Manage alert groups.
+* [gcx irm oncall compliance-rules](gcx_irm_oncall_compliance-rules.md)	 - Manage the org's notification compliance rules (expected configuration).
 * [gcx irm oncall escalate](gcx_irm_oncall_escalate.md)	 - Create a direct escalation.
 * [gcx irm oncall escalation-chains](gcx_irm_oncall_escalation-chains.md)	 - Manage escalation chains.
 * [gcx irm oncall escalation-policies](gcx_irm_oncall_escalation-policies.md)	 - Manage escalation policies.

--- a/docs/reference/cli/gcx_irm_oncall_compliance-rules.md
+++ b/docs/reference/cli/gcx_irm_oncall_compliance-rules.md
@@ -1,18 +1,18 @@
-## gcx irm
+## gcx irm oncall compliance-rules
 
-Manage Grafana IRM (OnCall + Incidents)
+Manage the org's notification compliance rules (expected configuration).
 
 ### Options
 
 ```
-      --config string   Path to the configuration file to use
-  -h, --help            help for irm
+  -h, --help   help for compliance-rules
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
       --context string              Name of the context to use (overrides current-context in config)
       --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
       --no-color                    Disable color output
@@ -22,8 +22,8 @@ Manage Grafana IRM (OnCall + Incidents)
 
 ### SEE ALSO
 
-* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
-* [gcx irm doctor](gcx_irm_doctor.md)	 - Check whether your OnCall notification setup meets the org's compliance rules.
-* [gcx irm incidents](gcx_irm_incidents.md)	 - Manage incidents.
 * [gcx irm oncall](gcx_irm_oncall.md)	 - Manage Grafana OnCall resources.
+* [gcx irm oncall compliance-rules evaluate](gcx_irm_oncall_compliance-rules_evaluate.md)	 - Evaluate org users against the compliance rules (who is ready to be paged).
+* [gcx irm oncall compliance-rules get](gcx_irm_oncall_compliance-rules_get.md)	 - Show the org's notification compliance rules.
+* [gcx irm oncall compliance-rules set](gcx_irm_oncall_compliance-rules_set.md)	 - Create or update the org's notification compliance rules.
 

--- a/docs/reference/cli/gcx_irm_oncall_compliance-rules_evaluate.md
+++ b/docs/reference/cli/gcx_irm_oncall_compliance-rules_evaluate.md
@@ -1,0 +1,36 @@
+## gcx irm oncall compliance-rules evaluate
+
+Evaluate org users against the compliance rules (who is ready to be paged).
+
+```
+gcx irm oncall compliance-rules evaluate [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for evaluate
+      --instance-id string    TEST-ONLY: X-Grafana-Instance-ID for direct transport. Defaults to $INSTANCE_ID.
+      --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --oncall-token string   TEST-ONLY: OnCall API token for direct transport. Defaults to $ONCALL_TOKEN.
+      --oncall-url string     TEST-ONLY: OnCall engine base URL (e.g. http://host:8084); bypasses the plugin proxy. Defaults to $ONCALL_URL.
+  -o, --output string         Output format. One of: agents, json, text, yaml (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx irm oncall compliance-rules](gcx_irm_oncall_compliance-rules.md)	 - Manage the org's notification compliance rules (expected configuration).
+

--- a/docs/reference/cli/gcx_irm_oncall_compliance-rules_evaluate.md
+++ b/docs/reference/cli/gcx_irm_oncall_compliance-rules_evaluate.md
@@ -15,7 +15,7 @@ gcx irm oncall compliance-rules evaluate [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --oncall-token string   TEST-ONLY: OnCall API token for direct transport. Defaults to $ONCALL_TOKEN.
       --oncall-url string     TEST-ONLY: OnCall engine base URL (e.g. http://host:8084); bypasses the plugin proxy. Defaults to $ONCALL_URL.
-  -o, --output string         Output format. One of: agents, json, text, yaml (default "text")
+  -o, --output string         Output format. One of: agents, json, table, text, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_irm_oncall_compliance-rules_get.md
+++ b/docs/reference/cli/gcx_irm_oncall_compliance-rules_get.md
@@ -1,0 +1,36 @@
+## gcx irm oncall compliance-rules get
+
+Show the org's notification compliance rules.
+
+```
+gcx irm oncall compliance-rules get [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for get
+      --instance-id string    TEST-ONLY: X-Grafana-Instance-ID for direct transport. Defaults to $INSTANCE_ID.
+      --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --oncall-token string   TEST-ONLY: OnCall API token for direct transport. Defaults to $ONCALL_TOKEN.
+      --oncall-url string     TEST-ONLY: OnCall engine base URL (e.g. http://host:8084); bypasses the plugin proxy. Defaults to $ONCALL_URL.
+  -o, --output string         Output format. One of: agents, json, text, yaml (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx irm oncall compliance-rules](gcx_irm_oncall_compliance-rules.md)	 - Manage the org's notification compliance rules (expected configuration).
+

--- a/docs/reference/cli/gcx_irm_oncall_compliance-rules_set.md
+++ b/docs/reference/cli/gcx_irm_oncall_compliance-rules_set.md
@@ -1,0 +1,40 @@
+## gcx irm oncall compliance-rules set
+
+Create or update the org's notification compliance rules.
+
+```
+gcx irm oncall compliance-rules set [flags]
+```
+
+### Options
+
+```
+      --default strings             Notification rule types required in the default policy (e.g. notify_by_slack)
+  -h, --help                        help for set
+      --important strings           Notification rule types required in the important policy (e.g. notify_by_sms,notify_by_slack)
+      --instance-id string          TEST-ONLY: X-Grafana-Instance-ID for direct transport. Defaults to $INSTANCE_ID.
+  -i, --interactive                 Select channels and notification rules interactively (pre-checked from the current ruleset)
+      --jq string                   jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string                 Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --oncall-token string         TEST-ONLY: OnCall API token for direct transport. Defaults to $ONCALL_TOKEN.
+      --oncall-url string           TEST-ONLY: OnCall engine base URL (e.g. http://host:8084); bypasses the plugin proxy. Defaults to $ONCALL_URL.
+  -o, --output string               Output format. One of: agents, json, text, yaml (default "text")
+      --required-channels strings   Channels every user must have configured (comma-separated, e.g. phone,slack)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx irm oncall compliance-rules](gcx_irm_oncall_compliance-rules.md)	 - Manage the org's notification compliance rules (expected configuration).
+

--- a/internal/providers/irm/oncall_client.go
+++ b/internal/providers/irm/oncall_client.go
@@ -88,10 +88,43 @@ func handleErrorResponse(resp *http.Response) error {
 	if err != nil {
 		return fmt.Errorf("request failed with status %d (could not read body: %w)", resp.StatusCode, err)
 	}
-	if len(body) > 0 {
-		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	if msg := summarizeErrorBody(resp, body); msg != "" {
+		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, msg)
 	}
 	return fmt.Errorf("request failed with status %d", resp.StatusCode)
+}
+
+// summarizeErrorBody turns an error response body into a concise message. HTML pages
+// (e.g. a Django debug/error page) are never dumped verbatim — only their <title> is
+// surfaced; other bodies are returned trimmed and length-capped.
+func summarizeErrorBody(resp *http.Response, body []byte) string {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return ""
+	}
+	if strings.Contains(resp.Header.Get("Content-Type"), "text/html") || trimmed[0] == '<' {
+		return htmlTitle(trimmed) // "" when no <title>, leaving just the status code
+	}
+	const maxLen = 500
+	if len(trimmed) > maxLen {
+		return string(trimmed[:maxLen]) + "…"
+	}
+	return string(trimmed)
+}
+
+// htmlTitle extracts and whitespace-normalizes the <title> of an HTML document.
+func htmlTitle(b []byte) string {
+	lower := bytes.ToLower(b)
+	start := bytes.Index(lower, []byte("<title>"))
+	if start < 0 {
+		return ""
+	}
+	start += len("<title>")
+	end := bytes.Index(lower[start:], []byte("</title>"))
+	if end < 0 {
+		return ""
+	}
+	return strings.Join(strings.Fields(string(b[start:start+end])), " ")
 }
 
 type paginatedResponse[T any] struct {

--- a/internal/providers/irm/oncall_client.go
+++ b/internal/providers/irm/oncall_client.go
@@ -41,6 +41,11 @@ const (
 	resolutionNotesPath    = "resolution_notes/"
 	shiftSwapsPath         = "shift_swaps/"
 	directPagingPath       = "direct_paging"
+	// oncallCompliancePath is the OnCall compliance ruleset resource. NOTE: the real
+	// endpoint lives on the OnCall *public* API (GET/POST /api/v1/oncall_compliance/,
+	// with an Authorization token + X-Grafana-Instance-ID header), not the plugin-proxy
+	// /api/internal/v1 surface the rest of this client uses. Transport is wired later.
+	oncallCompliancePath = "oncall_compliance/"
 )
 
 var _ OnCallAPI = (*OnCallClient)(nil)
@@ -750,4 +755,30 @@ func (c *OnCallClient) TakeShiftSwap(ctx context.Context, id string, input TakeS
 
 func (c *OnCallClient) CreateDirectPaging(ctx context.Context, input DirectPagingInput) (*DirectPagingResult, error) {
 	return createResource[DirectPagingInput, DirectPagingResult](ctx, c, directPagingPath, input, "direct paging")
+}
+
+// --- Compliance Rules ---
+
+// GetComplianceRules fetches the org's notification compliance rules.
+func (c *OnCallClient) GetComplianceRules(ctx context.Context) (*ComplianceRules, error) {
+	resp, err := c.DoRequest(ctx, http.MethodGet, oncallCompliancePath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("irm: get compliance rules: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, handleErrorResponse(resp)
+	}
+
+	var result ComplianceRules
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("irm: decode compliance rules: %w", err)
+	}
+	return &result, nil
+}
+
+// SetComplianceRules creates or updates the org's notification compliance rules.
+func (c *OnCallClient) SetComplianceRules(ctx context.Context, rules ComplianceRules) (*ComplianceRules, error) {
+	return createResource[ComplianceRules, ComplianceRules](ctx, c, oncallCompliancePath, rules, "compliance rules")
 }

--- a/internal/providers/irm/oncall_compliance_commands.go
+++ b/internal/providers/irm/oncall_compliance_commands.go
@@ -1,0 +1,570 @@
+package irm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/huh"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/term"
+)
+
+// Selectable values offered by the interactive `set` form.
+var (
+	complianceChannelOptions  = []string{"phone", "slack", "telegram", "msteams", "email", "mobile_app"}
+	complianceRuleTypeOptions = []string{
+		"notify_by_slack", "notify_by_sms", "notify_by_phone_call", "notify_by_telegram",
+		"notify_by_mobile_app", "notify_by_mobile_app_critical", "notify_by_email",
+	}
+
+	// complianceLabels maps raw API enum values to friendly display names. The raw value
+	// is always what gets sent to / received from the API; labels are display-only.
+	complianceLabels = map[string]string{
+		"phone":      "Phone",
+		"slack":      "Slack",
+		"telegram":   "Telegram",
+		"msteams":    "Microsoft Teams",
+		"email":      "Email",
+		"mobile_app": "Mobile app",
+
+		"notify_by_slack":               "Slack",
+		"notify_by_sms":                 "SMS",
+		"notify_by_phone_call":          "Phone call",
+		"notify_by_telegram":            "Telegram",
+		"notify_by_mobile_app":          "Mobile app",
+		"notify_by_mobile_app_critical": "Mobile app (critical)",
+		"notify_by_email":               "Email",
+	}
+)
+
+// complianceLabel returns the friendly display name for a value, falling back to the
+// raw value when no mapping exists.
+func complianceLabel(v string) string {
+	if l, ok := complianceLabels[v]; ok {
+		return l
+	}
+	return v
+}
+
+// ---------------------------------------------------------------------------
+// compliance-rules command group (org-level "expected configuration")
+//
+// The compliance API currently lives only on the OnCall *public* API
+// (GET/POST /api/v1/oncall_compliance/, evaluate at .../evaluate/), authenticated
+// with an Authorization token + X-Grafana-Instance-ID header — NOT the plugin-proxy
+// surface the rest of the IRM client uses. Until it is exposed through the proxy,
+// these commands support a TEST-ONLY direct transport via --oncall-url/--oncall-token/
+// --instance-id (env: ONCALL_URL/ONCALL_TOKEN/INSTANCE_ID). With no --oncall-url they
+// fall back to the plugin-proxy client (which 404s today).
+// ---------------------------------------------------------------------------
+
+// complianceAPI is the read/write surface the get/set commands need. Both the
+// plugin-proxy OnCallClient (via OnCallAPI) and the test-only public client satisfy it.
+type complianceAPI interface {
+	GetComplianceRules(ctx context.Context) (*ComplianceRules, error)
+	SetComplianceRules(ctx context.Context, rules ComplianceRules) (*ComplianceRules, error)
+}
+
+// complianceTransport holds the test-only direct-transport flags.
+type complianceTransport struct {
+	URL        string
+	Token      string
+	InstanceID string
+}
+
+func (t *complianceTransport) bind(flags *pflag.FlagSet) {
+	flags.StringVar(&t.URL, "oncall-url", os.Getenv("ONCALL_URL"),
+		"TEST-ONLY: OnCall engine base URL (e.g. http://host:8084); bypasses the plugin proxy. Defaults to $ONCALL_URL.")
+	flags.StringVar(&t.Token, "oncall-token", os.Getenv("ONCALL_TOKEN"),
+		"TEST-ONLY: OnCall API token for direct transport. Defaults to $ONCALL_TOKEN.")
+	flags.StringVar(&t.InstanceID, "instance-id", os.Getenv("INSTANCE_ID"),
+		"TEST-ONLY: X-Grafana-Instance-ID for direct transport. Defaults to $INSTANCE_ID.")
+}
+
+// resolve returns a complianceAPI: the direct public client when --oncall-url is set,
+// otherwise the plugin-proxy client.
+func (t *complianceTransport) resolve(ctx context.Context, loader OnCallConfigLoader) (complianceAPI, error) {
+	if t.URL != "" {
+		return newPublicComplianceClient(t.URL, t.Token, t.InstanceID), nil
+	}
+	client, _, err := loader.LoadOnCallClient(ctx)
+	return client, err
+}
+
+// newComplianceRulesCmd builds the `compliance-rules` group: get + set + evaluate.
+func newComplianceRulesCmd(loader OnCallConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "compliance-rules",
+		Short:   "Manage the org's notification compliance rules (expected configuration).",
+		Aliases: []string{"compliance"},
+	}
+	cmd.AddCommand(
+		newComplianceRulesGetCmd(loader),
+		newComplianceRulesSetCmd(loader),
+		newComplianceEvaluateCmd(loader),
+	)
+	return cmd
+}
+
+// registerComplianceCodecs wires the shared output codecs: text is the human default
+// (not built-in, so it must be registered), yaml uses stable key ordering, json/agents
+// are built-in.
+func registerComplianceCodecs(io *cmdio.Options, flags *pflag.FlagSet, textCodec format.Codec) {
+	io.RegisterCustomCodec("text", textCodec)
+	io.RegisterCustomCodec("yaml", format.NewOrderedYAMLCodec())
+	io.DefaultFormat("text")
+	io.BindFlags(flags)
+}
+
+type complianceRulesGetOpts struct {
+	IO        cmdio.Options
+	transport complianceTransport
+}
+
+func newComplianceRulesGetCmd(loader OnCallConfigLoader) *cobra.Command {
+	opts := &complianceRulesGetOpts{}
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Show the org's notification compliance rules.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			client, err := opts.transport.resolve(cmd.Context(), loader)
+			if err != nil {
+				return err
+			}
+			rules, err := client.GetComplianceRules(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), *rules)
+		},
+	}
+	registerComplianceCodecs(&opts.IO, cmd.Flags(), &complianceRulesTextCodec{})
+	opts.transport.bind(cmd.Flags())
+	return cmd
+}
+
+type complianceRulesSetOpts struct {
+	IO               cmdio.Options
+	transport        complianceTransport
+	Interactive      bool
+	RequiredChannels []string
+	DefaultRules     []string
+	ImportantRules   []string
+}
+
+func (o *complianceRulesSetOpts) setup(flags *pflag.FlagSet) {
+	registerComplianceCodecs(&o.IO, flags, &complianceRulesTextCodec{})
+	o.transport.bind(flags)
+	flags.BoolVarP(&o.Interactive, "interactive", "i", false,
+		"Select channels and notification rules interactively (pre-checked from the current ruleset)")
+	flags.StringSliceVar(&o.RequiredChannels, "required-channels", nil,
+		"Channels every user must have configured (comma-separated, e.g. phone,slack)")
+	flags.StringSliceVar(&o.DefaultRules, "default", nil,
+		"Notification rule types required in the default policy (e.g. notify_by_slack)")
+	flags.StringSliceVar(&o.ImportantRules, "important", nil,
+		"Notification rule types required in the important policy (e.g. notify_by_sms,notify_by_slack)")
+}
+
+func (o *complianceRulesSetOpts) Validate() error {
+	if len(o.RequiredChannels) == 0 && len(o.DefaultRules) == 0 && len(o.ImportantRules) == 0 {
+		return errors.New("at least one of --required-channels, --default, or --important is required (or use --interactive)")
+	}
+	return nil
+}
+
+// runInteractive pre-fills a multi-select form from the current ruleset (best-effort)
+// and returns the rules the user selected.
+func (o *complianceRulesSetOpts) runInteractive(ctx context.Context, client complianceAPI) (ComplianceRules, error) {
+	var cur ComplianceRules
+	if current, err := client.GetComplianceRules(ctx); err == nil && current != nil {
+		cur = *current
+	}
+
+	var channels, def, imp []string
+	form := huh.NewForm(huh.NewGroup(
+		complianceMultiSelect("Required channels", "Channels every user must have configured",
+			complianceChannelOptions, cur.RequiredChannels, &channels),
+		complianceMultiSelect("Default policy", "Notification rule types required in the default policy",
+			complianceRuleTypeOptions, cur.RequiredNotificationRules.Default, &def),
+		complianceMultiSelect("Important policy", "Notification rule types required in the important policy",
+			complianceRuleTypeOptions, cur.RequiredNotificationRules.Important, &imp),
+	))
+	if err := form.Run(); err != nil {
+		return ComplianceRules{}, err
+	}
+	return ComplianceRules{
+		RequiredChannels:          channels,
+		RequiredNotificationRules: ComplianceNotificationRules{Default: def, Important: imp},
+	}, nil
+}
+
+// complianceMultiSelect builds a multi-select with the items in `current` pre-checked.
+func complianceMultiSelect(title, desc string, all, current []string, out *[]string) *huh.MultiSelect[string] {
+	checked := make(map[string]bool, len(current))
+	for _, c := range current {
+		checked[c] = true
+	}
+	opts := make([]huh.Option[string], 0, len(all))
+	for _, v := range all {
+		opts = append(opts, huh.NewOption(complianceLabel(v), v).Selected(checked[v]))
+	}
+	return huh.NewMultiSelect[string]().Title(title).Description(desc).Options(opts...).Value(out)
+}
+
+func newComplianceRulesSetCmd(loader OnCallConfigLoader) *cobra.Command {
+	opts := &complianceRulesSetOpts{}
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Create or update the org's notification compliance rules.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			client, err := opts.transport.resolve(cmd.Context(), loader)
+			if err != nil {
+				return err
+			}
+
+			var rules ComplianceRules
+			if opts.Interactive {
+				if !term.IsTerminal(int(os.Stdin.Fd())) {
+					return errors.New("--interactive requires a terminal; pass --required-channels/--default/--important instead")
+				}
+				rules, err = opts.runInteractive(cmd.Context(), client)
+				if errors.Is(err, huh.ErrUserAborted) {
+					fmt.Fprintln(cmd.ErrOrStderr(), "Aborted; no changes made.")
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+			} else {
+				if err := opts.Validate(); err != nil {
+					return err
+				}
+				rules = ComplianceRules{
+					RequiredChannels: opts.RequiredChannels,
+					RequiredNotificationRules: ComplianceNotificationRules{
+						Default:   opts.DefaultRules,
+						Important: opts.ImportantRules,
+					},
+				}
+			}
+
+			result, err := client.SetComplianceRules(cmd.Context(), rules)
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), *result)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type complianceEvaluateOpts struct {
+	IO        cmdio.Options
+	transport complianceTransport
+}
+
+func newComplianceEvaluateCmd(loader OnCallConfigLoader) *cobra.Command {
+	opts := &complianceEvaluateOpts{}
+	cmd := &cobra.Command{
+		Use:   "evaluate",
+		Short: "Evaluate org users against the compliance rules (who is ready to be paged).",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			// evaluate is only on the public API today.
+			if opts.transport.URL == "" {
+				return errors.New("evaluate requires --oncall-url (test-only) until the endpoint is exposed via the plugin proxy")
+			}
+			client := newPublicComplianceClient(opts.transport.URL, opts.transport.Token, opts.transport.InstanceID)
+			report, err := client.Evaluate(cmd.Context())
+			if err != nil {
+				return err
+			}
+			users, err := client.ListUsers(cmd.Context())
+			if err != nil {
+				// Best-effort enrichment: fall back to IDs only.
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not fetch user names: %v\n", err)
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), enrichEvaluation(report, users))
+		},
+	}
+	registerComplianceCodecs(&opts.IO, cmd.Flags(), &complianceEvaluationTextCodec{})
+	opts.transport.bind(cmd.Flags())
+	return cmd
+}
+
+// --- test-only public OnCall API client ---
+
+// publicComplianceClient talks directly to the OnCall engine public API. It exists only
+// for end-to-end testing of the compliance endpoints until they are reachable through the
+// plugin proxy; see the package comment above.
+type publicComplianceClient struct {
+	httpClient *http.Client
+	baseURL    string
+	token      string
+	instanceID string
+}
+
+func newPublicComplianceClient(baseURL, token, instanceID string) *publicComplianceClient {
+	return &publicComplianceClient{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		token:      token,
+		instanceID: instanceID,
+	}
+}
+
+func (c *publicComplianceClient) do(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	return c.doURL(ctx, method, c.baseURL+path, body)
+}
+
+func (c *publicComplianceClient) doURL(ctx context.Context, method, fullURL string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", c.token)
+	req.Header.Set("X-Grafana-Instance-ID", c.instanceID)
+	req.Header.Set("Content-Type", "application/json")
+	return c.httpClient.Do(req)
+}
+
+// publicUser is the subset of the public users API we use to label evaluation results.
+type publicUser struct {
+	ID       string `json:"id"`
+	Email    string `json:"email"`
+	Username string `json:"username"`
+}
+
+type publicUsersPage struct {
+	Next    *string      `json:"next"`
+	Results []publicUser `json:"results"`
+}
+
+// ListUsers returns org users keyed by their OnCall user ID (follows pagination).
+func (c *publicComplianceClient) ListUsers(ctx context.Context) (map[string]publicUser, error) {
+	out := make(map[string]publicUser)
+	url := c.baseURL + "/api/v1/users/"
+	for url != "" {
+		resp, err := c.doURL(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("irm: list users: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			err := handleErrorResponse(resp)
+			resp.Body.Close()
+			return nil, err
+		}
+		var page publicUsersPage
+		decErr := json.NewDecoder(resp.Body).Decode(&page)
+		resp.Body.Close()
+		if decErr != nil {
+			return nil, fmt.Errorf("irm: decode users: %w", decErr)
+		}
+		for _, u := range page.Results {
+			out[u.ID] = u
+		}
+		if page.Next == nil {
+			break
+		}
+		url = *page.Next
+	}
+	return out, nil
+}
+
+func (c *publicComplianceClient) GetComplianceRules(ctx context.Context) (*ComplianceRules, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/api/v1/oncall_compliance/", nil)
+	if err != nil {
+		return nil, fmt.Errorf("irm: get compliance rules: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, handleErrorResponse(resp)
+	}
+	var result ComplianceRules
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("irm: decode compliance rules: %w", err)
+	}
+	return &result, nil
+}
+
+func (c *publicComplianceClient) SetComplianceRules(ctx context.Context, rules ComplianceRules) (*ComplianceRules, error) {
+	data, err := json.Marshal(rules)
+	if err != nil {
+		return nil, fmt.Errorf("irm: marshal compliance rules: %w", err)
+	}
+	resp, err := c.do(ctx, http.MethodPost, "/api/v1/oncall_compliance/", bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("irm: set compliance rules: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, handleErrorResponse(resp)
+	}
+	var result ComplianceRules
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("irm: decode compliance rules: %w", err)
+	}
+	return &result, nil
+}
+
+func (c *publicComplianceClient) Evaluate(ctx context.Context) (*ComplianceEvaluation, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/api/v1/oncall_compliance/evaluate/", nil)
+	if err != nil {
+		return nil, fmt.Errorf("irm: evaluate compliance: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, handleErrorResponse(resp)
+	}
+	var result ComplianceEvaluation
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("irm: decode compliance evaluation: %w", err)
+	}
+	return &result, nil
+}
+
+// --- output codecs ---
+
+// complianceRulesTextCodec renders ComplianceRules as a human summary.
+type complianceRulesTextCodec struct{}
+
+func (c *complianceRulesTextCodec) Format() format.Format { return format.Format("text") }
+
+func (c *complianceRulesTextCodec) Encode(w io.Writer, v any) error {
+	r, ok := v.(ComplianceRules)
+	if !ok {
+		return fmt.Errorf("text codec: unsupported value type %T (expected ComplianceRules)", v)
+	}
+	if _, err := fmt.Fprintln(w, "Notification compliance rules:"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "  Required channels: %s\n", joinOrDash(r.RequiredChannels)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "  Default policy:    %s\n", joinOrDash(r.RequiredNotificationRules.Default)); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "  Important policy:  %s\n", joinOrDash(r.RequiredNotificationRules.Important))
+	return err
+}
+
+func (c *complianceRulesTextCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("text format does not support decoding")
+}
+
+// evaluationView is the user-facing evaluation report: raw evaluation joined with user
+// names/emails. Used for all output formats so json/yaml also carry the labels.
+type evaluationView struct {
+	Compliant    []evalUser `json:"compliant"`
+	NonCompliant []evalUser `json:"non_compliant"`
+}
+
+type evalUser struct {
+	UserID     string   `json:"user_id"`
+	Email      string   `json:"email,omitempty"`
+	Username   string   `json:"username,omitempty"`
+	Violations []string `json:"violations,omitempty"`
+}
+
+// label renders "name (user_id)", preferring email, then username, then just the ID.
+func (u evalUser) label() string {
+	switch {
+	case u.Email != "":
+		return fmt.Sprintf("%s (%s)", u.Email, u.UserID)
+	case u.Username != "":
+		return fmt.Sprintf("%s (%s)", u.Username, u.UserID)
+	default:
+		return u.UserID
+	}
+}
+
+// enrichEvaluation joins a raw evaluation with user records (keyed by ID). users may be
+// nil, in which case only IDs are shown.
+func enrichEvaluation(e *ComplianceEvaluation, users map[string]publicUser) evaluationView {
+	mk := func(id string, viol []string) evalUser {
+		u := evalUser{UserID: id, Violations: viol}
+		if info, ok := users[id]; ok {
+			u.Email = info.Email
+			u.Username = info.Username
+		}
+		return u
+	}
+	view := evaluationView{}
+	for _, id := range e.Compliant {
+		view.Compliant = append(view.Compliant, mk(id, nil))
+	}
+	for _, nc := range e.NonCompliant {
+		view.NonCompliant = append(view.NonCompliant, mk(nc.UserID, nc.Violations))
+	}
+	return view
+}
+
+// complianceEvaluationTextCodec renders an evaluationView report.
+type complianceEvaluationTextCodec struct{}
+
+func (c *complianceEvaluationTextCodec) Format() format.Format { return format.Format("text") }
+
+func (c *complianceEvaluationTextCodec) Encode(w io.Writer, v any) error {
+	e, ok := v.(evaluationView)
+	if !ok {
+		return fmt.Errorf("text codec: unsupported value type %T (expected evaluationView)", v)
+	}
+	if _, err := fmt.Fprintf(w, "Compliant users: %d\n", len(e.Compliant)); err != nil {
+		return err
+	}
+	for _, u := range e.Compliant {
+		if _, err := fmt.Fprintf(w, "  ✓ %s\n", u.label()); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(w, "Non-compliant users: %d\n", len(e.NonCompliant)); err != nil {
+		return err
+	}
+	for _, u := range e.NonCompliant {
+		if _, err := fmt.Fprintf(w, "  ✗ %s\n", u.label()); err != nil {
+			return err
+		}
+		for _, v := range u.Violations {
+			if _, err := fmt.Fprintf(w, "      - %s\n", friendlyViolation(v)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c *complianceEvaluationTextCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("text format does not support decoding")
+}
+
+// joinOrDash joins friendly labels for display, or "-" when empty.
+func joinOrDash(s []string) string {
+	if len(s) == 0 {
+		return "-"
+	}
+	labels := make([]string, len(s))
+	for i, v := range s {
+		labels[i] = complianceLabel(v)
+	}
+	return strings.Join(labels, ", ")
+}

--- a/internal/providers/irm/oncall_compliance_commands.go
+++ b/internal/providers/irm/oncall_compliance_commands.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/style"
@@ -113,7 +114,7 @@ func newComplianceRulesCmd(loader OnCallConfigLoader) *cobra.Command {
 	cmd.AddCommand(
 		newComplianceRulesGetCmd(loader),
 		newComplianceRulesSetCmd(loader),
-		newComplianceEvaluateCmd(loader),
+		newComplianceEvaluateCmd(),
 	)
 	return cmd
 }
@@ -282,7 +283,7 @@ type complianceEvaluateOpts struct {
 	transport complianceTransport
 }
 
-func newComplianceEvaluateCmd(loader OnCallConfigLoader) *cobra.Command {
+func newComplianceEvaluateCmd() *cobra.Command {
 	opts := &complianceEvaluateOpts{}
 	cmd := &cobra.Command{
 		Use:   "evaluate",
@@ -369,7 +370,9 @@ type publicUsersPage struct {
 // ListUsers returns org users keyed by their OnCall user ID (follows pagination).
 func (c *publicComplianceClient) ListUsers(ctx context.Context) (map[string]publicUser, error) {
 	out := make(map[string]publicUser)
-	url := c.baseURL + "/api/v1/users/"
+	// short=true returns the lightweight user list (id/email/username/…) and skips the
+	// per-user Slack enrichment that otherwise 500s when a Slack integration is unhealthy.
+	url := c.baseURL + "/api/v1/users/?short=true"
 	for url != "" {
 		resp, err := c.doURL(ctx, http.MethodGet, url, nil)
 		if err != nil {
@@ -550,12 +553,24 @@ func (c *evaluationTableCodec) Encode(w io.Writer, v any) error {
 		for i, viol := range u.Violations {
 			problems[i] = friendlyViolation(viol)
 		}
-		t.Row("non-compliant", u.name(), strings.Join(problems, "; "))
+		t.Row(complianceStatusIcon(false), u.name(), strings.Join(problems, "; "))
 	}
 	for _, u := range e.Compliant {
-		t.Row("compliant", u.name(), "-")
+		t.Row(complianceStatusIcon(true), u.name(), "-")
 	}
 	return t.Render(w)
+}
+
+// complianceStatusIcon returns a green ✓ for compliant, a red ✗ otherwise. Falls back
+// to the bare glyph when styling is disabled (piped output / --no-color).
+func complianceStatusIcon(compliant bool) string {
+	if !compliant {
+		return style.ColorCell("✗", false, true)
+	}
+	if style.IsStylingEnabled() {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#7EB26D")).Render("✓")
+	}
+	return "✓"
 }
 
 // complianceEvaluationTextCodec renders an evaluationView report.

--- a/internal/providers/irm/oncall_compliance_commands.go
+++ b/internal/providers/irm/oncall_compliance_commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/term"
@@ -307,7 +308,12 @@ func newComplianceEvaluateCmd(loader OnCallConfigLoader) *cobra.Command {
 			return opts.IO.Encode(cmd.OutOrStdout(), enrichEvaluation(report, users))
 		},
 	}
-	registerComplianceCodecs(&opts.IO, cmd.Flags(), &complianceEvaluationTextCodec{})
+	// evaluate defaults to a table; text/yaml/json remain available via -o.
+	opts.IO.RegisterCustomCodec("table", &evaluationTableCodec{})
+	opts.IO.RegisterCustomCodec("text", &complianceEvaluationTextCodec{})
+	opts.IO.RegisterCustomCodec("yaml", format.NewOrderedYAMLCodec())
+	opts.IO.DefaultFormat("table")
+	opts.IO.BindFlags(cmd.Flags())
 	opts.transport.bind(cmd.Flags())
 	return cmd
 }
@@ -488,11 +494,19 @@ type evalUser struct {
 
 // label renders "name (user_id)", preferring email, then username, then just the ID.
 func (u evalUser) label() string {
+	if n := u.name(); n != u.UserID {
+		return fmt.Sprintf("%s (%s)", n, u.UserID)
+	}
+	return u.UserID
+}
+
+// name returns the best display name: email, then username, then the ID.
+func (u evalUser) name() string {
 	switch {
 	case u.Email != "":
-		return fmt.Sprintf("%s (%s)", u.Email, u.UserID)
+		return u.Email
 	case u.Username != "":
-		return fmt.Sprintf("%s (%s)", u.Username, u.UserID)
+		return u.Username
 	default:
 		return u.UserID
 	}
@@ -517,6 +531,31 @@ func enrichEvaluation(e *ComplianceEvaluation, users map[string]publicUser) eval
 		view.NonCompliant = append(view.NonCompliant, mk(nc.UserID, nc.Violations))
 	}
 	return view
+}
+
+// evaluationTableCodec renders an evaluationView as a STATUS/USER/PROBLEMS table,
+// non-compliant users first. It is the default format for `evaluate`.
+type evaluationTableCodec struct{ noDecodeCodec }
+
+func (c *evaluationTableCodec) Format() format.Format { return format.Format("table") }
+
+func (c *evaluationTableCodec) Encode(w io.Writer, v any) error {
+	e, ok := v.(evaluationView)
+	if !ok {
+		return fmt.Errorf("table codec: unsupported value type %T (expected evaluationView)", v)
+	}
+	t := style.NewTable("STATUS", "USER", "PROBLEMS")
+	for _, u := range e.NonCompliant {
+		problems := make([]string, len(u.Violations))
+		for i, viol := range u.Violations {
+			problems[i] = friendlyViolation(viol)
+		}
+		t.Row("non-compliant", u.name(), strings.Join(problems, "; "))
+	}
+	for _, u := range e.Compliant {
+		t.Row("compliant", u.name(), "-")
+	}
+	return t.Render(w)
 }
 
 // complianceEvaluationTextCodec renders an evaluationView report.

--- a/internal/providers/irm/oncall_compliance_commands_test.go
+++ b/internal/providers/irm/oncall_compliance_commands_test.go
@@ -1,0 +1,147 @@
+//nolint:testpackage // white-box tests require access to unexported IRM types and helpers
+package irm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// fakeComplianceAPI stubs the compliance-rules methods of OnCallAPI. It embeds
+// OnCallAPI so unrelated methods panic if called.
+type fakeComplianceAPI struct {
+	OnCallAPI
+
+	got    ComplianceRules
+	stored ComplianceRules
+}
+
+func (f *fakeComplianceAPI) GetComplianceRules(_ context.Context) (*ComplianceRules, error) {
+	r := f.stored
+	return &r, nil
+}
+
+func (f *fakeComplianceAPI) SetComplianceRules(_ context.Context, rules ComplianceRules) (*ComplianceRules, error) {
+	f.got = rules
+	return &rules, nil
+}
+
+func runComplianceCmd(t *testing.T, cmd *cobra.Command, args ...string) string {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stdout)
+	cmd.SetArgs(args)
+	cmd.SetContext(context.Background())
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute %v: %v\noutput=%s", args, err, stdout.String())
+	}
+	return stdout.String()
+}
+
+func TestComplianceRulesSet_BuildsBodyFromFlags(t *testing.T) {
+	fake := &fakeComplianceAPI{}
+	cmd := newComplianceRulesSetCmd(&fakeLoader{client: fake})
+
+	out := runComplianceCmd(t, cmd,
+		"--required-channels", "phone,slack",
+		"--default", "notify_by_slack",
+		"--important", "notify_by_sms,notify_by_slack",
+		"-o", "json",
+	)
+
+	want := ComplianceRules{
+		RequiredChannels: []string{"phone", "slack"},
+		RequiredNotificationRules: ComplianceNotificationRules{
+			Default:   []string{"notify_by_slack"},
+			Important: []string{"notify_by_sms", "notify_by_slack"},
+		},
+	}
+	if !reflectEqualRules(fake.got, want) {
+		t.Errorf("posted rules = %+v, want %+v", fake.got, want)
+	}
+
+	var got ComplianceRules
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nraw=%s", err, out)
+	}
+	if !reflectEqualRules(got, want) {
+		t.Errorf("json output = %+v, want %+v", got, want)
+	}
+}
+
+func TestComplianceRulesSet_RequiresAtLeastOneFlag(t *testing.T) {
+	cmd := newComplianceRulesSetCmd(&fakeLoader{client: &fakeComplianceAPI{}})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(nil)
+	cmd.SetContext(context.Background())
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "at least one of") {
+		t.Fatalf("expected validation error about required flags, got %v", err)
+	}
+}
+
+func TestComplianceRulesGet_RendersText(t *testing.T) {
+	resetAgentMode(t) // otherwise agent-mode detection overrides the text default with JSON
+	fake := &fakeComplianceAPI{stored: ComplianceRules{
+		RequiredChannels: []string{"phone"},
+		RequiredNotificationRules: ComplianceNotificationRules{
+			Important: []string{"notify_by_sms"},
+		},
+	}}
+	cmd := newComplianceRulesGetCmd(&fakeLoader{client: fake})
+
+	out := runComplianceCmd(t, cmd) // default -o text
+
+	for _, want := range []string{"Required channels: Phone", "Default policy:    -", "Important policy:  SMS"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+func TestDoctorResultFor(t *testing.T) {
+	eval := &ComplianceEvaluation{
+		Compliant: []string{"U_OK"},
+		NonCompliant: []UserComplianceViolation{
+			{UserID: "U_BAD", Violations: []string{"phone channel not configured", "missing notify_by_slack in default policy"}},
+		},
+	}
+	tests := []struct {
+		name          string
+		userID        string
+		wantCompliant bool
+		wantFound     bool
+		wantViols     int
+	}{
+		{"compliant", "U_OK", true, true, 0},
+		{"non-compliant", "U_BAD", false, true, 2},
+		{"absent", "U_MISSING", false, false, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := doctorResultFor(tc.userID, eval)
+			if got.Compliant != tc.wantCompliant || got.Found != tc.wantFound || len(got.Violations) != tc.wantViols {
+				t.Errorf("doctorResultFor(%q) = %+v", tc.userID, got)
+			}
+		})
+	}
+}
+
+func TestFriendlyViolation(t *testing.T) {
+	got := friendlyViolation("missing notify_by_slack in default policy")
+	if want := "missing Slack in default policy"; got != want {
+		t.Errorf("friendlyViolation = %q, want %q", got, want)
+	}
+}
+
+func reflectEqualRules(a, b ComplianceRules) bool {
+	ja, _ := json.Marshal(a)
+	jb, _ := json.Marshal(b)
+	return string(ja) == string(jb)
+}

--- a/internal/providers/irm/oncall_doctor_command.go
+++ b/internal/providers/irm/oncall_doctor_command.go
@@ -1,0 +1,159 @@
+package irm
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// ---------------------------------------------------------------------------
+// doctor command — "check your own config vs the expected configuration"
+//
+// Resolves the current user via the plugin-proxy (GetCurrentUser on the active gcx
+// context), then looks that user up in the org compliance evaluation. The evaluation
+// itself lives only on the OnCall public API today, so doctor reuses the same TEST-ONLY
+// direct transport as `compliance-rules evaluate` (--oncall-url/--oncall-token/--instance-id).
+// ---------------------------------------------------------------------------
+
+type doctorOpts struct {
+	IO        cmdio.Options
+	transport complianceTransport
+	UserID    string
+}
+
+func newDoctorCmd(loader OnCallConfigLoader) *cobra.Command {
+	opts := &doctorOpts{}
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Check whether your OnCall notification setup meets the org's compliance rules.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			if opts.transport.URL == "" {
+				return errors.New("doctor requires --oncall-url (test-only) until the endpoint is exposed via the plugin proxy")
+			}
+
+			userID := opts.UserID
+			if userID == "" {
+				client, _, err := loader.LoadOnCallClient(cmd.Context())
+				if err != nil {
+					return fmt.Errorf("resolve current user: %w", err)
+				}
+				u, err := client.GetCurrentUser(cmd.Context())
+				if err != nil {
+					return fmt.Errorf("resolve current user: %w", err)
+				}
+				userID = u.PK
+			}
+
+			public := newPublicComplianceClient(opts.transport.URL, opts.transport.Token, opts.transport.InstanceID)
+			eval, err := public.Evaluate(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			res := doctorResultFor(userID, eval)
+			if users, uerr := public.ListUsers(cmd.Context()); uerr == nil {
+				if info, ok := users[userID]; ok {
+					res.Email = info.Email
+					res.Username = info.Username
+				}
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), res)
+		},
+	}
+	registerComplianceCodecs(&opts.IO, cmd.Flags(), &doctorTextCodec{})
+	opts.transport.bind(cmd.Flags())
+	cmd.Flags().StringVar(&opts.UserID, "user", "", "OnCall user ID to check (defaults to the current user)")
+	return cmd
+}
+
+// DoctorResult is one user's compliance verdict.
+type DoctorResult struct {
+	UserID     string   `json:"user_id"`
+	Email      string   `json:"email,omitempty"`
+	Username   string   `json:"username,omitempty"`
+	Compliant  bool     `json:"compliant"`
+	Found      bool     `json:"found"`
+	Violations []string `json:"violations,omitempty"`
+}
+
+// label renders "name (user_id)", preferring email, then username, then just the ID.
+func (r DoctorResult) label() string {
+	switch {
+	case r.Email != "":
+		return fmt.Sprintf("%s (%s)", r.Email, r.UserID)
+	case r.Username != "":
+		return fmt.Sprintf("%s (%s)", r.Username, r.UserID)
+	default:
+		return r.UserID
+	}
+}
+
+// doctorResultFor finds userID in the evaluation report. A user absent from both lists
+// is reported as not found (the backend may omit users with no notification setup).
+func doctorResultFor(userID string, e *ComplianceEvaluation) DoctorResult {
+	for _, id := range e.Compliant {
+		if id == userID {
+			return DoctorResult{UserID: userID, Compliant: true, Found: true}
+		}
+	}
+	for _, u := range e.NonCompliant {
+		if u.UserID == userID {
+			return DoctorResult{UserID: userID, Compliant: false, Found: true, Violations: u.Violations}
+		}
+	}
+	return DoctorResult{UserID: userID, Compliant: false, Found: false}
+}
+
+// doctorTextCodec renders a DoctorResult as a human verdict.
+type doctorTextCodec struct{}
+
+func (c *doctorTextCodec) Format() format.Format { return format.Format("text") }
+
+func (c *doctorTextCodec) Encode(w io.Writer, v any) error {
+	r, ok := v.(DoctorResult)
+	if !ok {
+		return fmt.Errorf("text codec: unsupported value type %T (expected DoctorResult)", v)
+	}
+	switch {
+	case !r.Found:
+		_, err := fmt.Fprintf(w, "? %s was not found in the org evaluation report (no notification setup?).\n", r.label())
+		return err
+	case r.Compliant:
+		_, err := fmt.Fprintf(w, "✓ %s is ready to be paged — compliant with the org's notification rules.\n", r.label())
+		return err
+	default:
+		if _, err := fmt.Fprintf(w, "✗ %s is NOT compliant with the org's notification rules:\n", r.label()); err != nil {
+			return err
+		}
+		for _, v := range r.Violations {
+			if _, err := fmt.Fprintf(w, "    - %s\n", friendlyViolation(v)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func (c *doctorTextCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("text format does not support decoding")
+}
+
+// friendlyViolation replaces raw enum tokens (notify_by_*, channel names) inside a
+// backend violation sentence with their friendly labels, leaving everything else intact.
+func friendlyViolation(s string) string {
+	fields := strings.Fields(s)
+	for i, f := range fields {
+		if l, ok := complianceLabels[f]; ok {
+			fields[i] = l
+		}
+	}
+	return strings.Join(fields, " ")
+}

--- a/internal/providers/irm/oncall_doctor_command.go
+++ b/internal/providers/irm/oncall_doctor_command.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/grafana/gcx/internal/format"
@@ -99,10 +100,8 @@ func (r DoctorResult) label() string {
 // doctorResultFor finds userID in the evaluation report. A user absent from both lists
 // is reported as not found (the backend may omit users with no notification setup).
 func doctorResultFor(userID string, e *ComplianceEvaluation) DoctorResult {
-	for _, id := range e.Compliant {
-		if id == userID {
-			return DoctorResult{UserID: userID, Compliant: true, Found: true}
-		}
+	if slices.Contains(e.Compliant, userID) {
+		return DoctorResult{UserID: userID, Compliant: true, Found: true}
 	}
 	for _, u := range e.NonCompliant {
 		if u.UserID == userID {

--- a/internal/providers/irm/oncall_doctor_command.go
+++ b/internal/providers/irm/oncall_doctor_command.go
@@ -7,10 +7,32 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 )
+
+// Verdict palette (mirrors the shared threshold colors).
+var (
+	colorOK    = lipgloss.Color("#7EB26D") // green
+	colorBad   = lipgloss.Color("#E24D42") // red
+	colorWarn  = lipgloss.Color("#EAB839") // amber
+	colorMuted = lipgloss.Color("#8E8E8E") // gray
+)
+
+// paint colors text when styling is enabled, otherwise returns it unchanged.
+func paint(text string, color lipgloss.Color, bold bool) string {
+	if !style.IsStylingEnabled() {
+		return text
+	}
+	s := lipgloss.NewStyle().Foreground(color)
+	if bold {
+		s = s.Bold(true)
+	}
+	return s.Render(text)
+}
 
 // ---------------------------------------------------------------------------
 // doctor command — "check your own config vs the expected configuration"
@@ -60,6 +82,7 @@ func newDoctorCmd(loader OnCallConfigLoader) *cobra.Command {
 			}
 
 			res := doctorResultFor(userID, eval)
+			res.Self = opts.UserID == "" // resolved from the current user, not an explicit --user
 			if users, uerr := public.ListUsers(cmd.Context()); uerr == nil {
 				if info, ok := users[userID]; ok {
 					res.Email = info.Email
@@ -83,18 +106,27 @@ type DoctorResult struct {
 	Compliant  bool     `json:"compliant"`
 	Found      bool     `json:"found"`
 	Violations []string `json:"violations,omitempty"`
+	Self       bool     `json:"-"` // true when resolved from the current user (drives "you" phrasing)
+}
+
+// name returns the best display name: email, then username, then the ID.
+func (r DoctorResult) name() string {
+	switch {
+	case r.Email != "":
+		return r.Email
+	case r.Username != "":
+		return r.Username
+	default:
+		return r.UserID
+	}
 }
 
 // label renders "name (user_id)", preferring email, then username, then just the ID.
 func (r DoctorResult) label() string {
-	switch {
-	case r.Email != "":
-		return fmt.Sprintf("%s (%s)", r.Email, r.UserID)
-	case r.Username != "":
-		return fmt.Sprintf("%s (%s)", r.Username, r.UserID)
-	default:
-		return r.UserID
+	if n := r.name(); n != r.UserID {
+		return fmt.Sprintf("%s (%s)", n, r.UserID)
 	}
+	return r.UserID
 }
 
 // doctorResultFor finds userID in the evaluation report. A user absent from both lists
@@ -121,21 +153,49 @@ func (c *doctorTextCodec) Encode(w io.Writer, v any) error {
 	if !ok {
 		return fmt.Errorf("text codec: unsupported value type %T (expected DoctorResult)", v)
 	}
+
+	subject := r.label()
+	if r.Self {
+		subject = "You"
+		if n := r.name(); n != r.UserID {
+			subject = "You (" + n + ")"
+		}
+	}
+
 	switch {
 	case !r.Found:
-		_, err := fmt.Fprintf(w, "? %s was not found in the org evaluation report (no notification setup?).\n", r.label())
-		return err
-	case r.Compliant:
-		_, err := fmt.Fprintf(w, "✓ %s is ready to be paged — compliant with the org's notification rules.\n", r.label())
-		return err
-	default:
-		if _, err := fmt.Fprintf(w, "✗ %s is NOT compliant with the org's notification rules:\n", r.label()); err != nil {
-			return err
+		head := "no notification setup found"
+		if r.Self {
+			head = "we couldn't find your notification setup"
 		}
-		for _, v := range r.Violations {
-			if _, err := fmt.Fprintf(w, "    - %s\n", friendlyViolation(v)); err != nil {
-				return err
-			}
+		fmt.Fprintln(w, paint("⚠ "+subject+" — "+head, colorWarn, true))
+		detail := "This user doesn't appear in the org compliance report — they may have no notification policy at all."
+		if r.Self {
+			detail = "You don't appear in the org compliance report — you may have no notification policy at all. Set one up so pages can reach you."
+		}
+		fmt.Fprintln(w, paint("  "+detail, colorMuted, false))
+		return nil
+
+	case r.Compliant:
+		msg := subject + " is compliant — ready to be paged."
+		if r.Self {
+			msg = "You're all set — ready to be paged."
+		}
+		fmt.Fprintln(w, paint("✓ "+msg, colorOK, true))
+		fmt.Fprintln(w, paint("  Your notification setup meets all of the org's requirements.", colorMuted, false))
+		return nil
+
+	default:
+		head := subject + " is NOT compliant with the org's notification rules:"
+		if r.Self {
+			head = "You're not fully reachable yet — your setup is missing some requirements:"
+		}
+		fmt.Fprintln(w, paint("✗ "+head, colorBad, true))
+		for _, viol := range r.Violations {
+			fmt.Fprintln(w, "  "+paint("•", colorBad, false)+" "+paint(friendlyViolation(viol), colorWarn, false))
+		}
+		if r.Self {
+			fmt.Fprintln(w, paint("  Fix these in your OnCall notification settings so alerts reach you.", colorMuted, false))
 		}
 		return nil
 	}

--- a/internal/providers/irm/oncall_types.go
+++ b/internal/providers/irm/oncall_types.go
@@ -194,6 +194,41 @@ type OnCallAPI interface {
 	TakeShiftSwap(ctx context.Context, id string, input TakeShiftSwapInput) (*ShiftSwap, error)
 
 	CreateDirectPaging(ctx context.Context, input DirectPagingInput) (*DirectPagingResult, error)
+
+	GetComplianceRules(ctx context.Context) (*ComplianceRules, error)
+	SetComplianceRules(ctx context.Context, rules ComplianceRules) (*ComplianceRules, error)
+}
+
+// ComplianceRules is the org-level "expected configuration" that user notification
+// settings are checked against. Shape mirrors the documented compliance endpoint body
+// (required_channels + required_notification_rules); the backend is wired later.
+type ComplianceRules struct {
+	RequiredChannels          []string                    `json:"required_channels,omitempty"`
+	RequiredNotificationRules ComplianceNotificationRules `json:"required_notification_rules"`
+
+	// CreatedAt and UpdatedAt are server-set; read-only on GET responses.
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// ComplianceNotificationRules lists the notification rule types (notify_by_*) required
+// in each personal notification policy.
+type ComplianceNotificationRules struct {
+	Default   []string `json:"default,omitempty"`
+	Important []string `json:"important,omitempty"`
+}
+
+// ComplianceEvaluation is the result of evaluating org users against the compliance
+// rules: who is ready to be paged and who is not, with per-user violations.
+type ComplianceEvaluation struct {
+	Compliant    []string                  `json:"compliant"`
+	NonCompliant []UserComplianceViolation `json:"non_compliant"`
+}
+
+// UserComplianceViolation lists why a single user fails the compliance rules.
+type UserComplianceViolation struct {
+	UserID     string   `json:"user_id"`
+	Violations []string `json:"violations"`
 }
 
 func (x Integration) GetResourceName() string           { return x.ID }

--- a/internal/providers/irm/provider.go
+++ b/internal/providers/irm/provider.go
@@ -51,10 +51,12 @@ func (p *IRMProvider) Commands() []*cobra.Command {
 		newResolutionNotesCmd(loader),
 		newShiftSwapsCmd(loader),
 		newEscalateCommand(loader),
+		newComplianceRulesCmd(loader),
 	)
 
 	irmCmd.AddCommand(oncallCmd)
 	irmCmd.AddCommand(newIncidentsCmd(loader))
+	irmCmd.AddCommand(newDoctorCmd(loader))
 
 	return []*cobra.Command{irmCmd}
 }


### PR DESCRIPTION
## What

Adds an OnCall **notification-compliance** surface to gcx — the "safety net" idea: admins define a minimal required notification setup for the org, and anyone can check whether a user is actually reachable when paged.

### New commands

| Command | Purpose |
|---|---|
| `gcx irm oncall compliance-rules get` | Show the org's compliance ruleset |
| `gcx irm oncall compliance-rules set` | Create/update the ruleset — flags **or** `-i` interactive checkboxes (pre-checked from current) |
| `gcx irm oncall compliance-rules evaluate` | Audit **all** org users vs the rules |
| `gcx irm doctor` | Check **your own** (or `--user <id>`) compliance |

## How it talks to the backend

The compliance API currently lives **only on the OnCall public API** (`/api/v1/oncall_compliance/` + `/evaluate/`, auth via `Authorization` token + `X-Grafana-Instance-ID`), **not** the plugin-proxy surface the rest of the IRM client uses. Until it's exposed through the proxy, these commands support a **TEST-ONLY direct transport**:

- flags `--oncall-url` / `--oncall-token` / `--instance-id` (env: `ONCALL_URL` / `ONCALL_TOKEN` / `INSTANCE_ID`)
- without `--oncall-url`, `get`/`set` fall back to the plugin-proxy client; `evaluate`/`doctor` require it (evaluate is public-API-only today)
- `doctor` resolves the current user via the proxy's `GetCurrentUser`, then looks that user up in `evaluate`

This transport is clearly marked temporary in the code; the permanent wiring (expose via plugin proxy vs. a real public-API client config) is still open.

## Output

- **text** — friendly channel/rule labels (`Slack`, `SMS`, `Phone call`, …) and evaluation results joined with user **email/username**
- **json/yaml** — raw enum values preserved (`notify_by_slack`, `phone`, …) for scripting

## Try it locally

```bash
go build -buildvcs=false -o bin/gcx ./cmd/gcx/

export ONCALL_URL="http://<oncall-engine>:8084"
export ONCALL_TOKEN="<oncall-api-token>"
export INSTANCE_ID="<grafana-instance-id>"

./bin/gcx irm oncall compliance-rules set --required-channels phone,slack \
  --default notify_by_slack --important notify_by_sms,notify_by_slack
./bin/gcx irm oncall compliance-rules get
./bin/gcx irm oncall compliance-rules evaluate
./bin/gcx irm doctor --user <oncall-user-id>      # or run against a configured context for the current user
```

## Notes / open questions

- **Transport is test-only** — needs a decision before this is production-ready (proxy exposure would drop all the `--oncall-*` flags and the second auth path).
- `doctor` pairs the proxy `GetCurrentUser().PK` with the public-API `evaluate` `user_id`; they match today (same OnCall user PK).
- Enum label map (`complianceLabels`) and selectable option lists are in `oncall_compliance_commands.go` — adjust if the backend's valid values differ.
- Tests cover the body mapping, validation guard, evaluation lookup, and label rendering. Reference docs regenerated.