### PR TITLE
expand list of requested scopes

### DIFF
--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -28,13 +28,16 @@ func (opts *loginOpts) bindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.cloudToken, "cloud-token", "", "Cloud Access Policy token (skips interactive OAuth flow)")
 	flags.StringVar(&opts.oauthURL, "oauth-url", "https://grafana.com", "Base URL for the OAuth login flow (used only by this command)")
 	flags.StringVar(&opts.apiURL, "api-url", "https://grafana.com", "Base URL for Grafana Cloud API resource calls (stacks etc.)")
-	// Only stacks:* is grantable through the interactive OAuth flow (the gcx OAuth
-	// client's registered allowlist). The product scopes gcx also uses
-	// (metrics:*, logs:*, traces:*, fleet-management:*, set:alloy-data-write) are
-	// Cloud Access Policy scopes: they can't be obtained here, only on a token
-	// created in the Access Policies UI and passed via --cloud-token.
+	// The grafana.com API scopes gcx needs across all commands: stacks
+	// (discovery + management), the signal write scopes for minting the
+	// Synthetic Monitoring token (metrics/logs/traces:write), and Fleet
+	// Management.
 	flags.StringSliceVar(&opts.scopes, "scope", []string{
 		"stacks:read", "stacks:write", "stacks:delete",
+		"metrics:write",
+		"logs:write",
+		"traces:write",
+		"fleet-management:read", "fleet-management:write",
 	}, "OAuth2 scopes to request")
 }
 

--- a/docs/reference/cli/gcx_cloud_login.md
+++ b/docs/reference/cli/gcx_cloud_login.md
@@ -40,7 +40,7 @@ gcx cloud login [flags]
       --context string       Name of the context to use
   -h, --help                 help for login
       --oauth-url string     Base URL for the OAuth login flow (used only by this command) (default "https://grafana.com")
-      --scope strings        OAuth2 scopes to request (default [stacks:read,stacks:write,stacks:delete])
+      --scope strings        OAuth2 scopes to request (default [stacks:read,stacks:write,stacks:delete,metrics:write,logs:write,traces:write,fleet-management:read,fleet-management:write])
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Part of https://github.com/grafana/gcx-internal/issues/13

- [ ] Needs https://github.com/grafana/grafana-com/pull/19399 to be merged first

Expand the set of scopes that gcx requests from grafana.com. This should enable gcx to perform all commands with oauth (if all scopes are selected)