### PR TITLE
kg: apply timerange to entity scopes lookup

### DIFF
--- a/docs/reference/cli/gcx_kg_entities_inspect.md
+++ b/docs/reference/cli/gcx_kg_entities_inspect.md
@@ -36,7 +36,7 @@ gcx kg entities inspect [Type--Name] [flags]
       --open                               Open the entity in the RCA Workbench in your browser
   -o, --output string                      Output format. One of: agents, json, yaml (default "json")
       --share-link                         Print the RCA Workbench URL for this entity to stderr
-      --since string                       Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --since string                       Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)
       --site string                        Site scope (run 'gcx kg meta scopes' to see valid values)
       --to string                          End time (RFC3339, Unix timestamp, or relative like 'now')
       --type string                        Entity type (run 'gcx kg meta schema' to see available types)

--- a/docs/reference/cli/gcx_kg_entities_list.md
+++ b/docs/reference/cli/gcx_kg_entities_list.md
@@ -43,7 +43,7 @@ gcx kg entities list [flags]
   -o, --output string          Output format. One of: agents, json, table, yaml (default "table")
       --page int               Page number (0-based)
       --property stringArray   Filter by property: name=value (exact) or name=~value (contains); repeatable (run 'gcx kg meta schema' to list property names)
-      --since string           Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --since string           Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)
       --site string            Site scope (run 'gcx kg meta scopes' to see valid values)
       --to string              End time (RFC3339, Unix timestamp, or relative like 'now')
       --type string            Entity type to list (run 'gcx kg meta schema' to see available types)

--- a/docs/reference/cli/gcx_kg_entities_query.md
+++ b/docs/reference/cli/gcx_kg_entities_query.md
@@ -50,7 +50,7 @@ gcx kg entities query <cypher-query> [flags]
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
       --page int        Page number (0-based)
-      --since string    Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --since string    Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)
       --to string       End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 

--- a/docs/reference/cli/gcx_kg_insights_chart.md
+++ b/docs/reference/cli/gcx_kg_insights_chart.md
@@ -17,7 +17,7 @@ gcx kg insights chart [Type--Name] [flags]
       --label stringArray   Extra assertion label as key=value (repeatable; e.g. asserts_resource_type=jvm:live_threads to narrow ResourceRateAnomaly to a specific resource)
       --name string         Entity name
       --namespace string    Namespace scope
-      --since string        Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --since string        Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)
       --site string         Site scope
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
       --type string         Entity type

--- a/docs/reference/cli/gcx_kg_insights_sources.md
+++ b/docs/reference/cli/gcx_kg_insights_sources.md
@@ -17,7 +17,7 @@ gcx kg insights sources [Type--Name] [flags]
       --label stringArray   Assertion label as key=value (repeatable; typically copied from 'kg entities inspect' timeLines[].labels)
       --name string         Entity name
       --namespace string    Namespace scope
-      --since string        Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --since string        Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)
       --site string         Site scope
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
       --type string         Entity type

--- a/docs/reference/cli/gcx_kg_meta_all.md
+++ b/docs/reference/cli/gcx_kg_meta_all.md
@@ -14,7 +14,7 @@ gcx kg meta all [flags]
       --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
-      --since string    Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --since string    Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)
       --to string       End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 

--- a/docs/reference/cli/gcx_kg_meta_schema.md
+++ b/docs/reference/cli/gcx_kg_meta_schema.md
@@ -14,7 +14,7 @@ gcx kg meta schema [flags]
       --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
-      --since string    Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --since string    Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)
       --to string       End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 

--- a/docs/reference/cli/gcx_kg_meta_scopes.md
+++ b/docs/reference/cli/gcx_kg_meta_scopes.md
@@ -9,10 +9,13 @@ gcx kg meta scopes [flags]
 ### Options
 
 ```
+      --from string     Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help            help for scopes
       --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+      --since string    Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --to string       End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_meta_scopes.md
+++ b/docs/reference/cli/gcx_kg_meta_scopes.md
@@ -14,7 +14,7 @@ gcx kg meta scopes [flags]
       --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
-      --since string    Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --since string    Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)
       --to string       End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 

--- a/docs/reference/cli/gcx_kg_summary.md
+++ b/docs/reference/cli/gcx_kg_summary.md
@@ -16,7 +16,7 @@ gcx kg summary [flags]
       --json string        Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --namespace string   Namespace scope
   -o, --output string      Output format. One of: agents, json, yaml (default "json")
-      --since string       Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)
+      --since string       Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)
       --site string        Site scope
       --to string          End time (RFC3339, Unix timestamp, or relative like 'now')
       --type string        Limit to a specific entity type

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -407,17 +407,24 @@ func (c *Client) GetRelabelRules(ctx context.Context, t RelabelRuleType) (map[st
 // Entity operations
 // ---------------------------------------------------------------------------
 
-// GetEntityInfo retrieves rich entity information by type, name, and optional scope.
-func (c *Client) GetEntityInfo(ctx context.Context, entityType, name string, scope map[string]string, startMs, endMs int64) (*GraphEntity, error) {
+// timeRangeParams returns query params with start/end set for the given window,
+// defaulting to the last hour when either bound is unset.
+func timeRangeParams(startMs, endMs int64) url.Values {
 	if startMs == 0 || endMs == 0 {
 		endMs = time.Now().UnixMilli()
 		startMs = endMs - 3600000
 	}
 	q := url.Values{}
-	q.Set("entity_type", entityType)
-	q.Set("entity_name", name)
 	q.Set("start", strconv.FormatInt(startMs, 10))
 	q.Set("end", strconv.FormatInt(endMs, 10))
+	return q
+}
+
+// GetEntityInfo retrieves rich entity information by type, name, and optional scope.
+func (c *Client) GetEntityInfo(ctx context.Context, entityType, name string, scope map[string]string, startMs, endMs int64) (*GraphEntity, error) {
+	q := timeRangeParams(startMs, endMs)
+	q.Set("entity_type", entityType)
+	q.Set("entity_name", name)
 	for k, v := range scope {
 		q.Set(k, v)
 	}
@@ -431,15 +438,9 @@ func (c *Client) GetEntityInfo(ctx context.Context, entityType, name string, sco
 // LookupEntity retrieves entity details from Prometheus alert label params.
 // Returns nil, nil on 204 No Content (entity not found).
 func (c *Client) LookupEntity(ctx context.Context, entityType, name string, scope map[string]string, startMs, endMs int64) (*GraphEntity, error) {
-	if startMs == 0 || endMs == 0 {
-		endMs = time.Now().UnixMilli()
-		startMs = endMs - 3600000
-	}
-	q := url.Values{}
+	q := timeRangeParams(startMs, endMs)
 	q.Set("asserts_entity_type", entityType)
 	q.Set("asserts_entity_name", name)
-	q.Set("start", strconv.FormatInt(startMs, 10))
-	q.Set("end", strconv.FormatInt(endMs, 10))
 	for k, v := range scope {
 		q.Set(k, v)
 	}
@@ -482,13 +483,7 @@ func (c *Client) CountEntityTypes(ctx context.Context, startMs, endMs int64, sc 
 
 // ListEntityScopes retrieves the available scope dimension values.
 func (c *Client) ListEntityScopes(ctx context.Context, startMs, endMs int64) (map[string][]string, error) {
-	if startMs == 0 || endMs == 0 {
-		endMs = time.Now().UnixMilli()
-		startMs = endMs - 3600000
-	}
-	q := url.Values{}
-	q.Set("start", strconv.FormatInt(startMs, 10))
-	q.Set("end", strconv.FormatInt(endMs, 10))
+	q := timeRangeParams(startMs, endMs)
 	var wrapper struct {
 		ScopeValues map[string][]string `json:"scopeValues"`
 	}

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -481,11 +481,18 @@ func (c *Client) CountEntityTypes(ctx context.Context, startMs, endMs int64, sc 
 }
 
 // ListEntityScopes retrieves the available scope dimension values.
-func (c *Client) ListEntityScopes(ctx context.Context) (map[string][]string, error) {
+func (c *Client) ListEntityScopes(ctx context.Context, startMs, endMs int64) (map[string][]string, error) {
+	if startMs == 0 || endMs == 0 {
+		endMs = time.Now().UnixMilli()
+		startMs = endMs - 3600000
+	}
+	q := url.Values{}
+	q.Set("start", strconv.FormatInt(startMs, 10))
+	q.Set("end", strconv.FormatInt(endMs, 10))
 	var wrapper struct {
 		ScopeValues map[string][]string `json:"scopeValues"`
 	}
-	if err := c.getJSON(ctx, scopesPath, &wrapper); err != nil {
+	if err := c.getJSON(ctx, scopesPath+"?"+q.Encode(), &wrapper); err != nil {
 		return nil, fmt.Errorf("kg: list entity scopes: %w", err)
 	}
 	return wrapper.ScopeValues, nil

--- a/internal/providers/kg/client_test.go
+++ b/internal/providers/kg/client_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -193,6 +194,50 @@ func TestClient_CountEntityTypes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(42), counts["Service"])
 	assert.Equal(t, int64(5), counts["Namespace"])
+}
+
+func TestClient_ListEntityScopes(t *testing.T) {
+	t.Run("passes explicit time window as query params", func(t *testing.T) {
+		var gotStart, gotEnd string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Contains(t, r.URL.Path, "entity_scope")
+			gotStart = r.URL.Query().Get("start")
+			gotEnd = r.URL.Query().Get("end")
+			writeJSON(w, map[string]any{
+				"scopeValues": map[string][]string{
+					"env":       {"prod"},
+					"namespace": {"loki-prod-029"},
+				},
+			})
+		}))
+		defer server.Close()
+
+		client := newTestClient(t, server)
+		scopes, err := client.ListEntityScopes(t.Context(), 1000, 2000)
+		require.NoError(t, err)
+		assert.Equal(t, "1000", gotStart)
+		assert.Equal(t, "2000", gotEnd)
+		assert.Equal(t, []string{"prod"}, scopes["env"])
+		assert.Equal(t, []string{"loki-prod-029"}, scopes["namespace"])
+	})
+
+	t.Run("defaults to a one-hour window when unset", func(t *testing.T) {
+		var gotStart, gotEnd int64
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotStart, _ = strconv.ParseInt(r.URL.Query().Get("start"), 10, 64)
+			gotEnd, _ = strconv.ParseInt(r.URL.Query().Get("end"), 10, 64)
+			writeJSON(w, map[string]any{"scopeValues": map[string][]string{}})
+		}))
+		defer server.Close()
+
+		client := newTestClient(t, server)
+		_, err := client.ListEntityScopes(t.Context(), 0, 0)
+		require.NoError(t, err)
+		assert.Positive(t, gotStart)
+		assert.Positive(t, gotEnd)
+		assert.Equal(t, int64(3600000), gotEnd-gotStart, "default window should span one hour")
+	})
 }
 
 func TestClient_UploadPromRules(t *testing.T) {

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -50,7 +50,7 @@ func (f *scopeFlags) register(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.site, "site", "", "Site scope")
 	cmd.Flags().StringVar(&f.from, "from", "", "Start time (RFC3339, Unix timestamp, or relative like 'now-1h')")
 	cmd.Flags().StringVar(&f.to, "to", "", "End time (RFC3339, Unix timestamp, or relative like 'now')")
-	cmd.Flags().StringVar(&f.since, "since", "", "Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)")
+	cmd.Flags().StringVar(&f.since, "since", "", "Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)")
 }
 
 func (f *scopeFlags) resolveTime() (int64, int64, error) {
@@ -116,7 +116,10 @@ func (f *scopeFlags) validateScopes(ctx context.Context, client *Client) error {
 	if len(active) == 0 {
 		return nil
 	}
-	startMs, endMs, _ := f.resolveTime()
+	startMs, endMs, err := f.resolveTime()
+	if err != nil {
+		return err
+	}
 	scopes, err := client.ListEntityScopes(ctx, startMs, endMs)
 	if err != nil {
 		return nil //nolint:nilerr // best-effort: scope validation is advisory
@@ -2014,7 +2017,7 @@ Tips:
 	}
 	cmd.Flags().StringVar(&cypherScope.from, "from", "", "Start time (RFC3339, Unix timestamp, or relative like 'now-1h')")
 	cmd.Flags().StringVar(&cypherScope.to, "to", "", "End time (RFC3339, Unix timestamp, or relative like 'now')")
-	cmd.Flags().StringVar(&cypherScope.since, "since", "", "Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)")
+	cmd.Flags().StringVar(&cypherScope.since, "since", "", "Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)")
 	cmd.Flags().IntVar(&cypherPage, "page", 0, "Page number (0-based)")
 	cmd.Flags().BoolVar(&withInsights, "insights-only", false, "Return only entities with active insights")
 	ioOpts.setup(cmd.Flags())
@@ -2237,7 +2240,7 @@ func (o *describeOpts) setupWithTime(flags *pflag.FlagSet) {
 	o.setup(flags)
 	flags.StringVar(&o.Time.from, "from", "", "Start time (RFC3339, Unix timestamp, or relative like 'now-1h')")
 	flags.StringVar(&o.Time.to, "to", "", "End time (RFC3339, Unix timestamp, or relative like 'now')")
-	flags.StringVar(&o.Time.since, "since", "", "Duration before --to (or now); mutually exclusive with --from (e.g. 1h, 30m, 7d)")
+	flags.StringVar(&o.Time.since, "since", "", "Duration before --to (or now); mutually exclusive with --from/--to (e.g. 1h, 30m, 7d)")
 }
 
 // DescribeTextCodec renders KGMetadataOutput in the compact LLM-friendly text format

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -116,7 +116,8 @@ func (f *scopeFlags) validateScopes(ctx context.Context, client *Client) error {
 	if len(active) == 0 {
 		return nil
 	}
-	scopes, err := client.ListEntityScopes(ctx)
+	startMs, endMs, _ := f.resolveTime()
+	scopes, err := client.ListEntityScopes(ctx, startMs, endMs)
 	if err != nil {
 		return nil //nolint:nilerr // best-effort: scope validation is advisory
 	}
@@ -2378,14 +2379,18 @@ func newDescribeScopesCmd(loader RESTConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			scopes, err := client.ListEntityScopes(cmd.Context())
+			startMs, endMs, err := opts.Time.resolveTime()
+			if err != nil {
+				return err
+			}
+			scopes, err := client.ListEntityScopes(cmd.Context(), startMs, endMs)
 			if err != nil {
 				return err
 			}
 			return opts.IO.Encode(cmd.OutOrStdout(), KGMetadataOutput{Scopes: scopes})
 		},
 	}
-	opts.setup(cmd.Flags())
+	opts.setupWithTime(cmd.Flags())
 	return cmd
 }
 
@@ -2512,7 +2517,7 @@ func newDescribeAllCmd(loader RESTConfigLoader) *cobra.Command {
 				return nil
 			})
 			g.Go(func() error {
-				scopes, scopeErr := client.ListEntityScopes(gCtx)
+				scopes, scopeErr := client.ListEntityScopes(gCtx, startMs, endMs)
 				if scopeErr != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(), "warning: scope values failed to load: %v\n", scopeErr)
 					return nil

--- a/internal/providers/kg/diagnose.go
+++ b/internal/providers/kg/diagnose.go
@@ -582,7 +582,7 @@ func checkEntityCounts(ctx context.Context, client *Client) (CheckResult, map[st
 // scopes map so the Orientation block can detect known/unknown scope
 // values without a second API call. scopes is nil on API error.
 func checkScopeValues(ctx context.Context, client *Client) (CheckResult, map[string][]string) {
-	scopes, err := client.ListEntityScopes(ctx)
+	scopes, err := client.ListEntityScopes(ctx, 0, 0)
 	if err != nil {
 		return CheckResult{
 			Name:           "Scope values",

--- a/internal/providers/kg/diagnose_labels.go
+++ b/internal/providers/kg/diagnose_labels.go
@@ -103,7 +103,7 @@ func runLabelsDiagnose(ctx context.Context, client *Client, promClient *promethe
 	})
 
 	g.Go(func() error {
-		scopes, err := client.ListEntityScopes(ctx)
+		scopes, err := client.ListEntityScopes(ctx, 0, 0)
 		mu.Lock()
 		if err == nil {
 			scopeEnvs = scopes["env"]

--- a/internal/providers/kg/resource_adapter.go
+++ b/internal/providers/kg/resource_adapter.go
@@ -251,7 +251,7 @@ func scopeSpecSchema() map[string]any {
 func NewScopeAdapterFactory(loader RESTConfigLoader) adapter.Factory {
 	return newListOnlyFactory[Scope](loader, scopeDescriptor,
 		func(client *Client, ctx context.Context) ([]Scope, error) {
-			scopeMap, err := client.ListEntityScopes(ctx)
+			scopeMap, err := client.ListEntityScopes(ctx, 0, 0)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Problem

`gcx kg meta scopes` / `gcx kg meta all` returned env/namespace/site values that ignored the requested time window. `ListEntityScopes` issued a bare `GET /asserts/api-server/v1/entity_scope` with no `start`/`end` params, so `--from`/`--to` never reached the backend. The standalone `kg meta scopes` subcommand didn't even register the time flags.

Symptom: querying a replay/ops stack over a known-good incident window returned empty scope arrays, falsely suggesting the KG had no entities — when in fact the (unbounded) lookup just wasn't hitting the right window.

## Fix

- `ListEntityScopes(ctx)` → `ListEntityScopes(ctx, startMs, endMs)`, appending `start`/`end` query params, defaulting to the last hour when unset (matching `GetEntityInfo`/`LookupEntity`).
- `kg meta scopes` now uses `setupWithTime` and resolves the window (gains `--from`/`--to`/`--since`).
- `kg meta all` and `validateScopes` thread their resolved window through.
- Diagnose and adapter callers pass `0, 0` (preserving the prior last-hour default).


🤖 Generated with [Claude Code](https://claude.com/claude-code)