### PR TITLE
fix(skills): apply best-practices review to bundled skills

### DIFF
--- a/claude-plugin/skills/aio11y/SKILL.md
+++ b/claude-plugin/skills/aio11y/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: aio11y
 description: >
-  Use when the user wants to list or search AI Observability conversations, inspect generations,
+  Inspects and manages Grafana AI Observability resources via gcx:
+  conversations, generations, evaluators, rules, scores, and templates.
+  Use when the user wants to list or search conversations, inspect generations,
   manage evaluators (create, test, delete), set up evaluation rules, check scores,
   or browse evaluator templates. Trigger on phrases like "list conversations",
   "search generations", "what did the agent do", "debug LLM conversation",
   "create evaluator", "set up evaluation rule", "test evaluator", "check scores",
   "evaluate generation quality", or "set up online evaluation".
-allowed-tools: [Bash, Read, Write, Edit]
+allowed-tools: Bash, Read, Write, Edit
 ---
 
 # AI Observability

--- a/claude-plugin/skills/aio11y/SKILL.md
+++ b/claude-plugin/skills/aio11y/SKILL.md
@@ -7,12 +7,12 @@ description: >
   "search generations", "what did the agent do", "debug LLM conversation",
   "create evaluator", "set up evaluation rule", "test evaluator", "check scores",
   "evaluate generation quality", or "set up online evaluation".
-allowed-tools: [gcx, Bash, Read, Write, Edit]
+allowed-tools: [Bash, Read, Write, Edit]
 ---
 
 # AI Observability
 
-AI Observability is Grafana's AI observability platform. It records what LLM-powered applications do in production and scores the quality of their output.
+AI Observability records what LLM-powered applications do in production and scores the quality of their output.
 
 Applications send generations (individual LLM API calls — request, response, model, tokens, tool calls) to AI Observability. Generations belonging to the same user session are grouped into a conversation.
 
@@ -117,7 +117,7 @@ Evaluators use create-or-update semantics: re-creating with the same `evaluator_
 2. Write an evaluator YAML using the input format above, create: `gcx aio11y evaluators create -f evaluator.yaml`
 3. Test against a real generation: `gcx aio11y evaluators test -e <evaluator-id> -g <generation-id>`
 4. Iterate until the evaluator scores as expected
-5. Write a rule YAML (see `references/rule-templates.md`), create: `gcx aio11y rules create -f rule.yaml`
+5. Write a rule YAML (see [rule-templates.md](references/rule-templates.md) for copy-paste templates), create: `gcx aio11y rules create -f rule.yaml`
 6. Verify: `gcx aio11y rules list`
 
 ## Rule Selectors

--- a/claude-plugin/skills/create-dashboard/SKILL.md
+++ b/claude-plugin/skills/create-dashboard/SKILL.md
@@ -140,36 +140,26 @@ Dashboards should answer a diagnostic question. Prefer a top-to-bottom story:
 Context and health → user impact → traffic/errors/latency → dependency path → resources → logs/traces links
 ```
 
-Panel rules:
-
-- Put the most actionable row in the first screen.
-- Use variables for the entity scope users will actually change: cluster,
-  namespace, service, route, tenant, datasource.
-- Give every panel a clear title, unit, legend, and short description.
-- Use thresholds only where they encode an operational decision.
-- Collapse deep-dive/noisy rows by default.
-- Avoid panels that are empty by design in the normal case unless the panel
-  title/description says that empty is healthy.
-- Add drilldown links when a panel naturally leads to logs, traces, or another
-  dashboard.
-
-Dashboard quality checklist, distilled from Grafana dashboard best practices:
+Design rules, distilled from Grafana dashboard best practices:
 
 - Define the dashboard's job before adding panels. If a panel does not support
   that job, remove it or move it to a collapsed deep-dive row.
-- Prefer fewer, decision-oriented panels over metric inventory. The top row
-  should answer "is there a problem and where should I look next?"
-- Use consistent units, decimals, color semantics, thresholds, and legend names
-  across panels.
-- Keep variables useful but limited. Too many variables make snapshots and
-  debugging ambiguous.
+- Prefer fewer, decision-oriented panels over metric inventory. The first
+  screen should answer "is there a problem and where should I look next?"
+- Use variables for the entity scope users will actually change (cluster,
+  namespace, service, route, tenant, datasource), but keep them limited; too
+  many variables make snapshots and debugging ambiguous.
+- Give every panel a clear title, unit, legend, and short description. Keep
+  units, decimals, color semantics, and legend names consistent across panels.
+- Use thresholds only where they encode an operational decision.
 - Avoid unbounded/high-cardinality queries in default panels. Use aggregation,
   `topk()`, scoped variables, and sensible time ranges.
 - Tune refresh and time ranges for the use case. Do not make expensive panels
   auto-refresh faster than the data or the user decision requires.
-- Make empty states intentional: either empty means healthy and the description
-  says so, or the panel should be fixed/removed.
-- Validate readability at the expected viewport, not only the JSON structure.
+- Make empty states intentional: either empty means healthy and the panel
+  description says so, or the panel should be fixed/removed.
+- Add drilldown links when a panel naturally leads to logs, traces, or another
+  dashboard.
 
 ### 5. Author the dashboard
 

--- a/claude-plugin/skills/create-dashboard/SKILL.md
+++ b/claude-plugin/skills/create-dashboard/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: create-dashboard
 description: >
-  Use when the user wants to create a new Grafana dashboard, add panels,
-  variables, or annotations to an existing dashboard, design dashboard panels,
-  variables, queries, or layout, or make a material visual redesign of an
-  existing dashboard. This skill uses gcx plus `gcx dashboards snapshot` as
-  a visual feedback loop. Triggers on "create dashboard", "new dashboard",
+  Designs and creates Grafana dashboards with gcx, using `gcx dashboards
+  snapshot` as a visual feedback loop. Use when the user wants to create a
+  new Grafana dashboard, add panels, variables, or annotations to an existing
+  dashboard, design dashboard panels, variables, queries, or layout, or make
+  a material visual redesign. Triggers on "create dashboard", "new dashboard",
   "build dashboard", "dashboard for <service>", "add panels", "add variable",
   "add annotation", "improve this dashboard", or "iterate on a dashboard".
 ---

--- a/claude-plugin/skills/debug-with-grafana/SKILL.md
+++ b/claude-plugin/skills/debug-with-grafana/SKILL.md
@@ -428,204 +428,26 @@ data retrieved for your own analysis.
 
 ## Example Scenarios
 
-### Scenario 1: HTTP 500 Error Spike
+For complete end-to-end command sequences mapped to the steps above, see
+[`references/example-scenarios.md`](references/example-scenarios.md):
 
-**Trigger**: User reports "my API started returning 500 errors 30 minutes ago".
+- **Scenario 1: HTTP 500 error spike** - error rate trend, status-code
+  breakdown, log correlation
+- **Scenario 2: Latency degradation** - P95 trend, per-endpoint breakdown,
+  dependency latency
+- **Scenario 3: Service down / no data** - `up` checks, `absent()`, crash
+  signals in logs
 
-**Command sequence:**
-
-```bash
-# Step 1: Find datasource UIDs
-gcx datasources list -t prometheus -o json
-gcx datasources list -t loki -o json
-
-# Step 2: Confirm service is being scraped
-gcx metrics query -d <prom-uid> 'up{job="api"}' -o json
-
-# Step 3: Observe error rate over last 2 hours (wider window to see the spike start)
-gcx metrics query -d <prom-uid> \
-  'rate(http_requests_total{job="api",status=~"5.."}[5m])' \
-  --from now-2h --to now --step 1m -o graph
-
-# Identify which status codes are elevated
-gcx metrics query -d <prom-uid> \
-  'sum by(status) (rate(http_requests_total{job="api"}[5m]))' \
-  --from now-2h --to now --step 1m -o json
-
-# Step 4: Check if latency rose at the same time
-gcx metrics query -d <prom-uid> \
-  'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="api"}[5m]))' \
-  --from now-2h --to now --step 1m -o graph
-
-# Step 5: Get error logs in the spike window
-gcx logs query -d <loki-uid> \
-  '{job="api"} |= "error"' \
-  --from now-2h --to now -o json
-
-# Step 6: Check alert rules
-gcx alert rules list -o json | jq '.[] | .rules[]? | select(.state == "firing")'
-```
-
-**Expected output shape at Step 3 (matrix):**
-```json
-{
-  "status": "success",
-  "data": {
-    "resultType": "matrix",
-    "result": [
-      {
-        "metric": {"job": "api", "status": "500"},
-        "values": [[<timestamp>, "<rate>"], ...]
-      }
-    ]
-  }
-}
-```
-
-**Interpretation**: Look for the timestamp where `values` shows the rate
-increasing from baseline. Match this to log timestamps in Step 5.
-
----
-
-### Scenario 2: Latency Degradation
-
-**Trigger**: User reports "requests are taking much longer than usual, no errors yet".
-
-**Command sequence:**
-
-```bash
-# Step 1: Find datasource UIDs
-gcx datasources list -t prometheus -o json
-
-# Step 2: Confirm service health (latency without errors suggests slow dependency)
-gcx metrics query -d <prom-uid> 'up{job="api"}' -o json
-
-# Step 3: Error rate (confirm it's not elevated yet)
-gcx metrics query -d <prom-uid> \
-  'rate(http_requests_total{job="api",status=~"5.."}[5m])' \
-  --from now-1h --to now --step 1m -o json
-
-# Step 4: P95 latency is the primary signal — visualize trend
-gcx metrics query -d <prom-uid> \
-  'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="api"}[5m]))' \
-  --from now-2h --to now --step 1m -o graph
-
-# Break down by endpoint to isolate which routes are slow
-gcx metrics query -d <prom-uid> \
-  'histogram_quantile(0.95, sum by(le, handler) (rate(http_request_duration_seconds_bucket{job="api"}[5m])))' \
-  --from now-1h --to now --step 1m -o json
-
-# Step 5: Check for timeout log patterns suggesting upstream dependency issue
-gcx logs query -d <loki-uid> \
-  '{job="api"} |~ "timeout|slow|waiting"' \
-  --from now-2h --to now -o json
-
-# Check database or downstream service latency if metrics available
-gcx metrics query -d <prom-uid> \
-  'rate(db_query_duration_seconds_sum{job="api"}[5m]) / rate(db_query_duration_seconds_count{job="api"}[5m])' \
-  --from now-2h --to now --step 1m -o json
-```
-
-**Expected output shape at Step 4 (histogram):**
-```json
-{
-  "status": "success",
-  "data": {
-    "resultType": "matrix",
-    "result": [
-      {
-        "metric": {"job": "api"},
-        "values": [[<timestamp>, "<seconds>"], ...]
-      }
-    ]
-  }
-}
-```
-
-**Interpretation**: Rising `values` across all endpoints suggests a shared
-resource or dependency. Rising values for one endpoint only suggests a
-handler-specific issue. Compare latency onset time with log timestamps.
-
----
-
-### Scenario 3: Service Down / No Data
-
-**Trigger**: User reports "service seems completely down" or dashboard shows no data.
-
-**Command sequence:**
-
-```bash
-# Step 1: Verify datasource connectivity first (simplest possible query)
-gcx datasources list -o json
-
-# Step 2: Check whether the service is being scraped at all
-gcx metrics query -d <prom-uid> 'up{job="api"}' -o json
-
-# Confirm up metric — value "0" means scrape failure, absent means not scraped
-gcx metrics query -d <prom-uid> 'up{job="api"}' -o json
-
-# Check if the job label exists at all (absence = service was never registered)
-gcx metrics labels -d <prom-uid> -l job -o json
-
-# Step 3: Without error rate data, check for recent data gaps
-gcx metrics query -d <prom-uid> \
-  'absent(up{job="api"})' \
-  --from now-1h --to now --step 1m -o json
-
-# Step 4: Query latency from any recent data before the outage
-gcx metrics query -d <prom-uid> \
-  'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="api"}[5m]))' \
-  --from now-3h --to now --step 5m -o graph
-
-# Step 5: Check Loki for last known logs before data disappeared
-gcx logs query -d <loki-uid> \
-  '{job="api"}' \
-  --from now-3h --to now -o json
-
-# Crash or OOM signals in logs
-gcx logs query -d <loki-uid> \
-  '{job="api"} |~ "panic|OOM|killed|crashed|SIGTERM"' \
-  --from now-3h --to now -o json
-
-# Step 6: Check alert rules for any firing service-down alerts
-gcx alert rules list -o json | jq '.[] | .rules[]? | select(.state == "firing")'
-```
-
-**Expected output shape when service is down (up=0):**
-```json
-{
-  "status": "success",
-  "data": {
-    "resultType": "vector",
-    "result": [
-      {
-        "metric": {"__name__": "up", "job": "api", "instance": "<host:port>"},
-        "value": [<timestamp>, "0"]
-      }
-    ]
-  }
-}
-```
-
-**Expected output shape when service was never scraped (absent):**
-```json
-{
-  "status": "success",
-  "data": {
-    "resultType": "vector",
-    "result": []
-  }
-}
-```
-
-**Interpretation**:
-- `up=0`: Service is registered but failing health checks — check pod/process status
-- Empty result for `up{job="api"}`: Job never existed or was removed from scrape config
-- Data present up to a specific timestamp then absent: Service crashed at that time — correlate with crash logs
+Read the matching scenario when starting an investigation of that shape;
+otherwise follow the numbered workflow directly.
 
 ---
 
 ## References
+
+- [`references/example-scenarios.md`](references/example-scenarios.md) - Full
+  command sequences for the three common scenarios (error spike, latency
+  degradation, service down).
 
 - [`references/error-recovery.md`](references/error-recovery.md) — Recovery
   patterns for auth errors (401/403), datasource not found, empty results,
@@ -633,8 +455,8 @@ gcx alert rules list -o json | jq '.[] | .rules[]? | select(.state == "firing")'
 
 - [`references/query-patterns.md`](references/query-patterns.md) — Advanced
   query patterns for Prometheus and Loki datasources, including time range
-  formats, aggregation patterns, Loki stream operators, and output format
-  reference.
+  formats, label/metadata discovery workflows, output format reference, Loki
+  series limits, and indexed vs structured-metadata vs parsed label rules.
 
 - [`references/traceql-patterns.md`](references/traceql-patterns.md) — TraceQL
   query patterns for Tempo trace search, attribute scoping rules, and the

--- a/claude-plugin/skills/debug-with-grafana/references/error-recovery.md
+++ b/claude-plugin/skills/debug-with-grafana/references/error-recovery.md
@@ -2,8 +2,15 @@
 
 Recovery patterns for CLI failures encountered during diagnostic workflows.
 
-**Flags verified against**: `cmd/gcx/datasources/query/command.go`, `cmd/gcx/config/command.go`, `cmd/gcx/datasources/`
-**Source commit**: HEAD of branch `t1-cli-flag-audit`
+## Contents
+
+- [Failure Mode 1: Authentication / Authorization Error (401/403)](#failure-mode-1-authentication--authorization-error-401403)
+- [Failure Mode 2: Datasource Not Found](#failure-mode-2-datasource-not-found)
+- [Failure Mode 3: Query Returns Empty Result Set](#failure-mode-3-query-returns-empty-result-set)
+- [Failure Mode 4: Query Timeout or Server Error (5xx)](#failure-mode-4-query-timeout-or-server-error-5xx)
+- [Failure Mode 5: Malformed PromQL or LogQL Syntax Error](#failure-mode-5-malformed-promql-or-logql-syntax-error)
+- [Failure Mode 6: "Accepts between 0 and 1 arg(s), received 2"](#failure-mode-6-accepts-between-0-and-1-args-received-2)
+- [Quick Reference: Recovery Command Cheatsheet](#quick-reference-recovery-command-cheatsheet)
 
 ---
 

--- a/claude-plugin/skills/debug-with-grafana/references/example-scenarios.md
+++ b/claude-plugin/skills/debug-with-grafana/references/example-scenarios.md
@@ -1,0 +1,204 @@
+# Example Scenarios
+
+End-to-end command sequences for the three most common debugging entry points.
+Each scenario maps to the numbered steps in SKILL.md.
+
+## Contents
+
+- [Scenario 1: HTTP 500 Error Spike](#scenario-1-http-500-error-spike)
+- [Scenario 2: Latency Degradation](#scenario-2-latency-degradation)
+- [Scenario 3: Service Down / No Data](#scenario-3-service-down--no-data)
+
+---
+
+## Scenario 1: HTTP 500 Error Spike
+
+**Trigger**: User reports "my API started returning 500 errors 30 minutes ago".
+
+**Command sequence:**
+
+```bash
+# Step 1: Find datasource UIDs
+gcx datasources list -t prometheus -o json
+gcx datasources list -t loki -o json
+
+# Step 2: Confirm service is being scraped
+gcx metrics query -d <prom-uid> 'up{job="api"}' -o json
+
+# Step 3: Observe error rate over last 2 hours (wider window to see the spike start)
+gcx metrics query -d <prom-uid> \
+  'rate(http_requests_total{job="api",status=~"5.."}[5m])' \
+  --from now-2h --to now --step 1m -o graph
+
+# Identify which status codes are elevated
+gcx metrics query -d <prom-uid> \
+  'sum by(status) (rate(http_requests_total{job="api"}[5m]))' \
+  --from now-2h --to now --step 1m -o json
+
+# Step 4: Check if latency rose at the same time
+gcx metrics query -d <prom-uid> \
+  'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="api"}[5m]))' \
+  --from now-2h --to now --step 1m -o graph
+
+# Step 5: Get error logs in the spike window
+gcx logs query -d <loki-uid> \
+  '{job="api"} |= "error"' \
+  --from now-2h --to now -o json
+
+# Step 6: Check alert rules
+gcx alert rules list -o json | jq '.[] | .rules[]? | select(.state == "firing")'
+```
+
+**Expected output shape at Step 3 (matrix):**
+```json
+{
+  "status": "success",
+  "data": {
+    "resultType": "matrix",
+    "result": [
+      {
+        "metric": {"job": "api", "status": "500"},
+        "values": [[<timestamp>, "<rate>"], ...]
+      }
+    ]
+  }
+}
+```
+
+**Interpretation**: Look for the timestamp where `values` shows the rate
+increasing from baseline. Match this to log timestamps in Step 5.
+
+---
+
+## Scenario 2: Latency Degradation
+
+**Trigger**: User reports "requests are taking much longer than usual, no errors yet".
+
+**Command sequence:**
+
+```bash
+# Step 1: Find datasource UIDs
+gcx datasources list -t prometheus -o json
+
+# Step 2: Confirm service health (latency without errors suggests slow dependency)
+gcx metrics query -d <prom-uid> 'up{job="api"}' -o json
+
+# Step 3: Error rate (confirm it's not elevated yet)
+gcx metrics query -d <prom-uid> \
+  'rate(http_requests_total{job="api",status=~"5.."}[5m])' \
+  --from now-1h --to now --step 1m -o json
+
+# Step 4: P95 latency is the primary signal - visualize trend
+gcx metrics query -d <prom-uid> \
+  'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="api"}[5m]))' \
+  --from now-2h --to now --step 1m -o graph
+
+# Break down by endpoint to isolate which routes are slow
+gcx metrics query -d <prom-uid> \
+  'histogram_quantile(0.95, sum by(le, handler) (rate(http_request_duration_seconds_bucket{job="api"}[5m])))' \
+  --from now-1h --to now --step 1m -o json
+
+# Step 5: Check for timeout log patterns suggesting upstream dependency issue
+gcx logs query -d <loki-uid> \
+  '{job="api"} |~ "timeout|slow|waiting"' \
+  --from now-2h --to now -o json
+
+# Check database or downstream service latency if metrics available
+gcx metrics query -d <prom-uid> \
+  'rate(db_query_duration_seconds_sum{job="api"}[5m]) / rate(db_query_duration_seconds_count{job="api"}[5m])' \
+  --from now-2h --to now --step 1m -o json
+```
+
+**Expected output shape at Step 4 (histogram):**
+```json
+{
+  "status": "success",
+  "data": {
+    "resultType": "matrix",
+    "result": [
+      {
+        "metric": {"job": "api"},
+        "values": [[<timestamp>, "<seconds>"], ...]
+      }
+    ]
+  }
+}
+```
+
+**Interpretation**: Rising `values` across all endpoints suggests a shared
+resource or dependency. Rising values for one endpoint only suggests a
+handler-specific issue. Compare latency onset time with log timestamps.
+
+---
+
+## Scenario 3: Service Down / No Data
+
+**Trigger**: User reports "service seems completely down" or dashboard shows no data.
+
+**Command sequence:**
+
+```bash
+# Step 1: Verify datasource connectivity first (simplest possible query)
+gcx datasources list -o json
+
+# Step 2: Check whether the service is being scraped at all
+gcx metrics query -d <prom-uid> 'up{job="api"}' -o json
+
+# Check if the job label exists at all (absence = service was never registered)
+gcx metrics labels -d <prom-uid> -l job -o json
+
+# Step 3: Without error rate data, check for recent data gaps
+gcx metrics query -d <prom-uid> \
+  'absent(up{job="api"})' \
+  --from now-1h --to now --step 1m -o json
+
+# Step 4: Query latency from any recent data before the outage
+gcx metrics query -d <prom-uid> \
+  'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="api"}[5m]))' \
+  --from now-3h --to now --step 5m -o graph
+
+# Step 5: Check Loki for last known logs before data disappeared
+gcx logs query -d <loki-uid> \
+  '{job="api"}' \
+  --from now-3h --to now -o json
+
+# Crash or OOM signals in logs
+gcx logs query -d <loki-uid> \
+  '{job="api"} |~ "panic|OOM|killed|crashed|SIGTERM"' \
+  --from now-3h --to now -o json
+
+# Step 6: Check alert rules for any firing service-down alerts
+gcx alert rules list -o json | jq '.[] | .rules[]? | select(.state == "firing")'
+```
+
+**Expected output shape when service is down (up=0):**
+```json
+{
+  "status": "success",
+  "data": {
+    "resultType": "vector",
+    "result": [
+      {
+        "metric": {"__name__": "up", "job": "api", "instance": "<host:port>"},
+        "value": [<timestamp>, "0"]
+      }
+    ]
+  }
+}
+```
+
+**Expected output shape when service was never scraped (absent):**
+```json
+{
+  "status": "success",
+  "data": {
+    "resultType": "vector",
+    "result": []
+  }
+}
+```
+
+**Interpretation**:
+- `up=0`: Service is registered but failing health checks - check pod/process status
+- Empty result for `up{job="api"}`: Job never existed or was removed from scrape config
+- Data present up to a specific timestamp then absent: Service crashed at that time - correlate with crash logs

--- a/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
@@ -2,6 +2,17 @@
 
 Advanced patterns for querying Prometheus and Loki datasources with gcx.
 
+## Contents
+
+- [Datasource UID Resolution](#datasource-uid-resolution) - finding UIDs, setting defaults
+- [Prometheus Query Patterns](#prometheus-query-patterns) - instant vs range, time formats, step intervals
+- [Loki Query Patterns](#loki-query-patterns) - stream selectors, log metric queries
+- [Prometheus Datasource Operations](#prometheus-datasource-operations) - label/metadata discovery workflow
+- [Loki Datasource Operations](#loki-datasource-operations) - label/series discovery workflow
+- [Output Formats](#output-formats) - table, wide, JSON shapes, `--json` field selection
+- [Performance Tips](#performance-tips) - Loki series limits, distributed-request counting, indexed vs structured-metadata vs parsed labels
+- [Comparison Queries](#comparison-queries) - comparing now vs a past instant
+
 ## Datasource UID Resolution
 
 **CRITICAL**: Always use datasource UID, never the name.
@@ -138,35 +149,8 @@ gcx metrics query -d <uid> 'rate(requests[1h])' \
 
 **Rule of thumb**: Step should be ~1/100th of total range for smooth charts.
 
-### Aggregation Patterns
-
-```bash
-# Sum across all instances
-gcx metrics query -d <uid> 'sum(http_requests_total)'
-
-# Average by label
-gcx metrics query -d <uid> 'avg by(job) (cpu_usage)'
-
-# Top 5 by value
-gcx metrics query -d <uid> 'topk(5, http_requests_total)'
-
-# 95th percentile
-gcx metrics query -d <uid> 'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))'
-```
-
-### Combining with Graph
-
-```bash
-# Line chart (default) — pass -o graph directly to the query command
-gcx metrics query -d <uid> 'rate(http_requests_total[5m])' \
-  --from now-1h --to now --step 1m -o graph
-
-# Instant query as graph
-gcx metrics query -d <uid> 'up' -o graph
-
-# Range query as graph
-gcx metrics query -d <uid> 'cpu_usage' --from now-6h --to now --step 5m -o graph
-```
+Pass `-o graph` directly to any query command (instant or range) to render a
+terminal line chart.
 
 ## Loki Query Patterns
 
@@ -192,35 +176,10 @@ gcx logs query -d <loki-uid> '{job=~"mysql.*",level!="debug"}'
 gcx logs query -d <loki-uid> '{namespace="production",pod!~"test.*"}'
 ```
 
-### Log Stream Operators
-
-```bash
-# Contains text
-gcx logs query -d <loki-uid> '{job="varlogs"} |= "error"'
-
-# Doesn't contain text
-gcx logs query -d <loki-uid> '{job="varlogs"} != "debug"'
-
-# Regex match in log line
-gcx logs query -d <loki-uid> '{job="varlogs"} |~ "error|exception"'
-
-# JSON parsing
-gcx logs query -d <loki-uid> '{job="varlogs"} | json | level="error"'
-```
-
-### Log Range Queries
-
-Query logs over time:
-
-```bash
-# Last hour of logs
-gcx logs query -d <loki-uid> '{job="varlogs"}' \
-  --from now-1h --to now
-
-# Specific time range
-gcx logs query -d <loki-uid> '{namespace="prod"}' \
-  --from 2026-03-01T00:00:00Z --to 2026-03-01T12:00:00Z
-```
+Line filters and parsers (`|= "error"`, `|~ "regex"`, `| json`, `| logfmt`)
+follow standard LogQL syntax after the selector. Time ranges use the same
+`--from`/`--to` formats as Prometheus queries (see
+[Time Range Formats](#time-range-formats)).
 
 ### Log Metrics (Rate Queries)
 
@@ -241,17 +200,8 @@ gcx logs query -d <loki-uid> \
 gcx logs query -d <loki-uid> \
   'sum by(level) (rate({job="varlogs"} | json [5m]))' \
   --from now-1h --to now --step 1m
-```
 
-### Combining Loki with Graph
-
-```bash
-# Visualize log volume
-gcx logs query -d <loki-uid> \
-  'sum(rate({job="varlogs"}[5m]))' \
-  --from now-6h --to now --step 5m -o graph
-
-# Error rate over time
+# Visualize log volume with -o graph
 gcx logs query -d <loki-uid> \
   'sum(rate({job="app"} |= "error" [5m]))' \
   --from now-24h --to now --step 15m -o graph
@@ -398,12 +348,6 @@ JSON structure:
 }
 ```
 
-### YAML Format
-
-```bash
-gcx metrics query -d <uid> 'up' -o yaml
-```
-
 ### Field Selection
 
 Use `--json` to select fields without external tools:
@@ -423,84 +367,7 @@ gcx metrics query -d <uid> 'up' -o json 2>/dev/null | \
 > **Piping caution**: Never use `2>&1` when piping gcx JSON output — gcx writes
 > hints to stderr that break JSON parsers. Use `2>/dev/null` instead.
 
-## Scripting Patterns
-
-### Automated Monitoring
-
-```bash
-#!/bin/bash
-DS_UID=$(gcx datasources list --type prometheus -o json 2>/dev/null | \
-  python3 -c "import json,sys; print(json.load(sys.stdin)['datasources'][0]['uid'])")
-
-# Check if service is up
-UP=$(gcx metrics query -d $DS_UID 'up{job="critical-service"}' -o json 2>/dev/null | \
-     python3 -c "import json,sys; print(json.load(sys.stdin)['data']['result'][0]['value'][1])")
-
-if [ "$UP" != "1" ]; then
-  echo "ALERT: critical-service is down!"
-  exit 1
-fi
-```
-
-### Batch Queries
-
-```bash
-#!/bin/bash
-DS_UID="<your-datasource-uid>"
-
-QUERIES=(
-  "up"
-  "rate(http_requests_total[5m])"
-  "node_memory_MemAvailable_bytes"
-)
-
-for query in "${QUERIES[@]}"; do
-  echo "Query: $query"
-  gcx metrics query -d $DS_UID "$query" --from now-5m --to now -o graph
-  echo "---"
-done
-```
-
-### Exporting Data
-
-```bash
-# Export query results to file
-gcx metrics query -d <uid> 'cpu_usage' --from now-24h --to now --step 1m -o json > cpu-data.json
-
-# Convert to CSV
-gcx metrics query -d <uid> 'up' -o json 2>/dev/null | \
-  python3 -c "import json,sys,csv; w=csv.writer(sys.stdout); data=json.load(sys.stdin); [w.writerow([r['metric'].get('job',''),r['value'][0],r['value'][1]]) for r in data['data']['result']]" > results.csv
-```
-
 ## Performance Tips
-
-### Query Optimization
-
-1. **Use specific label filters**: More specific = faster queries
-```bash
-# Slow
-gcx metrics query -d <uid> 'http_requests_total'
-
-# Fast
-gcx metrics query -d <uid> 'http_requests_total{job="api",status="200"}'
-```
-
-2. **Choose appropriate range selectors**:
-```bash
-# For rate queries, match range to step
-gcx metrics query -d <uid> 'rate(requests[5m])' --step 5m
-
-# Don't use huge ranges for instant queries
-gcx metrics query -d <uid> 'rate(requests[5m])'  # Good
-gcx metrics query -d <uid> 'rate(requests[1h])'  # Usually unnecessary
-```
-
-3. **Limit time ranges**:
-```bash
-# Query only what you need
-gcx metrics query -d <uid> 'up' --from now-1h --to now  # Good
-gcx metrics query -d <uid> 'up' --from now-30d --to now  # Slow
-```
 
 ### Loki Performance
 
@@ -607,48 +474,10 @@ Common mistakes:
   label just because you saw it in query output — check whether it came from
   `stream` vs `structuredMetadata`.
 
-## Common Patterns
-
-### Health Check
-
-```bash
-# Check if services are up
-gcx metrics query -d <uid> 'up{job="critical-service"}' | grep "1"
-```
-
-### Error Rate
-
-```bash
-# HTTP error rate
-gcx metrics query -d <uid> 'rate(http_requests_total{status=~"5.."}[5m])' \
-  --from now-1h --to now --step 1m -o graph
-```
-
-### Resource Usage
-
-```bash
-# Memory usage by pod
-gcx metrics query -d <uid> 'container_memory_usage_bytes{namespace="production"}' -o graph
-```
-
-### Log Analysis
-
-```bash
-# Count errors in last hour
-gcx logs query -d <loki-uid> \
-  'count_over_time({job="app"} |= "error" [1h])'
-```
-
-### Comparison Queries
+## Comparison Queries
 
 ```bash
 # Compare current vs 24h ago — use --time for instant snapshots, not range queries
 gcx metrics query -d <uid> 'rate(requests[5m])' --time now -o json > now.json
 gcx metrics query -d <uid> 'rate(requests[5m])' --time now-24h -o json > yesterday.json
 ```
-
-## Tempo / TraceQL Patterns
-
-For TraceQL query syntax, `traces query` vs `traces get`, attribute scoping
-rules, and common trace search patterns, see
-[`traceql-patterns.md`](traceql-patterns.md).

--- a/claude-plugin/skills/debug-with-grafana/references/traceql-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/traceql-patterns.md
@@ -2,6 +2,12 @@
 
 Workflow and query patterns for Tempo trace search using gcx.
 
+## Contents
+
+- [Commands](#commands) - query/get/labels/tags surface
+- [Workflow: discover, search, get](#workflow-discover--search--get)
+- [Attribute scoping rules](#attribute-scoping-rules) - `resource.` / `span.` prefixes and intrinsics
+
 ## Commands
 
 | Command | Purpose | Positional arg |

--- a/claude-plugin/skills/diagnose-entity-graph/SKILL.md
+++ b/claude-plugin/skills/diagnose-entity-graph/SKILL.md
@@ -56,9 +56,9 @@ workflow before assuming it exists on this stack.
 
 ## Prerequisites
 
-gcx must be installed (v0.2.14+) and configured with a valid context. If
-`gcx kg diagnose` is available (fork or future release), use it as a shortcut
-where noted. Otherwise, the individual commands below produce equivalent results.
+gcx must be installed and configured with a valid context. `gcx kg diagnose`
+bundles most of the per-step checks below; the individual commands produce
+equivalent results when you need to drill into one check.
 
 ```bash
 gcx config view
@@ -150,7 +150,7 @@ gcx metrics query 'count(asserts:request:rate5m{asserts_env="ENV"})' --since 1h
 
 ## Step 5: Edge Source Analysis
 
-CALLS edges can come from 11 sources, not just OTel traces:
+CALLS edges can come from many sources, not just OTel traces:
 
 | Source | Input Metric | Requires Traces? |
 |--------|-------------|-----------------|
@@ -199,7 +199,7 @@ rule that maps `namespace` or another label to `asserts_env` for this metric.
 - If services are discovered via JMX (`job` contains `jmx`) → JMX alone
   cannot produce edges. Spring Boot Actuator or OTel tracing is needed.
 
-**Shortcut:** `gcx kg diagnose` now detects this gap automatically and warns
+**Shortcut:** `gcx kg diagnose` detects this gap automatically and warns
 when edge source metrics exist but lack `asserts_env`.
 
 **Most common fix:** If metrics have `deployment_environment` but not

--- a/claude-plugin/skills/diagnose-entity-graph/SKILL.md
+++ b/claude-plugin/skills/diagnose-entity-graph/SKILL.md
@@ -82,11 +82,11 @@ the Asserts app onboarding flow.
 ## Step 2: Entity Counts and Scopes
 
 ```bash
-gcx kg health --since 1h
+gcx kg summary --since 1h
 gcx kg meta scopes
 ```
 
-**Check:** `totalEntities` should be > 0. The `meta scopes` output shows
+**Check:** entity counts should be > 0. The `meta scopes` output shows
 available `env`, `site`, and `namespace` values.
 
 If scoping to a specific environment, note the exact `env` value — you'll
@@ -244,10 +244,10 @@ For a specific missing or edge-less service:
 
 ```bash
 # Find in graph
-gcx kg cypher "MATCH (s:Service {name: \"SERVICE\"}) RETURN s" --since 1h
+gcx kg entities query "MATCH (s:Service {name: \"SERVICE\"}) RETURN s" --since 1h
 
 # Check relationships
-gcx kg cypher "MATCH (s:Service {name: \"SERVICE\"})-[r]-(other) RETURN s, r, other" --since 1h
+gcx kg entities query "MATCH (s:Service {name: \"SERVICE\"})-[r]-(other) RETURN s, r, other" --since 1h
 
 # Source metrics
 gcx metrics query 'count(traces_service_graph_request_total{client="SERVICE"})' --since 1h

--- a/claude-plugin/skills/explore-datasources/SKILL.md
+++ b/claude-plugin/skills/explore-datasources/SKILL.md
@@ -133,11 +133,8 @@ After setting defaults, you can omit the `-d` flag in datasource commands.
 
 **Actions:**
 1. Verify datasource exists: `gcx datasources get <uid>`
-2. Check if service is being monitored:
-   - Prometheus: `gcx metrics query -d <uid> 'up{job="service-x"}'`
-   - Look for service in scrape results
-3. Verify labels exist: `gcx metrics labels -d <uid> --label job`
-4. Test simple query: `gcx metrics query -d <uid> 'up{job="service-x"}'`
+2. Verify labels exist: `gcx metrics labels -d <uid> --label job`
+3. Check if service is being scraped: `gcx metrics query -d <uid> 'up{job="service-x"}'`
 
 **Result:** Identifies whether datasource is misconfigured, service isn't being scraped, or label selectors are wrong.
 
@@ -213,9 +210,9 @@ gcx logs series -d <uid> -M {name="value"}
 
 ## Advanced Usage
 
-For detailed patterns, LogQL syntax guide, and advanced discovery workflows, see:
-- [`references/discovery-patterns.md`](references/discovery-patterns.md) - Common discovery patterns and workflows
-- [`references/logql-syntax.md`](references/logql-syntax.md) - LogQL selector syntax guide
+For detailed patterns and advanced discovery workflows, see:
+- [`references/discovery-patterns.md`](references/discovery-patterns.md) - Common discovery patterns and workflows (jq filtering, cross-datasource search, graph output)
+- [`references/logql-syntax.md`](references/logql-syntax.md) - gcx-specific selector rules for `logs series` (OR via multiple `-M` flags, shell quoting, indexed vs structured-metadata labels)
 
 ## Output Formats
 

--- a/claude-plugin/skills/explore-datasources/references/discovery-patterns.md
+++ b/claude-plugin/skills/explore-datasources/references/discovery-patterns.md
@@ -1,6 +1,19 @@
 # Datasource Discovery Patterns
 
-This document contains common patterns and workflows for discovering datasource contents.
+Common patterns and workflows for discovering datasource contents.
+
+## Contents
+
+- [Pattern 1: Finding HTTP Metrics](#pattern-1-finding-http-metrics)
+- [Pattern 2: Understanding Service Labels](#pattern-2-understanding-service-labels)
+- [Pattern 3: Discovering Available Services](#pattern-3-discovering-available-services)
+- [Pattern 4: Discovering Loki Log Streams](#pattern-4-discovering-loki-log-streams)
+- [Saving Datasource UIDs](#saving-datasource-uids)
+- [Searching Metrics with jq](#searching-metrics-with-jq)
+- [Filtering by Label](#filtering-by-label)
+- [Which Datasource Has Data for System X?](#which-datasource-has-data-for-system-x)
+- [Limitations](#limitations)
+- [Visualizing Query Results](#visualizing-query-results)
 
 ## Pattern 1: Finding HTTP Metrics
 
@@ -18,7 +31,7 @@ grep -i http metrics.json
 gcx metrics metadata -d <uid> --metric prometheus_http_requests_total
 
 # 5. Test query
-gcx metrics query <uid> 'rate(prometheus_http_requests_total[5m])'
+gcx metrics query -d <uid> 'rate(prometheus_http_requests_total[5m])'
 ```
 
 ## Pattern 2: Understanding Service Labels
@@ -31,7 +44,7 @@ gcx metrics labels -d <uid>
 gcx metrics labels -d <uid> --label job
 
 # 3. Get all instances for a specific job
-gcx metrics query <uid> 'up{job="my-service"}'
+gcx metrics query -d <uid> 'up{job="my-service"}'
 
 # 4. List available status codes
 gcx metrics labels -d <uid> --label code
@@ -46,8 +59,8 @@ gcx metrics query -d <uid> 'up'
 # 2. Get unique jobs
 gcx metrics labels -d <uid> --label job
 
-# 3. Check which services are up
-gcx metrics query <uid> 'up'
+# 3. Find down targets
+gcx metrics query -d <uid> 'up == 0'
 
 # 4. Get detailed labels for a service
 gcx metrics labels -d <uid> --label app
@@ -120,43 +133,18 @@ JOBS=$(gcx metrics labels -d <uid> --label job -o json)
 # Query each job
 for job in $(echo $JOBS | jq -r '.data[]'); do
   echo "Job: $job"
-  gcx metrics query <uid> "up{job=\"$job\"}"
+  gcx metrics query -d <uid> "up{job=\"$job\"}"
 done
 ```
 
-## Checking Target Health
-
-Monitor scrape target health:
-
-```bash
-# Check active targets via up metric
-gcx metrics query -d <uid> 'up'
-
-# Query for down targets
-gcx metrics query <uid> 'up == 0'
-
-# List available metrics metadata
-gcx metrics metadata -d <uid>
-```
-
-## Use Case Workflows
-
-### "What data is available for my dashboard?"
-
-1. List datasources to find relevant ones
-2. For Prometheus: list labels and metadata
-3. For Loki: list labels and log streams
-4. Search for metrics/logs related to your domain (http, database, etc.)
-5. Test queries to verify data exists
-
-### "Which datasource has data for system X?"
+## Which Datasource Has Data for System X?
 
 **For Prometheus:**
 1. List all datasources
 2. For each Prometheus datasource:
    - Get label values for `job`, `instance`, or `app`
    - Search for system name in labels
-3. Test query to confirm: `gcx metrics query <uid> 'up{job="system-x"}'`
+3. Test query to confirm: `gcx metrics query -d <uid> 'up{job="system-x"}'`
 
 **For Loki:**
 1. List all Loki datasources
@@ -164,39 +152,13 @@ gcx metrics metadata -d <uid>
    - Get label values for `job`, `namespace`, or `container_name`
    - List series matching the system: `gcx logs series -d <uid> -M '{job="system-x"}'`
 
-### "What metrics are available for HTTP requests?"
-
-1. Get datasource UID
-2. List all metrics as JSON
-3. Search for "http" in metric names using grep or jq
-4. Get metadata for specific HTTP metrics
-5. Test queries with discovered metrics
-
-### "Find all log streams for a specific application"
-
-1. Get Loki datasource UID
-2. List all available labels to understand structure
-3. Get values for relevant labels (job, namespace, app, etc.)
-4. Query series with LogQL selectors:
-   ```bash
-   # Find all streams for app
-   gcx logs series -d <uid> -M '{app="myapp"}'
-
-   # Find streams in specific namespace
-   gcx logs series -d <uid> -M '{namespace="production"}'
-
-   # Combine multiple criteria
-   gcx logs series -d <uid> -M '{app="myapp", namespace="production"}'
-   ```
-
 ## Limitations
 
-- **Prometheus-specific operations**: metadata and targets commands only work with Prometheus datasources
-- **Loki-specific operations**: series command requires at least one `--match` selector
+- **Prometheus-specific operations**: the `metadata` command only works with Prometheus datasources
+- **Loki-specific operations**: the `series` command requires at least one `--match` selector
 - **Other datasource types**: Postgres, MySQL, etc. require different exploration methods (not covered by these commands)
 - **Large datasources**: May have thousands of metrics/streams (use `-o json | jq` to filter)
-- **Target information**: Only available if Prometheus is configured to expose it
-- **LogQL complexity**: Series command supports label selectors only, not full LogQL queries with filters
+- **LogQL complexity**: the `series` command supports label selectors only, not full LogQL queries with filters
 
 ## Visualizing Query Results
 
@@ -204,7 +166,7 @@ For Prometheus range queries, use the `-o graph` output codec to render results 
 
 ```bash
 # Query and render as terminal graph
-gcx metrics query <uid> 'rate(http_requests_total[5m])' --from now-1h --to now --step 1m -o graph
+gcx metrics query -d <uid> 'rate(http_requests_total[5m])' --from now-1h --to now --step 1m -o graph
 ```
 
 Note: The graph output codec only works with range queries (requires `--from`, `--to`, and `--step`).

--- a/claude-plugin/skills/explore-datasources/references/logql-syntax.md
+++ b/claude-plugin/skills/explore-datasources/references/logql-syntax.md
@@ -1,105 +1,30 @@
-# LogQL Selector Syntax Guide
+# LogQL Selectors with gcx logs series
 
-This guide covers LogQL stream selector syntax used with the `gcx logs series` command.
+The `series` command requires at least one `--match` (`-M`) stream selector.
+It accepts label matchers only - `=`, `!=`, `=~`, `!~` (RE2 regex) inside
+`{...}` - not full LogQL.
 
-## Overview
+## Supported vs Not Supported
 
-The `series` command requires at least one `--match` (`-M`) selector using LogQL stream selector syntax. This is different from full LogQL queries - it only supports label matching, not log filtering or parsing.
-
-## Basic Syntax
-
-LogQL selectors use curly braces with label matchers:
-
-```
-{label="value"}
-```
-
-Multiple labels use comma separation (AND logic):
-
-```
-{label1="value1", label2="value2"}
-```
-
-## Operators
-
-### Exact Match: `=`
-
-Match label with exact value:
+Supported (label selectors):
 
 ```bash
-# Exact match
 gcx logs series -d <uid> -M '{job="varlogs"}'
-
-# Multiple exact matches (AND)
-gcx logs series -d <uid> -M '{job="varlogs", namespace="default"}'
+gcx logs series -d <uid> -M '{job="api", namespace="production"}'
+gcx logs series -d <uid> -M '{job=~"app-.*"}'
+gcx logs series -d <uid> -M '{namespace!~".*-test", job!="debug"}'
 ```
 
-### Not Equal: `!=`
+Not supported by `series` - run these as full LogQL queries with
+`gcx logs query -d <uid> '<logql>'` instead:
 
-Exclude label with specific value:
+- Line filters: `{job="varlogs"} |= "error"`
+- Parser stages: `{job="varlogs"} | json`
+- Metric queries: `rate({job="varlogs"}[5m])`
 
-```bash
-# Exclude specific job
-gcx logs series -d <uid> -M '{job!="system"}'
+## OR Logic: Multiple -M Flags
 
-# Combine with exact match
-gcx logs series -d <uid> -M '{namespace="production", job!="debug"}'
-```
-
-### Regex Match: `=~`
-
-Match label with regular expression:
-
-```bash
-# Match jobs starting with "app"
-gcx logs series -d <uid> -M '{job=~"app.*"}'
-
-# Match multiple patterns
-gcx logs series -d <uid> -M '{container_name=~"prometheus.*|grafana.*"}'
-
-# Match namespace pattern
-gcx logs series -d <uid> -M '{namespace=~"kube-.*"}'
-```
-
-### Regex Not Match: `!~`
-
-Exclude labels matching a regular expression:
-
-```bash
-# Exclude test namespaces
-gcx logs series -d <uid> -M '{namespace!~".*-test"}'
-
-# Exclude debug and temp jobs
-gcx logs series -d <uid> -M '{job!~"debug|temp"}'
-```
-
-## Common Patterns
-
-### Match Single Label
-
-```bash
-# Find all streams with specific job
-gcx logs series -d <uid> -M '{job="varlogs"}'
-
-# Find all streams in namespace
-gcx logs series -d <uid> -M '{namespace="production"}'
-```
-
-### Match Multiple Labels (AND)
-
-All labels must match:
-
-```bash
-# Job AND namespace
-gcx logs series -d <uid> -M '{job="varlogs", namespace="default"}'
-
-# Three labels
-gcx logs series -d <uid> -M '{job="api", namespace="production", environment="prod"}'
-```
-
-### Match Multiple Selectors (OR)
-
-Use multiple `-M` flags for OR logic:
+Labels inside one selector are ANDed. For OR, pass multiple `-M` flags:
 
 ```bash
 # Job A OR Job B
@@ -109,184 +34,51 @@ gcx logs series -d <uid> -M '{job="varlogs"}' -M '{job="systemlogs"}'
 gcx logs series -d <uid> -M '{namespace="prod"}' -M '{namespace="staging"}'
 ```
 
-### Regex for Multiple Values
+## Only Indexed Labels Are Valid Inside {}
 
-```bash
-# Match multiple jobs with regex
-gcx logs series -d <uid> -M '{job=~"app-.*"}'
+Loki also has *structured metadata* (per-line keys attached at ingest,
+including Loki's auto-added `detected_level`) and *parsed labels* (from
+`| json` / `| logfmt`). Those are NOT indexed and must be filtered after a
+pipe: `{app="myapp"} | detected_level="error"`, not
+`{detected_level="error"}` (which matches nothing).
 
-# Match containers with prefix
-gcx logs series -d <uid> -M '{container_name=~"prometheus.*", component="server"}'
-```
-
-### Exclude Patterns
-
-```bash
-# Exclude test environments
-gcx logs series -d <uid> -M '{namespace!~".*-test"}'
-
-# Production only, exclude debug
-gcx logs series -d <uid> -M '{environment="production", job!="debug"}'
-```
-
-## Real-World Examples
-
-### Find Application Logs
-
-```bash
-# All logs for myapp
-gcx logs series -d <uid> -M '{app="myapp"}'
-
-# Myapp in production
-gcx logs series -d <uid> -M '{app="myapp", environment="production"}'
-
-# Myapp, exclude debug logs
-gcx logs series -d <uid> -M '{app="myapp", level!="debug"}'
-```
-
-> **Only indexed labels are valid inside `{...}`.** Loki also has *structured
-> metadata* (per-line keys attached at ingest, including Loki's auto-added
-> `detected_level`) and *parsed labels* (from `| json` / `| logfmt`). Those are
-> NOT indexed and must be filtered **after a pipe** — `{app="myapp"} |
-> detected_level="error"`, not `{detected_level="error"}` (which matches
-> nothing). `gcx logs labels` lists the indexed labels; a key you saw in query
-> output is only `{}`-valid if it appeared in the `stream` map (`-o json`) /
-> `STREAM` column, not under `structuredMetadata` / `parsed` / `DETAILS`.
-
-### Find Container Logs
-
-```bash
-# Specific container
-gcx logs series -d <uid> -M '{container_name="nginx"}'
-
-# All containers in pod
-gcx logs series -d <uid> -M '{pod_name="web-server-abc123"}'
-
-# Containers matching pattern
-gcx logs series -d <uid> -M '{container_name=~"nginx.*"}'
-```
-
-### Find Kubernetes Logs
-
-```bash
-# All logs in namespace
-gcx logs series -d <uid> -M '{namespace="kube-system"}'
-
-# Specific deployment
-gcx logs series -d <uid> -M '{namespace="default", deployment="api-server"}'
-
-# All namespaces except system
-gcx logs series -d <uid> -M '{namespace!~"kube-.*"}'
-```
-
-### Find Service Logs
-
-```bash
-# Logs from specific service
-gcx logs series -d <uid> -M '{service="api"}'
-
-# Service in specific cluster
-gcx logs series -d <uid> -M '{service="api", cluster="us-west-1"}'
-
-# Multiple services (OR logic)
-gcx logs series -d <uid> -M '{service="api"}' -M '{service="worker"}'
-```
+`gcx logs labels` lists the indexed labels - every value it returns is safe
+inside `{}`. A key you saw in query output is only `{}`-valid if it appeared
+in the `stream` map (`-o json`) / `STREAM` column, not under
+`structuredMetadata` / `parsed` / `DETAILS`.
 
 ## Shell Quoting
 
 Always use single quotes around the selector to prevent shell interpretation:
 
 ```bash
-# ✅ Correct - single quotes outside
+# Correct - single quotes outside
 gcx logs series -d <uid> -M '{name="value", cluster="prod"}'
 
-# ❌ Wrong - shell interprets quotes
+# Wrong - shell interprets quotes
 gcx logs series -d <uid> -M {name="value"}
 
-# ❌ Wrong - double quotes outside cause parsing errors
+# Wrong - double quotes outside cause parsing errors
 gcx logs series -d <uid> -M "{name='value'}"
 ```
 
-## Limitations
+## Workflow Tips
 
-The `series` command supports **label selectors only**, not full LogQL features:
+1. **Check label values first** - see what exists before guessing:
 
-### ✅ Supported (Label Selectors)
-
-- Exact match: `{job="varlogs"}`
-- Regex match: `{job=~"app.*"}`
-- Not equal: `{job!="debug"}`
-- Regex not match: `{job!~"test.*"}`
-- Multiple labels: `{job="api", namespace="prod"}`
-
-### ❌ Not Supported (Query Features)
-
-- Log filters: `{job="varlogs"} |= "error"` (not supported)
-- Parser stages: `{job="varlogs"} | json` (not supported)
-- Line filters: `{job="varlogs"} |~ "error.*"` (not supported)
-- Metrics: `rate({job="varlogs"}[5m])` (not supported)
-
-For these advanced features, use `gcx logs query <uid> '<logql>'` to run full LogQL queries against a Loki datasource.
-
-## Regex Syntax
-
-Loki uses [RE2 regex syntax](https://github.com/google/re2/wiki/Syntax). Common patterns:
-
-```bash
-# Start with
-{job=~"app.*"}
-
-# End with
-{job=~".*-prod"}
-
-# Contains
-{job=~".*production.*"}
-
-# Multiple options (OR)
-{job=~"api|worker|scheduler"}
-
-# Case insensitive (use (?i) flag)
-{job=~"(?i)error.*"}
-
-# Character class
-{namespace=~"prod-[0-9]+"}
-```
-
-## Tips
-
-1. **Start broad, then narrow**: Begin with a single label, then add more filters
    ```bash
-   # Start
-   gcx logs series -d <uid> -M '{job="varlogs"}'
-
-   # Then narrow
-   gcx logs series -d <uid> -M '{job="varlogs", namespace="prod"}'
+   gcx logs labels -d <uid> --label job
+   gcx logs series -d <uid> -M '{job="<value-from-above>"}'
    ```
 
-2. **Use regex for exploration**: When you don't know exact values
+2. **Use regex for exploration** when you don't know exact values:
+
    ```bash
-   # Find all app-* jobs
    gcx logs series -d <uid> -M '{job=~"app-.*"}'
    ```
 
-3. **Check label values first**: Use `labels` command to see available values
-   ```bash
-   # See what jobs exist
-   gcx logs labels -d <uid> --label job
+3. **Use JSON output for large results** and pipe to jq:
 
-   # Then query specific job (job is an indexed label, so it's valid in {})
-   gcx logs series -d <uid> -M '{job="<value-from-above>"}'
-   ```
-   `gcx logs labels` returns indexed labels only — every value it lists is safe
-   inside `{}`. Structured-metadata keys (e.g. `detected_level`) won't appear
-   here and are not `{}`-valid; filter them after a pipe.
-
-4. **Use JSON output for large results**: Pipe to jq for filtering
    ```bash
    gcx logs series -d <uid> -M '{namespace="prod"}' -o json | jq '.data[] | select(.job=="api")'
    ```
-
-## See Also
-
-- [Discovery Patterns](discovery-patterns.md) - Common workflows and use cases
-- [Loki LogQL Documentation](https://grafana.com/docs/loki/latest/logql/) - Official LogQL documentation (for full query syntax)

--- a/claude-plugin/skills/gcx-observability/SKILL.md
+++ b/claude-plugin/skills/gcx-observability/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: gcx-observability
 description: >
-  (Experimental) End-to-end observability setup for Grafana Cloud. Covers
-  instrumentation, SLOs, alerting, synthetic monitoring, k6 load testing,
-  IRM on-call, dashboards, cost optimization, and GitOps export.
+  (Experimental) End-to-end observability setup for Grafana Cloud using gcx.
+  Covers instrumentation, SLOs, alerting, synthetic monitoring, k6 load
+  testing, IRM on-call, dashboards, cost optimization, and GitOps export.
+  Use when the user wants to set up observability for an application from
+  scratch or run a full observability rollout - phrases like "set up
+  monitoring", "instrument my app", "add observability", or "onboard my
+  service to Grafana Cloud".
 user-invocable: true
 argument-hint: "[phases]"
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, TaskCreate, TaskUpdate, TaskList, TaskGet
@@ -11,13 +15,13 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, Task
 
 You are helping the user implement comprehensive Grafana Cloud observability for their application using a **test-driven** approach. Use `gcx` to automate setup.
 
-**Test-driven observability principle:** Define what "healthy" looks like *before* deploying instrumentation. Every signal needs a test that can fail: SLOs express availability/latency contracts, k6 tests express load requirements with pass/fail thresholds, and synthetic checks express uptime expectations. Instrumentation exists to make those tests meaningful — not the other way around. Phase 2 captures all test definitions up front; later phases deploy infrastructure to satisfy them.
+**Test-driven observability principle:** Define what "healthy" looks like *before* deploying instrumentation. Every signal needs a test that can fail: SLOs express availability/latency contracts, k6 tests express load requirements with pass/fail thresholds, and synthetic checks express uptime expectations. Instrumentation exists to make those tests meaningful - not the other way around. Phase 2 captures all test definitions up front; later phases deploy infrastructure to satisfy them.
 
-Work interactively — explain each phase, generate YAML using the resource's `example` subcommand as a template, confirm before creating anything, and validate success.
+Work interactively - explain each phase, generate YAML using the resource's `example` subcommand as a template, confirm before creating anything, and validate success.
 
-**Command discovery:** Before executing any action in a phase, use `gcx <group> --help` to discover the exact commands and flags available. Use `gcx commands --flat -o json` to see all command groups. Never assume a command's exact syntax — always discover it first. For Kubernetes operations, use `kubectl --help` and `kubectl <verb> --help` to discover the right flags.
+**Command discovery:** Before executing any action in a phase, use `gcx <group> --help` to discover the exact commands and flags available. Use `gcx commands --flat -o json` to see all command groups. Never assume a command's exact syntax - always discover it first. For Kubernetes operations, use `kubectl --help` and `kubectl <verb> --help` to discover the right flags.
 
-**Parallelism rules (follow strictly):**
+**Parallelism rules:**
 - Use `TaskCreate` to register every unit of work before starting anything, so the user can see progress.
 - Use the `Agent` tool to run independent operations concurrently. Launch multiple agents in a single message whenever their inputs don't depend on each other.
 - Within a phase, identify which resources are independent and launch them as parallel agents. Only serialize when there is a true dependency (e.g. a contact point must exist before a notification policy references it).
@@ -28,7 +32,7 @@ Work interactively — explain each phase, generate YAML using the resource's `e
 
 ## Step 1: Select Phases
 
-If the user passed arguments (`$ARGUMENTS`), use them directly as the selected phases — do not show the menu. `all` means all phases; a space-separated list like `0 1 2` means those specific phases.
+If the user passed arguments (`$ARGUMENTS`), use them directly as the selected phases - do not show the menu. `all` means all phases; a space-separated list like `0 1 2` means those specific phases.
 
 Otherwise, show the following menu and ask which phases to run:
 
@@ -60,19 +64,19 @@ Once phases are selected, **immediately create a task for every selected phase**
 
 Phases have dependencies:
 - Phase 0 must complete before anything else.
-- Phase 1 must complete before Phases 2–11 (provides context).
-- Phase 2 must complete before Phases 3–6 (test definitions drive instrumentation and alerting).
+- Phase 1 must complete before Phases 2-11 (provides context).
+- Phase 2 must complete before Phases 3-6 (test definitions drive instrumentation and alerting).
 - Phase 3 should complete before Phase 4 (signals must flow before SLOs are meaningful).
 - Phase 4 must complete before Phase 7 (IRM wires into alerting contact points).
-- Phases 5, 6, 8, 9 are independent of each other and of Phase 7 — run them in parallel after Phase 3.
+- Phases 5, 6, 8, 9 are independent of each other and of Phase 7 - run them in parallel after Phase 3.
 - Phase 10 must be last (exports everything created).
 - Phase 11 must be last (validates everything).
 
 **Verification principle:** After every create operation, verify the resource exists and is healthy using list or get. Do not mark a phase completed until all resources pass verification. If a resource fails verification, debug before moving on.
 
-**Idempotency principle:** At the start of every phase, check what already exists before creating anything. If a resource with the expected name already exists, skip creation and go straight to verification. If a phase is partially complete, resume from the first missing resource — never re-create resources that are already healthy.
+**Idempotency principle:** At the start of every phase, check what already exists before creating anything. If a resource with the expected name already exists, skip creation and go straight to verification. If a phase is partially complete, resume from the first missing resource - never re-create resources that are already healthy.
 
-**Recommended parallel execution plan (after Phases 0–3):**
+**Recommended parallel execution plan (after Phases 0-3):**
 
 ```
 Wave A (parallel): Phases 4, 5, 6, 8, 9
@@ -82,456 +86,19 @@ Wave C (after Wave B): Phases 10, 11  (parallel with each other)
 
 Launch Wave A agents in a single message. Do not wait for one to finish before starting another.
 
-Within each phase, also parallelize at the resource level (see per-phase instructions below).
+Within each phase, also parallelize at the resource level (see the per-phase instructions in references/).
 
 ---
 
-### Phase 0: Bootstrap
-
-Mark task in_progress. Run sequentially (everything depends on this).
-
-Run `gcx config check` to verify the stack is initialized and authenticated. Then run `gcx config view` to capture the stack URL and context details.
-
-If not configured: ask for the Grafana instance URL and an API token (service account with Admin role), then set up a context:
-
-```bash
-gcx config set contexts.<name>.grafana.server <url>
-gcx config set contexts.<name>.grafana.token <token>
-gcx config use-context <name>
-gcx config check
-```
-
-Store: stack URL, context name. Mark task completed.
-
----
-
-### Phase 1: Discovery & Context
-
-Mark task in_progress. Ask the user all questions in a **single `AskUserQuestion` call** (don't ask one at a time):
-
-1. Application name and brief description
-2. K8s cluster(s) and namespaces
-3. Frontend stack (React / Vue / Angular / vanilla JS / none)
-4. Key user journeys (e.g. "login", "checkout", "search") — list them
-5. Critical API endpoints for synthetic checks and load tests
-6. On-call team structure (names/emails, time zones, escalation order)
-
-Store all answers in memory — every subsequent phase references them. Mark task completed.
-
----
-
-### Phase 2: Test Definitions
-
-Mark task in_progress.
-
-> **This is the test-driven foundation.** Before any infrastructure is deployed, define the contracts that describe a healthy system. These definitions will be referenced and validated in every subsequent phase.
-
-**Pre-check — skip files that already exist:**
-List local files matching `slo-*.yaml`, `k6-test-*.js`, `k6-schedule-*.yaml`, and `check-*.yaml`. For any files already present, skip writing them and use the existing versions in later phases. Only write files that are missing.
-
-Ask the user a **single `AskUserQuestion`** to confirm/adjust these defaults:
-
-- SLO targets per journey (default: 99.9% availability, p95 latency < 500ms over 28d)
-- k6 load profile per endpoint (default: 10 VUs, 30s, p95 < 500ms threshold)
-- k6 schedule (default: every 6 hours — **schedules are required, not optional**)
-- Synthetic check frequency (default: 30s for critical, 60s for standard)
-- Synthetic check assertions (default: status=200, latency < 500ms)
-
-**Step 1 — Create SLO definitions (one per journey, parallel):**
-
-For each journey `J` from Phase 1, launch an agent that:
-- Discovers the SLO command group (`gcx slo --help`, `gcx slo definitions --help`) to find available subcommands and flags.
-- Runs `gcx resources examples slo` to get a template if available, then customizes it: name, availability target, latency target, 28d window.
-- Writes the result to `slo-J.yaml`.
-
-Do **not** create the SLOs yet — Phase 4 does that after signals are flowing. Store all `slo-*.yaml` files for Phase 4.
-
-**Step 2 — Create k6 test scripts (one per endpoint, parallel):**
-
-For each critical endpoint from Phase 1, write a `k6-test-<endpoint>.js` script with:
-- 10 VUs, 30s duration
-- Thresholds: p95 latency < 500ms, failure rate < 1%
-- A default function that hits the endpoint and checks status=200 and response time < 500ms
-
-Also discover the k6 schedules command group (`gcx k6 schedules --help`) and run the schedules example subcommand if available. Customize it for a 6-hour frequency and write to `k6-schedule-<endpoint>.yaml`.
-
-Store all scripts and schedule YAMLs for Phase 6.
-
-**Step 3 — Create synthetic check definitions (one per endpoint, parallel):**
-
-For each critical endpoint, discover the synthetic monitoring checks command group (`gcx synthetic-monitoring checks --help`) and check for an example subcommand. Customize it: target=real URL, frequency=30s for critical / 60s for standard, assertions: status=200 and latency < 500ms. Do NOT set basicMetricsOnly: true. Write to `check-<endpoint>.yaml`.
-
-Store all `check-*.yaml` files for Phase 5.
-
-Show a summary of all test definitions created. Mark task completed.
-
----
-
-### Phase 3: Instrumentation
-
-Mark task in_progress.
-
-**Pre-check — skip if already deployed:**
-Run `gcx instrumentation status` to check current signal status. Also check whether Alloy pods are already running in the monitoring namespace using kubectl (list pods filtered by alloy labels). If Alloy is running and infrastructure signals are healthy, skip Step 1. If app signals are also healthy, skip the rest and mark the phase completed.
-
-**Pre-check — application must be running in Kubernetes first.**
-
-Before deploying Alloy, use kubectl to list deployments, daemonsets, and statefulsets in the application namespace. If no workloads are found, stop and ask the user to deploy their application first — autodiscovery and instrumentation will only detect workloads that exist at the time Alloy runs.
-
-**Pre-check — container image compatibility for observability**
-
-Scan the project's Dockerfiles for patterns that interfere with observability tooling (eBPF, profiling, log collection, debugging). For each Dockerfile found, check for and warn about:
-
-- **Alpine / musl-based runtime**: breaks eBPF uprobe attachment (Beyla), profiling, and SSL inspection. Recommend `debian:bookworm-slim` or `ubuntu:24.04`.
-- **Scratch / distroless runtime**: missing shared libraries, shell, and debug tools. Recommend a minimal Debian-based image instead.
-- **Stripped binaries**: (`strip`, `-s -w` ldflags) removes symbol tables needed by eBPF and profilers. Recommend keeping symbols.
-- **No signal handling**: missing `tini` or equivalent init — can cause zombie processes and missed graceful shutdown signals, leading to metric gaps.
-
-If issues are found, list them and ask the user whether to fix before proceeding.
-
----
-
-**Step 1 — Deploy Alloy collector (sequential, everything else depends on this):**
-
-Use `gcx fleet collectors --help` to discover collector management commands. Create an Alloy collector configuration:
-
-```bash
-gcx fleet collectors create -f alloy-collector.yaml
-```
-
-After Alloy is deployed, use kubectl to verify Alloy pods are Running and Ready (not CrashLoopBackOff). Check that a Service exposing port 4317 exists in the monitoring namespace. If not, create one targeting Alloy pods.
-
-Use `gcx fleet pipelines --help` to discover pipeline management. List pipelines (`gcx fleet pipelines list`). If no pipeline contains an OTLP receiver on port 4317, create or update a pipeline to add one:
-
-```bash
-gcx fleet pipelines create -f pipeline.yaml
-# or
-gcx fleet pipelines update <name> -f pipeline.yaml
-```
-
-Then wait for infrastructure signals to appear by polling `gcx instrumentation status` (timeout 5 minutes). If this times out, debug the Alloy deployment before continuing.
-
----
-
-**Step 2 — Parallel wave — launch all four agents simultaneously in one message:**
-
-- **Agent A** — Instrumentation setup:
-  Run `gcx instrumentation clusters list` to see all clusters and their current status.
-  Run `gcx instrumentation clusters get <cluster>` to review the cluster's current config.
-  Run `gcx instrumentation setup <cluster> --use-defaults` to configure K8s monitoring and print the helm install command to connect the cluster to Grafana Cloud via Fleet Management. (`--use-defaults` is required when stdin is not a TTY, which is always the case for agents.)
-  To adjust individual feature flags after initial setup (RMW): `gcx instrumentation clusters configure <cluster> --cost-metrics --cluster-events`.
-  Verify with `gcx instrumentation status`.
-
-- **Agent B** — Fleet pipelines verification:
-  List pipelines (`gcx fleet pipelines list`) to confirm pipeline exists and is receiving data.
-  Verify collectors are healthy: `gcx fleet collectors list`.
-
-- **Agent C** — Frontend observability (skip if no frontend stack from Phase 1):
-  Discover the frontend command group (`gcx frontend --help`, `gcx frontend apps --help`).
-  List existing Frontend Observability apps: `gcx frontend apps list`. If an app for this project already exists, skip creation.
-  Otherwise, create a Frontend Observability app configured for the application URL and name:
-  ```bash
-  gcx frontend apps create -f faro-app.yaml
-  ```
-  Verify: `gcx frontend apps list` to confirm the app was created and capture the app ID.
-  If the frontend uses sourcemaps, upload them: `gcx frontend apps apply-sourcemap <app-name> -f <sourcemap>`.
-
-- **Agent D** — Synthetic checks (early deployment for traffic seeding):
-  Deploy the `check-*.yaml` files from Phase 2 now, before instrumentation is fully verified. For each endpoint, check if the check already exists (`gcx synthetic-monitoring checks list`); if not, create it: `gcx synthetic-monitoring checks create -f check-<endpoint>.yaml`. List checks to confirm each is enabled with probes assigned.
-  > **Purpose:** SM checks start probing endpoints immediately, generating real HTTP traffic that flows through Alloy. This seeds the telemetry pipeline so Step 3's signal verification has live data.
-  > If endpoints are private, first list available probes (`gcx synthetic-monitoring probes list`), identify private probes, and ensure they are online before creating checks.
-
-Wait for all four agents. Report combined results.
-
-> **Note:** For SDK-based instrumentation, use the OTLP endpoint reported by the collector configuration. No additional credentials needed — apps send OTLP to Alloy's in-cluster endpoint.
-
----
-
-**Step 3 — Verify app signals are flowing after instrumentation:**
-Poll `gcx instrumentation status` (timeout 5 minutes). SM checks deployed in Step 2 should already be generating traffic, making this verification reliable. If this times out, check that instrumentation was applied correctly and that SM checks are active and targeting the correct endpoints.
-
-Mark task completed.
-
-After Wave A (Phases 4–6, 8–9) completes, do a final signal check using `gcx instrumentation status`. If signals are unhealthy, check that app deployments have OTEL instrumentation and are sending to Alloy.
-
----
-
-### Phase 4: SLO-Based Alerting
-
-Mark task in_progress.
-
-> **Best practice:** Always route alerts from Grafana Alertmanager → Grafana IRM → notification channels (Slack, PagerDuty, email, etc.). Never wire contact points directly to end channels. IRM provides deduplication, grouping, escalation policies, and on-call routing that raw Alertmanager cannot. Phase 7 completes this wiring.
-
-**Pre-check — skip resources that already exist:**
-List SLOs (`gcx slo definitions list`), alert rules (`gcx alert rules list`), and alert groups (`gcx alert groups list`). For each journey, skip its SLO and rule group if they already exist by name.
-
-For contact points, notification policies, and mute timings, use the Grafana provisioning API via `gcx api`:
-```bash
-gcx api /api/v1/provisioning/contact-points
-gcx api /api/v1/provisioning/notification-policies
-gcx api /api/v1/provisioning/mute-timings
-```
-Skip creation of any that already exist.
-
-**Step 1 — parallel: one agent per user journey**, using the `slo-J.yaml` files from Phase 2:
-
-For each journey `J`, launch an agent that:
-- Creates the SLO: `gcx slo definitions push slo-J.yaml --dry-run` then `gcx slo definitions push slo-J.yaml`. List SLOs to confirm.
-- Creates burn-rate alert rules as K8s resources. Get an example: `gcx resources examples AlertRule`. Build 1h/6h/24h burn-rate rules and push them:
-  ```bash
-  gcx resources push -f alert-rules-J.yaml --dry-run
-  gcx resources push -f alert-rules-J.yaml
-  ```
-  List rules to confirm: `gcx alert rules list`.
-
-Launch all journey agents simultaneously. Wait for all to complete.
-
-**Step 2 — sequential (depends on journeys existing):**
-
-Create a contact point targeting the IRM integration webhook (to be created in Phase 7). Use the Grafana provisioning API via `gcx api`:
-
-```bash
-# Create contact point
-gcx api /api/v1/provisioning/contact-points -X POST -d @contact-point.json
-
-# Verify
-gcx api /api/v1/provisioning/contact-points
-
-# Create/update notification policy routing SLO alerts to that contact point
-gcx api /api/v1/provisioning/notification-policies -X PUT -d @notification-policy.json
-
-# Verify
-gcx api /api/v1/provisioning/notification-policies
-```
-
-**Step 3 — parallel with Step 2 (independent):**
-
-Create a mute timing via the provisioning API:
-```bash
-gcx api /api/v1/provisioning/mute-timings -X POST -d @mute-timing.json
-gcx api /api/v1/provisioning/mute-timings
-```
-
-Launch mute-timings agent at the same time as Step 2. Mark task completed.
-
----
-
-### Phase 5: Synthetic Monitoring
-
-Mark task in_progress.
-
-> SM checks were deployed early in Phase 3 (Step 2, Agent C) to seed traffic for instrumentation verification. This phase validates that all checks are healthy, producing data, and covers all required check types.
-
-**Verify and complete check coverage — parallel, one agent per endpoint:**
-
-List all existing checks: `gcx synthetic-monitoring checks list`.
-
-For each endpoint, launch an agent that:
-- Gets the check by name/ID (`gcx synthetic-monitoring checks get <name>`) to verify: target field matches the intended endpoint exactly (scheme, host, path), probes list is non-empty, and the check is enabled.
-- Checks status: `gcx synthetic-monitoring checks status <id>` to confirm the check is producing recent results.
-- If the check is missing entirely (e.g. Phase 3 Agent C failed), create it now from `check-<endpoint>.yaml`.
-
-Ensure full check type coverage across all endpoints — not just HTTP. Add any missing check types in parallel:
-- DNS checks for critical domain resolution
-- TCP checks for database or service port connectivity
-- HTTP checks with relevant headers and methods (POST for write endpoints, not just GET)
-
-Ensure full metrics are collected on all checks (do not set `basicMetricsOnly: true`).
-
-Wait for all agents. Mark task completed.
-
----
-
-### Phase 6: k6 Load Testing
-
-Mark task in_progress.
-
-**Pre-check — skip resources that already exist:**
-Discover the k6 command group (`gcx k6 --help`) and list existing projects (`gcx k6 projects list`), load tests (`gcx k6 load-tests list`), and schedules (`gcx k6 schedules list`). If a project with the expected name exists, capture its ID and skip creation. Skip test and schedule creation for any endpoint that already has them.
-
-**Step 1 — parallel:**
-
-- **Agent A** — create k6 project: `gcx k6 projects create -f project.yaml`, then `gcx k6 projects list` to confirm and capture the project ID.
-
-- **Agent B** — confirm test artifacts from Phase 2: verify all `k6-test-<endpoint>.js` scripts and `k6-schedule-<endpoint>.yaml` files exist from Phase 2.
-
-Wait for Agent A (need project ID). Then **parallel — one agent per endpoint:**
-
-Each agent:
-- Creates the k6 test from the script file, lists tests to confirm and capture the test ID.
-- Updates the schedule YAML with the real test ID, creates the schedule, lists schedules to confirm it references the correct test ID.
-
-> **Schedules are mandatory.** Every load test must run on a recurring schedule so regressions are caught automatically. Use a minimum frequency of every 6 hours.
-
-Mark task completed.
-
----
-
-### Phase 7: IRM Setup
-
-Mark task in_progress. Requires Phase 4 contact points to exist.
-
-> **This phase completes the alerting -> IRM routing.** The contact point created in Phase 4 will be updated to point to the IRM integration webhook, ensuring all alerts flow through IRM for routing, escalation, and on-call management.
-
-**Pre-check — skip resources that already exist:**
-Discover the oncall command group (`gcx irm oncall --help`) and list integrations (`gcx irm oncall integrations list`), escalation chains (`gcx irm oncall escalation-chains list`), schedules (`gcx irm oncall schedules list`), and routes (`gcx irm oncall routes list`). Skip creation of any that already exist; capture IDs and webhook URLs from existing resources. Even if the integration already exists, still verify the Phase 4 contact point is pointing to its webhook URL.
-
-**Step 1 — parallel (independent of each other):**
-
-- **Agent A** — integration + escalation chain:
-  Discover oncall integration and escalation-chain subcommands (`gcx irm oncall integrations --help`, `gcx irm oncall escalation-chains --help`). Get examples if available, customize, create each, list to confirm and capture the integration webhook URL.
-
-- **Agent B** — schedules + shifts:
-  Discover oncall schedules and shifts subcommands (`gcx irm oncall schedules --help`, `gcx irm oncall shifts --help`). Get examples if available, customize for the on-call team from Phase 1, create each, list to confirm.
-
-Wait for both. Then **Step 2** (needs integration webhook URL from Agent A):
-
-Create a route via the API: `gcx api /api/v1/routes -X POST -d @route.yaml`, then `gcx irm oncall routes list` to confirm. Then update the Phase 4 contact point to use the IRM webhook URL:
-
-```bash
-gcx api /api/v1/provisioning/contact-points/<uid> -X PUT -d @contact-point-updated.json
-gcx api /api/v1/provisioning/contact-points
-```
-
-Verify the webhook URL is correct. Mark task completed.
-
----
-
-### Phase 8: Custom Dashboards
-
-Mark task in_progress.
-
-**Pre-check — skip resources that already exist:**
-List existing folders and dashboards:
-```bash
-gcx resources get folders
-gcx resources get dashboards
-```
-If the app folder already exists, capture its UID and skip creation. Skip any dashboard that already exists in the folder by title.
-
-**Step 1 — create folder** (needed before dashboards):
-Get an example folder manifest and customize it:
-```bash
-gcx resources examples Folder
-```
-Write folder YAML, then push:
-```bash
-gcx resources push -f folder.yaml --dry-run
-gcx resources push -f folder.yaml
-```
-List folders to confirm and capture the UID.
-
-**Step 2 — parallel: one agent per dashboard** (generate + push simultaneously):
-
-Generate dashboards covering:
-- SLO burn rates across all journeys
-- Error rate + latency percentiles (p50/p95/p99)
-- Request volume + top errors
-- Frontend RUM (if configured in Phase 3 — verify with `gcx frontend apps list`)
-- k6 load test results
-
-Each agent:
-1. Gets a dashboard example: `gcx resources examples Dashboard`
-2. Customizes the dashboard JSON with appropriate panels and queries
-3. Writes `dashboard-<name>.yaml`
-4. Pushes: `gcx resources push -f dashboard-<name>.yaml --dry-run` then `gcx resources push -f dashboard-<name>.yaml`
-5. Verifies: `gcx resources get dashboards` filtered by folder UID
-
-Launch all dashboard agents simultaneously. Mark task completed.
-
----
-
-### Phase 9: Cost Optimization via Adaptive Telemetry
-
-Mark task in_progress.
-
-**Pre-check — skip resources that already exist:**
-Discover the adaptive telemetry command groups and list existing rules:
-```bash
-gcx metrics adaptive --help
-gcx logs adaptive --help
-gcx traces adaptive --help
-```
-
-**All three steps are independent — launch in parallel:**
-
-- **Agent A** — adaptive metrics:
-  Discover the adaptive-metrics commands (`gcx metrics adaptive --help`).
-  List recommendations, review with user, sync rules if approved, list to confirm they were applied.
-
-- **Agent B** — adaptive logs:
-  Discover the adaptive-logs commands (`gcx logs adaptive --help`).
-  List patterns and recommendations, create adaptive log rules if beneficial, list to confirm.
-
-- **Agent C** — adaptive traces:
-  Discover the adaptive-traces commands (`gcx traces adaptive --help`).
-  List recommendations, apply rules if beneficial, list to confirm.
-
-Wait for all three. Report savings estimates and cardinality reduction. Mark task completed.
-
----
-
-### Phase 10: GitOps Export
-
-Mark task in_progress.
-
-**Pre-check — check if export already exists:**
-List files in the export directory (default: `./grafana/`). If the directory exists and contains YAML files, run a dry-run push to check for drift:
-```bash
-gcx resources push ./grafana/ --dry-run
-```
-If no drift is detected, the export is up to date — skip and report to the user.
-
-Ask the user where in their repo to place the export (default: `./grafana/`).
-
-**Parallel:**
-
-- **Agent A** — export (run_in_background: true, can be slow):
-  Pull all resources to the chosen directory:
-  ```bash
-  gcx resources pull -p ./grafana/
-  ```
-
-- **Agent B** — prepare CI snippet while export runs:
-  Generate a ready-to-paste GitHub Actions step or Makefile target that runs:
-  ```bash
-  gcx resources push ./grafana/ --dry-run
-  ```
-  This detects drift between the repo and live Grafana.
-
-Wait for Agent A. Then verify round-trip:
-```bash
-gcx resources push ./grafana/ --dry-run
-ls ./grafana/
-```
-
-Mark task completed.
-
----
-
-### Phase 11: Observability Review
-
-Mark task in_progress.
-
-**Step 1 — comprehensive signal health check:**
-Run `gcx instrumentation status` and `gcx setup status` for overall health. Report all signal statuses. If any signal is unhealthy, investigate before continuing.
-
-**Step 2 — Validate test definitions against actual signals — parallel:**
-
-- **Agent A** — SLO pass/fail status: list all SLOs (`gcx slo definitions list`) and check reports (`gcx slo reports list`). Flag any SLO already burning error budget — investigate before declaring setup complete.
-
-- **Agent B** — k6 schedule verification: list all k6 schedules (`gcx k6 schedules list`) and cross-reference with k6 load tests (`gcx k6 load-tests list`). Flag any test without a schedule — schedules are required.
-
-- **Agent C** — synthetic check health: list all synthetic checks (`gcx synthetic-monitoring checks list`) and check status for each (`gcx synthetic-monitoring checks status <id>`). Confirm all are enabled and showing recent results.
-
-Wait for all agents. Then synthesize a **prioritized recommendations list**:
-- k6 tests missing schedules -> add schedule immediately
-- Journeys missing custom spans -> add OTEL SDK instrumentation
-- Services with only auto-instrumentation -> add profiling
-- Frontend journeys -> add k6 browser test
-- SLOs with actual error rates near target -> tighten target or investigate
-
-Mark task completed.
+## Phase Instructions
+
+The detailed per-phase instructions (pre-checks, commands, parallel agent breakdowns, verification steps) live in reference files. Read the file covering a phase before executing it - e.g. read `phases-0-3-foundation.md` at the start, and `phases-4-7-alerting.md` when Wave A begins.
+
+| Phases | Read | Covers |
+|--------|------|--------|
+| 0-3 | [references/phases-0-3-foundation.md](references/phases-0-3-foundation.md) | Bootstrap, discovery & context, test definitions, instrumentation |
+| 4-7 | [references/phases-4-7-alerting.md](references/phases-4-7-alerting.md) | SLO-based alerting, synthetic monitoring, k6 load testing, IRM |
+| 8-11 | [references/phases-8-11-finalize.md](references/phases-8-11-finalize.md) | Custom dashboards, cost optimization, GitOps export, review |
 
 ---
 

--- a/claude-plugin/skills/gcx-observability/references/phases-0-3-foundation.md
+++ b/claude-plugin/skills/gcx-observability/references/phases-0-3-foundation.md
@@ -1,0 +1,180 @@
+# Phases 0-3: Foundation
+
+Bootstrap, discovery, test definitions, and instrumentation. These phases run sequentially - see SKILL.md for the dependency rules and the verification/idempotency principles that apply to every phase.
+
+## Contents
+
+- [Phase 0: Bootstrap](#phase-0-bootstrap)
+- [Phase 1: Discovery & Context](#phase-1-discovery--context)
+- [Phase 2: Test Definitions](#phase-2-test-definitions)
+- [Phase 3: Instrumentation](#phase-3-instrumentation)
+
+---
+
+## Phase 0: Bootstrap
+
+Mark task in_progress. Run sequentially (everything depends on this).
+
+Run `gcx config check` to verify the stack is initialized and authenticated. Then run `gcx config view` to capture the stack URL and context details.
+
+If not configured: ask for the Grafana instance URL and an API token (service account with Admin role), then set up a context:
+
+```bash
+gcx config set contexts.<name>.grafana.server <url>
+gcx config set contexts.<name>.grafana.token <token>
+gcx config use-context <name>
+gcx config check
+```
+
+Store: stack URL, context name. Mark task completed.
+
+---
+
+## Phase 1: Discovery & Context
+
+Mark task in_progress. Ask the user all questions in a **single `AskUserQuestion` call** (don't ask one at a time):
+
+1. Application name and brief description
+2. K8s cluster(s) and namespaces
+3. Frontend stack (React / Vue / Angular / vanilla JS / none)
+4. Key user journeys (e.g. "login", "checkout", "search") - list them
+5. Critical API endpoints for synthetic checks and load tests
+6. On-call team structure (names/emails, time zones, escalation order)
+
+Store all answers in memory - every subsequent phase references them. Mark task completed.
+
+---
+
+## Phase 2: Test Definitions
+
+Mark task in_progress.
+
+> **This is the test-driven foundation.** Before any infrastructure is deployed, define the contracts that describe a healthy system. These definitions will be referenced and validated in every subsequent phase.
+
+**Pre-check - skip files that already exist:**
+List local files matching `slo-*.yaml`, `k6-test-*.js`, `k6-schedule-*.yaml`, and `check-*.yaml`. For any files already present, skip writing them and use the existing versions in later phases. Only write files that are missing.
+
+Ask the user a **single `AskUserQuestion`** to confirm/adjust these defaults:
+
+- SLO targets per journey (default: 99.9% availability, p95 latency < 500ms over 28d)
+- k6 load profile per endpoint (default: 10 VUs, 30s, p95 < 500ms threshold)
+- k6 schedule (default: every 6 hours - schedules are required, not optional)
+- Synthetic check frequency (default: 30s for critical, 60s for standard)
+- Synthetic check assertions (default: status=200, latency < 500ms)
+
+**Step 1 - Create SLO definitions (one per journey, parallel):**
+
+For each journey `J` from Phase 1, launch an agent that:
+- Discovers the SLO command group (`gcx slo --help`, `gcx slo definitions --help`) to find available subcommands and flags.
+- Runs `gcx resources examples slo` to get a template if available, then customizes it: name, availability target, latency target, 28d window.
+- Writes the result to `slo-J.yaml`.
+
+Do **not** create the SLOs yet - Phase 4 does that after signals are flowing. Store all `slo-*.yaml` files for Phase 4.
+
+**Step 2 - Create k6 test scripts (one per endpoint, parallel):**
+
+For each critical endpoint from Phase 1, write a `k6-test-<endpoint>.js` script with:
+- 10 VUs, 30s duration
+- Thresholds: p95 latency < 500ms, failure rate < 1%
+- A default function that hits the endpoint and checks status=200 and response time < 500ms
+
+Also discover the k6 schedules command group (`gcx k6 schedules --help`) and run the schedules example subcommand if available. Customize it for a 6-hour frequency and write to `k6-schedule-<endpoint>.yaml`.
+
+Store all scripts and schedule YAMLs for Phase 6.
+
+**Step 3 - Create synthetic check definitions (one per endpoint, parallel):**
+
+For each critical endpoint, discover the synthetic monitoring checks command group (`gcx synthetic-monitoring checks --help`) and check for an example subcommand. Customize it: target=real URL, frequency=30s for critical / 60s for standard, assertions: status=200 and latency < 500ms. Do NOT set basicMetricsOnly: true. Write to `check-<endpoint>.yaml`.
+
+Store all `check-*.yaml` files for Phase 5.
+
+Show a summary of all test definitions created. Mark task completed.
+
+---
+
+## Phase 3: Instrumentation
+
+Mark task in_progress.
+
+**Pre-check - skip if already deployed:**
+Run `gcx instrumentation status` to check current signal status. Also check whether Alloy pods are already running in the monitoring namespace using kubectl (list pods filtered by alloy labels). If Alloy is running and infrastructure signals are healthy, skip Step 1. If app signals are also healthy, skip the rest and mark the phase completed.
+
+**Pre-check - application must be running in Kubernetes first.**
+
+Before deploying Alloy, use kubectl to list deployments, daemonsets, and statefulsets in the application namespace. If no workloads are found, stop and ask the user to deploy their application first - autodiscovery and instrumentation will only detect workloads that exist at the time Alloy runs.
+
+**Pre-check - container image compatibility for observability**
+
+Scan the project's Dockerfiles for patterns that interfere with observability tooling (eBPF, profiling, log collection, debugging). For each Dockerfile found, check for and warn about:
+
+- **Alpine / musl-based runtime**: breaks eBPF uprobe attachment (Beyla), profiling, and SSL inspection. Recommend `debian:bookworm-slim` or `ubuntu:24.04`.
+- **Scratch / distroless runtime**: missing shared libraries, shell, and debug tools. Recommend a minimal Debian-based image instead.
+- **Stripped binaries**: (`strip`, `-s -w` ldflags) removes symbol tables needed by eBPF and profilers. Recommend keeping symbols.
+- **No signal handling**: missing `tini` or equivalent init - can cause zombie processes and missed graceful shutdown signals, leading to metric gaps.
+
+If issues are found, list them and ask the user whether to fix before proceeding.
+
+---
+
+**Step 1 - Deploy Alloy collector (sequential, everything else depends on this):**
+
+Use `gcx fleet collectors --help` to discover collector management commands. Create an Alloy collector configuration:
+
+```bash
+gcx fleet collectors create -f alloy-collector.yaml
+```
+
+After Alloy is deployed, use kubectl to verify Alloy pods are Running and Ready (not CrashLoopBackOff). Check that a Service exposing port 4317 exists in the monitoring namespace. If not, create one targeting Alloy pods.
+
+Use `gcx fleet pipelines --help` to discover pipeline management. List pipelines (`gcx fleet pipelines list`). If no pipeline contains an OTLP receiver on port 4317, create or update a pipeline to add one:
+
+```bash
+gcx fleet pipelines create -f pipeline.yaml
+# or
+gcx fleet pipelines update <name> -f pipeline.yaml
+```
+
+Then wait for infrastructure signals to appear by polling `gcx instrumentation status` (timeout 5 minutes). If this times out, debug the Alloy deployment before continuing.
+
+---
+
+**Step 2 - Parallel wave - launch all four agents simultaneously in one message:**
+
+- **Agent A** - Instrumentation setup:
+  Run `gcx instrumentation clusters list` to see all clusters and their current status.
+  Run `gcx instrumentation clusters get <cluster>` to review the cluster's current config.
+  Run `gcx instrumentation setup <cluster> --use-defaults` to configure K8s monitoring and print the helm install command to connect the cluster to Grafana Cloud via Fleet Management. (`--use-defaults` is required when stdin is not a TTY, which is always the case for agents.)
+  To adjust individual feature flags after initial setup (RMW): `gcx instrumentation clusters configure <cluster> --cost-metrics --cluster-events`.
+  Verify with `gcx instrumentation status`.
+
+- **Agent B** - Fleet pipelines verification:
+  List pipelines (`gcx fleet pipelines list`) to confirm pipeline exists and is receiving data.
+  Verify collectors are healthy: `gcx fleet collectors list`.
+
+- **Agent C** - Frontend observability (skip if no frontend stack from Phase 1):
+  Discover the frontend command group (`gcx frontend --help`, `gcx frontend apps --help`).
+  List existing Frontend Observability apps: `gcx frontend apps list`. If an app for this project already exists, skip creation.
+  Otherwise, create a Frontend Observability app configured for the application URL and name:
+  ```bash
+  gcx frontend apps create -f faro-app.yaml
+  ```
+  Verify: `gcx frontend apps list` to confirm the app was created and capture the app ID.
+  If the frontend uses sourcemaps, upload them: `gcx frontend apps apply-sourcemap <app-name> -f <sourcemap>`.
+
+- **Agent D** - Synthetic checks (early deployment for traffic seeding):
+  Deploy the `check-*.yaml` files from Phase 2 now, before instrumentation is fully verified. For each endpoint, check if the check already exists (`gcx synthetic-monitoring checks list`); if not, create it: `gcx synthetic-monitoring checks create -f check-<endpoint>.yaml`. List checks to confirm each is enabled with probes assigned.
+  > **Purpose:** synthetic checks start probing endpoints immediately, generating real HTTP traffic that flows through Alloy. This seeds the telemetry pipeline so Step 3's signal verification has live data.
+  > If endpoints are private, first list available probes (`gcx synthetic-monitoring probes list`), identify private probes, and ensure they are online before creating checks.
+
+Wait for all four agents. Report combined results.
+
+> **Note:** For SDK-based instrumentation, use the OTLP endpoint reported by the collector configuration. No additional credentials needed - apps send OTLP to Alloy's in-cluster endpoint.
+
+---
+
+**Step 3 - Verify app signals are flowing after instrumentation:**
+Poll `gcx instrumentation status` (timeout 5 minutes). Synthetic checks deployed in Step 2 should already be generating traffic, making this verification reliable. If this times out, check that instrumentation was applied correctly and that synthetic checks are active and targeting the correct endpoints.
+
+Mark task completed.
+
+After Wave A (Phases 4-6, 8-9) completes, do a final signal check using `gcx instrumentation status`. If signals are unhealthy, check that app deployments have OTEL instrumentation and are sending to Alloy.

--- a/claude-plugin/skills/gcx-observability/references/phases-4-7-alerting.md
+++ b/claude-plugin/skills/gcx-observability/references/phases-4-7-alerting.md
@@ -1,0 +1,151 @@
+# Phases 4-7: Alerting, Synthetic Monitoring, k6, IRM
+
+SLO-based alerting, synthetic check coverage, k6 load testing, and IRM on-call setup. Phases 4, 5, and 6 run in parallel (Wave A); Phase 7 runs after Phase 4 (Wave B). See SKILL.md for the wave plan.
+
+## Contents
+
+- [Phase 4: SLO-Based Alerting](#phase-4-slo-based-alerting)
+- [Phase 5: Synthetic Monitoring](#phase-5-synthetic-monitoring)
+- [Phase 6: k6 Load Testing](#phase-6-k6-load-testing)
+- [Phase 7: IRM Setup](#phase-7-irm-setup)
+
+---
+
+## Phase 4: SLO-Based Alerting
+
+Mark task in_progress.
+
+> **Best practice:** Always route alerts from Grafana Alertmanager -> Grafana IRM -> notification channels (Slack, PagerDuty, email, etc.). Never wire contact points directly to end channels. IRM provides deduplication, grouping, escalation policies, and on-call routing that raw Alertmanager cannot. Phase 7 completes this wiring.
+
+**Pre-check - skip resources that already exist:**
+List SLOs (`gcx slo definitions list`), alert rules (`gcx alert rules list`), and alert groups (`gcx alert groups list`). For each journey, skip its SLO and rule group if they already exist by name.
+
+For contact points, notification policies, and mute timings, use the Grafana provisioning API via `gcx api`:
+```bash
+gcx api /api/v1/provisioning/contact-points
+gcx api /api/v1/provisioning/notification-policies
+gcx api /api/v1/provisioning/mute-timings
+```
+Skip creation of any that already exist.
+
+**Step 1 - parallel: one agent per user journey**, using the `slo-J.yaml` files from Phase 2:
+
+For each journey `J`, launch an agent that:
+- Creates the SLO: `gcx slo definitions push slo-J.yaml --dry-run` then `gcx slo definitions push slo-J.yaml`. List SLOs to confirm.
+- Creates burn-rate alert rules as K8s resources. Get an example: `gcx resources examples AlertRule`. Build 1h/6h/24h burn-rate rules and push them:
+  ```bash
+  gcx resources push -f alert-rules-J.yaml --dry-run
+  gcx resources push -f alert-rules-J.yaml
+  ```
+  List rules to confirm: `gcx alert rules list`.
+
+Launch all journey agents simultaneously. Wait for all to complete.
+
+**Step 2 - sequential (depends on journeys existing):**
+
+Create a contact point targeting the IRM integration webhook (to be created in Phase 7). Use the Grafana provisioning API via `gcx api`:
+
+```bash
+# Create contact point
+gcx api /api/v1/provisioning/contact-points -X POST -d @contact-point.json
+
+# Verify
+gcx api /api/v1/provisioning/contact-points
+
+# Create/update notification policy routing SLO alerts to that contact point
+gcx api /api/v1/provisioning/notification-policies -X PUT -d @notification-policy.json
+
+# Verify
+gcx api /api/v1/provisioning/notification-policies
+```
+
+**Step 3 - parallel with Step 2 (independent):**
+
+Create a mute timing via the provisioning API:
+```bash
+gcx api /api/v1/provisioning/mute-timings -X POST -d @mute-timing.json
+gcx api /api/v1/provisioning/mute-timings
+```
+
+Launch mute-timings agent at the same time as Step 2. Mark task completed.
+
+---
+
+## Phase 5: Synthetic Monitoring
+
+Mark task in_progress.
+
+> Synthetic checks were deployed early in Phase 3 (Step 2, Agent D) to seed traffic for instrumentation verification. This phase validates that all checks are healthy, producing data, and covers all required check types.
+
+**Verify and complete check coverage - parallel, one agent per endpoint:**
+
+List all existing checks: `gcx synthetic-monitoring checks list`.
+
+For each endpoint, launch an agent that:
+- Gets the check by name/ID (`gcx synthetic-monitoring checks get <name>`) to verify: target field matches the intended endpoint exactly (scheme, host, path), probes list is non-empty, and the check is enabled.
+- Checks status: `gcx synthetic-monitoring checks status <id>` to confirm the check is producing recent results.
+- If the check is missing entirely (e.g. Phase 3 Agent D failed), create it now from `check-<endpoint>.yaml`.
+
+Ensure full check type coverage across all endpoints - not just HTTP. Add any missing check types in parallel:
+- DNS checks for critical domain resolution
+- TCP checks for database or service port connectivity
+- HTTP checks with relevant headers and methods (POST for write endpoints, not just GET)
+
+Ensure full metrics are collected on all checks (do not set `basicMetricsOnly: true`).
+
+Wait for all agents. Mark task completed.
+
+---
+
+## Phase 6: k6 Load Testing
+
+Mark task in_progress.
+
+**Pre-check - skip resources that already exist:**
+Discover the k6 command group (`gcx k6 --help`) and list existing projects (`gcx k6 projects list`), load tests (`gcx k6 load-tests list`), and schedules (`gcx k6 schedules list`). If a project with the expected name exists, capture its ID and skip creation. Skip test and schedule creation for any endpoint that already has them.
+
+**Step 1 - parallel:**
+
+- **Agent A** - create k6 project: `gcx k6 projects create -f project.yaml`, then `gcx k6 projects list` to confirm and capture the project ID.
+
+- **Agent B** - confirm test artifacts from Phase 2: verify all `k6-test-<endpoint>.js` scripts and `k6-schedule-<endpoint>.yaml` files exist from Phase 2.
+
+Wait for Agent A (need project ID). Then **parallel - one agent per endpoint:**
+
+Each agent:
+- Creates the k6 test from the script file, lists tests to confirm and capture the test ID.
+- Updates the schedule YAML with the real test ID, creates the schedule, lists schedules to confirm it references the correct test ID.
+
+> **Schedules are mandatory.** Every load test must run on a recurring schedule so regressions are caught automatically. Use a minimum frequency of every 6 hours.
+
+Mark task completed.
+
+---
+
+## Phase 7: IRM Setup
+
+Mark task in_progress. Requires Phase 4 contact points to exist.
+
+> **This phase completes the alerting -> IRM routing.** The contact point created in Phase 4 will be updated to point to the IRM integration webhook, ensuring all alerts flow through IRM for routing, escalation, and on-call management.
+
+**Pre-check - skip resources that already exist:**
+Discover the oncall command group (`gcx irm oncall --help`) and list integrations (`gcx irm oncall integrations list`), escalation chains (`gcx irm oncall escalation-chains list`), schedules (`gcx irm oncall schedules list`), and routes (`gcx irm oncall routes list`). Skip creation of any that already exist; capture IDs and webhook URLs from existing resources. Even if the integration already exists, still verify the Phase 4 contact point is pointing to its webhook URL.
+
+**Step 1 - parallel (independent of each other):**
+
+- **Agent A** - integration + escalation chain:
+  Discover oncall integration and escalation-chain subcommands (`gcx irm oncall integrations --help`, `gcx irm oncall escalation-chains --help`). Get examples if available, customize, create each, list to confirm and capture the integration webhook URL.
+
+- **Agent B** - schedules + shifts:
+  Discover oncall schedules and shifts subcommands (`gcx irm oncall schedules --help`, `gcx irm oncall shifts --help`). Get examples if available, customize for the on-call team from Phase 1, create each, list to confirm.
+
+Wait for both. Then **Step 2** (needs integration webhook URL from Agent A):
+
+Create a route via the API: `gcx api /api/v1/routes -X POST -d @route.yaml`, then `gcx irm oncall routes list` to confirm. Then update the Phase 4 contact point to use the IRM webhook URL:
+
+```bash
+gcx api /api/v1/provisioning/contact-points/<uid> -X PUT -d @contact-point-updated.json
+gcx api /api/v1/provisioning/contact-points
+```
+
+Verify the webhook URL is correct. Mark task completed.

--- a/claude-plugin/skills/gcx-observability/references/phases-8-11-finalize.md
+++ b/claude-plugin/skills/gcx-observability/references/phases-8-11-finalize.md
@@ -1,0 +1,148 @@
+# Phases 8-11: Dashboards, Cost Optimization, GitOps, Review
+
+Custom dashboards and cost optimization run in Wave A; GitOps export and the observability review run last (Wave C). See SKILL.md for the wave plan.
+
+## Contents
+
+- [Phase 8: Custom Dashboards](#phase-8-custom-dashboards)
+- [Phase 9: Cost Optimization via Adaptive Telemetry](#phase-9-cost-optimization-via-adaptive-telemetry)
+- [Phase 10: GitOps Export](#phase-10-gitops-export)
+- [Phase 11: Observability Review](#phase-11-observability-review)
+
+---
+
+## Phase 8: Custom Dashboards
+
+Mark task in_progress.
+
+**Pre-check - skip resources that already exist:**
+List existing folders and dashboards:
+```bash
+gcx resources get folders
+gcx resources get dashboards
+```
+If the app folder already exists, capture its UID and skip creation. Skip any dashboard that already exists in the folder by title.
+
+**Step 1 - create folder** (needed before dashboards):
+Get an example folder manifest and customize it:
+```bash
+gcx resources examples Folder
+```
+Write folder YAML, then push:
+```bash
+gcx resources push -f folder.yaml --dry-run
+gcx resources push -f folder.yaml
+```
+List folders to confirm and capture the UID.
+
+**Step 2 - parallel: one agent per dashboard** (generate + push simultaneously):
+
+Generate dashboards covering:
+- SLO burn rates across all journeys
+- Error rate + latency percentiles (p50/p95/p99)
+- Request volume + top errors
+- Frontend RUM (if configured in Phase 3 - verify with `gcx frontend apps list`)
+- k6 load test results
+
+Each agent:
+1. Gets a dashboard example: `gcx resources examples Dashboard`
+2. Customizes the dashboard JSON with appropriate panels and queries
+3. Writes `dashboard-<name>.yaml`
+4. Pushes: `gcx resources push -f dashboard-<name>.yaml --dry-run` then `gcx resources push -f dashboard-<name>.yaml`
+5. Verifies: `gcx resources get dashboards` filtered by folder UID
+
+Launch all dashboard agents simultaneously. Mark task completed.
+
+---
+
+## Phase 9: Cost Optimization via Adaptive Telemetry
+
+Mark task in_progress.
+
+**Pre-check - skip resources that already exist:**
+Discover the adaptive telemetry command groups and list existing rules:
+```bash
+gcx metrics adaptive --help
+gcx logs adaptive --help
+gcx traces adaptive --help
+```
+
+**All three steps are independent - launch in parallel:**
+
+- **Agent A** - adaptive metrics:
+  Discover the adaptive-metrics commands (`gcx metrics adaptive --help`).
+  List recommendations, review with user, sync rules if approved, list to confirm they were applied.
+
+- **Agent B** - adaptive logs:
+  Discover the adaptive-logs commands (`gcx logs adaptive --help`).
+  List patterns and recommendations, create adaptive log rules if beneficial, list to confirm.
+
+- **Agent C** - adaptive traces:
+  Discover the adaptive-traces commands (`gcx traces adaptive --help`).
+  List recommendations, apply rules if beneficial, list to confirm.
+
+Wait for all three. Report savings estimates and cardinality reduction. Mark task completed.
+
+---
+
+## Phase 10: GitOps Export
+
+Mark task in_progress.
+
+**Pre-check - check if export already exists:**
+List files in the export directory (default: `./grafana/`). If the directory exists and contains YAML files, run a dry-run push to check for drift:
+```bash
+gcx resources push ./grafana/ --dry-run
+```
+If no drift is detected, the export is up to date - skip and report to the user.
+
+Ask the user where in their repo to place the export (default: `./grafana/`).
+
+**Parallel:**
+
+- **Agent A** - export (run_in_background: true, can be slow):
+  Pull all resources to the chosen directory:
+  ```bash
+  gcx resources pull -p ./grafana/
+  ```
+
+- **Agent B** - prepare CI snippet while export runs:
+  Generate a ready-to-paste GitHub Actions step or Makefile target that runs:
+  ```bash
+  gcx resources push ./grafana/ --dry-run
+  ```
+  This detects drift between the repo and live Grafana.
+
+Wait for Agent A. Then verify round-trip:
+```bash
+gcx resources push ./grafana/ --dry-run
+ls ./grafana/
+```
+
+Mark task completed.
+
+---
+
+## Phase 11: Observability Review
+
+Mark task in_progress.
+
+**Step 1 - comprehensive signal health check:**
+Run `gcx instrumentation status` and `gcx setup status` for overall health. Report all signal statuses. If any signal is unhealthy, investigate before continuing.
+
+**Step 2 - Validate test definitions against actual signals - parallel:**
+
+- **Agent A** - SLO pass/fail status: list all SLOs (`gcx slo definitions list`) and check reports (`gcx slo reports list`). Flag any SLO already burning error budget - investigate before declaring setup complete.
+
+- **Agent B** - k6 schedule verification: list all k6 schedules (`gcx k6 schedules list`) and cross-reference with k6 load tests (`gcx k6 load-tests list`). Flag any test without a schedule - schedules are required.
+
+- **Agent C** - synthetic check health: list all synthetic checks (`gcx synthetic-monitoring checks list`) and check status for each (`gcx synthetic-monitoring checks status <id>`). Confirm all are enabled and showing recent results.
+
+Wait for all agents. Then synthesize a **prioritized recommendations list**:
+- k6 tests missing schedules -> add schedule immediately
+- Journeys missing custom spans -> add OTEL SDK instrumentation
+- Services with only auto-instrumentation -> add profiling
+- Frontend journeys -> add k6 browser test
+- SLOs with actual error rates near target -> tighten target or investigate
+
+Mark task completed.

--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -38,7 +38,7 @@ gcx resources examples <kind>       # example manifest
 ```
 
 Only fall back to `gcx commands --flat -o json` when you need structured metadata
-for automation — it is 255KB and should not be used for orientation.
+for automation - the output is hundreds of kilobytes and unsuitable for orientation.
 
 ### Intent-to-Group Quick Reference
 
@@ -56,7 +56,7 @@ right group:
 | PromQL / Adaptive Metrics | `metrics` | `gcx metrics query -d <uid> 'up'` |
 | LogQL / Adaptive Logs | `logs` | `gcx logs query -d <uid> '{app="foo"}'` |
 | Profiling (Pyroscope) | `profiles` | `gcx profiles query` |
-| Tracing (Tempo) | `traces` | Search: `gcx traces query -d <uid> '{ status = error }'`; values: `gcx traces tags -d <uid> -l resource.service.name --llm -o json`; trace: `gcx traces get -d <uid> <trace-id> --llm -o json` |
+| Tracing (Tempo) | `traces` | `gcx traces query -d <uid> '{ status = error }'` (see Tempo LLM-friendly output below) |
 | Datasource info and queries | `datasources` | `gcx datasources list` |
 | Fleet pipelines, collectors | `fleet` | `gcx fleet pipelines list` |
 | Knowledge Graph (Asserts) | `kg` | `gcx kg entities list` |

--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gcx
 description: >
-  Use gcx CLI to manage Grafana Cloud resources. Trigger when the user wants to
-  inspect, create, update, delete, query, or automate any Grafana resource —
+  Manages Grafana Cloud resources via the gcx CLI. Trigger when the user wants to
+  inspect, create, update, delete, query, or automate any Grafana resource -
   dashboards, datasources, alerts, SLOs, synthetic checks, oncall, incidents,
   fleet, k6, knowledge graph, or adaptive telemetry.
 user-invocable: true

--- a/claude-plugin/skills/generate-resource-stubs/SKILL.md
+++ b/claude-plugin/skills/generate-resource-stubs/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: generate-resource-stubs
 description: >
-  Use when the user explicitly wants typed Go stub files, generated resource
-  skeletons, or grafana-foundation-sdk builder boilerplate for dashboards or
-  alert rules. This is scaffolding only; for designing or creating a usable
+  Generates typed Go stub files and grafana-foundation-sdk builder
+  boilerplate for dashboards and alert rules. Use only when the user
+  explicitly asks for stubs, generated resource skeletons, or builder
+  boilerplate. This is scaffolding only; for designing or creating a usable
   dashboard with datasource discovery and snapshot iteration, use the
   create-dashboard skill instead. Triggers on "generate stub", "dashboard
   stub", "create alert rule stub", "foundation-sdk builder", or "builder

--- a/claude-plugin/skills/generate-resource-stubs/references/foundation-sdk-guide.md
+++ b/claude-plugin/skills/generate-resource-stubs/references/foundation-sdk-guide.md
@@ -1,6 +1,16 @@
-# Grafana Foundation SDK — Go Builder Reference (v0.0.12)
+# Grafana Foundation SDK Go Builder Reference
 
 Reference for building dashboards and alerts using `grafana-foundation-sdk/go`.
+The generated project's `go.mod` pins the SDK version the stubs target.
+
+## Contents
+
+- [Import Paths](#import-paths)
+- [DashboardBuilder (dashboardv2beta1)](#dashboardbuilder-dashboardv2beta1)
+- [Visualization Types](#visualization-types)
+- [Datasource Query Types](#datasource-query-types)
+- [Alert Rule Builder (alerting)](#alert-rule-builder-alerting)
+- [Common Patterns](#common-patterns)
 
 ## Import Paths
 
@@ -139,45 +149,20 @@ return dashboard.Manifest("resource-name", builder)
 
 ## Visualization Types
 
-### Timeseries
-```go
-timeseries.NewVisualizationBuilder()  // Line/area/bar chart over time
-```
+Each visualization package exposes `NewVisualizationBuilder()`; pass the result
+to `.Visualization(...)` on a panel builder.
 
-### Stat
-```go
-stat.NewVisualizationBuilder()  // Single big number
-```
-
-### Gauge
-```go
-gauge.NewVisualizationBuilder()  // Gauge with thresholds
-```
-
-### Table
-```go
-table.NewVisualizationBuilder()  // Data table
-```
-
-### Bar Chart
-```go
-barchart.NewVisualizationBuilder()  // Category bar chart
-```
-
-### Heatmap
-```go
-heatmap.NewVisualizationBuilder()  // Heatmap
-```
-
-### Logs
-```go
-logs.NewVisualizationBuilder()  // Log viewer
-```
-
-### Text
-```go
-text.NewVisualizationBuilder()  // Markdown/HTML text panel
-```
+| Package | Use for |
+|---------|---------|
+| `timeseries` | Line/area/bar chart over time |
+| `stat` | Single big number |
+| `gauge` | Gauge with thresholds |
+| `barchart` | Category bar chart |
+| `table` | Data table |
+| `heatmap` | Heatmap |
+| `piechart` | Pie chart |
+| `logs` | Log viewer |
+| `text` | Markdown/HTML text panel |
 
 ## Datasource Query Types
 

--- a/claude-plugin/skills/import-dashboards/SKILL.md
+++ b/claude-plugin/skills/import-dashboards/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: import-dashboards
 description: >
-  Use when the user wants to import existing Grafana dashboards as Go code,
-  convert live dashboards to builder code, migrate dashboards to code,
-  or reverse-engineer a dashboard from a Grafana instance. Triggers on
+  Imports existing Grafana dashboards as Go builder code via gcx. Use when
+  the user wants to convert live dashboards to builder code, migrate
+  dashboards to code, or reverse-engineer a dashboard from a Grafana
+  instance. Triggers on
   "import dashboard", "convert to code", "dashboard as code", "export dashboard".
   For pulling dashboards as YAML/JSON resource files rather than Go code,
   use manage-dashboards instead.

--- a/claude-plugin/skills/import-dashboards/SKILL.md
+++ b/claude-plugin/skills/import-dashboards/SKILL.md
@@ -5,6 +5,8 @@ description: >
   convert live dashboards to builder code, migrate dashboards to code,
   or reverse-engineer a dashboard from a Grafana instance. Triggers on
   "import dashboard", "convert to code", "dashboard as code", "export dashboard".
+  For pulling dashboards as YAML/JSON resource files rather than Go code,
+  use manage-dashboards instead.
 ---
 
 # Import Dashboards as Code
@@ -56,7 +58,7 @@ Grafana Instance
 gcx dev import dashboards/foo
     │
     ├── 1. Fetches resource via K8s API (/apis endpoint)
-    ├── 2. Detects API version (v0alpha1, v1beta1, v2beta1)
+    ├── 2. Detects the resource API version
     ├── 3. Runs version-specific converter (JSON → SDK builder code)
     ├── 4. Wraps in resource.NewManifestBuilder()
     └── 5. Writes to imported/<snake_case_name>.go
@@ -91,7 +93,11 @@ gcx dev import dashboards --path internal/dashboards
 # 2. Review and edit the generated code
 #    (fix up builder calls, add variables, etc.)
 
-# 3. Push back to Grafana
+# 3. Render manifests from the builders. In a gcx-scaffolded project,
+#    `go run .` writes JSON manifests to ./resources
+go run .
+
+# 4. Push back to Grafana
 gcx resources push
 ```
 
@@ -99,7 +105,7 @@ gcx resources push
 
 | Issue | Fix |
 |-------|-----|
-| "no converter found" | Dashboard uses an unsupported API version; only v0alpha1, v1beta1, v2beta1 supported |
+| "no converter found" | The resource's API version has no converter; the error message names the unsupported version |
 | Auth error (401/403) | Run `gcx config check` to verify credentials |
 | Empty import | The selector matched no resources; check UID with `gcx resources get dashboards` |
 | Imported code doesn't compile | Some complex dashboards produce converter output that needs manual fixup |

--- a/claude-plugin/skills/investigate-alert/SKILL.md
+++ b/claude-plugin/skills/investigate-alert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: investigate-alert
-description: Investigate Grafana alerts to determine why they are firing, their scope, and impact. Use when the user asks about a specific alert, wants to understand alert behavior, or needs to diagnose why an alert is in a firing or pending state.
+description: Investigate Grafana alerts to determine why they are firing, their scope, and impact. Use when the user asks about a specific alert, wants to understand alert behavior, or needs to diagnose why an alert is in a firing or pending state. Trigger on phrases like "why is this alert firing", "investigate this alert", "what is this alert rule doing", or a named alert rule. For triaging what is actively paging in OnCall (alert groups, ack/silence/resolve) use oncall-triage instead.
 ---
 
 # Grafana Alert Investigator
@@ -60,12 +60,12 @@ Query the datasource. Use -o json to get the data for yourself. Use with a graph
 
 ```bash
 # Prometheus
-gcx metrics query <datasource-uid> '<query>' --from now-1h --to now --step 1m -o json
-gcx metrics query <datasource-uid> '<query>' --from now-1h --to now --step 1m -o graph
+gcx metrics query -d <datasource-uid> '<query>' --from now-1h --to now --step 1m -o json
+gcx metrics query -d <datasource-uid> '<query>' --from now-1h --to now --step 1m -o graph
 
 # Loki
-gcx logs query <datasource-uid> '<query>' --from now-1h --to now -o json
-gcx logs query <datasource-uid> '<query>' --from now-1h --to now -o graph
+gcx logs query -d <datasource-uid> '<query>' --from now-1h --to now -o json
+gcx logs query -d <datasource-uid> '<query>' --from now-1h --to now -o graph
 ```
 
 Analyze the results: What's the current value? Spike or gradual? When did it start?

--- a/claude-plugin/skills/investigate-alert/references/alert-investigation-patterns.md
+++ b/claude-plugin/skills/investigate-alert/references/alert-investigation-patterns.md
@@ -3,6 +3,15 @@
 Reference for investigating Grafana alerts with gcx. Covers the alert
 JSON structure, common investigation query patterns, and graph interpretation.
 
+## Contents
+
+- [Alert JSON Structure](#alert-json-structure) - fields returned by `gcx alert rules list -o json`, query extraction
+- [JSON Response Envelopes](#json-response-envelopes) - jq access patterns per command
+- [Common Investigation Query Patterns](#common-investigation-query-patterns) - by alert class (latency, error rate, resources, certs, availability)
+- [Loki Log Investigation Patterns](#loki-log-investigation-patterns) - log correlation, series limits, label kinds
+- [Interpreting Graph Output](#interpreting-graph-output) - visual pattern to likely cause
+- [Runbook Fetching](#runbook-fetching)
+
 ---
 
 ## Alert JSON Structure
@@ -105,12 +114,12 @@ For P99/P95 latency alerts:
 
 ```bash
 # Current latency percentiles
-gcx metrics query <uid> \
+gcx metrics query -d <uid> \
   'histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m]))' \
   --from now-1h --to now --step 1m -o graph
 
 # Latency by endpoint
-gcx metrics query <uid> \
+gcx metrics query -d <uid> \
   'histogram_quantile(0.99, sum by(job, handler) (rate(http_request_duration_seconds_bucket[5m])))' \
   --from now-1h --to now --step 1m -o json
 ```
@@ -121,12 +130,12 @@ For alerts on HTTP 5xx or error rates:
 
 ```bash
 # Overall error rate
-gcx metrics query <uid> \
+gcx metrics query -d <uid> \
   'rate(http_requests_total{status=~"5.."}[5m]) / rate(http_requests_total[5m])' \
   --from now-1h --to now --step 1m -o graph
 
 # Error rate by service
-gcx metrics query <uid> \
+gcx metrics query -d <uid> \
   'sum by(job) (rate(http_requests_total{status=~"5.."}[5m])) / sum by(job) (rate(http_requests_total[5m]))' \
   --from now-1h --to now --step 1m -o json
 ```
@@ -137,17 +146,17 @@ For CPU, memory, or disk alerts:
 
 ```bash
 # CPU usage by pod
-gcx metrics query <uid> \
+gcx metrics query -d <uid> \
   'sum by(pod) (rate(container_cpu_usage_seconds_total[5m]))' \
   --from now-1h --to now --step 1m -o graph
 
 # Memory usage
-gcx metrics query <uid> \
+gcx metrics query -d <uid> \
   'container_memory_working_set_bytes{container!=""}' \
   --from now-30m --to now --step 1m -o json
 
 # Disk free percentage
-gcx metrics query <uid> \
+gcx metrics query -d <uid> \
   'node_filesystem_avail_bytes / node_filesystem_size_bytes' \
   --from now-6h --to now --step 5m -o graph
 ```
@@ -158,7 +167,7 @@ For cert expiry alerts:
 
 ```bash
 # Days until certificate expiry
-gcx metrics query <uid> \
+gcx metrics query -d <uid> \
   '(certmanager_certificate_expiration_timestamp_seconds - time()) / 86400' \
   --from now-1h --to now --step 10m -o json
 ```
@@ -169,12 +178,12 @@ For availability or SLO breach alerts:
 
 ```bash
 # Uptime over last hour
-gcx metrics query <uid> \
+gcx metrics query -d <uid> \
   'avg_over_time(up[1h])' \
   --from now-6h --to now --step 5m -o graph
 
 # Current up/down status
-gcx metrics query <uid> \
+gcx metrics query -d <uid> \
   'up == 0' \
   --from now-15m --to now --step 1m -o json
 ```
@@ -187,15 +196,15 @@ After identifying an issue from metrics, correlate with logs:
 
 ```bash
 # Find error logs for a service
-gcx logs query <loki-uid> '{job="api-server"} |= "error"' \
+gcx logs query -d <loki-uid> '{job="api-server"} |= "error"' \
   --from now-1h --to now -o json
 
 # Find logs around the time the alert started firing (replace timestamp)
-gcx logs query <loki-uid> '{namespace="production"} |= "error"' \
+gcx logs query -d <loki-uid> '{namespace="production"} |= "error"' \
   --from 2024-01-15T10:00:00Z --to 2024-01-15T10:30:00Z -o json
 
 # Rate of error log lines (for trend analysis)
-gcx logs query <loki-uid> 'rate({job="api-server"} |= "error" [5m])' \
+gcx logs query -d <loki-uid> 'rate({job="api-server"} |= "error" [5m])' \
   --from now-2h --to now --step 1m -o graph
 ```
 
@@ -205,12 +214,12 @@ Loki metric queries (`rate()`, `count_over_time()`, etc.) produce one series per
 
 ```bash
 # BAD — one series per pod/namespace/level/... combination
-gcx logs query <loki-uid> 'count_over_time({job="app"} [5m])'
+gcx logs query -d <loki-uid> 'count_over_time({job="app"} [5m])'
 
 # GOOD — aggregate down to what you need
-gcx logs query <loki-uid> 'sum(count_over_time({job="app"} [5m]))'
-gcx logs query <loki-uid> 'sum by(level) (count_over_time({job="app"} | json [5m]))'
-gcx logs query <loki-uid> 'topk(10, sum by(pod) (rate({job="app"} [5m])))'
+gcx logs query -d <loki-uid> 'sum(count_over_time({job="app"} [5m]))'
+gcx logs query -d <loki-uid> 'sum by(level) (count_over_time({job="app"} | json [5m]))'
+gcx logs query -d <loki-uid> 'topk(10, sum by(pod) (rate({job="app"} [5m])))'
 ```
 
 Rule of thumb: if your query uses `rate()`, `count_over_time()`, or `bytes_over_time()`, wrap it with `sum()`, `sum by(label)`, or `topk()`.
@@ -259,8 +268,8 @@ Common mistakes:
 Use `-o json` after `-o graph` to extract exact values:
 ```bash
 # Get the peak value during the alert window
-gcx metrics query <uid> '<query>' --from now-2h --to now --step 1m -o json | \
-  jq '[.data[].values[] | .value] | max'
+gcx metrics query -d <uid> '<query>' --from now-2h --to now --step 1m -o json | \
+  jq '[.data.result[].values[][1] | tonumber] | max'
 ```
 
 ---

--- a/claude-plugin/skills/manage-dashboards/SKILL.md
+++ b/claude-plugin/skills/manage-dashboards/SKILL.md
@@ -147,7 +147,8 @@ review the newest version, and retry only if the restore is still correct.
 
 ## References
 
-- [`references/resource-operations.md`](references/resource-operations.md) —
-  selector syntax, pull/push/validate flags, and `gcx dev serve` details.
-- [`references/resource-model.md`](references/resource-model.md) — resource
-  structure, manager metadata, folder ordering, and lifecycle behavior.
+- For full flag sets, selector syntax, `--on-error` policy, and the
+  `gcx dev serve` live-reload workflow, read
+  [references/resource-operations.md](references/resource-operations.md).
+- For resource structure, manager metadata, push ordering, and lifecycle
+  behavior, read [references/resource-model.md](references/resource-model.md).

--- a/claude-plugin/skills/manage-dashboards/SKILL.md
+++ b/claude-plugin/skills/manage-dashboards/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: manage-dashboards
 description: >
-  Use for operational management of existing Grafana dashboards: list, get,
+  Manages existing Grafana dashboards operationally via gcx: list, get,
   search, create or update from an already-authored manifest, delete, inspect
   and restore versions, pull/push/validate/promote dashboard resource files,
   manage dashboard folders, or render PNG snapshots. Do NOT use when the task

--- a/claude-plugin/skills/manage-dashboards/references/resource-model.md
+++ b/claude-plugin/skills/manage-dashboards/references/resource-model.md
@@ -199,9 +199,6 @@ gcx resources pull dashboards/uid1,uid2,uid3
 # Preferred version (default)
 gcx resources pull dashboards
 
-# All versions
-gcx resources pull dashboards --all-versions
-
 # Specific version
 gcx resources pull dashboards.v1alpha1.dashboard.grafana.app
 ```

--- a/claude-plugin/skills/manage-dashboards/references/resource-model.md
+++ b/claude-plugin/skills/manage-dashboards/references/resource-model.md
@@ -2,6 +2,21 @@
 
 This document describes how Grafana resources are structured and how they relate to each other.
 
+## Contents
+
+- [Resource Structure](#resource-structure)
+- [Resource Relationships](#resource-relationships)
+- [Resource Groups](#resource-groups)
+- [Manager Metadata](#manager-metadata)
+- [API Versions](#api-versions)
+- [Discovery System](#discovery-system)
+- [Push Order](#push-order)
+- [Source Tracking](#source-tracking)
+- [Resource Filtering](#resource-filtering)
+- [Memory Considerations](#memory-considerations)
+- [Resource Lifecycle](#resource-lifecycle)
+- [Best Practices](#best-practices)
+
 ## Resource Structure
 
 All Grafana resources follow Kubernetes-style conventions:
@@ -108,31 +123,10 @@ metadata:
   - Use `--include-managed` to modify (use with caution)
   - Prevents accidental overwrites from different tools
 
-### Three-Way Merge (Future)
+## API Versions
 
-Currently gcx uses simple upsert logic. Future versions will implement proper three-way merge:
-- Track field ownership by manager
-- Allow multiple managers to coexist
-- Detect and resolve conflicts
-- Similar to `kubectl apply` behavior
-
-## Resource Versioning
-
-### API Versions
-
-Resources can have multiple API versions:
-- **v1alpha1**: Alpha version, subject to breaking changes
-- **v1beta1**: Beta version, more stable
-- **v1**: Stable version (when available)
-
-gcx uses **preferred version** by default (typically latest stable version).
-
-### Resource Versions (Future)
-
-Currently gcx does not track `resourceVersion` for optimistic locking. Future versions will:
-- Include `resourceVersion` in metadata
-- Detect concurrent modifications
-- Retry on conflict with exponential backoff
+Resources can have multiple API versions (e.g. v1alpha1, v1beta1, v1). gcx uses
+the **preferred version** by default (typically the latest stable version).
 
 ## Discovery System
 
@@ -218,8 +212,6 @@ gcx loads all resources into memory during operations:
 - **Typical usage**: ~1MB per 100 dashboards
 - **Practical limit**: ~10,000 resources before memory pressure
 - **Mitigation**: Use selective pulling (specific resource types or UIDs)
-
-Future versions may add streaming support for very large deployments.
 
 ## Resource Lifecycle
 

--- a/claude-plugin/skills/manage-dashboards/references/resource-operations.md
+++ b/claude-plugin/skills/manage-dashboards/references/resource-operations.md
@@ -7,6 +7,18 @@
 This file documents the full flag set and usage patterns for each `gcx resources`
 subcommand, the selector syntax, and the `serve` live development workflow.
 
+## Contents
+
+- [Selector Syntax](#selector-syntax)
+- [`gcx resources get`](#gcx-resources-get)
+- [`gcx resources push`](#gcx-resources-push)
+- [`gcx resources pull`](#gcx-resources-pull)
+- [`gcx resources delete`](#gcx-resources-delete)
+- [`gcx resources edit`](#gcx-resources-edit)
+- [`gcx resources validate`](#gcx-resources-validate)
+- [`gcx dev serve`](#gcx-dev-serve)
+- [`--on-error` Policy Reference](#--on-error-policy-reference)
+
 ---
 
 ## Selector Syntax

--- a/claude-plugin/skills/oncall-triage/SKILL.md
+++ b/claude-plugin/skills/oncall-triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: oncall-triage
-description: Use when the user is triaging what is actively paging in Grafana OnCall, or asks about active alert groups, acknowledging or silencing or resolving fires, on-call queue, or "what's paging right now". Trigger on phrases like "what's paging", "on-call alerts", "ack this", "silence the page", "what's firing in OnCall", "show me active pages", or any reference to OnCall alert groups. For root cause of why a Grafana alert rule is evaluating (rule-side, pre-routing) use investigate-alert. For schedules, integrations, or escalation chains use the gcx skill.
-allowed-tools: [Bash]
+description: Triages active Grafana OnCall alert groups via gcx - list, inspect, acknowledge, silence, resolve. Use when the user is triaging what is actively paging in Grafana OnCall, or asks about active alert groups, acknowledging or silencing or resolving fires, on-call queue, or "what's paging right now". Trigger on phrases like "what's paging", "on-call alerts", "ack this", "silence the page", "what's firing in OnCall", "show me active pages", or any reference to OnCall alert groups. For root cause of why a Grafana alert rule is evaluating (rule-side, pre-routing) use investigate-alert. For schedules, integrations, or escalation chains use the gcx skill.
+allowed-tools: Bash
 ---
 
 # OnCall Alert-Group Triage

--- a/claude-plugin/skills/oncall-triage/SKILL.md
+++ b/claude-plugin/skills/oncall-triage/SKILL.md
@@ -13,7 +13,7 @@ OnCall **alert groups** are post-routing aggregations of alert deliveries — th
 1. Use gcx — do not call OnCall APIs directly (no curl, no HTTP libraries).
 2. The CLI emits structured diagnostics on stderr (`hint:`, `note:`, `warn:`; JSONL with `class` in agent mode). Pass them through.
 3. The default `alert-groups list` filter excludes resolved + child groups. Surface `--all` only when the user asks about history.
-4. Action verbs in agent mode require `--yes` when matched count > 1. Never pre-fill `--yes` without user confirmation.
+4. Action verbs in agent mode require `--force` when matched count > 1. Never pre-fill `--force` without user confirmation.
 
 ## Prerequisites
 
@@ -98,7 +98,7 @@ gcx irm oncall alert-groups acknowledge <id>
 gcx irm oncall alert-groups silence <id> --duration 3600
 
 # Bulk-by-filter (filter flags mirror `list`)
-gcx irm oncall alert-groups acknowledge --team <PK> --state firing --yes
+gcx irm oncall alert-groups acknowledge --team <PK> --state firing --force
 ```
 
 Result envelopes:
@@ -113,12 +113,12 @@ Result envelopes:
 
 `changed:false` / `skipped++` on idempotent re-runs (not an error). `matched == succeeded + skipped + failed`. `failures[]` carries only errored targets.
 
-Bulk in agent mode REQUIRES `--yes` when matched count > 1. Show the user the filter set and confirm before running — do not pre-fill `--yes`. A bulk call with no `<id>` AND no filter flags is blocked with a structured error containing `suggestions[]`.
+Bulk in agent mode REQUIRES `--force` when matched count > 1. Show the user the filter set and confirm before running — do not pre-fill `--force`. A bulk call with no `<id>` AND no filter flags is blocked with a structured error containing `suggestions[]`.
 
 ## Error Handling
 
 - `<id> argument or filter flag required` — surface the error's `suggestions[]` to the user.
-- Agent mode + matched > 1 + no `--yes` — confirm scope with the user, then re-run with `--yes`.
+- Agent mode + matched > 1 + no `--force` — confirm scope with the user, then re-run with `--force`.
 - 404 on `get <id>` — group may have been purged; retry the prior `list` with `--all --state resolved`.
 - `webhook` / `formatted_webhook` integrations — partial `status.links.*` and empty `subject.labels` are expected, not errors.
 

--- a/claude-plugin/skills/oncall-triage/SKILL.md
+++ b/claude-plugin/skills/oncall-triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: oncall-triage
 description: Use when the user is triaging what is actively paging in Grafana OnCall, or asks about active alert groups, acknowledging or silencing or resolving fires, on-call queue, or "what's paging right now". Trigger on phrases like "what's paging", "on-call alerts", "ack this", "silence the page", "what's firing in OnCall", "show me active pages", or any reference to OnCall alert groups. For root cause of why a Grafana alert rule is evaluating (rule-side, pre-routing) use investigate-alert. For schedules, integrations, or escalation chains use the gcx skill.
-allowed-tools: [gcx, Bash]
+allowed-tools: [Bash]
 ---
 
 # OnCall Alert-Group Triage

--- a/claude-plugin/skills/scaffold-project/SKILL.md
+++ b/claude-plugin/skills/scaffold-project/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: scaffold-project
 description: >
-  Use when the user wants to create a new Grafana resources-as-code project,
-  start a new dashboards-as-code repo, scaffold a gcx project, or asks
-  "how do I get started with gcx". Triggers on phrases like "new project",
-  "scaffold", "bootstrap", "create project", "get started".
+  Scaffolds a new Go project for managing Grafana resources as code via
+  gcx dev scaffold. Use when the user wants to create a new Grafana
+  resources-as-code project, start a new dashboards-as-code repo, scaffold
+  a gcx project, or asks "how do I get started with gcx". Triggers on
+  phrases like "new project", "scaffold", "bootstrap", "create project",
+  "get started".
 ---
 
 # Scaffold a gcx Project
@@ -31,8 +33,8 @@ gcx dev scaffold
 ```
 
 Prompts for:
-- **Project name** — becomes the directory name (kebab-cased)
-- **Go module path** — e.g. `github.com/myorg/my-dashboards`
+- **Project name** - becomes the directory name (kebab-cased)
+- **Go module path** - e.g. `github.com/myorg/my-dashboards`
 
 ### Non-Interactive Mode
 
@@ -58,7 +60,7 @@ my-dashboards/
 ## Next Steps After Scaffolding
 
 1. `cd my-dashboards && go mod tidy`
-2. Configure gcx: `gcx config set server <URL>` and `gcx config set token <TOKEN>`
+2. Configure gcx: `gcx config set grafana.server <URL>` and `gcx config set grafana.token <TOKEN>`
 3. Edit `internal/dashboards/sample.go` or generate new stubs with `gcx dev generate`
 4. Push to Grafana: `gcx resources push`
 
@@ -66,6 +68,6 @@ my-dashboards/
 
 | Issue | Fix |
 |-------|-----|
-| `go mod tidy` fails | Ensure Go 1.24+ is installed |
+| `go mod tidy` fails | Ensure your Go toolchain meets the version required by the generated `go.mod` |
 | Project name has spaces | Names are auto-kebab-cased; spaces become hyphens |
 | Want to add alert rules | Create `internal/alerts/` and use `gcx dev generate alerts/my-rule.go` |

--- a/claude-plugin/skills/setup-gcx/SKILL.md
+++ b/claude-plugin/skills/setup-gcx/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: setup-gcx
 description: >
-  Use this skill to set up gcx, configure authentication, establish a
-  connection to a Grafana instance, and complete first-time configuration. This
-  skill covers Grafana Cloud and on-premise deployments, environment variable
-  overrides for CI/CD, default datasource configuration, and troubleshooting
-  connection and authentication problems.
+  Sets up gcx: installation, context creation, authentication, and connection
+  to a Grafana instance. Covers Grafana Cloud and on-premise deployments,
+  environment variable overrides for CI/CD, default datasource configuration,
+  and troubleshooting connection and authentication problems. Use when
+  installing gcx, connecting gcx to a Grafana instance for the first time, or
+  when gcx commands fail with auth or connectivity errors (401, 403,
+  connection refused, missing namespace).
 ---
 
 # Setup gcx
 
-This skill teaches agents to configure gcx for a Grafana instance,
-covering the three configuration paths (Grafana Cloud, on-premise, and
-environment variables) and resolving common setup errors.
+Three configuration paths: Grafana Cloud (Path A), on-premise (Path B), and
+environment variables for CI/CD (Path C). For the complete config reference
+(all `config set` paths, TLS options, namespace resolution rules, multi-context
+patterns), see [configuration.md](references/configuration.md).
 
 ## Step 0: Install gcx
 
@@ -23,7 +26,7 @@ gcx --version
 ```
 
 If the command is not found, build it from source. Requires
-[git](https://git-scm.com/) and [Go](https://go.dev/) v1.24+:
+[git](https://git-scm.com/) and a recent [Go](https://go.dev/) toolchain:
 
 ```bash
 tmp=$(mktemp -d) && git clone --depth 1 https://github.com/grafana/gcx.git "$tmp" && (cd "$tmp" && go install ./cmd/gcx) && rm -rf "$tmp"
@@ -108,13 +111,9 @@ errors. For Grafana Cloud, the stack ID (namespace) is auto-discovered from
 the server's `/bootdata` endpoint -- you do not need to set `grafana.stack-id`
 manually unless auto-discovery fails.
 
-**Namespace note**: gcx maps Grafana Cloud instances to a Kubernetes
-namespace of the form `stacks-<id>`. This namespace is discovered automatically
-by calling the `/bootdata` endpoint on the server URL. If the discovered stack
-ID conflicts with a manually configured `grafana.stack-id`, gcx raises a
-validation error. To resolve: either remove the manually configured stack ID
-(`gcx config unset contexts.cloud.grafana.stack-id`) or correct it to
-match the discovered value.
+If the discovered stack ID conflicts with a manually configured
+`grafana.stack-id`, gcx raises a validation error - see
+[Namespace resolution issues](#namespace-resolution-issues).
 
 ---
 
@@ -218,7 +217,7 @@ modify the config file on disk.
 
 ### Config file location
 
-If you need to supply a config file path explicitly:
+To supply a config file path explicitly:
 
 ```bash
 gcx --config /path/to/config.yaml resources get dashboards
@@ -226,13 +225,8 @@ gcx --config /path/to/config.yaml resources get dashboards
 export GCX_CONFIG=/path/to/config.yaml
 ```
 
-Config file search order (highest to lowest priority):
-
-1. `--config <path>` CLI flag
-2. `$GCX_CONFIG` environment variable
-3. `$XDG_CONFIG_HOME/gcx/config.yaml`
-4. `$HOME/.config/gcx/config.yaml`
-5. `$XDG_CONFIG_DIRS/gcx/config.yaml`
+For the full config file search order, see
+[configuration.md](references/configuration.md#config-file-location).
 
 ---
 
@@ -276,37 +270,22 @@ use the configured defaults automatically.
 
 ## Multi-Context Management
 
-To work with multiple Grafana environments, create a context for each:
+To work with multiple Grafana environments, repeat Path A or B once per
+environment with a distinct context name, then:
 
 ```bash
-# Create contexts
-gcx config set contexts.production.grafana.server https://grafana.example.com
-gcx config set contexts.production.grafana.token glsa_PROD_TOKEN
-gcx config set contexts.production.grafana.org-id 1
-
-gcx config set contexts.staging.grafana.server https://grafana-staging.example.com
-gcx config set contexts.staging.grafana.token glsa_STAGING_TOKEN
-gcx config set contexts.staging.grafana.org-id 1
-
 # Switch between contexts
-gcx config use-context production
 gcx config use-context staging
 
 # Use a context for a single command without switching
 gcx --context staging resources get dashboards
-```
 
-To list all configured contexts, view the full config:
-
-```bash
+# List all contexts (secrets redacted; add --raw to reveal)
 gcx config view
 ```
 
-Secrets (`token`, `password`) are redacted in this output. To see raw values:
-
-```bash
-gcx config view --raw
-```
+For create/update/remove patterns, see
+[configuration.md](references/configuration.md#multi-context-management).
 
 ---
 
@@ -406,7 +385,7 @@ gcx config set contexts.<name>.grafana.stack-id 12345
 
 ---
 
-## Complete Example: Grafana Cloud Setup
+## Complete Example: Grafana Cloud with a Service Account Token
 
 ```bash
 # 1. Set server and token
@@ -432,6 +411,6 @@ gcx resources get dashboards -o json
 
 ## Reference
 
-For a complete listing of all config set paths, environment variables,
-namespace resolution logic, and multi-context patterns, see
-`references/configuration.md`.
+For all config set paths, TLS fields, environment variables, namespace
+resolution rules, and multi-context patterns, see
+[configuration.md](references/configuration.md).

--- a/claude-plugin/skills/setup-gcx/references/configuration.md
+++ b/claude-plugin/skills/setup-gcx/references/configuration.md
@@ -4,6 +4,18 @@ gcx uses a context-based configuration model inspired by kubectl's kubeconfig. A
 file holds named contexts, each describing a Grafana instance. One context is "current" at any time;
 all commands operate against it unless overridden.
 
+## Contents
+
+- [Config File Location](#config-file-location)
+- [Config File Structure](#config-file-structure)
+- [Config Set Paths](#config-set-paths)
+- [Environment Variables](#environment-variables)
+- [Namespace Resolution](#namespace-resolution)
+- [Multi-Context Management](#multi-context-management)
+- [Authentication](#authentication)
+- [Secret Redaction](#secret-redaction)
+- [Quick-Start: Minimum Valid Configuration](#quick-start-minimum-valid-configuration)
+
 ---
 
 ## Config File Location

--- a/claude-plugin/skills/slo-check-status/SKILL.md
+++ b/claude-plugin/skills/slo-check-status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: slo-check-status
 description: Checks Grafana SLO health, error budget, and burn rate via gcx, with timeline graphs for trends. Use when the user asks about SLO health, wants an overview of all SLOs, or needs status of a specific SLO. Trigger on phrases like "how are my SLOs doing", "SLO status", "check my SLOs", "is my SLO healthy", "SLO budget", "SLO burn rate". For investigating breaching SLOs use slo-investigate. For optimization suggestions use slo-optimize. For creating or modifying SLO definitions use slo-manage.
-allowed-tools: [Bash]
+allowed-tools: Bash
 ---
 
 # SLO Status Checker

--- a/claude-plugin/skills/slo-check-status/SKILL.md
+++ b/claude-plugin/skills/slo-check-status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: slo-check-status
-description: Use when the user asks about SLO health, wants an overview of all SLOs, or needs status of a specific SLO. Trigger on phrases like "how are my SLOs doing", "SLO status", "check my SLOs", "is my SLO healthy", "SLO budget", "SLO burn rate". For investigating breaching SLOs use slo-investigate. For optimization suggestions use slo-optimize. For creating or modifying SLO definitions use slo-manage.
-allowed-tools: [gcx, Bash]
+description: Checks Grafana SLO health, error budget, and burn rate via gcx, with timeline graphs for trends. Use when the user asks about SLO health, wants an overview of all SLOs, or needs status of a specific SLO. Trigger on phrases like "how are my SLOs doing", "SLO status", "check my SLOs", "is my SLO healthy", "SLO budget", "SLO burn rate". For investigating breaching SLOs use slo-investigate. For optimization suggestions use slo-optimize. For creating or modifying SLO definitions use slo-manage.
+allowed-tools: [Bash]
 ---
 
 # SLO Status Checker

--- a/claude-plugin/skills/slo-investigate/SKILL.md
+++ b/claude-plugin/skills/slo-investigate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: slo-investigate
-description: Use when a specific SLO is breaching or alerting and the user needs to understand why — root cause analysis, dimensional breakdown, alert rule correlation, runbook access. Trigger on phrases like "investigate SLO", "why is my SLO breaching", "SLO error budget burning", "SLO alerting". For SLO status overview use slo-check-status. For creating or modifying SLOs use slo-manage. For optimization suggestions use slo-optimize.
-allowed-tools: [gcx, Bash]
+description: Diagnoses breaching Grafana SLOs via gcx - root cause analysis, dimensional breakdown, alert rule correlation, runbook access. Use when a specific SLO is breaching or alerting and the user needs to understand why. Trigger on phrases like "investigate SLO", "why is my SLO breaching", "SLO error budget burning", "SLO alerting". For SLO status overview use slo-check-status. For creating or modifying SLOs use slo-manage. For optimization suggestions use slo-optimize.
+allowed-tools: [Bash]
 ---
 
 # SLO Investigator
@@ -93,12 +93,12 @@ gcx datasources list --type prometheus
 
 ```bash
 # Success rate by dimension (e.g., cluster, status_code, endpoint)
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   'sum by (<groupByLabel>) (rate(<successMetric>[5m])) / sum by (<groupByLabel>) (rate(<totalMetric>[5m]))' \
   --from now-1h --to now --step 1m
 
 # Error rate by dimension to spot the bad actor
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   'sum by (<groupByLabel>) (rate(<totalMetric>[5m])) - sum by (<groupByLabel>) (rate(<successMetric>[5m]))' \
   --from now-1h --to now --step 1m
 ```
@@ -108,17 +108,19 @@ If `groupByLabels` is empty, try common dimensions: `cluster`, `namespace`, `ser
 **For freeform queries** — use the raw PromQL expression and add `by (<label>)` grouping:
 
 ```bash
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   '<freeform_expression> by (cluster)' \
   --from now-1h --to now --step 1m
 
 # Also try other likely breakdown dimensions
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   '<freeform_expression> by (namespace)' \
   --from now-1h --to now --step 1m
 ```
 
 Use graph output to display dimensional trends visually. Use `-o json` to extract exact values for the report.
+
+To query the SLO's own recording rule metrics instead (`grafana_slo_sli_window`, burn rate, error budget expressions), see [references/slo-promql-patterns.md](references/slo-promql-patterns.md) for the metric inventory and ready-made PromQL patterns.
 
 ### Step 5: Search for Related Alert Rules
 
@@ -185,8 +187,8 @@ Next actions:
 
 - **gcx slo definitions get fails with 404**: SLO UUID not found. Run `gcx slo definitions list` and confirm the UUID.
 - **gcx slo definitions status returns empty**: No status available — SLO may be newly created. Check if recording rules are running (STATUS may show NODATA).
-- **gcx datasources {kind} query fails with datasource error**: Datasource UID may be wrong. Run `gcx datasources list --type prometheus` to find the correct UID.
-- **gcx datasources {kind} query returns no data**: The SLO metrics may write to a separate datasource (check `.spec.destinationDatasource.uid`). Try both the destination datasource and the default Prometheus datasource.
+- **gcx metrics query fails with datasource error**: Datasource UID may be wrong. Run `gcx datasources list --type prometheus` to find the correct UID.
+- **gcx metrics query returns no data**: The SLO metrics may write to a separate datasource (check `.spec.destinationDatasource.uid`). Try both the destination datasource and the default Prometheus datasource.
 - **alert rules list returns empty**: Alert rules may be in a different folder. Try without filters: `gcx alert rules list -o json | jq length` to confirm total count.
 - **gh api fails**: If `gh` is not authenticated or unavailable, report the runbook URL directly and skip content fetching.
 - **SLO has no groupByLabels (ratio query)**: Try common breakdown dimensions: `cluster`, `namespace`, `service`, `endpoint`, `status_code`. Report which ones return data.

--- a/claude-plugin/skills/slo-investigate/SKILL.md
+++ b/claude-plugin/skills/slo-investigate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: slo-investigate
 description: Diagnoses breaching Grafana SLOs via gcx - root cause analysis, dimensional breakdown, alert rule correlation, runbook access. Use when a specific SLO is breaching or alerting and the user needs to understand why. Trigger on phrases like "investigate SLO", "why is my SLO breaching", "SLO error budget burning", "SLO alerting". For SLO status overview use slo-check-status. For creating or modifying SLOs use slo-manage. For optimization suggestions use slo-optimize.
-allowed-tools: [Bash]
+allowed-tools: Bash
 ---
 
 # SLO Investigator

--- a/claude-plugin/skills/slo-investigate/references/slo-promql-patterns.md
+++ b/claude-plugin/skills/slo-investigate/references/slo-promql-patterns.md
@@ -2,6 +2,13 @@
 
 Reference for querying Grafana-generated SLO recording rule metrics.
 
+## Contents
+
+- [Metric Inventory](#metric-inventory)
+- [Patterns by Use Case](#patterns-by-use-case): current SLI, short-window snapshots, error budget, burn rate, success/total rate, objective value
+- [Querying with gcx](#querying-with-gcx)
+- [Notes](#notes)
+
 ## Metric Inventory
 
 | Metric | Description | Labels |
@@ -62,8 +69,6 @@ Burn rate measures how fast the error budget is being consumed relative to the b
 # Burn rate = (1 - current_SLI) / (1 - objective)
 # A burn rate of 1.0 = consuming budget exactly as fast as it accrues
 # A burn rate of 2.0 = consuming budget 2x faster than it accrues
-(1 - grafana_slo_sli_1h{slo_uuid="<uuid>"}) /
-(1 - grafana_slo_objective{slo_uuid="<uuid>"})
 
 # Short-window burn rate (1h) — used for fast-burn alerting
 (1 - grafana_slo_sli_1h{slo_uuid="<uuid>"}) /
@@ -78,7 +83,7 @@ Burn rate measures how fast the error budget is being consumed relative to the b
 - `< 1.0` — budget accruing faster than consumed; on track
 - `1.0` — exactly on track to exhaust budget at end of window
 - `> 1.0` — breaching; budget will exhaust before window ends
-- `> 14.4` — fast-burn threshold for 1h window (burns 30-day budget in 2h)
+- `> 14.4` — fast-burn threshold for 1h window (consumes 2% of a 30-day budget per hour)
 
 ### Success/Total Rate (Ratio Queries)
 
@@ -108,17 +113,17 @@ sort_desc(grafana_slo_sli_window - on(slo_uuid) grafana_slo_objective)
 
 ```bash
 # Current window SLI
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   'grafana_slo_sli_window{slo_uuid="<uuid>"}' \
   --from now-1h --to now --step 1m
 
 # Burn rate over last hour
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   '(1 - grafana_slo_sli_1h{slo_uuid="<uuid>"}) / (1 - grafana_slo_objective{slo_uuid="<uuid>"})' \
   --from now-1h --to now --step 1m
 
 # Error budget trend (28-day window)
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   '(grafana_slo_sli_window{slo_uuid="<uuid>"} - grafana_slo_objective{slo_uuid="<uuid>"}) / (1 - grafana_slo_objective{slo_uuid="<uuid>"})' \
   --from now-28d --to now --step 1h
 ```

--- a/claude-plugin/skills/slo-manage/SKILL.md
+++ b/claude-plugin/skills/slo-manage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: slo-manage
 description: Creates, updates, syncs, and deletes Grafana SLO definitions via gcx with dry-run validation and GitOps pull/push workflows. Use when the user wants to create, update, pull, push, or delete SLO definitions. Trigger on phrases like "create an SLO", "update SLO objective", "push SLO", "pull SLOs", "delete SLO", or "GitOps sync SLOs". For checking SLO health or status, use slo-check-status instead. For investigating a breaching SLO, use slo-investigate instead.
-allowed-tools: [Bash, Read, Write, Edit]
+allowed-tools: Bash, Read, Write, Edit
 ---
 
 # SLO Management

--- a/claude-plugin/skills/slo-manage/SKILL.md
+++ b/claude-plugin/skills/slo-manage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: slo-manage
-description: Use when the user wants to create, update, pull, push, or delete SLO definitions. Trigger on phrases like "create an SLO", "update SLO objective", "push SLO", "pull SLOs", "delete SLO", or "GitOps sync SLOs". For checking SLO health or status, use slo-check-status instead. For investigating a breaching SLO, use slo-investigate instead.
-allowed-tools: [gcx, Bash, Read, Write, Edit]
+description: Creates, updates, syncs, and deletes Grafana SLO definitions via gcx with dry-run validation and GitOps pull/push workflows. Use when the user wants to create, update, pull, push, or delete SLO definitions. Trigger on phrases like "create an SLO", "update SLO objective", "push SLO", "pull SLOs", "delete SLO", or "GitOps sync SLOs". For checking SLO health or status, use slo-check-status instead. For investigating a breaching SLO, use slo-investigate instead.
+allowed-tools: [Bash, Read, Write, Edit]
 ---
 
 # SLO Management
@@ -55,7 +55,7 @@ Use the UID from the output. If multiple Prometheus datasources exist, ask the u
 
 ### Step 3: Build YAML from the appropriate template
 
-See `references/slo-templates.md` for complete templates. Key structure:
+For complete ratio, freeform, and threshold templates (including alerting, labels, and folder fields), see [references/slo-templates.md](references/slo-templates.md). Key structure:
 
 ```yaml
 apiVersion: slo.ext.grafana.app/v1alpha1

--- a/claude-plugin/skills/slo-manage/references/slo-templates.md
+++ b/claude-plugin/skills/slo-manage/references/slo-templates.md
@@ -2,6 +2,12 @@
 
 Use `apiVersion: slo.ext.grafana.app/v1alpha1` and `kind: SLO` for all SLO definitions.
 
+## Contents
+
+- [Ratio Query Template](#ratio-query-template) - success/total ratio (HTTP success rate, availability)
+- [Freeform Query Template](#freeform-query-template) - raw PromQL expression returning 0-1
+- [Threshold Query Template](#threshold-query-template) - metric above/below a fixed threshold
+
 ---
 
 ## Ratio Query Template

--- a/claude-plugin/skills/slo-optimize/SKILL.md
+++ b/claude-plugin/skills/slo-optimize/SKILL.md
@@ -9,7 +9,7 @@ description: |
   For SLO status overview use slo-check-status.
   For investigating breaching SLOs use slo-investigate.
   For creating or modifying SLO definitions use slo-manage.
-allowed-tools: [Bash]
+allowed-tools: Bash
 ---
 
 # SLO Optimizer

--- a/claude-plugin/skills/slo-optimize/SKILL.md
+++ b/claude-plugin/skills/slo-optimize/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: slo-optimize
 description: |
-  Use when the user wants to analyze SLO performance trends and receive improvement recommendations —
+  Analyzes Grafana SLO timeline trends via gcx and produces data-backed advisory recommendations:
   objective tuning, alerting sensitivity review, label visibility, or window adjustments.
+  Use when the user wants to analyze SLO performance trends and receive improvement suggestions.
   Trigger on phrases like "optimize my SLO", "SLO improvement suggestions", "tune my SLO",
   "SLO performance analysis", or "should I change my SLO objective".
   For SLO status overview use slo-check-status.
   For investigating breaching SLOs use slo-investigate.
   For creating or modifying SLO definitions use slo-manage.
-allowed-tools: [gcx, Bash]
+allowed-tools: [Bash]
 ---
 
 # SLO Optimizer
@@ -94,16 +95,16 @@ using the datasource UID from Step 1:
 
 ```bash
 # SLI window metric (primary trend signal)
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   'grafana_slo_sli_window{slo_uuid="<UUID>"}' \
   --from now-28d --to now --step 6h
 
 # Success and total rate for ratio SLOs
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   'grafana_slo_success_rate_5m{slo_uuid="<UUID>"}' \
   --from now-28d --to now --step 6h
 
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   'grafana_slo_total_rate_5m{slo_uuid="<UUID>"}' \
   --from now-28d --to now --step 6h
 ```

--- a/claude-plugin/skills/synth-check-status/SKILL.md
+++ b/claude-plugin/skills/synth-check-status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: synth-check-status
 description: Shows Synthetic Monitoring check health - check inventory, per-check pass/fail status with success rates, and success-rate timelines as terminal graphs. Use when the user asks about Synthetic Monitoring check health, status, or trends. Trigger on phrases like "are my checks healthy", "check status", "synth check", "probe status", or when users mention specific check names or IDs. For investigating failing checks use synth-investigate-check. For creating or managing checks use synth-manage-checks.
-allowed-tools: [Bash]
+allowed-tools: Bash
 ---
 
 # Synthetic Monitoring Check Status

--- a/claude-plugin/skills/synth-check-status/SKILL.md
+++ b/claude-plugin/skills/synth-check-status/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: synth-check-status
-description: Use when the user asks about Synthetic Monitoring check health, status, or trends. Trigger on phrases like "are my checks healthy", "check status", "synth check", "probe status", or when users mention specific check names or IDs. For investigating failing checks use synth-investigate-check. For creating or managing checks use synth-manage-checks.
-allowed-tools: [gcx, Bash]
+description: Shows Synthetic Monitoring check health - check inventory, per-check pass/fail status with success rates, and success-rate timelines as terminal graphs. Use when the user asks about Synthetic Monitoring check health, status, or trends. Trigger on phrases like "are my checks healthy", "check status", "synth check", "probe status", or when users mention specific check names or IDs. For investigating failing checks use synth-investigate-check. For creating or managing checks use synth-manage-checks.
+allowed-tools: [Bash]
 ---
 
 # Synthetic Monitoring Check Status
 
-View check health, status, and timelines. Concise and direct — experienced operators need actionable status, not hand-holding.
+View check health, status, and timelines.
 
 ## Core Principles
 
@@ -25,11 +25,11 @@ Always start with the full check inventory:
 gcx synthetic-monitoring checks list
 ```
 
-Output columns: ID, JOB, TARGET, TYPE. Identify the check(s) the user is asking about.
+Output columns: NAME, JOB, TARGET, TYPE. The NAME suffix is the numeric check ID (e.g. `web-check-1001` is ID `1001`) - use that ID in the commands below. Identify the check(s) the user is asking about.
 
-If the user specifies a check name or target, filter after listing:
+If the user specifies a check name, filter with a job glob:
 ```bash
-gcx synthetic-monitoring checks list -o json | jq '.[] | select(.spec.job == "my-check")'
+gcx synthetic-monitoring checks list --job 'my-check*'
 ```
 
 ### Step 2: Show Status
@@ -44,12 +44,17 @@ For a specific check:
 gcx synthetic-monitoring checks status <ID>
 ```
 
-Output columns: ID, JOB, SUCCESS%, STATUS, PROBES_UP.
+Only failing checks:
+```bash
+gcx synthetic-monitoring checks status --status FAILING
+```
 
-**Status interpretation:**
-- `OK` — success rate >= 50%; check is healthy
-- `FAILING` — success rate < 50%; more than half of probes failing; route to synth-investigate-check for deeper analysis
-- `NODATA` — no Prometheus data; check may be disabled or datasource misconfigured
+Output columns: NAME, JOB, TARGET, SUCCESS, LATENCY, STATUS. Use `-o wide` for PROBES_UP/PROBES_TOTAL, or `-o json` for all fields.
+
+**Status interpretation** (threshold depends on the check's `alertSensitivity`: high = 95%, medium/default = 90%, low = 75%):
+- `OK` - success rate at or above the threshold; check is healthy
+- `FAILING` - success rate below the threshold; route to synth-investigate-check for deeper analysis
+- `NODATA` - no Prometheus data; check may be disabled or datasource misconfigured
 
 ### Step 3: Conditional Timeline
 
@@ -69,10 +74,8 @@ gcx synthetic-monitoring checks timeline <ID> --from <start> --to <end>
 
 Examples:
 ```bash
-gcx synthetic-monitoring checks timeline 42 --since 1h
 gcx synthetic-monitoring checks timeline 42 --since 6h
 gcx synthetic-monitoring checks timeline 42 --from now-24h --to now
-gcx synthetic-monitoring checks timeline 42 --from 2026-01-01T00:00:00Z --to 2026-01-02T00:00:00Z
 ```
 
 Note: `--since` and `--from`/`--to` are mutually exclusive. Use one or the other.
@@ -138,13 +141,13 @@ Possible causes:
 - Synthetic Monitoring datasource not configured
 - Metrics not yet available (newly created check)
 
-Verify: gcx synthetic-monitoring checks status <ID> -o json | jq '.spec.enabled'
+Verify: gcx synthetic-monitoring checks get <ID> -o json | jq '.spec.enabled'
 ```
 
 ## Error Handling
 
 - **`gcx synthetic-monitoring checks list` returns empty**: No checks configured in this context. Verify the gcx context with `gcx config view`.
-- **`gcx synthetic-monitoring checks status <ID>` fails with "not found"**: Confirm the ID from `gcx synthetic-monitoring checks list`. IDs are numeric.
+- **`gcx synthetic-monitoring checks status <ID>` fails with "not found"**: Confirm the ID from `gcx synthetic-monitoring checks list` (the numeric suffix of NAME).
 - **`gcx synthetic-monitoring checks timeline <ID>` fails**: Verify the ID exists and that the check has been running long enough to have data. New checks may show no timeline data.
 - **`--since` and `--from`/`--to` both provided**: These flags are mutually exclusive. Use one or the other.
 - **Timeline shows no data for the selected range**: Try a longer duration (e.g., `--since 24h` instead of `--since 1h`). The check may have been created recently.

--- a/claude-plugin/skills/synth-investigate-check/SKILL.md
+++ b/claude-plugin/skills/synth-investigate-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: synth-investigate-check
 description: Diagnoses why a Synthetic Monitoring check is failing - triages probe failures, classifies failure scope, runs per-probe breakdown, and identifies root cause. Use when the user wants to investigate a failing check. Trigger on phrases like "why is my check failing", "investigate synthetic check", "probe failures", "check is down". For check status overview use synth-check-status. For creating or managing checks use synth-manage-checks.
-allowed-tools: [Bash]
+allowed-tools: Bash
 ---
 
 # Synthetic Check Investigator

--- a/claude-plugin/skills/synth-investigate-check/SKILL.md
+++ b/claude-plugin/skills/synth-investigate-check/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: synth-investigate-check
-description: Use when the user wants to diagnose why a Synthetic Monitoring check is failing — triage probe failures, classify failure scope, run per-probe breakdown, and identify root cause. Trigger on phrases like "why is my check failing", "investigate synthetic check", "probe failures", "check is down". For check status overview use synth-check-status. For creating or managing checks use synth-manage-checks.
-allowed-tools: [gcx, Bash]
+description: Diagnoses why a Synthetic Monitoring check is failing - triages probe failures, classifies failure scope, runs per-probe breakdown, and identifies root cause. Use when the user wants to investigate a failing check. Trigger on phrases like "why is my check failing", "investigate synthetic check", "probe failures", "check is down". For check status overview use synth-check-status. For creating or managing checks use synth-manage-checks.
+allowed-tools: [Bash]
 ---
 
 # Synthetic Check Investigator
 
-Investigate Synthetic Monitoring check failures by triaging probe data, classifying failure scope, and identifying root cause. Experienced operators need actionable diagnosis, not hand-holding.
+Investigate Synthetic Monitoring check failures by triaging probe data, classifying failure scope, and identifying root cause.
 
 ## Core Principles
 
@@ -16,10 +16,6 @@ Investigate Synthetic Monitoring check failures by triaging probe data, classify
 4. Show timeline graphs for time-series data — they communicate trends faster than text
 5. Collect errors; report them at the end, not interleaved in workflow steps
 
-## Prerequisites
-
-gcx configured with an active context and appropriate permissions.
-
 ## Investigation Workflow
 
 ### Step 1: Get Check Status (with early exit)
@@ -28,12 +24,12 @@ gcx configured with an active context and appropriate permissions.
 gcx synthetic-monitoring checks status <ID>
 ```
 
-If the user provided a name instead of ID, list first:
+If the user provided a name instead of ID, list first with a job glob (the numeric ID is the NAME suffix, e.g. `web-check-1001` is ID `1001`):
 ```bash
-gcx synthetic-monitoring checks list -o json | jq -r '.[] | select(.job | test("<name>"; "i")) | [.id, .job, .target, .type] | @tsv'
+gcx synthetic-monitoring checks list --job '*<name>*'
 ```
 
-**Early exit — OK:** Check success rate >= 50% across all probes.
+**Early exit — OK:** Status command reports `OK` (success rate at or above the check's alertSensitivity threshold: high = 95%, medium/default = 90%, low = 75%).
 Report: "Check `<job>` is healthy. Success rate: <rate>%. <probe_count> probes up."
 Stop unless the user asks for more.
 
@@ -81,7 +77,7 @@ Get the probe list for geographic mapping:
 gcx synthetic-monitoring probes list -o json
 ```
 
-Cross-reference probe IDs from the check config against probe regions. Map failing probes to their regions.
+Cross-reference the probe names from the check config against each probe's `region` field. Map failing probes to their regions.
 
 **All probes failing:** Target/service issue — likely target down, SSL error, or DNS failure.
 
@@ -99,39 +95,25 @@ Resolve datasource UID if not already known:
 gcx datasources list --type prometheus
 ```
 
-Run per-probe success rate to pinpoint failing probes:
+Run per-probe success rate to pinpoint failing probes (use `-o json` for parsing, `-o graph` to show the user):
 ```bash
-gcx metrics query <datasource-uid> \
-  'avg by (probe) (probe_success{job="<job>",instance="<target>"})' \
-  --from now-1h --to now --step 1m -o json
-```
-
-Show as graph for the user:
-```bash
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   'avg by (probe) (probe_success{job="<job>",instance="<target>"})' \
   --from now-1h --to now --step 1m -o graph
 ```
 
 For HTTP checks, also run HTTP phase latency to locate where time is spent:
 ```bash
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   'avg by (phase) (probe_http_duration_seconds{job="<job>",instance="<target>"})' \
   --from now-1h --to now --step 1m -o graph
 ```
 
-For SSL/TLS failures or near-expiry concerns:
-```bash
-gcx metrics query <datasource-uid> \
-  '(probe_ssl_earliest_cert_expiry{job="<job>",instance="<target>"} - time()) / 86400' \
-  --from now-1h --to now --step 5m -o json
-```
-
-See `references/sm-promql-patterns.md` for full PromQL pattern library.
+For SSL/TLS cert expiry, DNS latency, per-probe error rates, and other patterns, see [sm-promql-patterns.md](references/sm-promql-patterns.md).
 
 ### Step 6: Classify Failure Mode
 
-Cross-reference signals against `references/failure-modes.md` to select the most likely failure mode:
+Cross-reference signals against [failure-modes.md](references/failure-modes.md) (full signal/cause/next-action table and decision tree) to select the most likely failure mode:
 
 1. All probes failing + HTTP non-2xx or connection refused → **Target down**
 2. Subset of probes failing → **Regional/CDN**
@@ -144,17 +126,7 @@ Cross-reference signals against `references/failure-modes.md` to select the most
 
 ### Step 7: Diagnosis and Next Actions
 
-Synthesize findings into an actionable report (see Output Format below).
-
-Next actions depend on failure mode:
-- **Target down**: Check service health, recent deployments, upstream dependencies
-- **Regional/CDN**: Check CDN config, BGP routes, regional incidents for affected regions
-- **SSL/TLS**: Renew cert if expiring; check intermediate chain; verify TLS config
-- **DNS resolution**: Check DNS provider status, record TTLs, CNAME chains
-- **Timeout**: Increase check timeout (must stay < frequency); investigate latency spikes
-- **Content/assertion**: Check if response body/status code changed due to a deployment
-- **Private probe infra**: Check private probe agent health and connectivity
-- **Rate limiting**: Reduce check frequency or add allowlist for SM probe IPs
+Synthesize findings into an actionable report (see Output Format below). Take next actions from the "Next Action" column of the failure mode's row in [failure-modes.md](references/failure-modes.md).
 
 If deeper investigation is needed (e.g., logs, infra repos), ask the user if they want to proceed.
 
@@ -210,6 +182,6 @@ Use minimal formatting. Avoid excessive bold text. Trust the user to prioritize.
 
 - `gcx synthetic-monitoring checks status` returns no rows: check ID may be wrong — list all checks and confirm
 - `gcx synthetic-monitoring probes list` fails: skip geographic mapping; classify probes by name where possible
-- `gcx datasources {kind} query` fails with datasource error: note it, skip PromQL steps, classify using timeline data only
+- `gcx metrics query` fails with datasource error: note it, skip PromQL steps, classify using timeline data only
 - Multiple checks match the search name: list all with IDs and targets, ask which to investigate
 - Timeline returns no data for the window: widen to `--from now-6h --to now` before concluding NODATA

--- a/claude-plugin/skills/synth-investigate-check/references/sm-promql-patterns.md
+++ b/claude-plugin/skills/synth-investigate-check/references/sm-promql-patterns.md
@@ -1,8 +1,17 @@
 # SM PromQL Patterns
 
+## Contents
+
+- [probe_success Rate Over Time](#probe_success-rate-over-time)
+- [HTTP Phase Latency](#http-phase-latency)
+- [SSL Certificate Expiry](#ssl-certificate-expiry)
+- [Per-Probe Error Rates](#per-probe-error-rates)
+- [Useful Filters](#useful-filters)
+- [Example gcx Commands](#example-gcx-commands)
+
 PromQL query patterns for Synthetic Monitoring metrics. Run via:
 ```bash
-gcx metrics query <datasource-uid> '<query>' --from <start> --to <end> --step <step>
+gcx metrics query -d <datasource-uid> '<query>' --from <start> --to <end> --step <step>
 ```
 
 Replace `<job>` with the check job name and `<instance>` with the check target (URL or hostname).
@@ -115,25 +124,25 @@ probe_success{job="<job>",instance="<target>",probe=~"<probe1>|<probe2>"}
 
 ---
 
-## Recommended Gcx Commands
+## Example gcx Commands
 
 Quick per-probe check (JSON for agent processing):
 ```bash
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   'avg by (probe) (probe_success{job="<job>",instance="<target>"})' \
   --from now-1h --to now --step 1m -o json
 ```
 
 Graph for user display:
 ```bash
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   'avg by (probe) (probe_success{job="<job>",instance="<target>"})' \
   --from now-1h --to now --step 1m -o graph
 ```
 
 Cert expiry check:
 ```bash
-gcx metrics query <datasource-uid> \
+gcx metrics query -d <datasource-uid> \
   '(probe_ssl_earliest_cert_expiry{job="<job>",instance="<target>"} - time()) / 86400' \
   --from now-5m --to now --step 1m -o json
 ```

--- a/claude-plugin/skills/synth-manage-checks/SKILL.md
+++ b/claude-plugin/skills/synth-manage-checks/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: synth-manage-checks
 description: Creates, updates, exports, and deletes Synthetic Monitoring checks from YAML definitions via gcx. Use when the user wants to create, update, pull, push, or delete Synthetic Monitoring checks. Trigger on phrases like "create a check", "add a synthetic check", "update check", "pull my SM checks", "push checks", "delete check", or when the user provides a target URL/hostname/domain for monitoring. For check status overview use synth-check-status. For investigating failing checks use synth-investigate-check.
-allowed-tools: [Bash, Read, Write, Edit]
+allowed-tools: Bash, Read, Write, Edit
 ---
 
 # Synthetic Monitoring Check Manager

--- a/claude-plugin/skills/synth-manage-checks/SKILL.md
+++ b/claude-plugin/skills/synth-manage-checks/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: synth-manage-checks
-description: Use when the user wants to create, update, pull, push, or delete Synthetic Monitoring checks. Trigger on phrases like "create a check", "add a synthetic check", "update check", "pull my SM checks", "push checks", "delete check", or when the user provides a target URL/hostname/domain for monitoring. For check status overview use synth-check-status. For investigating failing checks use synth-investigate-check.
-allowed-tools: [gcx, Bash, Read, Write, Edit]
+description: Creates, updates, exports, and deletes Synthetic Monitoring checks from YAML definitions via gcx. Use when the user wants to create, update, pull, push, or delete Synthetic Monitoring checks. Trigger on phrases like "create a check", "add a synthetic check", "update check", "pull my SM checks", "push checks", "delete check", or when the user provides a target URL/hostname/domain for monitoring. For check status overview use synth-check-status. For investigating failing checks use synth-investigate-check.
+allowed-tools: [Bash, Read, Write, Edit]
 ---
 
 # Synthetic Monitoring Check Manager
 
-Manage SM checks using gcx. Experienced operators — no hand-holding.
+Manage Synthetic Monitoring checks using gcx.
 
 ## Core Principles
 
 1. Use gcx commands; never call Grafana APIs directly (no curl, no HTTP calls)
 2. Trust the user's expertise — no explanations of what SM or gcx is
 3. Use `-o json` for agent processing; default table format for user display
-4. Always dry-run before pushing: `--dry-run` first, actual push only on success
+4. gcx validates specs client-side before calling the API (probe names, check type, target format) — no separate dry-run step is needed
 5. Probe names are case-sensitive — always copy-paste from `gcx synthetic-monitoring probes list`
 
 ## Workflow 1: Create New Check
 
 ### Step 1: Determine Check Type
 
-Use the decision table in `references/check-types.md`:
+Pick the type from the target format (full decision tree and per-type templates: [check-types.md](references/check-types.md)):
 
 | Target | Check Type |
 |--------|------------|
@@ -42,13 +42,13 @@ Recommend at least 3 geographically distributed probes. Copy names exactly as sh
 
 ### Step 3: Build YAML Definition
 
-Use the template from `references/check-types.md` for the chosen type. Scaffold the file locally:
+Use the template from [check-types.md](references/check-types.md) for the chosen type, filling the type-specific `settings` block. Common fields:
 
 ```yaml
 apiVersion: syntheticmonitoring.ext.grafana.app/v1alpha1
 kind: Check
 metadata:
-  name: <job-name>   # Non-numeric = create; numeric = update
+  name: <job-name>   # gcx rewrites this to <job>-<id> after create
 spec:
   job: <job-name>
   target: <target>
@@ -56,8 +56,10 @@ spec:
   timeout: 10000      # milliseconds; must be < frequency
   enabled: true
   labels:
-    environment: production
-    team: platform
+    - name: environment
+      value: production
+    - name: team
+      value: platform
   probes:
     - Atlanta
     - Frankfurt
@@ -81,6 +83,8 @@ Configuration guidance:
 gcx synthetic-monitoring checks create -f <file.yaml>
 ```
 
+For HTTP checks, `--validate-targets` pre-flights the target with a HEAD request (warning only). If client-side validation fails, fix the field named in the error and re-run.
+
 After creation, verify with:
 ```bash
 gcx synthetic-monitoring checks list
@@ -99,7 +103,7 @@ gcx synthetic-monitoring checks get <ID> -o yaml > check-<ID>.yaml
 
 ### Step 2: Edit and Update
 
-Edit the YAML file (the `metadata.name` will be the numeric ID). Modify only the fields that need changing.
+Edit the YAML file, keeping `metadata.name` unchanged (it is the `<job>-<id>` composite that targets the right check). Modify only the fields that need changing.
 
 ```bash
 # Update the check from file
@@ -108,7 +112,7 @@ gcx synthetic-monitoring checks update <ID> -f check-<ID>.yaml
 
 ## Workflow 3: GitOps Sync (Pull/Push)
 
-List all checks, export to files, edit in source control, then update to apply:
+When users say "pull" they mean export with `checks get -o yaml`; "push" means apply with `checks create`/`checks update -f`. Export to files, edit in source control, then update to apply:
 
 ```bash
 # List all checks and export each to YAML
@@ -133,7 +137,7 @@ gcx synthetic-monitoring checks list
 gcx synthetic-monitoring checks delete <ID>
 
 # Skip confirmation prompt
-gcx synthetic-monitoring checks delete <ID> -f
+gcx synthetic-monitoring checks delete <ID> --force
 
 # Delete multiple checks
 gcx synthetic-monitoring checks delete <ID1> <ID2> <ID3>
@@ -149,15 +153,15 @@ Check: <job-name>
 Target: <target>
 Type: <HTTP|Ping|DNS|TCP|Traceroute>
 Probes: <count> selected (<list>)
-Push: SUCCESS — ID: <assigned-id>
+Result: <created (id=<ID>) | updated>
 
 Verify status:
   gcx synthetic-monitoring checks status <ID>
 ```
 
-After pull:
+After export:
 ```
-Pulled <N> checks to <dir>/
+Exported <N> checks to <dir>/
 Files: <list of filenames>
 ```
 
@@ -170,8 +174,8 @@ Deleted check <ID> (<job-name> -> <target>)
 
 - **"probe not found"**: Probe names are case-sensitive. Run `gcx synthetic-monitoring probes list` and copy names exactly.
 - **"timeout must be less than frequency"**: Reduce `timeout` value or increase `frequency`.
-- **"invalid frequency"**: `frequency` must be between 10,000ms and 120,000ms (10s–2min).
-- **Dry-run fails with validation error**: Fix the YAML field indicated in the error before pushing.
-- **Push fails with "check already exists"**: The check job+target combination may already exist. Use `gcx synthetic-monitoring checks list` to find it and update instead of create.
+- **"invalid frequency"**: The allowed `frequency` range depends on check type (e.g. traceroute allows longer intervals); the API error states the valid range.
+- **"check validation failed"**: gcx validates the spec client-side before calling the API. Fix the YAML field indicated in the error and re-run.
+- **Create fails with "check already exists"**: The check job+target combination may already exist. Use `gcx synthetic-monitoring checks list` to find it and update instead of create.
 - **No probes available**: Run `gcx synthetic-monitoring probes list`; if empty, verify gcx context and SM API access.
 - **Complex check types (MultiHTTP, Browser, Scripted)**: Settings map is not fully documented. Pull an existing check of that type as a template: `gcx synthetic-monitoring checks get <ID> -o yaml`.

--- a/claude-plugin/skills/synth-manage-checks/references/check-types.md
+++ b/claude-plugin/skills/synth-manage-checks/references/check-types.md
@@ -1,5 +1,14 @@
 # Check Type Reference
 
+## Contents
+
+- [Decision Tree](#decision-tree)
+- [HTTP Check](#http-check)
+- [Ping Check](#ping-check)
+- [DNS Check](#dns-check)
+- [TCP Check](#tcp-check)
+- [Traceroute Check](#traceroute-check)
+
 ## Decision Tree
 
 ```
@@ -23,7 +32,7 @@ Tests URL availability, response codes, response time, and optional content matc
 apiVersion: syntheticmonitoring.ext.grafana.app/v1alpha1
 kind: Check
 metadata:
-  name: my-api-http         # non-numeric = create
+  name: my-api-http         # gcx rewrites this to <job>-<id> after create
 spec:
   job: my-api-http
   target: https://api.example.com/health


### PR DESCRIPTION
## Summary

Part of https://github.com/grafana/gcx-internal/issues/8

First step of skills evaluation is to perform this analysis of their contents, making sure they are all following best practices. Once they are all "the best version" of what they can be, we can cut/keep based on performance data or heuristic evaluation.

Review of all 22 bundled skills against [Anthropic's agent-skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices), with fixes applied. Part of the skills evaluation work in grafana/gcx-internal#8 (full findings written up there).

The dominant defect was factual drift from the real CLI surface, not prose style:

- **32+ invalid query invocations** across 5 skills used `gcx metrics query <uid> '<expr>'` - the UID would have been sent as the PromQL expression. All fixed to `-d <uid>`.
- **Synth family asserted CLI facts that don't exist**: an invented `--dry-run` flag, a `-f` shorthand (`--force` only), wrong table columns, a made-up 50% OK/FAILING threshold (actual: sensitivity-based 95/90/75%), a YAML labels template in map form where the API needs a `{name, value}` list, and jq pipelines written against the wrong JSON shape. Verified against provider source.
- **Broken workflows**: import-dashboards was missing its render step (`go run .`) between editing builders and pushing; scaffold-project used stale `gcx config set server` keys (now `grafana.server`/`grafana.token`); gcx-observability's Phase 5 pointed at the wrong sub-agent label.
- **Structure**: gcx-observability (553 lines) and debug-with-grafana (641 lines) exceeded the 500-line body limit - both split into overview + reference files. slo-investigate's PromQL reference was never linked from its SKILL.md so it could never be read. TOCs added to all >100-line references.
- **Descriptions**: about half stated only when to trigger, not what the skill does - all now lead with a third-person capability statement, preserving trigger phrases and sibling cross-routing.
- **Trimmed**: ~250 lines of generic LogQL/PromQL/bash tutorial content, stale version pins, roadmap-speculation sections, and a bogus `gcx` entry in `allowed-tools` frontmatter (9 skills).

gcx-demo passed review clean and is untouched.

No skill directories or `name:` fields changed, so `gcx skills install/update` behaviour is unaffected. `go test ./internal/skills/... ./cmd/gcx/skills/...` passes.

## How to review this PR

It's one commit across 21 skills; reviewing per skill family is easiest. The riskiest changes are the command-syntax corrections (synth + query invocations) - each was verified against `docs/reference/cli/` or provider source, but a second pair of eyes on those is most valuable. The description rewrites are worth a skim for triggering regressions.


