### PR TITLE
feat(telemetry): add anonymous usage stats core library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,7 @@ internal/
 ├── notifier/    Update notifications (skills + gcx version checks; XDG state, throttling, message rendering — wired into root PersistentPostRun)
 ├── skills/      Portable Agent Skills installer primitives (BundledSkillNames, Install, Update — extracted from cmd/gcx/skills)
 ├── strcase/     String case conversion (snake_case, kebab-case, PascalCase)
+├── telemetry/   Anonymous usage stats library (wide-event model, GCX_TELEMETRY/DO_NOT_TRACK mode resolution, device ID, CI detection — not yet wired into the CLI)
 ├── xdg/         XDG Base Directory paths (config home, state home, config dirs)
 └── shared/      Shared utilities (date handling, duration, etc.) to be shared across integrations.
 ```

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -102,6 +102,7 @@ gcx/
 │   ├── secrets/              # Redaction of sensitive config fields
 │   ├── skills/               # Portable Agent Skills installer primitives (Install, Update, Bundled/InstalledBundledSkillNames)
 │   ├── strcase/              # String case conversion (snake_case, kebab-case, PascalCase)
+│   ├── telemetry/            # Anonymous usage stats library (event model, mode resolution, device ID, CI detection)
 │   ├── terminal/             # TTY detection: IsPiped(), NoTruncate(), Detect()
 │   ├── testutils/            # Shared test helpers (not exposed externally)
 │   ├── resources/            # Core resource abstraction layer

--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -141,8 +141,8 @@ diagnostics:
   # Default: $XDG_STATE_HOME/gcx/ (platform-specific).
   log-dir: string
   # Telemetry controls anonymous usage telemetry: "enabled", "disabled",
-  # or "log" (print the event to stderr and send nothing). Overridden by
-  # the GCX_TELEMETRY and DO_NOT_TRACK environment variables.
+  # or "log" (prints to stderr). Overridden by the GCX_TELEMETRY and
+  # DO_NOT_TRACK environment variables.
   telemetry: string
 
 ```

--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -140,5 +140,9 @@ diagnostics:
   # LogDir overrides the output directory for agent invocation log files.
   # Default: $XDG_STATE_HOME/gcx/ (platform-specific).
   log-dir: string
+  # Telemetry controls anonymous usage telemetry: "enabled", "disabled",
+  # or "log" (print the event to stderr and send nothing). Overridden by
+  # the GCX_TELEMETRY and DO_NOT_TRACK environment variables.
+  telemetry: string
 
 ```

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -1,5 +1,11 @@
 # Environment variables reference
 
+## `DO_NOT_TRACK`
+
+DoNotTrack disables anonymous usage telemetry when set to "1" or
+"true" (cross-tool convention, see https://consoledonottrack.com).
+Overridden by GCX_TELEMETRY.
+
 ## `GCX_AUTO_APPROVE`
 
 AutoApprove automatically enables the --force flag on delete operations,
@@ -10,6 +16,13 @@ enabling non-interactive operation in CI/CD pipelines.
 DisableUpdateNotifier disables the periodic notifier that reminds users
 when their installed gcx skills can be updated. Any non-empty value
 disables the notifier (NO_COLOR convention).
+
+## `GCX_TELEMETRY`
+
+Telemetry controls anonymous usage telemetry for this invocation:
+"enabled", "disabled", or "log" (print the event to stderr and send
+nothing). Takes precedence over DO_NOT_TRACK and the
+`diagnostics.telemetry` config field.
 
 ## `GRAFANA_CLOUD_API_URL`
 

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -3,8 +3,8 @@
 ## `DO_NOT_TRACK`
 
 DoNotTrack disables anonymous usage telemetry when set to "1" or
-"true" (cross-tool convention, see https://consoledonottrack.com).
-Overridden by GCX_TELEMETRY.
+"true" (cross-tool DO_NOT_TRACK convention). Overridden by
+GCX_TELEMETRY.
 
 ## `GCX_AUTO_APPROVE`
 

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 require (
 	github.com/go-openapi/runtime v0.32.4
 	github.com/gofrs/flock v0.13.0
+	github.com/google/uuid v1.6.0
 	github.com/grafana/otel-checker v0.2.0
 	github.com/itchyny/gojq v0.12.19
 	github.com/prometheus/common v0.69.0
@@ -111,7 +112,6 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -11,15 +11,16 @@ import (
 	"strings"
 )
 
-// Environment variables that signal agent mode.
-var agentEnvVars = []string{ //nolint:gochecknoglobals
-	"GCX_AGENT_MODE",
-	"CLAUDECODE",
-	"CLAUDE_CODE",
-	"CURSOR_AGENT",
-	"GITHUB_COPILOT",
-	"AMAZON_Q",
-	"OPENCODE",
+// Environment variables that signal agent mode, with the harness name each
+// one identifies. GCX_AGENT_MODE is handled separately (it is an explicit
+// override, not a harness signal).
+var harnessEnvVars = []struct{ envVar, name string }{ //nolint:gochecknoglobals
+	{"CLAUDECODE", "claude-code"},
+	{"CLAUDE_CODE", "claude-code"},
+	{"CURSOR_AGENT", "cursor"},
+	{"GITHUB_COPILOT", "github-copilot"},
+	{"AMAZON_Q", "amazon-q"},
+	{"OPENCODE", "opencode"},
 }
 
 var (
@@ -78,15 +79,28 @@ func detectFromEnv() {
 		}
 	}
 
-	// Check remaining env vars for a truthy value.
-	for _, env := range agentEnvVars {
-		if isTruthy(os.Getenv(env)) {
+	// Check harness env vars for a truthy value.
+	for _, h := range harnessEnvVars {
+		if isTruthy(os.Getenv(h.envVar)) {
 			detectedFromEnv = true
 			agentMode = true
 
 			return
 		}
 	}
+}
+
+// Harness returns the name of the detected agent harness (e.g. "claude-code"),
+// or "" when no known harness env var is set. It reports the harness even when
+// agent mode was explicitly disabled via GCX_AGENT_MODE or --agent=false;
+// callers should combine it with [IsAgentMode].
+func Harness() string {
+	for _, h := range harnessEnvVars {
+		if isTruthy(os.Getenv(h.envVar)) {
+			return h.name
+		}
+	}
+	return ""
 }
 
 // isTruthy returns true for the values "1", "true", and "yes" (case-insensitive).

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -90,11 +90,11 @@ func detectFromEnv() {
 	}
 }
 
-// Harness returns the name of the detected agent harness (e.g. "claude-code"),
-// or "" when no known harness env var is set. It reports the harness even when
-// agent mode was explicitly disabled via GCX_AGENT_MODE or --agent=false;
-// callers should combine it with [IsAgentMode].
-func Harness() string {
+// Name returns the name of the detected agent (e.g. "claude-code"), or ""
+// when no known agent env var is set. It reports the name even when agent
+// mode was explicitly disabled via GCX_AGENT_MODE or --agent=false; callers
+// should combine it with [IsAgentMode].
+func Name() string {
 	for _, h := range harnessEnvVars {
 		if isTruthy(os.Getenv(h.envVar)) {
 			return h.name

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -190,3 +190,52 @@ func TestDetectedFromEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestHarness(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		want    string
+	}{
+		{
+			name: "no harness env",
+			want: "",
+		},
+		{
+			name:    "CLAUDECODE",
+			envVars: map[string]string{"CLAUDECODE": "1"},
+			want:    "claude-code",
+		},
+		{
+			name:    "CLAUDE_CODE maps to the same harness",
+			envVars: map[string]string{"CLAUDE_CODE": "true"},
+			want:    "claude-code",
+		},
+		{
+			name:    "cursor",
+			envVars: map[string]string{"CURSOR_AGENT": "1"},
+			want:    "cursor",
+		},
+		{
+			name:    "GCX_AGENT_MODE alone names no harness",
+			envVars: map[string]string{"GCX_AGENT_MODE": "1"},
+			want:    "",
+		},
+		{
+			name:    "falsy harness var is ignored",
+			envVars: map[string]string{"CLAUDECODE": "0"},
+			want:    "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearAgentEnv(t)
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+
+			assert.Equal(t, tc.want, agent.Harness())
+		})
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -191,7 +191,7 @@ func TestDetectedFromEnv(t *testing.T) {
 	}
 }
 
-func TestHarness(t *testing.T) {
+func TestName(t *testing.T) {
 	tests := []struct {
 		name    string
 		envVars map[string]string
@@ -235,7 +235,7 @@ func TestHarness(t *testing.T) {
 				t.Setenv(k, v)
 			}
 
-			assert.Equal(t, tc.want, agent.Harness())
+			assert.Equal(t, tc.want, agent.Name())
 		})
 	}
 }

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -32,7 +32,8 @@ func MergeConfigs(base, over Config) Config {
 		}
 	}
 
-	// Diagnostics: propagate from any layer that enables it.
+	// Diagnostics: merged per field — bools propagate from any layer that
+	// enables them, strings are last-non-empty-wins (see mergeDiagnosticsConfig).
 	if over.Diagnostics != nil {
 		if result.Diagnostics == nil {
 			result.Diagnostics = over.Diagnostics

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -53,6 +53,9 @@ func mergeDiagnosticsConfig(base, over *DiagnosticsConfig) DiagnosticsConfig {
 	if over.LogDir != "" {
 		result.LogDir = over.LogDir
 	}
+	if over.Telemetry != "" {
+		result.Telemetry = over.Telemetry
+	}
 	return result
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -69,8 +69,8 @@ type DiagnosticsConfig struct {
 	LogDir string `json:"log-dir,omitempty" yaml:"log-dir,omitempty"`
 
 	// Telemetry controls anonymous usage telemetry: "enabled", "disabled",
-	// or "log" (print the event to stderr and send nothing). Overridden by
-	// the GCX_TELEMETRY and DO_NOT_TRACK environment variables.
+	// or "log" (prints to stderr). Overridden by the GCX_TELEMETRY and
+	// DO_NOT_TRACK environment variables.
 	Telemetry string `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -67,6 +67,11 @@ type DiagnosticsConfig struct {
 	// LogDir overrides the output directory for agent invocation log files.
 	// Default: $XDG_STATE_HOME/gcx/ (platform-specific).
 	LogDir string `json:"log-dir,omitempty" yaml:"log-dir,omitempty"`
+
+	// Telemetry controls anonymous usage telemetry: "enabled", "disabled",
+	// or "log" (print the event to stderr and send nothing). Overridden by
+	// the GCX_TELEMETRY and DO_NOT_TRACK environment variables.
+	Telemetry string `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`
 }
 
 func (config *Config) HasContext(name string) bool {

--- a/internal/telemetry/ci.go
+++ b/internal/telemetry/ci.go
@@ -1,0 +1,64 @@
+package telemetry
+
+import (
+	"os"
+	"strings"
+)
+
+// ciProviders maps CI providers to their signature environment variable.
+// Copied from the canonical ci-info list (github.com/watson/ci-info), not a
+// vendored dependency. Order matters: first match wins. We only ever read
+// these variables to detect presence — their values are never emitted (CI
+// env vars carry repo names, URLs, and sometimes tokens).
+var ciProviders = []struct{ name, envVar string }{ //nolint:gochecknoglobals
+	{"github_actions", "GITHUB_ACTIONS"},
+	{"gitlab", "GITLAB_CI"},
+	{"circleci", "CIRCLECI"},
+	{"jenkins", "JENKINS_URL"},
+	{"buildkite", "BUILDKITE"},
+	{"azure_pipelines", "TF_BUILD"},
+	{"travis", "TRAVIS"},
+	{"teamcity", "TEAMCITY_VERSION"},
+	{"bitbucket_pipelines", "BITBUCKET_COMMIT"},
+	{"drone", "DRONE"},
+	{"aws_codebuild", "CODEBUILD_BUILD_ARN"},
+	{"google_cloud_build", "BUILDER_OUTPUT"},
+	{"semaphore", "SEMAPHORE"},
+	{"appveyor", "APPVEYOR"},
+	{"woodpecker", "WOODPECKER"},
+}
+
+// genericCIVars signal CI without identifying the provider.
+var genericCIVars = []string{"CI", "CONTINUOUS_INTEGRATION", "BUILD_NUMBER"} //nolint:gochecknoglobals
+
+// DetectCI reports the CI provider label and whether gcx is running under
+// CI. A recognised provider returns its fixed label; a generic CI signal
+// with no recognised provider returns "unknown"; no CI returns "" and false.
+func DetectCI() (string, bool) {
+	return detectCI(os.Getenv)
+}
+
+func detectCI(getenv func(string) string) (string, bool) {
+	for _, p := range ciProviders {
+		if isEnvSet(getenv(p.envVar)) {
+			return p.name, true
+		}
+	}
+	for _, v := range genericCIVars {
+		if isEnvSet(getenv(v)) {
+			return "unknown", true
+		}
+	}
+	return "", false
+}
+
+// isEnvSet treats a variable as set when non-empty and not explicitly falsy
+// (some environments export CI=false to opt out).
+func isEnvSet(v string) bool {
+	switch strings.ToLower(v) {
+	case "", "0", "false", "no":
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/telemetry/ci_internal_test.go
+++ b/internal/telemetry/ci_internal_test.go
@@ -1,0 +1,68 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectCI(t *testing.T) {
+	tests := []struct {
+		name         string
+		env          map[string]string
+		wantProvider string
+		wantIsCI     bool
+	}{
+		{
+			name: "no CI env",
+		},
+		{
+			name:         "github actions",
+			env:          map[string]string{"GITHUB_ACTIONS": "true"},
+			wantProvider: "github_actions",
+			wantIsCI:     true,
+		},
+		{
+			name:         "specific provider wins over generic CI var",
+			env:          map[string]string{"GITLAB_CI": "true", "CI": "true"},
+			wantProvider: "gitlab",
+			wantIsCI:     true,
+		},
+		{
+			name:         "generic CI var only",
+			env:          map[string]string{"CI": "true"},
+			wantProvider: "unknown",
+			wantIsCI:     true,
+		},
+		{
+			name: "CI=false is not CI",
+			env:  map[string]string{"CI": "false"},
+		},
+		{
+			name:         "non-boolean signature value counts as set",
+			env:          map[string]string{"JENKINS_URL": "https://jenkins.internal/"},
+			wantProvider: "jenkins",
+			wantIsCI:     true,
+		},
+		{
+			name:         "BUILD_NUMBER falls back to unknown",
+			env:          map[string]string{"BUILD_NUMBER": "42"},
+			wantProvider: "unknown",
+			wantIsCI:     true,
+		},
+		{
+			name:         "first matching provider in table order wins",
+			env:          map[string]string{"GITHUB_ACTIONS": "true", "DRONE": "true"},
+			wantProvider: "github_actions",
+			wantIsCI:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			provider, isCI := detectCI(fakeGetenv(tc.env))
+			assert.Equal(t, tc.wantProvider, provider)
+			assert.Equal(t, tc.wantIsCI, isCI)
+		})
+	}
+}

--- a/internal/telemetry/deviceid.go
+++ b/internal/telemetry/deviceid.go
@@ -18,11 +18,10 @@ func DeviceIDPath() string {
 }
 
 // DeviceID returns the anonymous per-install device ID and whether it is
-// persisted, creating and storing a random UUIDv4 on first use. It is
-// random, never machine-derived. When the state dir is unwritable (or the
-// ID file is corrupt and cannot be rewritten) it returns a fresh ephemeral
-// ID with persisted=false, so ephemeral IDs can be excluded from install
-// counts.
+// persisted, creating and storing a random UUIDv4 on first use. When the
+// state dir is unwritable (or the ID file is corrupt and cannot be
+// rewritten) it returns a fresh ephemeral ID with persisted=false, so
+// ephemeral IDs can be excluded from install counts.
 func DeviceID() (string, bool) {
 	path := DeviceIDPath()
 	if data, err := os.ReadFile(path); err == nil {

--- a/internal/telemetry/deviceid.go
+++ b/internal/telemetry/deviceid.go
@@ -1,0 +1,45 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/grafana/gcx/internal/xdg"
+)
+
+const deviceIDFileName = "device-id"
+
+// DeviceIDPath returns the full path of the persistent device ID file.
+// Deleting the file resets the ID.
+func DeviceIDPath() string {
+	return filepath.Join(xdg.StateHome(), "gcx", deviceIDFileName)
+}
+
+// DeviceID returns the anonymous per-install device ID and whether it is
+// persisted, creating and storing a random UUIDv4 on first use. It is
+// random, never machine-derived. When the state dir is unwritable (or the
+// ID file is corrupt and cannot be rewritten) it returns a fresh ephemeral
+// ID with persisted=false, so ephemeral IDs can be excluded from install
+// counts.
+func DeviceID() (string, bool) {
+	path := DeviceIDPath()
+	if data, err := os.ReadFile(path); err == nil {
+		if parsed, err := uuid.Parse(strings.TrimSpace(string(data))); err == nil {
+			return parsed.String(), true
+		}
+	}
+	fresh, err := uuid.NewRandom()
+	if err != nil {
+		return "", false
+	}
+	id := fresh.String()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return id, false
+	}
+	if err := os.WriteFile(path, []byte(id+"\n"), 0o600); err != nil {
+		return id, false
+	}
+	return id, true
+}

--- a/internal/telemetry/deviceid_test.go
+++ b/internal/telemetry/deviceid_test.go
@@ -1,0 +1,61 @@
+package telemetry_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/grafana/gcx/internal/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceIDCreatesAndReuses(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	id, persisted := telemetry.DeviceID()
+	require.True(t, persisted)
+	_, err := uuid.Parse(id)
+	require.NoError(t, err)
+
+	again, persisted := telemetry.DeviceID()
+	assert.True(t, persisted)
+	assert.Equal(t, id, again, "second call must return the persisted ID")
+
+	info, err := os.Stat(telemetry.DeviceIDPath())
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestDeviceIDRewritesCorruptFile(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	require.NoError(t, os.MkdirAll(filepath.Dir(telemetry.DeviceIDPath()), 0o700))
+	require.NoError(t, os.WriteFile(telemetry.DeviceIDPath(), []byte("not-a-uuid\n"), 0o600))
+
+	id, persisted := telemetry.DeviceID()
+	assert.True(t, persisted)
+	_, err := uuid.Parse(id)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(telemetry.DeviceIDPath())
+	require.NoError(t, err)
+	assert.Equal(t, id+"\n", string(data), "corrupt file must be replaced with the fresh ID")
+}
+
+func TestDeviceIDEphemeralWhenStateDirUnwritable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission checks do not apply to root")
+	}
+	stateHome := filepath.Join(t.TempDir(), "readonly")
+	require.NoError(t, os.MkdirAll(stateHome, 0o500))
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	id, persisted := telemetry.DeviceID()
+	assert.False(t, persisted, "unwritable state dir must yield an ephemeral ID")
+	_, err := uuid.Parse(id)
+	require.NoError(t, err)
+
+	other, _ := telemetry.DeviceID()
+	assert.NotEqual(t, id, other, "ephemeral IDs must not repeat across invocations")
+}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -1,0 +1,61 @@
+package telemetry
+
+// ServiceName identifies gcx in the event envelope and as the OTLP resource
+// service.name; the usage-stats receiver dispatches on it.
+const ServiceName = "gcx"
+
+// Outcome values for Event.Outcome.
+const (
+	OutcomeOK           = "ok"
+	OutcomeRuntimeError = "runtime_error"
+	OutcomeParseError   = "parse_error"
+	OutcomeHelp         = "help"
+)
+
+// Event is the flat wide event describing one gcx invocation. Field names
+// follow the usage-stats JSON schema (snake_case); the same fields travel as
+// OTLP span/resource attributes on the wire.
+//
+// Privacy invariant: no field may carry argument or flag values, resource
+// names, hostnames, or anything else that identifies a person, an
+// organisation, or their data. Flags holds flag NAMES only; Command is the
+// resolved command path only. The parse_error_* fields are shape-filtered
+// before they are set (see #578).
+type Event struct {
+	// Envelope.
+	Service string `json:"service"`
+	Version string `json:"version"`
+	OS      string `json:"os"`
+	Arch    string `json:"arch"`
+
+	// Anonymous install identity.
+	DeviceID          string `json:"device_id"`
+	DeviceIDPersisted bool   `json:"device_id_persisted"`
+
+	// What ran.
+	Command    string `json:"command"`
+	Flags      string `json:"flags"`
+	Provider   string `json:"provider"`
+	Outcome    string `json:"outcome"`
+	ExitCode   int    `json:"exit_code"`
+	ErrorKind  string `json:"error_kind"`
+	DurationMS int64  `json:"duration_ms"`
+
+	// Execution context.
+	IsTTY        bool   `json:"is_tty"`
+	IsCI         bool   `json:"is_ci"`
+	CIProvider   string `json:"ci_provider"`
+	IsAgent      bool   `json:"is_agent"`
+	Agent        string `json:"agent"`
+	TargetKind   string `json:"target_kind"`
+	OutputFormat string `json:"output_format"`
+
+	// Parse-failure capture, set only when Outcome is OutcomeParseError.
+	ParseErrorKind     string `json:"parse_error_kind,omitempty"`
+	ParseErrorParent   string `json:"parse_error_parent,omitempty"`
+	ParseErrorToken    string `json:"parse_error_token,omitempty"`
+	AttemptedCommand   string `json:"attempted_command,omitempty"`
+	ParseErrorFlags    string `json:"parse_error_flags,omitempty"`
+	ParseErrorNearest  string `json:"parse_error_nearest,omitempty"`
+	ParseErrorDistance int    `json:"parse_error_distance,omitempty"`
+}

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -1,0 +1,94 @@
+package telemetry_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/gcx/internal/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The exact JSON field inventory of the event schema. Any change here changes
+// the public usage-stats contract (BigQuery columns and the documented field
+// list) and must be reflected in the usage-stats flattener and the docs.
+func wantAlwaysPresent() []string {
+	return []string{
+		"service", "version", "os", "arch",
+		"device_id", "device_id_persisted",
+		"command", "flags", "provider", "outcome", "exit_code", "error_kind", "duration_ms",
+		"is_tty", "is_ci", "ci_provider", "is_agent", "agent", "target_kind", "output_format",
+	}
+}
+
+func wantParseErrorOnly() []string {
+	return []string{
+		"parse_error_kind", "parse_error_parent", "parse_error_token",
+		"attempted_command", "parse_error_flags", "parse_error_nearest", "parse_error_distance",
+	}
+}
+
+func marshalKeys(t *testing.T, ev telemetry.Event) map[string]any {
+	t.Helper()
+	data, err := json.Marshal(ev)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	return m
+}
+
+func TestEventFieldInventory(t *testing.T) {
+	full := telemetry.Event{
+		Service:            telemetry.ServiceName,
+		Version:            "0.4.1",
+		OS:                 "linux",
+		Arch:               "arm64",
+		DeviceID:           "00000000-0000-4000-8000-000000000000",
+		DeviceIDPersisted:  true,
+		Command:            "dashboards push",
+		Flags:              "dry-run,folder",
+		Provider:           "dashboards",
+		Outcome:            telemetry.OutcomeParseError,
+		ExitCode:           2,
+		ErrorKind:          "usage_error",
+		DurationMS:         1234,
+		IsTTY:              true,
+		IsCI:               true,
+		CIProvider:         "github_actions",
+		IsAgent:            true,
+		Agent:              "claude-code",
+		TargetKind:         "cloud",
+		OutputFormat:       "json",
+		ParseErrorKind:     "unknown_command",
+		ParseErrorParent:   "dashboards",
+		ParseErrorToken:    "serch",
+		AttemptedCommand:   "dashboards serch",
+		ParseErrorFlags:    "verbsoe",
+		ParseErrorNearest:  "search",
+		ParseErrorDistance: 2,
+	}
+
+	got := marshalKeys(t, full)
+	want := append(wantAlwaysPresent(), wantParseErrorOnly()...)
+	assert.ElementsMatch(t, want, keys(got), "full event must emit exactly the documented field set")
+}
+
+func TestEventOmitsParseFieldsWhenUnset(t *testing.T) {
+	got := marshalKeys(t, telemetry.Event{Outcome: telemetry.OutcomeOK})
+	assert.ElementsMatch(t, wantAlwaysPresent(), keys(got),
+		"non-parse-error events must omit parse_error_* and keep all other fields, even zero-valued")
+}
+
+func TestEventNoNearMatchDistanceSurvives(t *testing.T) {
+	// -1 (novel guess, no near match) must not be dropped by omitempty.
+	got := marshalKeys(t, telemetry.Event{Outcome: telemetry.OutcomeParseError, ParseErrorDistance: -1})
+	assert.InDelta(t, float64(-1), got["parse_error_distance"], 0)
+}
+
+func keys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,89 @@
+// Package telemetry implements gcx's anonymous usage stats: one flat event
+// per invocation describing the shape of usage (command path, flag names,
+// outcome) and never its content (argument values, resource names, hosts).
+// The only correlator is a random, resettable, per-install device ID.
+//
+// This package is a library only: event construction and emission are wired
+// at the CLI lifecycle boundaries (cmd/gcx/main.go), not here.
+package telemetry
+
+import (
+	"os"
+	"strings"
+)
+
+// Mode is the resolved telemetry state for an invocation.
+type Mode string
+
+const (
+	// ModeEnabled emits the event.
+	ModeEnabled Mode = "enabled"
+	// ModeDisabled emits nothing.
+	ModeDisabled Mode = "disabled"
+	// ModeLog prints the event that would be sent to stderr and sends nothing.
+	ModeLog Mode = "log"
+)
+
+// defaultMode is the resolved mode when no env var or config setting applies.
+// It stays disabled until privacy/legal and usage-stats owner sign-off clear;
+// flipping to ModeEnabled is deliberately a one-line change gated on those.
+const defaultMode = ModeDisabled
+
+// Env documents the environment variables that control telemetry. The env
+// tags are read by scripts/env-vars-reference (docs generation); resolution
+// itself happens in ResolveMode.
+type Env struct {
+	// Telemetry controls anonymous usage telemetry for this invocation:
+	// "enabled", "disabled", or "log" (print the event to stderr and send
+	// nothing). Takes precedence over DO_NOT_TRACK and the
+	// `diagnostics.telemetry` config field.
+	Telemetry string `env:"GCX_TELEMETRY"`
+
+	// DoNotTrack disables anonymous usage telemetry when set to "1" or
+	// "true" (cross-tool convention, see https://consoledonottrack.com).
+	// Overridden by GCX_TELEMETRY.
+	DoNotTrack string `env:"DO_NOT_TRACK"`
+}
+
+// ResolveMode resolves the telemetry mode for this invocation. Precedence,
+// highest first: GCX_TELEMETRY, DO_NOT_TRACK, the diagnostics.telemetry
+// config value, the built-in default. Unrecognised values fall through to
+// the next level.
+func ResolveMode(configValue string) Mode {
+	return resolveMode(os.Getenv, configValue)
+}
+
+func resolveMode(getenv func(string) string, configValue string) Mode {
+	env := Env{
+		Telemetry:  getenv("GCX_TELEMETRY"),
+		DoNotTrack: getenv("DO_NOT_TRACK"),
+	}
+	if m, ok := parseMode(env.Telemetry); ok {
+		return m
+	}
+	if isDoNotTrack(env.DoNotTrack) {
+		return ModeDisabled
+	}
+	if m, ok := parseMode(configValue); ok {
+		return m
+	}
+	return defaultMode
+}
+
+func parseMode(s string) (Mode, bool) {
+	switch Mode(strings.ToLower(s)) {
+	case ModeEnabled, ModeDisabled, ModeLog:
+		return Mode(strings.ToLower(s)), true
+	default:
+		return "", false
+	}
+}
+
+func isDoNotTrack(s string) bool {
+	switch strings.ToLower(s) {
+	case "1", "true":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -40,8 +40,8 @@ type Env struct {
 	Telemetry string `env:"GCX_TELEMETRY"`
 
 	// DoNotTrack disables anonymous usage telemetry when set to "1" or
-	// "true" (cross-tool convention, see https://consoledonottrack.com).
-	// Overridden by GCX_TELEMETRY.
+	// "true" (cross-tool DO_NOT_TRACK convention). Overridden by
+	// GCX_TELEMETRY.
 	DoNotTrack string `env:"DO_NOT_TRACK"`
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -53,15 +53,19 @@ func ResolveMode(configValue string) Mode {
 	return resolveMode(os.Getenv, configValue)
 }
 
+// Env var names used by resolveMode. envConsistencyTest asserts they match
+// the Env struct tags the docs generator reads, so the documented names
+// cannot drift from the resolved ones.
+const (
+	envTelemetry  = "GCX_TELEMETRY"
+	envDoNotTrack = "DO_NOT_TRACK"
+)
+
 func resolveMode(getenv func(string) string, configValue string) Mode {
-	env := Env{
-		Telemetry:  getenv("GCX_TELEMETRY"),
-		DoNotTrack: getenv("DO_NOT_TRACK"),
-	}
-	if m, ok := parseMode(env.Telemetry); ok {
+	if m, ok := parseMode(getenv(envTelemetry)); ok {
 		return m
 	}
-	if isDoNotTrack(env.DoNotTrack) {
+	if isDoNotTrack(getenv(envDoNotTrack)) {
 		return ModeDisabled
 	}
 	if m, ok := parseMode(configValue); ok {
@@ -71,9 +75,10 @@ func resolveMode(getenv func(string) string, configValue string) Mode {
 }
 
 func parseMode(s string) (Mode, bool) {
-	switch Mode(strings.ToLower(s)) {
+	m := Mode(strings.ToLower(s))
+	switch m {
 	case ModeEnabled, ModeDisabled, ModeLog:
-		return Mode(strings.ToLower(s)), true
+		return m, true
 	default:
 		return "", false
 	}

--- a/internal/telemetry/telemetry_internal_test.go
+++ b/internal/telemetry/telemetry_internal_test.go
@@ -101,7 +101,6 @@ func TestEnvTagsMatchResolvedNames(t *testing.T) {
 	typ := reflect.TypeFor[Env]()
 	tags := make(map[string]string, typ.NumField())
 	for f := range typ.Fields() {
-		f := f
 		tags[f.Name] = f.Tag.Get("env")
 	}
 	assert.Equal(t, map[string]string{

--- a/internal/telemetry/telemetry_internal_test.go
+++ b/internal/telemetry/telemetry_internal_test.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,4 +92,20 @@ func TestResolveMode(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// The Env struct tags are what the docs generator publishes; resolveMode
+// reads the constants. If they drift, the docs advertise a variable that
+// does nothing while the real one is undocumented.
+func TestEnvTagsMatchResolvedNames(t *testing.T) {
+	typ := reflect.TypeFor[Env]()
+	tags := make(map[string]string, typ.NumField())
+	for f := range typ.Fields() {
+		f := f
+		tags[f.Name] = f.Tag.Get("env")
+	}
+	assert.Equal(t, map[string]string{
+		"Telemetry":  envTelemetry,
+		"DoNotTrack": envDoNotTrack,
+	}, tags)
 }

--- a/internal/telemetry/telemetry_internal_test.go
+++ b/internal/telemetry/telemetry_internal_test.go
@@ -1,0 +1,94 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func fakeGetenv(env map[string]string) func(string) string {
+	return func(key string) string { return env[key] }
+}
+
+func TestResolveMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         map[string]string
+		configValue string
+		want        Mode
+	}{
+		{
+			name: "no env, no config: built-in default",
+			want: defaultMode,
+		},
+		{
+			name: "GCX_TELEMETRY=enabled",
+			env:  map[string]string{"GCX_TELEMETRY": "enabled"},
+			want: ModeEnabled,
+		},
+		{
+			name: "GCX_TELEMETRY=log",
+			env:  map[string]string{"GCX_TELEMETRY": "log"},
+			want: ModeLog,
+		},
+		{
+			name:        "GCX_TELEMETRY=disabled overrides config enabled",
+			env:         map[string]string{"GCX_TELEMETRY": "disabled"},
+			configValue: "enabled",
+			want:        ModeDisabled,
+		},
+		{
+			name: "GCX_TELEMETRY is case-insensitive",
+			env:  map[string]string{"GCX_TELEMETRY": "ENABLED"},
+			want: ModeEnabled,
+		},
+		{
+			name:        "unrecognised GCX_TELEMETRY falls through to config",
+			env:         map[string]string{"GCX_TELEMETRY": "on"},
+			configValue: "enabled",
+			want:        ModeEnabled,
+		},
+		{
+			name:        "DO_NOT_TRACK=1 overrides config enabled",
+			env:         map[string]string{"DO_NOT_TRACK": "1"},
+			configValue: "enabled",
+			want:        ModeDisabled,
+		},
+		{
+			name: "DO_NOT_TRACK=true disables",
+			env:  map[string]string{"DO_NOT_TRACK": "true"},
+			want: ModeDisabled,
+		},
+		{
+			name:        "DO_NOT_TRACK=0 is ignored",
+			env:         map[string]string{"DO_NOT_TRACK": "0"},
+			configValue: "enabled",
+			want:        ModeEnabled,
+		},
+		{
+			name: "GCX_TELEMETRY=enabled beats DO_NOT_TRACK=1",
+			env: map[string]string{
+				"GCX_TELEMETRY": "enabled",
+				"DO_NOT_TRACK":  "1",
+			},
+			want: ModeEnabled,
+		},
+		{
+			name:        "config log mode",
+			configValue: "log",
+			want:        ModeLog,
+		},
+		{
+			name:        "unrecognised config value falls through to default",
+			configValue: "on",
+			want:        defaultMode,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveMode(fakeGetenv(tc.env), tc.configValue)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/scripts/env-vars-reference/main.go
+++ b/scripts/env-vars-reference/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/telemetry"
 )
 
 func main() {
@@ -31,9 +32,15 @@ func main() {
 		log.Fatal(err)
 	}
 
+	telemetryCommentsMap, err := buildCommentsMap("internal/telemetry/")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	envVarMap := make(map[string]string)
 	discoverEnvVars(reflect.TypeFor[config.Config](), typesCommentsMap, envVarMap)
 	discoverEnvVars(reflect.TypeFor[config.CLIOptions](), typesCommentsMap, envVarMap)
+	discoverEnvVars(reflect.TypeFor[telemetry.Env](), telemetryCommentsMap, envVarMap)
 
 	err = os.WriteFile(filepath.Join(outputDir, "index.md"), toMarkdown(envVarMap), 0600)
 	if err != nil {


### PR DESCRIPTION
## Summary

- new `internal/telemetry` package: 
  - add the `Event` model for usage stats
  - Add opt-out controls
  - Add persistent anonymous device ID (`$XDG_STATE_HOME/gcx/device-id`, with ephemeral fallback)
  - Add CI provider detection from env vars
- detect agents (e.g. `claude-code`)
- new `diagnostics.telemetry` config field, wired into layered merge

Nothing is activated yet and nothing is emitted. This is just laying some groundwork.

This is [stage G1](https://github.com/grafana/gcx-internal/pull/32/changes#diff-8c6b65564b71c720ea66e00b5245f6118877ae70ce09057b43f8d72325c58b62R52) of the implementation plan in grafana/gcx-internal#32 (`docs/specs/2026-07-09-usage-stats-implementation-plan.md`).

## Notes for review

- We'll re-use the Event struct in the usage-stats server. This will be the shape of the JSON schema.
- preparing for reporting missing commands: `parse_error_*` fields  are `omitempty` and only set on parse failures (populated later); a test guards that `parse_error_distance: -1` survives marshalling.