### PR TITLE
perf(datasources): parallelize per-plugin-group list fetch

### DIFF
--- a/internal/datasources/dualtransport_test.go
+++ b/internal/datasources/dualtransport_test.go
@@ -3,10 +3,14 @@ package datasources_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/datasources"
@@ -227,6 +231,62 @@ func TestDualListAndGetViaAppPlatform(t *testing.T) {
 	got, err := tr.GetByUID(context.Background(), "my-prom")
 	require.NoError(t, err)
 	assert.Equal(t, "My Prom", got.Name)
+}
+
+// TestDualListManyGroupsAggregatesConcurrently asserts that List fans the
+// per-plugin-group fetches out concurrently (bounded at 10), aggregates every
+// served group, and never exceeds the concurrency cap.
+func TestDualListManyGroupsAggregatesConcurrently(t *testing.T) {
+	const groups = 25
+
+	// Precompute discovery + per-group response bodies from trusted test data
+	// (keyed by request path), so the handler never echoes request-derived input
+	// back into the response.
+	var b strings.Builder
+	b.WriteString(`{"kind":"APIGroupList","groups":[`)
+	bodies := make(map[string]string, groups)
+	for i := range groups {
+		group := fmt.Sprintf("plugin-%02d-datasource.datasource.grafana.app", i)
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"name":%q}`, group)
+		path := "/apis/" + group + "/v0alpha1/namespaces/stacks-1/datasources"
+		bodies[path] = fmt.Sprintf(
+			`{"items":[{"apiVersion":"%s/v0alpha1","metadata":{"name":"ds-%02d"},"spec":{}}]}`, group, i)
+	}
+	b.WriteString(`]}`)
+	discovery := b.String()
+
+	var inFlight, maxInFlight int64
+	tr := newDualTransport(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apis" {
+			_, _ = w.Write([]byte(discovery))
+			return
+		}
+		body, ok := bodies[r.URL.Path]
+		if !ok {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		cur := atomic.AddInt64(&inFlight, 1)
+		for {
+			old := atomic.LoadInt64(&maxInFlight)
+			if cur <= old || atomic.CompareAndSwapInt64(&maxInFlight, old, cur) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond) // widen the concurrency window
+		atomic.AddInt64(&inFlight, -1)
+		_, _ = io.WriteString(w, body)
+	}))
+
+	list, err := tr.List(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, list, groups, "every served group must be aggregated")
+	assert.LessOrEqual(t, maxInFlight, int64(10), "fan-out must stay bounded at 10")
+	assert.Greater(t, maxInFlight, int64(1), "fetches must actually run concurrently")
 }
 
 // TestDualListForbiddenGroupFallsBackToREST asserts that when a served plugin

--- a/internal/datasources/k8stransport.go
+++ b/internal/datasources/k8stransport.go
@@ -12,8 +12,13 @@ import (
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/httputils"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/rest"
 )
+
+// maxConcurrentGroupFetches bounds the per-plugin-group fan-out in listAll,
+// matching the fan-out cap used elsewhere in the resources pipeline.
+const maxConcurrentGroupFetches = 10
 
 // errK8sNotServed signals that the app-platform datasource API did not serve a
 // request (the per-plugin group is absent, the discovery probe found no
@@ -164,31 +169,62 @@ func (t *k8sTransport) listAll(ctx context.Context) ([]*Datasource, bool, error)
 		return nil, false, errK8sNotServed
 	}
 
+	// Fetch each served group concurrently (bounded), writing into per-index
+	// slots so the merge below stays lock-free and order-deterministic. The
+	// legacy sequential loop made this the dominant cost of `datasources list`.
+	type groupResult struct {
+		datasources []*Datasource
+		incomplete  bool
+	}
+	results := make([]groupResult, len(plugins))
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentGroupFetches)
+	for i, pluginID := range plugins {
+		g.Go(func() error {
+			status, body, err := t.do(ctx, http.MethodGet, t.collectionPath(pluginID), nil)
+			if err != nil {
+				return err
+			}
+			if status != http.StatusOK {
+				// A served group may be inaccessible (403), gone (404), or backed
+				// by a broken/absent plugin (5xx). Any of these makes the
+				// app-platform enumeration incomplete: skip the group and flag it
+				// so List falls back to the permission-aware legacy list for a
+				// complete view.
+				results[i].incomplete = true
+				return nil
+			}
+			var list k8sList
+			if err := json.Unmarshal(body, &list); err != nil {
+				return fmt.Errorf("failed to parse datasources response: %w", err)
+			}
+			dss := make([]*Datasource, 0, len(list.Items))
+			for j := range list.Items {
+				ds, err := fromK8s(&list.Items[j])
+				if err != nil {
+					return err
+				}
+				dss = append(dss, ds)
+			}
+			results[i].datasources = dss
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, false, err
+	}
+
+	// Merge in plugin order (single goroutine — no lock needed on index).
 	var out []*Datasource
 	var incomplete bool
 	index := make(map[string]string)
-	for _, pluginID := range plugins {
-		status, body, err := t.do(ctx, http.MethodGet, t.collectionPath(pluginID), nil)
-		if err != nil {
-			return nil, false, err
-		}
-		if status != http.StatusOK {
-			// A served group may be inaccessible (403), gone (404), or backed by
-			// a broken/absent plugin (5xx). Any of these makes the app-platform
-			// enumeration incomplete: skip the group and flag it so List falls
-			// back to the permission-aware legacy list for a complete view.
+	for i, pluginID := range plugins {
+		if results[i].incomplete {
 			incomplete = true
 			continue
 		}
-		var list k8sList
-		if err := json.Unmarshal(body, &list); err != nil {
-			return nil, false, fmt.Errorf("failed to parse datasources response: %w", err)
-		}
-		for i := range list.Items {
-			ds, err := fromK8s(&list.Items[i])
-			if err != nil {
-				return nil, false, err
-			}
+		for _, ds := range results[i].datasources {
 			out = append(out, ds)
 			index[ds.UID] = pluginID
 		}


### PR DESCRIPTION
## Problem

`gcx datasources list` was taking **~10s** on well-populated stacks. Profiling against a live stack showed it fans out **one GET per served datasource plugin group (~40)** through the app-platform API, **strictly sequentially** (`request → response → request → response`, ~250ms each through the proxy).

Root cause: `k8sTransport.listAll` iterates `servedPlugins` in a sequential `for` loop. (Confirmed independently in a team thread — the dual-mode transport from #881 lists every `*.datasource.grafana.app` group.)

## Change

Bound the per-group fan-out with an `errgroup` (`SetLimit(10)`), collecting results into per-index slots merged in plugin order so the merge is lock-free and deterministic. App-platform stays the canonical surface; the legacy-REST fallback on an incomplete enumeration is unchanged — only the fetch is now concurrent.

## Result (live stack)

| | Before | After |
|---|---|---|
| `datasources list` | ~10.3s | **~1.6s** |

## Out of scope

The `--limit`/hint UX and the client-side truncate-after-fetch are tracked separately in #387; not touched here.

## Tests

- New `TestDualListManyGroupsAggregatesConcurrently` asserts every group is aggregated and the fan-out never exceeds 10.
- Full package suite passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)