### PR TITLE
feat(coreapi): shared HTTP client for core Grafana /api/* providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ internal/
 ├── config/      Config types, loader, editor, rest.Config builder, stack-id discovery, context name helpers (auto-migrates plaintext token-shaped secrets into the OS keychain via internal/credentials)
 ├── credentials/ OS-keychain backend (zalando/go-keyring) for token-shaped secrets; sentinel format + Store interface; auto-disabled under `go test`
 ├── cloud/       GCOM HTTP client for Grafana Cloud stack discovery
+├── coreapi/     Shared HTTP client + generic DoJSON/DoStatus helpers for core Grafana `/api/*` REST providers (annotations, org, permissions, publicdashboards)
 ├── fleet/       Shared fleet base client (HTTP, auth, config — used by fleet provider and instrumentation provider)
 ├── resources/
 │   ├── *.go     Core types: Resource, Selector, Filter, Descriptor, Resources collection

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -38,6 +38,7 @@ gcx/
 │   ├── auth/                 # OAuth PKCE flow, token refresh transport
 │   │   └── adaptive/         # Shared adaptive telemetry auth (GCOM caching, Basic auth)
 │   ├── cloud/                # Grafana Cloud stack discovery via GCOM API
+│   ├── coreapi/              # Shared HTTP client + generic DoJSON/DoStatus helpers for core Grafana `/api/*` REST providers (annotations, org, permissions, publicdashboards)
 │   ├── fleet/                # Shared fleet base client (HTTP + stack config, over the grafana-collector-app plugin proxy — shared by fleet provider and instrumentation provider)
 │   ├── config/               # Config loading, context management, auth types (auto-migrates plaintext token-shaped secrets into the OS keychain via internal/credentials)
 │   │   └── testdata/         # YAML fixtures for config unit tests

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -58,13 +58,12 @@ func (c *Client) DoRequest(ctx context.Context, method, path string, body io.Rea
 
 // DoJSON executes an HTTP request against the core API, optionally marshaling
 // body as the JSON request payload, and decodes a JSON response into Resp. Pass
-// a nil body for requests with no request body (e.g. GET/DELETE) — in that case
-// Req can be instantiated as `any`.
+// a nil body for requests with no request body (e.g. GET/DELETE).
 //
 // Any response status not present in okStatuses is treated as an error via
 // HandleErrorResponse.
-func DoJSON[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, okStatuses ...int) (Resp, error) {
-	return doJSON[Req, Resp](ctx, c, method, path, body, nil, okStatuses)
+func DoJSON[Resp any](ctx context.Context, c *Client, method, path string, body any, okStatuses ...int) (Resp, error) {
+	return doJSON[Resp](ctx, c, method, path, body, nil, okStatuses)
 }
 
 // DoJSONNotFound behaves like DoJSON, but returns notFoundErr instead of the
@@ -72,11 +71,11 @@ func DoJSON[Req, Resp any](ctx context.Context, c *Client, method, path string, 
 // typically pass a sentinel wrapped with request-specific context, e.g.
 // fmt.Errorf("%s: %w", id, ErrNotFound), so that errors.Is still matches the
 // resource-specific sentinel.
-func DoJSONNotFound[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses ...int) (Resp, error) {
-	return doJSON[Req, Resp](ctx, c, method, path, body, notFoundErr, okStatuses)
+func DoJSONNotFound[Resp any](ctx context.Context, c *Client, method, path string, body any, notFoundErr error, okStatuses ...int) (Resp, error) {
+	return doJSON[Resp](ctx, c, method, path, body, notFoundErr, okStatuses)
 }
 
-func doJSON[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses []int) (Resp, error) {
+func doJSON[Resp any](ctx context.Context, c *Client, method, path string, body any, notFoundErr error, okStatuses []int) (Resp, error) {
 	var zero Resp
 
 	var reader io.Reader
@@ -112,17 +111,17 @@ func doJSON[Req, Resp any](ctx context.Context, c *Client, method, path string, 
 // body as the JSON request payload, and checks that the response status is one
 // of okStatuses without decoding a response body. Use this for endpoints that
 // return no useful body (e.g. DELETE, or actions).
-func DoStatus[Req any](ctx context.Context, c *Client, method, path string, body *Req, okStatuses ...int) error {
-	return doStatus[Req](ctx, c, method, path, body, nil, okStatuses)
+func DoStatus(ctx context.Context, c *Client, method, path string, body any, okStatuses ...int) error {
+	return doStatus(ctx, c, method, path, body, nil, okStatuses)
 }
 
 // DoStatusNotFound behaves like DoStatus, but returns notFoundErr instead of the
 // generic HandleErrorResponse error when the response status is 404.
-func DoStatusNotFound[Req any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses ...int) error {
-	return doStatus[Req](ctx, c, method, path, body, notFoundErr, okStatuses)
+func DoStatusNotFound(ctx context.Context, c *Client, method, path string, body any, notFoundErr error, okStatuses ...int) error {
+	return doStatus(ctx, c, method, path, body, notFoundErr, okStatuses)
 }
 
-func doStatus[Req any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses []int) error {
+func doStatus(ctx context.Context, c *Client, method, path string, body any, notFoundErr error, okStatuses []int) error {
 	var reader io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -1,0 +1,192 @@
+// Package coreapi provides a shared HTTP client and generic request helpers for
+// gcx providers that talk to Grafana's core HTTP API (the legacy /api/* REST
+// endpoints, e.g. /api/annotations, /api/org/users, /api/access-control/...).
+//
+// It exists so individual providers do not each re-implement the same
+// marshal / execute / status-check / decode boilerplate. Callers pass the full
+// request path (including the /api prefix); the client prepends the configured
+// Grafana host.
+package coreapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"slices"
+
+	"github.com/grafana/gcx/internal/config"
+	"k8s.io/client-go/rest"
+)
+
+// Client is a base HTTP client for Grafana's core /api/* endpoints.
+type Client struct {
+	restConfig config.NamespacedRESTConfig
+	httpClient *http.Client
+}
+
+// NewClient creates a new core API client from a Grafana REST config.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	httpClient, err := rest.HTTPClientFor(&cfg.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+	return &Client{restConfig: cfg, httpClient: httpClient}, nil
+}
+
+// DoRequest builds and executes an HTTP request against the core API. The path
+// is appended to the configured host (e.g. "/api/annotations").
+func (c *Client) DoRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.restConfig.Host+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	return resp, nil
+}
+
+// DoJSON executes an HTTP request against the core API, optionally marshaling
+// body as the JSON request payload, and decodes a JSON response into Resp. Pass
+// a nil body for requests with no request body (e.g. GET/DELETE) — in that case
+// Req can be instantiated as `any`.
+//
+// Any response status not present in okStatuses is treated as an error via
+// HandleErrorResponse.
+func DoJSON[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, okStatuses ...int) (Resp, error) {
+	return doJSON[Req, Resp](ctx, c, method, path, body, nil, okStatuses)
+}
+
+// DoJSONNotFound behaves like DoJSON, but returns notFoundErr instead of the
+// generic HandleErrorResponse error when the response status is 404. Callers
+// typically pass a sentinel wrapped with request-specific context, e.g.
+// fmt.Errorf("%s: %w", id, ErrNotFound), so that errors.Is still matches the
+// resource-specific sentinel.
+func DoJSONNotFound[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses ...int) (Resp, error) {
+	return doJSON[Req, Resp](ctx, c, method, path, body, notFoundErr, okStatuses)
+}
+
+func doJSON[Req, Resp any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses []int) (Resp, error) {
+	var zero Resp
+
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return zero, fmt.Errorf("failed to marshal request: %w", err)
+		}
+		reader = bytes.NewReader(b)
+	}
+
+	resp, err := c.DoRequest(ctx, method, path, reader)
+	if err != nil {
+		return zero, err
+	}
+	defer resp.Body.Close()
+
+	if notFoundErr != nil && resp.StatusCode == http.StatusNotFound {
+		return zero, notFoundErr
+	}
+	if !slices.Contains(okStatuses, resp.StatusCode) {
+		return zero, HandleErrorResponse(resp)
+	}
+
+	var result Resp
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return zero, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return result, nil
+}
+
+// DoStatus executes an HTTP request against the core API, optionally marshaling
+// body as the JSON request payload, and checks that the response status is one
+// of okStatuses without decoding a response body. Use this for endpoints that
+// return no useful body (e.g. DELETE, or actions).
+func DoStatus[Req any](ctx context.Context, c *Client, method, path string, body *Req, okStatuses ...int) error {
+	return doStatus[Req](ctx, c, method, path, body, nil, okStatuses)
+}
+
+// DoStatusNotFound behaves like DoStatus, but returns notFoundErr instead of the
+// generic HandleErrorResponse error when the response status is 404.
+func DoStatusNotFound[Req any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses ...int) error {
+	return doStatus[Req](ctx, c, method, path, body, notFoundErr, okStatuses)
+}
+
+func doStatus[Req any](ctx context.Context, c *Client, method, path string, body *Req, notFoundErr error, okStatuses []int) error {
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request: %w", err)
+		}
+		reader = bytes.NewReader(b)
+	}
+
+	resp, err := c.DoRequest(ctx, method, path, reader)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if notFoundErr != nil && resp.StatusCode == http.StatusNotFound {
+		return notFoundErr
+	}
+	if !slices.Contains(okStatuses, resp.StatusCode) {
+		return HandleErrorResponse(resp)
+	}
+	return nil
+}
+
+// errorResponse is the standard Grafana core API error body.
+type errorResponse struct {
+	Message string `json:"message"`
+}
+
+// HandleErrorResponse reads an error response body and returns a formatted
+// error, preferring Grafana's {"message": "..."} field when present.
+func HandleErrorResponse(resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("request failed with status %d (could not read body: %w)", resp.StatusCode, err)
+	}
+
+	var errResp errorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Message != "" {
+		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, errResp.Message)
+	}
+	if len(body) > 0 {
+		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	return fmt.Errorf("request failed with status %d", resp.StatusCode)
+}
+
+// ReadInput reads a JSON (or other) spec from path, or from stdin when path is
+// "-". It is the shared file-or-stdin reader for provider `-f/--file` flags. A
+// nil stdin falls back to os.Stdin.
+func ReadInput(path string, stdin io.Reader) ([]byte, error) {
+	if path == "-" {
+		if stdin == nil {
+			stdin = os.Stdin
+		}
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading stdin: %w", err)
+		}
+		return data, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	return data, nil
+}

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -15,10 +15,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"slices"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers"
 	"k8s.io/client-go/rest"
 )
 
@@ -146,46 +146,7 @@ func doStatus(ctx context.Context, c *Client, method, path string, body any, not
 	return nil
 }
 
-// errorResponse is the standard Grafana core API error body.
-type errorResponse struct {
-	Message string `json:"message"`
-}
-
-// HandleErrorResponse reads an error response body and returns a formatted
-// error, preferring Grafana's {"message": "..."} field when present.
+// HandleErrorResponse uses the shared provider handler to format an error response.
 func HandleErrorResponse(resp *http.Response) error {
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("request failed with status %d (could not read body: %w)", resp.StatusCode, err)
-	}
-
-	var errResp errorResponse
-	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Message != "" {
-		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, errResp.Message)
-	}
-	if len(body) > 0 {
-		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-	return fmt.Errorf("request failed with status %d", resp.StatusCode)
-}
-
-// ReadInput reads a JSON (or other) spec from path, or from stdin when path is
-// "-". It is the shared file-or-stdin reader for provider `-f/--file` flags. A
-// nil stdin falls back to os.Stdin.
-func ReadInput(path string, stdin io.Reader) ([]byte, error) {
-	if path == "-" {
-		if stdin == nil {
-			stdin = os.Stdin
-		}
-		data, err := io.ReadAll(stdin)
-		if err != nil {
-			return nil, fmt.Errorf("reading stdin: %w", err)
-		}
-		return data, nil
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", path, err)
-	}
-	return data, nil
+	return providers.HandleErrorResponse(resp)
 }

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -44,7 +44,7 @@ func TestDoJSON_DecodesResponse(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(t, srv.URL)
-	got, err := coreapi.DoJSON[any, widget](context.Background(), c, http.MethodGet, "/api/widgets/7", nil, http.StatusOK)
+	got, err := coreapi.DoJSON[widget](context.Background(), c, http.MethodGet, "/api/widgets/7", nil, http.StatusOK)
 	require.NoError(t, err)
 	assert.Equal(t, widget{ID: 7, Name: "alpha"}, got)
 	assert.Equal(t, http.MethodGet, gotMethod)
@@ -66,7 +66,7 @@ func TestDoJSON_MarshalsBodyAndSetsContentType(t *testing.T) {
 
 	c := newTestClient(t, srv.URL)
 	in := widget{Name: "beta"}
-	got, err := coreapi.DoJSON[widget, widget](context.Background(), c, http.MethodPost, "/api/widgets", &in, http.StatusOK, http.StatusCreated)
+	got, err := coreapi.DoJSON[widget](context.Background(), c, http.MethodPost, "/api/widgets", &in, http.StatusOK, http.StatusCreated)
 	require.NoError(t, err)
 	assert.Equal(t, widget{ID: 9, Name: "beta"}, got)
 	assert.JSONEq(t, `{"id":0,"name":"beta"}`, gotBody)
@@ -81,7 +81,7 @@ func TestDoJSON_ErrorParsesMessage(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(t, srv.URL)
-	_, err := coreapi.DoJSON[any, widget](context.Background(), c, http.MethodGet, "/api/widgets/1", nil, http.StatusOK)
+	_, err := coreapi.DoJSON[widget](context.Background(), c, http.MethodGet, "/api/widgets/1", nil, http.StatusOK)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "403")
 	assert.Contains(t, err.Error(), "permission denied")
@@ -96,7 +96,7 @@ func TestDoJSONNotFound_ReturnsSentinel(t *testing.T) {
 
 	sentinel := errors.New("missing")
 	c := newTestClient(t, srv.URL)
-	_, err := coreapi.DoJSONNotFound[any, widget](context.Background(), c, http.MethodGet, "/api/widgets/1", nil, sentinel, http.StatusOK)
+	_, err := coreapi.DoJSONNotFound[widget](context.Background(), c, http.MethodGet, "/api/widgets/1", nil, sentinel, http.StatusOK)
 	require.ErrorIs(t, err, sentinel)
 }
 
@@ -108,7 +108,7 @@ func TestDoStatus_ChecksStatusWithoutDecoding(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(t, srv.URL)
-	err := coreapi.DoStatus[any](context.Background(), c, http.MethodDelete, "/api/widgets/1", nil, http.StatusOK, http.StatusNoContent)
+	err := coreapi.DoStatus(context.Background(), c, http.MethodDelete, "/api/widgets/1", nil, http.StatusOK, http.StatusNoContent)
 	require.NoError(t, err)
 }
 
@@ -120,7 +120,7 @@ func TestDoStatus_Error(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(t, srv.URL)
-	err := coreapi.DoStatus[any](context.Background(), c, http.MethodDelete, "/api/widgets/1", nil, http.StatusOK)
+	err := coreapi.DoStatus(context.Background(), c, http.MethodDelete, "/api/widgets/1", nil, http.StatusOK)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "500")
 	assert.Contains(t, err.Error(), "boom")

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -1,0 +1,148 @@
+package coreapi_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/coreapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newTestClient(t *testing.T, url string) *coreapi.Client {
+	t.Helper()
+	cfg := config.NamespacedRESTConfig{Config: rest.Config{Host: url}}
+	c, err := coreapi.NewClient(cfg)
+	require.NoError(t, err)
+	return c
+}
+
+type widget struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestDoJSON_DecodesResponse(t *testing.T) {
+	var gotMethod, gotPath, gotAccept, gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAccept = r.Header.Get("Accept")
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":7,"name":"alpha"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	got, err := coreapi.DoJSON[any, widget](context.Background(), c, http.MethodGet, "/api/widgets/7", nil, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, widget{ID: 7, Name: "alpha"}, got)
+	assert.Equal(t, http.MethodGet, gotMethod)
+	assert.Equal(t, "/api/widgets/7", gotPath)
+	assert.Equal(t, "application/json", gotAccept)
+	assert.Empty(t, gotContentType, "GET with nil body must not set Content-Type")
+}
+
+func TestDoJSON_MarshalsBodyAndSetsContentType(t *testing.T) {
+	var gotBody, gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":9,"name":"beta"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	in := widget{Name: "beta"}
+	got, err := coreapi.DoJSON[widget, widget](context.Background(), c, http.MethodPost, "/api/widgets", &in, http.StatusOK, http.StatusCreated)
+	require.NoError(t, err)
+	assert.Equal(t, widget{ID: 9, Name: "beta"}, got)
+	assert.JSONEq(t, `{"id":0,"name":"beta"}`, gotBody)
+	assert.Equal(t, "application/json", gotContentType)
+}
+
+func TestDoJSON_ErrorParsesMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"permission denied"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, err := coreapi.DoJSON[any, widget](context.Background(), c, http.MethodGet, "/api/widgets/1", nil, http.StatusOK)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+	assert.Contains(t, err.Error(), "permission denied")
+}
+
+func TestDoJSONNotFound_ReturnsSentinel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	}))
+	defer srv.Close()
+
+	sentinel := errors.New("missing")
+	c := newTestClient(t, srv.URL)
+	_, err := coreapi.DoJSONNotFound[any, widget](context.Background(), c, http.MethodGet, "/api/widgets/1", nil, sentinel, http.StatusOK)
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestDoStatus_ChecksStatusWithoutDecoding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	err := coreapi.DoStatus[any](context.Background(), c, http.MethodDelete, "/api/widgets/1", nil, http.StatusOK, http.StatusNoContent)
+	require.NoError(t, err)
+}
+
+func TestDoStatus_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`boom`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	err := coreapi.DoStatus[any](context.Background(), c, http.MethodDelete, "/api/widgets/1", nil, http.StatusOK)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestReadInput(t *testing.T) {
+	t.Run("reads from stdin when path is -", func(t *testing.T) {
+		got, err := coreapi.ReadInput("-", strings.NewReader(`{"a":1}`))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"a":1}`, string(got))
+	})
+
+	t.Run("reads from file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "spec.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"b":2}`), 0o600))
+		got, err := coreapi.ReadInput(path, nil)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"b":2}`, string(got))
+	})
+
+	t.Run("errors on missing file", func(t *testing.T) {
+		_, err := coreapi.ReadInput(filepath.Join(t.TempDir(), "nope.json"), nil)
+		require.Error(t, err)
+	})
+}

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -6,9 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/internal/config"
@@ -124,25 +121,4 @@ func TestDoStatus_Error(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "500")
 	assert.Contains(t, err.Error(), "boom")
-}
-
-func TestReadInput(t *testing.T) {
-	t.Run("reads from stdin when path is -", func(t *testing.T) {
-		got, err := coreapi.ReadInput("-", strings.NewReader(`{"a":1}`))
-		require.NoError(t, err)
-		assert.JSONEq(t, `{"a":1}`, string(got))
-	})
-
-	t.Run("reads from file", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "spec.json")
-		require.NoError(t, os.WriteFile(path, []byte(`{"b":2}`), 0o600))
-		got, err := coreapi.ReadInput(path, nil)
-		require.NoError(t, err)
-		assert.JSONEq(t, `{"b":2}`, string(got))
-	})
-
-	t.Run("errors on missing file", func(t *testing.T) {
-		_, err := coreapi.ReadInput(filepath.Join(t.TempDir(), "nope.json"), nil)
-		require.Error(t, err)
-	})
 }


### PR DESCRIPTION
Part **1 of 5** of the stack that splits #918 into reviewable parts.

## What

This PR adds `internal/coreapi`. This package provides a base HTTP client for legacy Grafana core `/api/*` REST endpoints.

- `DoJSON` and `DoJSONNotFound` marshal a request body, run the request, check the status, and decode the JSON response.
- `DoStatus` and `DoStatusNotFound` run the same flow for endpoints that have no useful response body.
- `HandleErrorResponse` uses the shared provider error handler. It limits the response body to 1 MiB and supports the common Grafana error fields.

The client uses `rest.HTTPClientFor`. This keeps the configured authentication, logging, and payload dump transport.

## Why a stack

#918 ported four independent provider packages on top of this helper. These packages support annotations, organization users, public dashboards, and permissions. The full change has 64 files and 5,738 added lines. The stack keeps each review small.

## Stack

1. **`coreapi` (this PR)** → `main`
2. annotations → this PR
3. organization users → annotations
4. public dashboards → organization users
5. permissions → public dashboards

## Test plan

- [x] `GCX_AGENT_MODE=false mise run lint`
- [x] `GCX_AGENT_MODE=false mise exec -- go test ./internal/coreapi/...`
- [x] `GCX_AGENT_MODE=false mise exec -- go test ./...`
- [x] `GCX_AGENT_MODE=false mise run reference`
- [x] `GCX_AGENT_MODE=false mise run docs`
- [x] `GCX_AGENT_MODE=false mise run all`