### PR TITLE
feat(metrics): add cardinality analysis commands

### DIFF
--- a/docs/reference/cli/gcx_metrics.md
+++ b/docs/reference/cli/gcx_metrics.md
@@ -25,6 +25,7 @@ Query Prometheus datasources and manage Adaptive Metrics
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx metrics adaptive](gcx_metrics_adaptive.md)	 - Manage Adaptive Metrics resources
 * [gcx metrics billing](gcx_metrics_billing.md)	 - Query Grafana Cloud billing metrics (grafanacloud_*)
+* [gcx metrics cardinality](gcx_metrics_cardinality.md)	 - Analyze series cardinality
 * [gcx metrics labels](gcx_metrics_labels.md)	 - List labels or label values
 * [gcx metrics metadata](gcx_metrics_metadata.md)	 - Get metric metadata
 * [gcx metrics query](gcx_metrics_query.md)	 - Execute a PromQL query against a Prometheus datasource

--- a/docs/reference/cli/gcx_metrics_cardinality.md
+++ b/docs/reference/cli/gcx_metrics_cardinality.md
@@ -1,0 +1,35 @@
+## gcx metrics cardinality
+
+Analyze series cardinality
+
+### Synopsis
+
+Analyze series cardinality by label names and values via the Mimir cardinality analysis API.
+
+These endpoints are available on Grafana Mimir (OSS) and Grafana Cloud; on
+self-hosted Mimir they require -querier.cardinality-analysis-enabled.
+
+### Options
+
+```
+  -h, --help   help for cardinality
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
+* [gcx metrics cardinality label-names](gcx_metrics_cardinality_label-names.md)	 - Show the number of distinct values per label name
+* [gcx metrics cardinality label-values](gcx_metrics_cardinality_label-values.md)	 - Show distinct values and per-value series counts for labels
+

--- a/docs/reference/cli/gcx_metrics_cardinality_label-names.md
+++ b/docs/reference/cli/gcx_metrics_cardinality_label-names.md
@@ -1,0 +1,55 @@
+## gcx metrics cardinality label-names
+
+Show the number of distinct values per label name
+
+### Synopsis
+
+Show, for each label name, how many distinct values it has, via the Mimir cardinality analysis API.
+
+```
+gcx metrics cardinality label-names [flags]
+```
+
+### Examples
+
+```
+
+  # Top label names by distinct value count (configured default datasource)
+  gcx metrics cardinality label-names
+
+  # Scope to a metric family and use active-series counting
+  gcx metrics cardinality label-names -d UID --selector '{__name__=~"grafanacloud_.*"}' --count-method active
+
+  # Output as JSON
+  gcx metrics cardinality label-names -d UID -o json
+```
+
+### Options
+
+```
+      --count-method string   Series counting method: "inmemory" or "active" (default "inmemory")
+  -d, --datasource string     Datasource UID (required unless datasources.prometheus is configured)
+  -h, --help                  help for label-names
+      --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int             Maximum number of items to return (0-500) (default 20)
+  -o, --output string         Output format. One of: agents, json, table, yaml (default "table")
+      --selector string       PromQL series selector scoping the analysis
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics cardinality](gcx_metrics_cardinality.md)	 - Analyze series cardinality
+

--- a/docs/reference/cli/gcx_metrics_cardinality_label-values.md
+++ b/docs/reference/cli/gcx_metrics_cardinality_label-values.md
@@ -1,0 +1,53 @@
+## gcx metrics cardinality label-values
+
+Show distinct values and per-value series counts for labels
+
+### Synopsis
+
+Show, for each requested label name, its distinct values and the number of series per value, via the Mimir cardinality analysis API.
+
+```
+gcx metrics cardinality label-values [flags]
+```
+
+### Examples
+
+```
+
+  # Per-value series counts for one label
+  gcx metrics cardinality label-values -d UID --label job
+
+  # Multiple labels, capped and as JSON
+  gcx metrics cardinality label-values -d UID --label job --label instance --limit 50 -o json
+```
+
+### Options
+
+```
+      --count-method string   Series counting method: "inmemory" or "active" (default "inmemory")
+  -d, --datasource string     Datasource UID (required unless datasources.prometheus is configured)
+  -h, --help                  help for label-values
+      --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -l, --label stringArray     Label name to analyze; repeatable (required)
+      --limit int             Maximum number of items to return per label (0-500) (default 20)
+  -o, --output string         Output format. One of: agents, json, table, yaml (default "table")
+      --selector string       PromQL series selector scoping the analysis
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx metrics cardinality](gcx_metrics_cardinality.md)	 - Analyze series cardinality
+

--- a/internal/providers/metrics/cardinality.go
+++ b/internal/providers/metrics/cardinality.go
@@ -1,0 +1,244 @@
+package metrics
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/agent"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// CardinalityCommands returns the `cardinality` subcommand group exposing the
+// Mimir cardinality analysis endpoints (label names and label values).
+func CardinalityCommands(loader *providers.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cardinality",
+		Short: "Analyze series cardinality",
+		Long: `Analyze series cardinality by label names and values via the Mimir cardinality analysis API.
+
+These endpoints are available on Grafana Mimir (OSS) and Grafana Cloud; on
+self-hosted Mimir they require -querier.cardinality-analysis-enabled.`,
+	}
+
+	cmd.AddCommand(newCardinalityLabelNamesCmd(loader), newCardinalityLabelValuesCmd(loader))
+
+	return cmd
+}
+
+type cardinalityOpts struct {
+	IO          cmdio.Options
+	Datasource  string
+	Selector    string
+	CountMethod string
+	Limit       int
+	Labels      []string // label-values only
+}
+
+func (opts *cardinalityOpts) setup(flags *pflag.FlagSet, withLabels bool) {
+	if withLabels {
+		opts.IO.RegisterCustomCodec("table", &cardinalityLabelValuesTableCodec{})
+	} else {
+		opts.IO.RegisterCustomCodec("table", &cardinalityLabelNamesTableCodec{})
+	}
+	opts.IO.DefaultFormat("table")
+	opts.IO.BindFlags(flags)
+
+	// For label_values the limit is applied per input label name; for
+	// label_names it caps the single list of returned label names.
+	limitUsage := "Maximum number of items to return (0-500)"
+	if withLabels {
+		limitUsage = "Maximum number of items to return per label (0-500)"
+	}
+
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.prometheus is configured)")
+	flags.StringVar(&opts.Selector, "selector", "", "PromQL series selector scoping the analysis")
+	flags.StringVar(&opts.CountMethod, "count-method", "inmemory", `Series counting method: "inmemory" or "active"`)
+	flags.IntVar(&opts.Limit, "limit", 20, limitUsage)
+
+	if withLabels {
+		flags.StringArrayVarP(&opts.Labels, "label", "l", nil, "Label name to analyze; repeatable (required)")
+	}
+}
+
+func (opts *cardinalityOpts) Validate(withLabels bool) error {
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	if opts.Limit < 0 || opts.Limit > 500 {
+		return errors.New("--limit must be between 0 and 500")
+	}
+	switch opts.CountMethod {
+	case "", "inmemory", "active":
+	default:
+		return errors.New(`--count-method must be "inmemory" or "active"`)
+	}
+	if withLabels && len(opts.Labels) == 0 {
+		return errors.New("at least one --label is required")
+	}
+	return nil
+}
+
+func (opts *cardinalityOpts) clientOptions() prometheus.CardinalityOptions {
+	return prometheus.CardinalityOptions{
+		Selector:    opts.Selector,
+		CountMethod: opts.CountMethod,
+		Limit:       opts.Limit,
+	}
+}
+
+// resolveClient runs the shared datasource-resolution and client-construction
+// flow used by both cardinality subcommands.
+func (opts *cardinalityOpts) resolveClient(cmd *cobra.Command, loader *providers.ConfigLoader) (*prometheus.Client, string, error) {
+	ctx := cmd.Context()
+
+	cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
+	if err != nil {
+		return nil, "", err
+	}
+
+	datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "prometheus")
+	if err != nil {
+		return nil, "", err
+	}
+
+	client, err := prometheus.NewClient(cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create client: %w", err)
+	}
+
+	return client, datasourceUID, nil
+}
+
+func newCardinalityLabelNamesCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &cardinalityOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "label-names",
+		Short: "Show the number of distinct values per label name",
+		Long:  "Show, for each label name, how many distinct values it has, via the Mimir cardinality analysis API.",
+		Example: `
+  # Top label names by distinct value count (configured default datasource)
+  gcx metrics cardinality label-names
+
+  # Scope to a metric family and use active-series counting
+  gcx metrics cardinality label-names -d UID --selector '{__name__=~"grafanacloud_.*"}' --count-method active
+
+  # Output as JSON
+  gcx metrics cardinality label-names -d UID -o json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(false); err != nil {
+				return err
+			}
+
+			client, datasourceUID, err := opts.resolveClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.CardinalityLabelNames(cmd.Context(), datasourceUID, opts.clientOptions())
+			if err != nil {
+				return fmt.Errorf("failed to get label names cardinality: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), resp)
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+		agent.AnnotationLLMHint:   "gcx metrics cardinality label-names -d UID -o json",
+	}
+
+	opts.setup(cmd.Flags(), false)
+
+	return cmd
+}
+
+func newCardinalityLabelValuesCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &cardinalityOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "label-values",
+		Short: "Show distinct values and per-value series counts for labels",
+		Long:  "Show, for each requested label name, its distinct values and the number of series per value, via the Mimir cardinality analysis API.",
+		Example: `
+  # Per-value series counts for one label
+  gcx metrics cardinality label-values -d UID --label job
+
+  # Multiple labels, capped and as JSON
+  gcx metrics cardinality label-values -d UID --label job --label instance --limit 50 -o json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(true); err != nil {
+				return err
+			}
+
+			client, datasourceUID, err := opts.resolveClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.CardinalityLabelValues(cmd.Context(), datasourceUID, opts.Labels, opts.clientOptions())
+			if err != nil {
+				return fmt.Errorf("failed to get label values cardinality: %w", err)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), resp)
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "medium",
+		agent.AnnotationLLMHint:   "gcx metrics cardinality label-values -d UID --label job -o json",
+	}
+
+	opts.setup(cmd.Flags(), true)
+
+	return cmd
+}
+
+type cardinalityLabelNamesTableCodec struct{}
+
+func (c *cardinalityLabelNamesTableCodec) Format() format.Format {
+	return "table"
+}
+
+func (c *cardinalityLabelNamesTableCodec) Encode(w io.Writer, data any) error {
+	resp, ok := data.(*prometheus.CardinalityLabelNamesResponse)
+	if !ok {
+		return errors.New("invalid data type for cardinality label names table codec")
+	}
+
+	return prometheus.FormatCardinalityLabelNamesTable(w, resp)
+}
+
+func (c *cardinalityLabelNamesTableCodec) Decode(io.Reader, any) error {
+	return errors.New("cardinality label names table codec does not support decoding")
+}
+
+type cardinalityLabelValuesTableCodec struct{}
+
+func (c *cardinalityLabelValuesTableCodec) Format() format.Format {
+	return "table"
+}
+
+func (c *cardinalityLabelValuesTableCodec) Encode(w io.Writer, data any) error {
+	resp, ok := data.(*prometheus.CardinalityLabelValuesResponse)
+	if !ok {
+		return errors.New("invalid data type for cardinality label values table codec")
+	}
+
+	return prometheus.FormatCardinalityLabelValuesTable(w, resp)
+}
+
+func (c *cardinalityLabelValuesTableCodec) Decode(io.Reader, any) error {
+	return errors.New("cardinality label values table codec does not support decoding")
+}

--- a/internal/providers/metrics/cardinality_test.go
+++ b/internal/providers/metrics/cardinality_test.go
@@ -1,0 +1,69 @@
+package metrics_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/metrics"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func executeCardinality(t *testing.T, args ...string) error {
+	t.Helper()
+	cmd := metrics.CardinalityCommands(nil)
+	cmd.SetArgs(args)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	return cmd.Execute()
+}
+
+func TestCardinalityCommands_Structure(t *testing.T) {
+	cmd := metrics.CardinalityCommands(nil)
+	assert.Equal(t, "cardinality", cmd.Name())
+
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.ElementsMatch(t, []string{"label-names", "label-values"}, names)
+}
+
+// TestCardinalityValidation drives validation through the wired command tree so
+// bad flags are rejected before any datasource resolution (nil loader is never
+// reached).
+func TestCardinalityValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "limit too high", args: []string{"label-names", "--limit=999"}, wantErr: "--limit"},
+		{name: "limit negative", args: []string{"label-names", "--limit=-1"}, wantErr: "--limit"},
+		{name: "bad count method", args: []string{"label-names", "--count-method=bogus"}, wantErr: "--count-method"},
+		{name: "label-values missing labels", args: []string{"label-values"}, wantErr: "--label"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := executeCardinality(t, tc.args...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestCardinalityFlags(t *testing.T) {
+	byName := map[string]*cobra.Command{}
+	for _, sub := range metrics.CardinalityCommands(nil).Commands() {
+		byName[sub.Name()] = sub
+	}
+
+	// --label (with -l shorthand) exists only on label-values.
+	require.NotNil(t, byName["label-values"].Flags().Lookup("label"))
+	require.NotNil(t, byName["label-values"].Flags().ShorthandLookup("l"))
+	assert.Nil(t, byName["label-names"].Flags().Lookup("label"))
+}

--- a/internal/providers/metrics/provider.go
+++ b/internal/providers/metrics/provider.go
@@ -78,7 +78,7 @@ func (p *Provider) descriptor() signals.Descriptor {
 				LLMHint:   `gcx metrics series -d abc123 '{__name__="up"}' --since 1h -o json`,
 			},
 		},
-		ExtraCommands: []signals.CommandBuilder{BillingCommands},
+		ExtraCommands: []signals.CommandBuilder{BillingCommands, CardinalityCommands},
 		Adaptive: &signals.AdaptiveSpec{
 			Build: adaptivemetrics.Commands,
 			Use:   "adaptive",

--- a/internal/query/prometheus/cardinality.go
+++ b/internal/query/prometheus/cardinality.go
@@ -1,0 +1,150 @@
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/grafana/gcx/internal/httputils"
+	"github.com/grafana/gcx/internal/queryerror"
+)
+
+// CardinalityLabelNamesResponse is the response from the Mimir cardinality
+// analysis endpoint /api/v1/cardinality/label_names.
+type CardinalityLabelNamesResponse struct {
+	LabelValuesCountTotal int                    `json:"label_values_count_total"`
+	LabelNamesCount       int                    `json:"label_names_count"`
+	Cardinality           []LabelNameCardinality `json:"cardinality"`
+}
+
+// LabelNameCardinality reports the number of distinct values for a label name.
+type LabelNameCardinality struct {
+	LabelName        string `json:"label_name"`
+	LabelValuesCount int    `json:"label_values_count"`
+}
+
+// CardinalityLabelValuesResponse is the response from the Mimir cardinality
+// analysis endpoint /api/v1/cardinality/label_values.
+type CardinalityLabelValuesResponse struct {
+	SeriesCountTotal int                      `json:"series_count_total"`
+	Labels           []LabelValuesCardinality `json:"labels"`
+}
+
+// LabelValuesCardinality reports, for one label name, its distinct values and
+// the per-value series counts.
+type LabelValuesCardinality struct {
+	LabelName        string                  `json:"label_name"`
+	LabelValuesCount int                     `json:"label_values_count"`
+	SeriesCount      int                     `json:"series_count"`
+	Cardinality      []LabelValueCardinality `json:"cardinality"`
+}
+
+// LabelValueCardinality reports the number of series carrying a label value.
+type LabelValueCardinality struct {
+	LabelValue  string `json:"label_value"`
+	SeriesCount int    `json:"series_count"`
+}
+
+// CardinalityOptions holds the parameters shared by both cardinality endpoints.
+type CardinalityOptions struct {
+	// Selector is a PromQL series selector scoping the analysis; empty omits it.
+	Selector string
+	// CountMethod is "inmemory" or "active"; empty uses the server default.
+	CountMethod string
+	// Limit caps the number of returned items (server range 0-500); always sent.
+	Limit int
+}
+
+// CardinalityLabelNames returns, per label name, the number of distinct values.
+func (c *Client) CardinalityLabelNames(ctx context.Context, datasourceUID string, opts CardinalityOptions) (*CardinalityLabelNamesResponse, error) {
+	respBody, err := c.getCardinality(ctx, c.buildCardinalityLabelNamesPath(datasourceUID), nil, opts, "cardinality label names query")
+	if err != nil {
+		return nil, err
+	}
+
+	var result CardinalityLabelNamesResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// CardinalityLabelValues returns, for each requested label name, its distinct
+// values and per-value series counts.
+func (c *Client) CardinalityLabelValues(ctx context.Context, datasourceUID string, labelNames []string, opts CardinalityOptions) (*CardinalityLabelValuesResponse, error) {
+	respBody, err := c.getCardinality(ctx, c.buildCardinalityLabelValuesPath(datasourceUID), labelNames, opts, "cardinality label values query")
+	if err != nil {
+		return nil, err
+	}
+
+	var result CardinalityLabelValuesResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// getCardinality performs a GET against a cardinality endpoint and returns the
+// raw response body, translating non-200 responses into typed errors.
+func (c *Client) getCardinality(ctx context.Context, apiPath string, labelNames []string, opts CardinalityOptions, operation string) ([]byte, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.restConfig.Host+apiPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	q := httpReq.URL.Query()
+	for _, name := range labelNames {
+		q.Add("label_names[]", name)
+	}
+	if opts.Selector != "" {
+		q.Set("selector", opts.Selector)
+	}
+	if opts.CountMethod != "" {
+		q.Set("count_method", opts.CountMethod)
+	}
+	q.Set("limit", strconv.Itoa(opts.Limit))
+	httpReq.URL.RawQuery = q.Encode()
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query cardinality: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, cardinalityError(operation, resp.StatusCode, respBody)
+	}
+
+	return respBody, nil
+}
+
+// cardinalityError builds an error for a non-200 cardinality response. A 404 or
+// 501 means the endpoint is unavailable — vanilla Prometheus, or Mimir with
+// cardinality analysis disabled — so it returns a friendlier message while
+// keeping the raw upstream error as the wrapped cause. Other statuses use the
+// standard typed API error.
+func cardinalityError(operation string, statusCode int, body []byte) error {
+	apiErr := queryerror.FromBody("prometheus", operation, statusCode, body)
+	if statusCode == http.StatusNotFound || statusCode == http.StatusNotImplemented {
+		return fmt.Errorf("cardinality analysis is only available on Grafana Mimir (OSS) and Grafana Cloud; on self-hosted Mimir it requires -querier.cardinality-analysis-enabled: %w", apiErr)
+	}
+	return apiErr
+}
+
+func (c *Client) buildCardinalityLabelNamesPath(datasourceUID string) string {
+	return fmt.Sprintf("/api/datasources/uid/%s/resources/api/v1/cardinality/label_names", url.PathEscape(datasourceUID))
+}
+
+func (c *Client) buildCardinalityLabelValuesPath(datasourceUID string) string {
+	return fmt.Sprintf("/api/datasources/uid/%s/resources/api/v1/cardinality/label_values", url.PathEscape(datasourceUID))
+}

--- a/internal/query/prometheus/cardinality_test.go
+++ b/internal/query/prometheus/cardinality_test.go
@@ -1,0 +1,253 @@
+package prometheus_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_CardinalityLabelNames(t *testing.T) {
+	var (
+		capturedPath  string
+		capturedQuery url.Values
+		capturedAuth  string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.Query()
+		capturedAuth = r.Header.Get("Authorization")
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(prometheus.CardinalityLabelNamesResponse{
+			LabelValuesCountTotal: 100,
+			LabelNamesCount:       2,
+			Cardinality: []prometheus.LabelNameCardinality{
+				{LabelName: "__name__", LabelValuesCount: 50},
+				{LabelName: "job", LabelValuesCount: 10},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	resp, err := client.CardinalityLabelNames(context.Background(), "grafanacloud-prom", prometheus.CardinalityOptions{
+		Selector:    `{__name__="up"}`,
+		CountMethod: "active",
+		Limit:       50,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/datasources/uid/grafanacloud-prom/resources/api/v1/cardinality/label_names", capturedPath)
+	assert.Equal(t, `{__name__="up"}`, capturedQuery.Get("selector"))
+	assert.Equal(t, "active", capturedQuery.Get("count_method"))
+	assert.Equal(t, "50", capturedQuery.Get("limit"))
+	assert.Empty(t, capturedQuery["label_names[]"])
+	assert.Equal(t, "Bearer test-token", capturedAuth)
+
+	require.NotNil(t, resp)
+	assert.Equal(t, 100, resp.LabelValuesCountTotal)
+	assert.Equal(t, 2, resp.LabelNamesCount)
+	require.Len(t, resp.Cardinality, 2)
+	assert.Equal(t, "__name__", resp.Cardinality[0].LabelName)
+	assert.Equal(t, 50, resp.Cardinality[0].LabelValuesCount)
+}
+
+func TestClient_CardinalityLabelNames_OmitsEmptyParams(t *testing.T) {
+	var capturedQuery url.Values
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(prometheus.CardinalityLabelNamesResponse{})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	_, err := client.CardinalityLabelNames(context.Background(), "prom", prometheus.CardinalityOptions{Limit: 0})
+	require.NoError(t, err)
+
+	// selector and count_method are omitted when empty; limit is always sent.
+	_, hasSelector := capturedQuery["selector"]
+	_, hasCountMethod := capturedQuery["count_method"]
+	assert.False(t, hasSelector)
+	assert.False(t, hasCountMethod)
+	assert.Equal(t, "0", capturedQuery.Get("limit"))
+}
+
+func TestClient_CardinalityLabelValues(t *testing.T) {
+	var (
+		capturedPath  string
+		capturedQuery url.Values
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(prometheus.CardinalityLabelValuesResponse{
+			SeriesCountTotal: 1000,
+			Labels: []prometheus.LabelValuesCardinality{
+				{
+					LabelName:        "job",
+					LabelValuesCount: 2,
+					SeriesCount:      500,
+					Cardinality: []prometheus.LabelValueCardinality{
+						{LabelValue: "grafana", SeriesCount: 300},
+						{LabelValue: "loki", SeriesCount: 200},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	resp, err := client.CardinalityLabelValues(context.Background(), "prom", []string{"job", "instance"}, prometheus.CardinalityOptions{Limit: 20})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/datasources/uid/prom/resources/api/v1/cardinality/label_values", capturedPath)
+	assert.Equal(t, []string{"job", "instance"}, capturedQuery["label_names[]"])
+	assert.Equal(t, "20", capturedQuery.Get("limit"))
+
+	require.NotNil(t, resp)
+	assert.Equal(t, 1000, resp.SeriesCountTotal)
+	require.Len(t, resp.Labels, 1)
+	assert.Equal(t, "job", resp.Labels[0].LabelName)
+	require.Len(t, resp.Labels[0].Cardinality, 2)
+	assert.Equal(t, "grafana", resp.Labels[0].Cardinality[0].LabelValue)
+	assert.Equal(t, 300, resp.Labels[0].Cardinality[0].SeriesCount)
+}
+
+func TestClient_Cardinality_UnavailableFriendlyError(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusNotImplemented} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"error":"cardinality analysis is disabled"}`))
+		}))
+
+		client := newTestClient(t, srv.URL)
+		_, err := client.CardinalityLabelNames(context.Background(), "prom", prometheus.CardinalityOptions{Limit: 20})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only available on Grafana Mimir")
+		// The raw upstream message is preserved as the wrapped cause.
+		assert.Contains(t, err.Error(), "cardinality analysis is disabled")
+
+		srv.Close()
+	}
+}
+
+func TestClient_Cardinality_OtherErrorIsRaw(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	_, err := client.CardinalityLabelValues(context.Background(), "prom", []string{"job"}, prometheus.CardinalityOptions{Limit: 20})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+	assert.NotContains(t, err.Error(), "only available on Grafana Mimir")
+}
+
+func TestClient_BuildCardinalityPathsEscapeUID(t *testing.T) {
+	c := &prometheus.Client{}
+
+	names := c.BuildCardinalityLabelNamesPath("uid/../admin")
+	assert.Contains(t, names, "uid%2F..%2Fadmin")
+	assert.NotContains(t, names, "uid/../admin")
+
+	values := c.BuildCardinalityLabelValuesPath("uid/../admin")
+	assert.Contains(t, values, "uid%2F..%2Fadmin")
+	assert.NotContains(t, values, "uid/../admin")
+}
+
+func TestFormatCardinalityLabelNamesTable(t *testing.T) {
+	var buf bytes.Buffer
+	resp := &prometheus.CardinalityLabelNamesResponse{
+		LabelValuesCountTotal: 60,
+		LabelNamesCount:       200, // more than the two shown rows: a genuine total
+		Cardinality: []prometheus.LabelNameCardinality{
+			{LabelName: "__name__", LabelValuesCount: 50},
+			{LabelName: "job", LabelValuesCount: 10},
+		},
+	}
+
+	require.NoError(t, prometheus.FormatCardinalityLabelNamesTable(&buf, resp))
+
+	out := buf.String()
+	// Both sections render: response-level totals summary, then the per-name list.
+	assert.Contains(t, out, "Summary:")
+	assert.Contains(t, out, "Label names:")
+	assert.Contains(t, out, "UNIQUE LABEL NAMES")
+	assert.Contains(t, out, "UNIQUE LABEL VALUES")
+	assert.Contains(t, out, "200") // label_names_count total
+	assert.Contains(t, out, "60")  // label_values_count_total
+	assert.Contains(t, out, "__name__")
+	assert.Contains(t, out, "50")
+	assert.Contains(t, out, "job")
+
+	assert.Less(t, strings.Index(out, "Summary:"), strings.Index(out, "Label names:"))
+}
+
+func TestFormatCardinalityLabelNamesTable_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, prometheus.FormatCardinalityLabelNamesTable(&buf, &prometheus.CardinalityLabelNamesResponse{}))
+	assert.Contains(t, buf.String(), "No data")
+}
+
+func TestFormatCardinalityLabelValuesTable(t *testing.T) {
+	var buf bytes.Buffer
+	resp := &prometheus.CardinalityLabelValuesResponse{
+		SeriesCountTotal: 500,
+		Labels: []prometheus.LabelValuesCardinality{
+			{
+				LabelName:        "job",
+				LabelValuesCount: 2,
+				SeriesCount:      500,
+				Cardinality: []prometheus.LabelValueCardinality{
+					{LabelValue: "grafana", SeriesCount: 300},
+					{LabelValue: "loki", SeriesCount: 200},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, prometheus.FormatCardinalityLabelValuesTable(&buf, resp))
+
+	out := buf.String()
+	// Both sections are rendered: a per-label summary and the per-value breakdown.
+	assert.Contains(t, out, "Summary:")
+	assert.Contains(t, out, "Label values:")
+	assert.Contains(t, out, "UNIQUE LABEL VALUES") // summary column
+	assert.Contains(t, out, "LABEL VALUE")         // breakdown column
+	assert.Contains(t, out, "SERIES")
+	// Summary row: distinct value count for the label.
+	assert.Contains(t, out, "2")
+	// Per-value breakdown rows.
+	assert.Contains(t, out, "grafana")
+	assert.Contains(t, out, "300")
+	assert.Contains(t, out, "loki")
+
+	// The "Summary:" section precedes the "Label values:" section.
+	assert.Less(t, strings.Index(out, "Summary:"), strings.Index(out, "Label values:"))
+}
+
+func TestFormatCardinalityLabelValuesTable_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, prometheus.FormatCardinalityLabelValuesTable(&buf, &prometheus.CardinalityLabelValuesResponse{}))
+	assert.Contains(t, buf.String(), "No data")
+}

--- a/internal/query/prometheus/export_test.go
+++ b/internal/query/prometheus/export_test.go
@@ -18,6 +18,14 @@ func (c *Client) BuildSeriesPath(datasourceUID string) string {
 	return c.buildSeriesPath(datasourceUID)
 }
 
+func (c *Client) BuildCardinalityLabelNamesPath(datasourceUID string) string {
+	return c.buildCardinalityLabelNamesPath(datasourceUID)
+}
+
+func (c *Client) BuildCardinalityLabelValuesPath(datasourceUID string) string {
+	return c.buildCardinalityLabelValuesPath(datasourceUID)
+}
+
 // ConvertGrafanaResponse exposes the unexported converter for the external test package.
 func ConvertGrafanaResponse(grafanaResp *GrafanaQueryResponse, isRange bool) *QueryResponse {
 	return convertGrafanaResponse(grafanaResp, isRange)

--- a/internal/query/prometheus/formatter.go
+++ b/internal/query/prometheus/formatter.go
@@ -245,6 +245,64 @@ func formatSeriesSelector(labels map[string]string) string {
 	return b.String()
 }
 
+// FormatCardinalityLabelNamesTable formats a label names cardinality response as
+// two tables: a summary of the response-level totals followed by the per-label-name
+// distinct value counts.
+func FormatCardinalityLabelNamesTable(w io.Writer, resp *CardinalityLabelNamesResponse) error {
+	if resp.LabelNamesCount == 0 && resp.LabelValuesCountTotal == 0 && len(resp.Cardinality) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+
+	fmt.Fprintln(w, "Summary:")
+	summary := style.NewTable("UNIQUE LABEL NAMES", "UNIQUE LABEL VALUES")
+	summary.Row(strconv.Itoa(resp.LabelNamesCount), strconv.Itoa(resp.LabelValuesCountTotal))
+	if err := summary.Render(w); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Label names:")
+	if len(resp.Cardinality) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+	t := style.NewTable("LABEL NAME", "UNIQUE LABEL VALUES")
+	for _, entry := range resp.Cardinality {
+		t.Row(entry.LabelName, strconv.Itoa(entry.LabelValuesCount))
+	}
+	return t.Render(w)
+}
+
+// FormatCardinalityLabelValuesTable formats a label values cardinality response
+// as two tables: a per-label summary (distinct value and series counts) followed
+// by the per-value series-count breakdown.
+func FormatCardinalityLabelValuesTable(w io.Writer, resp *CardinalityLabelValuesResponse) error {
+	if len(resp.Labels) == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+
+	fmt.Fprintln(w, "Summary:")
+	summary := style.NewTable("LABEL NAME", "UNIQUE LABEL VALUES", "SERIES")
+	for _, label := range resp.Labels {
+		summary.Row(label.LabelName, strconv.Itoa(label.LabelValuesCount), strconv.Itoa(label.SeriesCount))
+	}
+	if err := summary.Render(w); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Label values:")
+	values := style.NewTable("LABEL NAME", "LABEL VALUE", "SERIES")
+	for _, label := range resp.Labels {
+		for _, value := range label.Cardinality {
+			values.Row(label.LabelName, value.LabelValue, strconv.Itoa(value.SeriesCount))
+		}
+	}
+	return values.Render(w)
+}
+
 // FormatMetadataTable formats a MetadataResponse as a table.
 func FormatMetadataTable(w io.Writer, resp *MetadataResponse) error {
 	t := style.NewTable("METRIC", "TYPE", "HELP")


### PR DESCRIPTION
## Why

There's no CLI way to investigate what drives series and label cardinality in a
Grafana Cloud / Mimir tenant — today that means the cardinality management
dashboards. This adds the CLI counterpart, completing the read-only metrics
inspection set alongside `query` / `labels` / `metadata` / `series`.

## What

A `cardinality` command group under `gcx metrics`, wrapping Mimir's cardinality
analysis API:

- `gcx metrics cardinality label-names` — distinct value count per label name
- `gcx metrics cardinality label-values` — distinct values and per-value series
  counts for the given labels (`-l/--label`, repeatable)

Both go through the Grafana datasource resource proxy like the existing metrics
commands, so no new auth or transport code. `--selector`, `--count-method`
(`inmemory`/`active`) and `--limit` map to the API parameters; a 404/501 (vanilla
Prometheus, or Mimir without `-querier.cardinality-analysis-enabled`) surfaces a
friendly "available only on Grafana Mimir (OSS) and Grafana Cloud" message. Each
command renders a summary table plus a detail table; `json`/`yaml`/`agents` carry
the full response.

## Example output

Example output of `./bin/gcx metrics cardinality label-names -d REDACTED-UID --limit 5`:

```
Summary:
┌─────────────────────────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────┐
│ UNIQUE LABEL NAMES                                                                  │ UNIQUE LABEL VALUES                                                                 │
├─────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ 2307                                                                                │ 1548857                                                                             │
└─────────────────────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────┘

Label names:
┌─────────────────────────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────┐
│ LABEL NAME                                                                          │ UNIQUE LABEL VALUES                                                                 │
├─────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ id                                                                                  │ 198423                                                                              │
│ name                                                                                │ 185769                                                                              │
│ replicaset                                                                          │ 123319                                                                              │
│ container_id                                                                        │ 101547                                                                              │
│ pod_name                                                                            │ 74714                                                                               │
└─────────────────────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────┘
```

Example output of `./bin/gcx metrics cardinality label-values -d REDACTED-UID -l __name__ -l namespace --limit 5`:

```
Summary:
┌─────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────┐
│ LABEL NAME                                              │ UNIQUE LABEL VALUES                                    │ SERIES                                                 │
├─────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
│ __name__                                                │ 34003                                                  │ 58233553                                               │
└─────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────┘

Label values:
┌─────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────┐
│ LABEL NAME                                              │ LABEL VALUE                                            │ SERIES                                                 │
├─────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
│ __name__                                                │ REDACTED-LABEL-VALUE                                   │ 6381766                                                │
│ __name__                                                │ REDACTED-LABEL-VALUE                                   │ 3118147                                                │
│ __name__                                                │ REDACTED-LABEL-VALUE                                   │ 1554476                                                │
│ __name__                                                │ REDACTED-LABEL-VALUE                                   │ 1397629                                                │
│ __name__                                                │ REDACTED-LABEL-VALUE                                   │ 1380375                                                │
└─────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────┘
```
