### PR TITLE
Use main branch for deploy previews

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
       statuses: write
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/deploy-preview # zizmor: ignore[unpinned-uses]
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main # zizmor: ignore[unpinned-uses]
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}


### PR DESCRIPTION
The in-development feature to support GCX deploy previews was merged in https://github.com/grafana/writers-toolkit/pull/1393