### PR TITLE
docs: document OAuth login role requirement and Permission Required error

### DIFF
--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -29,6 +29,8 @@ When you run this:
 3. Complete the OAuth flow in the browser; gcx receives the tokens on a local callback and writes them to the `my-stack` context.
 4. The prompt then asks whether to add a Cloud Access Policy token for Cloud product API access — see the [Grafana Cloud product APIs](#grafana-cloud-product-apis) section. Press Enter to skip.
 
+**Required role.** The OAuth consent step is gated by the `grafana-assistant-app.tokens.gcx:access` permission, granted by the **gcx User** role that the grafana-assistant-app plugin registers (available since plugin version 2.0.26). Grafana assigns the role automatically to users with the basic role Viewer or higher. The permission only allows minting gcx tokens for the requesting user; proxied requests run with the user's own identity and RBAC permissions. If the consent page shows a `Permission Required` error, see the [troubleshooting entry](#troubleshooting) below.
+
 If OAuth does not suit your setup (corporate SSO restrictions, no browser available, etc.), pick "Service account token" at the prompt instead.
 
 ### Service account token
@@ -186,23 +188,27 @@ Each entry pairs the error you see with what it means and how to fix it.
     - *Means:* gcx tried to open a browser for OAuth but the system command returned an error, or the OAuth refresh flow failed.
     - *Fix:* Re-run `gcx login` to trigger a fresh flow. If your environment has no browser, use a service account token instead. For corporate proxies, check that the OAuth callback URL is reachable.
 
-4. **`grafana version X is not supported; gcx requires Grafana 12.0.0 or later`**
+4. **`Permission Required` on the OAuth consent page (`gcx User` role / `grafana-assistant-app.tokens.gcx:access`)**
+    - *Means:* your Grafana user lacks the `grafana-assistant-app.tokens.gcx:access` permission that gates gcx token minting. The **gcx User** role granting it is normally auto-assigned to Viewer and above, but the instance may run a grafana-assistant-app version older than 2.0.26 (role does not exist yet) or have customized basic-role grants.
+    - *Fix:* ask your Grafana administrator to assign the **gcx User** role, or a custom role including `grafana-assistant-app.tokens.gcx:access`. If the role is missing entirely, the grafana-assistant-app plugin needs updating. As a workaround, authenticate with a service account token instead.
+
+5. **`grafana version X is not supported; gcx requires Grafana 12.0.0 or later`**
     - *Means:* gcx requires Grafana 12 or newer because it uses the Grafana K8s-compatible `/apis` surface introduced in 12.
     - *Fix:* Upgrade your Grafana instance, or use a different tool for older versions.
 
-5. **GCOM 401 / Cloud Access Policy token rejected**
+6. **GCOM 401 / Cloud Access Policy token rejected**
     - *Means:* the Cloud Access Policy token was rejected by GCOM or a Cloud product API.
     - *Fix:* Verify the token at [grafana.com → Access Policies](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/). Rotate if compromised. Provide the new token via `gcx login --context X --cloud-token glc_...`.
 
-6. **Health check or `/apis` connectivity failures**
+7. **Health check or `/apis` connectivity failures**
     - *Means:* gcx could not reach the server during the validation pipeline — typically a wrong URL, DNS/proxy issue, or TLS mismatch.
     - *Fix:* Verify the server URL is correct and reachable. Check any corporate proxies (`HTTPS_PROXY`) and TLS configuration (`--insecure-skip-verify` for development only).
 
-7. **`gcx assistant` commands fail with a service account token**
+8. **`gcx assistant` commands fail with a service account token**
     - *Means:* `gcx assistant` commands (prompt, investigations) require OAuth, which is only available when you log in via the browser-based OAuth flow. Service account tokens are not supported.
     - *Fix:* Re-run `gcx login` and choose the OAuth (browser) option. If your environment cannot open a browser, `gcx assistant` is not available — use the Grafana UI instead.
 
-8. **Flag vs env-var precedence confusion**
+9. **Flag vs env-var precedence confusion**
     - *Means:* both a CLI flag and an environment variable are set for the same field, and gcx behaves unexpectedly.
     - *Fix:* Flags take precedence over env vars, which take precedence over config-file values. Run `gcx config view` to inspect the resolved config and spot the conflict.
 

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -10,6 +10,24 @@ You can configure `gcx` with a configuration file or using environment variables
 - A configuration file can store multiple contexts, which makes it easier to switch between Grafana instances. Check the [configuration file reference documentation](https://github.com/grafana/gcx/tree/main/docs/reference/configuration/index.md) for details on all available configuration options.
 - Environment variables describe a single context, so they work best in CI environments. Refer to [Configure `gcx` with environment variables ](#configure-gcx-with-environment-variables) for more information. 
 
+## Choose an authentication method
+
+`gcx` supports three ways to authenticate to Grafana:
+
+- **OAuth** (Grafana Cloud only): Browser-based sign-in with `gcx login`. Recommended for interactive use. The tokens are user-scoped: every request runs with your own identity and RBAC permissions, so you can't access anything through `gcx` that you can't already access in the Grafana UI. Refer to [Required role for OAuth sign-in](#required-role-for-oauth-sign-in) for the permission this flow needs.
+- **Service account token**: Works for Grafana Cloud and on-premises instances, and is the recommended method for CI and other non-interactive environments. Refer to [Grafana service accounts](https://grafana.com/docs/grafana/latest/administration/service-accounts/) for how to create one.
+- **Basic authentication**: Username and password. Use this only when service accounts aren't available.
+
+### Required role for OAuth sign-in
+
+To authorize a `gcx` CLI connection with OAuth, your Grafana user needs the `grafana-assistant-app.tokens.gcx:access` permission. The **gcx User** role, registered by the Grafana Assistant application, grants this permission and is assigned automatically to users with the basic role Viewer or higher.
+
+This permission only lets you create `gcx` tokens for your own user. It doesn't grant access to other users' tokens and it doesn't extend your existing Grafana permissions.
+
+{{< admonition type="note" >}}
+If `gcx login` fails with a `Permission Required` error naming the **gcx User** role, ask your Grafana administrator to assign you the **gcx User** role, or a custom role that includes the `grafana-assistant-app.tokens.gcx:access` permission. If the role doesn't exist on your instance, the Grafana Assistant application needs to be updated to a version that includes it.
+{{< /admonition >}}
+
 ## Understand the `gcx` configuration file in use
 
 Run `gcx config check` to display the configuration file currently in use.


### PR DESCRIPTION
Closes #899

## What

Documents the browser OAuth login path's RBAC requirements, which were previously only discoverable by reading grafana-assistant-app source code.

- `docs/sources/configuration.md` (published to grafana.com): new "Choose an authentication method" section listing all three auth methods, plus a "Required role for OAuth sign-in" subsection documenting the `gcx User` role and the `grafana-assistant-app.tokens.gcx:access` permission, with an admonition for the `Permission Required` error.
- `docs/reference/login.md`: names the role/permission in the OAuth procedure (including the minimum grafana-assistant-app version 2.0.26) and adds a troubleshooting entry for the `Permission Required` error.

## Why

A user hitting the `Permission Required` error finds nothing in the docs. Enterprise admins ask what exactly the role grants before approving it (real case: customer admin request this week). Facts sourced from `grafana-assistant-app` `apps/plugin/src/plugin.json` and grafana/grafana-assistant-app#7412.

Docs follow the Writers' Toolkit style used in `docs/sources/` (second person, present tense, sentence-case headings, admonition shortcode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
