### PR TITLE
feat(fleet)!: route fleet and instrumentation via collector-app proxy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -128,6 +128,8 @@ Action-verb command tree for Grafana Cloud's Instrumentation Hub. Backed by flee
 
 Uses `internal/providers/instrumentation/` (provider, types, output codecs, RMW helper, helm formatter, enumeration helper) and `internal/fleet/` (shared base HTTP client, also used by the fleet provider). See ADR-018 for the design.
 
+**Transport.** Both `fleet` and `instrumentation` reach the Fleet Management API through the `grafana-collector-app` app plugin proxy at `cfg.Host` (`/api/plugin-proxy/grafana-collector-app/fleet-management-api/…` + the unchanged Connect service/method path), built with `rest.HTTPClientFor(&cfg.Config)`. The Grafana bearer credential (OAuth included) is injected by the k8s round-tripper; the proxy injects the FM credential and the `X-Prom-*`/`X-Scope-OrgID` headers server-side. `instrumentation` sources backend datasource URLs from the collector-app's Viewer-role instance-metadata proxy route (`/api/plugin-proxy/grafana-collector-app/grafanacom-api/instances/`, decoded into `cloud.StackInfo`). No Cloud access-policy token is required; reads need the Viewer role and mutations the Grafana Admin role. See ADR-021.
+
 ### 7. Configuration
 
 kubectl-inspired context-based multi-environment configuration.
@@ -163,7 +165,7 @@ Multiple auth mechanisms for different tiers.
 | **Basic auth** | Legacy Grafana instances | Username/password in `rest.Config` |
 | **Adaptive auth** | Signal provider adaptive telemetry APIs | `internal/auth/adaptive/` — GCOM-cached Basic auth shared across signal providers |
 
-**Precedence:** Token > OAuth > user/password. Explicit flags override env vars override config file. `httputils.NewDefaultClient(ctx)` must be used for APIs outside the Grafana server (k6 Cloud, Synth, Fleet) — the k8s transport injects the Grafana bearer token on every request, which conflicts with product-specific auth.
+**Precedence:** Token > OAuth > user/password. Explicit flags override env vars override config file. `httputils.NewDefaultClient(ctx)` must be used for APIs outside the Grafana server (k6 Cloud, OnCall) — the k8s transport injects the Grafana bearer token on every request, which conflicts with product-specific auth. `fleet`/`instrumentation` are **not** in that set: they reach Fleet Management through the `grafana-collector-app` plugin proxy at `cfg.Host` via `rest.HTTPClientFor()` (ADR-021), so the Grafana bearer is the correct credential and no Cloud access-policy token is required.
 
 **Deep-dive:** [client-api-layer.md](docs/architecture/client-api-layer.md), [config-system.md](docs/architecture/config-system.md).
 
@@ -191,6 +193,7 @@ Multiple auth mechanisms for different tiers.
 | [018](docs/adrs/instrumentation/002-cli-redesign.md) | `gcx instrumentation` CLI redesign: action verbs over Set/Get + observed state | accepted |
 | [019](docs/adrs/oncall-alert-group-rich-shape/001-rich-shape-and-list-defaults.md) | Rich `AlertGroup` shape and actionable `alert-groups list` defaults | implemented |
 | [020](docs/adrs/sm-datasource-proxy/001-dual-mode-transport.md) | Synthetic Monitoring dual-mode transport: datasource proxy primary, direct SM API fallback | accepted |
+| [021](docs/adrs/fleet-plugin-proxy/001-route-fleet-via-collector-app-proxy.md) | Route `fleet`/`instrumentation` through the `grafana-collector-app` plugin proxy | accepted |
 
 See [docs/adrs/](docs/adrs/) for all ADRs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
   consulted. Reads require the Viewer role; mutations require the Grafana Admin
   role. No Cloud access-policy token is required.
 
-
 ## v0.4.4 (2026-07-10)
 
 - Add full CRUD lifecycle for datasources (create, update, delete, health, schemas)
@@ -37,7 +36,6 @@
 - Update Go dependencies
 - Fix docs links in README, CLI help text, and OAuth login docs
 - Use main branch for deploy previews; update SM CODEOWNERS
-
 
 ## v0.4.3 (2026-07-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+- **Breaking:** `gcx fleet` and `gcx instrumentation` now reach Fleet Management
+  through the `grafana-collector-app` plugin proxy using your Grafana credential
+  (OAuth included) instead of a direct Fleet Management API call. A context that
+  carried only a Fleet Management / Cloud access-policy token — with no Grafana
+  credential — no longer works for these commands; `cloud.token` /
+  `GRAFANA_CLOUD_TOKEN` and `AgentManagementInstanceURL`/`ID` are no longer
+  consulted. Reads require the Viewer role; mutations require the Grafana Admin
+  role. No Cloud access-policy token is required.
+
+
 ## v0.4.4 (2026-07-10)
 
 - Add full CRUD lifecycle for datasources (create, update, delete, health, schemas)

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -7,7 +7,7 @@
 **What it is:** Unified CLI for managing Grafana resources across two tiers — a K8s resource tier
 for dashboards, folders, and other resources via Grafana 12+'s Kubernetes-compatible API, and a
 Cloud provider tier with pluggable providers for Grafana Cloud products (SLO, Synthetic Monitoring,
-OnCall, Fleet Management, etc.) using product-specific REST APIs.
+OnCall, etc.) using product-specific REST APIs.
 
 **Primary values:** correctness, API stability, clean layered architecture, extensible provider model
 
@@ -159,13 +159,25 @@ agent mode detection, behavior changes, and opt-out mechanisms.
   credentials independently — this ensures consistent env var precedence,
   secret handling, and auth behavior across all providers.
 - **`httputils.NewDefaultClient(ctx)` for external APIs.** Provider clients
-  calling APIs outside the Grafana server (k6 Cloud, OnCall, Fleet —
+  calling APIs outside the Grafana server (k6 Cloud, OnCall —
   any domain other than `cfg.Host`) must use `httputils.NewDefaultClient(ctx)`,
   never `rest.HTTPClientFor()`. The k8s transport round-tripper injects the
   Grafana bearer token on every outgoing request, which conflicts with the
   product's own auth mechanism. `NewDefaultClient(ctx)` returns an `*http.Client`
   with `LoggingRoundTripper` and no auth injection — providers set their own
   auth headers per request.
+- **Fleet/instrumentation reach FM via the collector-app proxy (carve-out).**
+  `gcx fleet` and `gcx instrumentation` reach the Fleet Management API through the
+  `grafana-collector-app` app plugin proxy at `cfg.Host`
+  (`/api/plugin-proxy/grafana-collector-app/fleet-management-api/…`) using
+  `rest.HTTPClientFor(&cfg.Config)` — the same bearer transport the other
+  plugin-proxied providers use. Because the traffic targets `cfg.Host`, the k8s
+  round-tripper's Grafana bearer is exactly the right credential; the proxy injects
+  the FM credential and the `X-Prom-*`/`X-Scope-OrgID` headers server-side. This is
+  consistent with the rule above (proxy = `cfg.Host`, not an external domain) and
+  is why Fleet is no longer listed as an "outside the Grafana server" case. No
+  Cloud access-policy token is required for either command group. See ADR
+  `fleet-plugin-proxy/001`.
 - **Synth is dual-mode (carve-out).** Synthetic Monitoring reaches its API two
   ways: (1) primary — Grafana's datasource proxy at `cfg.Host`
   (`/api/datasources/proxy/uid/<sm-uid>/sm/…`) via `rest.HTTPClientFor()` in

--- a/claude-plugin/skills/gcx-demo/SKILL.md
+++ b/claude-plugin/skills/gcx-demo/SKILL.md
@@ -195,7 +195,7 @@ GitOps workflows."
 |-----------|--------|
 | `config check` fails | Stop. Ask user to fix the context before continuing. |
 | Signal datasource not found | Skip that signal type, note it. |
-| `cloud.token` / `cloud.stack` missing | Skip k6 and fleet, note what's needed. |
+| `cloud.token` / `cloud.stack` missing | Skip k6, note what's needed. (Fleet needs no Cloud token — it uses the Grafana credential via the collector-app proxy.) |
 | Assistant unavailable (self-hosted, OAuth missing, 403) | Skip assistant section, note Cloud + OAuth requirement. |
 | Auth scope missing (403) | Note the missing scope, skip, continue. |
 | Empty list (0 resources) | Report "none found" — not an error; continue. |

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -987,7 +987,7 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 	if strings.Contains(msg, "fleet:") && strings.Contains(msg, "status 401") {
 		return &gcxerrors.DetailedError{
 			Parent:  err,
-			Summary: "Fleet Management: authentication failed",
+			Summary: "Authentication failed",
 			Details: msg,
 			Suggestions: []string{
 				"Re-authenticate with your Grafana credential: gcx login",
@@ -1003,7 +1003,7 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 		(strings.Contains(msg, "list ") || strings.Contains(msg, "get ")) {
 		return &gcxerrors.DetailedError{
 			Parent:  err,
-			Summary: "Fleet Management: insufficient Grafana role",
+			Summary: "Authorization failed",
 			Details: msg,
 			Suggestions: []string{
 				"Fleet reads require the Viewer role on this Grafana instance (via the grafana-collector-app proxy)",
@@ -1020,7 +1020,7 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 		(strings.Contains(msg, "create ") || strings.Contains(msg, "update ") || strings.Contains(msg, "delete ")) {
 		return &gcxerrors.DetailedError{
 			Parent:  err,
-			Summary: "Fleet Management: insufficient Grafana role",
+			Summary: "Authorization failed",
 			Details: msg,
 			Suggestions: []string{
 				"Fleet mutations require the Grafana Admin role (via the grafana-collector-app proxy)",
@@ -1119,8 +1119,8 @@ func convertFleetHTTPErrors(err error) (*gcxerrors.DetailedError, bool) {
 	case http.StatusForbidden:
 		return &gcxerrors.DetailedError{
 			Parent:  err,
-			Summary: "Insufficient Grafana role",
-			Details: "HTTP 403 from " + httpErr.Path + " — denied by the grafana-collector-app proxy",
+			Summary: "Authorization failed",
+			Details: "HTTP 403 from " + httpErr.Path + " — denied by the grafana-collector-app proxy (insufficient Grafana role)",
 			Suggestions: []string{
 				"Fleet and instrumentation reads require the Viewer role; mutations require the Grafana Admin role",
 				"Ask a Grafana admin to grant your account the required role, then retry",

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -981,30 +981,52 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 		}, true
 	}
 
-	// Fleet API scope error on read operations.
-	if strings.Contains(msg, "fleet:") && strings.Contains(msg, "invalid scope") &&
-		(strings.Contains(msg, "list ") || strings.Contains(msg, "get ")) {
+	// Fleet Management authentication failure via the collector-app proxy: the
+	// Grafana credential was rejected (HTTP 401). Fleet no longer uses a Cloud
+	// access-policy token — the fix is to re-authenticate to Grafana.
+	if strings.Contains(msg, "fleet:") && strings.Contains(msg, "status 401") {
 		return &gcxerrors.DetailedError{
 			Parent:  err,
-			Summary: "Fleet Management: permission denied",
+			Summary: "Fleet Management: authentication failed",
+			Details: msg,
 			Suggestions: []string{
-				"Ensure your cloud.token access policy includes the fleet-management:read scope",
+				"Re-authenticate with your Grafana credential: gcx login",
+				"Verify the active context targets the intended Grafana instance: gcx config view",
 			},
-			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	}
 
-	// Fleet API scope error on write operations.
-	if strings.Contains(msg, "fleet:") && strings.Contains(msg, "invalid scope") &&
+	// Fleet Management RBAC denial via the collector-app proxy (HTTP 403) on read
+	// operations — the caller lacks the Viewer role.
+	if strings.Contains(msg, "fleet:") && strings.Contains(msg, "status 403") &&
+		(strings.Contains(msg, "list ") || strings.Contains(msg, "get ")) {
+		return &gcxerrors.DetailedError{
+			Parent:  err,
+			Summary: "Fleet Management: insufficient Grafana role",
+			Details: msg,
+			Suggestions: []string{
+				"Fleet reads require the Viewer role on this Grafana instance (via the grafana-collector-app proxy)",
+				"Ask a Grafana admin to grant your account the Viewer role, then retry",
+				"If your role is already sufficient, this may be a Fleet Management request rejection rather than an RBAC denial",
+			},
+			ExitCode: new(gcxerrors.ExitAuthFailure),
+		}, true
+	}
+
+	// Fleet Management RBAC denial via the collector-app proxy (HTTP 403) on write
+	// operations — the caller lacks the Grafana Admin role.
+	if strings.Contains(msg, "fleet:") && strings.Contains(msg, "status 403") &&
 		(strings.Contains(msg, "create ") || strings.Contains(msg, "update ") || strings.Contains(msg, "delete ")) {
 		return &gcxerrors.DetailedError{
 			Parent:  err,
-			Summary: "Fleet Management: permission denied",
+			Summary: "Fleet Management: insufficient Grafana role",
+			Details: msg,
 			Suggestions: []string{
-				"Ensure your cloud.token access policy includes the fleet-management:write scope",
+				"Fleet mutations require the Grafana Admin role (via the grafana-collector-app proxy)",
+				"Ask a Grafana admin to grant your account the Admin role, then retry",
+				"If your role is already sufficient, this may be a Fleet Management request rejection rather than an RBAC denial",
 			},
-			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	}
@@ -1087,26 +1109,23 @@ func convertFleetHTTPErrors(err error) (*gcxerrors.DetailedError, bool) {
 		return &gcxerrors.DetailedError{
 			Parent:  err,
 			Summary: "Authentication failed",
-			Details: "HTTP 401 from " + httpErr.Path,
+			Details: "HTTP 401 from " + httpErr.Path + " — the grafana-collector-app proxy rejected the Grafana credential",
 			Suggestions: []string{
-				"Ensure cloud.token is set: gcx config set cloud.token <TOKEN>",
-				"Verify the token has not expired: gcx config view",
-				reauthSuggestion,
+				"Re-authenticate with your Grafana credential: gcx login",
+				"Verify the active context targets the intended Grafana instance: gcx config view",
 			},
-			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	case http.StatusForbidden:
 		return &gcxerrors.DetailedError{
 			Parent:  err,
-			Summary: "Authorization failed",
-			Details: "HTTP 403 from " + httpErr.Path,
+			Summary: "Insufficient Grafana role",
+			Details: "HTTP 403 from " + httpErr.Path + " — denied by the grafana-collector-app proxy",
 			Suggestions: []string{
-				"Ensure your Cloud Access Policy includes the fleet-management:read scope",
-				"Ensure your Cloud Access Policy includes the fleet-management:write scope for mutation commands",
-				reauthSuggestion,
+				"Fleet and instrumentation reads require the Viewer role; mutations require the Grafana Admin role",
+				"Ask a Grafana admin to grant your account the required role, then retry",
+				"If your role is already sufficient, this may be a Fleet Management request rejection rather than an RBAC denial — see the error detail above",
 			},
-			DocsLink: docs.AccessPolicies,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	}

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -422,51 +422,52 @@ func TestErrorToDetailedError_CloudStackLookupForbidden(t *testing.T) {
 	}
 }
 
-func TestErrorToDetailedError_FleetScopeError(t *testing.T) {
+// TestErrorToDetailedError_FleetRoleError verifies that fleet errors from the
+// collector-app proxy map to role-based guidance (FR-016): 401 → re-authenticate,
+// 403 on reads → Viewer role, 403 on mutations → Grafana Admin role. Fleet no
+// longer references a Cloud access-policy token or fleet-management scopes.
+func TestErrorToDetailedError_FleetRoleError(t *testing.T) {
 	tests := []struct {
-		name      string
-		err       error
-		wantScope string
+		name        string
+		err         error
+		wantSummary string
+		wantContain string // substring expected in at least one suggestion
 	}{
 		{
-			name:      "list pipelines invalid scope suggests fleet-management:read",
-			err:       errors.New(`fleet: list pipelines: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:read",
+			name:        "fleet 401 suggests re-authentication",
+			err:         errors.New(`fleet: list pipelines: status 401: {"message":"unauthorized"}`),
+			wantSummary: "Fleet Management: authentication failed",
+			wantContain: "gcx login",
 		},
 		{
-			name:      "list collectors invalid scope suggests fleet-management:read",
-			err:       errors.New(`fleet: list collectors: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:read",
+			name:        "fleet 403 list read suggests Viewer role",
+			err:         errors.New(`fleet: list pipelines: status 403: {"message":"forbidden"}`),
+			wantSummary: "Fleet Management: insufficient Grafana role",
+			wantContain: "Viewer role",
 		},
 		{
-			name:      "get pipeline invalid scope suggests fleet-management:read",
-			err:       errors.New(`fleet: get pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:read",
+			name:        "fleet 403 get read suggests Viewer role",
+			err:         errors.New(`fleet: get pipeline abc123: status 403: {"message":"forbidden"}`),
+			wantSummary: "Fleet Management: insufficient Grafana role",
+			wantContain: "Viewer role",
 		},
 		{
-			name:      "create pipeline invalid scope suggests fleet-management:write",
-			err:       errors.New(`fleet: create pipeline: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:write",
+			name:        "fleet 403 create mutation suggests Admin role",
+			err:         errors.New(`fleet: create pipeline: status 403: {"message":"forbidden"}`),
+			wantSummary: "Fleet Management: insufficient Grafana role",
+			wantContain: "Admin role",
 		},
 		{
-			name:      "update pipeline invalid scope suggests fleet-management:write",
-			err:       errors.New(`fleet: update pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:write",
+			name:        "fleet 403 update mutation suggests Admin role",
+			err:         errors.New(`fleet: update collector abc123: status 403: {"message":"forbidden"}`),
+			wantSummary: "Fleet Management: insufficient Grafana role",
+			wantContain: "Admin role",
 		},
 		{
-			name:      "create collector invalid scope suggests fleet-management:write",
-			err:       errors.New(`fleet: create collector: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:write",
-		},
-		{
-			name:      "update collector invalid scope suggests fleet-management:write",
-			err:       errors.New(`fleet: update collector abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:write",
-		},
-		{
-			name:      "delete pipeline invalid scope suggests fleet-management:write",
-			err:       errors.New(`fleet: delete pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:write",
+			name:        "fleet 403 delete mutation suggests Admin role",
+			err:         errors.New(`fleet: delete pipeline abc123: status 403: {"message":"forbidden"}`),
+			wantSummary: "Fleet Management: insufficient Grafana role",
+			wantContain: "Admin role",
 		},
 	}
 
@@ -474,16 +475,17 @@ func TestErrorToDetailedError_FleetScopeError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := fail.ErrorToDetailedError(tc.err)
 
-			if tc.wantScope == "" {
-				assert.Equal(t, "Unexpected error", got.Summary)
-				return
-			}
-
-			assert.Equal(t, "Fleet Management: permission denied", got.Summary)
+			assert.Equal(t, tc.wantSummary, got.Summary)
 			require.NotNil(t, got.ExitCode)
 			assert.Equal(t, gcxerrors.ExitAuthFailure, *got.ExitCode)
-			require.Len(t, got.Suggestions, 1)
-			assert.Contains(t, got.Suggestions[0], tc.wantScope)
+			found := false
+			for _, s := range got.Suggestions {
+				if strings.Contains(s, tc.wantContain) {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected a suggestion containing %q, got %v", tc.wantContain, got.Suggestions)
 		})
 	}
 }
@@ -813,7 +815,7 @@ func TestConvertFleetHTTPErrors(t *testing.T) {
 		{
 			name:         "403 from fleet management",
 			err:          fmt.Errorf("clusters list: %w", &fleet.HTTPError{Status: 403, Path: "/instrumentation.v1.InstrumentationService/GetK8SInstrumentation"}),
-			wantSummary:  "Authorization failed",
+			wantSummary:  "Insufficient Grafana role",
 			wantAuthExit: true,
 		},
 		{

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -436,37 +436,37 @@ func TestErrorToDetailedError_FleetRoleError(t *testing.T) {
 		{
 			name:        "fleet 401 suggests re-authentication",
 			err:         errors.New(`fleet: list pipelines: status 401: {"message":"unauthorized"}`),
-			wantSummary: "Fleet Management: authentication failed",
+			wantSummary: "Authentication failed",
 			wantContain: "gcx login",
 		},
 		{
 			name:        "fleet 403 list read suggests Viewer role",
 			err:         errors.New(`fleet: list pipelines: status 403: {"message":"forbidden"}`),
-			wantSummary: "Fleet Management: insufficient Grafana role",
+			wantSummary: "Authorization failed",
 			wantContain: "Viewer role",
 		},
 		{
 			name:        "fleet 403 get read suggests Viewer role",
 			err:         errors.New(`fleet: get pipeline abc123: status 403: {"message":"forbidden"}`),
-			wantSummary: "Fleet Management: insufficient Grafana role",
+			wantSummary: "Authorization failed",
 			wantContain: "Viewer role",
 		},
 		{
 			name:        "fleet 403 create mutation suggests Admin role",
 			err:         errors.New(`fleet: create pipeline: status 403: {"message":"forbidden"}`),
-			wantSummary: "Fleet Management: insufficient Grafana role",
+			wantSummary: "Authorization failed",
 			wantContain: "Admin role",
 		},
 		{
 			name:        "fleet 403 update mutation suggests Admin role",
 			err:         errors.New(`fleet: update collector abc123: status 403: {"message":"forbidden"}`),
-			wantSummary: "Fleet Management: insufficient Grafana role",
+			wantSummary: "Authorization failed",
 			wantContain: "Admin role",
 		},
 		{
 			name:        "fleet 403 delete mutation suggests Admin role",
 			err:         errors.New(`fleet: delete pipeline abc123: status 403: {"message":"forbidden"}`),
-			wantSummary: "Fleet Management: insufficient Grafana role",
+			wantSummary: "Authorization failed",
 			wantContain: "Admin role",
 		},
 	}
@@ -815,7 +815,7 @@ func TestConvertFleetHTTPErrors(t *testing.T) {
 		{
 			name:         "403 from fleet management",
 			err:          fmt.Errorf("clusters list: %w", &fleet.HTTPError{Status: 403, Path: "/instrumentation.v1.InstrumentationService/GetK8SInstrumentation"}),
-			wantSummary:  "Insufficient Grafana role",
+			wantSummary:  "Authorization failed",
 			wantAuthExit: true,
 		},
 		{

--- a/cmd/gcx/instrumentation/clusters/apps/command.go
+++ b/cmd/gcx/instrumentation/clusters/apps/command.go
@@ -25,8 +25,8 @@ import (
 type appsClient interface {
 	GetAppInstrumentation(ctx context.Context, clusterName string) (*instrumentation.GetAppInstrumentationResponse, error)
 	SetAppInstrumentation(ctx context.Context, clusterName string, namespaces []instrumentation.App, urls instrumentation.BackendURLs) error
-	RunK8sDiscovery(ctx context.Context, promHeaders instrumentation.PromHeaders) (*instrumentation.RunK8sDiscoveryResponse, error)
-	IsNamespaceDiscovered(ctx context.Context, promHeaders instrumentation.PromHeaders, cluster, namespace string) (bool, error)
+	RunK8sDiscovery(ctx context.Context) (*instrumentation.RunK8sDiscoveryResponse, error)
+	IsNamespaceDiscovered(ctx context.Context, cluster, namespace string) (bool, error)
 	ListPipelines(ctx context.Context) ([]instrumentation.Pipeline, error)
 }
 
@@ -34,9 +34,9 @@ type appsClient interface {
 // command's RunE — after cobra has parsed all flags (including --context) — so
 // client construction is always lazy and never happens at Command() call time.
 //
-// Returning all three values from a single call ensures a single
+// Returning both values from a single call ensures a single
 // fleet.LoadClientWithStack round-trip per command invocation.
-type appClientFactory = func(ctx context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error)
+type appClientFactory = func(ctx context.Context) (appsClient, instrumentation.BackendURLs, error)
 
 // factoryFromLoader returns an appClientFactory that lazily constructs the
 // instrumentation client from the given fleet.ConfigLoader.
@@ -45,14 +45,13 @@ type appClientFactory = func(ctx context.Context) (appsClient, instrumentation.B
 // construction (fleet.LoadClientWithStack call) is deferred until the returned
 // function is invoked inside a command's RunE.
 func factoryFromLoader(loader fleet.ConfigLoader) appClientFactory {
-	return func(ctx context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
+	return func(ctx context.Context) (appsClient, instrumentation.BackendURLs, error) {
 		r, err := fleet.LoadClientWithStack(ctx, loader)
 		if err != nil {
-			return nil, instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, fmt.Errorf("apps: %w", err)
+			return nil, instrumentation.BackendURLs{}, fmt.Errorf("apps: %w", err)
 		}
 		return instrumentation.NewClient(r.Client),
-			instrumentation.BackendURLsFromStack(r.Stack),
-			instrumentation.PromHeadersFromStack(r.Stack), nil
+			instrumentation.BackendURLsFromStack(r.Stack), nil
 	}
 }
 

--- a/cmd/gcx/instrumentation/clusters/apps/configure.go
+++ b/cmd/gcx/instrumentation/clusters/apps/configure.go
@@ -76,7 +76,7 @@ Combining --use-defaults with any --<feat> flag is an error.`,
 				return err
 			}
 			ctx := cmd.Context()
-			client, urls, promHeaders, err := factory(ctx)
+			client, urls, err := factory(ctx)
 			if err != nil {
 				return err
 			}
@@ -109,7 +109,7 @@ Combining --use-defaults with any --<feat> flag is an error.`,
 				updated := replaceOrAppendNamespace(resp.Namespaces, namespace, defaults)
 				if equal, _ := appListEqual(resp.Namespaces, updated); equal {
 					// No write — discover post-state before emitting result.
-					disc, discErr := client.IsNamespaceDiscovered(ctx, promHeaders, cluster, namespace)
+					disc, discErr := client.IsNamespaceDiscovered(ctx, cluster, namespace)
 					if discErr != nil {
 						return fmt.Errorf("apps configure: %w", discErr)
 					}
@@ -124,7 +124,7 @@ Combining --use-defaults with any --<feat> flag is an error.`,
 					return err
 				}
 				// Discover post-write state.
-				disc, discErr := client.IsNamespaceDiscovered(ctx, promHeaders, cluster, namespace)
+				disc, discErr := client.IsNamespaceDiscovered(ctx, cluster, namespace)
 				if discErr != nil {
 					return fmt.Errorf("apps configure: %w", discErr)
 				}
@@ -147,7 +147,7 @@ Combining --use-defaults with any --<feat> flag is an error.`,
 			post := applyAppMutations(pre, namespace, flags,
 				opts.tracing, opts.logging, opts.processMetrics, opts.extendedMetrics, opts.profiling)
 			if equal, _ := appListEqual(pre, post); equal {
-				disc, discErr := client.IsNamespaceDiscovered(ctx, promHeaders, cluster, namespace)
+				disc, discErr := client.IsNamespaceDiscovered(ctx, cluster, namespace)
 				if discErr != nil {
 					return fmt.Errorf("apps configure: %w", discErr)
 				}
@@ -185,7 +185,7 @@ Combining --use-defaults with any --<feat> flag is an error.`,
 				return err
 			}
 			// Discover post-write state.
-			disc, discErr := client.IsNamespaceDiscovered(ctx, promHeaders, cluster, namespace)
+			disc, discErr := client.IsNamespaceDiscovered(ctx, cluster, namespace)
 			if discErr != nil {
 				return fmt.Errorf("apps configure: %w", discErr)
 			}
@@ -205,8 +205,8 @@ Combining --use-defaults with any --<feat> flag is an error.`,
 // newConfigureCmd is a test-facing constructor that injects a pre-built appsClient
 // and BackendURLs. Production code uses makeConfigureCmd(factoryFromLoader(loader)) instead.
 func newConfigureCmd(client appsClient, urls instrumentation.BackendURLs) *cobra.Command {
-	return makeConfigureCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
-		return client, urls, instrumentation.PromHeaders{}, nil
+	return makeConfigureCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, error) {
+		return client, urls, nil
 	})
 }
 

--- a/cmd/gcx/instrumentation/clusters/apps/fake_test.go
+++ b/cmd/gcx/instrumentation/clusters/apps/fake_test.go
@@ -76,7 +76,7 @@ func (f *fakeAppsClient) SetAppInstrumentation(_ context.Context, clusterName st
 	return f.setErr
 }
 
-func (f *fakeAppsClient) RunK8sDiscovery(_ context.Context, _ instrumentation.PromHeaders) (*instrumentation.RunK8sDiscoveryResponse, error) {
+func (f *fakeAppsClient) RunK8sDiscovery(_ context.Context) (*instrumentation.RunK8sDiscoveryResponse, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -86,7 +86,7 @@ func (f *fakeAppsClient) RunK8sDiscovery(_ context.Context, _ instrumentation.Pr
 	return &instrumentation.RunK8sDiscoveryResponse{Items: f.discoverItems}, nil
 }
 
-func (f *fakeAppsClient) IsNamespaceDiscovered(_ context.Context, _ instrumentation.PromHeaders, cluster, namespace string) (bool, error) {
+func (f *fakeAppsClient) IsNamespaceDiscovered(_ context.Context, cluster, namespace string) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/cmd/gcx/instrumentation/clusters/apps/get.go
+++ b/cmd/gcx/instrumentation/clusters/apps/get.go
@@ -40,7 +40,7 @@ namespace has no declared configuration.`,
 			}
 
 			ctx := cmd.Context()
-			client, _, promHeaders, err := factory(ctx)
+			client, _, err := factory(ctx)
 			if err != nil {
 				return err
 			}
@@ -54,7 +54,7 @@ namespace has no declared configuration.`,
 
 			// Cross-reference with RunK8sDiscovery to populate the discovered field.
 			// Discovery RPC error short-circuits — callers can retry.
-			discovered, err := client.IsNamespaceDiscovered(ctx, promHeaders, cluster, namespace)
+			discovered, err := client.IsNamespaceDiscovered(ctx, cluster, namespace)
 			if err != nil {
 				return fmt.Errorf("apps get: %w", err)
 			}
@@ -115,7 +115,7 @@ namespace has no declared configuration.`,
 // newGetCmd is a test-facing constructor that injects a pre-built appsClient.
 // Production code uses makeGetCmd(factoryFromLoader(loader)) instead.
 func newGetCmd(client appsClient) *cobra.Command {
-	return makeGetCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
-		return client, instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, nil
+	return makeGetCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, error) {
+		return client, instrumentation.BackendURLs{}, nil
 	})
 }

--- a/cmd/gcx/instrumentation/clusters/apps/list.go
+++ b/cmd/gcx/instrumentation/clusters/apps/list.go
@@ -48,7 +48,7 @@ Use "gcx instrumentation status" for observed-state status.`,
 			}
 
 			ctx := cmd.Context()
-			client, _, promHeaders, err := factory(ctx)
+			client, _, err := factory(ctx)
 			if err != nil {
 				return err
 			}
@@ -61,7 +61,7 @@ Use "gcx instrumentation status" for observed-state status.`,
 
 			// Call RunK8sDiscovery once and build a namespace set for this cluster.
 			// This populates the discovered field on each AppView.
-			discResp, err := client.RunK8sDiscovery(ctx, promHeaders)
+			discResp, err := client.RunK8sDiscovery(ctx)
 			if err != nil {
 				return err
 			}
@@ -99,7 +99,7 @@ Use "gcx instrumentation status" for observed-state status.`,
 // newListCmd is a test-facing constructor that injects a pre-built appsClient.
 // Production code uses makeListCmd(factoryFromLoader(loader)) instead.
 func newListCmd(client appsClient) *cobra.Command {
-	return makeListCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
-		return client, instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, nil
+	return makeListCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, error) {
+		return client, instrumentation.BackendURLs{}, nil
 	})
 }

--- a/cmd/gcx/instrumentation/clusters/apps/remove.go
+++ b/cmd/gcx/instrumentation/clusters/apps/remove.go
@@ -53,7 +53,7 @@ This command requires --yes to proceed.`,
 			}
 
 			ctx := cmd.Context()
-			client, urls, _, err := factory(ctx)
+			client, urls, err := factory(ctx)
 			if err != nil {
 				return err
 			}
@@ -105,7 +105,7 @@ func runAppRemove(
 // newRemoveCmd is a test-facing constructor that injects a pre-built appsClient
 // and BackendURLs. Production code uses makeRemoveCmd(factoryFromLoader(loader)) instead.
 func newRemoveCmd(client appsClient, urls instrumentation.BackendURLs) *cobra.Command {
-	return makeRemoveCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
-		return client, urls, instrumentation.PromHeaders{}, nil
+	return makeRemoveCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, error) {
+		return client, urls, nil
 	})
 }

--- a/cmd/gcx/instrumentation/clusters/apps/wait.go
+++ b/cmd/gcx/instrumentation/clusters/apps/wait.go
@@ -46,7 +46,7 @@ func (o *waitOpts) Validate() error {
 //   - Otherwise (all INSTRUMENTED, EXCLUDED, or other terminal non-error states) → exit 0.
 //
 // factory is called inside RunE — after cobra has parsed all flags — to
-// lazily construct the appsClient and PromHeaders.
+// lazily construct the appsClient.
 func makeWaitCmd(factory appClientFactory) *cobra.Command {
 	opts := &waitOpts{}
 

--- a/cmd/gcx/instrumentation/clusters/apps/wait.go
+++ b/cmd/gcx/instrumentation/clusters/apps/wait.go
@@ -73,7 +73,7 @@ Exit non-zero when:
 			timeout := opts.timeout
 
 			ctx := cmd.Context()
-			client, _, promHeaders, err := factory(ctx)
+			client, _, err := factory(ctx)
 			if err != nil {
 				return err
 			}
@@ -92,7 +92,7 @@ Exit non-zero when:
 
 			for {
 				// outcome is WaitOutcome; rawStatus is the wire string for logging.
-				outcome, rawStatus, pollErr := pollNamespaceStatus(ctx, client, promHeaders, cluster, namespace)
+				outcome, rawStatus, pollErr := pollNamespaceStatus(ctx, client, cluster, namespace)
 				if pollErr != nil {
 					return fmt.Errorf("apps wait: poll error: %w", pollErr)
 				}
@@ -170,11 +170,11 @@ Exit non-zero when:
 	return cmd
 }
 
-// newWaitCmd is a test-facing constructor that injects a pre-built appsClient
-// and PromHeaders. Production code uses makeWaitCmd(factoryFromLoader(loader)) instead.
-func newWaitCmd(client appsClient, promHeaders instrumentation.PromHeaders) *cobra.Command {
-	return makeWaitCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, instrumentation.PromHeaders, error) {
-		return client, instrumentation.BackendURLs{}, promHeaders, nil
+// newWaitCmd is a test-facing constructor that injects a pre-built appsClient.
+// Production code uses makeWaitCmd(factoryFromLoader(loader)) instead.
+func newWaitCmd(client appsClient) *cobra.Command {
+	return makeWaitCmd(func(_ context.Context) (appsClient, instrumentation.BackendURLs, error) {
+		return client, instrumentation.BackendURLs{}, nil
 	})
 }
 
@@ -208,10 +208,9 @@ func probePipelineMsg(ctx context.Context, client appsClient, cluster string) st
 func pollNamespaceStatus(
 	ctx context.Context,
 	client appsClient,
-	promHeaders instrumentation.PromHeaders,
 	cluster, namespace string,
 ) (instrumentation.WaitOutcome, instrumentation.InstrumentationStatus, error) {
-	resp, err := client.RunK8sDiscovery(ctx, promHeaders)
+	resp, err := client.RunK8sDiscovery(ctx)
 	if err != nil {
 		return instrumentation.WaitPending, "", err
 	}

--- a/cmd/gcx/instrumentation/clusters/apps/wait_test.go
+++ b/cmd/gcx/instrumentation/clusters/apps/wait_test.go
@@ -119,7 +119,7 @@ func TestPollNamespaceStatus(t *testing.T) {
 			}
 
 			ctx := t.Context()
-			outcome, rawStatus, err := pollNamespaceStatus(ctx, client, instrumentation.PromHeaders{}, tc.cluster, tc.namespace)
+			outcome, rawStatus, err := pollNamespaceStatus(ctx, client, tc.cluster, tc.namespace)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -151,7 +151,7 @@ func TestWaitCmd_Timeout(t *testing.T) {
 		},
 	}
 
-	cmd := newWaitCmd(client, instrumentation.PromHeaders{})
+	cmd := newWaitCmd(client)
 
 	// Use a very short timeout to keep the test fast.
 	cmd.SetArgs([]string{"c1", "grotshop", "--timeout=100ms"})
@@ -193,7 +193,7 @@ func TestWaitCmd_ErrorStatus(t *testing.T) {
 		},
 	}
 
-	cmd := newWaitCmd(client, instrumentation.PromHeaders{})
+	cmd := newWaitCmd(client)
 	cmd.SetArgs([]string{"c1", "grotshop", "--timeout=5m"})
 
 	err := cmd.Execute()
@@ -214,7 +214,7 @@ func TestWaitCmd_Success(t *testing.T) {
 		},
 	}
 
-	cmd := newWaitCmd(client, instrumentation.PromHeaders{})
+	cmd := newWaitCmd(client)
 	cmd.SetArgs([]string{"c1", "grotshop", "--timeout=5m"})
 
 	var stdout, stderr strings.Builder

--- a/cmd/gcx/instrumentation/clusters/client.go
+++ b/cmd/gcx/instrumentation/clusters/client.go
@@ -12,20 +12,18 @@ import (
 type clusterClient interface {
 	GetK8SInstrumentation(ctx context.Context, clusterName string) (*instrumentation.GetK8SInstrumentationResponse, error)
 	SetK8SInstrumentation(ctx context.Context, clusterName string, k8s instrumentation.Cluster, urls instrumentation.BackendURLs) error
-	RunK8sMonitoring(ctx context.Context, promHeaders instrumentation.PromHeaders) (*instrumentation.RunK8sMonitoringResponse, error)
+	RunK8sMonitoring(ctx context.Context) (*instrumentation.RunK8sMonitoringResponse, error)
 	ListPipelines(ctx context.Context) ([]instrumentation.Pipeline, error)
 }
 
-// monitoringAdapter adapts a clusterClient + PromHeaders to the
-// enumerate.MonitoringClient interface, which expects RunK8sMonitoring(ctx)
-// without PromHeaders. PromHeaders are bound at construction time.
+// monitoringAdapter adapts a clusterClient to the enumerate.MonitoringClient
+// interface, unwrapping the RunK8sMonitoring response to its cluster slice.
 type monitoringAdapter struct {
-	client      clusterClient
-	promHeaders instrumentation.PromHeaders
+	client clusterClient
 }
 
 func (a *monitoringAdapter) RunK8sMonitoring(ctx context.Context) ([]instrumentation.ClusterObservedState, error) {
-	resp, err := a.client.RunK8sMonitoring(ctx, a.promHeaders)
+	resp, err := a.client.RunK8sMonitoring(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gcx/instrumentation/clusters/client_test.go
+++ b/cmd/gcx/instrumentation/clusters/client_test.go
@@ -13,7 +13,7 @@ import (
 type fakeClient struct {
 	GetK8SInstrumentationFn func(ctx context.Context, clusterName string) (*instrumentation.GetK8SInstrumentationResponse, error)
 	SetK8SInstrumentationFn func(ctx context.Context, clusterName string, k8s instrumentation.Cluster, urls instrumentation.BackendURLs) error
-	RunK8sMonitoringFn      func(ctx context.Context, promHeaders instrumentation.PromHeaders) (*instrumentation.RunK8sMonitoringResponse, error)
+	RunK8sMonitoringFn      func(ctx context.Context) (*instrumentation.RunK8sMonitoringResponse, error)
 	ListPipelinesFn         func(ctx context.Context) ([]instrumentation.Pipeline, error)
 }
 
@@ -31,9 +31,9 @@ func (f *fakeClient) SetK8SInstrumentation(ctx context.Context, clusterName stri
 	return errors.New("fakeClient: SetK8SInstrumentation not configured")
 }
 
-func (f *fakeClient) RunK8sMonitoring(ctx context.Context, promHeaders instrumentation.PromHeaders) (*instrumentation.RunK8sMonitoringResponse, error) {
+func (f *fakeClient) RunK8sMonitoring(ctx context.Context) (*instrumentation.RunK8sMonitoringResponse, error) {
 	if f.RunK8sMonitoringFn != nil {
-		return f.RunK8sMonitoringFn(ctx, promHeaders)
+		return f.RunK8sMonitoringFn(ctx)
 	}
 	return nil, errors.New("fakeClient: RunK8sMonitoring not configured")
 }

--- a/cmd/gcx/instrumentation/clusters/get.go
+++ b/cmd/gcx/instrumentation/clusters/get.go
@@ -55,14 +55,13 @@ means PENDING_INSTRUMENTATION; absent means NOT_INSTRUMENTED.`,
 			ctx := cmd.Context()
 			clusterName := args[0]
 
-			r, err := fleet.LoadClientWithStack(ctx, loader)
+			base, _, err := fleet.LoadClient(ctx, loader)
 			if err != nil {
 				return fmt.Errorf("clusters get: %w", err)
 			}
-			client := instrumentation.NewClient(r.Client)
-			promHeaders := instrumentation.PromHeadersFromStack(r.Stack)
+			client := instrumentation.NewClient(base)
 
-			return runGet(ctx, opts, client, clusterName, promHeaders, cmd.OutOrStdout())
+			return runGet(ctx, opts, client, clusterName, cmd.OutOrStdout())
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -76,7 +75,6 @@ func runGet(
 	opts *getOpts,
 	client clusterClient,
 	clusterName string,
-	promHeaders instrumentation.PromHeaders,
 	w io.Writer,
 ) error {
 	// Fetch declared configuration.
@@ -103,7 +101,7 @@ func runGet(
 	}
 
 	// Cross-reference with observed state from RunK8sMonitoring.
-	monResp, err := client.RunK8sMonitoring(ctx, promHeaders)
+	monResp, err := client.RunK8sMonitoring(ctx)
 	if err != nil {
 		return fmt.Errorf("clusters get: RunK8sMonitoring: %w", err)
 	}

--- a/cmd/gcx/instrumentation/clusters/get_test.go
+++ b/cmd/gcx/instrumentation/clusters/get_test.go
@@ -110,7 +110,7 @@ func TestRunGet(t *testing.T) {
 					c.Name = name
 					return &instrumentation.GetK8SInstrumentationResponse{Cluster: c}, nil
 				},
-				RunK8sMonitoringFn: func(_ context.Context, _ instrumentation.PromHeaders) (*instrumentation.RunK8sMonitoringResponse, error) {
+				RunK8sMonitoringFn: func(_ context.Context) (*instrumentation.RunK8sMonitoringResponse, error) {
 					if tt.monErr != nil {
 						return nil, tt.monErr
 					}
@@ -136,7 +136,6 @@ func TestRunGet(t *testing.T) {
 				opts,
 				client,
 				tt.clusterName,
-				instrumentation.PromHeaders{},
 				&buf,
 			)
 

--- a/cmd/gcx/instrumentation/clusters/list.go
+++ b/cmd/gcx/instrumentation/clusters/list.go
@@ -57,14 +57,13 @@ GetK8SInstrumentation (up to 10 concurrent requests).`,
 				return err
 			}
 			ctx := cmd.Context()
-			r, err := fleet.LoadClientWithStack(ctx, loader)
+			base, _, err := fleet.LoadClient(ctx, loader)
 			if err != nil {
 				return fmt.Errorf("clusters list: %w", err)
 			}
-			client := instrumentation.NewClient(r.Client)
-			promHeaders := instrumentation.PromHeadersFromStack(r.Stack)
+			client := instrumentation.NewClient(base)
 
-			monClient := &monitoringAdapter{client: client, promHeaders: promHeaders}
+			monClient := &monitoringAdapter{client: client}
 			pipeClient := &pipelineAdapter{client: client}
 
 			return runList(ctx, opts, monClient, pipeClient, client, cmd.OutOrStdout())

--- a/cmd/gcx/instrumentation/clusters/wait.go
+++ b/cmd/gcx/instrumentation/clusters/wait.go
@@ -84,14 +84,13 @@ Exit codes:
 			ctx := cmd.Context()
 			clusterName := args[0]
 
-			r, err := fleet.LoadClientWithStack(ctx, loader)
+			base, _, err := fleet.LoadClient(ctx, loader)
 			if err != nil {
 				return fmt.Errorf("clusters wait: %w", err)
 			}
-			client := instrumentation.NewClient(r.Client)
-			promHeaders := instrumentation.PromHeadersFromStack(r.Stack)
+			client := instrumentation.NewClient(base)
 
-			monClient := &monitoringAdapter{client: client, promHeaders: promHeaders}
+			monClient := &monitoringAdapter{client: client}
 
 			return runWait(ctx, opts, client, monClient, clusterName, cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},

--- a/cmd/gcx/instrumentation/command.go
+++ b/cmd/gcx/instrumentation/command.go
@@ -54,7 +54,13 @@ The instrumentation command tree provides:
              Sub-group "apps" manages namespace-level Beyla configuration.
 
   services   Workload-level observed state and per-workload inclusion
-             overrides across the fleet: list, get, include, exclude, clear.`,
+             overrides across the fleet: list, get, include, exclude, clear.
+
+Authentication and roles: these commands reach Fleet Management through the
+grafana-collector-app plugin proxy using your active Grafana credential (OAuth
+included) — no Cloud access-policy token is required. Reads (list/get/status)
+need the Viewer role; mutations (setup, configure, remove, include, exclude,
+clear, and the K8s discovery/monitoring calls) require the Grafana Admin role.`,
 	}
 
 	// Bind --context and --config persistently so all subcommands inherit them.

--- a/cmd/gcx/instrumentation/services/clear.go
+++ b/cmd/gcx/instrumentation/services/clear.go
@@ -54,7 +54,7 @@ Examples:
 			}
 			client := instrumentation.NewClient(r.Client)
 			urls := instrumentation.BackendURLsFromStack(r.Stack)
-			return runClear(ctx, client, args[0], args[1], args[2], urls, instrumentation.PromHeadersFromStack(r.Stack), cmd.OutOrStdout())
+			return runClear(ctx, client, args[0], args[1], args[2], urls, cmd.OutOrStdout())
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -69,11 +69,10 @@ func runClear(
 	client *instrumentation.Client,
 	cluster, namespace, service string,
 	urls instrumentation.BackendURLs,
-	promHeaders instrumentation.PromHeaders,
 	out io.Writer,
 ) error {
 	// Workload existence pre-flight: verify the service appears in discovery.
-	if err := validateWorkloadExists(ctx, client, promHeaders, cluster, namespace, service); err != nil {
+	if err := validateWorkloadExists(ctx, client, cluster, namespace, service); err != nil {
 		return err
 	}
 

--- a/cmd/gcx/instrumentation/services/clear_test.go
+++ b/cmd/gcx/instrumentation/services/clear_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
@@ -32,7 +33,7 @@ func TestRunClear_RemovesOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, &out)
 	require.NoError(t, err, "clear must succeed")
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to remove the override")
 }
@@ -53,7 +54,7 @@ func TestRunClear_NoOp_NoOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, &out)
 	require.NoError(t, err, "clear with no override must be a no-op (exit 0)")
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when no override exists")
 }
@@ -72,7 +73,7 @@ func TestRunClear_NoOp_NamespaceNotFound(t *testing.T) {
 	srv := ts.start(t)
 	client := makeIncludeClient(t, srv.URL)
 
-	err := services.RunClear(context.Background(), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err := services.RunClear(context.Background(), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, &bytes.Buffer{})
 	require.NoError(t, err, "clear on missing namespace must be a no-op")
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call for missing namespace")
 }
@@ -88,14 +89,14 @@ func TestRunClear_Idempotent_TwoCalls(t *testing.T) {
 	callCount := 0
 	ts := &includeTestServer{}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{
 			{"clusterName": "c1", "namespace": "grotshop", "name": "frontend"},
 		}})
 	})
-	mux.HandleFunc("/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		// First 3 calls: pre-check + 2 RMW reads use the with-override state.
@@ -107,7 +108,7 @@ func TestRunClear_Idempotent_TwoCalls(t *testing.T) {
 		}
 		callCount++
 	})
-	mux.HandleFunc("/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
 		ts.setAppCalled.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -119,12 +120,12 @@ func TestRunClear_Idempotent_TwoCalls(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	// First clear: removes the INCLUDED override.
-	err1 := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err1 := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, &bytes.Buffer{})
 	require.NoError(t, err1, "first clear must succeed")
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "first clear must call Set once")
 
 	// Second clear: no override → no-op.
-	err2 := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err2 := services.RunClear(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, &bytes.Buffer{})
 	require.NoError(t, err2, "second clear must succeed (exit 0)")
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "second clear must be a no-op (no additional Set)")
 }
@@ -138,8 +139,8 @@ func TestRunClear_WorkloadNotFound(t *testing.T) {
 	callCounts := map[string]int{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		callCounts[r.URL.Path]++
-		switch r.URL.Path {
+		callCounts[strings.TrimPrefix(r.URL.Path, proxyFleetBase)]++
+		switch strings.TrimPrefix(r.URL.Path, proxyFleetBase) {
 		case "/discovery.v1.DiscoveryService/RunK8sDiscovery":
 			// Return empty items — workload not found.
 			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
@@ -154,7 +155,7 @@ func TestRunClear_WorkloadNotFound(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunClear(context.Background(), client, "prod-eu", "checkout", "nonexistent-svc",
-		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+		instrumentation.BackendURLs{}, &out)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Resource not found")
 	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).

--- a/cmd/gcx/instrumentation/services/exclude.go
+++ b/cmd/gcx/instrumentation/services/exclude.go
@@ -59,7 +59,7 @@ Examples:
 			}
 			client := instrumentation.NewClient(r.Client)
 			urls := instrumentation.BackendURLsFromStack(r.Stack)
-			return runExclude(ctx, client, args[0], args[1], args[2], urls, instrumentation.PromHeadersFromStack(r.Stack), cmd.OutOrStdout())
+			return runExclude(ctx, client, args[0], args[1], args[2], urls, cmd.OutOrStdout())
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -73,11 +73,10 @@ func runExclude(
 	client *instrumentation.Client,
 	cluster, namespace, service string,
 	urls instrumentation.BackendURLs,
-	promHeaders instrumentation.PromHeaders,
 	out io.Writer,
 ) error {
 	// Workload existence pre-flight: verify the service appears in discovery.
-	if err := validateWorkloadExists(ctx, client, promHeaders, cluster, namespace, service); err != nil {
+	if err := validateWorkloadExists(ctx, client, cluster, namespace, service); err != nil {
 		return err
 	}
 

--- a/cmd/gcx/instrumentation/services/exclude_test.go
+++ b/cmd/gcx/instrumentation/services/exclude_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
@@ -30,7 +31,7 @@ func TestRunExclude_AutoinstrumentTrue_AddsExcluded(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to add EXCLUDED override when autoinstrument=true")
 }
@@ -51,7 +52,7 @@ func TestRunExclude_AutoinstrumentFalse_NoOp(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=false (namespace default is already off)")
 }
@@ -71,7 +72,7 @@ func TestRunExclude_NilAutoinstrument_NoOp(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=nil")
 }
@@ -94,7 +95,7 @@ func TestRunExclude_RemovesIncludedOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to replace INCLUDED with EXCLUDED")
 }
@@ -113,7 +114,7 @@ func TestRunExclude_NamespaceNotFound(t *testing.T) {
 	srv := ts.start(t)
 	client := makeIncludeClient(t, srv.URL)
 
-	err := services.RunExclude(context.Background(), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err := services.RunExclude(context.Background(), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, &bytes.Buffer{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "services exclude")
 	assert.Contains(t, err.Error(), "missing-ns")
@@ -133,14 +134,14 @@ func TestRunExclude_Idempotent(t *testing.T) {
 	callCount := 0
 	ts := &includeTestServer{}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{
 			{"clusterName": "c1", "namespace": "ns", "name": "svc"},
 		}})
 	})
-	mux.HandleFunc("/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		// First 3 calls (pre-check + 2 RMW reads) use initial state.
@@ -152,7 +153,7 @@ func TestRunExclude_Idempotent(t *testing.T) {
 		}
 		callCount++
 	})
-	mux.HandleFunc("/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
 		ts.setAppCalled.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -165,14 +166,14 @@ func TestRunExclude_Idempotent(t *testing.T) {
 
 	// First invocation: should call SetApp once.
 	var out1 bytes.Buffer
-	err1 := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out1)
+	err1 := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, &out1)
 	require.NoError(t, err1, "first exclude must succeed")
 	firstCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, int64(1), firstCallCount, "first exclude must call SetApp once")
 
 	// Second invocation: reads post-write state (EXCLUDED already present) → no-op.
 	var out2 bytes.Buffer
-	err2 := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out2)
+	err2 := services.RunExclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, &out2)
 	require.NoError(t, err2, "second exclude must succeed (exit 0)")
 	secondCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, firstCallCount, secondCallCount, "second exclude must be a no-op: no additional Set calls")
@@ -187,8 +188,8 @@ func TestRunExclude_WorkloadNotFound(t *testing.T) {
 	callCounts := map[string]int{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		callCounts[r.URL.Path]++
-		switch r.URL.Path {
+		callCounts[strings.TrimPrefix(r.URL.Path, proxyFleetBase)]++
+		switch strings.TrimPrefix(r.URL.Path, proxyFleetBase) {
 		case "/discovery.v1.DiscoveryService/RunK8sDiscovery":
 			// Return empty items — workload not found.
 			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
@@ -203,7 +204,7 @@ func TestRunExclude_WorkloadNotFound(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunExclude(context.Background(), client, "prod-eu", "checkout", "nonexistent-svc",
-		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+		instrumentation.BackendURLs{}, &out)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Resource not found")
 	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).

--- a/cmd/gcx/instrumentation/services/export_test.go
+++ b/cmd/gcx/instrumentation/services/export_test.go
@@ -14,10 +14,9 @@ func RunList(
 	opts *ListOpts,
 	outOpts *cmdio.Options,
 	client *instrumentation.Client,
-	promHeaders instrumentation.PromHeaders,
 	out io.Writer,
 ) error {
-	return runList(ctx, opts, outOpts, client, promHeaders, out)
+	return runList(ctx, opts, outOpts, client, out)
 }
 
 // ListOpts is an alias for listOpts so external tests can construct opts.
@@ -29,10 +28,9 @@ func RunGet(
 	outOpts *cmdio.Options,
 	client *instrumentation.Client,
 	cluster, namespace, service string,
-	promHeaders instrumentation.PromHeaders,
 	out io.Writer,
 ) error {
-	return runGet(ctx, outOpts, client, cluster, namespace, service, promHeaders, out)
+	return runGet(ctx, outOpts, client, cluster, namespace, service, out)
 }
 
 // RunInclude exposes the internal runInclude function for use in external test packages.
@@ -41,10 +39,9 @@ func RunInclude(
 	client *instrumentation.Client,
 	cluster, namespace, service string,
 	urls instrumentation.BackendURLs,
-	promHeaders instrumentation.PromHeaders,
 	out io.Writer,
 ) error {
-	return runInclude(ctx, client, cluster, namespace, service, urls, promHeaders, out)
+	return runInclude(ctx, client, cluster, namespace, service, urls, out)
 }
 
 // RunExclude exposes the internal runExclude function for use in external test packages.
@@ -53,10 +50,9 @@ func RunExclude(
 	client *instrumentation.Client,
 	cluster, namespace, service string,
 	urls instrumentation.BackendURLs,
-	promHeaders instrumentation.PromHeaders,
 	out io.Writer,
 ) error {
-	return runExclude(ctx, client, cluster, namespace, service, urls, promHeaders, out)
+	return runExclude(ctx, client, cluster, namespace, service, urls, out)
 }
 
 // RunClear exposes the internal runClear function for use in external test packages.
@@ -65,10 +61,9 @@ func RunClear(
 	client *instrumentation.Client,
 	cluster, namespace, service string,
 	urls instrumentation.BackendURLs,
-	promHeaders instrumentation.PromHeaders,
 	out io.Writer,
 ) error {
-	return runClear(ctx, client, cluster, namespace, service, urls, promHeaders, out)
+	return runClear(ctx, client, cluster, namespace, service, urls, out)
 }
 
 // ApplyIncludeMutation exposes applyIncludeMutation for unit tests.
@@ -95,8 +90,7 @@ func NormalizeStatus(s string) instrumentation.InstrumentationStatus {
 func ValidateWorkloadExists(
 	ctx context.Context,
 	client *instrumentation.Client,
-	promHeaders instrumentation.PromHeaders,
 	cluster, namespace, service string,
 ) error {
-	return validateWorkloadExists(ctx, client, promHeaders, cluster, namespace, service)
+	return validateWorkloadExists(ctx, client, cluster, namespace, service)
 }

--- a/cmd/gcx/instrumentation/services/get.go
+++ b/cmd/gcx/instrumentation/services/get.go
@@ -52,13 +52,12 @@ Workload-level Selection / override state is not surfaced on this command. To in
 				return err
 			}
 			ctx := cmd.Context()
-			r, err := fleet.LoadClientWithStack(ctx, loader)
+			base, _, err := fleet.LoadClient(ctx, loader)
 			if err != nil {
 				return fmt.Errorf("services get: %w", err)
 			}
-			client := instrumentation.NewClient(r.Client)
-			promHeaders := instrumentation.PromHeadersFromStack(r.Stack)
-			return runGet(ctx, &opts.IO, client, args[0], args[1], args[2], promHeaders, cmd.OutOrStdout())
+			client := instrumentation.NewClient(base)
+			return runGet(ctx, &opts.IO, client, args[0], args[1], args[2], cmd.OutOrStdout())
 		},
 	}
 
@@ -74,10 +73,9 @@ func runGet(
 	outOpts *cmdio.Options,
 	client *instrumentation.Client,
 	cluster, namespace, service string,
-	promHeaders instrumentation.PromHeaders,
 	out io.Writer,
 ) error {
-	resp, err := client.RunK8sDiscovery(ctx, promHeaders)
+	resp, err := client.RunK8sDiscovery(ctx)
 	if err != nil {
 		return fmt.Errorf("services get: %w", err)
 	}

--- a/cmd/gcx/instrumentation/services/get_test.go
+++ b/cmd/gcx/instrumentation/services/get_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
 	gcxerrors "github.com/grafana/gcx/internal/gcxerrors"
 	cmdio "github.com/grafana/gcx/internal/output"
-	"github.com/grafana/gcx/internal/providers/instrumentation"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,7 +45,6 @@ func TestRunGet_HappyPath(t *testing.T) {
 		outOpts,
 		client,
 		"prod-1", "checkout", "frontend",
-		instrumentation.PromHeaders{},
 		&buf,
 	)
 	require.NoError(t, err)
@@ -82,7 +80,6 @@ func TestRunGet_NotFound(t *testing.T) {
 		outOpts,
 		client,
 		"prod-1", "checkout", "missing-svc",
-		instrumentation.PromHeaders{},
 		&bytes.Buffer{},
 	)
 	require.Error(t, err)
@@ -128,7 +125,6 @@ func TestRunGet_WrongCluster(t *testing.T) {
 		outOpts,
 		client,
 		"prod-2", "checkout", "frontend", // wrong cluster
-		instrumentation.PromHeaders{},
 		&bytes.Buffer{},
 	)
 	require.Error(t, err)
@@ -165,7 +161,6 @@ func TestRunGet_JSON_SingleObject(t *testing.T) {
 		outOpts,
 		client,
 		"prod-1", "checkout", "frontend",
-		instrumentation.PromHeaders{},
 		&buf,
 	)
 	require.NoError(t, err)

--- a/cmd/gcx/instrumentation/services/helpers.go
+++ b/cmd/gcx/instrumentation/services/helpers.go
@@ -17,10 +17,9 @@ import (
 func validateWorkloadExists(
 	ctx context.Context,
 	client *instrumentation.Client,
-	promHeaders instrumentation.PromHeaders,
 	cluster, namespace, service string,
 ) error {
-	resp, err := client.RunK8sDiscovery(ctx, promHeaders)
+	resp, err := client.RunK8sDiscovery(ctx)
 	if err != nil {
 		return fmt.Errorf("workload validation: %w", err)
 	}

--- a/cmd/gcx/instrumentation/services/include.go
+++ b/cmd/gcx/instrumentation/services/include.go
@@ -59,7 +59,7 @@ Examples:
 			}
 			client := instrumentation.NewClient(r.Client)
 			urls := instrumentation.BackendURLsFromStack(r.Stack)
-			return runInclude(ctx, client, args[0], args[1], args[2], urls, instrumentation.PromHeadersFromStack(r.Stack), cmd.OutOrStdout())
+			return runInclude(ctx, client, args[0], args[1], args[2], urls, cmd.OutOrStdout())
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -75,11 +75,10 @@ func runInclude(
 	client *instrumentation.Client,
 	cluster, namespace, service string,
 	urls instrumentation.BackendURLs,
-	promHeaders instrumentation.PromHeaders,
 	out io.Writer,
 ) error {
 	// Workload existence pre-flight: verify the service appears in discovery.
-	if err := validateWorkloadExists(ctx, client, promHeaders, cluster, namespace, service); err != nil {
+	if err := validateWorkloadExists(ctx, client, cluster, namespace, service); err != nil {
 		return err
 	}
 

--- a/cmd/gcx/instrumentation/services/include_test.go
+++ b/cmd/gcx/instrumentation/services/include_test.go
@@ -6,15 +6,18 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/fleet"
 	gcxerrors "github.com/grafana/gcx/internal/gcxerrors"
 	"github.com/grafana/gcx/internal/providers/instrumentation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
 
 // includeTestServer tracks GetApp and SetApp calls for include/exclude/clear tests.
@@ -39,18 +42,18 @@ func (s *includeTestServer) start(t *testing.T) *httptest.Server {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(s.getAppStatus)
 		_, _ = w.Write([]byte(s.getAppResp))
 	})
-	mux.HandleFunc("/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
 		s.setAppCalled.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(s.setAppStatus)
 		_, _ = w.Write([]byte(`{}`))
 	})
-	mux.HandleFunc("/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		items := s.discoveryItems
@@ -67,7 +70,10 @@ func (s *includeTestServer) start(t *testing.T) *httptest.Server {
 
 func makeIncludeClient(t *testing.T, serverURL string) *instrumentation.Client {
 	t.Helper()
-	f := fleet.NewClient(context.Background(), serverURL, "inst-id", "api-token", true, nil)
+	f, err := fleet.NewClient(config.NamespacedRESTConfig{
+		Config: rest.Config{Host: serverURL, BearerToken: "test-bearer"},
+	})
+	require.NoError(t, err)
 	return instrumentation.NewClient(f)
 }
 
@@ -109,14 +115,14 @@ func TestRunInclude_Idempotent_AutoinstrumentDefault(t *testing.T) {
 	ts := &includeTestServer{}
 	var srv *httptest.Server
 	mux := http.NewServeMux()
-	mux.HandleFunc("/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{
 			{"clusterName": "c1", "namespace": "grotshop", "name": "frontend"},
 		}})
 	})
-	mux.HandleFunc("/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/instrumentation.v1.InstrumentationService/GetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if callCount == 0 || callCount == 1 || callCount == 2 {
@@ -128,7 +134,7 @@ func TestRunInclude_Idempotent_AutoinstrumentDefault(t *testing.T) {
 		}
 		callCount++
 	})
-	mux.HandleFunc("/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/instrumentation.v1.InstrumentationService/SetAppInstrumentation", func(w http.ResponseWriter, _ *http.Request) {
 		ts.setAppCalled.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -141,14 +147,14 @@ func TestRunInclude_Idempotent_AutoinstrumentDefault(t *testing.T) {
 
 	// First invocation: should call SetApp once.
 	var out1 bytes.Buffer
-	err1 := services.RunInclude(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out1)
+	err1 := services.RunInclude(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, &out1)
 	require.NoError(t, err1, "first include must succeed (exit 0)")
 	firstCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, int64(1), firstCallCount, "first include must call SetApp once")
 
 	// Second invocation: reads post-write state (INCLUDED already present) → no-op.
 	var out2 bytes.Buffer
-	err2 := services.RunInclude(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out2)
+	err2 := services.RunInclude(context.Background(), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, &out2)
 	require.NoError(t, err2, "second include must succeed (exit 0)")
 	secondCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, firstCallCount, secondCallCount,
@@ -171,7 +177,7 @@ func TestRunInclude_AutoinstrumentTrue_NoOverrideAdded(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunInclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunInclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, &out)
 	require.NoError(t, err)
 	// autoinstrument=true: namespace default is on, no override needed → no-op.
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=true and service is not excluded")
@@ -195,7 +201,7 @@ func TestRunInclude_RemovesExcludedOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunInclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunInclude(context.Background(), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to remove EXCLUDED override")
 }
@@ -215,7 +221,7 @@ func TestRunInclude_NamespaceNotFound(t *testing.T) {
 	srv := ts.start(t)
 	client := makeIncludeClient(t, srv.URL)
 
-	err := services.RunInclude(context.Background(), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err := services.RunInclude(context.Background(), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, &bytes.Buffer{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "services include")
 	assert.Contains(t, err.Error(), "missing-ns")
@@ -230,8 +236,8 @@ func TestRunInclude_WorkloadNotFound(t *testing.T) {
 	callCounts := map[string]int{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		callCounts[r.URL.Path]++
-		switch r.URL.Path {
+		callCounts[strings.TrimPrefix(r.URL.Path, proxyFleetBase)]++
+		switch strings.TrimPrefix(r.URL.Path, proxyFleetBase) {
 		case "/discovery.v1.DiscoveryService/RunK8sDiscovery":
 			// Return empty items — workload not found.
 			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
@@ -246,7 +252,7 @@ func TestRunInclude_WorkloadNotFound(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunInclude(context.Background(), client, "prod-eu", "checkout", "nonexistent-svc",
-		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+		instrumentation.BackendURLs{}, &out)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Resource not found")
 	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).
@@ -261,7 +267,7 @@ func TestRunInclude_WorkloadNotFound(t *testing.T) {
 func TestRunInclude_WorkloadNotFound_ExitCode1(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
+		switch strings.TrimPrefix(r.URL.Path, proxyFleetBase) {
 		case "/discovery.v1.DiscoveryService/RunK8sDiscovery":
 			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
 		default:
@@ -275,7 +281,7 @@ func TestRunInclude_WorkloadNotFound_ExitCode1(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunInclude(context.Background(), client, "prod-eu", "checkout", "nonexistent-svc",
-		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+		instrumentation.BackendURLs{}, &out)
 	require.Error(t, err)
 
 	var de *gcxerrors.DetailedError

--- a/cmd/gcx/instrumentation/services/list.go
+++ b/cmd/gcx/instrumentation/services/list.go
@@ -72,13 +72,12 @@ Workload-level Selection / override state is not surfaced on this command. To in
 				return err
 			}
 			ctx := cmd.Context()
-			r, err := fleet.LoadClientWithStack(ctx, loader)
+			base, _, err := fleet.LoadClient(ctx, loader)
 			if err != nil {
 				return fmt.Errorf("services list: %w", err)
 			}
-			client := instrumentation.NewClient(r.Client)
-			promHeaders := instrumentation.PromHeadersFromStack(r.Stack)
-			return runList(ctx, opts, outOpts, client, promHeaders, cmd.OutOrStdout())
+			client := instrumentation.NewClient(base)
+			return runList(ctx, opts, outOpts, client, cmd.OutOrStdout())
 		},
 	}
 
@@ -96,10 +95,9 @@ func runList(
 	opts *listOpts,
 	outOpts *cmdio.Options,
 	client *instrumentation.Client,
-	promHeaders instrumentation.PromHeaders,
 	out io.Writer,
 ) error {
-	resp, err := client.RunK8sDiscovery(ctx, promHeaders)
+	resp, err := client.RunK8sDiscovery(ctx)
 	if err != nil {
 		return fmt.Errorf("services list: %w", err)
 	}

--- a/cmd/gcx/instrumentation/services/list_test.go
+++ b/cmd/gcx/instrumentation/services/list_test.go
@@ -10,16 +10,22 @@ import (
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/fleet"
 	gcxerrors "github.com/grafana/gcx/internal/gcxerrors"
 	cmdio "github.com/grafana/gcx/internal/output"
-	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/instrumentation"
 	instrumout "github.com/grafana/gcx/internal/providers/instrumentation/output"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
+
+// proxyFleetBase is the collector-app fleet-management-api proxy route prefix
+// the base client prepends to every Connect service/method path. Test servers
+// register (or trim) it so their route matching mirrors the live transport.
+const proxyFleetBase = "/api/plugin-proxy/grafana-collector-app/fleet-management-api"
 
 // discoveryTestServer serves fake RunK8sDiscovery responses.
 type discoveryTestServer struct {
@@ -29,7 +35,7 @@ type discoveryTestServer struct {
 func (s *discoveryTestServer) start(t *testing.T) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
-	mux.HandleFunc("/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(proxyFleetBase+"/discovery.v1.DiscoveryService/RunK8sDiscovery", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		resp := map[string]any{"items": s.items}
@@ -42,7 +48,10 @@ func (s *discoveryTestServer) start(t *testing.T) *httptest.Server {
 
 func makeDiscoveryClient(t *testing.T, serverURL string) *instrumentation.Client {
 	t.Helper()
-	f := fleet.NewClient(context.Background(), serverURL, "inst-id", "api-token", true, nil)
+	f, err := fleet.NewClient(config.NamespacedRESTConfig{
+		Config: rest.Config{Host: serverURL, BearerToken: "test-bearer"},
+	})
+	require.NoError(t, err)
 	return instrumentation.NewClient(f)
 }
 
@@ -94,7 +103,6 @@ func TestRunList_StatusFilter_ERROR(t *testing.T) {
 		&services.ListOpts{Status: "ERROR"},
 		outOpts,
 		client,
-		instrumentation.PromHeaders{},
 		&buf,
 	)
 	require.NoError(t, err)
@@ -136,7 +144,6 @@ func TestRunList_StatusFilter_FullEnum(t *testing.T) {
 		&services.ListOpts{Status: "INSTRUMENTATION_ERROR"},
 		outOpts,
 		client,
-		instrumentation.PromHeaders{},
 		&buf,
 	)
 	require.NoError(t, err)
@@ -166,7 +173,6 @@ func TestRunList_ClusterFilter(t *testing.T) {
 		&services.ListOpts{Cluster: "c1"},
 		outOpts,
 		client,
-		instrumentation.PromHeaders{},
 		&buf,
 	)
 	require.NoError(t, err)
@@ -196,7 +202,6 @@ func TestRunList_NamespaceFilter(t *testing.T) {
 		&services.ListOpts{Namespace: "checkout"},
 		outOpts,
 		client,
-		instrumentation.PromHeaders{},
 		&buf,
 	)
 	require.NoError(t, err)
@@ -224,7 +229,6 @@ func TestRunList_EmptyResult(t *testing.T) {
 		&services.ListOpts{},
 		outOpts,
 		client,
-		instrumentation.PromHeaders{},
 		&buf,
 	)
 	require.NoError(t, err)
@@ -256,7 +260,6 @@ func TestRunList_JSONEnvelope_NonEmpty(t *testing.T) {
 		&services.ListOpts{},
 		outOpts,
 		client,
-		instrumentation.PromHeaders{},
 		&buf,
 	)
 	require.NoError(t, err)
@@ -296,7 +299,6 @@ func TestRunList_JSONFieldSelection_Valid(t *testing.T) {
 		&services.ListOpts{},
 		outOpts,
 		client,
-		instrumentation.PromHeaders{},
 		&buf,
 	)
 	require.NoError(t, err)
@@ -341,7 +343,6 @@ func TestRunList_JSONFieldSelection_Unknown(t *testing.T) {
 		&services.ListOpts{},
 		outOpts,
 		client,
-		instrumentation.PromHeaders{},
 		&buf,
 	)
 	require.Error(t, err)
@@ -354,8 +355,8 @@ func TestRunList_JSONFieldSelection_Unknown(t *testing.T) {
 // Used for tests that only exercise cobra.Args validation without RunE.
 type noopConfigLoader struct{}
 
-func (noopConfigLoader) LoadCloudConfig(_ context.Context) (providers.CloudRESTConfig, error) {
-	return providers.CloudRESTConfig{}, errors.New("noop loader: not connected")
+func (noopConfigLoader) LoadGrafanaConfig(_ context.Context) (config.NamespacedRESTConfig, error) {
+	return config.NamespacedRESTConfig{}, errors.New("noop loader: not connected")
 }
 
 // TestListCmd_RejectsPositionalArgs verifies that cobra.NoArgs enforcement
@@ -422,7 +423,6 @@ func TestValidateWorkloadExists_SuggestionFlagForm(t *testing.T) {
 	err := services.ValidateWorkloadExists(
 		context.Background(),
 		client,
-		instrumentation.PromHeaders{},
 		"prod-1", "checkout", "frontend",
 	)
 	require.Error(t, err)

--- a/cmd/gcx/instrumentation/setup/command.go
+++ b/cmd/gcx/instrumentation/setup/command.go
@@ -116,13 +116,11 @@ Cloud Access Policy token scoped to metrics:read and set:alloy-data-write.`,
 				return fmt.Errorf("setup: %w", err)
 			}
 			urls := instrum.BackendURLsFromStack(r.Stack)
-			promHdrs := instrum.PromHeadersFromStack(r.Stack)
 			fm := instrum.FleetManagementFromStack(r.Stack)
 
 			rn := &runner{
 				urls:     urls,
 				fm:       fm,
-				promHdrs: promHdrs,
 				token:    accessPolicyTokenPlaceholder,
 				orgSlug:  r.Stack.OrgSlug,
 				stdout:   cmd.OutOrStdout(),

--- a/cmd/gcx/instrumentation/setup/run.go
+++ b/cmd/gcx/instrumentation/setup/run.go
@@ -20,7 +20,7 @@ import (
 // clientInterface abstracts the three instrumentation API calls made by setup.
 // The concrete implementation is *instrumentation.Client; tests inject a fake.
 type clientInterface interface {
-	SetupK8sDiscovery(ctx context.Context, urls instrumentation.BackendURLs, promHeaders instrumentation.PromHeaders) error
+	SetupK8sDiscovery(ctx context.Context, urls instrumentation.BackendURLs) error
 	GetK8SInstrumentation(ctx context.Context, clusterName string) (*instrumentation.GetK8SInstrumentationResponse, error)
 	SetK8SInstrumentation(ctx context.Context, clusterName string, k8s instrumentation.Cluster, urls instrumentation.BackendURLs) error
 }
@@ -30,10 +30,9 @@ type clientInterface interface {
 // allow table-driven tests to vary individual components.
 type runner struct {
 	// client is nil when --print-helm-only is set (structural no-call guarantee).
-	client   clientInterface
-	urls     instrumentation.BackendURLs
-	fm       instrumentation.FleetManagement // used by helm.Format
-	promHdrs instrumentation.PromHeaders
+	client clientInterface
+	urls   instrumentation.BackendURLs
+	fm     instrumentation.FleetManagement // used by helm.Format
 	// token is substituted into the helm command as the access-policy password.
 	token string
 	// orgSlug is the Grafana Cloud org slug used to build the access-policies URL
@@ -73,7 +72,7 @@ func run(ctx context.Context, o *opts, cluster string, r *runner) error {
 	}
 
 	// Step 2: SetupK8sDiscovery is idempotent — always call.
-	if err := r.client.SetupK8sDiscovery(ctx, r.urls, r.promHdrs); err != nil {
+	if err := r.client.SetupK8sDiscovery(ctx, r.urls); err != nil {
 		return fmt.Errorf("setup: %w", err)
 	}
 	fmt.Fprintln(r.stderr, "SetupK8sDiscovery: ok")

--- a/cmd/gcx/instrumentation/setup/run_test.go
+++ b/cmd/gcx/instrumentation/setup/run_test.go
@@ -35,7 +35,7 @@ type fakeClient struct {
 	getResponse *instrumentation.GetK8SInstrumentationResponse
 }
 
-func (f *fakeClient) SetupK8sDiscovery(_ context.Context, _ instrumentation.BackendURLs, _ instrumentation.PromHeaders) error {
+func (f *fakeClient) SetupK8sDiscovery(_ context.Context, _ instrumentation.BackendURLs) error {
 	f.setupCalled = true
 	return f.setupErr
 }
@@ -88,7 +88,6 @@ func TestRun(t *testing.T) { //nolint:maintidx // intentionally large table-driv
 			client:   client,
 			urls:     instrumentation.BackendURLs{},
 			fm:       instrumentation.FleetManagement{URL: "https://fleet.test", Username: "42"},
-			promHdrs: instrumentation.PromHeaders{},
 			token:    "<TOKEN>",
 			stdout:   &bytes.Buffer{},
 			stderr:   &bytes.Buffer{},

--- a/cmd/gcx/instrumentation/status/command.go
+++ b/cmd/gcx/instrumentation/status/command.go
@@ -76,18 +76,17 @@ workload-level status for a specific namespace, powered by RunK8sDiscovery.`,
 
 			ctx := cmd.Context()
 
-			r, err := fleetbase.LoadClientWithStack(ctx, opts.loader)
+			base, _, err := fleetbase.LoadClient(ctx, opts.loader)
 			if err != nil {
 				return fmt.Errorf("instrumentation status: %w", err)
 			}
 
-			client := instrum.NewClient(r.Client)
-			promHdrs := instrum.PromHeadersFromStack(r.Stack)
+			client := instrum.NewClient(base)
 
-			mon := &monitoringAdapter{client: client, promHeaders: promHdrs}
+			mon := &monitoringAdapter{client: client}
 			// *instrum.Client satisfies pipelineSource directly (ListPipelines matches).
 			var pipe pipelineSource = client
-			disc := &discoveryAdapter{client: client, promHeaders: promHdrs}
+			disc := &discoveryAdapter{client: client}
 
 			result, err := run(ctx, opts.Cluster, opts.Namespace, mon, pipe, disc)
 			if err != nil {

--- a/cmd/gcx/instrumentation/status/run.go
+++ b/cmd/gcx/instrumentation/status/run.go
@@ -12,10 +12,9 @@ import (
 	instroutput "github.com/grafana/gcx/internal/providers/instrumentation/output"
 )
 
-// monitoringSource is the minimal interface required to call RunK8sMonitoring
-// without PromHeaders in the signature. The real *instrumentation.Client
-// requires PromHeaders; the monitoringAdapter struct binds them at construction.
-// Structurally identical to enumerate.MonitoringClient.
+// monitoringSource is the minimal interface required to call RunK8sMonitoring.
+// The monitoringAdapter unwraps the *instrumentation.Client response to a
+// cluster slice. Structurally identical to enumerate.MonitoringClient.
 type monitoringSource interface {
 	RunK8sMonitoring(ctx context.Context) ([]instrumentation.ClusterObservedState, error)
 }
@@ -27,24 +26,23 @@ type pipelineSource interface {
 	ListPipelines(ctx context.Context) ([]instrumentation.Pipeline, error)
 }
 
-// discoverySource is the minimal interface required to call RunK8sDiscovery
-// without PromHeaders in the signature. The discoveryAdapter binds them at
-// construction time.
+// discoverySource is the minimal interface required to call RunK8sDiscovery.
+// The discoveryAdapter unwraps the *instrumentation.Client response to an item
+// slice.
 type discoverySource interface {
 	RunK8sDiscovery(ctx context.Context) ([]instrumentation.DiscoveryItem, error)
 }
 
 // monitoringAdapter adapts *instrumentation.Client to the monitoringSource
-// interface expected by enumerate.Enumerate. PromHeaders are bound at
-// construction so callers can pass this as enumerate.MonitoringClient.
+// interface expected by enumerate.Enumerate, unwrapping the response to its
+// cluster slice.
 type monitoringAdapter struct {
-	client      *instrumentation.Client
-	promHeaders instrumentation.PromHeaders
+	client *instrumentation.Client
 }
 
 // RunK8sMonitoring satisfies monitoringSource (and enumerate.MonitoringClient).
 func (a *monitoringAdapter) RunK8sMonitoring(ctx context.Context) ([]instrumentation.ClusterObservedState, error) {
-	resp, err := a.client.RunK8sMonitoring(ctx, a.promHeaders)
+	resp, err := a.client.RunK8sMonitoring(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -52,15 +50,14 @@ func (a *monitoringAdapter) RunK8sMonitoring(ctx context.Context) ([]instrumenta
 }
 
 // discoveryAdapter adapts *instrumentation.Client to the discoverySource
-// interface. PromHeaders are bound at construction.
+// interface, unwrapping the response to its item slice.
 type discoveryAdapter struct {
-	client      *instrumentation.Client
-	promHeaders instrumentation.PromHeaders
+	client *instrumentation.Client
 }
 
 // RunK8sDiscovery satisfies discoverySource.
 func (a *discoveryAdapter) RunK8sDiscovery(ctx context.Context) ([]instrumentation.DiscoveryItem, error) {
-	resp, err := a.client.RunK8sDiscovery(ctx, a.promHeaders)
+	resp, err := a.client.RunK8sDiscovery(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gcx/setup/command.go
+++ b/cmd/gcx/setup/command.go
@@ -62,14 +62,13 @@ func newStatusCommand(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			r, err := fleetbase.LoadClientWithStack(ctx, loader)
+			base, _, err := fleetbase.LoadClient(ctx, loader)
 			if err != nil {
 				return fmt.Errorf("setup: %w", err)
 			}
-			client := instrum.NewClient(r.Client)
-			promHdrs := instrum.PromHeadersFromStack(r.Stack)
+			client := instrum.NewClient(base)
 
-			monResp, err := client.RunK8sMonitoring(ctx, promHdrs)
+			monResp, err := client.RunK8sMonitoring(ctx)
 			if err != nil {
 				return fmt.Errorf("setup: %w", err)
 			}

--- a/docs/adrs/fleet-plugin-proxy/001-route-fleet-via-collector-app-proxy.md
+++ b/docs/adrs/fleet-plugin-proxy/001-route-fleet-via-collector-app-proxy.md
@@ -1,7 +1,8 @@
 # Route `fleet` and `instrumentation` through the `grafana-collector-app` plugin proxy
 
 **Created**: 2026-06-24
-**Status**: proposed
+**Updated**: 2026-07-07
+**Status**: accepted
 **Supersedes**: none
 
 <!-- Status lifecycle: proposed -> accepted -> deprecated | superseded -->
@@ -37,11 +38,15 @@ in gcx. Routing through the plugin puts `fleet`/`instrumentation` on the same
 Grafana-authenticated transport as every other provider.
 
 The plugin-proxy transport is also the **dominant** HTTP pattern in gcx already:
-assistant, aio11y, irm, k6, slo, and kg providers all reach
-`/api/plugins/<id>/resources/...` via `rest.HTTPClientFor(&cfg.Config)`
-(`internal/assistant/assistanthttp/` is the canonical template). The config
-plumbing exists with no new wiring: the same `providers.ConfigLoader` the fleet
-providers already instantiate exposes
+assistant, aio11y, irm, k6, slo, and kg providers all reach the plugin proxy via
+`rest.HTTPClientFor(&cfg.Config)` (`internal/assistant/assistanthttp/` is the
+canonical template). Those providers target a *backend* plugin's
+`/api/plugins/<id>/resources/...` endpoint. `grafana-collector-app` is a
+**frontend-only** app plugin (it ships no backend), so it is reached through
+Grafana's **app plugin-proxy** at `/api/plugin-proxy/grafana-collector-app/...` —
+the same `rest.HTTPClientFor()` bearer transport at `cfg.Host`, only a different
+path prefix. The config plumbing exists with no new wiring: the same
+`providers.ConfigLoader` the fleet providers already instantiate exposes
 `LoadGrafanaConfig(ctx) → config.NamespacedRESTConfig` (`Host` + `rest.Config`).
 
 This change is **CONSTITUTION-touching**. `CONSTITUTION.md`'s dependency rule
@@ -70,7 +75,10 @@ everything else.
 
 The wire format is identical (the proxy is transparent), and backend datasource
 URLs travel in the request **body**, so the instrumentation `Set*`/`Setup*`
-paths pass through unchanged.
+paths pass through unchanged. gcx keeps populating those body URLs; only their
+*source* moves — from a direct GCOM lookup to the collector-app's
+Grafana-authenticated instance-metadata proxy route (Viewer role), so no Cloud
+token is needed to build them.
 
 ### Alternatives considered
 
@@ -92,18 +100,29 @@ Route all `gcx fleet` and `gcx instrumentation` FM traffic through the
 1. **Transport.** Swap the `internal/fleet/` base client from the direct
    Basic-auth POST (to the FM endpoint) to the plugin-proxy pattern: build the
    HTTP client with `rest.HTTPClientFor(&cfg.Config)` and target
-   `cfg.Host + /api/plugins/grafana-collector-app/resources/fleet-management-api`
+   `cfg.Host + /api/plugin-proxy/grafana-collector-app/fleet-management-api`
    + the existing service/method path. Grafana auth is injected by the k8s
-   round-tripper.
+   round-tripper. (The **app plugin-proxy** path `/api/plugin-proxy/<id>/...` is
+   used — not the backend-plugin `/api/plugins/<id>/resources/...` endpoint —
+   because `grafana-collector-app` ships no backend; the resources endpoint would
+   not resolve for it.)
 2. **Config.** Resolve connection details via
    `providers.ConfigLoader.LoadGrafanaConfig(ctx)` (`NamespacedRESTConfig`)
    instead of `LoadCloudConfig(ctx)`'s `AgentManagementInstanceURL` + FM token.
    gcx no longer needs an FM-scoped access-policy token for these commands, nor
-   `AgentManagementInstanceURL`/`ID` from GCOM.
+   `AgentManagementInstanceURL`/`ID` from GCOM. `instrumentation` still needs the
+   stack's backend datasource URLs (Mimir/Loki/Tempo/Pyroscope) in its request
+   bodies, but sources them through the collector-app's Grafana-authenticated
+   instance-metadata proxy route (**Viewer** role) rather than a direct GCOM
+   call — so **no Cloud access-policy token is required for `instrumentation`
+   either**. The cutover removes the Cloud-token requirement for both command
+   groups outright; there is no residual dual-credential path.
 3. **Drop now-redundant request decoration.** The instrumentation client no
-   longer sets the `X-Prom-Cluster-ID`/`X-Prom-Instance-ID` headers itself.
-   Backend datasource URLs remain in the request body (still gcx's
-   responsibility).
+   longer sets the `X-Prom-Cluster-ID`/`X-Prom-Instance-ID` (or `X-Scope-OrgID`)
+   headers itself — the plugin proxy injects the cluster/instance and org-scope
+   headers server-side, so client-side decoration is redundant. Backend
+   datasource URLs remain in the request body (still gcx's responsibility, now
+   sourced via the proxy per item 2).
 4. **Clean cutover, no hybrid.** No fallback to direct FM access (see
    Alternatives).
 5. **Amend the CONSTITUTION.** Update the dependency rule in `CONSTITUTION.md`
@@ -122,7 +141,10 @@ FM-scoped token requirement.
 - **Enables OAuth support.** Direct FM access needs a Cloud access-policy token,
   so interactive OAuth users cannot drive `fleet`/`instrumentation` today.
   Because the proxy authenticates the caller to Grafana rather than to FM, any
-  Grafana credential — OAuth included — now works.
+  Grafana credential — OAuth included — now works. This holds for **both**
+  command groups: routing `instrumentation`'s backend-URL lookup through the
+  plugin proxy as well means neither `fleet` nor `instrumentation` keeps any
+  Cloud-token dependency.
 - **Consistency with the other providers.** `fleet`/`instrumentation` join the
   plugin-proxy transport family (assistant, aio11y, irm, k6, slo, kg) instead of
   being a Basic-auth special case. Behaviour converges too: errors, status
@@ -151,15 +173,48 @@ all in scope of executing this decision, not deferred beyond it:
 
 - Implement the transport + config swap in `internal/fleet/` (base client) and
   adjust the `internal/providers/fleet/` and `internal/providers/instrumentation/`
-  call sites; the per-method typed surfaces are unchanged.
-- Amend the `CONSTITUTION.md` dependency rule and set this ADR's status to
-  `accepted` on sign-off.
+  call sites; the per-method typed surfaces are unchanged. Target the app
+  plugin-proxy path (`/api/plugin-proxy/grafana-collector-app/fleet-management-api`).
+- Widen the `internal/fleet` `ConfigLoader` interface (today it declares
+  `LoadCloudConfig` only) to expose `LoadGrafanaConfig`, and rethread the
+  instrumentation commands typed against it.
+- Add an instance-metadata fetch for `instrumentation`'s backend datasource URLs
+  through the collector-app's Grafana-authenticated proxy route, reusing the
+  existing `StackInfo` field mapping to build request bodies. Verify the proxied
+  instance response carries the same fields `BackendURLsFromStack` consumes.
+- Amend the `CONSTITUTION.md` dependency rule (remove **Fleet** from the "outside
+  the Grafana server" list) to match this decision.
 - Update `gcx fleet` / `gcx instrumentation` command docs to state the Grafana
-  `Admin` role requirement for service-account tokens.
+  role requirement (Viewer for reads, `Admin` for mutations via the
+  `/fleet-management-api/*` catch-all). Edit the Cobra `Short`/`Long` help and
+  regenerate the CLI reference.
 - Review error mapping for proxy/RBAC responses so messages stay actionable
   (e.g. distinguishing "missing RBAC" from "FM rejected the request").
 - Update `ARCHITECTURE.md` (Instrumentation/Fleet sections + ADR index) and
   `internal/fleet` package docs to reflect the proxy transport.
 - Reconcile tests in `internal/fleet`, `internal/providers/fleet`, and
-  `internal/providers/instrumentation` (auth assertions move from Basic-auth to
-  plugin-proxy path/URL expectations).
+  `internal/providers/instrumentation` (drop the `useBasicAuth`/instance-ID/token
+  constructor args; auth assertions move from Basic-auth to plugin-proxy
+  path/URL expectations).
+- Respect the closed-source boundary: gcx is public, the collector-app plugin is
+  not — public docs describe gcx's proxy calls without documenting plugin
+  internals.
+
+### Validation (2026-07-07)
+
+Verified against the current `gcx` code and the `grafana-collector-app` plugin
+before spec-out; two corrections were folded into this ADR:
+
+- **Proxy path.** Transport targets the app plugin-proxy
+  (`/api/plugin-proxy/grafana-collector-app/...`), not the backend-plugin
+  resources endpoint (`/api/plugins/<id>/resources/...`) — the collector-app has
+  no backend, so the resources path would not resolve.
+- **`instrumentation` is fully OAuth-capable, no dual-config.** Its backend
+  datasource URLs are sourced through the collector-app's Grafana-authenticated
+  instance-metadata proxy route (Viewer role), so `instrumentation` keeps no
+  Cloud-token dependency — matching `fleet`. The earlier assumption that gcx
+  must reach GCOM directly (which would have left a residual token requirement)
+  does not hold once that lookup is routed through the same proxy.
+
+The `X-Prom-*`/`X-Scope-OrgID` header and FM-credential injection all occur
+server-side in the proxy, confirming the client-side decoration is safe to drop.

--- a/docs/adrs/fleet-plugin-proxy/001-route-fleet-via-collector-app-proxy.md
+++ b/docs/adrs/fleet-plugin-proxy/001-route-fleet-via-collector-app-proxy.md
@@ -1,0 +1,165 @@
+# Route `fleet` and `instrumentation` through the `grafana-collector-app` plugin proxy
+
+**Created**: 2026-06-24
+**Status**: proposed
+**Supersedes**: none
+
+<!-- Status lifecycle: proposed -> accepted -> deprecated | superseded -->
+
+## Context
+
+`gcx fleet` and `gcx instrumentation` both talk to the Grafana Fleet Management
+(FM) API **directly**. They share a base HTTP client (`internal/fleet/`) that
+POSTs Connect-style JSON to the FM gRPC endpoint with Basic auth (the FM instance
+ID as username, the FM access-policy token as password):
+
+- `internal/fleet/` — the base client and its config loader, which resolves the
+  FM instance URL/ID from GCOM stack info and the access-policy token from the
+  active context.
+- `internal/providers/fleet/` — typed pipeline/collector/tenant methods
+  (`ListPipelines`, `Create/Update/DeletePipeline`, `*Collector`, `GetLimits`).
+- `internal/providers/instrumentation/` — instrumentation, discovery, and
+  pipeline methods layered on the same base client; sets the per-request
+  `X-Prom-*` cluster/instance headers and embeds backend datasource push URLs in
+  request bodies.
+
+This direct path requires the caller to hold an **FM-scoped access-policy
+token**, which gcx uses as the Basic-auth password (username = FM instance ID).
+
+`grafana-collector-app` — the Grafana app plugin the Fleet Management UI already
+uses — exposes the same FM routes under `/fleet-management-api/...` and relies on
+**Grafana authNZ**. A caller authenticates to Grafana (`cfg.Host`) with its
+existing credential and reaches FM without holding an FM token of its own.
+
+**Why now.** FM's direct API doesn't accept Grafana OAuth credentials — it
+requires a Cloud access-policy token — and we want OAuth to work across the board
+in gcx. Routing through the plugin puts `fleet`/`instrumentation` on the same
+Grafana-authenticated transport as every other provider.
+
+The plugin-proxy transport is also the **dominant** HTTP pattern in gcx already:
+assistant, aio11y, irm, k6, slo, and kg providers all reach
+`/api/plugins/<id>/resources/...` via `rest.HTTPClientFor(&cfg.Config)`
+(`internal/assistant/assistanthttp/` is the canonical template). The config
+plumbing exists with no new wiring: the same `providers.ConfigLoader` the fleet
+providers already instantiate exposes
+`LoadGrafanaConfig(ctx) → config.NamespacedRESTConfig` (`Host` + `rest.Config`).
+
+This change is **CONSTITUTION-touching**. `CONSTITUTION.md`'s dependency rule
+mandates `httputils.NewDefaultClient(ctx)` (no auth injection) for "APIs outside
+the Grafana server" and explicitly names **Fleet** as such a case. Routing through
+the proxy moves these calls *to* `cfg.Host`, where the correct client is
+`rest.HTTPClientFor()` (which injects the Grafana bearer token) — the inverse of
+the current rule. The invariant is descriptive of today's design, not a
+prohibition on changing it, but the amendment requires explicit sign-off.
+
+### Route migration plan
+
+Every path gcx calls is reachable. Named routes grant **Viewer**-level reads; an
+`/fleet-management-api/*` catch-all route (requiring the **Admin** role) proxies
+everything else.
+
+| current RPC | target route | required role |
+|---|---|---|
+| `pipeline.v1` `ListPipelines` / `GetPipeline` | named | **Viewer** |
+| `collector.v1` `ListCollectors` / `GetCollector` | named | **Viewer** |
+| `pipeline.v1` `Create` / `Update` / `DeletePipeline` | `/fleet-management-api/*` | **Admin** |
+| `collector.v1` `Create` / `Update` / `DeleteCollector` | `/fleet-management-api/*` | **Admin** |
+| `tenant.v1` `GetLimits` (only `GetSummary` is named) | `/fleet-management-api/*` | **Admin** |
+| `instrumentation.v1` `Get/Set` `App`/`K8S` | `/fleet-management-api/*` | **Admin** |
+| `discovery.v1` `SetupK8sDiscovery` / `RunK8sDiscovery` / `RunK8sMonitoring` | `/fleet-management-api/*` | **Admin** |
+
+The wire format is identical (the proxy is transparent), and backend datasource
+URLs travel in the request **body**, so the instrumentation `Set*`/`Setup*`
+paths pass through unchanged.
+
+### Alternatives considered
+
+- **Keep direct access (status quo).** Self-contained and gcx-controlled, but
+  requires every user/CI job to obtain and carry an FM-scoped access-policy token
+  in addition to their Grafana credential.
+- **Hybrid: plugin-proxy when the plugin is detected, else fall back to direct.**
+  Rejected as unnecessary. Because the commands are Cloud-only and the plugin is
+  guaranteed on all Cloud stacks, the fallback branch would serve no environment
+  that exists for these commands. It would add a probe + two transports to
+  maintain for a dead path. Revisit only if FM becomes reachable outside Grafana
+  Cloud (i.e., a non-GCOM way to set the FM URL is introduced).
+
+## Decision
+
+Route all `gcx fleet` and `gcx instrumentation` FM traffic through the
+`grafana-collector-app` plugin proxy, replacing direct FM access. Specifically:
+
+1. **Transport.** Swap the `internal/fleet/` base client from the direct
+   Basic-auth POST (to the FM endpoint) to the plugin-proxy pattern: build the
+   HTTP client with `rest.HTTPClientFor(&cfg.Config)` and target
+   `cfg.Host + /api/plugins/grafana-collector-app/resources/fleet-management-api`
+   + the existing service/method path. Grafana auth is injected by the k8s
+   round-tripper.
+2. **Config.** Resolve connection details via
+   `providers.ConfigLoader.LoadGrafanaConfig(ctx)` (`NamespacedRESTConfig`)
+   instead of `LoadCloudConfig(ctx)`'s `AgentManagementInstanceURL` + FM token.
+   gcx no longer needs an FM-scoped access-policy token for these commands, nor
+   `AgentManagementInstanceURL`/`ID` from GCOM.
+3. **Drop now-redundant request decoration.** The instrumentation client no
+   longer sets the `X-Prom-Cluster-ID`/`X-Prom-Instance-ID` headers itself.
+   Backend datasource URLs remain in the request body (still gcx's
+   responsibility).
+4. **Clean cutover, no hybrid.** No fallback to direct FM access (see
+   Alternatives).
+5. **Amend the CONSTITUTION.** Update the dependency rule in `CONSTITUTION.md`
+   to remove **Fleet** from the "outside the Grafana server" list and document
+   that `fleet`/`instrumentation` reach FM via the collector-app proxy at
+   `cfg.Host`, using `rest.HTTPClientFor()` like the other plugin-proxied
+   providers.
+
+Explicitly **rejected**: a hybrid plugin-or-direct transport; keeping the
+FM-scoped token requirement.
+
+## Consequences
+
+### Positive
+
+- **Enables OAuth support.** Direct FM access needs a Cloud access-policy token,
+  so interactive OAuth users cannot drive `fleet`/`instrumentation` today.
+  Because the proxy authenticates the caller to Grafana rather than to FM, any
+  Grafana credential — OAuth included — now works.
+- **Consistency with the other providers.** `fleet`/`instrumentation` join the
+  plugin-proxy transport family (assistant, aio11y, irm, k6, slo, kg) instead of
+  being a Basic-auth special case. Behaviour converges too: errors, status
+  codes, and auth all come from Grafana now, so these commands fail and
+  authenticate the same way as the rest of gcx.
+- **One less provider to require Cloud access-policy tokens.** gcx stops
+  requiring an FM-scoped token for these commands and relies on the Grafana
+  credential the active context already holds. Dropping the two-tier "Grafana
+  credential *and* FM token" requirement removes real friction.
+- **Opens the door to proper RBAC.** With traffic flowing through Grafana and the
+  plugin, fine-grained authorization becomes achievable as a future enhancement
+  (once the Fleet/Instrumentation teams implement RBAC in the plugin) rather than
+  the all-or-nothing authority an FM token grants today.
+
+### Negative / trade-offs
+
+- **Breaking change.** This is a clean cutover with no hybrid fallback: callers
+  that relied on direct FM access now authenticate to Grafana instead of carrying
+  an FM token. Nothing else of note — the wire format, typed method surfaces, and
+  request bodies are unchanged.
+
+### Implementation plan
+
+Once this ADR is accepted, realizing the decision involves the following work —
+all in scope of executing this decision, not deferred beyond it:
+
+- Implement the transport + config swap in `internal/fleet/` (base client) and
+  adjust the `internal/providers/fleet/` and `internal/providers/instrumentation/`
+  call sites; the per-method typed surfaces are unchanged.
+- Amend the `CONSTITUTION.md` dependency rule and set this ADR's status to
+  `accepted` on sign-off.
+- Update `gcx fleet` / `gcx instrumentation` command docs to state the Grafana
+  `Admin` role requirement for service-account tokens.
+- Review error mapping for proxy/RBAC responses so messages stay actionable
+  (e.g. distinguishing "missing RBAC" from "FM rejected the request").
+- Update `ARCHITECTURE.md` (Instrumentation/Fleet sections + ADR index) and
+  `internal/fleet` package docs to reflect the proxy transport.
+- Reconcile tests in `internal/fleet`, `internal/providers/fleet`, and
+  `internal/providers/instrumentation` (auth assertions move from Basic-auth to
+  plugin-proxy path/URL expectations).

--- a/docs/adrs/fleet-plugin-proxy/001-route-fleet-via-collector-app-proxy.md
+++ b/docs/adrs/fleet-plugin-proxy/001-route-fleet-via-collector-app-proxy.md
@@ -59,19 +59,14 @@ prohibition on changing it, but the amendment requires explicit sign-off.
 
 ### Route migration plan
 
-Every path gcx calls is reachable. Named routes grant **Viewer**-level reads; an
-`/fleet-management-api/*` catch-all route (requiring the **Admin** role) proxies
-everything else.
-
-| current RPC | target route | required role |
-|---|---|---|
-| `pipeline.v1` `ListPipelines` / `GetPipeline` | named | **Viewer** |
-| `collector.v1` `ListCollectors` / `GetCollector` | named | **Viewer** |
-| `pipeline.v1` `Create` / `Update` / `DeletePipeline` | `/fleet-management-api/*` | **Admin** |
-| `collector.v1` `Create` / `Update` / `DeleteCollector` | `/fleet-management-api/*` | **Admin** |
-| `tenant.v1` `GetLimits` (only `GetSummary` is named) | `/fleet-management-api/*` | **Admin** |
-| `instrumentation.v1` `Get/Set` `App`/`K8S` | `/fleet-management-api/*` | **Admin** |
-| `discovery.v1` `SetupK8sDiscovery` / `RunK8sDiscovery` / `RunK8sMonitoring` | `/fleet-management-api/*` | **Admin** |
+Every RPC gcx calls today is reachable through the proxy. Role gating is coarse
+and observable at the caller: **read** RPCs (the `List*` / `Get*` surfaces)
+require the **Viewer** role, and every **mutation** — plus `tenant.v1 GetLimits`
+and all `instrumentation.v1` / `discovery.v1` calls — requires the **Grafana
+Admin** role. Finer per-resource authorization is a future plugin-side
+enhancement (see Open Questions in the spec). We deliberately do not enumerate
+the plugin's internal route configuration here — gcx describes only its own
+calls and the role each requires.
 
 The wire format is identical (the proxy is transparent), and backend datasource
 URLs travel in the request **body**, so the instrumentation `Set*`/`Setup*`
@@ -185,9 +180,8 @@ all in scope of executing this decision, not deferred beyond it:
 - Amend the `CONSTITUTION.md` dependency rule (remove **Fleet** from the "outside
   the Grafana server" list) to match this decision.
 - Update `gcx fleet` / `gcx instrumentation` command docs to state the Grafana
-  role requirement (Viewer for reads, `Admin` for mutations via the
-  `/fleet-management-api/*` catch-all). Edit the Cobra `Short`/`Long` help and
-  regenerate the CLI reference.
+  role requirement (Viewer for reads, `Admin` for mutations). Edit the Cobra
+  `Short`/`Long` help and regenerate the CLI reference.
 - Review error mapping for proxy/RBAC responses so messages stay actionable
   (e.g. distinguishing "missing RBAC" from "FM rejected the request").
 - Update `ARCHITECTURE.md` (Instrumentation/Fleet sections + ADR index) and

--- a/docs/architecture/auth-system.md
+++ b/docs/architecture/auth-system.md
@@ -116,7 +116,9 @@ admin, etc.). Tokens are prefixed `glc_`.
 gcx stores them in `CloudConfig.Token` (`datapolicy:"secret"`). They are
 attached to two different API surfaces: the GCOM API (via the
 `internal/cloud/` client) and Cloud product APIs (via product-specific REST
-clients for synth, k6, IRM, fleet, and others).
+clients for synth, k6, IRM, and others). Fleet Management and instrumentation
+no longer consume a Cloud access-policy token — they reach FM through the
+`grafana-collector-app` plugin proxy at `cfg.Host` (ADR-021).
 
 Rotation is manual: rotate the access policy in the Cloud UI, then update
 the context with `gcx login --context X --cloud-token glc_new_token`.

--- a/docs/architecture/client-api-layer.md
+++ b/docs/architecture/client-api-layer.md
@@ -436,8 +436,9 @@ dynamic client gets User-Agent through `rest.Config.UserAgent`.
 
 | Caller | Factory | Notes |
 |--------|---------|-------|
-| Provider clients (SLO, Synth, Fleet, k6) | `NewDefaultClient(ctx)` | Via `CloudRESTConfig.HTTPClient(ctx)` when `RESTConfig` is nil; see note below |
+| Provider clients (SLO, Synth, k6) | `NewDefaultClient(ctx)` | Via `CloudRESTConfig.HTTPClient(ctx)` when `RESTConfig` is nil; see note below |
 | Assistant client | `NewDefaultClient(ctx)` | Direct call |
+| Fleet / instrumentation clients | `rest.HTTPClientFor(&cfg.Config)` | Reach FM via the `grafana-collector-app` plugin proxy at `cfg.Host`; Grafana bearer injected by the round-tripper (ADR-021) |
 | K8s tier (dynamic client, query clients) | `rest.Config.WrapTransport` | Chains `LoggingRoundTripper` via `NewNamespacedRESTConfig` |
 | Dev server (`internal/server`) | `NewClient(ClientOpts{...})` | Custom TLS from config context |
 

--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -257,7 +257,7 @@ query/stream endpoints that return Grafana-native response formats, not
 all three client paths without duplication.
 
 **Contrast with external APIs:** Provider clients calling **external** APIs
-(k6 Cloud, OnCall, Synth, Fleet — domains outside the Grafana server) must
+(k6 Cloud, OnCall — domains outside the Grafana server) must
 **not** use `rest.HTTPClientFor`. The k8s transport round-tripper injects the
 Grafana bearer token on every outgoing request, which conflicts with the
 product's own auth mechanism (e.g. OnCall raw token, k6 X-Grafana-Key).
@@ -488,7 +488,7 @@ flag is owned by the root command and threaded to providers via
 | Method | Purpose | Used by |
 |--------|---------|---------|
 | `LoadGrafanaConfig(ctx)` | REST config for Grafana API calls | alert, fleet, incidents, kg, oncall, slo, synth |
-| `LoadCloudConfig(ctx)` | Cloud token + GCOM stack info | k6, fleet |
+| `LoadCloudConfig(ctx)` | Cloud token + GCOM stack info | k6 |
 | `LoadProviderConfig(ctx, name)` | Provider-specific `map[string]string` + namespace | synth, oncall, k6 |
 | `SaveProviderConfig(ctx, name, key, val)` | Write-back a single provider config key | synth (datasource UID) |
 | `LoadFullConfig(ctx)` | Full `*config.Config` (for cross-cutting lookups) | synth (datasource discovery) |

--- a/docs/design/errors.md
+++ b/docs/design/errors.md
@@ -79,18 +79,23 @@ converters before more general ones.
 
 #### Fleet Management HTTP errors
 
-HTTP 401 and 403 responses from the fleet management API are handled by the
-`convertFleetHTTPErrors` converter in `cmd/gcx/fail/convert.go`. This converter
-is ordered before the generic fallback.
+`gcx fleet` and `gcx instrumentation` reach Fleet Management through the
+`grafana-collector-app` plugin proxy (ADR-021), so 401/403 responses are Grafana
+auth/RBAC outcomes, not Cloud-token problems. They are handled by two converters
+in `cmd/gcx/fail/convert.go`, both ordered before the generic fallback:
+`convertFleetHTTPErrors` (typed `fleet.HTTPError`, from the instrumentation
+client) and the string-matched `fleet:` branches (from the fleet provider's
+`status <code>` errors).
 
-- HTTP 401 → summary: `"Authentication failed"`
-- HTTP 403 → summary: `"Authorization failed"`
+- HTTP 401 → summary: `"Authentication failed"` — the Grafana credential was
+  rejected; suggestion: re-authenticate with `gcx login`.
+- HTTP 403 → summary: `"Authorization failed"` — insufficient Grafana role;
+  suggestions name the required role (Viewer for reads, Grafana Admin for
+  mutations) and note the outcome is distinguishable from an FM request
+  rejection.
 
-Both produce `DetailedError` with `ExitAuthFailure` exit code and actionable suggestions
-pointing at `gcx config set cloud.token` and `gcx login`.
-
-The converter is enabled by `fleet.HTTPError` — a typed error returned by all non-2xx
-responses in `internal/providers/instrumentation/client.go`.
+Both produce `DetailedError` with the `ExitAuthFailure` exit code. Neither
+suggests a Cloud access-policy token — fleet/instrumentation no longer use one.
 
 ### 4.4 In-Band Error Reporting
 

--- a/docs/reference/cli/gcx_fleet.md
+++ b/docs/reference/cli/gcx_fleet.md
@@ -2,6 +2,15 @@
 
 Manage Grafana Fleet Management pipelines and collectors
 
+### Synopsis
+
+Manage Grafana Fleet Management pipelines and collectors.
+
+Authentication and roles: fleet commands reach Fleet Management through the
+grafana-collector-app plugin proxy using your active Grafana credential (OAuth
+included) — no Cloud access-policy token is required. Reads (list, get) need the
+Viewer role; mutations (create, update, delete) require the Grafana Admin role.
+
 ### Options
 
 ```

--- a/docs/reference/cli/gcx_instrumentation.md
+++ b/docs/reference/cli/gcx_instrumentation.md
@@ -25,6 +25,12 @@ The instrumentation command tree provides:
   services   Workload-level observed state and per-workload inclusion
              overrides across the fleet: list, get, include, exclude, clear.
 
+Authentication and roles: these commands reach Fleet Management through the
+grafana-collector-app plugin proxy using your active Grafana credential (OAuth
+included) — no Cloud access-policy token is required. Reads (list/get/status)
+need the Viewer role; mutations (setup, configure, remove, include, exclude,
+clear, and the K8s discovery/monitoring calls) require the Grafana Admin role.
+
 ### Options
 
 ```

--- a/docs/reference/grafana-cloud-api-tiers.md
+++ b/docs/reference/grafana-cloud-api-tiers.md
@@ -67,7 +67,7 @@ reflecting Grafana's 10-year evolution from REST to K8s-style to plugin-hosted:
 | Legacy REST                      | `/api/...`                          | Oldest, broadest. Dashboards, users, teams, datasources, alerting, library panels, annotations, reports.  |
 | K8s-style API (Grafana 12+)      | `/apis/<group>.grafana.app/...`     | 33+ groups. Kubeconfig-style auth via `k8s.io/client-go`. Future of all resources.                        |
 | Plugin resources                 | `/api/plugins/<id>/resources/...`   | Per-app-plugin backends. Where Cloud products (SLO, SM, IRM, k6-shim) live.                               |
-| Plugin proxy                     | `/api/plugin-proxy/<id>/...`        | Thin auth-passthrough to a plugin. Used by Fleet UI, App O11y, Faro CRUD.                                 |
+| Plugin proxy                     | `/api/plugin-proxy/<id>/...`        | Thin auth-passthrough to a plugin. Used by App O11y, Faro CRUD, and gcx `fleet`/`instrumentation` (via `grafana-collector-app`, ADR-021).            |
 | App routes + Live WebSocket      | `/a/<id>/...`, `/api/live/ws`       | UI deep-links, CLI proxies (Assistant), streaming.                                                        |
 
 **gcx mapping**:
@@ -134,7 +134,7 @@ Some products emit calls across tiers. Knowing the map avoids wrong-tier fixes:
 
 - **Alerting** — Tier 2 (legacy `/api/ruler` + K8s `rules.alerting.grafana.app`) + Tier 3 (regional ruler + AM)
 - **Synthetic Monitoring** — Tier 2 (plugin settings) + Tier 3 (REST + gRPC) + Tier 1 (install/register)
-- **Fleet Management** — Tier 1 (discovery) + Tier 3 (gRPC) + Tier 2 (plugin-proxy UI)
+- **Fleet Management** — gcx reaches it via Tier 2 (`grafana-collector-app` plugin-proxy at `cfg.Host`, ADR-021); server-side it fronts Tier 3 (gRPC) and Tier 1 (discovery)
 - **Frontend Observability (Faro)** — Tier 2 (plugin-proxy CRUD + sourcemaps) + Tier 3 (API + ingest)
 - **IRM** — Tier 2 (plugin-resources for OnCall + Incidents) + Tier 3 (OnCall public) + legacy Tier 3 Incident
 - **Adaptive {Metrics,Logs,Traces}** — Tier 2 (plugin UI) + Tier 3 (runtime config) + Tier 1 (enablement)

--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -59,7 +59,7 @@ For on-premises instances, gcx defaults the organization ID to 1 if you do not s
 
 ### Grafana Cloud product APIs
 
-Commands under `gcx sm`, `gcx k6`, `gcx irm`, `gcx slo`, `gcx fleet`, and other Cloud product surfaces require a [Cloud Access Policy token](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/) in addition to Grafana auth.
+Commands under `gcx sm`, `gcx k6`, `gcx irm`, `gcx slo`, and other Cloud product surfaces require a [Cloud Access Policy token](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/) in addition to Grafana auth. (`gcx fleet` and `gcx instrumentation` do **not** — they reach Fleet Management through the collector-app plugin proxy using your Grafana credential; see ADR-021.)
 
 #### Where to create the token and which scopes to grant
 
@@ -76,11 +76,10 @@ Scope the access policy to what you manage. `stacks:read` is the required baseli
 |-------|---------|
 | `stacks:read` | **Required.** Stack discovery (resolves the stack slug for all Cloud commands; also covers `gcx k6` reads) |
 | `metrics:write`, `logs:write`, `traces:write` | Synthetic Monitoring and k6 (`gcx sm`, `gcx k6`) — these write verbs are needed to mint the Synthetic Monitoring token |
-| `fleet-management:read` (and `fleet-management:write` for changes) | Fleet Management (`gcx fleet`) |
 | `stacks:write` | Creating or updating stacks |
 | `set:alloy-data-write` | Instrumentation Hub setup (`gcx instrumentation`) |
 
-The Cloud Access Policy token is for Grafana Cloud product APIs (GCOM stack management, Synthetic Monitoring, k6, Fleet, IRM, SLO). Signal queries (`gcx metrics`, `gcx logs`, `gcx traces`, `gcx profiles`) authenticate with your Grafana token (OAuth or service account), not this token. When in doubt, start narrow and widen the policy as commands report missing-scope errors — the token can be re-scoped without re-running `gcx login`.
+The Cloud Access Policy token is for Grafana Cloud product APIs (GCOM stack management, Synthetic Monitoring, k6, IRM, SLO). Signal queries (`gcx metrics`, `gcx logs`, `gcx traces`, `gcx profiles`) authenticate with your Grafana token (OAuth or service account), not this token. When in doubt, start narrow and widen the policy as commands report missing-scope errors — the token can be re-scoped without re-running `gcx login`.
 
 The interactive `gcx login` prompt links to this guidance when it asks for the Cloud Access Policy token.
 
@@ -166,7 +165,7 @@ A short vocabulary so the troubleshooting entries below make sense. For the inte
 
 **Cloud vs on-premises.** gcx detects whether `--server` points at Grafana Cloud or an on-premises instance. The hostname is matched against known Cloud suffixes first (no network call); loopback and RFC1918 addresses are classified as on-premises; anything else is probed with a short HTTP request. The classification drives which auth methods appear in the prompt.
 
-**Three auth methods, three API surfaces.** OAuth (browser-based, Cloud only) and service account tokens both authenticate to the Grafana API — dashboards, folders, datasources, alerts, and the K8s-compatible `/apis` endpoints. Cloud Access Policy tokens are a separate credential used for GCOM (stack management) and Cloud product APIs (Synthetic Monitoring, k6, IRM, SLO, Fleet, etc.). A Cloud context typically holds two tokens: one for Grafana, one for Cloud. An on-premises context holds only a service account token.
+**Three auth methods, three API surfaces.** OAuth (browser-based, Cloud only) and service account tokens both authenticate to the Grafana API — dashboards, folders, datasources, alerts, and the K8s-compatible `/apis` endpoints. Cloud Access Policy tokens are a separate credential used for GCOM (stack management) and Cloud product APIs (Synthetic Monitoring, k6, IRM, SLO, etc.). A Cloud context typically holds two tokens: one for Grafana, one for Cloud. An on-premises context holds only a service account token.
 
 **Interactive, `--yes`, and env-var modes.** Interactive mode opens prompts for anything you did not pass as a flag. `--yes` disables optional prompts and makes `gcx login` fail loudly if a required field is missing — the mode to use in CI. Environment variables (`GRAFANA_SERVER`, `GRAFANA_TOKEN`, `GRAFANA_CLOUD_TOKEN`, `GRAFANA_CLOUD_STACK`) skip `gcx login` entirely and resolve on each command invocation.
 

--- a/docs/specs/feature-fleet-collector-app-proxy/plan.md
+++ b/docs/specs/feature-fleet-collector-app-proxy/plan.md
@@ -54,8 +54,8 @@ internal/fleet.Client
         │   instrumentation backend URLs sourced via
         │   collector-app instance-metadata proxy route (Viewer) ── in request body
         ▼
-   /fleet-management-api/*  →  Fleet Management     ── any Grafana credential (OAuth)
-   (named routes = Viewer; catch-all mutations = Admin;
+   collector-app proxy  →  Fleet Management         ── any Grafana credential (OAuth)
+   (reads = Viewer, mutations = Grafana Admin;
     proxy injects FM credential + X-Prom-*/X-Scope-OrgID server-side)
 ```
 
@@ -97,9 +97,8 @@ internal/fleet.Client
   that carried only an FM/Cloud token — with no Grafana credential — will no longer
   work for fleet/instrumentation. Announce in `CHANGELOG.md` and add a doc callout
   on the affected commands.
-- Mutations now require the Grafana Admin role (via the `/fleet-management-api/*`
-  catch-all); reads require Viewer. Callers whose credential lacks the needed role
-  will be denied at the proxy.
+- Mutations now require the Grafana Admin role; reads require Viewer. Callers
+  whose credential lacks the needed role will be denied at the proxy.
 - `cloud.token` / `GRAFANA_CLOUD_TOKEN` and `AgentManagementInstanceURL`/`ID` are
   no longer consulted for these command groups.
 

--- a/docs/specs/feature-fleet-collector-app-proxy/plan.md
+++ b/docs/specs/feature-fleet-collector-app-proxy/plan.md
@@ -1,0 +1,114 @@
+---
+type: feature-plan
+title: "Route `fleet` and `instrumentation` through the collector-app plugin proxy"
+status: draft
+spec: spec.md
+created: 2026-07-07
+---
+
+# Architecture and Design Decisions
+
+## Pipeline Architecture
+
+Before — direct FM access (Basic auth, Cloud-token required):
+
+```
+gcx fleet / gcx instrumentation
+        │
+        ▼
+providers.ConfigLoader.LoadCloudConfig(ctx)      ── requires cloud.token
+        │                                            (loadCloudBase errors
+        ▼                                             "cloud token is required")
+GCOM GetStack(slug)
+        │  AgentManagementInstanceURL + InstanceID
+        │  + FM access-policy token
+        │  + backend datasource URLs (Mimir/Loki/Tempo/Pyroscope)
+        ▼
+internal/fleet.Client
+   NewClient(baseURL, instanceID, apiToken, useBasicAuth=true, httpClient)
+   DoRequest: POST  {AgentManagementInstanceURL}{/service.method}
+              Basic auth  instanceID:token
+              X-Prom-Cluster-ID / X-Prom-Instance-ID (instrumentation)
+        │
+        ▼
+   Fleet Management API (external domain)          ── OAuth users blocked
+```
+
+After — collector-app plugin proxy (Grafana auth, no Cloud token):
+
+```
+gcx fleet / gcx instrumentation
+        │
+        ▼
+providers.ConfigLoader.LoadGrafanaConfig(ctx)     ── no cloud.token needed
+        │  config.NamespacedRESTConfig (Host + rest.Config, Grafana bearer)
+        ▼
+internal/fleet.Client
+   NewClient(cfg NamespacedRESTConfig)             ── rest.HTTPClientFor(&cfg.Config)
+   DoRequest: POST  {cfg.Host}
+                    /api/plugin-proxy/grafana-collector-app/fleet-management-api
+                    {/service.method}              ── path suffix UNCHANGED
+              bearer injected by k8s round-tripper
+              (no Basic auth, no X-Prom-*/X-Scope-OrgID set client-side)
+        │
+        │   instrumentation backend URLs sourced via
+        │   collector-app instance-metadata proxy route (Viewer) ── in request body
+        ▼
+   /fleet-management-api/*  →  Fleet Management     ── any Grafana credential (OAuth)
+   (named routes = Viewer; catch-all mutations = Admin;
+    proxy injects FM credential + X-Prom-*/X-Scope-OrgID server-side)
+```
+
+## Design Decisions
+
+| Decision | Rationale |
+|---|---|
+| Rebuild `internal/fleet.Client` on `rest.HTTPClientFor(&cfg.Config)` targeting `cfg.Host + /api/plugin-proxy/grafana-collector-app/fleet-management-api` + the existing path suffix; drop `instanceID`/`apiToken`/`useBasicAuth`. | Moves transport to the Grafana-authenticated proxy so OAuth works; keeps the Connect path suffix stable. Traces FR-001/FR-002/FR-003. Files: `internal/fleet/client.go` (current `NewClient` L29, `DoRequestWithHeaders` L49-83, Basic auth L71-75). |
+| Reuse the transport construction pattern from `internal/assistant/assistanthttp/client.go` (`NewClient` → `rest.HTTPClientFor`; `DoRequest` builds `cfg.Host + basePath + path`), but with the **app plugin-proxy** prefix `/api/plugin-proxy/grafana-collector-app/...` rather than the backend-plugin `/api/plugins/<id>/resources/...`. | assistanthttp is the canonical bearer-transport template, but its target plugin has a Go backend; collector-app is frontend-only, so the resources endpoint would not resolve. Traces FR-001. Files: `internal/assistant/assistanthttp/client.go` L20-58. |
+| Widen the `internal/fleet.ConfigLoader` interface to add `LoadGrafanaConfig(ctx) (config.NamespacedRESTConfig, error)`; rework `LoadClient`/`LoadClientWithStack` to build the client from `NamespacedRESTConfig`. | The interface today declares only `LoadCloudConfig`; the Grafana-auth loader is the new dependency. Traces FR-004/FR-005. Files: `internal/fleet/config.go` (interface L15-17, `LoadClientWithStack` L43-68); loader `internal/providers/configloader.go` `LoadGrafanaConfig` L186. |
+| Stop reading `AgentManagementInstanceURL`/`AgentManagementInstanceID` and the FM token; do not gate on them. | These come from `LoadCloudConfig`/GCOM and `loadCloudBase` hard-requires `cloud.token` — the exact OAuth blocker being removed. Traces FR-006/FR-011. Files: `internal/fleet/config.go` L49-64; `internal/providers/configloader.go` `loadCloudBase` L234-236, `LoadCloudConfig` L278. |
+| Remove `PromHeaders`, `PromHeadersFromStack`, `toMap`, and the `PromHeaders` param threaded through `DoRequestWithHeaders` and the `cmd/gcx/instrumentation/**` call sites; keep `BackendURLs` in the body. | The proxy injects `X-Prom-*`/`X-Scope-OrgID` server-side, making client-side decoration vestigial; backend URLs stay gcx's responsibility. Traces FR-007/FR-008/FR-010. Files: `internal/providers/instrumentation/client.go` `PromHeaders` L91-110, `BackendURLs` L44-53, `BackendURLsFromStack` L58-69. |
+| Add an instance-metadata fetch that sources backend datasource URLs through the collector-app's Grafana-authenticated instance-metadata proxy route (Viewer role), reusing the existing `StackInfo` → `BackendURLsFromStack` field mapping to build request bodies. | Removes the residual direct-GCOM/Cloud-token dependency, keeping instrumentation fully OAuth-capable. Traces FR-009/FR-011. Exact route path/response shape verified at build time (Open Question OQ-1). Files: `internal/providers/instrumentation/client.go` L44-69. |
+| Keep the typed method surfaces and Connect service/method path suffixes byte-for-byte; only the base URL and auth change. | Preserves the public typed API and wire compatibility so only transport moves. Traces FR-012. Files: `internal/providers/instrumentation/client.go` path constants L17-26; `internal/providers/fleet/client.go` (`/pipeline.v1...`, `/collector.v1...`, `/tenant.v1.TenantService/GetLimits`). |
+| Amend `CONSTITUTION.md`: remove **Fleet** from the `httputils.NewDefaultClient` "outside the Grafana server" rule and the Project Identity intro; document the proxy transport at `cfg.Host` via `rest.HTTPClientFor()`. | The traffic now targets `cfg.Host`, inverting the current rule; the invariant is descriptive, and the amendment requires explicit sign-off. Traces FR-013. Files: `CONSTITUTION.md` intro L10, dependency rule L161-168. |
+| State the Viewer(read)/Grafana Admin(mutate) role requirement in the Cobra `Short`/`Long` help, then regenerate the CLI reference with `GCX_AGENT_MODE=false mise run reference`. | The reference docs are auto-generated from Cobra help; `mise run reference-drift` fails CI otherwise, and `GCX_AGENT_MODE=false` prevents agent-mode default flips. Traces FR-014/FR-015. Files: `internal/providers/fleet/provider.go` L104-116; `cmd/gcx/instrumentation/command.go` L37-38. |
+| Map proxy/RBAC responses to actionable errors distinguishing a missing-role denial from an FM request rejection. | Proxy status codes are opaque without mapping; users need to know whether to acquire a role or fix the request. Traces FR-016. |
+| Reconcile tests: replace `useBasicAuth`/instance-ID/token constructors, rewrite the Basic-auth assertion to expect the plugin-proxy path/URL + bearer transport, and augment `assertConnectRequest` for the new base path while keeping POST/json/path-suffix checks. | Tests currently encode the direct-FM contract; they must encode the proxy contract without loosening wire-format checks. Traces FR-017. Files: `internal/fleet/client_test.go` `TestNewClient_DoRequest_AuthHeaders` L17, `newTestClient`; `internal/providers/fleet/client_test.go` L15-17, `provider_test.go` L343; `internal/providers/instrumentation/client_test.go` L19-22, `assertConnectRequest` L52-58. |
+| Single plugin-proxy transport; no hybrid/fallback branch. | Commands are Cloud-only and the plugin is guaranteed on all Cloud stacks, so a fallback path is dead code. Traces FR-018. |
+
+## Compatibility
+
+**Continues unchanged**
+
+- Typed pipeline/collector/tenant/instrumentation/discovery method signatures and
+  their Connect service/method path suffixes.
+- The Connect JSON wire format of all request and response bodies, including the
+  instrumentation backend datasource URLs carried in `Set*`/`Setup*` bodies.
+- All other providers already on the plugin-proxy transport
+  (assistant/aio11y/irm/k6/slo/kg) — this change adds fleet/instrumentation to
+  that family without touching them.
+- gcx config file schema and context model (the change reuses the existing
+  `LoadGrafanaConfig` plumbing; no new config fields).
+
+**Breaking change**
+
+- Direct-FM callers that authenticated with an FM instance ID + FM-scoped Cloud
+  access-policy token now authenticate to Grafana at `cfg.Host` instead. A context
+  that carried only an FM/Cloud token — with no Grafana credential — will no longer
+  work for fleet/instrumentation. Announce in `CHANGELOG.md` and add a doc callout
+  on the affected commands.
+- Mutations now require the Grafana Admin role (via the `/fleet-management-api/*`
+  catch-all); reads require Viewer. Callers whose credential lacks the needed role
+  will be denied at the proxy.
+- `cloud.token` / `GRAFANA_CLOUD_TOKEN` and `AgentManagementInstanceURL`/`ID` are
+  no longer consulted for these command groups.
+
+**Newly available**
+
+- OAuth (and any Grafana credential) can now drive both `gcx fleet` and
+  `gcx instrumentation` — no FM-scoped Cloud access-policy token required.
+- The two-tier "Grafana credential *and* FM token" requirement is eliminated for
+  these commands; a single Grafana credential suffices.
+- fleet/instrumentation now fail, authenticate, and report errors consistently
+  with the rest of gcx's plugin-proxied providers, and are positioned for
+  fine-grained plugin-side RBAC as a future enhancement.

--- a/docs/specs/feature-fleet-collector-app-proxy/spec.md
+++ b/docs/specs/feature-fleet-collector-app-proxy/spec.md
@@ -94,7 +94,7 @@ decision is recorded and accepted in ADR 001.
 | Instrumentation backend-URL source | collector-app Grafana-authenticated instance-metadata proxy route (Viewer role) | Removes the residual direct-GCOM/Cloud-token dependency, keeping instrumentation fully OAuth-capable | ADR 001 |
 | Cutover strategy | Clean cutover, no hybrid/fallback | Commands are Cloud-only and the plugin is guaranteed on all Cloud stacks, so a fallback branch would serve no real environment | ADR 001 |
 | CONSTITUTION dependency rule | Amend to remove Fleet from the "outside the Grafana server" list | The traffic now targets `cfg.Host`, where `rest.HTTPClientFor()` is the correct client — the inverse of the current rule | ADR 001 |
-| Role gating | Viewer for named read routes; Grafana Admin for the `/fleet-management-api/*` catch-all (all mutations + `GetLimits`) | Matches the plugin's route-level authorization | ADR 001 |
+| Role gating | Viewer for reads (`List*`/`Get*`); Grafana Admin for all mutations (plus `GetLimits` and the instrumentation/discovery calls) | Matches the plugin's role-level authorization | ADR 001 |
 
 ## Functional Requirements
 
@@ -172,8 +172,8 @@ decision is recorded and accepted in ADR 001.
   Admin role
   WHEN the operator runs a `gcx fleet` mutation (create/update/delete pipeline or
   collector)
-  THEN the request is proxied to the `/fleet-management-api/*` route and completes
-  successfully.
+  THEN the request is proxied through the collector-app `fleet-management-api`
+  path and completes successfully.
 
 - GIVEN an OAuth-only context with the Viewer role and no Cloud token
   WHEN the operator runs a `gcx instrumentation` read (e.g. list clusters/services
@@ -196,8 +196,8 @@ decision is recorded and accepted in ADR 001.
   `X-Scope-OrgID` header.
 
 - GIVEN a caller holding only the Viewer role
-  WHEN they attempt a fleet or instrumentation mutation routed to
-  `/fleet-management-api/*`
+  WHEN they attempt a fleet or instrumentation mutation (a create/update/delete
+  or setup call that requires the Grafana Admin role)
   THEN the command exits with an actionable error that identifies the missing
   Grafana Admin role and is distinguishable from an FM request-rejection error.
 

--- a/docs/specs/feature-fleet-collector-app-proxy/spec.md
+++ b/docs/specs/feature-fleet-collector-app-proxy/spec.md
@@ -1,0 +1,268 @@
+---
+type: feature-spec
+title: "Route `fleet` and `instrumentation` through the collector-app plugin proxy"
+status: approved
+created: 2026-07-07
+---
+
+# Route `fleet` and `instrumentation` through the collector-app plugin proxy
+
+## Problem Statement
+
+`gcx fleet` and `gcx instrumentation` talk to the Grafana Fleet Management (FM)
+API directly. They share the base HTTP client in `internal/fleet/`, which POSTs
+Connect-style JSON with HTTP Basic auth — the FM instance ID as username and an
+**FM-scoped Cloud access-policy token** as password. Configuration for that path
+is resolved through `providers.ConfigLoader.LoadCloudConfig`, which hard-requires
+`cloud.token` (it fails with `cloud token is required` when absent) and reads
+`AgentManagementInstanceURL` / `AgentManagementInstanceID` from GCOM stack info.
+
+Who is affected: every operator or CI job that wants to drive fleet or
+instrumentation commands. FM's direct API does not accept a Grafana OAuth
+credential, so interactive OAuth users are blocked outright — they can
+authenticate to Grafana but cannot obtain the FM-scoped token these commands
+demand.
+
+Current workaround: users must provision and carry a second, FM-scoped Cloud
+access-policy token alongside their Grafana credential — the two-tier "Grafana
+credential *and* FM token" requirement. There is no workaround at all for a
+pure-OAuth context.
+
+The `grafana-collector-app` app plugin (which the Fleet Management UI already
+uses) exposes the same FM routes under `/fleet-management-api/...` behind Grafana
+authNZ. Routing gcx's fleet/instrumentation traffic through that plugin proxy at
+`cfg.Host` lets any Grafana credential — OAuth included — drive these commands,
+converges them onto gcx's dominant plugin-proxy transport
+(assistant/aio11y/irm/k6/slo/kg), and removes the Cloud-token requirement. This
+decision is recorded and accepted in ADR 001.
+
+## Scope
+
+### In Scope
+
+- Swapping the `internal/fleet/` base client transport from direct FM Basic-auth
+  POST to the `grafana-collector-app` app plugin-proxy pattern at `cfg.Host`,
+  using `rest.HTTPClientFor(&cfg.Config)`.
+- Resolving connection details for both command groups via
+  `providers.ConfigLoader.LoadGrafanaConfig(ctx)` instead of `LoadCloudConfig`.
+- Widening the `internal/fleet` `ConfigLoader` interface to expose
+  `LoadGrafanaConfig`, and reworking `LoadClient` / `LoadClientWithStack`.
+- Dropping the FM access-policy token and the `AgentManagementInstanceURL` /
+  `AgentManagementInstanceID` GCOM lookups from the fleet load path.
+- Dropping client-side `X-Prom-Cluster-ID` / `X-Prom-Instance-ID` and
+  `X-Scope-OrgID` request decoration in `internal/providers/instrumentation/`,
+  and removing the now-vestigial `PromHeaders` plumbing threaded through the
+  `cmd/gcx/instrumentation/**` call sites.
+- Re-sourcing `instrumentation`'s backend datasource URLs (Mimir/Loki/Tempo/
+  Pyroscope) via the collector-app's Grafana-authenticated instance-metadata
+  proxy route (Viewer role) so no Cloud token is required, while keeping those
+  URLs in the request body.
+- Amending `CONSTITUTION.md` to remove **Fleet** from the "APIs outside the
+  Grafana server" dependency rule and the Project Identity intro naming.
+- Stating the Grafana role requirement (Viewer for reads, Grafana Admin for
+  mutations) in the `gcx fleet` / `gcx instrumentation` Cobra help and
+  regenerating the auto-generated CLI reference.
+- Reconciling tests in `internal/fleet`, `internal/providers/fleet`, and
+  `internal/providers/instrumentation` to the new constructor signature and
+  auth expectations.
+- Error mapping for proxy/RBAC responses so failures stay actionable.
+
+### Out of Scope
+
+- Changing typed method surfaces (`ListPipelines`, `*Pipeline`, `*Collector`,
+  `GetLimits`, `Get/Set` `App`/`K8S` instrumentation, `SetupK8sDiscovery`,
+  `RunK8sDiscovery`, `RunK8sMonitoring`) or the Connect service/method path
+  suffixes — these remain byte-for-byte unchanged.
+- Changing the Connect JSON wire format of request or response bodies.
+- Implementing fine-grained per-resource RBAC in the plugin — the proxy today
+  gates on Viewer/Admin roles only; finer authorization is a future plugin-side
+  enhancement (see Open Questions).
+- Any hybrid or fallback transport that retains direct FM access.
+- Documenting `grafana-collector-app` plugin internals (the public gcx repo
+  describes only gcx's own proxy calls).
+- Changing behaviour of any other provider that already uses the plugin-proxy
+  transport.
+
+## Key Decisions
+
+| Decision | Chosen | Rationale | Source |
+|---|---|---|---|
+| Transport for fleet/instrumentation FM traffic | `grafana-collector-app` app plugin-proxy at `cfg.Host` via `rest.HTTPClientFor(&cfg.Config)` | Grafana authNZ works for any credential (OAuth included); converges onto gcx's dominant transport family | ADR 001 |
+| Proxy path prefix | `/api/plugin-proxy/grafana-collector-app/...` (app plugin-proxy), NOT `/api/plugins/<id>/resources/...` | collector-app is frontend-only and ships no backend, so the backend-resources endpoint would not resolve | ADR 001 |
+| Config resolution | `LoadGrafanaConfig(ctx) → config.NamespacedRESTConfig` | Grafana-auth config already plumbed; removes the `cloud.token` hard requirement in `LoadCloudConfig`/`loadCloudBase` | ADR 001 |
+| Cloud/FM token requirement | Removed for both command groups | Proxy authenticates the caller to Grafana, not to FM; instrumentation backend URLs re-sourced via a Grafana-auth proxy route | ADR 001 |
+| Instrumentation backend-URL source | collector-app Grafana-authenticated instance-metadata proxy route (Viewer role) | Removes the residual direct-GCOM/Cloud-token dependency, keeping instrumentation fully OAuth-capable | ADR 001 |
+| Cutover strategy | Clean cutover, no hybrid/fallback | Commands are Cloud-only and the plugin is guaranteed on all Cloud stacks, so a fallback branch would serve no real environment | ADR 001 |
+| CONSTITUTION dependency rule | Amend to remove Fleet from the "outside the Grafana server" list | The traffic now targets `cfg.Host`, where `rest.HTTPClientFor()` is the correct client — the inverse of the current rule | ADR 001 |
+| Role gating | Viewer for named read routes; Grafana Admin for the `/fleet-management-api/*` catch-all (all mutations + `GetLimits`) | Matches the plugin's route-level authorization | ADR 001 |
+
+## Functional Requirements
+
+- **FR-001** — The `internal/fleet` base client MUST build its HTTP client via
+  `rest.HTTPClientFor(&cfg.Config)` from a `config.NamespacedRESTConfig` and MUST
+  target `cfg.Host + /api/plugin-proxy/grafana-collector-app/fleet-management-api`
+  concatenated with the existing Connect service/method path.
+- **FR-002** — The `internal/fleet` base client constructor MUST drop the
+  `instanceID`, `apiToken`, and `useBasicAuth` parameters.
+- **FR-003** — The base client MUST NOT set an `Authorization` header or Basic
+  auth itself; the Grafana bearer credential MUST be injected by the k8s
+  round-tripper obtained from `rest.HTTPClientFor`.
+- **FR-004** — Both command groups MUST resolve connection details via
+  `providers.ConfigLoader.LoadGrafanaConfig(ctx)` returning
+  `config.NamespacedRESTConfig`, and MUST NOT call `LoadCloudConfig` for fleet or
+  instrumentation transport.
+- **FR-005** — The `internal/fleet` `ConfigLoader` interface MUST be widened to
+  declare `LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig,
+  error)`, and `LoadClient` / `LoadClientWithStack` MUST build the plugin-proxy
+  client from that `NamespacedRESTConfig`.
+- **FR-006** — The fleet load path MUST NOT read `AgentManagementInstanceURL`,
+  `AgentManagementInstanceID`, or an FM access-policy token, and MUST NOT emit the
+  `fleet management endpoint is not available` / `instance ID is not available`
+  errors that gate on those fields.
+- **FR-007** — The instrumentation client MUST NOT set the `X-Prom-Cluster-ID`,
+  `X-Prom-Instance-ID`, or `X-Scope-OrgID` headers; these are injected server-side
+  by the proxy.
+- **FR-008** — The `PromHeaders` type, `PromHeadersFromStack`, `toMap`, and the
+  `PromHeaders` parameter threaded through `DoRequestWithHeaders` and the
+  `cmd/gcx/instrumentation/**` call sites MUST be removed.
+- **FR-009** — The instrumentation command group MUST source backend datasource
+  URLs (Mimir/Loki/Tempo/Pyroscope) via the collector-app's Grafana-authenticated
+  instance-metadata proxy route (Viewer role), NOT via a direct GCOM call or a
+  Cloud access-policy token.
+- **FR-010** — Backend datasource URLs MUST continue to travel in the
+  instrumentation `Set*` / `Setup*` request bodies unchanged; only their source
+  moves.
+- **FR-011** — Running any `gcx fleet` or `gcx instrumentation` command MUST NOT
+  require `cloud.token`, `GRAFANA_CLOUD_TOKEN`, or an FM-scoped access-policy
+  token.
+- **FR-012** — The typed pipeline/collector/tenant/instrumentation/discovery
+  method surfaces and their Connect service/method path suffixes MUST remain
+  unchanged.
+- **FR-013** — `CONSTITUTION.md` MUST be amended to remove **Fleet** from the
+  `httputils.NewDefaultClient(ctx)` "APIs outside the Grafana server" dependency
+  rule and from the Project Identity intro naming, and MUST document that
+  fleet/instrumentation reach FM via the collector-app proxy at `cfg.Host` using
+  `rest.HTTPClientFor()`.
+- **FR-014** — The `gcx fleet` and `gcx instrumentation` Cobra `Short`/`Long`
+  help MUST state the Grafana role requirement: Viewer for reads, Grafana Admin
+  for mutations.
+- **FR-015** — The auto-generated CLI reference (`docs/reference/cli/gcx_fleet*.md`,
+  `gcx_instrumentation*.md`) MUST be regenerated via
+  `GCX_AGENT_MODE=false mise run reference` so `mise run reference-drift` passes.
+- **FR-016** — Proxy/RBAC error responses MUST be mapped to actionable messages
+  that distinguish an insufficient-role/RBAC denial from an FM rejection of the
+  request.
+- **FR-017** — Tests in `internal/fleet`, `internal/providers/fleet`, and
+  `internal/providers/instrumentation` MUST be updated to the new constructor
+  signature (no `useBasicAuth`/instance-ID/token) and MUST assert the plugin-proxy
+  path/URL and bearer-injected transport instead of Basic auth.
+- **FR-018** — The implementation MUST NOT provide any hybrid or fallback path to
+  direct FM access; a single plugin-proxy transport MUST serve all fleet and
+  instrumentation FM traffic.
+
+## Acceptance Criteria
+
+- GIVEN a context authenticated to Grafana by OAuth with no `cloud.token`,
+  `GRAFANA_CLOUD_TOKEN`, or FM access-policy token, and the caller has the Viewer
+  role
+  WHEN the operator runs a `gcx fleet` read (e.g. list pipelines / list collectors)
+  THEN the command succeeds and MUST NOT fail with `cloud token is required`.
+
+- GIVEN the same OAuth-only context where the caller additionally has the Grafana
+  Admin role
+  WHEN the operator runs a `gcx fleet` mutation (create/update/delete pipeline or
+  collector)
+  THEN the request is proxied to the `/fleet-management-api/*` route and completes
+  successfully.
+
+- GIVEN an OAuth-only context with the Viewer role and no Cloud token
+  WHEN the operator runs a `gcx instrumentation` read (e.g. list clusters/services
+  or get instrumentation status)
+  THEN the command succeeds without requiring any Cloud access-policy token.
+
+- GIVEN an OAuth-only context with the Grafana Admin role and no Cloud token
+  WHEN the operator runs a `gcx instrumentation` setup/mutation
+    (e.g. set app/K8S instrumentation, run K8s discovery/monitoring)
+  THEN the backend datasource URLs are sourced via the collector-app
+  instance-metadata proxy route, embedded in the request body, and the mutation
+  completes successfully.
+
+- GIVEN any fleet or instrumentation command
+  WHEN it constructs its HTTP request
+  THEN the request URL is
+  `cfg.Host + /api/plugin-proxy/grafana-collector-app/fleet-management-api` + the
+  unchanged Connect service/method path, and the request carries no client-set
+  Basic auth, no client-set `Authorization` header, and no `X-Prom-*` /
+  `X-Scope-OrgID` header.
+
+- GIVEN a caller holding only the Viewer role
+  WHEN they attempt a fleet or instrumentation mutation routed to
+  `/fleet-management-api/*`
+  THEN the command exits with an actionable error that identifies the missing
+  Grafana Admin role and is distinguishable from an FM request-rejection error.
+
+- GIVEN the amended `CONSTITUTION.md`
+  WHEN the dependency rule and Project Identity intro are read
+  THEN **Fleet** no longer appears in the `httputils.NewDefaultClient` "outside
+  the Grafana server" list, and the document states fleet/instrumentation reach FM
+  via the collector-app proxy at `cfg.Host` using `rest.HTTPClientFor()`.
+
+- GIVEN the regenerated CLI reference
+  WHEN `GCX_AGENT_MODE=false mise run reference` and `mise run reference-drift`
+  run in CI
+  THEN the `gcx fleet` / `gcx instrumentation` reference docs state the Viewer
+  (read) / Grafana Admin (mutate) role requirement and the drift check passes.
+
+- GIVEN the reconciled test suites
+  WHEN `go test ./internal/fleet/... ./internal/providers/fleet/...
+  ./internal/providers/instrumentation/...` runs
+  THEN no test constructs the base client with `useBasicAuth`/instance-ID/token,
+  auth assertions verify the plugin-proxy path/URL and bearer transport, and the
+  Connect method paths and JSON wire format assertions are unchanged.
+
+## Negative Constraints
+
+- **NEVER** add a hybrid or fallback path that retains direct FM (Basic-auth)
+  access — the cutover is clean and single-transport (FR-018).
+- **NEVER** use `rest.HTTPClientFor()` for any API that remains outside `cfg.Host`;
+  it injects the Grafana bearer token and would conflict with a product's own auth.
+  It is correct here only because the traffic now targets `cfg.Host`.
+- **DO NOT** set the FM Basic-auth credential, a client-side `Authorization`
+  header, or the `X-Prom-Cluster-ID` / `X-Prom-Instance-ID` / `X-Scope-OrgID`
+  headers from gcx — the round-tripper and the proxy inject these.
+- **DO NOT** require a Cloud access-policy token (`cloud.token` /
+  `GRAFANA_CLOUD_TOKEN`) or `AgentManagementInstanceURL`/`ID` for any fleet or
+  instrumentation command.
+- **DO NOT** change the typed method surfaces, Connect service/method path
+  suffixes, or the JSON wire format of request/response bodies.
+- **DO NOT** document `grafana-collector-app` plugin internals in the public gcx
+  repo (no token-injection mechanics, no plugin.json route templates, no internal
+  route enumeration) — describe only gcx's own proxy calls.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| The instance-metadata proxy response shape may not match the fields `BackendURLsFromStack` consumes (e.g. `HMInstancePromURL`, `HMInstancePromID`, `HLInstanceURL`, `HTInstanceURL`, `HPInstanceURL`). | Instrumentation setup builds malformed or empty backend URLs; mutations fail or misconfigure ingestion. | Verify the proxied instance response carries the same fields during implementation; add a decode/validation step and cover with a test against the confirmed shape (Open Question OQ-1). |
+| RBAC/role misconfiguration (caller lacks Viewer or Admin) surfaces as an opaque proxy status. | Users cannot tell a missing-role denial from an FM rejection; support burden rises. | Implement error mapping (FR-016) distinguishing insufficient-role from FM request-rejection, and document the Viewer/Admin requirement in command help (FR-014). |
+| Breaking change: existing callers relying on direct FM access + an FM/Cloud token now authenticate to Grafana instead. | Scripts/CI carrying only an FM token break at cutover. | Announce in `CHANGELOG.md` and add a doc callout on the fleet/instrumentation commands stating the new Grafana-credential requirement and role gating. |
+| The exact instance-metadata proxy route path is not yet pinned against the plugin. | Wrong path yields a 404 that looks like a transport bug. | Treat the path as build-time verification against the plugin (Open Question OQ-1); keep it out of committed public docs until confirmed. |
+| Wrong proxy prefix (`/api/plugins/<id>/resources/...` instead of `/api/plugin-proxy/<id>/...`). | Silent 404 — collector-app has no backend, so the resources endpoint never resolves. | Follow ADR 001 explicitly; assert the app plugin-proxy prefix in the base-client test (FR-001, FR-017). |
+
+## Open Questions
+
+- **OQ-1** [NEEDS CLARIFICATION] — The exact route path and JSON response shape of
+  the collector-app Grafana-authenticated instance-metadata proxy route (Viewer
+  role) used to source instrumentation backend datasource URLs. Confirm the path
+  and verify the response carries every field `BackendURLsFromStack` consumes,
+  against the plugin at build time.
+- **OQ-2** [RESOLVED] — Should a hybrid plugin-or-direct transport be retained?
+  No; rejected in ADR 001 (commands are Cloud-only and the plugin is guaranteed on
+  all Cloud stacks, so a fallback branch serves no real environment).
+- **OQ-3** [RESOLVED] — Does `instrumentation` still need a Cloud token for backend
+  URLs? No; the ADR 001 validation (2026-07-07) routes that lookup through the
+  proxy, leaving no Cloud-token dependency.
+- **OQ-4** [DEFERRED] — Fine-grained per-resource RBAC (beyond Viewer/Admin) is a
+  future plugin-side enhancement, out of scope for this cutover.
+- **OQ-5** [DEFERRED] — Revisit a non-GCOM way to set the FM URL (and thus a
+  possible direct path) only if FM becomes reachable outside Grafana Cloud.

--- a/docs/specs/feature-fleet-collector-app-proxy/spec.md
+++ b/docs/specs/feature-fleet-collector-app-proxy/spec.md
@@ -1,7 +1,7 @@
 ---
 type: feature-spec
 title: "Route `fleet` and `instrumentation` through the collector-app plugin proxy"
-status: approved
+status: done
 created: 2026-07-07
 ---
 

--- a/internal/fleet/client.go
+++ b/internal/fleet/client.go
@@ -14,24 +14,19 @@ import (
 )
 
 const (
-	// collectorAppProxyBase is the Grafana app plugin-proxy prefix for the
-	// grafana-collector-app plugin. It is reached at cfg.Host with the Grafana
-	// bearer credential injected by the k8s round-tripper. The collector-app is a
-	// frontend-only plugin (it ships no backend), so it is reached through the app
-	// plugin-proxy path rather than the backend-plugin
-	// /api/plugins/<id>/resources/... endpoint, which would not resolve for it.
+	// collectorAppProxyBase is the app plugin-proxy prefix for grafana-collector-app.
+	// The plugin is frontend-only (no backend), so it is reached via the app
+	// plugin-proxy path, not the backend-plugin /api/plugins/<id>/resources/... route.
 	collectorAppProxyBase = "/api/plugin-proxy/grafana-collector-app"
 
-	// fleetManagementAPIPath is the collector-app proxy route prefix that forwards
-	// to the Fleet Management API. The Connect service/method path is appended to
-	// it unchanged, and the proxy injects the FM credential and the
-	// X-Prom-*/X-Scope-OrgID headers server-side.
+	// fleetManagementAPIPath forwards to the Fleet Management API. The Connect
+	// service/method path is appended unchanged; the proxy injects the FM
+	// credential and the X-Prom-*/X-Scope-OrgID headers server-side.
 	fleetManagementAPIPath = collectorAppProxyBase + "/fleet-management-api"
 
-	// instanceMetadataPath is the Viewer-role collector-app proxy route that
-	// returns the caller's Grafana Cloud stack instance metadata (proxying GCOM's
-	// /api/instances/{stackId}). The plugin injects the stack ID, so gcx sends no
-	// slug.
+	// instanceMetadataPath is the Viewer-role route returning the caller's stack
+	// instance metadata (proxying GCOM's /api/instances/{stackId}; the plugin
+	// injects the stack ID).
 	instanceMetadataPath = collectorAppProxyBase + "/grafanacom-api/instances/"
 )
 

--- a/internal/fleet/client.go
+++ b/internal/fleet/client.go
@@ -7,46 +7,66 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
-	"github.com/grafana/gcx/internal/httputils"
+	"github.com/grafana/gcx/internal/cloud"
+	"github.com/grafana/gcx/internal/config"
+	"k8s.io/client-go/rest"
 )
 
-// Client is a base HTTP client for the Grafana Fleet Management API.
-// All operations use POST (gRPC/Connect style JSON-over-HTTP).
+const (
+	// collectorAppProxyBase is the Grafana app plugin-proxy prefix for the
+	// grafana-collector-app plugin. It is reached at cfg.Host with the Grafana
+	// bearer credential injected by the k8s round-tripper. The collector-app is a
+	// frontend-only plugin (it ships no backend), so it is reached through the app
+	// plugin-proxy path rather than the backend-plugin
+	// /api/plugins/<id>/resources/... endpoint, which would not resolve for it.
+	collectorAppProxyBase = "/api/plugin-proxy/grafana-collector-app"
+
+	// fleetManagementAPIPath is the collector-app proxy route prefix that forwards
+	// to the Fleet Management API. The Connect service/method path is appended to
+	// it unchanged, and the proxy injects the FM credential and the
+	// X-Prom-*/X-Scope-OrgID headers server-side.
+	fleetManagementAPIPath = collectorAppProxyBase + "/fleet-management-api"
+
+	// instanceMetadataPath is the Viewer-role collector-app proxy route that
+	// returns the caller's Grafana Cloud stack instance metadata (proxying GCOM's
+	// /api/instances/{stackId}). The plugin injects the stack ID, so gcx sends no
+	// slug.
+	instanceMetadataPath = collectorAppProxyBase + "/grafanacom-api/instances/"
+)
+
+// Client is a base HTTP client for the Grafana Fleet Management API, reached
+// through the grafana-collector-app plugin proxy at cfg.Host. All Fleet
+// Management operations use POST (gRPC/Connect style JSON-over-HTTP). The
+// Grafana bearer credential (including OAuth) is injected by the k8s
+// round-tripper obtained from rest.HTTPClientFor; this client sets no
+// Authorization header or Basic auth of its own.
 type Client struct {
-	baseURL      string
-	instanceID   string
-	apiToken     string
-	useBasicAuth bool
-	httpClient   *http.Client
+	restConfig config.NamespacedRESTConfig
+	httpClient *http.Client
 }
 
-// NewClient creates a new Fleet Management base client.
-// When useBasicAuth is true, requests use Basic auth with instanceID:apiToken.
-// Otherwise, requests use Bearer token auth.
-// If httpClient is nil, httputils.NewDefaultClient is used.
-func NewClient(ctx context.Context, baseURL, instanceID, apiToken string, useBasicAuth bool, httpClient *http.Client) *Client {
-	if httpClient == nil {
-		httpClient = httputils.NewDefaultClient(ctx)
+// NewClient creates a new Fleet Management base client from a Grafana REST
+// config. The HTTP client is built with rest.HTTPClientFor(&cfg.Config) so the
+// Grafana bearer token is injected by the round-tripper — the same transport
+// the other plugin-proxied providers use.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	httpClient, err := rest.HTTPClientFor(&cfg.Config)
+	if err != nil {
+		return nil, fmt.Errorf("fleet: create HTTP client: %w", err)
 	}
 	return &Client{
-		baseURL:      strings.TrimRight(baseURL, "/"),
-		instanceID:   instanceID,
-		apiToken:     apiToken,
-		useBasicAuth: useBasicAuth,
-		httpClient:   httpClient,
-	}
+		restConfig: cfg,
+		httpClient: httpClient,
+	}, nil
 }
 
-// DoRequest builds and executes a POST request against the Fleet Management API.
-// It is exported so that packages composing this client can call the base transport.
+// DoRequest builds and executes a POST request against the Fleet Management API
+// via the collector-app plugin proxy. path is the Connect service/method path
+// (e.g. "/pipeline.v1.PipelineService/ListPipelines"); it is appended to the
+// proxy's fleet-management-api route unchanged. It is exported so packages
+// composing this client can call the base transport.
 func (c *Client) DoRequest(ctx context.Context, path string, body any) (*http.Response, error) {
-	return c.DoRequestWithHeaders(ctx, path, body, nil)
-}
-
-// DoRequestWithHeaders is like DoRequest but adds extra headers to the request.
-func (c *Client) DoRequestWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (*http.Response, error) {
 	var reqBody io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -56,7 +76,8 @@ func (c *Client) DoRequestWithHeaders(ctx context.Context, path string, body any
 		reqBody = bytes.NewReader(data)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, reqBody)
+	url := c.restConfig.Host + fleetManagementAPIPath + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("fleet: create request: %w", err)
 	}
@@ -64,20 +85,44 @@ func (c *Client) DoRequestWithHeaders(ctx context.Context, path string, body any
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
-
-	if c.useBasicAuth {
-		req.SetBasicAuth(c.instanceID, c.apiToken)
-	} else {
-		req.Header.Set("Authorization", "Bearer "+c.apiToken)
-	}
-
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fleet: execute request: %w", err)
 	}
 
 	return resp, nil
+}
+
+// FetchInstanceMetadata retrieves the caller's Grafana Cloud stack instance
+// metadata through the collector-app's Viewer-role instance-metadata proxy
+// route. The response is the same GCOM /api/instances/{stackId} object gcx
+// decodes elsewhere, so instrumentation can derive backend datasource URLs from
+// it without a Cloud access-policy token. The plugin injects the stack ID.
+func (c *Client) FetchInstanceMetadata(ctx context.Context) (cloud.StackInfo, error) {
+	url := c.restConfig.Host + instanceMetadataPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return cloud.StackInfo{}, fmt.Errorf("fleet: create instance-metadata request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return cloud.StackInfo{}, fmt.Errorf("fleet: fetch instance metadata: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return cloud.StackInfo{}, &HTTPError{
+			Status: resp.StatusCode,
+			Path:   instanceMetadataPath,
+			Body:   ReadErrorBody(resp),
+		}
+	}
+
+	var stack cloud.StackInfo
+	if err := json.NewDecoder(resp.Body).Decode(&stack); err != nil {
+		return cloud.StackInfo{}, fmt.Errorf("fleet: decode instance metadata: %w", err)
+	}
+	return stack, nil
 }

--- a/internal/fleet/client_test.go
+++ b/internal/fleet/client_test.go
@@ -187,44 +187,16 @@ func TestClient_FetchInstanceMetadata_ErrorStatus(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, httpErr.Status)
 }
 
-// TestHTTPError_RoleHint asserts that proxy auth/RBAC statuses map to actionable
-// messages distinguishing a missing-role denial from an FM request rejection
-// (FR-016).
-func TestHTTPError_RoleHint(t *testing.T) {
-	tests := []struct {
-		name        string
-		status      int
-		wantContain string
-		wantAbsent  string
-	}{
-		{
-			name:        "403 names the Grafana Admin role requirement",
-			status:      http.StatusForbidden,
-			wantContain: "Grafana Admin",
-		},
-		{
-			name:        "401 points to re-authentication",
-			status:      http.StatusUnauthorized,
-			wantContain: "gcx login",
-		},
-		{
-			name:       "FM rejection (400) carries no role hint",
-			status:     http.StatusBadRequest,
-			wantAbsent: "Grafana Admin",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := &fleet.HTTPError{Status: tt.status, Path: "/x", Body: "boom"}
-			msg := err.Error()
-			if tt.wantContain != "" {
-				assert.Contains(t, msg, tt.wantContain)
-			}
-			if tt.wantAbsent != "" {
-				assert.NotContains(t, msg, tt.wantAbsent)
-			}
-		})
-	}
+// TestHTTPError_Error asserts Error() reports only the raw HTTP diagnostic.
+// Role/auth guidance is added once by the cmd/gcx/fail converter (as
+// DetailedError suggestions), not appended here, so it must be absent from the
+// error string to avoid duplicate emission.
+func TestHTTPError_Error(t *testing.T) {
+	err := &fleet.HTTPError{Status: http.StatusForbidden, Path: "/x", Body: "boom"}
+	msg := err.Error()
+	assert.Equal(t, "fleet: HTTP 403 from /x: boom", msg)
+	assert.NotContains(t, msg, "Grafana Admin")
+	assert.NotContains(t, msg, "gcx login")
 }
 
 func TestReadErrorBody(t *testing.T) {

--- a/internal/fleet/client_test.go
+++ b/internal/fleet/client_test.go
@@ -2,74 +2,74 @@ package fleet_test
 
 import (
 	"context"
-	"encoding/base64"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/fleet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
 
-func TestNewClient_DoRequest_AuthHeaders(t *testing.T) {
-	tests := []struct {
-		name         string
-		instanceID   string
-		apiToken     string
-		useBasicAuth bool
-		checkAuth    func(t *testing.T, r *http.Request)
-	}{
-		{
-			name:         "basic auth sends Authorization: Basic header",
-			instanceID:   "12345",
-			apiToken:     "secret-token",
-			useBasicAuth: true,
-			checkAuth: func(t *testing.T, r *http.Request) {
-				t.Helper()
-				user, pass, ok := r.BasicAuth()
-				require.True(t, ok, "expected Basic auth header")
-				assert.Equal(t, "12345", user)
-				assert.Equal(t, "secret-token", pass)
+const (
+	// proxyFleetBase is the collector-app app plugin-proxy prefix the base client
+	// targets for Fleet Management traffic.
+	proxyFleetBase = "/api/plugin-proxy/grafana-collector-app/fleet-management-api"
+	// proxyInstancesPath is the Viewer-role instance-metadata proxy route.
+	proxyInstancesPath = "/api/plugin-proxy/grafana-collector-app/grafanacom-api/instances/"
+)
 
-				// Verify the raw header format: Basic base64(instanceID:apiToken)
-				expected := "Basic " + base64.StdEncoding.EncodeToString([]byte("12345:secret-token"))
-				assert.Equal(t, expected, r.Header.Get("Authorization"))
-			},
-		},
-		{
-			name:         "bearer auth sends Authorization: Bearer header",
-			instanceID:   "",
-			apiToken:     "bearer-token",
-			useBasicAuth: false,
-			checkAuth: func(t *testing.T, r *http.Request) {
-				t.Helper()
-				assert.Equal(t, "Bearer bearer-token", r.Header.Get("Authorization"))
-			},
-		},
-	}
+// newTestClient builds a base client whose Grafana bearer credential is
+// "test-bearer", pointed at the given host. The bearer is injected by the k8s
+// round-tripper from rest.HTTPClientFor — never set by the client itself.
+func newTestClient(t *testing.T, host string) *fleet.Client {
+	t.Helper()
+	c, err := fleet.NewClient(config.NamespacedRESTConfig{
+		Config: rest.Config{Host: host, BearerToken: "test-bearer"},
+	})
+	require.NoError(t, err)
+	return c
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var capturedReq *http.Request
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				capturedReq = r
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{}`))
-			}))
-			defer server.Close()
+// TestNewClient_DoRequest_PluginProxyTransport asserts the base client targets
+// the collector-app fleet-management-api proxy route, relies on the round-tripper
+// for the Grafana bearer, and sets no Basic auth or client-side Authorization of
+// its own (FR-001, FR-003, and the "no client-set Basic/Authorization" AC).
+func TestNewClient_DoRequest_PluginProxyTransport(t *testing.T) {
+	var captured *http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
 
-			client := fleet.NewClient(context.Background(), server.URL, tt.instanceID, tt.apiToken, tt.useBasicAuth, nil)
-			resp, err := client.DoRequest(context.Background(), "/some.v1.Service/Method", nil)
-			require.NoError(t, err)
-			defer resp.Body.Close()
+	client := newTestClient(t, server.URL)
+	resp, err := client.DoRequest(context.Background(), "/pipeline.v1.PipelineService/ListPipelines", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
 
-			require.NotNil(t, capturedReq)
-			tt.checkAuth(t, capturedReq)
-		})
-	}
+	require.NotNil(t, captured)
+
+	// URL is cfg.Host + collector-app fleet-management-api prefix + the Connect
+	// service/method path, byte-for-byte.
+	assert.Equal(t, proxyFleetBase+"/pipeline.v1.PipelineService/ListPipelines", captured.URL.Path)
+
+	// The Grafana bearer is injected by the k8s round-tripper.
+	assert.Equal(t, "Bearer test-bearer", captured.Header.Get("Authorization"))
+
+	// The client sets no Basic auth of its own.
+	_, _, hasBasic := captured.BasicAuth()
+	assert.False(t, hasBasic, "client must not set Basic auth")
+
+	// The client sets no X-Prom-*/X-Scope-OrgID headers (the proxy injects them).
+	assert.Empty(t, captured.Header.Get("X-Prom-Cluster-Id"))
+	assert.Empty(t, captured.Header.Get("X-Prom-Instance-Id"))
+	assert.Empty(t, captured.Header.Get("X-Scope-Orgid"))
 }
 
 func TestNewClient_DoRequest_RequestFormat(t *testing.T) {
@@ -114,7 +114,7 @@ func TestNewClient_DoRequest_RequestFormat(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := fleet.NewClient(context.Background(), server.URL, "inst", "tok", true, nil)
+			client := newTestClient(t, server.URL)
 			resp, err := client.DoRequest(context.Background(), tt.path, tt.body)
 			require.NoError(t, err)
 			defer resp.Body.Close()
@@ -122,8 +122,8 @@ func TestNewClient_DoRequest_RequestFormat(t *testing.T) {
 			assert.Equal(t, tt.wantMethod, capturedReq.Method)
 			assert.Equal(t, tt.wantCT, capturedReq.Header.Get("Content-Type"))
 			assert.Equal(t, tt.wantAccept, capturedReq.Header.Get("Accept"))
-			assert.True(t, strings.HasSuffix(capturedReq.URL.Path, tt.path),
-				"expected path %q, got %q", tt.path, capturedReq.URL.Path)
+			// Connect service/method path suffix is preserved unchanged under the proxy prefix.
+			assert.Equal(t, proxyFleetBase+tt.path, capturedReq.URL.Path)
 
 			if tt.wantBodyStr != "" {
 				assert.Contains(t, string(capturedBody), tt.wantBodyStr)
@@ -132,19 +132,99 @@ func TestNewClient_DoRequest_RequestFormat(t *testing.T) {
 	}
 }
 
-func TestNewClient_DoRequest_URLTrimming(t *testing.T) {
-	// Verify that trailing slashes on baseURL are trimmed so paths are clean.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+// TestClient_FetchInstanceMetadata asserts the Viewer-role instance-metadata
+// proxy route is a GET at the expected path and decodes into cloud.StackInfo,
+// reusing the same GCOM /api/instances/{stackId} shape (FR-009, OQ-1).
+func TestClient_FetchInstanceMetadata(t *testing.T) {
+	var captured *http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{
+			"hmInstancePromUrl": "https://prometheus-prod-1.grafana.net",
+			"hmInstancePromId": 111,
+			"hmInstancePromClusterId": 7,
+			"hlInstanceUrl": "https://logs-prod-1.grafana.net",
+			"hlInstanceId": 222,
+			"htInstanceUrl": "https://tempo-prod-1.grafana.net",
+			"htInstanceId": 333,
+			"hpInstanceUrl": "https://profiles-prod-1.grafana.net",
+			"hpInstanceId": 444,
+			"agentManagementInstanceUrl": "https://fleet-management-prod-1.grafana.net",
+			"agentManagementInstanceId": 555,
+			"orgSlug": "myorg"
+		}`))
 	}))
 	defer server.Close()
 
-	client := fleet.NewClient(context.Background(), server.URL+"/", "inst", "tok", true, nil)
-	resp, err := client.DoRequest(context.Background(), "/path.v1.Service/Method", nil)
+	client := newTestClient(t, server.URL)
+	stack, err := client.FetchInstanceMetadata(context.Background())
 	require.NoError(t, err)
-	defer resp.Body.Close()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.NotNil(t, captured)
+	assert.Equal(t, http.MethodGet, captured.Method)
+	assert.Equal(t, proxyInstancesPath, captured.URL.Path)
+	assert.Equal(t, "Bearer test-bearer", captured.Header.Get("Authorization"))
+
+	assert.Equal(t, "https://prometheus-prod-1.grafana.net", stack.HMInstancePromURL)
+	assert.Equal(t, 111, stack.HMInstancePromID)
+	assert.Equal(t, "https://fleet-management-prod-1.grafana.net", stack.AgentManagementInstanceURL)
+	assert.Equal(t, "myorg", stack.OrgSlug)
+}
+
+func TestClient_FetchInstanceMetadata_ErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	_, err := client.FetchInstanceMetadata(context.Background())
+	require.Error(t, err)
+	var httpErr *fleet.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusForbidden, httpErr.Status)
+}
+
+// TestHTTPError_RoleHint asserts that proxy auth/RBAC statuses map to actionable
+// messages distinguishing a missing-role denial from an FM request rejection
+// (FR-016).
+func TestHTTPError_RoleHint(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		wantContain string
+		wantAbsent  string
+	}{
+		{
+			name:        "403 names the Grafana Admin role requirement",
+			status:      http.StatusForbidden,
+			wantContain: "Grafana Admin",
+		},
+		{
+			name:        "401 points to re-authentication",
+			status:      http.StatusUnauthorized,
+			wantContain: "gcx login",
+		},
+		{
+			name:       "FM rejection (400) carries no role hint",
+			status:     http.StatusBadRequest,
+			wantAbsent: "Grafana Admin",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &fleet.HTTPError{Status: tt.status, Path: "/x", Body: "boom"}
+			msg := err.Error()
+			if tt.wantContain != "" {
+				assert.Contains(t, msg, tt.wantContain)
+			}
+			if tt.wantAbsent != "" {
+				assert.NotContains(t, msg, tt.wantAbsent)
+			}
+		})
+	}
 }
 
 func TestReadErrorBody(t *testing.T) {

--- a/internal/fleet/config.go
+++ b/internal/fleet/config.go
@@ -2,67 +2,68 @@ package fleet
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"strconv"
 
 	"github.com/grafana/gcx/internal/cloud"
-	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/config"
 )
 
-// ConfigLoader can load Grafana Cloud configuration from the active context.
-// This mirrors the interface in internal/providers/fleet/ to avoid a circular import.
+// ConfigLoader resolves the Grafana REST config for the active context. Fleet
+// and instrumentation reach the Fleet Management API through the
+// grafana-collector-app plugin proxy at cfg.Host, so they authenticate with the
+// active context's Grafana credential — no Cloud access-policy token is
+// required.
+//
+// This declares the subset of internal/providers.ConfigLoader that the fleet
+// packages need, kept here to avoid a circular import.
 type ConfigLoader interface {
-	LoadCloudConfig(ctx context.Context) (providers.CloudRESTConfig, error)
+	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
 }
 
-// ClientResult holds the results of LoadClient including the fleet base client,
-// resolved namespace, and the full stack info for deriving backend URLs and
-// prom headers.
+// ClientResult holds the results of LoadClientWithStack: the fleet base client,
+// the resolved namespace, and the stack instance metadata used by
+// instrumentation to derive backend datasource URLs.
 type ClientResult struct {
 	Client    *Client
 	Namespace string
 	Stack     cloud.StackInfo
 }
 
-// LoadClient loads cloud configuration and constructs a Fleet Management client
-// using Basic auth ({instanceID}:{apiToken}).
-// Returns the client, the resolved namespace, and any error.
-// Fails with a descriptive error if AgentManagementInstanceURL or
-// AgentManagementInstanceID is not available for the stack.
+// LoadClient resolves the Grafana REST config for the active context and
+// constructs a Fleet Management base client routed through the collector-app
+// plugin proxy. Returns the client and the resolved namespace. No Cloud
+// access-policy token or Fleet Management instance URL/ID is consulted.
 func LoadClient(ctx context.Context, loader ConfigLoader) (*Client, string, error) {
-	r, err := LoadClientWithStack(ctx, loader)
+	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
 		return nil, "", err
 	}
-	return r.Client, r.Namespace, nil
+	client, err := NewClient(cfg)
+	if err != nil {
+		return nil, "", err
+	}
+	return client, cfg.Namespace, nil
 }
 
-// LoadClientWithStack is like LoadClient but also returns the full stack info,
-// needed by instrumentation commands to derive backend URLs and prom headers.
+// LoadClientWithStack is like LoadClient but also fetches the stack instance
+// metadata through the collector-app's Viewer-role instance-metadata proxy
+// route. Instrumentation mutations use the returned Stack to build backend
+// datasource URLs; reads that do not need it should call LoadClient instead.
 func LoadClientWithStack(ctx context.Context, loader ConfigLoader) (*ClientResult, error) {
-	cloudCfg, err := loader.LoadCloudConfig(ctx)
+	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	url := cloudCfg.Stack.AgentManagementInstanceURL
-	if url == "" {
-		return nil, errors.New("fleet management endpoint is not available for this stack")
-	}
-	if cloudCfg.Stack.AgentManagementInstanceID == 0 {
-		return nil, errors.New("fleet management instance ID is not available for this stack")
-	}
-
-	instanceID := strconv.Itoa(cloudCfg.Stack.AgentManagementInstanceID)
-	httpClient, err := cloudCfg.HTTPClient(ctx)
+	client, err := NewClient(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("fleet: failed to create HTTP client: %w", err)
+		return nil, err
 	}
-
+	stack, err := client.FetchInstanceMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return &ClientResult{
-		Client:    NewClient(ctx, url, instanceID, cloudCfg.Token, true, httpClient),
-		Namespace: cloudCfg.Namespace,
-		Stack:     cloudCfg.Stack,
+		Client:    client,
+		Namespace: cfg.Namespace,
+		Stack:     stack,
 	}, nil
 }

--- a/internal/fleet/errors.go
+++ b/internal/fleet/errors.go
@@ -28,5 +28,25 @@ type HTTPError struct {
 }
 
 func (e *HTTPError) Error() string {
-	return fmt.Sprintf("fleet: HTTP %d from %s: %s", e.Status, e.Path, e.Body)
+	base := fmt.Sprintf("fleet: HTTP %d from %s: %s", e.Status, e.Path, e.Body)
+	if hint := e.roleHint(); hint != "" {
+		return base + " (" + hint + ")"
+	}
+	return base
+}
+
+// roleHint returns an actionable message for the auth/RBAC statuses the Grafana
+// collector-app plugin proxy returns before it forwards to Fleet Management,
+// distinguishing a missing-role denial from an FM request rejection. It is
+// empty for statuses that originate from Fleet Management itself (e.g. 400/404/
+// 409), whose body already carries an FM-specific diagnostic.
+func (e *HTTPError) roleHint() string {
+	switch e.Status {
+	case http.StatusUnauthorized:
+		return "the Grafana credential was rejected by the collector-app proxy; re-authenticate with `gcx login`"
+	case http.StatusForbidden:
+		return "insufficient Grafana role for this operation via the grafana-collector-app proxy: reads require Viewer, mutations require Grafana Admin"
+	default:
+		return ""
+	}
 }

--- a/internal/fleet/errors.go
+++ b/internal/fleet/errors.go
@@ -27,26 +27,20 @@ type HTTPError struct {
 	Body string
 }
 
+// Error returns the raw HTTP diagnostic. Actionable role/auth guidance for 401
+// and 403 is added once, as DetailedError suggestions, by the converter in
+// cmd/gcx/fail — it is deliberately not appended here to avoid emitting the same
+// guidance twice in the rendered error.
 func (e *HTTPError) Error() string {
-	base := fmt.Sprintf("fleet: HTTP %d from %s: %s", e.Status, e.Path, e.Body)
-	if hint := e.roleHint(); hint != "" {
-		return base + " (" + hint + ")"
-	}
-	return base
+	return fmt.Sprintf("fleet: HTTP %d from %s: %s", e.Status, e.Path, e.Body)
 }
 
-// roleHint returns an actionable message for the auth/RBAC statuses the Grafana
-// collector-app plugin proxy returns before it forwards to Fleet Management,
-// distinguishing a missing-role denial from an FM request rejection. It is
-// empty for statuses that originate from Fleet Management itself (e.g. 400/404/
-// 409), whose body already carries an FM-specific diagnostic.
-func (e *HTTPError) roleHint() string {
-	switch e.Status {
-	case http.StatusUnauthorized:
-		return "the Grafana credential was rejected by the collector-app proxy; re-authenticate with `gcx login`"
-	case http.StatusForbidden:
-		return "insufficient Grafana role for this operation via the grafana-collector-app proxy: reads require Viewer, mutations require Grafana Admin"
-	default:
-		return ""
-	}
+// StatusError wraps a non-2xx response as an *HTTPError, prefixed with op (the
+// calling method name) for context. It reads the response body for diagnostics.
+func StatusError(op, path string, resp *http.Response) error {
+	return fmt.Errorf("%s: %w", op, &HTTPError{
+		Status: resp.StatusCode,
+		Path:   path,
+		Body:   ReadErrorBody(resp),
+	})
 }

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -32,7 +32,6 @@ func cloudTokenHint(server string) string {
 	return create + " (Access Policies → Create access policy).\n" +
 		"Recommended scopes: stacks:read (required — resolves your stack). Then add per product:\n" +
 		"  metrics:write, logs:write, traces:write — Synthetic Monitoring\n" +
-		"  fleet-management:read — Fleet\n" +
 		"  stacks:write — create or update stacks\n" +
 		"Docs: https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies\n" +
 		"Press Enter to skip (Cloud management features will be unavailable)."

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1334,8 +1334,8 @@ func TestRun_CloudTokenHintGuidance(t *testing.T) {
 	assert.Contains(t, hint, "access-policies", "hint must link to the access-policies docs")
 	assert.Contains(t, hint, "stacks:read", "hint must name stacks:read as the required baseline scope")
 	assert.Contains(t, hint, "metrics:write", "hint must name the Synthetic Monitoring write scopes")
-	assert.Contains(t, hint, "fleet-management:read", "hint must name the Fleet scope")
 	assert.Contains(t, hint, "stacks:write", "hint must name the stack-management scope")
+	assert.NotContains(t, hint, "fleet-management", "hint must NOT recommend the fleet-management scope — fleet reaches FM via the collector-app proxy (ADR-021)")
 	assert.Contains(t, strings.ToLower(hint), "skip", "hint must retain the skip affordance")
 }
 

--- a/internal/providers/fleet/client.go
+++ b/internal/providers/fleet/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/grafana/gcx/internal/config"
 	fleetbase "github.com/grafana/gcx/internal/fleet"
 )
 
@@ -16,14 +17,16 @@ type Client struct {
 	*fleetbase.Client
 }
 
-// NewClient creates a new Fleet Management client.
-// When useBasicAuth is true, requests use Basic auth with instanceID:apiToken.
-// Otherwise, requests use Bearer token auth.
-// If httpClient is nil, a default client with a 30-second timeout is used.
-func NewClient(ctx context.Context, baseURL, instanceID, apiToken string, useBasicAuth bool, httpClient *http.Client) *Client {
-	return &Client{
-		Client: fleetbase.NewClient(ctx, baseURL, instanceID, apiToken, useBasicAuth, httpClient),
+// NewClient creates a new Fleet Management client from a Grafana REST config.
+// It wraps the shared base client, which routes through the
+// grafana-collector-app plugin proxy at cfg.Host using the Grafana bearer
+// credential.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	base, err := fleetbase.NewClient(cfg)
+	if err != nil {
+		return nil, err
 	}
+	return &Client{Client: base}, nil
 }
 
 // doRequest delegates to the embedded base client's DoRequest.

--- a/internal/providers/fleet/client_test.go
+++ b/internal/providers/fleet/client_test.go
@@ -7,14 +7,20 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers/fleet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
 
 func newTestClient(t *testing.T, server *httptest.Server) *fleet.Client {
 	t.Helper()
-	return fleet.NewClient(context.Background(), server.URL, "test-instance", "test-token", true, nil)
+	c, err := fleet.NewClient(config.NamespacedRESTConfig{
+		Config: rest.Config{Host: server.URL, BearerToken: "test-bearer"},
+	})
+	require.NoError(t, err)
+	return c
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/providers/fleet/provider.go
+++ b/internal/providers/fleet/provider.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/grafana/gcx/internal/config"
 	fleetbase "github.com/grafana/gcx/internal/fleet"
 	"github.com/grafana/gcx/internal/format"
 	"github.com/grafana/gcx/internal/gcxerrors"
@@ -113,6 +114,12 @@ func (p *FleetProvider) Commands() []*cobra.Command {
 	fleetCmd := &cobra.Command{
 		Use:   "fleet",
 		Short: p.ShortDesc(),
+		Long: `Manage Grafana Fleet Management pipelines and collectors.
+
+Authentication and roles: fleet commands reach Fleet Management through the
+grafana-collector-app plugin proxy using your active Grafana credential (OAuth
+included) — no Cloud access-policy token is required. Reads (list, get) need the
+Viewer role; mutations (create, update, delete) require the Grafana Admin role.`,
 	}
 
 	loader.BindFlags(fleetCmd.PersistentFlags())
@@ -1136,13 +1143,16 @@ func readCollectorFromFile(filename string, stdin io.Reader) (*Collector, error)
 // Resource adapter factories
 // ---------------------------------------------------------------------------
 
-// CloudConfigLoader can load Grafana Cloud configuration from the active context.
-type CloudConfigLoader interface {
-	LoadCloudConfig(ctx context.Context) (providers.CloudRESTConfig, error)
+// ConfigLoader resolves the Grafana REST config for the active context. Fleet
+// resources reach the Fleet Management API through the grafana-collector-app
+// plugin proxy at cfg.Host, authenticating with the active context's Grafana
+// credential — no Cloud access-policy token is required.
+type ConfigLoader interface {
+	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
 }
 
 // NewPipelineTypedCRUD creates a TypedCRUD for Fleet pipelines.
-func NewPipelineTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adapter.TypedCRUD[Pipeline], string, error) {
+func NewPipelineTypedCRUD(ctx context.Context, loader ConfigLoader) (*adapter.TypedCRUD[Pipeline], string, error) {
 	base, namespace, err := fleetbase.LoadClient(ctx, loader)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load Fleet config for pipelines: %w", err)
@@ -1189,7 +1199,7 @@ func NewPipelineTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adapt
 }
 
 // NewPipelineAdapterFactory returns a lazy adapter.Factory for fleet pipelines.
-func NewPipelineAdapterFactory(loader CloudConfigLoader) adapter.Factory {
+func NewPipelineAdapterFactory(loader ConfigLoader) adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
 		crud, _, err := NewPipelineTypedCRUD(ctx, loader)
 		if err != nil {
@@ -1200,7 +1210,7 @@ func NewPipelineAdapterFactory(loader CloudConfigLoader) adapter.Factory {
 }
 
 // NewCollectorTypedCRUD creates a TypedCRUD for Fleet collectors.
-func NewCollectorTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adapter.TypedCRUD[Collector], string, error) {
+func NewCollectorTypedCRUD(ctx context.Context, loader ConfigLoader) (*adapter.TypedCRUD[Collector], string, error) {
 	base, namespace, err := fleetbase.LoadClient(ctx, loader)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load Fleet config for collectors: %w", err)
@@ -1248,7 +1258,7 @@ func NewCollectorTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adap
 }
 
 // NewCollectorAdapterFactory returns a lazy adapter.Factory for fleet collectors.
-func NewCollectorAdapterFactory(loader CloudConfigLoader) adapter.Factory {
+func NewCollectorAdapterFactory(loader ConfigLoader) adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
 		crud, _, err := NewCollectorTypedCRUD(ctx, loader)
 		if err != nil {

--- a/internal/providers/fleet/provider_test.go
+++ b/internal/providers/fleet/provider_test.go
@@ -340,7 +340,7 @@ func TestPipelineProtectionGuard(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := fleet.NewClient(context.Background(), server.URL, "inst", "token", true, nil)
+			client := newTestClient(t, server)
 			pipeline, err := client.GetPipeline(context.Background(), "123")
 			require.NoError(t, err)
 			require.NotNil(t, pipeline)

--- a/internal/providers/instrumentation/client.go
+++ b/internal/providers/instrumentation/client.go
@@ -261,11 +261,7 @@ func (c *Client) GetAppInstrumentation(ctx context.Context, clusterName string) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GetAppInstrumentation: %w", &fleet.HTTPError{
-			Status: resp.StatusCode,
-			Path:   pathGetAppInstrumentation,
-			Body:   fleet.ReadErrorBody(resp),
-		})
+		return nil, fleet.StatusError("GetAppInstrumentation", pathGetAppInstrumentation, resp)
 	}
 
 	var envelope getAppResponse
@@ -324,11 +320,7 @@ func (c *Client) SetAppInstrumentation(ctx context.Context, clusterName string, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("SetAppInstrumentation: %w", &fleet.HTTPError{
-			Status: resp.StatusCode,
-			Path:   pathSetAppInstrumentation,
-			Body:   fleet.ReadErrorBody(resp),
-		})
+		return fleet.StatusError("SetAppInstrumentation", pathSetAppInstrumentation, resp)
 	}
 	return nil
 }
@@ -347,11 +339,7 @@ func (c *Client) GetK8SInstrumentation(ctx context.Context, clusterName string) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GetK8SInstrumentation: %w", &fleet.HTTPError{
-			Status: resp.StatusCode,
-			Path:   pathGetK8SInstrumentation,
-			Body:   fleet.ReadErrorBody(resp),
-		})
+		return nil, fleet.StatusError("GetK8SInstrumentation", pathGetK8SInstrumentation, resp)
 	}
 
 	var envelope getK8SResponse
@@ -396,11 +384,7 @@ func (c *Client) SetK8SInstrumentation(ctx context.Context, clusterName string, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("SetK8SInstrumentation: %w", &fleet.HTTPError{
-			Status: resp.StatusCode,
-			Path:   pathSetK8SInstrumentation,
-			Body:   fleet.ReadErrorBody(resp),
-		})
+		return fleet.StatusError("SetK8SInstrumentation", pathSetK8SInstrumentation, resp)
 	}
 	return nil
 }
@@ -416,11 +400,7 @@ func (c *Client) SetupK8sDiscovery(ctx context.Context, urls BackendURLs) error 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("SetupK8sDiscovery: %w", &fleet.HTTPError{
-			Status: resp.StatusCode,
-			Path:   pathSetupK8sDiscovery,
-			Body:   fleet.ReadErrorBody(resp),
-		})
+		return fleet.StatusError("SetupK8sDiscovery", pathSetupK8sDiscovery, resp)
 	}
 	return nil
 }
@@ -436,11 +416,7 @@ func (c *Client) RunK8sDiscovery(ctx context.Context) (*RunK8sDiscoveryResponse,
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("RunK8sDiscovery: %w", &fleet.HTTPError{
-			Status: resp.StatusCode,
-			Path:   pathRunK8sDiscovery,
-			Body:   fleet.ReadErrorBody(resp),
-		})
+		return nil, fleet.StatusError("RunK8sDiscovery", pathRunK8sDiscovery, resp)
 	}
 
 	var wire wireRunK8sDiscoveryResponse
@@ -476,11 +452,7 @@ func (c *Client) RunK8sMonitoring(ctx context.Context) (*RunK8sMonitoringRespons
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("RunK8sMonitoring: %w", &fleet.HTTPError{
-			Status: resp.StatusCode,
-			Path:   pathRunK8sMonitoring,
-			Body:   fleet.ReadErrorBody(resp),
-		})
+		return nil, fleet.StatusError("RunK8sMonitoring", pathRunK8sMonitoring, resp)
 	}
 
 	var wire wireRunK8sMonitoringResponse
@@ -525,11 +497,7 @@ func (c *Client) ListPipelines(ctx context.Context) ([]Pipeline, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("ListPipelines: %w", &fleet.HTTPError{
-			Status: resp.StatusCode,
-			Path:   pathListPipelines,
-			Body:   fleet.ReadErrorBody(resp),
-		})
+		return nil, fleet.StatusError("ListPipelines", pathListPipelines, resp)
 	}
 
 	var wire wireListPipelinesResponse

--- a/internal/providers/instrumentation/client.go
+++ b/internal/providers/instrumentation/client.go
@@ -88,27 +88,6 @@ func FleetManagementFromStack(stack cloud.StackInfo) FleetManagement {
 	}
 }
 
-// PromHeaders holds the X-Prom-* header values required by discovery/monitoring endpoints.
-type PromHeaders struct {
-	ClusterID  string
-	InstanceID string
-}
-
-// PromHeadersFromStack extracts the X-Prom-* header values from stack info.
-func PromHeadersFromStack(stack cloud.StackInfo) PromHeaders {
-	return PromHeaders{
-		ClusterID:  strconv.Itoa(stack.HMInstancePromClusterID),
-		InstanceID: strconv.Itoa(stack.HMInstancePromID),
-	}
-}
-
-func (h PromHeaders) toMap() map[string]string {
-	return map[string]string{
-		"X-Prom-Cluster-ID":  h.ClusterID,
-		"X-Prom-Instance-ID": h.InstanceID,
-	}
-}
-
 // --- Wire-format types (internal to client.go) ---
 //
 // Wire types use concrete bool fields for JSON marshaling / unmarshaling.
@@ -429,8 +408,8 @@ func (c *Client) SetK8SInstrumentation(ctx context.Context, clusterName string, 
 // SetupK8sDiscovery initializes K8s discovery datasource endpoints.
 // This call is idempotent: if a Beyla survey pipeline already exists,
 // the backend returns success without modification.
-func (c *Client) SetupK8sDiscovery(ctx context.Context, urls BackendURLs, promHeaders PromHeaders) error {
-	resp, err := c.fleet.DoRequestWithHeaders(ctx, pathSetupK8sDiscovery, setupDiscoveryRequest{BackendURLs: urls}, promHeaders.toMap())
+func (c *Client) SetupK8sDiscovery(ctx context.Context, urls BackendURLs) error {
+	resp, err := c.fleet.DoRequest(ctx, pathSetupK8sDiscovery, setupDiscoveryRequest{BackendURLs: urls})
 	if err != nil {
 		return err
 	}
@@ -449,8 +428,8 @@ func (c *Client) SetupK8sDiscovery(ctx context.Context, urls BackendURLs, promHe
 // RunK8sDiscovery executes discovery and returns all discovered workloads
 // across all clusters. Filtering by cluster, namespace, or status is performed
 // client-side by the callers.
-func (c *Client) RunK8sDiscovery(ctx context.Context, promHeaders PromHeaders) (*RunK8sDiscoveryResponse, error) {
-	resp, err := c.fleet.DoRequestWithHeaders(ctx, pathRunK8sDiscovery, struct{}{}, promHeaders.toMap())
+func (c *Client) RunK8sDiscovery(ctx context.Context) (*RunK8sDiscoveryResponse, error) {
+	resp, err := c.fleet.DoRequest(ctx, pathRunK8sDiscovery, struct{}{})
 	if err != nil {
 		return nil, err
 	}
@@ -489,8 +468,8 @@ func (c *Client) RunK8sDiscovery(ctx context.Context, promHeaders PromHeaders) (
 // RunK8sMonitoring retrieves the instrumentation monitoring state for all clusters.
 // Clusters that have been Set but are not yet reporting survey_info will be absent
 // from this response — the enumerate helper (T5) resolves them via ListPipelines.
-func (c *Client) RunK8sMonitoring(ctx context.Context, promHeaders PromHeaders) (*RunK8sMonitoringResponse, error) {
-	resp, err := c.fleet.DoRequestWithHeaders(ctx, pathRunK8sMonitoring, struct{}{}, promHeaders.toMap())
+func (c *Client) RunK8sMonitoring(ctx context.Context) (*RunK8sMonitoringResponse, error) {
+	resp, err := c.fleet.DoRequest(ctx, pathRunK8sMonitoring, struct{}{})
 	if err != nil {
 		return nil, err
 	}
@@ -573,8 +552,8 @@ func (c *Client) ListPipelines(ctx context.Context) ([]Pipeline, error) {
 // The RunK8sDiscovery response is a flat list of workloads (DiscoveryItems).
 // A namespace is considered "discovered" iff at least one workload with
 // ClusterName == cluster and Namespace == namespace exists in the response.
-func (c *Client) IsNamespaceDiscovered(ctx context.Context, promHeaders PromHeaders, cluster, namespace string) (bool, error) {
-	resp, err := c.RunK8sDiscovery(ctx, promHeaders)
+func (c *Client) IsNamespaceDiscovered(ctx context.Context, cluster, namespace string) (bool, error) {
+	resp, err := c.RunK8sDiscovery(ctx)
 	if err != nil {
 		return false, fmt.Errorf("discovery: %w", err)
 	}

--- a/internal/providers/instrumentation/client_test.go
+++ b/internal/providers/instrumentation/client_test.go
@@ -6,18 +6,29 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/fleet"
 	"github.com/grafana/gcx/internal/providers/instrumentation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
 
-// newTestClient creates an instrumentation Client pointed at the given test server URL.
-func newTestClient(serverURL string) *instrumentation.Client {
-	f := fleet.NewClient(context.Background(), serverURL, "inst-id", "api-token", true, nil)
+// proxyFleetBase is the collector-app fleet-management-api proxy route prefix
+// prepended to every Connect service/method path by the base client.
+const proxyFleetBase = "/api/plugin-proxy/grafana-collector-app/fleet-management-api"
+
+// newTestClient creates an instrumentation Client pointed at the given test
+// server URL. The Grafana bearer credential ("test-bearer") is injected by the
+// k8s round-tripper — the client sets no Basic auth of its own.
+func newTestClient(t *testing.T, serverURL string) *instrumentation.Client {
+	t.Helper()
+	f, err := fleet.NewClient(config.NamespacedRESTConfig{
+		Config: rest.Config{Host: serverURL, BearerToken: "test-bearer"},
+	})
+	require.NoError(t, err)
 	return instrumentation.NewClient(f)
 }
 
@@ -31,6 +42,11 @@ func captureHandler(t *testing.T, statusCode int, respBody string) (http.Handler
 		cr.Path = r.URL.Path
 		cr.ContentType = r.Header.Get("Content-Type")
 		cr.Accept = r.Header.Get("Accept")
+		cr.Authorization = r.Header.Get("Authorization")
+		_, _, cr.HasBasicAuth = r.BasicAuth()
+		cr.PromClusterID = r.Header.Get("X-Prom-Cluster-Id")
+		cr.PromInstanceID = r.Header.Get("X-Prom-Instance-Id")
+		cr.ScopeOrgID = r.Header.Get("X-Scope-Orgid")
 		b, _ := io.ReadAll(r.Body)
 		cr.Body = string(b)
 		w.Header().Set("Content-Type", "application/json")
@@ -40,21 +56,34 @@ func captureHandler(t *testing.T, statusCode int, respBody string) (http.Handler
 }
 
 type capturedRequest struct {
-	Method      string
-	Path        string
-	ContentType string
-	Accept      string
-	Body        string
+	Method         string
+	Path           string
+	ContentType    string
+	Accept         string
+	Authorization  string
+	HasBasicAuth   bool
+	PromClusterID  string
+	PromInstanceID string
+	ScopeOrgID     string
+	Body           string
 }
 
-// assertConnectRequest verifies that a captured request conforms to the Connect RPC
-// over HTTP POST contract (NC-006): POST method, application/json content type and accept.
+// assertConnectRequest verifies that a captured request conforms to the Connect
+// RPC over HTTP POST contract (NC-006) AND the collector-app plugin-proxy
+// transport contract: POST, JSON content/accept, the full proxy-prefixed URL,
+// the round-tripper-injected Grafana bearer, and no client-set Basic auth or
+// X-Prom-*/X-Scope-OrgID headers (FR-001, FR-003, FR-007, FR-017).
 func assertConnectRequest(t *testing.T, cr *capturedRequest, wantPath string) {
 	t.Helper()
 	assert.Equal(t, http.MethodPost, cr.Method, "must use POST")
 	assert.Equal(t, "application/json", cr.ContentType, "must set Content-Type: application/json")
 	assert.Equal(t, "application/json", cr.Accept, "must set Accept: application/json")
-	assert.True(t, strings.HasSuffix(cr.Path, wantPath), "expected path suffix %q, got %q", wantPath, cr.Path)
+	assert.Equal(t, proxyFleetBase+wantPath, cr.Path, "must target the collector-app fleet-management-api proxy route with the unchanged Connect path suffix")
+	assert.Equal(t, "Bearer test-bearer", cr.Authorization, "bearer must be injected by the round-tripper")
+	assert.False(t, cr.HasBasicAuth, "client must not set Basic auth")
+	assert.Empty(t, cr.PromClusterID, "client must not set X-Prom-Cluster-ID")
+	assert.Empty(t, cr.PromInstanceID, "client must not set X-Prom-Instance-ID")
+	assert.Empty(t, cr.ScopeOrgID, "client must not set X-Scope-OrgID")
 }
 
 func TestClient_GetAppInstrumentation(t *testing.T) {
@@ -95,7 +124,7 @@ func TestClient_GetAppInstrumentation(t *testing.T) {
 			srv := httptest.NewServer(handler)
 			defer srv.Close()
 
-			client := newTestClient(srv.URL)
+			client := newTestClient(t, srv.URL)
 			resp, err := client.GetAppInstrumentation(context.Background(), tt.clusterName)
 
 			assertConnectRequest(t, cr, "/instrumentation.v1.InstrumentationService/GetAppInstrumentation")
@@ -120,7 +149,7 @@ func TestClient_GetAppInstrumentation_Converts(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp, err := newTestClient(srv.URL).GetAppInstrumentation(context.Background(), "c1")
+	resp, err := newTestClient(t, srv.URL).GetAppInstrumentation(context.Background(), "c1")
 	require.NoError(t, err)
 	require.Len(t, resp.Namespaces, 1)
 
@@ -167,7 +196,7 @@ func TestClient_SetAppInstrumentation(t *testing.T) {
 			srv := httptest.NewServer(handler)
 			defer srv.Close()
 
-			client := newTestClient(srv.URL)
+			client := newTestClient(t, srv.URL)
 			err := client.SetAppInstrumentation(context.Background(), tt.clusterName, tt.namespaces, instrumentation.BackendURLs{})
 
 			assertConnectRequest(t, cr, "/instrumentation.v1.InstrumentationService/SetAppInstrumentation")
@@ -213,7 +242,7 @@ func TestClient_GetK8SInstrumentation(t *testing.T) {
 			srv := httptest.NewServer(handler)
 			defer srv.Close()
 
-			client := newTestClient(srv.URL)
+			client := newTestClient(t, srv.URL)
 			resp, err := client.GetK8SInstrumentation(context.Background(), tt.clusterName)
 
 			assertConnectRequest(t, cr, "/instrumentation.v1.InstrumentationService/GetK8SInstrumentation")
@@ -263,7 +292,7 @@ func TestClient_SetK8SInstrumentation(t *testing.T) {
 			srv := httptest.NewServer(handler)
 			defer srv.Close()
 
-			client := newTestClient(srv.URL)
+			client := newTestClient(t, srv.URL)
 			err := client.SetK8SInstrumentation(context.Background(), tt.clusterName, tt.k8s, instrumentation.BackendURLs{})
 
 			assertConnectRequest(t, cr, "/instrumentation.v1.InstrumentationService/SetK8SInstrumentation")
@@ -289,7 +318,7 @@ func TestGetK8SInstrumentation_SelectionRoundTrip(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp, err := newTestClient(srv.URL).GetK8SInstrumentation(context.Background(), "test-cluster")
+	resp, err := newTestClient(t, srv.URL).GetK8SInstrumentation(context.Background(), "test-cluster")
 	require.NoError(t, err)
 	assert.Equal(t, "SELECTION_EXCLUDED", resp.Cluster.Selection,
 		"Selection must survive wire→domain mapping")
@@ -312,7 +341,7 @@ func TestSetK8SInstrumentation_SendsSelectionExcluded(t *testing.T) {
 		Name:      "test-cluster",
 		Selection: "SELECTION_EXCLUDED",
 	}
-	err := newTestClient(srv.URL).SetK8SInstrumentation(context.Background(), "test-cluster", excluded, instrumentation.BackendURLs{})
+	err := newTestClient(t, srv.URL).SetK8SInstrumentation(context.Background(), "test-cluster", excluded, instrumentation.BackendURLs{})
 	require.NoError(t, err)
 	assert.Contains(t, capturedBody, `"SELECTION_EXCLUDED"`,
 		"SetK8SInstrumentation must send SELECTION_EXCLUDED in request body")
@@ -331,7 +360,7 @@ func TestClient_SetK8SInstrumentation_DefaultsSelection(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := newTestClient(srv.URL).SetK8SInstrumentation(context.Background(), "c1",
+	err := newTestClient(t, srv.URL).SetK8SInstrumentation(context.Background(), "c1",
 		instrumentation.Cluster{Name: "c1"}, instrumentation.BackendURLs{})
 	require.NoError(t, err)
 	assert.Contains(t, capturedBody, "SELECTION_INCLUDED", "empty Selection must default to SELECTION_INCLUDED")
@@ -363,10 +392,9 @@ func TestClient_SetupK8sDiscovery(t *testing.T) {
 			srv := httptest.NewServer(handler)
 			defer srv.Close()
 
-			client := newTestClient(srv.URL)
+			client := newTestClient(t, srv.URL)
 			err := client.SetupK8sDiscovery(context.Background(),
-				instrumentation.BackendURLs{},
-				instrumentation.PromHeaders{ClusterID: "42", InstanceID: "123"})
+				instrumentation.BackendURLs{})
 
 			assertConnectRequest(t, cr, "/discovery.v1.DiscoveryService/SetupK8sDiscovery")
 
@@ -413,9 +441,8 @@ func TestClient_RunK8sDiscovery(t *testing.T) {
 			srv := httptest.NewServer(handler)
 			defer srv.Close()
 
-			client := newTestClient(srv.URL)
-			resp, err := client.RunK8sDiscovery(context.Background(),
-				instrumentation.PromHeaders{ClusterID: "42", InstanceID: "123"})
+			client := newTestClient(t, srv.URL)
+			resp, err := client.RunK8sDiscovery(context.Background())
 
 			assertConnectRequest(t, cr, "/discovery.v1.DiscoveryService/RunK8sDiscovery")
 
@@ -496,9 +523,8 @@ func TestClient_IsNamespaceDiscovered(t *testing.T) {
 			srv := httptest.NewServer(handler)
 			defer srv.Close()
 
-			client := newTestClient(srv.URL)
+			client := newTestClient(t, srv.URL)
 			got, err := client.IsNamespaceDiscovered(context.Background(),
-				instrumentation.PromHeaders{ClusterID: "1", InstanceID: "2"},
 				tt.cluster, tt.namespace)
 
 			if tt.wantErr {
@@ -519,8 +545,7 @@ func TestClient_RunK8sDiscovery_StatusConversion(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp, err := newTestClient(srv.URL).RunK8sDiscovery(context.Background(),
-		instrumentation.PromHeaders{ClusterID: "1", InstanceID: "2"})
+	resp, err := newTestClient(t, srv.URL).RunK8sDiscovery(context.Background())
 	require.NoError(t, err)
 	require.Len(t, resp.Items, 1)
 	assert.Equal(t, instrumentation.StatusPendingInstrumentation, resp.Items[0].InstrumentationStatus)
@@ -561,9 +586,8 @@ func TestClient_RunK8sMonitoring(t *testing.T) {
 			srv := httptest.NewServer(handler)
 			defer srv.Close()
 
-			client := newTestClient(srv.URL)
-			resp, err := client.RunK8sMonitoring(context.Background(),
-				instrumentation.PromHeaders{ClusterID: "42", InstanceID: "123"})
+			client := newTestClient(t, srv.URL)
+			resp, err := client.RunK8sMonitoring(context.Background())
 
 			assertConnectRequest(t, cr, "/discovery.v1.DiscoveryService/RunK8sMonitoring")
 
@@ -614,7 +638,7 @@ func TestClient_ListPipelines(t *testing.T) {
 			srv := httptest.NewServer(handler)
 			defer srv.Close()
 
-			client := newTestClient(srv.URL)
+			client := newTestClient(t, srv.URL)
 			pipelines, err := client.ListPipelines(context.Background())
 
 			assertConnectRequest(t, cr, "/pipeline.v1.PipelineService/ListPipelines")
@@ -637,7 +661,7 @@ func TestClient_ListPipelines_MetadataPreserved(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	pipelines, err := newTestClient(srv.URL).ListPipelines(context.Background())
+	pipelines, err := newTestClient(t, srv.URL).ListPipelines(context.Background())
 	require.NoError(t, err)
 	require.Len(t, pipelines, 1)
 	assert.Equal(t, "abc", pipelines[0].ID)
@@ -692,7 +716,7 @@ func TestClient_AllEndpoints_RequestBodyContainsClusterName(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			err := tt.invoke(newTestClient(srv.URL))
+			err := tt.invoke(newTestClient(t, srv.URL))
 			require.NoError(t, err)
 
 			var body map[string]json.RawMessage

--- a/internal/providers/instrumentation/enumerate/enumerate.go
+++ b/internal/providers/instrumentation/enumerate/enumerate.go
@@ -27,7 +27,7 @@ const k8sMonitoringPipelineType = "k8s_monitoring"
 
 // MonitoringClient is the minimal interface required by Enumerate to call
 // RunK8sMonitoring. The real *instrumentation.Client satisfies this via an
-// adapter (PromHeaders are bound at the call site).
+// adapter that unwraps the response to a cluster slice.
 type MonitoringClient interface {
 	RunK8sMonitoring(ctx context.Context) ([]instrumentation.ClusterObservedState, error)
 }


### PR DESCRIPTION
## What

`gcx fleet` and `gcx instrumentation` now reach the Grafana Fleet Management API through the `grafana-collector-app` app plugin proxy at `cfg.Host` (`/api/plugin-proxy/grafana-collector-app/fleet-management-api/...`), built with `rest.HTTPClientFor(&cfg.Config)`, instead of calling Fleet Management directly over Basic auth. Config resolution switches from `LoadCloudConfig` to `LoadGrafanaConfig` for both command groups, and the Cloud/Fleet Management access-policy token is no longer required to use either command group.

Several pieces of the old direct-FM transport are removed as a result:

- Client-side `X-Prom-*`/`X-Scope-OrgID` header decoration, the `PromHeaders` type, and `PromHeadersFromStack` are deleted — the proxy injects these headers server-side.
- `fleet.Client.DoRequestWithHeaders` is removed in favor of a single `DoRequest` method; typed method signatures on the instrumentation client (`SetupK8sDiscovery`, `RunK8sDiscovery`, `RunK8sMonitoring`, `IsNamespaceDiscovered`) drop their `promHeaders` parameter.
- Instrumentation now sources backend datasource URLs (Mimir/Loki/Tempo/Pyroscope) from the collector-app's Viewer-role instance-metadata proxy route (`/api/plugin-proxy/grafana-collector-app/grafanacom-api/instances/`) instead of a separate Cloud API call.
- HTTP 401/403 responses from the proxy are mapped to Grafana auth/RBAC guidance — re-authenticate with `gcx login`, or acquire the Viewer/Grafana Admin role — instead of Cloud access-policy-scope hints.

Typed method surfaces, Connect service/method path suffixes, and the JSON wire format are unchanged. `CONSTITUTION.md`'s external-API carve-out no longer lists Fleet, since fleet and instrumentation traffic now targets `cfg.Host` like the other plugin-proxied providers. The CLI reference, `docs/design/errors.md`, and related architecture docs are updated to describe the new transport and the Viewer/Grafana Admin role split.

## Why

Fleet Management was previously reached directly with Basic auth, requiring a separate Cloud access-policy token (`fleet-management:read`/`fleet-management:write`) on top of the Grafana credential every other command needs. That diverged from the pattern the rest of the plugin-proxied providers follow — reaching `cfg.Host` through the shared bearer transport `rest.HTTPClientFor` already injects — and meant a user authenticated to Grafana via OAuth still could not use `gcx fleet` or `gcx instrumentation` without also minting and scoping a Cloud token.

Routing both command groups through the `grafana-collector-app` proxy removes that redundant credential requirement and lets role enforcement happen where it is observable and actionable: a missing Viewer or Grafana Admin role produces a clear re-authentication or role-request suggestion, rather than an opaque Cloud-scope error. An alternative hybrid transport that kept the Cloud token as a fallback path was considered and rejected in favor of a single, consistent credential path across both command groups.

## How it was tested

- [x] `GCX_AGENT_MODE=false go test -race -count=1 ./...` passed across the full module
- [x] Scoped `golangci-lint` run against the changed packages (`internal/fleet`, `internal/providers/fleet`, `internal/providers/instrumentation`, `cmd/gcx/instrumentation/...`, `cmd/gcx/fail`) reported no issues
- [x] `mise run reference` regenerated the CLI reference docs; `docs/reference/cli/gcx_fleet.md` and `docs/reference/cli/gcx_instrumentation.md` now document the Viewer/Grafana Admin role split and no longer reference a Cloud token
- [x] Passed the `/review-spec` five-check gate (verdict PASS after a 3-round fix loop)

BREAKING CHANGE: `gcx fleet` and `gcx instrumentation` now authenticate through the `grafana-collector-app` plugin proxy instead of calling Fleet Management directly with Basic auth. `internal/providers/instrumentation.PromHeaders`, `PromHeadersFromStack`, and `fleet.Client.DoRequestWithHeaders` are removed. A context carrying only a Cloud/Fleet-Management access-policy token (no Grafana credential) no longer authenticates; reads require the Viewer role and mutations require the Grafana Admin role.

---
**Generated by Claude Code**