### PR TITLE
fix(dev): derive SDK imports for generated import code from usage

### DIFF
--- a/claude-plugin/skills/import-dashboards/SKILL.md
+++ b/claude-plugin/skills/import-dashboards/SKILL.md
@@ -109,4 +109,5 @@ gcx resources push
 | "no converter found" | The resource's API version has no converter; the error message names the unsupported version |
 | Auth error (401/403) | Run `gcx config check` to verify credentials |
 | Empty import | The selector matched no resources; check UID with `gcx resources get dashboards` |
-| Imported code doesn't compile | Some complex dashboards produce converter output that needs manual fixup |
+| Build fails with `undefined: cog` (or another lowercase SDK identifier) | Older gcx versions omit SDK imports from generated files. Add the missing import `github.com/grafana/grafana-foundation-sdk/go/<pkg>` for each undefined identifier — `variants` is nested at `go/cog/variants`. Newer gcx emits complete imports |
+| Imported code doesn't compile for other reasons | Complex dashboards can produce converter output that needs manual fixup: build, read the first error, fix, repeat |

--- a/cmd/gcx/dev/import.go
+++ b/cmd/gcx/dev/import.go
@@ -4,8 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
 	"os"
 	"path/filepath"
+	"sort"
 	"text/template"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
@@ -108,6 +113,70 @@ func importCmd() *cobra.Command {
 
 type resourceConverter func(resource *model.Resource) (string, string, error)
 
+// sdkImportOverrides maps package identifiers referenced by foundation-sdk
+// converter output to their subpath within the SDK module when that subpath
+// is not simply go/<identifier>. These are the SDK's only nested packages.
+//
+//nolint:gochecknoglobals
+var sdkImportOverrides = map[string]string{
+	"variants": "cog/variants",
+	"plugins":  "cog/plugins",
+}
+
+func sdkImportPath(ident string) string {
+	sub := ident
+	if override, ok := sdkImportOverrides[ident]; ok {
+		sub = override
+	}
+	return "github.com/grafana/grafana-foundation-sdk/go/" + sub
+}
+
+// computeSDKImports parses generated source and returns the import paths its
+// selector expressions need. Foundation-sdk converters emit builder code that
+// references SDK packages (cog, common, panel and query packages, …) without
+// any import information, and goimports cannot resolve them reliably — the
+// module cache offers several candidates for e.g. "cog" — so the importer
+// derives the import list from actual usage instead. Selector roots that
+// resolve to declarations in the file (locals) or to predeclared identifiers
+// are ignored.
+func computeSDKImports(src []byte) ([]string, error) {
+	fset := token.NewFileSet()
+	// Object resolution is what lets us tell locals apart from package
+	// references below; it is on by default in parser.ParseFile.
+	file, err := parser.ParseFile(fset, "generated.go", src, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parsing generated code: %w", err)
+	}
+
+	idents := map[string]struct{}{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		// ast.Object is deprecated but still populated; a nil Obj on a
+		// selector root means "not declared in this file", i.e. a package
+		// reference.
+		if ident.Obj != nil || types.Universe.Lookup(ident.Name) != nil {
+			return true
+		}
+		idents[ident.Name] = struct{}{}
+		return true
+	})
+
+	paths := make([]string, 0, len(idents))
+	for ident := range idents {
+		paths = append(paths, sdkImportPath(ident))
+	}
+	sort.Strings(paths)
+
+	return paths, nil
+}
+
 func convertResource(destinationRoot string, resource *model.Resource) error {
 	tmpl, err := template.New("").Option("missingkey=error").ParseFS(templatesFS, "templates/import/*.tmpl")
 	if err != nil {
@@ -122,7 +191,7 @@ func convertResource(destinationRoot string, resource *model.Resource) error {
 		return fmt.Errorf("no converter found for %s", converterKey)
 	}
 
-	converted, sdkPkg, err := converter(resource)
+	converted, _, err := converter(resource)
 	if err != nil {
 		return err
 	}
@@ -133,23 +202,41 @@ func convertResource(destinationRoot string, resource *model.Resource) error {
 		return err
 	}
 
-	var buf bytes.Buffer
-	err = tmpl.ExecuteTemplate(&buf, "resource.go.tmpl", map[string]any{
+	templateData := map[string]any{
 		"Package":          filepath.Base(destinationRoot),
 		"GroupVersion":     gvk.GroupVersion().String(),
 		"Kind":             resource.Kind(),
 		"Name":             resource.Name(),
-		"SDKPackage":       sdkPkg,
 		"FuncName":         strcase.ToPascalCase(resource.Name()),
 		"ConvertedBuilder": converted,
-	})
-	if err != nil {
+		"Imports":          []string(nil),
+	}
+
+	// First render without imports to discover, from the code itself, which
+	// SDK packages the converter output references; then render again with
+	// the complete import block so the file compiles regardless of whether
+	// goimports can resolve anything.
+	var scanBuf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&scanBuf, "resource.go.tmpl", templateData); err != nil {
 		return err
 	}
 
+	sdkImports, err := computeSDKImports(scanBuf.Bytes())
+	if err != nil {
+		return err
+	}
+	templateData["Imports"] = sdkImports
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "resource.go.tmpl", templateData); err != nil {
+		return err
+	}
+
+	// The import list is already complete; goimports only formats and sorts.
 	formatted, err := imports.Process(convertedFile, buf.Bytes(), nil)
 	if err != nil {
-		// Fall back to unformatted output if goimports fails.
+		// Fall back to unformatted output if goimports fails — the file
+		// still compiles since its imports were derived from usage.
 		formatted = buf.Bytes()
 	}
 

--- a/cmd/gcx/dev/import.go
+++ b/cmd/gcx/dev/import.go
@@ -92,7 +92,7 @@ func importCmd() *cobra.Command {
 					return nil
 				}
 
-				imported += 1
+				imported++
 				return nil
 			})
 			if err != nil {
@@ -111,7 +111,7 @@ func importCmd() *cobra.Command {
 	return cmd
 }
 
-type resourceConverter func(resource *model.Resource) (string, string, error)
+type resourceConverter func(resource *model.Resource) (string, error)
 
 // sdkImportOverrides maps package identifiers referenced by foundation-sdk
 // converter output to their subpath within the SDK module when that subpath
@@ -191,7 +191,7 @@ func convertResource(destinationRoot string, resource *model.Resource) error {
 		return fmt.Errorf("no converter found for %s", converterKey)
 	}
 
-	converted, _, err := converter(resource)
+	converted, err := converter(resource)
 	if err != nil {
 		return err
 	}
@@ -232,8 +232,14 @@ func convertResource(destinationRoot string, resource *model.Resource) error {
 		return err
 	}
 
-	// The import list is already complete; goimports only formats and sorts.
-	formatted, err := imports.Process(convertedFile, buf.Bytes(), nil)
+	// The import list is already complete; FormatOnly keeps goimports from
+	// running its own (ambiguous-package-prone) import resolution.
+	formatted, err := imports.Process(convertedFile, buf.Bytes(), &imports.Options{
+		Comments:   true,
+		TabIndent:  true,
+		TabWidth:   8,
+		FormatOnly: true,
+	})
 	if err != nil {
 		// Fall back to unformatted output if goimports fails — the file
 		// still compiles since its imports were derived from usage.
@@ -243,15 +249,15 @@ func convertResource(destinationRoot string, resource *model.Resource) error {
 	return os.WriteFile(convertedFile, formatted, 0600)
 }
 
-func dashboardv1Converter(resource *model.Resource) (string, string, error) {
+func dashboardv1Converter(resource *model.Resource) (string, error) {
 	spec, err := resource.Spec()
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	marshalled, err := json.Marshal(spec)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	// Intentionally uses the v1 dashboard schema: convertersMap routes the
@@ -259,21 +265,21 @@ func dashboardv1Converter(resource *model.Resource) (string, string, error) {
 	// correct one for these versions (dashboardv2 has an incompatible schema).
 	object := dashboard.Dashboard{} //nolint:staticcheck // intentional v1 schema for v0alpha1/v1/v1beta1 imports
 	if err = json.Unmarshal(marshalled, &object); err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	return dashboard.DashboardConverter(object), "dashboard", nil
+	return dashboard.DashboardConverter(object), nil
 }
 
-func dashboardv2Converter(resource *model.Resource) (string, string, error) {
+func dashboardv2Converter(resource *model.Resource) (string, error) {
 	spec, err := resource.Spec()
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	marshalled, err := json.Marshal(spec)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	// Intentionally uses the v2beta1 dashboard schema: convertersMap routes the
@@ -281,29 +287,29 @@ func dashboardv2Converter(resource *model.Resource) (string, string, error) {
 	// resource's version.
 	object := dashboardv2beta1.Dashboard{} //nolint:staticcheck // intentional v2beta1 schema for v2beta1 imports
 	if err = json.Unmarshal(marshalled, &object); err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	return dashboardv2beta1.DashboardConverter(object), "dashboardv2beta1", nil
+	return dashboardv2beta1.DashboardConverter(object), nil
 }
 
-func folderConverter(resource *model.Resource) (string, string, error) {
+func folderConverter(resource *model.Resource) (string, error) {
 	spec, err := resource.Spec()
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	marshalled, err := json.Marshal(spec)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	// Intentionally uses the v1beta1 folder schema: convertersMap routes the
 	// folder v1 API version here, matching the imported resource's version.
 	object := folderv1beta1.Folder{} //nolint:staticcheck // intentional v1beta1 schema for folder imports
 	if err = json.Unmarshal(marshalled, &object); err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	return folderv1beta1.FolderConverter(object), "folderv1beta1", nil
+	return folderv1beta1.FolderConverter(object), nil
 }

--- a/cmd/gcx/dev/import_test.go
+++ b/cmd/gcx/dev/import_test.go
@@ -2,9 +2,17 @@
 package dev
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	model "github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/grafana-foundation-sdk/go/cog/plugins"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -25,6 +33,171 @@ func TestConvertersMapCoversReportedGVKs(t *testing.T) {
 			assert.True(t, ok, "convertersMap missing entry for %s", key)
 		})
 	}
+}
+
+func TestComputeSDKImports(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "sdk packages including nested variants",
+			src: `package imported
+
+import ()
+
+func Example() {
+	builder := dashboard.NewDashboardBuilder("t").
+		Tooltip(common.TooltipDisplayModeSingle).
+		Min(cog.ToPtr[float64](0)).
+		WithTarget(prometheus.NewDataqueryBuilder().Expr("up"))
+	var q []cog.Builder[variants.Dataquery]
+	_, _ = builder, q
+}
+`,
+			want: []string{
+				"github.com/grafana/grafana-foundation-sdk/go/cog",
+				"github.com/grafana/grafana-foundation-sdk/go/cog/variants",
+				"github.com/grafana/grafana-foundation-sdk/go/common",
+				"github.com/grafana/grafana-foundation-sdk/go/dashboard",
+				"github.com/grafana/grafana-foundation-sdk/go/prometheus",
+			},
+		},
+		{
+			name: "locals and predeclared identifiers are not imports",
+			src: `package imported
+
+import ()
+
+func Example() error {
+	builder := resource.NewManifestBuilder()
+	object, err := builder.Build()
+	if err != nil {
+		return err
+	}
+	_ = object.String()
+	return nil
+}
+`,
+			// builder/object/err resolve locally; only the package
+			// reference `resource` remains.
+			want: []string{"github.com/grafana/grafana-foundation-sdk/go/resource"},
+		},
+		{
+			name: "selector-looking text inside string literals is ignored",
+			src: `package imported
+
+import ()
+
+func Example() {
+	_ = dashboard.NewDashboardBuilder("rate(http_requests_total{job=\"api\"}[5m]) and fake.Selector(x)")
+}
+`,
+			want: []string{"github.com/grafana/grafana-foundation-sdk/go/dashboard"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := computeSDKImports([]byte(tt.src))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestComputeSDKImportsRejectsInvalidSource(t *testing.T) {
+	_, err := computeSDKImports([]byte("not valid go"))
+	require.Error(t, err)
+}
+
+// TestConvertResourceEmitsCompleteImports runs a realistic dashboard through
+// convertResource and asserts the self-consistency property that motivated
+// the usage-derived import block: every package referenced by a selector in
+// the generated file is satisfied by its import list, without relying on
+// goimports resolution (which cannot disambiguate e.g. "cog" candidates).
+func TestConvertResourceEmitsCompleteImports(t *testing.T) {
+	plugins.RegisterDefaultPlugins()
+
+	res, err := model.FromUnstructured(&unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "dashboard.grafana.app/v1",
+		"kind":       "Dashboard",
+		"metadata":   map[string]any{"name": "import-test"},
+		"spec": map[string]any{
+			"title":         "Import Test",
+			"schemaVersion": float64(39),
+			"panels": []any{
+				map[string]any{
+					"id":    float64(1),
+					"type":  "timeseries",
+					"title": "Latency",
+					"datasource": map[string]any{
+						"type": "prometheus",
+						"uid":  "prom",
+					},
+					"fieldConfig": map[string]any{
+						"defaults": map[string]any{
+							"unit": "s",
+							"custom": map[string]any{
+								"fillOpacity": float64(10),
+								"lineWidth":   float64(2),
+							},
+						},
+						"overrides": []any{},
+					},
+					"gridPos": map[string]any{"h": float64(8), "w": float64(12), "x": float64(0), "y": float64(0)},
+					"targets": []any{
+						map[string]any{
+							"datasource": map[string]any{"type": "prometheus", "uid": "prom"},
+							"expr":       `histogram_quantile(0.95, sum by (le) (rate(req_seconds_bucket[5m])))`,
+							"refId":      "A",
+						},
+					},
+				},
+			},
+		},
+	}})
+	require.NoError(t, err)
+
+	dir := filepath.Join(t.TempDir(), "imported")
+	require.NoError(t, convertResource(dir, res))
+
+	generated, err := os.ReadFile(filepath.Join(dir, "import_test.go"))
+	require.NoError(t, err)
+
+	// Sanity: this spec must exercise the ambiguous-package case that broke
+	// goimports-based resolution. If the SDK converter stops emitting cog
+	// references for it, pick a spec that does.
+	require.Contains(t, string(generated), "cog.")
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "import_test.go", generated, 0)
+	require.NoError(t, err)
+
+	imported := map[string]struct{}{}
+	for _, imp := range file.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		imported[filepath.Base(path)] = struct{}{}
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		// Same resolution rule as computeSDKImports.
+		if ident.Obj != nil || types.Universe.Lookup(ident.Name) != nil {
+			return true
+		}
+		_, ok = imported[ident.Name]
+		assert.True(t, ok, "generated file references package %q with no matching import", ident.Name)
+		return true
+	})
 }
 
 func TestConverters(t *testing.T) {

--- a/cmd/gcx/dev/import_test.go
+++ b/cmd/gcx/dev/import_test.go
@@ -202,10 +202,9 @@ func TestConvertResourceEmitsCompleteImports(t *testing.T) {
 
 func TestConverters(t *testing.T) {
 	tests := []struct {
-		name           string
-		object         map[string]any
-		wantSDKPackage string
-		wantContains   string
+		name         string
+		object       map[string]any
+		wantContains string
 	}{
 		{
 			name: "dashboard v1",
@@ -218,8 +217,7 @@ func TestConverters(t *testing.T) {
 					"schemaVersion": float64(36),
 				},
 			},
-			wantSDKPackage: "dashboard",
-			wantContains:   "NewDashboardBuilder",
+			wantContains: "NewDashboardBuilder",
 		},
 		{
 			name: "folder v1",
@@ -232,8 +230,7 @@ func TestConverters(t *testing.T) {
 					"description": "a folder",
 				},
 			},
-			wantSDKPackage: "folderv1beta1",
-			wantContains:   "NewFolderBuilder",
+			wantContains: "NewFolderBuilder",
 		},
 	}
 
@@ -248,9 +245,8 @@ func TestConverters(t *testing.T) {
 			converter, ok := convertersMap[key]
 			require.True(t, ok, "no converter registered for %s", key)
 
-			code, sdkPkg, err := converter(res)
+			code, err := converter(res)
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantSDKPackage, sdkPkg)
 			assert.Contains(t, code, tt.wantContains)
 		})
 	}

--- a/cmd/gcx/dev/templates/import/resource.go.tmpl
+++ b/cmd/gcx/dev/templates/import/resource.go.tmpl
@@ -1,8 +1,9 @@
 package {{ .Package }}
 
 import (
-	"github.com/grafana/grafana-foundation-sdk/go/{{ .SDKPackage }}"
-	"github.com/grafana/grafana-foundation-sdk/go/resource"
+{{- range .Imports }}
+	"{{ . }}"
+{{- end }}
 )
 
 func {{ .FuncName }}() *resource.ManifestBuilder {


### PR DESCRIPTION
## Problem

`gcx dev import` emitted Go files that never compiled. Converter output references up to nine foundation-sdk packages (`cog`, `common`, panel/query packages, nested `cog/variants`) while the generated file imported only two, relying on goimports discovery for the rest — and goimports cannot resolve them reliably (the module cache offers several `cog` candidates: foundation-sdk vs promql-builder). Result: `undefined: cog` on first build, or a silently wrong `promql-builder/go/cog` import. The goimports-failure fallback then wrote the uncompilable file anyway.

## Fix

Derive the import list from the generated code itself:

- render the template, parse the result, and collect selector roots that resolve to nothing declared in the file (AST object resolution excludes locals like `builder`/`err` and predeclared identifiers; string literals are naturally ignored)
- map each identifier to its SDK import path, with overrides for the SDK's only nested packages (`variants` → `go/cog/variants`, `plugins` → `go/cog/plugins`)
- re-render with the complete import block; goimports is now formatter-only, so its failure can no longer produce uncompilable output

Also updates the import-dashboards skill's Common Issues table to name the exact failure signature and remedy for users on older gcx binaries.

## Testing

- New table-driven unit tests for the scanner (locals/shadowing, predeclared identifiers, selector-lookalikes inside string literals, nested `variants` mapping) plus an end-to-end self-consistency test through `convertResource`: every selector root in a generated file must be satisfied by its import block.
- Live end-to-end against a seeded Grafana 12.4: imported 5 dashboards of varying complexity (including a 125-panel one) — all build **untouched** and render via `go run .`.
- Measured with paired with/without-skill agent evals (3 runs per config, deterministic graders), before vs after: compile-failure recovery loops disappeared entirely; mean task time −25%/−22%, tokens −38%/−32%, variance halved in both configurations, with pass rates unchanged (no regression). Full findings: https://github.com/grafana/gcx-internal/issues/8#issuecomment-4920296821
- `mise run gate` green (lint 0 issues, full test suite, build); reference docs regenerated with no drift.

Part of the Category B skill evaluation work in grafana/gcx-internal#8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)