### PR TITLE
docs: add product labels front matter to published pages

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,5 +1,10 @@
 ---
 title: gcx CLI
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
 description: Use gcx to manage Grafana and Grafana Cloud from the terminal and from agentic coding tools.
 keywords:
   - gcx

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -1,5 +1,10 @@
 ---
 title: Configure gcx
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
 weight: 3
 ---
 

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -1,5 +1,10 @@
 ---
 title: Install gcx
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
 weight: 2
 ---
 

--- a/docs/sources/overview.md
+++ b/docs/sources/overview.md
@@ -1,5 +1,10 @@
 ---
 title: Introduction to gcx
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
 weight: 1
 ---
 


### PR DESCRIPTION
## What

Adds `labels.products` front matter (`cloud`, `enterprise`, `oss`) to all pages under `docs/sources/`.

## Why

The published pages currently render only the Enterprise and Open source badges — the Grafana Cloud badge is missing because no `labels.products` front matter is set, so the site falls back to defaults. gcx supports Grafana Cloud (OAuth login is Cloud-only) plus OSS/Enterprise v12+, so all three product labels apply.

Follows the Writers' Toolkit front matter convention used across grafana.com docs.
