### PR TITLE
feat(output): include output-shape hint in --jq runtime errors

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -48,6 +48,7 @@ func ErrorToDetailedError(err error) *gcxerrors.DetailedError {
 	errorConverters := []func(err error) (*gcxerrors.DetailedError, bool){
 		convertWaitTimeoutEmitted,          // Wait timeout already emitted fused envelope — suppress secondary output
 		convertUnknownFieldSelectionErrors, // --json unknown-field validation
+		convertJQRuntimeErrors,             // --jq runtime failures — includes output shape summary
 		convertPartialFailureErrors,
 		convertUsageErrors,
 		convertCobraUnknownCommandErrors,
@@ -1220,6 +1221,48 @@ func convertUnknownFieldSelectionErrors(err error) (*gcxerrors.DetailedError, bo
 		Suggestions: []string{
 			"Run the command with --json list to enumerate valid field names",
 		},
+	}, true
+}
+
+// convertJQRuntimeErrors converts JQRuntimeError (a --jq expression failed
+// against the actual output) into a DetailedError with exit code 2
+// (ExitUsageError). Details carry a compact summary of the output shape —
+// top-level type plus a capped field-path list — so the expression can be
+// corrected in one retry instead of blind trial and error.
+func convertJQRuntimeErrors(err error) (*gcxerrors.DetailedError, bool) {
+	var jqErr cmdoutput.JQRuntimeError
+	if !errors.As(err, &jqErr) {
+		return nil, false
+	}
+
+	details := fmt.Sprintf("jq: %v\n\nThe command's output is %s.", jqErr.Err, jqErr.Shape)
+	if len(jqErr.Fields) > 0 {
+		label := "Fields"
+		if jqErr.ArrayInput {
+			label = "Element fields"
+		}
+		fieldList := strings.Join(jqErr.Fields, ", ")
+		if jqErr.MoreFields > 0 {
+			fieldList += fmt.Sprintf(" (+%d more)", jqErr.MoreFields)
+		}
+		details += fmt.Sprintf("\n%s: %s", label, fieldList)
+	}
+
+	var suggestions []string
+	if jqErr.ArrayInput {
+		suggestions = append(suggestions,
+			"Iterate array elements with .[], e.g. --jq '.items[].name' or --jq '.[].name'")
+	}
+	suggestions = append(suggestions,
+		"Run the command with --json list to enumerate all available field paths",
+		"Run the command without --jq (-o json) to inspect the raw output shape")
+
+	exitCode := gcxerrors.ExitUsageError
+	return &gcxerrors.DetailedError{
+		Summary:     "Invalid command usage",
+		Details:     details,
+		ExitCode:    &exitCode,
+		Suggestions: suggestions,
 	}, true
 }
 

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -961,6 +961,87 @@ func TestErrorToDetailedError_UnknownFieldSelectionError(t *testing.T) {
 	}
 }
 
+// TestErrorToDetailedError_JQRuntimeError verifies that JQRuntimeError (a --jq
+// expression failed against the actual output) is converted to a DetailedError
+// with:
+//   - Summary: "Invalid command usage"
+//   - ExitCode: 2 (ExitUsageError)
+//   - Details containing the gojq message and the output shape summary
+//   - Suggestions for array iteration (arrays only) and --json list discovery
+func TestErrorToDetailedError_JQRuntimeError(t *testing.T) {
+	tests := []struct {
+		name            string
+		err             error
+		wantInDetails   []string
+		wantSuggestions []string
+		notSuggestions  []string
+	}{
+		{
+			name: "array input includes element fields and iteration hint",
+			err: cmdoutput.JQRuntimeError{
+				Err:        errors.New(`cannot index array with "string"`),
+				Shape:      "an array of 25 objects",
+				Fields:     []string{"name", "ns"},
+				MoreFields: 3,
+				ArrayInput: true,
+			},
+			wantInDetails:   []string{`cannot index array with "string"`, "an array of 25 objects", "Element fields: name, ns (+3 more)"},
+			wantSuggestions: []string{".[]", "--json list"},
+		},
+		{
+			name: "object input has plain fields label and no iteration hint",
+			err: cmdoutput.JQRuntimeError{
+				Err:    errors.New("cannot index number with \"bar\""),
+				Shape:  "an object",
+				Fields: []string{"foo"},
+			},
+			wantInDetails:   []string{"an object", "Fields: foo"},
+			wantSuggestions: []string{"--json list"},
+			notSuggestions:  []string{".[]"},
+		},
+		{
+			name: "scalar input omits field list",
+			err: cmdoutput.JQRuntimeError{
+				Err:   errors.New("cannot index number with \"foo\""),
+				Shape: "a number",
+			},
+			wantInDetails:   []string{"a number"},
+			wantSuggestions: []string{"--json list"},
+		},
+		{
+			name: "wrapped error still converts",
+			err: fmt.Errorf("encode: %w", cmdoutput.JQRuntimeError{
+				Err:        errors.New("cannot iterate over null"),
+				Shape:      "an array of 2 objects",
+				ArrayInput: true,
+			}),
+			wantInDetails:   []string{"cannot iterate over null", "an array of 2 objects"},
+			wantSuggestions: []string{".[]"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fail.ErrorToDetailedError(tc.err)
+
+			require.NotNil(t, got)
+			assert.Equal(t, "Invalid command usage", got.Summary)
+			require.NotNil(t, got.ExitCode)
+			assert.Equal(t, gcxerrors.ExitUsageError, *got.ExitCode)
+			for _, want := range tc.wantInDetails {
+				assert.Contains(t, got.Details, want)
+			}
+			joined := strings.Join(got.Suggestions, "\n")
+			for _, want := range tc.wantSuggestions {
+				assert.Contains(t, joined, want)
+			}
+			for _, notWant := range tc.notSuggestions {
+				assert.NotContains(t, joined, notWant)
+			}
+		})
+	}
+}
+
 func TestErrorToDetailedError_UsageErrorExitCode(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/output/jq.go
+++ b/internal/output/jq.go
@@ -4,11 +4,107 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/grafana/gcx/internal/format"
 	"github.com/itchyny/gojq"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+const (
+	jqShapeMaxFields     = 20 // cap on field paths carried in JQRuntimeError
+	jqShapeMaxFieldDepth = 3  // max dot-separated segments per carried path
+)
+
+// JQRuntimeError is returned by JQCodec.Encode when the compiled --jq
+// expression fails against the actual output value. It carries a compact
+// description of the input shape so the expression can be corrected in one
+// retry instead of blind trial and error.
+type JQRuntimeError struct {
+	Err        error    // underlying gojq evaluation error
+	Shape      string   // e.g. "an array of 25 objects"
+	Fields     []string // capped, sorted dot-notation paths of a sample object/element
+	MoreFields int      // discovered paths beyond the cap
+	ArrayInput bool     // input is an array or an object with an items[] array
+}
+
+func (e JQRuntimeError) Error() string {
+	return fmt.Sprintf("jq runtime: %v", e.Err)
+}
+
+func (e JQRuntimeError) Unwrap() error {
+	return e.Err
+}
+
+// newJQRuntimeError builds a JQRuntimeError from the already-normalized jq
+// input (the output of toJQInput): the top-level shape plus field paths from
+// a representative object, filtered to shallow paths and capped so the error
+// stays compact regardless of input size.
+func newJQRuntimeError(evalErr error, input any) JQRuntimeError {
+	jqErr := JQRuntimeError{Err: evalErr}
+
+	var sample map[string]any
+	switch v := input.(type) {
+	case nil:
+		jqErr.Shape = "null"
+	case string:
+		jqErr.Shape = "a string"
+	case bool:
+		jqErr.Shape = "a boolean"
+	case []any:
+		jqErr.ArrayInput = true
+		if first, ok := firstObject(v); ok {
+			jqErr.Shape = fmt.Sprintf("an array of %d objects", len(v))
+			sample = first
+		} else {
+			jqErr.Shape = fmt.Sprintf("an array of %d elements", len(v))
+		}
+	case map[string]any:
+		items, _ := v["items"].([]any)
+		if first, ok := firstObject(items); ok {
+			jqErr.ArrayInput = true
+			jqErr.Shape = fmt.Sprintf(`an object with an "items" array of %d objects`, len(items))
+			sample = first
+		} else {
+			jqErr.Shape = "an object"
+			sample = v
+		}
+	default:
+		// toJQInput normalizes everything else to JSON numbers.
+		jqErr.Shape = "a number"
+	}
+
+	if sample != nil {
+		jqErr.Fields, jqErr.MoreFields = shallowFieldPaths(sample)
+	}
+	return jqErr
+}
+
+// firstObject returns the first element of vals as an object map, when the
+// slice is non-empty and its first element is one.
+func firstObject(vals []any) (map[string]any, bool) {
+	if len(vals) == 0 {
+		return nil, false
+	}
+	m, ok := vals[0].(map[string]any)
+	return m, ok
+}
+
+// shallowFieldPaths discovers dot-notation field paths on sample, keeps only
+// paths shallower than jqShapeMaxFieldDepth segments (deep k8s metadata noise
+// would drown the useful ones), and caps the result at jqShapeMaxFields.
+func shallowFieldPaths(sample map[string]any) ([]string, int) {
+	var shallow []string
+	for _, p := range DiscoverFields(sample) {
+		if strings.Count(p, ".") < jqShapeMaxFieldDepth {
+			shallow = append(shallow, p)
+		}
+	}
+	if len(shallow) > jqShapeMaxFields {
+		return shallow[:jqShapeMaxFields], len(shallow) - jqShapeMaxFields
+	}
+	return shallow, 0
+}
 
 // JQCodec applies a jq expression to a value and writes each yielded result
 // as pretty-printed JSON on its own line (NDJSON shape, matching real jq).
@@ -48,7 +144,7 @@ func (c *JQCodec) Encode(dst io.Writer, value any) error {
 			return nil
 		}
 		if e, ok := v.(error); ok {
-			return fmt.Errorf("jq runtime: %w", e)
+			return newJQRuntimeError(e, input)
 		}
 		if err := encoder.Encode(v); err != nil {
 			return err

--- a/internal/output/jq_test.go
+++ b/internal/output/jq_test.go
@@ -129,6 +129,141 @@ func TestJQCodec_Encode(t *testing.T) {
 	}
 }
 
+// TestJQCodec_RuntimeErrorShape verifies that a runtime jq failure returns a
+// JQRuntimeError carrying a compact description of the input shape (top-level
+// type, capped field paths) so the expression can be corrected in one retry.
+func TestJQCodec_RuntimeErrorShape(t *testing.T) {
+	t.Parallel()
+
+	wideObject := map[string]any{}
+	for _, r := range "abcdefghijklmnopqrstuvwxy" { // 25 top-level keys
+		wideObject["key_"+string(r)] = 1.0
+	}
+
+	tests := []struct {
+		name           string
+		query          string
+		value          any
+		wantShape      string
+		wantFields     []string
+		wantFieldCount int // when >0, assert exact count instead of wantFields
+		wantMoreFields int
+		wantAbsent     []string // paths that must not appear in Fields
+		wantArrayInput bool
+	}{
+		{
+			name:       "object input",
+			query:      ".foo | .bar",
+			value:      map[string]any{"foo": 42},
+			wantShape:  "an object",
+			wantFields: []string{"foo"},
+		},
+		{
+			name:  "items wrapper samples first element",
+			query: ".items.name",
+			value: map[string]any{
+				"items": []any{
+					map[string]any{"name": "a", "ns": "x"},
+					map[string]any{"name": "b", "ns": "y"},
+				},
+			},
+			wantShape:      `an object with an "items" array of 2 objects`,
+			wantFields:     []string{"name", "ns"},
+			wantArrayInput: true,
+		},
+		{
+			name:  "plain array of objects",
+			query: ".name",
+			value: []any{
+				map[string]any{"name": "a"},
+				map[string]any{"name": "b"},
+			},
+			wantShape:      "an array of 2 objects",
+			wantFields:     []string{"name"},
+			wantArrayInput: true,
+		},
+		{
+			name:      "scalar input",
+			query:     ".foo",
+			value:     42,
+			wantShape: "a number",
+		},
+		{
+			name:      "string input",
+			query:     ".foo",
+			value:     "hello",
+			wantShape: "a string",
+		},
+		{
+			name:      "null input",
+			query:     ".[]",
+			value:     nil,
+			wantShape: "null",
+		},
+		{
+			name:           "empty array",
+			query:          ".foo",
+			value:          []any{},
+			wantShape:      "an array of 0 elements",
+			wantArrayInput: true,
+		},
+		{
+			name:           "heterogeneous array",
+			query:          ".foo",
+			value:          []any{"a", 1.0},
+			wantShape:      "an array of 2 elements",
+			wantArrayInput: true,
+		},
+		{
+			name:           "field count is capped",
+			query:          ".[0]",
+			value:          wideObject,
+			wantShape:      "an object",
+			wantFieldCount: 20,
+			wantMoreFields: 5,
+		},
+		{
+			name:       "deep paths are filtered",
+			query:      ".[0]",
+			value:      map[string]any{"a": map[string]any{"b": map[string]any{"c": map[string]any{"d": 1}}}},
+			wantShape:  "an object",
+			wantFields: []string{"a", "a.b", "a.b.c"},
+			wantAbsent: []string{"a.b.c.d"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			query, err := gojq.Parse(tt.query)
+			require.NoError(t, err, "test query must parse")
+
+			var buf bytes.Buffer
+			err = cmdio.NewJQCodec(query).Encode(&buf, tt.value)
+			require.Error(t, err)
+
+			var jqErr cmdio.JQRuntimeError
+			require.ErrorAs(t, err, &jqErr, "runtime failures must yield JQRuntimeError")
+
+			assert.Contains(t, err.Error(), "jq runtime")
+			require.Error(t, jqErr.Unwrap(), "wrapped gojq error must be reachable")
+			assert.Equal(t, tt.wantShape, jqErr.Shape)
+			assert.Equal(t, tt.wantArrayInput, jqErr.ArrayInput)
+			assert.Equal(t, tt.wantMoreFields, jqErr.MoreFields)
+
+			if tt.wantFieldCount > 0 {
+				assert.Len(t, jqErr.Fields, tt.wantFieldCount)
+			} else {
+				assert.Equal(t, tt.wantFields, jqErr.Fields)
+			}
+			for _, absent := range tt.wantAbsent {
+				assert.NotContains(t, jqErr.Fields, absent)
+			}
+		})
+	}
+}
+
 // decodeJSONLines splits NDJSON output and decodes each non-empty line.
 func decodeJSONLines(t *testing.T, data []byte) []any {
 	t.Helper()


### PR DESCRIPTION
## Summary
- A failing `--jq` expression now returns a typed `JQRuntimeError` carrying a compact summary of the actual output shape — top-level type (e.g. "an array of 18 objects") plus a capped list of shallow dot-notation field paths sampled from a representative element — so the expression can be corrected in one retry instead of blind trial and error.
- A new converter in `cmd/gcx/fail` renders it as a `DetailedError` (summary `Invalid command usage`, exit 2) with the shape in Details and runnable suggestions: iterate arrays with `.[]`, run with `--json list` for full field discovery, or re-run without `--jq`.
- Follows the existing `UnknownFieldSelectionError` precedent for the sibling `--json` flag; agent-mode JSON error envelopes carry the shape and suggestions with no extra wiring.

## Changes
- `internal/output/jq.go` — `JQRuntimeError` type + `newJQRuntimeError` shape constructor (computed from the already-normalized jq input; fields filtered to <3 dot-segments, capped at 20 with a `(+N more)` overflow count)
- `cmd/gcx/fail/convert.go` — `convertJQRuntimeErrors` registered in the converter chain
- `internal/output/jq_test.go`, `cmd/gcx/fail/convert_test.go` — table-driven tests (object/array/items-wrapper/scalar/null/empty/heterogeneous inputs, field-count and depth caps, wrapped-error conversion, suggestion presence)

## Example

```
$ gcx providers list --jq '.foo.bar'
Error: Invalid command usage
│
│ jq: expected an object but got: array ([{"description":"Manage G ...])
│
│ The command's output is an array of 18 objects.
│ Element fields: description, name
│
├─ Suggestions:
│
│ • Iterate array elements with .[], e.g. --jq '.items[].name' or --jq '.[].name'
│ • Run the command with --json list to enumerate all available field paths
│ • Run the command without --jq (-o json) to inspect the raw output shape
```

## Test Plan
- [x] Tests pass locally (`GCX_AGENT_MODE=false mise run all`)
- [x] New tests cover the change (shape table, caps, converter mapping)
- [x] Lints clean
- [x] Live smoke: failing `--jq` renders shape + suggestions in both human and agent-mode JSON output; the suggested `.[]` fix succeeds in one retry
- [x] `mise run reference-drift` clean (no flag/command changes)

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)