### PR TITLE
fix(login): help text - drop k6 from write scopes, keep doc URLs clickable

### DIFF
--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -131,14 +131,11 @@ Without CONTEXT_NAME, re-authenticates the current context, or starts a
 first-time setup if no current context is configured.
 
 Auth sources (for non-interactive use):
-  --oauth        Browser-based OAuth (recommended for Grafana Cloud). Opens a
-                 browser for the user to approve; works in agent mode.
-  --token        Grafana service-account token (created inside the Grafana
-                 instance). See:
-                 ` + docs.ServiceAccounts + `
+  --oauth        Browser-based OAuth (recommended for Grafana Cloud). Opens a browser for the user to approve; works in agent mode.
+  --token        Grafana service-account token (created inside the Grafana instance).
+                 See: ` + docs.ServiceAccounts + `
   --cloud-token  Grafana Cloud access-policy token (created at grafana.com).
-                 See:
-                 ` + docs.AccessPolicies,
+                 See: ` + docs.AccessPolicies,
 		Example: `  gcx login
   gcx login prod
   gcx login prod --server https://prod.grafana.net

--- a/docs/reference/cli/gcx_login.md
+++ b/docs/reference/cli/gcx_login.md
@@ -15,14 +15,11 @@ Without CONTEXT_NAME, re-authenticates the current context, or starts a
 first-time setup if no current context is configured.
 
 Auth sources (for non-interactive use):
-  --oauth        Browser-based OAuth (recommended for Grafana Cloud). Opens a
-                 browser for the user to approve; works in agent mode.
-  --token        Grafana service-account token (created inside the Grafana
-                 instance). See:
-                 https://grafana.com/docs/grafana/latest/administration/service-accounts.md
+  --oauth        Browser-based OAuth (recommended for Grafana Cloud). Opens a browser for the user to approve; works in agent mode.
+  --token        Grafana service-account token (created inside the Grafana instance).
+                 See: https://grafana.com/docs/grafana/latest/administration/service-accounts.md
   --cloud-token  Grafana Cloud access-policy token (created at grafana.com).
-                 See:
-                 https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies.md
+                 See: https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies.md
 
 ```
 gcx login [CONTEXT_NAME] [flags]

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -31,7 +31,7 @@ func cloudTokenHint(server string) string {
 	}
 	return create + " (Access Policies → Create access policy).\n" +
 		"Recommended scopes: stacks:read (required — resolves your stack). Then add per product:\n" +
-		"  metrics:write, logs:write, traces:write — Synthetic Monitoring & k6\n" +
+		"  metrics:write, logs:write, traces:write — Synthetic Monitoring\n" +
 		"  fleet-management:read — Fleet\n" +
 		"  stacks:write — create or update stacks\n" +
 		"Docs: https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies\n" +

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1299,7 +1299,7 @@ func TestRun_CloudTokenHintGuidance(t *testing.T) {
 		"hint must deep-link to the in-stack Access Policies app for the known server")
 	assert.Contains(t, hint, "access-policies", "hint must link to the access-policies docs")
 	assert.Contains(t, hint, "stacks:read", "hint must name stacks:read as the required baseline scope")
-	assert.Contains(t, hint, "metrics:write", "hint must name the Synthetic Monitoring & k6 write scopes")
+	assert.Contains(t, hint, "metrics:write", "hint must name the Synthetic Monitoring write scopes")
 	assert.Contains(t, hint, "fleet-management:read", "hint must name the Fleet scope")
 	assert.Contains(t, hint, "stacks:write", "hint must name the stack-management scope")
 	assert.Contains(t, strings.ToLower(hint), "skip", "hint must retain the skip affordance")

--- a/internal/style/help.go
+++ b/internal/style/help.go
@@ -14,6 +14,17 @@ import (
 // jsonDiscoveryTip is the help text shown for commands that support --json field selection.
 const jsonDiscoveryTip = "Use --json list to discover available fields, --json field1,field2 to select specific fields."
 
+// renderLong renders a command's Long description with word wrap disabled so
+// long tokens such as documentation URLs stay on a single logical line and
+// remain clickable in terminals that auto-detect links.
+func renderLong(long string) (string, error) {
+	r, err := glamour.NewTermRenderer(glamour.WithStandardStyle("dark"), glamour.WithWordWrap(0))
+	if err != nil {
+		return "", err
+	}
+	return r.Render(long)
+}
+
 // relatedSkillFooter returns the "Related skill" footer lines for a command, or
 // nil when no skill is mapped to the command or its ancestors.
 func relatedSkillFooter(cmd *cobra.Command) []string {
@@ -72,7 +83,11 @@ func HelpFunc(defaultHelp func(*cobra.Command, []string)) func(*cobra.Command, [
 
 		// --- Long description ---
 		if cmd.Long != "" {
-			rendered, err := glamour.Render(cmd.Long, "dark")
+			// Word wrap is disabled so long tokens (notably doc URLs) are not
+			// hard-broken across lines, which would stop terminals from
+			// detecting them as clickable links. This matches the non-styled
+			// fallback, which prints Long verbatim.
+			rendered, err := renderLong(cmd.Long)
 			if err == nil {
 				fmt.Fprint(w, rendered)
 			} else {

--- a/internal/style/help_internal_test.go
+++ b/internal/style/help_internal_test.go
@@ -1,0 +1,31 @@
+package style
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// renderLong must not hard-break long tokens such as documentation URLs, or
+// terminals stop detecting them as clickable links.
+func TestRenderLong_KeepsLongURLOnOneLine(t *testing.T) {
+	url := "https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies.md"
+
+	out, err := renderLong("See:\n" + url)
+	require.NoError(t, err)
+
+	// Strip ANSI escapes before inspecting line contents.
+	plain := regexp.MustCompile(`\x1b\[[0-9;]*m`).ReplaceAllString(out, "")
+
+	var found bool
+	for line := range strings.SplitSeq(plain, "\n") {
+		if strings.Contains(line, url) {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "the full URL must appear on a single line, got:\n%s", plain)
+}


### PR DESCRIPTION
Two fixes to the `gcx login` help/hint text.

## Drop k6 from the write-scope hint

The cloud access-policy token hint shown at the interactive login prompt attributed the `metrics:write`/`logs:write`/`traces:write` scopes to both Synthetic Monitoring and k6. k6's dependency on those write scopes is resolved, so this drops k6 - the scopes remain required for Synthetic Monitoring only.

## Keep doc URLs in `login -h` on one clickable line

Glamour word-wraps the `Long` description at 80 columns and hard-breaks long tokens, so the access-policy docs URL was split across three lines and terminals stopped detecting it as a clickable link:

```
See:
https://grafana.com/docs/grafana-cloud/security-and-account-
management/authentication-and-permissions/access-policies/create-access-
policies.md
```

`Long` descriptions now render with word wrap disabled (`WithWordWrap(0)`), so long URLs stay on a single logical line. This matches the non-styled help fallback, which already prints `Long` verbatim. The login auth-sources block is reformatted so it reads cleanly without the hanging-indent alignment glamour normalises away:

```
Auth sources (for non-interactive use):
  --oauth        Browser-based OAuth (recommended for Grafana Cloud). Opens a browser for the user to approve; works in agent mode.
  --token        Grafana service-account token (created inside the Grafana instance).
                 See: https://grafana.com/docs/grafana/latest/administration/service-accounts.md
  --cloud-token  Grafana Cloud access-policy token (created at grafana.com).
                 See: https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies.md
```