### PR TITLE
docs(costs): disclose per-product Grafana Cloud costs in docs and help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ gcx provides dedicated commands for each Grafana Cloud product:
 | **Profiles (Pyroscope)** | `gcx profiles` | `profiles query`, `profiles labels` |
 | **Traces (Tempo)** | `gcx traces` | `traces query`, `traces get`, `traces labels` |
 
+> **Note — Grafana Cloud costs:** gcx itself is free, but some of these products are billed based on usage: Grafana Assistant per token consumed (including requests made through gcx), Synthetic Monitoring per test execution, k6 per Virtual User Hour, and IRM per monthly active user. Queries and resource push/pull are not billed. See [Costs and billing](docs/reference/costs.md) and the [Grafana Cloud Cost Management and Billing documentation](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/).
+
 ## Resource Management
 
 Manage both Grafana-native resources (dashboards, folders) and Grafana Cloud resources from a single CLI:

--- a/cmd/gcx/assistant/command.go
+++ b/cmd/gcx/assistant/command.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/gcx/internal/assistant/investigations"
 	"github.com/grafana/gcx/internal/auth"
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/docs"
 	"github.com/grafana/gcx/internal/gcxerrors"
 	"github.com/grafana/gcx/internal/httputils"
 	cmdio "github.com/grafana/gcx/internal/output"
@@ -50,7 +51,10 @@ func Command() *cobra.Command {
 		Long: `Send prompts to Grafana Assistant and receive streaming responses via the A2A protocol.
 
 Requires Grafana Cloud with OAuth authentication (gcx login with browser flow).
-Service account tokens are not supported.`,
+Service account tokens are not supported.
+
+Note: Grafana Assistant is billed based on tokens consumed, including requests
+made through gcx. See ` + docs.AssistantPricing + `.`,
 	}
 	// We need a "before each run" hook to block assistant commands on self-hosted
 	// instances. Defining one here replaces the root command's hook (cobra doesn't
@@ -179,7 +183,10 @@ Known agent IDs:
   grafana_assistant_cli   General-purpose assistant (default)
   grafana_dashboarding    Dashboard builder — queries live Prometheus to discover
                           metrics and returns complete dashboard JSON ready for
-                          'gcx resources push'. See also: gcx assistant dashboard`,
+                          'gcx resources push'. See also: gcx assistant dashboard
+
+Note: each prompt consumes billable Grafana Assistant tokens, including requests
+made through gcx. See ` + docs.AssistantPricing + `.`,
 		Args: cobra.ExactArgs(1),
 		Example: `  gcx assistant prompt "What alerts are firing?"
   gcx assistant prompt "Show CPU usage" --json
@@ -187,7 +194,7 @@ Known agent IDs:
   gcx assistant prompt "Build a CPU dashboard" --agent-id grafana_dashboarding`,
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "large",
-			agent.AnnotationLLMHint:   "Prefer deterministic gcx commands (gcx metrics query, gcx slo definitions status, gcx alert instances list) for precise data retrieval. Use assistant prompt for reasoning: root cause analysis, holistic health questions, or when you don't know which metrics/labels exist — the Assistant's Infrastructure Memories know your stack topology. Example: \"Why is checkout-latency spiking?\" --json",
+			agent.AnnotationLLMHint:   "Prefer deterministic gcx commands (gcx metrics query, gcx slo definitions status, gcx alert instances list) for precise data retrieval. Use assistant prompt for reasoning: root cause analysis, holistic health questions, or when you don't know which metrics/labels exist — the Assistant's Infrastructure Memories know your stack topology. Each prompt consumes billable Grafana Assistant tokens (" + docs.AssistantPricing + "). Example: \"Why is checkout-latency spiking?\" --json",
 		},
 		RunE: promptRunE(opts, configOpts),
 	}
@@ -212,13 +219,16 @@ names, then returns complete dashboard JSON that can be pushed directly with
 'gcx resources push'.
 
 This is equivalent to:
-  gcx assistant prompt --agent-id grafana_dashboarding <message>`,
+  gcx assistant prompt --agent-id grafana_dashboarding <message>
+
+Note: each request consumes billable Grafana Assistant tokens, including
+requests made through gcx. See ` + docs.AssistantPricing + `.`,
 		Args: cobra.ExactArgs(1),
 		Example: `  gcx assistant dashboard "Build a CPU usage dashboard across all clusters"
   gcx assistant dashboard "Create a dashboard for HTTP error rates by service" --json`,
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "large",
-			agent.AnnotationLLMHint:   "Use assistant dashboard to build Grafana dashboards from natural language. The agent discovers live Prometheus metrics and returns complete dashboard JSON. Pipe the result to 'gcx resources push' to publish it.",
+			agent.AnnotationLLMHint:   "Use assistant dashboard to build Grafana dashboards from natural language. The agent discovers live Prometheus metrics and returns complete dashboard JSON. Pipe the result to 'gcx resources push' to publish it. Each request consumes billable Grafana Assistant tokens (" + docs.AssistantPricing + ").",
 		},
 		RunE: promptRunE(opts, configOpts),
 	}

--- a/docs/reference/cli/gcx_assistant.md
+++ b/docs/reference/cli/gcx_assistant.md
@@ -9,6 +9,9 @@ Send prompts to Grafana Assistant and receive streaming responses via the A2A pr
 Requires Grafana Cloud with OAuth authentication (gcx login with browser flow).
 Service account tokens are not supported.
 
+Note: Grafana Assistant is billed based on tokens consumed, including requests
+made through gcx. See https://grafana.com/docs/grafana-cloud/machine-learning/assistant/pricing.md.
+
 ### Options
 
 ```

--- a/docs/reference/cli/gcx_assistant_dashboard.md
+++ b/docs/reference/cli/gcx_assistant_dashboard.md
@@ -13,6 +13,9 @@ names, then returns complete dashboard JSON that can be pushed directly with
 This is equivalent to:
   gcx assistant prompt --agent-id grafana_dashboarding <message>
 
+Note: each request consumes billable Grafana Assistant tokens, including
+requests made through gcx. See https://grafana.com/docs/grafana-cloud/machine-learning/assistant/pricing.md.
+
 ```
 gcx assistant dashboard <message> [flags]
 ```

--- a/docs/reference/cli/gcx_assistant_prompt.md
+++ b/docs/reference/cli/gcx_assistant_prompt.md
@@ -15,6 +15,9 @@ Known agent IDs:
                           metrics and returns complete dashboard JSON ready for
                           'gcx resources push'. See also: gcx assistant dashboard
 
+Note: each prompt consumes billable Grafana Assistant tokens, including requests
+made through gcx. See https://grafana.com/docs/grafana-cloud/machine-learning/assistant/pricing.md.
+
 ```
 gcx assistant prompt <message> [flags]
 ```

--- a/docs/reference/cli/gcx_irm.md
+++ b/docs/reference/cli/gcx_irm.md
@@ -2,6 +2,15 @@
 
 Manage Grafana IRM (OnCall + Incidents)
 
+### Synopsis
+
+Manage Grafana IRM (OnCall + Incidents).
+
+Note: Grafana IRM is billed per monthly active user. Actions such as being on
+an OnCall schedule or escalation chain, changing alert group status, or
+creating and editing incidents count a user as active.
+See https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/irm-invoice.md.
+
 ### Options
 
 ```

--- a/docs/reference/cli/gcx_k6_load-tests_create.md
+++ b/docs/reference/cli/gcx_k6_load-tests_create.md
@@ -2,6 +2,13 @@
 
 Create a new k6 load test.
 
+### Synopsis
+
+Create a new k6 load test.
+
+Note: running the created test in Grafana Cloud consumes billable Virtual User
+Hours (VUh). See https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/performance-testing-invoice.md.
+
 ```
 gcx k6 load-tests create [flags]
 ```

--- a/docs/reference/cli/gcx_k6_test-run_emit.md
+++ b/docs/reference/cli/gcx_k6_test-run_emit.md
@@ -2,6 +2,13 @@
 
 Fetch a k6 Cloud test and emit Kubernetes TestRun CRD manifests.
 
+### Synopsis
+
+Fetch a k6 Cloud test and emit Kubernetes TestRun CRD manifests.
+
+Note: applying the manifests (--apply) starts a test run that consumes billable
+Virtual User Hours (VUh). See https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/performance-testing-invoice.md.
+
 ```
 gcx k6 test-run emit [test-name] [flags]
 ```

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_create.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_create.md
@@ -7,8 +7,8 @@ Create a Synthetic Monitoring check from a file.
 Create a Synthetic Monitoring check from a file.
 
 Note: checks incur Grafana Cloud usage — each test execution is billed, and
-check results are stored as metrics and logs, which are billed as such.
-See https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/synthetic-monitoring-invoice.md.
+check results are stored as metrics and logs, which count toward your metrics
+and logs usage. See https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/synthetic-monitoring-invoice.md.
 
 ```
 gcx synthetic-monitoring checks create [flags]

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_create.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_create.md
@@ -2,6 +2,14 @@
 
 Create a Synthetic Monitoring check from a file.
 
+### Synopsis
+
+Create a Synthetic Monitoring check from a file.
+
+Note: checks incur Grafana Cloud usage — each test execution is billed, and
+check results are stored as metrics and logs, which are billed as such.
+See https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/synthetic-monitoring-invoice.md.
+
 ```
 gcx synthetic-monitoring checks create [flags]
 ```

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_update.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_update.md
@@ -7,8 +7,8 @@ Update a Synthetic Monitoring check from a file.
 Update a Synthetic Monitoring check from a file.
 
 Note: frequency and probe changes affect billable usage — each test execution
-is billed, and check results are stored as metrics and logs, which are billed
-as such. See https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/synthetic-monitoring-invoice.md.
+is billed, and check results are stored as metrics and logs, which count
+toward your metrics and logs usage. See https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/synthetic-monitoring-invoice.md.
 
 ```
 gcx synthetic-monitoring checks update <name> [flags]

--- a/docs/reference/cli/gcx_synthetic-monitoring_checks_update.md
+++ b/docs/reference/cli/gcx_synthetic-monitoring_checks_update.md
@@ -2,6 +2,14 @@
 
 Update a Synthetic Monitoring check from a file.
 
+### Synopsis
+
+Update a Synthetic Monitoring check from a file.
+
+Note: frequency and probe changes affect billable usage — each test execution
+is billed, and check results are stored as metrics and logs, which are billed
+as such. See https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/synthetic-monitoring-invoice.md.
+
 ```
 gcx synthetic-monitoring checks update <name> [flags]
 ```

--- a/docs/reference/costs.md
+++ b/docs/reference/costs.md
@@ -1,0 +1,53 @@
+---
+title: Costs and billing
+---
+
+# Costs and billing
+
+gcx itself is free and open source. However, several gcx commands operate
+Grafana Cloud products that are **billed based on usage**. Creating, updating,
+or invoking those products through gcx counts toward your Grafana Cloud bill
+exactly as if you had used the Grafana UI or API directly.
+
+!!! note
+
+    [Grafana Assistant pricing](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/pricing/)
+    explicitly counts token usage made through the gcx CLI. Automated or
+    agent-driven `gcx assistant` invocations consume tokens the same way
+    interactive use does.
+
+## Billable products reachable from gcx
+
+| Product | Billing unit | gcx commands | Details |
+|---|---|---|---|
+| Grafana Assistant | Tokens consumed per request (usage-based) | `gcx assistant prompt`, `gcx assistant dashboard` | [Assistant pricing](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/pricing/) |
+| Synthetic Monitoring | Test executions (per probe, per run) plus resulting metrics and logs | `gcx synthetic-monitoring checks create` / `update` | [Synthetic Monitoring invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/synthetic-monitoring-invoice/) |
+| Performance Testing (k6) | Virtual User Hours (VUh); browser VUs are billed at a higher rate | `gcx k6 load-tests create`, `gcx k6 test-run emit --apply` | [Performance Testing invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/performance-testing-invoice/) |
+| IRM (OnCall + Incident) | Monthly active IRM users | `gcx irm oncall …`, `gcx irm incidents …` write actions | [IRM invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/irm-invoice/) |
+
+Notes on the table:
+
+- **Assistant Investigations** (`gcx assistant investigations …`) is in public
+  preview and currently has no charge.
+- **IRM**: a user counts as active when they are on an OnCall schedule or
+  escalation chain, change alert group status, or create or edit incidents —
+  actions gcx can perform on a user's behalf.
+- Each plan includes free monthly allowances (for example, included Assistant
+  tokens per active user and included Synthetic Monitoring executions). For
+  current amounts and rates, refer to [Grafana Cloud pricing](https://grafana.com/pricing/).
+
+## What is not billed
+
+- Querying metrics, logs, traces, and profiles (`gcx metrics query`,
+  `gcx logs query`, and so on) — Grafana Cloud bills telemetry ingestion and
+  retention, not queries.
+- Managing dashboards, folders, datasources, alert rules, and other resources
+  (`gcx resources push` / `pull`, `gcx datasources`, `gcx alert`).
+- Adaptive Metrics, Logs, and Traces commands — these are cost-*reduction*
+  features.
+
+## Monitor your usage
+
+Grafana Cloud provides usage dashboards, cost attribution, and usage alerts so
+you can watch spend before it lands on an invoice. See the
+[Cost Management and Billing documentation](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -14,4 +14,6 @@ title: Reference
 
 - :material-shield-check-outline:{ .lg .middle } __[Linter rules](./linter-rules/index.md)__
 
+- :material-currency-usd:{ .lg .middle } __[Costs and billing](./costs.md)__
+
 </div>

--- a/docs/sources/overview.md
+++ b/docs/sources/overview.md
@@ -36,6 +36,14 @@ Among others, `gcx` provides the following benefits:
 - **Multi-environment:** Use named contexts to switch between development, staging, and production environments.
 - **AI agent friendly:** Agent mode auto-detected for Claude Code, Copilot, Cursor, and other.
 
+## Costs
+
+{{< admonition type="note" >}}
+
+`gcx` itself is free, but some commands operate Grafana Cloud products that are billed based on usage: Grafana Assistant is billed per token consumed — including requests made through `gcx` — Synthetic Monitoring per test execution, Performance Testing (k6) per Virtual User Hour, and IRM per monthly active user. For details, refer to the [Cost Management and Billing documentation](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/) and [Grafana Cloud pricing](https://grafana.com/pricing/).
+
+{{< /admonition >}}
+
 ## Compatibility
 
 `gcx` is compatible with any agentic coding tool.

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -260,7 +260,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx k6 env-vars delete":                      {Cost: "small"},
 	"gcx k6 env-vars list":                        {Cost: "small"},
 	"gcx k6 env-vars update":                      {Cost: "small"},
-	"gcx k6 load-tests create":                    {Cost: "small", Hint: "-f <manifest.yaml>"},
+	"gcx k6 load-tests create":                    {Cost: "small", Hint: "-f <manifest.yaml>. Running the created test consumes billable VU hours (" + docs.PerformanceTestingInvoice + ")."},
 	"gcx k6 load-tests delete":                    {Cost: "small"},
 	"gcx k6 load-tests get":                       {Cost: "small", Hint: "<id-or-name> [--project-id <id>]"},
 	"gcx k6 load-tests list":                      {Cost: "small"},
@@ -284,7 +284,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx k6 schedules get":                        {Cost: "small"},
 	"gcx k6 schedules list":                       {Cost: "small"},
 	"gcx k6 schedules update":                     {Cost: "small"},
-	"gcx k6 test-run emit":                        {Cost: "small", Hint: "[test-name] --project-id <id> [--apply]"},
+	"gcx k6 test-run emit":                        {Cost: "small", Hint: "[test-name] --project-id <id> [--apply]. --apply starts a run that consumes billable VU hours (" + docs.PerformanceTestingInvoice + ")."},
 	"gcx k6 test-run runs list":                   {Cost: "small"},
 	"gcx k6 test-run status":                      {Cost: "small"},
 
@@ -581,13 +581,13 @@ var commandAnnotations = map[string]annotation{
 	// -----------------------------------------------------------------------
 	// Synthetic Monitoring provider
 	// -----------------------------------------------------------------------
-	"gcx synthetic-monitoring checks create":      {Cost: "small"},
+	"gcx synthetic-monitoring checks create":      {Cost: "small", Hint: "-f <check.yaml>. Creates a billable check: each test execution and its resulting metrics/logs count toward Grafana Cloud usage (" + docs.SyntheticMonitoringInvoice + ")."},
 	"gcx synthetic-monitoring checks delete":      {Cost: "small"},
 	"gcx synthetic-monitoring checks get":         {Cost: "small"},
 	"gcx synthetic-monitoring checks list":        {Cost: "small"},
 	"gcx synthetic-monitoring checks status":      {Cost: "medium", Hint: "--job <name> -o json"},
 	"gcx synthetic-monitoring checks timeline":    {Cost: "medium", Hint: "<id> --since 1h -o json"},
-	"gcx synthetic-monitoring checks update":      {Cost: "small"},
+	"gcx synthetic-monitoring checks update":      {Cost: "small", Hint: "<name> -f <check.yaml>. Frequency and probe changes affect billable execution volume (" + docs.SyntheticMonitoringInvoice + ")."},
 	"gcx synthetic-monitoring probes create":      {Cost: "small"},
 	"gcx synthetic-monitoring probes delete":      {Cost: "small"},
 	"gcx synthetic-monitoring probes deploy":      {Cost: "small"},

--- a/internal/docs/links.go
+++ b/internal/docs/links.go
@@ -61,10 +61,6 @@ const (
 	// AdaptiveTraces documents reducing traces costs (Adaptive Traces).
 	AdaptiveTraces = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/traces-costs.md"
 
-	// CostManagementBilling is the Grafana Cloud Cost Management and Billing
-	// hub — the canonical entry point for usage monitoring and invoices.
-	CostManagementBilling = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing.md"
-
 	// AssistantPricing documents Grafana Assistant token-based pricing,
 	// which explicitly counts usage made through the gcx CLI.
 	AssistantPricing = "https://grafana.com/docs/grafana-cloud/machine-learning/assistant/pricing.md"
@@ -99,7 +95,6 @@ func All() []string {
 		AdaptiveMetrics,
 		AdaptiveLogs,
 		AdaptiveTraces,
-		CostManagementBilling,
 		AssistantPricing,
 		SyntheticMonitoringInvoice,
 		PerformanceTestingInvoice,

--- a/internal/docs/links.go
+++ b/internal/docs/links.go
@@ -60,6 +60,25 @@ const (
 
 	// AdaptiveTraces documents reducing traces costs (Adaptive Traces).
 	AdaptiveTraces = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/traces-costs.md"
+
+	// CostManagementBilling is the Grafana Cloud Cost Management and Billing
+	// hub — the canonical entry point for usage monitoring and invoices.
+	CostManagementBilling = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing.md"
+
+	// AssistantPricing documents Grafana Assistant token-based pricing,
+	// which explicitly counts usage made through the gcx CLI.
+	AssistantPricing = "https://grafana.com/docs/grafana-cloud/machine-learning/assistant/pricing.md"
+
+	// SyntheticMonitoringInvoice documents how Synthetic Monitoring test
+	// executions and their resulting metrics/logs are billed.
+	SyntheticMonitoringInvoice = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/synthetic-monitoring-invoice.md"
+
+	// PerformanceTestingInvoice documents how Grafana Cloud k6 test runs are
+	// billed in Virtual User Hours (VUh).
+	PerformanceTestingInvoice = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/performance-testing-invoice.md"
+
+	// IRMInvoice documents how Grafana IRM is billed per monthly active user.
+	IRMInvoice = "https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/irm-invoice.md"
 )
 
 // All returns every documentation URL in the registry. Used by the
@@ -80,5 +99,10 @@ func All() []string {
 		AdaptiveMetrics,
 		AdaptiveLogs,
 		AdaptiveTraces,
+		CostManagementBilling,
+		AssistantPricing,
+		SyntheticMonitoringInvoice,
+		PerformanceTestingInvoice,
+		IRMInvoice,
 	}
 }

--- a/internal/providers/irm/provider.go
+++ b/internal/providers/irm/provider.go
@@ -1,6 +1,7 @@
 package irm
 
 import (
+	"github.com/grafana/gcx/internal/docs"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/spf13/cobra"
@@ -24,6 +25,12 @@ func (p *IRMProvider) Commands() []*cobra.Command {
 	irmCmd := &cobra.Command{
 		Use:   "irm",
 		Short: p.ShortDesc(),
+		Long: `Manage Grafana IRM (OnCall + Incidents).
+
+Note: Grafana IRM is billed per monthly active user. Actions such as being on
+an OnCall schedule or escalation chain, changing alert group status, or
+creating and editing incidents count a user as active.
+See ` + docs.IRMInvoice + `.`,
 	}
 
 	oncallCmd := &cobra.Command{

--- a/internal/providers/k6/commands.go
+++ b/internal/providers/k6/commands.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/grafana/gcx/internal/docs"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources"
@@ -689,6 +690,10 @@ func newTestsCreateCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new k6 load test.",
+		Long: `Create a new k6 load test.
+
+Note: running the created test in Grafana Cloud consumes billable Virtual User
+Hours (VUh). See ` + docs.PerformanceTestingInvoice + `.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err
@@ -1954,7 +1959,11 @@ func newTestrunEmitCommand(loader CloudConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "emit [test-name]",
 		Short: "Fetch a k6 Cloud test and emit Kubernetes TestRun CRD manifests.",
-		Args:  cobra.RangeArgs(0, 1),
+		Long: `Fetch a k6 Cloud test and emit Kubernetes TestRun CRD manifests.
+
+Note: applying the manifests (--apply) starts a test run that consumes billable
+Virtual User Hours (VUh). See ` + docs.PerformanceTestingInvoice + `.`,
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			testName, err := requireNameOrID(opts.ID, args)
 			if err != nil {

--- a/internal/providers/synth/checks/commands.go
+++ b/internal/providers/synth/checks/commands.go
@@ -352,8 +352,8 @@ func newCreateCommand(loader smcfg.StatusLoader) *cobra.Command {
 		Long: `Create a Synthetic Monitoring check from a file.
 
 Note: checks incur Grafana Cloud usage — each test execution is billed, and
-check results are stored as metrics and logs, which are billed as such.
-See ` + docs.SyntheticMonitoringInvoice + `.`,
+check results are stored as metrics and logs, which count toward your metrics
+and logs usage. See ` + docs.SyntheticMonitoringInvoice + `.`,
 		Example: `  # Create a check from a YAML file.
   gcx synthetic-monitoring checks create -f check.yaml
 
@@ -469,8 +469,8 @@ func newUpdateCommand(loader smcfg.StatusLoader) *cobra.Command {
 		Long: `Update a Synthetic Monitoring check from a file.
 
 Note: frequency and probe changes affect billable usage — each test execution
-is billed, and check results are stored as metrics and logs, which are billed
-as such. See ` + docs.SyntheticMonitoringInvoice + `.`,
+is billed, and check results are stored as metrics and logs, which count
+toward your metrics and logs usage. See ` + docs.SyntheticMonitoringInvoice + `.`,
 		Example: `  # Update a check using its resource name.
   gcx synthetic-monitoring checks update web-check-1234 -f check.yaml
 

--- a/internal/providers/synth/checks/commands.go
+++ b/internal/providers/synth/checks/commands.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/gcx/internal/docs"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
@@ -348,6 +349,11 @@ func newCreateCommand(loader smcfg.StatusLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a Synthetic Monitoring check from a file.",
+		Long: `Create a Synthetic Monitoring check from a file.
+
+Note: checks incur Grafana Cloud usage — each test execution is billed, and
+check results are stored as metrics and logs, which are billed as such.
+See ` + docs.SyntheticMonitoringInvoice + `.`,
 		Example: `  # Create a check from a YAML file.
   gcx synthetic-monitoring checks create -f check.yaml
 
@@ -460,6 +466,11 @@ func newUpdateCommand(loader smcfg.StatusLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <name>",
 		Short: "Update a Synthetic Monitoring check from a file.",
+		Long: `Update a Synthetic Monitoring check from a file.
+
+Note: frequency and probe changes affect billable usage — each test execution
+is billed, and check results are stored as metrics and logs, which are billed
+as such. See ` + docs.SyntheticMonitoringInvoice + `.`,
 		Example: `  # Update a check using its resource name.
   gcx synthetic-monitoring checks update web-check-1234 -f check.yaml
 


### PR DESCRIPTION
## Why

gcx commands operate Grafana Cloud products that are billed by usage, but neither the docs nor the CLI mentioned this anywhere. Notably, the [Grafana Assistant pricing page](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/pricing/) explicitly counts token usage made through the gcx CLI — yet gcx said nothing about it.

## What

Follows the Grafana Cloud docs convention (one-line prose note + cross-link to the [Cost Management and Billing hub](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/); no dollar figures — those defer to grafana.com/pricing). No runtime warnings, consistent with the rest of the Grafana CLI ecosystem (grafanactl, mimirtool, etc. emit none).

- **New `docs/reference/costs.md`** — maps each billable product to its billing unit, the gcx commands that trigger it, and its "Understand your invoice" page:
  - Grafana Assistant — tokens per request (`assistant prompt` / `dashboard`)
  - Synthetic Monitoring — test executions + resulting metrics/logs (`checks create/update`)
  - Performance Testing (k6) — VU hours (`load-tests create`, `test-run emit --apply`)
  - IRM — monthly active users (`irm oncall` / `irm incidents` write actions)

  Also documents what is *not* billed (signal queries, resource push/pull, Adaptive telemetry).
- **Cost notes in command help** (cobra `Long`) for the commands above — flows into the generated CLI reference (regenerated here).
- **Agent hints** — billing sentences appended to the `llm_hint` annotations of the same commands so coding agents see cost implications before invoking.
- **`internal/docs/links.go`** — five new canonical billing/pricing URLs (all verified to resolve, guarded by the link-registry test).
- **README** note under Grafana Cloud Products; **Costs admonition** in `docs/sources/overview.md`; costs card in `docs/reference/index.md`.

## Verification

- `GCX_AGENT_MODE=false mise run all` passes (lint 0 issues, full race suite, build, docs).
- `mise run reference` regenerated exactly the eight affected CLI reference pages; drift check clean.
- All five new docs URLs return HTTP 200.
- `bin/gcx assistant prompt --help` shows the cost note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)