### PR TITLE
fix(skills): correct SLO recording-rule label and close eval-found guidance gaps

### DIFF
--- a/claude-plugin/skills/slo-check-status/SKILL.md
+++ b/claude-plugin/skills/slo-check-status/SKILL.md
@@ -84,6 +84,13 @@ Adjust the time range based on the SLO window:
 - 7d window SLO → use `--from now-7d --to now`
 - 28d or 30d window SLO → use `--from now-28d --to now`
 
+The window you request is not necessarily the history you have: on a young
+stack or a recently created SLO, a 28d query may return only a few days of
+points. Check the timestamp of the earliest returned point, report the actual
+observed span alongside the requested window, and scope any whole-window
+claims to the data you actually saw — "steady for the 2 days of available
+history (28d window requested)", not "steady for the entire 28-day window".
+
 ### Step 4: SLO Reports Status (Conditional)
 
 When the user asks about SLO reports or wants combined SLO health from the reports subsystem:

--- a/claude-plugin/skills/slo-investigate/SKILL.md
+++ b/claude-plugin/skills/slo-investigate/SKILL.md
@@ -67,6 +67,13 @@ Check: gcx datasources list --type prometheus
 Then verify the destination datasource UID matches what the SLO expects.
 ```
 
+When diagnosing NODATA, two environment realities save wasted queries: on
+remote-write stacks there are no scrape targets, so `up`-based scrape-health
+checks return nothing — absence of `up` series is not evidence of a problem.
+And if `datasources list --type prometheus` returns an empty list, the stack
+may leave `type` blank in list payloads (known issue) — rerun without `--type`
+or use the UID from `.spec.destinationDatasource.uid` directly.
+
 **Lifecycle states:** If status is Creating/Updating/Deleting/Error, report that the SLO is in a transient state and investigate the Grafana backend.
 
 ### Step 3: Render Timeline
@@ -130,7 +137,7 @@ gcx alert rules list -o json | jq '[.[] | .rules[]? | select(.name | test("<slo-
 
 Also try searching by UUID fragment if the name-based search returns no results:
 ```bash
-gcx alert rules list -o json | jq '[.[] | .rules[]? | select(.labels.slo_uuid == "<UUID>" or (.name | test("<slo-name>"; "i")))]'
+gcx alert rules list -o json | jq '[.[] | .rules[]? | select(.labels.grafana_slo_uuid == "<UUID>" or (.name | test("<slo-name>"; "i")))]'
 ```
 
 Extract for each matching rule: name, state (firing/pending/inactive), labels, and annotations.
@@ -187,7 +194,7 @@ Next actions:
 
 - **gcx slo definitions get fails with 404**: SLO UUID not found. Run `gcx slo definitions list` and confirm the UUID.
 - **gcx slo definitions status returns empty**: No status available — SLO may be newly created. Check if recording rules are running (STATUS may show NODATA).
-- **gcx metrics query fails with datasource error**: Datasource UID may be wrong. Run `gcx datasources list --type prometheus` to find the correct UID.
+- **gcx metrics query fails with datasource error**: Datasource UID may be wrong. Run `gcx datasources list --type prometheus` to find the correct UID. If that list is empty (blank `type` fields in the payload), rerun without `--type` and select by name.
 - **gcx metrics query returns no data**: The SLO metrics may write to a separate datasource (check `.spec.destinationDatasource.uid`). Try both the destination datasource and the default Prometheus datasource.
 - **alert rules list returns empty**: Alert rules may be in a different folder. Try without filters: `gcx alert rules list -o json | jq length` to confirm total count.
 - **gh api fails**: If `gh` is not authenticated or unavailable, report the runbook URL directly and skip content fetching.

--- a/claude-plugin/skills/slo-investigate/references/slo-promql-patterns.md
+++ b/claude-plugin/skills/slo-investigate/references/slo-promql-patterns.md
@@ -13,12 +13,12 @@ Reference for querying Grafana-generated SLO recording rule metrics.
 
 | Metric | Description | Labels |
 |--------|-------------|--------|
-| `grafana_slo_sli_window` | SLI over the full objective window (e.g., 28d) | `slo_uuid`, `slo_name` |
-| `grafana_slo_sli_1h` | SLI snapshot over the past 1 hour | `slo_uuid`, `slo_name` |
-| `grafana_slo_sli_1d` | SLI snapshot over the past 1 day | `slo_uuid`, `slo_name` |
-| `grafana_slo_success_rate_5m` | 5-minute success rate (ratio queries only) | `slo_uuid`, `slo_name` |
-| `grafana_slo_total_rate_5m` | 5-minute total request rate (ratio queries only) | `slo_uuid`, `slo_name` |
-| `grafana_slo_objective` | Configured objective value (0–1) | `slo_uuid`, `slo_name` |
+| `grafana_slo_sli_window` | SLI over the full objective window (e.g., 28d) | `grafana_slo_uuid` |
+| `grafana_slo_sli_1h` | SLI snapshot over the past 1 hour | `grafana_slo_uuid` |
+| `grafana_slo_sli_1d` | SLI snapshot over the past 1 day | `grafana_slo_uuid` |
+| `grafana_slo_success_rate_5m` | 5-minute success rate (ratio queries only) | `grafana_slo_uuid` |
+| `grafana_slo_total_rate_5m` | 5-minute total request rate (ratio queries only) | `grafana_slo_uuid` |
+| `grafana_slo_objective` | Configured objective value (0–1) | `grafana_slo_uuid` |
 
 These metrics are written by Grafana recording rules to the destination datasource configured on the SLO. They may not be available on the default Prometheus datasource — always use `.spec.destinationDatasource.uid`.
 
@@ -28,37 +28,37 @@ These metrics are written by Grafana recording rules to the destination datasour
 
 ```promql
 # Current SLI value for a specific SLO
-grafana_slo_sli_window{slo_uuid="<uuid>"}
+grafana_slo_sli_window{grafana_slo_uuid="<uuid>"}
 
 # All SLOs — compare SLI to objective
-grafana_slo_sli_window / on(slo_uuid) grafana_slo_objective
+grafana_slo_sli_window / on(grafana_slo_uuid) grafana_slo_objective
 ```
 
 ### Short-Window SLI Snapshots
 
 ```promql
 # 1-hour SLI (fast feedback on recent changes)
-grafana_slo_sli_1h{slo_uuid="<uuid>"}
+grafana_slo_sli_1h{grafana_slo_uuid="<uuid>"}
 
 # 1-day SLI (catch gradual degradation)
-grafana_slo_sli_1d{slo_uuid="<uuid>"}
+grafana_slo_sli_1d{grafana_slo_uuid="<uuid>"}
 
 # Both together for trend comparison
-grafana_slo_sli_1h{slo_uuid="<uuid>"}
-grafana_slo_sli_1d{slo_uuid="<uuid>"}
-grafana_slo_sli_window{slo_uuid="<uuid>"}
+grafana_slo_sli_1h{grafana_slo_uuid="<uuid>"}
+grafana_slo_sli_1d{grafana_slo_uuid="<uuid>"}
+grafana_slo_sli_window{grafana_slo_uuid="<uuid>"}
 ```
 
 ### Error Budget
 
 ```promql
 # Error budget remaining (as fraction, 0–1)
-(grafana_slo_sli_window{slo_uuid="<uuid>"} - grafana_slo_objective{slo_uuid="<uuid>"}) /
-(1 - grafana_slo_objective{slo_uuid="<uuid>"})
+(grafana_slo_sli_window{grafana_slo_uuid="<uuid>"} - grafana_slo_objective{grafana_slo_uuid="<uuid>"}) /
+(1 - grafana_slo_objective{grafana_slo_uuid="<uuid>"})
 
 # Error budget consumed (percentage)
-(1 - (grafana_slo_sli_window{slo_uuid="<uuid>"} - grafana_slo_objective{slo_uuid="<uuid>"}) /
-(1 - grafana_slo_objective{slo_uuid="<uuid>"})) * 100
+(1 - (grafana_slo_sli_window{grafana_slo_uuid="<uuid>"} - grafana_slo_objective{grafana_slo_uuid="<uuid>"}) /
+(1 - grafana_slo_objective{grafana_slo_uuid="<uuid>"})) * 100
 ```
 
 ### Burn Rate
@@ -71,12 +71,12 @@ Burn rate measures how fast the error budget is being consumed relative to the b
 # A burn rate of 2.0 = consuming budget 2x faster than it accrues
 
 # Short-window burn rate (1h) — used for fast-burn alerting
-(1 - grafana_slo_sli_1h{slo_uuid="<uuid>"}) /
-(1 - grafana_slo_objective{slo_uuid="<uuid>"})
+(1 - grafana_slo_sli_1h{grafana_slo_uuid="<uuid>"}) /
+(1 - grafana_slo_objective{grafana_slo_uuid="<uuid>"})
 
 # Long-window burn rate (24h) — used for slow-burn alerting
-(1 - grafana_slo_sli_1d{slo_uuid="<uuid>"}) /
-(1 - grafana_slo_objective{slo_uuid="<uuid>"})
+(1 - grafana_slo_sli_1d{grafana_slo_uuid="<uuid>"}) /
+(1 - grafana_slo_objective{grafana_slo_uuid="<uuid>"})
 ```
 
 **Burn rate interpretation:**
@@ -89,24 +89,24 @@ Burn rate measures how fast the error budget is being consumed relative to the b
 
 ```promql
 # Real-time success rate (5-minute window)
-grafana_slo_success_rate_5m{slo_uuid="<uuid>"}
-grafana_slo_total_rate_5m{slo_uuid="<uuid>"}
+grafana_slo_success_rate_5m{grafana_slo_uuid="<uuid>"}
+grafana_slo_total_rate_5m{grafana_slo_uuid="<uuid>"}
 
 # Derived error rate (requests/sec failing)
-grafana_slo_total_rate_5m{slo_uuid="<uuid>"} - grafana_slo_success_rate_5m{slo_uuid="<uuid>"}
+grafana_slo_total_rate_5m{grafana_slo_uuid="<uuid>"} - grafana_slo_success_rate_5m{grafana_slo_uuid="<uuid>"}
 
 # Success ratio from the 5-minute rates
-grafana_slo_success_rate_5m{slo_uuid="<uuid>"} / grafana_slo_total_rate_5m{slo_uuid="<uuid>"}
+grafana_slo_success_rate_5m{grafana_slo_uuid="<uuid>"} / grafana_slo_total_rate_5m{grafana_slo_uuid="<uuid>"}
 ```
 
 ### Objective Value
 
 ```promql
 # Configured objective for comparison in expressions
-grafana_slo_objective{slo_uuid="<uuid>"}
+grafana_slo_objective{grafana_slo_uuid="<uuid>"}
 
 # All SLOs sorted by how far they are from their objective (worst first)
-sort_desc(grafana_slo_sli_window - on(slo_uuid) grafana_slo_objective)
+sort_desc(grafana_slo_sli_window - on(grafana_slo_uuid) grafana_slo_objective)
 ```
 
 ## Querying with gcx
@@ -114,23 +114,29 @@ sort_desc(grafana_slo_sli_window - on(slo_uuid) grafana_slo_objective)
 ```bash
 # Current window SLI
 gcx metrics query -d <datasource-uid> \
-  'grafana_slo_sli_window{slo_uuid="<uuid>"}' \
+  'grafana_slo_sli_window{grafana_slo_uuid="<uuid>"}' \
   --from now-1h --to now --step 1m
 
 # Burn rate over last hour
 gcx metrics query -d <datasource-uid> \
-  '(1 - grafana_slo_sli_1h{slo_uuid="<uuid>"}) / (1 - grafana_slo_objective{slo_uuid="<uuid>"})' \
+  '(1 - grafana_slo_sli_1h{grafana_slo_uuid="<uuid>"}) / (1 - grafana_slo_objective{grafana_slo_uuid="<uuid>"})' \
   --from now-1h --to now --step 1m
 
 # Error budget trend (28-day window)
 gcx metrics query -d <datasource-uid> \
-  '(grafana_slo_sli_window{slo_uuid="<uuid>"} - grafana_slo_objective{slo_uuid="<uuid>"}) / (1 - grafana_slo_objective{slo_uuid="<uuid>"})' \
+  '(grafana_slo_sli_window{grafana_slo_uuid="<uuid>"} - grafana_slo_objective{grafana_slo_uuid="<uuid>"}) / (1 - grafana_slo_objective{grafana_slo_uuid="<uuid>"})' \
   --from now-28d --to now --step 1h
 ```
 
 ## Notes
 
-- `slo_uuid` label matches `.metadata.name` in the SLO definition (UUID format)
+- `grafana_slo_uuid` label matches `.metadata.name` in the SLO definition (UUID format)
+- There is no name label on these series — they carry `grafana_slo_uuid`, rule-specific
+  labels (e.g. `grafana_slo_window`), and labels inherited from the source query (e.g.
+  `job`). Resolve names to UUIDs with `gcx slo definitions list`.
+- An empty result from a `grafana_slo_uuid` selector almost always means a label or UUID
+  mismatch, not absent data — verify with a bare metric query (no matcher) before
+  concluding there is a data gap
 - Metrics are only available after recording rules complete their first evaluation (typically 1–2 minutes after SLO creation)
 - If metrics return NODATA, verify the destination datasource UID and that Grafana recording rules are active
 - For dimensional breakdown during investigation, query the raw success/total metrics directly (not the recording rule aggregates) using selectors from `.spec.query.ratio.successMetric` / `.spec.query.ratio.totalMetric`

--- a/claude-plugin/skills/slo-investigate/references/slo-promql-patterns.md
+++ b/claude-plugin/skills/slo-investigate/references/slo-promql-patterns.md
@@ -134,9 +134,10 @@ gcx metrics query -d <datasource-uid> \
 - There is no name label on these series — they carry `grafana_slo_uuid`, rule-specific
   labels (e.g. `grafana_slo_window`), and labels inherited from the source query (e.g.
   `job`). Resolve names to UUIDs with `gcx slo definitions list`.
-- An empty result from a `grafana_slo_uuid` selector almost always means a label or UUID
-  mismatch, not absent data — verify with a bare metric query (no matcher) before
-  concluding there is a data gap
+- An empty result is not proof of absent data — rule out label, UUID,
+  datasource, and time-range mismatches before concluding there is a data gap
+  (a bare metric query with no matcher separates a selector problem from
+  genuinely missing series)
 - Metrics are only available after recording rules complete their first evaluation (typically 1–2 minutes after SLO creation)
 - If metrics return NODATA, verify the destination datasource UID and that Grafana recording rules are active
 - For dimensional breakdown during investigation, query the raw success/total metrics directly (not the recording rule aggregates) using selectors from `.spec.query.ratio.successMetric` / `.spec.query.ratio.totalMetric`

--- a/claude-plugin/skills/slo-optimize/SKILL.md
+++ b/claude-plugin/skills/slo-optimize/SKILL.md
@@ -110,9 +110,12 @@ gcx metrics query -d <datasource-uid> \
 ```
 
 The recording rules label these series with `grafana_slo_uuid` (not `slo_uuid`).
-An empty result from these selectors almost always means a label or UUID
-mismatch, not a data gap — re-check the selector against a bare
-`grafana_slo_sli_window` query before concluding the SLO has no data.
+An empty result is not proof of a data gap — first rule out label, UUID,
+datasource, and time-range mismatches (these series live on the SLO's
+destination datasource, and a new SLO has no history yet). A bare
+`grafana_slo_sli_window` query discriminates quickly: series present means
+the selector is wrong; none at all points to a new SLO or the wrong
+datasource.
 
 If the datasource UID is not in the definition, resolve it:
 

--- a/claude-plugin/skills/slo-optimize/SKILL.md
+++ b/claude-plugin/skills/slo-optimize/SKILL.md
@@ -96,24 +96,34 @@ using the datasource UID from Step 1:
 ```bash
 # SLI window metric (primary trend signal)
 gcx metrics query -d <datasource-uid> \
-  'grafana_slo_sli_window{slo_uuid="<UUID>"}' \
+  'grafana_slo_sli_window{grafana_slo_uuid="<UUID>"}' \
   --from now-28d --to now --step 6h
 
 # Success and total rate for ratio SLOs
 gcx metrics query -d <datasource-uid> \
-  'grafana_slo_success_rate_5m{slo_uuid="<UUID>"}' \
+  'grafana_slo_success_rate_5m{grafana_slo_uuid="<UUID>"}' \
   --from now-28d --to now --step 6h
 
 gcx metrics query -d <datasource-uid> \
-  'grafana_slo_total_rate_5m{slo_uuid="<UUID>"}' \
+  'grafana_slo_total_rate_5m{grafana_slo_uuid="<UUID>"}' \
   --from now-28d --to now --step 6h
 ```
+
+The recording rules label these series with `grafana_slo_uuid` (not `slo_uuid`).
+An empty result from these selectors almost always means a label or UUID
+mismatch, not a data gap — re-check the selector against a bare
+`grafana_slo_sli_window` query before concluding the SLO has no data.
 
 If the datasource UID is not in the definition, resolve it:
 
 ```bash
 gcx datasources list --type prometheus
 ```
+
+If the filtered list comes back empty, the stack may leave the `type` field
+blank in list payloads (known issue) — rerun without `--type` and pick the
+Prometheus datasource by name, or use the UID from
+`.spec.destinationDatasource.uid` directly.
 
 ### Step 5: Analyze Trends
 
@@ -147,6 +157,15 @@ Produce numbered recommendations. Each recommendation requires:
 3. Expected outcome
 
 **Objective tuning**
+
+Objective changes need enough history to be trustworthy: a `mean_sli` computed
+over less than 7 days of data reflects startup noise as much as real
+performance. With shorter history, still report the numbers, but frame any
+objective recommendation as provisional pending adequate history and say when
+enough data will exist to confirm it. And when the SLO is chronically
+breaching, lead with investigation (slo-investigate) before proposing a lower
+target — a persistent breach can mean a service problem to fix, not a target
+to relax.
 
 If `mean_sli < objective - 0.005` (more than 0.5 pp below the objective):
 - Suggest lowering the objective to `floor(mean_sli * 1000) / 1000` (rounded down to 3 dp).
@@ -225,6 +244,7 @@ Advisory Recommendations:
    Current: <value>
    Proposed: <value>
    Why: <rationale with numbers>
+   [If based on < 7 days of history: "Provisional — re-evaluate after <N> more days of data"]
 
 2. <Recommendation title>
    ...
@@ -251,8 +271,9 @@ Collect errors; report them at the end of the analysis, not interleaved with fin
   recording rules are evaluating correctly.
 
 - **Datasource UID not in definition**: Run `gcx datasources list --type prometheus`
-  and present the list to the user. Do not block the analysis — use the remaining timeline
-  data from Step 2.
+  and present the list to the user. If the filtered list is empty (blank `type` fields in
+  the list payload), rerun without `--type` and select by name. Do not block the
+  analysis — use the remaining timeline data from Step 2.
 
 - **Timeline data < 7 days of points**: The SLO may be newly created. Note the limited
   analysis window, proceed with available data, and suppress trend classifications that

--- a/claude-plugin/skills/synth-check-status/SKILL.md
+++ b/claude-plugin/skills/synth-check-status/SKILL.md
@@ -91,7 +91,7 @@ Note: `--since` and `--from`/`--to` are mutually exclusive. Use one or the other
 After presenting status:
 
 - If any check is `FAILING`: suggest `synth-investigate-check` for per-probe breakdown, failure mode classification, and PromQL deep-dive
-- If any check is `NODATA`: note that no Prometheus data is available; suggest checking if the check is enabled and verifying datasource configuration
+- If any check is `NODATA`: note that no Prometheus data is available; suggest checking if the check is enabled and verifying datasource configuration. A diagnosis alone leaves the user without a path forward — always close with the remediation step: rule out intentional disablement, then recommend re-enabling (route to `synth-manage-checks`) and confirming data resumes
 - If user wants to create, update, or delete checks: route to `synth-manage-checks`
 
 ## Output Format
@@ -142,6 +142,11 @@ Possible causes:
 - Metrics not yet available (newly created check)
 
 Verify: gcx synthetic-monitoring checks get <ID> -o json | jq '.spec.enabled'
+
+Next step:
+- If the check was disabled intentionally, note that and stop.
+- Otherwise, re-enable it (route to synth-manage-checks), then re-run status
+  after a few minutes to confirm data resumes.
 ```
 
 ## Error Handling

--- a/claude-plugin/skills/synth-investigate-check/SKILL.md
+++ b/claude-plugin/skills/synth-investigate-check/SKILL.md
@@ -95,6 +95,10 @@ Resolve datasource UID if not already known:
 gcx datasources list --type prometheus
 ```
 
+If the filtered list comes back empty, the stack may leave the `type` field
+blank in list payloads (known issue) — rerun without `--type` and pick the
+Prometheus datasource by name.
+
 Run per-probe success rate to pinpoint failing probes (use `-o json` for parsing, `-o graph` to show the user):
 ```bash
 gcx metrics query -d <datasource-uid> \


### PR DESCRIPTION
## What

Six guidance fixes to the SLO / Synthetic Monitoring judgment skills, all found by the live skill evaluation for gcx-internal#8 (Category C) and verified against a live eval stack before and after the change. Skills-only — no product code.

1. **`slo_uuid` → `grafana_slo_uuid`** in slo-optimize Step 4, the slo-investigate PromQL reference (metric/label table, all patterns), and an alert-rule jq selector with the same bug. The recording rules and the SLO plugin's alert rules label by `grafana_slo_uuid` (`internal/providers/slo/definitions/status.go`); the old selectors returned silently empty results that executors misread as data gaps in live runs. Also removed the reference table's `slo_name` label claim — series carry no name label at all (verified live: `grafana_slo_uuid`, `grafana_slo_window`, plus source-query labels).
2. **Empty-result caution** in both files: rule out label/UUID/datasource/time-range mismatches before concluding there is a data gap (these series live on the SLO's destination datasource; a new SLO has no history).
3. **synth-check-status NODATA remediation**: the diagnosis path now closes with a next step (rule out intentional disablement → re-enable via synth-manage-checks → verify data resumes). A blind judge scored a factually perfect diagnosis 5/7 for lacking any next step; 7/7 after this fix.
4. **slo-optimize data-adequacy guard**: objective recommendations based on <7d of history are framed as provisional, and chronic breaches lead with investigation before target changes.
5. **slo-check-status window-vs-history rule**: report the actually-observed data span alongside the requested window; scope whole-window claims to observed data (a live run generalized ~2 days of points to "the entire 28-day window").
6. **Datasource-filter fallback** in slo-optimize, slo-investigate, synth-investigate-check: when `datasources list --type prometheus` returns empty (blank `type` in list payloads on some stacks — separate product issue to be filed), rerun unfiltered or use `.spec.destinationDatasource.uid`.

## Verification

- Every corrected query live-verified in both directions on the eval stack: fixed label returns series; old label returns an empty result (the defect mechanism).
- Fixed skills re-run on the original failing scenarios (all fact + judge items passed, including the judge's calibration ladder) **and on two scenarios kept unseen by the fix author** — the old failure signatures did not reproduce.
- Paired with-skill vs no-skill comparison on one scenario per skill (20 runs): zero safety violations, 100% deterministic fact accuracy both configs, with-skill 11–25% fewer executor tokens and 17–27% faster on the analysis-heavy skills. Full results in gcx-internal#8.
- `mise run validate-skills`, lint, tests, build, reference all green; skill descriptions untouched (trigger tuning is a separate workstream); all SKILL.md files remain under 500 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)