### PR TITLE
warn that OAuth cloud login is experimental

### DIFF
--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -82,6 +82,11 @@ Cloud resources like stacks and access policies.
 
 By default, opens a browser for interactive OAuth2 authentication.
 
+EXPERIMENTAL: interactive OAuth login is an experimental flow that stores an
+OAuth-issued token as the context's cloud.token. Some commands that talk to
+grafana.com do not yet work with an OAuth token. For full functionality, pass
+a Cloud Access Policy token via --cloud-token instead.
+
 For non-interactive use (CI/CD, scripts), pass a Cloud Access Policy token
 directly via --cloud-token.
 
@@ -148,6 +153,9 @@ func runTokenLogin(ctx context.Context, configOpts *cmdconfig.Options, opts *log
 }
 
 func runOAuthLogin(ctx context.Context, configOpts *cmdconfig.Options, opts *loginOpts) error {
+	fmt.Fprintln(os.Stderr, "Warning: interactive OAuth login is experimental. It stores an OAuth-issued token as the context's cloud.token.")
+	fmt.Fprintln(os.Stderr, "Some commands that talk to grafana.com do not yet work with an OAuth token. For full functionality, use --cloud-token with a Cloud Access Policy token.")
+
 	flow := auth.NewGCOMFlow(auth.GCOMOptions{
 		ClientID: defaultClientID,
 		GCOMURL:  opts.oauthURL,

--- a/docs/reference/cli/gcx_cloud_login.md
+++ b/docs/reference/cli/gcx_cloud_login.md
@@ -13,6 +13,11 @@ Cloud resources like stacks and access policies.
 
 By default, opens a browser for interactive OAuth2 authentication.
 
+EXPERIMENTAL: interactive OAuth login is an experimental flow that stores an
+OAuth-issued token as the context's cloud.token. Some commands that talk to
+grafana.com do not yet work with an OAuth token. For full functionality, pass
+a Cloud Access Policy token via --cloud-token instead.
+
 For non-interactive use (CI/CD, scripts), pass a Cloud Access Policy token
 directly via --cloud-token.
 


### PR DESCRIPTION
Interactive `gcx cloud login` stores an OAuth-issued token as the context's `cloud.token`, but some commands that talk to grafana.com don't yet work with an OAuth token. This flags the flow as experimental so users know to fall back to using Access Policy tokens when they have issues.

## Summary

- add an `EXPERIMENTAL:` note to the `gcx cloud login` help text
- print a warning to stderr on the interactive OAuth login path (the `--cloud-token` path is unaffected — it uses a normal Access Policy token)
- regenerate the CLI reference doc

Warning kept generic for now: not naming specific commands until we have a firmer list.