### PR TITLE
feat(sm): add x-client-id header to requests

### DIFF
--- a/internal/query/synth/client.go
+++ b/internal/query/synth/client.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/version"
 	"k8s.io/client-go/rest"
 )
 
@@ -32,6 +33,27 @@ const maxResponseBytes = 50 << 20 // 50 MB
 // API ({{.JsonData.apiHost}}/api/v1/). A logical SM path like "check/list" is
 // reached at "<proxy>/sm/check/list".
 const smRoute = "sm"
+
+// The SM API classifies callers in its request logs (the "mux" subsystem) by the
+// X-Client-ID / X-Client-Version headers — NOT the User-Agent, which Grafana's
+// datasource proxy unconditionally overwrites with "Grafana/<version>".
+//
+// clientIDValue must match an entry in sm-api's allowedClientTypes; any other
+// value is logged as client_type="unknown". Both headers survive the assistant
+// CLI proxy and datasource proxy hops intact (verified end-to-end).
+const (
+	clientIDHeader      = "X-Client-Id"
+	clientVersionHeader = "X-Client-Version"
+	clientIDValue       = "gcx"
+)
+
+// setClientIdentity stamps gcx's SM-API client identity onto a request so the SM
+// API attributes it as client_type="gcx" rather than "unknown". Applied on both
+// the datasource-proxy and direct SM-API request paths.
+func setClientIdentity(h http.Header) {
+	h.Set(clientIDHeader, clientIDValue)
+	h.Set(clientVersionHeader, version.Get())
+}
 
 // Response is the outcome of a proxied SM request. Non-2xx statuses are
 // returned here (not as an error) so callers can inspect StatusCode and decide
@@ -91,6 +113,7 @@ func (c *Client) do(ctx context.Context, method, datasourceUID, smPath string, b
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	setClientIdentity(req.Header)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/internal/query/synth/client_test.go
+++ b/internal/query/synth/client_test.go
@@ -48,6 +48,25 @@ func TestGet_BuildsProxyPathAndReturnsBody(t *testing.T) {
 	assert.JSONEq(t, `[{"id":1}]`, string(resp.Body))
 }
 
+// TestGet_SendsClientIdentityHeaders locks the SM-attribution contract: gcx must
+// send X-Client-ID / X-Client-Version on the proxy path, because sm-api classifies
+// callers by those headers (not User-Agent). Without X-Client-ID="gcx" the request
+// is logged as client_type="unknown".
+func TestGet_SendsClientIdentityHeaders(t *testing.T) {
+	var gotClientID, gotClientVersion string
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotClientID = r.Header.Get("X-Client-Id")
+		gotClientVersion = r.Header.Get("X-Client-Version")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	_, err := client.Get(context.Background(), testDSUID, "check/list")
+	require.NoError(t, err)
+
+	assert.Equal(t, "gcx", gotClientID, "sm-api attributes callers by X-Client-ID")
+	assert.NotEmpty(t, gotClientVersion, "X-Client-Version must be set so client_version is not \"unknown\"")
+}
+
 func TestPost_SendsBodyWithJSONContentType(t *testing.T) {
 	var gotMethod, gotPath, gotContentType string
 	var gotBody []byte

--- a/internal/query/synth/transport.go
+++ b/internal/query/synth/transport.go
@@ -113,6 +113,7 @@ func (t *Transport) directDo(ctx context.Context, method, smPath string, body []
 		return 0, nil, fmt.Errorf("creating request: %w", err)
 	}
 
+	setClientIdentity(req.Header)
 	req.Header.Set("Authorization", "Bearer "+t.directTok)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")

--- a/internal/query/synth/transport_test.go
+++ b/internal/query/synth/transport_test.go
@@ -244,6 +244,29 @@ func TestTransport_FallbackResolvedOnceAcrossCalls(t *testing.T) {
 	assert.Equal(t, 1, fallback.calls, "credentials must be resolved exactly once across calls")
 }
 
+// TestTransport_DirectPathSendsClientIdentity verifies the fallback (direct
+// SM-API) path also stamps the X-Client-Id / X-Client-Version headers, so gcx is
+// attributed as client_type="gcx" regardless of which mode serves the request.
+func TestTransport_DirectPathSendsClientIdentity(t *testing.T) {
+	var gotClientID, gotClientVersion string
+	directSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotClientID = r.Header.Get("X-Client-Id")
+		gotClientVersion = r.Header.Get("X-Client-Version")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer directSrv.Close()
+
+	fallback := &fakeFallback{baseURL: directSrv.URL, token: "direct-token"}
+	tr, err := synth.NewTransport(config.NamespacedRESTConfig{}, "", fallback)
+	require.NoError(t, err)
+
+	_, _, err = tr.Do(context.Background(), http.MethodGet, "check/list", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "gcx", gotClientID, "sm-api attributes callers by X-Client-ID")
+	assert.NotEmpty(t, gotClientVersion, "X-Client-Version must be set so client_version is not \"unknown\"")
+}
+
 func TestTransport_UnsupportedMethod(t *testing.T) {
 	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This adds a header `X-Client-Id` that will be sent to SM api requests to allow us to better track gcx requests. There's a corresponding PR in our api(https://github.com/grafana/synthetic-monitoring-api/pull/2303) that updates our allow list for client types.