### PR TITLE
fix(skills): retune skill descriptions for real-world triggering

### DIFF
--- a/claude-plugin/skills/debug-with-grafana/SKILL.md
+++ b/claude-plugin/skills/debug-with-grafana/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: debug-with-grafana
 description: >
-  Structured diagnostic workflow for debugging application issues using
-  Grafana observability data. Use when the user reports errors, latency
-  spikes, service degradation, HTTP 500s, or wants to investigate why a
-  service is behaving unexpectedly. Triggers for: "my API is returning 500
-  errors", "latency is spiking", "service seems down", "help me debug
-  using Grafana", "investigate why requests are failing", "something is
-  wrong with my service".
+  Structured workflow for investigating application problems with Grafana
+  observability data (metrics, logs, traces) via gcx. Covers live
+  firefighting AND retrospective incident analysis: incident triage,
+  root-cause analysis, blast-radius checks (did an incident spill into
+  other services), verifying whether a deployment or rollout triggered an
+  incident, finding which service, endpoint, or path owns the most errors
+  or slow requests, checking whether retries or queue backlogs piled up,
+  and quantifying error or latency shares over a time window. Trigger on:
+  "my API is returning 500 errors", "latency is spiking", "investigate why
+  requests are failing", "triage the incident", "blast radius", "root
+  cause", "did the rollout cause it", "which endpoint owns the most 5xx",
+  "did retries pile up", or any request to analyse an earlier incident
+  window using telemetry. For authoring dashboards use create-dashboard;
+  for listing datasources or dashboard inventory use explore-datasources
+  or manage-dashboards.
 ---
 
 # Debug with Grafana

--- a/claude-plugin/skills/explore-datasources/SKILL.md
+++ b/claude-plugin/skills/explore-datasources/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: explore-datasources
-description: Discover what datasources, metrics, labels, and log streams are available in a Grafana instance. Use when the user asks what data exists, what metrics are available, what services are being monitored, or needs to find a datasource UID.
+description: Discovers what observability data exists in a Grafana instance via gcx - configured datasources (names, types, UIDs, URL and access settings), available metrics and which services emit them, label values, log streams, and which services show up in traces. Use when the user asks what datasources are configured, how a datasource is configured (URL, proxy or direct access), what metrics exist or which services emit a given metric, which services are monitored or have tracing coverage, or needs a datasource UID. Trigger on "what datasources are configured", "list datasources", "how is our Prometheus datasource configured", "which services emit http_requests_total", "which services have tracing coverage", "what data do we have". For querying and analysing the data use debug-with-grafana; for what a dashboard contains use manage-dashboards.
 ---
 
 # Datasource Discovery

--- a/claude-plugin/skills/manage-dashboards/SKILL.md
+++ b/claude-plugin/skills/manage-dashboards/SKILL.md
@@ -1,14 +1,19 @@
 ---
 name: manage-dashboards
 description: >
-  Manages existing Grafana dashboards operationally via gcx: list, get,
-  search, create or update from an already-authored manifest, delete, inspect
-  and restore versions, pull/push/validate/promote dashboard resource files,
-  manage dashboard folders, or render PNG snapshots. Do NOT use when the task
-  involves adding new panels, variables, or annotations — those require
-  discovering real metrics or log schema, so use create-dashboard instead.
-  For designing or creating a new dashboard, or for material visual/dashboard
-  UX changes, also use create-dashboard.
+  Manages and inspects existing Grafana dashboards via gcx: list, get, search,
+  audit what a saved dashboard actually contains (its panels and their types,
+  the queries and expressions as saved, which datasource each panel uses,
+  variables and what they are wired to), create or update from an
+  already-authored manifest, delete, inspect and restore versions,
+  pull/push/validate/promote dashboard resource files, manage dashboard
+  folders, or render PNG snapshots. Trigger on "what's on dashboard X",
+  "what is each panel querying", "audit this dashboard", "which datasource
+  does each panel use", "does the dashboard have a service dropdown".
+  Do NOT use when the task involves adding new panels, variables, or
+  annotations - those require discovering real metrics or log schema, so use
+  create-dashboard instead. For designing or creating a new dashboard, or for
+  material visual/dashboard UX changes, also use create-dashboard.
 ---
 
 # Manage Dashboards


### PR DESCRIPTION
## Summary

Retunes three skill descriptions using real under-triggering prompts from the 622-trial skills experiment (grafana/gcx-internal#8), one commit per skill group, each validated by re-running the relevant bench tasks (opus-4-8, skills installed, k=3).

The experiment showed OpenCode's native skill triggering is strongly description-sensitive: skills whose descriptions didn't speak the phrasing of their real tasks effectively didn't exist, even installed. Descriptions rewritten from the actual miss lists.

## Validated results

**debug-with-grafana** (investigation tasks, 33 trials):

| | old | new |
|---|---|---|
| consultation rate | 6/33 (18%) | **31/33 (94%)** |
| mean score | 0.803 | **0.844** (`payments-path-root-cause` 0.00 -> 0.62) |
| tokens/trial | 772k | 677k (-12%) |

**manage-dashboards** (its 4 primary grafana_api tasks, 12 trials):

| | old | new |
|---|---|---|
| consultation rate | 3/12 | **12/12** |
| mean score | 1.0 | 1.0 (already at ceiling) |

**explore-datasources** (its 5 primary tasks, 15 trials):

| | old | new |
|---|---|---|
| consultation rate | 1/15 | **6/15** |
| mean score | 0.912 | 0.904 (ceiling + k=3 noise on one tempo task) |

explore-datasources' remaining non-fires are benign: `list-datasources` and `promql-discover-http-metric` are simple enough that agents answer directly without consulting any skill, and score 1.0 doing so; `traceql-discover-*` routes to debug-with-grafana, which the expected-skill matrix allows.

create-dashboard was deliberately left unchanged: its only trigger misses route acceptably to manage-dashboards and score clean.

## How to review this PR

- **fix(skills): retune debug-with-grafana description** - the incident-analysis phrasing gap (blast radius, rollout causality, "which endpoint owns the most 5xx")
- **fix(skills): retune manage-dashboards and explore-datasources descriptions** - dashboard-inspection phrasing ("what's on dashboard X", "audit this dashboard") and datasource-config/coverage phrasing ("how is our Prometheus datasource configured", "which services have tracing coverage")

Sibling cross-routing in all three descriptions protects precision (no wrong-family fires observed in any validation run). Skill tests and the drift check pass.
