### PR TITLE
chore(release): v0.4.2 changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "gcx",
       "source": "./claude-plugin",
       "description": "Debug, explore, and instrument with Grafana using gcx CLI",
-      "version": "0.4.1"
+      "version": "0.4.2"
     }
   ]
 }

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,14 +1,6 @@
-- **Breaking:** `--log-http-payload` has been renamed to `--insecure-log-http-payload`. The old flag name now exits with an error naming the replacement. Payload-dump behavior is unchanged — credentials, cookies, OAuth refresh tokens, and request bodies still appear in the dump when the flag is set. A startup warning is now printed to stderr when the flag is active.
-- **Breaking:** `gcx dev serve --address` now defaults to `127.0.0.1` (loopback) instead of `0.0.0.0`. Users who need LAN or remote access should pass `--address 0.0.0.0` explicitly. The WebSocket livereload endpoint now rejects cross-origin requests from hosts other than `localhost`, `127.0.0.1`, `[::1]`, or the configured listen address.
-- **Soft-breaking:** Custom Rego rules loaded via `gcx dev lint --rules` can no longer call `http.send`, any `net.*` builtin, or `opa.runtime`. No flag is provided to re-enable them. Bundled rules are unaffected.
-- Added `--jq` for inline JSON transformation and improved agent-mode hints.
-- Added OAuth login support for agent and non-interactive workflows.
-- Improved config performance with lazy keychain checks and StackID caching.
-- Moved stack management under the `gcx cloud stacks` command group.
-- Added App O11y service list, get, map, and operation breakdown commands.
-- Added Instrumentation Hub `gcx instrumentation check` diagnostics.
-- Expanded Assistant investigations with Lodestone v2 capability detection.
-- Expanded Knowledge Graph diagnose, meta metrics, and model-rules support.
-- Improved IRM incident filtering, paging, and OnCall escalation output.
-- Added metrics instant-query timestamps and richer Tempo tag-value output.
-- Hardened local debug surfaces and JSON error output for agent workflows.
+- Add Athena datasource provider (query, list catalogs/databases/tables, describe-table)
+- Introduce shared SQL query package, refactoring ClickHouse onto it
+- Synthetic Monitoring now syncs via a Grafana datasource proxy client
+- Set X-Grafana-Caller-Id header on all datasource queries
+- Refine output formatting (format and jq handling)
+- Remove obsolete publish-technical-documentation workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.4.2 (2026-06-29)
+
+- Add Athena datasource provider (query, list catalogs/databases/tables, describe-table)
+- Introduce shared SQL query package, refactoring ClickHouse onto it
+- Synthetic Monitoring now syncs via a Grafana datasource proxy client
+- Set X-Grafana-Caller-Id header on all datasource queries
+- Refine output formatting (format and jq handling)
+- Remove obsolete publish-technical-documentation workflows
+
+
 ## Unreleased
 
 ## v0.4.1 (2026-06-23)

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcx",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Debug, explore, and instrument with Grafana using gcx CLI",
   "keywords": ["grafana", "observability", "monitoring", "prometheus", "loki", "dashboards"],
   "author": {


### PR DESCRIPTION
Release v0.4.2

## Changelog

- Add Athena datasource provider (query, list catalogs/databases/tables, describe-table)
- Introduce shared SQL query package, refactoring ClickHouse onto it
- Synthetic Monitoring now syncs via a Grafana datasource proxy client
- Set X-Grafana-Caller-Id header on all datasource queries
- Refine output formatting (format and jq handling)
- Remove obsolete publish-technical-documentation workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)