### PR TITLE
feat: port Grafana core CRUD (annotations, org users, public dashboards, RBAC permissions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ internal/
 ├── config/      Config types, loader, editor, rest.Config builder, stack-id discovery, context name helpers (auto-migrates plaintext token-shaped secrets into the OS keychain via internal/credentials)
 ├── credentials/ OS-keychain backend (zalando/go-keyring) for token-shaped secrets; sentinel format + Store interface; auto-disabled under `go test`
 ├── cloud/       GCOM HTTP client for Grafana Cloud stack discovery
+├── coreapi/     Shared HTTP client + generic DoJSON/DoStatus helpers for core Grafana `/api/*` REST providers (annotations, org, permissions, publicdashboards)
 ├── fleet/       Shared fleet base client (HTTP, auth, config — used by fleet provider and instrumentation provider)
 ├── resources/
 │   ├── *.go     Core types: Resource, Selector, Filter, Descriptor, Resources collection
@@ -104,6 +105,7 @@ internal/
 │   └── remote/     Pusher, Puller, Deleter, FolderHierarchy, Summary
 ├── providers/   Provider plugin system (interface, registry, self-registration)
 │   ├── alert/      Alert provider (rules, groups — read-only)
+│   ├── annotations/ Annotations provider (CRUD + tags + mass-delete via /api/annotations; coreapi client, resources-pipeline bridge)
 │   ├── dashboards/ Dashboards provider (CRUD, search, versions, snapshot)
 │   ├── datasources/ Datasources provider — bridges /api/datasources into the resources pipeline via ResourceAdapter (no commands; managed via `gcx resources`)
 │   ├── faro/       Frontend Observability provider (apps CRUD, sourcemaps sub-resource) — CLI: `gcx frontend`
@@ -119,7 +121,10 @@ internal/
 │   ├── logs/       Logs signal provider (Loki queries + Adaptive Logs commands)
 │   ├── metrics/    Metrics signal provider (Prometheus queries + Adaptive Metrics commands)
 │   ├── appo11y/    App Observability provider (overrides, settings — singleton resources; services discovery via target_info)
+│   ├── org/        Organization provider (org users — list/get/add/update-role/remove via /api/org/users; coreapi client)
+│   ├── permissions/ Permissions provider (granular RBAC via /api/access-control/{resource}/{id} — get/set/grant/levels over folders|dashboards|datasources|teams|serviceaccounts; command-only)
 │   ├── profiles/   Profiles signal provider (Pyroscope queries + adaptive stub)
+│   ├── publicdashboards/ Public Dashboards provider (CRUD via /api/dashboards/uid/{uid}/public-dashboards; coreapi client, resources-pipeline bridge)
 │   ├── aio11y/     AI Observability provider (conversations, agents, generations, evaluators, rules, hook-rules (guards), templates, scores, judge, saved-conversations, collections, experiments — via grafana-sigil-app plugin API)
 │   ├── slo/        SLO provider (definitions, reports)
 │   ├── synth/      Synthetic Monitoring provider (checks, probes)

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -33,24 +33,28 @@ import (
 	"github.com/grafana/gcx/internal/logs"
 	"github.com/grafana/gcx/internal/notifier"
 	"github.com/grafana/gcx/internal/providers"
-	_ "github.com/grafana/gcx/internal/providers/aio11y"          // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/alert"           // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/appo11y"         // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/dashboards"      // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/datasources"     // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/faro"            // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/fleet"           // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/instrumentation" // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/irm"             // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/k6"              // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/kg"              // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/logs"            // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/metrics"         // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/profiles"        // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/slo"             // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/stacks"          // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/synth"           // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/traces"          // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/aio11y"           // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/alert"            // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/annotations"      // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/appo11y"          // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/dashboards"       // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/datasources"      // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/faro"             // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/fleet"            // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/instrumentation"  // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/irm"              // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/k6"               // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/kg"               // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/logs"             // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/metrics"          // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/org"              // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/permissions"      // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/profiles"         // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/publicdashboards" // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/slo"              // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/stacks"           // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/synth"            // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/traces"           // Provider registrations — blank imports trigger init() self-registration.
 	"github.com/grafana/gcx/internal/style"
 	"github.com/grafana/gcx/internal/terminal"
 	appversion "github.com/grafana/gcx/internal/version"

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -25,6 +25,7 @@ Run 'gcx agent skills list' to see bundled Agent Skills with task-specific guida
 * [gcx agent](gcx_agent.md)	 - Agent mode utilities
 * [gcx aio11y](gcx_aio11y.md)	 - Manage Grafana AI Observability resources
 * [gcx alert](gcx_alert.md)	 - Manage Grafana alert rules and alert groups
+* [gcx annotations](gcx_annotations.md)	 - Manage Grafana annotations
 * [gcx api](gcx_api.md)	 - Make direct HTTP requests to the Grafana API
 * [gcx appo11y](gcx_appo11y.md)	 - Manage Grafana App Observability settings
 * [gcx assistant](gcx_assistant.md)	 - Interact with Grafana Assistant
@@ -45,8 +46,11 @@ Run 'gcx agent skills list' to see bundled Agent Skills with task-specific guida
 * [gcx login](gcx_login.md)	 - Log in to a Grafana instance
 * [gcx logs](gcx_logs.md)	 - Query Loki datasources and manage Adaptive Logs
 * [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
+* [gcx org](gcx_org.md)	 - Manage Grafana organization resources
+* [gcx permissions](gcx_permissions.md)	 - Manage Grafana resource permissions (RBAC)
 * [gcx profiles](gcx_profiles.md)	 - Query Pyroscope datasources and manage continuous profiling
 * [gcx providers](gcx_providers.md)	 - Manage registered providers
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
 * [gcx resources](gcx_resources.md)	 - Manipulate Grafana resources
 * [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
 * [gcx slo](gcx_slo.md)	 - Manage Grafana SLO definitions and reports

--- a/docs/reference/cli/gcx_annotations.md
+++ b/docs/reference/cli/gcx_annotations.md
@@ -1,0 +1,33 @@
+## gcx annotations
+
+Manage Grafana annotations
+
+### Options
+
+```
+      --config string   Path to the configuration file to use
+  -h, --help            help for annotations
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx annotations create](gcx_annotations_create.md)	 - Create an annotation from a JSON file.
+* [gcx annotations delete](gcx_annotations_delete.md)	 - Delete an annotation by ID.
+* [gcx annotations get](gcx_annotations_get.md)	 - Get an annotation by ID.
+* [gcx annotations list](gcx_annotations_list.md)	 - List annotations (last 24h by default).
+* [gcx annotations mass-delete](gcx_annotations_mass-delete.md)	 - Delete multiple annotations by annotation ID, or by dashboard + panel.
+* [gcx annotations tags](gcx_annotations_tags.md)	 - List annotation tags with usage counts.
+* [gcx annotations update](gcx_annotations_update.md)	 - Update an annotation from a JSON file (PATCH).
+

--- a/docs/reference/cli/gcx_annotations_create.md
+++ b/docs/reference/cli/gcx_annotations_create.md
@@ -1,0 +1,38 @@
+## gcx annotations create
+
+Create an annotation from a JSON file.
+
+```
+gcx annotations create [flags]
+```
+
+### Examples
+
+```
+  gcx annotations create -f annotation.json
+  cat annotation.json | gcx annotations create -f -
+```
+
+### Options
+
+```
+  -f, --file string   JSON file containing the annotation (use - for stdin)
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx annotations](gcx_annotations.md)	 - Manage Grafana annotations
+

--- a/docs/reference/cli/gcx_annotations_delete.md
+++ b/docs/reference/cli/gcx_annotations_delete.md
@@ -1,0 +1,36 @@
+## gcx annotations delete
+
+Delete an annotation by ID.
+
+```
+gcx annotations delete ID [flags]
+```
+
+### Examples
+
+```
+  gcx annotations delete 1
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx annotations](gcx_annotations.md)	 - Manage Grafana annotations
+

--- a/docs/reference/cli/gcx_annotations_get.md
+++ b/docs/reference/cli/gcx_annotations_get.md
@@ -1,0 +1,39 @@
+## gcx annotations get
+
+Get an annotation by ID.
+
+```
+gcx annotations get ID [flags]
+```
+
+### Examples
+
+```
+  gcx annotations get 1
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx annotations](gcx_annotations.md)	 - Manage Grafana annotations
+

--- a/docs/reference/cli/gcx_annotations_list.md
+++ b/docs/reference/cli/gcx_annotations_list.md
@@ -1,0 +1,54 @@
+## gcx annotations list
+
+List annotations (last 24h by default).
+
+### Synopsis
+
+List annotations from Grafana.
+
+By default, returns only annotations from the last 24 hours. Use --lookback
+to widen the window, or --from/--to for an explicit time range (epoch ms).
+
+```
+gcx annotations list [flags]
+```
+
+### Examples
+
+```
+  gcx annotations list
+  gcx annotations list --lookback 168h
+  gcx annotations list --tags deploy,prod
+  gcx annotations list --limit 20
+```
+
+### Options
+
+```
+      --from int            Start time in epoch milliseconds
+  -h, --help                help for list
+      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int           Maximum results to return (0 = unlimited) (default 100)
+      --lookback duration   Lookback duration (e.g. 24h, 48h, 7d); ignored if --from/--to are set (default 24h0m0s)
+  -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+      --tags strings        Filter by tags (comma-separated or repeated)
+      --to int              End time in epoch milliseconds
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx annotations](gcx_annotations.md)	 - Manage Grafana annotations
+

--- a/docs/reference/cli/gcx_annotations_mass-delete.md
+++ b/docs/reference/cli/gcx_annotations_mass-delete.md
@@ -1,0 +1,48 @@
+## gcx annotations mass-delete
+
+Delete multiple annotations by annotation ID, or by dashboard + panel.
+
+### Synopsis
+
+Delete multiple annotations in a single request.
+
+Provide either --annotation-id, or a dashboard selector (--dashboard-uid or
+--dashboard-id) together with --panel-id.
+
+```
+gcx annotations mass-delete [flags]
+```
+
+### Examples
+
+```
+  gcx annotations mass-delete --annotation-id 42
+  gcx annotations mass-delete --dashboard-uid abcdef123 --panel-id 3
+```
+
+### Options
+
+```
+      --annotation-id int      Delete a single annotation by ID
+      --dashboard-id int       Dashboard numeric ID (with --panel-id)
+      --dashboard-uid string   Dashboard UID (with --panel-id)
+  -h, --help                   help for mass-delete
+      --panel-id int           Panel ID (with a dashboard selector)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx annotations](gcx_annotations.md)	 - Manage Grafana annotations
+

--- a/docs/reference/cli/gcx_annotations_tags.md
+++ b/docs/reference/cli/gcx_annotations_tags.md
@@ -1,0 +1,39 @@
+## gcx annotations tags
+
+List annotation tags with usage counts.
+
+```
+gcx annotations tags [flags]
+```
+
+### Examples
+
+```
+  gcx annotations tags
+```
+
+### Options
+
+```
+  -h, --help            help for tags
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx annotations](gcx_annotations.md)	 - Manage Grafana annotations
+

--- a/docs/reference/cli/gcx_annotations_update.md
+++ b/docs/reference/cli/gcx_annotations_update.md
@@ -1,0 +1,37 @@
+## gcx annotations update
+
+Update an annotation from a JSON file (PATCH).
+
+```
+gcx annotations update ID [flags]
+```
+
+### Examples
+
+```
+  gcx annotations update 1 -f patch.json
+```
+
+### Options
+
+```
+  -f, --file string   JSON file containing the patch (use - for stdin)
+  -h, --help          help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx annotations](gcx_annotations.md)	 - Manage Grafana annotations
+

--- a/docs/reference/cli/gcx_org.md
+++ b/docs/reference/cli/gcx_org.md
@@ -1,0 +1,27 @@
+## gcx org
+
+Manage Grafana organization resources
+
+### Options
+
+```
+      --config string   Path to the configuration file to use
+  -h, --help            help for org
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx org users](gcx_org_users.md)	 - Manage users in the current organization.
+

--- a/docs/reference/cli/gcx_org_users.md
+++ b/docs/reference/cli/gcx_org_users.md
@@ -1,0 +1,31 @@
+## gcx org users
+
+Manage users in the current organization.
+
+### Options
+
+```
+  -h, --help   help for users
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx org](gcx_org.md)	 - Manage Grafana organization resources
+* [gcx org users add](gcx_org_users_add.md)	 - Add a user to the current organization.
+* [gcx org users get](gcx_org_users_get.md)	 - Get a single org user by login or email.
+* [gcx org users list](gcx_org_users_list.md)	 - List users in the current organization.
+* [gcx org users remove](gcx_org_users_remove.md)	 - Remove a user from the current organization.
+* [gcx org users update-role](gcx_org_users_update-role.md)	 - Update the role of a user in the current organization.
+

--- a/docs/reference/cli/gcx_org_users_add.md
+++ b/docs/reference/cli/gcx_org_users_add.md
@@ -1,0 +1,32 @@
+## gcx org users add
+
+Add a user to the current organization.
+
+```
+gcx org users add [flags]
+```
+
+### Options
+
+```
+  -h, --help           help for add
+      --login string   Login or email of the user to add (required)
+      --role string    Role for the user, e.g. Admin, Editor, Viewer (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx org users](gcx_org_users.md)	 - Manage users in the current organization.
+

--- a/docs/reference/cli/gcx_org_users_get.md
+++ b/docs/reference/cli/gcx_org_users_get.md
@@ -1,0 +1,33 @@
+## gcx org users get
+
+Get a single org user by login or email.
+
+```
+gcx org users get LOGIN-OR-EMAIL [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx org users](gcx_org_users.md)	 - Manage users in the current organization.
+

--- a/docs/reference/cli/gcx_org_users_list.md
+++ b/docs/reference/cli/gcx_org_users_list.md
@@ -1,0 +1,34 @@
+## gcx org users list
+
+List users in the current organization.
+
+```
+gcx org users list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for unlimited) (default 50)
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx org users](gcx_org_users.md)	 - Manage users in the current organization.
+

--- a/docs/reference/cli/gcx_org_users_remove.md
+++ b/docs/reference/cli/gcx_org_users_remove.md
@@ -1,0 +1,30 @@
+## gcx org users remove
+
+Remove a user from the current organization.
+
+```
+gcx org users remove USER-ID [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx org users](gcx_org_users.md)	 - Manage users in the current organization.
+

--- a/docs/reference/cli/gcx_org_users_update-role.md
+++ b/docs/reference/cli/gcx_org_users_update-role.md
@@ -1,0 +1,31 @@
+## gcx org users update-role
+
+Update the role of a user in the current organization.
+
+```
+gcx org users update-role USER-ID [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for update-role
+      --role string   New role for the user, e.g. Admin, Editor, Viewer (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx org users](gcx_org_users.md)	 - Manage users in the current organization.
+

--- a/docs/reference/cli/gcx_permissions.md
+++ b/docs/reference/cli/gcx_permissions.md
@@ -1,0 +1,37 @@
+## gcx permissions
+
+Manage Grafana resource permissions (RBAC)
+
+### Synopsis
+
+Manage Grafana resource permissions via the granular access-control (RBAC) API.
+
+Supported resources: folders, dashboards, datasources, teams, serviceaccounts.
+Reads work on all editions; writes require RBAC (Grafana Enterprise or Cloud).
+
+### Options
+
+```
+      --config string   Path to the configuration file to use
+  -h, --help            help for permissions
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx permissions get](gcx_permissions_get.md)	 - Get the permission list for a resource instance.
+* [gcx permissions grant](gcx_permissions_grant.md)	 - Grant a permission level to a single user, team, or built-in role.
+* [gcx permissions levels](gcx_permissions_levels.md)	 - Show the assignable permission levels for a resource kind.
+* [gcx permissions set](gcx_permissions_set.md)	 - Replace the full permission set for a resource instance.
+

--- a/docs/reference/cli/gcx_permissions_get.md
+++ b/docs/reference/cli/gcx_permissions_get.md
@@ -1,0 +1,46 @@
+## gcx permissions get
+
+Get the permission list for a resource instance.
+
+### Synopsis
+
+Get the granular RBAC permission list for a resource instance.
+
+<resource> is one of: folders, dashboards, datasources, teams, serviceaccounts
+
+```
+gcx permissions get <resource> <id> [flags]
+```
+
+### Examples
+
+```
+  gcx permissions get dashboards my-dashboard-uid
+  gcx permissions get folders my-folder-uid -o json
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx permissions](gcx_permissions.md)	 - Manage Grafana resource permissions (RBAC)
+

--- a/docs/reference/cli/gcx_permissions_grant.md
+++ b/docs/reference/cli/gcx_permissions_grant.md
@@ -1,0 +1,50 @@
+## gcx permissions grant
+
+Grant a permission level to a single user, team, or built-in role.
+
+### Synopsis
+
+Grant a permission level to a single principal on a resource instance.
+
+Specify exactly one of --user, --team, or --role, plus --level.
+
+<resource> is one of: folders, dashboards, datasources, teams, serviceaccounts
+
+```
+gcx permissions grant <resource> <id> [flags]
+```
+
+### Examples
+
+```
+  gcx permissions grant dashboards my-uid --team 3 --level Edit
+  gcx permissions grant folders my-uid --role Viewer --level View
+  gcx permissions grant datasources my-uid --user alice --level Admin
+```
+
+### Options
+
+```
+  -h, --help           help for grant
+      --level string   Permission level (e.g. View, Edit, Admin)
+      --role string    Built-in role to grant to (e.g. Viewer, Editor, Admin)
+      --team string    Team to grant to (numeric ID or UID)
+      --user string    User to grant to (numeric ID or UID)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx permissions](gcx_permissions.md)	 - Manage Grafana resource permissions (RBAC)
+

--- a/docs/reference/cli/gcx_permissions_levels.md
+++ b/docs/reference/cli/gcx_permissions_levels.md
@@ -1,0 +1,45 @@
+## gcx permissions levels
+
+Show the assignable permission levels for a resource kind.
+
+### Synopsis
+
+Show the assignable permission levels and assignment types for a resource kind.
+
+<resource> is one of: folders, dashboards, datasources, teams, serviceaccounts
+
+```
+gcx permissions levels <resource> [flags]
+```
+
+### Examples
+
+```
+  gcx permissions levels dashboards
+```
+
+### Options
+
+```
+  -h, --help            help for levels
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx permissions](gcx_permissions.md)	 - Manage Grafana resource permissions (RBAC)
+

--- a/docs/reference/cli/gcx_permissions_set.md
+++ b/docs/reference/cli/gcx_permissions_set.md
@@ -1,0 +1,48 @@
+## gcx permissions set
+
+Replace the full permission set for a resource instance.
+
+### Synopsis
+
+Replace the full permission set for a resource instance from a JSON file.
+
+The file is a JSON array of assignments (or a {"permissions": [...]} object),
+each with a "permission" level (View/Edit/Admin) and exactly one of
+"userId", "teamId", or "builtInRole".
+
+<resource> is one of: folders, dashboards, datasources, teams, serviceaccounts
+
+```
+gcx permissions set <resource> <id> -f FILE [flags]
+```
+
+### Examples
+
+```
+  gcx permissions set dashboards my-uid -f acl.json
+  cat acl.json | gcx permissions set folders my-uid -f -
+```
+
+### Options
+
+```
+  -f, --file string   JSON file with the permission set (use - for stdin)
+  -h, --help          help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx permissions](gcx_permissions.md)	 - Manage Grafana resource permissions (RBAC)
+

--- a/docs/reference/cli/gcx_public-dashboards.md
+++ b/docs/reference/cli/gcx_public-dashboards.md
@@ -1,0 +1,31 @@
+## gcx public-dashboards
+
+Manage public dashboards
+
+### Options
+
+```
+      --config string   Path to the configuration file to use
+  -h, --help            help for public-dashboards
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx public-dashboards create](gcx_public-dashboards_create.md)	 - Create a public dashboard config from a JSON file.
+* [gcx public-dashboards delete](gcx_public-dashboards_delete.md)	 - Delete a public dashboard config.
+* [gcx public-dashboards get](gcx_public-dashboards_get.md)	 - Get a public dashboard by its UID.
+* [gcx public-dashboards list](gcx_public-dashboards_list.md)	 - List all public dashboards.
+* [gcx public-dashboards update](gcx_public-dashboards_update.md)	 - Update a public dashboard config from a JSON file.
+

--- a/docs/reference/cli/gcx_public-dashboards_create.md
+++ b/docs/reference/cli/gcx_public-dashboards_create.md
@@ -1,0 +1,35 @@
+## gcx public-dashboards create
+
+Create a public dashboard config from a JSON file.
+
+```
+gcx public-dashboards create [flags]
+```
+
+### Options
+
+```
+      --dashboard-uid string   Parent dashboard UID (required)
+  -f, --file string            File containing the public dashboard spec (JSON), or '-' for stdin (required)
+  -h, --help                   help for create
+      --jq string              jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string            Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string          Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
+

--- a/docs/reference/cli/gcx_public-dashboards_delete.md
+++ b/docs/reference/cli/gcx_public-dashboards_delete.md
@@ -1,0 +1,30 @@
+## gcx public-dashboards delete
+
+Delete a public dashboard config.
+
+```
+gcx public-dashboards delete PD_UID [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
+

--- a/docs/reference/cli/gcx_public-dashboards_get.md
+++ b/docs/reference/cli/gcx_public-dashboards_get.md
@@ -1,0 +1,33 @@
+## gcx public-dashboards get
+
+Get a public dashboard by its UID.
+
+```
+gcx public-dashboards get PD_UID [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
+

--- a/docs/reference/cli/gcx_public-dashboards_list.md
+++ b/docs/reference/cli/gcx_public-dashboards_list.md
@@ -1,0 +1,34 @@
+## gcx public-dashboards list
+
+List all public dashboards.
+
+```
+gcx public-dashboards list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for unlimited) (default 50)
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
+

--- a/docs/reference/cli/gcx_public-dashboards_update.md
+++ b/docs/reference/cli/gcx_public-dashboards_update.md
@@ -1,0 +1,35 @@
+## gcx public-dashboards update
+
+Update a public dashboard config from a JSON file.
+
+```
+gcx public-dashboards update PD_UID [flags]
+```
+
+### Options
+
+```
+      --dashboard-uid string   Parent dashboard UID (required)
+  -f, --file string            File containing the public dashboard spec (JSON), or '-' for stdin (required)
+  -h, --help                   help for update
+      --jq string              jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string            Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string          Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -205,6 +205,43 @@ var commandAnnotations = map[string]annotation{
 	"gcx alert templates delete":             {Cost: "small"},
 
 	// -----------------------------------------------------------------------
+	// Annotations provider
+	// -----------------------------------------------------------------------
+	"gcx annotations list":        {Cost: "medium", Hint: "--lookback 24h --tags deploy --limit 20 -o json"},
+	"gcx annotations get":         {Cost: "small", Hint: "<id> -o json"},
+	"gcx annotations create":      {Cost: "small", Hint: "-f annotation.json"},
+	"gcx annotations update":      {Cost: "small", Hint: "<id> -f patch.json"},
+	"gcx annotations delete":      {Cost: "small"},
+	"gcx annotations tags":        {Cost: "small", Hint: "-o json"},
+	"gcx annotations mass-delete": {Cost: "small", Hint: "--dashboard-uid <uid> --panel-id <n>"},
+
+	// -----------------------------------------------------------------------
+	// Organization provider
+	// -----------------------------------------------------------------------
+	"gcx org users list":        {Cost: "medium", Hint: "--limit 50 -o json"},
+	"gcx org users get":         {Cost: "small", Hint: "<login-or-email> -o json"},
+	"gcx org users add":         {Cost: "small", Hint: "--login <login-or-email> --role Editor"},
+	"gcx org users update-role": {Cost: "small", Hint: "<user-id> --role Admin"},
+	"gcx org users remove":      {Cost: "small"},
+
+	// -----------------------------------------------------------------------
+	// Permissions provider (granular RBAC)
+	// -----------------------------------------------------------------------
+	"gcx permissions get":    {Cost: "medium", Hint: "<resource> <id> -o json; resource is folders|dashboards|datasources|teams|serviceaccounts"},
+	"gcx permissions set":    {Cost: "small", Hint: "<resource> <id> -f acl.json"},
+	"gcx permissions grant":  {Cost: "small", Hint: "<resource> <id> --team 3 --level Edit"},
+	"gcx permissions levels": {Cost: "small", Hint: "<resource> -o json"},
+
+	// -----------------------------------------------------------------------
+	// Public Dashboards provider
+	// -----------------------------------------------------------------------
+	"gcx public-dashboards list":   {Cost: "medium", Hint: "-o json"},
+	"gcx public-dashboards get":    {Cost: "small", Hint: "<dashboard-uid> -o json"},
+	"gcx public-dashboards create": {Cost: "small", Hint: "<dashboard-uid> -f public-dashboard.json"},
+	"gcx public-dashboards update": {Cost: "small", Hint: "<dashboard-uid> <pd-uid> -f patch.json"},
+	"gcx public-dashboards delete": {Cost: "small"},
+
+	// -----------------------------------------------------------------------
 	// App Observability provider
 	// -----------------------------------------------------------------------
 	"gcx appo11y overrides get":    {Cost: "small"},

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -1,0 +1,203 @@
+// Package coreapi provides a shared HTTP client and generic request helpers for
+// gcx providers that talk to Grafana's core HTTP API (the legacy /api/* REST
+// endpoints, e.g. /api/annotations, /api/org/users, /api/access-control/...).
+//
+// It exists so individual providers do not each re-implement the same
+// marshal / execute / status-check / decode boilerplate. Callers pass the full
+// request path (including the /api prefix); the client prepends the configured
+// Grafana host.
+package coreapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
+)
+
+// Client is a base HTTP client for Grafana's core /api/* endpoints.
+type Client struct {
+	restConfig config.NamespacedRESTConfig
+	httpClient *http.Client
+}
+
+// NewClient creates a new core API client from a Grafana REST config.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	httpClient, err := rest.HTTPClientFor(&cfg.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+	return &Client{restConfig: cfg, httpClient: httpClient}, nil
+}
+
+// NewClientFromCommand creates a Client from a cobra command and config loader.
+func NewClientFromCommand(cmd *cobra.Command, loader *providers.ConfigLoader) (*Client, error) {
+	cfg, err := loader.LoadGrafanaConfig(cmd.Context())
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(cfg)
+}
+
+// DoRequest builds and executes an HTTP request against the core API. The path
+// is appended to the configured host (e.g. "/api/annotations").
+func (c *Client) DoRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.restConfig.Host+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	return resp, nil
+}
+
+// DoJSON executes an HTTP request against the core API, optionally marshaling
+// body as the JSON request payload, and decodes a JSON response into Resp. Pass
+// a nil body for requests with no request body (e.g. GET/DELETE) — in that case
+// Req can be instantiated as `any`.
+//
+// Any response status not present in okStatuses is treated as an error via
+// HandleErrorResponse.
+func DoJSON[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, okStatuses ...int) (Resp, error) {
+	return doJSON[Req, Resp](ctx, c, method, path, body, nil, okStatuses)
+}
+
+// DoJSONNotFound behaves like DoJSON, but returns notFoundErr instead of the
+// generic HandleErrorResponse error when the response status is 404. Callers
+// typically pass a sentinel wrapped with request-specific context, e.g.
+// fmt.Errorf("%s: %w", id, ErrNotFound), so that errors.Is still matches the
+// resource-specific sentinel.
+func DoJSONNotFound[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses ...int) (Resp, error) {
+	return doJSON[Req, Resp](ctx, c, method, path, body, notFoundErr, okStatuses)
+}
+
+func doJSON[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses []int) (Resp, error) {
+	var zero Resp
+
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return zero, fmt.Errorf("failed to marshal request: %w", err)
+		}
+		reader = bytes.NewReader(b)
+	}
+
+	resp, err := c.DoRequest(ctx, method, path, reader)
+	if err != nil {
+		return zero, err
+	}
+	defer resp.Body.Close()
+
+	if notFoundErr != nil && resp.StatusCode == http.StatusNotFound {
+		return zero, notFoundErr
+	}
+	if !slices.Contains(okStatuses, resp.StatusCode) {
+		return zero, HandleErrorResponse(resp)
+	}
+
+	var result Resp
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return zero, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return result, nil
+}
+
+// DoStatus executes an HTTP request against the core API, optionally marshaling
+// body as the JSON request payload, and checks that the response status is one
+// of okStatuses without decoding a response body. Use this for endpoints that
+// return no useful body (e.g. DELETE, or actions).
+func DoStatus[Req any](ctx context.Context, c *Client, method, path string, body *Req, okStatuses ...int) error {
+	return doStatus[Req](ctx, c, method, path, body, nil, okStatuses)
+}
+
+// DoStatusNotFound behaves like DoStatus, but returns notFoundErr instead of the
+// generic HandleErrorResponse error when the response status is 404.
+func DoStatusNotFound[Req any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses ...int) error {
+	return doStatus[Req](ctx, c, method, path, body, notFoundErr, okStatuses)
+}
+
+func doStatus[Req any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses []int) error {
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request: %w", err)
+		}
+		reader = bytes.NewReader(b)
+	}
+
+	resp, err := c.DoRequest(ctx, method, path, reader)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if notFoundErr != nil && resp.StatusCode == http.StatusNotFound {
+		return notFoundErr
+	}
+	if !slices.Contains(okStatuses, resp.StatusCode) {
+		return HandleErrorResponse(resp)
+	}
+	return nil
+}
+
+// errorResponse is the standard Grafana core API error body.
+type errorResponse struct {
+	Message string `json:"message"`
+}
+
+// HandleErrorResponse reads an error response body and returns a formatted
+// error, preferring Grafana's {"message": "..."} field when present.
+func HandleErrorResponse(resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("request failed with status %d (could not read body: %w)", resp.StatusCode, err)
+	}
+
+	var errResp errorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Message != "" {
+		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, errResp.Message)
+	}
+	if len(body) > 0 {
+		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	return fmt.Errorf("request failed with status %d", resp.StatusCode)
+}
+
+// FormatTime formats a time for table display, returning "-" for zero values.
+func FormatTime(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.Format("2006-01-02 15:04")
+}
+
+// Truncate returns s shortened to maxLen runes, adding "..." if truncated.
+// Returns "-" for empty strings.
+func Truncate(s string, maxLen int) string {
+	if s == "" {
+		return "-"
+	}
+	r := []rune(s)
+	if len(r) > maxLen {
+		return string(r[:maxLen-3]) + "..."
+	}
+	return s
+}

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -15,12 +15,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"slices"
-	"time"
 
 	"github.com/grafana/gcx/internal/config"
-	"github.com/grafana/gcx/internal/providers"
-	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 )
 
@@ -37,15 +35,6 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 	return &Client{restConfig: cfg, httpClient: httpClient}, nil
-}
-
-// NewClientFromCommand creates a Client from a cobra command and config loader.
-func NewClientFromCommand(cmd *cobra.Command, loader *providers.ConfigLoader) (*Client, error) {
-	cfg, err := loader.LoadGrafanaConfig(cmd.Context())
-	if err != nil {
-		return nil, err
-	}
-	return NewClient(cfg)
 }
 
 // DoRequest builds and executes an HTTP request against the core API. The path
@@ -181,23 +170,23 @@ func HandleErrorResponse(resp *http.Response) error {
 	return fmt.Errorf("request failed with status %d", resp.StatusCode)
 }
 
-// FormatTime formats a time for table display, returning "-" for zero values.
-func FormatTime(t time.Time) string {
-	if t.IsZero() {
-		return "-"
+// ReadInput reads a JSON (or other) spec from path, or from stdin when path is
+// "-". It is the shared file-or-stdin reader for provider `-f/--file` flags. A
+// nil stdin falls back to os.Stdin.
+func ReadInput(path string, stdin io.Reader) ([]byte, error) {
+	if path == "-" {
+		if stdin == nil {
+			stdin = os.Stdin
+		}
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading stdin: %w", err)
+		}
+		return data, nil
 	}
-	return t.Format("2006-01-02 15:04")
-}
-
-// Truncate returns s shortened to maxLen runes, adding "..." if truncated.
-// Returns "-" for empty strings.
-func Truncate(s string, maxLen int) string {
-	if s == "" {
-		return "-"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
-	r := []rune(s)
-	if len(r) > maxLen {
-		return string(r[:maxLen-3]) + "..."
-	}
-	return s
+	return data, nil
 }

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -1,0 +1,132 @@
+package coreapi_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/coreapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newTestClient(t *testing.T, url string) *coreapi.Client {
+	t.Helper()
+	cfg := config.NamespacedRESTConfig{Config: rest.Config{Host: url}}
+	c, err := coreapi.NewClient(cfg)
+	require.NoError(t, err)
+	return c
+}
+
+type widget struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestDoJSON_DecodesResponse(t *testing.T) {
+	var gotMethod, gotPath, gotAccept, gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAccept = r.Header.Get("Accept")
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":7,"name":"alpha"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	got, err := coreapi.DoJSON[any, widget](context.Background(), c, http.MethodGet, "/api/widgets/7", nil, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, widget{ID: 7, Name: "alpha"}, got)
+	assert.Equal(t, http.MethodGet, gotMethod)
+	assert.Equal(t, "/api/widgets/7", gotPath)
+	assert.Equal(t, "application/json", gotAccept)
+	assert.Empty(t, gotContentType, "GET with nil body must not set Content-Type")
+}
+
+func TestDoJSON_MarshalsBodyAndSetsContentType(t *testing.T) {
+	var gotBody, gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":9,"name":"beta"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	in := widget{Name: "beta"}
+	got, err := coreapi.DoJSON[widget, widget](context.Background(), c, http.MethodPost, "/api/widgets", &in, http.StatusOK, http.StatusCreated)
+	require.NoError(t, err)
+	assert.Equal(t, widget{ID: 9, Name: "beta"}, got)
+	assert.JSONEq(t, `{"id":0,"name":"beta"}`, gotBody)
+	assert.Equal(t, "application/json", gotContentType)
+}
+
+func TestDoJSON_ErrorParsesMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"permission denied"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, err := coreapi.DoJSON[any, widget](context.Background(), c, http.MethodGet, "/api/widgets/1", nil, http.StatusOK)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+	assert.Contains(t, err.Error(), "permission denied")
+}
+
+func TestDoJSONNotFound_ReturnsSentinel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	}))
+	defer srv.Close()
+
+	sentinel := errors.New("missing")
+	c := newTestClient(t, srv.URL)
+	_, err := coreapi.DoJSONNotFound[any, widget](context.Background(), c, http.MethodGet, "/api/widgets/1", nil, sentinel, http.StatusOK)
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestDoStatus_ChecksStatusWithoutDecoding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	err := coreapi.DoStatus[any](context.Background(), c, http.MethodDelete, "/api/widgets/1", nil, http.StatusOK, http.StatusNoContent)
+	require.NoError(t, err)
+}
+
+func TestDoStatus_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`boom`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	err := coreapi.DoStatus[any](context.Background(), c, http.MethodDelete, "/api/widgets/1", nil, http.StatusOK)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestFormatTimeAndTruncate(t *testing.T) {
+	assert.Equal(t, "-", coreapi.FormatTime(time.Time{}))
+	assert.Equal(t, "-", coreapi.Truncate("", 10))
+	assert.Equal(t, "abc", coreapi.Truncate("abc", 10))
+	assert.Equal(t, "abcde...", coreapi.Truncate("abcdefghij", 8))
+}

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/coreapi"
@@ -124,9 +126,23 @@ func TestDoStatus_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "boom")
 }
 
-func TestFormatTimeAndTruncate(t *testing.T) {
-	assert.Equal(t, "-", coreapi.FormatTime(time.Time{}))
-	assert.Equal(t, "-", coreapi.Truncate("", 10))
-	assert.Equal(t, "abc", coreapi.Truncate("abc", 10))
-	assert.Equal(t, "abcde...", coreapi.Truncate("abcdefghij", 8))
+func TestReadInput(t *testing.T) {
+	t.Run("reads from stdin when path is -", func(t *testing.T) {
+		got, err := coreapi.ReadInput("-", strings.NewReader(`{"a":1}`))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"a":1}`, string(got))
+	})
+
+	t.Run("reads from file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "spec.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"b":2}`), 0o600))
+		got, err := coreapi.ReadInput(path, nil)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"b":2}`, string(got))
+	})
+
+	t.Run("errors on missing file", func(t *testing.T) {
+		_, err := coreapi.ReadInput(filepath.Join(t.TempDir(), "nope.json"), nil)
+		require.Error(t, err)
+	})
 }

--- a/internal/providers/annotations/client.go
+++ b/internal/providers/annotations/client.go
@@ -1,0 +1,110 @@
+package annotations
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/coreapi"
+)
+
+const basePath = "/api/annotations"
+
+// Client is a Grafana annotations API client.
+type Client struct {
+	base *coreapi.Client
+}
+
+// NewClient creates a new annotations client.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	base, err := coreapi.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{base: base}, nil
+}
+
+// ListOptions configures filtering for List operations.
+// From and To are epoch milliseconds.
+type ListOptions struct {
+	From  int64
+	To    int64
+	Tags  []string
+	Limit int
+}
+
+// List returns annotations matching the given options.
+func (c *Client) List(ctx context.Context, opts ListOptions) ([]Annotation, error) {
+	params := url.Values{}
+	if opts.From > 0 {
+		params.Set("from", strconv.FormatInt(opts.From, 10))
+	}
+	if opts.To > 0 {
+		params.Set("to", strconv.FormatInt(opts.To, 10))
+	}
+	for _, tag := range opts.Tags {
+		params.Add("tags", tag)
+	}
+	if opts.Limit > 0 {
+		params.Set("limit", strconv.Itoa(opts.Limit))
+	}
+
+	path := basePath
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	return coreapi.DoJSON[any, []Annotation](ctx, c.base, http.MethodGet, path, nil, http.StatusOK)
+}
+
+// Get retrieves a single annotation by ID.
+func (c *Client) Get(ctx context.Context, id int64) (*Annotation, error) {
+	a, err := coreapi.DoJSON[any, Annotation](ctx, c.base, http.MethodGet, fmt.Sprintf("%s/%d", basePath, id), nil, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+// Create creates a new annotation. On success, a.ID is populated with the
+// server-assigned identifier.
+func (c *Client) Create(ctx context.Context, a *Annotation) error {
+	type createResp struct {
+		ID int64 `json:"id"`
+	}
+	res, err := coreapi.DoJSON[Annotation, createResp](ctx, c.base, http.MethodPost, basePath, a, http.StatusOK)
+	if err != nil {
+		return err
+	}
+	a.ID = res.ID
+	return nil
+}
+
+// Update patches an existing annotation. The patch map may include any subset
+// of text, tags, time, timeEnd.
+func (c *Client) Update(ctx context.Context, id int64, patch map[string]any) error {
+	return coreapi.DoStatus[map[string]any](ctx, c.base, http.MethodPatch, fmt.Sprintf("%s/%d", basePath, id), &patch, http.StatusOK)
+}
+
+// Delete removes an annotation by ID.
+func (c *Client) Delete(ctx context.Context, id int64) error {
+	return coreapi.DoStatus[any](ctx, c.base, http.MethodDelete, fmt.Sprintf("%s/%d", basePath, id), nil, http.StatusOK)
+}
+
+// Tags returns the annotation tags known to the org, with usage counts.
+func (c *Client) Tags(ctx context.Context) ([]AnnotationTag, error) {
+	res, err := coreapi.DoJSON[any, tagsResponse](ctx, c.base, http.MethodGet, basePath+"/tags", nil, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return res.Result.Tags, nil
+}
+
+// MassDelete deletes multiple annotations selected by the given request
+// (by annotation ID, or by dashboard + panel).
+func (c *Client) MassDelete(ctx context.Context, req MassDeleteRequest) error {
+	return coreapi.DoStatus[MassDeleteRequest](ctx, c.base, http.MethodPost, basePath+"/mass-delete", &req, http.StatusOK)
+}

--- a/internal/providers/annotations/client_test.go
+++ b/internal/providers/annotations/client_test.go
@@ -1,0 +1,147 @@
+package annotations_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/annotations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newClient(t *testing.T, url string) *annotations.Client {
+	t.Helper()
+	c, err := annotations.NewClient(config.NamespacedRESTConfig{Config: rest.Config{Host: url}})
+	require.NoError(t, err)
+	return c
+}
+
+func TestClient_List(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/annotations", r.URL.Path)
+		q := r.URL.Query()
+		assert.Equal(t, "1000", q.Get("from"))
+		assert.Equal(t, "2000", q.Get("to"))
+		assert.ElementsMatch(t, []string{"deploy", "prod"}, q["tags"])
+		assert.Equal(t, "25", q.Get("limit"))
+		_, _ = w.Write([]byte(`[{"id":1,"text":"a"},{"id":2,"text":"b"}]`))
+	}))
+	defer srv.Close()
+
+	got, err := newClient(t, srv.URL).List(context.Background(), annotations.ListOptions{
+		From: 1000, To: 2000, Tags: []string{"deploy", "prod"}, Limit: 25,
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, int64(1), got[0].ID)
+}
+
+func TestClient_Get(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/annotations/7", r.URL.Path)
+		_, _ = w.Write([]byte(`{"id":7,"text":"hello"}`))
+	}))
+	defer srv.Close()
+
+	got, err := newClient(t, srv.URL).Get(context.Background(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), got.ID)
+	assert.Equal(t, "hello", got.Text)
+}
+
+func TestClient_Create(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		_, _ = w.Write([]byte(`{"id":99,"message":"Annotation added"}`))
+	}))
+	defer srv.Close()
+
+	a := &annotations.Annotation{Text: "deploy"}
+	err := newClient(t, srv.URL).Create(context.Background(), a)
+	require.NoError(t, err)
+	assert.Equal(t, int64(99), a.ID)
+	assert.Equal(t, "deploy", gotBody["text"])
+}
+
+func TestClient_Update(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/api/annotations/5", r.URL.Path)
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		_, _ = w.Write([]byte(`{"message":"Annotation patched"}`))
+	}))
+	defer srv.Close()
+
+	err := newClient(t, srv.URL).Update(context.Background(), 5, map[string]any{"text": "updated"})
+	require.NoError(t, err)
+	assert.Equal(t, "updated", gotBody["text"])
+}
+
+func TestClient_Delete(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/annotations/3", r.URL.Path)
+		_, _ = w.Write([]byte(`{"message":"Annotation deleted"}`))
+	}))
+	defer srv.Close()
+
+	err := newClient(t, srv.URL).Delete(context.Background(), 3)
+	require.NoError(t, err)
+}
+
+func TestClient_Tags(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/annotations/tags", r.URL.Path)
+		_, _ = w.Write([]byte(`{"result":{"tags":[{"tag":"deploy","count":3},{"tag":"prod","count":7}]}}`))
+	}))
+	defer srv.Close()
+
+	tags, err := newClient(t, srv.URL).Tags(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tags, 2)
+	assert.Equal(t, "deploy", tags[0].Tag)
+	assert.Equal(t, int64(7), tags[1].Count)
+}
+
+func TestClient_MassDelete(t *testing.T) {
+	var gotBody annotations.MassDeleteRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/annotations/mass-delete", r.URL.Path)
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		_, _ = w.Write([]byte(`{"message":"Annotations deleted"}`))
+	}))
+	defer srv.Close()
+
+	err := newClient(t, srv.URL).MassDelete(context.Background(), annotations.MassDeleteRequest{
+		DashboardUID: "abc", PanelID: 3,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "abc", gotBody.DashboardUID)
+	assert.Equal(t, int64(3), gotBody.PanelID)
+}
+
+func TestClient_ErrorParsesMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+	}))
+	defer srv.Close()
+
+	_, err := newClient(t, srv.URL).Get(context.Background(), 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+	assert.Contains(t, err.Error(), "forbidden")
+}

--- a/internal/providers/annotations/commands.go
+++ b/internal/providers/annotations/commands.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/grafana/gcx/internal/coreapi"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources/adapter"
@@ -487,7 +487,7 @@ func validateID(s string) error {
 // readAnnotationFromFile reads the given path (or stdin for "-") and parses it
 // as a JSON Annotation spec.
 func readAnnotationFromFile(stdin io.Reader, path string) (*Annotation, error) {
-	data, err := readFileOrStdin(stdin, path)
+	data, err := coreapi.ReadInput(path, stdin)
 	if err != nil {
 		return nil, err
 	}
@@ -496,20 +496,4 @@ func readAnnotationFromFile(stdin io.Reader, path string) (*Annotation, error) {
 		return nil, fmt.Errorf("failed to parse annotation: %w", err)
 	}
 	return &a, nil
-}
-
-// readFileOrStdin reads the given path, or stdin when path is "-".
-func readFileOrStdin(stdin io.Reader, path string) ([]byte, error) {
-	if path == "-" {
-		data, err := io.ReadAll(stdin)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read stdin: %w", err)
-		}
-		return data, nil
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file %q: %w", path, err)
-	}
-	return data, nil
 }

--- a/internal/providers/annotations/commands.go
+++ b/internal/providers/annotations/commands.go
@@ -1,0 +1,515 @@
+package annotations
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const defaultLookback = 24 * time.Hour
+
+// clientFromLoader loads the REST config and builds an annotations Client. Used
+// by commands (tags, mass-delete) that operate outside the TypedCRUD adapter.
+func clientFromLoader(ctx context.Context, loader RESTConfigLoader) (*Client, error) {
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load REST config for annotations: %w", err)
+	}
+	return NewClient(cfg)
+}
+
+// ---- list ----
+
+type listOpts struct {
+	IO       cmdio.Options
+	Lookback time.Duration
+	From     int64
+	To       int64
+	Tags     []string
+	Limit    int
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ListTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.DurationVar(&o.Lookback, "lookback", defaultLookback, "Lookback duration (e.g. 24h, 48h, 7d); ignored if --from/--to are set")
+	flags.Int64Var(&o.From, "from", 0, "Start time in epoch milliseconds")
+	flags.Int64Var(&o.To, "to", 0, "End time in epoch milliseconds")
+	flags.StringSliceVar(&o.Tags, "tags", nil, "Filter by tags (comma-separated or repeated)")
+	flags.IntVar(&o.Limit, "limit", 100, "Maximum results to return (0 = unlimited)")
+}
+
+// resolveRange returns the from/to window based on the user's flags.
+// --from/--to override --lookback; when neither is set, --lookback applies
+// ending at now.
+func (o *listOpts) resolveRange(cmd *cobra.Command) (int64, int64, error) {
+	flags := cmd.Flags()
+	fromChanged := flags.Changed("from")
+	toChanged := flags.Changed("to")
+
+	if flags.Changed("lookback") && (fromChanged || toChanged) {
+		return 0, 0, errors.New("--lookback cannot be used together with --from or --to")
+	}
+
+	if fromChanged || toChanged {
+		return o.From, o.To, nil
+	}
+
+	now := time.Now()
+	return now.Add(-o.Lookback).UnixMilli(), now.UnixMilli(), nil
+}
+
+func newListCommand(loader RESTConfigLoader) *cobra.Command {
+	opts := &listOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List annotations (last 24h by default).",
+		Long: `List annotations from Grafana.
+
+By default, returns only annotations from the last 24 hours. Use --lookback
+to widen the window, or --from/--to for an explicit time range (epoch ms).`,
+		Example: "  gcx annotations list\n" +
+			"  gcx annotations list --lookback 168h\n" +
+			"  gcx annotations list --tags deploy,prod\n" +
+			"  gcx annotations list --limit 20",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			from, to, err := opts.resolveRange(cmd)
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			base := ListOptions{
+				From:  from,
+				To:    to,
+				Tags:  opts.Tags,
+				Limit: opts.Limit,
+			}
+
+			crud, _, err := NewTypedCRUD(ctx, loader, base)
+			if err != nil {
+				return err
+			}
+
+			// The per-call limit in TypedCRUD.List is a client-side cap on
+			// TypedObject results. The server-side limit is already carried by
+			// base.Limit, so we pass 0 here to avoid double-truncation.
+			typedObjs, err := crud.List(ctx, 0)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), typedObjs)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ListTableCodec renders annotations as a tabular table.
+// It accepts []adapter.TypedObject[Annotation] and extracts .Spec for each row.
+type ListTableCodec struct{}
+
+// Format returns the output format name.
+func (c *ListTableCodec) Format() format.Format { return "table" }
+
+// Encode writes annotations to the writer as a table.
+func (c *ListTableCodec) Encode(w io.Writer, v any) error {
+	typedObjs, ok := v.([]adapter.TypedObject[Annotation])
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []TypedObject[Annotation]")
+	}
+
+	t := style.NewTable("ID", "TIME", "DASHBOARD", "TAGS", "TEXT")
+	for _, obj := range typedObjs {
+		a := obj.Spec
+		ts := ""
+		if a.Time > 0 {
+			ts = time.Unix(a.Time/1000, 0).UTC().Format(time.RFC3339)
+		}
+		t.Row(
+			strconv.FormatInt(a.ID, 10),
+			ts,
+			a.DashboardUID,
+			strings.Join(a.Tags, ","),
+			truncate(a.Text, 60),
+		)
+	}
+	return t.Render(w)
+}
+
+// Decode is not supported for the table format.
+func (c *ListTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 1 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-1] + "…"
+}
+
+// ---- get ----
+
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ListTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newGetCommand(loader RESTConfigLoader) *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:     "get ID",
+		Short:   "Get an annotation by ID.",
+		Example: "  gcx annotations get 1",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			// Validate the ID up front so users get a clear error before we
+			// open a client connection.
+			if err := validateID(args[0]); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			crud, _, err := NewTypedCRUD(ctx, loader, ListOptions{})
+			if err != nil {
+				return err
+			}
+
+			typedObj, err := crud.Get(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), []adapter.TypedObject[Annotation]{*typedObj})
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---- create ----
+
+type createOpts struct {
+	File string
+}
+
+func newCreateCommand(loader RESTConfigLoader) *cobra.Command {
+	opts := &createOpts{}
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Create an annotation from a JSON file.",
+		Example: "  gcx annotations create -f annotation.json\n  cat annotation.json | gcx annotations create -f -",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if opts.File == "" {
+				return errors.New("--file is required")
+			}
+
+			a, err := readAnnotationFromFile(cmd.InOrStdin(), opts.File)
+			if err != nil {
+				return err
+			}
+			if a.Text == "" {
+				return errors.New("annotation text is required")
+			}
+
+			ctx := cmd.Context()
+
+			crud, restCfg, err := NewTypedCRUD(ctx, loader, ListOptions{})
+			if err != nil {
+				return err
+			}
+
+			typedObj := &adapter.TypedObject[Annotation]{Spec: *a}
+			typedObj.SetName(a.GetResourceName())
+			typedObj.SetNamespace(restCfg.Namespace)
+
+			created, err := crud.Create(ctx, typedObj)
+			if err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.OutOrStdout(), "Annotation created id=%d", created.Spec.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "JSON file containing the annotation (use - for stdin)")
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+// ---- update ----
+
+type updateOpts struct {
+	File string
+}
+
+func newUpdateCommand(loader RESTConfigLoader) *cobra.Command {
+	opts := &updateOpts{}
+	cmd := &cobra.Command{
+		Use:     "update ID",
+		Short:   "Update an annotation from a JSON file (PATCH).",
+		Example: "  gcx annotations update 1 -f patch.json",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateID(args[0]); err != nil {
+				return err
+			}
+			if opts.File == "" {
+				return errors.New("--file is required")
+			}
+
+			a, err := readAnnotationFromFile(cmd.InOrStdin(), opts.File)
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			crud, restCfg, err := NewTypedCRUD(ctx, loader, ListOptions{})
+			if err != nil {
+				return err
+			}
+
+			typedObj := &adapter.TypedObject[Annotation]{Spec: *a}
+			typedObj.SetName(args[0])
+			typedObj.SetNamespace(restCfg.Namespace)
+
+			if _, err := crud.Update(ctx, args[0], typedObj); err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.OutOrStdout(), "Annotation updated id=%s", args[0])
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "JSON file containing the patch (use - for stdin)")
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+// ---- delete ----
+
+func newDeleteCommand(loader RESTConfigLoader) *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete ID",
+		Short:   "Delete an annotation by ID.",
+		Example: "  gcx annotations delete 1",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateID(args[0]); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			crud, _, err := NewTypedCRUD(ctx, loader, ListOptions{})
+			if err != nil {
+				return err
+			}
+
+			if err := crud.Delete(ctx, args[0]); err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.OutOrStdout(), "Annotation deleted id=%s", args[0])
+			return nil
+		},
+	}
+}
+
+// ---- tags ----
+
+type tagsOpts struct {
+	IO cmdio.Options
+}
+
+func (o *tagsOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &TagsTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newTagsCommand(loader RESTConfigLoader) *cobra.Command {
+	opts := &tagsOpts{}
+	cmd := &cobra.Command{
+		Use:     "tags",
+		Short:   "List annotation tags with usage counts.",
+		Example: "  gcx annotations tags",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := clientFromLoader(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			tags, err := client.Tags(ctx)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), tags)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// TagsTableCodec renders annotation tags as a table.
+type TagsTableCodec struct{}
+
+// Format returns the output format name.
+func (c *TagsTableCodec) Format() format.Format { return "table" }
+
+// Encode writes annotation tags to the writer as a table.
+func (c *TagsTableCodec) Encode(w io.Writer, v any) error {
+	tags, ok := v.([]AnnotationTag)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []AnnotationTag")
+	}
+	t := style.NewTable("TAG", "COUNT")
+	for _, tag := range tags {
+		t.Row(tag.Tag, strconv.FormatInt(tag.Count, 10))
+	}
+	return t.Render(w)
+}
+
+// Decode is not supported for the table format.
+func (c *TagsTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// ---- mass-delete ----
+
+type massDeleteOpts struct {
+	AnnotationID int64
+	DashboardUID string
+	DashboardID  int64
+	PanelID      int64
+}
+
+func newMassDeleteCommand(loader RESTConfigLoader) *cobra.Command {
+	opts := &massDeleteOpts{}
+	cmd := &cobra.Command{
+		Use:   "mass-delete",
+		Short: "Delete multiple annotations by annotation ID, or by dashboard + panel.",
+		Long: `Delete multiple annotations in a single request.
+
+Provide either --annotation-id, or a dashboard selector (--dashboard-uid or
+--dashboard-id) together with --panel-id.`,
+		Example: "  gcx annotations mass-delete --annotation-id 42\n" +
+			"  gcx annotations mass-delete --dashboard-uid abcdef123 --panel-id 3",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			req := MassDeleteRequest{
+				AnnotationID: opts.AnnotationID,
+				DashboardUID: opts.DashboardUID,
+				DashboardID:  opts.DashboardID,
+				PanelID:      opts.PanelID,
+			}
+
+			hasDashboard := opts.DashboardUID != "" || opts.DashboardID > 0
+			switch {
+			case opts.AnnotationID > 0:
+				// delete a single annotation by ID
+			case hasDashboard && opts.PanelID > 0:
+				// delete all annotations for a dashboard panel
+			default:
+				return errors.New("provide --annotation-id, or a dashboard selector (--dashboard-uid/--dashboard-id) together with --panel-id")
+			}
+
+			ctx := cmd.Context()
+			client, err := clientFromLoader(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			if err := client.MassDelete(ctx, req); err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.OutOrStdout(), "Annotations deleted")
+			return nil
+		},
+	}
+	cmd.Flags().Int64Var(&opts.AnnotationID, "annotation-id", 0, "Delete a single annotation by ID")
+	cmd.Flags().StringVar(&opts.DashboardUID, "dashboard-uid", "", "Dashboard UID (with --panel-id)")
+	cmd.Flags().Int64Var(&opts.DashboardID, "dashboard-id", 0, "Dashboard numeric ID (with --panel-id)")
+	cmd.Flags().Int64Var(&opts.PanelID, "panel-id", 0, "Panel ID (with a dashboard selector)")
+	return cmd
+}
+
+// ---- helpers ----
+
+func validateID(s string) error {
+	if _, err := strconv.ParseInt(s, 10, 64); err != nil {
+		return fmt.Errorf("invalid annotation ID %q: %w", s, err)
+	}
+	return nil
+}
+
+// readAnnotationFromFile reads the given path (or stdin for "-") and parses it
+// as a JSON Annotation spec.
+func readAnnotationFromFile(stdin io.Reader, path string) (*Annotation, error) {
+	data, err := readFileOrStdin(stdin, path)
+	if err != nil {
+		return nil, err
+	}
+	var a Annotation
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, fmt.Errorf("failed to parse annotation: %w", err)
+	}
+	return &a, nil
+}
+
+// readFileOrStdin reads the given path, or stdin when path is "-".
+func readFileOrStdin(stdin io.Reader, path string) ([]byte, error) {
+	if path == "-" {
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read stdin: %w", err)
+		}
+		return data, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %q: %w", path, err)
+	}
+	return data, nil
+}

--- a/internal/providers/annotations/commands_test.go
+++ b/internal/providers/annotations/commands_test.go
@@ -1,0 +1,189 @@
+package annotations_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/annotations"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+// stubLoader satisfies RESTConfigLoader for tests, pointing at the given
+// httptest server.
+type stubLoader struct{ host string }
+
+func (s *stubLoader) LoadGrafanaConfig(_ context.Context) (config.NamespacedRESTConfig, error) {
+	return config.NamespacedRESTConfig{Config: rest.Config{Host: s.host}}, nil
+}
+
+type recordingServer struct {
+	server  *httptest.Server
+	request *http.Request
+	body    []byte
+}
+
+// newRecordingServer returns a server that records the last request and
+// responds with a "[]" JSON body.
+func newRecordingServer(t *testing.T) *recordingServer {
+	t.Helper()
+	rs := &recordingServer{}
+	rs.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rs.request = r
+		data, _ := io.ReadAll(r.Body)
+		rs.body = data
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(rs.server.Close)
+	return rs
+}
+
+// runListCmd executes the list subcommand with the given args against the
+// recording server.
+func runListCmd(t *testing.T, rs *recordingServer, args ...string) error {
+	t.Helper()
+	cmd := annotations.NewListCommandForTest(&stubLoader{host: rs.server.URL})
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(append([]string{"-o", "json"}, args...))
+	return cmd.ExecuteContext(context.Background())
+}
+
+func TestListCommand_LookbackToFromTo(t *testing.T) {
+	rs := newRecordingServer(t)
+
+	before := time.Now()
+	err := runListCmd(t, rs, "--lookback", "1h")
+	after := time.Now()
+	require.NoError(t, err)
+
+	require.NotNil(t, rs.request)
+	assert.Equal(t, "/api/annotations", rs.request.URL.Path)
+
+	q := rs.request.URL.Query()
+	fromStr := q.Get("from")
+	toStr := q.Get("to")
+	require.NotEmpty(t, fromStr)
+	require.NotEmpty(t, toStr)
+
+	fromMs, err := strconv.ParseInt(fromStr, 10, 64)
+	require.NoError(t, err)
+	toMs, err := strconv.ParseInt(toStr, 10, 64)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, toMs, before.UnixMilli())
+	assert.LessOrEqual(t, toMs, after.UnixMilli())
+
+	// to - from should be ~1h.
+	const tolMs = int64(5_000)
+	assert.InDelta(t, int64(time.Hour/time.Millisecond), toMs-fromMs, float64(tolMs))
+}
+
+func TestListCommand_DefaultLookbackIs24h(t *testing.T) {
+	rs := newRecordingServer(t)
+
+	err := runListCmd(t, rs)
+	require.NoError(t, err)
+
+	q := rs.request.URL.Query()
+	fromMs, _ := strconv.ParseInt(q.Get("from"), 10, 64)
+	toMs, _ := strconv.ParseInt(q.Get("to"), 10, 64)
+	// to - from should be ~24h.
+	const tolMs = int64(5_000)
+	assert.InDelta(t, int64(24*time.Hour/time.Millisecond), toMs-fromMs, float64(tolMs))
+}
+
+func TestListCommand_ExplicitFromToOverridesLookback(t *testing.T) {
+	rs := newRecordingServer(t)
+
+	err := runListCmd(t, rs, "--from", "1000", "--to", "2000")
+	require.NoError(t, err)
+
+	q := rs.request.URL.Query()
+	assert.Equal(t, "1000", q.Get("from"))
+	assert.Equal(t, "2000", q.Get("to"))
+}
+
+func TestListCommand_LookbackWithFromOrToFails(t *testing.T) {
+	rs := newRecordingServer(t)
+
+	err := runListCmd(t, rs, "--lookback", "1h", "--from", "1000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--lookback")
+}
+
+func TestListCommand_TagsAndLimit(t *testing.T) {
+	rs := newRecordingServer(t)
+
+	err := runListCmd(t, rs, "--tags", "deploy,prod", "--limit", "25")
+	require.NoError(t, err)
+
+	q := rs.request.URL.Query()
+	assert.ElementsMatch(t, []string{"deploy", "prod"}, q["tags"])
+	assert.Equal(t, "25", q.Get("limit"))
+}
+
+func TestListTableCodec_Truncation(t *testing.T) {
+	codec := &annotations.ListTableCodec{}
+	long := strings.Repeat("x", 120)
+	a := annotations.Annotation{
+		ID:   1,
+		Time: 1700000000000,
+		Text: long,
+		Tags: []string{"a", "b"},
+	}
+
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, []adapter.TypedObject[annotations.Annotation]{{Spec: a}})
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "TIME")
+	assert.Contains(t, out, "DASHBOARD")
+	assert.Contains(t, out, "TAGS")
+	assert.Contains(t, out, "TEXT")
+	// The full-length text must be truncated.
+	assert.NotContains(t, out, long)
+}
+
+func TestProvider_CommandsShape(t *testing.T) {
+	p := &annotations.AnnotationsProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+	root := cmds[0]
+	assert.Equal(t, "annotations", root.Use)
+
+	subNames := make([]string, 0, len(root.Commands()))
+	for _, c := range root.Commands() {
+		subNames = append(subNames, strings.Fields(c.Use)[0])
+	}
+	assert.ElementsMatch(t, []string{"list", "get", "create", "update", "delete", "tags", "mass-delete"}, subNames)
+}
+
+func TestTagsTableCodec(t *testing.T) {
+	codec := &annotations.TagsTableCodec{}
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, []annotations.AnnotationTag{
+		{Tag: "deploy", Count: 3},
+		{Tag: "prod", Count: 7},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "TAG")
+	assert.Contains(t, out, "COUNT")
+	assert.Contains(t, out, "deploy")
+	assert.Contains(t, out, "7")
+}

--- a/internal/providers/annotations/export_test.go
+++ b/internal/providers/annotations/export_test.go
@@ -1,0 +1,8 @@
+package annotations
+
+import "github.com/spf13/cobra"
+
+// NewListCommandForTest exposes newListCommand for external tests.
+func NewListCommandForTest(loader RESTConfigLoader) *cobra.Command {
+	return newListCommand(loader)
+}

--- a/internal/providers/annotations/provider.go
+++ b/internal/providers/annotations/provider.go
@@ -1,0 +1,73 @@
+package annotations
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/spf13/cobra"
+)
+
+var _ providers.Provider = &AnnotationsProvider{}
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	providers.Register(&AnnotationsProvider{})
+}
+
+// AnnotationsProvider manages Grafana annotations.
+type AnnotationsProvider struct{}
+
+// Name returns the unique identifier for this provider.
+func (p *AnnotationsProvider) Name() string { return "annotations" }
+
+// ShortDesc returns a one-line description of the provider.
+func (p *AnnotationsProvider) ShortDesc() string { return "Manage Grafana annotations" }
+
+// Commands returns the Cobra commands contributed by this provider.
+func (p *AnnotationsProvider) Commands() []*cobra.Command {
+	loader := &providers.ConfigLoader{}
+
+	root := &cobra.Command{
+		Use:   "annotations",
+		Short: p.ShortDesc(),
+	}
+	// Bubble parent PersistentPreRun when attached to a real CLI root; guard
+	// against self-recursion when root itself is used as the root (e.g. in
+	// isolated tests where cmd.Root() == root).
+	root.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if r := cmd.Root(); r != root && r.PersistentPreRun != nil {
+			r.PersistentPreRun(cmd, args)
+		}
+	}
+
+	loader.BindFlags(root.PersistentFlags())
+	root.AddCommand(
+		newListCommand(loader),
+		newGetCommand(loader),
+		newCreateCommand(loader),
+		newUpdateCommand(loader),
+		newDeleteCommand(loader),
+		newTagsCommand(loader),
+		newMassDeleteCommand(loader),
+	)
+
+	return []*cobra.Command{root}
+}
+
+// Validate checks that the given provider configuration is valid.
+func (p *AnnotationsProvider) Validate(_ map[string]string) error { return nil }
+
+// ConfigKeys returns the configuration keys used by this provider.
+func (p *AnnotationsProvider) ConfigKeys() []providers.ConfigKey { return nil }
+
+// TypedRegistrations returns adapter registrations for Annotation resource types.
+func (p *AnnotationsProvider) TypedRegistrations() []adapter.Registration {
+	loader := &providers.ConfigLoader{}
+	return []adapter.Registration{
+		{
+			Factory:    NewAdapterFactory(loader),
+			Descriptor: staticDescriptor,
+			GVK:        staticDescriptor.GroupVersionKind(),
+			Schema:     AnnotationSchema(),
+			Example:    AnnotationExample(),
+		},
+	}
+}

--- a/internal/providers/annotations/resource_adapter.go
+++ b/internal/providers/annotations/resource_adapter.go
@@ -1,0 +1,207 @@
+package annotations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	internalconfig "github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	// APIVersion is the API version for Annotation resources.
+	APIVersion = "annotations.ext.grafana.app/v1alpha1"
+	// Kind is the kind for Annotation resources.
+	Kind = "Annotation"
+)
+
+// staticDescriptor is the resource descriptor for Annotation resources.
+//
+//nolint:gochecknoglobals // Static descriptor used in self-registration pattern.
+var staticDescriptor = resources.Descriptor{
+	GroupVersion: schema.GroupVersion{
+		Group:   "annotations.ext.grafana.app",
+		Version: "v1alpha1",
+	},
+	Kind:     Kind,
+	Singular: "annotation",
+	Plural:   "annotations",
+}
+
+// StaticDescriptor returns the descriptor for Annotation resources.
+func StaticDescriptor() resources.Descriptor {
+	return staticDescriptor
+}
+
+// AnnotationSchema returns a JSON Schema for the Annotation resource type,
+// derived from the Annotation struct via reflection.
+func AnnotationSchema() json.RawMessage {
+	return adapter.SchemaFromType[Annotation](staticDescriptor)
+}
+
+// AnnotationExample returns an example Annotation manifest as JSON.
+func AnnotationExample() json.RawMessage {
+	example := map[string]any{
+		"apiVersion": APIVersion,
+		"kind":       Kind,
+		"metadata": map[string]any{
+			"name": "42",
+		},
+		"spec": map[string]any{
+			"dashboardUID": "abcdef123",
+			"text":         "Deploy v2.3.0",
+			"tags":         []string{"deploy", "prod"},
+			"time":         1700000000000,
+		},
+	}
+	b, err := json.Marshal(example)
+	if err != nil {
+		panic(fmt.Sprintf("annotations: failed to marshal example: %v", err))
+	}
+	return b
+}
+
+// RESTConfigLoader can load a NamespacedRESTConfig from the active context.
+type RESTConfigLoader interface {
+	LoadGrafanaConfig(ctx context.Context) (internalconfig.NamespacedRESTConfig, error)
+}
+
+// NewAdapterFactory returns a lazy adapter.Factory for Annotation resources.
+// The factory captures the RESTConfigLoader and constructs the client on first
+// invocation.
+func NewAdapterFactory(loader RESTConfigLoader) adapter.Factory {
+	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
+		cfg, err := loader.LoadGrafanaConfig(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load REST config for annotations adapter: %w", err)
+		}
+
+		client, err := NewClient(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create annotations client: %w", err)
+		}
+
+		return newTypedAdapter(client, cfg.Namespace), nil
+	}
+}
+
+// NewFactoryFromConfig returns an adapter.Factory for Annotation resources that
+// creates a Client using the provided NamespacedRESTConfig.
+func NewFactoryFromConfig(cfg internalconfig.NamespacedRESTConfig) adapter.Factory {
+	return func(_ context.Context) (adapter.ResourceAdapter, error) {
+		client, err := NewClient(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create annotations client: %w", err)
+		}
+		return newTypedAdapter(client, cfg.Namespace), nil
+	}
+}
+
+// newTypedAdapter builds the TypedCRUD[Annotation] adapter for the given
+// client and namespace. It uses the default (unfiltered) List semantics — CLI
+// commands that need --from/--to/--tags plumbing build their own TypedCRUD
+// with a scoped ListFn closure.
+func newTypedAdapter(client *Client, namespace string) adapter.ResourceAdapter {
+	crud := buildTypedCRUD(client, namespace, ListOptions{})
+	return crud.AsAdapter()
+}
+
+// buildTypedCRUD assembles a TypedCRUD[Annotation] around the given client,
+// namespace, and base list options. The list options let the CLI pass through
+// --from/--to/--tags/--limit without mutating the client.
+func buildTypedCRUD(client *Client, namespace string, baseListOpts ListOptions) *adapter.TypedCRUD[Annotation] {
+	return &adapter.TypedCRUD[Annotation]{
+		ListFn: func(ctx context.Context, limit int64) ([]Annotation, error) {
+			opts := baseListOpts
+			if limit > 0 {
+				opts.Limit = int(limit)
+			}
+			return client.List(ctx, opts)
+		},
+
+		GetFn: func(ctx context.Context, name string) (*Annotation, error) {
+			id, err := strconv.ParseInt(name, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid annotation ID %q: %w", name, err)
+			}
+			return client.Get(ctx, id)
+		},
+
+		CreateFn: func(ctx context.Context, a *Annotation) (*Annotation, error) {
+			if err := client.Create(ctx, a); err != nil {
+				return nil, err
+			}
+			return a, nil
+		},
+
+		UpdateFn: func(ctx context.Context, name string, a *Annotation) (*Annotation, error) {
+			id, err := strconv.ParseInt(name, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid annotation ID %q: %w", name, err)
+			}
+			// PATCH the annotation as a full object: marshal to JSON, then
+			// unmarshal into a patch map so the existing Client.Update signature
+			// (which takes map[string]any) remains unchanged.
+			patch, perr := annotationToPatch(a)
+			if perr != nil {
+				return nil, perr
+			}
+			if err := client.Update(ctx, id, patch); err != nil {
+				return nil, err
+			}
+			// The Grafana API does not echo back the updated object, so return
+			// the caller's annotation with the ID set from the path.
+			a.ID = id
+			return a, nil
+		},
+
+		DeleteFn: func(ctx context.Context, name string) error {
+			id, err := strconv.ParseInt(name, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid annotation ID %q: %w", name, err)
+			}
+			return client.Delete(ctx, id)
+		},
+
+		StripFields: []string{"id"},
+		Namespace:   namespace,
+		Descriptor:  staticDescriptor,
+	}
+}
+
+// annotationToPatch marshals an Annotation to a patch map suitable for PATCH,
+// omitting the server-assigned ID.
+func annotationToPatch(a *Annotation) (map[string]any, error) {
+	data, err := json.Marshal(a)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal annotation: %w", err)
+	}
+	var patch map[string]any
+	if err := json.Unmarshal(data, &patch); err != nil {
+		return nil, fmt.Errorf("failed to build annotation patch: %w", err)
+	}
+	delete(patch, "id")
+	return patch, nil
+}
+
+// NewTypedCRUD creates a TypedCRUD[Annotation] for use in provider commands.
+// It loads the REST config from the loader and constructs the annotations
+// client. The caller may optionally pass base ListOptions (From/To/Tags/Limit)
+// that will be applied to the ListFn.
+func NewTypedCRUD(ctx context.Context, loader RESTConfigLoader, baseListOpts ListOptions) (*adapter.TypedCRUD[Annotation], internalconfig.NamespacedRESTConfig, error) {
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to load REST config for annotations: %w", err)
+	}
+
+	client, err := NewClient(cfg)
+	if err != nil {
+		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to create annotations client: %w", err)
+	}
+
+	return buildTypedCRUD(client, cfg.Namespace, baseListOpts), cfg, nil
+}

--- a/internal/providers/annotations/resource_adapter.go
+++ b/internal/providers/annotations/resource_adapter.go
@@ -72,42 +72,17 @@ type RESTConfigLoader interface {
 
 // NewAdapterFactory returns a lazy adapter.Factory for Annotation resources.
 // The factory captures the RESTConfigLoader and constructs the client on first
-// invocation.
+// invocation. It uses the default (unfiltered) List semantics — CLI commands
+// that need --from/--to/--tags plumbing build their own TypedCRUD with a scoped
+// ListFn closure.
 func NewAdapterFactory(loader RESTConfigLoader) adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
-		cfg, err := loader.LoadGrafanaConfig(ctx)
+		crud, _, err := NewTypedCRUD(ctx, loader, ListOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("failed to load REST config for annotations adapter: %w", err)
+			return nil, err
 		}
-
-		client, err := NewClient(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create annotations client: %w", err)
-		}
-
-		return newTypedAdapter(client, cfg.Namespace), nil
+		return crud.AsAdapter(), nil
 	}
-}
-
-// NewFactoryFromConfig returns an adapter.Factory for Annotation resources that
-// creates a Client using the provided NamespacedRESTConfig.
-func NewFactoryFromConfig(cfg internalconfig.NamespacedRESTConfig) adapter.Factory {
-	return func(_ context.Context) (adapter.ResourceAdapter, error) {
-		client, err := NewClient(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create annotations client: %w", err)
-		}
-		return newTypedAdapter(client, cfg.Namespace), nil
-	}
-}
-
-// newTypedAdapter builds the TypedCRUD[Annotation] adapter for the given
-// client and namespace. It uses the default (unfiltered) List semantics — CLI
-// commands that need --from/--to/--tags plumbing build their own TypedCRUD
-// with a scoped ListFn closure.
-func newTypedAdapter(client *Client, namespace string) adapter.ResourceAdapter {
-	crud := buildTypedCRUD(client, namespace, ListOptions{})
-	return crud.AsAdapter()
 }
 
 // buildTypedCRUD assembles a TypedCRUD[Annotation] around the given client,

--- a/internal/providers/annotations/types.go
+++ b/internal/providers/annotations/types.go
@@ -1,0 +1,63 @@
+// Package annotations provides a client and commands for managing Grafana
+// annotations via the Grafana HTTP API.
+package annotations
+
+import "strconv"
+
+// Annotation represents a Grafana annotation.
+//
+// Annotations are identified purely by a numeric ID; there is no human-readable
+// slug. The ResourceIdentity implementation therefore uses the stringified ID
+// as the K8s-style resource name.
+//
+//nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
+type Annotation struct {
+	ID           int64    `json:"id,omitempty"`
+	DashboardUID string   `json:"dashboardUID,omitempty"`
+	PanelID      int64    `json:"panelId,omitempty"`
+	Time         int64    `json:"time,omitempty"`
+	TimeEnd      int64    `json:"timeEnd,omitempty"`
+	Tags         []string `json:"tags,omitempty"`
+	Text         string   `json:"text"`
+}
+
+// GetResourceName returns the numeric annotation ID as a string.
+// When ID is zero (unset), it returns the empty string.
+func (a Annotation) GetResourceName() string {
+	if a.ID == 0 {
+		return ""
+	}
+	return strconv.FormatInt(a.ID, 10)
+}
+
+// SetResourceName parses the given name as an int64 and assigns it to a.ID.
+// Parse errors are silently ignored per CONSTITUTION guidance for numeric-ID
+// resource types — the existing ID is preserved.
+func (a *Annotation) SetResourceName(name string) {
+	if id, err := strconv.ParseInt(name, 10, 64); err == nil {
+		a.ID = id
+	}
+}
+
+// AnnotationTag is an annotation tag with its usage count, as returned by
+// GET /api/annotations/tags.
+type AnnotationTag struct {
+	Tag   string `json:"tag"`
+	Count int64  `json:"count"`
+}
+
+// tagsResponse is the envelope returned by GET /api/annotations/tags.
+type tagsResponse struct {
+	Result struct {
+		Tags []AnnotationTag `json:"tags"`
+	} `json:"result"`
+}
+
+// MassDeleteRequest is the body for POST /api/annotations/mass-delete. Provide
+// either AnnotationID, or a DashboardID/DashboardUID together with PanelID.
+type MassDeleteRequest struct {
+	DashboardID  int64  `json:"dashboardId,omitempty"`
+	PanelID      int64  `json:"panelId,omitempty"`
+	AnnotationID int64  `json:"annotationId,omitempty"`
+	DashboardUID string `json:"dashboardUID,omitempty"`
+}

--- a/internal/providers/annotations/types.go
+++ b/internal/providers/annotations/types.go
@@ -18,7 +18,9 @@ type Annotation struct {
 	Time         int64    `json:"time,omitempty"`
 	TimeEnd      int64    `json:"timeEnd,omitempty"`
 	Tags         []string `json:"tags,omitempty"`
-	Text         string   `json:"text"`
+	// Text has omitempty so a partial update omits it rather than sending an
+	// empty string that would clear the annotation text server-side.
+	Text string `json:"text,omitempty"`
 }
 
 // GetResourceName returns the numeric annotation ID as a string.

--- a/internal/providers/annotations/types_identity_test.go
+++ b/internal/providers/annotations/types_identity_test.go
@@ -1,0 +1,93 @@
+package annotations_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/annotations"
+	"github.com/grafana/gcx/internal/resources/adapter"
+)
+
+// Compile-time assertion that *Annotation satisfies ResourceIdentity.
+var _ adapter.ResourceIdentity = &annotations.Annotation{}
+
+func TestAnnotation_GetResourceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		ann      annotations.Annotation
+		wantName string
+	}{
+		{
+			name:     "numeric ID",
+			ann:      annotations.Annotation{ID: 42, Text: "deploy"},
+			wantName: "42",
+		},
+		{
+			name:     "zero ID returns empty",
+			ann:      annotations.Annotation{Text: "new"},
+			wantName: "",
+		},
+		{
+			name:     "large ID",
+			ann:      annotations.Annotation{ID: 9007199254740991},
+			wantName: "9007199254740991",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ann.GetResourceName(); got != tt.wantName {
+				t.Errorf("GetResourceName() = %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestAnnotation_SetResourceName(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial int64
+		input   string
+		wantID  int64
+	}{
+		{
+			name:    "numeric string sets ID",
+			initial: 0,
+			input:   "42",
+			wantID:  42,
+		},
+		{
+			name:    "non-numeric leaves ID unchanged",
+			initial: 7,
+			input:   "not-a-number",
+			wantID:  7,
+		},
+		{
+			name:    "empty string leaves ID unchanged",
+			initial: 3,
+			input:   "",
+			wantID:  3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &annotations.Annotation{ID: tt.initial}
+			a.SetResourceName(tt.input)
+			if a.ID != tt.wantID {
+				t.Errorf("ID = %d, want %d", a.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestAnnotation_RoundTripIdentity(t *testing.T) {
+	original := annotations.Annotation{ID: 42, Text: "deploy"}
+	name := original.GetResourceName()
+
+	restored := &annotations.Annotation{}
+	restored.SetResourceName(name)
+
+	if restored.ID != original.ID {
+		t.Errorf("round-trip ID = %d, want %d", restored.ID, original.ID)
+	}
+}

--- a/internal/providers/org/client.go
+++ b/internal/providers/org/client.go
@@ -1,0 +1,84 @@
+package org
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/coreapi"
+)
+
+// ErrNotFound is returned when an org resource does not exist.
+var ErrNotFound = errors.New("org resource not found")
+
+// Client is an HTTP client for the /api/org endpoints of the Grafana API.
+type Client struct {
+	base *coreapi.Client
+}
+
+// NewClient creates a new org API client from a namespaced REST config.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	base, err := coreapi.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{base: base}, nil
+}
+
+// List returns all users in the current organization.
+func (c *Client) List(ctx context.Context) ([]OrgUser, error) {
+	return coreapi.DoJSON[any, []OrgUser](ctx, c.base, http.MethodGet, "/api/org/users", nil, http.StatusOK)
+}
+
+// Get returns a single user in the current organization by numeric user ID.
+// The Grafana /api/org/users endpoint has no single-user sub-resource, so this
+// lists all users and filters client-side.
+func (c *Client) Get(ctx context.Context, userID int) (*OrgUser, error) {
+	users, err := c.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range users {
+		if users[i].UserID == userID {
+			return &users[i], nil
+		}
+	}
+	return nil, fmt.Errorf("user id %d: %w", userID, ErrNotFound)
+}
+
+// GetByLoginOrEmail returns a single user matching the given login or email.
+func (c *Client) GetByLoginOrEmail(ctx context.Context, loginOrEmail string) (*OrgUser, error) {
+	users, err := c.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range users {
+		if strings.EqualFold(users[i].Login, loginOrEmail) || strings.EqualFold(users[i].Email, loginOrEmail) {
+			return &users[i], nil
+		}
+	}
+	return nil, fmt.Errorf("user %q: %w", loginOrEmail, ErrNotFound)
+}
+
+// Add adds a user (by login or email) to the current organization.
+func (c *Client) Add(ctx context.Context, req AddUserRequest) error {
+	return coreapi.DoStatus[AddUserRequest](ctx, c.base, http.MethodPost, "/api/org/users", &req, http.StatusOK)
+}
+
+// UpdateUserRole changes the role of a user in the current organization.
+func (c *Client) UpdateUserRole(ctx context.Context, userID int, role string) error {
+	body := map[string]string{"role": role}
+	return coreapi.DoStatusNotFound[map[string]string](ctx, c.base, http.MethodPatch,
+		fmt.Sprintf("/api/org/users/%d", userID), &body,
+		fmt.Errorf("user id %d: %w", userID, ErrNotFound), http.StatusOK)
+}
+
+// RemoveUser removes a user from the current organization.
+func (c *Client) RemoveUser(ctx context.Context, userID int) error {
+	return coreapi.DoStatusNotFound[any](ctx, c.base, http.MethodDelete,
+		fmt.Sprintf("/api/org/users/%d", userID), nil,
+		fmt.Errorf("user id %d: %w", userID, ErrNotFound), http.StatusOK)
+}

--- a/internal/providers/org/client_test.go
+++ b/internal/providers/org/client_test.go
@@ -1,0 +1,233 @@
+package org_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/org"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+// newTestServer starts an httptest.Server with the given handler and returns
+// an org.Client pointed at it. The server is closed when the test ends.
+func newTestServer(t *testing.T, handler http.HandlerFunc) *org.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := org.NewClient(config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}})
+	require.NoError(t, err)
+	return client
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	_, _ = w.Write(data)
+}
+
+func TestClient_List(t *testing.T) {
+	tests := []struct {
+		name      string
+		handler   http.HandlerFunc
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name: "success with users",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/api/org/users", r.URL.Path)
+				writeJSON(w, []org.OrgUser{
+					{UserID: 1, Login: "alice", Email: "alice@example.com", Role: "Admin"},
+					{UserID: 2, Login: "bob", Email: "bob@example.com", Role: "Editor"},
+				})
+			},
+			wantCount: 2,
+		},
+		{
+			name: "empty",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, []org.OrgUser{})
+			},
+			wantCount: 0,
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"boom"}`))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestServer(t, tt.handler)
+			users, err := client.List(t.Context())
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, users, tt.wantCount)
+		})
+	}
+}
+
+func TestClient_Add(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     org.AddUserRequest
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name: "success",
+			req:  org.AddUserRequest{LoginOrEmail: "alice@example.com", Role: "Editor"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/api/org/users", r.URL.Path)
+
+				body, err := io.ReadAll(r.Body)
+				if !assert.NoError(t, err) {
+					return
+				}
+				var got org.AddUserRequest
+				if !assert.NoError(t, json.Unmarshal(body, &got)) {
+					return
+				}
+				assert.Equal(t, "alice@example.com", got.LoginOrEmail)
+				assert.Equal(t, "Editor", got.Role)
+
+				writeJSON(w, map[string]any{"message": "user added to org"})
+			},
+		},
+		{
+			name: "missing role rejected by server",
+			req:  org.AddUserRequest{LoginOrEmail: "alice@example.com"},
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"message":"role is required"}`))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestServer(t, tt.handler)
+			err := client.Add(t.Context(), tt.req)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestClient_UpdateUserRole(t *testing.T) {
+	tests := []struct {
+		name    string
+		userID  int
+		role    string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name:   "success",
+			userID: 42,
+			role:   "Admin",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPatch, r.Method)
+				assert.Equal(t, "/api/org/users/42", r.URL.Path)
+
+				body, err := io.ReadAll(r.Body)
+				if !assert.NoError(t, err) {
+					return
+				}
+				var got map[string]string
+				if !assert.NoError(t, json.Unmarshal(body, &got)) {
+					return
+				}
+				assert.Equal(t, "Admin", got["role"])
+
+				writeJSON(w, map[string]any{"message": "role updated"})
+			},
+		},
+		{
+			name:    "not found",
+			userID:  999,
+			role:    "Viewer",
+			handler: func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNotFound) },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestServer(t, tt.handler)
+			err := client.UpdateUserRole(t.Context(), tt.userID, tt.role)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestClient_RemoveUser(t *testing.T) {
+	tests := []struct {
+		name    string
+		userID  int
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name:   "success",
+			userID: 42,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodDelete, r.Method)
+				assert.Equal(t, "/api/org/users/42", r.URL.Path)
+				writeJSON(w, map[string]any{"message": "user removed"})
+			},
+		},
+		{
+			name:   "not found",
+			userID: 999,
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"not found"}`))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestServer(t, tt.handler)
+			err := client.RemoveUser(t.Context(), tt.userID)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/providers/org/commands_test.go
+++ b/internal/providers/org/commands_test.go
@@ -1,0 +1,85 @@
+package org_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/org"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func findSubcommand(t *testing.T, root *cobra.Command, path ...string) *cobra.Command {
+	t.Helper()
+	cur := root
+	for _, name := range path {
+		var next *cobra.Command
+		for _, sub := range cur.Commands() {
+			if sub.Name() == name {
+				next = sub
+				break
+			}
+		}
+		require.NotNilf(t, next, "expected subcommand %q under %q", name, cur.CommandPath())
+		cur = next
+	}
+	return cur
+}
+
+// silence suppresses errors/usage on the entire command tree so failing
+// Execute calls don't spam test output.
+func silence(cmd *cobra.Command) {
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	for _, sub := range cmd.Commands() {
+		silence(sub)
+	}
+}
+
+// orgRoot returns the provider's root "org" command with output silenced.
+func orgRoot(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmds := (&org.OrgProvider{}).Commands()
+	require.Len(t, cmds, 1)
+	silence(cmds[0])
+	return cmds[0]
+}
+
+func TestOrgProvider_CommandShape(t *testing.T) {
+	p := &org.OrgProvider{}
+	assert.Equal(t, "org", p.Name())
+	assert.NotEmpty(t, p.ShortDesc())
+	require.NoError(t, p.Validate(nil))
+	assert.Nil(t, p.ConfigKeys())
+
+	orgCmd := orgRoot(t)
+	assert.Equal(t, "org", orgCmd.Name())
+
+	users := findSubcommand(t, orgCmd, "users")
+	subs := map[string]*cobra.Command{}
+	for _, s := range users.Commands() {
+		subs[s.Name()] = s
+	}
+	for _, name := range []string{"list", "get", "add", "update-role", "remove"} {
+		assert.Contains(t, subs, name)
+	}
+}
+
+func TestOrgUsersAdd_RequiresLogin(t *testing.T) {
+	orgCmd := orgRoot(t)
+	orgCmd.SetArgs([]string{"users", "add", "--role", "Editor"})
+
+	err := orgCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "login")
+}
+
+func TestOrgUsersUpdateRole_ParsesIntArg(t *testing.T) {
+	orgCmd := orgRoot(t)
+	// Non-integer user ID must error during arg parsing, before any HTTP call.
+	orgCmd.SetArgs([]string{"users", "update-role", "not-an-int", "--role", "Admin"})
+
+	err := orgCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not-an-int")
+}

--- a/internal/providers/org/provider.go
+++ b/internal/providers/org/provider.go
@@ -1,0 +1,65 @@
+package org
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/spf13/cobra"
+)
+
+var _ providers.Provider = &OrgProvider{}
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	providers.Register(&OrgProvider{})
+}
+
+// OrgProvider manages Grafana organization resources.
+type OrgProvider struct{}
+
+// Name returns the unique identifier for this provider.
+func (p *OrgProvider) Name() string { return "org" }
+
+// ShortDesc returns a one-line description of the provider.
+func (p *OrgProvider) ShortDesc() string { return "Manage Grafana organization resources" }
+
+// Commands returns the Cobra commands contributed by this provider.
+func (p *OrgProvider) Commands() []*cobra.Command {
+	loader := &providers.ConfigLoader{}
+
+	orgCmd := &cobra.Command{
+		Use:   "org",
+		Short: p.ShortDesc(),
+	}
+	// Bubble parent PersistentPreRun when attached to a real CLI root; guard
+	// against self-recursion when orgCmd itself is used as the root (e.g. in
+	// isolated tests where cmd.Root() == orgCmd).
+	orgCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if root := cmd.Root(); root != orgCmd && root.PersistentPreRun != nil {
+			root.PersistentPreRun(cmd, args)
+		}
+	}
+
+	loader.BindFlags(orgCmd.PersistentFlags())
+	orgCmd.AddCommand(usersCommands(loader))
+
+	return []*cobra.Command{orgCmd}
+}
+
+// Validate checks that the given provider configuration is valid.
+func (p *OrgProvider) Validate(_ map[string]string) error { return nil }
+
+// ConfigKeys returns the configuration keys used by this provider.
+func (p *OrgProvider) ConfigKeys() []providers.ConfigKey { return nil }
+
+// TypedRegistrations returns adapter registrations for OrgUser resource types.
+func (p *OrgProvider) TypedRegistrations() []adapter.Registration {
+	loader := &providers.ConfigLoader{}
+	return []adapter.Registration{
+		{
+			Factory:    NewUsersAdapterFactory(loader),
+			Descriptor: staticUsersDescriptor,
+			GVK:        staticUsersDescriptor.GroupVersionKind(),
+			Schema:     OrgUserSchema(),
+			Example:    OrgUserExample(),
+		},
+	}
+}

--- a/internal/providers/org/resource_adapter.go
+++ b/internal/providers/org/resource_adapter.go
@@ -1,0 +1,150 @@
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	internalconfig "github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	// APIVersion is the API version for org user resources.
+	APIVersion = "org.ext.grafana.app/v1alpha1"
+	// Kind is the kind for org user resources.
+	Kind = "OrgUser"
+)
+
+// staticUsersDescriptor is the resource descriptor for org user resources.
+//
+//nolint:gochecknoglobals // Static descriptor used in self-registration pattern.
+var staticUsersDescriptor = resources.Descriptor{
+	GroupVersion: schema.GroupVersion{
+		Group:   "org.ext.grafana.app",
+		Version: "v1alpha1",
+	},
+	Kind:     Kind,
+	Singular: "user",
+	Plural:   "users",
+}
+
+// StaticUsersDescriptor returns the static descriptor for org user resources.
+func StaticUsersDescriptor() resources.Descriptor {
+	return staticUsersDescriptor
+}
+
+// OrgUserSchema returns a JSON Schema for the OrgUser resource type.
+func OrgUserSchema() json.RawMessage {
+	return adapter.SchemaFromType[OrgUser](StaticUsersDescriptor())
+}
+
+// OrgUserExample returns an example OrgUser manifest as JSON.
+func OrgUserExample() json.RawMessage {
+	example := map[string]any{
+		"apiVersion": APIVersion,
+		"kind":       Kind,
+		"metadata": map[string]any{
+			"name": "42",
+		},
+		"spec": map[string]any{
+			"login": "alice",
+			"email": "alice@example.com",
+			"role":  "Editor",
+		},
+	}
+	b, err := json.Marshal(example)
+	if err != nil {
+		panic(fmt.Sprintf("org: failed to marshal example: %v", err))
+	}
+	return b
+}
+
+// NewUsersAdapterFactory returns a lazy adapter.Factory for org users.
+// The factory captures the loader and constructs the client on first invocation.
+func NewUsersAdapterFactory(loader GrafanaConfigLoader) adapter.Factory {
+	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
+		crud, _, err := NewUsersTypedCRUD(ctx, loader)
+		if err != nil {
+			return nil, err
+		}
+		return crud.AsAdapter(), nil
+	}
+}
+
+// NewUsersTypedCRUD creates a TypedCRUD[OrgUser] for the org users resource,
+// wiring the org API client into typed CRUD operations. It is exported so CLI
+// commands can route through the same pipeline as adapter registration.
+func NewUsersTypedCRUD(ctx context.Context, loader GrafanaConfigLoader) (*adapter.TypedCRUD[OrgUser], internalconfig.NamespacedRESTConfig, error) {
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to load REST config for org: %w", err)
+	}
+
+	client, err := NewClient(cfg)
+	if err != nil {
+		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to create org client: %w", err)
+	}
+
+	crud := &adapter.TypedCRUD[OrgUser]{
+		ListFn: adapter.LimitedListFn(client.List),
+
+		GetFn: func(ctx context.Context, name string) (*OrgUser, error) {
+			id, err := parseUserID(name)
+			if err != nil {
+				return nil, err
+			}
+			return client.Get(ctx, id)
+		},
+
+		CreateFn: func(ctx context.Context, u *OrgUser) (*OrgUser, error) {
+			loginOrEmail := u.LoginOrEmail
+			if loginOrEmail == "" {
+				loginOrEmail = u.Login
+			}
+			if loginOrEmail == "" {
+				loginOrEmail = u.Email
+			}
+			if err := client.Add(ctx, AddUserRequest{
+				LoginOrEmail: loginOrEmail,
+				Role:         u.Role,
+			}); err != nil {
+				return nil, err
+			}
+			// POST /api/org/users returns no body with the new ID; re-fetch by
+			// login/email to populate UserID for the returned spec.
+			fetched, err := client.GetByLoginOrEmail(ctx, loginOrEmail)
+			if err != nil {
+				return nil, fmt.Errorf("fetching org user %q after add: %w", loginOrEmail, err)
+			}
+			return fetched, nil
+		},
+
+		UpdateFn: func(ctx context.Context, name string, u *OrgUser) (*OrgUser, error) {
+			id, err := parseUserID(name)
+			if err != nil {
+				return nil, err
+			}
+			if err := client.UpdateUserRole(ctx, id, u.Role); err != nil {
+				return nil, err
+			}
+			return client.Get(ctx, id)
+		},
+
+		DeleteFn: func(ctx context.Context, name string) error {
+			id, err := parseUserID(name)
+			if err != nil {
+				return err
+			}
+			return client.RemoveUser(ctx, id)
+		},
+
+		StripFields: []string{"userId", "orgId"},
+		Namespace:   cfg.Namespace,
+		Descriptor:  staticUsersDescriptor,
+	}
+
+	return crud, cfg, nil
+}

--- a/internal/providers/org/types.go
+++ b/internal/providers/org/types.go
@@ -1,0 +1,41 @@
+// Package org provides commands for managing Grafana organization resources.
+package org
+
+import "strconv"
+
+// OrgUser represents a user membership in the current Grafana organization.
+//
+//nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
+type OrgUser struct {
+	OrgID         int    `json:"orgId,omitempty"`
+	UserID        int    `json:"userId,omitempty"`
+	Login         string `json:"login,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Email         string `json:"email,omitempty"`
+	LoginOrEmail  string `json:"loginOrEmail,omitempty"`
+	Role          string `json:"role"`
+	AvatarURL     string `json:"avatarUrl,omitempty"`
+	LastSeenAt    string `json:"lastSeenAt,omitempty"`
+	LastSeenAtAge string `json:"lastSeenAtAge,omitempty"`
+}
+
+// GetResourceName returns the numeric UserID as a string, acting as the
+// stable identity for this org user.
+func (u OrgUser) GetResourceName() string {
+	return strconv.Itoa(u.UserID)
+}
+
+// SetResourceName restores the numeric UserID from a string (e.g., after a
+// Kubernetes-style round-trip via metadata.name). Parse errors are silently
+// ignored, per the ResourceIdentity contract for numeric identifiers.
+func (u *OrgUser) SetResourceName(name string) {
+	if id, err := strconv.Atoi(name); err == nil {
+		u.UserID = id
+	}
+}
+
+// AddUserRequest is the payload for POST /api/org/users.
+type AddUserRequest struct {
+	LoginOrEmail string `json:"loginOrEmail"`
+	Role         string `json:"role"`
+}

--- a/internal/providers/org/types_identity_test.go
+++ b/internal/providers/org/types_identity_test.go
@@ -1,0 +1,89 @@
+package org_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/org"
+	"github.com/grafana/gcx/internal/resources/adapter"
+)
+
+// Compile-time assertion that *OrgUser satisfies ResourceIdentity.
+var _ adapter.ResourceIdentity = &org.OrgUser{}
+
+func TestOrgUser_GetResourceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     org.OrgUser
+		wantName string
+	}{
+		{
+			name:     "numeric user id",
+			user:     org.OrgUser{UserID: 42, Login: "alice"},
+			wantName: "42",
+		},
+		{
+			name:     "zero user id renders as 0",
+			user:     org.OrgUser{UserID: 0},
+			wantName: "0",
+		},
+		{
+			name:     "large user id",
+			user:     org.OrgUser{UserID: 1234567},
+			wantName: "1234567",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.user.GetResourceName(); got != tt.wantName {
+				t.Errorf("GetResourceName() = %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestOrgUser_SetResourceName(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		wantID int
+	}{
+		{
+			name:   "numeric id is parsed",
+			input:  "42",
+			wantID: 42,
+		},
+		{
+			name:   "non-numeric leaves user id at zero value",
+			input:  "alice",
+			wantID: 0,
+		},
+		{
+			name:   "empty string leaves user id at zero value",
+			input:  "",
+			wantID: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &org.OrgUser{}
+			u.SetResourceName(tt.input)
+			if u.UserID != tt.wantID {
+				t.Errorf("UserID = %d, want %d", u.UserID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestOrgUser_RoundTripIdentity(t *testing.T) {
+	original := org.OrgUser{UserID: 42, Login: "alice"}
+	name := original.GetResourceName()
+
+	restored := &org.OrgUser{}
+	restored.SetResourceName(name)
+
+	if restored.UserID != original.UserID {
+		t.Errorf("round-trip UserID = %d, want %d", restored.UserID, original.UserID)
+	}
+}

--- a/internal/providers/org/users_commands.go
+++ b/internal/providers/org/users_commands.go
@@ -1,0 +1,308 @@
+package org
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// GrafanaConfigLoader can load a NamespacedRESTConfig from the active context.
+type GrafanaConfigLoader interface {
+	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
+}
+
+func usersCommands(loader GrafanaConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "users",
+		Short: "Manage users in the current organization.",
+	}
+	cmd.AddCommand(
+		newUsersListCommand(loader),
+		newUsersGetCommand(loader),
+		newUsersAddCommand(loader),
+		newUsersUpdateRoleCommand(loader),
+		newUsersRemoveCommand(loader),
+	)
+	return cmd
+}
+
+// parseUserID parses a positional USER-ID argument.
+func parseUserID(arg string) (int, error) {
+	id, err := strconv.Atoi(arg)
+	if err != nil {
+		return 0, fmt.Errorf("invalid user id %q: %w", arg, err)
+	}
+	return id, nil
+}
+
+// ---------------------------------------------------------------------------
+// list command
+// ---------------------------------------------------------------------------
+
+type usersListOpts struct {
+	IO    cmdio.Options
+	Limit int64
+}
+
+func (o *usersListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &UsersTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for unlimited)")
+}
+
+func newUsersListCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &usersListOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List users in the current organization.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewUsersTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			typedObjs, err := crud.List(ctx, opts.Limit)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), typedObjs)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// UsersTableCodec renders org users as a table.
+type UsersTableCodec struct{}
+
+// Format returns the output format name.
+func (c *UsersTableCodec) Format() format.Format { return "table" }
+
+// Encode writes users to the writer as a table.
+// It accepts []adapter.TypedObject[OrgUser] (from commands) and extracts .Spec internally.
+func (c *UsersTableCodec) Encode(w io.Writer, v any) error {
+	typedObjs, ok := v.([]adapter.TypedObject[OrgUser])
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []TypedObject[OrgUser]")
+	}
+
+	t := style.NewTable("USER_ID", "LOGIN", "NAME", "EMAIL", "ROLE", "LAST_SEEN")
+	for _, obj := range typedObjs {
+		u := obj.Spec
+		lastSeen := u.LastSeenAtAge
+		if lastSeen == "" {
+			lastSeen = u.LastSeenAt
+		}
+		t.Row(strconv.Itoa(u.UserID), u.Login, u.Name, u.Email, u.Role, lastSeen)
+	}
+	return t.Render(w)
+}
+
+// Decode is not supported for table format.
+func (c *UsersTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// ---------------------------------------------------------------------------
+// get command
+// ---------------------------------------------------------------------------
+
+type usersGetOpts struct {
+	IO cmdio.Options
+}
+
+func (o *usersGetOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &UsersTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newUsersGetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &usersGetOpts{}
+	cmd := &cobra.Command{
+		Use:   "get LOGIN-OR-EMAIL",
+		Short: "Get a single org user by login or email.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, cfg, err := NewUsersTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			// Resolve login/email → numeric ID using a raw client call,
+			// then route through TypedCRUD.Get by the canonical ID name.
+			client, err := NewClient(cfg)
+			if err != nil {
+				return err
+			}
+			user, err := client.GetByLoginOrEmail(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			typedObj, err := crud.Get(ctx, strconv.Itoa(user.UserID))
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), []adapter.TypedObject[OrgUser]{*typedObj})
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// add command
+// ---------------------------------------------------------------------------
+
+type usersAddOpts struct {
+	Login string
+	Role  string
+}
+
+func (o *usersAddOpts) Validate() error {
+	if o.Login == "" {
+		return errors.New("--login is required")
+	}
+	if o.Role == "" {
+		return errors.New("--role is required")
+	}
+	return nil
+}
+
+func newUsersAddCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &usersAddOpts{}
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a user to the current organization.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, cfg, err := NewUsersTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			ou := OrgUser{
+				LoginOrEmail: opts.Login,
+				Role:         opts.Role,
+			}
+			typedObj := &adapter.TypedObject[OrgUser]{Spec: ou}
+			typedObj.SetNamespace(cfg.Namespace)
+
+			created, err := crud.Create(ctx, typedObj)
+			if err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.OutOrStdout(), "Added user %s to organization with role %s (id=%d).",
+				opts.Login, opts.Role, created.Spec.UserID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.Login, "login", "", "Login or email of the user to add (required)")
+	cmd.Flags().StringVar(&opts.Role, "role", "", "Role for the user, e.g. Admin, Editor, Viewer (required)")
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// update-role command
+// ---------------------------------------------------------------------------
+
+type usersUpdateRoleOpts struct {
+	Role string
+}
+
+func newUsersUpdateRoleCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &usersUpdateRoleOpts{}
+	cmd := &cobra.Command{
+		Use:   "update-role USER-ID",
+		Short: "Update the role of a user in the current organization.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Role == "" {
+				return errors.New("--role is required")
+			}
+			userID, err := parseUserID(args[0])
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, cfg, err := NewUsersTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			ou := OrgUser{Role: opts.Role}
+			typedObj := &adapter.TypedObject[OrgUser]{Spec: ou}
+			typedObj.SetNamespace(cfg.Namespace)
+
+			if _, err := crud.Update(ctx, args[0], typedObj); err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.OutOrStdout(), "Updated user %d role to %s.", userID, opts.Role)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.Role, "role", "", "New role for the user, e.g. Admin, Editor, Viewer (required)")
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// remove command
+// ---------------------------------------------------------------------------
+
+func newUsersRemoveCommand(loader GrafanaConfigLoader) *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove USER-ID",
+		Short: "Remove a user from the current organization.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			userID, err := parseUserID(args[0])
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewUsersTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			if err := crud.Delete(ctx, args[0]); err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.OutOrStdout(), "Removed user %d from organization.", userID)
+			return nil
+		},
+	}
+}

--- a/internal/providers/permissions/client.go
+++ b/internal/providers/permissions/client.go
@@ -1,0 +1,92 @@
+package permissions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/coreapi"
+)
+
+// Client talks to Grafana's granular access-control (RBAC) permissions API.
+type Client struct {
+	base *coreapi.Client
+}
+
+// NewClient creates a new permissions client bound to the provided REST config.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	base, err := coreapi.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{base: base}, nil
+}
+
+func basePath(resource string) string {
+	return "/api/access-control/" + resource
+}
+
+// Describe returns the assignable permission levels and assignment types for a
+// resource kind.
+func (c *Client) Describe(ctx context.Context, resource string) (*Description, error) {
+	d, err := coreapi.DoJSON[any, Description](ctx, c.base, http.MethodGet, basePath(resource)+"/description", nil, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+// Get returns the permission list for a resource instance.
+func (c *Client) Get(ctx context.Context, resource, resourceID string) ([]ResourcePermission, error) {
+	return coreapi.DoJSON[any, []ResourcePermission](ctx, c.base, http.MethodGet,
+		fmt.Sprintf("%s/%s", basePath(resource), url.PathEscape(resourceID)), nil, http.StatusOK)
+}
+
+// Set replaces the full permission set for a resource instance.
+func (c *Client) Set(ctx context.Context, resource, resourceID string, perms []SetResourcePermissionCommand) error {
+	body := setPermissionsBody{Permissions: perms}
+	err := coreapi.DoStatus[setPermissionsBody](ctx, c.base, http.MethodPost,
+		fmt.Sprintf("%s/%s", basePath(resource), url.PathEscape(resourceID)), &body, http.StatusOK)
+	return annotateForbidden(err)
+}
+
+// SetUserPermission sets (or, with an empty level, removes) one user's
+// permission on a resource instance. userRef may be a numeric user ID or a UID.
+func (c *Client) SetUserPermission(ctx context.Context, resource, resourceID, userRef, level string) error {
+	return c.setPrincipal(ctx, resource, resourceID, "users", userRef, level)
+}
+
+// SetTeamPermission sets (or removes) one team's permission on a resource
+// instance. teamRef may be a numeric team ID or a UID.
+func (c *Client) SetTeamPermission(ctx context.Context, resource, resourceID, teamRef, level string) error {
+	return c.setPrincipal(ctx, resource, resourceID, "teams", teamRef, level)
+}
+
+// SetBuiltInRolePermission sets (or removes) a built-in role's permission on a
+// resource instance (e.g. role "Viewer", "Editor", "Admin").
+func (c *Client) SetBuiltInRolePermission(ctx context.Context, resource, resourceID, role, level string) error {
+	return c.setPrincipal(ctx, resource, resourceID, "builtInRoles", role, level)
+}
+
+func (c *Client) setPrincipal(ctx context.Context, resource, resourceID, principalKind, principalRef, level string) error {
+	body := setPermissionBody{Permission: level}
+	path := fmt.Sprintf("%s/%s/%s/%s", basePath(resource), url.PathEscape(resourceID), principalKind, url.PathEscape(principalRef))
+	err := coreapi.DoStatus[setPermissionBody](ctx, c.base, http.MethodPost, path, &body, http.StatusOK)
+	return annotateForbidden(err)
+}
+
+// annotateForbidden adds an actionable hint when a write is rejected with 403,
+// which on Grafana OSS without Enterprise/RBAC means the granular permission
+// API is unavailable.
+func annotateForbidden(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "status 403") {
+		return fmt.Errorf("%w\nwriting granular permissions requires RBAC (Grafana Enterprise or Cloud); reads work on all editions", err)
+	}
+	return err
+}

--- a/internal/providers/permissions/client_test.go
+++ b/internal/providers/permissions/client_test.go
@@ -1,0 +1,132 @@
+package permissions_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/permissions"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newClient(t *testing.T, url string) *permissions.Client {
+	t.Helper()
+	c, err := permissions.NewClient(config.NamespacedRESTConfig{Config: rest.Config{Host: url}})
+	require.NoError(t, err)
+	return c
+}
+
+func TestClient_Describe(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/access-control/dashboards/description", r.URL.Path)
+		_, _ = w.Write([]byte(`{"assignments":{"users":true,"teams":true,"serviceAccounts":true,"builtInRoles":true},"permissions":["View","Edit","Admin"]}`))
+	}))
+	defer srv.Close()
+
+	desc, err := newClient(t, srv.URL).Describe(context.Background(), "dashboards")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"View", "Edit", "Admin"}, desc.Permissions)
+	assert.True(t, desc.Assignments.ServiceAccounts)
+}
+
+func TestClient_Get(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/access-control/folders/my-uid", r.URL.Path)
+		_, _ = w.Write([]byte(`[{"id":1,"builtInRole":"Editor","permission":"Edit","isManaged":true},{"id":2,"userLogin":"alice","permission":"Admin"}]`))
+	}))
+	defer srv.Close()
+
+	perms, err := newClient(t, srv.URL).Get(context.Background(), "folders", "my-uid")
+	require.NoError(t, err)
+	require.Len(t, perms, 2)
+	assert.Equal(t, "Editor", perms[0].BuiltInRole)
+	assert.Equal(t, "alice", perms[1].UserLogin)
+}
+
+func TestClient_Set(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/access-control/dashboards/my-uid", r.URL.Path)
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		_, _ = w.Write([]byte(`{"message":"Permissions updated"}`))
+	}))
+	defer srv.Close()
+
+	err := newClient(t, srv.URL).Set(context.Background(), "dashboards", "my-uid", []permissions.SetResourcePermissionCommand{
+		{TeamID: 3, Permission: "Edit"},
+		{BuiltInRole: "Viewer", Permission: "View"},
+	})
+	require.NoError(t, err)
+	perms, ok := gotBody["permissions"].([]any)
+	require.True(t, ok)
+	assert.Len(t, perms, 2)
+}
+
+func TestClient_SetGrantsPerPrincipal(t *testing.T) {
+	tests := []struct {
+		name     string
+		call     func(c *permissions.Client) error
+		wantPath string
+	}{
+		{
+			name: "user",
+			call: func(c *permissions.Client) error {
+				return c.SetUserPermission(context.Background(), "dashboards", "d1", "42", "Edit")
+			},
+			wantPath: "/api/access-control/dashboards/d1/users/42",
+		},
+		{
+			name: "team",
+			call: func(c *permissions.Client) error {
+				return c.SetTeamPermission(context.Background(), "folders", "f1", "3", "Admin")
+			},
+			wantPath: "/api/access-control/folders/f1/teams/3",
+		},
+		{
+			name: "role",
+			call: func(c *permissions.Client) error {
+				return c.SetBuiltInRolePermission(context.Background(), "datasources", "ds1", "Viewer", "View")
+			},
+			wantPath: "/api/access-control/datasources/ds1/builtInRoles/Viewer",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath, gotLevel string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				var body map[string]string
+				b, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(b, &body)
+				gotLevel = body["permission"]
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			require.NoError(t, tt.call(newClient(t, srv.URL)))
+			assert.Equal(t, tt.wantPath, gotPath)
+			assert.NotEmpty(t, gotLevel)
+		})
+	}
+}
+
+func TestClient_SetForbiddenHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"access denied"}`))
+	}))
+	defer srv.Close()
+
+	err := newClient(t, srv.URL).SetTeamPermission(context.Background(), "dashboards", "d1", "3", "Edit")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+	assert.Contains(t, err.Error(), "requires RBAC")
+}

--- a/internal/providers/permissions/commands.go
+++ b/internal/providers/permissions/commands.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/coreapi"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/style"
@@ -255,20 +255,9 @@ func readPermissionsFromFile(path string, stdin io.Reader) ([]SetResourcePermiss
 	if path == "" {
 		return nil, errors.New("--file is required")
 	}
-	var (
-		data []byte
-		err  error
-	)
-	if path == "-" {
-		if stdin == nil {
-			stdin = os.Stdin
-		}
-		data, err = io.ReadAll(stdin)
-	} else {
-		data, err = os.ReadFile(path)
-	}
+	data, err := coreapi.ReadInput(path, stdin)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read permissions file: %w", err)
+		return nil, err
 	}
 	return parsePermissions(data)
 }

--- a/internal/providers/permissions/commands.go
+++ b/internal/providers/permissions/commands.go
@@ -1,0 +1,374 @@
+package permissions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// GrafanaConfigLoader can load a NamespacedRESTConfig from the active context.
+type GrafanaConfigLoader interface {
+	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
+}
+
+func clientFromLoader(ctx context.Context, loader GrafanaConfigLoader) (*Client, error) {
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(cfg)
+}
+
+const resourceArgHelp = "<resource> is one of: folders, dashboards, datasources, teams, serviceaccounts"
+
+// ---- get ----
+
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &PermissionsTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newGetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:     "get <resource> <id>",
+		Short:   "Get the permission list for a resource instance.",
+		Long:    "Get the granular RBAC permission list for a resource instance.\n\n" + resourceArgHelp,
+		Example: "  gcx permissions get dashboards my-dashboard-uid\n  gcx permissions get folders my-folder-uid -o json",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateResource(args[0]); err != nil {
+				return err
+			}
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := clientFromLoader(ctx, loader)
+			if err != nil {
+				return err
+			}
+			perms, err := client.Get(ctx, args[0], args[1])
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), perms)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---- set ----
+
+type setOpts struct {
+	File string
+}
+
+func newSetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &setOpts{}
+	cmd := &cobra.Command{
+		Use:   "set <resource> <id> -f FILE",
+		Short: "Replace the full permission set for a resource instance.",
+		Long: "Replace the full permission set for a resource instance from a JSON file.\n\n" +
+			"The file is a JSON array of assignments (or a {\"permissions\": [...]} object),\n" +
+			"each with a \"permission\" level (View/Edit/Admin) and exactly one of\n" +
+			"\"userId\", \"teamId\", or \"builtInRole\".\n\n" + resourceArgHelp,
+		Example: "  gcx permissions set dashboards my-uid -f acl.json\n  cat acl.json | gcx permissions set folders my-uid -f -",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateResource(args[0]); err != nil {
+				return err
+			}
+			perms, err := readPermissionsFromFile(opts.File, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := clientFromLoader(ctx, loader)
+			if err != nil {
+				return err
+			}
+			if err := client.Set(ctx, args[0], args[1], perms); err != nil {
+				return err
+			}
+			cmdio.Success(cmd.OutOrStdout(), "updated permissions for %s %s", args[0], args[1])
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "JSON file with the permission set (use - for stdin)")
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+// ---- grant ----
+
+type grantOpts struct {
+	User  string
+	Team  string
+	Role  string
+	Level string
+}
+
+func (o *grantOpts) validate() (string, string, error) {
+	var principalKind, principalRef string
+	set := 0
+	if o.User != "" {
+		set++
+		principalKind, principalRef = "user", o.User
+	}
+	if o.Team != "" {
+		set++
+		principalKind, principalRef = "team", o.Team
+	}
+	if o.Role != "" {
+		set++
+		principalKind, principalRef = "role", o.Role
+	}
+	if set != 1 {
+		return "", "", errors.New("provide exactly one of --user, --team, or --role")
+	}
+	if o.Level == "" {
+		return "", "", errors.New("--level is required (e.g. View, Edit, Admin; use \"\" via set to remove)")
+	}
+	return principalKind, principalRef, nil
+}
+
+func newGrantCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &grantOpts{}
+	cmd := &cobra.Command{
+		Use:   "grant <resource> <id>",
+		Short: "Grant a permission level to a single user, team, or built-in role.",
+		Long: "Grant a permission level to a single principal on a resource instance.\n\n" +
+			"Specify exactly one of --user, --team, or --role, plus --level.\n\n" + resourceArgHelp,
+		Example: "  gcx permissions grant dashboards my-uid --team 3 --level Edit\n" +
+			"  gcx permissions grant folders my-uid --role Viewer --level View\n" +
+			"  gcx permissions grant datasources my-uid --user alice --level Admin",
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateResource(args[0]); err != nil {
+				return err
+			}
+			principalKind, principalRef, err := opts.validate()
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := clientFromLoader(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			resource, id := args[0], args[1]
+			switch principalKind {
+			case "user":
+				err = client.SetUserPermission(ctx, resource, id, principalRef, opts.Level)
+			case "team":
+				err = client.SetTeamPermission(ctx, resource, id, principalRef, opts.Level)
+			case "role":
+				err = client.SetBuiltInRolePermission(ctx, resource, id, principalRef, opts.Level)
+			}
+			if err != nil {
+				return err
+			}
+			cmdio.Success(cmd.OutOrStdout(), "granted %s permission to %s %s on %s %s", opts.Level, principalKind, principalRef, resource, id)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.User, "user", "", "User to grant to (numeric ID or UID)")
+	cmd.Flags().StringVar(&opts.Team, "team", "", "Team to grant to (numeric ID or UID)")
+	cmd.Flags().StringVar(&opts.Role, "role", "", "Built-in role to grant to (e.g. Viewer, Editor, Admin)")
+	cmd.Flags().StringVar(&opts.Level, "level", "", "Permission level (e.g. View, Edit, Admin)")
+	return cmd
+}
+
+// ---- levels ----
+
+type levelsOpts struct {
+	IO cmdio.Options
+}
+
+func (o *levelsOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &DescriptionTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newLevelsCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &levelsOpts{}
+	cmd := &cobra.Command{
+		Use:     "levels <resource>",
+		Short:   "Show the assignable permission levels for a resource kind.",
+		Long:    "Show the assignable permission levels and assignment types for a resource kind.\n\n" + resourceArgHelp,
+		Example: "  gcx permissions levels dashboards",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateResource(args[0]); err != nil {
+				return err
+			}
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := clientFromLoader(ctx, loader)
+			if err != nil {
+				return err
+			}
+			desc, err := client.Describe(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), desc)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---- input parsing ----
+
+// readPermissionsFromFile reads a JSON permission set from path (or stdin for
+// "-"). The input may be a bare array of assignments or a {"permissions":[...]}
+// envelope.
+func readPermissionsFromFile(path string, stdin io.Reader) ([]SetResourcePermissionCommand, error) {
+	if path == "" {
+		return nil, errors.New("--file is required")
+	}
+	var (
+		data []byte
+		err  error
+	)
+	if path == "-" {
+		if stdin == nil {
+			stdin = os.Stdin
+		}
+		data, err = io.ReadAll(stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read permissions file: %w", err)
+	}
+	return parsePermissions(data)
+}
+
+// parsePermissions accepts either a bare JSON array or a {"permissions":[…]} envelope.
+func parsePermissions(data []byte) ([]SetResourcePermissionCommand, error) {
+	var perms []SetResourcePermissionCommand
+	if err := json.Unmarshal(data, &perms); err == nil {
+		return perms, nil
+	}
+	var envelope setPermissionsBody
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, fmt.Errorf("failed to parse permissions: expected JSON array or object with 'permissions' field: %w", err)
+	}
+	return envelope.Permissions, nil
+}
+
+// ---- table codecs ----
+
+// PermissionsTableCodec renders a resource's permission list as a table.
+type PermissionsTableCodec struct{}
+
+// Format reports the codec's output format identifier.
+func (c *PermissionsTableCodec) Format() format.Format { return "table" }
+
+// Encode writes the table representation of v to w.
+func (c *PermissionsTableCodec) Encode(w io.Writer, v any) error {
+	perms, ok := v.([]ResourcePermission)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []ResourcePermission")
+	}
+	t := style.NewTable("PERMISSION", "USER", "TEAM", "BUILT-IN ROLE", "MANAGED", "INHERITED")
+	for _, p := range perms {
+		user := p.UserLogin
+		if user == "" && p.UserID != 0 {
+			user = strconv.FormatInt(p.UserID, 10)
+		}
+		team := p.Team
+		if team == "" && p.TeamID != 0 {
+			team = strconv.FormatInt(p.TeamID, 10)
+		}
+		t.Row(p.Permission, user, team, p.BuiltInRole, boolStr(p.IsManaged), boolStr(p.IsInherited))
+	}
+	return t.Render(w)
+}
+
+// Decode is not supported for the table codec.
+func (c *PermissionsTableCodec) Decode(io.Reader, any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// DescriptionTableCodec renders a resource's assignable levels as a table.
+type DescriptionTableCodec struct{}
+
+// Format reports the codec's output format identifier.
+func (c *DescriptionTableCodec) Format() format.Format { return "table" }
+
+// Encode writes the table representation of v to w.
+func (c *DescriptionTableCodec) Encode(w io.Writer, v any) error {
+	desc, ok := v.(*Description)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected *Description")
+	}
+	t := style.NewTable("ASSIGNABLE LEVEL", "ASSIGNMENT TYPES")
+	types := assignmentTypes(desc.Assignments)
+	for i, level := range desc.Permissions {
+		typesCell := ""
+		if i == 0 {
+			typesCell = strings.Join(types, ", ")
+		}
+		t.Row(level, typesCell)
+	}
+	return t.Render(w)
+}
+
+// Decode is not supported for the table codec.
+func (c *DescriptionTableCodec) Decode(io.Reader, any) error {
+	return errors.New("table format does not support decoding")
+}
+
+func assignmentTypes(a Assignments) []string {
+	var out []string
+	if a.Users {
+		out = append(out, "users")
+	}
+	if a.ServiceAccounts {
+		out = append(out, "serviceAccounts")
+	}
+	if a.Teams {
+		out = append(out, "teams")
+	}
+	if a.BuiltInRoles {
+		out = append(out, "builtInRoles")
+	}
+	return out
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/providers/permissions/commands_test.go
+++ b/internal/providers/permissions/commands_test.go
@@ -1,0 +1,81 @@
+package permissions_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/permissions"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider_CommandShape(t *testing.T) {
+	p := &permissions.PermissionsProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+	root := cmds[0]
+	assert.Equal(t, "permissions", root.Use)
+
+	subNames := make([]string, 0, len(root.Commands()))
+	for _, c := range root.Commands() {
+		subNames = append(subNames, strings.Fields(c.Use)[0])
+	}
+	assert.ElementsMatch(t, []string{"get", "set", "grant", "levels"}, subNames)
+
+	// Command-only provider: no adapter registrations.
+	assert.Empty(t, p.TypedRegistrations())
+}
+
+func TestGetCommand_RejectsInvalidResource(t *testing.T) {
+	p := &permissions.PermissionsProvider{}
+	root := p.Commands()[0]
+	root.SetArgs([]string{"get", "widgets", "some-id"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid resource")
+}
+
+func TestGrantCommand_RequiresExactlyOnePrincipal(t *testing.T) {
+	p := &permissions.PermissionsProvider{}
+	root := p.Commands()[0]
+	root.SetArgs([]string{"grant", "dashboards", "d1", "--user", "1", "--team", "2", "--level", "Edit"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
+}
+
+func TestPermissionsTableCodec(t *testing.T) {
+	codec := &permissions.PermissionsTableCodec{}
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, []permissions.ResourcePermission{
+		{BuiltInRole: "Editor", Permission: "Edit", IsManaged: true},
+		{UserLogin: "alice", Permission: "Admin"},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "PERMISSION")
+	assert.Contains(t, out, "BUILT-IN ROLE")
+	assert.Contains(t, out, "Editor")
+	assert.Contains(t, out, "alice")
+}
+
+func TestDescriptionTableCodec(t *testing.T) {
+	codec := &permissions.DescriptionTableCodec{}
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, &permissions.Description{
+		Assignments: permissions.Assignments{Users: true, Teams: true},
+		Permissions: []string{"View", "Edit", "Admin"},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "ASSIGNABLE LEVEL")
+	assert.Contains(t, out, "View")
+	assert.Contains(t, out, "users")
+}

--- a/internal/providers/permissions/provider.go
+++ b/internal/providers/permissions/provider.go
@@ -1,0 +1,64 @@
+package permissions
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/spf13/cobra"
+)
+
+var _ providers.Provider = &PermissionsProvider{}
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	providers.Register(&PermissionsProvider{})
+}
+
+// PermissionsProvider manages Grafana resource permissions via the granular
+// access-control (RBAC) API.
+type PermissionsProvider struct{}
+
+// Name returns the unique identifier for this provider.
+func (p *PermissionsProvider) Name() string { return "permissions" }
+
+// ShortDesc returns a one-line description of the provider.
+func (p *PermissionsProvider) ShortDesc() string {
+	return "Manage Grafana resource permissions (RBAC)"
+}
+
+// Commands returns the Cobra commands contributed by this provider.
+func (p *PermissionsProvider) Commands() []*cobra.Command {
+	loader := &providers.ConfigLoader{}
+
+	root := &cobra.Command{
+		Use:   "permissions",
+		Short: p.ShortDesc(),
+		Long: "Manage Grafana resource permissions via the granular access-control (RBAC) API.\n\n" +
+			"Supported resources: folders, dashboards, datasources, teams, serviceaccounts.\n" +
+			"Reads work on all editions; writes require RBAC (Grafana Enterprise or Cloud).",
+	}
+	root.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if r := cmd.Root(); r != root && r.PersistentPreRun != nil {
+			r.PersistentPreRun(cmd, args)
+		}
+	}
+
+	loader.BindFlags(root.PersistentFlags())
+	root.AddCommand(
+		newGetCommand(loader),
+		newSetCommand(loader),
+		newGrantCommand(loader),
+		newLevelsCommand(loader),
+	)
+
+	return []*cobra.Command{root}
+}
+
+// Validate checks that the given provider configuration is valid.
+func (p *PermissionsProvider) Validate(map[string]string) error { return nil }
+
+// ConfigKeys returns the configuration keys used by this provider.
+func (p *PermissionsProvider) ConfigKeys() []providers.ConfigKey { return nil }
+
+// TypedRegistrations returns no adapter registrations: RBAC permissions are a
+// per-resource attribute across five resource kinds, not standalone resources,
+// so this provider is command-only.
+func (p *PermissionsProvider) TypedRegistrations() []adapter.Registration { return nil }

--- a/internal/providers/permissions/types.go
+++ b/internal/providers/permissions/types.go
@@ -1,0 +1,80 @@
+// Package permissions provides commands for managing Grafana resource
+// permissions via the granular access-control (RBAC) API,
+// /api/access-control/{resource}/{resourceID}.
+package permissions
+
+import (
+	"fmt"
+	"slices"
+)
+
+// ValidResources are the resource kinds the granular RBAC permissions API
+// exposes. A management CLI targets these uniformly.
+//
+//nolint:gochecknoglobals // immutable lookup table.
+var ValidResources = []string{"folders", "dashboards", "datasources", "teams", "serviceaccounts"}
+
+// validateResource returns an error if resource is not a supported RBAC
+// permission resource kind.
+func validateResource(resource string) error {
+	if !slices.Contains(ValidResources, resource) {
+		return fmt.Errorf("invalid resource %q: must be one of %v", resource, ValidResources)
+	}
+	return nil
+}
+
+// ResourcePermission is one entry in a resource's permission list, as returned
+// by GET /api/access-control/{resource}/{resourceID}.
+type ResourcePermission struct {
+	ID               int64    `json:"id"`
+	RoleName         string   `json:"roleName,omitempty"`
+	IsManaged        bool     `json:"isManaged"`
+	IsInherited      bool     `json:"isInherited"`
+	IsServiceAccount bool     `json:"isServiceAccount"`
+	UserID           int64    `json:"userId,omitempty"`
+	UserUID          string   `json:"userUid,omitempty"`
+	UserLogin        string   `json:"userLogin,omitempty"`
+	Team             string   `json:"team,omitempty"`
+	TeamID           int64    `json:"teamId,omitempty"`
+	TeamUID          string   `json:"teamUid,omitempty"`
+	BuiltInRole      string   `json:"builtInRole,omitempty"`
+	Actions          []string `json:"actions,omitempty"`
+	Permission       string   `json:"permission"`
+}
+
+// Description reports the assignable permission levels and assignment types for
+// a resource kind, as returned by GET /api/access-control/{resource}/description.
+type Description struct {
+	Assignments Assignments `json:"assignments"`
+	Permissions []string    `json:"permissions"`
+}
+
+// Assignments reports which principal types can be assigned permissions on a
+// resource kind.
+type Assignments struct {
+	Users           bool `json:"users"`
+	ServiceAccounts bool `json:"serviceAccounts"`
+	Teams           bool `json:"teams"`
+	BuiltInRoles    bool `json:"builtInRoles"`
+}
+
+// SetResourcePermissionCommand is one assignment in a full permission-set
+// request. Provide exactly one of UserID, TeamID, or BuiltInRole.
+type SetResourcePermissionCommand struct {
+	UserID      int64  `json:"userId,omitempty"`
+	TeamID      int64  `json:"teamId,omitempty"`
+	BuiltInRole string `json:"builtInRole,omitempty"`
+	Permission  string `json:"permission"`
+}
+
+// setPermissionsBody is the request body for POST /api/access-control/{resource}/{resourceID}.
+type setPermissionsBody struct {
+	Permissions []SetResourcePermissionCommand `json:"permissions"`
+}
+
+// setPermissionBody is the request body for the per-principal grant endpoints
+// (.../users/{id}, .../teams/{id}, .../builtInRoles/{role}). An empty
+// Permission removes the assignment.
+type setPermissionBody struct {
+	Permission string `json:"permission"`
+}

--- a/internal/providers/publicdashboards/client.go
+++ b/internal/providers/publicdashboards/client.go
@@ -1,0 +1,76 @@
+package publicdashboards
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/coreapi"
+)
+
+const listPath = "/api/dashboards/public-dashboards"
+
+// Client is a Grafana Public Dashboards API client.
+type Client struct {
+	base *coreapi.Client
+}
+
+// NewClient creates a new Public Dashboards client bound to the provided REST config.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	base, err := coreapi.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{base: base}, nil
+}
+
+func dashboardPath(dashboardUID string) string {
+	return fmt.Sprintf("/api/dashboards/uid/%s/public-dashboards", url.PathEscape(dashboardUID))
+}
+
+func dashboardItemPath(dashboardUID, pdUID string) string {
+	return fmt.Sprintf("/api/dashboards/uid/%s/public-dashboards/%s", url.PathEscape(dashboardUID), url.PathEscape(pdUID))
+}
+
+// List returns all public dashboards in the stack.
+func (c *Client) List(ctx context.Context) ([]PublicDashboard, error) {
+	wrapper, err := coreapi.DoJSON[any, listResp](ctx, c.base, http.MethodGet, listPath, nil, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return wrapper.PublicDashboards, nil
+}
+
+// Get returns the public dashboard config for the given parent dashboard UID.
+func (c *Client) Get(ctx context.Context, dashboardUID string) (*PublicDashboard, error) {
+	pd, err := coreapi.DoJSON[any, PublicDashboard](ctx, c.base, http.MethodGet, dashboardPath(dashboardUID), nil, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return &pd, nil
+}
+
+// Create creates a new public dashboard config for the given parent dashboard UID.
+func (c *Client) Create(ctx context.Context, dashboardUID string, pd *PublicDashboard) (*PublicDashboard, error) {
+	created, err := coreapi.DoJSON[PublicDashboard, PublicDashboard](ctx, c.base, http.MethodPost, dashboardPath(dashboardUID), pd, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return &created, nil
+}
+
+// Update patches an existing public dashboard config.
+func (c *Client) Update(ctx context.Context, dashboardUID, pdUID string, pd *PublicDashboard) (*PublicDashboard, error) {
+	updated, err := coreapi.DoJSON[PublicDashboard, PublicDashboard](ctx, c.base, http.MethodPatch, dashboardItemPath(dashboardUID, pdUID), pd, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return &updated, nil
+}
+
+// Delete removes a public dashboard config.
+func (c *Client) Delete(ctx context.Context, dashboardUID, pdUID string) error {
+	return coreapi.DoStatus[any](ctx, c.base, http.MethodDelete, dashboardItemPath(dashboardUID, pdUID), nil, http.StatusOK)
+}

--- a/internal/providers/publicdashboards/client_test.go
+++ b/internal/providers/publicdashboards/client_test.go
@@ -1,0 +1,246 @@
+package publicdashboards_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/publicdashboards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newTestClient(t *testing.T, server *httptest.Server) *publicdashboards.Client {
+	t.Helper()
+	cfg := config.NamespacedRESTConfig{
+		Config: rest.Config{Host: server.URL},
+	}
+	client, err := publicdashboards.NewClient(cfg)
+	require.NoError(t, err)
+	return client
+}
+
+// writeJSON encodes v as JSON to w.
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	_, _ = w.Write(data)
+}
+
+func TestClient_List(t *testing.T) {
+	tests := []struct {
+		name     string
+		handler  http.HandlerFunc
+		wantLen  int
+		wantErr  bool
+		firstUID string
+	}{
+		{
+			name: "success with items unwraps publicDashboards",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/api/dashboards/public-dashboards", r.URL.Path)
+				writeJSON(w, map[string]any{
+					"publicDashboards": []publicdashboards.PublicDashboard{
+						{UID: "pd-1", DashboardUID: "d-1", IsEnabled: true},
+						{UID: "pd-2", DashboardUID: "d-2"},
+					},
+				})
+			},
+			wantLen:  2,
+			firstUID: "pd-1",
+		},
+		{
+			name: "empty list",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, map[string]any{"publicDashboards": []publicdashboards.PublicDashboard{}})
+			},
+			wantLen: 0,
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, `{"message":"boom"}`)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			list, err := client.List(t.Context())
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, list, tt.wantLen)
+			if tt.wantLen > 0 {
+				assert.Equal(t, tt.firstUID, list[0].UID)
+			}
+		})
+	}
+}
+
+func TestClient_Get(t *testing.T) {
+	tests := []struct {
+		name         string
+		dashboardUID string
+		handler      http.HandlerFunc
+		wantErr      bool
+	}{
+		{
+			name:         "success escapes uid",
+			dashboardUID: "abc 123",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				// r.URL.Path is the decoded form; the raw wire path comes through RequestURI.
+				assert.Equal(t, "/api/dashboards/uid/abc%20123/public-dashboards", r.RequestURI)
+				writeJSON(w, publicdashboards.PublicDashboard{UID: "pd-1", DashboardUID: "abc 123", IsEnabled: true})
+			},
+		},
+		{
+			name:         "404 error",
+			dashboardUID: "missing",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.WriteString(w, `{"message":"not found"}`)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			pd, err := client.Get(t.Context(), tt.dashboardUID)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, pd)
+			assert.Equal(t, "pd-1", pd.UID)
+		})
+	}
+}
+
+func TestClient_Create(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/dashboards/uid/dash-1/public-dashboards", r.URL.Path)
+
+		var body publicdashboards.PublicDashboard
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			return
+		}
+		assert.True(t, body.IsEnabled)
+		assert.Equal(t, "public", body.Share)
+
+		writeJSON(w, publicdashboards.PublicDashboard{
+			UID:          "pd-new",
+			DashboardUID: "dash-1",
+			AccessToken:  "token-xyz",
+			IsEnabled:    true,
+			Share:        "public",
+		})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	created, err := client.Create(t.Context(), "dash-1", &publicdashboards.PublicDashboard{
+		IsEnabled: true,
+		Share:     "public",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assert.Equal(t, "pd-new", created.UID)
+	assert.Equal(t, "token-xyz", created.AccessToken)
+}
+
+func TestClient_Update(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/api/dashboards/uid/dash-1/public-dashboards/pd-1", r.URL.Path)
+
+		var body publicdashboards.PublicDashboard
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			return
+		}
+		assert.True(t, body.AnnotationsEnabled)
+
+		writeJSON(w, publicdashboards.PublicDashboard{
+			UID:                "pd-1",
+			DashboardUID:       "dash-1",
+			AnnotationsEnabled: true,
+		})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	updated, err := client.Update(t.Context(), "dash-1", "pd-1", &publicdashboards.PublicDashboard{
+		AnnotationsEnabled: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, "pd-1", updated.UID)
+	assert.True(t, updated.AnnotationsEnabled)
+}
+
+func TestClient_Delete(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name: "success",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodDelete, r.Method)
+				assert.Equal(t, "/api/dashboards/uid/dash-1/public-dashboards/pd-1", r.URL.Path)
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, `{"message":"oops"}`)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			err := client.Delete(t.Context(), "dash-1", "pd-1")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/providers/publicdashboards/client_test.go
+++ b/internal/providers/publicdashboards/client_test.go
@@ -49,7 +49,7 @@ func TestClient_List(t *testing.T) {
 				assert.Equal(t, "/api/dashboards/public-dashboards", r.URL.Path)
 				writeJSON(w, map[string]any{
 					"publicDashboards": []publicdashboards.PublicDashboard{
-						{UID: "pd-1", DashboardUID: "d-1", IsEnabled: true},
+						{UID: "pd-1", DashboardUID: "d-1", IsEnabled: new(true)},
 						{UID: "pd-2", DashboardUID: "d-2"},
 					},
 				})
@@ -109,7 +109,7 @@ func TestClient_Get(t *testing.T) {
 				assert.Equal(t, http.MethodGet, r.Method)
 				// r.URL.Path is the decoded form; the raw wire path comes through RequestURI.
 				assert.Equal(t, "/api/dashboards/uid/abc%20123/public-dashboards", r.RequestURI)
-				writeJSON(w, publicdashboards.PublicDashboard{UID: "pd-1", DashboardUID: "abc 123", IsEnabled: true})
+				writeJSON(w, publicdashboards.PublicDashboard{UID: "pd-1", DashboardUID: "abc 123", IsEnabled: new(true)})
 			},
 		},
 		{
@@ -151,14 +151,16 @@ func TestClient_Create(t *testing.T) {
 		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
 			return
 		}
-		assert.True(t, body.IsEnabled)
+		if assert.NotNil(t, body.IsEnabled) {
+			assert.True(t, *body.IsEnabled)
+		}
 		assert.Equal(t, "public", body.Share)
 
 		writeJSON(w, publicdashboards.PublicDashboard{
 			UID:          "pd-new",
 			DashboardUID: "dash-1",
 			AccessToken:  "token-xyz",
-			IsEnabled:    true,
+			IsEnabled:    new(true),
 			Share:        "public",
 		})
 	}))
@@ -166,7 +168,7 @@ func TestClient_Create(t *testing.T) {
 
 	client := newTestClient(t, server)
 	created, err := client.Create(t.Context(), "dash-1", &publicdashboards.PublicDashboard{
-		IsEnabled: true,
+		IsEnabled: new(true),
 		Share:     "public",
 	})
 	require.NoError(t, err)
@@ -184,24 +186,27 @@ func TestClient_Update(t *testing.T) {
 		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
 			return
 		}
-		assert.True(t, body.AnnotationsEnabled)
+		if assert.NotNil(t, body.AnnotationsEnabled) {
+			assert.True(t, *body.AnnotationsEnabled)
+		}
 
 		writeJSON(w, publicdashboards.PublicDashboard{
 			UID:                "pd-1",
 			DashboardUID:       "dash-1",
-			AnnotationsEnabled: true,
+			AnnotationsEnabled: new(true),
 		})
 	}))
 	defer server.Close()
 
 	client := newTestClient(t, server)
 	updated, err := client.Update(t.Context(), "dash-1", "pd-1", &publicdashboards.PublicDashboard{
-		AnnotationsEnabled: true,
+		AnnotationsEnabled: new(true),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, updated)
 	assert.Equal(t, "pd-1", updated.UID)
-	assert.True(t, updated.AnnotationsEnabled)
+	require.NotNil(t, updated.AnnotationsEnabled)
+	assert.True(t, *updated.AnnotationsEnabled)
 }
 
 func TestClient_Delete(t *testing.T) {

--- a/internal/providers/publicdashboards/commands.go
+++ b/internal/providers/publicdashboards/commands.go
@@ -1,0 +1,335 @@
+package publicdashboards
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// GrafanaConfigLoader is the loader interface used by command constructors.
+// It is an alias for RESTConfigLoader to keep existing test names stable.
+type GrafanaConfigLoader = RESTConfigLoader
+
+func boolLabel(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+// readPublicDashboardSpec reads a JSON public dashboard spec from path, or from
+// stdin when path is "-".
+func readPublicDashboardSpec(path string, stdin io.Reader) (*PublicDashboard, error) {
+	var (
+		data []byte
+		err  error
+	)
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading stdin: %w", err)
+		}
+	} else {
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", path, err)
+		}
+	}
+
+	var pd PublicDashboard
+	if err := json.Unmarshal(data, &pd); err != nil {
+		return nil, fmt.Errorf("parsing public dashboard spec: %w", err)
+	}
+	return &pd, nil
+}
+
+// encodeOne encodes a single TypedObject[PublicDashboard], wrapping it in a
+// slice so the table codec can render it uniformly with list results.
+func encodeOne(opts *cmdio.Options, w io.Writer, obj *adapter.TypedObject[PublicDashboard]) error {
+	codec, err := opts.Codec()
+	if err != nil {
+		return err
+	}
+	if codec.Format() == "table" {
+		return codec.Encode(w, []adapter.TypedObject[PublicDashboard]{*obj})
+	}
+	return opts.Encode(w, obj)
+}
+
+// ---- list ----
+
+type listOpts struct {
+	IO    cmdio.Options
+	Limit int64
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ListTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for unlimited)")
+}
+
+func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &listOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all public dashboards.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			typedObjs, err := crud.List(ctx, opts.Limit)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), typedObjs)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ListTableCodec renders public dashboards as a tabular table.
+// It consumes []adapter.TypedObject[PublicDashboard].
+type ListTableCodec struct{}
+
+// Format returns the output format name.
+func (c *ListTableCodec) Format() format.Format { return "table" }
+
+// Encode writes public dashboards to w as a table.
+func (c *ListTableCodec) Encode(w io.Writer, v any) error {
+	objs, ok := v.([]adapter.TypedObject[PublicDashboard])
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []TypedObject[PublicDashboard]")
+	}
+
+	t := style.NewTable("DASHBOARD_UID", "PD_UID", "ACCESS_TOKEN", "ENABLED", "ANNOTATIONS", "TIME_SELECT", "SHARE")
+	for _, obj := range objs {
+		pd := obj.Spec
+		t.Row(
+			pd.DashboardUID,
+			pd.UID,
+			pd.AccessToken,
+			boolLabel(pd.IsEnabled),
+			boolLabel(pd.AnnotationsEnabled),
+			boolLabel(pd.TimeSelectionEnabled),
+			pd.Share,
+		)
+	}
+	return t.Render(w)
+}
+
+// Decode is not supported for table format.
+func (c *ListTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// ---- get ----
+
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ListTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newGetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:   "get PD_UID",
+		Short: "Get a public dashboard by its UID.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			obj, err := crud.Get(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			return encodeOne(&opts.IO, cmd.OutOrStdout(), obj)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---- create ----
+
+type createOpts struct {
+	IO           cmdio.Options
+	DashboardUID string
+	File         string
+}
+
+func (o *createOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ListTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.DashboardUID, "dashboard-uid", "", "Parent dashboard UID (required)")
+	flags.StringVarP(&o.File, "file", "f", "", "File containing the public dashboard spec (JSON), or '-' for stdin (required)")
+}
+
+func newCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &createOpts{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a public dashboard config from a JSON file.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			spec, err := readPublicDashboardSpec(opts.File, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+			// The --dashboard-uid flag is authoritative for the parent dashboard.
+			spec.DashboardUID = opts.DashboardUID
+
+			ctx := cmd.Context()
+			crud, restCfg, err := NewTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			typedObj := &adapter.TypedObject[PublicDashboard]{Spec: *spec}
+			typedObj.SetName(spec.UID)
+			typedObj.SetNamespace(restCfg.Namespace)
+
+			created, err := crud.Create(ctx, typedObj)
+			if err != nil {
+				return err
+			}
+
+			return encodeOne(&opts.IO, cmd.OutOrStdout(), created)
+		},
+	}
+	opts.setup(cmd.Flags())
+	_ = cmd.MarkFlagRequired("dashboard-uid")
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+// ---- update ----
+
+type updateOpts struct {
+	IO           cmdio.Options
+	DashboardUID string
+	File         string
+}
+
+func (o *updateOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ListTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.DashboardUID, "dashboard-uid", "", "Parent dashboard UID (required)")
+	flags.StringVarP(&o.File, "file", "f", "", "File containing the public dashboard spec (JSON), or '-' for stdin (required)")
+}
+
+func newUpdateCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &updateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update PD_UID",
+		Short: "Update a public dashboard config from a JSON file.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			spec, err := readPublicDashboardSpec(opts.File, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+			// The --dashboard-uid flag is authoritative for the parent dashboard.
+			spec.DashboardUID = opts.DashboardUID
+
+			ctx := cmd.Context()
+			name := args[0]
+
+			crud, restCfg, err := NewTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			typedObj := &adapter.TypedObject[PublicDashboard]{Spec: *spec}
+			typedObj.SetName(name)
+			typedObj.SetNamespace(restCfg.Namespace)
+
+			updated, err := crud.Update(ctx, name, typedObj)
+			if err != nil {
+				return err
+			}
+
+			return encodeOne(&opts.IO, cmd.OutOrStdout(), updated)
+		},
+	}
+	opts.setup(cmd.Flags())
+	_ = cmd.MarkFlagRequired("dashboard-uid")
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+// ---- delete ----
+
+type deleteOpts struct{}
+
+func (o *deleteOpts) setup(_ *pflag.FlagSet) {}
+
+func newDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &deleteOpts{}
+	cmd := &cobra.Command{
+		Use:   "delete PD_UID",
+		Short: "Delete a public dashboard config.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			name := args[0]
+
+			crud, _, err := NewTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			if err := crud.Delete(ctx, name); err != nil {
+				return err
+			}
+
+			cmdio.Info(cmd.OutOrStdout(), "deleted public dashboard %s", strconv.Quote(name))
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/publicdashboards/commands.go
+++ b/internal/providers/publicdashboards/commands.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 
+	"github.com/grafana/gcx/internal/coreapi"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources/adapter"
@@ -20,30 +20,26 @@ import (
 // It is an alias for RESTConfigLoader to keep existing test names stable.
 type GrafanaConfigLoader = RESTConfigLoader
 
-func boolLabel(v bool) string {
-	if v {
+// boolLabel renders a nullable toggle: "yes"/"no" when set, "-" when unset
+// (the server always returns concrete values, so "-" only appears for a spec
+// that omitted the field).
+func boolLabel(v *bool) string {
+	switch {
+	case v == nil:
+		return "-"
+	case *v:
 		return "yes"
+	default:
+		return "no"
 	}
-	return "no"
 }
 
 // readPublicDashboardSpec reads a JSON public dashboard spec from path, or from
 // stdin when path is "-".
 func readPublicDashboardSpec(path string, stdin io.Reader) (*PublicDashboard, error) {
-	var (
-		data []byte
-		err  error
-	)
-	if path == "-" {
-		data, err = io.ReadAll(stdin)
-		if err != nil {
-			return nil, fmt.Errorf("reading stdin: %w", err)
-		}
-	} else {
-		data, err = os.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("reading %s: %w", path, err)
-		}
+	data, err := coreapi.ReadInput(path, stdin)
+	if err != nil {
+		return nil, err
 	}
 
 	var pd PublicDashboard

--- a/internal/providers/publicdashboards/commands_test.go
+++ b/internal/providers/publicdashboards/commands_test.go
@@ -1,0 +1,88 @@
+package publicdashboards_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/publicdashboards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubLoader implements GrafanaConfigLoader for tests without triggering real config loading.
+type stubLoader struct{}
+
+func (stubLoader) LoadGrafanaConfig(_ context.Context) (config.NamespacedRESTConfig, error) {
+	return config.NamespacedRESTConfig{}, assert.AnError
+}
+
+func TestReadPublicDashboardSpec_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pd.json")
+	payload := []byte(`{"isEnabled":true,"annotationsEnabled":true,"share":"public"}`)
+	require.NoError(t, os.WriteFile(path, payload, 0o600))
+
+	pd, err := publicdashboards.ReadPublicDashboardSpecForTest(path, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pd)
+	assert.True(t, pd.IsEnabled)
+	assert.True(t, pd.AnnotationsEnabled)
+	assert.Equal(t, "public", pd.Share)
+}
+
+func TestReadPublicDashboardSpec_FromStdin(t *testing.T) {
+	payload := []byte(`{"isEnabled":false,"share":"public_with_email"}`)
+	pd, err := publicdashboards.ReadPublicDashboardSpecForTest("-", bytes.NewReader(payload))
+	require.NoError(t, err)
+	require.NotNil(t, pd)
+	assert.False(t, pd.IsEnabled)
+	assert.Equal(t, "public_with_email", pd.Share)
+}
+
+func TestReadPublicDashboardSpec_BadJSON(t *testing.T) {
+	_, err := publicdashboards.ReadPublicDashboardSpecForTest("-", bytes.NewReader([]byte("not json")))
+	require.Error(t, err)
+}
+
+func TestReadPublicDashboardSpec_FileMissing(t *testing.T) {
+	_, err := publicdashboards.ReadPublicDashboardSpecForTest(filepath.Join(t.TempDir(), "missing.json"), nil)
+	require.Error(t, err)
+}
+
+func TestCreateCommand_RequiredFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantInError string
+	}{
+		{
+			name:        "missing dashboard-uid",
+			args:        []string{"-f", "pd.json"},
+			wantInError: "dashboard-uid",
+		},
+		{
+			name:        "missing file",
+			args:        []string{"--dashboard-uid", "abc"},
+			wantInError: "file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := publicdashboards.NewCreateCommandForTest(stubLoader{})
+			cmd.SetArgs(tt.args)
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantInError)
+		})
+	}
+}

--- a/internal/providers/publicdashboards/commands_test.go
+++ b/internal/providers/publicdashboards/commands_test.go
@@ -3,6 +3,7 @@ package publicdashboards_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,8 +30,10 @@ func TestReadPublicDashboardSpec_FromFile(t *testing.T) {
 	pd, err := publicdashboards.ReadPublicDashboardSpecForTest(path, nil)
 	require.NoError(t, err)
 	require.NotNil(t, pd)
-	assert.True(t, pd.IsEnabled)
-	assert.True(t, pd.AnnotationsEnabled)
+	require.NotNil(t, pd.IsEnabled)
+	assert.True(t, *pd.IsEnabled)
+	require.NotNil(t, pd.AnnotationsEnabled)
+	assert.True(t, *pd.AnnotationsEnabled)
 	assert.Equal(t, "public", pd.Share)
 }
 
@@ -39,8 +42,28 @@ func TestReadPublicDashboardSpec_FromStdin(t *testing.T) {
 	pd, err := publicdashboards.ReadPublicDashboardSpecForTest("-", bytes.NewReader(payload))
 	require.NoError(t, err)
 	require.NotNil(t, pd)
-	assert.False(t, pd.IsEnabled)
+	require.NotNil(t, pd.IsEnabled)
+	assert.False(t, *pd.IsEnabled)
 	assert.Equal(t, "public_with_email", pd.Share)
+}
+
+// TestReadPublicDashboardSpec_PartialOmitsToggles proves the PATCH bug fix: a
+// partial spec that omits the toggle fields yields nil pointers (not false), so
+// marshaling the spec into a PATCH body omits them and the server preserves the
+// existing values instead of silently disabling the dashboard.
+func TestReadPublicDashboardSpec_PartialOmitsToggles(t *testing.T) {
+	pd, err := publicdashboards.ReadPublicDashboardSpecForTest("-", bytes.NewReader([]byte(`{"share":"public"}`)))
+	require.NoError(t, err)
+	require.NotNil(t, pd)
+	assert.Nil(t, pd.IsEnabled, "omitted isEnabled must stay nil, not default to false")
+	assert.Nil(t, pd.AnnotationsEnabled)
+	assert.Nil(t, pd.TimeSelectionEnabled)
+
+	body, err := json.Marshal(pd)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "isEnabled")
+	assert.NotContains(t, string(body), "annotationsEnabled")
+	assert.NotContains(t, string(body), "timeSelectionEnabled")
 }
 
 func TestReadPublicDashboardSpec_BadJSON(t *testing.T) {

--- a/internal/providers/publicdashboards/export_test.go
+++ b/internal/providers/publicdashboards/export_test.go
@@ -1,0 +1,17 @@
+package publicdashboards
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// ReadPublicDashboardSpecForTest exposes readPublicDashboardSpec for external tests.
+func ReadPublicDashboardSpecForTest(path string, stdin io.Reader) (*PublicDashboard, error) {
+	return readPublicDashboardSpec(path, stdin)
+}
+
+// NewCreateCommandForTest exposes newCreateCommand for external tests.
+func NewCreateCommandForTest(loader GrafanaConfigLoader) *cobra.Command {
+	return newCreateCommand(loader)
+}

--- a/internal/providers/publicdashboards/provider.go
+++ b/internal/providers/publicdashboards/provider.go
@@ -1,0 +1,73 @@
+package publicdashboards
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/spf13/cobra"
+)
+
+var _ providers.Provider = &PublicDashboardsProvider{}
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	providers.Register(&PublicDashboardsProvider{})
+}
+
+// PublicDashboardsProvider manages Grafana public dashboard resources.
+type PublicDashboardsProvider struct{}
+
+// Name returns the unique identifier for this provider.
+func (p *PublicDashboardsProvider) Name() string { return "public-dashboards" }
+
+// ShortDesc returns a one-line description of the provider.
+func (p *PublicDashboardsProvider) ShortDesc() string { return "Manage public dashboards" }
+
+// Commands returns the Cobra commands contributed by this provider.
+func (p *PublicDashboardsProvider) Commands() []*cobra.Command {
+	loader := &providers.ConfigLoader{}
+
+	cmd := &cobra.Command{
+		Use:   "public-dashboards",
+		Short: p.ShortDesc(),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if root := cmd.Root(); root.PersistentPreRun != nil {
+				root.PersistentPreRun(cmd, args)
+			}
+		},
+	}
+
+	loader.BindFlags(cmd.PersistentFlags())
+
+	cmd.AddCommand(
+		newListCommand(loader),
+		newGetCommand(loader),
+		newCreateCommand(loader),
+		newUpdateCommand(loader),
+		newDeleteCommand(loader),
+	)
+
+	return []*cobra.Command{cmd}
+}
+
+// Validate checks that the given provider configuration is valid.
+func (p *PublicDashboardsProvider) Validate(_ map[string]string) error {
+	return nil
+}
+
+// ConfigKeys returns the configuration keys used by this provider.
+func (p *PublicDashboardsProvider) ConfigKeys() []providers.ConfigKey {
+	return nil
+}
+
+// TypedRegistrations returns adapter registrations for PublicDashboard resource types.
+func (p *PublicDashboardsProvider) TypedRegistrations() []adapter.Registration {
+	loader := &providers.ConfigLoader{}
+	return []adapter.Registration{
+		{
+			Factory:    NewAdapterFactory(loader),
+			Descriptor: staticDescriptor,
+			GVK:        staticDescriptor.GroupVersionKind(),
+			Schema:     PublicDashboardSchema(),
+			Example:    PublicDashboardExample(),
+		},
+	}
+}

--- a/internal/providers/publicdashboards/resource_adapter.go
+++ b/internal/providers/publicdashboards/resource_adapter.go
@@ -1,0 +1,154 @@
+package publicdashboards
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	internalconfig "github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	// APIVersion is the API version for PublicDashboard resources.
+	APIVersion = "publicdashboards.ext.grafana.app/v1alpha1"
+	// Kind is the kind for PublicDashboard resources.
+	Kind = "PublicDashboard"
+)
+
+// staticDescriptor is the resource descriptor for PublicDashboard resources.
+//
+//nolint:gochecknoglobals // Static descriptor used in self-registration pattern.
+var staticDescriptor = resources.Descriptor{
+	GroupVersion: schema.GroupVersion{
+		Group:   "publicdashboards.ext.grafana.app",
+		Version: "v1alpha1",
+	},
+	Kind:     "PublicDashboard",
+	Singular: "publicdashboard",
+	Plural:   "publicdashboards",
+}
+
+// StaticDescriptor returns the resource descriptor for PublicDashboard.
+func StaticDescriptor() resources.Descriptor { return staticDescriptor }
+
+// PublicDashboardSchema returns a JSON Schema for the PublicDashboard resource type.
+func PublicDashboardSchema() json.RawMessage {
+	return adapter.SchemaFromType[PublicDashboard](StaticDescriptor())
+}
+
+// PublicDashboardExample returns an example PublicDashboard manifest as JSON.
+func PublicDashboardExample() json.RawMessage {
+	example := map[string]any{
+		"apiVersion": APIVersion,
+		"kind":       Kind,
+		"metadata": map[string]any{
+			"name": "pd-abc123",
+		},
+		"spec": map[string]any{
+			"uid":                  "pd-abc123",
+			"dashboardUid":         "dash-xyz",
+			"isEnabled":            true,
+			"annotationsEnabled":   false,
+			"timeSelectionEnabled": false,
+			"share":                "public",
+		},
+	}
+	b, err := json.Marshal(example)
+	if err != nil {
+		panic(fmt.Sprintf("publicdashboards: failed to marshal example: %v", err))
+	}
+	return b
+}
+
+// RESTConfigLoader can load a NamespacedRESTConfig from the active context.
+type RESTConfigLoader interface {
+	LoadGrafanaConfig(ctx context.Context) (internalconfig.NamespacedRESTConfig, error)
+}
+
+// NewAdapterFactory returns a lazy adapter.Factory for PublicDashboards.
+// The factory captures the RESTConfigLoader and constructs the client on first invocation.
+func NewAdapterFactory(loader RESTConfigLoader) adapter.Factory {
+	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
+		crud, _, err := NewTypedCRUD(ctx, loader)
+		if err != nil {
+			return nil, err
+		}
+		return crud.AsAdapter(), nil
+	}
+}
+
+// NewTypedCRUD creates a TypedCRUD[PublicDashboard] for use in commands and
+// the adapter factory. It loads the REST config and constructs the client.
+func NewTypedCRUD(ctx context.Context, loader RESTConfigLoader) (*adapter.TypedCRUD[PublicDashboard], internalconfig.NamespacedRESTConfig, error) {
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to load REST config for publicdashboards: %w", err)
+	}
+
+	client, err := NewClient(cfg)
+	if err != nil {
+		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to create publicdashboards client: %w", err)
+	}
+
+	crud := &adapter.TypedCRUD[PublicDashboard]{
+		ListFn: func(ctx context.Context, limit int64) ([]PublicDashboard, error) {
+			items, err := client.List(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return adapter.TruncateSlice(items, limit), nil
+		},
+
+		GetFn: func(ctx context.Context, name string) (*PublicDashboard, error) {
+			items, err := client.List(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for i := range items {
+				if items[i].UID == name {
+					pd := items[i]
+					return &pd, nil
+				}
+			}
+			return nil, fmt.Errorf("public dashboard %q: %w", name, adapter.ErrNotFound)
+		},
+
+		CreateFn: func(ctx context.Context, spec *PublicDashboard) (*PublicDashboard, error) {
+			if spec.DashboardUID == "" {
+				return nil, errors.New("spec.dashboardUid is required to create a public dashboard")
+			}
+			return client.Create(ctx, spec.DashboardUID, spec)
+		},
+
+		UpdateFn: func(ctx context.Context, name string, spec *PublicDashboard) (*PublicDashboard, error) {
+			if spec.DashboardUID == "" {
+				return nil, errors.New("spec.dashboardUid is required to update a public dashboard")
+			}
+			return client.Update(ctx, spec.DashboardUID, name, spec)
+		},
+
+		DeleteFn: func(ctx context.Context, name string) error {
+			items, err := client.List(ctx)
+			if err != nil {
+				return err
+			}
+			for _, pd := range items {
+				if pd.UID == name {
+					return client.Delete(ctx, pd.DashboardUID, name)
+				}
+			}
+			return fmt.Errorf("public dashboard %q: %w", name, adapter.ErrNotFound)
+		},
+
+		// AccessToken is server-generated; never round-trip it back to the server.
+		StripFields: []string{"accessToken"},
+		Namespace:   cfg.Namespace,
+		Descriptor:  staticDescriptor,
+	}
+
+	return crud, cfg, nil
+}

--- a/internal/providers/publicdashboards/types.go
+++ b/internal/providers/publicdashboards/types.go
@@ -1,0 +1,35 @@
+package publicdashboards
+
+// PublicDashboard represents a Grafana public dashboard configuration.
+//
+// A public dashboard has two UIDs: UID is the id of the public dashboard
+// itself (identifies THIS pd) and DashboardUID is the parent dashboard.
+// The K8s resource name is the PD UID (the leaf id); the parent DashboardUID
+// is carried in the spec.
+//
+//nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
+type PublicDashboard struct {
+	UID                  string `json:"uid,omitempty"`
+	DashboardUID         string `json:"dashboardUid,omitempty"`
+	AccessToken          string `json:"accessToken,omitempty"`
+	IsEnabled            bool   `json:"isEnabled"`
+	AnnotationsEnabled   bool   `json:"annotationsEnabled"`
+	TimeSelectionEnabled bool   `json:"timeSelectionEnabled"`
+	Share                string `json:"share,omitempty"`
+}
+
+// GetResourceName returns the public dashboard's own UID — the leaf id that
+// identifies this pd uniquely within the stack.
+func (pd PublicDashboard) GetResourceName() string {
+	return pd.UID
+}
+
+// SetResourceName restores the UID from a K8s metadata.name round-trip.
+func (pd *PublicDashboard) SetResourceName(name string) {
+	pd.UID = name
+}
+
+// listResp is the shape of the /api/dashboards/public-dashboards response.
+type listResp struct {
+	PublicDashboards []PublicDashboard `json:"publicDashboards"`
+}

--- a/internal/providers/publicdashboards/types.go
+++ b/internal/providers/publicdashboards/types.go
@@ -9,12 +9,17 @@ package publicdashboards
 //
 //nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
 type PublicDashboard struct {
-	UID                  string `json:"uid,omitempty"`
-	DashboardUID         string `json:"dashboardUid,omitempty"`
-	AccessToken          string `json:"accessToken,omitempty"`
-	IsEnabled            bool   `json:"isEnabled"`
-	AnnotationsEnabled   bool   `json:"annotationsEnabled"`
-	TimeSelectionEnabled bool   `json:"timeSelectionEnabled"`
+	UID          string `json:"uid,omitempty"`
+	DashboardUID string `json:"dashboardUid,omitempty"`
+	AccessToken  string `json:"accessToken,omitempty"`
+	// The three toggles are pointers with omitempty so a partial update (e.g.
+	// `-f patch.json` containing only some fields) omits the unset ones from the
+	// PATCH body instead of sending them as false — which would otherwise
+	// silently disable the dashboard and its toggles server-side. A nil pointer
+	// means "leave unchanged"; a non-nil pointer sends the explicit value.
+	IsEnabled            *bool  `json:"isEnabled,omitempty"`
+	AnnotationsEnabled   *bool  `json:"annotationsEnabled,omitempty"`
+	TimeSelectionEnabled *bool  `json:"timeSelectionEnabled,omitempty"`
 	Share                string `json:"share,omitempty"`
 }
 

--- a/internal/providers/publicdashboards/types_identity_test.go
+++ b/internal/providers/publicdashboards/types_identity_test.go
@@ -1,0 +1,62 @@
+package publicdashboards_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/publicdashboards"
+	"github.com/grafana/gcx/internal/resources/adapter"
+)
+
+// Compile-time assertion that *PublicDashboard satisfies ResourceIdentity.
+var _ adapter.ResourceIdentity = &publicdashboards.PublicDashboard{}
+
+func TestPublicDashboard_GetResourceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		pd       publicdashboards.PublicDashboard
+		wantName string
+	}{
+		{
+			name:     "returns UID",
+			pd:       publicdashboards.PublicDashboard{UID: "pd-abc123", DashboardUID: "dash-xyz"},
+			wantName: "pd-abc123",
+		},
+		{
+			name:     "empty UID returns empty",
+			pd:       publicdashboards.PublicDashboard{DashboardUID: "dash-xyz"},
+			wantName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.pd.GetResourceName(); got != tt.wantName {
+				t.Errorf("GetResourceName() = %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestPublicDashboard_SetResourceName(t *testing.T) {
+	pd := &publicdashboards.PublicDashboard{DashboardUID: "dash-xyz"}
+	pd.SetResourceName("pd-abc123")
+	if pd.UID != "pd-abc123" {
+		t.Errorf("UID = %q, want %q", pd.UID, "pd-abc123")
+	}
+	// Parent UID must be preserved.
+	if pd.DashboardUID != "dash-xyz" {
+		t.Errorf("DashboardUID = %q, want %q", pd.DashboardUID, "dash-xyz")
+	}
+}
+
+func TestPublicDashboard_RoundTripIdentity(t *testing.T) {
+	original := publicdashboards.PublicDashboard{UID: "pd-abc123", DashboardUID: "dash-xyz"}
+	name := original.GetResourceName()
+
+	restored := &publicdashboards.PublicDashboard{}
+	restored.SetResourceName(name)
+
+	if restored.UID != original.UID {
+		t.Errorf("round-trip UID = %q, want %q", restored.UID, original.UID)
+	}
+}


### PR DESCRIPTION
## Summary

Ports four legacy Grafana `/api/*` command groups into gcx, built on a new shared core-API HTTP helper. **Supersedes #516** (Wave 2 of `migration-gap-analysis`), with two deliberate changes from that PR based on source + live-stack investigation.

## New commands

| Group | Operations | Endpoint(s) |
|---|---|---|
| `gcx annotations` | list / get / create / update / delete / **tags** / **mass-delete** | `/api/annotations[/…]` |
| `gcx org users` | list / get / add / update-role / remove | `/api/org/users[/{id}]` |
| `gcx public-dashboards` | list / get / create / update / delete | `/api/dashboards[/uid/{uid}]/public-dashboards[/{pd-uid}]` |
| `gcx permissions` | get / set / grant / levels | `/api/access-control/{resource}/{id}` (granular RBAC) |

`<resource>` for permissions is one of `folders \| dashboards \| datasources \| teams \| serviceaccounts`.

## Key decisions (differences from #516)

- **Shared `internal/coreapi` helper.** One HTTP client with generic `DoJSON`/`DoStatus`/`DoStatusNotFound` helpers backs all four providers — no per-package marshal/status/decode boilerplate (mirrors the recent aio11y `DoJSON`/`DoStatus` refactor, #895).
- **Granular RBAC for permissions, not classic ACL.** #516 used the classic `/api/folders|dashboards/{uid}/permissions` ACL-list API. The granular `/api/access-control/{resource}/{id}` API supersedes it: functional superset (adds service accounts + datasources/teams/serviceaccounts resources and per-principal setters), k8s-backed with legacy fallback, verified live on a Cloud stack. Writes are RBAC-gated (Enterprise/Cloud) — the client surfaces a clear hint on 403; reads work on all editions. Permissions are a per-resource attribute across five kinds, so this provider is **command-only** (no resources-pipeline bridge).
- **Dropped `preferences`.** #516 added an `/api/org/preferences` provider, but org preferences are already served by the `preferences.grafana.app` K8s resource tier (`gcx resources get preferences` works today). A dedicated REST provider is redundant and against the K8s-native-goes-through-the-resource-tier convention.

`annotations`, `org users`, and `public-dashboards` bridge into the resources pipeline via `TypedRegistrations`.

## Test plan

- [x] `go test -race -count=1 ./...` — full suite passes (CI env)
- [x] `golangci-lint run` — 0 issues on the new packages
- [x] `go build -buildvcs=false -o bin/gcx ./cmd/gcx/` — clean build
- [x] Consistency tests (`TestConsistency_*`) — every new leaf has `token_cost` (+ `llm_hint`)
- [x] `GCX_AGENT_MODE=false mise run reference` — CLI reference regenerated (no other drift); `mise run docs` builds
- [x] Live reads on a Cloud stack: `annotations list/tags`, `org users list`, `public-dashboards list`, `permissions levels/get dashboards <uid>`

## Follow-up

Once merged, #516 can be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)