### PR TITLE
feat(skills): add drift check for gcx invocations in bundled skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Two tiers: **K8s resource tier** (dashboards, folders via `/apis`) and **Cloud p
 - **Format-agnostic data fetching**: Commands fetch all data regardless of `--output` format; codecs control display, not data acquisition (see Pattern 13 in `docs/architecture/patterns.md`)
 - **PromQL via promql-builder**: Use `github.com/grafana/promql-builder/go/promql` for PromQL construction, not string formatting (see Pattern 14 in `docs/architecture/patterns.md`)
 - **Datasource query reuse**: Datasource clients that call Grafana's unified datasource query API (`/apis/query.grafana.app/.../query`, with `/api/ds/query` fallback) should reuse `internal/query/grafanaquery` for HTTP transport and `internal/query/dataframe` for Grafana data frame wire types. Do not duplicate POST/fallback/response-limit logic or `GrafanaQueryResponse`/`DataFrame` structs in each datasource package.
-- **Portable agent skills live under `claude-plugin/skills/`**: Treat that tree as the canonical portable Agent Skills bundle. Do not add distributable gcx skills under repo-local `.agents/skills/` — that changes repo-context discovery semantics for tools that scan `.agents`.
+- **Portable agent skills live under `claude-plugin/skills/`**: Treat that tree as the canonical portable Agent Skills bundle. Do not add distributable gcx skills under repo-local `.agents/skills/` — that changes repo-context discovery semantics for tools that scan `.agents`. `gcx` invocations in skill markdown are validated against the real command tree by `TestSkillsGcxInvocationsMatchCommandTree` (`cmd/gcx/root/skillsdrift_test.go`), which fails CI on unknown commands or flags.
 
 ## Essential Commands
 

--- a/claude-plugin/skills/gcx-observability/references/phases-4-7-alerting.md
+++ b/claude-plugin/skills/gcx-observability/references/phases-4-7-alerting.md
@@ -34,8 +34,8 @@ For each journey `J`, launch an agent that:
 - Creates the SLO: `gcx slo definitions push slo-J.yaml --dry-run` then `gcx slo definitions push slo-J.yaml`. List SLOs to confirm.
 - Creates burn-rate alert rules as K8s resources. Get an example: `gcx resources examples AlertRule`. Build 1h/6h/24h burn-rate rules and push them:
   ```bash
-  gcx resources push -f alert-rules-J.yaml --dry-run
-  gcx resources push -f alert-rules-J.yaml
+  gcx resources push -p alert-rules-J.yaml --dry-run
+  gcx resources push -p alert-rules-J.yaml
   ```
   List rules to confirm: `gcx alert rules list`.
 

--- a/claude-plugin/skills/gcx-observability/references/phases-8-11-finalize.md
+++ b/claude-plugin/skills/gcx-observability/references/phases-8-11-finalize.md
@@ -30,8 +30,8 @@ gcx resources examples Folder
 ```
 Write folder YAML, then push:
 ```bash
-gcx resources push -f folder.yaml --dry-run
-gcx resources push -f folder.yaml
+gcx resources push -p folder.yaml --dry-run
+gcx resources push -p folder.yaml
 ```
 List folders to confirm and capture the UID.
 
@@ -48,7 +48,7 @@ Each agent:
 1. Gets a dashboard example: `gcx resources examples Dashboard`
 2. Customizes the dashboard JSON with appropriate panels and queries
 3. Writes `dashboard-<name>.yaml`
-4. Pushes: `gcx resources push -f dashboard-<name>.yaml --dry-run` then `gcx resources push -f dashboard-<name>.yaml`
+4. Pushes: `gcx resources push -p dashboard-<name>.yaml --dry-run` then `gcx resources push -p dashboard-<name>.yaml`
 5. Verifies: `gcx resources get dashboards` filtered by folder UID
 
 Launch all dashboard agents simultaneously. Mark task completed.

--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -152,7 +152,7 @@ Manage datasource instances with Kubernetes-style manifests (file or stdin):
 - `create -f FILE` / `update UID -f FILE` — apply a manifest; `--dry-run` previews
   a secret-redacted diff. Secrets go in the top-level `secure` block via
   `{create: <value>}`, `{fromEnv: <VAR>}`, or `{fromFile: <path>}` — never on argv.
-- `delete UID...` — prompts unless `--force`/`--yes` (auto-approved in agent mode);
+- `delete UID...` — prompts unless `--force` (auto-approved in agent mode);
   batch-safe with partial-failure exit code 4.
 - `health [UID]` — exit 0 healthy, 4 unhealthy (resource failure), 1/2/3 command failure.
 - `schemas get --type <plugin>` — plugin configuration schema (when the server

--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -61,7 +61,7 @@ right group:
 | Fleet pipelines, collectors | `fleet` | `gcx fleet pipelines list` |
 | Knowledge Graph (Asserts) | `kg` | `gcx kg entities list` |
 | Frontend Observability | `frontend` | `gcx frontend apps list` |
-| App Observability | `appo11y` | `gcx appo11y overrides list` |
+| App Observability | `appo11y` | `gcx appo11y overrides get` |
 
 If no command exists for the requested operation, say so and propose the nearest
 supported flow.
@@ -152,7 +152,7 @@ Manage datasource instances with Kubernetes-style manifests (file or stdin):
 - `create -f FILE` / `update UID -f FILE` — apply a manifest; `--dry-run` previews
   a secret-redacted diff. Secrets go in the top-level `secure` block via
   `{create: <value>}`, `{fromEnv: <VAR>}`, or `{fromFile: <path>}` — never on argv.
-- `delete UID...` — prompts unless `--force` (auto-approved in agent mode);
+- `delete UID...` — prompts unless `--force`/`--yes` (auto-approved in agent mode);
   batch-safe with partial-failure exit code 4.
 - `health [UID]` — exit 0 healthy, 4 unhealthy (resource failure), 1/2/3 command failure.
 - `schemas get --type <plugin>` — plugin configuration schema (when the server

--- a/claude-plugin/skills/manage-dashboards/SKILL.md
+++ b/claude-plugin/skills/manage-dashboards/SKILL.md
@@ -80,7 +80,7 @@ Use JSON/YAML for programmatic work and table/wide output for human summaries.
 | Create from finished file | `gcx dashboards create -f <dashboard.yaml>` |
 | Update from finished file | `gcx dashboards update <dashboard-name> -f <dashboard.yaml>` |
 | Delete with confirmation | `gcx dashboards delete <dashboard-name>` |
-| Delete non-interactively | `gcx dashboards delete <dashboard-name> --yes` |
+| Delete non-interactively | `gcx dashboards delete <dashboard-name> --force` |
 | Version history | `gcx dashboards versions list <dashboard-name>` |
 | Restore version | `gcx dashboards versions restore <dashboard-name> <version> --message "<why>"` |
 | Pull dashboards/folders | `gcx resources pull dashboards folders -p <dir> -o yaml` |

--- a/cmd/gcx/root/skillsdrift_extract_test.go
+++ b/cmd/gcx/root/skillsdrift_extract_test.go
@@ -1,0 +1,95 @@
+package root_test
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractInvocations(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []invocation
+	}{
+		{
+			name:    "simple bash fence",
+			content: "```bash\ngcx slo definitions list\n```\n",
+			want:    []invocation{{line: 2, args: []string{"slo", "definitions", "list"}}},
+		},
+		{
+			name:    "bare fence",
+			content: "```\ngcx providers\n```\n",
+			want:    []invocation{{line: 2, args: []string{"providers"}}},
+		},
+		{
+			name:    "non-shell fence skipped",
+			content: "```go\ngcx not a command\n```\n```promql\ngcx neither\n```\n",
+			want:    nil,
+		},
+		{
+			name:    "outside fences skipped",
+			content: "run `gcx slo definitions list` to see them\n",
+			want:    nil,
+		},
+		{
+			name:    "comment lines skipped",
+			content: "```bash\n# gcx old command\ngcx synth checks list  # trailing comment\n```\n",
+			want:    []invocation{{line: 3, args: []string{"synth", "checks", "list"}}},
+		},
+		{
+			name:    "backslash continuation",
+			content: "```bash\ngcx metrics query -d <uid> \\\n  'up{job=\"x\"}' \\\n  --from 1h\n```\n",
+			want:    []invocation{{line: 2, args: []string{"metrics", "query", "-d", "<uid>", `up{job="x"}`, "--from", "1h"}}},
+		},
+		{
+			name:    "env prefix and pipe",
+			content: "```bash\nGCX_AGENT_MODE=true gcx dashboards list -o json | jq '.[]'\n```\n",
+			want:    []invocation{{line: 2, args: []string{"dashboards", "list", "-o", "json"}}},
+		},
+		{
+			name:    "command substitution in assignment",
+			content: "```bash\nUID=$(gcx datasources list -t prometheus -o json 2>/dev/null | jq -r '.uid')\n```\n",
+			want:    []invocation{{line: 2, args: []string{"datasources", "list", "-t", "prometheus", "-o", "json"}}},
+		},
+		{
+			name:    "nested substitution as argument",
+			content: "```bash\ngcx metrics query -d $(gcx datasources list -o json) 'up'\n```\n",
+			want: []invocation{
+				{line: 2, args: []string{"datasources", "list", "-o", "json"}},
+				{line: 2, args: []string{"metrics", "query", "-d", "$(...)", "up"}},
+			},
+		},
+		{
+			name:    "chained with && and semicolon",
+			content: "```bash\ngcx config check && gcx providers; gcx slo definitions list\n```\n",
+			want: []invocation{
+				{line: 2, args: []string{"config", "check"}},
+				{line: 2, args: []string{"providers"}},
+				{line: 2, args: []string{"slo", "definitions", "list"}},
+			},
+		},
+		{
+			name:    "placeholder not read as redirect",
+			content: "```bash\ngcx resources get <kind> <name|uuid> -o yaml > out.yaml\n```\n",
+			want:    []invocation{{line: 2, args: []string{"resources", "get", "<kind>", "<name|uuid>", "-o", "yaml"}}},
+		},
+		{
+			name:    "loop keyword stripped",
+			content: "```bash\nfor id in 1 2; do gcx synth checks get $id; done\n```\n",
+			want:    []invocation{{line: 2, args: []string{"synth", "checks", "get", "$id"}}},
+		},
+		{
+			name:    "double quoted argument kept whole",
+			content: "```bash\ngcx logs query -d <uid> \"{job=\\\"app\\\"} |= `error`\"\n```\n",
+			want:    []invocation{{line: 2, args: []string{"logs", "query", "-d", "<uid>", "{job=\"app\"} |= `error`"}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractInvocations(tt.content)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractInvocations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/gcx/root/skillsdrift_extract_test.go
+++ b/cmd/gcx/root/skillsdrift_extract_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 )
 
+// TestExtractInvocations pins the extraction behaviour of the skills drift
+// check: which parts of a skill markdown document count as gcx invocations
+// (shell fences, inline code spans) and how shell syntax within them is
+// tokenized (continuations, pipes, substitutions, quoting, placeholders).
+// When TestSkillsGcxInvocationsMatchCommandTree misbehaves, these cases
+// separate extractor bugs from genuine command-tree drift.
 func TestExtractInvocations(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/gcx/root/skillsdrift_extract_test.go
+++ b/cmd/gcx/root/skillsdrift_extract_test.go
@@ -27,8 +27,41 @@ func TestExtractInvocations(t *testing.T) {
 			want:    nil,
 		},
 		{
-			name:    "outside fences skipped",
+			name:    "inline span in prose extracted",
 			content: "run `gcx slo definitions list` to see them\n",
+			want:    []invocation{{line: 1, args: []string{"slo", "definitions", "list"}}},
+		},
+		{
+			name:    "inline span in table cell",
+			content: "| delete | `gcx dashboards delete <name> --force` | notes |\n",
+			want:    []invocation{{line: 1, args: []string{"dashboards", "delete", "<name>", "--force"}}},
+		},
+		{
+			name:    "inline span with placeholder",
+			content: "fetch it with `gcx slo definitions get <uid>` first\n",
+			want:    []invocation{{line: 1, args: []string{"slo", "definitions", "get", "<uid>"}}},
+		},
+		{
+			name:    "non-gcx inline span ignored",
+			content: "use `kubectl get pods` instead\n",
+			want:    nil,
+		},
+		{
+			name:    "fragment inline spans ignored",
+			content: "pass `--force` to `resources delete`, or just `gcx` alone\n",
+			want:    nil,
+		},
+		{
+			name:    "double-backtick span and second span",
+			content: "``gcx providers`` and `gcx config check`\n",
+			want: []invocation{
+				{line: 1, args: []string{"providers"}},
+				{line: 1, args: []string{"config", "check"}},
+			},
+		},
+		{
+			name:    "inline span inside non-shell fence not scanned",
+			content: "```go\n// see `gcx providers` for details\n```\n",
 			want:    nil,
 		},
 		{

--- a/cmd/gcx/root/skillsdrift_test.go
+++ b/cmd/gcx/root/skillsdrift_test.go
@@ -18,24 +18,6 @@ type driftAllowance struct {
 	contains string
 }
 
-// knownSkillDrift lists gcx invocations in the bundled skills that are known
-// to be wrong on main and are being fixed in PR #936; delete entries as the
-// fixes merge. Each entry suppresses failures in one file whose message
-// contains the given substring.
-func knownSkillDrift() []driftAllowance {
-	return []driftAllowance{
-		{"diagnose-entity-graph/SKILL.md", "unknown command `gcx kg health`"},
-		{"diagnose-entity-graph/SKILL.md", "unknown command `gcx kg cypher`"},
-		// push takes -p/--path, not -f
-		{"gcx-observability/SKILL.md", "unknown flag -f on `gcx resources push`"},
-		{"manage-dashboards/references/resource-model.md", "unknown flag --all-versions on `gcx resources pull`"},
-		// the acknowledge confirmation flag is --force, not --yes
-		{"oncall-triage/SKILL.md", "unknown flag --yes on `gcx irm oncall alert-groups acknowledge`"},
-		// overrides is a singleton resource: the verbs are get/update, not list
-		{"gcx/SKILL.md", "unknown command `gcx appo11y overrides list`"},
-	}
-}
-
 // intentionalReferences lists mentions of removed gcx commands that skills
 // reference deliberately as historical context. These are permanent
 // allowances, not drift.
@@ -158,11 +140,9 @@ func TestValidateInvocation(t *testing.T) {
 }
 
 func allowedDrift(file, msg string) bool {
-	for _, list := range [][]driftAllowance{knownSkillDrift(), intentionalReferences()} {
-		for _, k := range list {
-			if k.file == file && strings.Contains(msg, k.contains) {
-				return true
-			}
+	for _, k := range intentionalReferences() {
+		if k.file == file && strings.Contains(msg, k.contains) {
+			return true
 		}
 	}
 	return false

--- a/cmd/gcx/root/skillsdrift_test.go
+++ b/cmd/gcx/root/skillsdrift_test.go
@@ -79,6 +79,11 @@ func TestSkillsGcxInvocationsMatchCommandTree(t *testing.T) {
 	t.Logf("validated %d gcx invocations from bundled skills", total)
 }
 
+// TestValidateInvocation pins the validation behaviour of the skills drift
+// check against the real command tree: alias resolution, flags written before
+// their subcommand (resolved by cobra's Find, not the token position),
+// placeholders in command position, and the exact "unknown command"/"unknown
+// flag" message formats that the drift test and its allowances match on.
 func TestValidateInvocation(t *testing.T) {
 	rootCmd := buildRootCmd()
 	rootCmd.InitDefaultHelpCmd()

--- a/cmd/gcx/root/skillsdrift_test.go
+++ b/cmd/gcx/root/skillsdrift_test.go
@@ -421,47 +421,29 @@ func isFlagToken(tok string) bool {
 // against the real command tree and checks that every flag used exists on the
 // resolved command (including persistent flags inherited from parents).
 //
-// Like cobra, it resolves the command path first, skipping over flag tokens,
-// and only then parses flags against the resolved leaf - so a flag may
-// legally appear before the subcommand it belongs to (e.g. `gcx --config x
-// resources get`, where --config lives on the resources subtree).
+// Resolution is cobra's own Find, which skips flag tokens the way execution
+// would - so a flag may legally appear before the subcommand it belongs to
+// (e.g. `gcx --config x resources get`, where --config lives on the resources
+// subtree).
 func validateInvocation(rootCmd *cobra.Command, args []string) error {
-	// pass 1: resolve the command path, skipping flag tokens
-	cmd := rootCmd
-	var pathTokens []string
-	descending := true
-	for i := 0; i < len(args); i++ {
-		tok := args[i]
-		if tok == "--" {
-			break
+	// Find's own error only covers root-level unknowns (legacyArgs); the
+	// post-check below reports those and deeper ones uniformly.
+	cmd, remaining, _ := rootCmd.Find(args)
+
+	// Find stops descending at the first token that is not a subcommand;
+	// that token is the first positional of the remaining args.
+	if tok := firstPositional(cmd, remaining); tok != "" {
+		if isPlaceholder(tok) {
+			// placeholder in command position: the rest cannot be resolved
+			return nil
 		}
-		if isFlagToken(tok) {
-			if flagConsumesValue(cmd, tok) {
-				i++
-			}
-			continue
+		if !cmd.Runnable() && cmd.HasSubCommands() {
+			return fmt.Errorf("unknown command `gcx %s`", strings.Join(append(pathOf(cmd), tok), " "))
 		}
-		if !descending {
-			continue
-		}
-		child := findChild(cmd, tok)
-		if child == nil {
-			if isPlaceholder(tok) {
-				// placeholder in command position: the rest cannot be resolved
-				return nil
-			}
-			if !cmd.Runnable() && cmd.HasSubCommands() {
-				return fmt.Errorf("unknown command `gcx %s`", strings.Join(append(pathTokens, tok), " "))
-			}
-			descending = false // positional argument of a runnable command
-			continue
-		}
-		cmd = child
-		pathTokens = append(pathTokens, tok)
 	}
 	cmdPath := "gcx"
-	if len(pathTokens) > 0 {
-		cmdPath += " " + strings.Join(pathTokens, " ")
+	if p := pathOf(cmd); len(p) > 0 {
+		cmdPath += " " + strings.Join(p, " ")
 	}
 
 	// pass 2: validate every flag against the resolved leaf
@@ -478,7 +460,7 @@ func validateInvocation(rootCmd *cobra.Command, args []string) error {
 			if long == "help" || long == "version" {
 				continue
 			}
-			f := lookupFlag(cmd, long)
+			f := cmd.Flag(long)
 			if f == nil {
 				return fmt.Errorf("unknown flag %s on `%s`", name, cmdPath)
 			}
@@ -494,7 +476,7 @@ func validateInvocation(rootCmd *cobra.Command, args []string) error {
 			if s == "h" {
 				continue
 			}
-			f := lookupShorthand(cmd, s)
+			f := shorthand(cmd, s)
 			if f == nil {
 				return fmt.Errorf("unknown flag -%s on `%s`", s, cmdPath)
 			}
@@ -511,64 +493,53 @@ func validateInvocation(rootCmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// flagConsumesValue reports whether a flag token eats the next token during
-// path resolution. Mirrors cobra's stripFlags: a space-separated flag not yet
-// known at the current node is assumed to consume a value, because its
-// definition may live on a leaf that is still being resolved.
-func flagConsumesValue(cmd *cobra.Command, tok string) bool {
-	name, _, hasValue := strings.Cut(tok, "=")
-	if hasValue {
-		return false
-	}
-	if long, isLong := strings.CutPrefix(name, "--"); isLong {
-		if long == "help" || long == "version" {
-			return false
+// firstPositional returns the first non-flag token in remaining, skipping
+// flag values: a known bool-like flag consumes nothing, while known value
+// flags and unknown space-separated flags consume the next token, mirroring
+// the stripFlags heuristic cobra's Find used to produce remaining.
+func firstPositional(cmd *cobra.Command, remaining []string) string {
+	for i := 0; i < len(remaining); i++ {
+		tok := remaining[i]
+		if tok == "--" {
+			return ""
 		}
-		if f := lookupFlag(cmd, long); f != nil {
-			return f.NoOptDefVal == ""
+		if !isFlagToken(tok) {
+			return tok
 		}
-		return true
+		name, _, hasValue := strings.Cut(tok, "=")
+		if hasValue {
+			continue
+		}
+		if long, isLong := strings.CutPrefix(name, "--"); isLong {
+			if f := cmd.Flag(long); f != nil && f.NoOptDefVal != "" {
+				continue
+			}
+			i++
+			continue
+		}
+		// cobra only consumes a value for single-letter shorthands
+		if short := name[1:]; len(short) == 1 {
+			if f := shorthand(cmd, short); f != nil && f.NoOptDefVal != "" {
+				continue
+			}
+			i++
+		}
 	}
-	short := name[1:]
-	// cobra only consumes a value for single-letter shorthands
-	if len(short) != 1 || short == "h" {
-		return false
-	}
-	if f := lookupShorthand(cmd, short); f != nil {
-		return f.NoOptDefVal == ""
-	}
-	return true
+	return ""
 }
 
-func findChild(cmd *cobra.Command, name string) *cobra.Command {
-	for _, c := range cmd.Commands() {
-		if c.Name() == name || c.HasAlias(name) {
-			return c
-		}
+// pathOf returns the command path below the root.
+func pathOf(cmd *cobra.Command) []string {
+	var names []string
+	for c := cmd; c.HasParent(); c = c.Parent() {
+		names = append([]string{c.Name()}, names...)
 	}
-	return nil
+	return names
 }
 
-func lookupFlag(cmd *cobra.Command, name string) *pflag.Flag {
-	if f := cmd.Flags().Lookup(name); f != nil {
-		return f
-	}
-	for c := cmd; c != nil; c = c.Parent() {
-		if f := c.PersistentFlags().Lookup(name); f != nil {
-			return f
-		}
-	}
-	return nil
-}
-
-func lookupShorthand(cmd *cobra.Command, s string) *pflag.Flag {
+func shorthand(cmd *cobra.Command, s string) *pflag.Flag {
 	if f := cmd.Flags().ShorthandLookup(s); f != nil {
 		return f
 	}
-	for c := cmd; c != nil; c = c.Parent() {
-		if f := c.PersistentFlags().ShorthandLookup(s); f != nil {
-			return f
-		}
-	}
-	return nil
+	return cmd.InheritedFlags().ShorthandLookup(s)
 }

--- a/cmd/gcx/root/skillsdrift_test.go
+++ b/cmd/gcx/root/skillsdrift_test.go
@@ -19,9 +19,9 @@ type driftAllowance struct {
 }
 
 // knownSkillDrift lists gcx invocations in the bundled skills that are known
-// to be wrong on main. All entries are already fixed on the PR #936 branch;
-// delete the whole list when #936 merges. Each entry suppresses failures in
-// one file whose message contains the given substring.
+// to be wrong on main and are being fixed in PR #936; delete entries as the
+// fixes merge. Each entry suppresses failures in one file whose message
+// contains the given substring.
 func knownSkillDrift() []driftAllowance {
 	return []driftAllowance{
 		{"diagnose-entity-graph/SKILL.md", "unknown command `gcx kg health`"},
@@ -31,6 +31,19 @@ func knownSkillDrift() []driftAllowance {
 		{"manage-dashboards/references/resource-model.md", "unknown flag --all-versions on `gcx resources pull`"},
 		// the acknowledge confirmation flag is --force, not --yes
 		{"oncall-triage/SKILL.md", "unknown flag --yes on `gcx irm oncall alert-groups acknowledge`"},
+		// overrides is a singleton resource: the verbs are get/update, not list
+		{"gcx/SKILL.md", "unknown command `gcx appo11y overrides list`"},
+	}
+}
+
+// intentionalReferences lists mentions of removed gcx commands that skills
+// reference deliberately as historical context. These are permanent
+// allowances, not drift.
+func intentionalReferences() []driftAllowance {
+	return []driftAllowance{
+		// documents the removed `irm oncall alerts` commands and points
+		// readers at `alert-groups list-alerts` instead
+		{"oncall-triage/SKILL.md", "unknown command `gcx irm oncall alerts`"},
 	}
 }
 
@@ -75,8 +88,11 @@ func TestSkillsGcxInvocationsMatchCommandTree(t *testing.T) {
 	}
 
 	// Guard against the extractor silently matching nothing after a refactor.
-	if total < 100 {
-		t.Fatalf("extracted only %d gcx invocations from bundled skills, expected hundreds; extractor is likely broken", total)
+	// The bundle currently yields ~1000 invocations (~700 from fences, ~330
+	// from inline spans); 500 catches a broken fence scan or total collapse
+	// while leaving room for skills to shrink.
+	if total < 500 {
+		t.Fatalf("extracted only %d gcx invocations from bundled skills, expected around a thousand; extractor is likely broken", total)
 	}
 	t.Logf("validated %d gcx invocations from bundled skills", total)
 }
@@ -142,9 +158,11 @@ func TestValidateInvocation(t *testing.T) {
 }
 
 func allowedDrift(file, msg string) bool {
-	for _, k := range knownSkillDrift() {
-		if k.file == file && strings.Contains(msg, k.contains) {
-			return true
+	for _, list := range [][]driftAllowance{knownSkillDrift(), intentionalReferences()} {
+		for _, k := range list {
+			if k.file == file && strings.Contains(msg, k.contains) {
+				return true
+			}
 		}
 	}
 	return false
@@ -172,7 +190,8 @@ func isShellKeyword(tok string) bool {
 }
 
 // extractInvocations returns every gcx invocation found in shell-flavoured
-// (bash, sh, shell, or bare) fenced code blocks of a markdown document.
+// (bash, sh, shell, or bare) fenced code blocks of a markdown document, plus
+// invocations in inline code spans of prose and tables outside fences.
 func extractInvocations(content string) []invocation {
 	lines := strings.Split(content, "\n")
 	var invs []invocation
@@ -189,7 +208,15 @@ func extractInvocations(content string) []invocation {
 			shellFence = lang == "" || lang == "bash" || lang == "sh" || lang == "shell"
 			continue
 		}
-		if !inFence || !shellFence {
+		if !inFence {
+			for _, cmd := range inlineGcxCommands(lines[i]) {
+				if args, ok := gcxArgs(cmd); ok {
+					invs = append(invs, invocation{line: i + 1, args: args})
+				}
+			}
+			continue
+		}
+		if !shellFence {
 			continue
 		}
 		start := i
@@ -206,6 +233,37 @@ func extractInvocations(content string) []invocation {
 		}
 	}
 	return invs
+}
+
+// inlineGcxCommands returns the simple commands found in backtick code spans
+// of a prose or table line. A span opens and closes with equal-length backtick
+// runs, so double-backtick spans quoting text with backticks are matched too.
+// Only spans starting with "gcx " are treated as invocations; anything else
+// (fragments like `--force` or `resources delete`) is a mention, not a
+// runnable command.
+func inlineGcxCommands(line string) [][]string {
+	var cmds [][]string
+	for i := 0; i < len(line); {
+		if line[i] != '`' {
+			i++
+			continue
+		}
+		open := i
+		for i < len(line) && line[i] == '`' {
+			i++
+		}
+		delim := line[open:i]
+		end := strings.Index(line[i:], delim)
+		if end < 0 {
+			break
+		}
+		content := strings.TrimSpace(line[i : i+end])
+		i += end + len(delim)
+		if strings.HasPrefix(content, "gcx ") {
+			cmds = append(cmds, parseCommands(content)...)
+		}
+	}
+	return cmds
 }
 
 // gcxArgs strips env-var assignment prefixes and shell keywords and reports

--- a/cmd/gcx/root/skillsdrift_test.go
+++ b/cmd/gcx/root/skillsdrift_test.go
@@ -13,21 +13,25 @@ import (
 	"github.com/spf13/pflag"
 )
 
+type driftAllowance struct {
+	file     string
+	contains string
+}
+
 // knownSkillDrift lists gcx invocations in the bundled skills that are known
 // to be wrong on main. All entries are already fixed on the PR #936 branch;
 // delete the whole list when #936 merges. Each entry suppresses failures in
 // one file whose message contains the given substring.
-var knownSkillDrift = []struct {
-	file     string
-	contains string
-}{
-	{"diagnose-entity-graph/SKILL.md", "unknown command `gcx kg health`"},
-	{"diagnose-entity-graph/SKILL.md", "unknown command `gcx kg cypher`"},
-	// push takes -p/--path, not -f
-	{"gcx-observability/SKILL.md", "unknown flag -f on `gcx resources push`"},
-	{"manage-dashboards/references/resource-model.md", "unknown flag --all-versions on `gcx resources pull`"},
-	// the acknowledge confirmation flag is --force, not --yes
-	{"oncall-triage/SKILL.md", "unknown flag --yes on `gcx irm oncall alert-groups acknowledge`"},
+func knownSkillDrift() []driftAllowance {
+	return []driftAllowance{
+		{"diagnose-entity-graph/SKILL.md", "unknown command `gcx kg health`"},
+		{"diagnose-entity-graph/SKILL.md", "unknown command `gcx kg cypher`"},
+		// push takes -p/--path, not -f
+		{"gcx-observability/SKILL.md", "unknown flag -f on `gcx resources push`"},
+		{"manage-dashboards/references/resource-model.md", "unknown flag --all-versions on `gcx resources pull`"},
+		// the acknowledge confirmation flag is --force, not --yes
+		{"oncall-triage/SKILL.md", "unknown flag --yes on `gcx irm oncall alert-groups acknowledge`"},
+	}
 }
 
 // TestSkillsGcxInvocationsMatchCommandTree extracts every gcx invocation from
@@ -138,7 +142,7 @@ func TestValidateInvocation(t *testing.T) {
 }
 
 func allowedDrift(file, msg string) bool {
-	for _, k := range knownSkillDrift {
+	for _, k := range knownSkillDrift() {
 		if k.file == file && strings.Contains(msg, k.contains) {
 			return true
 		}
@@ -157,9 +161,15 @@ func (inv invocation) String() string {
 
 var envAssignRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
 
-// shellKeywords are leading words stripped so invocations inside loops and
-// conditionals (e.g. `do gcx ...`) are still recognised.
-var shellKeywords = map[string]bool{"do": true, "then": true, "else": true, "time": true, "exec": true}
+// isShellKeyword reports leading words stripped so invocations inside loops
+// and conditionals (e.g. `do gcx ...`) are still recognised.
+func isShellKeyword(tok string) bool {
+	switch tok {
+	case "do", "then", "else", "time", "exec":
+		return true
+	}
+	return false
+}
 
 // extractInvocations returns every gcx invocation found in shell-flavoured
 // (bash, sh, shell, or bare) fenced code blocks of a markdown document.
@@ -201,7 +211,7 @@ func extractInvocations(content string) []invocation {
 // gcxArgs strips env-var assignment prefixes and shell keywords and reports
 // whether the remaining simple command is a gcx invocation.
 func gcxArgs(tokens []string) ([]string, bool) {
-	for len(tokens) > 0 && (envAssignRe.MatchString(tokens[0]) || shellKeywords[tokens[0]]) {
+	for len(tokens) > 0 && (envAssignRe.MatchString(tokens[0]) || isShellKeyword(tokens[0])) {
 		tokens = tokens[1:]
 	}
 	if len(tokens) == 0 || tokens[0] != "gcx" {
@@ -244,36 +254,13 @@ func parseCommands(line string) [][]string {
 		c := line[i]
 		switch {
 		case c == '\'':
-			end := strings.IndexByte(line[i+1:], '\'')
-			if end < 0 {
-				word.WriteString(line[i+1:])
-				inWord = true
-				i = len(line)
-				break
-			}
-			word.WriteString(line[i+1 : i+1+end])
+			i = scanSingleQuoted(line, i+1, &word)
 			inWord = true
-			i += end + 2
 		case c == '"':
-			i++
-			for i < len(line) && line[i] != '"' {
-				if line[i] == '\\' && i+1 < len(line) {
-					word.WriteByte(line[i+1])
-					i += 2
-					continue
-				}
-				if line[i] == '$' && i+1 < len(line) && line[i+1] == '(' {
-					inner, next := captureParen(line, i+2)
-					cmds = append(cmds, parseCommands(inner)...)
-					word.WriteString("$(...)")
-					i = next
-					continue
-				}
-				word.WriteByte(line[i])
-				i++
-			}
+			var nested [][]string
+			nested, i = scanDoubleQuoted(line, i+1, &word)
+			cmds = append(cmds, nested...)
 			inWord = true
-			i++
 		case c == '$' && i+1 < len(line) && line[i+1] == '(':
 			inner, next := captureParen(line, i+2)
 			cmds = append(cmds, parseCommands(inner)...)
@@ -328,6 +315,44 @@ func parseCommands(line string) [][]string {
 	}
 	flushCmd()
 	return cmds
+}
+
+// scanSingleQuoted consumes a single-quoted section starting just after the
+// opening quote, appending its content to word; it returns the index just
+// past the closing quote.
+func scanSingleQuoted(line string, i int, word *strings.Builder) int {
+	end := strings.IndexByte(line[i:], '\'')
+	if end < 0 {
+		word.WriteString(line[i:])
+		return len(line)
+	}
+	word.WriteString(line[i : i+end])
+	return i + end + 1
+}
+
+// scanDoubleQuoted consumes a double-quoted section starting just after the
+// opening quote, appending its content to word, honouring backslash escapes
+// and recursing into $(...) substitutions. It returns commands found in the
+// substitutions and the index just past the closing quote.
+func scanDoubleQuoted(line string, i int, word *strings.Builder) ([][]string, int) {
+	var cmds [][]string
+	for i < len(line) && line[i] != '"' {
+		if line[i] == '\\' && i+1 < len(line) {
+			word.WriteByte(line[i+1])
+			i += 2
+			continue
+		}
+		if line[i] == '$' && i+1 < len(line) && line[i+1] == '(' {
+			inner, next := captureParen(line, i+2)
+			cmds = append(cmds, parseCommands(inner)...)
+			word.WriteString("$(...)")
+			i = next
+			continue
+		}
+		word.WriteByte(line[i])
+		i++
+	}
+	return cmds, i + 1
 }
 
 // captureParen returns the content up to the parenthesis matching an already
@@ -449,8 +474,7 @@ func validateInvocation(rootCmd *cobra.Command, args []string) error {
 			continue
 		}
 		name, _, hasValue := strings.Cut(tok, "=")
-		if strings.HasPrefix(name, "--") {
-			long := strings.TrimPrefix(name, "--")
+		if long, isLong := strings.CutPrefix(name, "--"); isLong {
 			if long == "help" || long == "version" {
 				continue
 			}
@@ -464,7 +488,7 @@ func validateInvocation(rootCmd *cobra.Command, args []string) error {
 			continue
 		}
 		shorts := name[1:]
-		for k := 0; k < len(shorts); k++ {
+		for k := range len(shorts) {
 			s := string(shorts[k])
 			// the help flag is registered lazily by cobra at execute time
 			if s == "h" {
@@ -496,8 +520,7 @@ func flagConsumesValue(cmd *cobra.Command, tok string) bool {
 	if hasValue {
 		return false
 	}
-	if strings.HasPrefix(name, "--") {
-		long := strings.TrimPrefix(name, "--")
+	if long, isLong := strings.CutPrefix(name, "--"); isLong {
 		if long == "help" || long == "version" {
 			return false
 		}

--- a/cmd/gcx/root/skillsdrift_test.go
+++ b/cmd/gcx/root/skillsdrift_test.go
@@ -1,0 +1,551 @@
+package root_test
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+
+	claudeplugin "github.com/grafana/gcx/claude-plugin"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// knownSkillDrift lists gcx invocations in the bundled skills that are known
+// to be wrong on main. All entries are already fixed on the PR #936 branch;
+// delete the whole list when #936 merges. Each entry suppresses failures in
+// one file whose message contains the given substring.
+var knownSkillDrift = []struct {
+	file     string
+	contains string
+}{
+	{"diagnose-entity-graph/SKILL.md", "unknown command `gcx kg health`"},
+	{"diagnose-entity-graph/SKILL.md", "unknown command `gcx kg cypher`"},
+	// push takes -p/--path, not -f
+	{"gcx-observability/SKILL.md", "unknown flag -f on `gcx resources push`"},
+	{"manage-dashboards/references/resource-model.md", "unknown flag --all-versions on `gcx resources pull`"},
+	// the acknowledge confirmation flag is --force, not --yes
+	{"oncall-triage/SKILL.md", "unknown flag --yes on `gcx irm oncall alert-groups acknowledge`"},
+}
+
+// TestSkillsGcxInvocationsMatchCommandTree extracts every gcx invocation from
+// fenced code blocks in the bundled skills and validates the command path and
+// flags against the real command tree, so skills fail CI when the CLI surface
+// moves out from under them.
+func TestSkillsGcxInvocationsMatchCommandTree(t *testing.T) {
+	rootCmd := buildRootCmd()
+	rootCmd.InitDefaultHelpCmd()
+	rootCmd.InitDefaultCompletionCmd()
+
+	total := 0
+	skillsFS := claudeplugin.SkillsFS()
+	err := fs.WalkDir(skillsFS, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || path.Ext(p) != ".md" {
+			return nil
+		}
+		content, err := fs.ReadFile(skillsFS, p)
+		if err != nil {
+			return err
+		}
+		for _, inv := range extractInvocations(string(content)) {
+			total++
+			verr := validateInvocation(rootCmd, inv.args)
+			if verr == nil {
+				continue
+			}
+			msg := fmt.Sprintf("`%s`: %v", inv, verr)
+			if allowedDrift(p, msg) {
+				continue
+			}
+			t.Errorf("claude-plugin/skills/%s:%d: %s", p, inv.line, msg)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking skills FS: %v", err)
+	}
+
+	// Guard against the extractor silently matching nothing after a refactor.
+	if total < 100 {
+		t.Fatalf("extracted only %d gcx invocations from bundled skills, expected hundreds; extractor is likely broken", total)
+	}
+	t.Logf("validated %d gcx invocations from bundled skills", total)
+}
+
+func TestValidateInvocation(t *testing.T) {
+	rootCmd := buildRootCmd()
+	rootCmd.InitDefaultHelpCmd()
+	rootCmd.InitDefaultCompletionCmd()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string // substring of the error, empty for valid
+	}{
+		{
+			name: "simple valid command",
+			args: []string{"slo", "definitions", "list"},
+		},
+		{
+			name: "alias resolves",
+			args: []string{"synth", "checks", "list"},
+		},
+		{
+			// flags before the subcommand are parsed by the resolved leaf,
+			// mirroring cobra: --config exists on the resources subtree only
+			name: "leaf flag written before subcommand",
+			args: []string{"--config", "x", "resources", "get", "dashboards"},
+		},
+		{
+			name: "placeholder in command position skipped",
+			args: []string{"<provider>", "--help"},
+		},
+		{
+			name:    "unknown command",
+			args:    []string{"kg", "health"},
+			wantErr: "unknown command `gcx kg health`",
+		},
+		{
+			name:    "unknown flag",
+			args:    []string{"resources", "pull", "dashboards", "--all-versions"},
+			wantErr: "unknown flag --all-versions on `gcx resources pull`",
+		},
+		{
+			name:    "unknown shorthand",
+			args:    []string{"resources", "push", "-f", "x.yaml"},
+			wantErr: "unknown flag -f on `gcx resources push`",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInvocation(rootCmd, tt.args)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("validateInvocation(%v) = %v, want nil", tt.args, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("validateInvocation(%v) = %v, want error containing %q", tt.args, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func allowedDrift(file, msg string) bool {
+	for _, k := range knownSkillDrift {
+		if k.file == file && strings.Contains(msg, k.contains) {
+			return true
+		}
+	}
+	return false
+}
+
+type invocation struct {
+	line int
+	args []string // tokens following "gcx"
+}
+
+func (inv invocation) String() string {
+	return "gcx " + strings.Join(inv.args, " ")
+}
+
+var envAssignRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
+
+// shellKeywords are leading words stripped so invocations inside loops and
+// conditionals (e.g. `do gcx ...`) are still recognised.
+var shellKeywords = map[string]bool{"do": true, "then": true, "else": true, "time": true, "exec": true}
+
+// extractInvocations returns every gcx invocation found in shell-flavoured
+// (bash, sh, shell, or bare) fenced code blocks of a markdown document.
+func extractInvocations(content string) []invocation {
+	lines := strings.Split(content, "\n")
+	var invs []invocation
+	inFence, shellFence := false, false
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "```") {
+			if inFence {
+				inFence = false
+				continue
+			}
+			inFence = true
+			lang := strings.TrimSpace(strings.TrimPrefix(trimmed, "```"))
+			shellFence = lang == "" || lang == "bash" || lang == "sh" || lang == "shell"
+			continue
+		}
+		if !inFence || !shellFence {
+			continue
+		}
+		start := i
+		logical := lines[i]
+		for strings.HasSuffix(strings.TrimRight(logical, " \t"), "\\") &&
+			i+1 < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i+1]), "```") {
+			logical = strings.TrimSuffix(strings.TrimRight(logical, " \t"), "\\") + " " + lines[i+1]
+			i++
+		}
+		for _, cmd := range parseCommands(logical) {
+			if args, ok := gcxArgs(cmd); ok {
+				invs = append(invs, invocation{line: start + 1, args: args})
+			}
+		}
+	}
+	return invs
+}
+
+// gcxArgs strips env-var assignment prefixes and shell keywords and reports
+// whether the remaining simple command is a gcx invocation.
+func gcxArgs(tokens []string) ([]string, bool) {
+	for len(tokens) > 0 && (envAssignRe.MatchString(tokens[0]) || shellKeywords[tokens[0]]) {
+		tokens = tokens[1:]
+	}
+	if len(tokens) == 0 || tokens[0] != "gcx" {
+		return nil, false
+	}
+	return tokens[1:], true
+}
+
+// placeholderStartRe matches doc placeholders like <uid> or <name|uuid> so
+// they are kept as argument tokens instead of being read as redirects.
+var placeholderStartRe = regexp.MustCompile(`^<[^<>\s]+>`)
+
+// parseCommands splits a logical shell line into simple commands, splitting on
+// pipes, &&, ||, ;, and subshell parens. It recurses into $(...) and backtick
+// substitutions so nested gcx calls are extracted too, keeps quoted strings as
+// single tokens, and stops collecting arguments at redirects.
+func parseCommands(line string) [][]string {
+	var (
+		cmds   [][]string
+		cur    []string
+		word   strings.Builder
+		inWord bool
+	)
+	flushWord := func() {
+		if inWord {
+			cur = append(cur, word.String())
+			word.Reset()
+			inWord = false
+		}
+	}
+	flushCmd := func() {
+		flushWord()
+		if len(cur) > 0 {
+			cmds = append(cmds, cur)
+			cur = nil
+		}
+	}
+	i := 0
+	for i < len(line) {
+		c := line[i]
+		switch {
+		case c == '\'':
+			end := strings.IndexByte(line[i+1:], '\'')
+			if end < 0 {
+				word.WriteString(line[i+1:])
+				inWord = true
+				i = len(line)
+				break
+			}
+			word.WriteString(line[i+1 : i+1+end])
+			inWord = true
+			i += end + 2
+		case c == '"':
+			i++
+			for i < len(line) && line[i] != '"' {
+				if line[i] == '\\' && i+1 < len(line) {
+					word.WriteByte(line[i+1])
+					i += 2
+					continue
+				}
+				if line[i] == '$' && i+1 < len(line) && line[i+1] == '(' {
+					inner, next := captureParen(line, i+2)
+					cmds = append(cmds, parseCommands(inner)...)
+					word.WriteString("$(...)")
+					i = next
+					continue
+				}
+				word.WriteByte(line[i])
+				i++
+			}
+			inWord = true
+			i++
+		case c == '$' && i+1 < len(line) && line[i+1] == '(':
+			inner, next := captureParen(line, i+2)
+			cmds = append(cmds, parseCommands(inner)...)
+			word.WriteString("$(...)")
+			inWord = true
+			i = next
+		case c == '`':
+			end := strings.IndexByte(line[i+1:], '`')
+			if end < 0 {
+				i = len(line)
+				break
+			}
+			cmds = append(cmds, parseCommands(line[i+1:i+1+end])...)
+			word.WriteString("$(...)")
+			inWord = true
+			i += end + 2
+		case c == ' ' || c == '\t':
+			flushWord()
+			i++
+		case c == '|' || c == ';' || c == '&' || c == '(' || c == ')':
+			flushCmd()
+			i++
+		case c == '<':
+			if m := placeholderStartRe.FindString(line[i:]); m != "" {
+				word.WriteString(m)
+				inWord = true
+				i += len(m)
+				break
+			}
+			flushCmd()
+			i++
+		case c == '>':
+			// drop a bare fd-number word so 2>/dev/null leaves no stray arg
+			if inWord && isDigits(word.String()) {
+				word.Reset()
+				inWord = false
+			}
+			flushCmd()
+			i++
+		case c == '#' && !inWord:
+			flushCmd()
+			return cmds
+		case c == '\\' && i+1 < len(line):
+			word.WriteByte(line[i+1])
+			inWord = true
+			i += 2
+		default:
+			word.WriteByte(c)
+			inWord = true
+			i++
+		}
+	}
+	flushCmd()
+	return cmds
+}
+
+// captureParen returns the content up to the parenthesis matching an already
+// consumed "$(" plus the index just past the closing paren, skipping over
+// quoted sections.
+func captureParen(line string, start int) (string, int) {
+	depth := 1
+	i := start
+	for i < len(line) {
+		switch line[i] {
+		case '\'':
+			end := strings.IndexByte(line[i+1:], '\'')
+			if end < 0 {
+				return line[start:], len(line)
+			}
+			i += end + 2
+			continue
+		case '"':
+			j := i + 1
+			for j < len(line) && line[j] != '"' {
+				if line[j] == '\\' {
+					j++
+				}
+				j++
+			}
+			i = j + 1
+			continue
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return line[start:i], i + 1
+			}
+		}
+		i++
+	}
+	return line[start:], len(line)
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isPlaceholder(tok string) bool {
+	return strings.ContainsAny(tok, "<>{}[]") || strings.HasPrefix(tok, "$")
+}
+
+func isFlagToken(tok string) bool {
+	if len(tok) < 2 || tok[0] != '-' {
+		return false
+	}
+	// negative numbers and placeholder-ish tokens are not flags
+	return !isDigits(strings.TrimLeft(tok, "-")) && !isPlaceholder(tok)
+}
+
+// validateInvocation resolves the subcommand path of a single gcx invocation
+// against the real command tree and checks that every flag used exists on the
+// resolved command (including persistent flags inherited from parents).
+//
+// Like cobra, it resolves the command path first, skipping over flag tokens,
+// and only then parses flags against the resolved leaf - so a flag may
+// legally appear before the subcommand it belongs to (e.g. `gcx --config x
+// resources get`, where --config lives on the resources subtree).
+func validateInvocation(rootCmd *cobra.Command, args []string) error {
+	// pass 1: resolve the command path, skipping flag tokens
+	cmd := rootCmd
+	var pathTokens []string
+	descending := true
+	for i := 0; i < len(args); i++ {
+		tok := args[i]
+		if tok == "--" {
+			break
+		}
+		if isFlagToken(tok) {
+			if flagConsumesValue(cmd, tok) {
+				i++
+			}
+			continue
+		}
+		if !descending {
+			continue
+		}
+		child := findChild(cmd, tok)
+		if child == nil {
+			if isPlaceholder(tok) {
+				// placeholder in command position: the rest cannot be resolved
+				return nil
+			}
+			if !cmd.Runnable() && cmd.HasSubCommands() {
+				return fmt.Errorf("unknown command `gcx %s`", strings.Join(append(pathTokens, tok), " "))
+			}
+			descending = false // positional argument of a runnable command
+			continue
+		}
+		cmd = child
+		pathTokens = append(pathTokens, tok)
+	}
+	cmdPath := "gcx"
+	if len(pathTokens) > 0 {
+		cmdPath += " " + strings.Join(pathTokens, " ")
+	}
+
+	// pass 2: validate every flag against the resolved leaf
+	for i := 0; i < len(args); i++ {
+		tok := args[i]
+		if tok == "--" {
+			break
+		}
+		if !isFlagToken(tok) {
+			continue
+		}
+		name, _, hasValue := strings.Cut(tok, "=")
+		if strings.HasPrefix(name, "--") {
+			long := strings.TrimPrefix(name, "--")
+			if long == "help" || long == "version" {
+				continue
+			}
+			f := lookupFlag(cmd, long)
+			if f == nil {
+				return fmt.Errorf("unknown flag %s on `%s`", name, cmdPath)
+			}
+			if !hasValue && f.NoOptDefVal == "" {
+				i++ // the next token is this flag's value
+			}
+			continue
+		}
+		shorts := name[1:]
+		for k := 0; k < len(shorts); k++ {
+			s := string(shorts[k])
+			// the help flag is registered lazily by cobra at execute time
+			if s == "h" {
+				continue
+			}
+			f := lookupShorthand(cmd, s)
+			if f == nil {
+				return fmt.Errorf("unknown flag -%s on `%s`", s, cmdPath)
+			}
+			if f.NoOptDefVal != "" {
+				continue // bool-like: further letters may be more shorthands
+			}
+			// non-bool: the rest of the token, an =value, or the next token is its value
+			if k == len(shorts)-1 && !hasValue {
+				i++
+			}
+			break
+		}
+	}
+	return nil
+}
+
+// flagConsumesValue reports whether a flag token eats the next token during
+// path resolution. Mirrors cobra's stripFlags: a space-separated flag not yet
+// known at the current node is assumed to consume a value, because its
+// definition may live on a leaf that is still being resolved.
+func flagConsumesValue(cmd *cobra.Command, tok string) bool {
+	name, _, hasValue := strings.Cut(tok, "=")
+	if hasValue {
+		return false
+	}
+	if strings.HasPrefix(name, "--") {
+		long := strings.TrimPrefix(name, "--")
+		if long == "help" || long == "version" {
+			return false
+		}
+		if f := lookupFlag(cmd, long); f != nil {
+			return f.NoOptDefVal == ""
+		}
+		return true
+	}
+	short := name[1:]
+	// cobra only consumes a value for single-letter shorthands
+	if len(short) != 1 || short == "h" {
+		return false
+	}
+	if f := lookupShorthand(cmd, short); f != nil {
+		return f.NoOptDefVal == ""
+	}
+	return true
+}
+
+func findChild(cmd *cobra.Command, name string) *cobra.Command {
+	for _, c := range cmd.Commands() {
+		if c.Name() == name || c.HasAlias(name) {
+			return c
+		}
+	}
+	return nil
+}
+
+func lookupFlag(cmd *cobra.Command, name string) *pflag.Flag {
+	if f := cmd.Flags().Lookup(name); f != nil {
+		return f
+	}
+	for c := cmd; c != nil; c = c.Parent() {
+		if f := c.PersistentFlags().Lookup(name); f != nil {
+			return f
+		}
+	}
+	return nil
+}
+
+func lookupShorthand(cmd *cobra.Command, s string) *pflag.Flag {
+	if f := cmd.Flags().ShorthandLookup(s); f != nil {
+		return f
+	}
+	for c := cmd; c != nil; c = c.Parent() {
+		if f := c.PersistentFlags().ShorthandLookup(s); f != nil {
+			return f
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds a test that fails CI whenever a bundled skill documents a `gcx` command that doesn't actually exist. It's the skills equivalent of `mise run reference-drift`. Part of grafana/gcx-internal#8; motivated by the review behind #936, where the most common defect was skills confidently documenting commands and flags that had drifted from the real CLI (or never existed).

How it works:

- a new test in `cmd/gcx/root` scans every code example in `claude-plugin/skills/**` and pulls out each `gcx ...` command it finds. It understands enough shell to get this right: commands split across lines with `\`, commands joined by pipes or `&&`, env vars in front (`GCX_X=1 gcx ...`), comments, and quoting. Placeholder values like `<uid>` are left alone rather than misread as syntax
- each extracted command is then checked against the real command tree, built the same way the binary builds it: does `gcx kg cypher` exist as a command path (aliases like `synth` count), and does every `--flag` it mentions exist on that command
- when something doesn't match, the failure message says which file and line, the offending command, and what's wrong ("unknown command", "unknown flag --dry-run on gcx synthetic-monitoring checks create"), so the fix is obvious
- it runs as part of the normal `go test ./...`, so CI picks it up with no new workflow
- as a sanity guard, the test also asserts it extracted a healthy number of commands (currently 703), so we'd notice if the scanner ever broke and silently started checking nothing

What it deliberately doesn't catch: wrong *positional* arguments (e.g. passing a UID where an expression is expected) - placeholders in doc examples make that too noisy to check reliably. That class still needs review, which is what #936 fixed by hand.

Running it against main found 6 problems. 5 were real (nonexistent `kg health` / `kg cypher` commands, a nonexistent `--all-versions` flag, `--yes` instead of `--force`, `-f` instead of `-p`) and are fixed on the #936 branch (commit https://github.com/grafana/gcx/commit/eb5cb674e442237158d9ad098f803082668a72c7). The 6th was a bug in this checker itself (`gcx --config <path> resources get ...` is valid - the flag may be written before the subcommand), which is fixed. The 5 real ones are temporarily allow-listed with a comment so this PR is green against main; the allow-list gets deleted once #936 merges.

- [x] Companion to #936; merge that first.


Any changes to the `claude-plugin/skills` dir are fixes from running these tests against the skills as part of the dev work 🙈 