### PR TITLE
fix(irm): repair build break from #896/#898 semantic merge conflict

### DIFF
--- a/internal/providers/irm/oncall_client.go
+++ b/internal/providers/irm/oncall_client.go
@@ -297,7 +297,7 @@ func listUnpaginated[T any](ctx context.Context, c *OnCallClient, path, resource
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, handleErrorResponse(resp)
+		return nil, providers.HandleErrorResponse(resp)
 	}
 
 	var result []T
@@ -497,7 +497,7 @@ func (c *OnCallClient) ListRouteFilterTypes(ctx context.Context) ([]RouteFilterT
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, handleErrorResponse(resp)
+		return nil, providers.HandleErrorResponse(resp)
 	}
 
 	var meta struct {


### PR DESCRIPTION
## What

Repairs a build break on `main`. The IRM provider failed to compile:

```
internal/providers/irm/oncall_client.go:300:15: undefined: handleErrorResponse
internal/providers/irm/oncall_client.go:500:15: undefined: handleErrorResponse
```

This blocked CI (Tests, Linters, Documentation) on every branch cut from or merged with `main`.

## Root cause — semantic merge conflict between #896 and #898

Two already-merged PRs, each green against its own base, combined into a tree that doesn't compile:

- **#898** (`feat(irm): add CRUD verbs and discovery`) added `listUnpaginated` and `ListRouteFilterTypes`, which call the then-existing package-local `handleErrorResponse` (lines 300, 500).
- **#896** (`refactor(providers): dedupe error parsing`) renamed `handleErrorResponse` → `providers.HandleErrorResponse`, deleted the old helper, and updated every caller it could see.

#896 branched before #898 landed and was never rebased on it, so it never saw #898's two new callers. The merge is textually clean but semantically broken. Neither PR's CI could catch it, since each was tested against its own base, not the merged result. Confirmed by building a clean `origin/main` checkout — it fails; `git blame` attributes both lines to #898, and the `handleErrorResponse` definition no longer exists on `main`.

## The fix

Point the two stragglers at the shared helper, making them identical to the 11 sibling callers #896 already migrated in the same file:

```diff
 	if resp.StatusCode != http.StatusOK {
-		return nil, handleErrorResponse(resp)
+		return nil, providers.HandleErrorResponse(resp)
 	}
```

Both are pure error paths — nothing on the success path changes. `providers.HandleErrorResponse` is behavior-equivalent to the old local helper, only better (caps the error-body read at 1 MiB; extracts the JSON `error`/`message`/`msg` field when present). This completes #896's migration rather than diverging from it.

## Testing

- `go build ./internal/providers/irm/` — OK (was failing on `main`)
- `go test ./internal/providers/irm/...` — pass
- `golangci-lint run ./internal/providers/irm/...` — 0 issues

## Follow-up

Enable branch protection **"Require branches to be up to date before merging"** on `main` — it re-tests against the current tip and would have caught this class of break before #896 merged.
