### PR TITLE
fix(logs): distinguish structured metadata from indexed stream labels

### DIFF
--- a/claude-plugin/skills/debug-with-grafana/SKILL.md
+++ b/claude-plugin/skills/debug-with-grafana/SKILL.md
@@ -240,17 +240,36 @@ gcx logs query -d <loki-uid> \
     "resultType": "streams",
     "result": [
       {
-        "stream": {"job": "<service-name>", "level": "<level>"},
-        "values": [["<ns-timestamp>", "<log-line>"], ...]
+        "stream": {"job": "<service-name>"},
+        "values": [
+          {
+            "timestamp": "<ns-timestamp>",
+            "line": "<log-line>",
+            "structuredMetadata": {"detected_level": "error"},
+            "parsed": {"status": "500"}
+          }
+        ]
       }
     ]
   }
 }
 ```
+`stream` holds indexed labels only (valid inside `{...}`). `structuredMetadata`
+(per-line, e.g. `detected_level`) and `parsed` (from `| json` / `| logfmt`) are
+present only when the line has them, and are usable only after a pipe — not in a
+`{}` selector.
 
 > **LogQL pitfall**: Loki requires at least one non-empty label matcher in the
 > stream selector. `{}` and `{} |~ "pattern"` will be rejected. Always include
 > at least one label, e.g., `{job=~".+"}` as a catch-all.
+>
+> **Label-kind pitfall**: only *indexed* labels are valid inside `{...}`. Loki's
+> structured metadata (e.g. its auto-added `detected_level`) and parsed fields
+> are NOT — `{detected_level="error"}` returns zero streams silently. Filter
+> them after a pipe: `{job="app"} | detected_level="error"`. In `gcx logs query`
+> output, indexed labels are in the `stream` map / `STREAM` column; structured
+> metadata and parsed labels are in per-entry `structuredMetadata` / `parsed`
+> (`-o json`) or `DETAILS` (`-o table`).
 
 Look for:
 - Repeated error messages pointing to a specific code path or dependency

--- a/claude-plugin/skills/debug-with-grafana/references/error-recovery.md
+++ b/claude-plugin/skills/debug-with-grafana/references/error-recovery.md
@@ -127,6 +127,7 @@ Or for a range query:
 - The time range (`--from` / `--to`) falls outside the retention period or before the service was instrumented.
 - The label filters in the query are too restrictive (e.g., a `job` label value that does not exist).
 - The datasource is healthy but the service being queried is down and emitting no data.
+- **Loki-specific**: a structured-metadata or parsed key was placed inside the `{...}` selector. Only indexed stream labels are valid there. `{detected_level="error"}` matches nothing — Loki's `detected_level` is structured metadata, so it must go after a pipe: `{job="app"} | detected_level="error"`. Parsed fields need the parser stage first: `{job="app"} | json | status="500"`.
 
 ### Corrective Action
 

--- a/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
@@ -178,7 +178,11 @@ Basic log filtering:
 # All logs from a job
 gcx logs query -d <loki-uid> '{job="varlogs"}'
 
-# Multiple labels (AND)
+# Multiple labels (AND) — every key inside {} must be an INDEXED label.
+# `level` works here only if it's indexed on your stack; Loki's auto-added
+# `detected_level` is structured metadata, so it must go after a pipe instead:
+#   {job="varlogs"} | detected_level="error"
+# See "Label kinds" below.
 gcx logs query -d <loki-uid> '{job="varlogs",level="error"}'
 
 # Regex matching
@@ -363,10 +367,11 @@ Shows all labels plus the log line:
 
 ```bash
 gcx logs query -d <loki-uid> '{job="varlogs"}' --from now-5m --to now -o wide
-# Output:
-# CLUSTER        DETECTED_LEVEL  JOB       NAMESPACE  POD          LINE
-# dev-eu-west-2  info            varlogs   prod       app-abc123   ts=2026-03-06T10:30:00Z...
-# dev-eu-west-2  error           varlogs   prod       app-abc123   ts=2026-03-06T10:30:01Z...
+# Output (STREAM columns are indexed labels; detected_level is structured
+# metadata surfaced in DETAILS/LEVEL, NOT a stream label you can put in {}):
+# CLUSTER        JOB       NAMESPACE  POD          LEVEL  MESSAGE                  DETAILS
+# dev-eu-west-2  varlogs   prod       app-abc123   info   ts=2026-03-06T10:30:00Z  detected_level=info
+# dev-eu-west-2  varlogs   prod       app-abc123   error  ts=2026-03-06T10:30:01Z  detected_level=error
 ```
 
 ### JSON Format
@@ -571,21 +576,36 @@ Always include `| __error__=""` after `| json` to drop lines that failed to
 parse, otherwise the parser stage silently keeps them and they pollute the
 count.
 
-### Stream Labels vs Extracted Labels
+### Label kinds: indexed vs structured metadata vs parsed
 
-Loki has two kinds of labels — confusing them causes silent failures:
+Loki has **three** kinds of key/value data on a log line. Confusing them causes
+silent empty results — a query that returns `success` with zero streams:
 
-| | Stream labels | Extracted labels |
-|---|---|---|
-| Set by | Log ingestion config | Parser stages (`| json`, `| logfmt`) |
-| Used in | Stream selector `{job="app"}` | Filter expressions after `|` |
-| Indexed | Yes (fast) | No (line-by-line scan) |
-| Available | Always | Only after parser stage |
+| | Indexed stream labels | Structured metadata | Parsed labels |
+|---|---|---|---|
+| Set by | Ingestion / stream config | Attached per-line at ingest (incl. Loki's auto-added `detected_level`) | Parser stages (`\| json`, `\| logfmt`) |
+| Used in | Stream selector `{job="app"}` | Filter **after** a pipe: `\| detected_level="error"` | Filter **after** the parser: `\| json \| status="500"` |
+| Indexed | Yes (fast) | No | No |
+| Valid inside `{}` | **Yes** | **No** | **No** |
+
+How gcx surfaces them in `gcx logs query` output (as of the label-type split):
+- `-o json`: each stream's `stream` map is **indexed labels only**; each entry
+  carries `structuredMetadata` and `parsed` maps for the non-indexed keys.
+- `-o table`: the `STREAM` column shows indexed labels; structured metadata and
+  parsed labels land in `DETAILS` (and `detected_level` fills `LEVEL`).
+
+So the rule is simple: **only keys that appear in `stream` (or the `STREAM`
+column) are valid inside `{...}`.** Anything under `structuredMetadata` / `parsed`
+/ `DETAILS` must go after a `|`.
 
 Common mistakes:
-- Filtering extracted labels in `{}` — fails silently: `{namespace="prod", pod="app-123"}` won't work if `pod` is extracted, not a stream label
-- Using `label_format` to rename extracted fields before they're parsed — add the parser stage first
-- Assuming a field visible in Grafana Explore is a stream label — check with `gcx logs labels -d <uid>` (only shows stream labels)
+- Putting a structured-metadata key inside `{}` — fails silently:
+  `{detected_level="error"}` matches nothing; use `{job="app"} | detected_level="error"` instead.
+- Putting a parsed field in `{}` before the parser runs — add `| json` / `| logfmt` first, then `| status="500"`.
+- `gcx logs labels` lists the **indexed** label names (what's valid in `{}`); it
+  does NOT enumerate structured-metadata keys, so don't assume a key is a stream
+  label just because you saw it in query output — check whether it came from
+  `stream` vs `structuredMetadata`.
 
 ## Common Patterns
 

--- a/claude-plugin/skills/explore-datasources/SKILL.md
+++ b/claude-plugin/skills/explore-datasources/SKILL.md
@@ -65,6 +65,8 @@ gcx logs series -d <datasource-uid> -M '{job="varlogs"}'
 
 **Note:** The `series` command requires at least one `-M` (match) selector using LogQL syntax.
 
+**Note:** `gcx logs labels` lists *indexed* stream labels — the keys valid inside a `{...}` selector. Loki also has structured metadata (per-line, e.g. `detected_level`) and parsed labels that are NOT indexed and must be filtered after a pipe (`{job="x"} | detected_level="error"`), never inside `{}`. In `gcx logs query` output they appear under each entry's `structuredMetadata` / `parsed` (not the `stream` map).
+
 ### Step 3: Test Queries (Optional)
 
 Once you've identified available data, verify with a test query.

--- a/claude-plugin/skills/explore-datasources/references/logql-syntax.md
+++ b/claude-plugin/skills/explore-datasources/references/logql-syntax.md
@@ -144,6 +144,15 @@ gcx logs series -d <uid> -M '{app="myapp", environment="production"}'
 gcx logs series -d <uid> -M '{app="myapp", level!="debug"}'
 ```
 
+> **Only indexed labels are valid inside `{...}`.** Loki also has *structured
+> metadata* (per-line keys attached at ingest, including Loki's auto-added
+> `detected_level`) and *parsed labels* (from `| json` / `| logfmt`). Those are
+> NOT indexed and must be filtered **after a pipe** — `{app="myapp"} |
+> detected_level="error"`, not `{detected_level="error"}` (which matches
+> nothing). `gcx logs labels` lists the indexed labels; a key you saw in query
+> output is only `{}`-valid if it appeared in the `stream` map (`-o json`) /
+> `STREAM` column, not under `structuredMetadata` / `parsed` / `DETAILS`.
+
 ### Find Container Logs
 
 ```bash
@@ -265,9 +274,12 @@ Loki uses [RE2 regex syntax](https://github.com/google/re2/wiki/Syntax). Common 
    # See what jobs exist
    gcx logs labels -d <uid> --label job
 
-   # Then query specific job
+   # Then query specific job (job is an indexed label, so it's valid in {})
    gcx logs series -d <uid> -M '{job="<value-from-above>"}'
    ```
+   `gcx logs labels` returns indexed labels only — every value it lists is safe
+   inside `{}`. Structured-metadata keys (e.g. `detected_level`) won't appear
+   here and are not `{}`-valid; filter them after a pipe.
 
 4. **Use JSON output for large results**: Pipe to jq for filtering
    ```bash

--- a/claude-plugin/skills/investigate-alert/references/alert-investigation-patterns.md
+++ b/claude-plugin/skills/investigate-alert/references/alert-investigation-patterns.md
@@ -215,21 +215,31 @@ gcx logs query <loki-uid> 'topk(10, sum by(pod) (rate({job="app"} [5m])))'
 
 Rule of thumb: if your query uses `rate()`, `count_over_time()`, or `bytes_over_time()`, wrap it with `sum()`, `sum by(label)`, or `topk()`.
 
-### Stream Labels vs Extracted Labels
+### Label kinds: indexed vs structured metadata vs parsed
 
-Loki has two kinds of labels — confusing them causes silent failures:
+Loki has **three** kinds of key/value data on a log line. Confusing them causes
+silent failures — a query that returns `success` with zero streams:
 
-| | Stream labels | Extracted labels |
-|---|---|---|
-| Set by | Log ingestion config | Parser stages (`| json`, `| logfmt`) |
-| Used in | Stream selector `{job="app"}` | Filter expressions after `|` |
-| Indexed | Yes (fast) | No (line-by-line scan) |
-| Available | Always | Only after parser stage |
+| | Indexed stream labels | Structured metadata | Parsed labels |
+|---|---|---|---|
+| Set by | Ingestion / stream config | Attached per-line at ingest (incl. Loki's auto-added `detected_level`) | Parser stages (`\| json`, `\| logfmt`) |
+| Used in | Stream selector `{job="app"}` | Filter **after** a pipe: `\| detected_level="error"` | Filter **after** the parser: `\| json \| status="500"` |
+| Indexed | Yes (fast) | No | No |
+| Valid inside `{}` | **Yes** | **No** | **No** |
+
+gcx separates these in `gcx logs query` output: `-o json` puts indexed labels in
+each stream's `stream` map and the rest in per-entry `structuredMetadata` /
+`parsed` maps; `-o table` shows indexed labels in `STREAM` and the rest in
+`DETAILS`. **Only keys in `stream` / the `STREAM` column are valid inside `{...}`.**
 
 Common mistakes:
-- Filtering extracted labels in `{}` — fails silently: `{namespace="prod", pod="app-123"}` won't work if `pod` is extracted, not a stream label
-- Using `label_format` to rename extracted fields before they're parsed — add the parser stage first
-- Assuming a field visible in Grafana Explore is a stream label — check with `gcx logs labels -d <uid>` (only shows stream labels)
+- Putting a structured-metadata key inside `{}` — fails silently:
+  `{detected_level="error"}` matches nothing; use `{job="app"} | detected_level="error"`.
+- Putting a parsed field in `{}` before the parser runs — add `| json` / `| logfmt` first, then `| status="500"`.
+- Assuming a key is a stream label just because it appeared in query output —
+  check whether it came from `stream` vs `structuredMetadata`. `gcx logs labels`
+  lists the indexed labels (what's valid in `{}`); it does not enumerate
+  structured-metadata keys.
 
 ---
 

--- a/internal/graph/convert.go
+++ b/internal/graph/convert.go
@@ -132,14 +132,12 @@ func FromLokiResponse(resp *loki.QueryResponse) (*ChartData, error) {
 			Points: make([]Point, 0),
 		}
 
-		for _, vals := range stream.Values {
-			if len(vals) >= 2 {
-				t, v, err := parseLokiPoint(vals[0], vals[1])
-				if err != nil {
-					continue
-				}
-				series.Points = append(series.Points, Point{Time: t, Value: v})
+		for _, entry := range stream.Values {
+			t, v, err := parseLokiPoint(entry.Timestamp, entry.Line)
+			if err != nil {
+				continue
 			}
+			series.Points = append(series.Points, Point{Time: t, Value: v})
 		}
 
 		if len(series.Points) > 0 {

--- a/internal/query/loki/client.go
+++ b/internal/query/loki/client.go
@@ -290,6 +290,15 @@ func convertGrafanaResponse(grafanaResp *GrafanaQueryResponse) *QueryResponse {
 
 		labelsIdx, hasLabels := fieldIndices["labels"]
 
+		// labelTypes is a companion field emitted by Grafana's Loki datasource
+		// mapping each label name to its category ("I"=indexed, "S"=structured
+		// metadata, "P"=parsed). It's absent on older Grafana; -1 means "treat
+		// every label as indexed", which preserves the pre-categorization output.
+		labelTypesIdx := -1
+		if idx, ok := fieldIndices["labelTypes"]; ok {
+			labelTypesIdx = idx
+		}
+
 		timestampIdx, hasTimestamp := fieldIndices["timestamp"]
 		if !hasTimestamp {
 			timestampIdx, hasTimestamp = fieldIndices["Time"]
@@ -302,7 +311,7 @@ func convertGrafanaResponse(grafanaResp *GrafanaQueryResponse) *QueryResponse {
 
 		// Handle log-lines format (per-line labels in values)
 		if hasLabels && hasTimestamp && hasBody {
-			convertLogLines(frame, labelsIdx, timestampIdx, bodyIdx, result)
+			convertLogLines(frame, labelsIdx, labelTypesIdx, timestampIdx, bodyIdx, result)
 			continue
 		}
 
@@ -313,7 +322,7 @@ func convertGrafanaResponse(grafanaResp *GrafanaQueryResponse) *QueryResponse {
 	return result
 }
 
-func convertLogLines(frame DataFrame, labelsIdx, timestampIdx, bodyIdx int, result *QueryResponse) {
+func convertLogLines(frame DataFrame, labelsIdx, labelTypesIdx, timestampIdx, bodyIdx int, result *QueryResponse) {
 	if len(frame.Data.Values) <= labelsIdx ||
 		len(frame.Data.Values) <= timestampIdx ||
 		len(frame.Data.Values) <= bodyIdx {
@@ -323,6 +332,11 @@ func convertLogLines(frame DataFrame, labelsIdx, timestampIdx, bodyIdx int, resu
 	labelsValues := frame.Data.Values[labelsIdx]
 	timestampValues := frame.Data.Values[timestampIdx]
 	bodyValues := frame.Data.Values[bodyIdx]
+
+	var labelTypesValues []any
+	if labelTypesIdx >= 0 && labelTypesIdx < len(frame.Data.Values) {
+		labelTypesValues = frame.Data.Values[labelTypesIdx]
+	}
 
 	numEntries := len(timestampValues)
 	if numEntries == 0 {
@@ -335,31 +349,77 @@ func convertLogLines(frame DataFrame, labelsIdx, timestampIdx, bodyIdx int, resu
 		nanos = frame.Data.Nanos[timestampIdx]
 	}
 
-	// Group entries by labels
+	// Group entries by their INDEXED labels only. Structured metadata (e.g.
+	// detected_level) and parsed labels are per-line and often high-cardinality
+	// (e.g. a unique execution_id per line); grouping by the merged set would
+	// explode one logical stream into one entry per line.
 	streamMap := make(map[string]*StreamEntry)
 	streamOrder := make([]string, 0)
 
 	for i := range numEntries {
-		labels := parseLabels(labelsValues[i])
+		merged := parseLabels(labelsValues[i])
+		var types map[string]string
+		if labelTypesValues != nil && i < len(labelTypesValues) {
+			types = parseLabels(labelTypesValues[i])
+		}
+		indexed, structured, parsed := splitLabelsByType(merged, types)
+
 		ts := formatTimestampWithNanos(timestampValues[i], nanos, i)
 		body := toString(bodyValues[i])
 
-		key := labelsKey(labels)
+		key := labelsKey(indexed)
 		entry, exists := streamMap[key]
 		if !exists {
 			entry = &StreamEntry{
-				Stream: labels,
-				Values: make([][]string, 0),
+				Stream: indexed,
+				Values: make([]LogEntry, 0),
 			}
 			streamMap[key] = entry
 			streamOrder = append(streamOrder, key)
 		}
-		entry.Values = append(entry.Values, []string{ts, body})
+		entry.Values = append(entry.Values, LogEntry{
+			Timestamp:          ts,
+			Line:               body,
+			StructuredMetadata: nilIfEmpty(structured),
+			Parsed:             nilIfEmpty(parsed),
+		})
 	}
 
 	for _, key := range streamOrder {
 		result.Data.Result = append(result.Data.Result, *streamMap[key])
 	}
+}
+
+// splitLabelsByType partitions a merged Loki label map into indexed stream
+// labels, structured metadata, and query-time parsed labels using Grafana's
+// per-line labelTypes categorization ("I"=indexed, "S"=structured metadata,
+// "P"=parsed). Keys with no type information — older Grafana that doesn't emit
+// labelTypes — default to indexed, preserving the previous (merged) behaviour
+// rather than silently moving labels out of the {...}-selectable set.
+func splitLabelsByType(labels, types map[string]string) (map[string]string, map[string]string, map[string]string) {
+	indexed := make(map[string]string)
+	structured := make(map[string]string)
+	parsed := make(map[string]string)
+	for k, v := range labels {
+		switch types[k] {
+		case "S":
+			structured[k] = v
+		case "P":
+			parsed[k] = v
+		default:
+			indexed[k] = v
+		}
+	}
+	return indexed, structured, parsed
+}
+
+// nilIfEmpty returns nil for an empty map so that omitempty drops the field from
+// JSON/YAML output instead of emitting an empty object.
+func nilIfEmpty(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 func convertLegacyFormat(frame DataFrame, result *QueryResponse) {
@@ -407,13 +467,13 @@ func convertLegacyFormat(frame DataFrame, result *QueryResponse) {
 
 	entry := StreamEntry{
 		Stream: labels,
-		Values: make([][]string, 0, len(timeValues)),
+		Values: make([]LogEntry, 0, len(timeValues)),
 	}
 
 	for i := range timeValues {
 		ts := formatTimestamp(timeValues[i])
 		value := toString(dataValues[i])
-		entry.Values = append(entry.Values, []string{ts, value})
+		entry.Values = append(entry.Values, LogEntry{Timestamp: ts, Line: value})
 	}
 
 	result.Data.Result = append(result.Data.Result, entry)

--- a/internal/query/loki/convert_test.go
+++ b/internal/query/loki/convert_test.go
@@ -49,7 +49,7 @@ func TestConvertGrafanaResponse_NewFieldNames(t *testing.T) {
 
 	// Values must contain actual log content, not ID hashes
 	require.Len(t, entry.Values, 1)
-	assert.Equal(t, "level=info msg=\"HTTP request\" status=200", entry.Values[0][1])
+	assert.Equal(t, "level=info msg=\"HTTP request\" status=200", entry.Values[0].Line)
 }
 
 func TestConvertGrafanaResponse_OldFieldNames(t *testing.T) {
@@ -81,7 +81,7 @@ func TestConvertGrafanaResponse_OldFieldNames(t *testing.T) {
 
 	require.Len(t, resp.Data.Result, 1)
 	assert.Equal(t, map[string]string{"app": "test"}, resp.Data.Result[0].Stream)
-	assert.Equal(t, "hello world", resp.Data.Result[0].Values[0][1])
+	assert.Equal(t, "hello world", resp.Data.Result[0].Values[0].Line)
 }
 
 func TestConvertGrafanaResponse_MultipleStreams(t *testing.T) {
@@ -126,6 +126,96 @@ func TestConvertGrafanaResponse_MultipleStreams(t *testing.T) {
 	assert.Len(t, resp.Data.Result[1].Values, 1)
 }
 
+func TestConvertGrafanaResponse_CategorizesLabelTypes(t *testing.T) {
+	// Grafana's Loki datasource emits a labelTypes field categorizing each label
+	// as "I" (indexed), "S" (structured metadata), or "P" (parsed). Those three
+	// categories must be split apart, and streams must be grouped by INDEXED
+	// labels only so per-line structured metadata (e.g. execution_id) doesn't
+	// explode one stream into one entry per line.
+	resp := loki.ConvertGrafanaResponse(&loki.GrafanaQueryResponse{
+		Results: map[string]loki.GrafanaResult{
+			"A": {
+				Frames: []loki.DataFrame{
+					{
+						Schema: loki.DataFrameSchema{
+							Fields: []loki.Field{
+								{Name: "labels", Type: "other"},
+								{Name: "Time", Type: "time"},
+								{Name: "Line", Type: "string"},
+								{Name: "labelTypes", Type: "other"},
+							},
+						},
+						Data: loki.DataFrameData{
+							Values: [][]any{
+								{
+									map[string]any{"job": "opnsense", "detected_level": "info", "execution_id": "aaa", "tenant": "t1"},
+									map[string]any{"job": "opnsense", "detected_level": "warn", "execution_id": "bbb", "tenant": "t1"},
+								},
+								{float64(1000), float64(2000)},
+								{"line-1", "line-2"},
+								{
+									map[string]any{"job": "I", "detected_level": "S", "execution_id": "S", "tenant": "P"},
+									map[string]any{"job": "I", "detected_level": "S", "execution_id": "S", "tenant": "P"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// Both lines share the same indexed labels -> a single stream, not two.
+	require.Len(t, resp.Data.Result, 1)
+	entry := resp.Data.Result[0]
+
+	// Stream holds ONLY indexed labels; structured metadata and parsed labels
+	// must not leak into it.
+	assert.Equal(t, map[string]string{"job": "opnsense"}, entry.Stream)
+
+	require.Len(t, entry.Values, 2)
+	assert.Equal(t, "line-1", entry.Values[0].Line)
+	assert.Equal(t, map[string]string{"detected_level": "info", "execution_id": "aaa"}, entry.Values[0].StructuredMetadata)
+	assert.Equal(t, map[string]string{"tenant": "t1"}, entry.Values[0].Parsed)
+	assert.Equal(t, map[string]string{"detected_level": "warn", "execution_id": "bbb"}, entry.Values[1].StructuredMetadata)
+}
+
+func TestConvertGrafanaResponse_NoLabelTypesDefaultsToIndexed(t *testing.T) {
+	// Older Grafana without a labelTypes field: every label is treated as
+	// indexed, preserving the pre-categorization behaviour (no data lost).
+	resp := loki.ConvertGrafanaResponse(&loki.GrafanaQueryResponse{
+		Results: map[string]loki.GrafanaResult{
+			"A": {
+				Frames: []loki.DataFrame{
+					{
+						Schema: loki.DataFrameSchema{
+							Fields: []loki.Field{
+								{Name: "labels", Type: "other"},
+								{Name: "Time", Type: "time"},
+								{Name: "Line", Type: "string"},
+							},
+						},
+						Data: loki.DataFrameData{
+							Values: [][]any{
+								{map[string]any{"job": "grafana", "detected_level": "info"}},
+								{float64(1000)},
+								{"a line"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, resp.Data.Result, 1)
+	entry := resp.Data.Result[0]
+	assert.Equal(t, map[string]string{"job": "grafana", "detected_level": "info"}, entry.Stream)
+	require.Len(t, entry.Values, 1)
+	assert.Nil(t, entry.Values[0].StructuredMetadata)
+	assert.Nil(t, entry.Values[0].Parsed)
+}
+
 func TestConvertGrafanaResponse_LegacyFormat(t *testing.T) {
 	// Legacy format: no "labels" field, labels in field metadata.
 	resp := loki.ConvertGrafanaResponse(&loki.GrafanaQueryResponse{
@@ -153,7 +243,7 @@ func TestConvertGrafanaResponse_LegacyFormat(t *testing.T) {
 
 	require.Len(t, resp.Data.Result, 1)
 	assert.Equal(t, map[string]string{"job": "legacy"}, resp.Data.Result[0].Stream)
-	assert.Equal(t, "legacy log line", resp.Data.Result[0].Values[0][1])
+	assert.Equal(t, "legacy log line", resp.Data.Result[0].Values[0].Line)
 }
 
 func TestConvertGrafanaResponse_LegacyFormat_PrefersContentField(t *testing.T) {
@@ -187,7 +277,7 @@ func TestConvertGrafanaResponse_LegacyFormat_PrefersContentField(t *testing.T) {
 	})
 
 	require.Len(t, resp.Data.Result, 1)
-	assert.Equal(t, "the actual log line", resp.Data.Result[0].Values[0][1])
+	assert.Equal(t, "the actual log line", resp.Data.Result[0].Values[0].Line)
 }
 
 func TestParseLabels(t *testing.T) {

--- a/internal/query/loki/formatter.go
+++ b/internal/query/loki/formatter.go
@@ -156,11 +156,8 @@ func FormatQueryRaw(w io.Writer, resp *QueryResponse) error {
 	}
 
 	for _, stream := range resp.Data.Result {
-		for _, value := range stream.Values {
-			if len(value) < 2 {
-				continue
-			}
-			fmt.Fprintln(w, value[1])
+		for _, entry := range stream.Values {
+			fmt.Fprintln(w, entry.Line)
 		}
 	}
 
@@ -254,25 +251,43 @@ func buildDisplayEntries(resp *QueryResponse) []displayLogEntry {
 	entries := make([]displayLogEntry, 0)
 	for _, stream := range resp.Data.Result {
 		for _, value := range stream.Values {
-			if len(value) < 2 {
-				continue
-			}
-			entries = append(entries, newDisplayLogEntry(stream.Stream, value[0], value[1]))
+			entries = append(entries, newDisplayLogEntry(stream.Stream, value))
 		}
 	}
 	return entries
 }
 
-func newDisplayLogEntry(stream map[string]string, rawTimestamp, rawLine string) displayLogEntry {
+func newDisplayLogEntry(stream map[string]string, e LogEntry) displayLogEntry {
 	entry := displayLogEntry{
-		Timestamp: formatHumanTimestamp(rawTimestamp),
-		Message:   rawLine,
+		Timestamp: formatHumanTimestamp(e.Timestamp),
+		Message:   e.Line,
 		Stream:    stream,
 	}
 
+	fields := promoteBodyFields(&entry, e.Line)
+
+	// Structured metadata and parsed labels are per-line, non-indexed context.
+	// Surface them in DETAILS so they're visible without being confused with the
+	// indexed STREAM labels. Fall back to detected_level for the LEVEL column
+	// when the log body itself carried no level.
+	mergeDetailFields(fields, e.Parsed)
+	mergeDetailFields(fields, e.StructuredMetadata)
+	if entry.Level == "" {
+		entry.Level = popFirst(fields, "detected_level")
+	}
+
+	entry.Details = formatDetails(fields)
+
+	return entry
+}
+
+// promoteBodyFields parses structured key/values out of the log body, promoting
+// level/source/message onto entry, and returns the remaining fields for DETAILS.
+// It returns an empty map when the body is not structured.
+func promoteBodyFields(entry *displayLogEntry, rawLine string) map[string]string {
 	fields, ok := parseStructuredLogBody(rawLine)
 	if !ok {
-		return entry
+		return map[string]string{}
 	}
 
 	entry.Level = popFirst(fields, "level", "lvl", "severity")
@@ -295,9 +310,18 @@ func newDisplayLogEntry(stream map[string]string, rawTimestamp, rawLine string) 
 	if entry.Message == "" {
 		entry.Message = rawLine
 	}
-	entry.Details = formatDetails(fields)
 
-	return entry
+	return fields
+}
+
+// mergeDetailFields copies src entries into dst without overwriting keys already
+// present (body-parsed fields take precedence over per-line metadata).
+func mergeDetailFields(dst, src map[string]string) {
+	for k, v := range src {
+		if _, exists := dst[k]; !exists {
+			dst[k] = v
+		}
+	}
 }
 
 func anyEntry(entries []displayLogEntry, field func(displayLogEntry) string) bool {

--- a/internal/query/loki/formatter_test.go
+++ b/internal/query/loki/formatter_test.go
@@ -16,16 +16,16 @@ func TestFormatQueryTable_HumanFriendlyMixedFormats(t *testing.T) {
 			Result: []loki.StreamEntry{
 				{
 					Stream: map[string]string{"namespace": "tempo-prod"},
-					Values: [][]string{{
-						"1775637286777686890",
-						`level=info ts=2026-04-08T08:34:46.77768689Z caller=retention.go:113 msg="deleting block" blockID=47f92c6c tenantID=120351`,
+					Values: []loki.LogEntry{{
+						Timestamp: "1775637286777686890",
+						Line:      `level=info ts=2026-04-08T08:34:46.77768689Z caller=retention.go:113 msg="deleting block" blockID=47f92c6c tenantID=120351`,
 					}},
 				},
 				{
 					Stream: map[string]string{"app": "adaptive-traces", "namespace": "tempo-prod"},
-					Values: [][]string{{
-						"1775637286554667000",
-						`{"level":"info","ts":1775637286.554667,"caller":"zap@v1.1.7/zap.go:125","msg":"/adaptive-traces/api/v1/config","component":"api","status":200,"method":"GET","path":"/adaptive-traces/api/v1/config","query":"","tenant":1336544}`,
+					Values: []loki.LogEntry{{
+						Timestamp: "1775637286554667000",
+						Line:      `{"level":"info","ts":1775637286.554667,"caller":"zap@v1.1.7/zap.go:125","msg":"/adaptive-traces/api/v1/config","component":"api","status":200,"method":"GET","path":"/adaptive-traces/api/v1/config","query":"","tenant":1336544}`,
 					}},
 				},
 			},
@@ -67,9 +67,9 @@ func TestFormatQueryTableWide_IncludesTimestampAndLabels(t *testing.T) {
 					"namespace": "prod",
 					"__meta":    "hidden",
 				},
-				Values: [][]string{{
-					"1775637286777686890",
-					`level=warn caller=retention.go:113 msg="compaction delayed" tenantID=120351`,
+				Values: []loki.LogEntry{{
+					Timestamp: "1775637286777686890",
+					Line:      `level=warn caller=retention.go:113 msg="compaction delayed" tenantID=120351`,
 				}},
 			}},
 		},
@@ -102,7 +102,7 @@ func TestFormatQueryTable_FallsBackToPlainMessage(t *testing.T) {
 	resp := &loki.QueryResponse{
 		Data: loki.QueryResultData{
 			Result: []loki.StreamEntry{{
-				Values: [][]string{{"1775637286777686890", "plain unstructured log line"}},
+				Values: []loki.LogEntry{{Timestamp: "1775637286777686890", Line: "plain unstructured log line"}},
 			}},
 		},
 	}
@@ -124,7 +124,7 @@ func TestFormatQueryTable_RejectsAmbiguousLogfmtBareTokens(t *testing.T) {
 	resp := &loki.QueryResponse{
 		Data: loki.QueryResultData{
 			Result: []loki.StreamEntry{{
-				Values: [][]string{{"1775637286777686890", `msg=login failed for user=bob`}},
+				Values: []loki.LogEntry{{Timestamp: "1775637286777686890", Line: `msg=login failed for user=bob`}},
 			}},
 		},
 	}
@@ -145,7 +145,7 @@ func TestFormatQueryTable_RejectsAmbiguousLogfmtWithoutQuotedMessage(t *testing.
 	resp := &loki.QueryResponse{
 		Data: loki.QueryResultData{
 			Result: []loki.StreamEntry{{
-				Values: [][]string{{"1775637286777686890", `level=info request completed status=200`}},
+				Values: []loki.LogEntry{{Timestamp: "1775637286777686890", Line: `level=info request completed status=200`}},
 			}},
 		},
 	}
@@ -161,11 +161,40 @@ func TestFormatQueryTable_RejectsAmbiguousLogfmtWithoutQuotedMessage(t *testing.
 	assert.NotContains(t, out, "DETAILS")
 }
 
+func TestFormatQueryTable_SurfacesStructuredMetadataInDetails(t *testing.T) {
+	// Structured metadata (and parsed labels) are per-line, non-indexed context.
+	// They should appear in DETAILS, and detected_level should populate LEVEL
+	// when the body carried none, but they must NOT appear in the STREAM column.
+	resp := &loki.QueryResponse{
+		Data: loki.QueryResultData{
+			Result: []loki.StreamEntry{{
+				Stream: map[string]string{"service_name": "checkout"},
+				Values: []loki.LogEntry{{
+					Timestamp:          "1775637286777686890",
+					Line:               "a plain unstructured line",
+					StructuredMetadata: map[string]string{"detected_level": "error", "trace_id": "abc123"},
+				}},
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, loki.FormatQueryTable(&buf, resp))
+
+	out := buf.String()
+	assert.Contains(t, out, "LEVEL")
+	assert.Contains(t, out, "error")           // detected_level -> LEVEL
+	assert.Contains(t, out, "trace_id=abc123") // structured metadata -> DETAILS
+	assert.Contains(t, out, "DETAILS")
+	// detected_level was consumed into LEVEL, not left dangling in DETAILS.
+	assert.NotContains(t, out, "detected_level=")
+}
+
 func TestFormatQueryRaw_PrintsOriginalLineBodies(t *testing.T) {
 	resp := &loki.QueryResponse{
 		Data: loki.QueryResultData{
 			Result: []loki.StreamEntry{{
-				Values: [][]string{{"1", "first line"}, {"2", "second line"}},
+				Values: []loki.LogEntry{{Timestamp: "1", Line: "first line"}, {Timestamp: "2", Line: "second line"}},
 			}},
 		},
 	}

--- a/internal/query/loki/types.go
+++ b/internal/query/loki/types.go
@@ -37,9 +37,32 @@ type QueryResultData struct {
 }
 
 // StreamEntry represents a single log stream from the query result.
+//
+// Stream holds ONLY the indexed stream labels — the labels that are valid
+// inside a {...} LogQL selector. Structured metadata and query-time parsed
+// labels are per-line (they can differ between lines that share the same
+// indexed labels), so they live on each LogEntry in Values, not here.
 type StreamEntry struct {
 	Stream map[string]string `json:"stream"`
-	Values [][]string        `json:"values"` // [[timestamp, line], ...]
+	Values []LogEntry        `json:"values"`
+}
+
+// LogEntry is a single log line within a stream. It carries the line body plus
+// the two categories of non-indexed key/value data Loki attaches per line:
+//
+//   - StructuredMetadata: attached at ingest, not indexed. Only usable as a
+//     post-pipe label filter (e.g. `{app="x"} | detected_level="error"`),
+//     never inside a {...} selector.
+//   - Parsed: extracted at query time by a parser stage (`| json`, `| logfmt`).
+//
+// Keeping them distinct from the indexed Stream labels lets callers build valid
+// LogQL instead of dropping a structured-metadata key into a {...} selector
+// (which matches nothing).
+type LogEntry struct {
+	Timestamp          string            `json:"timestamp"`
+	Line               string            `json:"line"`
+	StructuredMetadata map[string]string `json:"structuredMetadata,omitempty"`
+	Parsed             map[string]string `json:"parsed,omitempty"`
 }
 
 // QueryStats contains statistics about the query execution.


### PR DESCRIPTION
## What

Fixes #907 — `gcx logs query` merged Loki's three kinds of per-line keys (indexed stream labels, structured metadata, query-time parsed labels) into one undifferentiated `stream` map. So structured metadata like Loki's auto-added `detected_level` sat flat among real indexed labels, and anyone who then put it in a `{...}` selector got a silently-empty result because it isn't indexed.

Grafana's Loki datasource already hands us a `labelTypes` field (`I`/`S`/`P` per key) in the dataframe — we were parsing right past it. This wires it up.

## Changes

- **Split by label type** (`internal/query/loki`): parse `labelTypes`; `StreamEntry.Stream` now holds indexed labels only, and streams group by indexed labels (which also fixes per-line structured metadata such as a unique `execution_id` exploding one stream into one entry per line). Each log entry carries its own `structuredMetadata` and `parsed` maps.
- **Table output**: `STREAM` stays indexed-only; structured metadata + parsed labels surface in `DETAILS`, and `detected_level` fills `LEVEL` when the body carried none.
- **Graceful fallback**: no `labelTypes` (older Grafana) → everything defaults to indexed, so nothing is lost or moved unexpectedly.
- **Skills hardening**: the bundled agent skills taught a two-category "stream vs extracted" model that omitted structured metadata and showed examples putting non-indexed keys inside `{}`. Replaced with the three-category model, corrected the examples, and pointed agents at the new `structuredMetadata`/`parsed` output so they build valid LogQL.

## Breaking change

The `gcx logs query` JSON/YAML output shape changed. Each element of a stream's `values` is now an object `{timestamp, line, structuredMetadata?, parsed?}` instead of a `[timestamp, line]` tuple, and `stream` contains indexed labels only. This matches how gcx already models rich per-item data (named structs, like tempo's typed attributes) rather than positional tuples. Blast radius is contained to the loki query path, the graph converter, and the table/raw formatters.

## Verification

- Full `go test ./...` green; `go vet` and `golangci-lint run` clean; `validate-skills` passes.
- Verified live against a Grafana Cloud stack: `gcx logs query -o json` now returns `stream` with indexed labels only and `detected_level` correctly under each entry's `structuredMetadata`; `{detected_level="info"}` returns 0 streams while `{...} | detected_level="info"` returns results, confirming the distinction is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
