### PR TITLE
fix(config): interrupt `config check` on Ctrl+C during connectivity check

### DIFF
--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -437,8 +437,9 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 	}
 	restCfg.WireTokenPersistence(cmd.Context(), source, gCtx.Name, cfg.Sources)
 
-	_, err = runWithContext(cmd.Context(), func() (*discovery.Registry, error) {
-		return discovery.NewDefaultRegistry(cmd.Context(), restCfg)
+	err = runWithContext(cmd.Context(), func() error {
+		_, err := discovery.NewDefaultRegistry(cmd.Context(), restCfg)
+		return err
 	})
 	if errors.Is(err, context.Canceled) {
 		return err
@@ -483,26 +484,20 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 // runWithContext runs fn in a goroutine and returns as soon as ctx is
 // cancelled, even if fn is still blocked. The connectivity check relies on
 // client-go discovery, whose HTTP calls run on their own internal context and
-// don't observe cancellation — without this a Ctrl+C during `config check`
+// don't observe cancellation - without this a Ctrl+C during `config check`
 // would hang until the client-go request timeout (32s) expired. The abandoned
 // goroutine is reclaimed when the process exits.
-func runWithContext[T any](ctx context.Context, fn func() (T, error)) (T, error) {
-	type result struct {
-		val T
-		err error
-	}
-	done := make(chan result, 1)
+func runWithContext(ctx context.Context, fn func() error) error {
+	done := make(chan error, 1)
 	go func() {
-		val, err := fn()
-		done <- result{val: val, err: err}
+		done <- fn()
 	}()
 
 	select {
 	case <-ctx.Done():
-		var zero T
-		return zero, ctx.Err()
-	case r := <-done:
-		return r.val, r.err
+		return ctx.Err()
+	case err := <-done:
+		return err
 	}
 }
 

--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -362,7 +362,13 @@ func checkCmd(configOpts *Options) *cobra.Command {
 
 			var checkErr error
 			for _, gCtx := range cfg.Contexts {
+				if err := cmd.Context().Err(); err != nil {
+					return err
+				}
 				if err := checkContext(cmd, cfg, gCtx, configOpts.ConfigSource()); err != nil {
+					if errors.Is(err, context.Canceled) {
+						return err
+					}
 					checkErr = err
 				}
 			}
@@ -431,7 +437,13 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 	}
 	restCfg.WireTokenPersistence(cmd.Context(), source, gCtx.Name, cfg.Sources)
 
-	if _, err := discovery.NewDefaultRegistry(cmd.Context(), restCfg); err != nil {
+	_, err = runWithContext(cmd.Context(), func() (*discovery.Registry, error) {
+		return discovery.NewDefaultRegistry(cmd.Context(), restCfg)
+	})
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+	if err != nil {
 		cmdio.Error(stdout, "Connectivity: %s", cmdio.Red(summarizeError(err)))
 		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped")+"\n")
 		printSuggestions(err)
@@ -441,6 +453,9 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 	cmdio.Success(stdout, "Connectivity: %s", cmdio.Green("online"))
 
 	version, raw, err := grafana.GetVersion(cmd.Context(), gCtx)
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
 	if err != nil {
 		cmdio.Error(stdout, "Grafana version: %s", cmdio.Red(summarizeError(err))+"\n")
 		return nil
@@ -463,6 +478,32 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 	}
 
 	return nil
+}
+
+// runWithContext runs fn in a goroutine and returns as soon as ctx is
+// cancelled, even if fn is still blocked. The connectivity check relies on
+// client-go discovery, whose HTTP calls run on their own internal context and
+// don't observe cancellation — without this a Ctrl+C during `config check`
+// would hang until the client-go request timeout (32s) expired. The abandoned
+// goroutine is reclaimed when the process exits.
+func runWithContext[T any](ctx context.Context, fn func() (T, error)) (T, error) {
+	type result struct {
+		val T
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		val, err := fn()
+		done <- result{val: val, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		var zero T
+		return zero, ctx.Err()
+	case r := <-done:
+		return r.val, r.err
+	}
 }
 
 func useContextCmd(configOpts *Options) *cobra.Command {

--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -366,9 +366,6 @@ func checkCmd(configOpts *Options) *cobra.Command {
 					return err
 				}
 				if err := checkContext(cmd, cfg, gCtx, configOpts.ConfigSource()); err != nil {
-					if errors.Is(err, context.Canceled) {
-						return err
-					}
 					checkErr = err
 				}
 			}
@@ -406,7 +403,15 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 	cmd.Println(cmdio.Yellow(title))
 	cmd.Println(cmdio.Yellow(strings.Repeat("=", titleLen)))
 
+	// Cancellation guards below check cmd.Context() directly instead of the
+	// returned error's chain: client-go's discovery aggregates per-group
+	// failures into an error with no Unwrap, and validateNamespace replaces
+	// the discovery error entirely, so context.Canceled is not always
+	// reachable via errors.Is.
 	if err := gCtx.Validate(cmd.Context()); err != nil {
+		if ctxErr := cmd.Context().Err(); ctxErr != nil {
+			return ctxErr
+		}
 		cmdio.Error(stdout, "Configuration: %s", cmdio.Red(summarizeError(err)))
 		cmdio.Warning(stdout, "Connectivity: %s", cmdio.Yellow("skipped"))
 		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped")+"\n")
@@ -437,14 +442,10 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 	}
 	restCfg.WireTokenPersistence(cmd.Context(), source, gCtx.Name, cfg.Sources)
 
-	err = runWithContext(cmd.Context(), func() error {
-		_, err := discovery.NewDefaultRegistry(cmd.Context(), restCfg)
-		return err
-	})
-	if errors.Is(err, context.Canceled) {
-		return err
-	}
-	if err != nil {
+	if _, err := discovery.NewDefaultRegistry(cmd.Context(), restCfg); err != nil {
+		if ctxErr := cmd.Context().Err(); ctxErr != nil {
+			return ctxErr
+		}
 		cmdio.Error(stdout, "Connectivity: %s", cmdio.Red(summarizeError(err)))
 		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped")+"\n")
 		printSuggestions(err)
@@ -454,10 +455,10 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 	cmdio.Success(stdout, "Connectivity: %s", cmdio.Green("online"))
 
 	version, raw, err := grafana.GetVersion(cmd.Context(), gCtx)
-	if errors.Is(err, context.Canceled) {
-		return err
-	}
 	if err != nil {
+		if ctxErr := cmd.Context().Err(); ctxErr != nil {
+			return ctxErr
+		}
 		cmdio.Error(stdout, "Grafana version: %s", cmdio.Red(summarizeError(err))+"\n")
 		return nil
 	}
@@ -479,26 +480,6 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 	}
 
 	return nil
-}
-
-// runWithContext runs fn in a goroutine and returns as soon as ctx is
-// cancelled, even if fn is still blocked. The connectivity check relies on
-// client-go discovery, whose HTTP calls run on their own internal context and
-// don't observe cancellation - without this a Ctrl+C during `config check`
-// would hang until the client-go request timeout (32s) expired. The abandoned
-// goroutine is reclaimed when the process exits.
-func runWithContext(ctx context.Context, fn func() error) error {
-	done := make(chan error, 1)
-	go func() {
-		done <- fn()
-	}()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-done:
-		return err
-	}
 }
 
 func useContextCmd(configOpts *Options) *cobra.Command {

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -132,7 +132,7 @@ func GetVersion(ctx context.Context, cfgCtx *config.Context) (*semver.Version, s
 	gClient := res.api
 	gClient.WithHTTPClient(httputils.NewDefaultClientWithTLS(ctx, res.tlsConfig))
 
-	healthResponse, err := gClient.Health.GetHealthWithParams(health.NewGetHealthParamsWithContext(ctx))
+	healthResponse, err := gClient.Health.GetHealthWithParams(health.NewGetHealthParams().WithContext(ctx))
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/gcx/internal/version"
 	"github.com/grafana/grafana-app-sdk/logging"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/client/health"
 )
 
 // VersionIncompatibleError is returned when a Grafana instance is too old for gcx.
@@ -131,7 +132,7 @@ func GetVersion(ctx context.Context, cfgCtx *config.Context) (*semver.Version, s
 	gClient := res.api
 	gClient.WithHTTPClient(httputils.NewDefaultClientWithTLS(ctx, res.tlsConfig))
 
-	healthResponse, err := gClient.Health.GetHealth()
+	healthResponse, err := gClient.Health.GetHealthWithParams(health.NewGetHealthParamsWithContext(ctx))
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/login/detect.go
+++ b/internal/login/detect.go
@@ -2,6 +2,7 @@ package login
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/url"
@@ -81,7 +82,13 @@ func probeTarget(ctx context.Context, server string, httpClient *http.Client) (T
 
 	settings, err := grafana.FetchAnonymousSettings(probeCtx, server, httpClient)
 	if err != nil {
-		// Any error (network failure, timeout, non-200, decode failure) → TargetUnknown.
+		// Ctrl+C must abort detection, not degrade into a clarification
+		// prompt. Only propagate cancellation: a deadline on either ctx is
+		// a normal timeout and stays a TargetUnknown outcome.
+		if ctxErr := ctx.Err(); errors.Is(ctxErr, context.Canceled) {
+			return TargetUnknown, ctxErr
+		}
+		// Any other error (network failure, timeout, non-200, decode failure) → TargetUnknown.
 		return TargetUnknown, nil
 	}
 

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -325,11 +325,13 @@ func Run(ctx context.Context, opts *Options) (Result, error) {
 		case err == nil:
 			grafanaVersion = v
 
-		case errors.Is(err, context.Canceled):
+		case ctx.Err() != nil:
 			// Ctrl+C during connectivity validation is a clean cancellation, not
 			// a reason to prompt "save anyway" - propagate it so it exits via the
-			// context.Canceled fast-path.
-			return Result{}, err
+			// context.Canceled fast-path. Check ctx directly rather than the
+			// error chain: client-go's discovery aggregates per-group failures
+			// into an error with no Unwrap, hiding the cancellation.
+			return Result{}, ctx.Err()
 
 		case errors.As(err, &capErr):
 			// The Cloud Access Policy (CAP) token is optional: its absence does

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -325,6 +325,12 @@ func Run(ctx context.Context, opts *Options) (Result, error) {
 		case err == nil:
 			grafanaVersion = v
 
+		case errors.Is(err, context.Canceled):
+			// Ctrl+C during connectivity validation is a clean cancellation, not
+			// a reason to prompt "save anyway" - propagate it so it exits via the
+			// context.Canceled fast-path.
+			return Result{}, err
+
 		case errors.As(err, &capErr):
 			// The Cloud Access Policy (CAP) token is optional: its absence does
 			// not block login (resolveCloudAuth skips it under --yes/agent mode),

--- a/internal/resources/discovery/registry.go
+++ b/internal/resources/discovery/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -61,6 +62,16 @@ func NewDefaultRegistry(ctx context.Context, cfg config.NamespacedRESTConfig) (*
 // NewDefaultRegistryWithCacheDir creates a new discovery registry using a disk-cached
 // discovery client with the specified cache directory.
 func NewDefaultRegistryWithCacheDir(ctx context.Context, cfg config.NamespacedRESTConfig, cacheDir string) (*Registry, error) {
+	// client-go's discovery client issues its HTTP requests on context.TODO(),
+	// so the ctx passed here never reaches the wire and a Ctrl+C would hang
+	// until the client-go request timeout expired. Discovery only happens at
+	// construction (via NewRegistry), so rebinding every request to the
+	// constructor ctx is safe and makes discovery cancellable. cfg is a copy,
+	// the caller's config is not mutated.
+	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return contextTransport{ctx: ctx, base: rt}
+	})
+
 	client, err := diskcached.NewCachedDiscoveryClientForConfig(&cfg.Config, cacheDir, "", defaultDiscoveryCacheTTL)
 	if err != nil {
 		return nil, err
@@ -74,6 +85,18 @@ func NewDefaultRegistryWithCacheDir(ctx context.Context, cfg config.NamespacedRE
 	adapter.RegisterAll(ctx, reg)
 
 	return reg, nil
+}
+
+// contextTransport rebinds each request to ctx so cancellation propagates to
+// HTTP calls that client-go issues on its own internal context.
+type contextTransport struct {
+	//nolint:containedctx // deliberate: replaces client-go's context.TODO() on discovery requests
+	ctx  context.Context
+	base http.RoundTripper
+}
+
+func (t contextTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.base.RoundTrip(req.Clone(t.ctx))
 }
 
 // DiscoveryCacheDir returns the directory to use for caching discovery results.


### PR DESCRIPTION
## Summary

`gcx config check` does not respect interrupts. This PR changes it so it does.

When you run `config check`, it tries to reach your Grafana server. If the server is unreachable and just hangs, the command would sit there for up to 32 seconds and ignore Ctrl+C the whole time — you couldn't back out.

The reason: the check waits on two network calls that weren't set up to listen for "the user pressed Ctrl+C", so they kept waiting for the server no matter what. This PR wires that signal into both of them, so pressing Ctrl+C stops the command straight away.

## Before / After

Against a server that accepts connections but never responds, sending SIGINT ~3s in:

**Before**
```
✔ Configuration: valid
🛈 Context type: On-prem
>>> sending SIGINT
✘ Connectivity: Network error: ... context deadline exceeded
>>> exited after 32.0s
```

**After**
```
✔ Configuration: valid
🛈 Context type: On-prem
>>> sending SIGINT
>>> exited (rc=5) after 0.005s
```

The normal connectivity-error path (connection refused, etc.) still prints its error and suggestions unchanged.