### PR TITLE
fix(kg): align entity/relationship deletes with collection-path API

### DIFF
--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -51,11 +51,12 @@ const (
 	v2RelabelRulesPath   = v2ConfigPath + "/relabel-rules"
 
 	// KG Write API (K8s-style, namespaced). %s is the stacks-<id> namespace.
+	// Entity and relationship deletes use these collection paths with identity
+	// in the query string (type/name are not path segments), so names containing
+	// '/' are addressable without Tomcat rejecting encoded solidus.
 	kgWriteAPIBase     = "/apis/kg.grafana.com/v1alpha1/namespaces/%s"
 	kgEntitiesPathFmt  = kgWriteAPIBase + "/entities"
-	kgEntityPathFmt    = kgWriteAPIBase + "/entities/%s/%s" // type, name
 	kgRelationshipsFmt = kgWriteAPIBase + "/relationships"
-	kgRelationshipFmt  = kgWriteAPIBase + "/relationships/%s" // type
 )
 
 // RelabelRuleType identifies which Mimir relabel rule group to operate on.
@@ -798,10 +799,12 @@ func (c *Client) UpsertRelationship(ctx context.Context, req RelationshipWriteRe
 }
 
 // DeleteRelationship deletes a custom edge of relType between from and to.
-// The endpoint coordinates travel as from.*/to.* query params.
+// Identity travels as query params on the collection path (type, from.*, to.*);
+// there is no request body.
 func (c *Client) DeleteRelationship(ctx context.Context, relType string, from, to EntityRef) error {
-	path := fmt.Sprintf(kgRelationshipFmt, url.PathEscape(c.namespace), url.PathEscape(relType))
+	path := fmt.Sprintf(kgRelationshipsFmt, url.PathEscape(c.namespace))
 	q := url.Values{}
+	q.Set("type", relType)
 	addRef := func(prefix string, ref EntityRef) {
 		q.Set(prefix+".domain", ref.Domain)
 		q.Set(prefix+".type", ref.Type)
@@ -844,11 +847,15 @@ func (c *Client) UpsertEntity(ctx context.Context, req EntityWriteRequest) (*Ent
 }
 
 // DeleteEntity deletes a custom entity identified by (domain, type, name, scope).
-// Scope is identity-significant and must match the value used at create.
+// Identity travels as query params on the collection path (domain, type, name,
+// and optional scope[key]=value); there is no request body. Scope is
+// identity-significant and must match the value used at create.
 func (c *Client) DeleteEntity(ctx context.Context, domain, entityType, name string, scope map[string]string) error {
-	path := fmt.Sprintf(kgEntityPathFmt, url.PathEscape(c.namespace), url.PathEscape(entityType), url.PathEscape(name))
+	path := fmt.Sprintf(kgEntitiesPathFmt, url.PathEscape(c.namespace))
 	q := url.Values{}
 	q.Set("domain", domain)
+	q.Set("type", entityType)
+	q.Set("name", name)
 	for k, v := range scope {
 		q.Set("scope["+k+"]", v)
 	}

--- a/internal/providers/kg/client_test.go
+++ b/internal/providers/kg/client_test.go
@@ -799,17 +799,31 @@ func TestClient_UpsertEntity(t *testing.T) {
 }
 
 func TestClient_DeleteEntity(t *testing.T) {
-	t.Run("sends domain and scope query params", func(t *testing.T) {
+	t.Run("sends identity as query params on collection path", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodDelete, r.Method)
-			assert.Contains(t, r.URL.Path, "/namespaces/stack-123/entities/Service/checkout")
-			assert.Equal(t, "myapp", r.URL.Query().Get("domain"))
-			assert.Equal(t, "prod", r.URL.Query().Get("scope[env]"))
+			assert.Equal(t, "/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/entities", r.URL.Path)
+			q := r.URL.Query()
+			assert.Equal(t, "myapp", q.Get("domain"))
+			assert.Equal(t, "Service", q.Get("type"))
+			assert.Equal(t, "checkout", q.Get("name"))
+			assert.Equal(t, "prod", q.Get("scope[env]"))
 			w.WriteHeader(http.StatusNoContent)
 		}))
 		defer server.Close()
 		client := newTestClient(t, server)
 		require.NoError(t, client.DeleteEntity(t.Context(), "myapp", "Service", "checkout", map[string]string{"env": "prod"}))
+	})
+	t.Run("allows slash in name via query params", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodDelete, r.Method)
+			assert.Equal(t, "/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/entities", r.URL.Path)
+			assert.Equal(t, "foo/bar", r.URL.Query().Get("name"))
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+		client := newTestClient(t, server)
+		require.NoError(t, client.DeleteEntity(t.Context(), "myapp", "Service", "foo/bar", nil))
 	})
 	t.Run("404 surfaces APIError", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -827,8 +841,9 @@ func TestClient_DeleteEntity(t *testing.T) {
 func TestClient_DeleteRelationship(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Contains(t, r.URL.Path, "/namespaces/stack-123/relationships/CALLS")
+		assert.Equal(t, "/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/relationships", r.URL.Path)
 		q := r.URL.Query()
+		assert.Equal(t, "CALLS", q.Get("type"))
 		assert.Equal(t, "myapp", q.Get("from.domain"))
 		assert.Equal(t, "Service", q.Get("from.type"))
 		assert.Equal(t, "checkout", q.Get("from.name"))

--- a/internal/providers/kg/write_commands_test.go
+++ b/internal/providers/kg/write_commands_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	internalconfig "github.com/grafana/gcx/internal/config"
@@ -90,7 +91,10 @@ func TestEntitiesDelete_ForceSendsDelete(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/entities"), "delete must hit collection path, got %s", r.URL.Path)
 		assert.Equal(t, "myapp", r.URL.Query().Get("domain"))
+		assert.Equal(t, "Service", r.URL.Query().Get("type"))
+		assert.Equal(t, "checkout", r.URL.Query().Get("name"))
 		assert.Equal(t, "prod", r.URL.Query().Get("scope[env]"), "scope must reach the server")
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -198,6 +202,8 @@ func TestRelationshipsDelete_ForceSendsDelete(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/relationships"), "delete must hit collection path, got %s", r.URL.Path)
+		assert.Equal(t, "CALLS", r.URL.Query().Get("type"))
 		assert.Equal(t, "checkout", r.URL.Query().Get("from.name"))
 		assert.Equal(t, "cart", r.URL.Query().Get("to.name"))
 		w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
## Summary
- Update `DeleteEntity` / `DeleteRelationship` to hit the KG Write collection paths (`/entities`, `/relationships`) with identity in query params, matching [asserts-adi#6513](https://github.com/grafana/asserts-adi/pull/6513).
- This allows entity names containing `/` (Tomcat no longer rejects encoded solidus in the path) and removes the need for subresource delete gateway routes.
- CLI command surface is unchanged; only the HTTP wire format for deletes changes.

## Test plan
- [x] `go test -mod=mod -race -count=1 ./internal/providers/kg/ -run 'TestClient_DeleteEntity|TestClient_DeleteRelationship|TestEntitiesDelete|TestRelationshipsDelete'`
- [ ] Confirm against a stack with the asserts-adi delete API change: create an entity named `foo/bar`, then `gcx kg entities delete` succeeds with 204


Made with [Cursor](https://cursor.com)