### PR TITLE
fix(auth): open browser via explorer.exe on Windows so OAuth URL survives

### DIFF
--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -1,8 +1,16 @@
 package auth
 
-import "context"
+import (
+	"context"
+	"os/exec"
+)
 
 // ExchangeCodeForToken exposes the unexported exchangeCodeForToken for black-box tests.
 func ExchangeCodeForToken(ctx context.Context, endpoint, code, codeVerifier string) (any, error) {
 	return exchangeCodeForToken(ctx, endpoint, code, codeVerifier)
+}
+
+// BrowserCommand exposes the unexported browserCommand for black-box tests.
+func BrowserCommand(ctx context.Context, goos, url string) (*exec.Cmd, error) {
+	return browserCommand(ctx, goos, url)
 }

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -2,15 +2,9 @@ package auth
 
 import (
 	"context"
-	"os/exec"
 )
 
 // ExchangeCodeForToken exposes the unexported exchangeCodeForToken for black-box tests.
 func ExchangeCodeForToken(ctx context.Context, endpoint, code, codeVerifier string) (any, error) {
 	return exchangeCodeForToken(ctx, endpoint, code, codeVerifier)
-}
-
-// BrowserCommand exposes the unexported browserCommand for black-box tests.
-func BrowserCommand(ctx context.Context, goos, url string) (*exec.Cmd, error) {
-	return browserCommand(ctx, goos, url)
 }

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -19,11 +19,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/grafana/gcx/internal/deeplink"
 )
 
 //go:embed templates/*.html
@@ -159,7 +159,7 @@ func (f *Flow) Run(ctx context.Context) (*Result, error) {
 	fmt.Fprintln(f.writer, "Check that this code matches what is shown in the browser before approving.")
 	fmt.Fprintln(f.writer)
 
-	if err := openBrowser(ctx, authURL); err != nil {
+	if err := deeplink.Open(authURL); err != nil {
 		fmt.Fprintln(f.writer, "(Could not open browser automatically)")
 	}
 
@@ -430,35 +430,6 @@ func verificationCode(codeChallenge string) string {
 	}
 	h := hex.EncodeToString(raw[:4])
 	return h[:4] + "-" + h[4:]
-}
-
-func openBrowser(ctx context.Context, url string) error {
-	cmd, err := browserCommand(ctx, runtime.GOOS, url)
-	if err != nil {
-		return err
-	}
-	return cmd.Start()
-}
-
-// browserCommand builds the platform-specific command that opens url in the
-// user's default browser. goos is passed explicitly (rather than read from
-// runtime.GOOS) so the per-platform argv is unit-testable.
-func browserCommand(ctx context.Context, goos, url string) (*exec.Cmd, error) {
-	switch goos {
-	case "darwin":
-		return exec.CommandContext(ctx, "open", url), nil
-	case "linux":
-		return exec.CommandContext(ctx, "xdg-open", url), nil
-	case "windows":
-		// explorer.exe parses its arguments with CommandLineToArgvW (whitespace
-		// split only), so query-string separators like & survive intact. Using
-		// cmd.exe ("cmd /c start") truncates the URL at the first & because cmd
-		// treats it as a command separator, dropping state/code_challenge and
-		// breaking OAuth login (#814).
-		return exec.CommandContext(ctx, "explorer.exe", url), nil
-	default:
-		return nil, fmt.Errorf("unsupported platform: %s", goos)
-	}
 }
 
 // StripControlChars sanitises errors to stop potentially malicious errors from

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -433,20 +433,32 @@ func verificationCode(codeChallenge string) string {
 }
 
 func openBrowser(ctx context.Context, url string) error {
-	var cmd *exec.Cmd
-
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.CommandContext(ctx, "open", url)
-	case "linux":
-		cmd = exec.CommandContext(ctx, "xdg-open", url)
-	case "windows":
-		cmd = exec.CommandContext(ctx, "cmd", "/c", "start", url)
-	default:
-		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	cmd, err := browserCommand(ctx, runtime.GOOS, url)
+	if err != nil {
+		return err
 	}
-
 	return cmd.Start()
+}
+
+// browserCommand builds the platform-specific command that opens url in the
+// user's default browser. goos is passed explicitly (rather than read from
+// runtime.GOOS) so the per-platform argv is unit-testable.
+func browserCommand(ctx context.Context, goos, url string) (*exec.Cmd, error) {
+	switch goos {
+	case "darwin":
+		return exec.CommandContext(ctx, "open", url), nil
+	case "linux":
+		return exec.CommandContext(ctx, "xdg-open", url), nil
+	case "windows":
+		// explorer.exe parses its arguments with CommandLineToArgvW (whitespace
+		// split only), so query-string separators like & survive intact. Using
+		// cmd.exe ("cmd /c start") truncates the URL at the first & because cmd
+		// treats it as a command separator, dropping state/code_challenge and
+		// breaking OAuth login (#814).
+		return exec.CommandContext(ctx, "explorer.exe", url), nil
+	default:
+		return nil, fmt.Errorf("unsupported platform: %s", goos)
+	}
 }
 
 // StripControlChars sanitises errors to stop potentially malicious errors from

--- a/internal/auth/flow_test.go
+++ b/internal/auth/flow_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -83,44 +82,5 @@ func TestFlowRun_FailsBeforeBrowserOutputWhenFixedPortUnavailable(t *testing.T) 
 	}
 	if writer.Len() != 0 {
 		t.Fatalf("expected no browser instructions before bind failure, got %q", writer.String())
-	}
-}
-
-func TestBrowserCommand(t *testing.T) {
-	// A representative OAuth URL: the query string carries & separators that
-	// cmd.exe would treat as command separators (#814).
-	const url = "https://mystack.grafana.net/a/grafana-assistant-app/cli/auth?callback_port=54321&state=abc&code_challenge=xyz&code_challenge_method=S256"
-
-	tests := []struct {
-		name     string
-		goos     string
-		wantArgs []string
-	}{
-		{"darwin", "darwin", []string{"open", url}},
-		{"linux", "linux", []string{"xdg-open", url}},
-		{"windows", "windows", []string{"explorer.exe", url}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := auth.BrowserCommand(context.Background(), tt.goos, url)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !reflect.DeepEqual(cmd.Args, tt.wantArgs) {
-				t.Fatalf("args = %v, want %v", cmd.Args, tt.wantArgs)
-			}
-			// Regression for #814: the full URL must be passed as a single,
-			// intact argument — never split or truncated at an & separator.
-			if got := cmd.Args[len(cmd.Args)-1]; got != url {
-				t.Fatalf("url argument = %q, want %q", got, url)
-			}
-		})
-	}
-}
-
-func TestBrowserCommand_UnsupportedPlatform(t *testing.T) {
-	if _, err := auth.BrowserCommand(context.Background(), "plan9", "https://mystack.grafana.net"); err == nil {
-		t.Fatal("expected error for unsupported platform")
 	}
 }

--- a/internal/auth/flow_test.go
+++ b/internal/auth/flow_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -82,5 +83,44 @@ func TestFlowRun_FailsBeforeBrowserOutputWhenFixedPortUnavailable(t *testing.T) 
 	}
 	if writer.Len() != 0 {
 		t.Fatalf("expected no browser instructions before bind failure, got %q", writer.String())
+	}
+}
+
+func TestBrowserCommand(t *testing.T) {
+	// A representative OAuth URL: the query string carries & separators that
+	// cmd.exe would treat as command separators (#814).
+	const url = "https://mystack.grafana.net/a/grafana-assistant-app/cli/auth?callback_port=54321&state=abc&code_challenge=xyz&code_challenge_method=S256"
+
+	tests := []struct {
+		name     string
+		goos     string
+		wantArgs []string
+	}{
+		{"darwin", "darwin", []string{"open", url}},
+		{"linux", "linux", []string{"xdg-open", url}},
+		{"windows", "windows", []string{"explorer.exe", url}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, err := auth.BrowserCommand(context.Background(), tt.goos, url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(cmd.Args, tt.wantArgs) {
+				t.Fatalf("args = %v, want %v", cmd.Args, tt.wantArgs)
+			}
+			// Regression for #814: the full URL must be passed as a single,
+			// intact argument — never split or truncated at an & separator.
+			if got := cmd.Args[len(cmd.Args)-1]; got != url {
+				t.Fatalf("url argument = %q, want %q", got, url)
+			}
+		})
+	}
+}
+
+func TestBrowserCommand_UnsupportedPlatform(t *testing.T) {
+	if _, err := auth.BrowserCommand(context.Background(), "plan9", "https://mystack.grafana.net"); err == nil {
+		t.Fatal("expected error for unsupported platform")
 	}
 }


### PR DESCRIPTION
## Summary
- On Windows, `gcx login` (OAuth) failed at the browser step: `cmd.exe` treats `&` as a command separator, so `cmd /c start <url>` truncated the auth URL at the first query param — dropping `state`, `code_challenge`, and `code_challenge_method` (#814).
- The initial fix here switched to `explorer.exe <url>`, but that regressed: `explorer.exe` with a URL is unreliable and frequently just opens a **File Explorer window** instead of dispatching the URL to the default browser.
- **Final fix:** reuse the codebase's existing browser opener, `deeplink.Open`, instead of a bespoke launcher in `internal/auth`. On Windows `deeplink` uses `rundll32 url.dll,FileProtocolHandler <url>`, invoked directly via `CreateProcess` (no `cmd.exe` shell), so `&` survives intact in a single argument (fixes #814) **and** the URL reliably launches the default browser.

## Why reuse `deeplink.Open`
`deeplink.Open` is already the standard browser opener used by 6+ commands (`resources get`, investigations, IRM incidents, KG, share links, …). It also has a regression test asserting the Windows command does not go through a shell (`internal/deeplink/browser_test.go::TestBrowserCommandWindowsDoesNotUseShell`). The auth package had independently reinvented this helper and picked the wrong Windows command; consolidating removes the duplication and inherits the correct, tested behavior.

## Changes
- `internal/auth/flow.go` — call `deeplink.Open(authURL)` and delete the local `openBrowser`/`browserCommand` helpers (net −75 lines).
- `internal/auth/flow_test.go` / `export_test.go` — remove the now-obsolete `BrowserCommand` tests/export; regression coverage for `&` lives in the `deeplink` package.

## Test Plan
- [x] `GCX_AGENT_MODE=false mise run lint` — 0 issues
- [x] `GCX_AGENT_MODE=false mise run tests` — full suite with race detection passes
- [x] `GCX_AGENT_MODE=false mise run build` — pass
- [x] `mise run reference-drift` — no drift (no command/flag/config changes)
- [ ] Manual on Windows: `gcx login <stack>` opens the default browser at the full Grafana auth URL (state + code_challenge present), not a File Explorer window.

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)