### PR TITLE
refactor(query): dedupe prometheus/loki/cloudwatch onto shared grafanaquery transport

### DIFF
--- a/internal/query/cloudwatch/client.go
+++ b/internal/query/cloudwatch/client.go
@@ -1,7 +1,6 @@
 package cloudwatch
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/httputils"
+	"github.com/grafana/gcx/internal/query/grafanaquery"
 	"github.com/grafana/gcx/internal/queryerror"
 	"k8s.io/client-go/rest"
 )
@@ -19,8 +19,9 @@ const maxResourceResponseBytes = 1 << 20 // 1 MB
 
 // Client is an HTTP client for CloudWatch queries and resource listing via Grafana's proxy.
 type Client struct {
-	restConfig config.NamespacedRESTConfig
-	httpClient *http.Client
+	restConfig  config.NamespacedRESTConfig
+	httpClient  *http.Client
+	queryClient *grafanaquery.Client
 }
 
 // NewClient creates a new CloudWatch query client.
@@ -29,7 +30,11 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
-	return &Client{restConfig: cfg, httpClient: httpClient}, nil
+	return &Client{
+		restConfig:  cfg,
+		httpClient:  httpClient,
+		queryClient: grafanaquery.NewClientWithHTTPClient(cfg, httpClient),
+	}, nil
 }
 
 // Query executes a CloudWatch metric query via the Grafana datasource proxy.
@@ -84,24 +89,9 @@ func (c *Client) Query(ctx context.Context, dsUID string, req QueryRequest) (*Qu
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	apiPath := c.buildK8sQueryPath()
-	respBody, statusCode, err := c.post(ctx, apiPath, body)
+	respBody, err := c.queryClient.Execute(ctx, body, "cloudwatch", "query")
 	if err != nil {
 		return nil, err
-	}
-
-	// The K8s query API is not enabled everywhere and can return a non-200
-	// (e.g. 403 for some roles); fall back to the legacy /api/ds/query.
-	if statusCode != http.StatusOK {
-		apiPath = "/api/ds/query"
-		respBody, statusCode, err = c.post(ctx, apiPath, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if statusCode != http.StatusOK {
-		return nil, queryerror.FromBody("cloudwatch", "query", statusCode, respBody)
 	}
 
 	return ParseQueryResponse(respBody)
@@ -207,32 +197,6 @@ func (c *Client) getResource(ctx context.Context, dsUID, resource string, params
 	}
 
 	return body, nil
-}
-
-func (c *Client) post(ctx context.Context, apiPath string, body []byte) ([]byte, int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to execute query: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
-	if err != nil {
-		return nil, resp.StatusCode, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	return respBody, resp.StatusCode, nil
-}
-
-func (c *Client) buildK8sQueryPath() string {
-	return fmt.Sprintf("/apis/query.grafana.app/v0alpha1/namespaces/%s/query",
-		c.restConfig.Namespace)
 }
 
 // orEmptyDimensions returns an empty map (instead of nil) so the JSON body

--- a/internal/query/cloudwatch/types.go
+++ b/internal/query/cloudwatch/types.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/grafana/gcx/internal/query/dataframe"
 	"github.com/grafana/gcx/internal/queryerror"
 )
 
@@ -56,46 +57,9 @@ type Account struct {
 	ARN   string `json:"arn"`
 }
 
-// grafanaQueryResponse is the raw Grafana /api/ds/query (or K8s query API) response.
-type grafanaQueryResponse struct {
-	Results map[string]grafanaResult `json:"results"`
-}
-
-type grafanaResult struct {
-	Frames      []dataFrame `json:"frames,omitempty"`
-	Error       string      `json:"error,omitempty"`
-	ErrorSource string      `json:"errorSource,omitempty"`
-	Status      int         `json:"status,omitempty"`
-}
-
-type dataFrame struct {
-	Schema dataFrameSchema `json:"schema"`
-	Data   dataFrameData   `json:"data"`
-}
-
-type dataFrameSchema struct {
-	Name   string  `json:"name,omitempty"`
-	Fields []field `json:"fields,omitempty"`
-}
-
-type fieldConfig struct {
-	DisplayNameFromDS string `json:"displayNameFromDS,omitempty"`
-}
-
-type field struct {
-	Name   string            `json:"name,omitempty"`
-	Type   string            `json:"type,omitempty"`
-	Labels map[string]string `json:"labels,omitempty"`
-	Config *fieldConfig      `json:"config,omitempty"`
-}
-
-type dataFrameData struct {
-	Values []json.RawMessage `json:"values,omitempty"`
-}
-
 // ParseQueryResponse converts the raw Grafana response bytes into a QueryResponse.
 func ParseQueryResponse(body []byte) (*QueryResponse, error) {
-	var raw grafanaQueryResponse
+	var raw dataframe.Response
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, fmt.Errorf("failed to parse cloudwatch response: %w", err)
 	}
@@ -118,10 +82,7 @@ func ParseQueryResponse(body []byte) (*QueryResponse, error) {
 	}
 
 	for _, df := range result.Frames {
-		frame, ok, err := parseDataFrame(df)
-		if err != nil {
-			return nil, err
-		}
+		frame, ok := parseDataFrame(df)
 		if ok {
 			resp.Frames = append(resp.Frames, frame)
 		}
@@ -130,10 +91,10 @@ func ParseQueryResponse(body []byte) (*QueryResponse, error) {
 	return resp, nil
 }
 
-func parseDataFrame(df dataFrame) (Frame, bool, error) {
+func parseDataFrame(df dataframe.Frame) (Frame, bool) {
 	// Treat schema/data length mismatch as malformed (don't index past Data).
 	if len(df.Schema.Fields) != len(df.Data.Values) || len(df.Data.Values) < 2 {
-		return Frame{}, false, nil
+		return Frame{}, false
 	}
 
 	var timeIdx, valueIdx = -1, -1
@@ -157,18 +118,11 @@ func parseDataFrame(df dataFrame) (Frame, bool, error) {
 	}
 
 	if timeIdx == -1 || valueIdx == -1 {
-		return Frame{}, false, nil
+		return Frame{}, false
 	}
 
-	var tsRaw []any
-	if err := json.Unmarshal(df.Data.Values[timeIdx], &tsRaw); err != nil {
-		return Frame{}, false, fmt.Errorf("failed to parse timestamps: %w", err)
-	}
-
-	var valRaw []any
-	if err := json.Unmarshal(df.Data.Values[valueIdx], &valRaw); err != nil {
-		return Frame{}, false, fmt.Errorf("failed to parse values: %w", err)
-	}
+	tsRaw := df.Data.Values[timeIdx]
+	valRaw := df.Data.Values[valueIdx]
 
 	n := min(len(tsRaw), len(valRaw))
 
@@ -198,7 +152,7 @@ func parseDataFrame(df dataFrame) (Frame, bool, error) {
 
 	if len(timestamps) == 0 {
 		// Drop empty/all-unparseable frames so callers see "no data" rather than a phantom series.
-		return Frame{}, false, nil
+		return Frame{}, false
 	}
 
 	return Frame{
@@ -206,7 +160,7 @@ func parseDataFrame(df dataFrame) (Frame, bool, error) {
 		Labels:     labels,
 		Timestamps: timestamps,
 		Values:     values,
-	}, true, nil
+	}, true
 }
 
 // toFloat64 returns ok=false if v is not a number or a parseable numeric string.

--- a/internal/query/dataframe/types.go
+++ b/internal/query/dataframe/types.go
@@ -22,8 +22,32 @@ type Frame struct {
 
 // Schema describes a Grafana data frame schema.
 type Schema struct {
+	RefId  string  `json:"refId,omitempty"`
 	Name   string  `json:"name,omitempty"`
+	Meta   *Meta   `json:"meta,omitempty"`
 	Fields []Field `json:"fields,omitempty"`
+}
+
+// Meta contains metadata about a data frame, such as query execution stats
+// and notices surfaced by the datasource plugin.
+type Meta struct {
+	Type                string   `json:"type,omitempty"`
+	Stats               []Stat   `json:"stats,omitempty"`
+	Notices             []Notice `json:"notices,omitempty"`
+	ExecutedQueryString string   `json:"executedQueryString,omitempty"`
+}
+
+// Stat represents a single statistic from query execution.
+type Stat struct {
+	DisplayName string  `json:"displayName"`
+	Unit        string  `json:"unit,omitempty"`
+	Value       float64 `json:"value"`
+}
+
+// Notice represents a notice or warning attached to a data frame.
+type Notice struct {
+	Severity string `json:"severity"`
+	Text     string `json:"text"`
 }
 
 // Field describes a field in a Grafana data frame.
@@ -31,9 +55,16 @@ type Field struct {
 	Name   string            `json:"name,omitempty"`
 	Type   string            `json:"type,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
+	Config *FieldConfig      `json:"config,omitempty"`
+}
+
+// FieldConfig holds display/formatting hints for a data frame field.
+type FieldConfig struct {
+	DisplayNameFromDS string `json:"displayNameFromDS,omitempty"`
 }
 
 // Data contains column-oriented Grafana data frame values.
 type Data struct {
 	Values [][]any `json:"values,omitempty"`
+	Nanos  [][]int `json:"nanos,omitempty"`
 }

--- a/internal/query/loki/client.go
+++ b/internal/query/loki/client.go
@@ -1,7 +1,6 @@
 package loki
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,13 +10,15 @@ import (
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/httputils"
+	"github.com/grafana/gcx/internal/query/grafanaquery"
 	"github.com/grafana/gcx/internal/queryerror"
 	"k8s.io/client-go/rest"
 )
 
 type Client struct {
-	restConfig config.NamespacedRESTConfig
-	httpClient *http.Client
+	restConfig  config.NamespacedRESTConfig
+	httpClient  *http.Client
+	queryClient *grafanaquery.Client
 }
 
 func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
@@ -27,14 +28,46 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 	}
 
 	return &Client{
-		restConfig: cfg,
-		httpClient: httpClient,
+		restConfig:  cfg,
+		httpClient:  httpClient,
+		queryClient: grafanaquery.NewClientWithHTTPClient(cfg, httpClient),
 	}, nil
 }
 
 func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryRequest) (*QueryResponse, error) {
-	apiPath := c.buildQueryPath()
+	body, err := c.buildQueryBody(datasourceUID, req, true)
+	if err != nil {
+		return nil, err
+	}
 
+	grafanaResp, err := c.executeQuery(ctx, body, "query")
+	if err != nil {
+		return nil, err
+	}
+
+	return convertGrafanaResponse(grafanaResp), nil
+}
+
+// MetricQuery executes a metric LogQL query and returns a Prometheus-compatible time-series response.
+// Metric LogQL expressions (e.g., rate, count_over_time) return time-series data rather than log streams.
+func (c *Client) MetricQuery(ctx context.Context, datasourceUID string, req QueryRequest) (*MetricQueryResponse, error) {
+	body, err := c.buildQueryBody(datasourceUID, req, false)
+	if err != nil {
+		return nil, err
+	}
+
+	grafanaResp, err := c.executeQuery(ctx, body, "metric query")
+	if err != nil {
+		return nil, err
+	}
+
+	return convertMetricResponse(grafanaResp), nil
+}
+
+// buildQueryBody builds the Grafana datasource query API request body shared by
+// Query and MetricQuery. includeMaxLines controls whether req.Limit is sent as
+// maxLines — MetricQuery results are time-series, not log lines, so it doesn't apply.
+func (c *Client) buildQueryBody(datasourceUID string, req QueryRequest, includeMaxLines bool) ([]byte, error) {
 	query := map[string]any{
 		"refId": "A",
 		"datasource": map[string]any{
@@ -58,7 +91,7 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		query["instant"] = true
 	}
 
-	if req.Limit > 0 {
+	if includeMaxLines && req.Limit > 0 {
 		query["maxLines"] = req.Limit
 	}
 
@@ -73,147 +106,16 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute query: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	// The K8s query API is not enabled everywhere and can return a non-200
-	// (e.g. 403 for some roles); fall back to the legacy /api/ds/query.
-	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
-		apiPath = "/api/ds/query"
-		httpReq, err = http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create request: %w", err)
-		}
-		httpReq.Header.Set("Content-Type", "application/json")
-		resp, err = c.httpClient.Do(httpReq)
-		if err != nil {
-			return nil, fmt.Errorf("failed to execute query: %w", err)
-		}
-		defer resp.Body.Close()
-		respBody, err = httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read response: %w", err)
-		}
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, queryerror.FromBody("loki", "query", resp.StatusCode, respBody)
-	}
-
-	var grafanaResp GrafanaQueryResponse
-	if err := json.Unmarshal(respBody, &grafanaResp); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	if result, ok := grafanaResp.Results["A"]; ok {
-		if result.Error != "" {
-			status := result.Status
-			if status == 0 {
-				status = http.StatusBadRequest
-			}
-			return nil, queryerror.New("loki", "query", status, result.Error, result.ErrorSource)
-		}
-	}
-
-	return convertGrafanaResponse(&grafanaResp), nil
+	return body, nil
 }
 
-// MetricQuery executes a metric LogQL query and returns a Prometheus-compatible time-series response.
-// Metric LogQL expressions (e.g., rate, count_over_time) return time-series data rather than log streams.
-func (c *Client) MetricQuery(ctx context.Context, datasourceUID string, req QueryRequest) (*MetricQueryResponse, error) {
-	apiPath := c.buildQueryPath()
-
-	query := map[string]any{
-		"refId": "A",
-		"datasource": map[string]any{
-			"type": "loki",
-			"uid":  datasourceUID,
-		},
-		"expr":       req.Query,
-		"intervalMs": 60000,
-	}
-
-	var from, to string
-	if req.IsRange() {
-		from = strconv.FormatInt(req.Start.UnixMilli(), 10)
-		to = strconv.FormatInt(req.End.UnixMilli(), 10)
-		if req.Step > 0 {
-			query["intervalMs"] = req.Step.Milliseconds()
-		}
-	} else {
-		from = "now-1m"
-		to = "now"
-		query["instant"] = true
-	}
-
-	bodyMap := map[string]any{
-		"queries": []any{query},
-		"from":    from,
-		"to":      to,
-	}
-
-	body, err := json.Marshal(bodyMap)
+// executeQuery posts body to Grafana's datasource query API (fallback to the
+// legacy endpoint is handled by grafanaquery.Client) and decodes the envelope,
+// translating an embedded query-level error into a typed API error.
+func (c *Client) executeQuery(ctx context.Context, body []byte, operation string) (*GrafanaQueryResponse, error) {
+	respBody, err := c.queryClient.Execute(ctx, body, "loki", operation)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute query: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	// The K8s query API is not enabled everywhere and can return a non-200
-	// (e.g. 403 for some roles); fall back to the legacy /api/ds/query.
-	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
-		apiPath = "/api/ds/query"
-		httpReq, err = http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create request: %w", err)
-		}
-		httpReq.Header.Set("Content-Type", "application/json")
-		resp, err = c.httpClient.Do(httpReq)
-		if err != nil {
-			return nil, fmt.Errorf("failed to execute query: %w", err)
-		}
-		defer resp.Body.Close()
-		respBody, err = httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read response: %w", err)
-		}
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, queryerror.FromBody("loki", "metric query", resp.StatusCode, respBody)
+		return nil, err
 	}
 
 	var grafanaResp GrafanaQueryResponse
@@ -227,11 +129,11 @@ func (c *Client) MetricQuery(ctx context.Context, datasourceUID string, req Quer
 			if status == 0 {
 				status = http.StatusBadRequest
 			}
-			return nil, queryerror.New("loki", "metric query", status, result.Error, result.ErrorSource)
+			return nil, queryerror.New("loki", operation, status, result.Error, result.ErrorSource)
 		}
 	}
 
-	return convertMetricResponse(&grafanaResp), nil
+	return &grafanaResp, nil
 }
 
 func (c *Client) Labels(ctx context.Context, datasourceUID string) (*LabelsResponse, error) {
@@ -333,11 +235,6 @@ func (c *Client) Series(ctx context.Context, datasourceUID string, matchers []st
 	}
 
 	return &result, nil
-}
-
-func (c *Client) buildQueryPath() string {
-	return fmt.Sprintf("/apis/query.grafana.app/v0alpha1/namespaces/%s/query",
-		c.restConfig.Namespace)
 }
 
 func (c *Client) buildLabelsPath(datasourceUID string) string {

--- a/internal/query/loki/types.go
+++ b/internal/query/loki/types.go
@@ -2,6 +2,8 @@ package loki
 
 import (
 	"time"
+
+	"github.com/grafana/gcx/internal/query/dataframe"
 )
 
 // QueryRequest represents a Loki query request.
@@ -86,63 +88,29 @@ type MetricQuerySample struct {
 	Values [][]any           `json:"values,omitempty"` // [[timestamp, value], ...] for range queries
 }
 
-// GrafanaQueryResponse represents the response from Grafana's datasource query API.
-type GrafanaQueryResponse struct {
-	Results map[string]GrafanaResult `json:"results"`
-}
+// GrafanaQueryResponse is the top-level Grafana datasource query response.
+type GrafanaQueryResponse = dataframe.Response
 
 // GrafanaResult represents a single result from a Grafana query.
-type GrafanaResult struct {
-	Frames      []DataFrame `json:"frames,omitempty"`
-	Error       string      `json:"error,omitempty"`
-	ErrorSource string      `json:"errorSource,omitempty"`
-	Status      int         `json:"status,omitempty"`
-}
+type GrafanaResult = dataframe.Result
 
 // DataFrame represents a Grafana data frame.
-type DataFrame struct {
-	Schema DataFrameSchema `json:"schema"`
-	Data   DataFrameData   `json:"data"`
-}
+type DataFrame = dataframe.Frame
 
 // DataFrameSchema describes the structure of a data frame.
-type DataFrameSchema struct {
-	RefId  string     `json:"refId,omitempty"`
-	Meta   *FrameMeta `json:"meta,omitempty"`
-	Name   string     `json:"name,omitempty"`
-	Fields []Field    `json:"fields,omitempty"`
-}
+type DataFrameSchema = dataframe.Schema
 
 // FrameMeta contains metadata about a data frame.
-type FrameMeta struct {
-	Type                string        `json:"type,omitempty"`
-	Stats               []FrameStat   `json:"stats,omitempty"`
-	Notices             []FrameNotice `json:"notices,omitempty"`
-	ExecutedQueryString string        `json:"executedQueryString,omitempty"`
-}
+type FrameMeta = dataframe.Meta
 
 // FrameStat represents a single statistic from query execution.
-type FrameStat struct {
-	DisplayName string  `json:"displayName"`
-	Unit        string  `json:"unit,omitempty"`
-	Value       float64 `json:"value"`
-}
+type FrameStat = dataframe.Stat
 
 // FrameNotice represents a notice or warning from the query.
-type FrameNotice struct {
-	Severity string `json:"severity"`
-	Text     string `json:"text"`
-}
+type FrameNotice = dataframe.Notice
 
 // Field describes a field in a data frame.
-type Field struct {
-	Name   string            `json:"name,omitempty"`
-	Type   string            `json:"type,omitempty"`
-	Labels map[string]string `json:"labels,omitempty"`
-}
+type Field = dataframe.Field
 
 // DataFrameData contains the actual data values.
-type DataFrameData struct {
-	Values [][]any `json:"values,omitempty"`
-	Nanos  [][]int `json:"nanos,omitempty"`
-}
+type DataFrameData = dataframe.Data

--- a/internal/query/prometheus/client.go
+++ b/internal/query/prometheus/client.go
@@ -1,7 +1,6 @@
 package prometheus
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,14 +10,16 @@ import (
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/httputils"
+	"github.com/grafana/gcx/internal/query/grafanaquery"
 	"github.com/grafana/gcx/internal/queryerror"
 	"k8s.io/client-go/rest"
 )
 
 // Client is a client for executing Prometheus queries via Grafana's datasource API.
 type Client struct {
-	restConfig config.NamespacedRESTConfig
-	httpClient *http.Client
+	restConfig  config.NamespacedRESTConfig
+	httpClient  *http.Client
+	queryClient *grafanaquery.Client
 }
 
 // NewClient creates a new Prometheus query client.
@@ -29,15 +30,14 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 	}
 
 	return &Client{
-		restConfig: cfg,
-		httpClient: httpClient,
+		restConfig:  cfg,
+		httpClient:  httpClient,
+		queryClient: grafanaquery.NewClientWithHTTPClient(cfg, httpClient),
 	}, nil
 }
 
 // Query executes a Prometheus query against the specified datasource.
 func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryRequest) (*QueryResponse, error) {
-	apiPath := c.buildQueryPath()
-
 	// Build the query object with datasource info
 	query := map[string]any{
 		"refId": "A",
@@ -82,47 +82,9 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
+	respBody, err := c.queryClient.Execute(ctx, body, "prometheus", "query")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute query: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	// The K8s query API is not enabled everywhere and can return a non-200
-	// (e.g. 403 for some roles); fall back to the legacy /api/ds/query.
-	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
-		apiPath = "/api/ds/query"
-		httpReq, err = http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create request: %w", err)
-		}
-		httpReq.Header.Set("Content-Type", "application/json")
-		resp, err = c.httpClient.Do(httpReq)
-		if err != nil {
-			return nil, fmt.Errorf("failed to execute query: %w", err)
-		}
-		defer resp.Body.Close()
-		respBody, err = httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read response: %w", err)
-		}
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, queryerror.FromBody("prometheus", "query", resp.StatusCode, respBody)
+		return nil, err
 	}
 
 	// Parse the Grafana datasource response format
@@ -248,11 +210,6 @@ func (c *Client) Metadata(ctx context.Context, datasourceUID string, metric stri
 	}
 
 	return &result, nil
-}
-
-func (c *Client) buildQueryPath() string {
-	return fmt.Sprintf("/apis/query.grafana.app/v0alpha1/namespaces/%s/query",
-		c.restConfig.Namespace)
 }
 
 func (c *Client) buildLabelsPath(datasourceUID string) string {

--- a/internal/query/prometheus/types.go
+++ b/internal/query/prometheus/types.go
@@ -3,6 +3,8 @@ package prometheus
 import (
 	"strconv"
 	"time"
+
+	"github.com/grafana/gcx/internal/query/dataframe"
 )
 
 // QueryRequest represents a Prometheus query request.
@@ -59,42 +61,23 @@ type MetadataEntry struct {
 	Unit string `json:"unit,omitempty"`
 }
 
-// GrafanaQueryResponse represents the response from Grafana's datasource query API.
-type GrafanaQueryResponse struct {
-	Results map[string]GrafanaResult `json:"results"`
-}
+// GrafanaQueryResponse is the top-level Grafana datasource query response.
+type GrafanaQueryResponse = dataframe.Response
 
 // GrafanaResult represents a single result from a Grafana query.
-type GrafanaResult struct {
-	Frames      []DataFrame `json:"frames,omitempty"`
-	Error       string      `json:"error,omitempty"`
-	ErrorSource string      `json:"errorSource,omitempty"`
-	Status      int         `json:"status,omitempty"`
-}
+type GrafanaResult = dataframe.Result
 
 // DataFrame represents a Grafana data frame.
-type DataFrame struct {
-	Schema DataFrameSchema `json:"schema"`
-	Data   DataFrameData   `json:"data"`
-}
+type DataFrame = dataframe.Frame
 
 // DataFrameSchema describes the structure of a data frame.
-type DataFrameSchema struct {
-	Name   string  `json:"name,omitempty"`
-	Fields []Field `json:"fields,omitempty"`
-}
+type DataFrameSchema = dataframe.Schema
 
 // Field describes a field in a data frame.
-type Field struct {
-	Name   string            `json:"name,omitempty"`
-	Type   string            `json:"type,omitempty"`
-	Labels map[string]string `json:"labels,omitempty"`
-}
+type Field = dataframe.Field
 
 // DataFrameData contains the actual data values.
-type DataFrameData struct {
-	Values [][]any `json:"values,omitempty"`
-}
+type DataFrameData = dataframe.Data
 
 // convertGrafanaResponse converts a Grafana query response to the Prometheus-style
 // format. The result type reflects the request intent, not the shape of the data


### PR DESCRIPTION
## Summary
- `internal/query/prometheus/client.go`, `internal/query/loki/client.go` (both `Query` and `MetricQuery`), and `internal/query/cloudwatch/client.go`/`types.go` each hand-rolled their own POST + `/api/ds/query` fallback logic and duplicated the Grafana data frame wire structs (`GrafanaQueryResponse`/`DataFrame`/`Field`/`Data`), instead of reusing `internal/query/grafanaquery` and `internal/query/dataframe` like the clickhouse/infinity/influxdb/athena clients already do (per `CLAUDE.md`'s "Datasource query reuse" convention).
- Migrated all three to `grafanaquery.Client.Execute` for transport and `dataframe.Response` for wire types, deleting the duplicated structs and fallback code entirely (no compatibility shims).
- Extended the shared `internal/query/dataframe` types with `Schema.Meta`/`Stat`/`Notice`, `Field.Config`/`FieldConfig`, and `Data.Nanos` — these are generic parts of Grafana's data frame wire format that loki (query stats/notices, nanosecond timestamps) and cloudwatch (`displayNameFromDS`) depend on, so they needed to move into the shared type rather than staying as datasource-local one-offs.
- Loki's `Query` and `MetricQuery` had two near-identical ~50-line fallback blocks; these are now a single `buildQueryBody`/`executeQuery` pair shared by both.
- Domain-specific response parsing (Prometheus vector/matrix shaping, Loki stream/legacy-format conversion, CloudWatch frame parsing incl. the `displayNameFromDS` series-naming quirk) is preserved as-is — only the generic transport/wire-struct layer changed.

## Test plan
- [x] `go test -race -count=1 ./...` — full suite passes (one pre-existing, unrelated flake in `internal/providers/kg` was confirmed via `git stash`/`git stash pop` to reproduce on `main` too, caused by `CLAUDECODE=1` auto-enabling agent mode in this sandbox; it does not reproduce with `GCX_AGENT_MODE=false`, which `mise run all` sets, and is unrelated to this change)
- [x] `mise run lint` — 0 issues
- [x] `GCX_AGENT_MODE=false mise run all` — lint + tests + build + docs all pass, no reference/doc drift
- [x] `go build -buildvcs=false -o bin/gcx ./cmd/gcx/` succeeds
- [x] Verified prometheus/loki/cloudwatch query output unchanged via the existing unit/table tests for each package (all pass unmodified against the new transport, including the fallback-on-non-200, typed-API-error, and malformed-JSON cases). No live Grafana stack was available in this environment, so this was verified via unit tests rather than a live round-trip — noting that explicitly per the task's verification requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)