### PR TITLE
fix(query): fall back to /api/ds/query on any non-200 from the k8s query API

### DIFF
--- a/internal/query/cloudwatch/client.go
+++ b/internal/query/cloudwatch/client.go
@@ -90,8 +90,9 @@ func (c *Client) Query(ctx context.Context, dsUID string, req QueryRequest) (*Qu
 		return nil, err
 	}
 
-	// Fall back to legacy /api/ds/query if K8s query API is not available.
-	if statusCode == http.StatusNotFound {
+	// Fall back to legacy /api/ds/query if the K8s query API is unavailable
+	// (404) or forbidden for the user's role (403, e.g. Viewer).
+	if statusCode == http.StatusNotFound || statusCode == http.StatusForbidden {
 		apiPath = "/api/ds/query"
 		respBody, statusCode, err = c.post(ctx, apiPath, body)
 		if err != nil {

--- a/internal/query/cloudwatch/client.go
+++ b/internal/query/cloudwatch/client.go
@@ -90,9 +90,10 @@ func (c *Client) Query(ctx context.Context, dsUID string, req QueryRequest) (*Qu
 		return nil, err
 	}
 
-	// Fall back to legacy /api/ds/query if the K8s query API is unavailable
-	// (404) or forbidden for the user's role (403, e.g. Viewer).
-	if statusCode == http.StatusNotFound || statusCode == http.StatusForbidden {
+	// Fall back to the legacy /api/ds/query endpoint on any non-200 response.
+	// The K8s query API is not enabled everywhere and can fail in ways beyond
+	// 404 (e.g. 403 for a Viewer role); /api/ds/query is the universal path.
+	if statusCode != http.StatusOK {
 		apiPath = "/api/ds/query"
 		respBody, statusCode, err = c.post(ctx, apiPath, body)
 		if err != nil {

--- a/internal/query/cloudwatch/client.go
+++ b/internal/query/cloudwatch/client.go
@@ -90,9 +90,8 @@ func (c *Client) Query(ctx context.Context, dsUID string, req QueryRequest) (*Qu
 		return nil, err
 	}
 
-	// Fall back to the legacy /api/ds/query endpoint on any non-200 response.
-	// The K8s query API is not enabled everywhere and can fail in ways beyond
-	// 404 (e.g. 403 for a Viewer role); /api/ds/query is the universal path.
+	// The K8s query API is not enabled everywhere and can return a non-200
+	// (e.g. 403 for some roles); fall back to the legacy /api/ds/query.
 	if statusCode != http.StatusOK {
 		apiPath = "/api/ds/query"
 		respBody, statusCode, err = c.post(ctx, apiPath, body)

--- a/internal/query/cloudwatch/client_test.go
+++ b/internal/query/cloudwatch/client_test.go
@@ -214,6 +214,26 @@ func TestClient_Query(t *testing.T) {
 		assert.Contains(t, paths, "/api/ds/query")
 	})
 
+	t.Run("K8s 403 falls back to legacy /api/ds/query", func(t *testing.T) {
+		var paths []string
+		client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			paths = append(paths, r.URL.Path)
+			if r.URL.Path != "/api/ds/query" {
+				http.Error(w, `{"message":"forbidden"}`, http.StatusForbidden)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(queryResultBody(t, testResultEntry{
+				Frames: []testFrame{simpleFrame([]float64{1747000000000}, []any{5.0})},
+			}))
+		}))
+
+		resp, err := client.Query(context.Background(), "test-uid", testQueryReq())
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Frames)
+		assert.Contains(t, paths, "/api/ds/query")
+	})
+
 	t.Run("malformed JSON", func(t *testing.T) {
 		client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/internal/query/grafanaquery/client.go
+++ b/internal/query/grafanaquery/client.go
@@ -45,15 +45,18 @@ func NewClientWithHTTPClient(cfg config.NamespacedRESTConfig, httpClient *http.C
 }
 
 // Execute posts body to Grafana's K8s datasource query API, falls back to the
-// legacy /api/ds/query endpoint on 404, and converts non-200 responses to a
-// typed query API error for datasource and operation.
+// legacy /api/ds/query endpoint when that API is unavailable (404) or forbidden
+// (403), and converts non-200 responses to a typed query API error for
+// datasource and operation.
 func (c *Client) Execute(ctx context.Context, body []byte, datasource, operation string) ([]byte, error) {
 	statusCode, respBody, err := c.post(ctx, c.k8sQueryPath(), body)
 	if err != nil {
 		return nil, err
 	}
 
-	if statusCode == http.StatusNotFound {
+	// The K8s query API may be unavailable (404) or forbidden for the user's
+	// role (403, e.g. Viewer); fall back to the universally-available endpoint.
+	if statusCode == http.StatusNotFound || statusCode == http.StatusForbidden {
 		statusCode, respBody, err = c.post(ctx, "/api/ds/query", body)
 		if err != nil {
 			return nil, err

--- a/internal/query/grafanaquery/client.go
+++ b/internal/query/grafanaquery/client.go
@@ -54,10 +54,9 @@ func (c *Client) Execute(ctx context.Context, body []byte, datasource, operation
 		return nil, err
 	}
 
-	// The K8s query API is not enabled everywhere and can fail in ways beyond
-	// 404 (e.g. 403 for a Viewer role); on any non-200, fall back to the
-	// universally-available endpoint. Queries are idempotent reads, so the
-	// retry is safe.
+	// The K8s query API is not enabled everywhere and can return a non-200
+	// (e.g. 403 for some roles); fall back to the universally-available
+	// endpoint. Queries are idempotent reads, so the retry is safe.
 	if statusCode != http.StatusOK {
 		statusCode, respBody, err = c.post(ctx, "/api/ds/query", body)
 		if err != nil {

--- a/internal/query/grafanaquery/client.go
+++ b/internal/query/grafanaquery/client.go
@@ -45,18 +45,20 @@ func NewClientWithHTTPClient(cfg config.NamespacedRESTConfig, httpClient *http.C
 }
 
 // Execute posts body to Grafana's K8s datasource query API, falls back to the
-// legacy /api/ds/query endpoint when that API is unavailable (404) or forbidden
-// (403), and converts non-200 responses to a typed query API error for
-// datasource and operation.
+// legacy /api/ds/query endpoint on any non-200 response (the K8s query API is
+// not enabled everywhere), and converts non-200 responses to a typed query API
+// error for datasource and operation.
 func (c *Client) Execute(ctx context.Context, body []byte, datasource, operation string) ([]byte, error) {
 	statusCode, respBody, err := c.post(ctx, c.k8sQueryPath(), body)
 	if err != nil {
 		return nil, err
 	}
 
-	// The K8s query API may be unavailable (404) or forbidden for the user's
-	// role (403, e.g. Viewer); fall back to the universally-available endpoint.
-	if statusCode == http.StatusNotFound || statusCode == http.StatusForbidden {
+	// The K8s query API is not enabled everywhere and can fail in ways beyond
+	// 404 (e.g. 403 for a Viewer role); on any non-200, fall back to the
+	// universally-available endpoint. Queries are idempotent reads, so the
+	// retry is safe.
+	if statusCode != http.StatusOK {
 		statusCode, respBody, err = c.post(ctx, "/api/ds/query", body)
 		if err != nil {
 			return nil, err

--- a/internal/query/infinity/client_test.go
+++ b/internal/query/infinity/client_test.go
@@ -296,6 +296,46 @@ func TestQuery_FallbackOn403(t *testing.T) {
 	assert.Equal(t, []any{float64(1)}, resp.Rows[0])
 }
 
+func TestQuery_FallbackOn500(t *testing.T) {
+	var callCount atomic.Int32
+	var mu sync.Mutex
+	var paths []string
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"Internal Server Error"}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"id","type":"number"}]},"data":{"values":[[1]]}}]}}}`))
+	})
+
+	resp, err := client.Query(context.Background(), "ds-uid", infinity.QueryRequest{Expr: "$.data[*]"})
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), callCount.Load(), "expected exactly 2 requests (primary + fallback)")
+
+	mu.Lock()
+	capturedPaths := make([]string, len(paths))
+	copy(capturedPaths, paths)
+	mu.Unlock()
+
+	assert.Contains(t, capturedPaths[0], "/apis/query.grafana.app/v0alpha1")
+	assert.Equal(t, "/api/ds/query", capturedPaths[1])
+
+	require.NotNil(t, resp)
+	require.Len(t, resp.Rows, 1)
+	assert.Equal(t, []any{float64(1)}, resp.Rows[0])
+}
+
 func TestQuery_FallbackOn404BothFail(t *testing.T) {
 	var callCount atomic.Int32
 

--- a/internal/query/infinity/client_test.go
+++ b/internal/query/infinity/client_test.go
@@ -256,6 +256,46 @@ func TestQuery_FallbackOn404(t *testing.T) {
 	assert.Equal(t, []any{float64(1)}, resp.Rows[0])
 }
 
+func TestQuery_FallbackOn403(t *testing.T) {
+	var callCount atomic.Int32
+	var mu sync.Mutex
+	var paths []string
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+
+		if n == 1 {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"Forbidden"}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"id","type":"number"}]},"data":{"values":[[1]]}}]}}}`))
+	})
+
+	resp, err := client.Query(context.Background(), "ds-uid", infinity.QueryRequest{Expr: "$.data[*]"})
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), callCount.Load(), "expected exactly 2 requests (primary + fallback)")
+
+	mu.Lock()
+	capturedPaths := make([]string, len(paths))
+	copy(capturedPaths, paths)
+	mu.Unlock()
+
+	assert.Contains(t, capturedPaths[0], "/apis/query.grafana.app/v0alpha1")
+	assert.Equal(t, "/api/ds/query", capturedPaths[1])
+
+	require.NotNil(t, resp)
+	require.Len(t, resp.Rows, 1)
+	assert.Equal(t, []any{float64(1)}, resp.Rows[0])
+}
+
 func TestQuery_FallbackOn404BothFail(t *testing.T) {
 	var callCount atomic.Int32
 

--- a/internal/query/infinity/client_test.go
+++ b/internal/query/infinity/client_test.go
@@ -215,125 +215,60 @@ func TestQuery_HTTPErrorReturnsAPIError(t *testing.T) {
 	}
 }
 
-func TestQuery_FallbackOn404(t *testing.T) {
-	var callCount atomic.Int32
-	var mu sync.Mutex
-	var paths []string
+// Any non-200 from the K8s query API (404 not deployed, 403 RBAC, 500 from a
+// rolling-out query service, ...) should fall back to /api/ds/query.
+func TestQuery_FallbackOnNon200(t *testing.T) {
+	statuses := []struct {
+		name        string
+		firstStatus int
+	}{
+		{"not found", http.StatusNotFound},
+		{"forbidden", http.StatusForbidden},
+		{"server error", http.StatusInternalServerError},
+	}
 
-	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		n := callCount.Add(1)
+	for _, tc := range statuses {
+		t.Run(tc.name, func(t *testing.T) {
+			var callCount atomic.Int32
+			var mu sync.Mutex
+			var paths []string
 
-		mu.Lock()
-		paths = append(paths, r.URL.Path)
-		mu.Unlock()
+			client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				n := callCount.Add(1)
 
-		if n == 1 {
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
-			return
-		}
+				mu.Lock()
+				paths = append(paths, r.URL.Path)
+				mu.Unlock()
 
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"id","type":"number"}]},"data":{"values":[[1]]}}]}}}`))
-	})
+				if n == 1 {
+					w.WriteHeader(tc.firstStatus)
+					_, _ = w.Write([]byte(`{"message":"error"}`))
+					return
+				}
 
-	resp, err := client.Query(context.Background(), "ds-uid", infinity.QueryRequest{Expr: "$.data[*]"})
-	require.NoError(t, err)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"id","type":"number"}]},"data":{"values":[[1]]}}]}}}`))
+			})
 
-	assert.Equal(t, int32(2), callCount.Load(), "expected exactly 2 requests (primary + fallback)")
+			resp, err := client.Query(context.Background(), "ds-uid", infinity.QueryRequest{Expr: "$.data[*]"})
+			require.NoError(t, err)
 
-	mu.Lock()
-	capturedPaths := make([]string, len(paths))
-	copy(capturedPaths, paths)
-	mu.Unlock()
+			assert.Equal(t, int32(2), callCount.Load(), "expected exactly 2 requests (primary + fallback)")
 
-	assert.Contains(t, capturedPaths[0], "/apis/query.grafana.app/v0alpha1")
-	assert.Equal(t, "/api/ds/query", capturedPaths[1])
+			mu.Lock()
+			capturedPaths := make([]string, len(paths))
+			copy(capturedPaths, paths)
+			mu.Unlock()
 
-	require.NotNil(t, resp)
-	assert.Equal(t, []infinity.Column{{Name: "id", Type: "number"}}, resp.Columns)
-	require.Len(t, resp.Rows, 1)
-	assert.Equal(t, []any{float64(1)}, resp.Rows[0])
-}
+			assert.Contains(t, capturedPaths[0], "/apis/query.grafana.app/v0alpha1")
+			assert.Equal(t, "/api/ds/query", capturedPaths[1])
 
-func TestQuery_FallbackOn403(t *testing.T) {
-	var callCount atomic.Int32
-	var mu sync.Mutex
-	var paths []string
-
-	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		n := callCount.Add(1)
-
-		mu.Lock()
-		paths = append(paths, r.URL.Path)
-		mu.Unlock()
-
-		if n == 1 {
-			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte(`{"message":"Forbidden"}`))
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"id","type":"number"}]},"data":{"values":[[1]]}}]}}}`))
-	})
-
-	resp, err := client.Query(context.Background(), "ds-uid", infinity.QueryRequest{Expr: "$.data[*]"})
-	require.NoError(t, err)
-
-	assert.Equal(t, int32(2), callCount.Load(), "expected exactly 2 requests (primary + fallback)")
-
-	mu.Lock()
-	capturedPaths := make([]string, len(paths))
-	copy(capturedPaths, paths)
-	mu.Unlock()
-
-	assert.Contains(t, capturedPaths[0], "/apis/query.grafana.app/v0alpha1")
-	assert.Equal(t, "/api/ds/query", capturedPaths[1])
-
-	require.NotNil(t, resp)
-	require.Len(t, resp.Rows, 1)
-	assert.Equal(t, []any{float64(1)}, resp.Rows[0])
-}
-
-func TestQuery_FallbackOn500(t *testing.T) {
-	var callCount atomic.Int32
-	var mu sync.Mutex
-	var paths []string
-
-	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		n := callCount.Add(1)
-
-		mu.Lock()
-		paths = append(paths, r.URL.Path)
-		mu.Unlock()
-
-		if n == 1 {
-			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = w.Write([]byte(`{"message":"Internal Server Error"}`))
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"id","type":"number"}]},"data":{"values":[[1]]}}]}}}`))
-	})
-
-	resp, err := client.Query(context.Background(), "ds-uid", infinity.QueryRequest{Expr: "$.data[*]"})
-	require.NoError(t, err)
-
-	assert.Equal(t, int32(2), callCount.Load(), "expected exactly 2 requests (primary + fallback)")
-
-	mu.Lock()
-	capturedPaths := make([]string, len(paths))
-	copy(capturedPaths, paths)
-	mu.Unlock()
-
-	assert.Contains(t, capturedPaths[0], "/apis/query.grafana.app/v0alpha1")
-	assert.Equal(t, "/api/ds/query", capturedPaths[1])
-
-	require.NotNil(t, resp)
-	require.Len(t, resp.Rows, 1)
-	assert.Equal(t, []any{float64(1)}, resp.Rows[0])
+			require.NotNil(t, resp)
+			assert.Equal(t, []infinity.Column{{Name: "id", Type: "number"}}, resp.Columns)
+			require.Len(t, resp.Rows, 1)
+			assert.Equal(t, []any{float64(1)}, resp.Rows[0])
+		})
+	}
 }
 
 func TestQuery_FallbackOn404BothFail(t *testing.T) {

--- a/internal/query/loki/client.go
+++ b/internal/query/loki/client.go
@@ -91,8 +91,9 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Fall back to legacy /api/ds/query if K8s query API doesn't exist.
-	if resp.StatusCode == http.StatusNotFound {
+	// Fall back to legacy /api/ds/query if the K8s query API is unavailable
+	// (404) or forbidden for the user's role (403, e.g. Viewer).
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
 		resp.Body.Close()
 		apiPath = "/api/ds/query"
 		httpReq, err = http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
@@ -190,8 +191,9 @@ func (c *Client) MetricQuery(ctx context.Context, datasourceUID string, req Quer
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Fall back to legacy /api/ds/query if K8s query API doesn't exist.
-	if resp.StatusCode == http.StatusNotFound {
+	// Fall back to legacy /api/ds/query if the K8s query API is unavailable
+	// (404) or forbidden for the user's role (403, e.g. Viewer).
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
 		resp.Body.Close()
 		apiPath = "/api/ds/query"
 		httpReq, err = http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))

--- a/internal/query/loki/client.go
+++ b/internal/query/loki/client.go
@@ -91,9 +91,8 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Fall back to the legacy /api/ds/query endpoint on any non-200 response.
-	// The K8s query API is not enabled everywhere and can fail in ways beyond
-	// 404 (e.g. 403 for a Viewer role); /api/ds/query is the universal path.
+	// The K8s query API is not enabled everywhere and can return a non-200
+	// (e.g. 403 for some roles); fall back to the legacy /api/ds/query.
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
 		apiPath = "/api/ds/query"
@@ -192,9 +191,8 @@ func (c *Client) MetricQuery(ctx context.Context, datasourceUID string, req Quer
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Fall back to the legacy /api/ds/query endpoint on any non-200 response.
-	// The K8s query API is not enabled everywhere and can fail in ways beyond
-	// 404 (e.g. 403 for a Viewer role); /api/ds/query is the universal path.
+	// The K8s query API is not enabled everywhere and can return a non-200
+	// (e.g. 403 for some roles); fall back to the legacy /api/ds/query.
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
 		apiPath = "/api/ds/query"

--- a/internal/query/loki/client.go
+++ b/internal/query/loki/client.go
@@ -91,9 +91,10 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Fall back to legacy /api/ds/query if the K8s query API is unavailable
-	// (404) or forbidden for the user's role (403, e.g. Viewer).
-	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
+	// Fall back to the legacy /api/ds/query endpoint on any non-200 response.
+	// The K8s query API is not enabled everywhere and can fail in ways beyond
+	// 404 (e.g. 403 for a Viewer role); /api/ds/query is the universal path.
+	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
 		apiPath = "/api/ds/query"
 		httpReq, err = http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
@@ -191,9 +192,10 @@ func (c *Client) MetricQuery(ctx context.Context, datasourceUID string, req Quer
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Fall back to legacy /api/ds/query if the K8s query API is unavailable
-	// (404) or forbidden for the user's role (403, e.g. Viewer).
-	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
+	// Fall back to the legacy /api/ds/query endpoint on any non-200 response.
+	// The K8s query API is not enabled everywhere and can fail in ways beyond
+	// 404 (e.g. 403 for a Viewer role); /api/ds/query is the universal path.
+	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
 		apiPath = "/api/ds/query"
 		httpReq, err = http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))

--- a/internal/query/loki/client_test.go
+++ b/internal/query/loki/client_test.go
@@ -41,6 +41,35 @@ func TestBuildPathsEscapeDatasourceUID(t *testing.T) {
 	}
 }
 
+func TestQuery_FallsBackOn403(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path != "/api/ds/query" {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":{"A":{"frames":[]}}}`))
+	}))
+	defer server.Close()
+
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: server.URL},
+		Namespace: "default",
+	}
+	client, err := loki.NewClient(cfg)
+	require.NoError(t, err)
+
+	_, err = client.Query(context.Background(), "loki-uid", loki.QueryRequest{Query: `{job="grafana"}`})
+	require.NoError(t, err)
+
+	require.Len(t, paths, 2)
+	assert.Contains(t, paths[0], "/apis/query.grafana.app/v0alpha1/namespaces/default/query")
+	assert.Equal(t, "/api/ds/query", paths[1])
+}
+
 func TestQuery_ReturnsTypedAPIErrorForGrafanaEnvelope(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)

--- a/internal/query/loki/client_test.go
+++ b/internal/query/loki/client_test.go
@@ -71,9 +71,10 @@ func TestQuery_FallsBackOn403(t *testing.T) {
 }
 
 func TestQuery_ReturnsTypedAPIErrorForGrafanaEnvelope(t *testing.T) {
+	// A 400 from the k8s query API now triggers the fallback, so both endpoints
+	// return the same envelope; the typed error from the final response surfaces.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Contains(t, r.URL.Path, "/apis/query.grafana.app/v0alpha1/namespaces/default/query")
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"results":{"A":{"error":"parse error at line 1, col 12: syntax error: unexpected IDENTIFIER, expecting STRING","errorSource":"downstream","status":400}}}`))
 	}))

--- a/internal/query/prometheus/client.go
+++ b/internal/query/prometheus/client.go
@@ -100,9 +100,10 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Fall back to legacy /api/ds/query if the K8s query API is unavailable
-	// (404) or forbidden for the user's role (403, e.g. Viewer).
-	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
+	// Fall back to the legacy /api/ds/query endpoint on any non-200 response.
+	// The K8s query API is not enabled everywhere and can fail in ways beyond
+	// 404 (e.g. 403 for a Viewer role); /api/ds/query is the universal path.
+	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
 		apiPath = "/api/ds/query"
 		httpReq, err = http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))

--- a/internal/query/prometheus/client.go
+++ b/internal/query/prometheus/client.go
@@ -100,9 +100,8 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Fall back to the legacy /api/ds/query endpoint on any non-200 response.
-	// The K8s query API is not enabled everywhere and can fail in ways beyond
-	// 404 (e.g. 403 for a Viewer role); /api/ds/query is the universal path.
+	// The K8s query API is not enabled everywhere and can return a non-200
+	// (e.g. 403 for some roles); fall back to the legacy /api/ds/query.
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
 		apiPath = "/api/ds/query"

--- a/internal/query/prometheus/client.go
+++ b/internal/query/prometheus/client.go
@@ -100,8 +100,9 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Fall back to legacy /api/ds/query if K8s query API doesn't exist.
-	if resp.StatusCode == http.StatusNotFound {
+	// Fall back to legacy /api/ds/query if the K8s query API is unavailable
+	// (404) or forbidden for the user's role (403, e.g. Viewer).
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
 		resp.Body.Close()
 		apiPath = "/api/ds/query"
 		httpReq, err = http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))

--- a/internal/query/prometheus/client_test.go
+++ b/internal/query/prometheus/client_test.go
@@ -1,12 +1,48 @@
 package prometheus_test
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
+
+func TestQuery_FallsBackOn403(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path != "/api/ds/query" {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":{"A":{"frames":[]}}}`))
+	}))
+	defer server.Close()
+
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: server.URL},
+		Namespace: "default",
+	}
+	client, err := prometheus.NewClient(cfg)
+	require.NoError(t, err)
+
+	_, err = client.Query(context.Background(), "prom-uid", prometheus.QueryRequest{Query: "up"})
+	require.NoError(t, err)
+
+	require.Len(t, paths, 2)
+	assert.Contains(t, paths[0], "/apis/query.grafana.app/v0alpha1/namespaces/default/query")
+	assert.Equal(t, "/api/ds/query", paths[1])
+}
 
 func TestBuildPathsEscapeDatasourceUID(t *testing.T) {
 	c := &prometheus.Client{}


### PR DESCRIPTION
## Summary

- The datasource query clients try Grafana's k8s query API (`/apis/query.grafana.app/.../query`) first, then fall back to the legacy `/api/ds/query`. The fallback only fired on `404`, so a user whose Grafana role can't `create` the `query` resource under `query.grafana.app` (e.g. Viewer) got a hard `403` — even though `/api/ds/query` would have served them.
- Broadens the fallback to trigger on **any non-200** response, not a `404`/`403` allowlist. The k8s query API is not enabled everywhere yet and can fail in other ways (e.g. a `500` from a rolling-out query service, or `501`); the legacy path is the universally-available one, so on any failure we fall through to it.
- Queries are idempotent reads, so the retry is always safe. Transient `429`/`5xx` are still absorbed by the retry transport below this layer, so a fallback only happens on a *persistent* non-200.
- Applies across the shared `grafanaquery` transport (athena, clickhouse, influxdb, infinity) and the bespoke loki, prometheus, and cloudwatch clients.
- Tests: 404/403/500 fallback coverage on the shared transport plus the bespoke clients; the loki error-envelope test now reflects that a `400` triggers the fallback too.

## Why

A Viewer-role user hit:

```
query failed with status 403: {"kind":"Status",...,"message":"query.query.grafana.app \"name\" is forbidden:
User \"<user>\" cannot create resource \"query\" in API group \"query.grafana.app\" in the namespace \"<ns>\"...",
"reason":"Forbidden","code":403}
```

The 403 is a Kubernetes apiserver RBAC artifact: the new query API maps a POST to a `create` verb on the `query` resource, which the Viewer role lacks. The legacy `/api/ds/query` enforces the real datasource-query permission (`datasources:query`) and serves these users fine. Rather than allowlisting specific status codes, we treat any non-200 from the not-yet-ubiquitous k8s path as a signal to use the proven legacy endpoint — which grants no access the user wouldn't already have via `/api/ds/query`.