### PR TITLE
perf(config): skip /bootdata namespace validation when stack-id is set

### DIFF
--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -121,7 +121,7 @@ func (opts *Options) LoadConfig(ctx context.Context) (config.Config, error) {
 			return config.ContextNotFound(cfg.CurrentContext)
 		}
 
-		return cfg.GetCurrentContext().Validate()
+		return cfg.GetCurrentContext().Validate(ctx)
 	}
 
 	return opts.LoadConfigTolerant(ctx, validator)
@@ -400,7 +400,7 @@ func checkContext(cmd *cobra.Command, cfg config.Config, gCtx *config.Context, s
 	cmd.Println(cmdio.Yellow(title))
 	cmd.Println(cmdio.Yellow(strings.Repeat("=", titleLen)))
 
-	if err := gCtx.Validate(); err != nil {
+	if err := gCtx.Validate(cmd.Context()); err != nil {
 		cmdio.Error(stdout, "Configuration: %s", cmdio.Red(summarizeError(err)))
 		cmdio.Warning(stdout, "Connectivity: %s", cmdio.Yellow("skipped"))
 		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped")+"\n")

--- a/internal/config/export_test.go
+++ b/internal/config/export_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"strings"
+
 	"github.com/grafana/gcx/internal/auth"
 	"github.com/grafana/gcx/internal/credentials"
 )
@@ -21,4 +23,18 @@ func (n *NamespacedRESTConfig) OnRefreshForTest() auth.TokenRefresher {
 		return nil
 	}
 	return n.oauthTransport.OnRefresh
+}
+
+// SeedStackIDCacheForTest primes the process-lifetime stack-ID discovery cache
+// for a server, then returns a function that clears the whole cache. Exposed
+// solely for tests in config_test that exercise the cache-peek mismatch path.
+func SeedStackIDCacheForTest(server string, stackID int64) func() {
+	stackIDCacheMu.Lock()
+	stackIDCache[strings.TrimSuffix(server, "/")] = stackID
+	stackIDCacheMu.Unlock()
+	return func() {
+		stackIDCacheMu.Lock()
+		stackIDCache = map[string]int64{}
+		stackIDCacheMu.Unlock()
+	}
 }

--- a/internal/config/stack_id.go
+++ b/internal/config/stack_id.go
@@ -61,6 +61,17 @@ func resolveNamespace(ctx context.Context, cfg GrafanaConfig) string {
 	return authlib.CloudNamespaceFormatter(cfg.StackID)
 }
 
+// cachedStackID peeks the process-lifetime discovery cache for a server without
+// issuing a /bootdata round-trip. ok is false when no successful discovery has
+// been memoized for the server yet.
+func cachedStackID(server string) (int64, bool) {
+	key := strings.TrimSuffix(server, "/")
+	stackIDCacheMu.Lock()
+	defer stackIDCacheMu.Unlock()
+	id, ok := stackIDCache[key]
+	return id, ok
+}
+
 // discoverStackIDCached wraps DiscoverStackID with a process-lifetime positive
 // cache keyed by server URL. Failures are not cached so a transient error does
 // not pin a missing stack ID for the rest of the process.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -174,7 +174,7 @@ type Context struct {
 	Providers map[string]map[string]string `json:"providers,omitempty" yaml:"providers,omitempty"`
 }
 
-func (context *Context) Validate() error {
+func (context *Context) Validate(ctx context.Context) error {
 	if context.Grafana == nil || context.Grafana.IsEmpty() {
 		return ValidationError{
 			Path:    fmt.Sprintf("$.contexts.'%s'", context.Name),
@@ -182,7 +182,7 @@ func (context *Context) Validate() error {
 		}
 	}
 
-	return context.Grafana.Validate(context.Name)
+	return context.Grafana.Validate(ctx, context.Name)
 }
 
 // ToRESTConfig returns a REST config for the context.
@@ -437,41 +437,31 @@ type GrafanaConfig struct {
 	TLS *TLS `json:"tls,omitempty" yaml:"tls,omitempty"`
 }
 
-func (grafana GrafanaConfig) validateNamespace(contextName string) error {
+func (grafana GrafanaConfig) validateNamespace(ctx context.Context, contextName string) error {
 	if grafana.OrgID != 0 {
 		return nil
 	}
 
-	discoveredStackID, discoveryErr := DiscoverStackID(context.Background(), grafana)
-
-	if grafana.StackID == 0 {
-		if discoveryErr != nil {
-			return ValidationError{
-				Path:    fmt.Sprintf("$.contexts.'%s'.grafana", contextName),
-				Message: fmt.Sprintf("missing contexts.%[1]s.grafana.org-id or contexts.%[1]s.grafana.stack-id", contextName),
-				Suggestions: []string{
-					"Specify the Grafana Org ID for on-prem Grafana",
-					"Specify the Grafana Cloud Stack ID for Grafana Cloud",
-					"Find your Stack ID at grafana.com under your stack's details page",
-				},
-			}
+	// A configured StackID is authoritative (matching resolveNamespace). Don't pay
+	// a /bootdata round-trip on every command just to preflight it — only assert
+	// against discovery when a value is already memoized this process. A wrong id
+	// still surfaces at the first real API call.
+	if grafana.StackID != 0 {
+		if discoveredStackID, ok := cachedStackID(grafana.Server); ok && discoveredStackID != grafana.StackID {
+			return grafana.stackIDMismatchError(contextName, discoveredStackID)
 		}
-
 		return nil
 	}
 
-	// If discovery failed but grafana.StackID is set, we proceed with the configured StackID
-	//nolint:nilerr // We intentionally ignore the error when StackID is configured
-	if discoveryErr != nil {
-		return nil
-	}
-
-	if discoveredStackID != grafana.StackID {
+	// No StackID configured: discover it (cached, reused by resolveNamespace).
+	if _, err := discoverStackIDCached(ctx, grafana); err != nil {
 		return ValidationError{
 			Path:    fmt.Sprintf("$.contexts.'%s'.grafana", contextName),
-			Message: fmt.Sprintf("mismatched contexts.%[1]s.grafana.stack-id, discovered %d - was %d in config", contextName, discoveredStackID, grafana.StackID),
+			Message: fmt.Sprintf("missing contexts.%[1]s.grafana.org-id or contexts.%[1]s.grafana.stack-id", contextName),
 			Suggestions: []string{
-				"Specify the correct Grafana Cloud Stack ID for Grafana Cloud or omit the stack-id param",
+				"Specify the Grafana Org ID for on-prem Grafana",
+				"Specify the Grafana Cloud Stack ID for Grafana Cloud",
+				"Find your Stack ID at grafana.com under your stack's details page",
 			},
 		}
 	}
@@ -479,7 +469,17 @@ func (grafana GrafanaConfig) validateNamespace(contextName string) error {
 	return nil
 }
 
-func (grafana GrafanaConfig) Validate(contextName string) error {
+func (grafana GrafanaConfig) stackIDMismatchError(contextName string, discoveredStackID int64) error {
+	return ValidationError{
+		Path:    fmt.Sprintf("$.contexts.'%s'.grafana", contextName),
+		Message: fmt.Sprintf("mismatched contexts.%[1]s.grafana.stack-id, discovered %d - was %d in config", contextName, discoveredStackID, grafana.StackID),
+		Suggestions: []string{
+			"Specify the correct Grafana Cloud Stack ID for Grafana Cloud or omit the stack-id param",
+		},
+	}
+}
+
+func (grafana GrafanaConfig) Validate(ctx context.Context, contextName string) error {
 	if grafana.Server == "" {
 		return ValidationError{
 			Path:    fmt.Sprintf("$.contexts.'%s'.grafana", contextName),
@@ -503,7 +503,7 @@ func (grafana GrafanaConfig) Validate(contextName string) error {
 		}
 	}
 
-	if err := grafana.validateNamespace(contextName); err != nil {
+	if err := grafana.validateNamespace(ctx, contextName); err != nil {
 		return err
 	}
 

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -49,7 +50,7 @@ func TestGrafanaConfig_Validate_AllowsDiscoveredStackID(t *testing.T) {
 
 	cfg := config.GrafanaConfig{Server: server.URL}
 
-	req.NoError(cfg.Validate("ctx"))
+	req.NoError(cfg.Validate(context.Background(), "ctx"))
 }
 
 func TestGrafanaConfig_Validate_AllowsDiscoveredStackIDAndSuppliedStackID(t *testing.T) {
@@ -68,7 +69,7 @@ func TestGrafanaConfig_Validate_AllowsDiscoveredStackIDAndSuppliedStackID(t *tes
 		Server:  server.URL,
 		StackID: 12345,
 	}
-	req.NoError(cfg.Validate("ctx"))
+	req.NoError(cfg.Validate(context.Background(), "ctx"))
 }
 
 func TestGrafanaConfig_Validate_AllowsOrgId(t *testing.T) {
@@ -87,7 +88,7 @@ func TestGrafanaConfig_Validate_AllowsOrgId(t *testing.T) {
 		Server: server.URL,
 		OrgID:  1,
 	}
-	req.NoError(cfg.Validate("ctx"))
+	req.NoError(cfg.Validate(context.Background(), "ctx"))
 }
 
 func TestGrafanaConfig_Validate_AllowsOrgIdWhenDiscoveryFails(t *testing.T) {
@@ -102,27 +103,24 @@ func TestGrafanaConfig_Validate_AllowsOrgIdWhenDiscoveryFails(t *testing.T) {
 		Server: server.URL,
 		OrgID:  1,
 	}
-	req.NoError(cfg.Validate("ctx"))
+	req.NoError(cfg.Validate(context.Background(), "ctx"))
 }
 
 func TestGrafanaConfig_Validate_MismatchedStackID(t *testing.T) {
 	req := require.New(t)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"settings": map[string]any{
-				"namespace": "stacks-12345",
-			},
-		})
-	}))
-	defer server.Close()
-
+	// A configured StackID is trusted without a /bootdata round-trip; the
+	// mismatch check only fires when a discovered value is already memoized this
+	// process (e.g. warmed by an earlier resolveNamespace). Seed the cache to
+	// exercise that path.
 	cfg := config.GrafanaConfig{
-		Server:  server.URL,
+		Server:  "https://mismatch.example.net",
 		StackID: 54321,
 	}
+	restore := config.SeedStackIDCacheForTest(cfg.Server, 12345)
+	defer restore()
 
-	err := cfg.Validate("ctx")
+	err := cfg.Validate(context.Background(), "ctx")
 	req.Error(err)
 	req.ErrorContains(err, "mismatched")
 	req.ErrorContains(err, "contexts.ctx.grafana.stack-id")
@@ -138,7 +136,7 @@ func TestGrafanaConfig_Validate_MissingStackWhenBootdataUnavailable(t *testing.T
 
 	cfg := config.GrafanaConfig{Server: server.URL}
 
-	err := cfg.Validate("ctx")
+	err := cfg.Validate(context.Background(), "ctx")
 	req.Error(err)
 	req.ErrorContains(err, "missing")
 	req.ErrorContains(err, "contexts.ctx.grafana.org-id")
@@ -155,7 +153,7 @@ func TestGrafanaConfig_Validate_BootdataUnavailableAndSuppliedStackId(t *testing
 
 	cfg := config.GrafanaConfig{Server: server.URL, StackID: 5431}
 
-	req.NoError(cfg.Validate("ctx"))
+	req.NoError(cfg.Validate(context.Background(), "ctx"))
 }
 
 func TestContext_WithProviders(t *testing.T) {

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -190,7 +190,7 @@ func (l *ConfigLoader) LoadGrafanaConfig(ctx context.Context) (config.Namespaced
 		envOverride,
 		contextMustExist,
 		func(cfg *config.Config) error {
-			return cfg.GetCurrentContext().Validate()
+			return cfg.GetCurrentContext().Validate(ctx)
 		},
 	}
 


### PR DESCRIPTION
## Problem

Profiling showed every command targeting Grafana Cloud pays an **uncached `/bootdata` GET** as part of its fixed startup cost. Root cause: `GrafanaConfig.validateNamespace` calls `DiscoverStackID(context.Background(), ...)` on every command **even when `stack-id` is already configured** — purely to preflight a stack-id mismatch. It also bypasses the process cache and uses `context.Background()` (ignoring command cancellation).

## Change

A configured `StackID` is already treated as authoritative by `resolveNamespace`. Do the same in validation:
- **`stack-id` set:** don't fetch. Only assert a mismatch if a discovered value is already memoized this process (via a new `cachedStackID` peek). A wrong id still surfaces at the first real API call.
- **`stack-id == 0`:** discover via `discoverStackIDCached` (command ctx), so the result is reused by `resolveNamespace` later in the same process.
- Fixes the `context.Background()` cancellation bug by threading `ctx` through `Context.Validate` / `GrafanaConfig.Validate`.

## Result (live stack, stack-id configured)

`resources get folders` floor dropped ~1.73s → ~1.34s — one round-trip removed from nearly every Cloud command.

## Trade-off

Single-shot commands lose the friendly *preflight* mismatch message; a genuinely wrong `stack-id` now fails at the first real API call instead of during validation. Accepted for the per-command latency win.

## Tests

`types_test.go` updated (ctx arg); the mismatch test seeds the cache to exercise the peek path. Full config/providers suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)