### PR TITLE
feat(appo11y): filter, group-by, and label discovery for services get/map/list-operations

### DIFF
--- a/docs/reference/cli/gcx_appo11y_services.md
+++ b/docs/reference/cli/gcx_appo11y_services.md
@@ -24,6 +24,7 @@ Inspect Application Observability services discovered from telemetry
 
 * [gcx appo11y](gcx_appo11y.md)	 - Manage Grafana App Observability settings
 * [gcx appo11y services get](gcx_appo11y_services_get.md)	 - Inspect a single Application Observability service: metadata + RED snapshot.
+* [gcx appo11y services labels](gcx_appo11y_services_labels.md)	 - Discover the labels (and values) available to --filter and --group-by for a service.
 * [gcx appo11y services list](gcx_appo11y_services_list.md)	 - List Application Observability services discovered from target_info/traces_target_info telemetry.
 * [gcx appo11y services list-operations](gcx_appo11y_services_list-operations.md)	 - List a service's operations with per-operation RED (span_name × rate/errors/latency).
 * [gcx appo11y services map](gcx_appo11y_services_map.md)	 - Show a service's neighbourhood: who calls it (callers) and who it calls (callees).

--- a/docs/reference/cli/gcx_appo11y_services_get.md
+++ b/docs/reference/cli/gcx_appo11y_services_get.md
@@ -54,6 +54,9 @@ gcx appo11y services get <service> [--namespace ns] [flags]
 
   # Break a multi-cluster service down to a single cluster
   gcx appo11y services get faro-collector --filter k8s_cluster_name=prod-us-central-0
+
+  # Compare a service's RED across all clusters to spot the outlier
+  gcx appo11y services get faro-collector --group-by k8s_cluster_name
 ```
 
 ### Options
@@ -61,6 +64,7 @@ gcx appo11y services get <service> [--namespace ns] [flags]
 ```
   -d, --datasource string     Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
       --filter stringArray    Scope the RED snapshot to series matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the span metrics
+      --group-by strings      Pivot the RED snapshot into one row per distinct value of a label, e.g. --group-by k8s_cluster_name (comma-separated or repeatable). Surfaces outliers across clusters/regions without naming each one; the label must exist on the span metrics
   -h, --help                  help for get
       --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_appo11y_services_get.md
+++ b/docs/reference/cli/gcx_appo11y_services_get.md
@@ -51,12 +51,16 @@ gcx appo11y services get <service> [--namespace ns] [flags]
 
   # Stack double-emits both families; force the Tempo metrics-generator numbers
   gcx appo11y services get checkoutservice --metrics-mode tempo
+
+  # Break a multi-cluster service down to a single cluster
+  gcx appo11y services get faro-collector --filter k8s_cluster_name=prod-us-central-0
 ```
 
 ### Options
 
 ```
   -d, --datasource string     Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
+      --filter stringArray    Scope the RED snapshot to series matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the span metrics
   -h, --help                  help for get
       --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_appo11y_services_labels.md
+++ b/docs/reference/cli/gcx_appo11y_services_labels.md
@@ -1,0 +1,71 @@
+## gcx appo11y services labels
+
+Discover the labels (and values) available to --filter and --group-by for a service.
+
+### Synopsis
+
+List the labels present on a service's span-metric series — the exact set
+that "gcx appo11y services get/list-operations --filter/--group-by" can
+operate on — with each label's distinct-value count.
+
+This answers "what can I break this service down by?" without guessing.
+Pass --label <name> to list the distinct values of a single label so you
+know what to feed --filter (e.g. --filter k8s_cluster_name=<value>).
+
+Labels come from the span-metric calls series (auto-detected metrics-mode),
+which is what the RED commands filter and group on. Note:
+
+  - "services map" groups on the Tempo service-graph metric family, whose
+    labels may differ (and often omit cluster labels).
+  - "services get <svc> -o json" additionally surfaces the target_info
+    resource attributes under .service.labels.
+
+```
+gcx appo11y services labels <service> [--namespace ns] [flags]
+```
+
+### Examples
+
+```
+
+  # What can I filter/group checkoutservice by?
+  gcx appo11y services labels checkoutservice
+
+  # Which clusters does it run in? (values to feed --filter/--group-by)
+  gcx appo11y services labels checkoutservice --label k8s_cluster_name
+
+  # JSON for scripting
+  gcx appo11y services labels checkoutservice -o json
+```
+
+### Options
+
+```
+  -d, --datasource string     Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
+      --filter stringArray    Restrict discovery to series matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable)
+  -h, --help                  help for labels
+      --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --label string          Show the distinct values of a single label instead of the label summary (e.g. --label k8s_cluster_name)
+      --metrics-mode string   Span-metrics family whose labels to inspect. One of: auto (probes the stack), v3, tempo, or otel (default "auto")
+  -n, --namespace string      Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)
+  -o, --output string         Output format. One of: agents, json, table, wide, yaml (default "table")
+      --since string          Lookback window for series discovery (e.g. 15m, 1h, 1d) — PromQL duration syntax (default "1h")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx appo11y services](gcx_appo11y_services.md)	 - Inspect Application Observability services discovered from telemetry
+

--- a/docs/reference/cli/gcx_appo11y_services_list-operations.md
+++ b/docs/reference/cli/gcx_appo11y_services_list-operations.md
@@ -39,6 +39,9 @@ gcx appo11y services list-operations <service> [--namespace ns] [flags]
 
   # Break a multi-cluster service down to a single cluster
   gcx appo11y services list-operations faro-collector --filter k8s_cluster_name=prod-us-central-0
+
+  # Break each operation out per cluster to spot per-cluster hotspots
+  gcx appo11y services list-operations faro-collector --group-by k8s_cluster_name
 ```
 
 ### Options
@@ -46,6 +49,7 @@ gcx appo11y services list-operations <service> [--namespace ns] [flags]
 ```
   -d, --datasource string     Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
       --filter stringArray    Scope the operations breakdown to series matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the span metrics
+      --group-by strings      Break each operation out per distinct value of a label, e.g. --group-by k8s_cluster_name (comma-separated or repeatable). Time-share is normalized within each group so per-cluster hotspots are comparable; the label must exist on the span metrics
   -h, --help                  help for list-operations
       --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_appo11y_services_list-operations.md
+++ b/docs/reference/cli/gcx_appo11y_services_list-operations.md
@@ -36,12 +36,16 @@ gcx appo11y services list-operations <service> [--namespace ns] [flags]
 
   # Last hour, unlimited rows, JSON for scripting
   gcx appo11y services list-operations payments/checkoutservice --since 1h --limit 0 -o json
+
+  # Break a multi-cluster service down to a single cluster
+  gcx appo11y services list-operations faro-collector --filter k8s_cluster_name=prod-us-central-0
 ```
 
 ### Options
 
 ```
   -d, --datasource string     Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
+      --filter stringArray    Scope the operations breakdown to series matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the span metrics
   -h, --help                  help for list-operations
       --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_appo11y_services_map.md
+++ b/docs/reference/cli/gcx_appo11y_services_map.md
@@ -52,6 +52,9 @@ gcx appo11y services map <service> [--namespace ns] [flags]
 
   # Break a multi-cluster service's map down to a single cluster
   gcx appo11y services map faro-collector --filter k8s_cluster_name=prod-us-central-0
+
+  # Split each edge per cluster (service-graph metrics must carry the label)
+  gcx appo11y services map faro-collector --group-by k8s_cluster_name
 ```
 
 ### Options
@@ -59,6 +62,7 @@ gcx appo11y services map <service> [--namespace ns] [flags]
 ```
   -d, --datasource string    Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
       --filter stringArray   Scope the map to service-graph edges matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the service-graph metrics
+      --group-by strings     Split each edge per distinct value of a label, e.g. --group-by k8s_cluster_name (comma-separated or repeatable). The label must exist on the service-graph metrics — note the Tempo service-graph family often omits cluster labels, in which case no edges match
   -h, --help                 help for map
       --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_appo11y_services_map.md
+++ b/docs/reference/cli/gcx_appo11y_services_map.md
@@ -49,18 +49,22 @@ gcx appo11y services map <service> [--namespace ns] [flags]
 
   # JSON for scripting
   gcx appo11y services map checkoutservice -o json
+
+  # Break a multi-cluster service's map down to a single cluster
+  gcx appo11y services map faro-collector --filter k8s_cluster_name=prod-us-central-0
 ```
 
 ### Options
 
 ```
-  -d, --datasource string   Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
-  -h, --help                help for map
-      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
-      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -n, --namespace string    Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)
-  -o, --output string       Output format. One of: agents, dot, json, mermaid, table, wide, yaml (default "table")
-      --since string        Rate/quantile window applied to service-graph metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax (default "5m")
+  -d, --datasource string    Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
+      --filter stringArray   Scope the map to service-graph edges matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the service-graph metrics
+  -h, --help                 help for map
+      --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -n, --namespace string     Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)
+  -o, --output string        Output format. One of: agents, dot, json, mermaid, table, wide, yaml (default "table")
+      --since string         Rate/quantile window applied to service-graph metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax (default "5m")
 ```
 
 ### Options inherited from parent commands

--- a/internal/providers/appo11y/services/commands.go
+++ b/internal/providers/appo11y/services/commands.go
@@ -32,6 +32,7 @@ func Commands() *cobra.Command {
 	cmd.AddCommand(newGetCommand())
 	cmd.AddCommand(newMapCommand())
 	cmd.AddCommand(newListOperationsCommand())
+	cmd.AddCommand(newLabelsCommand())
 	return cmd
 }
 

--- a/internal/providers/appo11y/services/get.go
+++ b/internal/providers/appo11y/services/get.go
@@ -36,6 +36,7 @@ type getOpts struct {
 	Namespace   string
 	Kind        string
 	MetricsMode string
+	Filters     []string
 }
 
 func (o *getOpts) setup(flags *pflag.FlagSet) {
@@ -49,6 +50,7 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVar(&o.Since, "since", defaultRedWindow, "Rate/quantile window applied to span metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax")
 	flags.StringVar(&o.Kind, "kind", "inbound", "Span kinds to include. One of: inbound (server+consumer), server, consumer, all, or a comma-separated list of SPAN_KIND_* literals")
 	flags.StringVar(&o.MetricsMode, "metrics-mode", metricsModeAuto, "Span-metrics family. One of: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket)")
+	flags.StringArrayVar(&o.Filters, "filter", nil, "Scope the RED snapshot to series matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the span metrics")
 }
 
 func (o *getOpts) Validate(cmd *cobra.Command) error {
@@ -171,12 +173,15 @@ which family produced the numbers.`,
   gcx appo11y services get checkoutservice --kind server
 
   # Stack double-emits both families; force the Tempo metrics-generator numbers
-  gcx appo11y services get checkoutservice --metrics-mode tempo`,
+  gcx appo11y services get checkoutservice --metrics-mode tempo
+
+  # Break a multi-cluster service down to a single cluster
+  gcx appo11y services get faro-collector --filter k8s_cluster_name=prod-us-central-0`,
 		Args: cobra.ExactArgs(1),
 		RunE: runGet(opts),
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
-			agent.AnnotationLLMHint:   `Per-service RED snapshot from Tempo/OTel span metrics: rate (req/s), error rate, error percent, p50/p95/p99 latency (seconds) over --since (default 5m), scoped to inbound spans (SERVER+CONSUMER). --metrics-mode picks the family: auto (default, probes the stack), v3 (traces_span_metrics_*, OTel Collector >= 0.109 / Alloy >= 1.5), tempo (traces_spanmetrics_*, Tempo metrics-generator — Grafana Cloud default — and Beyla), otel (bare calls_total/duration_seconds_bucket, older Collector/Alloy/Agent). Pairs with 'gcx appo11y services list' to drill into a single row. Examples: gcx appo11y services get <name> -o json; gcx appo11y services get <ns>/<name> --since 1h -o json; gcx appo11y services get <name> --metrics-mode tempo -o json`,
+			agent.AnnotationLLMHint:   `Per-service RED snapshot from Tempo/OTel span metrics: rate (req/s), error rate, error percent, p50/p95/p99 latency (seconds) over --since (default 5m), scoped to inbound spans (SERVER+CONSUMER). --metrics-mode picks the family: auto (default, probes the stack), v3 (traces_span_metrics_*, OTel Collector >= 0.109 / Alloy >= 1.5), tempo (traces_spanmetrics_*, Tempo metrics-generator — Grafana Cloud default — and Beyla), otel (bare calls_total/duration_seconds_bucket, older Collector/Alloy/Agent). Pairs with 'gcx appo11y services list' to drill into a single row. Use --filter <label><op><value> (repeatable) to scope the snapshot to a subset of series — most usefully a cluster/region label (e.g. --filter k8s_cluster_name=prod-us) to break a multi-cluster service down one cluster at a time. Examples: gcx appo11y services get <name> -o json; gcx appo11y services get <ns>/<name> --since 1h -o json; gcx appo11y services get <name> --metrics-mode tempo -o json; gcx appo11y services get <name> --filter k8s_cluster_name=<cluster> -o json`,
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -197,6 +202,10 @@ func runGet(opts *getOpts) func(*cobra.Command, []string) error {
 			return fail.NewCommandUsageError(cmd, "", err)
 		}
 		mode, auto, err := resolveMetricsMode(opts.MetricsMode)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+		matchers, err := parseFilters(opts.Filters)
 		if err != nil {
 			return fail.NewCommandUsageError(cmd, "", err)
 		}
@@ -232,7 +241,7 @@ func runGet(opts *getOpts) func(*cobra.Command, []string) error {
 		// service via its bare name silently returns no data because the
 		// `job` label is `<ns>/<name>`, not `<name>`.
 		if namespace == "" {
-			resolved, err := resolveNamespaceForBareName(ctx, client, datasourceUID, name)
+			resolved, err := resolveNamespaceForBareName(ctx, client, datasourceUID, name, matchers)
 			if err != nil {
 				return err
 			}
@@ -240,13 +249,13 @@ func runGet(opts *getOpts) func(*cobra.Command, []string) error {
 		}
 
 		if auto {
-			mode, err = detectMetricsMode(ctx, client, datasourceUID, namespace, name)
+			mode, err = detectMetricsMode(ctx, client, datasourceUID, namespace, name, matchers)
 			if err != nil {
 				return fmt.Errorf("metrics-mode auto-detect failed: %w", err)
 			}
 		}
 
-		detail, err := fetchServiceDetail(ctx, client, datasourceUID, namespace, name, opts.Since, kinds, mode)
+		detail, err := fetchServiceDetail(ctx, client, datasourceUID, namespace, name, opts.Since, kinds, mode, matchers)
 		if err != nil {
 			return err
 		}
@@ -280,14 +289,14 @@ func runGet(opts *getOpts) func(*cobra.Command, []string) error {
 //   - an error listing the candidates when multiple namespaces have a
 //     service with the requested name — ambiguity is something the user
 //     must resolve explicitly with `<ns>/<name>` or `--namespace`.
-func resolveNamespaceForBareName(ctx context.Context, client *prometheus.Client, datasourceUID, name string) (string, error) {
+func resolveNamespaceForBareName(ctx context.Context, client *prometheus.Client, datasourceUID, name string, matchers []Matcher) (string, error) {
 	metrics := targetInfoMetrics()
 	responses := make([]*prometheus.QueryResponse, len(metrics))
 
 	eg, egCtx := errgroup.WithContext(ctx)
 	for i, metric := range metrics {
 		eg.Go(func() error {
-			expr, err := buildBareNameLookupQuery(metric, name)
+			expr, err := buildBareNameLookupQuery(metric, name, matchers)
 			if err != nil {
 				return fmt.Errorf("failed to build %s lookup query: %w", metric, err)
 			}
@@ -345,7 +354,7 @@ func summarizeNamespaces(namespaces []string, limit int) string {
 // (see metricsModePreference). When no family has data — uninstrumented
 // service, stale telemetry, wrong stack — it falls back to v3 so the RED
 // snapshot still renders (just with "no traffic") instead of erroring.
-func detectMetricsMode(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name string) (MetricsMode, error) {
+func detectMetricsMode(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name string, matchers []Matcher) (MetricsMode, error) {
 	preference := metricsModePreference()
 	found := make([]bool, len(preference))
 	job := jobLabel(namespace, name)
@@ -357,7 +366,7 @@ func detectMetricsMode(ctx context.Context, client *prometheus.Client, datasourc
 			return "", fmt.Errorf("unknown metrics mode %q", m)
 		}
 		eg.Go(func() error {
-			expr, err := buildModeProbeQuery(names.calls, job)
+			expr, err := buildModeProbeQuery(names.calls, job, matchers)
 			if err != nil {
 				return fmt.Errorf("failed to build %s probe query: %w", m, err)
 			}
@@ -386,7 +395,7 @@ func detectMetricsMode(ctx context.Context, client *prometheus.Client, datasourc
 // the responses into one ServiceDetail. Latency and error queries return
 // zero with HasX=false when there's no series in the window; the table
 // codec renders those as `-`.
-func fetchServiceDetail(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, kinds []string, mode MetricsMode) (*ServiceDetail, error) {
+func fetchServiceDetail(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, kinds []string, mode MetricsMode, matchers []Matcher) (*ServiceDetail, error) {
 	names, ok := metricNamesByMode(mode)
 	if !ok {
 		return nil, fmt.Errorf("unknown metrics mode %q", mode)
@@ -399,7 +408,7 @@ func fetchServiceDetail(ctx context.Context, client *prometheus.Client, datasour
 	eg, egCtx := errgroup.WithContext(ctx)
 	for i, metric := range metrics {
 		eg.Go(func() error {
-			expr, err := buildServiceMetadataQuery(metric, namespace, name)
+			expr, err := buildServiceMetadataQuery(metric, namespace, name, matchers)
 			if err != nil {
 				return fmt.Errorf("failed to build %s metadata query: %w", metric, err)
 			}
@@ -412,7 +421,7 @@ func fetchServiceDetail(ctx context.Context, client *prometheus.Client, datasour
 		})
 	}
 	eg.Go(func() error {
-		expr, err := buildRateQuery(names, namespace, name, window, kinds)
+		expr, err := buildRateQuery(names, namespace, name, window, kinds, matchers)
 		if err != nil {
 			return fmt.Errorf("failed to build rate query: %w", err)
 		}
@@ -424,7 +433,7 @@ func fetchServiceDetail(ctx context.Context, client *prometheus.Client, datasour
 		return nil
 	})
 	eg.Go(func() error {
-		expr, err := buildErrorRateQuery(names, namespace, name, window, kinds)
+		expr, err := buildErrorRateQuery(names, namespace, name, window, kinds, matchers)
 		if err != nil {
 			return fmt.Errorf("failed to build error-rate query: %w", err)
 		}
@@ -441,7 +450,7 @@ func fetchServiceDetail(ctx context.Context, client *prometheus.Client, datasour
 		0.99: &p99Resp,
 	} {
 		eg.Go(func() error {
-			expr, err := buildLatencyQuantileQuery(names, namespace, name, window, kinds, phi)
+			expr, err := buildLatencyQuantileQuery(names, namespace, name, window, kinds, phi, matchers)
 			if err != nil {
 				return fmt.Errorf("failed to build p%.0f latency query: %w", phi*100, err)
 			}

--- a/internal/providers/appo11y/services/get.go
+++ b/internal/providers/appo11y/services/get.go
@@ -17,6 +17,7 @@ import (
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/style"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/prometheus/common/model"
 	"github.com/spf13/cobra"
@@ -37,6 +38,7 @@ type getOpts struct {
 	Kind        string
 	MetricsMode string
 	Filters     []string
+	GroupBy     []string
 }
 
 func (o *getOpts) setup(flags *pflag.FlagSet) {
@@ -51,6 +53,7 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVar(&o.Kind, "kind", "inbound", "Span kinds to include. One of: inbound (server+consumer), server, consumer, all, or a comma-separated list of SPAN_KIND_* literals")
 	flags.StringVar(&o.MetricsMode, "metrics-mode", metricsModeAuto, "Span-metrics family. One of: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket)")
 	flags.StringArrayVar(&o.Filters, "filter", nil, "Scope the RED snapshot to series matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the span metrics")
+	flags.StringSliceVar(&o.GroupBy, "group-by", nil, "Pivot the RED snapshot into one row per distinct value of a label, e.g. --group-by k8s_cluster_name (comma-separated or repeatable). Surfaces outliers across clusters/regions without naming each one; the label must exist on the span metrics")
 }
 
 func (o *getOpts) Validate(cmd *cobra.Command) error {
@@ -176,12 +179,15 @@ which family produced the numbers.`,
   gcx appo11y services get checkoutservice --metrics-mode tempo
 
   # Break a multi-cluster service down to a single cluster
-  gcx appo11y services get faro-collector --filter k8s_cluster_name=prod-us-central-0`,
+  gcx appo11y services get faro-collector --filter k8s_cluster_name=prod-us-central-0
+
+  # Compare a service's RED across all clusters to spot the outlier
+  gcx appo11y services get faro-collector --group-by k8s_cluster_name`,
 		Args: cobra.ExactArgs(1),
 		RunE: runGet(opts),
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
-			agent.AnnotationLLMHint:   `Per-service RED snapshot from Tempo/OTel span metrics: rate (req/s), error rate, error percent, p50/p95/p99 latency (seconds) over --since (default 5m), scoped to inbound spans (SERVER+CONSUMER). --metrics-mode picks the family: auto (default, probes the stack), v3 (traces_span_metrics_*, OTel Collector >= 0.109 / Alloy >= 1.5), tempo (traces_spanmetrics_*, Tempo metrics-generator — Grafana Cloud default — and Beyla), otel (bare calls_total/duration_seconds_bucket, older Collector/Alloy/Agent). Pairs with 'gcx appo11y services list' to drill into a single row. Use --filter <label><op><value> (repeatable) to scope the snapshot to a subset of series — most usefully a cluster/region label (e.g. --filter k8s_cluster_name=prod-us) to break a multi-cluster service down one cluster at a time. Examples: gcx appo11y services get <name> -o json; gcx appo11y services get <ns>/<name> --since 1h -o json; gcx appo11y services get <name> --metrics-mode tempo -o json; gcx appo11y services get <name> --filter k8s_cluster_name=<cluster> -o json`,
+			agent.AnnotationLLMHint:   `Per-service RED snapshot from Tempo/OTel span metrics: rate (req/s), error rate, error percent, p50/p95/p99 latency (seconds) over --since (default 5m), scoped to inbound spans (SERVER+CONSUMER). --metrics-mode picks the family: auto (default, probes the stack), v3 (traces_span_metrics_*, OTel Collector >= 0.109 / Alloy >= 1.5), tempo (traces_spanmetrics_*, Tempo metrics-generator — Grafana Cloud default — and Beyla), otel (bare calls_total/duration_seconds_bucket, older Collector/Alloy/Agent). Pairs with 'gcx appo11y services list' to drill into a single row. Use --filter <label><op><value> (repeatable) to scope the snapshot to a subset of series — most usefully a cluster/region label (e.g. --filter k8s_cluster_name=prod-us) to break a multi-cluster service down one cluster at a time. Use --group-by <label> to instead pivot the snapshot into one RED row per distinct value of that label (comma-separated for multiple) — the outlier-finding view: 'get <name> --group-by k8s_cluster_name -o json' returns items[] each with the group's labels and RED, so you can spot which cluster/region is slow or erroring without naming them. Examples: gcx appo11y services get <name> -o json; gcx appo11y services get <ns>/<name> --since 1h -o json; gcx appo11y services get <name> --metrics-mode tempo -o json; gcx appo11y services get <name> --filter k8s_cluster_name=<cluster> -o json; gcx appo11y services get <name> --group-by k8s_cluster_name -o json`,
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -206,6 +212,10 @@ func runGet(opts *getOpts) func(*cobra.Command, []string) error {
 			return fail.NewCommandUsageError(cmd, "", err)
 		}
 		matchers, err := parseFilters(opts.Filters)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+		groupBy, err := parseGroupBy(opts.GroupBy)
 		if err != nil {
 			return fail.NewCommandUsageError(cmd, "", err)
 		}
@@ -253,6 +263,24 @@ func runGet(opts *getOpts) func(*cobra.Command, []string) error {
 			if err != nil {
 				return fmt.Errorf("metrics-mode auto-detect failed: %w", err)
 			}
+		}
+
+		if len(groupBy) > 0 {
+			grouped, err := fetchGroupedServiceDetail(ctx, client, datasourceUID, namespace, name, opts.Since, kinds, mode, matchers, groupBy)
+			if err != nil {
+				return err
+			}
+			notFound := !anyGroupHasTraffic(grouped.Items)
+			if notFound {
+				emitNoDataHint(cmd.ErrOrStderr(), namespace, name)
+			}
+			if err := opts.IO.Encode(cmd.OutOrStdout(), grouped); err != nil {
+				return err
+			}
+			if notFound {
+				return fmt.Errorf("service %q has no telemetry in the requested window (for group-by %s)", jobLabel(namespace, name), strings.Join(groupBy, ", "))
+			}
+			return nil
 		}
 
 		detail, err := fetchServiceDetail(ctx, client, datasourceUID, namespace, name, opts.Since, kinds, mode, matchers)
@@ -421,7 +449,7 @@ func fetchServiceDetail(ctx context.Context, client *prometheus.Client, datasour
 		})
 	}
 	eg.Go(func() error {
-		expr, err := buildRateQuery(names, namespace, name, window, kinds, matchers)
+		expr, err := buildRateQuery(names, namespace, name, window, kinds, matchers, nil)
 		if err != nil {
 			return fmt.Errorf("failed to build rate query: %w", err)
 		}
@@ -433,7 +461,7 @@ func fetchServiceDetail(ctx context.Context, client *prometheus.Client, datasour
 		return nil
 	})
 	eg.Go(func() error {
-		expr, err := buildErrorRateQuery(names, namespace, name, window, kinds, matchers)
+		expr, err := buildErrorRateQuery(names, namespace, name, window, kinds, matchers, nil)
 		if err != nil {
 			return fmt.Errorf("failed to build error-rate query: %w", err)
 		}
@@ -450,7 +478,7 @@ func fetchServiceDetail(ctx context.Context, client *prometheus.Client, datasour
 		0.99: &p99Resp,
 	} {
 		eg.Go(func() error {
-			expr, err := buildLatencyQuantileQuery(names, namespace, name, window, kinds, phi, matchers)
+			expr, err := buildLatencyQuantileQuery(names, namespace, name, window, kinds, phi, matchers, nil)
 			if err != nil {
 				return fmt.Errorf("failed to build p%.0f latency query: %w", phi*100, err)
 			}
@@ -503,6 +531,116 @@ func fetchServiceDetail(ctx context.Context, client *prometheus.Client, datasour
 	}, nil
 }
 
+// fetchGroupedServiceDetail runs the metadata lookup plus the grouped
+// rate/error/latency queries in parallel and folds them into one
+// GroupedServiceDetail — a RED row per distinct --group-by combination.
+// Metadata stays service-level (language/labels identify the service, not
+// the group); only the RED numbers are pivoted per group.
+func fetchGroupedServiceDetail(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, kinds []string, mode MetricsMode, matchers []Matcher, groupBy []string) (*GroupedServiceDetail, error) {
+	names, ok := metricNamesByMode(mode)
+	if !ok {
+		return nil, fmt.Errorf("unknown metrics mode %q", mode)
+	}
+
+	metrics := targetInfoMetrics()
+	metadataResponses := make([]*prometheus.QueryResponse, len(metrics))
+	var rateResp, errorResp, p50Resp, p95Resp, p99Resp *prometheus.QueryResponse
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	for i, metric := range metrics {
+		eg.Go(func() error {
+			expr, err := buildServiceMetadataQuery(metric, namespace, name, matchers)
+			if err != nil {
+				return fmt.Errorf("failed to build %s metadata query: %w", metric, err)
+			}
+			resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+			if err != nil {
+				return fmt.Errorf("%s metadata query failed: %w", metric, err)
+			}
+			metadataResponses[i] = resp
+			return nil
+		})
+	}
+	eg.Go(func() error {
+		expr, err := buildRateQuery(names, namespace, name, window, kinds, matchers, groupBy)
+		if err != nil {
+			return fmt.Errorf("failed to build rate query: %w", err)
+		}
+		resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+		if err != nil {
+			return fmt.Errorf("rate query failed: %w", err)
+		}
+		rateResp = resp
+		return nil
+	})
+	eg.Go(func() error {
+		expr, err := buildErrorRateQuery(names, namespace, name, window, kinds, matchers, groupBy)
+		if err != nil {
+			return fmt.Errorf("failed to build error-rate query: %w", err)
+		}
+		resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+		if err != nil {
+			return fmt.Errorf("error-rate query failed: %w", err)
+		}
+		errorResp = resp
+		return nil
+	})
+	for phi, sink := range map[float64]**prometheus.QueryResponse{
+		0.50: &p50Resp,
+		0.95: &p95Resp,
+		0.99: &p99Resp,
+	} {
+		eg.Go(func() error {
+			expr, err := buildLatencyQuantileQuery(names, namespace, name, window, kinds, phi, matchers, groupBy)
+			if err != nil {
+				return fmt.Errorf("failed to build p%.0f latency query: %w", phi*100, err)
+			}
+			resp, err := client.Query(egCtx, datasourceUID, prometheus.QueryRequest{Query: expr})
+			if err != nil {
+				return fmt.Errorf("p%.0f latency query failed: %w", phi*100, err)
+			}
+			*sink = resp
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	metadata, err := parseServicesResponses(metadataResponses)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse metadata response: %w", err)
+	}
+	svc := selectMetadataService(metadata, namespace, name)
+
+	items := mergeGroupedRED(
+		window, mode, kinds, groupBy,
+		extractGrouped(rateResp, groupBy),
+		extractGrouped(errorResp, groupBy),
+		extractGrouped(p50Resp, groupBy),
+		extractGrouped(p95Resp, groupBy),
+		extractGrouped(p99Resp, groupBy),
+	)
+
+	return &GroupedServiceDetail{
+		Service: svc,
+		GroupBy: groupBy,
+		Window:  window,
+		Items:   items,
+	}, nil
+}
+
+// anyGroupHasTraffic reports whether at least one grouped RED row saw
+// traffic in the window — used to decide the not-found exit code.
+func anyGroupHasTraffic(items []GroupedRED) bool {
+	for _, it := range items {
+		if it.RED.HasTraffic {
+			return true
+		}
+	}
+	return false
+}
+
 // selectMetadataService picks the best metadata match from a list returned
 // by the filtered target_info query. The filter is already narrow (job
 // matches exactly), so 0 or 1 results are expected; on >1 we prefer an exact
@@ -553,6 +691,9 @@ func (c *serviceDetailCodec) Decode(io.Reader, any) error {
 }
 
 func (c *serviceDetailCodec) Encode(w io.Writer, v any) error {
+	if grouped, ok := v.(*GroupedServiceDetail); ok {
+		return c.encodeGrouped(w, grouped)
+	}
 	detail, ok := v.(*ServiceDetail)
 	if !ok {
 		return fmt.Errorf("invalid data type for services get table codec: %T", v)
@@ -609,6 +750,60 @@ func (c *serviceDetailCodec) Encode(w io.Writer, v any) error {
 	fmt.Fprintf(tw, "  p99:\t%s\n", formatDuration(r.P99Seconds, r.HasLatencyP99))
 
 	return tw.Flush()
+}
+
+// encodeGrouped renders a --group-by result: a one-line service header
+// followed by a table with a column per group label and the RED columns.
+// Rows are already sorted (rate desc) by mergeGroupedRED so the busiest /
+// outlier groups sit at the top. Wide adds the absolute error rate and
+// p50/p99.
+func (c *serviceDetailCodec) encodeGrouped(w io.Writer, g *GroupedServiceDetail) error {
+	if len(g.Items) == 0 {
+		_, err := fmt.Fprintf(w, "No telemetry found for %q grouped by %s in the requested window.\n",
+			jobLabel(g.Service.Namespace, g.Service.Name), strings.Join(g.GroupBy, ", "))
+		return err
+	}
+
+	groupHeaders := make([]string, len(g.GroupBy))
+	for i, l := range g.GroupBy {
+		groupHeaders[i] = strings.ToUpper(l)
+	}
+
+	var headers []string
+	headers = append(headers, groupHeaders...)
+	if c.Wide {
+		headers = append(headers, "RATE", "ERRORS", "ERROR %", "P50", "P95", "P99")
+	} else {
+		headers = append(headers, "RATE", "ERROR %", "P95")
+	}
+
+	t := style.NewTable(headers...)
+	for i := range g.Items {
+		item := &g.Items[i]
+		row := make([]string, 0, len(headers))
+		for _, l := range g.GroupBy {
+			row = append(row, orDash(item.Labels[l]))
+		}
+		r := &item.RED
+		if c.Wide {
+			row = append(row,
+				formatRateWithUnit(r.RatePerSecond, r.HasTraffic),
+				formatRateWithUnit(r.ErrorRatePerSec, r.HasErrors),
+				formatPercentMaybe(r.ErrorPercent, r.HasTraffic),
+				formatDuration(r.P50Seconds, r.HasLatencyP50),
+				formatDuration(r.P95Seconds, r.HasLatencyP95),
+				formatDuration(r.P99Seconds, r.HasLatencyP99),
+			)
+		} else {
+			row = append(row,
+				formatRateWithUnit(r.RatePerSecond, r.HasTraffic),
+				formatPercentMaybe(r.ErrorPercent, r.HasTraffic),
+				formatDuration(r.P95Seconds, r.HasLatencyP95),
+			)
+		}
+		t.Row(row...)
+	}
+	return t.Render(w)
 }
 
 func formatRateWithUnit(v float64, has bool) string {

--- a/internal/providers/appo11y/services/get_test.go
+++ b/internal/providers/appo11y/services/get_test.go
@@ -129,7 +129,7 @@ func TestBuildServiceMetadataQuery(t *testing.T) {
 
 func TestBuildRateQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer, spanKindConsumer}, nil)
+	got, err := buildRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer, spanKindConsumer}, nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -140,7 +140,7 @@ func TestBuildRateQuery(t *testing.T) {
 
 	// Tempo (legacy) mode swaps to traces_spanmetrics_* without changing the job/kind filters.
 	tempo, _ := metricNamesByMode(MetricsModeTempo)
-	got, err = buildRateQuery(tempo, "", "auth", "1m", []string{spanKindServer}, nil)
+	got, err = buildRateQuery(tempo, "", "auth", "1m", []string{spanKindServer}, nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -149,14 +149,14 @@ func TestBuildRateQuery(t *testing.T) {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
 
-	if _, err := buildRateQuery(v3, "", "", "5m", nil, nil); err == nil {
+	if _, err := buildRateQuery(v3, "", "", "5m", nil, nil, nil); err == nil {
 		t.Error("expected error for empty service name")
 	}
 }
 
 func TestBuildErrorRateQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildErrorRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, nil)
+	got, err := buildErrorRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -168,7 +168,7 @@ func TestBuildErrorRateQuery(t *testing.T) {
 
 func TestBuildLatencyQuantileQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, nil)
+	got, err := buildLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -179,7 +179,7 @@ func TestBuildLatencyQuantileQuery(t *testing.T) {
 
 	// OTel mode uses the bare names (no traces_ prefix).
 	otel, _ := metricNamesByMode(MetricsModeOTel)
-	got, err = buildLatencyQuantileQuery(otel, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, nil)
+	got, err = buildLatencyQuantileQuery(otel, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -188,7 +188,7 @@ func TestBuildLatencyQuantileQuery(t *testing.T) {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
 
-	if _, err := buildLatencyQuantileQuery(v3, "", "x", "5m", nil, 1.5, nil); err == nil {
+	if _, err := buildLatencyQuantileQuery(v3, "", "x", "5m", nil, 1.5, nil, nil); err == nil {
 		t.Error("expected error for phi out of range")
 	}
 }

--- a/internal/providers/appo11y/services/get_test.go
+++ b/internal/providers/appo11y/services/get_test.go
@@ -111,7 +111,7 @@ func TestBuildServiceMetadataQuery(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildServiceMetadataQuery(tt.metric, tt.ns, tt.svc)
+			got, err := buildServiceMetadataQuery(tt.metric, tt.ns, tt.svc, nil)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -129,7 +129,7 @@ func TestBuildServiceMetadataQuery(t *testing.T) {
 
 func TestBuildRateQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer, spanKindConsumer})
+	got, err := buildRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer, spanKindConsumer}, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -140,7 +140,7 @@ func TestBuildRateQuery(t *testing.T) {
 
 	// Tempo (legacy) mode swaps to traces_spanmetrics_* without changing the job/kind filters.
 	tempo, _ := metricNamesByMode(MetricsModeTempo)
-	got, err = buildRateQuery(tempo, "", "auth", "1m", []string{spanKindServer})
+	got, err = buildRateQuery(tempo, "", "auth", "1m", []string{spanKindServer}, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -149,14 +149,14 @@ func TestBuildRateQuery(t *testing.T) {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
 
-	if _, err := buildRateQuery(v3, "", "", "5m", nil); err == nil {
+	if _, err := buildRateQuery(v3, "", "", "5m", nil, nil); err == nil {
 		t.Error("expected error for empty service name")
 	}
 }
 
 func TestBuildErrorRateQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildErrorRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer})
+	got, err := buildErrorRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -168,7 +168,7 @@ func TestBuildErrorRateQuery(t *testing.T) {
 
 func TestBuildLatencyQuantileQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95)
+	got, err := buildLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -179,7 +179,7 @@ func TestBuildLatencyQuantileQuery(t *testing.T) {
 
 	// OTel mode uses the bare names (no traces_ prefix).
 	otel, _ := metricNamesByMode(MetricsModeOTel)
-	got, err = buildLatencyQuantileQuery(otel, "billing", "checkout", "5m", []string{spanKindServer}, 0.95)
+	got, err = buildLatencyQuantileQuery(otel, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -188,7 +188,7 @@ func TestBuildLatencyQuantileQuery(t *testing.T) {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
 
-	if _, err := buildLatencyQuantileQuery(v3, "", "x", "5m", nil, 1.5); err == nil {
+	if _, err := buildLatencyQuantileQuery(v3, "", "x", "5m", nil, 1.5, nil); err == nil {
 		t.Error("expected error for phi out of range")
 	}
 }
@@ -232,7 +232,7 @@ func TestResolveMetricsMode(t *testing.T) {
 }
 
 func TestBuildBareNameLookupQuery(t *testing.T) {
-	got, err := buildBareNameLookupQuery("target_info", "checkoutservice")
+	got, err := buildBareNameLookupQuery("target_info", "checkoutservice", nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -243,7 +243,7 @@ func TestBuildBareNameLookupQuery(t *testing.T) {
 
 	// Regex metachars in the name are escaped so a service named "v1.api"
 	// doesn't accidentally match "v1Xapi" via the literal `.`.
-	got, err = buildBareNameLookupQuery("traces_target_info", "v1.api")
+	got, err = buildBareNameLookupQuery("traces_target_info", "v1.api", nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -252,7 +252,7 @@ func TestBuildBareNameLookupQuery(t *testing.T) {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
 
-	if _, err := buildBareNameLookupQuery("target_info", ""); err == nil {
+	if _, err := buildBareNameLookupQuery("target_info", "", nil); err == nil {
 		t.Error("expected error for empty name")
 	}
 }
@@ -324,7 +324,7 @@ func TestNamespacesForName(t *testing.T) {
 }
 
 func TestBuildModeProbeQuery(t *testing.T) {
-	got, err := buildModeProbeQuery("traces_span_metrics_calls_total", "billing/checkout")
+	got, err := buildModeProbeQuery("traces_span_metrics_calls_total", "billing/checkout", nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -333,10 +333,10 @@ func TestBuildModeProbeQuery(t *testing.T) {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
 
-	if _, err := buildModeProbeQuery("", "x"); err == nil {
+	if _, err := buildModeProbeQuery("", "x", nil); err == nil {
 		t.Error("expected error for empty metric")
 	}
-	if _, err := buildModeProbeQuery("metric", ""); err == nil {
+	if _, err := buildModeProbeQuery("metric", "", nil); err == nil {
 		t.Error("expected error for empty job")
 	}
 }

--- a/internal/providers/appo11y/services/labels.go
+++ b/internal/providers/appo11y/services/labels.go
@@ -1,0 +1,324 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/agent"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/prometheus/common/model"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// labelsDefaultWindow is wider than the RED default (5m): label discovery
+// wants to catch every value that appeared recently, not just the current
+// instant, so a value that only shows up intermittently still surfaces.
+const labelsDefaultWindow = "1h"
+
+// labelsSampleSize caps how many values the default (all-labels) view
+// prints per label; the full count is still reported so users know when
+// there's more. Drill into one label with --label to see them all.
+const labelsSampleSize = 5
+
+type labelsOpts struct {
+	IO          cmdio.Options
+	Datasource  string
+	Since       string
+	Namespace   string
+	MetricsMode string
+	Label       string
+	Filters     []string
+}
+
+func (o *labelsOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &labelsTableCodec{opts: o})
+	o.IO.RegisterCustomCodec("wide", &labelsTableCodec{opts: o, Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+
+	flags.StringVarP(&o.Datasource, "datasource", "d", "", "Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)")
+	flags.StringVarP(&o.Namespace, "namespace", "n", "", "Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)")
+	flags.StringVar(&o.Since, "since", labelsDefaultWindow, "Lookback window for series discovery (e.g. 15m, 1h, 1d) — PromQL duration syntax")
+	flags.StringVar(&o.MetricsMode, "metrics-mode", metricsModeAuto, "Span-metrics family whose labels to inspect. One of: auto (probes the stack), v3, tempo, or otel")
+	flags.StringVar(&o.Label, "label", "", "Show the distinct values of a single label instead of the label summary (e.g. --label k8s_cluster_name)")
+	flags.StringArrayVar(&o.Filters, "filter", nil, "Restrict discovery to series matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable)")
+}
+
+func (o *labelsOpts) Validate(cmd *cobra.Command) error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(o.Since) == "" {
+		return fail.NewCommandUsageError(cmd, "--since must not be empty", nil)
+	}
+	if _, err := model.ParseDuration(o.Since); err != nil {
+		return fail.NewCommandUsageError(cmd, fmt.Sprintf("--since %q is not a valid PromQL duration", o.Since), err)
+	}
+	if _, _, err := resolveMetricsMode(o.MetricsMode); err != nil {
+		return fail.NewCommandUsageError(cmd, "", err)
+	}
+	return nil
+}
+
+func newLabelsCommand() *cobra.Command {
+	opts := &labelsOpts{}
+	cmd := &cobra.Command{
+		Use:   "labels <service> [--namespace ns]",
+		Short: "Discover the labels (and values) available to --filter and --group-by for a service.",
+		Long: `List the labels present on a service's span-metric series — the exact set
+that "gcx appo11y services get/list-operations --filter/--group-by" can
+operate on — with each label's distinct-value count.
+
+This answers "what can I break this service down by?" without guessing.
+Pass --label <name> to list the distinct values of a single label so you
+know what to feed --filter (e.g. --filter k8s_cluster_name=<value>).
+
+Labels come from the span-metric calls series (auto-detected metrics-mode),
+which is what the RED commands filter and group on. Note:
+
+  - "services map" groups on the Tempo service-graph metric family, whose
+    labels may differ (and often omit cluster labels).
+  - "services get <svc> -o json" additionally surfaces the target_info
+    resource attributes under .service.labels.`,
+		Example: `
+  # What can I filter/group checkoutservice by?
+  gcx appo11y services labels checkoutservice
+
+  # Which clusters does it run in? (values to feed --filter/--group-by)
+  gcx appo11y services labels checkoutservice --label k8s_cluster_name
+
+  # JSON for scripting
+  gcx appo11y services labels checkoutservice -o json`,
+		Args: cobra.ExactArgs(1),
+		RunE: runLabels(opts),
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "small",
+			agent.AnnotationLLMHint:   `Discovery helper for 'gcx appo11y services' --filter/--group-by: lists the labels present on a service's span-metric series with each label's distinct-value count (cardinality). Use before --filter/--group-by to learn what dimensions exist. --label <name> lists that label's distinct values (the valid --filter values). Sourced from the span-metric calls series (what get/list-operations filter and group on); map uses the service-graph family whose labels may differ. Examples: gcx appo11y services labels <name> -o json; gcx appo11y services labels <name> --label k8s_cluster_name -o json`,
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func runLabels(opts *labelsOpts) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := opts.Validate(cmd); err != nil {
+			return err
+		}
+		namespace, name, err := parseServiceArg(args[0], opts.Namespace)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+		mode, auto, err := resolveMetricsMode(opts.MetricsMode)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+		matchers, err := parseFilters(opts.Filters)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+		window, err := model.ParseDuration(opts.Since)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, fmt.Sprintf("--since %q is not a valid PromQL duration", opts.Since), err)
+		}
+
+		ctx := cmd.Context()
+		var loader providers.ConfigLoader
+
+		cfg, err := loader.LoadGrafanaConfig(ctx)
+		if err != nil {
+			return err
+		}
+
+		var cfgCtx *internalconfig.Context
+		if fullCfg, err := loader.LoadFullConfig(ctx); err != nil {
+			logging.FromContext(ctx).Warn("could not load config; falling back to auto-discovery", slog.String("error", err.Error()))
+		} else {
+			cfgCtx = fullCfg.GetCurrentContext()
+		}
+
+		datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, &loader, opts.Datasource, cfgCtx, cfg, "prometheus")
+		if err != nil {
+			return err
+		}
+
+		client, err := prometheus.NewClient(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create prometheus client: %w", err)
+		}
+
+		// Bare-name resolution: same UX as `services get`.
+		if namespace == "" {
+			resolved, err := resolveNamespaceForBareName(ctx, client, datasourceUID, name, matchers)
+			if err != nil {
+				return err
+			}
+			namespace = resolved
+		}
+
+		if auto {
+			mode, err = detectMetricsMode(ctx, client, datasourceUID, namespace, name, matchers)
+			if err != nil {
+				return fmt.Errorf("metrics-mode auto-detect failed: %w", err)
+			}
+		}
+		names, ok := metricNamesByMode(mode)
+		if !ok {
+			return fmt.Errorf("unknown metrics mode %q", mode)
+		}
+
+		response, err := fetchServiceLabels(ctx, client, datasourceUID, names.calls, namespace, name, opts.Since, time.Duration(window), matchers)
+		if err != nil {
+			return err
+		}
+
+		// --label: keep only the requested label (full value set).
+		if opts.Label != "" {
+			response.Items = filterToLabel(response.Items, opts.Label)
+		}
+
+		notFound := len(response.Items) == 0
+		if notFound {
+			emitLabelsNoDataHint(cmd.ErrOrStderr(), namespace, name, opts.Label)
+		}
+		if err := opts.IO.Encode(cmd.OutOrStdout(), response); err != nil {
+			return err
+		}
+		if notFound {
+			if opts.Label != "" {
+				return fmt.Errorf("label %q not found on %q in the requested window", opts.Label, jobLabel(namespace, name))
+			}
+			return fmt.Errorf("no labels found for %q in the requested window", jobLabel(namespace, name))
+		}
+		return nil
+	}
+}
+
+// fetchServiceLabels runs a /series query for the service's calls metric
+// and folds the result into a ServiceLabelsResponse. sampleN caps the
+// per-label value sample in the summary view; the drill-down (--label)
+// re-reads the full set from the same response.
+func fetchServiceLabels(ctx context.Context, client *prometheus.Client, datasourceUID, metric, namespace, name, windowStr string, window time.Duration, matchers []Matcher) (*ServiceLabelsResponse, error) {
+	selector := buildSeriesSelector(metric, jobLabel(namespace, name), matchers)
+	end := time.Now()
+	start := end.Add(-window)
+
+	resp, err := client.Series(ctx, datasourceUID, []string{selector}, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("series query failed: %w", err)
+	}
+
+	index := collectSeriesLabels(resp.Data)
+	return &ServiceLabelsResponse{
+		Service: Service{Name: name, Namespace: namespace},
+		Metric:  metric,
+		Window:  windowStr,
+		Items:   summarizeLabels(index, labelsSampleSize),
+	}, nil
+}
+
+// filterToLabel narrows a summary to the single requested label and drops
+// the sample cap so all its values render. Returns an empty slice when the
+// label isn't present (caller treats that as not-found).
+func filterToLabel(items []LabelSummary, label string) []LabelSummary {
+	for _, it := range items {
+		if it.Name == label {
+			return []LabelSummary{it}
+		}
+	}
+	return nil
+}
+
+func emitLabelsNoDataHint(stderr io.Writer, namespace, name, label string) {
+	svc := name
+	if namespace != "" {
+		svc = namespace + "/" + name
+	}
+	if label != "" {
+		cmdio.EmitHint(stderr,
+			fmt.Sprintf("label %q not found on %q", label, svc),
+			"gcx appo11y services labels "+svc)
+		return
+	}
+	cmdio.EmitHint(stderr,
+		fmt.Sprintf("no span-metric series found for %q in the window", svc),
+		"gcx appo11y services list")
+}
+
+// labelsTableCodec renders either the label summary (LABEL / CARDINALITY /
+// SAMPLE VALUES) or, when --label is set, a single-column value list.
+type labelsTableCodec struct {
+	opts *labelsOpts
+	Wide bool
+}
+
+func (c *labelsTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *labelsTableCodec) Decode(io.Reader, any) error {
+	return errors.New("services labels table codec does not support decoding")
+}
+
+func (c *labelsTableCodec) Encode(w io.Writer, v any) error {
+	resp, ok := v.(*ServiceLabelsResponse)
+	if !ok {
+		return fmt.Errorf("invalid data type for services labels table codec: %T", v)
+	}
+
+	// --label drill-down: one column of values for the requested label.
+	if c.opts != nil && c.opts.Label != "" {
+		if len(resp.Items) == 0 {
+			_, err := fmt.Fprintf(w, "Label %q not found on %q in the requested window.\n", c.opts.Label, jobLabel(resp.Service.Namespace, resp.Service.Name))
+			return err
+		}
+		t := style.NewTable(strings.ToUpper(c.opts.Label))
+		for _, v := range resp.Items[0].Values {
+			t.Row(v)
+		}
+		return t.Render(w)
+	}
+
+	if len(resp.Items) == 0 {
+		_, err := fmt.Fprintf(w, "No labels found for %q in the requested window. Verify the service emits span metrics.\n", jobLabel(resp.Service.Namespace, resp.Service.Name))
+		return err
+	}
+
+	t := style.NewTable("LABEL", "CARDINALITY", "SAMPLE VALUES")
+	for _, it := range resp.Items {
+		t.Row(it.Name, strconv.Itoa(it.Cardinality), sampleValues(it))
+	}
+	return t.Render(w)
+}
+
+// sampleValues renders the sample column: the carried values joined, with
+// a trailing "… (+N more)" when the label has more distinct values than
+// the sample holds.
+func sampleValues(it LabelSummary) string {
+	if len(it.Values) == 0 {
+		return "-"
+	}
+	joined := strings.Join(it.Values, ", ")
+	if it.Cardinality > len(it.Values) {
+		joined += fmt.Sprintf(", … (+%d more)", it.Cardinality-len(it.Values))
+	}
+	return joined
+}

--- a/internal/providers/appo11y/services/labels_test.go
+++ b/internal/providers/appo11y/services/labels_test.go
@@ -1,0 +1,81 @@
+package services //nolint:testpackage // Tests cover unexported helpers and the table codec.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestFilterToLabel(t *testing.T) {
+	items := []LabelSummary{
+		{Name: "k8s_cluster_name", Cardinality: 2, Values: []string{"east", "west"}},
+		{Name: "span_name", Cardinality: 5, Values: []string{"a"}},
+	}
+	got := filterToLabel(items, "k8s_cluster_name")
+	if len(got) != 1 || got[0].Name != "k8s_cluster_name" || len(got[0].Values) != 2 {
+		t.Fatalf("filterToLabel wrong: %+v", got)
+	}
+	if got := filterToLabel(items, "nope"); got != nil {
+		t.Errorf("missing label should return nil, got %+v", got)
+	}
+}
+
+func TestSampleValues(t *testing.T) {
+	// No values → dash.
+	if got := sampleValues(LabelSummary{Name: "x"}); got != "-" {
+		t.Errorf("empty = %q, want -", got)
+	}
+	// All values present → plain join, no "more".
+	if got := sampleValues(LabelSummary{Cardinality: 2, Values: []string{"a", "b"}}); got != "a, b" {
+		t.Errorf("got %q, want 'a, b'", got)
+	}
+	// Sample smaller than cardinality → "+N more".
+	got := sampleValues(LabelSummary{Cardinality: 5, Values: []string{"a", "b"}})
+	if !strings.Contains(got, "a, b") || !strings.Contains(got, "+3 more") {
+		t.Errorf("got %q, want a,b + '+3 more'", got)
+	}
+}
+
+func TestLabelsTableCodec_Summary(t *testing.T) {
+	resp := &ServiceLabelsResponse{
+		Service: Service{Name: "checkout", Namespace: "billing"},
+		Metric:  "traces_span_metrics_calls_total",
+		Window:  "1h",
+		Items: []LabelSummary{
+			{Name: "k8s_cluster_name", Cardinality: 3, Values: []string{"a", "b"}},
+		},
+	}
+	var buf bytes.Buffer
+	c := &labelsTableCodec{opts: &labelsOpts{}}
+	if err := c.Encode(&buf, resp); err != nil {
+		t.Fatalf("encode err = %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"LABEL", "CARDINALITY", "SAMPLE VALUES", "k8s_cluster_name", "+1 more"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestLabelsTableCodec_LabelDrilldown(t *testing.T) {
+	resp := &ServiceLabelsResponse{
+		Service: Service{Name: "checkout", Namespace: "billing"},
+		Items: []LabelSummary{
+			{Name: "k8s_cluster_name", Cardinality: 2, Values: []string{"east", "west"}},
+		},
+	}
+	var buf bytes.Buffer
+	c := &labelsTableCodec{opts: &labelsOpts{Label: "k8s_cluster_name"}}
+	if err := c.Encode(&buf, resp); err != nil {
+		t.Fatalf("encode err = %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "east") || !strings.Contains(out, "west") {
+		t.Errorf("drill-down missing values:\n%s", out)
+	}
+	// Summary-only headers must NOT appear in the value list.
+	if strings.Contains(out, "CARDINALITY") {
+		t.Errorf("drill-down should not show CARDINALITY header:\n%s", out)
+	}
+}

--- a/internal/providers/appo11y/services/map.go
+++ b/internal/providers/appo11y/services/map.go
@@ -30,6 +30,7 @@ type mapOpts struct {
 	Datasource string
 	Since      string
 	Namespace  string
+	Filters    []string
 }
 
 func (o *mapOpts) setup(flags *pflag.FlagSet) {
@@ -43,6 +44,7 @@ func (o *mapOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.Datasource, "datasource", "d", "", "Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)")
 	flags.StringVarP(&o.Namespace, "namespace", "n", "", "Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)")
 	flags.StringVar(&o.Since, "since", defaultRedWindow, "Rate/quantile window applied to service-graph metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax")
+	flags.StringArrayVar(&o.Filters, "filter", nil, "Scope the map to service-graph edges matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the service-graph metrics")
 }
 
 func (o *mapOpts) Validate(cmd *cobra.Command) error {
@@ -99,12 +101,15 @@ suitable for inlining in markdown / piping to "dot -Tpng".`,
   gcx appo11y services map payments/checkoutservice --since 1h -o wide
 
   # JSON for scripting
-  gcx appo11y services map checkoutservice -o json`,
+  gcx appo11y services map checkoutservice -o json
+
+  # Break a multi-cluster service's map down to a single cluster
+  gcx appo11y services map faro-collector --filter k8s_cluster_name=prod-us-central-0`,
 		Args: cobra.ExactArgs(1),
 		RunE: runMap(opts),
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
-			agent.AnnotationLLMHint:   `Service-graph slice for one App Observability service: callers (peers calling into the service) and callees (peers the service calls), with per-edge rate (req/s), error %, and direction-aware p95 latency (server-side for callers, client-side for callees). Connection-type label distinguishes HTTP/gRPC (empty), database, messaging, and virtual_node (uninstrumented upstreams synthesised by Tempo). Output formats: table/wide (default two-section view), json/yaml (structured), mermaid (markdown-renderable graph), dot (Graphviz). Pairs with 'gcx appo11y services get' (single-service RED) and 'gcx appo11y services list-operations' (per-endpoint breakdown). Examples: gcx appo11y services map <name> -o json; gcx appo11y services map <ns>/<name> --since 1h -o mermaid`,
+			agent.AnnotationLLMHint:   `Service-graph slice for one App Observability service: callers (peers calling into the service) and callees (peers the service calls), with per-edge rate (req/s), error %, and direction-aware p95 latency (server-side for callers, client-side for callees). Connection-type label distinguishes HTTP/gRPC (empty), database, messaging, and virtual_node (uninstrumented upstreams synthesised by Tempo). Output formats: table/wide (default two-section view), json/yaml (structured), mermaid (markdown-renderable graph), dot (Graphviz). Pairs with 'gcx appo11y services get' (single-service RED) and 'gcx appo11y services list-operations' (per-endpoint breakdown). Use --filter <label><op><value> (repeatable) to scope the edges to a subset of series — most usefully a cluster/region label (e.g. --filter k8s_cluster_name=prod-us) to break a multi-cluster service down one cluster at a time. Examples: gcx appo11y services map <name> -o json; gcx appo11y services map <ns>/<name> --since 1h -o mermaid; gcx appo11y services map <name> --filter k8s_cluster_name=<cluster> -o json`,
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -117,6 +122,10 @@ func runMap(opts *mapOpts) func(*cobra.Command, []string) error {
 			return err
 		}
 		namespace, name, err := parseServiceArg(args[0], opts.Namespace)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+		matchers, err := parseFilters(opts.Filters)
 		if err != nil {
 			return fail.NewCommandUsageError(cmd, "", err)
 		}
@@ -148,14 +157,14 @@ func runMap(opts *mapOpts) func(*cobra.Command, []string) error {
 
 		// Bare-name resolution: same UX as `services get` and `services list-operations`.
 		if namespace == "" {
-			resolved, err := resolveNamespaceForBareName(ctx, client, datasourceUID, name)
+			resolved, err := resolveNamespaceForBareName(ctx, client, datasourceUID, name, matchers)
 			if err != nil {
 				return err
 			}
 			namespace = resolved
 		}
 
-		result, err := fetchServiceMap(ctx, client, datasourceUID, namespace, name, opts.Since)
+		result, err := fetchServiceMap(ctx, client, datasourceUID, namespace, name, opts.Since, matchers)
 		if err != nil {
 			return err
 		}
@@ -177,7 +186,7 @@ func runMap(opts *mapOpts) func(*cobra.Command, []string) error {
 // fetchServiceMap runs both direction × {rate, errors, p95} = 6 queries
 // in parallel and folds them into a ServiceMap. Each direction's edges
 // are independently parsed and merged, then sorted by rate desc.
-func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string) (*ServiceMap, error) {
+func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, matchers []Matcher) (*ServiceMap, error) {
 	type edgeQuerySet struct {
 		rate, errors, p95 *prometheus.QueryResponse
 	}
@@ -194,7 +203,7 @@ func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceU
 	eg, egCtx := errgroup.WithContext(ctx)
 	for _, d := range directions {
 		eg.Go(func() error {
-			expr, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, d.dir, namespace, name, window)
+			expr, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, d.dir, namespace, name, window, matchers)
 			if err != nil {
 				return fmt.Errorf("failed to build %s rate query: %w", directionLabel(d.dir), err)
 			}
@@ -206,7 +215,7 @@ func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceU
 			return nil
 		})
 		eg.Go(func() error {
-			expr, err := buildServiceMapEdgeQuery(serviceGraphRequestFailedTotalMetric, d.dir, namespace, name, window)
+			expr, err := buildServiceMapEdgeQuery(serviceGraphRequestFailedTotalMetric, d.dir, namespace, name, window, matchers)
 			if err != nil {
 				return fmt.Errorf("failed to build %s error-rate query: %w", directionLabel(d.dir), err)
 			}
@@ -218,7 +227,7 @@ func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceU
 			return nil
 		})
 		eg.Go(func() error {
-			expr, err := buildServiceMapLatencyQuery(d.dir, namespace, name, window, 0.95)
+			expr, err := buildServiceMapLatencyQuery(d.dir, namespace, name, window, 0.95, matchers)
 			if err != nil {
 				return fmt.Errorf("failed to build %s p95 latency query: %w", directionLabel(d.dir), err)
 			}

--- a/internal/providers/appo11y/services/map.go
+++ b/internal/providers/appo11y/services/map.go
@@ -31,6 +31,7 @@ type mapOpts struct {
 	Since      string
 	Namespace  string
 	Filters    []string
+	GroupBy    []string
 }
 
 func (o *mapOpts) setup(flags *pflag.FlagSet) {
@@ -45,6 +46,7 @@ func (o *mapOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.Namespace, "namespace", "n", "", "Service namespace (only needed when the argument is the bare service name and multiple namespaces are in play)")
 	flags.StringVar(&o.Since, "since", defaultRedWindow, "Rate/quantile window applied to service-graph metrics (e.g. 1m, 5m, 1h, 1d) — PromQL duration syntax")
 	flags.StringArrayVar(&o.Filters, "filter", nil, "Scope the map to service-graph edges matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the service-graph metrics")
+	flags.StringSliceVar(&o.GroupBy, "group-by", nil, "Split each edge per distinct value of a label, e.g. --group-by k8s_cluster_name (comma-separated or repeatable). The label must exist on the service-graph metrics — note the Tempo service-graph family often omits cluster labels, in which case no edges match")
 }
 
 func (o *mapOpts) Validate(cmd *cobra.Command) error {
@@ -104,12 +106,15 @@ suitable for inlining in markdown / piping to "dot -Tpng".`,
   gcx appo11y services map checkoutservice -o json
 
   # Break a multi-cluster service's map down to a single cluster
-  gcx appo11y services map faro-collector --filter k8s_cluster_name=prod-us-central-0`,
+  gcx appo11y services map faro-collector --filter k8s_cluster_name=prod-us-central-0
+
+  # Split each edge per cluster (service-graph metrics must carry the label)
+  gcx appo11y services map faro-collector --group-by k8s_cluster_name`,
 		Args: cobra.ExactArgs(1),
 		RunE: runMap(opts),
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
-			agent.AnnotationLLMHint:   `Service-graph slice for one App Observability service: callers (peers calling into the service) and callees (peers the service calls), with per-edge rate (req/s), error %, and direction-aware p95 latency (server-side for callers, client-side for callees). Connection-type label distinguishes HTTP/gRPC (empty), database, messaging, and virtual_node (uninstrumented upstreams synthesised by Tempo). Output formats: table/wide (default two-section view), json/yaml (structured), mermaid (markdown-renderable graph), dot (Graphviz). Pairs with 'gcx appo11y services get' (single-service RED) and 'gcx appo11y services list-operations' (per-endpoint breakdown). Use --filter <label><op><value> (repeatable) to scope the edges to a subset of series — most usefully a cluster/region label (e.g. --filter k8s_cluster_name=prod-us) to break a multi-cluster service down one cluster at a time. Examples: gcx appo11y services map <name> -o json; gcx appo11y services map <ns>/<name> --since 1h -o mermaid; gcx appo11y services map <name> --filter k8s_cluster_name=<cluster> -o json`,
+			agent.AnnotationLLMHint:   `Service-graph slice for one App Observability service: callers (peers calling into the service) and callees (peers the service calls), with per-edge rate (req/s), error %, and direction-aware p95 latency (server-side for callers, client-side for callees). Connection-type label distinguishes HTTP/gRPC (empty), database, messaging, and virtual_node (uninstrumented upstreams synthesised by Tempo). Output formats: table/wide (default two-section view), json/yaml (structured), mermaid (markdown-renderable graph), dot (Graphviz). Pairs with 'gcx appo11y services get' (single-service RED) and 'gcx appo11y services list-operations' (per-endpoint breakdown). Use --filter <label><op><value> (repeatable) to scope the edges to a subset of series — most usefully a cluster/region label (e.g. --filter k8s_cluster_name=prod-us) to break a multi-cluster service down one cluster at a time. Use --group-by <label> to instead split each edge per distinct value of that label (note: the Tempo service-graph family often omits cluster labels, so this may return no edges — --filter/--group-by on span-metric-backed 'get'/'list-operations' is more reliable for cluster breakdowns). Examples: gcx appo11y services map <name> -o json; gcx appo11y services map <ns>/<name> --since 1h -o mermaid; gcx appo11y services map <name> --filter k8s_cluster_name=<cluster> -o json`,
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -126,6 +131,10 @@ func runMap(opts *mapOpts) func(*cobra.Command, []string) error {
 			return fail.NewCommandUsageError(cmd, "", err)
 		}
 		matchers, err := parseFilters(opts.Filters)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+		groupBy, err := parseGroupBy(opts.GroupBy)
 		if err != nil {
 			return fail.NewCommandUsageError(cmd, "", err)
 		}
@@ -164,7 +173,7 @@ func runMap(opts *mapOpts) func(*cobra.Command, []string) error {
 			namespace = resolved
 		}
 
-		result, err := fetchServiceMap(ctx, client, datasourceUID, namespace, name, opts.Since, matchers)
+		result, err := fetchServiceMap(ctx, client, datasourceUID, namespace, name, opts.Since, matchers, groupBy)
 		if err != nil {
 			return err
 		}
@@ -186,7 +195,7 @@ func runMap(opts *mapOpts) func(*cobra.Command, []string) error {
 // fetchServiceMap runs both direction × {rate, errors, p95} = 6 queries
 // in parallel and folds them into a ServiceMap. Each direction's edges
 // are independently parsed and merged, then sorted by rate desc.
-func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, matchers []Matcher) (*ServiceMap, error) {
+func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, matchers []Matcher, groupBy []string) (*ServiceMap, error) {
 	type edgeQuerySet struct {
 		rate, errors, p95 *prometheus.QueryResponse
 	}
@@ -203,7 +212,7 @@ func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceU
 	eg, egCtx := errgroup.WithContext(ctx)
 	for _, d := range directions {
 		eg.Go(func() error {
-			expr, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, d.dir, namespace, name, window, matchers)
+			expr, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, d.dir, namespace, name, window, matchers, groupBy)
 			if err != nil {
 				return fmt.Errorf("failed to build %s rate query: %w", directionLabel(d.dir), err)
 			}
@@ -215,7 +224,7 @@ func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceU
 			return nil
 		})
 		eg.Go(func() error {
-			expr, err := buildServiceMapEdgeQuery(serviceGraphRequestFailedTotalMetric, d.dir, namespace, name, window, matchers)
+			expr, err := buildServiceMapEdgeQuery(serviceGraphRequestFailedTotalMetric, d.dir, namespace, name, window, matchers, groupBy)
 			if err != nil {
 				return fmt.Errorf("failed to build %s error-rate query: %w", directionLabel(d.dir), err)
 			}
@@ -227,7 +236,7 @@ func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceU
 			return nil
 		})
 		eg.Go(func() error {
-			expr, err := buildServiceMapLatencyQuery(d.dir, namespace, name, window, 0.95, matchers)
+			expr, err := buildServiceMapLatencyQuery(d.dir, namespace, name, window, 0.95, matchers, groupBy)
 			if err != nil {
 				return fmt.Errorf("failed to build %s p95 latency query: %w", directionLabel(d.dir), err)
 			}
@@ -246,15 +255,17 @@ func fetchServiceMap(ctx context.Context, client *prometheus.Client, datasourceU
 	parseEdges := func(set edgeQuerySet, dir mapDirection) []Edge {
 		peerName, peerNs := dir.peerLabels()
 		return mergeEdges(
-			extractEdges(set.rate, peerName, peerNs),
-			extractEdges(set.errors, peerName, peerNs),
-			extractEdges(set.p95, peerName, peerNs),
+			extractEdges(set.rate, peerName, peerNs, groupBy),
+			extractEdges(set.errors, peerName, peerNs, groupBy),
+			extractEdges(set.p95, peerName, peerNs, groupBy),
+			groupBy,
 		)
 	}
 
 	return &ServiceMap{
 		Service: Service{Name: name, Namespace: namespace},
 		Window:  window,
+		GroupBy: groupBy,
 		Callers: parseEdges(callerSet, callersDirection),
 		Callees: parseEdges(calleeSet, calleesDirection),
 	}, nil
@@ -284,6 +295,27 @@ func orDashConnType(t string) string {
 	return t
 }
 
+// peerDisplayLabel renders a peer for graph output, appending the
+// --group-by combination in braces (e.g. "cart (billing) {prod-us}") so
+// the same peer in two groups reads as two distinct, labelled nodes.
+func peerDisplayLabel(e Edge, groupBy []string) string {
+	label := formatPeer(e)
+	if len(groupBy) > 0 {
+		label += " {" + groupLabelString(e.Labels, groupBy) + "}"
+	}
+	return label
+}
+
+// mermaidPeerID folds the group combination into the Mermaid node ID so
+// per-group edges to the same peer don't collapse onto one node.
+func mermaidPeerID(e Edge, groupBy []string) string {
+	ns := e.Peer.Namespace
+	if len(groupBy) > 0 {
+		ns += "_" + groupLabelString(e.Labels, groupBy)
+	}
+	return mermaidNodeID(e.Peer.Name, ns)
+}
+
 // serviceMapTableCodec renders a two-section table: callers above,
 // callees below, separated by a blank line. Default columns:
 // PEER, RATE, ERROR %, P95, TYPE. --output wide is identical for now
@@ -308,30 +340,39 @@ func (c *serviceMapTableCodec) Encode(w io.Writer, v any) error {
 	if !ok {
 		return fmt.Errorf("invalid data type for services map table codec: %T", v)
 	}
-	if err := c.encodeSection(w, "CALLERS", resp.Callers); err != nil {
+	if err := c.encodeSection(w, "CALLERS", resp.Callers, resp.GroupBy); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintln(w); err != nil {
 		return err
 	}
-	return c.encodeSection(w, "CALLEES", resp.Callees)
+	return c.encodeSection(w, "CALLEES", resp.Callees, resp.GroupBy)
 }
 
-func (c *serviceMapTableCodec) encodeSection(w io.Writer, label string, edges []Edge) error {
+func (c *serviceMapTableCodec) encodeSection(w io.Writer, label string, edges []Edge, groupBy []string) error {
 	if len(edges) == 0 {
 		_, err := fmt.Fprintf(w, "%s: (none)\n", label)
 		return err
 	}
-	headers := []string{label, "RATE", "ERROR %", "P95", "TYPE"}
+	// When grouping, a column per group label is inserted after the peer
+	// column so each row reads "<peer> <group> ...".
+	headers := make([]string, 0, len(groupBy)+5)
+	headers = append(headers, label)
+	headers = append(headers, upperHeaders(groupBy)...)
+	headers = append(headers, "RATE", "ERROR %", "P95", "TYPE")
 	t := style.NewTable(headers...)
 	for _, e := range edges {
-		t.Row(
-			formatPeer(e),
+		row := []string{formatPeer(e)}
+		for _, l := range groupBy {
+			row = append(row, orDash(e.Labels[l]))
+		}
+		row = append(row,
 			formatRateWithUnit(e.RatePerSecond, e.RatePerSecond > 0),
 			formatPercentMaybe(e.ErrorPercent, e.RatePerSecond > 0),
 			formatDuration(e.P95Seconds, e.HasLatency),
 			orDashConnType(e.ConnectionType),
 		)
+		t.Row(row...)
 	}
 	return t.Render(w)
 }
@@ -426,8 +467,8 @@ func (c *serviceMapMermaidCodec) Encode(w io.Writer, v any) error {
 
 	emitEdges := func(edges []Edge, into bool) {
 		for _, e := range edges {
-			peerID := mermaidNodeID(e.Peer.Name, e.Peer.Namespace)
-			fmt.Fprintf(tw, "  %s\n", mermaidNode(peerID, formatPeer(e), e.ConnectionType, false))
+			peerID := mermaidPeerID(e, resp.GroupBy)
+			fmt.Fprintf(tw, "  %s\n", mermaidNode(peerID, peerDisplayLabel(e, resp.GroupBy), e.ConnectionType, false))
 			label := formatMermaidEdgeLabel(e)
 			if into {
 				fmt.Fprintf(tw, "  %s -->|%s| %s\n", peerID, label, centerID)
@@ -475,7 +516,7 @@ func (c *serviceMapDOTCodec) Encode(w io.Writer, v any) error {
 
 	emit := func(edges []Edge, into bool) {
 		for _, e := range edges {
-			peerLabel := formatPeer(e)
+			peerLabel := peerDisplayLabel(e, resp.GroupBy)
 			fmt.Fprintf(w, "  %q [%s];\n", peerLabel, dotPeerAttrs(e.ConnectionType))
 			edgeLabel := formatRateWithUnit(e.RatePerSecond, e.RatePerSecond > 0)
 			if into {

--- a/internal/providers/appo11y/services/map_test.go
+++ b/internal/providers/appo11y/services/map_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBuildServiceMapEdgeQuery_Callers(t *testing.T) {
-	got, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "billing", "checkout", "5m")
+	got, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "billing", "checkout", "5m", nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -22,7 +22,7 @@ func TestBuildServiceMapEdgeQuery_Callers(t *testing.T) {
 }
 
 func TestBuildServiceMapEdgeQuery_Callees(t *testing.T) {
-	got, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, calleesDirection, "billing", "checkout", "5m")
+	got, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, calleesDirection, "billing", "checkout", "5m", nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -34,7 +34,7 @@ func TestBuildServiceMapEdgeQuery_Callees(t *testing.T) {
 }
 
 func TestBuildServiceMapEdgeQuery_BareName(t *testing.T) {
-	got, err := buildServiceMapEdgeQuery(serviceGraphRequestFailedTotalMetric, callersDirection, "", "auth", "1m")
+	got, err := buildServiceMapEdgeQuery(serviceGraphRequestFailedTotalMetric, callersDirection, "", "auth", "1m", nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -43,17 +43,17 @@ func TestBuildServiceMapEdgeQuery_BareName(t *testing.T) {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
 
-	if _, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "", "", "5m"); err == nil {
+	if _, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "", "", "5m", nil); err == nil {
 		t.Error("expected error for empty service name")
 	}
-	if _, err := buildServiceMapEdgeQuery("", callersDirection, "", "auth", "5m"); err == nil {
+	if _, err := buildServiceMapEdgeQuery("", callersDirection, "", "auth", "5m", nil); err == nil {
 		t.Error("expected error for empty metric")
 	}
 }
 
 func TestBuildServiceMapLatencyQuery_DirectionPicksHistogram(t *testing.T) {
 	// Callers should query the server_seconds bucket (how long X took to respond).
-	got, err := buildServiceMapLatencyQuery(callersDirection, "billing", "checkout", "5m", 0.95)
+	got, err := buildServiceMapLatencyQuery(callersDirection, "billing", "checkout", "5m", 0.95, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -63,7 +63,7 @@ func TestBuildServiceMapLatencyQuery_DirectionPicksHistogram(t *testing.T) {
 	}
 
 	// Callees should query the client_seconds bucket (how long X waited on the peer).
-	got, err = buildServiceMapLatencyQuery(calleesDirection, "billing", "checkout", "5m", 0.95)
+	got, err = buildServiceMapLatencyQuery(calleesDirection, "billing", "checkout", "5m", 0.95, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -72,7 +72,7 @@ func TestBuildServiceMapLatencyQuery_DirectionPicksHistogram(t *testing.T) {
 		t.Errorf("callees latency query wrong\ngot %q\nwant %q", got, want)
 	}
 
-	if _, err := buildServiceMapLatencyQuery(callersDirection, "", "x", "5m", 1.5); err == nil {
+	if _, err := buildServiceMapLatencyQuery(callersDirection, "", "x", "5m", 1.5, nil); err == nil {
 		t.Error("expected error for phi out of range")
 	}
 }

--- a/internal/providers/appo11y/services/map_test.go
+++ b/internal/providers/appo11y/services/map_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBuildServiceMapEdgeQuery_Callers(t *testing.T) {
-	got, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "billing", "checkout", "5m", nil)
+	got, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "billing", "checkout", "5m", nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -19,10 +19,20 @@ func TestBuildServiceMapEdgeQuery_Callers(t *testing.T) {
 	if got != want {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
+
+	// With --group-by, the label joins the peer aggregation.
+	got, err = buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "billing", "checkout", "5m", nil, []string{"k8s_cluster_name"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want = `sum by (client, client_service_namespace, connection_type, k8s_cluster_name) (rate(traces_service_graph_request_total{server="checkout",server_service_namespace="billing"}[5m]))`
+	if got != want {
+		t.Errorf("grouped got %q\nwant %q", got, want)
+	}
 }
 
 func TestBuildServiceMapEdgeQuery_Callees(t *testing.T) {
-	got, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, calleesDirection, "billing", "checkout", "5m", nil)
+	got, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, calleesDirection, "billing", "checkout", "5m", nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -34,7 +44,7 @@ func TestBuildServiceMapEdgeQuery_Callees(t *testing.T) {
 }
 
 func TestBuildServiceMapEdgeQuery_BareName(t *testing.T) {
-	got, err := buildServiceMapEdgeQuery(serviceGraphRequestFailedTotalMetric, callersDirection, "", "auth", "1m", nil)
+	got, err := buildServiceMapEdgeQuery(serviceGraphRequestFailedTotalMetric, callersDirection, "", "auth", "1m", nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -43,17 +53,17 @@ func TestBuildServiceMapEdgeQuery_BareName(t *testing.T) {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
 
-	if _, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "", "", "5m", nil); err == nil {
+	if _, err := buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "", "", "5m", nil, nil); err == nil {
 		t.Error("expected error for empty service name")
 	}
-	if _, err := buildServiceMapEdgeQuery("", callersDirection, "", "auth", "5m", nil); err == nil {
+	if _, err := buildServiceMapEdgeQuery("", callersDirection, "", "auth", "5m", nil, nil); err == nil {
 		t.Error("expected error for empty metric")
 	}
 }
 
 func TestBuildServiceMapLatencyQuery_DirectionPicksHistogram(t *testing.T) {
 	// Callers should query the server_seconds bucket (how long X took to respond).
-	got, err := buildServiceMapLatencyQuery(callersDirection, "billing", "checkout", "5m", 0.95, nil)
+	got, err := buildServiceMapLatencyQuery(callersDirection, "billing", "checkout", "5m", 0.95, nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -63,7 +73,7 @@ func TestBuildServiceMapLatencyQuery_DirectionPicksHistogram(t *testing.T) {
 	}
 
 	// Callees should query the client_seconds bucket (how long X waited on the peer).
-	got, err = buildServiceMapLatencyQuery(calleesDirection, "billing", "checkout", "5m", 0.95, nil)
+	got, err = buildServiceMapLatencyQuery(calleesDirection, "billing", "checkout", "5m", 0.95, nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -72,7 +82,7 @@ func TestBuildServiceMapLatencyQuery_DirectionPicksHistogram(t *testing.T) {
 		t.Errorf("callees latency query wrong\ngot %q\nwant %q", got, want)
 	}
 
-	if _, err := buildServiceMapLatencyQuery(callersDirection, "", "x", "5m", 1.5, nil); err == nil {
+	if _, err := buildServiceMapLatencyQuery(callersDirection, "", "x", "5m", 1.5, nil, nil); err == nil {
 		t.Error("expected error for phi out of range")
 	}
 }
@@ -87,35 +97,52 @@ func TestExtractEdges(t *testing.T) {
 		{Metric: map[string]string{"client": "user", "connection_type": "virtual_node"}, Value: []any{1.0, "NaN"}}, // dropped
 		{Metric: map[string]string{"client": "noop"}, Value: []any{1.0}},                                           // dropped (short)
 	}}}
-	got := extractEdges(resp, "client", "client_service_namespace")
+	got := extractEdges(resp, "client", "client_service_namespace", nil)
 	if len(got) != 2 {
 		t.Fatalf("len = %d, want 2: %v", len(got), got)
 	}
-	if got[edgeKey{name: "frontend", namespace: "oteldemo01", connType: ""}] != 0.5 {
+	if got[edgeKey{name: "frontend", namespace: "oteldemo01", connType: ""}].value != 0.5 {
 		t.Errorf("frontend value wrong: %v", got)
 	}
-	if got[edgeKey{name: "postgres", namespace: "", connType: "database"}] != 0.044 {
+	if got[edgeKey{name: "postgres", namespace: "", connType: "database"}].value != 0.044 {
 		t.Errorf("postgres value wrong: %v", got)
 	}
 
-	if got := extractEdges(nil, "client", "client_service_namespace"); len(got) != 0 {
+	if got := extractEdges(nil, "client", "client_service_namespace", nil); len(got) != 0 {
 		t.Errorf("nil response should produce empty map, got %v", got)
 	}
 }
 
+func TestExtractEdges_Grouped(t *testing.T) {
+	// Same peer in two clusters → two distinct edgeKeys, each carrying
+	// its group labels for display.
+	resp := &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
+		{Metric: map[string]string{"client": "frontend", "k8s_cluster_name": "east"}, Value: []any{1.0, "0.5"}},
+		{Metric: map[string]string{"client": "frontend", "k8s_cluster_name": "west"}, Value: []any{1.0, "0.2"}},
+	}}}
+	got := extractEdges(resp, "client", "client_service_namespace", []string{"k8s_cluster_name"})
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %v", len(got), got)
+	}
+	east := got[edgeKey{name: "frontend", groupKey: "east"}]
+	if east.value != 0.5 || east.labels["k8s_cluster_name"] != "east" {
+		t.Errorf("east edge wrong: %+v", east)
+	}
+}
+
 func TestMergeEdges(t *testing.T) {
-	rates := map[edgeKey]float64{
-		{name: "A", namespace: "ns"}:             1.0,
-		{name: "B", namespace: "ns"}:             5.0,
-		{name: "postgres", connType: "database"}: 0.5,
+	rates := map[edgeKey]groupBucket{
+		{name: "A", namespace: "ns"}:             {value: 1.0},
+		{name: "B", namespace: "ns"}:             {value: 5.0},
+		{name: "postgres", connType: "database"}: {value: 0.5},
 	}
-	errors := map[edgeKey]float64{
-		{name: "A", namespace: "ns"}: 0.1, // 10% error
+	errors := map[edgeKey]groupBucket{
+		{name: "A", namespace: "ns"}: {value: 0.1}, // 10% error
 	}
-	p95s := map[edgeKey]float64{
-		{name: "B", namespace: "ns"}: 0.020,
+	p95s := map[edgeKey]groupBucket{
+		{name: "B", namespace: "ns"}: {value: 0.020},
 	}
-	got := mergeEdges(rates, errors, p95s)
+	got := mergeEdges(rates, errors, p95s, nil)
 	if len(got) != 3 {
 		t.Fatalf("len = %d, want 3", len(got))
 	}
@@ -143,7 +170,7 @@ func TestMergeEdges(t *testing.T) {
 }
 
 func TestMergeEdges_Empty(t *testing.T) {
-	if got := mergeEdges(nil, nil, nil); len(got) != 0 {
+	if got := mergeEdges(nil, nil, nil, nil); len(got) != 0 {
 		t.Errorf("expected empty slice, got %v", got)
 	}
 }

--- a/internal/providers/appo11y/services/operations.go
+++ b/internal/providers/appo11y/services/operations.go
@@ -37,6 +37,7 @@ type operationsOpts struct {
 	Kind        string
 	MetricsMode string
 	Limit       int
+	Filters     []string
 }
 
 func (o *operationsOpts) setup(flags *pflag.FlagSet) {
@@ -51,6 +52,7 @@ func (o *operationsOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVar(&o.Kind, "kind", "inbound", "Span kinds to include. One of: inbound (server+consumer), server, consumer, all, or a comma-separated list of SPAN_KIND_* literals")
 	flags.StringVar(&o.MetricsMode, "metrics-mode", metricsModeAuto, "Span-metrics family. One of: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket)")
 	flags.IntVar(&o.Limit, "limit", operationsDefaultLimit, "Limit the number of operations returned (0 = unlimited; applied after sorting by time-share desc)")
+	flags.StringArrayVar(&o.Filters, "filter", nil, "Scope the operations breakdown to series matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the span metrics")
 }
 
 func (o *operationsOpts) Validate(cmd *cobra.Command) error {
@@ -103,12 +105,15 @@ default. Use --metrics-mode to pin it; see "gcx appo11y services get
   gcx appo11y services list-operations checkoutservice -o wide
 
   # Last hour, unlimited rows, JSON for scripting
-  gcx appo11y services list-operations payments/checkoutservice --since 1h --limit 0 -o json`,
+  gcx appo11y services list-operations payments/checkoutservice --since 1h --limit 0 -o json
+
+  # Break a multi-cluster service down to a single cluster
+  gcx appo11y services list-operations faro-collector --filter k8s_cluster_name=prod-us-central-0`,
 		Args: cobra.ExactArgs(1),
 		RunE: runOperations(opts),
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
-			agent.AnnotationLLMHint:   `Per-operation RED breakdown for one App Observability service: one row per span_name with rate (req/s), error rate, error percent, avg latency, p50/p95/p99, and time-share % (rate * avg_latency normalized across the service). Sorted by time-share desc to surface latency hotspots. Pairs with 'gcx appo11y services get' (which is the headline summary) — use 'list-operations' once a service is identified as hot to find which endpoints carry the load. Examples: gcx appo11y services list-operations <name> -o json; gcx appo11y services list-operations <ns>/<name> --since 1h --limit 0 -o json; gcx appo11y services list-operations <name> -o wide`,
+			agent.AnnotationLLMHint:   `Per-operation RED breakdown for one App Observability service: one row per span_name with rate (req/s), error rate, error percent, avg latency, p50/p95/p99, and time-share % (rate * avg_latency normalized across the service). Sorted by time-share desc to surface latency hotspots. Pairs with 'gcx appo11y services get' (which is the headline summary) — use 'list-operations' once a service is identified as hot to find which endpoints carry the load. Use --filter <label><op><value> (repeatable) to scope the breakdown to a subset of series — most usefully a cluster/region label (e.g. --filter k8s_cluster_name=prod-us) to break a multi-cluster service down one cluster at a time. Examples: gcx appo11y services list-operations <name> -o json; gcx appo11y services list-operations <ns>/<name> --since 1h --limit 0 -o json; gcx appo11y services list-operations <name> -o wide; gcx appo11y services list-operations <name> --filter k8s_cluster_name=<cluster> -o json`,
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -129,6 +134,10 @@ func runOperations(opts *operationsOpts) func(*cobra.Command, []string) error {
 			return fail.NewCommandUsageError(cmd, "", err)
 		}
 		mode, auto, err := resolveMetricsMode(opts.MetricsMode)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+		matchers, err := parseFilters(opts.Filters)
 		if err != nil {
 			return fail.NewCommandUsageError(cmd, "", err)
 		}
@@ -163,7 +172,7 @@ func runOperations(opts *operationsOpts) func(*cobra.Command, []string) error {
 		// bare name silently returns no rows because the `job` label is
 		// `<ns>/<name>`, not `<name>`.
 		if namespace == "" {
-			resolved, err := resolveNamespaceForBareName(ctx, client, datasourceUID, name)
+			resolved, err := resolveNamespaceForBareName(ctx, client, datasourceUID, name, matchers)
 			if err != nil {
 				return err
 			}
@@ -171,13 +180,13 @@ func runOperations(opts *operationsOpts) func(*cobra.Command, []string) error {
 		}
 
 		if auto {
-			mode, err = detectMetricsMode(ctx, client, datasourceUID, namespace, name)
+			mode, err = detectMetricsMode(ctx, client, datasourceUID, namespace, name, matchers)
 			if err != nil {
 				return fmt.Errorf("metrics-mode auto-detect failed: %w", err)
 			}
 		}
 
-		response, err := fetchOperations(ctx, client, datasourceUID, namespace, name, opts.Since, kinds, mode)
+		response, err := fetchOperations(ctx, client, datasourceUID, namespace, name, opts.Since, kinds, mode, matchers)
 		if err != nil {
 			return err
 		}
@@ -210,7 +219,7 @@ func runOperations(opts *operationsOpts) func(*cobra.Command, []string) error {
 // lookup in parallel and folds the responses into an OperationsResponse.
 // Metadata uses the same target_info union as `services get` so the
 // language/labels/env fields are consistent between commands.
-func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, kinds []string, mode MetricsMode) (*OperationsResponse, error) {
+func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, kinds []string, mode MetricsMode, matchers []Matcher) (*OperationsResponse, error) {
 	names, ok := metricNamesByMode(mode)
 	if !ok {
 		return nil, fmt.Errorf("unknown metrics mode %q", mode)
@@ -223,7 +232,7 @@ func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceU
 	eg, egCtx := errgroup.WithContext(ctx)
 	for i, metric := range metrics {
 		eg.Go(func() error {
-			expr, err := buildServiceMetadataQuery(metric, namespace, name)
+			expr, err := buildServiceMetadataQuery(metric, namespace, name, matchers)
 			if err != nil {
 				return fmt.Errorf("failed to build %s metadata query: %w", metric, err)
 			}
@@ -236,7 +245,7 @@ func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceU
 		})
 	}
 	eg.Go(func() error {
-		expr, err := buildOperationsRateQuery(names, namespace, name, window, kinds)
+		expr, err := buildOperationsRateQuery(names, namespace, name, window, kinds, matchers)
 		if err != nil {
 			return fmt.Errorf("failed to build rate query: %w", err)
 		}
@@ -248,7 +257,7 @@ func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceU
 		return nil
 	})
 	eg.Go(func() error {
-		expr, err := buildOperationsErrorRateQuery(names, namespace, name, window, kinds)
+		expr, err := buildOperationsErrorRateQuery(names, namespace, name, window, kinds, matchers)
 		if err != nil {
 			return fmt.Errorf("failed to build error-rate query: %w", err)
 		}
@@ -260,7 +269,7 @@ func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceU
 		return nil
 	})
 	eg.Go(func() error {
-		expr, err := buildOperationsAvgLatencyQuery(names, namespace, name, window, kinds)
+		expr, err := buildOperationsAvgLatencyQuery(names, namespace, name, window, kinds, matchers)
 		if err != nil {
 			return fmt.Errorf("failed to build avg-latency query: %w", err)
 		}
@@ -277,7 +286,7 @@ func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceU
 		0.99: &p99Resp,
 	} {
 		eg.Go(func() error {
-			expr, err := buildOperationsLatencyQuantileQuery(names, namespace, name, window, kinds, phi)
+			expr, err := buildOperationsLatencyQuantileQuery(names, namespace, name, window, kinds, phi, matchers)
 			if err != nil {
 				return fmt.Errorf("failed to build p%.0f latency query: %w", phi*100, err)
 			}

--- a/internal/providers/appo11y/services/operations.go
+++ b/internal/providers/appo11y/services/operations.go
@@ -38,6 +38,7 @@ type operationsOpts struct {
 	MetricsMode string
 	Limit       int
 	Filters     []string
+	GroupBy     []string
 }
 
 func (o *operationsOpts) setup(flags *pflag.FlagSet) {
@@ -53,6 +54,7 @@ func (o *operationsOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVar(&o.MetricsMode, "metrics-mode", metricsModeAuto, "Span-metrics family. One of: auto (probes the stack), v3 (traces_span_metrics_*), tempo (traces_spanmetrics_*), or otel (bare calls_total + duration_seconds_bucket)")
 	flags.IntVar(&o.Limit, "limit", operationsDefaultLimit, "Limit the number of operations returned (0 = unlimited; applied after sorting by time-share desc)")
 	flags.StringArrayVar(&o.Filters, "filter", nil, "Scope the operations breakdown to series matching a label matcher, e.g. --filter k8s_cluster_name=prod-us (repeatable). Use to break a multi-cluster/multi-region service down one cluster at a time; the label must exist on the span metrics")
+	flags.StringSliceVar(&o.GroupBy, "group-by", nil, "Break each operation out per distinct value of a label, e.g. --group-by k8s_cluster_name (comma-separated or repeatable). Time-share is normalized within each group so per-cluster hotspots are comparable; the label must exist on the span metrics")
 }
 
 func (o *operationsOpts) Validate(cmd *cobra.Command) error {
@@ -108,12 +110,15 @@ default. Use --metrics-mode to pin it; see "gcx appo11y services get
   gcx appo11y services list-operations payments/checkoutservice --since 1h --limit 0 -o json
 
   # Break a multi-cluster service down to a single cluster
-  gcx appo11y services list-operations faro-collector --filter k8s_cluster_name=prod-us-central-0`,
+  gcx appo11y services list-operations faro-collector --filter k8s_cluster_name=prod-us-central-0
+
+  # Break each operation out per cluster to spot per-cluster hotspots
+  gcx appo11y services list-operations faro-collector --group-by k8s_cluster_name`,
 		Args: cobra.ExactArgs(1),
 		RunE: runOperations(opts),
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
-			agent.AnnotationLLMHint:   `Per-operation RED breakdown for one App Observability service: one row per span_name with rate (req/s), error rate, error percent, avg latency, p50/p95/p99, and time-share % (rate * avg_latency normalized across the service). Sorted by time-share desc to surface latency hotspots. Pairs with 'gcx appo11y services get' (which is the headline summary) — use 'list-operations' once a service is identified as hot to find which endpoints carry the load. Use --filter <label><op><value> (repeatable) to scope the breakdown to a subset of series — most usefully a cluster/region label (e.g. --filter k8s_cluster_name=prod-us) to break a multi-cluster service down one cluster at a time. Examples: gcx appo11y services list-operations <name> -o json; gcx appo11y services list-operations <ns>/<name> --since 1h --limit 0 -o json; gcx appo11y services list-operations <name> -o wide; gcx appo11y services list-operations <name> --filter k8s_cluster_name=<cluster> -o json`,
+			agent.AnnotationLLMHint:   `Per-operation RED breakdown for one App Observability service: one row per span_name with rate (req/s), error rate, error percent, avg latency, p50/p95/p99, and time-share % (rate * avg_latency normalized across the service). Sorted by time-share desc to surface latency hotspots. Pairs with 'gcx appo11y services get' (which is the headline summary) — use 'list-operations' once a service is identified as hot to find which endpoints carry the load. Use --filter <label><op><value> (repeatable) to scope the breakdown to a subset of series — most usefully a cluster/region label (e.g. --filter k8s_cluster_name=prod-us) to break a multi-cluster service down one cluster at a time. Use --group-by <label> to instead break every operation out per distinct value of that label (time-share is normalized within each group) — surfaces per-cluster/per-region hotspots. Examples: gcx appo11y services list-operations <name> -o json; gcx appo11y services list-operations <ns>/<name> --since 1h --limit 0 -o json; gcx appo11y services list-operations <name> -o wide; gcx appo11y services list-operations <name> --filter k8s_cluster_name=<cluster> -o json; gcx appo11y services list-operations <name> --group-by k8s_cluster_name -o json`,
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -138,6 +143,10 @@ func runOperations(opts *operationsOpts) func(*cobra.Command, []string) error {
 			return fail.NewCommandUsageError(cmd, "", err)
 		}
 		matchers, err := parseFilters(opts.Filters)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+		groupBy, err := parseGroupBy(opts.GroupBy)
 		if err != nil {
 			return fail.NewCommandUsageError(cmd, "", err)
 		}
@@ -186,7 +195,7 @@ func runOperations(opts *operationsOpts) func(*cobra.Command, []string) error {
 			}
 		}
 
-		response, err := fetchOperations(ctx, client, datasourceUID, namespace, name, opts.Since, kinds, mode, matchers)
+		response, err := fetchOperations(ctx, client, datasourceUID, namespace, name, opts.Since, kinds, mode, matchers, groupBy)
 		if err != nil {
 			return err
 		}
@@ -219,7 +228,7 @@ func runOperations(opts *operationsOpts) func(*cobra.Command, []string) error {
 // lookup in parallel and folds the responses into an OperationsResponse.
 // Metadata uses the same target_info union as `services get` so the
 // language/labels/env fields are consistent between commands.
-func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, kinds []string, mode MetricsMode, matchers []Matcher) (*OperationsResponse, error) {
+func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceUID, namespace, name, window string, kinds []string, mode MetricsMode, matchers []Matcher, groupBy []string) (*OperationsResponse, error) {
 	names, ok := metricNamesByMode(mode)
 	if !ok {
 		return nil, fmt.Errorf("unknown metrics mode %q", mode)
@@ -245,7 +254,7 @@ func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceU
 		})
 	}
 	eg.Go(func() error {
-		expr, err := buildOperationsRateQuery(names, namespace, name, window, kinds, matchers)
+		expr, err := buildOperationsRateQuery(names, namespace, name, window, kinds, matchers, groupBy)
 		if err != nil {
 			return fmt.Errorf("failed to build rate query: %w", err)
 		}
@@ -257,7 +266,7 @@ func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceU
 		return nil
 	})
 	eg.Go(func() error {
-		expr, err := buildOperationsErrorRateQuery(names, namespace, name, window, kinds, matchers)
+		expr, err := buildOperationsErrorRateQuery(names, namespace, name, window, kinds, matchers, groupBy)
 		if err != nil {
 			return fmt.Errorf("failed to build error-rate query: %w", err)
 		}
@@ -269,7 +278,7 @@ func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceU
 		return nil
 	})
 	eg.Go(func() error {
-		expr, err := buildOperationsAvgLatencyQuery(names, namespace, name, window, kinds, matchers)
+		expr, err := buildOperationsAvgLatencyQuery(names, namespace, name, window, kinds, matchers, groupBy)
 		if err != nil {
 			return fmt.Errorf("failed to build avg-latency query: %w", err)
 		}
@@ -286,7 +295,7 @@ func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceU
 		0.99: &p99Resp,
 	} {
 		eg.Go(func() error {
-			expr, err := buildOperationsLatencyQuantileQuery(names, namespace, name, window, kinds, phi, matchers)
+			expr, err := buildOperationsLatencyQuantileQuery(names, namespace, name, window, kinds, phi, matchers, groupBy)
 			if err != nil {
 				return fmt.Errorf("failed to build p%.0f latency query: %w", phi*100, err)
 			}
@@ -309,12 +318,13 @@ func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceU
 	svc := selectMetadataService(metadata, namespace, name)
 
 	items := mergeOperations(
-		extractBySpanName(rateResp),
-		extractBySpanName(errorResp),
-		extractBySpanName(avgResp),
-		extractBySpanName(p50Resp),
-		extractBySpanName(p95Resp),
-		extractBySpanName(p99Resp),
+		extractOperations(rateResp, groupBy),
+		extractOperations(errorResp, groupBy),
+		extractOperations(avgResp, groupBy),
+		extractOperations(p50Resp, groupBy),
+		extractOperations(p95Resp, groupBy),
+		extractOperations(p99Resp, groupBy),
+		groupBy,
 	)
 
 	return &OperationsResponse{
@@ -322,6 +332,7 @@ func fetchOperations(ctx context.Context, client *prometheus.Client, datasourceU
 		Window:      window,
 		MetricsMode: mode,
 		SpanKinds:   spanKindRegex(kinds),
+		GroupBy:     groupBy,
 		Items:       items,
 	}, nil
 }
@@ -360,14 +371,27 @@ func (c *operationsTableCodec) Encode(w io.Writer, v any) error {
 		return err
 	}
 
-	headers := []string{"OPERATION", "RATE", "ERROR %", "P95", "TIME %"}
+	// When grouping, a column per group label is prepended so each row
+	// reads "<group> <operation> ...". mergeOperations already clusters
+	// rows by group then time-share.
+	groupHeaders := upperHeaders(resp.GroupBy)
+
+	var headers []string
+	headers = append(headers, groupHeaders...)
 	if c.Wide {
-		headers = []string{"OPERATION", "RATE", "ERRORS", "ERROR %", "P50", "P95", "P99", "TIME %"}
+		headers = append(headers, "OPERATION", "RATE", "ERRORS", "ERROR %", "P50", "P95", "P99", "TIME %")
+	} else {
+		headers = append(headers, "OPERATION", "RATE", "ERROR %", "P95", "TIME %")
 	}
 	t := style.NewTable(headers...)
-	for _, op := range resp.Items {
+	for i := range resp.Items {
+		op := &resp.Items[i]
+		row := make([]string, 0, len(headers))
+		for _, l := range resp.GroupBy {
+			row = append(row, orDash(op.Labels[l]))
+		}
 		if c.Wide {
-			t.Row(
+			row = append(row,
 				op.Name,
 				formatRateWithUnit(op.RatePerSecond, op.HasTraffic),
 				formatRateWithUnit(op.ErrorRatePerSec, op.HasErrors),
@@ -377,15 +401,16 @@ func (c *operationsTableCodec) Encode(w io.Writer, v any) error {
 				formatDuration(op.P99Seconds, op.HasLatencyP99),
 				formatPercentMaybe(op.TimeSharePercent, op.HasAvgLatency && op.HasTraffic),
 			)
-			continue
+		} else {
+			row = append(row,
+				op.Name,
+				formatRateWithUnit(op.RatePerSecond, op.HasTraffic),
+				formatPercentMaybe(op.ErrorPercent, op.HasTraffic),
+				formatDuration(op.P95Seconds, op.HasLatencyP95),
+				formatPercentMaybe(op.TimeSharePercent, op.HasAvgLatency && op.HasTraffic),
+			)
 		}
-		t.Row(
-			op.Name,
-			formatRateWithUnit(op.RatePerSecond, op.HasTraffic),
-			formatPercentMaybe(op.ErrorPercent, op.HasTraffic),
-			formatDuration(op.P95Seconds, op.HasLatencyP95),
-			formatPercentMaybe(op.TimeSharePercent, op.HasAvgLatency && op.HasTraffic),
-		)
+		t.Row(row...)
 	}
 	return t.Render(w)
 }

--- a/internal/providers/appo11y/services/operations_test.go
+++ b/internal/providers/appo11y/services/operations_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestBuildOperationsRateQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildOperationsRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer, spanKindConsumer})
+	got, err := buildOperationsRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer, spanKindConsumer}, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -21,14 +21,14 @@ func TestBuildOperationsRateQuery(t *testing.T) {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
 
-	if _, err := buildOperationsRateQuery(v3, "", "", "5m", nil); err == nil {
+	if _, err := buildOperationsRateQuery(v3, "", "", "5m", nil, nil); err == nil {
 		t.Error("expected error for empty service name")
 	}
 }
 
 func TestBuildOperationsErrorRateQuery(t *testing.T) {
 	tempo, _ := metricNamesByMode(MetricsModeTempo)
-	got, err := buildOperationsErrorRateQuery(tempo, "", "auth", "1m", []string{spanKindServer})
+	got, err := buildOperationsErrorRateQuery(tempo, "", "auth", "1m", []string{spanKindServer}, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -40,7 +40,7 @@ func TestBuildOperationsErrorRateQuery(t *testing.T) {
 
 func TestBuildOperationsLatencyQuantileQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildOperationsLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95)
+	got, err := buildOperationsLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -48,14 +48,14 @@ func TestBuildOperationsLatencyQuantileQuery(t *testing.T) {
 	if got != want {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
-	if _, err := buildOperationsLatencyQuantileQuery(v3, "", "x", "5m", nil, 1.5); err == nil {
+	if _, err := buildOperationsLatencyQuantileQuery(v3, "", "x", "5m", nil, 1.5, nil); err == nil {
 		t.Error("expected error for phi out of range")
 	}
 }
 
 func TestBuildOperationsAvgLatencyQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildOperationsAvgLatencyQuery(v3, "billing", "checkout", "5m", []string{spanKindServer})
+	got, err := buildOperationsAvgLatencyQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}

--- a/internal/providers/appo11y/services/operations_test.go
+++ b/internal/providers/appo11y/services/operations_test.go
@@ -2,6 +2,7 @@ package services //nolint:testpackage // Tests cover unexported builders, merge 
 
 import (
 	"bytes"
+	"maps"
 	"math"
 	"strings"
 	"testing"
@@ -12,7 +13,7 @@ import (
 
 func TestBuildOperationsRateQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildOperationsRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer, spanKindConsumer}, nil)
+	got, err := buildOperationsRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer, spanKindConsumer}, nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -21,14 +22,24 @@ func TestBuildOperationsRateQuery(t *testing.T) {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
 
-	if _, err := buildOperationsRateQuery(v3, "", "", "5m", nil, nil); err == nil {
+	// With --group-by, the label joins the span_name aggregation.
+	got, err = buildOperationsRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, nil, []string{"k8s_cluster_name"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want = `sum by (span_name, k8s_cluster_name) (rate(traces_span_metrics_calls_total{job="billing/checkout",span_kind=~"SPAN_KIND_SERVER"}[5m]))`
+	if got != want {
+		t.Errorf("grouped got %q\nwant %q", got, want)
+	}
+
+	if _, err := buildOperationsRateQuery(v3, "", "", "5m", nil, nil, nil); err == nil {
 		t.Error("expected error for empty service name")
 	}
 }
 
 func TestBuildOperationsErrorRateQuery(t *testing.T) {
 	tempo, _ := metricNamesByMode(MetricsModeTempo)
-	got, err := buildOperationsErrorRateQuery(tempo, "", "auth", "1m", []string{spanKindServer}, nil)
+	got, err := buildOperationsErrorRateQuery(tempo, "", "auth", "1m", []string{spanKindServer}, nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -40,7 +51,7 @@ func TestBuildOperationsErrorRateQuery(t *testing.T) {
 
 func TestBuildOperationsLatencyQuantileQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildOperationsLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, nil)
+	got, err := buildOperationsLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -48,14 +59,14 @@ func TestBuildOperationsLatencyQuantileQuery(t *testing.T) {
 	if got != want {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
-	if _, err := buildOperationsLatencyQuantileQuery(v3, "", "x", "5m", nil, 1.5, nil); err == nil {
+	if _, err := buildOperationsLatencyQuantileQuery(v3, "", "x", "5m", nil, 1.5, nil, nil); err == nil {
 		t.Error("expected error for phi out of range")
 	}
 }
 
 func TestBuildOperationsAvgLatencyQuery(t *testing.T) {
 	v3, _ := metricNamesByMode(MetricsModeV3)
-	got, err := buildOperationsAvgLatencyQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, nil)
+	got, err := buildOperationsAvgLatencyQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, nil, nil)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -67,7 +78,17 @@ func TestBuildOperationsAvgLatencyQuery(t *testing.T) {
 	}
 }
 
-func TestExtractBySpanName(t *testing.T) {
+// opBuckets builds an extractOperations-style map from span_name→value,
+// with no group labels (groupKey empty) — the non-grouped shape.
+func opBuckets(m map[string]float64) map[opAggKey]groupBucket {
+	out := make(map[opAggKey]groupBucket, len(m))
+	for name, v := range m {
+		out[opAggKey{name: name}] = groupBucket{value: v}
+	}
+	return out
+}
+
+func TestExtractOperations(t *testing.T) {
 	resp := &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
 		{Metric: map[string]string{"span_name": "GET /api/foo"}, Value: []any{1.0, "12.5"}},
 		{Metric: map[string]string{"span_name": "POST /api/bar"}, Value: []any{1.0, "0.5"}},
@@ -75,16 +96,37 @@ func TestExtractBySpanName(t *testing.T) {
 		{Metric: map[string]string{"span_name": "noop"}, Value: []any{1.0, "NaN"}}, // dropped (NaN)
 		{Metric: map[string]string{"span_name": "noop2"}, Value: []any{1.0}},       // dropped (short)
 	}}}
-	got := extractBySpanName(resp)
+	got := extractOperations(resp, nil)
 	if len(got) != 2 {
 		t.Fatalf("len = %d, want 2: %v", len(got), got)
 	}
-	if got["GET /api/foo"] != 12.5 || got["POST /api/bar"] != 0.5 {
+	if got[opAggKey{name: "GET /api/foo"}].value != 12.5 || got[opAggKey{name: "POST /api/bar"}].value != 0.5 {
 		t.Errorf("values wrong: %v", got)
 	}
 
-	if got := extractBySpanName(nil); len(got) != 0 {
+	if got := extractOperations(nil, nil); len(got) != 0 {
 		t.Errorf("nil response should produce empty map, got %v", got)
+	}
+}
+
+func TestExtractOperations_Grouped(t *testing.T) {
+	// Same span_name in two clusters must produce two distinct keys, each
+	// carrying its group labels.
+	resp := &prometheus.QueryResponse{Data: prometheus.ResultData{Result: []prometheus.Sample{
+		{Metric: map[string]string{"span_name": "GET /", "k8s_cluster_name": "east"}, Value: []any{1.0, "10"}},
+		{Metric: map[string]string{"span_name": "GET /", "k8s_cluster_name": "west"}, Value: []any{1.0, "3"}},
+	}}}
+	got := extractOperations(resp, []string{"k8s_cluster_name"})
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %v", len(got), got)
+	}
+	east := got[opAggKey{name: "GET /", groupKey: "east"}]
+	if east.value != 10 || east.labels["k8s_cluster_name"] != "east" {
+		t.Errorf("east bucket wrong: %+v", east)
+	}
+	west := got[opAggKey{name: "GET /", groupKey: "west"}]
+	if west.value != 3 || west.labels["k8s_cluster_name"] != "west" {
+		t.Errorf("west bucket wrong: %+v", west)
 	}
 }
 
@@ -93,14 +135,14 @@ func TestMergeOperations_TimeShareNormalisation(t *testing.T) {
 	// B is low-rate-slow (1 req/s × 200ms = 200ms/s). Time-share
 	// must rank B above A even though A has higher rate — that's the
 	// whole point of the metric.
-	rates := map[string]float64{"A": 10, "B": 1}
-	errors := map[string]float64{}
-	avgs := map[string]float64{"A": 0.005, "B": 0.200}
-	p50s := map[string]float64{"A": 0.004, "B": 0.150}
-	p95s := map[string]float64{"A": 0.008, "B": 0.300}
-	p99s := map[string]float64{"A": 0.010, "B": 0.400}
+	rates := opBuckets(map[string]float64{"A": 10, "B": 1})
+	errors := opBuckets(map[string]float64{})
+	avgs := opBuckets(map[string]float64{"A": 0.005, "B": 0.200})
+	p50s := opBuckets(map[string]float64{"A": 0.004, "B": 0.150})
+	p95s := opBuckets(map[string]float64{"A": 0.008, "B": 0.300})
+	p99s := opBuckets(map[string]float64{"A": 0.010, "B": 0.400})
 
-	got := mergeOperations(rates, errors, avgs, p50s, p95s, p99s)
+	got := mergeOperations(rates, errors, avgs, p50s, p95s, p99s, nil)
 	if len(got) != 2 {
 		t.Fatalf("len = %d, want 2", len(got))
 	}
@@ -126,13 +168,46 @@ func TestMergeOperations_TimeShareNormalisation(t *testing.T) {
 	}
 }
 
+func TestMergeOperations_TimeShareNormalisedWithinGroup(t *testing.T) {
+	// Same op "A" in two clusters. Time-share is normalized WITHIN each
+	// group, so each cluster's lone op is 100% of its own group — not
+	// split across clusters.
+	mk := func(cluster string, v float64) map[opAggKey]groupBucket {
+		return map[opAggKey]groupBucket{
+			{name: "A", groupKey: cluster}: {value: v, labels: map[string]string{"k8s_cluster_name": cluster}},
+		}
+	}
+	merge := func(m1, m2 map[opAggKey]groupBucket) map[opAggKey]groupBucket {
+		out := map[opAggKey]groupBucket{}
+		maps.Copy(out, m1)
+		maps.Copy(out, m2)
+		return out
+	}
+	rates := merge(mk("east", 10), mk("west", 1))
+	avgs := merge(mk("east", 0.01), mk("west", 0.5))
+
+	got := mergeOperations(rates, nil, avgs, nil, nil, nil, []string{"k8s_cluster_name"})
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %+v", len(got), got)
+	}
+	for _, op := range got {
+		if math.Abs(op.TimeSharePercent-100) > 0.001 {
+			t.Errorf("op in cluster %q time-share = %.4f, want 100 (within-group)", op.Labels["k8s_cluster_name"], op.TimeSharePercent)
+		}
+	}
+	// Sorted by group label asc: east before west.
+	if got[0].Labels["k8s_cluster_name"] != "east" || got[1].Labels["k8s_cluster_name"] != "west" {
+		t.Errorf("expected east,west order, got %q,%q", got[0].Labels["k8s_cluster_name"], got[1].Labels["k8s_cluster_name"])
+	}
+}
+
 func TestMergeOperations_OperationWithoutAvgLatencyHasZeroTimeShare(t *testing.T) {
 	// Op "C" appears only in the rate map — no latency at all. Should
 	// render in the output with HasTraffic=true but TimeSharePercent=0,
 	// not crash and not skew the others' shares.
-	rates := map[string]float64{"A": 10, "C": 5}
-	avgs := map[string]float64{"A": 0.010}
-	got := mergeOperations(rates, nil, avgs, nil, nil, nil)
+	rates := opBuckets(map[string]float64{"A": 10, "C": 5})
+	avgs := opBuckets(map[string]float64{"A": 0.010})
+	got := mergeOperations(rates, nil, avgs, nil, nil, nil, nil)
 
 	byName := map[string]Operation{}
 	for _, op := range got {
@@ -150,16 +225,16 @@ func TestMergeOperations_OperationWithoutAvgLatencyHasZeroTimeShare(t *testing.T
 func TestMergeOperations_NoTrafficAtAll(t *testing.T) {
 	// Edge case: no rate data anywhere. We should return an empty
 	// slice (not nil-deref) and not panic on a zero denominator.
-	got := mergeOperations(nil, nil, nil, nil, nil, nil)
+	got := mergeOperations(nil, nil, nil, nil, nil, nil, nil)
 	if len(got) != 0 {
 		t.Errorf("expected empty, got %v", got)
 	}
 }
 
 func TestMergeOperations_ErrorPercentBoundedAndHasErrorsInferred(t *testing.T) {
-	rates := map[string]float64{"A": 10, "B": 5}
-	errors := map[string]float64{"A": 2} // only A has errors observed
-	got := mergeOperations(rates, errors, nil, nil, nil, nil)
+	rates := opBuckets(map[string]float64{"A": 10, "B": 5})
+	errors := opBuckets(map[string]float64{"A": 2}) // only A has errors observed
+	got := mergeOperations(rates, errors, nil, nil, nil, nil, nil)
 
 	byName := map[string]Operation{}
 	for _, op := range got {

--- a/internal/providers/appo11y/services/query.go
+++ b/internal/providers/appo11y/services/query.go
@@ -133,6 +133,73 @@ func parseFilter(raw string) (Matcher, error) {
 	return Matcher{Label: label, Op: op, Value: val}, nil
 }
 
+// labelNamePattern is the PromQL label-name grammar; `--group-by` values
+// must match it so they can be dropped into a `by (...)` clause verbatim.
+var labelNamePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// parseGroupBy splits and validates the `--group-by` values (comma-separated
+// or repeated) into an ordered, de-duplicated slice of label names. Grouping
+// pivots a command's aggregation from a single collapsed number into one row
+// per distinct value of the label(s) — the outlier-finding counterpart to
+// --filter. Returns nil when nothing was requested.
+func parseGroupBy(raw []string) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		for label := range strings.SplitSeq(entry, ",") {
+			label = strings.TrimSpace(label)
+			if label == "" {
+				continue
+			}
+			if !labelNamePattern.MatchString(label) {
+				return nil, fmt.Errorf("invalid --group-by %q: expected a PromQL label name (letters, digits, underscore; not starting with a digit)", label)
+			}
+			if _, dup := seen[label]; dup {
+				continue
+			}
+			seen[label] = struct{}{}
+			out = append(out, label)
+		}
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// groupKeyDelim separates label values in a canonical group key. NUL never
+// appears in a Prometheus label value, so it can't collide two distinct
+// combinations into one key.
+const groupKeyDelim = "\x00"
+
+// groupKeyFor builds a canonical key for a sample's values of groupLabels
+// (in order) and returns the label→value map for display. An absent label
+// contributes an empty string, so series missing a group label collapse
+// into a single "(none)"-style bucket rather than vanishing.
+func groupKeyFor(metric map[string]string, groupLabels []string) (string, map[string]string) {
+	labels := make(map[string]string, len(groupLabels))
+	parts := make([]string, len(groupLabels))
+	for i, l := range groupLabels {
+		v := metric[l]
+		labels[l] = v
+		parts[i] = v
+	}
+	return strings.Join(parts, groupKeyDelim), labels
+}
+
+// sumBy returns the group-by label set for a plain (non-quantile)
+// aggregation: exactly the requested group labels, or nil to signal the
+// caller should emit `sum(...)` with no `by` clause at all.
+func sumBy(groupBy []string) []string {
+	if len(groupBy) == 0 {
+		return nil
+	}
+	return groupBy
+}
+
 // parseFilters validates a slice of raw `--filter` strings into Matchers.
 // Shared by the per-service commands (get, map, list-operations) so a
 // single service can be scoped to a dimension the underlying metric
@@ -652,13 +719,19 @@ func namespacesForName(jobs []string, name string) []string {
 
 // buildRateQuery returns the PromQL for the headline request rate (per
 // second) over the given window, scoped to the service, span kinds, and
-// any caller-supplied `--filter` matchers.
-func buildRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher) (string, error) {
+// any caller-supplied `--filter` matchers. When groupBy is non-empty the
+// aggregation pivots to `sum by (<groupBy>)` so each label combination
+// yields its own row.
+func buildRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher, groupBy []string) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
 	v := scopedSpanMetric(names.calls, namespace, name, kinds, window, matchers)
-	expr, err := promql.Sum(promql.Rate(v)).Build()
+	agg := promql.Sum(promql.Rate(v))
+	if by := sumBy(groupBy); by != nil {
+		agg = agg.By(by)
+	}
+	expr, err := agg.Build()
 	if err != nil {
 		return "", err
 	}
@@ -667,13 +740,17 @@ func buildRateQuery(names metricNames, namespace, name, window string, kinds []s
 
 // buildErrorRateQuery returns the PromQL for the error rate (per second)
 // over the given window, scoped to status_code=STATUS_CODE_ERROR.
-func buildErrorRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher) (string, error) {
+func buildErrorRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher, groupBy []string) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
 	v := scopedSpanMetric(names.calls, namespace, name, kinds, window, matchers).
 		Label("status_code", statusCodeError)
-	expr, err := promql.Sum(promql.Rate(v)).Build()
+	agg := promql.Sum(promql.Rate(v))
+	if by := sumBy(groupBy); by != nil {
+		agg = agg.By(by)
+	}
+	expr, err := agg.Build()
 	if err != nil {
 		return "", err
 	}
@@ -681,8 +758,10 @@ func buildErrorRateQuery(names metricNames, namespace, name, window string, kind
 }
 
 // buildLatencyQuantileQuery returns the PromQL for `histogram_quantile(phi,
-// sum by (le) (rate(... [window]))) `. phi must be in [0, 1].
-func buildLatencyQuantileQuery(names metricNames, namespace, name, window string, kinds []string, phi float64, matchers []Matcher) (string, error) {
+// sum by (le[, groupBy]) (rate(... [window]))) `. phi must be in [0, 1].
+// The group-by labels are preserved through the quantile so each
+// combination keeps its own latency.
+func buildLatencyQuantileQuery(names metricNames, namespace, name, window string, kinds []string, phi float64, matchers []Matcher, groupBy []string) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
@@ -690,7 +769,7 @@ func buildLatencyQuantileQuery(names metricNames, namespace, name, window string
 		return "", fmt.Errorf("phi must be in [0,1], got %v", phi)
 	}
 	v := scopedSpanMetric(names.latencyBucket, namespace, name, kinds, window, matchers)
-	sumByLe := promql.Sum(promql.Rate(v)).By([]string{"le"})
+	sumByLe := promql.Sum(promql.Rate(v)).By(append([]string{"le"}, groupBy...))
 	expr, err := promql.HistogramQuantile(phi, sumByLe).Build()
 	if err != nil {
 		return "", err
@@ -702,12 +781,12 @@ func buildLatencyQuantileQuery(names metricNames, namespace, name, window string
 // the given window: `sum by (span_name) (rate(<calls>[<window>]))`.
 // Shape parallels buildRateQuery but the aggregation is grouped by
 // span_name so the response can be pivoted into one row per operation.
-func buildOperationsRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher) (string, error) {
+func buildOperationsRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher, groupBy []string) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
 	v := scopedSpanMetric(names.calls, namespace, name, kinds, window, matchers)
-	expr, err := promql.Sum(promql.Rate(v)).By([]string{"span_name"}).Build()
+	expr, err := promql.Sum(promql.Rate(v)).By(append([]string{"span_name"}, groupBy...)).Build()
 	if err != nil {
 		return "", err
 	}
@@ -717,13 +796,13 @@ func buildOperationsRateQuery(names metricNames, namespace, name, window string,
 // buildOperationsErrorRateQuery returns the per-operation error rate,
 // filtered to status_code=STATUS_CODE_ERROR. An operation with no errors
 // in the window produces no series — the caller treats that as 0.
-func buildOperationsErrorRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher) (string, error) {
+func buildOperationsErrorRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher, groupBy []string) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
 	v := scopedSpanMetric(names.calls, namespace, name, kinds, window, matchers).
 		Label("status_code", statusCodeError)
-	expr, err := promql.Sum(promql.Rate(v)).By([]string{"span_name"}).Build()
+	expr, err := promql.Sum(promql.Rate(v)).By(append([]string{"span_name"}, groupBy...)).Build()
 	if err != nil {
 		return "", err
 	}
@@ -734,7 +813,7 @@ func buildOperationsErrorRateQuery(names metricNames, namespace, name, window st
 // `histogram_quantile(phi, sum by (le, span_name) (rate(<bucket>[<window>])))`.
 // span_name is preserved through the histogram_quantile call so quantiles
 // stay per-operation.
-func buildOperationsLatencyQuantileQuery(names metricNames, namespace, name, window string, kinds []string, phi float64, matchers []Matcher) (string, error) {
+func buildOperationsLatencyQuantileQuery(names metricNames, namespace, name, window string, kinds []string, phi float64, matchers []Matcher, groupBy []string) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
@@ -742,7 +821,7 @@ func buildOperationsLatencyQuantileQuery(names metricNames, namespace, name, win
 		return "", fmt.Errorf("phi must be in [0,1], got %v", phi)
 	}
 	v := scopedSpanMetric(names.latencyBucket, namespace, name, kinds, window, matchers)
-	sumByLeAndOp := promql.Sum(promql.Rate(v)).By([]string{"le", "span_name"})
+	sumByLeAndOp := promql.Sum(promql.Rate(v)).By(append([]string{"le", "span_name"}, groupBy...))
 	expr, err := promql.HistogramQuantile(phi, sumByLeAndOp).Build()
 	if err != nil {
 		return "", err
@@ -758,14 +837,15 @@ func buildOperationsLatencyQuantileQuery(names metricNames, namespace, name, win
 // The average × rate gives wall-clock time spent per second, which is
 // what we sort the table by (time share). Native quantiles aren't a
 // substitute — the time-share signal needs the first moment.
-func buildOperationsAvgLatencyQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher) (string, error) {
+func buildOperationsAvgLatencyQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher, groupBy []string) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
 	sumV := scopedSpanMetric(names.latencySum, namespace, name, kinds, window, matchers)
 	countV := scopedSpanMetric(names.latencyCount, namespace, name, kinds, window, matchers)
-	num := promql.Sum(promql.Rate(sumV)).By([]string{"span_name"})
-	den := promql.Sum(promql.Rate(countV)).By([]string{"span_name"})
+	byOp := append([]string{"span_name"}, groupBy...)
+	num := promql.Sum(promql.Rate(sumV)).By(byOp)
+	den := promql.Sum(promql.Rate(countV)).By(byOp)
 	expr, err := promql.Div(num, den).Build()
 	if err != nil {
 		return "", err
@@ -807,7 +887,13 @@ func instantScalar(resp *prometheus.QueryResponse) (float64, bool) {
 	if resp == nil || len(resp.Data.Result) == 0 {
 		return 0, false
 	}
-	sample := resp.Data.Result[0]
+	return sampleScalar(resp.Data.Result[0])
+}
+
+// sampleScalar parses one Prometheus sample's instant value as float64.
+// Returns false for a missing value, NaN/Inf, or an unparseable string so
+// callers can render "no data" rather than a misleading zero.
+func sampleScalar(sample prometheus.Sample) (float64, bool) {
 	if len(sample.Value) < 2 {
 		return 0, false
 	}
@@ -820,6 +906,34 @@ func instantScalar(resp *prometheus.QueryResponse) (float64, bool) {
 		return 0, false
 	}
 	return f, true
+}
+
+// groupBucket carries a value plus the label→value map that identifies its
+// group, so a grouped response can be pivoted into per-combination rows.
+type groupBucket struct {
+	value  float64
+	labels map[string]string
+}
+
+// extractGrouped pivots a grouped instant response into one bucket per
+// distinct combination of groupLabels. The canonical key (groupKeyFor)
+// dedupes; the last sample wins for a given key (a well-formed grouped
+// query emits one series per combination, so collisions don't occur in
+// practice). Samples with unparseable values are dropped.
+func extractGrouped(resp *prometheus.QueryResponse, groupLabels []string) map[string]groupBucket {
+	out := make(map[string]groupBucket)
+	if resp == nil {
+		return out
+	}
+	for _, sample := range resp.Data.Result {
+		f, ok := sampleScalar(sample)
+		if !ok {
+			continue
+		}
+		key, labels := groupKeyFor(sample.Metric, groupLabels)
+		out[key] = groupBucket{value: f, labels: labels}
+	}
+	return out
 }
 
 // REDStats holds the rate / errors / duration snapshot for one service over
@@ -851,6 +965,104 @@ type REDStats struct {
 type ServiceDetail struct {
 	Service Service  `json:"service" yaml:"service"`
 	RED     REDStats `json:"red" yaml:"red"`
+}
+
+// GroupedRED is one row of a `services get --group-by` result: the group's
+// label values plus that group's RED snapshot. Labels is keyed by the
+// requested group label name(s); an empty value means the series didn't
+// carry that label.
+type GroupedRED struct {
+	Labels map[string]string `json:"labels" yaml:"labels"`
+	RED    REDStats          `json:"red" yaml:"red"`
+}
+
+// GroupedServiceDetail is the get-command response when --group-by is set:
+// the service identity plus one RED row per distinct group-label
+// combination, sorted by request rate desc so the busiest/outlier groups
+// surface first.
+type GroupedServiceDetail struct {
+	Service Service      `json:"service" yaml:"service"`
+	GroupBy []string     `json:"group_by" yaml:"group_by"`
+	Window  string       `json:"window" yaml:"window"`
+	Items   []GroupedRED `json:"items" yaml:"items"`
+}
+
+// mergeGroupedRED joins the per-group rate/error/latency buckets into one
+// GroupedRED per distinct group key, mirroring the single-service field
+// semantics in fetchServiceDetail (HasErrors is inferred once there's
+// traffic; latency flags track "measured" vs "no series"). Rows are sorted
+// by rate desc with a stable group-label tiebreak so outliers surface and
+// output is reproducible.
+func mergeGroupedRED(window string, mode MetricsMode, kinds []string, groupBy []string, rates, errs, p50s, p95s, p99s map[string]groupBucket) []GroupedRED {
+	keys := make(map[string]struct{})
+	for _, m := range []map[string]groupBucket{rates, errs, p50s, p95s, p99s} {
+		for k := range m {
+			keys[k] = struct{}{}
+		}
+	}
+
+	// labelsFor prefers whichever bucket carried the group labels for a key;
+	// rate is the most likely to be present, but any of them will do.
+	labelsFor := func(key string) map[string]string {
+		for _, m := range []map[string]groupBucket{rates, errs, p50s, p95s, p99s} {
+			if b, ok := m[key]; ok {
+				return b.labels
+			}
+		}
+		return map[string]string{}
+	}
+
+	out := make([]GroupedRED, 0, len(keys))
+	for key := range keys {
+		rate, hasRate := rates[key]
+		errRate, hasErr := errs[key]
+		p50, hasP50 := p50s[key]
+		p95, hasP95 := p95s[key]
+		p99, hasP99 := p99s[key]
+		hasTraffic := hasRate && rate.value > 0
+		out = append(out, GroupedRED{
+			Labels: labelsFor(key),
+			RED: REDStats{
+				Window:          window,
+				MetricsMode:     mode,
+				SpanKinds:       spanKindRegex(kinds),
+				RatePerSecond:   rate.value,
+				ErrorRatePerSec: errRate.value,
+				ErrorPercent:    computeErrorPercent(errRate.value, rate.value),
+				P50Seconds:      p50.value,
+				P95Seconds:      p95.value,
+				P99Seconds:      p99.value,
+				HasTraffic:      hasTraffic,
+				HasErrors:       hasErr || hasTraffic,
+				HasLatencyP50:   hasP50,
+				HasLatencyP95:   hasP95,
+				HasLatencyP99:   hasP99,
+			},
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].RED.RatePerSecond != out[j].RED.RatePerSecond {
+			return out[i].RED.RatePerSecond > out[j].RED.RatePerSecond
+		}
+		return groupLabelString(out[i].Labels, groupBy) < groupLabelString(out[j].Labels, groupBy)
+	})
+	return out
+}
+
+// groupLabelString renders a group's label values in groupBy order for a
+// stable sort tiebreak and for table display (e.g. "prod-us" or
+// "prod-us / go" for multi-label grouping). Empty values render as "(none)".
+func groupLabelString(labels map[string]string, groupBy []string) string {
+	parts := make([]string, len(groupBy))
+	for i, l := range groupBy {
+		v := labels[l]
+		if v == "" {
+			v = "(none)"
+		}
+		parts[i] = v
+	}
+	return strings.Join(parts, " / ")
 }
 
 // Service-graph metric names. These are emitted by Tempo's
@@ -913,7 +1125,7 @@ func (d mapDirection) latencyBucketMetric() string {
 // aggregates a service-graph counter to one row per peer per
 // connection-type. metric is one of the service-graph counter metrics
 // (request_total, request_failed_total).
-func buildServiceMapEdgeQuery(metric string, dir mapDirection, namespace, name, window string, matchers []Matcher) (string, error) {
+func buildServiceMapEdgeQuery(metric string, dir mapDirection, namespace, name, window string, matchers []Matcher, groupBy []string) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
@@ -933,7 +1145,7 @@ func buildServiceMapEdgeQuery(metric string, dir mapDirection, namespace, name, 
 	v = v.Range(window)
 
 	expr, err := promql.Sum(promql.Rate(v)).
-		By([]string{peerName, peerNs, "connection_type"}).
+		By(append([]string{peerName, peerNs, "connection_type"}, groupBy...)).
 		Build()
 	if err != nil {
 		return "", err
@@ -946,7 +1158,7 @@ func buildServiceMapEdgeQuery(metric string, dir mapDirection, namespace, name, 
 //	histogram_quantile(phi, sum by (le, peer_name, peer_namespace, connection_type) (rate(<bucket>[window])))
 //
 // with the bucket metric picked by `dir.latencyBucketMetric()`.
-func buildServiceMapLatencyQuery(dir mapDirection, namespace, name, window string, phi float64, matchers []Matcher) (string, error) {
+func buildServiceMapLatencyQuery(dir mapDirection, namespace, name, window string, phi float64, matchers []Matcher, groupBy []string) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
@@ -965,7 +1177,7 @@ func buildServiceMapLatencyQuery(dir mapDirection, namespace, name, window strin
 	}
 	v = v.Range(window)
 
-	sumByLe := promql.Sum(promql.Rate(v)).By([]string{"le", peerName, peerNs, "connection_type"})
+	sumByLe := promql.Sum(promql.Rate(v)).By(append([]string{"le", peerName, peerNs, "connection_type"}, groupBy...))
 	expr, err := promql.HistogramQuantile(phi, sumByLe).Build()
 	if err != nil {
 		return "", err
@@ -978,14 +1190,15 @@ func buildServiceMapLatencyQuery(dir mapDirection, namespace, name, window strin
 // Connection type is empty for HTTP/gRPC peers; `database` / `messaging`
 // / `virtual_node` for typed edges.
 type Edge struct {
-	Peer            Service `json:"peer" yaml:"peer"`
-	ConnectionType  string  `json:"connection_type,omitempty" yaml:"connection_type,omitempty"`
-	RatePerSecond   float64 `json:"rate_per_second" yaml:"rate_per_second"`
-	ErrorRatePerSec float64 `json:"error_rate_per_second" yaml:"error_rate_per_second"`
-	ErrorPercent    float64 `json:"error_percent" yaml:"error_percent"`
-	P95Seconds      float64 `json:"p95_seconds" yaml:"p95_seconds"`
-	HasErrors       bool    `json:"has_errors" yaml:"has_errors"`
-	HasLatency      bool    `json:"has_latency" yaml:"has_latency"`
+	Peer            Service           `json:"peer" yaml:"peer"`
+	ConnectionType  string            `json:"connection_type,omitempty" yaml:"connection_type,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	RatePerSecond   float64           `json:"rate_per_second" yaml:"rate_per_second"`
+	ErrorRatePerSec float64           `json:"error_rate_per_second" yaml:"error_rate_per_second"`
+	ErrorPercent    float64           `json:"error_percent" yaml:"error_percent"`
+	P95Seconds      float64           `json:"p95_seconds" yaml:"p95_seconds"`
+	HasErrors       bool              `json:"has_errors" yaml:"has_errors"`
+	HasLatency      bool              `json:"has_latency" yaml:"has_latency"`
 }
 
 // ServiceMap is the response shape for `services map`: the queried
@@ -993,27 +1206,31 @@ type Edge struct {
 // the Tempo service-graph metric. Each direction is independently
 // sorted by rate desc.
 type ServiceMap struct {
-	Service Service `json:"service" yaml:"service"`
-	Window  string  `json:"window" yaml:"window"`
-	Callers []Edge  `json:"callers" yaml:"callers"`
-	Callees []Edge  `json:"callees" yaml:"callees"`
+	Service Service  `json:"service" yaml:"service"`
+	Window  string   `json:"window" yaml:"window"`
+	GroupBy []string `json:"group_by,omitempty" yaml:"group_by,omitempty"`
+	Callers []Edge   `json:"callers" yaml:"callers"`
+	Callees []Edge   `json:"callees" yaml:"callees"`
 }
 
 // edgeKey identifies an edge for the purpose of joining the rate /
 // error / latency responses. The same peer reached over two different
-// connection types is two distinct edges in the service graph.
+// connection types is two distinct edges in the service graph; groupKey
+// splits an edge further per --group-by combination.
 type edgeKey struct {
 	name      string
 	namespace string
 	connType  string
+	groupKey  string
 }
 
 // extractEdges flattens a Prometheus instant response into a map keyed
-// by (peer name, peer namespace, connection_type). Samples with empty
-// peer name or unparseable values are dropped so callers can treat
-// absence as "no data". peerName / peerNs name which labels to read.
-func extractEdges(resp *prometheus.QueryResponse, peerName, peerNs string) map[edgeKey]float64 {
-	out := make(map[edgeKey]float64)
+// by (peer name, peer namespace, connection_type, group). Samples with
+// empty peer name or unparseable values are dropped so callers can treat
+// absence as "no data". peerName / peerNs name which labels to read;
+// groupLabels are the --group-by dimensions carried in the bucket.
+func extractEdges(resp *prometheus.QueryResponse, peerName, peerNs string, groupLabels []string) map[edgeKey]groupBucket {
+	out := make(map[edgeKey]groupBucket)
 	if resp == nil {
 		return out
 	}
@@ -1022,23 +1239,18 @@ func extractEdges(resp *prometheus.QueryResponse, peerName, peerNs string) map[e
 		if n == "" {
 			continue
 		}
-		if len(sample.Value) < 2 {
-			continue
-		}
-		str, ok := sample.Value[1].(string)
+		f, ok := sampleScalar(sample)
 		if !ok {
 			continue
 		}
-		f, err := strconv.ParseFloat(str, 64)
-		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
-			continue
-		}
+		gkey, glabels := groupKeyFor(sample.Metric, groupLabels)
 		key := edgeKey{
 			name:      n,
 			namespace: sample.Metric[peerNs],
 			connType:  sample.Metric["connection_type"],
+			groupKey:  gkey,
 		}
-		out[key] = f
+		out[key] = groupBucket{value: f, labels: glabels}
 	}
 	return out
 }
@@ -1049,21 +1261,22 @@ func extractEdges(resp *prometheus.QueryResponse, peerName, peerNs string) map[e
 // used to compute time-share. *Has* flags distinguish "0 measured" from
 // "no series in window" the same way REDStats does.
 type Operation struct {
-	Name             string  `json:"operation" yaml:"operation"`
-	RatePerSecond    float64 `json:"rate_per_second" yaml:"rate_per_second"`
-	ErrorRatePerSec  float64 `json:"error_rate_per_second" yaml:"error_rate_per_second"`
-	ErrorPercent     float64 `json:"error_percent" yaml:"error_percent"`
-	AvgSeconds       float64 `json:"avg_seconds" yaml:"avg_seconds"`
-	P50Seconds       float64 `json:"p50_seconds" yaml:"p50_seconds"`
-	P95Seconds       float64 `json:"p95_seconds" yaml:"p95_seconds"`
-	P99Seconds       float64 `json:"p99_seconds" yaml:"p99_seconds"`
-	TimeSharePercent float64 `json:"time_share_percent" yaml:"time_share_percent"`
-	HasTraffic       bool    `json:"has_traffic" yaml:"has_traffic"`
-	HasErrors        bool    `json:"has_errors" yaml:"has_errors"`
-	HasAvgLatency    bool    `json:"has_avg_latency" yaml:"has_avg_latency"`
-	HasLatencyP50    bool    `json:"has_latency_p50" yaml:"has_latency_p50"`
-	HasLatencyP95    bool    `json:"has_latency_p95" yaml:"has_latency_p95"`
-	HasLatencyP99    bool    `json:"has_latency_p99" yaml:"has_latency_p99"`
+	Name             string            `json:"operation" yaml:"operation"`
+	Labels           map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	RatePerSecond    float64           `json:"rate_per_second" yaml:"rate_per_second"`
+	ErrorRatePerSec  float64           `json:"error_rate_per_second" yaml:"error_rate_per_second"`
+	ErrorPercent     float64           `json:"error_percent" yaml:"error_percent"`
+	AvgSeconds       float64           `json:"avg_seconds" yaml:"avg_seconds"`
+	P50Seconds       float64           `json:"p50_seconds" yaml:"p50_seconds"`
+	P95Seconds       float64           `json:"p95_seconds" yaml:"p95_seconds"`
+	P99Seconds       float64           `json:"p99_seconds" yaml:"p99_seconds"`
+	TimeSharePercent float64           `json:"time_share_percent" yaml:"time_share_percent"`
+	HasTraffic       bool              `json:"has_traffic" yaml:"has_traffic"`
+	HasErrors        bool              `json:"has_errors" yaml:"has_errors"`
+	HasAvgLatency    bool              `json:"has_avg_latency" yaml:"has_avg_latency"`
+	HasLatencyP50    bool              `json:"has_latency_p50" yaml:"has_latency_p50"`
+	HasLatencyP95    bool              `json:"has_latency_p95" yaml:"has_latency_p95"`
+	HasLatencyP99    bool              `json:"has_latency_p99" yaml:"has_latency_p99"`
 }
 
 // OperationsResponse is the top-level shape for the operations command:
@@ -1075,15 +1288,25 @@ type OperationsResponse struct {
 	Window      string      `json:"window" yaml:"window"`
 	MetricsMode MetricsMode `json:"metrics_mode" yaml:"metrics_mode"`
 	SpanKinds   string      `json:"span_kinds" yaml:"span_kinds"`
+	GroupBy     []string    `json:"group_by,omitempty" yaml:"group_by,omitempty"`
 	Items       []Operation `json:"items" yaml:"items"`
 }
 
-// extractBySpanName collapses a Prometheus instant response into a map
-// of span_name → scalar value. Samples with empty span_name or
+// opAggKey identifies an operations row: the span_name plus the
+// canonical --group-by combination (empty when not grouping, so the map
+// collapses to one row per span_name exactly as before).
+type opAggKey struct {
+	name     string
+	groupKey string
+}
+
+// extractOperations collapses a Prometheus instant response into a map
+// keyed by (span_name, group). Samples with empty span_name or
 // unparseable values are dropped so callers can treat absence as
-// "no data".
-func extractBySpanName(resp *prometheus.QueryResponse) map[string]float64 {
-	out := make(map[string]float64)
+// "no data". groupLabels are the --group-by dimensions carried in the
+// bucket.
+func extractOperations(resp *prometheus.QueryResponse, groupLabels []string) map[opAggKey]groupBucket {
+	out := make(map[opAggKey]groupBucket)
 	if resp == nil {
 		return out
 	}
@@ -1092,51 +1315,63 @@ func extractBySpanName(resp *prometheus.QueryResponse) map[string]float64 {
 		if op == "" {
 			continue
 		}
-		if len(sample.Value) < 2 {
-			continue
-		}
-		str, ok := sample.Value[1].(string)
+		f, ok := sampleScalar(sample)
 		if !ok {
 			continue
 		}
-		f, err := strconv.ParseFloat(str, 64)
-		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
-			continue
-		}
-		out[op] = f
+		gkey, glabels := groupKeyFor(sample.Metric, groupLabels)
+		out[opAggKey{name: op, groupKey: gkey}] = groupBucket{value: f, labels: glabels}
 	}
 	return out
 }
 
+// bucketLabelsFor returns the group-label map for key, preferring
+// whichever of the supplied maps carries it (rate is usually present).
+func edgeLabelsFor(key edgeKey, maps ...map[edgeKey]groupBucket) map[string]string {
+	for _, m := range maps {
+		if b, ok := m[key]; ok {
+			return b.labels
+		}
+	}
+	return nil
+}
+
+func opLabelsFor(key opAggKey, maps ...map[opAggKey]groupBucket) map[string]string {
+	for _, m := range maps {
+		if b, ok := m[key]; ok {
+			return b.labels
+		}
+	}
+	return nil
+}
+
 // mergeEdges joins per-quantity maps (rate, errors, p95) into one row
-// per (peer, connection_type), then sorts by rate desc with a stable
-// (name, namespace) tiebreak. HasErrors is inferred when rate>0 — a
-// healthy edge with no STATUS_CODE_ERROR series prints 0% rather than
-// "no data". Matches the convention from REDStats / Operation.
-func mergeEdges(rates, errors, p95s map[edgeKey]float64) []Edge {
+// per (peer, connection_type, group), then sorts by rate desc with a
+// stable (group, namespace, name, connType) tiebreak. HasErrors is
+// inferred when rate>0 — a healthy edge with no STATUS_CODE_ERROR series
+// prints 0% rather than "no data". Matches the convention from REDStats /
+// Operation. groupBy orders the group tiebreak.
+func mergeEdges(rates, errors, p95s map[edgeKey]groupBucket, groupBy []string) []Edge {
 	keys := make(map[edgeKey]struct{})
-	for k := range rates {
-		keys[k] = struct{}{}
-	}
-	for k := range errors {
-		keys[k] = struct{}{}
-	}
-	for k := range p95s {
-		keys[k] = struct{}{}
+	for _, m := range []map[edgeKey]groupBucket{rates, errors, p95s} {
+		for k := range m {
+			keys[k] = struct{}{}
+		}
 	}
 	out := make([]Edge, 0, len(keys))
 	for k := range keys {
 		rate, hasRate := rates[k]
 		errRate, hasErr := errors[k]
 		p95, hasP95 := p95s[k]
-		hasTraffic := hasRate && rate > 0
+		hasTraffic := hasRate && rate.value > 0
 		out = append(out, Edge{
 			Peer:            Service{Name: k.name, Namespace: k.namespace},
 			ConnectionType:  k.connType,
-			RatePerSecond:   rate,
-			ErrorRatePerSec: errRate,
-			ErrorPercent:    computeErrorPercent(errRate, rate),
-			P95Seconds:      p95,
+			Labels:          edgeLabelsFor(k, rates, errors, p95s),
+			RatePerSecond:   rate.value,
+			ErrorRatePerSec: errRate.value,
+			ErrorPercent:    computeErrorPercent(errRate.value, rate.value),
+			P95Seconds:      p95.value,
 			HasErrors:       hasErr || hasTraffic,
 			HasLatency:      hasP95,
 		})
@@ -1144,6 +1379,9 @@ func mergeEdges(rates, errors, p95s map[edgeKey]float64) []Edge {
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].RatePerSecond != out[j].RatePerSecond {
 			return out[i].RatePerSecond > out[j].RatePerSecond
+		}
+		if gi, gj := groupLabelString(out[i].Labels, groupBy), groupLabelString(out[j].Labels, groupBy); gi != gj {
+			return gi < gj
 		}
 		if out[i].Peer.Namespace != out[j].Peer.Namespace {
 			return out[i].Peer.Namespace < out[j].Peer.Namespace
@@ -1157,58 +1395,48 @@ func mergeEdges(rates, errors, p95s map[edgeKey]float64) []Edge {
 }
 
 // mergeOperations joins per-quantity maps (rate, errors, avg, p50, p95,
-// p99) into one row per distinct span_name, then computes time-share
-// client-side. The time-share denominator is the sum of (avg × rate)
-// across all observed operations — i.e. the share of total wall-clock
-// time each operation consumes. Operations missing an avg-latency
-// signal contribute 0 to the denominator and a 0 share to the output.
-func mergeOperations(rates, errors, avgs, p50s, p95s, p99s map[string]float64) []Operation {
-	names := make(map[string]struct{})
-	for k := range rates {
-		names[k] = struct{}{}
-	}
-	for k := range errors {
-		names[k] = struct{}{}
-	}
-	for k := range avgs {
-		names[k] = struct{}{}
-	}
-	for k := range p50s {
-		names[k] = struct{}{}
-	}
-	for k := range p95s {
-		names[k] = struct{}{}
-	}
-	for k := range p99s {
-		names[k] = struct{}{}
+// p99) into one row per distinct (span_name, group), then computes
+// time-share client-side. Time-share is normalized WITHIN each group —
+// the denominator is the sum of (avg × rate) across the operations
+// sharing that group key — so a per-cluster breakdown has each cluster's
+// operations sum to ~100%, which is what makes cross-group outliers
+// comparable. Operations missing an avg-latency signal contribute 0.
+func mergeOperations(rates, errors, avgs, p50s, p95s, p99s map[opAggKey]groupBucket, groupBy []string) []Operation {
+	keys := make(map[opAggKey]struct{})
+	for _, m := range []map[opAggKey]groupBucket{rates, errors, avgs, p50s, p95s, p99s} {
+		for k := range m {
+			keys[k] = struct{}{}
+		}
 	}
 
-	out := make([]Operation, 0, len(names))
-	totalWall := 0.0
-	for n := range names {
-		rate, hasRate := rates[n]
-		errRate, hasErr := errors[n]
-		avg, hasAvg := avgs[n]
-		p50, hasP50 := p50s[n]
-		p95, hasP95 := p95s[n]
-		p99, hasP99 := p99s[n]
+	out := make([]Operation, 0, len(keys))
+	rowGroupKeys := make([]string, 0, len(keys))
+	totalWall := make(map[string]float64)
+	for k := range keys {
+		rate, hasRate := rates[k]
+		errRate, hasErr := errors[k]
+		avg, hasAvg := avgs[k]
+		p50, hasP50 := p50s[k]
+		p95, hasP95 := p95s[k]
+		p99, hasP99 := p99s[k]
 
-		hasTraffic := hasRate && rate > 0
+		hasTraffic := hasRate && rate.value > 0
 		// Once we know there's traffic, missing error series ⇒ 0 errors,
 		// not "unknown" — same logic as REDStats.HasErrors in services get.
 		hasErrors := hasErr || hasTraffic
 		if hasAvg && hasTraffic {
-			totalWall += avg * rate
+			totalWall[k.groupKey] += avg.value * rate.value
 		}
 		out = append(out, Operation{
-			Name:            n,
-			RatePerSecond:   rate,
-			ErrorRatePerSec: errRate,
-			ErrorPercent:    computeErrorPercent(errRate, rate),
-			AvgSeconds:      avg,
-			P50Seconds:      p50,
-			P95Seconds:      p95,
-			P99Seconds:      p99,
+			Name:            k.name,
+			Labels:          opLabelsFor(k, rates, errors, avgs, p50s, p95s, p99s),
+			RatePerSecond:   rate.value,
+			ErrorRatePerSec: errRate.value,
+			ErrorPercent:    computeErrorPercent(errRate.value, rate.value),
+			AvgSeconds:      avg.value,
+			P50Seconds:      p50.value,
+			P95Seconds:      p95.value,
+			P99Seconds:      p99.value,
 			HasTraffic:      hasTraffic,
 			HasErrors:       hasErrors,
 			HasAvgLatency:   hasAvg,
@@ -1216,20 +1444,25 @@ func mergeOperations(rates, errors, avgs, p50s, p95s, p99s map[string]float64) [
 			HasLatencyP95:   hasP95,
 			HasLatencyP99:   hasP99,
 		})
+		rowGroupKeys = append(rowGroupKeys, k.groupKey)
 	}
 
-	if totalWall > 0 {
-		for i := range out {
-			if out[i].HasAvgLatency && out[i].HasTraffic {
-				out[i].TimeSharePercent = (out[i].AvgSeconds * out[i].RatePerSecond / totalWall) * 100
+	for i := range out {
+		if out[i].HasAvgLatency && out[i].HasTraffic {
+			if tw := totalWall[rowGroupKeys[i]]; tw > 0 {
+				out[i].TimeSharePercent = (out[i].AvgSeconds * out[i].RatePerSecond / tw) * 100
 			}
 		}
 	}
 
-	// Default order matches the plugin: time-share desc, then by name
-	// asc so equal-share rows (typically the zero-share tail) are
-	// reproducible across runs.
+	// Default order: group asc (rows cluster by group), then time-share
+	// desc, then name asc so equal-share rows are reproducible. When not
+	// grouping, the group key is "" for every row and this collapses to
+	// the original (time-share desc, name asc).
 	sort.Slice(out, func(i, j int) bool {
+		if gi, gj := groupLabelString(out[i].Labels, groupBy), groupLabelString(out[j].Labels, groupBy); gi != gj {
+			return gi < gj
+		}
 		if out[i].TimeSharePercent != out[j].TimeSharePercent {
 			return out[i].TimeSharePercent > out[j].TimeSharePercent
 		}

--- a/internal/providers/appo11y/services/query.go
+++ b/internal/providers/appo11y/services/query.go
@@ -133,6 +133,26 @@ func parseFilter(raw string) (Matcher, error) {
 	return Matcher{Label: label, Op: op, Value: val}, nil
 }
 
+// parseFilters validates a slice of raw `--filter` strings into Matchers.
+// Shared by the per-service commands (get, map, list-operations) so a
+// single service can be scoped to a dimension the underlying metric
+// carries — most usefully a cluster/region label. The list command has
+// its own buildFilters wrapper because it layers --language/--env on top.
+func parseFilters(raw []string) ([]Matcher, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]Matcher, 0, len(raw))
+	for _, f := range raw {
+		parsed, err := parseFilter(f)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, parsed)
+	}
+	return out, nil
+}
+
 // Service is a single row in the services inventory.
 //
 // Name is the bare service name (no namespace prefix). Namespace is parsed
@@ -479,11 +499,14 @@ func resolveMetricsMode(raw string) (MetricsMode, bool, error) {
 // single scalar when the named calls metric has any series for the
 // requested job, and empty otherwise. Used by auto-detection to pick a
 // MetricsMode without running the full RED query against every family.
-func buildModeProbeQuery(metric, job string) (string, error) {
+func buildModeProbeQuery(metric, job string, matchers []Matcher) (string, error) {
 	if metric == "" || job == "" {
 		return "", errors.New("metric and job are required")
 	}
 	v := promql.Vector(metric).Label("job", escapePromqlValue(job))
+	for _, m := range matchers {
+		v = m.apply(v)
+	}
 	expr, err := promql.Count(v).Build()
 	if err != nil {
 		return "", err
@@ -523,7 +546,7 @@ func spanKindRegex(kinds []string) string {
 // to catch the `job="auth"` shape; otherwise it matches the canonical
 // `<namespace>/<name>` encoding. metric must be one of `target_info` or
 // `traces_target_info`.
-func buildServiceMetadataQuery(metric, namespace, name string) (string, error) {
+func buildServiceMetadataQuery(metric, namespace, name string, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
@@ -532,6 +555,9 @@ func buildServiceMetadataQuery(metric, namespace, name string) (string, error) {
 		job = namespace + "/" + name
 	}
 	v := promql.Vector(metric).Label("job", escapePromqlValue(job))
+	for _, m := range matchers {
+		v = m.apply(v)
+	}
 	expr, err := promql.Group(v).By(groupByLabels(nil)).Build()
 	if err != nil {
 		return "", err
@@ -544,7 +570,7 @@ func buildServiceMetadataQuery(metric, namespace, name string) (string, error) {
 // Used to auto-resolve the namespace when the user passes only a bare
 // service name (the alternative is silent no-data for namespaced services).
 // metric must be one of `target_info` or `traces_target_info`.
-func buildBareNameLookupQuery(metric, name string) (string, error) {
+func buildBareNameLookupQuery(metric, name string, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
@@ -553,6 +579,9 @@ func buildBareNameLookupQuery(metric, name string) (string, error) {
 	// for full-match, so we don't need ^/$ markers.
 	pattern := "(.+/)?" + regexp.QuoteMeta(name)
 	v := promql.Vector(metric).LabelMatchRegexp("job", escapePromqlValue(pattern))
+	for _, m := range matchers {
+		v = m.apply(v)
+	}
 	expr, err := promql.Group(v).By([]string{"job"}).Build()
 	if err != nil {
 		return "", err
@@ -622,12 +651,13 @@ func namespacesForName(jobs []string, name string) []string {
 }
 
 // buildRateQuery returns the PromQL for the headline request rate (per
-// second) over the given window, scoped to the service and span kinds.
-func buildRateQuery(names metricNames, namespace, name, window string, kinds []string) (string, error) {
+// second) over the given window, scoped to the service, span kinds, and
+// any caller-supplied `--filter` matchers.
+func buildRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
-	v := scopedSpanMetric(names.calls, namespace, name, kinds, window)
+	v := scopedSpanMetric(names.calls, namespace, name, kinds, window, matchers)
 	expr, err := promql.Sum(promql.Rate(v)).Build()
 	if err != nil {
 		return "", err
@@ -637,11 +667,11 @@ func buildRateQuery(names metricNames, namespace, name, window string, kinds []s
 
 // buildErrorRateQuery returns the PromQL for the error rate (per second)
 // over the given window, scoped to status_code=STATUS_CODE_ERROR.
-func buildErrorRateQuery(names metricNames, namespace, name, window string, kinds []string) (string, error) {
+func buildErrorRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
-	v := scopedSpanMetric(names.calls, namespace, name, kinds, window).
+	v := scopedSpanMetric(names.calls, namespace, name, kinds, window, matchers).
 		Label("status_code", statusCodeError)
 	expr, err := promql.Sum(promql.Rate(v)).Build()
 	if err != nil {
@@ -652,14 +682,14 @@ func buildErrorRateQuery(names metricNames, namespace, name, window string, kind
 
 // buildLatencyQuantileQuery returns the PromQL for `histogram_quantile(phi,
 // sum by (le) (rate(... [window]))) `. phi must be in [0, 1].
-func buildLatencyQuantileQuery(names metricNames, namespace, name, window string, kinds []string, phi float64) (string, error) {
+func buildLatencyQuantileQuery(names metricNames, namespace, name, window string, kinds []string, phi float64, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
 	if phi < 0 || phi > 1 {
 		return "", fmt.Errorf("phi must be in [0,1], got %v", phi)
 	}
-	v := scopedSpanMetric(names.latencyBucket, namespace, name, kinds, window)
+	v := scopedSpanMetric(names.latencyBucket, namespace, name, kinds, window, matchers)
 	sumByLe := promql.Sum(promql.Rate(v)).By([]string{"le"})
 	expr, err := promql.HistogramQuantile(phi, sumByLe).Build()
 	if err != nil {
@@ -672,11 +702,11 @@ func buildLatencyQuantileQuery(names metricNames, namespace, name, window string
 // the given window: `sum by (span_name) (rate(<calls>[<window>]))`.
 // Shape parallels buildRateQuery but the aggregation is grouped by
 // span_name so the response can be pivoted into one row per operation.
-func buildOperationsRateQuery(names metricNames, namespace, name, window string, kinds []string) (string, error) {
+func buildOperationsRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
-	v := scopedSpanMetric(names.calls, namespace, name, kinds, window)
+	v := scopedSpanMetric(names.calls, namespace, name, kinds, window, matchers)
 	expr, err := promql.Sum(promql.Rate(v)).By([]string{"span_name"}).Build()
 	if err != nil {
 		return "", err
@@ -687,11 +717,11 @@ func buildOperationsRateQuery(names metricNames, namespace, name, window string,
 // buildOperationsErrorRateQuery returns the per-operation error rate,
 // filtered to status_code=STATUS_CODE_ERROR. An operation with no errors
 // in the window produces no series — the caller treats that as 0.
-func buildOperationsErrorRateQuery(names metricNames, namespace, name, window string, kinds []string) (string, error) {
+func buildOperationsErrorRateQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
-	v := scopedSpanMetric(names.calls, namespace, name, kinds, window).
+	v := scopedSpanMetric(names.calls, namespace, name, kinds, window, matchers).
 		Label("status_code", statusCodeError)
 	expr, err := promql.Sum(promql.Rate(v)).By([]string{"span_name"}).Build()
 	if err != nil {
@@ -704,14 +734,14 @@ func buildOperationsErrorRateQuery(names metricNames, namespace, name, window st
 // `histogram_quantile(phi, sum by (le, span_name) (rate(<bucket>[<window>])))`.
 // span_name is preserved through the histogram_quantile call so quantiles
 // stay per-operation.
-func buildOperationsLatencyQuantileQuery(names metricNames, namespace, name, window string, kinds []string, phi float64) (string, error) {
+func buildOperationsLatencyQuantileQuery(names metricNames, namespace, name, window string, kinds []string, phi float64, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
 	if phi < 0 || phi > 1 {
 		return "", fmt.Errorf("phi must be in [0,1], got %v", phi)
 	}
-	v := scopedSpanMetric(names.latencyBucket, namespace, name, kinds, window)
+	v := scopedSpanMetric(names.latencyBucket, namespace, name, kinds, window, matchers)
 	sumByLeAndOp := promql.Sum(promql.Rate(v)).By([]string{"le", "span_name"})
 	expr, err := promql.HistogramQuantile(phi, sumByLeAndOp).Build()
 	if err != nil {
@@ -728,12 +758,12 @@ func buildOperationsLatencyQuantileQuery(names metricNames, namespace, name, win
 // The average × rate gives wall-clock time spent per second, which is
 // what we sort the table by (time share). Native quantiles aren't a
 // substitute — the time-share signal needs the first moment.
-func buildOperationsAvgLatencyQuery(names metricNames, namespace, name, window string, kinds []string) (string, error) {
+func buildOperationsAvgLatencyQuery(names metricNames, namespace, name, window string, kinds []string, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
-	sumV := scopedSpanMetric(names.latencySum, namespace, name, kinds, window)
-	countV := scopedSpanMetric(names.latencyCount, namespace, name, kinds, window)
+	sumV := scopedSpanMetric(names.latencySum, namespace, name, kinds, window, matchers)
+	countV := scopedSpanMetric(names.latencyCount, namespace, name, kinds, window, matchers)
 	num := promql.Sum(promql.Rate(sumV)).By([]string{"span_name"})
 	den := promql.Sum(promql.Rate(countV)).By([]string{"span_name"})
 	expr, err := promql.Div(num, den).Build()
@@ -745,18 +775,27 @@ func buildOperationsAvgLatencyQuery(names metricNames, namespace, name, window s
 
 // scopedSpanMetric returns a vector selector for `metric` filtered by a
 // single `job="<ns>/<name>"` (or bare `job="<name>"`) label plus a
-// span_kind regex. Range is applied so the caller can wrap in `rate()`.
+// span_kind regex, then any caller-supplied matchers. Range is applied so
+// the caller can wrap in `rate()`.
 //
 // We keep `service` + `service_namespace` out of the selector on purpose:
 // not every metric family emits them. Newer stacks emit both, but the
 // legacy Tempo `traces_spanmetrics_*` family and the OTel Collector
 // variant only emit `job`. Filtering on `job` alone keeps the query
 // portable across every metrics-mode this command supports.
-func scopedSpanMetric(metric, namespace, name string, kinds []string, window string) *promql.VectorExprBuilder {
-	return promql.Vector(metric).
+//
+// matchers are the user's `--filter` label selectors; they scope the
+// numbers to a dimension the span metric happens to carry — most
+// commonly a cluster label (k8s_cluster_name / cluster) so a service
+// deployed across regions can be broken out one region at a time.
+func scopedSpanMetric(metric, namespace, name string, kinds []string, window string, matchers []Matcher) *promql.VectorExprBuilder {
+	v := promql.Vector(metric).
 		Label("job", escapePromqlValue(jobLabel(namespace, name))).
-		LabelMatchRegexp("span_kind", spanKindRegex(kinds)).
-		Range(window)
+		LabelMatchRegexp("span_kind", spanKindRegex(kinds))
+	for _, m := range matchers {
+		v = m.apply(v)
+	}
+	return v.Range(window)
 }
 
 // instantScalar pulls the first sample's value out of a Prometheus instant
@@ -874,7 +913,7 @@ func (d mapDirection) latencyBucketMetric() string {
 // aggregates a service-graph counter to one row per peer per
 // connection-type. metric is one of the service-graph counter metrics
 // (request_total, request_failed_total).
-func buildServiceMapEdgeQuery(metric string, dir mapDirection, namespace, name, window string) (string, error) {
+func buildServiceMapEdgeQuery(metric string, dir mapDirection, namespace, name, window string, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
@@ -887,6 +926,9 @@ func buildServiceMapEdgeQuery(metric string, dir mapDirection, namespace, name, 
 	v := promql.Vector(metric).Label(selfName, escapePromqlValue(name))
 	if namespace != "" {
 		v = v.Label(selfNs, escapePromqlValue(namespace))
+	}
+	for _, m := range matchers {
+		v = m.apply(v)
 	}
 	v = v.Range(window)
 
@@ -904,7 +946,7 @@ func buildServiceMapEdgeQuery(metric string, dir mapDirection, namespace, name, 
 //	histogram_quantile(phi, sum by (le, peer_name, peer_namespace, connection_type) (rate(<bucket>[window])))
 //
 // with the bucket metric picked by `dir.latencyBucketMetric()`.
-func buildServiceMapLatencyQuery(dir mapDirection, namespace, name, window string, phi float64) (string, error) {
+func buildServiceMapLatencyQuery(dir mapDirection, namespace, name, window string, phi float64, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("service name is required")
 	}
@@ -917,6 +959,9 @@ func buildServiceMapLatencyQuery(dir mapDirection, namespace, name, window strin
 	v := promql.Vector(dir.latencyBucketMetric()).Label(selfName, escapePromqlValue(name))
 	if namespace != "" {
 		v = v.Label(selfNs, escapePromqlValue(namespace))
+	}
+	for _, m := range matchers {
+		v = m.apply(v)
 	}
 	v = v.Range(window)
 

--- a/internal/providers/appo11y/services/query.go
+++ b/internal/providers/appo11y/services/query.go
@@ -581,6 +581,90 @@ func buildModeProbeQuery(metric, job string, matchers []Matcher) (string, error)
 	return expr.String(), nil
 }
 
+// buildSeriesSelector renders a Prometheus `/series` match selector for a
+// metric scoped to one service (job) plus any --filter matchers, e.g.
+// `traces_span_metrics_calls_total{job="billing/checkout",k8s_cluster_name="prod"}`.
+// Used by `services labels` to enumerate the label keys/values that
+// --filter and --group-by can operate on. Values are escaped the same way
+// as the query builders (no injection).
+func buildSeriesSelector(metric, job string, matchers []Matcher) string {
+	var b strings.Builder
+	b.WriteString(metric)
+	b.WriteString(`{job="`)
+	b.WriteString(escapePromqlValue(job))
+	b.WriteString(`"`)
+	for _, m := range matchers {
+		b.WriteString(",")
+		b.WriteString(m.Label)
+		b.WriteString(m.Op)
+		b.WriteString(`"`)
+		b.WriteString(escapePromqlValue(m.Value))
+		b.WriteString(`"`)
+	}
+	b.WriteString("}")
+	return b.String()
+}
+
+// LabelSummary is one row of `services labels`: a label present on the
+// service's series, its distinct-value count, and either a sample of
+// values (default view) or the full set (when a single label is
+// requested).
+type LabelSummary struct {
+	Name        string   `json:"name" yaml:"name"`
+	Cardinality int      `json:"cardinality" yaml:"cardinality"`
+	Values      []string `json:"values,omitempty" yaml:"values,omitempty"`
+}
+
+// ServiceLabelsResponse is the `services labels` response: the queried
+// service, the metric whose series were inspected, and one entry per
+// discovered label (sorted by name).
+type ServiceLabelsResponse struct {
+	Service Service        `json:"service" yaml:"service"`
+	Metric  string         `json:"metric" yaml:"metric"`
+	Window  string         `json:"window" yaml:"window"`
+	Items   []LabelSummary `json:"items" yaml:"items"`
+}
+
+// collectSeriesLabels folds a /series response (one map per series) into a
+// label→distinct-values index, dropping the synthetic __name__. Callers
+// turn this into LabelSummary rows.
+func collectSeriesLabels(series []map[string]string) map[string]map[string]struct{} {
+	out := make(map[string]map[string]struct{})
+	for _, s := range series {
+		for k, v := range s {
+			if k == "__name__" {
+				continue
+			}
+			if out[k] == nil {
+				out[k] = make(map[string]struct{})
+			}
+			out[k][v] = struct{}{}
+		}
+	}
+	return out
+}
+
+// summarizeLabels turns the collectSeriesLabels index into sorted
+// LabelSummary rows. sampleN caps how many values each row carries (0 =
+// all); the full count is always reported via Cardinality so the caller
+// can show "N more".
+func summarizeLabels(index map[string]map[string]struct{}, sampleN int) []LabelSummary {
+	out := make([]LabelSummary, 0, len(index))
+	for name, vals := range index {
+		values := make([]string, 0, len(vals))
+		for v := range vals {
+			values = append(values, v)
+		}
+		sort.Strings(values)
+		if sampleN > 0 && len(values) > sampleN {
+			values = values[:sampleN]
+		}
+		out = append(out, LabelSummary{Name: name, Cardinality: len(vals), Values: values})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
 // jobLabel returns the PromQL `job` label value for a (namespace, name)
 // pair, matching the `<namespace>/<service>` encoding target_info uses
 // throughout this package.

--- a/internal/providers/appo11y/services/query_test.go
+++ b/internal/providers/appo11y/services/query_test.go
@@ -1,6 +1,8 @@
 package services //nolint:testpackage // Tests cover unexported helpers (buildServicesQuery, parseFilter, parseServicesResponse).
 
 import (
+	"maps"
+	"math"
 	"strings"
 	"testing"
 
@@ -274,6 +276,79 @@ func TestParseFilters(t *testing.T) {
 	}
 }
 
+func TestParseGroupBy(t *testing.T) {
+	// nil / empty in → nil out.
+	if got, err := parseGroupBy(nil); err != nil || got != nil {
+		t.Fatalf("parseGroupBy(nil) = %v, %v; want nil, nil", got, err)
+	}
+
+	// Comma-separated and repeated entries flatten, trim, and de-dupe
+	// (order preserved by first occurrence).
+	got, err := parseGroupBy([]string{"k8s_cluster_name, cloud_region", "k8s_cluster_name", " deployment_environment "})
+	if err != nil {
+		t.Fatalf("parseGroupBy err = %v", err)
+	}
+	want := []string{"k8s_cluster_name", "cloud_region", "deployment_environment"}
+	if len(got) != len(want) {
+		t.Fatalf("parseGroupBy = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("parseGroupBy[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// An invalid label name is rejected (protects the `by (...)` clause).
+	if _, err := parseGroupBy([]string{"1bad"}); err == nil {
+		t.Error("expected error for label name starting with a digit")
+	}
+	if _, err := parseGroupBy([]string{"has-dash"}); err == nil {
+		t.Error("expected error for label name with a dash")
+	}
+}
+
+func TestMergeGroupedRED(t *testing.T) {
+	// Two clusters; "west" is the latency/error outlier. mergeGroupedRED
+	// sorts by rate desc, so east (busier) comes first, but the point is
+	// each row carries its own RED + group label.
+	bucket := func(cluster string, v float64) map[string]groupBucket {
+		return map[string]groupBucket{cluster: {value: v, labels: map[string]string{"k8s_cluster_name": cluster}}}
+	}
+	merge2 := func(a, b map[string]groupBucket) map[string]groupBucket {
+		out := map[string]groupBucket{}
+		maps.Copy(out, a)
+		maps.Copy(out, b)
+		return out
+	}
+	rates := merge2(bucket("east", 12), bucket("west", 3))
+	errs := merge2(bucket("east", 0), bucket("west", 1.5)) // west 50% errors
+	p95s := merge2(bucket("east", 0.05), bucket("west", 1.2))
+
+	items := mergeGroupedRED("5m", MetricsModeV3, []string{spanKindServer}, []string{"k8s_cluster_name"},
+		rates, errs, nil, p95s, nil)
+	if len(items) != 2 {
+		t.Fatalf("len = %d, want 2: %+v", len(items), items)
+	}
+	// Sorted by rate desc → east first.
+	if items[0].Labels["k8s_cluster_name"] != "east" || items[1].Labels["k8s_cluster_name"] != "west" {
+		t.Fatalf("order wrong: %q, %q", items[0].Labels["k8s_cluster_name"], items[1].Labels["k8s_cluster_name"])
+	}
+	west := items[1].RED
+	if !west.HasTraffic || west.RatePerSecond != 3 {
+		t.Errorf("west RED wrong: %+v", west)
+	}
+	if math.Abs(west.ErrorPercent-50) > 0.001 {
+		t.Errorf("west error%% = %.4f, want 50", west.ErrorPercent)
+	}
+	if !west.HasLatencyP95 || west.P95Seconds != 1.2 {
+		t.Errorf("west p95 wrong: %+v", west)
+	}
+	// east: traffic present, no error series → HasErrors inferred true, 0%.
+	if east := items[0].RED; !east.HasErrors || east.ErrorPercent != 0 {
+		t.Errorf("east errors wrong: %+v", east)
+	}
+}
+
 // TestFilterMatchersThreadIntoQueries locks in that a --filter matcher is
 // appended to every per-service query family that carries it — the RED
 // span-metric queries, the operations breakdown, the service-graph edges,
@@ -290,25 +365,25 @@ func TestFilterMatchersThreadIntoQueries(t *testing.T) {
 		build func() (string, error)
 	}{
 		{"rate", func() (string, error) {
-			return buildRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m)
+			return buildRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m, nil)
 		}},
 		{"error", func() (string, error) {
-			return buildErrorRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m)
+			return buildErrorRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m, nil)
 		}},
 		{"latency", func() (string, error) {
-			return buildLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, m)
+			return buildLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, m, nil)
 		}},
 		{"ops-rate", func() (string, error) {
-			return buildOperationsRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m)
+			return buildOperationsRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m, nil)
 		}},
 		{"ops-avg", func() (string, error) {
-			return buildOperationsAvgLatencyQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m)
+			return buildOperationsAvgLatencyQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m, nil)
 		}},
 		{"map-edge", func() (string, error) {
-			return buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "billing", "checkout", "5m", m)
+			return buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "billing", "checkout", "5m", m, nil)
 		}},
 		{"map-latency", func() (string, error) {
-			return buildServiceMapLatencyQuery(callersDirection, "billing", "checkout", "5m", 0.95, m)
+			return buildServiceMapLatencyQuery(callersDirection, "billing", "checkout", "5m", 0.95, m, nil)
 		}},
 		{"metadata", func() (string, error) { return buildServiceMetadataQuery("target_info", "billing", "checkout", m) }},
 		{"probe", func() (string, error) { return buildModeProbeQuery(v3.calls, "billing/checkout", m) }},
@@ -329,7 +404,7 @@ func TestFilterMatchersThreadIntoQueries(t *testing.T) {
 	// Injection guard: a matcher value with an embedded quote is escaped so
 	// it can't break out of the selector.
 	evil := []Matcher{{Label: "cloud_region", Op: "=", Value: `x"} or up{`}}
-	got, err := buildRateQuery(v3, "", "checkout", "5m", []string{spanKindServer}, evil)
+	got, err := buildRateQuery(v3, "", "checkout", "5m", []string{spanKindServer}, evil, nil)
 	if err != nil {
 		t.Fatalf("build err = %v", err)
 	}

--- a/internal/providers/appo11y/services/query_test.go
+++ b/internal/providers/appo11y/services/query_test.go
@@ -307,6 +307,65 @@ func TestParseGroupBy(t *testing.T) {
 	}
 }
 
+func TestBuildSeriesSelector(t *testing.T) {
+	got := buildSeriesSelector("traces_span_metrics_calls_total", "billing/checkout", nil)
+	want := `traces_span_metrics_calls_total{job="billing/checkout"}`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+
+	got = buildSeriesSelector("traces_span_metrics_calls_total", "auth", []Matcher{
+		{Label: "k8s_cluster_name", Op: "=", Value: "prod"},
+		{Label: "cloud_region", Op: "!=", Value: `eu"west`}, // embedded quote escaped
+	})
+	want = `traces_span_metrics_calls_total{job="auth",k8s_cluster_name="prod",cloud_region!="eu\"west"}`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestCollectAndSummarizeLabels(t *testing.T) {
+	series := []map[string]string{
+		{"__name__": "traces_span_metrics_calls_total", "job": "billing/checkout", "k8s_cluster_name": "east", "span_name": "GET /"},
+		{"__name__": "traces_span_metrics_calls_total", "job": "billing/checkout", "k8s_cluster_name": "west", "span_name": "GET /"},
+		{"__name__": "traces_span_metrics_calls_total", "job": "billing/checkout", "k8s_cluster_name": "east", "span_name": "POST /x"},
+	}
+	index := collectSeriesLabels(series)
+	// __name__ dropped; job/k8s_cluster_name/span_name kept.
+	if _, ok := index["__name__"]; ok {
+		t.Error("__name__ should be dropped")
+	}
+	if len(index["k8s_cluster_name"]) != 2 {
+		t.Errorf("k8s_cluster_name distinct = %d, want 2", len(index["k8s_cluster_name"]))
+	}
+	if len(index["job"]) != 1 {
+		t.Errorf("job distinct = %d, want 1", len(index["job"]))
+	}
+
+	// Summary is sorted by name; sampleN caps values but Cardinality is full.
+	rows := summarizeLabels(index, 1)
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d, want 3: %+v", len(rows), rows)
+	}
+	if rows[0].Name != "job" || rows[1].Name != "k8s_cluster_name" || rows[2].Name != "span_name" {
+		t.Errorf("rows not sorted by name: %+v", rows)
+	}
+	cluster := rows[1]
+	if cluster.Cardinality != 2 || len(cluster.Values) != 1 {
+		t.Errorf("cluster row wrong (want cardinality 2, 1 sampled value): %+v", cluster)
+	}
+
+	// sampleN=0 returns all values.
+	rows = summarizeLabels(index, 0)
+	for _, r := range rows {
+		if r.Name == "k8s_cluster_name" {
+			if len(r.Values) != 2 || r.Values[0] != "east" || r.Values[1] != "west" {
+				t.Errorf("full values wrong/unsorted: %+v", r)
+			}
+		}
+	}
+}
+
 func TestMergeGroupedRED(t *testing.T) {
 	// Two clusters; "west" is the latency/error outlier. mergeGroupedRED
 	// sorts by rate desc, so east (busier) comes first, but the point is

--- a/internal/providers/appo11y/services/query_test.go
+++ b/internal/providers/appo11y/services/query_test.go
@@ -1,6 +1,7 @@
 package services //nolint:testpackage // Tests cover unexported helpers (buildServicesQuery, parseFilter, parseServicesResponse).
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/internal/query/prometheus"
@@ -238,6 +239,102 @@ func TestParseFilter(t *testing.T) {
 				t.Errorf("parseFilter() = %+v, want %+v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseFilters(t *testing.T) {
+	// Empty in → nil out (callers treat nil as "no scoping").
+	got, err := parseFilters(nil)
+	if err != nil {
+		t.Fatalf("parseFilters(nil) err = %v", err)
+	}
+	if got != nil {
+		t.Errorf("parseFilters(nil) = %v, want nil", got)
+	}
+
+	got, err = parseFilters([]string{"k8s_cluster_name=prod-us", "telemetry_sdk_language!=java"})
+	if err != nil {
+		t.Fatalf("parseFilters() err = %v", err)
+	}
+	want := []Matcher{
+		{Label: "k8s_cluster_name", Op: "=", Value: "prod-us"},
+		{Label: "telemetry_sdk_language", Op: "!=", Value: "java"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parseFilters() = %+v, want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("parseFilters()[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	if _, err := parseFilters([]string{"bogus"}); err == nil {
+		t.Error("expected error for malformed filter")
+	}
+}
+
+// TestFilterMatchersThreadIntoQueries locks in that a --filter matcher is
+// appended to every per-service query family that carries it — the RED
+// span-metric queries, the operations breakdown, the service-graph edges,
+// and the target_info metadata/lookup queries — so a multi-cluster service
+// can be scoped one cluster at a time. It also confirms the matcher value
+// is quote-escaped identically to the job selector (no injection).
+func TestFilterMatchersThreadIntoQueries(t *testing.T) {
+	v3, _ := metricNamesByMode(MetricsModeV3)
+	m := []Matcher{{Label: "k8s_cluster_name", Op: "=", Value: "prod-us"}}
+	const clusterSel = `k8s_cluster_name="prod-us"`
+
+	checks := []struct {
+		name  string
+		build func() (string, error)
+	}{
+		{"rate", func() (string, error) {
+			return buildRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m)
+		}},
+		{"error", func() (string, error) {
+			return buildErrorRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m)
+		}},
+		{"latency", func() (string, error) {
+			return buildLatencyQuantileQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, 0.95, m)
+		}},
+		{"ops-rate", func() (string, error) {
+			return buildOperationsRateQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m)
+		}},
+		{"ops-avg", func() (string, error) {
+			return buildOperationsAvgLatencyQuery(v3, "billing", "checkout", "5m", []string{spanKindServer}, m)
+		}},
+		{"map-edge", func() (string, error) {
+			return buildServiceMapEdgeQuery(serviceGraphRequestTotalMetric, callersDirection, "billing", "checkout", "5m", m)
+		}},
+		{"map-latency", func() (string, error) {
+			return buildServiceMapLatencyQuery(callersDirection, "billing", "checkout", "5m", 0.95, m)
+		}},
+		{"metadata", func() (string, error) { return buildServiceMetadataQuery("target_info", "billing", "checkout", m) }},
+		{"probe", func() (string, error) { return buildModeProbeQuery(v3.calls, "billing/checkout", m) }},
+		{"bare-name", func() (string, error) { return buildBareNameLookupQuery("target_info", "checkout", m) }},
+	}
+	for _, c := range checks {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := c.build()
+			if err != nil {
+				t.Fatalf("build err = %v", err)
+			}
+			if !strings.Contains(got, clusterSel) {
+				t.Errorf("query missing cluster selector %q: %s", clusterSel, got)
+			}
+		})
+	}
+
+	// Injection guard: a matcher value with an embedded quote is escaped so
+	// it can't break out of the selector.
+	evil := []Matcher{{Label: "cloud_region", Op: "=", Value: `x"} or up{`}}
+	got, err := buildRateQuery(v3, "", "checkout", "5m", []string{spanKindServer}, evil)
+	if err != nil {
+		t.Fatalf("build err = %v", err)
+	}
+	if !strings.Contains(got, `cloud_region="x\"} or up{"`) {
+		t.Errorf("matcher value not escaped: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

The per-service `appo11y services` commands — `get` (RED snapshot), `map` (service-graph slice), and `list-operations` (per-operation breakdown) — aggregated their numbers across everything (all clusters/regions), with no way to narrow, compare, or even discover the available dimensions. A service like `faro-collector` running across many clusters was un-sliceable.

> _"it renders for the whole collector across all regions … being able to break it down by cluster is critical."_ → _"the same PR should allow grouping, so users can find outliers."_ → _"how do users know the list of available filters?"_ → _"both labels and values deserve a little love."_

## Change — three composable pieces

### 1. `--filter <label><op><value>` (repeatable) — narrow
Restricts to matching series (goes into the metric's `{…}` selector). Ops `= != =~ !~`, values quote-escaped (no PromQL injection).
```
gcx appo11y services get faro-collector --filter k8s_cluster_name=prod-us-central-0
```

### 2. `--group-by <label[,label…]>` — pivot / find outliers
Emits **one row per distinct value** (goes into `sum by (…)`). No need to know the values up front.
```
$ gcx appo11y services get checkoutservice --group-by k8s_cluster_name
K8S_CLUSTER_NAME   RATE        ERROR %  P95
prod-us-east-0     12.4 req/s  0.10%    180ms
prod-us-west-0      9.1 req/s  6.80%    1.90s   ← outlier
prod-eu-west-0      8.7 req/s  0.05%    150ms
```
- **get** → one RED row per group (`GroupedServiceDetail`), sorted by rate desc.
- **list-operations** → each operation per group, time-share normalized **within** each group.
- **map** → each edge split per group (table column; mermaid/dot distinct nodes).

**Filter + group-by compose**: `--filter deployment_environment=production --group-by k8s_cluster_name` → per-cluster RED, prod only.

### 3. `services labels <svc>` — discover (the answer to "what can I filter/group by?")
Lists the labels on the service's span-metric series (exactly what get/list-operations filter and group on), each with its distinct-value count; `--label <name>` drills into a single label's values (what to feed `--filter`).
```
$ gcx appo11y services labels checkoutservice
LABEL                   CARDINALITY  SAMPLE VALUES
deployment_environment  1            oteldemo01
k8s_cluster_name        1            appo11ydev01
service                 1            checkoutservice
…
$ gcx appo11y services labels checkoutservice --label k8s_cluster_name
K8S_CLUSTER_NAME
appo11ydev01
```
Backed by the existing `prometheus.Client.Series` support, scoped to the service, metrics-mode auto-detected.

## Validation (live dev stack)
- `--filter`/`--group-by` on get & list-operations produce correct scoped/per-group RED; combined filter+group-by works; multi-label group-by works; invalid `--group-by` label rejected.
- `services labels` lists real labels + cardinality; `--label` lists values; missing label → hint + exit 1.
- **map** caveat (documented): the Tempo service-graph family often omits cluster labels, so `--filter` there can zero the edges and `--group-by` collapses them into a `(none)` bucket. The span-metric-backed `get`/`list-operations` (and `labels`) are the reliable cluster tools.

## Tests
`parseFilters`, `parseGroupBy`, `buildSeriesSelector`, `collectSeriesLabels`/`summarizeLabels`, `mergeGroupedRED`, grouped `extractOperations`/`extractEdges`, within-group time-share, filter-threading + injection-escaping, labels codec (summary + drill-down). Full `go test ./...` green, `mise run lint` clean, CLI reference regenerated.