### PR TITLE
feat(config): move cloud auth into a shared top-level section

### DIFF
--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -38,6 +38,7 @@ func loginCmd() *cobra.Command {
 		apiURL     string
 		scopes     []string
 		cloudToken string
+		envName    string
 	)
 
 	cmd := &cobra.Command{
@@ -55,21 +56,34 @@ By default, opens a browser for interactive OAuth2 authentication.
 For non-interactive use (CI/CD, scripts), pass a Cloud Access Policy token
 directly via --cloud-token.
 
+The result is written to a shared cloud environment (cloud.envs in the
+config) so every context can use it by default. Staff working against
+non-public environments can keep several (e.g. prod, ops, dev) and select one
+with --env. Pass --context to instead write a stack-scoped override on that
+context (contexts.<name>.cloud), for stack-scoped access policies.
+
 Two endpoints can be configured independently, both defaulting to
 https://grafana.com: --oauth-url is used only for the login flow here, while
 --api-url is used by every command that talks to the Grafana Cloud API.`,
 		Example: `  gcx cloud login
-  gcx cloud login --cloud-token glsa_abc123`,
+  gcx cloud login --cloud-token glsa_abc123
+  gcx cloud login --env ops --oauth-url https://grafana-ops.com --api-url https://grafana-ops.com
+  gcx --context pdc-dev cloud login --cloud-token glsa_abc123`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// Endpoint URLs are sticky across re-auth: when not passed
-			// explicitly, carry over whatever the current context already has so
-			// a plain `gcx cloud login` doesn't wipe a previously set value.
-			cur := currentCloudContext(cmd.Context(), configOpts)
-			if !cmd.Flags().Changed("oauth-url") && cur != nil && cur.Cloud != nil && cur.Cloud.OAuthUrl != "" {
-				oauthURL = cur.Cloud.OAuthUrl
+			tgt, err := resolveLoginTarget(cmd, configOpts, envName)
+			if err != nil {
+				return err
 			}
-			if !cmd.Flags().Changed("api-url") && cur != nil && cur.Cloud != nil && cur.Cloud.APIUrl != "" {
-				apiURL = cur.Cloud.APIUrl
+
+			// Endpoint URLs are sticky across re-auth: when not passed
+			// explicitly, carry over whatever the target already has so a plain
+			// `gcx cloud login` doesn't wipe a previously set value.
+			existing := tgt.existingCloud(cmd.Context(), configOpts)
+			if !cmd.Flags().Changed("oauth-url") && existing != nil && existing.OAuthUrl != "" {
+				oauthURL = existing.OAuthUrl
+			}
+			if !cmd.Flags().Changed("api-url") && existing != nil && existing.APIUrl != "" {
+				apiURL = existing.APIUrl
 			}
 			// Normalize whichever values won (flag, carry-over, or default)
 			// so a bare host (e.g. "grafana.example.com") gets an https:// scheme
@@ -77,14 +91,15 @@ https://grafana.com: --oauth-url is used only for the login flow here, while
 			oauthURL = config.NormalizeCloudURL(oauthURL)
 			apiURL = config.NormalizeCloudURL(apiURL)
 			if cloudToken != "" {
-				return runTokenLogin(cmd.Context(), configOpts, cloudToken, oauthURL, apiURL)
+				return runTokenLogin(cmd.Context(), configOpts, tgt, cloudToken, oauthURL, apiURL)
 			}
-			return runOAuthLogin(cmd.Context(), configOpts, oauthURL, apiURL, scopes)
+			return runOAuthLogin(cmd.Context(), configOpts, tgt, oauthURL, apiURL, scopes)
 		},
 	}
 
 	configOpts.BindFlags(cmd.Flags())
 	cmd.Flags().StringVar(&cloudToken, "cloud-token", "", "Cloud Access Policy token (skips interactive OAuth flow)")
+	cmd.Flags().StringVar(&envName, "env", "", "Cloud environment to write to (default: the current environment)")
 	cmd.Flags().StringVar(&oauthURL, "oauth-url", "https://grafana.com", "Base URL for the OAuth login flow (used only by this command)")
 	cmd.Flags().StringVar(&apiURL, "api-url", "https://grafana.com", "Base URL for Grafana Cloud API resource calls (stacks etc.)")
 	cmd.Flags().StringSliceVar(&scopes, "scope", []string{
@@ -95,34 +110,70 @@ https://grafana.com: --oauth-url is used only for the login flow here, while
 	return cmd
 }
 
-// currentCloudContext loads the config and returns the current context, or nil
-// if config can't be loaded or the context doesn't exist yet.
-func currentCloudContext(ctx context.Context, configOpts *cmdconfig.Options) *config.Context {
+// writeTarget identifies where `gcx cloud login` writes its result: either a
+// top-level cloud environment (envName set) or a per-context stack-scoped
+// override (ctxName set). Exactly one field is non-empty.
+type writeTarget struct {
+	ctxName string
+	envName string
+}
+
+// resolveLoginTarget decides where to write the login result. A --context
+// (threaded as the global flag) selects a per-context override; otherwise the
+// result goes to a top-level environment named by --env, defaulting to the
+// current environment. The two are mutually exclusive.
+func resolveLoginTarget(cmd *cobra.Command, configOpts *cmdconfig.Options, envFlag string) (writeTarget, error) {
+	ctxName := config.ContextNameFromCtx(cmd.Context())
+	if ctxName != "" {
+		if cmd.Flags().Changed("env") {
+			return writeTarget{}, &gcxerrors.DetailedError{
+				Summary: "--context and --env cannot be combined",
+				Suggestions: []string{
+					"Use --context to write a stack-scoped cloud token override",
+					"Use --env to write a shared cloud environment",
+				},
+			}
+		}
+		return writeTarget{ctxName: ctxName}, nil
+	}
+
+	envName := envFlag
+	if envName == "" {
+		cfg, _ := config.Load(cmd.Context(), configOpts.ConfigSource())
+		envName = cfg.ResolveCloudEnvName(cfg.CurrentContext)
+	}
+	return writeTarget{envName: envName}, nil
+}
+
+// existingCloud returns the cloud config currently stored at the target, or nil.
+// Used to carry over sticky endpoint URLs across re-auth.
+func (t writeTarget) existingCloud(ctx context.Context, configOpts *cmdconfig.Options) *config.CloudConfig {
 	cfg, err := config.Load(ctx, configOpts.ConfigSource())
 	if err != nil {
 		return nil
 	}
-	ctxName := cfg.CurrentContext
-	if ctxName == "" {
-		ctxName = config.DefaultContextName
+	if t.ctxName != "" {
+		if c := cfg.Contexts[t.ctxName]; c != nil {
+			return c.Cloud
+		}
+		return nil
 	}
-	return cfg.Contexts[ctxName]
+	if cfg.Cloud != nil {
+		return cfg.Cloud.Envs[t.envName]
+	}
+	return nil
 }
 
-func runTokenLogin(ctx context.Context, configOpts *cmdconfig.Options, token, oauthURL, apiURL string) error {
+func runTokenLogin(ctx context.Context, configOpts *cmdconfig.Options, tgt writeTarget, token, oauthURL, apiURL string) error {
 	cloud := &config.CloudConfig{
 		Token:    token,
 		OAuthUrl: oauthURL,
 		APIUrl:   apiURL,
 	}
-	if err := saveCloudConfig(ctx, configOpts, cloud); err != nil {
-		return err
-	}
-	fmt.Fprintln(os.Stderr, "Cloud token saved.")
-	return nil
+	return saveCloudConfig(ctx, configOpts, tgt, cloud)
 }
 
-func runOAuthLogin(ctx context.Context, configOpts *cmdconfig.Options, oauthURL, apiURL string, scopes []string) error {
+func runOAuthLogin(ctx context.Context, configOpts *cmdconfig.Options, tgt writeTarget, oauthURL, apiURL string, scopes []string) error {
 	flow := auth.NewGCOMFlow(auth.GCOMOptions{
 		ClientID: defaultClientID,
 		GCOMURL:  oauthURL,
@@ -151,10 +202,10 @@ func runOAuthLogin(ctx context.Context, configOpts *cmdconfig.Options, oauthURL,
 		OAuthUrl: oauthURL,
 		APIUrl:   apiURL,
 	}
-	return saveCloudConfig(ctx, configOpts, cloud)
+	return saveCloudConfig(ctx, configOpts, tgt, cloud)
 }
 
-func saveCloudConfig(ctx context.Context, configOpts *cmdconfig.Options, cloud *config.CloudConfig) error {
+func saveCloudConfig(ctx context.Context, configOpts *cmdconfig.Options, tgt writeTarget, cloud *config.CloudConfig) error {
 	source := configOpts.ConfigSource()
 
 	cfg, err := config.Load(ctx, source)
@@ -172,22 +223,10 @@ func saveCloudConfig(ctx context.Context, configOpts *cmdconfig.Options, cloud *
 		cfg = config.Config{}
 	}
 
-	contextName := cfg.CurrentContext
-	if contextName == "" {
-		contextName = config.DefaultContextName
+	dest, err := applyCloudConfig(&cfg, tgt, cloud)
+	if err != nil {
+		return err
 	}
-
-	if !cfg.HasContext(contextName) {
-		cfg.SetContext(contextName, true, config.Context{})
-	}
-	curCtx := cfg.Contexts[contextName]
-	// Replace the entire cloud config to clear any stale OAuth/token fields
-	// when switching from OAuth to SA token or vice versa, but preserve the
-	// non-auth Stack selection so re-authenticating doesn't drop it.
-	if curCtx.Cloud != nil {
-		cloud.Stack = curCtx.Cloud.Stack
-	}
-	curCtx.Cloud = cloud
 
 	if err := config.Write(ctx, source, cfg); err != nil {
 		return &gcxerrors.DetailedError{
@@ -200,6 +239,37 @@ func saveCloudConfig(ctx context.Context, configOpts *cmdconfig.Options, cloud *
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "Token saved to context %q\n", contextName)
+	fmt.Fprintf(os.Stderr, "Cloud token saved to %s\n", dest)
 	return nil
+}
+
+// applyCloudConfig writes cloud into cfg at the target and returns a
+// human-readable description of where it landed. The cloud block is replaced
+// wholesale so stale OAuth fields are cleared when switching auth methods, but
+// the non-auth Stack selection is preserved so re-authenticating never drops it.
+func applyCloudConfig(cfg *config.Config, tgt writeTarget, cloud *config.CloudConfig) (string, error) {
+	if tgt.ctxName != "" {
+		if !cfg.HasContext(tgt.ctxName) {
+			return "", config.ContextNotFound(tgt.ctxName)
+		}
+		if existing := cfg.Contexts[tgt.ctxName].Cloud; existing != nil {
+			cloud.Stack = existing.Stack
+		}
+		cfg.Contexts[tgt.ctxName].Cloud = cloud
+		return fmt.Sprintf("context %q", tgt.ctxName), nil
+	}
+
+	if cfg.Cloud == nil {
+		cfg.Cloud = &config.CloudSettings{}
+	}
+	if cfg.Cloud.Envs == nil {
+		cfg.Cloud.Envs = make(map[string]*config.CloudConfig)
+	}
+	cfg.Cloud.Envs[tgt.envName] = cloud
+	// First environment configured becomes the default; adding more never
+	// silently switches the current one.
+	if cfg.Cloud.Current == "" {
+		cfg.Cloud.Current = tgt.envName
+	}
+	return fmt.Sprintf("environment %q", tgt.envName), nil
 }

--- a/cmd/gcx/cloud/command_test.go
+++ b/cmd/gcx/cloud/command_test.go
@@ -1,4 +1,4 @@
-//nolint:testpackage // white-box testing: accesses unexported saveCloudConfig.
+//nolint:testpackage // white-box testing: accesses unexported saveCloudConfig/applyCloudConfig.
 package cloud
 
 import (
@@ -8,11 +8,13 @@ import (
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
 	"github.com/grafana/gcx/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSaveCloudConfigPreservesStack verifies that re-authenticating (which
 // writes a fresh CloudConfig with only auth fields) does not drop a previously
-// configured non-auth Stack selection.
+// configured non-auth Stack selection on a per-context override.
 func TestSaveCloudConfigPreservesStack(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "config.yaml")
@@ -26,9 +28,7 @@ func TestSaveCloudConfigPreservesStack(t *testing.T) {
 			OAuthUrl: "https://old.example",
 		},
 	})
-	if err := config.Write(ctx, source, seed); err != nil {
-		t.Fatalf("seed write: %v", err)
-	}
+	require.NoError(t, config.Write(ctx, source, seed))
 
 	configOpts := &cmdconfig.Options{ConfigFile: path}
 	newCloud := &config.CloudConfig{
@@ -36,19 +36,63 @@ func TestSaveCloudConfigPreservesStack(t *testing.T) {
 		OAuthUrl: "https://grafana.com",
 		APIUrl:   "https://grafana.com",
 	}
-	if err := saveCloudConfig(ctx, configOpts, newCloud); err != nil {
-		t.Fatalf("saveCloudConfig: %v", err)
-	}
+	require.NoError(t, saveCloudConfig(ctx, configOpts, writeTarget{ctxName: config.DefaultContextName}, newCloud))
 
 	got, err := config.Load(ctx, source)
-	if err != nil {
-		t.Fatalf("reload: %v", err)
-	}
+	require.NoError(t, err)
 	cloud := got.Contexts[config.DefaultContextName].Cloud
-	if cloud.Stack != "mystack" {
-		t.Errorf("Stack not preserved: got %q, want %q", cloud.Stack, "mystack")
-	}
-	if cloud.Token != "new-token" {
-		t.Errorf("Token not updated: got %q, want %q", cloud.Token, "new-token")
-	}
+	assert.Equal(t, "mystack", cloud.Stack, "Stack must be preserved across re-auth")
+	assert.Equal(t, "new-token", cloud.Token, "Token must be updated")
+}
+
+func TestApplyCloudConfig_EnvTarget(t *testing.T) {
+	t.Run("creates env and sets current on first login", func(t *testing.T) {
+		cfg := &config.Config{}
+		dest, err := applyCloudConfig(cfg, writeTarget{envName: "prod"}, &config.CloudConfig{Token: "tok"})
+		require.NoError(t, err)
+		assert.Equal(t, `environment "prod"`, dest)
+		require.NotNil(t, cfg.Cloud)
+		assert.Equal(t, "prod", cfg.Cloud.Current, "first env configured becomes current")
+		assert.Equal(t, "tok", cfg.Cloud.Envs["prod"].Token)
+	})
+
+	t.Run("adding an env never switches the current one", func(t *testing.T) {
+		cfg := &config.Config{Cloud: &config.CloudSettings{
+			Current: "prod",
+			Envs:    map[string]*config.CloudConfig{"prod": {Token: "p"}},
+		}}
+		_, err := applyCloudConfig(cfg, writeTarget{envName: "ops"}, &config.CloudConfig{Token: "o"})
+		require.NoError(t, err)
+		assert.Equal(t, "prod", cfg.Cloud.Current)
+		assert.Equal(t, "o", cfg.Cloud.Envs["ops"].Token)
+	})
+}
+
+func TestApplyCloudConfig_ContextTarget(t *testing.T) {
+	t.Run("writes the per-context override", func(t *testing.T) {
+		cfg := &config.Config{Contexts: map[string]*config.Context{
+			"pdc-dev": {Grafana: &config.GrafanaConfig{Server: "https://x.invalid"}},
+		}}
+		dest, err := applyCloudConfig(cfg, writeTarget{ctxName: "pdc-dev"}, &config.CloudConfig{Token: "cap"})
+		require.NoError(t, err)
+		assert.Equal(t, `context "pdc-dev"`, dest)
+		assert.Equal(t, "cap", cfg.Contexts["pdc-dev"].Cloud.Token)
+		assert.Nil(t, cfg.Cloud, "context target must not touch the top-level section")
+	})
+
+	t.Run("preserves an existing stack selection", func(t *testing.T) {
+		cfg := &config.Config{Contexts: map[string]*config.Context{
+			"pdc-dev": {Cloud: &config.CloudConfig{Token: "old", Stack: "mystack"}},
+		}}
+		_, err := applyCloudConfig(cfg, writeTarget{ctxName: "pdc-dev"}, &config.CloudConfig{Token: "new"})
+		require.NoError(t, err)
+		assert.Equal(t, "mystack", cfg.Contexts["pdc-dev"].Cloud.Stack)
+		assert.Equal(t, "new", cfg.Contexts["pdc-dev"].Cloud.Token)
+	})
+
+	t.Run("errors when the context does not exist", func(t *testing.T) {
+		cfg := &config.Config{Contexts: map[string]*config.Context{}}
+		_, err := applyCloudConfig(cfg, writeTarget{ctxName: "missing"}, &config.CloudConfig{Token: "cap"})
+		require.Error(t, err)
+	})
 }

--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -643,7 +643,7 @@ func setCmd(configOpts *Options) *cobra.Command {
 
 PROPERTY_NAME is a dot-delimited reference to the value to set. It can either represent a field or a map entry.
 
-A bare path (e.g. "cloud.token") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context.
+A bare path (e.g. "grafana.server") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context. Paths starting with "cloud." target the shared top-level cloud auth section (e.g. "cloud.current", "cloud.envs.prod.token").
 
 PROPERTY_VALUE is the new value to set.`,
 		Example: `
@@ -693,7 +693,7 @@ func unsetCmd(configOpts *Options) *cobra.Command {
 
 PROPERTY_NAME is a dot-delimited reference to the value to unset. It can either represent a field or a map entry.
 
-A bare path (e.g. "cloud.token") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context.`,
+A bare path (e.g. "grafana.server") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context. Paths starting with "cloud." target the shared top-level cloud auth section.`,
 		Example: `
 	# Unset the "foo" context
 	gcx config unset contexts.foo

--- a/cmd/gcx/config/command_test.go
+++ b/cmd/gcx/config/command_test.go
@@ -400,22 +400,22 @@ func Test_SetCommand_barePathResolvesAgainstCurrentContext(t *testing.T) {
 
 	configFile := testutils.CreateTempFile(t, cfg)
 
-	setCloudToken := testutils.CommandTestCase{
+	setUser := testutils.CommandTestCase{
 		Cmd:     config.Command(),
-		Command: []string{"set", "--config", configFile, "cloud.token", "glc_abc123"},
+		Command: []string{"set", "--config", configFile, "grafana.user", "admin"},
 		Assertions: []testutils.CommandAssertion{
 			testutils.CommandSuccess(),
 		},
 	}
-	setCloudToken.Run(t)
+	setUser.Run(t)
 
 	viewCmd := testutils.CommandTestCase{
 		Cmd:     config.Command(),
 		Command: []string{"view", "--config", configFile, "--minify", "--raw"},
 		Assertions: []testutils.CommandAssertion{
 			testutils.CommandSuccess(),
-			testutils.CommandOutputContains(`cloud:
-      token: glc_abc123`),
+			testutils.CommandOutputContains(`grafana:
+      user: admin`),
 		},
 	}
 	viewCmd.Run(t)
@@ -426,12 +426,74 @@ func Test_SetCommand_barePathWithoutCurrentContextErrors(t *testing.T) {
 
 	testCase := testutils.CommandTestCase{
 		Cmd:     config.Command(),
-		Command: []string{"set", "--config", configFile, "cloud.token", "glc_abc123"},
+		Command: []string{"set", "--config", configFile, "grafana.user", "admin"},
 		Assertions: []testutils.CommandAssertion{
 			testutils.CommandErrorContains("no current context set"),
 		},
 	}
 	testCase.Run(t)
+}
+
+func Test_SetCommand_cloudPathTargetsTopLevel(t *testing.T) {
+	configFile := testutils.CreateTempFile(t, `current-context: dev`)
+
+	setEnvToken := testutils.CommandTestCase{
+		Cmd:     config.Command(),
+		Command: []string{"set", "--config", configFile, "cloud.envs.prod.token", "glc_abc123"},
+		Assertions: []testutils.CommandAssertion{
+			testutils.CommandSuccess(),
+		},
+	}
+	setEnvToken.Run(t)
+
+	setCurrent := testutils.CommandTestCase{
+		Cmd:     config.Command(),
+		Command: []string{"set", "--config", configFile, "cloud.current", "prod"},
+		Assertions: []testutils.CommandAssertion{
+			testutils.CommandSuccess(),
+		},
+	}
+	setCurrent.Run(t)
+
+	viewCmd := testutils.CommandTestCase{
+		Cmd:     config.Command(),
+		Command: []string{"view", "--config", configFile, "--raw"},
+		Assertions: []testutils.CommandAssertion{
+			testutils.CommandSuccess(),
+			testutils.CommandOutputContains(`cloud:
+  current: prod
+  envs:
+    prod:
+      token: glc_abc123`),
+		},
+	}
+	viewCmd.Run(t)
+}
+
+func Test_ViewCommand_RedactsTopLevelCloudToken(t *testing.T) {
+	configFile := testutils.CreateTempFile(t, `cloud:
+  current: prod
+  envs:
+    prod:
+      token: glc_supersecret
+      api-url: https://grafana.com
+current-context: dev
+contexts:
+  dev:
+    grafana:
+      server: https://example.invalid
+`)
+
+	viewCmd := testutils.CommandTestCase{
+		Cmd:     config.Command(),
+		Command: []string{"view", "--config", configFile},
+		Assertions: []testutils.CommandAssertion{
+			testutils.CommandSuccess(),
+			testutils.CommandOutputContains("**REDACTED**"),
+			testutils.CommandOutputDoesNotContain("glc_supersecret"),
+		},
+	}
+	viewCmd.Run(t)
 }
 
 func Test_UnsetCommand(t *testing.T) {

--- a/docs/architecture/config-system.md
+++ b/docs/architecture/config-system.md
@@ -319,22 +319,38 @@ Context.Cloud *CloudConfig
   └── APIUrl     (GRAFANA_CLOUD_API_URL)    — GCOM base URL (default: "https://grafana.com")
 ```
 
-The `Cloud` struct is optional. It is used by provider implementations (e.g.,
-`internal/cloud/client.go`) to discover stack metadata via the Grafana Cloud
-OpenAPI (GCOM). Token is marked `datapolicy:"secret"` and is redacted in
-`config view` output unless `--raw` is passed.
+Token is marked `datapolicy:"secret"` and is redacted in `config view` output
+unless `--raw` is passed.
+
+GCOM auth is shared across contexts via a top-level `cloud` section holding
+named **environments** (staff use prod/ops/dev; public users have one). `gcx
+cloud login` writes the current environment by default. The per-context `cloud`
+block is an **override** layer for stack-scoped access policy tokens. Cloud auth
+for a context resolves as (`Config.ResolveCloudConfig`):
+
+1. `GRAFANA_CLOUD_TOKEN` / env vars (parsed into the per-context block, highest priority)
+2. per-context `contexts.<ctx>.cloud` fields
+3. the selected environment — `contexts.<ctx>.cloud.env`, else `cloud.current`, else the sole env, else `prod`
+
+`stack` is always per-context. Environment tokens are keychain-backed under the
+`cloud-env:<name>` scope, like context tokens.
 
 Example:
 ```yaml
+cloud:
+  current: prod                      # hidden in UX when only one env exists
+  envs:
+    prod:
+      token: "glc_xxxx"              # GCOM token (keychain-backed)
+      api-url: "https://grafana.com" # optional: defaults to https://grafana.com
 contexts:
   cloud-prod:
     grafana:
       server: "https://mystack.grafana.net"
       token: "glsa_xxxx"
     cloud:
-      token: "glc_xxxx"              # separate GCOM token
       stack: "mystack"               # optional: slug derived from server if not set
-      api-url: "https://grafana.com" # optional: defaults to https://grafana.com
+      # token: "glc_stack_scoped"    # optional: overrides the env token for this stack
 ```
 
 ---

--- a/docs/reference/cli/gcx_cloud_login.md
+++ b/docs/reference/cli/gcx_cloud_login.md
@@ -16,6 +16,12 @@ By default, opens a browser for interactive OAuth2 authentication.
 For non-interactive use (CI/CD, scripts), pass a Cloud Access Policy token
 directly via --cloud-token.
 
+The result is written to a shared cloud environment (cloud.envs in the
+config) so every context can use it by default. Staff working against
+non-public environments can keep several (e.g. prod, ops, dev) and select one
+with --env. Pass --context to instead write a stack-scoped override on that
+context (contexts.<name>.cloud), for stack-scoped access policies.
+
 Two endpoints can be configured independently, both defaulting to
 https://grafana.com: --oauth-url is used only for the login flow here, while
 --api-url is used by every command that talks to the Grafana Cloud API.
@@ -29,6 +35,8 @@ gcx cloud login [flags]
 ```
   gcx cloud login
   gcx cloud login --cloud-token glsa_abc123
+  gcx cloud login --env ops --oauth-url https://grafana-ops.com --api-url https://grafana-ops.com
+  gcx --context pdc-dev cloud login --cloud-token glsa_abc123
 ```
 
 ### Options
@@ -38,6 +46,7 @@ gcx cloud login [flags]
       --cloud-token string   Cloud Access Policy token (skips interactive OAuth flow)
       --config string        Path to the configuration file to use
       --context string       Name of the context to use
+      --env string           Cloud environment to write to (default: the current environment)
   -h, --help                 help for login
       --oauth-url string     Base URL for the OAuth login flow (used only by this command) (default "https://grafana.com")
       --scope strings        OAuth2 scopes to request (default [stacks:read,stacks:write,stacks:delete,accesspolicies:read,accesspolicies:write,accesspolicies:delete])

--- a/docs/reference/cli/gcx_config_set.md
+++ b/docs/reference/cli/gcx_config_set.md
@@ -8,7 +8,7 @@ Set a single value in a configuration file.
 
 PROPERTY_NAME is a dot-delimited reference to the value to set. It can either represent a field or a map entry.
 
-A bare path (e.g. "cloud.token") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context.
+A bare path (e.g. "grafana.server") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context. Paths starting with "cloud." target the shared top-level cloud auth section (e.g. "cloud.current", "cloud.envs.prod.token").
 
 PROPERTY_VALUE is the new value to set.
 

--- a/docs/reference/cli/gcx_config_unset.md
+++ b/docs/reference/cli/gcx_config_unset.md
@@ -8,7 +8,7 @@ Unset a single value in a configuration file.
 
 PROPERTY_NAME is a dot-delimited reference to the value to unset. It can either represent a field or a map entry.
 
-A bare path (e.g. "cloud.token") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context.
+A bare path (e.g. "grafana.server") is resolved against the current context and is equivalent to "contexts.<current-context>.<path>". Use a fully qualified path (starting with "contexts.<name>.") to target a specific context. Paths starting with "cloud." target the shared top-level cloud auth section.
 
 ```
 gcx config unset PROPERTY_NAME [flags]

--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -93,9 +93,16 @@ contexts:
           - ...
           
     cloud: 
-      # CloudConfig holds Grafana Cloud platform credentials and configuration.
+      # CloudConfig holds Grafana Cloud platform credentials and configuration. It is
+      # used both for a top-level environment entry (CloudSettings.Envs) and as a
+      # per-context override block (Context.Cloud). On a context block, non-empty
+      # fields override the selected environment; Env and Stack are context-only.
       # Token is a Grafana Cloud API token used to authenticate against GCOM.
       token: string
+      # Env names the top-level cloud environment (CloudSettings.Envs) this
+      # context uses. Only meaningful on a per-context cloud block; when empty the
+      # context uses CloudSettings.Current. Ignored on environment entries.
+      env: string
       # Stack is the Grafana Cloud stack slug (e.g. "mystack").
       # Optional: if not set, the slug may be derived from Grafana.Server.
       stack: string
@@ -130,6 +137,41 @@ contexts:
           string
 # CurrentContext is the name of the context currently in use.
 current-context: string
+# Cloud holds the top-level Grafana Cloud auth configuration shared across
+# contexts. Contexts use the selected environment by default; per-context
+# cloud blocks override it (see CloudConfig).
+cloud: 
+  # CloudSettings holds the top-level Grafana Cloud auth configuration. Each named
+  # environment carries its own GCOM credentials and endpoints; staff use several
+  # (prod, ops, dev) while public users have only one. Current names the
+  # environment used by default.
+  # Current is the name of the cloud environment used by default. When empty,
+  # the sole environment is used, falling back to DefaultCloudEnv.
+  current: string
+  # Envs maps environment name to its cloud auth configuration.
+  envs: 
+    ${string}:
+      # CloudConfig holds Grafana Cloud platform credentials and configuration. It is
+      # used both for a top-level environment entry (CloudSettings.Envs) and as a
+      # per-context override block (Context.Cloud). On a context block, non-empty
+      # fields override the selected environment; Env and Stack are context-only.
+      # Token is a Grafana Cloud API token used to authenticate against GCOM.
+      token: string
+      # Env names the top-level cloud environment (CloudSettings.Envs) this
+      # context uses. Only meaningful on a per-context cloud block; when empty the
+      # context uses CloudSettings.Current. Ignored on environment entries.
+      env: string
+      # Stack is the Grafana Cloud stack slug (e.g. "mystack").
+      # Optional: if not set, the slug may be derived from Grafana.Server.
+      stack: string
+      # OAuthUrl is the base URL for the OAuth login flow run by `gcx cloud
+      # login`. It is used only during login. Optional: defaults to
+      # "https://grafana.com".
+      oauth-url: string
+      # APIUrl is the base URL for all Grafana Cloud API (GCOM) resource calls
+      # (stacks, regions, access policies, etc.). Every client talking to GCOM
+      # uses it. Optional: defaults to "https://grafana.com".
+      api-url: string
 # Diagnostics holds optional local diagnostic settings. All features are off by default.
 diagnostics: 
   # DiagnosticsConfig controls optional local diagnostic features.

--- a/internal/config/cloud_resolve_test.go
+++ b/internal/config/cloud_resolve_test.go
@@ -1,0 +1,131 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_ResolveCloudEnvName(t *testing.T) {
+	testCases := []struct {
+		name string
+		cfg  config.Config
+		ctx  string
+		want string
+	}{
+		{
+			name: "no cloud section falls back to prod",
+			cfg:  config.Config{},
+			want: "prod",
+		},
+		{
+			name: "explicit current wins",
+			cfg: config.Config{Cloud: &config.CloudSettings{
+				Current: "ops",
+				Envs:    map[string]*config.CloudConfig{"prod": {}, "ops": {}},
+			}},
+			want: "ops",
+		},
+		{
+			name: "sole env is used when current unset",
+			cfg: config.Config{Cloud: &config.CloudSettings{
+				Envs: map[string]*config.CloudConfig{"dev": {}},
+			}},
+			want: "dev",
+		},
+		{
+			name: "multiple envs without current falls back to prod",
+			cfg: config.Config{Cloud: &config.CloudSettings{
+				Envs: map[string]*config.CloudConfig{"a": {}, "b": {}},
+			}},
+			want: "prod",
+		},
+		{
+			name: "context pins an environment by name",
+			cfg: config.Config{
+				Cloud: &config.CloudSettings{
+					Current: "prod",
+					Envs:    map[string]*config.CloudConfig{"prod": {}, "dev": {}},
+				},
+				Contexts: map[string]*config.Context{
+					"pdc-dev": {Cloud: &config.CloudConfig{Env: "dev"}},
+				},
+			},
+			ctx:  "pdc-dev",
+			want: "dev",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cfg.ResolveCloudEnvName(tc.ctx))
+		})
+	}
+}
+
+func TestConfig_ResolveCloudConfig(t *testing.T) {
+	base := config.Config{
+		Cloud: &config.CloudSettings{
+			Current: "prod",
+			Envs: map[string]*config.CloudConfig{
+				"prod": {Token: "env-token", APIUrl: "https://grafana.com", OAuthUrl: "https://grafana.com"},
+				"dev":  {Token: "dev-token", APIUrl: "https://grafana-dev.com"},
+			},
+		},
+		Contexts: map[string]*config.Context{},
+	}
+
+	t.Run("uses the current environment", func(t *testing.T) {
+		cfg := base
+		cfg.Contexts = map[string]*config.Context{"stack": {}}
+		got := cfg.ResolveCloudConfig("stack")
+		assert.Equal(t, "env-token", got.Token)
+		assert.Equal(t, "https://grafana.com", got.APIUrl)
+	})
+
+	t.Run("per-context token overrides the environment", func(t *testing.T) {
+		cfg := base
+		cfg.Contexts = map[string]*config.Context{
+			"stack": {Cloud: &config.CloudConfig{Token: "stack-cap", Stack: "mystack"}},
+		}
+		got := cfg.ResolveCloudConfig("stack")
+		assert.Equal(t, "stack-cap", got.Token, "stack-scoped CAP should win")
+		assert.Equal(t, "https://grafana.com", got.APIUrl, "URL still from env")
+		assert.Equal(t, "mystack", got.Stack, "stack is per-context")
+	})
+
+	t.Run("context pinning an env resolves that env's auth", func(t *testing.T) {
+		cfg := base
+		cfg.Contexts = map[string]*config.Context{
+			"stack": {Cloud: &config.CloudConfig{Env: "dev"}},
+		}
+		got := cfg.ResolveCloudConfig("stack")
+		assert.Equal(t, "dev-token", got.Token)
+		assert.Equal(t, "https://grafana-dev.com", got.APIUrl)
+	})
+
+	t.Run("no cloud section yields empty without panicking", func(t *testing.T) {
+		cfg := config.Config{Contexts: map[string]*config.Context{"stack": {}}}
+		got := cfg.ResolveCloudConfig("stack")
+		assert.Empty(t, got.Token)
+	})
+}
+
+func TestConfig_ResolveCloudAPIURL(t *testing.T) {
+	t.Run("env api-url wins", func(t *testing.T) {
+		cfg := config.Config{
+			Cloud: &config.CloudSettings{
+				Current: "ops",
+				Envs:    map[string]*config.CloudConfig{"ops": {APIUrl: "https://grafana-ops.com"}},
+			},
+			Contexts: map[string]*config.Context{"stack": {}},
+		}
+		assert.Equal(t, "https://grafana-ops.com", cfg.ResolveCloudAPIURL("stack"))
+	})
+
+	t.Run("falls back to default when nothing configured", func(t *testing.T) {
+		cfg := config.Config{Contexts: map[string]*config.Context{"stack": {}}}
+		assert.Equal(t, "https://grafana.com", cfg.ResolveCloudAPIURL("stack"))
+	})
+}

--- a/internal/config/keychain.go
+++ b/internal/config/keychain.go
@@ -45,6 +45,23 @@ func (k keychainBacked) mark(ctx string, field credentials.Field) {
 	k[ctx][field] = true
 }
 
+// mergeBacked folds src into dst, allocating dst when nil. Used to combine
+// per-context and cloud-environment resolution results at load time.
+func mergeBacked(dst, src keychainBacked) keychainBacked {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = keychainBacked{}
+	}
+	for scope, fields := range src {
+		for field := range fields {
+			dst.mark(scope, field)
+		}
+	}
+	return dst
+}
+
 // secretRef is a get/set handle for a secret field. Provider-map secrets
 // cannot be addressed by *string (Go map values are not addressable), so all
 // callers go through this interface uniformly.
@@ -128,12 +145,90 @@ func providerFieldRef(ctx *Context, provider, key string) (secretRef, bool) {
 	}, true
 }
 
+// cloudEnvScope returns the keychain scope name for a top-level cloud
+// environment token. It is namespaced with a "cloud-env:" prefix so it never
+// collides with a context name; ParseSentinel splits on the final colon, so the
+// environment name itself may contain colons.
+func cloudEnvScope(envName string) string {
+	return "cloud-env:" + envName
+}
+
+// secretScope pairs a keychain scope name (a context name, or a cloud-env scope)
+// with the secret field references it owns.
+type secretScope struct {
+	name string
+	refs map[credentials.Field]secretRef
+}
+
+// secretScopes enumerates every secret-bearing scope in the config: one per
+// context, plus one per top-level cloud environment (which owns only a cloud
+// token). It is the single source of truth for the migrate/reconcile/
+// has-secrets walkers so contexts and environments are handled uniformly.
+func (cfg *Config) secretScopes() []secretScope {
+	var scopes []secretScope
+	for ctxName, ctx := range cfg.Contexts {
+		if ctx == nil {
+			continue
+		}
+		refs := make(map[credentials.Field]secretRef)
+		for _, field := range credentials.AllFields {
+			if ref, ok := fieldRef(ctx, field); ok {
+				refs[field] = ref
+			}
+		}
+		scopes = append(scopes, secretScope{name: ctxName, refs: refs})
+	}
+	if cfg.Cloud != nil {
+		for name, env := range cfg.Cloud.Envs {
+			if env == nil {
+				continue
+			}
+			env := env
+			scopes = append(scopes, secretScope{
+				name: cloudEnvScope(name),
+				refs: map[credentials.Field]secretRef{
+					credentials.FieldCloudToken: {
+						get: func() string { return env.Token },
+						set: func(v string) { env.Token = v },
+					},
+				},
+			})
+		}
+	}
+	return scopes
+}
+
+// resolveSentinelRef replaces a single sentinel-valued secret with its plaintext
+// from the store, recording the outcome in backed/preserve. On any failure the
+// in-memory value is cleared so the command surfaces a missing credential rather
+// than sending a sentinel string as one.
+func resolveSentinelRef(scope string, field credentials.Field, ref secretRef, store credentials.Store, backed, preserve keychainBacked) {
+	cur := ref.get()
+	if !credentials.IsSentinel(cur) {
+		return
+	}
+	parsedScope, parsedField, ok := credentials.ParseSentinel(cur)
+	if !ok || parsedScope != scope || parsedField != field {
+		ref.set("")
+		return
+	}
+	value, err := store.Get(credentials.AccountKey(scope, field))
+	if err != nil {
+		ref.set("")
+		if errors.Is(err, credentials.ErrNotFound) {
+			return
+		}
+		preserve.mark(scope, field)
+		return
+	}
+	ref.set(value)
+	backed.mark(scope, field)
+}
+
 // resolveSentinelsForContext replaces keychain sentinels with their plaintext
 // values from the store for a single context. It returns two maps: backed lists
 // the (context, field) pairs that resolved successfully, and preserve lists
-// pairs whose lookup failed because the keychain was unavailable. In both
-// failure cases the in-memory value is cleared so the command surfaces a
-// missing credential rather than sending a sentinel string as one.
+// pairs whose lookup failed because the keychain was unavailable.
 func resolveSentinelsForContext(ctxName string, ctx *Context, store credentials.Store) (keychainBacked, keychainBacked) {
 	backed, preserve := keychainBacked{}, keychainBacked{}
 	for _, field := range credentials.AllFields {
@@ -141,26 +236,30 @@ func resolveSentinelsForContext(ctxName string, ctx *Context, store credentials.
 		if !ok {
 			continue
 		}
-		cur := ref.get()
-		if !credentials.IsSentinel(cur) {
+		resolveSentinelRef(ctxName, field, ref, store, backed, preserve)
+	}
+	return backed, preserve
+}
+
+// resolveEnvSentinels replaces keychain sentinels with plaintext for every
+// top-level cloud environment token. Unlike contexts (resolved lazily), cloud
+// environments are global, so the loader resolves them eagerly.
+func resolveEnvSentinels(cfg *Config, store credentials.Store) (keychainBacked, keychainBacked) {
+	backed, preserve := keychainBacked{}, keychainBacked{}
+	if cfg.Cloud == nil {
+		return backed, preserve
+	}
+	for name, env := range cfg.Cloud.Envs {
+		if env == nil {
 			continue
 		}
-		parsedCtx, parsedField, ok := credentials.ParseSentinel(cur)
-		if !ok || parsedCtx != ctxName || parsedField != field {
-			ref.set("")
-			continue
+		env := env
+		scope := cloudEnvScope(name)
+		ref := secretRef{
+			get: func() string { return env.Token },
+			set: func(v string) { env.Token = v },
 		}
-		value, err := store.Get(credentials.AccountKey(ctxName, field))
-		if err != nil {
-			ref.set("")
-			if errors.Is(err, credentials.ErrNotFound) {
-				continue
-			}
-			preserve.mark(ctxName, field)
-			continue
-		}
-		ref.set(value)
-		backed.mark(ctxName, field)
+		resolveSentinelRef(scope, credentials.FieldCloudToken, ref, store, backed, preserve)
 	}
 	return backed, preserve
 }
@@ -170,23 +269,16 @@ func resolveSentinelsForContext(ctxName string, ctx *Context, store credentials.
 // If the store is unavailable, it emits a one-time warning and returns 0.
 func migratePlaintextSecrets(cfg *Config, store credentials.Store, log logging.Logger) int {
 	migrated := 0
-	for ctxName, ctx := range cfg.Contexts {
-		if ctx == nil {
-			continue
-		}
-		for _, field := range credentials.AllFields {
-			ref, ok := fieldRef(ctx, field)
-			if !ok {
-				continue
-			}
+	for _, scope := range cfg.secretScopes() {
+		for field, ref := range scope.refs {
 			cur := ref.get()
 			if cur == "" || credentials.IsSentinel(cur) {
 				continue
 			}
-			if cfg.keychainFields[ctxName][field] {
+			if cfg.keychainFields[scope.name][field] {
 				continue
 			}
-			if err := store.Set(credentials.AccountKey(ctxName, field), cur); err != nil {
+			if err := store.Set(credentials.AccountKey(scope.name, field), cur); err != nil {
 				if errors.Is(err, credentials.ErrUnavailable) {
 					credentials.WarnUnavailableOnce(func() {
 						log.Warn("keychain unavailable; credentials remain in plaintext on disk",
@@ -195,7 +287,7 @@ func migratePlaintextSecrets(cfg *Config, store credentials.Store, log logging.L
 					return migrated
 				}
 				log.Warn("could not write keychain entry",
-					"context", ctxName,
+					"context", scope.name,
 					"field", string(field),
 					"error", err.Error())
 				continue
@@ -203,7 +295,7 @@ func migratePlaintextSecrets(cfg *Config, store credentials.Store, log logging.L
 			if cfg.keychainFields == nil {
 				cfg.keychainFields = keychainBacked{}
 			}
-			cfg.keychainFields.mark(ctxName, field)
+			cfg.keychainFields.mark(scope.name, field)
 			migrated++
 		}
 	}
@@ -220,12 +312,9 @@ func (cfg *Config) hasSecretsToReconcile() bool {
 	if len(cfg.keychainFields) > 0 || len(cfg.keychainPreserve) > 0 {
 		return true
 	}
-	for _, ctx := range cfg.Contexts {
-		if ctx == nil {
-			continue
-		}
-		for _, field := range credentials.AllFields {
-			if ref, ok := fieldRef(ctx, field); ok && ref.get() != "" {
+	for _, scope := range cfg.secretScopes() {
+		for _, ref := range scope.refs {
+			if ref.get() != "" {
 				return true
 			}
 		}
@@ -256,21 +345,14 @@ func reconcileKeychain(cfg *Config, store credentials.Store, log logging.Logger)
 		plaintext string
 	}
 	var swaps []swap
-	for ctxName, ctx := range cfg.Contexts {
-		if ctx == nil {
-			continue
-		}
-		for _, field := range credentials.AllFields {
-			ref, ok := fieldRef(ctx, field)
-			if !ok {
-				continue
-			}
-			key := credentials.AccountKey(ctxName, field)
+	for _, scope := range cfg.secretScopes() {
+		for field, ref := range scope.refs {
+			key := credentials.AccountKey(scope.name, field)
 
 			// Unresolvable at load: round-trip the sentinel verbatim.
-			if cfg.keychainPreserve[ctxName][field] {
+			if cfg.keychainPreserve[scope.name][field] {
 				swaps = append(swaps, swap{ref: ref, plaintext: ref.get()})
-				ref.set(credentials.FormatSentinel(ctxName, field))
+				ref.set(credentials.FormatSentinel(scope.name, field))
 				continue
 			}
 
@@ -279,14 +361,14 @@ func reconcileKeychain(cfg *Config, store credentials.Store, log logging.Logger)
 			if cur == "" {
 				// Field cleared. If it was keychain-backed, remove the now-stale
 				// entry instead of orphaning it.
-				if cfg.keychainFields[ctxName][field] {
+				if cfg.keychainFields[scope.name][field] {
 					if err := store.Delete(key); err != nil && !errors.Is(err, credentials.ErrUnavailable) {
 						log.Warn("could not remove stale keychain entry",
-							"context", ctxName,
+							"context", scope.name,
 							"field", string(field),
 							"error", err.Error())
 					}
-					delete(cfg.keychainFields[ctxName], field)
+					delete(cfg.keychainFields[scope.name], field)
 				}
 				continue
 			}
@@ -306,14 +388,14 @@ func reconcileKeychain(cfg *Config, store credentials.Store, log logging.Logger)
 					continue
 				}
 				log.Warn("could not write keychain entry",
-					"context", ctxName,
+					"context", scope.name,
 					"field", string(field),
 					"error", err.Error())
 				continue
 			}
-			cfg.keychainFields.mark(ctxName, field)
+			cfg.keychainFields.mark(scope.name, field)
 			swaps = append(swaps, swap{ref: ref, plaintext: cur})
-			ref.set(credentials.FormatSentinel(ctxName, field))
+			ref.set(credentials.FormatSentinel(scope.name, field))
 		}
 	}
 	return func() {

--- a/internal/config/keychain_test.go
+++ b/internal/config/keychain_test.go
@@ -190,6 +190,58 @@ current-context: default
 	assert.Equal(t, "plain-svc-token", got)
 }
 
+func TestLoad_MigratesEnvCloudTokenIntoKeychain(t *testing.T) {
+	store := withFakeStore(t)
+	path := writeYAML(t, `
+cloud:
+  current: prod
+  envs:
+    prod:
+      token: plain-env-token
+      api-url: https://grafana.com
+current-context: default
+contexts:
+  default:
+    grafana:
+      server: https://example.invalid
+`)
+
+	cfg, err := config.Load(t.Context(), config.ExplicitConfigFile(path))
+	require.NoError(t, err)
+
+	assert.Equal(t, "plain-env-token", cfg.Cloud.Envs["prod"].Token, "in-memory value should be plaintext")
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	disk := string(raw)
+	assert.Contains(t, disk, "keychain:gcx:cloud-env:prod:cloud-token")
+	assert.NotContains(t, disk, "plain-env-token")
+
+	got, err := store.Get(credentials.AccountKey("cloud-env:prod", credentials.FieldCloudToken))
+	require.NoError(t, err)
+	assert.Equal(t, "plain-env-token", got)
+}
+
+func TestLoad_ResolvesEnvCloudTokenSentinel(t *testing.T) {
+	store := withFakeStore(t)
+	require.NoError(t, store.Set(credentials.AccountKey("cloud-env:ops", credentials.FieldCloudToken), "resolved-env-token"))
+
+	path := writeYAML(t, `
+cloud:
+  current: ops
+  envs:
+    ops:
+      token: keychain:gcx:cloud-env:ops:cloud-token
+contexts: {}
+`)
+
+	cfg, err := config.Load(t.Context(), config.ExplicitConfigFile(path))
+	require.NoError(t, err)
+
+	assert.Equal(t, "resolved-env-token", cfg.Cloud.Envs["ops"].Token,
+		"cloud environment token sentinels must be resolved eagerly at load")
+}
+
 func TestLoad_MigratesProviderSMToken(t *testing.T) {
 	store := withFakeStore(t)
 	path := writeYAML(t, `

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -385,6 +385,12 @@ func Load(ctx context.Context, source Source, overrides ...Override) (Config, er
 		config.keychainFields, config.keychainPreserve = resolveSentinelsForContext(config.CurrentContext, cur, store)
 	}
 
+	// Cloud environments are global (not tied to a context), so resolve their
+	// token sentinels eagerly and fold the results into the same tracking maps.
+	envBacked, envPreserve := resolveEnvSentinels(&config, store)
+	config.keychainFields = mergeBacked(config.keychainFields, envBacked)
+	config.keychainPreserve = mergeBacked(config.keychainPreserve, envPreserve)
+
 	if migrated := migratePlaintextSecrets(&config, store, log); migrated > 0 {
 		log.Info("migrated plaintext credentials into OS keychain",
 			"count", migrated,

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -32,6 +32,16 @@ func MergeConfigs(base, over Config) Config {
 		}
 	}
 
+	// Top-level cloud: merge environments by key; current-env wins if non-empty.
+	if over.Cloud != nil {
+		if result.Cloud == nil {
+			result.Cloud = over.Cloud
+		} else {
+			merged := mergeCloudSettings(result.Cloud, over.Cloud)
+			result.Cloud = &merged
+		}
+	}
+
 	// Diagnostics: propagate from any layer that enables it.
 	if over.Diagnostics != nil {
 		if result.Diagnostics == nil {
@@ -167,10 +177,34 @@ func mergeGrafanaConfig(base, over *GrafanaConfig) GrafanaConfig {
 	return result
 }
 
+func mergeCloudSettings(base, over *CloudSettings) CloudSettings {
+	result := *base
+	if over.Current != "" {
+		result.Current = over.Current
+	}
+	if over.Envs != nil {
+		if result.Envs == nil {
+			result.Envs = make(map[string]*CloudConfig)
+		}
+		for name, overEnv := range over.Envs {
+			if baseEnv, ok := result.Envs[name]; ok {
+				merged := mergeCloudConfig(baseEnv, overEnv)
+				result.Envs[name] = &merged
+			} else {
+				result.Envs[name] = overEnv
+			}
+		}
+	}
+	return result
+}
+
 func mergeCloudConfig(base, over *CloudConfig) CloudConfig {
 	result := *base
 	if over.Token != "" {
 		result.Token = over.Token
+	}
+	if over.Env != "" {
+		result.Env = over.Env
 	}
 	if over.Stack != "" {
 		result.Stack = over.Stack

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -192,6 +192,30 @@ func TestMergeConfigs_DiagnosticsLayering(t *testing.T) {
 	assert.True(t, merged.Diagnostics.AgentInvocationLog)
 }
 
+func TestMergeConfigs_CloudSettingsLayering(t *testing.T) {
+	// User layer defines prod; local layer adds ops and switches current.
+	// Envs merge by key and the higher layer's current wins.
+	userCfg := config.Config{
+		Cloud: &config.CloudSettings{
+			Current: "prod",
+			Envs:    map[string]*config.CloudConfig{"prod": {Token: "prod-token"}},
+		},
+	}
+	localCfg := config.Config{
+		Cloud: &config.CloudSettings{
+			Current: "ops",
+			Envs:    map[string]*config.CloudConfig{"ops": {Token: "ops-token"}},
+		},
+	}
+
+	merged := config.MergeConfigs(userCfg, localCfg)
+
+	require.NotNil(t, merged.Cloud)
+	assert.Equal(t, "ops", merged.Cloud.Current, "higher layer current wins")
+	assert.Equal(t, "prod-token", merged.Cloud.Envs["prod"].Token, "base env survives")
+	assert.Equal(t, "ops-token", merged.Cloud.Envs["ops"].Token, "overlay env is added")
+}
+
 func TestMergeGrafanaConfig_OAuthAndProxyFields(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -5,16 +5,16 @@ import (
 	"strings"
 )
 
-// ResolveContextPath rewrites a bare config path (e.g. "cloud.token") to a
-// context-qualified path (e.g. "contexts.dev.cloud.token") by prefixing the
+// ResolveContextPath rewrites a bare config path (e.g. "grafana.server") to a
+// context-qualified path (e.g. "contexts.dev.grafana.server") by prefixing the
 // current context. Paths whose first segment already targets a top-level
-// Config field (see types.go) are returned unchanged.
+// Config field (contexts, current-context, cloud) are returned unchanged.
 //
 // Returns an error if the path is bare but no current context is set.
 func ResolveContextPath(cfg Config, path string) (string, error) {
 	first, _, _ := strings.Cut(path, ".")
 	switch first {
-	case "contexts", "current-context":
+	case "contexts", "current-context", "cloud":
 		return path, nil
 	}
 	if cfg.CurrentContext == "" {

--- a/internal/config/path_test.go
+++ b/internal/config/path_test.go
@@ -19,8 +19,14 @@ func TestResolveContextPath(t *testing.T) {
 		{
 			name: "bare path resolves under current context",
 			cfg:  config.Config{CurrentContext: "dev"},
-			path: "cloud.token",
-			want: "contexts.dev.cloud.token",
+			path: "grafana.server",
+			want: "contexts.dev.grafana.server",
+		},
+		{
+			name: "cloud prefix targets the top-level section",
+			cfg:  config.Config{CurrentContext: "dev"},
+			path: "cloud.envs.prod.token",
+			want: "cloud.envs.prod.token",
 		},
 		{
 			name: "nested bare path resolves under current context",
@@ -43,7 +49,7 @@ func TestResolveContextPath(t *testing.T) {
 		{
 			name:    "bare path with no current context errors",
 			cfg:     config.Config{},
-			path:    "cloud.token",
+			path:    "grafana.server",
 			wantErr: "no current context set",
 		},
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -34,6 +34,11 @@ type Config struct {
 	// CurrentContext is the name of the context currently in use.
 	CurrentContext string `json:"current-context" yaml:"current-context"`
 
+	// Cloud holds the top-level Grafana Cloud auth configuration shared across
+	// contexts. Contexts use the selected environment by default; per-context
+	// cloud blocks override it (see CloudConfig).
+	Cloud *CloudSettings `json:"cloud,omitempty" yaml:"cloud,omitempty"`
+
 	// Diagnostics holds optional local diagnostic settings. All features are off by default.
 	Diagnostics *DiagnosticsConfig `json:"diagnostics,omitempty" yaml:"diagnostics,omitempty"`
 
@@ -123,10 +128,34 @@ func (config *Config) SetContext(name string, makeCurrent bool, context Context)
 	}
 }
 
-// CloudConfig holds Grafana Cloud platform credentials and configuration.
+// DefaultCloudEnv is the cloud environment name used when none is configured.
+const DefaultCloudEnv = "prod"
+
+// CloudSettings holds the top-level Grafana Cloud auth configuration. Each named
+// environment carries its own GCOM credentials and endpoints; staff use several
+// (prod, ops, dev) while public users have only one. Current names the
+// environment used by default.
+type CloudSettings struct {
+	// Current is the name of the cloud environment used by default. When empty,
+	// the sole environment is used, falling back to DefaultCloudEnv.
+	Current string `json:"current,omitempty" yaml:"current,omitempty"`
+
+	// Envs maps environment name to its cloud auth configuration.
+	Envs map[string]*CloudConfig `json:"envs,omitempty" yaml:"envs,omitempty"`
+}
+
+// CloudConfig holds Grafana Cloud platform credentials and configuration. It is
+// used both for a top-level environment entry (CloudSettings.Envs) and as a
+// per-context override block (Context.Cloud). On a context block, non-empty
+// fields override the selected environment; Env and Stack are context-only.
 type CloudConfig struct {
 	// Token is a Grafana Cloud API token used to authenticate against GCOM.
 	Token string `datapolicy:"secret" env:"GRAFANA_CLOUD_TOKEN" json:"token,omitempty" yaml:"token,omitempty"`
+
+	// Env names the top-level cloud environment (CloudSettings.Envs) this
+	// context uses. Only meaningful on a per-context cloud block; when empty the
+	// context uses CloudSettings.Current. Ignored on environment entries.
+	Env string `json:"env,omitempty" yaml:"env,omitempty"`
 
 	// Stack is the Grafana Cloud stack slug (e.g. "mystack").
 	// Optional: if not set, the slug may be derived from Grafana.Server.
@@ -347,6 +376,71 @@ func ContextNameFromServerURL(serverURL string) string {
 	}
 
 	return strings.ReplaceAll(parsed.Hostname(), ".", "-")
+}
+
+// ResolveCloudEnvName returns the cloud environment a context resolves to:
+// the context's explicit Cloud.Env, else CloudSettings.Current, else the sole
+// configured environment, else DefaultCloudEnv.
+func (config *Config) ResolveCloudEnvName(ctxName string) string {
+	if ctx := config.Contexts[ctxName]; ctx != nil && ctx.Cloud != nil && ctx.Cloud.Env != "" {
+		return ctx.Cloud.Env
+	}
+	if config.Cloud != nil {
+		if config.Cloud.Current != "" {
+			return config.Cloud.Current
+		}
+		if len(config.Cloud.Envs) == 1 {
+			for name := range config.Cloud.Envs {
+				return name
+			}
+		}
+	}
+	return DefaultCloudEnv
+}
+
+// ResolveCloudConfig returns the effective cloud auth for the named context:
+// the selected environment's config overlaid with any non-empty per-context
+// override fields. Stack is always taken from the context; Env is not carried
+// through. The result is always non-nil (possibly empty).
+func (config *Config) ResolveCloudConfig(ctxName string) *CloudConfig {
+	out := &CloudConfig{}
+	if config.Cloud != nil {
+		if env := config.Cloud.Envs[config.ResolveCloudEnvName(ctxName)]; env != nil {
+			*out = *env
+		}
+	}
+	out.Env = ""
+	out.Stack = ""
+
+	if ctx := config.Contexts[ctxName]; ctx != nil && ctx.Cloud != nil {
+		over := ctx.Cloud
+		if over.Token != "" {
+			out.Token = over.Token
+		}
+		if over.OAuthUrl != "" {
+			out.OAuthUrl = over.OAuthUrl
+		}
+		if over.APIUrl != "" {
+			out.APIUrl = over.APIUrl
+		}
+		out.Stack = over.Stack
+	}
+	return out
+}
+
+// ResolveCloudAPIURL returns the effective Grafana Cloud API (GCOM) base URL for
+// the named context, resolving the environment and per-context overrides, then
+// falling back to the GCOM root derived from the stack server URL.
+func (config *Config) ResolveCloudAPIURL(ctxName string) string {
+	if merged := config.ResolveCloudConfig(ctxName); merged.APIUrl != "" {
+		return NormalizeCloudURL(merged.APIUrl)
+	}
+	if ctx := config.Contexts[ctxName]; ctx != nil && ctx.Grafana != nil {
+		if root, ok := GCOMRootFromServerURL(ctx.Grafana.Server); ok {
+			return root
+		}
+	}
+	return "https://grafana.com"
 }
 
 // ResolveCloudAPIURL returns the base URL for Grafana Cloud API (GCOM) resource

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -231,12 +231,13 @@ func (l *ConfigLoader) loadCloudBase(ctx context.Context) (cloudBase, error) {
 
 	curCtx := loaded.GetCurrentContext()
 
-	if curCtx.Cloud == nil || curCtx.Cloud.Token == "" {
-		return cloudBase{}, errors.New("cloud token is required: set cloud.token in config or GRAFANA_CLOUD_TOKEN env var")
+	merged := loaded.ResolveCloudConfig(loaded.CurrentContext)
+	if merged.Token == "" {
+		return cloudBase{}, errors.New("cloud token is required: run `gcx cloud login`, set a cloud token in config, or set GRAFANA_CLOUD_TOKEN")
 	}
 
-	token := curCtx.Cloud.Token
-	apiURL := curCtx.ResolveCloudAPIURL()
+	token := merged.Token
+	apiURL := loaded.ResolveCloudAPIURL(loaded.CurrentContext)
 
 	client, err := cloud.NewGCOMClient(apiURL, token)
 	if err != nil {

--- a/internal/providers/configloader_test.go
+++ b/internal/providers/configloader_test.go
@@ -44,6 +44,19 @@ func newMockGCOMServer(t *testing.T, info cloud.StackInfo) *httptest.Server {
 	}))
 }
 
+// newMockGCOMServerWithAuth behaves like newMockGCOMServer but records the
+// Authorization header of the last request into *seenAuth.
+func newMockGCOMServerWithAuth(t *testing.T, info cloud.StackInfo, seenAuth *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*seenAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(info); err != nil {
+			t.Errorf("mock GCOM server: encode response: %v", err)
+		}
+	}))
+}
+
 // writeConfigFile writes YAML content to a temp file and returns its path.
 func writeConfigFile(t *testing.T, content string) string {
 	t.Helper()
@@ -715,6 +728,67 @@ current-context: default
 	assert.Equal(t, 789, got.Stack.AgentManagementInstanceID)
 	assert.Equal(t, "https://fleet.example.com", got.Stack.AgentManagementInstanceURL)
 	assert.Equal(t, "default", got.Namespace)
+}
+
+// TestConfigLoader_LoadCloudConfig_FromTopLevelEnv verifies a context with no
+// per-context cloud token resolves its auth from the shared top-level
+// cloud.envs section, while the stack slug still comes from the context.
+func TestConfigLoader_LoadCloudConfig_FromTopLevelEnv(t *testing.T) {
+	wantStack := cloud.StackInfo{ID: 7, Slug: "mystack", Name: "My Stack", URL: "https://mystack.grafana.net"}
+	srv := newMockGCOMServer(t, wantStack)
+	defer srv.Close()
+
+	cfgFile := writeConfigFile(t, `
+cloud:
+  current: prod
+  envs:
+    prod:
+      token: "env-token"
+      api-url: "`+srv.URL+`"
+contexts:
+  default:
+    cloud:
+      stack: "mystack"
+current-context: default
+`)
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(cfgFile)
+
+	got, err := loader.LoadCloudConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "env-token", got.Token, "token resolved from top-level env")
+	assert.Equal(t, "mystack", got.Stack.Slug)
+}
+
+// TestConfigLoader_LoadCloudConfig_ContextTokenOverridesEnv verifies a
+// per-context cloud token (stack-scoped CAP) wins over the shared env token.
+func TestConfigLoader_LoadCloudConfig_ContextTokenOverridesEnv(t *testing.T) {
+	var seenAuth string
+	wantStack := cloud.StackInfo{ID: 7, Slug: "mystack", Name: "My Stack"}
+	srv := newMockGCOMServerWithAuth(t, wantStack, &seenAuth)
+	defer srv.Close()
+
+	cfgFile := writeConfigFile(t, `
+cloud:
+  current: prod
+  envs:
+    prod:
+      token: "env-token"
+      api-url: "`+srv.URL+`"
+contexts:
+  default:
+    cloud:
+      token: "stack-cap"
+      stack: "mystack"
+current-context: default
+`)
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(cfgFile)
+
+	got, err := loader.LoadCloudConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "stack-cap", got.Token, "per-context token must override the env token")
+	assert.Contains(t, seenAuth, "stack-cap", "request must carry the overriding token")
 }
 
 func TestConfigLoader_SaveProviderConfig_ContextOverrideBeforeEnvVars(t *testing.T) {

--- a/internal/testutils/command.go
+++ b/internal/testutils/command.go
@@ -38,6 +38,14 @@ func CommandOutputContains(expected string) CommandAssertion {
 	}
 }
 
+func CommandOutputDoesNotContain(unexpected string) CommandAssertion {
+	return func(t *testing.T, result CommandResult) {
+		t.Helper()
+
+		require.NotContains(t, result.Stdout, unexpected)
+	}
+}
+
 func CommandOutputEquals(expected string) CommandAssertion {
 	return func(t *testing.T, result CommandResult) {
 		t.Helper()


### PR DESCRIPTION
closes #890

Part of the `gcx cloud login` work — targets `cloud-login-slim`.

## Summary

Moves Grafana Cloud auth out of per-context config into a shared top-level `cloud` section, so contexts use the same cloud auth by default instead of setting a token per context.

- **`cloud.envs.<name>`** holds shared GCOM auth (token + endpoints). Staff can keep several environments (prod/ops/dev); public users have one. **`cloud.current`** selects the default (hidden in UX when only one exists).
- **Per-context `cloud` becomes an override layer**: `contexts.<ctx>.cloud.env` pins an environment, and `contexts.<ctx>.cloud.token` overrides the token for stack-scoped access policies (the per-stack CAP case from the issue).
- **Resolution order** (`Config.ResolveCloudConfig`): `GRAFANA_CLOUD_TOKEN` / env vars → per-context override → selected environment. `stack` is always per-context.
- **`gcx cloud login`** writes the current environment by default; `--env <name>` targets a named one (first env configured becomes `current`; adding more never silently switches it); `gcx --context <name> cloud login` writes the per-context override. `--env`/`--context` are mutually exclusive.
- `gcx login --cloud-token` is unchanged — it still writes the per-context override.
- Environment tokens are **keychain-backed** under a `cloud-env:<name>` scope, same as context tokens (no plaintext regression).
- `cloud.*` config paths target the top-level section: `gcx config set cloud.current ops`, `gcx config set cloud.envs.prod.token …`.

Existing on-disk `contexts.<ctx>.cloud` configs keep working unchanged (they're now the override layer), so there's no data migration.

## Config shape

```yaml
cloud:
  current: prod                      # hidden in UX when only one env exists
  envs:
    prod: { token: glc_xxx, api-url: https://grafana.com }
    ops:  { token: glc_yyy, api-url: https://grafana-ops.com }
contexts:
  pdc-dev:
    grafana: { server: https://mystack.grafana.net }
    cloud:
      # env: dev                     # optional: pin a specific environment
      # token: glc_stack_scoped      # optional: stack-scoped CAP override
      stack: mystack
```

## Behaviour change

`gcx config set cloud.token X` no longer means "current context's cloud token" — `cloud.*` is now the top-level section. Per-context overrides use the fully-qualified `contexts.<name>.cloud.token`.

## Notes for review

- @radiohead's suggestion on #890 is a broader, fully-normalised (kubectl-style) model that also lifts `grafana`+`providers` into a top-level `stacks` map with contexts as pure references. That's a larger refactor than #890's stated scope; this PR does the targeted cloud-auth move only. Happy to follow up with the full normalisation as a separate issue if we want to go there — worth deciding before this locks in the `cloud.envs` shape.
- Local `golangci-lint` can't run here (built with go1.25 vs target 1.26.2); relying on CI. `go vet` and the full test suite are clean.

## Tests

Unit + integration coverage added: cloud resolution (env default / sole-env / per-context override / pinned env), keychain round-trip for env tokens, `gcx cloud login` targeting incl. stack preservation and missing-context error, loader consumption (env token + override precedence), layered-config merge of the `cloud` section, and `config set` dot-paths + `config view` env-token redaction.
