### PR TITLE
Dashboard V2 support in the resource linter

### DIFF
--- a/internal/linter/bundle/gcx/utils/dashboard.rego
+++ b/internal/linter/bundle/gcx/utils/dashboard.rego
@@ -17,7 +17,7 @@ dashboard_v1_variables(dashboard) := object.get(dashboard.spec, ["templating", "
 
 resource_is_dashboard_v2(resource) if {
 	resource.kind in {"Dashboard", "DashboardWithAccessInfo"}
-	resource.apiVersion in {"dashboard.grafana.app/v2beta1"}
+	resource.apiVersion in {"dashboard.grafana.app/v2alpha1", "dashboard.grafana.app/v2beta1", "dashboard.grafana.app/v2"}
 }
 
 dashboard_v2_panels(dashboard) := [{"id": i, "object": panel} | panel := dashboard.spec.elements[i]; panel.kind == "Panel"]

--- a/internal/linter/bundle/gcx/utils/dashboard_test.rego
+++ b/internal/linter/bundle/gcx/utils/dashboard_test.rego
@@ -111,3 +111,25 @@ test_resource_is_dashboard_v2_recognizes_DashboardWithAccessInfo_v2beta1 if {
 
 	utils.resource_is_dashboard_v2(resource)
 }
+
+test_resource_is_dashboard_v2_recognizes_Dashboard_v2 if {
+	resource := {
+	    "kind": "Dashboard",
+	    "apiVersion": "dashboard.grafana.app/v2",
+	    "metadata": {"name": "test-dashboard"},
+	    "spec": {"does not": "matter"}
+	}
+
+	utils.resource_is_dashboard_v2(resource)
+}
+
+test_resource_is_dashboard_v2_recognizes_DashboardWithAccessInfo_v2 if {
+	resource := {
+	    "kind": "DashboardWithAccessInfo",
+	    "apiVersion": "dashboard.grafana.app/v2",
+	    "metadata": {"name": "test-dashboard"},
+	    "spec": {"does not": "matter"}
+	}
+
+	utils.resource_is_dashboard_v2(resource)
+}

--- a/internal/linter/doc.go
+++ b/internal/linter/doc.go
@@ -1,0 +1,3 @@
+package linter
+
+// This package is inspired by the linter implemented in Regal: https://github.com/open-policy-agent/regal/tree/main/pkg/linter


### PR DESCRIPTION
This PR updates the resource linter to natively recognize `dashboard.grafana.app/v2` manifests and adds a comment linking it to Regal: it's original inspiration.