### PR TITLE
refactor(aio11y): dedupe marshal/status-check/decode pattern with DoJSON/DoStatus

### DIFF
--- a/internal/providers/aio11y/agents/client.go
+++ b/internal/providers/aio11y/agents/client.go
@@ -2,8 +2,6 @@ package agents
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -43,19 +41,9 @@ func (c *Client) Lookup(ctx context.Context, name, version string) (*AgentDetail
 		query.Set("version", version)
 	}
 
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, agentLookupPath+"?"+query.Encode(), nil)
+	detail, err := aio11yhttp.DoJSON[any, AgentDetail](ctx, c.base, http.MethodGet, agentLookupPath+"?"+query.Encode(), nil, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to lookup agent %s: %w", name, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var detail AgentDetail
-	if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
-		return nil, fmt.Errorf("failed to decode agent response: %w", err)
+		return nil, err
 	}
 	return &detail, nil
 }

--- a/internal/providers/aio11y/aio11yhttp/client.go
+++ b/internal/providers/aio11y/aio11yhttp/client.go
@@ -1,6 +1,7 @@
 package aio11yhttp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/grafana/gcx/internal/config"
@@ -117,6 +119,98 @@ func ListAll[T any](ctx context.Context, c *Client, basePath string, query url.V
 		return []T{}, nil
 	}
 	return all, nil
+}
+
+// DoJSON executes an HTTP request against the plugin API, optionally
+// marshaling body as the JSON request payload, and decodes a JSON response
+// into Resp. Pass a nil body for requests with no request body (e.g.
+// GET/DELETE) — in that case Req can be instantiated as `any`.
+//
+// Any response status not present in okStatuses is treated as an error via
+// HandleErrorResponse.
+func DoJSON[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, okStatuses ...int) (Resp, error) {
+	return doJSON[Req, Resp](ctx, c, method, path, body, nil, okStatuses)
+}
+
+// DoJSONNotFound behaves like DoJSON, but returns notFoundErr instead of the
+// generic HandleErrorResponse error when the response status is 404.
+// Callers typically pass a sentinel wrapped with request-specific context,
+// e.g. fmt.Errorf("%s: %w", id, ErrNotFound), so that errors.Is still
+// matches the resource-specific sentinel.
+func DoJSONNotFound[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses ...int) (Resp, error) {
+	return doJSON[Req, Resp](ctx, c, method, path, body, notFoundErr, okStatuses)
+}
+
+func doJSON[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses []int) (Resp, error) {
+	var zero Resp
+
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return zero, fmt.Errorf("failed to marshal request: %w", err)
+		}
+		reader = bytes.NewReader(b)
+	}
+
+	resp, err := c.DoRequest(ctx, method, path, reader)
+	if err != nil {
+		return zero, err
+	}
+	defer resp.Body.Close()
+
+	if notFoundErr != nil && resp.StatusCode == http.StatusNotFound {
+		return zero, notFoundErr
+	}
+	if !slices.Contains(okStatuses, resp.StatusCode) {
+		return zero, HandleErrorResponse(resp)
+	}
+
+	var result Resp
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return zero, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return result, nil
+}
+
+// DoStatus executes an HTTP request against the plugin API, optionally
+// marshaling body as the JSON request payload, and checks that the response
+// status is one of okStatuses without decoding a response body. Use this for
+// endpoints that return no useful body (e.g. DELETE, or actions like
+// cancel/add-members).
+func DoStatus[Req any](ctx context.Context, c *Client, method, path string, body *Req, okStatuses ...int) error {
+	return doStatus[Req](ctx, c, method, path, body, nil, okStatuses)
+}
+
+// DoStatusNotFound behaves like DoStatus, but returns notFoundErr instead of
+// the generic HandleErrorResponse error when the response status is 404.
+func DoStatusNotFound[Req any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses ...int) error {
+	return doStatus[Req](ctx, c, method, path, body, notFoundErr, okStatuses)
+}
+
+func doStatus[Req any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses []int) error {
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request: %w", err)
+		}
+		reader = bytes.NewReader(b)
+	}
+
+	resp, err := c.DoRequest(ctx, method, path, reader)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if notFoundErr != nil && resp.StatusCode == http.StatusNotFound {
+		return notFoundErr
+	}
+	if !slices.Contains(okStatuses, resp.StatusCode) {
+		return HandleErrorResponse(resp)
+	}
+	return nil
 }
 
 // NewClientFromCommand creates a Client from a cobra command and config loader.

--- a/internal/providers/aio11y/conversations/client.go
+++ b/internal/providers/aio11y/conversations/client.go
@@ -1,9 +1,7 @@
 package conversations
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -34,43 +32,18 @@ func (c *Client) List(ctx context.Context, limit int) ([]Conversation, error) {
 
 // Get returns a single conversation by ID with all its generations.
 func (c *Client) Get(ctx context.Context, id string) (*ConversationDetail, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(conversationByIDFmt, url.PathEscape(id)), nil)
+	detail, err := aio11yhttp.DoJSON[any, ConversationDetail](ctx, c.base, http.MethodGet, fmt.Sprintf(conversationByIDFmt, url.PathEscape(id)), nil, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get conversation %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var detail ConversationDetail
-	if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
-		return nil, fmt.Errorf("failed to decode conversation response: %w", err)
+		return nil, err
 	}
 	return &detail, nil
 }
 
 // Search searches conversations with filters and time range.
 func (c *Client) Search(ctx context.Context, req SearchRequest) (*SearchResponse, error) {
-	body, err := json.Marshal(req)
+	searchResp, err := aio11yhttp.DoJSON[SearchRequest, SearchResponse](ctx, c.base, http.MethodPost, conversationSearchPath, &req, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal search request: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, conversationSearchPath, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to search conversations: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var searchResp SearchResponse
-	if err := json.NewDecoder(resp.Body).Decode(&searchResp); err != nil {
-		return nil, fmt.Errorf("failed to decode search response: %w", err)
+		return nil, err
 	}
 	return &searchResp, nil
 }

--- a/internal/providers/aio11y/eval/collections/client.go
+++ b/internal/providers/aio11y/eval/collections/client.go
@@ -1,9 +1,7 @@
 package collections
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -36,22 +34,10 @@ func (c *Client) List(ctx context.Context, limit int) ([]Collection, error) {
 // callers (and the resource adapter) can distinguish missing resources from
 // other API errors.
 func (c *Client) Get(ctx context.Context, id string) (*Collection, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, basePath+"/"+url.PathEscape(id), nil)
+	col, err := aio11yhttp.DoJSONNotFound[any, Collection](ctx, c.base, http.MethodGet, basePath+"/"+url.PathEscape(id), nil,
+		fmt.Errorf("%s: %w", id, ErrNotFound), http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get collection %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("%s: %w", id, ErrNotFound)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var col Collection
-	if err := json.NewDecoder(resp.Body).Decode(&col); err != nil {
-		return nil, fmt.Errorf("failed to decode collection response: %w", err)
+		return nil, err
 	}
 	return &col, nil
 }
@@ -59,24 +45,9 @@ func (c *Client) Get(ctx context.Context, id string) (*Collection, error) {
 // Create creates a new collection. Server-managed fields on the input are
 // dropped on the wire by the `omitempty` / `omitzero` JSON tags.
 func (c *Client) Create(ctx context.Context, col *Collection) (*Collection, error) {
-	body, err := json.Marshal(col)
+	created, err := aio11yhttp.DoJSON[Collection, Collection](ctx, c.base, http.MethodPost, basePath, col, http.StatusOK, http.StatusCreated)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal create request: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, basePath, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create collection: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var created Collection
-	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
-		return nil, fmt.Errorf("failed to decode collection response: %w", err)
+		return nil, err
 	}
 	return &created, nil
 }
@@ -84,40 +55,16 @@ func (c *Client) Create(ctx context.Context, col *Collection) (*Collection, erro
 // Update patches a collection's name and/or description. The collections API
 // is not an upsert — Update must be called against an existing collection.
 func (c *Client) Update(ctx context.Context, id string, req *UpdateRequest) (*Collection, error) {
-	body, err := json.Marshal(req)
+	col, err := aio11yhttp.DoJSON[UpdateRequest, Collection](ctx, c.base, http.MethodPatch, basePath+"/"+url.PathEscape(id), req, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal update request: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPatch, basePath+"/"+url.PathEscape(id), bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to update collection %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var col Collection
-	if err := json.NewDecoder(resp.Body).Decode(&col); err != nil {
-		return nil, fmt.Errorf("failed to decode collection response: %w", err)
+		return nil, err
 	}
 	return &col, nil
 }
 
 // Delete removes a collection by ID.
 func (c *Client) Delete(ctx context.Context, id string) error {
-	resp, err := c.base.DoRequest(ctx, http.MethodDelete, basePath+"/"+url.PathEscape(id), nil)
-	if err != nil {
-		return fmt.Errorf("failed to delete collection %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return aio11yhttp.HandleErrorResponse(resp)
-	}
-	return nil
+	return aio11yhttp.DoStatus[any](ctx, c.base, http.MethodDelete, basePath+"/"+url.PathEscape(id), nil, http.StatusOK, http.StatusNoContent)
 }
 
 // ListMembers returns the saved conversations belonging to a collection.
@@ -130,35 +77,12 @@ func (c *Client) ListMembers(ctx context.Context, id string, limit int) ([]saved
 
 // AddMembers adds one or more saved conversations to a collection.
 func (c *Client) AddMembers(ctx context.Context, id string, savedIDs []string) error {
-	body, err := json.Marshal(&AddMembersRequest{SavedIDs: savedIDs})
-	if err != nil {
-		return fmt.Errorf("failed to marshal add-members request: %w", err)
-	}
-
 	path := basePath + "/" + url.PathEscape(id) + "/members"
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, path, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("failed to add members to collection %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
-		return aio11yhttp.HandleErrorResponse(resp)
-	}
-	return nil
+	return aio11yhttp.DoStatus(ctx, c.base, http.MethodPost, path, &AddMembersRequest{SavedIDs: savedIDs}, http.StatusOK, http.StatusCreated, http.StatusNoContent)
 }
 
 // RemoveMember removes a single saved conversation from a collection.
 func (c *Client) RemoveMember(ctx context.Context, id, savedID string) error {
 	path := basePath + "/" + url.PathEscape(id) + "/members/" + url.PathEscape(savedID)
-	resp, err := c.base.DoRequest(ctx, http.MethodDelete, path, nil)
-	if err != nil {
-		return fmt.Errorf("failed to remove member %s from collection %s: %w", savedID, id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return aio11yhttp.HandleErrorResponse(resp)
-	}
-	return nil
+	return aio11yhttp.DoStatus[any](ctx, c.base, http.MethodDelete, path, nil, http.StatusOK, http.StatusNoContent)
 }

--- a/internal/providers/aio11y/eval/evaluators/client.go
+++ b/internal/providers/aio11y/eval/evaluators/client.go
@@ -1,9 +1,7 @@
 package evaluators
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -35,81 +33,32 @@ func (c *Client) List(ctx context.Context) ([]eval.EvaluatorDefinition, error) {
 
 // Get returns a single evaluator by ID.
 func (c *Client) Get(ctx context.Context, id string) (*eval.EvaluatorDefinition, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(evaluatorByIDFmt, url.PathEscape(id)), nil)
+	evaluator, err := aio11yhttp.DoJSON[any, eval.EvaluatorDefinition](ctx, c.base, http.MethodGet, fmt.Sprintf(evaluatorByIDFmt, url.PathEscape(id)), nil, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get evaluator %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var evaluator eval.EvaluatorDefinition
-	if err := json.NewDecoder(resp.Body).Decode(&evaluator); err != nil {
-		return nil, fmt.Errorf("failed to decode evaluator response: %w", err)
+		return nil, err
 	}
 	return &evaluator, nil
 }
 
 // Create creates or updates an evaluator (POST is create-or-update).
 func (c *Client) Create(ctx context.Context, evaluator *eval.EvaluatorDefinition) (*eval.EvaluatorDefinition, error) {
-	body, err := json.Marshal(evaluator)
+	created, err := aio11yhttp.DoJSON[eval.EvaluatorDefinition, eval.EvaluatorDefinition](ctx, c.base, http.MethodPost, basePath, evaluator, http.StatusOK, http.StatusCreated)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal evaluator: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, basePath, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create evaluator: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var created eval.EvaluatorDefinition
-	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
-		return nil, fmt.Errorf("failed to decode evaluator response: %w", err)
+		return nil, err
 	}
 	return &created, nil
 }
 
 // RunTest executes a one-shot eval:test against a generation.
 func (c *Client) RunTest(ctx context.Context, req *eval.EvalTestRequest) (*eval.EvalTestResponse, error) {
-	body, err := json.Marshal(req)
+	result, err := aio11yhttp.DoJSON[eval.EvalTestRequest, eval.EvalTestResponse](ctx, c.base, http.MethodPost, evalTestPath, req, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal test request: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, evalTestPath, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to run eval test: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var result eval.EvalTestResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode test response: %w", err)
+		return nil, err
 	}
 	return &result, nil
 }
 
 // Delete soft-deletes an evaluator by ID.
 func (c *Client) Delete(ctx context.Context, id string) error {
-	resp, err := c.base.DoRequest(ctx, http.MethodDelete, fmt.Sprintf(evaluatorByIDFmt, url.PathEscape(id)), nil)
-	if err != nil {
-		return fmt.Errorf("failed to delete evaluator %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return aio11yhttp.HandleErrorResponse(resp)
-	}
-	return nil
+	return aio11yhttp.DoStatus[any](ctx, c.base, http.MethodDelete, fmt.Sprintf(evaluatorByIDFmt, url.PathEscape(id)), nil, http.StatusOK, http.StatusNoContent)
 }

--- a/internal/providers/aio11y/eval/experiments/client.go
+++ b/internal/providers/aio11y/eval/experiments/client.go
@@ -1,9 +1,7 @@
 package experiments
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -37,73 +35,29 @@ func (c *Client) List(ctx context.Context, limit int) ([]Experiment, error) {
 
 // Get returns a single experiment by run ID.
 func (c *Client) Get(ctx context.Context, runID string) (*Experiment, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, basePath+"/"+url.PathEscape(runID), nil)
+	exp, err := aio11yhttp.DoJSONNotFound[any, Experiment](ctx, c.base, http.MethodGet, basePath+"/"+url.PathEscape(runID), nil,
+		fmt.Errorf("%s: %w", runID, ErrNotFound), http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get experiment %s: %w", runID, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("%s: %w", runID, ErrNotFound)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var exp Experiment
-	if err := json.NewDecoder(resp.Body).Decode(&exp); err != nil {
-		return nil, fmt.Errorf("failed to decode experiment response: %w", err)
+		return nil, err
 	}
 	return &exp, nil
 }
 
 // Create creates a new experiment.
 func (c *Client) Create(ctx context.Context, exp *Experiment) (*Experiment, error) {
-	body, err := json.Marshal(exp)
+	created, err := aio11yhttp.DoJSON[Experiment, Experiment](ctx, c.base, http.MethodPost, basePath, exp, http.StatusOK, http.StatusCreated)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal create request: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, basePath, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create experiment: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var created Experiment
-	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
-		return nil, fmt.Errorf("failed to decode experiment response: %w", err)
+		return nil, err
 	}
 	return &created, nil
 }
 
 // Update sends a partial PATCH against an existing experiment.
 func (c *Client) Update(ctx context.Context, runID string, req *UpdateRequest) (*Experiment, error) {
-	body, err := json.Marshal(req)
+	exp, err := aio11yhttp.DoJSONNotFound[UpdateRequest, Experiment](ctx, c.base, http.MethodPatch, basePath+"/"+url.PathEscape(runID), req,
+		fmt.Errorf("%s: %w", runID, ErrNotFound), http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal update request: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPatch, basePath+"/"+url.PathEscape(runID), bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to update experiment %s: %w", runID, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("%s: %w", runID, ErrNotFound)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var exp Experiment
-	if err := json.NewDecoder(resp.Body).Decode(&exp); err != nil {
-		return nil, fmt.Errorf("failed to decode experiment response: %w", err)
+		return nil, err
 	}
 	return &exp, nil
 }
@@ -117,19 +71,8 @@ func (c *Client) Update(ctx context.Context, runID string, req *UpdateRequest) (
 // it manually before appending the action suffix.
 func (c *Client) Cancel(ctx context.Context, runID string) error {
 	escaped := strings.ReplaceAll(url.PathEscape(runID), ":", "%3A")
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, basePath+"/"+escaped+":cancel", nil)
-	if err != nil {
-		return fmt.Errorf("failed to cancel experiment %s: %w", runID, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("%s: %w", runID, ErrNotFound)
-	}
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusAccepted {
-		return aio11yhttp.HandleErrorResponse(resp)
-	}
-	return nil
+	return aio11yhttp.DoStatusNotFound[any](ctx, c.base, http.MethodPost, basePath+"/"+escaped+":cancel", nil,
+		fmt.Errorf("%s: %w", runID, ErrNotFound), http.StatusOK, http.StatusNoContent, http.StatusAccepted)
 }
 
 // ListScores returns scores associated with a single experiment run.
@@ -140,22 +83,10 @@ func (c *Client) ListScores(ctx context.Context, runID string, limit int) ([]Sco
 
 // GetReport returns the aggregate report for an experiment run.
 func (c *Client) GetReport(ctx context.Context, runID string) (*ExperimentReport, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, basePath+"/"+url.PathEscape(runID)+"/report", nil)
+	report, err := aio11yhttp.DoJSONNotFound[any, ExperimentReport](ctx, c.base, http.MethodGet, basePath+"/"+url.PathEscape(runID)+"/report", nil,
+		fmt.Errorf("%s: %w", runID, ErrNotFound), http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get experiment report %s: %w", runID, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("%s: %w", runID, ErrNotFound)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var report ExperimentReport
-	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
-		return nil, fmt.Errorf("failed to decode experiment report: %w", err)
+		return nil, err
 	}
 	return &report, nil
 }

--- a/internal/providers/aio11y/eval/guards/client.go
+++ b/internal/providers/aio11y/eval/guards/client.go
@@ -1,9 +1,7 @@
 package guards
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -38,46 +36,19 @@ func (c *Client) List(ctx context.Context) ([]eval.HookRuleDefinition, error) {
 
 // Get returns a single hook rule by ID.
 func (c *Client) Get(ctx context.Context, id string) (*eval.HookRuleDefinition, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(hookRuleByIDFmt, url.PathEscape(id)), nil)
+	rule, err := aio11yhttp.DoJSONNotFound[any, eval.HookRuleDefinition](ctx, c.base, http.MethodGet, fmt.Sprintf(hookRuleByIDFmt, url.PathEscape(id)), nil,
+		fmt.Errorf("hook rule %s: %w", id, ErrNotFound), http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get hook rule %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("hook rule %s: %w", id, ErrNotFound)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var rule eval.HookRuleDefinition
-	if err := json.NewDecoder(resp.Body).Decode(&rule); err != nil {
-		return nil, fmt.Errorf("failed to decode hook rule response: %w", err)
+		return nil, err
 	}
 	return &rule, nil
 }
 
 // Create creates a new hook rule.
 func (c *Client) Create(ctx context.Context, rule *eval.HookRuleDefinition) (*eval.HookRuleDefinition, error) {
-	body, err := json.Marshal(rule)
+	created, err := aio11yhttp.DoJSON[eval.HookRuleDefinition, eval.HookRuleDefinition](ctx, c.base, http.MethodPost, basePath, rule, http.StatusOK, http.StatusCreated)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal hook rule: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, basePath, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create hook rule: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var created eval.HookRuleDefinition
-	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
-		return nil, fmt.Errorf("failed to decode hook rule response: %w", err)
+		return nil, err
 	}
 	return &created, nil
 }
@@ -86,24 +57,9 @@ func (c *Client) Create(ctx context.Context, rule *eval.HookRuleDefinition) (*ev
 // does not support PATCH; omitted fields reset to server defaults, so callers
 // must send the complete state.
 func (c *Client) Update(ctx context.Context, id string, rule *eval.HookRuleDefinition) (*eval.HookRuleDefinition, error) {
-	body, err := json.Marshal(rule)
+	updated, err := aio11yhttp.DoJSON[eval.HookRuleDefinition, eval.HookRuleDefinition](ctx, c.base, http.MethodPut, fmt.Sprintf(hookRuleByIDFmt, url.PathEscape(id)), rule, http.StatusOK, http.StatusCreated)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal hook rule: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPut, fmt.Sprintf(hookRuleByIDFmt, url.PathEscape(id)), bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to update hook rule: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var updated eval.HookRuleDefinition
-	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
-		return nil, fmt.Errorf("failed to decode hook rule response: %w", err)
+		return nil, err
 	}
 	return &updated, nil
 }
@@ -113,14 +69,5 @@ func (c *Client) Update(ctx context.Context, id string, rule *eval.HookRuleDefin
 // Sigil returns 204 No Content on success; 200 is also accepted for forward
 // compatibility.
 func (c *Client) Delete(ctx context.Context, id string) error {
-	resp, err := c.base.DoRequest(ctx, http.MethodDelete, fmt.Sprintf(hookRuleByIDFmt, url.PathEscape(id)), nil)
-	if err != nil {
-		return fmt.Errorf("failed to delete hook rule %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return aio11yhttp.HandleErrorResponse(resp)
-	}
-	return nil
+	return aio11yhttp.DoStatus[any](ctx, c.base, http.MethodDelete, fmt.Sprintf(hookRuleByIDFmt, url.PathEscape(id)), nil, http.StatusOK, http.StatusNoContent)
 }

--- a/internal/providers/aio11y/eval/judge/client.go
+++ b/internal/providers/aio11y/eval/judge/client.go
@@ -2,8 +2,6 @@ package judge
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -26,23 +24,21 @@ func NewClient(base *aio11yhttp.Client) *Client {
 	return &Client{base: base}
 }
 
+// providersEnvelope is the response envelope for the judge providers endpoint.
+type providersEnvelope struct {
+	Providers []eval.JudgeProvider `json:"providers"`
+}
+
+// modelsEnvelope is the response envelope for the judge models endpoint.
+type modelsEnvelope struct {
+	Models []eval.JudgeModel `json:"models"`
+}
+
 // ListProviders returns available judge providers.
 func (c *Client) ListProviders(ctx context.Context) ([]eval.JudgeProvider, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, judgeProvidersPath, nil)
+	envelope, err := aio11yhttp.DoJSON[any, providersEnvelope](ctx, c.base, http.MethodGet, judgeProvidersPath, nil, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list judge providers: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var envelope struct {
-		Providers []eval.JudgeProvider `json:"providers"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
-		return nil, fmt.Errorf("failed to decode judge providers response: %w", err)
+		return nil, err
 	}
 	return envelope.Providers, nil
 }
@@ -59,21 +55,9 @@ func (c *Client) ListModels(ctx context.Context, provider string) ([]eval.JudgeM
 		path += "?" + encoded
 	}
 
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, path, nil)
+	envelope, err := aio11yhttp.DoJSON[any, modelsEnvelope](ctx, c.base, http.MethodGet, path, nil, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list judge models: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var envelope struct {
-		Models []eval.JudgeModel `json:"models"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
-		return nil, fmt.Errorf("failed to decode judge models response: %w", err)
+		return nil, err
 	}
 	return envelope.Models, nil
 }

--- a/internal/providers/aio11y/eval/rules/client.go
+++ b/internal/providers/aio11y/eval/rules/client.go
@@ -1,9 +1,7 @@
 package rules
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -34,81 +32,32 @@ func (c *Client) List(ctx context.Context) ([]eval.RuleDefinition, error) {
 
 // Get returns a single rule by ID.
 func (c *Client) Get(ctx context.Context, id string) (*eval.RuleDefinition, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(ruleByIDFmt, url.PathEscape(id)), nil)
+	rule, err := aio11yhttp.DoJSON[any, eval.RuleDefinition](ctx, c.base, http.MethodGet, fmt.Sprintf(ruleByIDFmt, url.PathEscape(id)), nil, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get rule %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var rule eval.RuleDefinition
-	if err := json.NewDecoder(resp.Body).Decode(&rule); err != nil {
-		return nil, fmt.Errorf("failed to decode rule response: %w", err)
+		return nil, err
 	}
 	return &rule, nil
 }
 
 // Create creates a new rule.
 func (c *Client) Create(ctx context.Context, rule *eval.RuleDefinition) (*eval.RuleDefinition, error) {
-	body, err := json.Marshal(rule)
+	created, err := aio11yhttp.DoJSON[eval.RuleDefinition, eval.RuleDefinition](ctx, c.base, http.MethodPost, basePath, rule, http.StatusOK, http.StatusCreated)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal rule: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, basePath, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create rule: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var created eval.RuleDefinition
-	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
-		return nil, fmt.Errorf("failed to decode rule response: %w", err)
+		return nil, err
 	}
 	return &created, nil
 }
 
 // Update sends a full rule definition as a PATCH request.
 func (c *Client) Update(ctx context.Context, id string, rule *eval.RuleDefinition) (*eval.RuleDefinition, error) {
-	body, err := json.Marshal(rule)
+	updated, err := aio11yhttp.DoJSON[eval.RuleDefinition, eval.RuleDefinition](ctx, c.base, http.MethodPatch, fmt.Sprintf(ruleByIDFmt, url.PathEscape(id)), rule, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal rule: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPatch, fmt.Sprintf(ruleByIDFmt, url.PathEscape(id)), bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to update rule: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var updated eval.RuleDefinition
-	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
-		return nil, fmt.Errorf("failed to decode rule response: %w", err)
+		return nil, err
 	}
 	return &updated, nil
 }
 
 // Delete deletes a rule by ID.
 func (c *Client) Delete(ctx context.Context, id string) error {
-	resp, err := c.base.DoRequest(ctx, http.MethodDelete, fmt.Sprintf(ruleByIDFmt, url.PathEscape(id)), nil)
-	if err != nil {
-		return fmt.Errorf("failed to delete rule %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return aio11yhttp.HandleErrorResponse(resp)
-	}
-	return nil
+	return aio11yhttp.DoStatus[any](ctx, c.base, http.MethodDelete, fmt.Sprintf(ruleByIDFmt, url.PathEscape(id)), nil, http.StatusOK, http.StatusNoContent)
 }

--- a/internal/providers/aio11y/eval/savedconversations/client.go
+++ b/internal/providers/aio11y/eval/savedconversations/client.go
@@ -1,10 +1,7 @@
 package savedconversations
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -35,59 +32,31 @@ func (c *Client) List(ctx context.Context, source string, limit int) ([]SavedCon
 
 // Get returns a single saved conversation by saved ID.
 func (c *Client) Get(ctx context.Context, savedID string) (*SavedConversation, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, basePath+"/"+url.PathEscape(savedID), nil)
+	sc, err := aio11yhttp.DoJSON[any, SavedConversation](ctx, c.base, http.MethodGet, basePath+"/"+url.PathEscape(savedID), nil, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get saved conversation %s: %w", savedID, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var sc SavedConversation
-	if err := json.NewDecoder(resp.Body).Decode(&sc); err != nil {
-		return nil, fmt.Errorf("failed to decode saved conversation response: %w", err)
+		return nil, err
 	}
 	return &sc, nil
 }
 
 // Save bookmarks an existing live conversation.
 func (c *Client) Save(ctx context.Context, req *SaveRequest) (*SavedConversation, error) {
-	body, err := json.Marshal(req)
+	sc, err := aio11yhttp.DoJSON[SaveRequest, SavedConversation](ctx, c.base, http.MethodPost, basePath, req, http.StatusOK, http.StatusCreated)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal save request: %w", err)
-	}
-
-	resp, err := c.base.DoRequest(ctx, http.MethodPost, basePath, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to save conversation: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var sc SavedConversation
-	if err := json.NewDecoder(resp.Body).Decode(&sc); err != nil {
-		return nil, fmt.Errorf("failed to decode save response: %w", err)
+		return nil, err
 	}
 	return &sc, nil
 }
 
 // Delete removes a saved conversation by saved ID.
 func (c *Client) Delete(ctx context.Context, savedID string) error {
-	resp, err := c.base.DoRequest(ctx, http.MethodDelete, basePath+"/"+url.PathEscape(savedID), nil)
-	if err != nil {
-		return fmt.Errorf("failed to delete saved conversation %s: %w", savedID, err)
-	}
-	defer resp.Body.Close()
+	return aio11yhttp.DoStatus[any](ctx, c.base, http.MethodDelete, basePath+"/"+url.PathEscape(savedID), nil, http.StatusOK, http.StatusNoContent)
+}
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return aio11yhttp.HandleErrorResponse(resp)
-	}
-	return nil
+// collectionsEnvelope is the response envelope for the saved-conversation
+// collections endpoint.
+type collectionsEnvelope struct {
+	Items []CollectionRef `json:"items"`
 }
 
 // ListCollections returns all collections that contain the given saved
@@ -95,21 +64,9 @@ func (c *Client) Delete(ctx context.Context, savedID string) error {
 // set in one response.
 func (c *Client) ListCollections(ctx context.Context, savedID string) ([]CollectionRef, error) {
 	path := basePath + "/" + url.PathEscape(savedID) + "/collections"
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, path, nil)
+	page, err := aio11yhttp.DoJSON[any, collectionsEnvelope](ctx, c.base, http.MethodGet, path, nil, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list collections for saved conversation %s: %w", savedID, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var page struct {
-		Items []CollectionRef `json:"items"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
-		return nil, fmt.Errorf("failed to decode collections response: %w", err)
+		return nil, err
 	}
 	if page.Items == nil {
 		return []CollectionRef{}, nil

--- a/internal/providers/aio11y/eval/templates/client.go
+++ b/internal/providers/aio11y/eval/templates/client.go
@@ -2,7 +2,6 @@ package templates
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -39,19 +38,9 @@ func (c *Client) List(ctx context.Context, scope string, maxItems ...int) ([]eva
 
 // Get returns a single template by ID.
 func (c *Client) Get(ctx context.Context, id string) (*eval.TemplateDetail, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(templateByIDFmt, url.PathEscape(id)), nil)
+	detail, err := aio11yhttp.DoJSON[any, eval.TemplateDetail](ctx, c.base, http.MethodGet, fmt.Sprintf(templateByIDFmt, url.PathEscape(id)), nil, http.StatusOK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get template %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var detail eval.TemplateDetail
-	if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
-		return nil, fmt.Errorf("failed to decode template response: %w", err)
+		return nil, err
 	}
 	return &detail, nil
 }

--- a/internal/providers/aio11y/generations/client.go
+++ b/internal/providers/aio11y/generations/client.go
@@ -2,7 +2,6 @@ package generations
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -27,19 +26,5 @@ func NewClient(base *aio11yhttp.Client) *Client {
 
 // Get returns a single generation by ID.
 func (c *Client) Get(ctx context.Context, id string) (map[string]any, error) {
-	resp, err := c.base.DoRequest(ctx, http.MethodGet, fmt.Sprintf(generationByIDFmt, url.PathEscape(id)), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get generation %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, aio11yhttp.HandleErrorResponse(resp)
-	}
-
-	var detail map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
-		return nil, fmt.Errorf("failed to decode generation response: %w", err)
-	}
-	return detail, nil
+	return aio11yhttp.DoJSON[any, map[string]any](ctx, c.base, http.MethodGet, fmt.Sprintf(generationByIDFmt, url.PathEscape(id)), nil, http.StatusOK)
 }


### PR DESCRIPTION
## Summary
- `internal/providers/aio11y/aio11yhttp` already provided `DoRequest`, `ListAll[T]`, and `HandleErrorResponse`, but every leaf resource client (agents, conversations, generations, and the eval/* clients) still repeated the same `json.Marshal` -> `DoRequest` -> status-check -> `HandleErrorResponse` -> decode block for every Create/Update/Get/Delete-style call (~35 status checks, ~27 decodes across 12 packages).
- Added `DoJSON`/`DoJSONNotFound` (decode a JSON response) and `DoStatus`/`DoStatusNotFound` (status-only, no decode) generic helpers to `aio11yhttp`. The `NotFound` variants let 404 responses map to a caller-supplied sentinel error (e.g. `fmt.Errorf("%s: %w", id, ErrNotFound)`) instead of the generic `HandleErrorResponse` formatting, preserving existing `errors.Is` behavior.
- Migrated all 12 leaf client files (agents, conversations, generations, scores, eval/collections, eval/evaluators, eval/experiments, eval/guards, eval/judge, eval/rules, eval/savedconversations, eval/templates) to use the new helpers, removing ~330 net lines of duplicated boilerplate. `scores/client.go` needed no changes — it only uses `ListAll` and has no Create/Update/Get/Delete-style calls.
- Did not touch `eval/*/commands.go` (cobra command files) or `aio11yhttp.NewClient` — both owned by a separate parallel workstream, per instructions.

## Test plan
- [x] `go test -race -count=1 ./...` (with `GCX_AGENT_MODE=false` — see note below)
- [x] `mise run lint`
- [x] `GCX_AGENT_MODE=false mise run reference` (no diff)
- [x] `GCX_AGENT_MODE=false mise run all`
- [x] `go build -buildvcs=false -o bin/gcx ./cmd/gcx/`

Note: running tests inside a Claude Code shell leaks `CLAUDECODE=1` into `go test`, which flips a handful of unrelated destructive-operation confirmation tests (`dashboards`, `kg`, and the aio11y eval delete/cancel tests) into agent-mode behavior — reproducible on `main` with no changes applied. Passing `GCX_AGENT_MODE=false` to `go test` (in addition to the doc-generation tasks) resolves it; the full suite is clean under that flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)