### PR TITLE
feat(login): offer grafana.com OAuth in interactive login

### DIFF
--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -265,7 +266,7 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 			if !isInteractive {
 				return structuredMissingFieldsError(needInput)
 			}
-			if formErr := askForInput(needInput, &opts, sourceCtx); formErr != nil {
+			if formErr := askForInput(ctx, needInput, &opts, sourceCtx); formErr != nil {
 				if errors.Is(formErr, huh.ErrUserAborted) {
 					// Route advisory to stderr so stdout remains parseable
 					// for -o json / -o yaml consumers.
@@ -296,13 +297,11 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 }
 
 // askForInput shows an interactive huh prompt for each field in ErrNeedInput.
-// For "cloud-token" with Optional=true: empty user input sets opts.Yes=true so
-// that the next Run() call skips this step instead of looping forever (AC-002).
-//
-// When sourceCtx carries an existing stored token (re-auth), the prompt offers
-// "Press Enter to keep existing token" semantics — empty input reuses the
-// stored value instead of skipping or erroring.
-func askForInput(e *login.ErrNeedInput, opts *login.Options, sourceCtx *config.Context) error {
+// For "cloud-token" the optional Grafana Cloud login step is delegated to
+// askCloudAuth (browser OAuth, pasted token, or skip). When sourceCtx carries
+// an existing stored token (re-auth), the prompts offer a "keep existing token"
+// affordance instead of skipping or erroring.
+func askForInput(ctx context.Context, e *login.ErrNeedInput, opts *login.Options, sourceCtx *config.Context) error {
 	existingGrafanaToken := ""
 	existingCloudToken := ""
 	if sourceCtx != nil {
@@ -347,35 +346,124 @@ func askForInput(e *login.ErrNeedInput, opts *login.Options, sourceCtx *config.C
 			}
 
 		case "cloud-token":
-			hint := e.Hint
-			switch {
-			case existingCloudToken != "":
-				hint = "Press Enter to keep existing token"
-			case hint == "":
-				hint = "Press Enter to skip (Cloud management features will be unavailable)"
-			}
-			form := huh.NewForm(huh.NewGroup(
-				huh.NewInput().
-					Title("Grafana Cloud API token").
-					Description(hint).
-					EchoMode(huh.EchoModePassword).
-					Value(&opts.CloudToken),
-			))
-			if err := form.Run(); err != nil {
+			if err := askCloudAuth(ctx, e, opts, existingCloudToken); err != nil {
 				return err
-			}
-			switch {
-			case opts.CloudToken == "" && existingCloudToken != "":
-				// Re-auth: user kept the existing token.
-				opts.CloudToken = existingCloudToken
-			case opts.CloudToken == "":
-				// New context or user chose to skip Cloud auth. Set Yes=true
-				// so the next Run() call bypasses this sentinel instead of
-				// re-prompting.
-				opts.Yes = true
 			}
 		}
 	}
+	return nil
+}
+
+// askCloudAuth handles the optional Grafana Cloud (grafana.com) login shown
+// after stack auth completes. It offers browser OAuth — the same GCOM PKCE flow
+// as `gcx cloud login` — alongside pasting a Cloud Access Policy token and
+// skipping. On re-auth, keeping the existing token is offered first.
+//
+// The resolved credential is written to opts.CloudToken, consumed by the next
+// Run() as the Cloud API token. Skipping sets opts.Yes so the next Run()
+// bypasses this sentinel instead of re-prompting.
+func askCloudAuth(ctx context.Context, e *login.ErrNeedInput, opts *login.Options, existingToken string) error {
+	const (
+		choiceKeep  = "keep"
+		choiceOAuth = "oauth"
+		choiceToken = "token"
+		choiceSkip  = "skip"
+	)
+
+	// "recommended" marks the default (first) option: keeping a still-valid
+	// token on re-auth, or browser login when there's no token yet.
+	var options []huh.Option[string]
+	if existingToken != "" {
+		options = append(options,
+			huh.NewOption("Keep the existing Cloud token (recommended)", choiceKeep),
+			huh.NewOption("OAuth (browser)", choiceOAuth),
+		)
+	} else {
+		options = append(options, huh.NewOption("OAuth (browser) (recommended)", choiceOAuth))
+	}
+	options = append(options,
+		huh.NewOption("Paste a Cloud Access Policy token", choiceToken),
+		huh.NewOption("Skip — Cloud management features will be unavailable", choiceSkip),
+	)
+
+	choice := options[0].Value
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("Also log in to Grafana Cloud (grafana.com)?").
+			Description("Enables managing Cloud resources like stacks and access policies.").
+			Options(options...).
+			Value(&choice),
+	))
+	if err := form.Run(); err != nil {
+		return err
+	}
+
+	switch choice {
+	case choiceKeep:
+		opts.CloudToken = existingToken
+		// The kept token was already accepted on a prior login, so skip the GCOM
+		// stack re-check — same treatment as a freshly OAuth'd token. Without this
+		// a kept OAuth token would 403 spuriously on non-prod stacks and surface a
+		// confusing "could not verify Cloud access" warning on every re-auth.
+		opts.CloudTokenFromOAuth = true
+		return nil
+	case choiceOAuth:
+		return runCloudOAuth(ctx, opts)
+	case choiceSkip:
+		// Set Yes=true so the next Run() call bypasses this sentinel instead
+		// of re-prompting.
+		opts.Yes = true
+		return nil
+	}
+
+	// choiceToken: prompt for a pasted Cloud Access Policy token.
+	hint := e.Hint
+	if hint == "" {
+		hint = "Press Enter to skip (Cloud management features will be unavailable)"
+	}
+	tokenForm := huh.NewForm(huh.NewGroup(
+		huh.NewInput().
+			Title("Grafana Cloud API token").
+			Description(hint).
+			EchoMode(huh.EchoModePassword).
+			Value(&opts.CloudToken),
+	))
+	if err := tokenForm.Run(); err != nil {
+		return err
+	}
+	if opts.CloudToken == "" {
+		opts.Yes = true
+	}
+	return nil
+}
+
+// runCloudOAuth runs the GCOM OAuth2 PKCE browser flow (the same flow used by
+// `gcx cloud login`) and stores the resulting access token in opts.CloudToken so
+// the next Run() persists it as the Cloud API token. The GCOM endpoint is
+// derived from the stack server so dev/ops stacks authenticate against
+// grafana-dev.com / grafana-ops.com instead of prod grafana.com.
+func runCloudOAuth(ctx context.Context, opts *login.Options) error {
+	gcomURL, _ := config.GCOMRootFromServerURL(opts.Server)
+	flow := internalauth.NewGCOMFlow(internalauth.GCOMOptions{
+		ClientID: internalauth.DefaultGCOMClientID,
+		GCOMURL:  gcomURL,
+		Scopes:   internalauth.DefaultGCOMScopes,
+		Writer:   opts.Writer,
+	})
+	result, err := flow.Run(ctx)
+	if err != nil {
+		return gcxerrors.DetailedError{
+			Summary: "Grafana Cloud authentication failed",
+			Parent:  err,
+			Suggestions: []string{
+				"Ensure you are logged in to Grafana Cloud in your browser",
+				"Re-run and choose \"Skip\" to finish without Cloud management features",
+				"Or add a token later with: gcx cloud login",
+			},
+		}
+	}
+	opts.CloudToken = result.AccessToken
+	opts.CloudTokenFromOAuth = true
 	return nil
 }
 

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -447,7 +447,7 @@ func runCloudOAuth(ctx context.Context, opts *login.Options) error {
 	flow := internalauth.NewGCOMFlow(internalauth.GCOMOptions{
 		ClientID: internalauth.DefaultGCOMClientID,
 		GCOMURL:  gcomURL,
-		Scopes:   internalauth.DefaultGCOMScopes,
+		Scopes:   internalauth.DefaultGCOMScopes(),
 		Writer:   opts.Writer,
 	})
 	result, err := flow.Run(ctx)

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -18,6 +18,17 @@ import (
 	"github.com/grafana/gcx/internal/httputils"
 )
 
+// DefaultGCOMClientID is the OAuth2 client ID registered in GCOM for gcx.
+const DefaultGCOMClientID = "gcx"
+
+// DefaultGCOMScopes are the OAuth2 scopes requested when logging in to the
+// Grafana Cloud platform API (grafana.com) for stack and access-policy
+// management.
+var DefaultGCOMScopes = []string{
+	"stacks:read", "stacks:write", "stacks:delete",
+	"accesspolicies:read", "accesspolicies:write", "accesspolicies:delete",
+}
+
 // GCOMResult contains the result of a GCOM OAuth2 PKCE authentication flow.
 type GCOMResult struct {
 	AccessToken string

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -22,13 +22,12 @@ import (
 const DefaultGCOMClientID = "gcx"
 
 // DefaultGCOMScopes returns the OAuth2 scopes requested when logging in to the
-// Grafana Cloud platform API (grafana.com) for stack and access-policy
-// management. A fresh slice is returned on each call so callers (e.g. a Cobra
-// flag default) can mutate their copy without affecting others.
+// Grafana Cloud platform API (grafana.com) for stack management. A fresh slice
+// is returned on each call so callers (e.g. a Cobra flag default) can mutate
+// their copy without affecting others.
 func DefaultGCOMScopes() []string {
 	return []string{
 		"stacks:read", "stacks:write", "stacks:delete",
-		"accesspolicies:read", "accesspolicies:write", "accesspolicies:delete",
 	}
 }
 

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -21,12 +21,15 @@ import (
 // DefaultGCOMClientID is the OAuth2 client ID registered in GCOM for gcx.
 const DefaultGCOMClientID = "gcx"
 
-// DefaultGCOMScopes are the OAuth2 scopes requested when logging in to the
+// DefaultGCOMScopes returns the OAuth2 scopes requested when logging in to the
 // Grafana Cloud platform API (grafana.com) for stack and access-policy
-// management.
-var DefaultGCOMScopes = []string{
-	"stacks:read", "stacks:write", "stacks:delete",
-	"accesspolicies:read", "accesspolicies:write", "accesspolicies:delete",
+// management. A fresh slice is returned on each call so callers (e.g. a Cobra
+// flag default) can mutate their copy without affecting others.
+func DefaultGCOMScopes() []string {
+	return []string{
+		"stacks:read", "stacks:write", "stacks:delete",
+		"accesspolicies:read", "accesspolicies:write", "accesspolicies:delete",
+	}
 }
 
 // GCOMResult contains the result of a GCOM OAuth2 PKCE authentication flow.

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -505,27 +505,7 @@ func resolveCloudAuth(opts Options, target Target) (*config.CloudConfig, error) 
 	}
 
 	if opts.CloudToken != "" {
-		cc := &config.CloudConfig{
-			Token:  opts.CloudToken,
-			APIUrl: opts.CloudAPIURL,
-		}
-		// For an OAuth or kept (already-trusted) token, record the GCOM endpoint
-		// for this stack env, matching `gcx cloud login`. Without this a later
-		// `gcx cloud login` on an ops/dev context would default to prod
-		// grafana.com. A freshly pasted CAP token carries no such origin, so it
-		// is left to APIUrl auto-derivation at use time.
-		if opts.CloudTokenFromOAuth {
-			if root, ok := config.GCOMRootFromServerURL(opts.Server); ok {
-				cc.OAuthUrl = root
-				if cc.APIUrl == "" {
-					cc.APIUrl = root
-				}
-			}
-		}
-		if slug := resolveStackSlug(opts.Server); slug != "" {
-			cc.Stack = slug
-		}
-		return cc, nil
+		return cloudConfigForToken(opts), nil
 	}
 
 	// Cloud target with no token: skip if Yes or agent mode (D9, D10).
@@ -546,6 +526,29 @@ func resolveCloudAuth(opts Options, target Target) (*config.CloudConfig, error) 
 		Optional: true,
 		Hint:     cloudTokenHint(opts.Server),
 	}
+}
+
+// cloudConfigForToken builds the CloudConfig for a Cloud target that has a
+// resolved token. For an OAuth or kept (already-trusted) token it records the
+// GCOM endpoint for this stack env, matching `gcx cloud login`; without this a
+// later `gcx cloud login` on an ops/dev context would default to prod
+// grafana.com. A freshly pasted CAP token carries no such origin, so its API
+// URL is left to auto-derivation at use time.
+func cloudConfigForToken(opts Options) *config.CloudConfig {
+	cc := &config.CloudConfig{
+		Token:  opts.CloudToken,
+		APIUrl: opts.CloudAPIURL,
+	}
+	if root, ok := config.GCOMRootFromServerURL(opts.Server); ok && opts.CloudTokenFromOAuth {
+		cc.OAuthUrl = root
+		if cc.APIUrl == "" {
+			cc.APIUrl = root
+		}
+	}
+	if slug := resolveStackSlug(opts.Server); slug != "" {
+		cc.Stack = slug
+	}
+	return cc
 }
 
 // announceOAuthLogin surfaces a clear success message once the interactive OAuth

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -58,8 +58,16 @@ type Inputs struct {
 	GrafanaToken string
 	CloudToken   string
 	CloudAPIURL  string
-	OrgID        int
-	UseOAuth     bool
+	// CloudTokenFromOAuth marks CloudToken as already trusted, so the GCOM stack
+	// check in Validate is skipped for it. Set when the token was obtained via
+	// the browser OAuth login (freshly minted with the requested scopes) or when
+	// an already-accepted token is being kept on re-auth. That check exists to
+	// catch typos in freshly pasted Cloud Access Policy tokens; it 403s
+	// spuriously on non-prod stacks, so it must not run for these (matching
+	// `gcx cloud login`, which does not validate at all).
+	CloudTokenFromOAuth bool
+	OrgID               int
+	UseOAuth            bool
 	// OAuthCallbackPort fixes the local port for the OAuth callback server.
 	// Zero means auto-pick from the default range. Useful when only specific
 	// ports are forwarded between a remote dev host and the user's browser.
@@ -501,6 +509,19 @@ func resolveCloudAuth(opts Options, target Target) (*config.CloudConfig, error) 
 			Token:  opts.CloudToken,
 			APIUrl: opts.CloudAPIURL,
 		}
+		// For an OAuth or kept (already-trusted) token, record the GCOM endpoint
+		// for this stack env, matching `gcx cloud login`. Without this a later
+		// `gcx cloud login` on an ops/dev context would default to prod
+		// grafana.com. A freshly pasted CAP token carries no such origin, so it
+		// is left to APIUrl auto-derivation at use time.
+		if opts.CloudTokenFromOAuth {
+			if root, ok := config.GCOMRootFromServerURL(opts.Server); ok {
+				cc.OAuthUrl = root
+				if cc.APIUrl == "" {
+					cc.APIUrl = root
+				}
+			}
+		}
 		if slug := resolveStackSlug(opts.Server); slug != "" {
 			cc.Stack = slug
 		}
@@ -556,23 +577,25 @@ func announceCloudTokenStep(w io.Writer) {
 	if w == nil {
 		w = io.Discard
 	}
-	fmt.Fprintln(w, "\nOptional: add a Grafana Cloud API token to enable Cloud management features.")
+	fmt.Fprintln(w, "\nOptional: log in to Grafana Cloud to enable Cloud management features.")
 }
 
-// warnCloudTokenUnvalidated surfaces a non-fatal advisory when a Cloud Access
-// Policy (CAP) token is present but its GCOM validation failed. Because the CAP
-// token is optional, login proceeds; this explains why Cloud management features
-// may not work. It writes to w (the caller-supplied progress writer); a nil
-// writer discards, keeping internal/login free of process streams (NC-001).
+// warnCloudTokenUnvalidated surfaces a non-fatal advisory when a Cloud token is
+// present (from a pasted CAP token or the browser OAuth login) but its GCOM
+// stack check failed. Because Cloud auth is optional, login proceeds; this
+// explains why Cloud management features may not work. The wording is kept
+// auth-method-neutral so it reads correctly for both the token and OAuth paths.
+// It writes to w (the caller-supplied progress writer); a nil writer discards,
+// keeping internal/login free of process streams (NC-001).
 func warnCloudTokenUnvalidated(w io.Writer, e *GCOMStackError) {
 	if w == nil {
 		w = io.Discard
 	}
-	msg := fmt.Sprintf("Warning: Cloud Access Policy token could not be validated for stack %q", e.Slug)
+	msg := fmt.Sprintf("Warning: could not verify Grafana Cloud access for stack %q", e.Slug)
 	if e.Status != 0 {
 		msg += fmt.Sprintf(" (GCOM returned %d)", e.Status)
 	}
-	fmt.Fprintln(w, msg+". Logging in anyway; Cloud management features may be unavailable until a working token is provided.")
+	fmt.Fprintln(w, msg+". Logging in anyway; some Cloud management features may be unavailable.")
 }
 
 // persistContext loads the existing config (tolerating ErrNotExist), upserts the

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -106,6 +106,40 @@ func TestRun(t *testing.T) { //nolint:maintidx // 8 table-driven cases; complexi
 			},
 		},
 		{
+			// A browser-OAuth Cloud token records the GCOM endpoint it came from
+			// (derived from the ops-stack env), matching `gcx cloud login`, so a
+			// later cloud re-auth targets grafana-ops.com rather than prod.
+			name: "cloud_oauth_token_records_gcom_endpoint",
+			opts: func(dir string) login.Options {
+				return login.Options{
+					Inputs: login.Inputs{
+						Server:              "https://ops.grafana-ops.net",
+						ContextName:         "ops-stack",
+						Target:              login.TargetCloud,
+						UseOAuth:            true,
+						CloudToken:          "gcom-oauth-token",
+						CloudTokenFromOAuth: true,
+					},
+					Hooks: login.Hooks{
+						ConfigSource: configSource(dir),
+						NewAuthFlow: func(_ string, _ auth.Options) login.AuthFlow {
+							return &stubAuthFlow{result: oauthResult}
+						},
+						ValidateFn: noopValidate,
+					},
+				}
+			},
+			checkConfig: func(t *testing.T, cfg config.Config) {
+				t.Helper()
+				ctx := cfg.Contexts["ops-stack"]
+				require.NotNil(t, ctx)
+				require.NotNil(t, ctx.Cloud)
+				assert.Equal(t, "gcom-oauth-token", ctx.Cloud.Token)
+				assert.Equal(t, "https://grafana-ops.com", ctx.Cloud.OAuthUrl, "OAuth token must record its GCOM origin")
+				assert.Equal(t, "https://grafana-ops.com", ctx.Cloud.APIUrl, "APIUrl defaults to the same GCOM root")
+			},
+		},
+		{
 			// AC-002: First-run Cloud without CAP (Yes=true skips cloud-token prompt)
 			name: "cloud_oauth_skip_cap",
 			opts: func(dir string) login.Options {
@@ -945,7 +979,7 @@ func TestRun_OptionalCloudTokenRejected_WarnsAndPersists(t *testing.T) {
 	result, err := login.Run(context.Background(), &opts)
 	require.NoError(t, err, "an optional CAP-token rejection must not fail login")
 	assert.True(t, result.HasCloudToken, "the CAP token should still be persisted")
-	assert.Contains(t, warnBuf.String(), "Cloud Access Policy token could not be validated")
+	assert.Contains(t, warnBuf.String(), "could not verify Grafana Cloud access")
 	assert.Contains(t, warnBuf.String(), "401")
 
 	// The context must have been written despite the CAP validation failure.
@@ -1389,7 +1423,7 @@ func TestRun_OAuthSuccess_AnnouncesSignInBeforeCloudTokenPrompt(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "Signed in to https://mystack.grafana.net as you@example.com",
 		"OAuth completion must be acknowledged with identity and endpoint")
-	assert.Contains(t, out, "Grafana Cloud API token",
+	assert.Contains(t, out, "log in to Grafana Cloud",
 		"the optional next step must be framed before the prompt appears")
 }
 

--- a/internal/login/validate.go
+++ b/internal/login/validate.go
@@ -65,8 +65,12 @@ func (v *validator) validate(ctx context.Context, opts Options, restCfg config.N
 		return "", &VersionCheckError{Cause: &intgrafana.VersionIncompatibleError{Version: version}}
 	}
 
-	// Step 4: GCOM stack check when Cloud target has a CAP token and a derivable slug
-	if opts.Target == TargetCloud && opts.CloudToken != "" && v.gcom != nil {
+	// Step 4: GCOM stack check when Cloud target has a pasted CAP token and a
+	// derivable slug. Skipped for OAuth-obtained tokens (CloudTokenFromOAuth):
+	// they are freshly minted with the requested scopes, so this check only adds
+	// a spurious 403 warning on non-prod stacks. v.gcom is nil in that case (see
+	// Validate), so the guard is belt-and-braces for direct callers.
+	if opts.Target == TargetCloud && opts.CloudToken != "" && !opts.CloudTokenFromOAuth && v.gcom != nil {
 		slug := resolveStackSlug(opts.Server)
 		if slug != "" {
 			if _, err := v.gcom.GetStack(ctx, slug); err != nil {
@@ -145,7 +149,7 @@ func Validate(ctx context.Context, opts Options, restCfg config.NamespacedRESTCo
 		},
 	}
 
-	if opts.Target == TargetCloud && opts.CloudToken != "" {
+	if opts.Target == TargetCloud && opts.CloudToken != "" && !opts.CloudTokenFromOAuth {
 		// Resolve the GCOM root the same way runtime cloud commands do: an
 		// explicit --cloud-api-url wins, otherwise it is derived from the stack
 		// server URL's environment (ops/dev stacks → grafana-ops.com /

--- a/internal/login/validate_test.go
+++ b/internal/login/validate_test.go
@@ -114,6 +114,15 @@ func TestValidate(t *testing.T) {
 			wantGCOMHit: true,
 		},
 		{
+			name:        "Cloud + OAuth token: GCOM skipped",
+			opts:        Options{Inputs: Inputs{Target: TargetCloud, CloudToken: "oauth-token", CloudTokenFromOAuth: true, Server: "https://mystack.grafana.net"}},
+			grafana:     &stubGrafanaClient{version: v12},
+			discovery:   okDiscovery,
+			gcom:        &stubGCOMClient{},
+			wantErr:     false,
+			wantGCOMHit: false,
+		},
+		{
 			name:        "Cloud without CAP token: GCOM skipped",
 			opts:        Options{Inputs: Inputs{Target: TargetCloud, CloudToken: ""}},
 			grafana:     &stubGrafanaClient{version: v12},


### PR DESCRIPTION
 Follow-up to the `gcx cloud login` work: wire the same GCOM OAuth flow into interactive `gcx login`.

This is an **incremental improvement**: we'll improve the `gcx login` flow, but it will need https://github.com/grafana/gcx/issues/890 first, since I think we'll want separate cloud/stack config objects (it will make it easier to e.g. put the cloud login first)

- [x] Needs https://github.com/grafana/gcx/pull/847 merged first

## Summary

- After the stack auth step, `gcx login` now asks **"Also log in to Grafana Cloud (grafana.com)?"** and offers browser OAuth (the same PKCE flow as `gcx cloud login`), pasting a Cloud Access Policy token, or skipping. On re-auth, keeping the existing token is offered first.
- Shares the GCOM client ID + default scopes from `internal/auth` so `gcx cloud login` and `gcx login` no longer duplicate them.
- Derives the GCOM endpoint from the stack env, so dev/ops stacks authenticate against `grafana-dev.com` / `grafana-ops.com` instead of prod, and records it in the context so a later `gcx cloud login` targets the right platform.
- Skips the GCOM stack re-check for OAuth-obtained and kept tokens (that check exists to catch typos in freshly pasted CAP tokens and 403s spuriously on non-prod stacks). The unverified-token warning is reworded to be auth-method-neutral.

## Before / After

Interactive `gcx login` against a Cloud stack, after the stack OAuth step:

**Before** — only prompted to paste a grafana.com token:
```
Grafana Cloud API token
Press Enter to skip (Cloud management features will be unavailable)
> ____
```

**After** — offers the browser flow:
```
Also log in to Grafana Cloud (grafana.com)?
Enables managing Cloud resources like stacks and access policies.
> OAuth (browser) (recommended)
  Paste a Cloud Access Policy token
  Skip — Cloud management features will be unavailable
```

## Notes for review

- Cloud OAuth runs in the CLI layer (feeding the token back through the existing `cloud-token` sentinel), not via a `Hooks` seam like the stack OAuth — cloud-token resolution is interactive input the CLI already owns, and `internal/login` stays UI-free.
- `CloudTokenFromOAuth` gates both the validation skip and the OAuth-endpoint recording; it's also set on the "keep existing token" path so a kept OAuth token doesn't resurface the spurious 403 warning on re-auth.