### PR TITLE
feat(datasources): add --name filter to datasources list

### DIFF
--- a/cmd/gcx/datasources/list.go
+++ b/cmd/gcx/datasources/list.go
@@ -19,6 +19,7 @@ import (
 type listOpts struct {
 	IO    cmdio.Options
 	Type  string
+	Name  string
 	Limit int
 }
 
@@ -28,6 +29,7 @@ func (opts *listOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 
 	flags.StringVarP(&opts.Type, "type", "t", "", "Filter by datasource type (e.g., prometheus, loki)")
+	flags.StringVar(&opts.Name, "name", "", "Filter by datasource name (case-insensitive substring match)")
 	flags.IntVar(&opts.Limit, "limit", 50, "Maximum number of datasources to return")
 }
 
@@ -42,10 +44,10 @@ func listCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all datasources",
-		Long:  "List all datasources configured in Grafana.",
+		Long:  "List all datasources configured in Grafana. Filter by type and/or name (case-insensitive substring match).",
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "medium",
-			agent.AnnotationLLMHint:   "--type prometheus -o json",
+			agent.AnnotationLLMHint:   "--type prometheus --name prod -o json",
 		},
 		Example: `
 	# List all datasources
@@ -53,6 +55,12 @@ func listCmd() *cobra.Command {
 
 	# List only Prometheus datasources
 	gcx datasources list --type prometheus
+
+	# Filter by name substring (matches "prometheus-prod-eu", "loki-prod-us", ...)
+	gcx datasources list --name prod
+
+	# Combine type and name filters
+	gcx datasources list --type prometheus --name prod
 
 	# Output as JSON
 	gcx datasources list -o json`,
@@ -78,9 +86,16 @@ func listCmd() *cobra.Command {
 				return fmt.Errorf("failed to list datasources: %w", err)
 			}
 
+			// Name is a case-insensitive substring match, composable (AND) with
+			// the type filter. Grafana's /api/datasources API has no server-side
+			// name filter, so both are applied client-side before the limit trim.
+			name := strings.ToLower(opts.Name)
 			infos := make([]*datasourceInfo, 0, len(datasources))
 			for _, ds := range datasources {
 				if opts.Type != "" && !strings.EqualFold(ds.Type, opts.Type) {
+					continue
+				}
+				if name != "" && !strings.Contains(strings.ToLower(ds.Name), name) {
 					continue
 				}
 				infos = append(infos, &datasourceInfo{

--- a/cmd/gcx/datasources/list_test.go
+++ b/cmd/gcx/datasources/list_test.go
@@ -29,6 +29,34 @@ func executeDatasourceCommand(t *testing.T, args []string) (string, error) {
 	return stdout.String(), err
 }
 
+// newDatasourceServer serves the given items from /api/datasources. It mimics a
+// Grafana instance where app-platform discovery (/apis) is unavailable, so the
+// dual transport falls back to the REST API.
+func newDatasourceServer(t *testing.T, items []map[string]any) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/bootdata":
+			http.NotFound(w, r)
+			return
+		case r.Method == http.MethodGet && r.URL.Path == "/apis":
+			http.NotFound(w, r)
+			return
+		case r.Method == http.MethodGet && r.URL.Path == "/api/datasources":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(items); err != nil {
+				t.Errorf("encode datasources response: %v", err)
+			}
+			return
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+}
+
+// newDatasourceListServer serves count generated prometheus datasources.
 func newDatasourceListServer(t *testing.T, count int) *httptest.Server {
 	t.Helper()
 
@@ -45,26 +73,82 @@ func newDatasourceListServer(t *testing.T, count int) *httptest.Server {
 		})
 	}
 
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/bootdata":
-			http.NotFound(w, r)
-			return
-		case r.Method == http.MethodGet && r.URL.Path == "/apis":
-			// App-platform discovery unavailable — dual transport falls back to REST.
-			http.NotFound(w, r)
-			return
-		case r.Method == http.MethodGet && r.URL.Path == "/api/datasources":
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(items); err != nil {
-				t.Errorf("encode datasources response: %v", err)
-			}
-			return
-		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-			http.Error(w, "unexpected request", http.StatusInternalServerError)
+	return newDatasourceServer(t, items)
+}
+
+func TestListNameFilter(t *testing.T) {
+	items := []map[string]any{
+		{"uid": "prom-prod-eu", "name": "prometheus-prod-eu", "type": "prometheus", "url": "https://example.com", "access": "proxy"},
+		{"uid": "prom-prod-us", "name": "prometheus-prod-us", "type": "prometheus", "url": "https://example.com", "access": "proxy"},
+		{"uid": "prom-dev", "name": "prometheus-dev", "type": "prometheus", "url": "https://example.com", "access": "proxy"},
+		{"uid": "loki-prod-eu", "name": "loki-prod-eu", "type": "loki", "url": "https://example.com", "access": "proxy"},
+	}
+
+	server := newDatasourceServer(t, items)
+	defer server.Close()
+
+	configFile := newConfigFileForServer(t, server.URL)
+
+	listUIDs := func(t *testing.T, args ...string) []string {
+		t.Helper()
+		base := append([]string{"datasources", "list", "--config", configFile, "--limit", "0", "-o", "json"}, args...)
+		stdout, err := executeDatasourceCommand(t, base)
+		require.NoError(t, err)
+
+		var result struct {
+			Datasources []struct {
+				UID string `json:"uid"`
+			} `json:"datasources"`
 		}
-	}))
+		require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+		uids := make([]string, len(result.Datasources))
+		for i, ds := range result.Datasources {
+			uids[i] = ds.UID
+		}
+		return uids
+	}
+
+	t.Run("empty name does not filter", func(t *testing.T) {
+		assert.Len(t, listUIDs(t), 4)
+	})
+
+	t.Run("substring match across types", func(t *testing.T) {
+		assert.ElementsMatch(t, []string{"prom-prod-eu", "prom-prod-us", "loki-prod-eu"}, listUIDs(t, "--name", "prod"))
+	})
+
+	t.Run("case-insensitive match", func(t *testing.T) {
+		assert.ElementsMatch(t, []string{"prom-prod-eu", "loki-prod-eu"}, listUIDs(t, "--name", "PROD-EU"))
+	})
+
+	t.Run("composes with type filter (AND)", func(t *testing.T) {
+		assert.ElementsMatch(t, []string{"prom-prod-eu", "prom-prod-us"}, listUIDs(t, "--type", "prometheus", "--name", "prod"))
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		assert.Empty(t, listUIDs(t, "--name", "does-not-exist"))
+	})
+}
+
+func TestListNameFilterRespectsLimit(t *testing.T) {
+	items := []map[string]any{
+		{"uid": "prom-prod-eu", "name": "prometheus-prod-eu", "type": "prometheus", "url": "https://example.com", "access": "proxy"},
+		{"uid": "prom-prod-us", "name": "prometheus-prod-us", "type": "prometheus", "url": "https://example.com", "access": "proxy"},
+		{"uid": "prom-dev", "name": "prometheus-dev", "type": "prometheus", "url": "https://example.com", "access": "proxy"},
+	}
+
+	server := newDatasourceServer(t, items)
+	defer server.Close()
+
+	configFile := newConfigFileForServer(t, server.URL)
+	stdout, err := executeDatasourceCommand(t, []string{"datasources", "list", "--config", configFile, "--name", "prod", "--limit", "1", "-o", "json"})
+	require.NoError(t, err)
+
+	var result struct {
+		Datasources []map[string]any `json:"datasources"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	// Two datasources match "prod"; the limit trims the matched set to 1.
+	assert.Len(t, result.Datasources, 1)
 }
 
 func TestListDefaultReturnsAllDatasources(t *testing.T) {

--- a/docs/reference/cli/gcx_datasources_list.md
+++ b/docs/reference/cli/gcx_datasources_list.md
@@ -4,7 +4,7 @@ List all datasources
 
 ### Synopsis
 
-List all datasources configured in Grafana.
+List all datasources configured in Grafana. Filter by type and/or name (case-insensitive substring match).
 
 ```
 gcx datasources list [flags]
@@ -20,6 +20,12 @@ gcx datasources list [flags]
 	# List only Prometheus datasources
 	gcx datasources list --type prometheus
 
+	# Filter by name substring (matches "prometheus-prod-eu", "loki-prod-us", ...)
+	gcx datasources list --name prod
+
+	# Combine type and name filters
+	gcx datasources list --type prometheus --name prod
+
 	# Output as JSON
 	gcx datasources list -o json
 ```
@@ -33,6 +39,7 @@ gcx datasources list [flags]
       --jq string        jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int        Maximum number of datasources to return (default 50)
+      --name string      Filter by datasource name (case-insensitive substring match)
   -o, --output string    Output format. One of: agents, json, table, yaml (default "table")
   -t, --type string      Filter by datasource type (e.g., prometheus, loki)
 ```


### PR DESCRIPTION
## Summary

- Adds a `--name` flag to `gcx datasources list` for **case-insensitive substring** matching on the datasource name, composable (AND) with the existing `--type` filter.
- Motivated by Grafana instances with thousands of datasources, where `--type` alone returns too many entries. The caller can narrow to a partial name they already know (e.g. `--name prod`).

Ports [grafana/mcp-grafana#973](https://github.com/grafana/mcp-grafana/pull/973) (the `name` parameter on the `list_datasources` MCP tool) to the gcx CLI.

## Changes

- `cmd/gcx/datasources/list.go`: new `--name` flag on `listOpts`; case-insensitive substring filter applied before the `--limit` trim, composed with `--type` (AND). `--type` semantics unchanged (exact, case-insensitive `EqualFold`). Example block and `AnnotationLLMHint` updated to surface `--name`.
- `cmd/gcx/datasources/list_test.go`: table-driven `TestListNameFilter` (empty=no filter, substring across types, case-insensitive, AND with `--type`, no-match) + `TestListNameFilterRespectsLimit`. Consolidated the duplicated httptest server helper into `newDatasourceServer`.
- `docs/reference/cli/gcx_datasources_list.md`: regenerated CLI reference.

Note: Grafana's `/api/datasources` API has no server-side name filter, so matching is done client-side — mirroring the existing `--type` behavior.

The `--name` flag intentionally has no `-n` shorthand: `-n` is reserved for `--namespace` across gcx (kubectl convention).

## Test Plan
- [x] `go test ./cmd/gcx/datasources/...`
- [x] `golangci-lint run -c .golangci.yaml ./...` — 0 issues
- [x] `GCX_AGENT_MODE=false mise run all` — full suite green (lint/tests/build/docs)
- [x] Reference docs regenerated (`mise run reference`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)