### PR TITLE
feat(publicdashboards): port Grafana public dashboards CRUD onto coreapi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ internal/
 │   ├── metrics/    Metrics signal provider (Prometheus queries + Adaptive Metrics commands)
 │   ├── appo11y/    App Observability provider (overrides, settings — singleton resources; services discovery via target_info)
 │   ├── org/        Organization provider (org users — list/get/add/update-role/remove via /api/org/users; coreapi client)
+│   ├── permissions/ Permissions provider (granular RBAC via /api/access-control/{resource}/{id} — get/set/grant/levels over folders|dashboards|datasources|teams|serviceaccounts; command-only)
 │   ├── profiles/   Profiles signal provider (Pyroscope queries + adaptive stub)
 │   ├── publicdashboards/ Public Dashboards provider (CRUD via /api/dashboards/uid/{uid}/public-dashboards; coreapi client, resources-pipeline bridge)
 │   ├── aio11y/     AI Observability provider (conversations, agents, generations, evaluators, rules, hook-rules (guards), templates, scores, judge, saved-conversations, collections, experiments — via grafana-sigil-app plugin API)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ internal/
 │   ├── appo11y/    App Observability provider (overrides, settings — singleton resources; services discovery via target_info)
 │   ├── org/        Organization provider (org users — list/get/add/update-role/remove via /api/org/users; coreapi client)
 │   ├── profiles/   Profiles signal provider (Pyroscope queries + adaptive stub)
+│   ├── publicdashboards/ Public Dashboards provider (CRUD via /api/dashboards/uid/{uid}/public-dashboards; coreapi client, resources-pipeline bridge)
 │   ├── aio11y/     AI Observability provider (conversations, agents, generations, evaluators, rules, hook-rules (guards), templates, scores, judge, saved-conversations, collections, experiments — via grafana-sigil-app plugin API)
 │   ├── slo/        SLO provider (definitions, reports)
 │   ├── synth/      Synthetic Monitoring provider (checks, probes)

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -48,6 +48,7 @@ import (
 	_ "github.com/grafana/gcx/internal/providers/logs"             // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/metrics"          // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/org"              // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/permissions"      // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/profiles"         // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/publicdashboards" // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/slo"              // Provider registrations — blank imports trigger init() self-registration.

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -33,26 +33,27 @@ import (
 	"github.com/grafana/gcx/internal/logs"
 	"github.com/grafana/gcx/internal/notifier"
 	"github.com/grafana/gcx/internal/providers"
-	_ "github.com/grafana/gcx/internal/providers/aio11y"          // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/alert"           // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/annotations"     // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/appo11y"         // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/dashboards"      // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/datasources"     // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/faro"            // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/fleet"           // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/instrumentation" // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/irm"             // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/k6"              // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/kg"              // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/logs"            // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/metrics"         // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/org"             // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/profiles"        // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/slo"             // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/stacks"          // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/synth"           // Provider registrations — blank imports trigger init() self-registration.
-	_ "github.com/grafana/gcx/internal/providers/traces"          // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/aio11y"           // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/alert"            // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/annotations"      // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/appo11y"          // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/dashboards"       // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/datasources"      // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/faro"             // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/fleet"            // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/instrumentation"  // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/irm"              // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/k6"               // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/kg"               // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/logs"             // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/metrics"          // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/org"              // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/profiles"         // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/publicdashboards" // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/slo"              // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/stacks"           // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/synth"            // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/traces"           // Provider registrations — blank imports trigger init() self-registration.
 	"github.com/grafana/gcx/internal/style"
 	"github.com/grafana/gcx/internal/terminal"
 	appversion "github.com/grafana/gcx/internal/version"

--- a/cmd/gcx/root/consistency_test.go
+++ b/cmd/gcx/root/consistency_test.go
@@ -230,7 +230,7 @@ func TestConsistency_PublicDashboardsHintsMatchCommandArity(t *testing.T) {
 			}
 
 			positionals := 0
-			for _, tok := range strings.Fields(hint) {
+			for tok := range strings.FieldsSeq(hint) {
 				if strings.HasPrefix(tok, "-") {
 					break
 				}

--- a/cmd/gcx/root/consistency_test.go
+++ b/cmd/gcx/root/consistency_test.go
@@ -2,6 +2,7 @@ package root_test
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/root"
@@ -192,6 +193,73 @@ func TestConsistency_AvailabilityValuesValid(t *testing.T) {
 			}
 		})
 	})
+}
+
+// TestConsistency_PublicDashboardsHintsMatchCommandArity guards against the
+// class of bug reported on PR #924: an LLMHint whose leading positional
+// tokens don't match the command's actual cobra.Args arity, or whose flag
+// tokens omit a flag the command marks required. Either causes an agent
+// following the hint to hit a hard cobra error on the first call.
+func TestConsistency_PublicDashboardsHintsMatchCommandArity(t *testing.T) {
+	rootCmd := buildRootCmd()
+
+	cmdsByPath := make(map[string]*cobra.Command)
+	agent.WalkCommands(rootCmd, func(cmd *cobra.Command) {
+		cmdsByPath[cmd.CommandPath()] = cmd
+	})
+
+	cases := []struct {
+		path        string
+		positionals int      // leading hint tokens before the first flag
+		wantFlags   []string // flags the hint must reference
+	}{
+		{path: "gcx public-dashboards get", positionals: 1},
+		{path: "gcx public-dashboards create", positionals: 0, wantFlags: []string{"--dashboard-uid", "-f"}},
+		{path: "gcx public-dashboards update", positionals: 1, wantFlags: []string{"--dashboard-uid", "-f"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			cmd, ok := cmdsByPath[tc.path]
+			if !ok {
+				t.Fatalf("command %q not found in tree", tc.path)
+			}
+			hint := cmd.Annotations[agent.AnnotationLLMHint]
+			if hint == "" {
+				t.Fatalf("missing %s annotation", agent.AnnotationLLMHint)
+			}
+
+			positionals := 0
+			for _, tok := range strings.Fields(hint) {
+				if strings.HasPrefix(tok, "-") {
+					break
+				}
+				positionals++
+			}
+			if positionals != tc.positionals {
+				t.Errorf("hint %q implies %d positional arg(s), want %d", hint, positionals, tc.positionals)
+			}
+
+			// Validate the implied positional count against the command's own
+			// arity check (e.g. cobra.ExactArgs), not just the fixture above.
+			// A nil Args means cobra falls back to ArbitraryArgs (no check).
+			if cmd.Args != nil {
+				dummyArgs := make([]string, positionals)
+				for i := range dummyArgs {
+					dummyArgs[i] = "x"
+				}
+				if err := cmd.Args(cmd, dummyArgs); err != nil {
+					t.Errorf("hint implies %d positional arg(s) but the command rejects them: %v", positionals, err)
+				}
+			}
+
+			for _, flag := range tc.wantFlags {
+				if !strings.Contains(hint, flag) {
+					t.Errorf("hint %q does not reference required flag %q", hint, flag)
+				}
+			}
+		})
+	}
 }
 
 // TestConsistency_SkillMappingResolvesToCommands verifies every key in the

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -49,6 +49,7 @@ Run 'gcx agent skills list' to see bundled Agent Skills with task-specific guida
 * [gcx org](gcx_org.md)	 - Manage Grafana organization resources
 * [gcx profiles](gcx_profiles.md)	 - Query Pyroscope datasources and manage continuous profiling
 * [gcx providers](gcx_providers.md)	 - Manage registered providers
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
 * [gcx resources](gcx_resources.md)	 - Manipulate Grafana resources
 * [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
 * [gcx slo](gcx_slo.md)	 - Manage Grafana SLO definitions and reports

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -47,6 +47,7 @@ Run 'gcx agent skills list' to see bundled Agent Skills with task-specific guida
 * [gcx logs](gcx_logs.md)	 - Query Loki datasources and manage Adaptive Logs
 * [gcx metrics](gcx_metrics.md)	 - Query Prometheus datasources and manage Adaptive Metrics
 * [gcx org](gcx_org.md)	 - Manage Grafana organization resources
+* [gcx permissions](gcx_permissions.md)	 - Manage Grafana resource permissions (RBAC)
 * [gcx profiles](gcx_profiles.md)	 - Query Pyroscope datasources and manage continuous profiling
 * [gcx providers](gcx_providers.md)	 - Manage registered providers
 * [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards

--- a/docs/reference/cli/gcx_permissions.md
+++ b/docs/reference/cli/gcx_permissions.md
@@ -1,0 +1,37 @@
+## gcx permissions
+
+Manage Grafana resource permissions (RBAC)
+
+### Synopsis
+
+Manage Grafana resource permissions via the granular access-control (RBAC) API.
+
+Supported resources: folders, dashboards, datasources, teams, serviceaccounts.
+Reads work on all editions; writes require RBAC (Grafana Enterprise or Cloud).
+
+### Options
+
+```
+      --config string   Path to the configuration file to use
+  -h, --help            help for permissions
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx permissions get](gcx_permissions_get.md)	 - Get the permission list for a resource instance.
+* [gcx permissions grant](gcx_permissions_grant.md)	 - Grant a permission level to a single user, team, or built-in role.
+* [gcx permissions levels](gcx_permissions_levels.md)	 - Show the assignable permission levels for a resource kind.
+* [gcx permissions set](gcx_permissions_set.md)	 - Replace the full permission set for a resource instance.
+

--- a/docs/reference/cli/gcx_permissions_get.md
+++ b/docs/reference/cli/gcx_permissions_get.md
@@ -1,0 +1,46 @@
+## gcx permissions get
+
+Get the permission list for a resource instance.
+
+### Synopsis
+
+Get the granular RBAC permission list for a resource instance.
+
+<resource> is one of: folders, dashboards, datasources, teams, serviceaccounts
+
+```
+gcx permissions get <resource> <id> [flags]
+```
+
+### Examples
+
+```
+  gcx permissions get dashboards my-dashboard-uid
+  gcx permissions get folders my-folder-uid -o json
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx permissions](gcx_permissions.md)	 - Manage Grafana resource permissions (RBAC)
+

--- a/docs/reference/cli/gcx_permissions_grant.md
+++ b/docs/reference/cli/gcx_permissions_grant.md
@@ -1,0 +1,50 @@
+## gcx permissions grant
+
+Grant a permission level to a single user, team, or built-in role.
+
+### Synopsis
+
+Grant a permission level to a single principal on a resource instance.
+
+Specify exactly one of --user, --team, or --role, plus --level.
+
+<resource> is one of: folders, dashboards, datasources, teams, serviceaccounts
+
+```
+gcx permissions grant <resource> <id> [flags]
+```
+
+### Examples
+
+```
+  gcx permissions grant dashboards my-uid --team 3 --level Edit
+  gcx permissions grant folders my-uid --role Viewer --level View
+  gcx permissions grant datasources my-uid --user alice --level Admin
+```
+
+### Options
+
+```
+  -h, --help           help for grant
+      --level string   Permission level (e.g. View, Edit, Admin)
+      --role string    Built-in role to grant to (e.g. Viewer, Editor, Admin)
+      --team string    Team to grant to (numeric ID or UID)
+      --user string    User to grant to (numeric ID or UID)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx permissions](gcx_permissions.md)	 - Manage Grafana resource permissions (RBAC)
+

--- a/docs/reference/cli/gcx_permissions_levels.md
+++ b/docs/reference/cli/gcx_permissions_levels.md
@@ -1,0 +1,45 @@
+## gcx permissions levels
+
+Show the assignable permission levels for a resource kind.
+
+### Synopsis
+
+Show the assignable permission levels and assignment types for a resource kind.
+
+<resource> is one of: folders, dashboards, datasources, teams, serviceaccounts
+
+```
+gcx permissions levels <resource> [flags]
+```
+
+### Examples
+
+```
+  gcx permissions levels dashboards
+```
+
+### Options
+
+```
+  -h, --help            help for levels
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx permissions](gcx_permissions.md)	 - Manage Grafana resource permissions (RBAC)
+

--- a/docs/reference/cli/gcx_permissions_set.md
+++ b/docs/reference/cli/gcx_permissions_set.md
@@ -1,0 +1,49 @@
+## gcx permissions set
+
+Replace the full permission set for a resource instance.
+
+### Synopsis
+
+Replace the full permission set for a resource instance from a JSON file.
+
+The file is a JSON array of assignments (or a {"permissions": [...]} object),
+each with a "permission" level (View/Edit/Admin) and exactly one of
+"userId", "teamId", or "builtInRole".
+
+<resource> is one of: folders, dashboards, datasources, teams, serviceaccounts
+
+```
+gcx permissions set <resource> <id> -f FILE [flags]
+```
+
+### Examples
+
+```
+  gcx permissions set dashboards my-uid -f acl.json
+  cat acl.json | gcx permissions set folders my-uid -f -
+```
+
+### Options
+
+```
+  -f, --file string   JSON file with the permission set (use - for stdin)
+      --force         Skip confirmation prompt
+  -h, --help          help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx permissions](gcx_permissions.md)	 - Manage Grafana resource permissions (RBAC)
+

--- a/docs/reference/cli/gcx_public-dashboards.md
+++ b/docs/reference/cli/gcx_public-dashboards.md
@@ -1,0 +1,31 @@
+## gcx public-dashboards
+
+Manage public dashboards
+
+### Options
+
+```
+      --config string   Path to the configuration file to use
+  -h, --help            help for public-dashboards
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx public-dashboards create](gcx_public-dashboards_create.md)	 - Create a public dashboard config from a JSON file.
+* [gcx public-dashboards delete](gcx_public-dashboards_delete.md)	 - Delete a public dashboard config.
+* [gcx public-dashboards get](gcx_public-dashboards_get.md)	 - Get a public dashboard by its UID.
+* [gcx public-dashboards list](gcx_public-dashboards_list.md)	 - List all public dashboards.
+* [gcx public-dashboards update](gcx_public-dashboards_update.md)	 - Update a public dashboard config from a JSON file.
+

--- a/docs/reference/cli/gcx_public-dashboards_create.md
+++ b/docs/reference/cli/gcx_public-dashboards_create.md
@@ -1,0 +1,35 @@
+## gcx public-dashboards create
+
+Create a public dashboard config from a JSON file.
+
+```
+gcx public-dashboards create [flags]
+```
+
+### Options
+
+```
+      --dashboard-uid string   Parent dashboard UID (required)
+  -f, --file string            File containing the public dashboard spec (JSON), or '-' for stdin (required)
+  -h, --help                   help for create
+      --jq string              jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string            Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string          Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
+

--- a/docs/reference/cli/gcx_public-dashboards_delete.md
+++ b/docs/reference/cli/gcx_public-dashboards_delete.md
@@ -1,0 +1,30 @@
+## gcx public-dashboards delete
+
+Delete a public dashboard config.
+
+```
+gcx public-dashboards delete PD_UID [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
+

--- a/docs/reference/cli/gcx_public-dashboards_get.md
+++ b/docs/reference/cli/gcx_public-dashboards_get.md
@@ -1,0 +1,33 @@
+## gcx public-dashboards get
+
+Get a public dashboard by its UID.
+
+```
+gcx public-dashboards get PD_UID [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
+

--- a/docs/reference/cli/gcx_public-dashboards_list.md
+++ b/docs/reference/cli/gcx_public-dashboards_list.md
@@ -1,0 +1,34 @@
+## gcx public-dashboards list
+
+List all public dashboards.
+
+```
+gcx public-dashboards list [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Maximum number of items to return (0 for unlimited) (default 50)
+  -o, --output string   Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
+

--- a/docs/reference/cli/gcx_public-dashboards_update.md
+++ b/docs/reference/cli/gcx_public-dashboards_update.md
@@ -1,0 +1,35 @@
+## gcx public-dashboards update
+
+Update a public dashboard config from a JSON file.
+
+```
+gcx public-dashboards update PD_UID [flags]
+```
+
+### Options
+
+```
+      --dashboard-uid string   Parent dashboard UID (required)
+  -f, --file string            File containing the public dashboard spec (JSON), or '-' for stdin (required)
+  -h, --help                   help for update
+      --jq string              jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string            Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string          Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx public-dashboards](gcx_public-dashboards.md)	 - Manage public dashboards
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -234,6 +234,14 @@ var commandAnnotations = map[string]annotation{
 	"gcx public-dashboards delete": {Cost: "small"},
 
 	// -----------------------------------------------------------------------
+	// Permissions provider (granular RBAC)
+	// -----------------------------------------------------------------------
+	"gcx permissions get":    {Cost: "medium", Hint: "<resource> <id> -o json; resource is folders|dashboards|datasources|teams|serviceaccounts"},
+	"gcx permissions set":    {Cost: "small", Hint: "<resource> <id> -f acl.json"},
+	"gcx permissions grant":  {Cost: "small", Hint: "<resource> <id> --team 3 --level Edit"},
+	"gcx permissions levels": {Cost: "small", Hint: "<resource> -o json"},
+
+	// -----------------------------------------------------------------------
 	// App Observability provider
 	// -----------------------------------------------------------------------
 	"gcx appo11y overrides get":    {Cost: "small"},

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -228,9 +228,9 @@ var commandAnnotations = map[string]annotation{
 	// Public Dashboards provider
 	// -----------------------------------------------------------------------
 	"gcx public-dashboards list":   {Cost: "medium", Hint: "-o json"},
-	"gcx public-dashboards get":    {Cost: "small", Hint: "<dashboard-uid> -o json"},
-	"gcx public-dashboards create": {Cost: "small", Hint: "<dashboard-uid> -f public-dashboard.json"},
-	"gcx public-dashboards update": {Cost: "small", Hint: "<dashboard-uid> <pd-uid> -f patch.json"},
+	"gcx public-dashboards get":    {Cost: "small", Hint: "<pd-uid> -o json"},
+	"gcx public-dashboards create": {Cost: "small", Hint: "--dashboard-uid <dashboard-uid> -f public-dashboard.json"},
+	"gcx public-dashboards update": {Cost: "small", Hint: "<pd-uid> --dashboard-uid <dashboard-uid> -f patch.json"},
 	"gcx public-dashboards delete": {Cost: "small"},
 
 	// -----------------------------------------------------------------------

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -225,6 +225,15 @@ var commandAnnotations = map[string]annotation{
 	"gcx org users remove":      {Cost: "small"},
 
 	// -----------------------------------------------------------------------
+	// Public Dashboards provider
+	// -----------------------------------------------------------------------
+	"gcx public-dashboards list":   {Cost: "medium", Hint: "-o json"},
+	"gcx public-dashboards get":    {Cost: "small", Hint: "<dashboard-uid> -o json"},
+	"gcx public-dashboards create": {Cost: "small", Hint: "<dashboard-uid> -f public-dashboard.json"},
+	"gcx public-dashboards update": {Cost: "small", Hint: "<dashboard-uid> <pd-uid> -f patch.json"},
+	"gcx public-dashboards delete": {Cost: "small"},
+
+	// -----------------------------------------------------------------------
 	// App Observability provider
 	// -----------------------------------------------------------------------
 	"gcx appo11y overrides get":    {Cost: "small"},

--- a/internal/providers/permissions/client.go
+++ b/internal/providers/permissions/client.go
@@ -1,0 +1,92 @@
+package permissions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/coreapi"
+)
+
+// Client talks to Grafana's granular access-control (RBAC) permissions API.
+type Client struct {
+	base *coreapi.Client
+}
+
+// NewClient creates a new permissions client bound to the provided REST config.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	base, err := coreapi.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{base: base}, nil
+}
+
+func basePath(resource string) string {
+	return "/api/access-control/" + resource
+}
+
+// Describe returns the assignable permission levels and assignment types for a
+// resource kind.
+func (c *Client) Describe(ctx context.Context, resource string) (*Description, error) {
+	d, err := coreapi.DoJSON[any, Description](ctx, c.base, http.MethodGet, basePath(resource)+"/description", nil, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+// Get returns the permission list for a resource instance.
+func (c *Client) Get(ctx context.Context, resource, resourceID string) ([]ResourcePermission, error) {
+	return coreapi.DoJSON[any, []ResourcePermission](ctx, c.base, http.MethodGet,
+		fmt.Sprintf("%s/%s", basePath(resource), url.PathEscape(resourceID)), nil, http.StatusOK)
+}
+
+// Set replaces the full permission set for a resource instance.
+func (c *Client) Set(ctx context.Context, resource, resourceID string, perms []SetResourcePermissionCommand) error {
+	body := setPermissionsBody{Permissions: perms}
+	err := coreapi.DoStatus[setPermissionsBody](ctx, c.base, http.MethodPost,
+		fmt.Sprintf("%s/%s", basePath(resource), url.PathEscape(resourceID)), &body, http.StatusOK)
+	return annotateForbidden(err)
+}
+
+// SetUserPermission sets (or, with an empty level, removes) one user's
+// permission on a resource instance. userRef may be a numeric user ID or a UID.
+func (c *Client) SetUserPermission(ctx context.Context, resource, resourceID, userRef, level string) error {
+	return c.setPrincipal(ctx, resource, resourceID, "users", userRef, level)
+}
+
+// SetTeamPermission sets (or removes) one team's permission on a resource
+// instance. teamRef may be a numeric team ID or a UID.
+func (c *Client) SetTeamPermission(ctx context.Context, resource, resourceID, teamRef, level string) error {
+	return c.setPrincipal(ctx, resource, resourceID, "teams", teamRef, level)
+}
+
+// SetBuiltInRolePermission sets (or removes) a built-in role's permission on a
+// resource instance (e.g. role "Viewer", "Editor", "Admin").
+func (c *Client) SetBuiltInRolePermission(ctx context.Context, resource, resourceID, role, level string) error {
+	return c.setPrincipal(ctx, resource, resourceID, "builtInRoles", role, level)
+}
+
+func (c *Client) setPrincipal(ctx context.Context, resource, resourceID, principalKind, principalRef, level string) error {
+	body := setPermissionBody{Permission: level}
+	path := fmt.Sprintf("%s/%s/%s/%s", basePath(resource), url.PathEscape(resourceID), principalKind, url.PathEscape(principalRef))
+	err := coreapi.DoStatus[setPermissionBody](ctx, c.base, http.MethodPost, path, &body, http.StatusOK)
+	return annotateForbidden(err)
+}
+
+// annotateForbidden adds an actionable hint when a write is rejected with 403,
+// which on Grafana OSS without Enterprise/RBAC means the granular permission
+// API is unavailable.
+func annotateForbidden(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "status 403") {
+		return fmt.Errorf("%w\nwriting granular permissions requires RBAC (Grafana Enterprise or Cloud); reads work on all editions", err)
+	}
+	return err
+}

--- a/internal/providers/permissions/client_test.go
+++ b/internal/providers/permissions/client_test.go
@@ -1,0 +1,132 @@
+package permissions_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/permissions"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newClient(t *testing.T, url string) *permissions.Client {
+	t.Helper()
+	c, err := permissions.NewClient(config.NamespacedRESTConfig{Config: rest.Config{Host: url}})
+	require.NoError(t, err)
+	return c
+}
+
+func TestClient_Describe(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/access-control/dashboards/description", r.URL.Path)
+		_, _ = w.Write([]byte(`{"assignments":{"users":true,"teams":true,"serviceAccounts":true,"builtInRoles":true},"permissions":["View","Edit","Admin"]}`))
+	}))
+	defer srv.Close()
+
+	desc, err := newClient(t, srv.URL).Describe(context.Background(), "dashboards")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"View", "Edit", "Admin"}, desc.Permissions)
+	assert.True(t, desc.Assignments.ServiceAccounts)
+}
+
+func TestClient_Get(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/access-control/folders/my-uid", r.URL.Path)
+		_, _ = w.Write([]byte(`[{"id":1,"builtInRole":"Editor","permission":"Edit","isManaged":true},{"id":2,"userLogin":"alice","permission":"Admin"}]`))
+	}))
+	defer srv.Close()
+
+	perms, err := newClient(t, srv.URL).Get(context.Background(), "folders", "my-uid")
+	require.NoError(t, err)
+	require.Len(t, perms, 2)
+	assert.Equal(t, "Editor", perms[0].BuiltInRole)
+	assert.Equal(t, "alice", perms[1].UserLogin)
+}
+
+func TestClient_Set(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/access-control/dashboards/my-uid", r.URL.Path)
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		_, _ = w.Write([]byte(`{"message":"Permissions updated"}`))
+	}))
+	defer srv.Close()
+
+	err := newClient(t, srv.URL).Set(context.Background(), "dashboards", "my-uid", []permissions.SetResourcePermissionCommand{
+		{TeamID: 3, Permission: "Edit"},
+		{BuiltInRole: "Viewer", Permission: "View"},
+	})
+	require.NoError(t, err)
+	perms, ok := gotBody["permissions"].([]any)
+	require.True(t, ok)
+	assert.Len(t, perms, 2)
+}
+
+func TestClient_SetGrantsPerPrincipal(t *testing.T) {
+	tests := []struct {
+		name     string
+		call     func(c *permissions.Client) error
+		wantPath string
+	}{
+		{
+			name: "user",
+			call: func(c *permissions.Client) error {
+				return c.SetUserPermission(context.Background(), "dashboards", "d1", "42", "Edit")
+			},
+			wantPath: "/api/access-control/dashboards/d1/users/42",
+		},
+		{
+			name: "team",
+			call: func(c *permissions.Client) error {
+				return c.SetTeamPermission(context.Background(), "folders", "f1", "3", "Admin")
+			},
+			wantPath: "/api/access-control/folders/f1/teams/3",
+		},
+		{
+			name: "role",
+			call: func(c *permissions.Client) error {
+				return c.SetBuiltInRolePermission(context.Background(), "datasources", "ds1", "Viewer", "View")
+			},
+			wantPath: "/api/access-control/datasources/ds1/builtInRoles/Viewer",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath, gotLevel string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				var body map[string]string
+				b, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(b, &body)
+				gotLevel = body["permission"]
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			require.NoError(t, tt.call(newClient(t, srv.URL)))
+			assert.Equal(t, tt.wantPath, gotPath)
+			assert.NotEmpty(t, gotLevel)
+		})
+	}
+}
+
+func TestClient_SetForbiddenHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"access denied"}`))
+	}))
+	defer srv.Close()
+
+	err := newClient(t, srv.URL).SetTeamPermission(context.Background(), "dashboards", "d1", "3", "Edit")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+	assert.Contains(t, err.Error(), "requires RBAC")
+}

--- a/internal/providers/permissions/commands.go
+++ b/internal/providers/permissions/commands.go
@@ -1,0 +1,401 @@
+package permissions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/coreapi"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// GrafanaConfigLoader can load a NamespacedRESTConfig from the active context.
+type GrafanaConfigLoader interface {
+	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
+}
+
+func clientFromLoader(ctx context.Context, loader GrafanaConfigLoader) (*Client, error) {
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(cfg)
+}
+
+const resourceArgHelp = "<resource> is one of: folders, dashboards, datasources, teams, serviceaccounts"
+
+// ---- get ----
+
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &PermissionsTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newGetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:     "get <resource> <id>",
+		Short:   "Get the permission list for a resource instance.",
+		Long:    "Get the granular RBAC permission list for a resource instance.\n\n" + resourceArgHelp,
+		Example: "  gcx permissions get dashboards my-dashboard-uid\n  gcx permissions get folders my-folder-uid -o json",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateResource(args[0]); err != nil {
+				return err
+			}
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := clientFromLoader(ctx, loader)
+			if err != nil {
+				return err
+			}
+			perms, err := client.Get(ctx, args[0], args[1])
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), perms)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---- set ----
+
+type setOpts struct {
+	File  string
+	Force bool
+}
+
+func (o *setOpts) setup(flags *pflag.FlagSet) {
+	flags.StringVarP(&o.File, "file", "f", "", "JSON file with the permission set (use - for stdin)")
+	flags.BoolVar(&o.Force, "force", false, "Skip confirmation prompt")
+}
+
+func newSetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &setOpts{}
+	cmd := &cobra.Command{
+		Use:   "set <resource> <id> -f FILE",
+		Short: "Replace the full permission set for a resource instance.",
+		Long: "Replace the full permission set for a resource instance from a JSON file.\n\n" +
+			"The file is a JSON array of assignments (or a {\"permissions\": [...]} object),\n" +
+			"each with a \"permission\" level (View/Edit/Admin) and exactly one of\n" +
+			"\"userId\", \"teamId\", or \"builtInRole\".\n\n" + resourceArgHelp,
+		Example: "  gcx permissions set dashboards my-uid -f acl.json\n  cat acl.json | gcx permissions set folders my-uid -f -",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateResource(args[0]); err != nil {
+				return err
+			}
+			perms, err := readPermissionsFromFile(opts.File, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+
+			proceed, err := providers.ConfirmDestructive(cmd.InOrStdin(), cmd.OutOrStdout(), opts.Force,
+				fmt.Sprintf("Replace all managed permissions on %s %s?", args[0], args[1]))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
+			}
+
+			ctx := cmd.Context()
+			client, err := clientFromLoader(ctx, loader)
+			if err != nil {
+				return err
+			}
+			if err := client.Set(ctx, args[0], args[1], perms); err != nil {
+				return err
+			}
+			cmdio.Success(cmd.OutOrStdout(), "updated permissions for %s %s", args[0], args[1])
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+// ---- grant ----
+
+type grantOpts struct {
+	User  string
+	Team  string
+	Role  string
+	Level string
+
+	// principalKind and principalRef are derived by Validate from exactly
+	// one of User, Team, or Role.
+	principalKind string
+	principalRef  string
+}
+
+func (o *grantOpts) setup(flags *pflag.FlagSet) {
+	flags.StringVar(&o.User, "user", "", "User to grant to (numeric ID or UID)")
+	flags.StringVar(&o.Team, "team", "", "Team to grant to (numeric ID or UID)")
+	flags.StringVar(&o.Role, "role", "", "Built-in role to grant to (e.g. Viewer, Editor, Admin)")
+	flags.StringVar(&o.Level, "level", "", "Permission level (e.g. View, Edit, Admin)")
+}
+
+// Validate checks that exactly one of --user, --team, or --role was provided
+// alongside --level, and records the resolved principal kind/ref for RunE.
+func (o *grantOpts) Validate() error {
+	o.principalKind, o.principalRef = "", ""
+	set := 0
+	if o.User != "" {
+		set++
+		o.principalKind, o.principalRef = "user", o.User
+	}
+	if o.Team != "" {
+		set++
+		o.principalKind, o.principalRef = "team", o.Team
+	}
+	if o.Role != "" {
+		set++
+		o.principalKind, o.principalRef = "role", o.Role
+	}
+	if set != 1 {
+		return errors.New("provide exactly one of --user, --team, or --role")
+	}
+	if o.Level == "" {
+		return errors.New("--level is required (e.g. View, Edit, Admin; use \"\" via set to remove)")
+	}
+	return nil
+}
+
+func newGrantCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &grantOpts{}
+	cmd := &cobra.Command{
+		Use:   "grant <resource> <id>",
+		Short: "Grant a permission level to a single user, team, or built-in role.",
+		Long: "Grant a permission level to a single principal on a resource instance.\n\n" +
+			"Specify exactly one of --user, --team, or --role, plus --level.\n\n" + resourceArgHelp,
+		Example: "  gcx permissions grant dashboards my-uid --team 3 --level Edit\n" +
+			"  gcx permissions grant folders my-uid --role Viewer --level View\n" +
+			"  gcx permissions grant datasources my-uid --user alice --level Admin",
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateResource(args[0]); err != nil {
+				return err
+			}
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := clientFromLoader(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			resource, id := args[0], args[1]
+			switch opts.principalKind {
+			case "user":
+				err = client.SetUserPermission(ctx, resource, id, opts.principalRef, opts.Level)
+			case "team":
+				err = client.SetTeamPermission(ctx, resource, id, opts.principalRef, opts.Level)
+			case "role":
+				err = client.SetBuiltInRolePermission(ctx, resource, id, opts.principalRef, opts.Level)
+			}
+			if err != nil {
+				return err
+			}
+			cmdio.Success(cmd.OutOrStdout(), "granted %s permission to %s %s on %s %s", opts.Level, opts.principalKind, opts.principalRef, resource, id)
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---- levels ----
+
+type levelsOpts struct {
+	IO cmdio.Options
+}
+
+func (o *levelsOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &DescriptionTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newLevelsCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &levelsOpts{}
+	cmd := &cobra.Command{
+		Use:     "levels <resource>",
+		Short:   "Show the assignable permission levels for a resource kind.",
+		Long:    "Show the assignable permission levels and assignment types for a resource kind.\n\n" + resourceArgHelp,
+		Example: "  gcx permissions levels dashboards",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateResource(args[0]); err != nil {
+				return err
+			}
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			client, err := clientFromLoader(ctx, loader)
+			if err != nil {
+				return err
+			}
+			desc, err := client.Describe(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), desc)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---- input parsing ----
+
+// readPermissionsFromFile reads a JSON permission set from path (or stdin for
+// "-"). The input may be a bare array of assignments or a {"permissions":[...]}
+// envelope.
+func readPermissionsFromFile(path string, stdin io.Reader) ([]SetResourcePermissionCommand, error) {
+	if path == "" {
+		return nil, errors.New("--file is required")
+	}
+	data, err := coreapi.ReadInput(path, stdin)
+	if err != nil {
+		return nil, err
+	}
+	return parsePermissions(data)
+}
+
+// parsePermissions accepts either a bare JSON array or a {"permissions":[…]}
+// envelope. It rejects nil/empty results rather than returning them: an empty
+// result here would make Client.Set POST {"permissions": null}, wiping every
+// managed permission on the resource, so unrecognized or empty JSON shapes
+// must fail loudly instead of decoding into a silent no-op.
+func parsePermissions(data []byte) ([]SetResourcePermissionCommand, error) {
+	var perms []SetResourcePermissionCommand
+	if err := json.Unmarshal(data, &perms); err != nil {
+		// Not a bare array: require the {"permissions":[...]} envelope shape,
+		// rejecting any unrecognized keys.
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		var envelope setPermissionsBody
+		if err := dec.Decode(&envelope); err != nil {
+			return nil, fmt.Errorf("failed to parse permissions: expected JSON array or object with 'permissions' field: %w", err)
+		}
+		perms = envelope.Permissions
+	}
+	if len(perms) == 0 {
+		return nil, errors.New("permissions payload is empty")
+	}
+	return perms, nil
+}
+
+// ---- table codecs ----
+
+// PermissionsTableCodec renders a resource's permission list as a table.
+type PermissionsTableCodec struct{}
+
+// Format reports the codec's output format identifier.
+func (c *PermissionsTableCodec) Format() format.Format { return "table" }
+
+// Encode writes the table representation of v to w.
+func (c *PermissionsTableCodec) Encode(w io.Writer, v any) error {
+	perms, ok := v.([]ResourcePermission)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []ResourcePermission")
+	}
+	t := style.NewTable("PERMISSION", "USER", "TEAM", "BUILT-IN ROLE", "MANAGED", "INHERITED")
+	for _, p := range perms {
+		user := p.UserLogin
+		if user == "" && p.UserID != 0 {
+			user = strconv.FormatInt(p.UserID, 10)
+		}
+		team := p.Team
+		if team == "" && p.TeamID != 0 {
+			team = strconv.FormatInt(p.TeamID, 10)
+		}
+		t.Row(p.Permission, user, team, p.BuiltInRole, boolStr(p.IsManaged), boolStr(p.IsInherited))
+	}
+	return t.Render(w)
+}
+
+// Decode is not supported for the table codec.
+func (c *PermissionsTableCodec) Decode(io.Reader, any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// DescriptionTableCodec renders a resource's assignable levels as a table.
+type DescriptionTableCodec struct{}
+
+// Format reports the codec's output format identifier.
+func (c *DescriptionTableCodec) Format() format.Format { return "table" }
+
+// Encode writes the table representation of v to w.
+func (c *DescriptionTableCodec) Encode(w io.Writer, v any) error {
+	desc, ok := v.(*Description)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected *Description")
+	}
+	t := style.NewTable("ASSIGNABLE LEVEL", "ASSIGNMENT TYPES")
+	types := assignmentTypes(desc.Assignments)
+	for i, level := range desc.Permissions {
+		typesCell := ""
+		if i == 0 {
+			typesCell = strings.Join(types, ", ")
+		}
+		t.Row(level, typesCell)
+	}
+	return t.Render(w)
+}
+
+// Decode is not supported for the table codec.
+func (c *DescriptionTableCodec) Decode(io.Reader, any) error {
+	return errors.New("table format does not support decoding")
+}
+
+func assignmentTypes(a Assignments) []string {
+	var out []string
+	if a.Users {
+		out = append(out, "users")
+	}
+	if a.ServiceAccounts {
+		out = append(out, "serviceAccounts")
+	}
+	if a.Teams {
+		out = append(out, "teams")
+	}
+	if a.BuiltInRoles {
+		out = append(out, "builtInRoles")
+	}
+	return out
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/providers/permissions/commands_test.go
+++ b/internal/providers/permissions/commands_test.go
@@ -1,0 +1,199 @@
+package permissions_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/permissions"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider_CommandShape(t *testing.T) {
+	p := &permissions.PermissionsProvider{}
+	cmds := p.Commands()
+	require.Len(t, cmds, 1)
+	root := cmds[0]
+	assert.Equal(t, "permissions", root.Use)
+
+	subNames := make([]string, 0, len(root.Commands()))
+	for _, c := range root.Commands() {
+		subNames = append(subNames, strings.Fields(c.Use)[0])
+	}
+	assert.ElementsMatch(t, []string{"get", "set", "grant", "levels"}, subNames)
+
+	// Command-only provider: no adapter registrations.
+	assert.Empty(t, p.TypedRegistrations())
+}
+
+func TestGetCommand_RejectsInvalidResource(t *testing.T) {
+	p := &permissions.PermissionsProvider{}
+	root := p.Commands()[0]
+	root.SetArgs([]string{"get", "widgets", "some-id"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid resource")
+}
+
+func TestGrantCommand_RequiresExactlyOnePrincipal(t *testing.T) {
+	p := &permissions.PermissionsProvider{}
+	root := p.Commands()[0]
+	root.SetArgs([]string{"grant", "dashboards", "d1", "--user", "1", "--team", "2", "--level", "Edit"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
+}
+
+func TestSetCommand_DeclineConfirmationSkipsOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "acl.json")
+	require.NoError(t, os.WriteFile(file, []byte(`[{"permission":"Edit","userId":1}]`), 0o600))
+
+	p := &permissions.PermissionsProvider{}
+	root := p.Commands()[0]
+	root.SetArgs([]string{"set", "dashboards", "d1", "-f", file})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetIn(strings.NewReader("n\n"))
+
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "[y/N]")
+	assert.NotContains(t, out.String(), "updated permissions")
+}
+
+// TestSetCommand_RejectsEmptyOrUnrecognizedPermissionsPayload covers the
+// data-loss bug where parsing silently produced an empty permission list for
+// JSON shapes that don't match the documented bare-array or
+// {"permissions":[...]} envelope. Client.Set would then POST
+// {"permissions": null}, wiping every managed permission on the resource.
+// --force is passed so parsing/validation failures surface before any
+// confirmation prompt or network call.
+func TestSetCommand_RejectsEmptyOrUnrecognizedPermissionsPayload(t *testing.T) {
+	tests := []struct {
+		name          string
+		payload       string
+		wantErrSubstr string
+	}{
+		{"empty array", `[]`, "permissions payload is empty"},
+		{"null", `null`, "permissions payload is empty"},
+		{"empty envelope", `{}`, "permissions payload is empty"},
+		// A natural mistake given the sibling `grant` command's flags: this
+		// looks like a permission assignment but isn't the documented
+		// envelope shape.
+		{"unrecognized envelope shape", `{"userId":1,"permission":"Edit"}`, "failed to parse permissions"},
+		{"wrong envelope key", `{"perms":[{"permission":"Edit","userId":1}]}`, "failed to parse permissions"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			file := filepath.Join(dir, "acl.json")
+			require.NoError(t, os.WriteFile(file, []byte(tt.payload), 0o600))
+
+			p := &permissions.PermissionsProvider{}
+			root := p.Commands()[0]
+			root.SetArgs([]string{"set", "dashboards", "d1", "-f", file, "--force"})
+			var out bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&out)
+
+			err := root.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrSubstr)
+		})
+	}
+}
+
+func TestSetCommand_AcceptsRecognizedPermissionsPayloadShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{"bare array", `[{"permission":"Edit","userId":1}]`},
+		{"envelope", `{"permissions":[{"permission":"Admin","teamId":2}]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			file := filepath.Join(dir, "acl.json")
+			require.NoError(t, os.WriteFile(file, []byte(tt.payload), 0o600))
+
+			p := &permissions.PermissionsProvider{}
+			root := p.Commands()[0]
+			root.SetArgs([]string{"set", "dashboards", "d1", "-f", file, "--force"})
+			var out bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&out)
+
+			// A recognized payload parses successfully; the command goes on
+			// to fail at client/config loading in this unconfigured test
+			// environment, but that failure must not be a parsing error.
+			err := root.Execute()
+			if err != nil {
+				assert.NotContains(t, err.Error(), "permissions payload is empty")
+				assert.NotContains(t, err.Error(), "failed to parse permissions")
+			}
+		})
+	}
+}
+
+func TestSetCommand_ForceSkipsConfirmationPrompt(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "acl.json")
+	require.NoError(t, os.WriteFile(file, []byte(`[{"permission":"Edit","userId":1}]`), 0o600))
+
+	p := &permissions.PermissionsProvider{}
+	root := p.Commands()[0]
+	root.SetArgs([]string{"set", "dashboards", "d1", "-f", file, "--force"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	// --force bypasses the prompt; the command then goes on to load a
+	// Grafana client from the (unconfigured) test context and fails there —
+	// what matters here is only that no confirmation prompt was shown.
+	_ = root.Execute()
+	assert.NotContains(t, out.String(), "[y/N]")
+	assert.NotContains(t, out.String(), "Aborted.")
+}
+
+func TestPermissionsTableCodec(t *testing.T) {
+	codec := &permissions.PermissionsTableCodec{}
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, []permissions.ResourcePermission{
+		{BuiltInRole: "Editor", Permission: "Edit", IsManaged: true},
+		{UserLogin: "alice", Permission: "Admin"},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "PERMISSION")
+	assert.Contains(t, out, "BUILT-IN ROLE")
+	assert.Contains(t, out, "Editor")
+	assert.Contains(t, out, "alice")
+}
+
+func TestDescriptionTableCodec(t *testing.T) {
+	codec := &permissions.DescriptionTableCodec{}
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, &permissions.Description{
+		Assignments: permissions.Assignments{Users: true, Teams: true},
+		Permissions: []string{"View", "Edit", "Admin"},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "ASSIGNABLE LEVEL")
+	assert.Contains(t, out, "View")
+	assert.Contains(t, out, "users")
+}

--- a/internal/providers/permissions/provider.go
+++ b/internal/providers/permissions/provider.go
@@ -1,0 +1,64 @@
+package permissions
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/spf13/cobra"
+)
+
+var _ providers.Provider = &PermissionsProvider{}
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	providers.Register(&PermissionsProvider{})
+}
+
+// PermissionsProvider manages Grafana resource permissions via the granular
+// access-control (RBAC) API.
+type PermissionsProvider struct{}
+
+// Name returns the unique identifier for this provider.
+func (p *PermissionsProvider) Name() string { return "permissions" }
+
+// ShortDesc returns a one-line description of the provider.
+func (p *PermissionsProvider) ShortDesc() string {
+	return "Manage Grafana resource permissions (RBAC)"
+}
+
+// Commands returns the Cobra commands contributed by this provider.
+func (p *PermissionsProvider) Commands() []*cobra.Command {
+	loader := &providers.ConfigLoader{}
+
+	root := &cobra.Command{
+		Use:   "permissions",
+		Short: p.ShortDesc(),
+		Long: "Manage Grafana resource permissions via the granular access-control (RBAC) API.\n\n" +
+			"Supported resources: folders, dashboards, datasources, teams, serviceaccounts.\n" +
+			"Reads work on all editions; writes require RBAC (Grafana Enterprise or Cloud).",
+	}
+	root.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if r := cmd.Root(); r != root && r.PersistentPreRun != nil {
+			r.PersistentPreRun(cmd, args)
+		}
+	}
+
+	loader.BindFlags(root.PersistentFlags())
+	root.AddCommand(
+		newGetCommand(loader),
+		newSetCommand(loader),
+		newGrantCommand(loader),
+		newLevelsCommand(loader),
+	)
+
+	return []*cobra.Command{root}
+}
+
+// Validate checks that the given provider configuration is valid.
+func (p *PermissionsProvider) Validate(map[string]string) error { return nil }
+
+// ConfigKeys returns the configuration keys used by this provider.
+func (p *PermissionsProvider) ConfigKeys() []providers.ConfigKey { return nil }
+
+// TypedRegistrations returns no adapter registrations: RBAC permissions are a
+// per-resource attribute across five resource kinds, not standalone resources,
+// so this provider is command-only.
+func (p *PermissionsProvider) TypedRegistrations() []adapter.Registration { return nil }

--- a/internal/providers/permissions/types.go
+++ b/internal/providers/permissions/types.go
@@ -1,0 +1,80 @@
+// Package permissions provides commands for managing Grafana resource
+// permissions via the granular access-control (RBAC) API,
+// /api/access-control/{resource}/{resourceID}.
+package permissions
+
+import (
+	"fmt"
+	"slices"
+)
+
+// ValidResources are the resource kinds the granular RBAC permissions API
+// exposes. A management CLI targets these uniformly.
+//
+//nolint:gochecknoglobals // immutable lookup table.
+var ValidResources = []string{"folders", "dashboards", "datasources", "teams", "serviceaccounts"}
+
+// validateResource returns an error if resource is not a supported RBAC
+// permission resource kind.
+func validateResource(resource string) error {
+	if !slices.Contains(ValidResources, resource) {
+		return fmt.Errorf("invalid resource %q: must be one of %v", resource, ValidResources)
+	}
+	return nil
+}
+
+// ResourcePermission is one entry in a resource's permission list, as returned
+// by GET /api/access-control/{resource}/{resourceID}.
+type ResourcePermission struct {
+	ID               int64    `json:"id"`
+	RoleName         string   `json:"roleName,omitempty"`
+	IsManaged        bool     `json:"isManaged"`
+	IsInherited      bool     `json:"isInherited"`
+	IsServiceAccount bool     `json:"isServiceAccount"`
+	UserID           int64    `json:"userId,omitempty"`
+	UserUID          string   `json:"userUid,omitempty"`
+	UserLogin        string   `json:"userLogin,omitempty"`
+	Team             string   `json:"team,omitempty"`
+	TeamID           int64    `json:"teamId,omitempty"`
+	TeamUID          string   `json:"teamUid,omitempty"`
+	BuiltInRole      string   `json:"builtInRole,omitempty"`
+	Actions          []string `json:"actions,omitempty"`
+	Permission       string   `json:"permission"`
+}
+
+// Description reports the assignable permission levels and assignment types for
+// a resource kind, as returned by GET /api/access-control/{resource}/description.
+type Description struct {
+	Assignments Assignments `json:"assignments"`
+	Permissions []string    `json:"permissions"`
+}
+
+// Assignments reports which principal types can be assigned permissions on a
+// resource kind.
+type Assignments struct {
+	Users           bool `json:"users"`
+	ServiceAccounts bool `json:"serviceAccounts"`
+	Teams           bool `json:"teams"`
+	BuiltInRoles    bool `json:"builtInRoles"`
+}
+
+// SetResourcePermissionCommand is one assignment in a full permission-set
+// request. Provide exactly one of UserID, TeamID, or BuiltInRole.
+type SetResourcePermissionCommand struct {
+	UserID      int64  `json:"userId,omitempty"`
+	TeamID      int64  `json:"teamId,omitempty"`
+	BuiltInRole string `json:"builtInRole,omitempty"`
+	Permission  string `json:"permission"`
+}
+
+// setPermissionsBody is the request body for POST /api/access-control/{resource}/{resourceID}.
+type setPermissionsBody struct {
+	Permissions []SetResourcePermissionCommand `json:"permissions"`
+}
+
+// setPermissionBody is the request body for the per-principal grant endpoints
+// (.../users/{id}, .../teams/{id}, .../builtInRoles/{role}). An empty
+// Permission removes the assignment.
+type setPermissionBody struct {
+	Permission string `json:"permission"`
+}

--- a/internal/providers/publicdashboards/client.go
+++ b/internal/providers/publicdashboards/client.go
@@ -1,0 +1,76 @@
+package publicdashboards
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/coreapi"
+)
+
+const listPath = "/api/dashboards/public-dashboards"
+
+// Client is a Grafana Public Dashboards API client.
+type Client struct {
+	base *coreapi.Client
+}
+
+// NewClient creates a new Public Dashboards client bound to the provided REST config.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	base, err := coreapi.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{base: base}, nil
+}
+
+func dashboardPath(dashboardUID string) string {
+	return fmt.Sprintf("/api/dashboards/uid/%s/public-dashboards", url.PathEscape(dashboardUID))
+}
+
+func dashboardItemPath(dashboardUID, pdUID string) string {
+	return fmt.Sprintf("/api/dashboards/uid/%s/public-dashboards/%s", url.PathEscape(dashboardUID), url.PathEscape(pdUID))
+}
+
+// List returns all public dashboards in the stack.
+func (c *Client) List(ctx context.Context) ([]PublicDashboard, error) {
+	wrapper, err := coreapi.DoJSON[any, listResp](ctx, c.base, http.MethodGet, listPath, nil, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return wrapper.PublicDashboards, nil
+}
+
+// Get returns the public dashboard config for the given parent dashboard UID.
+func (c *Client) Get(ctx context.Context, dashboardUID string) (*PublicDashboard, error) {
+	pd, err := coreapi.DoJSON[any, PublicDashboard](ctx, c.base, http.MethodGet, dashboardPath(dashboardUID), nil, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return &pd, nil
+}
+
+// Create creates a new public dashboard config for the given parent dashboard UID.
+func (c *Client) Create(ctx context.Context, dashboardUID string, pd *PublicDashboard) (*PublicDashboard, error) {
+	created, err := coreapi.DoJSON[PublicDashboard, PublicDashboard](ctx, c.base, http.MethodPost, dashboardPath(dashboardUID), pd, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return &created, nil
+}
+
+// Update patches an existing public dashboard config.
+func (c *Client) Update(ctx context.Context, dashboardUID, pdUID string, pd *PublicDashboard) (*PublicDashboard, error) {
+	updated, err := coreapi.DoJSON[PublicDashboard, PublicDashboard](ctx, c.base, http.MethodPatch, dashboardItemPath(dashboardUID, pdUID), pd, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return &updated, nil
+}
+
+// Delete removes a public dashboard config.
+func (c *Client) Delete(ctx context.Context, dashboardUID, pdUID string) error {
+	return coreapi.DoStatus[any](ctx, c.base, http.MethodDelete, dashboardItemPath(dashboardUID, pdUID), nil, http.StatusOK)
+}

--- a/internal/providers/publicdashboards/client_test.go
+++ b/internal/providers/publicdashboards/client_test.go
@@ -1,0 +1,251 @@
+package publicdashboards_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/publicdashboards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func newTestClient(t *testing.T, server *httptest.Server) *publicdashboards.Client {
+	t.Helper()
+	cfg := config.NamespacedRESTConfig{
+		Config: rest.Config{Host: server.URL},
+	}
+	client, err := publicdashboards.NewClient(cfg)
+	require.NoError(t, err)
+	return client
+}
+
+// writeJSON encodes v as JSON to w.
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	_, _ = w.Write(data)
+}
+
+func TestClient_List(t *testing.T) {
+	tests := []struct {
+		name     string
+		handler  http.HandlerFunc
+		wantLen  int
+		wantErr  bool
+		firstUID string
+	}{
+		{
+			name: "success with items unwraps publicDashboards",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/api/dashboards/public-dashboards", r.URL.Path)
+				writeJSON(w, map[string]any{
+					"publicDashboards": []publicdashboards.PublicDashboard{
+						{UID: "pd-1", DashboardUID: "d-1", IsEnabled: new(true)},
+						{UID: "pd-2", DashboardUID: "d-2"},
+					},
+				})
+			},
+			wantLen:  2,
+			firstUID: "pd-1",
+		},
+		{
+			name: "empty list",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, map[string]any{"publicDashboards": []publicdashboards.PublicDashboard{}})
+			},
+			wantLen: 0,
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, `{"message":"boom"}`)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			list, err := client.List(t.Context())
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, list, tt.wantLen)
+			if tt.wantLen > 0 {
+				assert.Equal(t, tt.firstUID, list[0].UID)
+			}
+		})
+	}
+}
+
+func TestClient_Get(t *testing.T) {
+	tests := []struct {
+		name         string
+		dashboardUID string
+		handler      http.HandlerFunc
+		wantErr      bool
+	}{
+		{
+			name:         "success escapes uid",
+			dashboardUID: "abc 123",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				// r.URL.Path is the decoded form; the raw wire path comes through RequestURI.
+				assert.Equal(t, "/api/dashboards/uid/abc%20123/public-dashboards", r.RequestURI)
+				writeJSON(w, publicdashboards.PublicDashboard{UID: "pd-1", DashboardUID: "abc 123", IsEnabled: new(true)})
+			},
+		},
+		{
+			name:         "404 error",
+			dashboardUID: "missing",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.WriteString(w, `{"message":"not found"}`)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			pd, err := client.Get(t.Context(), tt.dashboardUID)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, pd)
+			assert.Equal(t, "pd-1", pd.UID)
+		})
+	}
+}
+
+func TestClient_Create(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/dashboards/uid/dash-1/public-dashboards", r.URL.Path)
+
+		var body publicdashboards.PublicDashboard
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			return
+		}
+		if assert.NotNil(t, body.IsEnabled) {
+			assert.True(t, *body.IsEnabled)
+		}
+		assert.Equal(t, "public", body.Share)
+
+		writeJSON(w, publicdashboards.PublicDashboard{
+			UID:          "pd-new",
+			DashboardUID: "dash-1",
+			AccessToken:  "token-xyz",
+			IsEnabled:    new(true),
+			Share:        "public",
+		})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	created, err := client.Create(t.Context(), "dash-1", &publicdashboards.PublicDashboard{
+		IsEnabled: new(true),
+		Share:     "public",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assert.Equal(t, "pd-new", created.UID)
+	assert.Equal(t, "token-xyz", created.AccessToken)
+}
+
+func TestClient_Update(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/api/dashboards/uid/dash-1/public-dashboards/pd-1", r.URL.Path)
+
+		var body publicdashboards.PublicDashboard
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			return
+		}
+		if assert.NotNil(t, body.AnnotationsEnabled) {
+			assert.True(t, *body.AnnotationsEnabled)
+		}
+
+		writeJSON(w, publicdashboards.PublicDashboard{
+			UID:                "pd-1",
+			DashboardUID:       "dash-1",
+			AnnotationsEnabled: new(true),
+		})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	updated, err := client.Update(t.Context(), "dash-1", "pd-1", &publicdashboards.PublicDashboard{
+		AnnotationsEnabled: new(true),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, "pd-1", updated.UID)
+	require.NotNil(t, updated.AnnotationsEnabled)
+	assert.True(t, *updated.AnnotationsEnabled)
+}
+
+func TestClient_Delete(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name: "success",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodDelete, r.Method)
+				assert.Equal(t, "/api/dashboards/uid/dash-1/public-dashboards/pd-1", r.URL.Path)
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, `{"message":"oops"}`)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			err := client.Delete(t.Context(), "dash-1", "pd-1")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/providers/publicdashboards/commands.go
+++ b/internal/providers/publicdashboards/commands.go
@@ -16,10 +16,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// GrafanaConfigLoader is the loader interface used by command constructors.
-// It is an alias for RESTConfigLoader to keep existing test names stable.
-type GrafanaConfigLoader = RESTConfigLoader
-
 // boolLabel renders a nullable toggle: "yes"/"no" when set, "-" when unset
 // (the server always returns concrete values, so "-" only appears for a spec
 // that omitted the field).
@@ -76,7 +72,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for unlimited)")
 }
 
-func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
+func newListCommand(loader RESTConfigLoader) *cobra.Command {
 	opts := &listOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -151,7 +147,7 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newGetCommand(loader GrafanaConfigLoader) *cobra.Command {
+func newGetCommand(loader RESTConfigLoader) *cobra.Command {
 	opts := &getOpts{}
 	cmd := &cobra.Command{
 		Use:   "get PD_UID",
@@ -196,7 +192,7 @@ func (o *createOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.File, "file", "f", "", "File containing the public dashboard spec (JSON), or '-' for stdin (required)")
 }
 
-func newCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
+func newCreateCommand(loader RESTConfigLoader) *cobra.Command {
 	opts := &createOpts{}
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -253,7 +249,7 @@ func (o *updateOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.File, "file", "f", "", "File containing the public dashboard spec (JSON), or '-' for stdin (required)")
 }
 
-func newUpdateCommand(loader GrafanaConfigLoader) *cobra.Command {
+func newUpdateCommand(loader RESTConfigLoader) *cobra.Command {
 	opts := &updateOpts{}
 	cmd := &cobra.Command{
 		Use:   "update PD_UID",
@@ -303,7 +299,7 @@ type deleteOpts struct{}
 
 func (o *deleteOpts) setup(_ *pflag.FlagSet) {}
 
-func newDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
+func newDeleteCommand(loader RESTConfigLoader) *cobra.Command {
 	opts := &deleteOpts{}
 	cmd := &cobra.Command{
 		Use:   "delete PD_UID",

--- a/internal/providers/publicdashboards/commands.go
+++ b/internal/providers/publicdashboards/commands.go
@@ -1,0 +1,331 @@
+package publicdashboards
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/grafana/gcx/internal/coreapi"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// GrafanaConfigLoader is the loader interface used by command constructors.
+// It is an alias for RESTConfigLoader to keep existing test names stable.
+type GrafanaConfigLoader = RESTConfigLoader
+
+// boolLabel renders a nullable toggle: "yes"/"no" when set, "-" when unset
+// (the server always returns concrete values, so "-" only appears for a spec
+// that omitted the field).
+func boolLabel(v *bool) string {
+	switch {
+	case v == nil:
+		return "-"
+	case *v:
+		return "yes"
+	default:
+		return "no"
+	}
+}
+
+// readPublicDashboardSpec reads a JSON public dashboard spec from path, or from
+// stdin when path is "-".
+func readPublicDashboardSpec(path string, stdin io.Reader) (*PublicDashboard, error) {
+	data, err := coreapi.ReadInput(path, stdin)
+	if err != nil {
+		return nil, err
+	}
+
+	var pd PublicDashboard
+	if err := json.Unmarshal(data, &pd); err != nil {
+		return nil, fmt.Errorf("parsing public dashboard spec: %w", err)
+	}
+	return &pd, nil
+}
+
+// encodeOne encodes a single TypedObject[PublicDashboard], wrapping it in a
+// slice so the table codec can render it uniformly with list results.
+func encodeOne(opts *cmdio.Options, w io.Writer, obj *adapter.TypedObject[PublicDashboard]) error {
+	codec, err := opts.Codec()
+	if err != nil {
+		return err
+	}
+	if codec.Format() == "table" {
+		return codec.Encode(w, []adapter.TypedObject[PublicDashboard]{*obj})
+	}
+	return opts.Encode(w, obj)
+}
+
+// ---- list ----
+
+type listOpts struct {
+	IO    cmdio.Options
+	Limit int64
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ListTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of items to return (0 for unlimited)")
+}
+
+func newListCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &listOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all public dashboards.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			typedObjs, err := crud.List(ctx, opts.Limit)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), typedObjs)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ListTableCodec renders public dashboards as a tabular table.
+// It consumes []adapter.TypedObject[PublicDashboard].
+type ListTableCodec struct{}
+
+// Format returns the output format name.
+func (c *ListTableCodec) Format() format.Format { return "table" }
+
+// Encode writes public dashboards to w as a table.
+func (c *ListTableCodec) Encode(w io.Writer, v any) error {
+	objs, ok := v.([]adapter.TypedObject[PublicDashboard])
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []TypedObject[PublicDashboard]")
+	}
+
+	t := style.NewTable("DASHBOARD_UID", "PD_UID", "ACCESS_TOKEN", "ENABLED", "ANNOTATIONS", "TIME_SELECT", "SHARE")
+	for _, obj := range objs {
+		pd := obj.Spec
+		t.Row(
+			pd.DashboardUID,
+			pd.UID,
+			pd.AccessToken,
+			boolLabel(pd.IsEnabled),
+			boolLabel(pd.AnnotationsEnabled),
+			boolLabel(pd.TimeSelectionEnabled),
+			pd.Share,
+		)
+	}
+	return t.Render(w)
+}
+
+// Decode is not supported for table format.
+func (c *ListTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+// ---- get ----
+
+type getOpts struct {
+	IO cmdio.Options
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ListTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+func newGetCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:   "get PD_UID",
+		Short: "Get a public dashboard by its UID.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			crud, _, err := NewTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			obj, err := crud.Get(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			return encodeOne(&opts.IO, cmd.OutOrStdout(), obj)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// ---- create ----
+
+type createOpts struct {
+	IO           cmdio.Options
+	DashboardUID string
+	File         string
+}
+
+func (o *createOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ListTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.DashboardUID, "dashboard-uid", "", "Parent dashboard UID (required)")
+	flags.StringVarP(&o.File, "file", "f", "", "File containing the public dashboard spec (JSON), or '-' for stdin (required)")
+}
+
+func newCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &createOpts{}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a public dashboard config from a JSON file.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			spec, err := readPublicDashboardSpec(opts.File, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+			// The --dashboard-uid flag is authoritative for the parent dashboard.
+			spec.DashboardUID = opts.DashboardUID
+
+			ctx := cmd.Context()
+			crud, restCfg, err := NewTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			typedObj := &adapter.TypedObject[PublicDashboard]{Spec: *spec}
+			typedObj.SetName(spec.UID)
+			typedObj.SetNamespace(restCfg.Namespace)
+
+			created, err := crud.Create(ctx, typedObj)
+			if err != nil {
+				return err
+			}
+
+			return encodeOne(&opts.IO, cmd.OutOrStdout(), created)
+		},
+	}
+	opts.setup(cmd.Flags())
+	_ = cmd.MarkFlagRequired("dashboard-uid")
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+// ---- update ----
+
+type updateOpts struct {
+	IO           cmdio.Options
+	DashboardUID string
+	File         string
+}
+
+func (o *updateOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &ListTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.DashboardUID, "dashboard-uid", "", "Parent dashboard UID (required)")
+	flags.StringVarP(&o.File, "file", "f", "", "File containing the public dashboard spec (JSON), or '-' for stdin (required)")
+}
+
+func newUpdateCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &updateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update PD_UID",
+		Short: "Update a public dashboard config from a JSON file.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+
+			spec, err := readPublicDashboardSpec(opts.File, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+			// The --dashboard-uid flag is authoritative for the parent dashboard.
+			spec.DashboardUID = opts.DashboardUID
+
+			ctx := cmd.Context()
+			name := args[0]
+
+			crud, restCfg, err := NewTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			typedObj := &adapter.TypedObject[PublicDashboard]{Spec: *spec}
+			typedObj.SetName(name)
+			typedObj.SetNamespace(restCfg.Namespace)
+
+			updated, err := crud.Update(ctx, name, typedObj)
+			if err != nil {
+				return err
+			}
+
+			return encodeOne(&opts.IO, cmd.OutOrStdout(), updated)
+		},
+	}
+	opts.setup(cmd.Flags())
+	_ = cmd.MarkFlagRequired("dashboard-uid")
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+// ---- delete ----
+
+type deleteOpts struct{}
+
+func (o *deleteOpts) setup(_ *pflag.FlagSet) {}
+
+func newDeleteCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &deleteOpts{}
+	cmd := &cobra.Command{
+		Use:   "delete PD_UID",
+		Short: "Delete a public dashboard config.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			name := args[0]
+
+			crud, _, err := NewTypedCRUD(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			if err := crud.Delete(ctx, name); err != nil {
+				return err
+			}
+
+			cmdio.Info(cmd.OutOrStdout(), "deleted public dashboard %s", strconv.Quote(name))
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/publicdashboards/commands_test.go
+++ b/internal/providers/publicdashboards/commands_test.go
@@ -1,0 +1,111 @@
+package publicdashboards_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/publicdashboards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubLoader implements GrafanaConfigLoader for tests without triggering real config loading.
+type stubLoader struct{}
+
+func (stubLoader) LoadGrafanaConfig(_ context.Context) (config.NamespacedRESTConfig, error) {
+	return config.NamespacedRESTConfig{}, assert.AnError
+}
+
+func TestReadPublicDashboardSpec_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pd.json")
+	payload := []byte(`{"isEnabled":true,"annotationsEnabled":true,"share":"public"}`)
+	require.NoError(t, os.WriteFile(path, payload, 0o600))
+
+	pd, err := publicdashboards.ReadPublicDashboardSpecForTest(path, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pd)
+	require.NotNil(t, pd.IsEnabled)
+	assert.True(t, *pd.IsEnabled)
+	require.NotNil(t, pd.AnnotationsEnabled)
+	assert.True(t, *pd.AnnotationsEnabled)
+	assert.Equal(t, "public", pd.Share)
+}
+
+func TestReadPublicDashboardSpec_FromStdin(t *testing.T) {
+	payload := []byte(`{"isEnabled":false,"share":"public_with_email"}`)
+	pd, err := publicdashboards.ReadPublicDashboardSpecForTest("-", bytes.NewReader(payload))
+	require.NoError(t, err)
+	require.NotNil(t, pd)
+	require.NotNil(t, pd.IsEnabled)
+	assert.False(t, *pd.IsEnabled)
+	assert.Equal(t, "public_with_email", pd.Share)
+}
+
+// TestReadPublicDashboardSpec_PartialOmitsToggles proves the PATCH bug fix: a
+// partial spec that omits the toggle fields yields nil pointers (not false), so
+// marshaling the spec into a PATCH body omits them and the server preserves the
+// existing values instead of silently disabling the dashboard.
+func TestReadPublicDashboardSpec_PartialOmitsToggles(t *testing.T) {
+	pd, err := publicdashboards.ReadPublicDashboardSpecForTest("-", bytes.NewReader([]byte(`{"share":"public"}`)))
+	require.NoError(t, err)
+	require.NotNil(t, pd)
+	assert.Nil(t, pd.IsEnabled, "omitted isEnabled must stay nil, not default to false")
+	assert.Nil(t, pd.AnnotationsEnabled)
+	assert.Nil(t, pd.TimeSelectionEnabled)
+
+	body, err := json.Marshal(pd)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "isEnabled")
+	assert.NotContains(t, string(body), "annotationsEnabled")
+	assert.NotContains(t, string(body), "timeSelectionEnabled")
+}
+
+func TestReadPublicDashboardSpec_BadJSON(t *testing.T) {
+	_, err := publicdashboards.ReadPublicDashboardSpecForTest("-", bytes.NewReader([]byte("not json")))
+	require.Error(t, err)
+}
+
+func TestReadPublicDashboardSpec_FileMissing(t *testing.T) {
+	_, err := publicdashboards.ReadPublicDashboardSpecForTest(filepath.Join(t.TempDir(), "missing.json"), nil)
+	require.Error(t, err)
+}
+
+func TestCreateCommand_RequiredFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantInError string
+	}{
+		{
+			name:        "missing dashboard-uid",
+			args:        []string{"-f", "pd.json"},
+			wantInError: "dashboard-uid",
+		},
+		{
+			name:        "missing file",
+			args:        []string{"--dashboard-uid", "abc"},
+			wantInError: "file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := publicdashboards.NewCreateCommandForTest(stubLoader{})
+			cmd.SetArgs(tt.args)
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantInError)
+		})
+	}
+}

--- a/internal/providers/publicdashboards/commands_test.go
+++ b/internal/providers/publicdashboards/commands_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// stubLoader implements GrafanaConfigLoader for tests without triggering real config loading.
+// stubLoader implements RESTConfigLoader for tests without triggering real config loading.
 type stubLoader struct{}
 
 func (stubLoader) LoadGrafanaConfig(_ context.Context) (config.NamespacedRESTConfig, error) {

--- a/internal/providers/publicdashboards/export_test.go
+++ b/internal/providers/publicdashboards/export_test.go
@@ -1,0 +1,17 @@
+package publicdashboards
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// ReadPublicDashboardSpecForTest exposes readPublicDashboardSpec for external tests.
+func ReadPublicDashboardSpecForTest(path string, stdin io.Reader) (*PublicDashboard, error) {
+	return readPublicDashboardSpec(path, stdin)
+}
+
+// NewCreateCommandForTest exposes newCreateCommand for external tests.
+func NewCreateCommandForTest(loader GrafanaConfigLoader) *cobra.Command {
+	return newCreateCommand(loader)
+}

--- a/internal/providers/publicdashboards/export_test.go
+++ b/internal/providers/publicdashboards/export_test.go
@@ -12,6 +12,6 @@ func ReadPublicDashboardSpecForTest(path string, stdin io.Reader) (*PublicDashbo
 }
 
 // NewCreateCommandForTest exposes newCreateCommand for external tests.
-func NewCreateCommandForTest(loader GrafanaConfigLoader) *cobra.Command {
+func NewCreateCommandForTest(loader RESTConfigLoader) *cobra.Command {
 	return newCreateCommand(loader)
 }

--- a/internal/providers/publicdashboards/provider.go
+++ b/internal/providers/publicdashboards/provider.go
@@ -1,0 +1,73 @@
+package publicdashboards
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/spf13/cobra"
+)
+
+var _ providers.Provider = &PublicDashboardsProvider{}
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	providers.Register(&PublicDashboardsProvider{})
+}
+
+// PublicDashboardsProvider manages Grafana public dashboard resources.
+type PublicDashboardsProvider struct{}
+
+// Name returns the unique identifier for this provider.
+func (p *PublicDashboardsProvider) Name() string { return "public-dashboards" }
+
+// ShortDesc returns a one-line description of the provider.
+func (p *PublicDashboardsProvider) ShortDesc() string { return "Manage public dashboards" }
+
+// Commands returns the Cobra commands contributed by this provider.
+func (p *PublicDashboardsProvider) Commands() []*cobra.Command {
+	loader := &providers.ConfigLoader{}
+
+	cmd := &cobra.Command{
+		Use:   "public-dashboards",
+		Short: p.ShortDesc(),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if root := cmd.Root(); root.PersistentPreRun != nil {
+				root.PersistentPreRun(cmd, args)
+			}
+		},
+	}
+
+	loader.BindFlags(cmd.PersistentFlags())
+
+	cmd.AddCommand(
+		newListCommand(loader),
+		newGetCommand(loader),
+		newCreateCommand(loader),
+		newUpdateCommand(loader),
+		newDeleteCommand(loader),
+	)
+
+	return []*cobra.Command{cmd}
+}
+
+// Validate checks that the given provider configuration is valid.
+func (p *PublicDashboardsProvider) Validate(_ map[string]string) error {
+	return nil
+}
+
+// ConfigKeys returns the configuration keys used by this provider.
+func (p *PublicDashboardsProvider) ConfigKeys() []providers.ConfigKey {
+	return nil
+}
+
+// TypedRegistrations returns adapter registrations for PublicDashboard resource types.
+func (p *PublicDashboardsProvider) TypedRegistrations() []adapter.Registration {
+	loader := &providers.ConfigLoader{}
+	return []adapter.Registration{
+		{
+			Factory:    NewAdapterFactory(loader),
+			Descriptor: staticDescriptor,
+			GVK:        staticDescriptor.GroupVersionKind(),
+			Schema:     PublicDashboardSchema(),
+			Example:    PublicDashboardExample(),
+		},
+	}
+}

--- a/internal/providers/publicdashboards/provider.go
+++ b/internal/providers/publicdashboards/provider.go
@@ -28,11 +28,14 @@ func (p *PublicDashboardsProvider) Commands() []*cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "public-dashboards",
 		Short: p.ShortDesc(),
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if root := cmd.Root(); root.PersistentPreRun != nil {
-				root.PersistentPreRun(cmd, args)
-			}
-		},
+	}
+	// Bubble parent PersistentPreRun when attached to a real CLI root; guard
+	// against self-recursion when cmd itself is used as the root (e.g. in
+	// isolated tests where cmd.Root() == cmd).
+	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
+		if root := c.Root(); root != cmd && root.PersistentPreRun != nil {
+			root.PersistentPreRun(c, args)
+		}
 	}
 
 	loader.BindFlags(cmd.PersistentFlags())

--- a/internal/providers/publicdashboards/resource_adapter.go
+++ b/internal/providers/publicdashboards/resource_adapter.go
@@ -1,0 +1,154 @@
+package publicdashboards
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	internalconfig "github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	// APIVersion is the API version for PublicDashboard resources.
+	APIVersion = "publicdashboards.ext.grafana.app/v1alpha1"
+	// Kind is the kind for PublicDashboard resources.
+	Kind = "PublicDashboard"
+)
+
+// staticDescriptor is the resource descriptor for PublicDashboard resources.
+//
+//nolint:gochecknoglobals // Static descriptor used in self-registration pattern.
+var staticDescriptor = resources.Descriptor{
+	GroupVersion: schema.GroupVersion{
+		Group:   "publicdashboards.ext.grafana.app",
+		Version: "v1alpha1",
+	},
+	Kind:     "PublicDashboard",
+	Singular: "publicdashboard",
+	Plural:   "publicdashboards",
+}
+
+// StaticDescriptor returns the resource descriptor for PublicDashboard.
+func StaticDescriptor() resources.Descriptor { return staticDescriptor }
+
+// PublicDashboardSchema returns a JSON Schema for the PublicDashboard resource type.
+func PublicDashboardSchema() json.RawMessage {
+	return adapter.SchemaFromType[PublicDashboard](StaticDescriptor())
+}
+
+// PublicDashboardExample returns an example PublicDashboard manifest as JSON.
+func PublicDashboardExample() json.RawMessage {
+	example := map[string]any{
+		"apiVersion": APIVersion,
+		"kind":       Kind,
+		"metadata": map[string]any{
+			"name": "pd-abc123",
+		},
+		"spec": map[string]any{
+			"uid":                  "pd-abc123",
+			"dashboardUid":         "dash-xyz",
+			"isEnabled":            true,
+			"annotationsEnabled":   false,
+			"timeSelectionEnabled": false,
+			"share":                "public",
+		},
+	}
+	b, err := json.Marshal(example)
+	if err != nil {
+		panic(fmt.Sprintf("publicdashboards: failed to marshal example: %v", err))
+	}
+	return b
+}
+
+// RESTConfigLoader can load a NamespacedRESTConfig from the active context.
+type RESTConfigLoader interface {
+	LoadGrafanaConfig(ctx context.Context) (internalconfig.NamespacedRESTConfig, error)
+}
+
+// NewAdapterFactory returns a lazy adapter.Factory for PublicDashboards.
+// The factory captures the RESTConfigLoader and constructs the client on first invocation.
+func NewAdapterFactory(loader RESTConfigLoader) adapter.Factory {
+	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
+		crud, _, err := NewTypedCRUD(ctx, loader)
+		if err != nil {
+			return nil, err
+		}
+		return crud.AsAdapter(), nil
+	}
+}
+
+// NewTypedCRUD creates a TypedCRUD[PublicDashboard] for use in commands and
+// the adapter factory. It loads the REST config and constructs the client.
+func NewTypedCRUD(ctx context.Context, loader RESTConfigLoader) (*adapter.TypedCRUD[PublicDashboard], internalconfig.NamespacedRESTConfig, error) {
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to load REST config for publicdashboards: %w", err)
+	}
+
+	client, err := NewClient(cfg)
+	if err != nil {
+		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to create publicdashboards client: %w", err)
+	}
+
+	crud := &adapter.TypedCRUD[PublicDashboard]{
+		ListFn: func(ctx context.Context, limit int64) ([]PublicDashboard, error) {
+			items, err := client.List(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return adapter.TruncateSlice(items, limit), nil
+		},
+
+		GetFn: func(ctx context.Context, name string) (*PublicDashboard, error) {
+			items, err := client.List(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for i := range items {
+				if items[i].UID == name {
+					pd := items[i]
+					return &pd, nil
+				}
+			}
+			return nil, fmt.Errorf("public dashboard %q: %w", name, adapter.ErrNotFound)
+		},
+
+		CreateFn: func(ctx context.Context, spec *PublicDashboard) (*PublicDashboard, error) {
+			if spec.DashboardUID == "" {
+				return nil, errors.New("spec.dashboardUid is required to create a public dashboard")
+			}
+			return client.Create(ctx, spec.DashboardUID, spec)
+		},
+
+		UpdateFn: func(ctx context.Context, name string, spec *PublicDashboard) (*PublicDashboard, error) {
+			if spec.DashboardUID == "" {
+				return nil, errors.New("spec.dashboardUid is required to update a public dashboard")
+			}
+			return client.Update(ctx, spec.DashboardUID, name, spec)
+		},
+
+		DeleteFn: func(ctx context.Context, name string) error {
+			items, err := client.List(ctx)
+			if err != nil {
+				return err
+			}
+			for _, pd := range items {
+				if pd.UID == name {
+					return client.Delete(ctx, pd.DashboardUID, name)
+				}
+			}
+			return fmt.Errorf("public dashboard %q: %w", name, adapter.ErrNotFound)
+		},
+
+		// AccessToken is server-generated; never round-trip it back to the server.
+		StripFields: []string{"accessToken"},
+		Namespace:   cfg.Namespace,
+		Descriptor:  staticDescriptor,
+	}
+
+	return crud, cfg, nil
+}

--- a/internal/providers/publicdashboards/types.go
+++ b/internal/providers/publicdashboards/types.go
@@ -1,0 +1,40 @@
+package publicdashboards
+
+// PublicDashboard represents a Grafana public dashboard configuration.
+//
+// A public dashboard has two UIDs: UID is the id of the public dashboard
+// itself (identifies THIS pd) and DashboardUID is the parent dashboard.
+// The K8s resource name is the PD UID (the leaf id); the parent DashboardUID
+// is carried in the spec.
+//
+//nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
+type PublicDashboard struct {
+	UID          string `json:"uid,omitempty"`
+	DashboardUID string `json:"dashboardUid,omitempty"`
+	AccessToken  string `json:"accessToken,omitempty"`
+	// The three toggles are pointers with omitempty so a partial update (e.g.
+	// `-f patch.json` containing only some fields) omits the unset ones from the
+	// PATCH body instead of sending them as false — which would otherwise
+	// silently disable the dashboard and its toggles server-side. A nil pointer
+	// means "leave unchanged"; a non-nil pointer sends the explicit value.
+	IsEnabled            *bool  `json:"isEnabled,omitempty"`
+	AnnotationsEnabled   *bool  `json:"annotationsEnabled,omitempty"`
+	TimeSelectionEnabled *bool  `json:"timeSelectionEnabled,omitempty"`
+	Share                string `json:"share,omitempty"`
+}
+
+// GetResourceName returns the public dashboard's own UID — the leaf id that
+// identifies this pd uniquely within the stack.
+func (pd PublicDashboard) GetResourceName() string {
+	return pd.UID
+}
+
+// SetResourceName restores the UID from a K8s metadata.name round-trip.
+func (pd *PublicDashboard) SetResourceName(name string) {
+	pd.UID = name
+}
+
+// listResp is the shape of the /api/dashboards/public-dashboards response.
+type listResp struct {
+	PublicDashboards []PublicDashboard `json:"publicDashboards"`
+}

--- a/internal/providers/publicdashboards/types_identity_test.go
+++ b/internal/providers/publicdashboards/types_identity_test.go
@@ -1,0 +1,62 @@
+package publicdashboards_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/publicdashboards"
+	"github.com/grafana/gcx/internal/resources/adapter"
+)
+
+// Compile-time assertion that *PublicDashboard satisfies ResourceIdentity.
+var _ adapter.ResourceIdentity = &publicdashboards.PublicDashboard{}
+
+func TestPublicDashboard_GetResourceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		pd       publicdashboards.PublicDashboard
+		wantName string
+	}{
+		{
+			name:     "returns UID",
+			pd:       publicdashboards.PublicDashboard{UID: "pd-abc123", DashboardUID: "dash-xyz"},
+			wantName: "pd-abc123",
+		},
+		{
+			name:     "empty UID returns empty",
+			pd:       publicdashboards.PublicDashboard{DashboardUID: "dash-xyz"},
+			wantName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.pd.GetResourceName(); got != tt.wantName {
+				t.Errorf("GetResourceName() = %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestPublicDashboard_SetResourceName(t *testing.T) {
+	pd := &publicdashboards.PublicDashboard{DashboardUID: "dash-xyz"}
+	pd.SetResourceName("pd-abc123")
+	if pd.UID != "pd-abc123" {
+		t.Errorf("UID = %q, want %q", pd.UID, "pd-abc123")
+	}
+	// Parent UID must be preserved.
+	if pd.DashboardUID != "dash-xyz" {
+		t.Errorf("DashboardUID = %q, want %q", pd.DashboardUID, "dash-xyz")
+	}
+}
+
+func TestPublicDashboard_RoundTripIdentity(t *testing.T) {
+	original := publicdashboards.PublicDashboard{UID: "pd-abc123", DashboardUID: "dash-xyz"}
+	name := original.GetResourceName()
+
+	restored := &publicdashboards.PublicDashboard{}
+	restored.SetResourceName(name)
+
+	if restored.UID != original.UID {
+		t.Errorf("round-trip UID = %q, want %q", restored.UID, original.UID)
+	}
+}


### PR DESCRIPTION
Part **4 of 5** of the stack splitting #918. **Base: `split/org` (#922)**.

## What
Adds `gcx public-dashboards` — list / get / create / update / delete — backed by `/api/dashboards/uid/{uid}/public-dashboards` via the shared `coreapi` client. Bridges into the resources pipeline via `TypedRegistrations` (pd-UID as the K8s resource name).

**Includes the partial-PATCH fix:** the three toggle fields (`isEnabled`, `annotationsEnabled`, `timeSelectionEnabled`) are `*bool` with `omitempty`, so a partial `-f patch.json` omits unset fields from the PATCH body and the server preserves their current values — instead of silently disabling the dashboard and both toggles. A nil pointer means "leave unchanged"; a non-nil pointer sends the explicit value (including `false`). Regression test included.

## Stack
1. `coreapi` → `main` (#920)
2. annotations → coreapi (#921)
3. org users → annotations (#922)
4. **public-dashboards (this PR)** → org
5. permissions → public-dashboards

## Test plan
- [x] `go build` clean
- [x] `go test ./internal/providers/publicdashboards/... ./internal/agent/...`
- [x] `golangci-lint run` — 0 issues
- [x] `mise run reference` — CLI reference regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)