### PR TITLE
build: lint in Go module mode, drop vendor/ requirement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Restore go vendors
+      - name: Restore go module cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -51,7 +51,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Restore go vendors
+      - name: Restore go module cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # 5.0.5
         with:
           path: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   go: "1.26"
-  modules-download-mode: vendor
+  modules-download-mode: readonly
 
 linters:
   default: all

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,11 +44,12 @@ Two tiers: **K8s resource tier** (dashboards, folders via `/apis`) and **Cloud p
 mise run build       # Build to bin/gcx
 mise run tests       # Run all tests with race detection
 mise run lint        # Run golangci-lint
+mise run gate        # lint + tests + build (no docs) — fast pre-push gate for code changes
 mise run all         # lint + tests + build + docs
 mise run docs        # Generate + build all documentation
 ```
 
-**Without mise**: replace with direct Go commands — `go build -buildvcs=false -o bin/gcx ./cmd/gcx/` and `go test ./...`. Always build to `bin/gcx`.
+**Without mise**: replace with direct Go commands — `go build -buildvcs=false -o bin/gcx ./cmd/gcx/` and `go test ./...`. Always build to `bin/gcx`. Lint runs in Go **module mode** (`golangci-lint`'s `modules-download-mode: readonly`), so no `vendor/` directory is needed locally — the module cache (`go mod download`, run automatically on worktree entry) is sufficient.
 
 > **Agent environments**: always prefix with `GCX_AGENT_MODE=false` — agent-mode auto-detection changes output defaults in `mise run docs`, producing wrong CLI reference docs.
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -96,7 +96,7 @@
 1. **Kubernetes client libraries as foundation.** Grafana 12+ exposes a K8s-compatible
    API. Using `k8s.io/client-go` directly gives gcx pagination, discovery,
    dry-run, error handling, and unstructured object support for free. The trade-off
-   is a large vendor directory, but the implementation savings are substantial.
+   is a large dependency graph, but the implementation savings are substantial.
 
 2. **No public Go API.** Everything is under `internal/`. gcx is a CLI tool,
    not a library. This gives the team freedom to refactor without worrying about
@@ -106,9 +106,11 @@
    API's discovery endpoint, not hardcoded. This means new resource types added to
    Grafana are automatically available without gcx code changes.
 
-4. **Vendored dependencies.** All Go dependencies are committed to `vendor/`. This
-   ensures reproducible builds without network access and makes the full dependency
-   graph auditable in code review.
+4. **Go module mode.** Dependencies are resolved from the Go module cache (`go mod
+   download`), not a committed `vendor/` tree. `go.mod`/`go.sum` pin exact versions
+   and hashes, so builds are reproducible and the dependency graph is auditable in
+   code review without the overhead of vendoring. Lint runs with
+   `modules-download-mode: readonly`, matching `go build`/`go test`.
 
 ---
 
@@ -484,8 +486,8 @@ and checked for drift in CI.
    resource transformation from I/O, making it easy to add new transformations
    without touching pipeline code.
 
-6. **Reproducible builds.** Vendored dependencies, mise, and CI caching ensure
-   identical builds across environments.
+6. **Reproducible builds.** `go.mod`/`go.sum` version pinning, mise toolchain pinning,
+   and CI module caching ensure identical builds across environments.
 
 7. **Serve command.** The local development server with live reload, reverse proxy,
    and dashboard interception is a genuinely differentiating feature for

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -139,7 +139,6 @@ gcx/
 │   ├── default-config.yaml   # Default config fixture
 │   └── folder.yaml           # Sample resource manifest
 │
-├── vendor/                   # Vendored Go dependencies (committed to repo)
 ├── bin/                      # Build output (gitignored)
 ├── build/                    # mkdocs output (gitignored)
 │
@@ -182,7 +181,7 @@ tool versions are used regardless of shell configuration.
 | `mise run install` | Copies binary to `$GOPATH/bin` |
 | `mise run tests` | `go test -v ./...` (all packages, with race detection implied) |
 | `mise run lint` | Runs `golangci-lint run -c .golangci.yaml` |
-| `mise run deps` | `go mod vendor` + `uv pip install -r requirements.txt` |
+| `mise run deps` | `go mod download` + `uv pip install -r requirements.txt` |
 | `mise run docs` | Runs `reference` then `mkdocs build` → `build/documentation/` |
 | `mise run reference` | Runs all four doc-generation scripts |
 | `mise run reference-drift` | Re-generates docs, fails if `git diff` finds changes |
@@ -190,7 +189,7 @@ tool versions are used regardless of shell configuration.
 | `mise run test-env-up` | `docker-compose up -d` + health-wait loop |
 | `mise run test-env-down` | `docker-compose down` |
 | `mise run test-env-clean` | `docker-compose down -v` (removes volumes) |
-| `mise run clean` | Removes `bin/`, `vendor/`, `.venv/` |
+| `mise run clean` | Removes `bin/`, `.venv/` |
 
 ### Version injection
 
@@ -232,7 +231,7 @@ uv = "latest"
 ```
 
 A new contributor runs `mise install` to get the full toolchain, then `mise run deps`
-to install Go vendors and Python packages. CI uses `jdx/mise-action` to replicate
+to download Go modules and install Python packages. CI uses `jdx/mise-action` to replicate
 this.
 
 ---
@@ -295,13 +294,16 @@ the release workflow.
 
 ## 5. Dependency Management
 
-**Strategy: vendoring.** All dependencies are committed to `vendor/` and
-`go mod vendor` is the canonical way to update them. The linter runs with
-`modules-download-mode: vendor`, and the build uses vendored code.
+**Strategy: Go module mode.** Dependencies are resolved from the Go module cache,
+not a committed `vendor/` tree. `go mod download` populates the cache (`mise run deps`),
+and `go.mod`/`go.sum` are the canonical record. The linter runs with
+`modules-download-mode: readonly`, matching `go build`/`go test`.
 
-**Rationale**: Vendoring ensures reproducible builds without a module proxy,
-avoids network dependencies in CI, and makes the full dependency graph auditable
-in code review.
+**Rationale**: `go.sum` already pins exact versions and hashes for reproducible,
+auditable builds, so a vendored copy was redundant overhead (~99MB regenerated on
+every CI run and worktree). The module cache is shared across builds and cached in
+CI by `go.sum` key. Run `go mod vendor` manually only if you need a local vendored
+tree (e.g. fully offline work); it is never required.
 
 ### Dependency categories
 
@@ -401,7 +403,7 @@ set of linters that conflict with the project's style:
 - `depguard` denies `github.com/davecgh/go-spew` — debug statements must
   be removed before merging
 - `revive`'s `var-naming` rule is disabled (allows non-standard naming)
-- `modules-download-mode: vendor` — uses vendored deps, not module cache
+- `modules-download-mode: readonly` — resolves deps from the module cache (no `vendor/`)
 
 ---
 
@@ -505,6 +507,6 @@ git tag v1.2.3 && git push --tags
 ### Add a New Dependency
 ```bash
 go get github.com/some/package
-mise run deps                 # runs go mod vendor to vendor new dep
-git add vendor/ go.mod go.sum
+go mod tidy                   # update go.mod/go.sum
+git add go.mod go.sum
 ```

--- a/mise.toml
+++ b/mise.toml
@@ -84,7 +84,7 @@ uv pip install --system -q -r requirements.txt
 
 [tasks.clean]
 description = "Remove build artifacts"
-run = "rm -rf bin vendor .venv"
+run = "rm -rf bin .venv"
 
 [tasks.setup]
 description = "Set up local development environment (commit template, etc.)"

--- a/mise.toml
+++ b/mise.toml
@@ -15,6 +15,10 @@ uv = "latest"
 description = "Validate skills, lint, test, build, and generate docs"
 depends = ["validate-skills", "lint", "tests", "build", "docs"]
 
+[tasks.gate]
+description = "Fast pre-push gate for code changes: lint + tests + build (no docs)"
+depends = ["lint", "tests", "build"]
+
 # =============================================================================
 # DEVELOPMENT
 # =============================================================================
@@ -74,7 +78,7 @@ description = "Install Go and Python dependencies"
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
-go mod vendor
+go mod download
 uv pip install --system -q -r requirements.txt
 """
 


### PR DESCRIPTION
Closes nothing — build/tooling cleanup.

## What

`golangci-lint` was pinned to `modules-download-mode: vendor`, which forced a 99 MB `vendor/` directory to exist before linting could run. But `vendor/` is gitignored and regenerated on every CI run (and every fresh worktree), while `go build`/`go test` already work in Go **module mode**. So the vendor copy was pure overhead — and it broke linting in fresh worktrees that only ran `go mod download` (the common agent/worktree setup), surfacing as `inconsistent vendoring`.

This switches the whole project to module mode.

## Changes

- **`.golangci.yaml`**: `modules-download-mode: vendor` → `readonly`. Lint now uses the module cache (warmed by `go mod download`); no `vendor/` needed.
- **`mise.toml` `deps`**: `go mod vendor` → `go mod download`. This task is invoked by every CI/release/docs job, so the whole project moves to module mode in one edit. CI keeps its existing `~/go/pkg/mod` + `~/.cache/go-build` cache.
- **`mise.toml`**: add a `gate` task (`lint + tests + build`, no docs) for fast pre-push checks on code-only changes.
- **`.github/workflows/ci.yaml`**: rename the now-misnamed `Restore go vendors` cache steps → `Restore go module cache` (cosmetic).
- **`AGENTS.md`**: document the `gate` task and the module-mode / no-vendor behavior.

## Verification

- `GCX_AGENT_MODE=false mise run all` passes in a **fresh worktree with no `vendor/`** (lint: 0 issues; tests/build/docs green; ~87s, single parallel pass).
- `go build ./...` and `go test ./...` already work without `vendor/`.
- Confirmed no `-mod=vendor` / `GOFLAGS` anywhere; `.goreleaser.yaml` + `release.yaml` build in module mode via `mise run deps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)