### PR TITLE
feat(datasources): manage datasources as resources via REST-backed adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ internal/
 ├── providers/   Provider plugin system (interface, registry, self-registration)
 │   ├── alert/      Alert provider (rules, groups — read-only)
 │   ├── dashboards/ Dashboards provider (CRUD, search, versions, snapshot)
+│   ├── datasources/ Datasources-as-resources provider (TypedCRUD adapter over the legacy /api/datasources REST API; synthetic GVK datasource.grafana.app/v0alpha1 since Grafana Cloud does not expose datasources via /apis — exposed through `gcx resources`, no commands of its own)
 │   ├── faro/       Frontend Observability provider (apps CRUD, sourcemaps sub-resource) — CLI: `gcx frontend`
 │   ├── fleet/      Fleet Management provider (pipeline and collector resources)
 │   ├── instrumentation/  Instrumentation Hub provider (typed connect-go client, RMW with optimistic-lock, output codecs, helm formatter, enumerate helper)

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/grafana/gcx/internal/providers/alert"           // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/appo11y"         // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/dashboards"      // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/datasources"     // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/faro"            // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/fleet"           // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/instrumentation" // Provider registrations — blank imports trigger init() self-registration.

--- a/internal/datasources/apierror.go
+++ b/internal/datasources/apierror.go
@@ -3,6 +3,7 @@ package datasources
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -36,6 +37,13 @@ func (e *APIError) Error() string {
 
 func (e *APIError) HTTPStatusCode() int {
 	return e.StatusCode
+}
+
+// NotFound reports whether the error represents an HTTP 404 from the datasource
+// API. The resource adapter uses this to translate misses into Kubernetes-style
+// NotFound so the push pipeline falls through to Create.
+func (e *APIError) NotFound() bool {
+	return e.StatusCode == http.StatusNotFound
 }
 
 func (e *APIError) APIServiceName() string {

--- a/internal/datasources/client.go
+++ b/internal/datasources/client.go
@@ -1,6 +1,7 @@
 package datasources
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -20,20 +21,37 @@ const (
 	datasourceByNamePath = "/api/datasources/name/"
 )
 
-// Datasource holds the fields returned by the legacy Grafana datasource REST API.
+// Datasource holds the fields exchanged with the legacy Grafana datasource REST
+// API. The same struct is used for reads (list/get) and writes (create/update),
+// so write-only and optional fields carry omitempty to keep manifests clean.
+//
+// secureJsonData is write-only: the API never returns it on reads, so it is
+// absent from pulled manifests but honored on push when present.
+//
+//nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
 type Datasource struct {
-	UID             string `json:"uid"`
-	Name            string `json:"name"`
-	Type            string `json:"type"`
-	URL             string `json:"url"`
-	Access          string `json:"access"`
-	IsDefault       bool   `json:"isDefault"`
-	ReadOnly        bool   `json:"readOnly"`
-	Database        string `json:"database"`
-	BasicAuth       bool   `json:"basicAuth"`
-	WithCredentials bool   `json:"withCredentials"`
-	JSONData        any    `json:"jsonData"`
+	UID             string            `json:"uid,omitempty"`
+	Name            string            `json:"name"`
+	Type            string            `json:"type"`
+	URL             string            `json:"url,omitempty"`
+	Access          string            `json:"access,omitempty"`
+	Database        string            `json:"database,omitempty"`
+	User            string            `json:"user,omitempty"`
+	IsDefault       bool              `json:"isDefault,omitempty"`
+	ReadOnly        bool              `json:"readOnly,omitempty"`
+	BasicAuth       bool              `json:"basicAuth,omitempty"`
+	BasicAuthUser   string            `json:"basicAuthUser,omitempty"`
+	WithCredentials bool              `json:"withCredentials,omitempty"`
+	JSONData        map[string]any    `json:"jsonData,omitempty"`
+	SecureJSONData  map[string]string `json:"secureJsonData,omitempty"`
 }
+
+// GetResourceName returns the datasource UID, which serves as the stable
+// resource identity (metadata.name) in the resources pipeline.
+func (d Datasource) GetResourceName() string { return d.UID }
+
+// SetResourceName restores the UID from metadata.name after a round-trip.
+func (d *Datasource) SetResourceName(name string) { d.UID = name }
 
 // Client queries Grafana datasources via the NamespacedRESTConfig
 // transport, ensuring OAuth proxy mode and token refresh are respected.
@@ -94,6 +112,88 @@ func (c *Client) GetByUID(ctx context.Context, uid string) (*Datasource, error) 
 // GetByName returns the datasource with the given display name.
 func (c *Client) GetByName(ctx context.Context, name string) (*Datasource, error) {
 	return c.get(ctx, datasourceByNamePath+url.PathEscape(name), name)
+}
+
+// mutationResponse is the envelope returned by the legacy create/update
+// endpoints, e.g. {"datasource": {...}, "id": 1, "message": "Datasource added"}.
+type mutationResponse struct {
+	Datasource *Datasource `json:"datasource"`
+}
+
+// Create creates a new datasource via POST /api/datasources and returns the
+// persisted datasource as echoed back by the API.
+func (c *Client) Create(ctx context.Context, ds *Datasource) (*Datasource, error) {
+	return c.write(ctx, http.MethodPost, c.host+datasourcesPath, "create datasource", ds.UID, ds)
+}
+
+// Update updates the datasource identified by uid via PUT
+// /api/datasources/uid/{uid} and returns the persisted datasource.
+func (c *Client) Update(ctx context.Context, uid string, ds *Datasource) (*Datasource, error) {
+	return c.write(ctx, http.MethodPut, c.host+datasourceByUIDPath+url.PathEscape(uid), "update datasource", uid, ds)
+}
+
+// Delete removes the datasource identified by uid via DELETE
+// /api/datasources/uid/{uid}.
+func (c *Client) Delete(ctx context.Context, uid string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.host+datasourceByUIDPath+url.PathEscape(uid), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to delete datasource: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := httputils.ReadResponseBody(resp.Body, maxResponseBytes)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return NewAPIError("delete datasource", uid, resp.StatusCode, body)
+	}
+
+	return nil
+}
+
+func (c *Client) write(ctx context.Context, method, endpoint, operation, identifier string, ds *Datasource) (*Datasource, error) {
+	payload, err := json.Marshal(ds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode datasource: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to %s: %w", operation, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := httputils.ReadResponseBody(resp.Body, maxResponseBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, NewAPIError(operation, identifier, resp.StatusCode, body)
+	}
+
+	var wrapped mutationResponse
+	if err := json.Unmarshal(body, &wrapped); err != nil {
+		return nil, fmt.Errorf("failed to parse %s response: %w", operation, err)
+	}
+	if wrapped.Datasource == nil {
+		return nil, fmt.Errorf("%s response did not include a datasource", operation)
+	}
+
+	return wrapped.Datasource, nil
 }
 
 func (c *Client) get(ctx context.Context, path, identifier string) (*Datasource, error) {

--- a/internal/datasources/client.go
+++ b/internal/datasources/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -135,27 +136,8 @@ func (c *Client) Update(ctx context.Context, uid string, ds *Datasource) (*Datas
 // Delete removes the datasource identified by uid via DELETE
 // /api/datasources/uid/{uid}.
 func (c *Client) Delete(ctx context.Context, uid string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.host+datasourceByUIDPath+url.PathEscape(uid), nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to delete datasource: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := httputils.ReadResponseBody(resp.Body, maxResponseBytes)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return NewAPIError("delete datasource", uid, resp.StatusCode, body)
-	}
-
-	return nil
+	_, err := c.do(ctx, http.MethodDelete, c.host+datasourceByUIDPath+url.PathEscape(uid), "delete datasource", uid, nil)
+	return err
 }
 
 func (c *Client) write(ctx context.Context, method, endpoint, operation, identifier string, ds *Datasource) (*Datasource, error) {
@@ -164,11 +146,53 @@ func (c *Client) write(ctx context.Context, method, endpoint, operation, identif
 		return nil, fmt.Errorf("failed to encode datasource: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(payload))
+	body, err := c.do(ctx, method, endpoint, operation, identifier, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var wrapped mutationResponse
+	if err := json.Unmarshal(body, &wrapped); err != nil {
+		return nil, fmt.Errorf("failed to parse %s response: %w", operation, err)
+	}
+	if wrapped.Datasource == nil {
+		return nil, fmt.Errorf("%s response did not include a datasource", operation)
+	}
+
+	return wrapped.Datasource, nil
+}
+
+func (c *Client) get(ctx context.Context, path, identifier string) (*Datasource, error) {
+	body, err := c.do(ctx, http.MethodGet, c.host+path, "get datasource", identifier, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var ds Datasource
+	if err := json.Unmarshal(body, &ds); err != nil {
+		return nil, fmt.Errorf("failed to parse datasource response: %w", err)
+	}
+
+	return &ds, nil
+}
+
+// do issues an HTTP request against the legacy datasource API, reads the
+// (size-limited) response body, and converts a non-200 status into an APIError.
+// operation names the action for error messages (e.g. "delete datasource");
+// a non-nil payload is sent as a JSON request body.
+func (c *Client) do(ctx context.Context, method, endpoint, operation, identifier string, payload []byte) ([]byte, error) {
+	var reqBody io.Reader
+	if payload != nil {
+		reqBody = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -185,42 +209,5 @@ func (c *Client) write(ctx context.Context, method, endpoint, operation, identif
 		return nil, NewAPIError(operation, identifier, resp.StatusCode, body)
 	}
 
-	var wrapped mutationResponse
-	if err := json.Unmarshal(body, &wrapped); err != nil {
-		return nil, fmt.Errorf("failed to parse %s response: %w", operation, err)
-	}
-	if wrapped.Datasource == nil {
-		return nil, fmt.Errorf("%s response did not include a datasource", operation)
-	}
-
-	return wrapped.Datasource, nil
-}
-
-func (c *Client) get(ctx context.Context, path, identifier string) (*Datasource, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.host+path, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get datasource: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := httputils.ReadResponseBody(resp.Body, maxResponseBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, NewAPIError("get datasource", identifier, resp.StatusCode, body)
-	}
-
-	var ds Datasource
-	if err := json.Unmarshal(body, &ds); err != nil {
-		return nil, fmt.Errorf("failed to parse datasource response: %w", err)
-	}
-
-	return &ds, nil
+	return body, nil
 }

--- a/internal/datasources/client_test.go
+++ b/internal/datasources/client_test.go
@@ -2,6 +2,8 @@ package datasources_test
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -59,4 +61,82 @@ func TestGetByUID_ReturnsTypedNotFoundError(t *testing.T) {
 	assert.Equal(t, "missing", apiErr.Identifier)
 	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
 	assert.Equal(t, "Datasource not found", apiErr.Message)
+	assert.True(t, apiErr.NotFound())
+}
+
+func TestCreate_PostsDatasourceAndParsesEnvelope(t *testing.T) {
+	var gotBody datasources.Datasource
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/datasources", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(r.Body)
+		if !assert.NoError(t, json.Unmarshal(body, &gotBody)) {
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":7,"message":"Datasource added","datasource":{"uid":"new-ds","name":"New DS","type":"prometheus"}}`))
+	}))
+
+	created, err := client.Create(context.Background(), &datasources.Datasource{
+		UID:            "new-ds",
+		Name:           "New DS",
+		Type:           "prometheus",
+		SecureJSONData: map[string]string{"basicAuthPassword": "secret"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "new-ds", created.UID)
+	assert.Equal(t, "New DS", created.Name)
+
+	// The request body carries the write-only secret.
+	assert.Equal(t, "secret", gotBody.SecureJSONData["basicAuthPassword"])
+}
+
+func TestUpdate_PutsToUIDPath(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/datasources/uid/my-ds", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"Datasource updated","datasource":{"uid":"my-ds","name":"Updated","type":"loki"}}`))
+	}))
+
+	updated, err := client.Update(context.Background(), "my-ds", &datasources.Datasource{UID: "my-ds", Name: "Updated", Type: "loki"})
+	require.NoError(t, err)
+	assert.Equal(t, "Updated", updated.Name)
+	assert.Equal(t, "loki", updated.Type)
+}
+
+func TestDelete_DeletesUIDPath(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/datasources/uid/my-ds", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"Data source deleted"}`))
+	}))
+
+	require.NoError(t, client.Delete(context.Background(), "my-ds"))
+}
+
+func TestDelete_ReturnsTypedErrorOnFailure(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Data source not found"}`))
+	}))
+
+	err := client.Delete(context.Background(), "missing")
+	require.Error(t, err)
+
+	var apiErr *datasources.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, "delete datasource", apiErr.Operation)
+	assert.True(t, apiErr.NotFound())
+}
+
+func TestIdentityRoundTrip(t *testing.T) {
+	ds := datasources.Datasource{UID: "abc"}
+	assert.Equal(t, "abc", ds.GetResourceName())
+
+	ds.SetResourceName("xyz")
+	assert.Equal(t, "xyz", ds.UID)
+	assert.Equal(t, "xyz", ds.GetResourceName())
 }

--- a/internal/datasources/query/influxdb_mode.go
+++ b/internal/datasources/query/influxdb_mode.go
@@ -28,8 +28,8 @@ func GetInfluxDBConfig(ctx context.Context, cfg config.NamespacedRESTConfig, uid
 		return InfluxDBConfig{Mode: "InfluxQL"}, fmt.Errorf("failed to get datasource %q: %w", uid, err)
 	}
 
-	jsonData, ok := ds.JSONData.(map[string]any)
-	if !ok || jsonData == nil {
+	jsonData := ds.JSONData
+	if jsonData == nil {
 		return InfluxDBConfig{Mode: "InfluxQL"}, nil
 	}
 

--- a/internal/providers/datasources/provider.go
+++ b/internal/providers/datasources/provider.go
@@ -1,0 +1,51 @@
+package datasources
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/spf13/cobra"
+)
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	providers.Register(&Provider{})
+}
+
+// Provider bridges Grafana datasources into the unified resources pipeline.
+// It contributes no commands of its own — the human-facing `gcx datasources`
+// command tree is mounted separately — but registers a resource adapter so
+// datasources can be managed declaratively via `gcx resources`.
+type Provider struct{}
+
+// Name returns the unique identifier for this provider.
+func (p *Provider) Name() string { return "datasources" }
+
+// ShortDesc returns a one-line description of the provider.
+func (p *Provider) ShortDesc() string { return "Manage Grafana datasources as resources" }
+
+// Commands returns the Cobra commands contributed by this provider. The
+// datasource resource type is exposed through `gcx resources`, so this provider
+// adds no commands of its own.
+func (p *Provider) Commands() []*cobra.Command { return nil }
+
+// Validate checks that the given provider configuration is valid. Datasources
+// use Grafana's built-in authentication, so no extra keys are required.
+func (p *Provider) Validate(cfg map[string]string) error { return nil }
+
+// ConfigKeys returns the configuration keys used by this provider. Datasources
+// use Grafana's built-in authentication and require no provider-specific keys.
+func (p *Provider) ConfigKeys() []providers.ConfigKey { return nil }
+
+// TypedRegistrations returns adapter registrations for the datasource resource type.
+func (p *Provider) TypedRegistrations() []adapter.Registration {
+	desc := StaticDescriptor()
+	return []adapter.Registration{
+		{
+			Factory:     NewLazyFactory(),
+			Descriptor:  desc,
+			GVK:         desc.GroupVersionKind(),
+			Schema:      DatasourceSchema(),
+			Example:     DatasourceExample(),
+			URLTemplate: "/connections/datasources/edit/{name}",
+		},
+	}
+}

--- a/internal/providers/datasources/resource_adapter.go
+++ b/internal/providers/datasources/resource_adapter.go
@@ -1,0 +1,165 @@
+// Package datasources bridges Grafana datasources into the unified resources
+// pipeline so they can be managed with `gcx resources get/pull/push/delete`.
+//
+// Unlike dashboards or folders, datasources are not exposed through Grafana's
+// Kubernetes-compatible /apis surface on Grafana Cloud. This provider therefore
+// backs a synthetic resource descriptor (datasource.grafana.app/v0alpha1,
+// DataSource) with the legacy /api/datasources REST API via a TypedCRUD
+// adapter, the same mechanism SLO and Synthetic Monitoring use.
+package datasources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsclient "github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Compile-time guard that the datasource domain type satisfies the full
+// ResourceIdentity contract (GetResourceName + SetResourceName), which TypedCRUD
+// relies on for name extraction and restoration across round-trips.
+var _ adapter.ResourceIdentity = &dsclient.Datasource{}
+
+func init() { //nolint:gochecknoinits // Natural key registration for cross-stack push identity matching.
+	adapter.RegisterNaturalKey(
+		StaticDescriptor().GroupVersionKind(),
+		adapter.SpecFieldKey("name"),
+	)
+}
+
+// StaticDescriptor returns the resource descriptor for datasources.
+func StaticDescriptor() resources.Descriptor {
+	return resources.Descriptor{
+		GroupVersion: schema.GroupVersion{
+			Group:   "datasource.grafana.app",
+			Version: "v0alpha1",
+		},
+		Kind:     "DataSource",
+		Singular: "datasource",
+		Plural:   "datasources",
+	}
+}
+
+// DatasourceSchema returns a JSON Schema for the datasource resource type.
+func DatasourceSchema() json.RawMessage {
+	return adapter.SchemaFromType[dsclient.Datasource](StaticDescriptor())
+}
+
+// DatasourceExample returns an example datasource manifest as JSON.
+func DatasourceExample() json.RawMessage {
+	example := map[string]any{
+		"apiVersion": StaticDescriptor().GroupVersion.String(),
+		"kind":       StaticDescriptor().Kind,
+		"metadata": map[string]any{
+			// metadata.name is the datasource UID — stable and user-chosen.
+			"name": "my-prometheus",
+		},
+		"spec": map[string]any{
+			"name":      "My Prometheus",
+			"type":      "prometheus",
+			"access":    "proxy",
+			"url":       "https://prometheus.example.com",
+			"isDefault": false,
+			"jsonData": map[string]any{
+				"httpMethod": "POST",
+			},
+			// secureJsonData is write-only and never returned on reads; include
+			// it on push to set credentials such as passwords or API keys.
+			"secureJsonData": map[string]any{
+				"basicAuthPassword": "REDACTED",
+			},
+		},
+	}
+	b, err := json.Marshal(example)
+	if err != nil {
+		panic(fmt.Sprintf("providers/datasources: failed to marshal example: %v", err))
+	}
+	return b
+}
+
+// NewTypedCRUD creates a TypedCRUD for datasources backed by the legacy REST API.
+func NewTypedCRUD(ctx context.Context, loader *providers.ConfigLoader) (*adapter.TypedCRUD[dsclient.Datasource], internalconfig.NamespacedRESTConfig, error) {
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to load REST config for datasources: %w", err)
+	}
+
+	client, err := dsclient.NewClient(cfg)
+	if err != nil {
+		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to create datasource client: %w", err)
+	}
+
+	crud := &adapter.TypedCRUD[dsclient.Datasource]{
+		ListFn: adapter.LimitedListFn(func(ctx context.Context) ([]dsclient.Datasource, error) {
+			items, err := client.List(ctx)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]dsclient.Datasource, 0, len(items))
+			for _, item := range items {
+				out = append(out, *item)
+			}
+			return out, nil
+		}),
+		GetFn: func(ctx context.Context, name string) (*dsclient.Datasource, error) {
+			ds, err := client.GetByUID(ctx, name)
+			if err != nil {
+				return nil, mapNotFound(name, err)
+			}
+			return ds, nil
+		},
+		CreateFn: func(ctx context.Context, ds *dsclient.Datasource) (*dsclient.Datasource, error) {
+			warnIfSecretMissing(ds)
+			created, err := client.Create(ctx, ds)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create datasource: %w", err)
+			}
+			return created, nil
+		},
+		UpdateFn: func(ctx context.Context, name string, ds *dsclient.Datasource) (*dsclient.Datasource, error) {
+			warnIfSecretMissing(ds)
+			updated, err := client.Update(ctx, name, ds)
+			if err != nil {
+				return nil, fmt.Errorf("failed to update datasource %q: %w", name, err)
+			}
+			return updated, nil
+		},
+		DeleteFn: func(ctx context.Context, name string) error {
+			return client.Delete(ctx, name)
+		},
+		Namespace:   cfg.Namespace,
+		StripFields: []string{"uid", "readOnly"},
+		Descriptor:  StaticDescriptor(),
+	}
+	return crud, cfg, nil
+}
+
+// NewLazyFactory returns an adapter.Factory that loads its config lazily from
+// the default config file when invoked.
+func NewLazyFactory() adapter.Factory {
+	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
+		var loader providers.ConfigLoader
+		crud, _, err := NewTypedCRUD(ctx, &loader)
+		if err != nil {
+			return nil, err
+		}
+		return crud.AsAdapter(), nil
+	}
+}
+
+// mapNotFound translates a datasource API 404 into adapter.ErrNotFound so the
+// push pipeline's upsert path can fall through to Create.
+func mapNotFound(name string, err error) error {
+	var apiErr *dsclient.APIError
+	if errors.As(err, &apiErr) && apiErr.NotFound() {
+		return fmt.Errorf("datasource %q: %w", name, adapter.ErrNotFound)
+	}
+	return err
+}

--- a/internal/providers/datasources/resource_adapter_test.go
+++ b/internal/providers/datasources/resource_adapter_test.go
@@ -1,0 +1,61 @@
+package datasources_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	dsclient "github.com/grafana/gcx/internal/datasources"
+	provds "github.com/grafana/gcx/internal/providers/datasources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaticDescriptor(t *testing.T) {
+	desc := provds.StaticDescriptor()
+	assert.Equal(t, "datasource.grafana.app", desc.GroupVersion.Group)
+	assert.Equal(t, "v0alpha1", desc.GroupVersion.Version)
+	assert.Equal(t, "DataSource", desc.Kind)
+	assert.Equal(t, "datasource", desc.Singular)
+	assert.Equal(t, "datasources", desc.Plural)
+}
+
+func TestProviderTypedRegistrations(t *testing.T) {
+	regs := (&provds.Provider{}).TypedRegistrations()
+	require.Len(t, regs, 1)
+
+	reg := regs[0]
+	assert.Equal(t, provds.StaticDescriptor().GroupVersionKind(), reg.GVK)
+	// CONSTITUTION: every registration must carry a non-nil Schema, and a
+	// non-nil Example for writable resources.
+	require.NotNil(t, reg.Schema)
+	require.NotNil(t, reg.Example)
+	require.NotNil(t, reg.Factory)
+}
+
+func TestDatasourceSchemaIsValidEnvelope(t *testing.T) {
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(provds.DatasourceSchema(), &schema))
+
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	for _, key := range []string{"apiVersion", "kind", "metadata", "spec"} {
+		assert.Contains(t, props, key)
+	}
+}
+
+func TestDatasourceExampleIsValidManifest(t *testing.T) {
+	var example map[string]any
+	require.NoError(t, json.Unmarshal(provds.DatasourceExample(), &example))
+
+	assert.Equal(t, provds.StaticDescriptor().GroupVersion.String(), example["apiVersion"])
+	assert.Equal(t, "DataSource", example["kind"])
+	require.Contains(t, example, "metadata")
+	require.Contains(t, example, "spec")
+
+	// The example must decode into the domain type so it stays a valid template.
+	spec, err := json.Marshal(example["spec"])
+	require.NoError(t, err)
+	var ds dsclient.Datasource
+	require.NoError(t, json.Unmarshal(spec, &ds))
+	assert.Equal(t, "prometheus", ds.Type)
+}

--- a/internal/providers/datasources/secrets.go
+++ b/internal/providers/datasources/secrets.go
@@ -1,0 +1,57 @@
+package datasources
+
+import (
+	"log/slog"
+
+	dsclient "github.com/grafana/gcx/internal/datasources"
+)
+
+// secretRequiringTypes lists datasource types that typically need credentials
+// (database passwords, API keys) supplied via secureJsonData. It is a
+// best-effort heuristic used only to warn on push — never to block it.
+//
+//nolint:gochecknoglobals // Static lookup table for the warn-only secret heuristic.
+var secretRequiringTypes = map[string]bool{
+	"mysql":                         true,
+	"postgres":                      true,
+	"grafana-postgresql-datasource": true,
+	"mssql":                         true,
+	"elasticsearch":                 true,
+	"influxdb":                      true,
+	"cloudwatch":                    true,
+	"grafana-athena-datasource":     true,
+	"grafana-redshift-datasource":   true,
+	"grafana-x-ray-datasource":      true,
+	"grafana-bigquery-datasource":   true,
+	"grafana-snowflake-datasource":  true,
+	"grafana-mongodb-datasource":    true,
+	"grafana-clickhouse-datasource": true,
+	"grafana-databricks-datasource": true,
+}
+
+// secretLikelyRequired reports whether ds is being pushed without any
+// secureJsonData even though its configuration suggests credentials are needed:
+// either basic auth is enabled (and thus needs a password) or its type is one
+// that conventionally requires a secret. Secrets are write-only and absent from
+// pulled manifests, so this catches the common pull→push round-trip that would
+// silently drop credentials.
+func secretLikelyRequired(ds *dsclient.Datasource) bool {
+	if len(ds.SecureJSONData) > 0 {
+		return false
+	}
+	return ds.BasicAuth || secretRequiringTypes[ds.Type]
+}
+
+// warnIfSecretMissing emits a warning when a push is unlikely to carry the
+// credentials the datasource needs. It does not prevent the push.
+func warnIfSecretMissing(ds *dsclient.Datasource) {
+	if !secretLikelyRequired(ds) {
+		return
+	}
+	slog.Warn(
+		"datasource pushed without secureJsonData; credentials such as passwords or API keys are write-only and will not be set — add spec.secureJsonData to configure them",
+		"name", ds.Name,
+		"type", ds.Type,
+		"uid", ds.UID,
+	)
+}

--- a/internal/providers/datasources/secrets_test.go
+++ b/internal/providers/datasources/secrets_test.go
@@ -1,0 +1,63 @@
+//nolint:testpackage // Internal test: exercises unexported helpers (secretLikelyRequired, mapNotFound).
+package datasources
+
+import (
+	"net/http"
+	"testing"
+
+	dsclient "github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretLikelyRequired(t *testing.T) {
+	tests := []struct {
+		name string
+		ds   dsclient.Datasource
+		want bool
+	}{
+		{
+			name: "public datasource without auth",
+			ds:   dsclient.Datasource{Type: "prometheus"},
+			want: false,
+		},
+		{
+			name: "basic auth without secret",
+			ds:   dsclient.Datasource{Type: "prometheus", BasicAuth: true},
+			want: true,
+		},
+		{
+			name: "basic auth with secret",
+			ds:   dsclient.Datasource{Type: "prometheus", BasicAuth: true, SecureJSONData: map[string]string{"basicAuthPassword": "x"}},
+			want: false,
+		},
+		{
+			name: "secret-requiring type without secret",
+			ds:   dsclient.Datasource{Type: "postgres"},
+			want: true,
+		},
+		{
+			name: "secret-requiring type with secret",
+			ds:   dsclient.Datasource{Type: "postgres", SecureJSONData: map[string]string{"password": "x"}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := tt.ds
+			assert.Equal(t, tt.want, secretLikelyRequired(&ds))
+		})
+	}
+}
+
+func TestMapNotFound(t *testing.T) {
+	notFound := dsclient.NewAPIError("get datasource", "x", http.StatusNotFound, []byte(`{"message":"nope"}`))
+	require.ErrorIs(t, mapNotFound("x", notFound), adapter.ErrNotFound)
+
+	forbidden := dsclient.NewAPIError("get datasource", "x", http.StatusForbidden, []byte(`{"message":"nope"}`))
+	mapped := mapNotFound("x", forbidden)
+	require.Error(t, mapped)
+	assert.NotErrorIs(t, mapped, adapter.ErrNotFound)
+}


### PR DESCRIPTION
## Summary
- Makes `gcx resources get/pull/push/delete datasources` work, unblocking datasources-as-code (e.g. migrating from grizzly + jsonnet, the request in #878).
- Root cause (verified against a live Grafana Cloud stack): datasources are **not** exposed through Grafana's Kubernetes-compatible `/apis` surface on Cloud — `/apis` lists no `*.datasource.grafana.app` group — so the resources pipeline had no GVK to route to.
- Fix: a datasources provider bridges them into the unified resources pipeline via a `TypedCRUD` adapter (same mechanism SLO / Synthetic Monitoring use), backed by the legacy `/api/datasources` REST API and registered under a synthetic descriptor `datasource.grafana.app/v0alpha1` (Kind `DataSource`). It resolves through the discovery registry even though no matching K8s group exists on the server.

## Changes
- `internal/datasources/client.go` — add `Create`/`Update`/`Delete`, widen the `Datasource` struct to writable fields, add `ResourceIdentity` (UID = `metadata.name`).
- `internal/datasources/apierror.go` — `NotFound()` helper so 404 maps to a Kubernetes-style NotFound and the push upsert falls through to create.
- `internal/providers/datasources/` — new provider: descriptor, schema, example, `TypedCRUD` factory, registration. Contributes no commands of its own; the human-facing `gcx datasources` tree is unchanged.
- `cmd/gcx/root/command.go` — blank-import the provider for self-registration.
- `internal/datasources/query/influxdb_mode.go` — adapt to `JSONData` now being `map[string]any`.

## Design notes
- **Secrets**: `secureJsonData` is write-only (the API never returns it). It is absent from pulled manifests, honored on push, and a best-effort warning fires when a push omits credentials a datasource likely needs (basic auth on, or a known secret-requiring type).
- **Idempotent round-trip**: server-managed fields are stripped — `uid` (carried by `metadata.name`) and `readOnly` — so pull → edit → push is stable.
- **GVK** `datasource.grafana.app/v0alpha1` matches Grafana's intended K8s naming, so manifests stay forward-compatible if the native API later lands on Cloud.

## Test Plan
- [x] Unit tests for client write methods, identity round-trip, schema/example envelope, not-found mapping, and the secret heuristic.
- [x] `mise run lint` — 0 issues.
- [x] Affected packages pass (`resources`, `discovery`, `adapter`, `agent`, `providers`, both `datasources` trees, `cmd/gcx/resources`).
- [x] **Live verification** against a Grafana Cloud stack: `get` (list + single), `pull` (13 datasources → disk), `push` create, `push` update, `delete`, `schemas` — all succeed; secret warning fires/suppresses correctly. Test datasource cleaned up.
- [x] Reference docs regenerated — no drift.

Closes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)