### PR TITLE
refactor(datasources): dedupe config-loading boilerplate

### DIFF
--- a/internal/datasources/athena/describe_table.go
+++ b/internal/datasources/athena/describe_table.go
@@ -3,15 +3,12 @@ package athena
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/athena"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -63,15 +60,7 @@ func DescribeTableCmd(loader *providers.ConfigLoader) *cobra.Command {
 			table := args[0]
 			ctx := cmd.Context()
 
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/athena/list_catalogs.go
+++ b/internal/datasources/athena/list_catalogs.go
@@ -3,15 +3,12 @@ package athena
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/athena"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -53,15 +50,7 @@ func ListCatalogsCmd(loader *providers.ConfigLoader) *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/athena/list_databases.go
+++ b/internal/datasources/athena/list_databases.go
@@ -3,15 +3,12 @@ package athena
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/athena"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -55,15 +52,7 @@ func ListDatabasesCmd(loader *providers.ConfigLoader) *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/athena/list_tables.go
+++ b/internal/datasources/athena/list_tables.go
@@ -3,15 +3,12 @@ package athena
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/athena"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -60,15 +57,7 @@ func ListTablesCmd(loader *providers.ConfigLoader) *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/athena/query.go
+++ b/internal/datasources/athena/query.go
@@ -2,15 +2,12 @@ package athena
 
 import (
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/athena"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -67,15 +64,7 @@ open it in your browser after the query succeeds.`,
 
 			ctx := cmd.Context()
 
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/clickhouse/describe_table.go
+++ b/internal/datasources/clickhouse/describe_table.go
@@ -2,15 +2,12 @@ package clickhouse
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/clickhouse"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -59,15 +56,7 @@ func DescribeTableCmd(loader *providers.ConfigLoader) *cobra.Command {
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/clickhouse/list_tables.go
+++ b/internal/datasources/clickhouse/list_tables.go
@@ -2,15 +2,12 @@ package clickhouse
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/clickhouse"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -60,15 +57,7 @@ Shows database, name, engine, total_rows, and total_bytes for each table.`,
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/clickhouse/query.go
+++ b/internal/datasources/clickhouse/query.go
@@ -2,15 +2,12 @@ package clickhouse
 
 import (
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/clickhouse"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -65,15 +62,7 @@ open it in your browser after the query succeeds.`,
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/cloudwatch/list_accounts.go
+++ b/internal/datasources/cloudwatch/list_accounts.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -64,15 +61,7 @@ may return a 404 which is surfaced as a clear error.`,
 
 			ctx := cmd.Context()
 
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/cloudwatch/list_dimensions.go
+++ b/internal/datasources/cloudwatch/list_dimensions.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -74,15 +71,7 @@ func ListDimensionsCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/cloudwatch/list_metrics.go
+++ b/internal/datasources/cloudwatch/list_metrics.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -69,15 +66,7 @@ func ListMetricsCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/cloudwatch/list_namespaces.go
+++ b/internal/datasources/cloudwatch/list_namespaces.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -64,15 +61,7 @@ func ListNamespacesCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/cloudwatch/list_regions.go
+++ b/internal/datasources/cloudwatch/list_regions.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -54,15 +51,7 @@ func ListRegionsCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/cloudwatch/query.go
+++ b/internal/datasources/cloudwatch/query.go
@@ -4,18 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	cwclient "github.com/grafana/gcx/internal/query/cloudwatch"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -136,15 +133,7 @@ accounts, pass --account-id <id> (run list-accounts to discover IDs) or
 
 			ctx := cmd.Context()
 
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/infinity/query.go
+++ b/internal/datasources/infinity/query.go
@@ -2,15 +2,12 @@ package infinity
 
 import (
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/infinity"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -71,15 +68,7 @@ Datasource is resolved from -d flag or datasources.infinity in your context.`,
 
 			ctx := cmd.Context()
 
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/influxdb/fieldkeys.go
+++ b/internal/datasources/influxdb/fieldkeys.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/influxdb"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -61,17 +58,9 @@ func FieldKeysCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 
 			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "influxdb")

--- a/internal/datasources/influxdb/measurements.go
+++ b/internal/datasources/influxdb/measurements.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/influxdb"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -61,17 +58,9 @@ func MeasurementsCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 
 			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "influxdb")

--- a/internal/datasources/influxdb/query.go
+++ b/internal/datasources/influxdb/query.go
@@ -2,15 +2,12 @@ package influxdb
 
 import (
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/influxdb"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -65,15 +62,7 @@ Datasource is resolved from -d flag or datasources.influxdb in your context.`,
 
 			ctx := cmd.Context()
 
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/influxdb/tagkeys.go
+++ b/internal/datasources/influxdb/tagkeys.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/influxdb"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -61,17 +58,9 @@ func TagKeysCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 
 			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "influxdb")

--- a/internal/datasources/influxdb/tagvalues.go
+++ b/internal/datasources/influxdb/tagvalues.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/influxdb"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -66,17 +63,9 @@ func TagValuesCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 
 			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "influxdb")

--- a/internal/datasources/loki/labels.go
+++ b/internal/datasources/loki/labels.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/loki"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -60,17 +57,9 @@ func LabelsCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 
 			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "loki")

--- a/internal/datasources/loki/metrics.go
+++ b/internal/datasources/loki/metrics.go
@@ -2,15 +2,12 @@ package loki
 
 import (
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/loki"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -64,15 +61,7 @@ open it in your browser after the query succeeds.`,
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/loki/query.go
+++ b/internal/datasources/loki/query.go
@@ -2,15 +2,12 @@ package loki
 
 import (
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/loki"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -64,15 +61,7 @@ open it in your browser after the query succeeds.`,
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/loki/series.go
+++ b/internal/datasources/loki/series.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/loki"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -69,17 +66,9 @@ func SeriesCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 
 			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "loki")

--- a/internal/datasources/prometheus/labels.go
+++ b/internal/datasources/prometheus/labels.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/prometheus"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -66,17 +63,9 @@ func LabelsCmdWithDefault(loader *providers.ConfigLoader, defaultDS string) *cob
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 
 			effectiveDS := opts.Datasource

--- a/internal/datasources/prometheus/metadata.go
+++ b/internal/datasources/prometheus/metadata.go
@@ -4,18 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"sort"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/prometheus"
 	"github.com/grafana/gcx/internal/style"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -62,17 +59,9 @@ func MetadataCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 
 			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "prometheus")

--- a/internal/datasources/prometheus/query.go
+++ b/internal/datasources/prometheus/query.go
@@ -2,15 +2,12 @@ package prometheus
 
 import (
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/prometheus"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -68,15 +65,7 @@ open it in your browser after the query succeeds.`,
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/pyroscope/exemplars.go
+++ b/internal/datasources/pyroscope/exemplars.go
@@ -4,18 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/pyroscope"
 	"github.com/grafana/gcx/internal/queryerror"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -135,16 +132,9 @@ EXPR is the label selector (e.g. '{service_name="frontend"}').`,
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 			datasourceUID, _, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "pyroscope")
 			if err != nil {
@@ -219,16 +209,9 @@ EXPR is the label selector (e.g. '{service_name="frontend"}').`,
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 			datasourceUID, _, err := dsquery.ResolveValidateAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "pyroscope")
 			if err != nil {

--- a/internal/datasources/pyroscope/labels.go
+++ b/internal/datasources/pyroscope/labels.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/pyroscope"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -60,17 +57,9 @@ func LabelsCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 
 			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "pyroscope")

--- a/internal/datasources/pyroscope/profile_types.go
+++ b/internal/datasources/pyroscope/profile_types.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/pyroscope"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -55,17 +52,9 @@ func ProfileTypesCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
-			}
-
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
 			}
 
 			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "pyroscope")

--- a/internal/datasources/pyroscope/query.go
+++ b/internal/datasources/pyroscope/query.go
@@ -4,17 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/pyroscope"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -158,15 +155,7 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/pyroscope/series.go
+++ b/internal/datasources/pyroscope/series.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/grafana/gcx/internal/graph"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/pyroscope"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -118,15 +116,7 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/query/resolve.go
+++ b/internal/datasources/query/resolve.go
@@ -45,6 +45,33 @@ type DatasourceSaver interface {
 	SaveDatasourceUID(ctx context.Context, kind, uid string) error
 }
 
+// ConfigLoader loads gcx's full config and the Grafana REST config. Satisfied
+// by *providers.ConfigLoader.
+type ConfigLoader interface {
+	LoadFullConfig(ctx context.Context) (*config.Config, error)
+	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
+}
+
+// LoadContextAndConfig loads the current config context and the Grafana REST
+// config used for datasource resolution (e.g. via ResolveDatasource,
+// ResolveAndSaveDatasource, or ResolveValidateAndSaveDatasource).
+//
+// Failure to load the full config is non-fatal: a warning is logged and a nil
+// context is returned so callers fall back to auto-discovery. Failure to load
+// the Grafana config is fatal and is returned to the caller.
+func LoadContextAndConfig(ctx context.Context, loader ConfigLoader) (*config.Context, config.NamespacedRESTConfig, error) {
+	var cfgCtx *config.Context
+	fullCfg, err := loader.LoadFullConfig(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+	} else {
+		cfgCtx = fullCfg.GetCurrentContext()
+	}
+
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	return cfgCtx, cfg, err
+}
+
 // ResolveDatasource resolves a datasource UID from the -d flag, config fallback,
 // or auto-discovery from Grafana when a single matching datasource is visible.
 //

--- a/internal/datasources/tempo/get.go
+++ b/internal/datasources/tempo/get.go
@@ -2,16 +2,13 @@ package tempo
 
 import (
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/tempo"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -83,15 +80,7 @@ explicit time range via --since or --from/--to.`,
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/tempo/metrics.go
+++ b/internal/datasources/tempo/metrics.go
@@ -3,15 +3,12 @@ package tempo
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/tempo"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -70,15 +67,7 @@ open it in your browser after the query succeeds.`,
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/tempo/search.go
+++ b/internal/datasources/tempo/search.go
@@ -2,15 +2,12 @@ package tempo
 
 import (
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/tempo"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -62,15 +59,7 @@ explicit time range via --since or --from/--to.`,
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/tempo/tags.go
+++ b/internal/datasources/tempo/tags.go
@@ -4,16 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/grafana/gcx/internal/agent"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/tempo"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -94,15 +91,7 @@ Datasource is resolved from -d flag or datasources.tempo in your context.`,
 			ctx := cmd.Context()
 
 			// Resolve datasource UID from -d flag, config, or Grafana auto-discovery.
-			var cfgCtx *internalconfig.Context
-			fullCfg, err := loader.LoadFullConfig(ctx)
-			if err != nil {
-				logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
-			} else {
-				cfgCtx = fullCfg.GetCurrentContext()
-			}
-
-			cfg, err := loader.LoadGrafanaConfig(ctx)
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary
- 35 call sites across the prometheus, loki, tempo, pyroscope, cloudwatch, clickhouse, influxdb, infinity, and athena datasource commands duplicated the same block: load the full gcx config for the current context (warn and fall back to auto-discovery on failure), then load the Grafana REST config.
- Extracted this into `internal/datasources/query.LoadContextAndConfig` (plus a small `ConfigLoader` interface, mirroring the existing `DatasourceSaver` interface pattern) and updated every call site to use it, deleting the inlined block. Callers still invoke whichever resolver they used before (`ResolveAndSaveDatasource` or `ResolveValidateAndSaveDatasource`) — only the config-loading prefix was deduplicated, so this is a pure refactor with no behavior change.

## Test plan
- [x] go test -race -count=1 ./...
- [x] mise run lint
- [x] GCX_AGENT_MODE=false mise run reference (no diff — pure internal refactor)