### PR TITLE
chore: update sm codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 # Providers
 /internal/providers/slo/ @grafana/grafana-gcx @grafana/slo-squad
 /internal/providers/synth/ @grafana/grafana-gcx @grafana/synthetic-monitoring-dev
+/internal/query/synth/ @grafana/grafana-gcx @grafana/synthetic-monitoring-dev
 /internal/providers/irm/ @grafana/grafana-gcx @grafana/grafana-irm-backend
 /internal/providers/k6/ @grafana/grafana-gcx @grafana/k6-backend
 /internal/providers/faro/ @grafana/grafana-gcx @grafana/kowalski


### PR DESCRIPTION
Adds `internal/query/synth` to the list of folders synthetic-monitoring-dev is the codeowners of. I discovered this in https://github.com/grafana/gcx/pull/932.