### PR TITLE
fix(skills): correct dashboard, observability, demo, and KG guidance

### DIFF
--- a/claude-plugin/skills/create-dashboard/SKILL.md
+++ b/claude-plugin/skills/create-dashboard/SKILL.md
@@ -95,8 +95,9 @@ gcx resources get folders -o json
 gcx dashboards search "<service-or-team-keyword>" -o json
 
 # Pin the API version. Without --api-version the server returns its preferred
-# version (v2 on current Grafana Cloud), whose spec uses elements/layout/
-# variables — the jq recipes below would then silently return nothing.
+# version, which may use a different spec shape (elements/layout/variables
+# instead of panels/templating) — the jq recipes below would then silently
+# return nothing.
 gcx dashboards get <similar-dashboard-uid> --api-version dashboard.grafana.app/v1beta1 -o json > /tmp/similar-dashboard.json
 ```
 
@@ -189,11 +190,11 @@ Start from the live schema instead of guessing fields:
 gcx resources schemas dashboards -o json > /tmp/dashboard-schema.json
 ```
 
-Note: the server returns the schema of its *preferred* dashboard API version
-(v2 on current Grafana Cloud, with `elements`/`layout`/`variables`), while the
-template below uses the classic `v1beta1` shape (`panels`/`templating`). Both
-versions are accepted on push — just author consistently against one version
-and don't mix fields between them.
+Note: the server returns the schema of its *preferred* dashboard API version,
+which may use a different spec shape (`elements`/`layout`/`variables`), while
+the template below uses the classic `v1beta1` shape (`panels`/`templating`).
+Both versions are accepted on push — just author consistently against one
+version and don't mix fields between them.
 
 `gcx resources examples` is useful for resource types that ship examples, but
 current dashboard authoring should not depend on an example being available.

--- a/claude-plugin/skills/create-dashboard/SKILL.md
+++ b/claude-plugin/skills/create-dashboard/SKILL.md
@@ -93,7 +93,11 @@ gcx resources get folders -o json
 # Similar live dashboards are better than generic examples for variables,
 # datasource UIDs, tags, units, and team conventions.
 gcx dashboards search "<service-or-team-keyword>" -o json
-gcx dashboards get <similar-dashboard-uid> -o json > /tmp/similar-dashboard.json
+
+# Pin the API version. Without --api-version the server returns its preferred
+# version (v2 on current Grafana Cloud), whose spec uses elements/layout/
+# variables — the jq recipes below would then silently return nothing.
+gcx dashboards get <similar-dashboard-uid> --api-version dashboard.grafana.app/v1beta1 -o json > /tmp/similar-dashboard.json
 ```
 
 Extract useful patterns:
@@ -125,7 +129,7 @@ gcx datasources list -o json
 | Pyroscope | `gcx datasources pyroscope profile-types -d <uid>` then `labels -d <uid>` | `gcx datasources pyroscope labels -d <uid> --label <label>` |
 
 Prometheus also has `gcx datasources prometheus metadata -d <uid>` for metric type and help text.
-For Prometheus scoped label lookups, fall back to `gcx api "/api/datasources/proxy/<id>/api/v1/label/<label>/values?match[]=<selector>"`.
+For Prometheus scoped label lookups, fall back to `gcx api "/api/datasources/proxy/uid/<uid>/api/v1/label/<label>/values?match[]=<selector>"` — use the datasource `uid` from `gcx datasources list`; the list output has no numeric id.
 Other datasource types may have their own discovery subcommands — check `gcx datasources <type> --help` before using `gcx api`.
 
 Check units, histogram buckets, status labels, route/operation labels, cluster
@@ -185,6 +189,12 @@ Start from the live schema instead of guessing fields:
 gcx resources schemas dashboards -o json > /tmp/dashboard-schema.json
 ```
 
+Note: the server returns the schema of its *preferred* dashboard API version
+(v2 on current Grafana Cloud, with `elements`/`layout`/`variables`), while the
+template below uses the classic `v1beta1` shape (`panels`/`templating`). Both
+versions are accepted on push — just author consistently against one version
+and don't mix fields between them.
+
 `gcx resources examples` is useful for resource types that ship examples, but
 current dashboard authoring should not depend on an example being available.
 
@@ -197,16 +207,23 @@ apiVersion: dashboard.grafana.app/v1beta1
 kind: Dashboard
 metadata:
   name: <stable-dashboard-slug>
+  annotations:
+    grafana.app/folder: <folder-uid>
 spec:
   title: "<Human readable dashboard title>"
   tags: [gcx]
   timezone: browser
   schemaVersion: 36
-  # folderUID: <folder-uid>
   templating:
     list: []
   panels: []
 ```
+
+Folder placement is the `grafana.app/folder` **metadata annotation** shown
+above — the same key `gcx resources get dashboards` reads to display the
+FOLDER column. There is no `folderUID` field inside `spec`; putting one there
+is ignored and silently lands the dashboard in General, violating the folder
+rule at the top of this skill.
 
 Fill in panels, variables, links, and layout using patterns discovered above.
 
@@ -252,7 +269,8 @@ Then read/open the PNG returned in `file_path`. Inspect for:
 - overlapping panels, gaps, or poor row order
 - unreadable high-cardinality series
 - missing units/thresholds/descriptions
-- too much chrome; consider a larger width or kiosk-style settings if available
+- too much chrome; consider a larger `--width` (the renderer already hides nav
+  chrome — there is no separate kiosk flag)
 
 Render individual panels when a panel is suspect:
 

--- a/claude-plugin/skills/diagnose-entity-graph/SKILL.md
+++ b/claude-plugin/skills/diagnose-entity-graph/SKILL.md
@@ -65,7 +65,13 @@ gcx config view
 gcx kg status
 ```
 
-If `kg status` returns an error, use the `setup-gcx` skill first.
+If `kg status` fails with a config or auth error (no context, connection
+refused, 401), use the `setup-gcx` skill first. Do not route every error
+there: a 404 means the Asserts plugin isn't installed on this stack, and 403s
+from entity endpoints while `kg status` itself succeeds usually mean the
+Knowledge Graph isn't onboarded (or the token lacks plugin access) — those are
+Asserts onboarding/permission issues `setup-gcx` cannot fix; handle them via
+Step 1's onboarding stop instead.
 
 ## Step 1: Stack Health
 
@@ -121,10 +127,11 @@ gcx metrics query 'count(traces_service_graph_request_total{server_deployment_en
   via Prometheus scraping. Continue to Step 4.
 
 For more specific verdicts on this metric pair (Tempo metrics generation
-disabled, broken trace context propagation, service-name collision via
-self-loop edges), run `gcx kg diagnose --env ENV` and read the check
-results — the command encodes the detection logic and emits a targeted
-recommendation per case.
+disabled, broken trace context propagation), run `gcx kg diagnose --env ENV`
+and read the check results — the command encodes the detection logic for
+those two cases and emits a targeted recommendation. Service-name collisions
+are **not** detected by the command; spot them manually via self-loop edges
+(Step 7).
 
 ## Step 4: Recording Rules
 
@@ -265,16 +272,20 @@ gcx metrics query 'count(asserts:mixin_workload_job{service="SERVICE"})' --since
 - Not found via Cypher → check `traces_target_info{service_name="SERVICE"}`.
 - Leaf services (queue consumers, processors) correctly have no outgoing edges.
 
-**Shortcut:** `gcx kg diagnose service SERVICE --env ENV` runs all checks and
-produces an interpreted diagnosis with suggested next steps. It also
-detects two common patterns that present as "missing entities":
+**Shortcut:** `gcx kg diagnose service SERVICE --env ENV` runs the checks
+above and produces an interpreted diagnosis with suggested next steps.
+
+Two common patterns that present as "missing entities" are **not** detected
+by the command — check for them manually:
 
 - **Service-name collision** (multiple workloads share one `service.name`,
-  collapsing into one entity).
+  collapsing into one entity): look for self-loop edges — series where both
+  `client` and `server` equal SERVICE in `traces_service_graph_request_total`
+  — and for a single entity where you expected several workloads.
 - **Env-scope split** (workloads in the same namespace disagree on
-  `deployment.environment`, so cross-env calls don't render as edges).
-
-Read the diagnose check's `Recommendation` for the specific fix.
+  `deployment.environment`, so cross-env calls don't render as edges):
+  compare `client_deployment_environment` vs `server_deployment_environment`
+  on the service's edge series from Step 3.
 
 ## Producing a Report
 

--- a/claude-plugin/skills/gcx-demo/SKILL.md
+++ b/claude-plugin/skills/gcx-demo/SKILL.md
@@ -74,7 +74,9 @@ Dashboards are K8s resources — listable, pushable, validateable. The `URL`
 column in `-o wide` gives a direct deep link for every dashboard. `gcx
 resources schemas` reveals the full type catalog including any plugin-installed
 types (e.g. Adaptive Logs `DropRule`). `gcx resources examples <Kind>` produces
-a ready-to-push template for any of them.
+a ready-to-push template for provider-registered kinds (try `slos` or
+`DropRule`) — core kinds like dashboards and folders don't ship examples, so
+don't demo it on those.
 
 ### Datasources
 
@@ -138,9 +140,12 @@ gcx alert instances list --state firing
 gcx alert rules list --no-truncate
 ```
 
-SLOs return SLI, error budget, and burn rate in one command — scriptable for
-release gates. Firing alerts include labels, annotations, and runbook URLs.
-Alert rules expose full PromQL, evaluation timing, and datasource UIDs.
+SLOs return SLI, error budget, and status in one command (add `-o wide` for
+burn rate) — scriptable for release gates. Firing alerts include labels,
+annotations, and runbook URLs. The rules list shows state and health at a
+glance; drill into a single rule with `gcx alert rules get <uid> -o json` when
+the audience wants the full PromQL, evaluation timing, or datasource UIDs —
+the list table doesn't carry those.
 
 ### Synthetic Monitoring
 
@@ -149,8 +154,9 @@ gcx synth checks list
 gcx synth probes list
 ```
 
-HTTP and browser checks from a global probe network — probes list shows
-regions, coordinates, and capabilities.
+HTTP and browser checks from a global probe network — the probes table shows
+each probe's region and online status; `-o json` adds coordinates and
+capabilities if the audience asks.
 
 ### IRM
 
@@ -184,8 +190,9 @@ and the commands used. Adapt the summary to what was interesting on this
 particular stack. Don't recite a fixed table.
 
 Close with: "One binary, one context, every Grafana Cloud product. All
-scriptable, all pipelineable — and with `--dry-run` on mutations for safe
-GitOps workflows."
+scriptable, all pipelineable — and with `--dry-run` on resource and SLO pushes
+for safe GitOps workflows." (Don't claim every mutation verb has `--dry-run`;
+the create commands for checks, schedules, and pipelines currently don't.)
 
 ---
 

--- a/claude-plugin/skills/gcx-observability/SKILL.md
+++ b/claude-plugin/skills/gcx-observability/SKILL.md
@@ -17,7 +17,7 @@ You are helping the user implement comprehensive Grafana Cloud observability for
 
 **Test-driven observability principle:** Define what "healthy" looks like *before* deploying instrumentation. Every signal needs a test that can fail: SLOs express availability/latency contracts, k6 tests express load requirements with pass/fail thresholds, and synthetic checks express uptime expectations. Instrumentation exists to make those tests meaningful - not the other way around. Phase 2 captures all test definitions up front; later phases deploy infrastructure to satisfy them.
 
-Work interactively - explain each phase, generate YAML using the resource's `example` subcommand as a template, confirm before creating anything, and validate success.
+Work interactively - explain each phase, generate YAML from the resource's `example` subcommand where one exists (not every kind ships an example — fall back to `gcx resources schemas <type>` and a minimal manifest), confirm before creating anything, and validate success.
 
 **Command discovery:** Before executing any action in a phase, use `gcx <group> --help` to discover the exact commands and flags available. Use `gcx commands --flat -o json` to see all command groups. Never assume a command's exact syntax - always discover it first. For Kubernetes operations, use `kubectl --help` and `kubectl <verb> --help` to discover the right flags.
 

--- a/claude-plugin/skills/gcx-observability/SKILL.md
+++ b/claude-plugin/skills/gcx-observability/SKILL.md
@@ -50,7 +50,7 @@ Grafana Cloud Observability Setup
   Phase 7   IRM Setup              Oncall integrations, escalation chains, schedules
   Phase 8   Custom Dashboards      Dashboards via gcx resources push
   Phase 9   Cost Optimization      Adaptive metrics/logs/traces for cardinality control
-  Phase 10  GitOps Export          Export all resources as declarative YAML
+  Phase 10  GitOps Export          Export managed resources as declarative YAML
   Phase 11  Observability Review   Validate signals, find gaps, recommend next steps
 
 Enter phases to run (e.g. "0 1 2" or "all"):

--- a/claude-plugin/skills/gcx-observability/references/phases-0-3-foundation.md
+++ b/claude-plugin/skills/gcx-observability/references/phases-0-3-foundation.md
@@ -68,8 +68,12 @@ For each journey `J` from Phase 1, launch an agent that:
 - Discovers the SLO command group (`gcx slo --help`, `gcx slo definitions --help`) to find available subcommands and flags.
 - Runs `gcx resources examples slo -o yaml` to get a template (the default text
   output is only a descriptor table), then customizes it: name, availability
-  target, latency target, 28d window — and enable burn-rate alerting in the
-  SLO's `alerting` section now; Phase 4 relies on it.
+  target, latency target, 28d window.
+- Adds an `alerting` section with `fastBurn` and `slowBurn` entries under
+  `spec.alerting`. The example template omits this section, and an SLO without
+  it deploys fine but never generates burn-rate alert rules — the SLO plugin
+  creates those rules server-side from this section, and Phase 4 only wires
+  notification routing on top, so the omission surfaces late.
 - Writes the result to `slo-J.yaml`.
 
 Do **not** create the SLOs yet - Phase 4 does that after signals are flowing. Store all `slo-*.yaml` files for Phase 4.
@@ -169,7 +173,7 @@ Once Step 2's helm install has run on the cluster, use kubectl to verify Alloy p
   If the frontend uses sourcemaps, upload them: `gcx frontend apps apply-sourcemap <app-name> -f <sourcemap>`.
 
 - **Agent D** - Synthetic checks (early deployment for traffic seeding):
-  Deploy the `check-*.yaml` files from Phase 2 now, before instrumentation is fully verified. For each endpoint, check if the check already exists (`gcx synthetic-monitoring checks list`); if not, create it: `gcx synthetic-monitoring checks create -f check-<endpoint>.yaml`. List checks to confirm each is enabled with probes assigned.
+  Deploy the `check-*.yaml` files from Phase 2 now, before instrumentation is fully verified. For each endpoint, check if the check already exists (`gcx synthetic-monitoring checks list`); if not, create it: `gcx synthetic-monitoring checks create -f check-<endpoint>.yaml`. List checks to confirm each is enabled with probes assigned. After each create, read the check back with `gcx synthetic-monitoring checks get <id> -o json` and confirm `basicMetricsOnly` persisted as intended — if the server keeps it `true`, report that full metrics are unavailable for that check rather than re-submitting.
   > **Purpose:** synthetic checks start probing endpoints immediately, generating real HTTP traffic that flows through Alloy. This seeds the telemetry pipeline so Step 3's signal verification has live data.
   > If endpoints are private, first list available probes (`gcx synthetic-monitoring probes list`), identify private probes, and ensure they are online before creating checks.
 

--- a/claude-plugin/skills/gcx-observability/references/phases-0-3-foundation.md
+++ b/claude-plugin/skills/gcx-observability/references/phases-0-3-foundation.md
@@ -66,7 +66,10 @@ Ask the user a **single `AskUserQuestion`** to confirm/adjust these defaults:
 
 For each journey `J` from Phase 1, launch an agent that:
 - Discovers the SLO command group (`gcx slo --help`, `gcx slo definitions --help`) to find available subcommands and flags.
-- Runs `gcx resources examples slo` to get a template if available, then customizes it: name, availability target, latency target, 28d window.
+- Runs `gcx resources examples slo -o yaml` to get a template (the default text
+  output is only a descriptor table), then customizes it: name, availability
+  target, latency target, 28d window — and enable burn-rate alerting in the
+  SLO's `alerting` section now; Phase 4 relies on it.
 - Writes the result to `slo-J.yaml`.
 
 Do **not** create the SLOs yet - Phase 4 does that after signals are flowing. Store all `slo-*.yaml` files for Phase 4.
@@ -84,7 +87,7 @@ Store all scripts and schedule YAMLs for Phase 6.
 
 **Step 3 - Create synthetic check definitions (one per endpoint, parallel):**
 
-For each critical endpoint, discover the synthetic monitoring checks command group (`gcx synthetic-monitoring checks --help`) and check for an example subcommand. Customize it: target=real URL, frequency=30s for critical / 60s for standard, assertions: status=200 and latency < 500ms. Do NOT set basicMetricsOnly: true. Write to `check-<endpoint>.yaml`.
+For each critical endpoint, discover the synthetic monitoring checks command group (`gcx synthetic-monitoring checks --help`) and check for an example subcommand. Customize it: target=real URL, frequency=30s for critical / 60s for standard, assertions: status=200 and latency < 500ms. Do NOT set basicMetricsOnly: true. Leave `alertSensitivity` unset or `none` — on unified-alerting stacks any other value is rejected with a 403 (legacy SM alerts). Write to `check-<endpoint>.yaml`.
 
 Store all `check-*.yaml` files for Phase 5.
 
@@ -116,17 +119,21 @@ If issues are found, list them and ask the user whether to fix before proceeding
 
 ---
 
-**Step 1 - Deploy Alloy collector (sequential, everything else depends on this):**
+**Step 1 - Register Fleet collector configuration (sequential, everything else depends on this):**
 
-Use `gcx fleet collectors --help` to discover collector management commands. Create an Alloy collector configuration:
+Use `gcx fleet collectors --help` to discover collector management commands. Create an Alloy collector configuration record:
 
 ```bash
 gcx fleet collectors create -f alloy-collector.yaml
 ```
 
-After Alloy is deployed, use kubectl to verify Alloy pods are Running and Ready (not CrashLoopBackOff). Check that a Service exposing port 4317 exists in the monitoring namespace. If not, create one targeting Alloy pods.
+Registering a collector or pipeline in Fleet Management only stores
+configuration — **nothing is deployed to the cluster by this step**. The
+actual deployment happens when the helm command printed by
+`gcx instrumentation setup` (Step 2, Agent A) is run on the cluster, so do
+not poll for signals or expect Alloy pods yet.
 
-Use `gcx fleet pipelines --help` to discover pipeline management. List pipelines (`gcx fleet pipelines list`). If no pipeline contains an OTLP receiver on port 4317, create or update a pipeline to add one:
+Use `gcx fleet pipelines --help` to discover pipeline management. List pipelines (`gcx fleet pipelines list`). If no pipeline contains an OTLP receiver on port 4317, create or update a pipeline record to add one:
 
 ```bash
 gcx fleet pipelines create -f pipeline.yaml
@@ -134,7 +141,7 @@ gcx fleet pipelines create -f pipeline.yaml
 gcx fleet pipelines update <name> -f pipeline.yaml
 ```
 
-Then wait for infrastructure signals to appear by polling `gcx instrumentation status` (timeout 5 minutes). If this times out, debug the Alloy deployment before continuing.
+Once Step 2's helm install has run on the cluster, use kubectl to verify Alloy pods are Running and Ready (not CrashLoopBackOff) and that a Service exposing port 4317 exists in the monitoring namespace; signal polling happens in Step 3.
 
 ---
 

--- a/claude-plugin/skills/gcx-observability/references/phases-4-7-alerting.md
+++ b/claude-plugin/skills/gcx-observability/references/phases-4-7-alerting.md
@@ -20,51 +20,54 @@ Mark task in_progress.
 **Pre-check - skip resources that already exist:**
 List SLOs (`gcx slo definitions list`), alert rules (`gcx alert rules list`), and alert groups (`gcx alert groups list`). For each journey, skip its SLO and rule group if they already exist by name.
 
-For contact points, notification policies, and mute timings, use the Grafana provisioning API via `gcx api`:
+For contact points, notification policies, and mute timings, use the native alert commands:
 ```bash
-gcx api /api/v1/provisioning/contact-points
-gcx api /api/v1/provisioning/notification-policies
-gcx api /api/v1/provisioning/mute-timings
+gcx alert contact-points list
+gcx alert notification-policies get
+gcx alert mute-timings list
 ```
 Skip creation of any that already exist.
 
 **Step 1 - parallel: one agent per user journey**, using the `slo-J.yaml` files from Phase 2:
 
 For each journey `J`, launch an agent that:
+- Ensures `slo-J.yaml` enables burn-rate alerting in the SLO definition itself
+  (the SLO spec's `alerting` section with fast-burn/slow-burn rules) — the SLO
+  plugin then generates and manages the burn-rate alert rules server-side.
+  Do not hand-author AlertRule manifests: there is no
+  `gcx resources examples AlertRule` template, and gcx's alert provider is
+  read-only for rules, so `gcx resources push` cannot create them.
 - Creates the SLO: `gcx slo definitions push slo-J.yaml --dry-run` then `gcx slo definitions push slo-J.yaml`. List SLOs to confirm.
-- Creates burn-rate alert rules as K8s resources. Get an example: `gcx resources examples AlertRule`. Build 1h/6h/24h burn-rate rules and push them:
-  ```bash
-  gcx resources push -p alert-rules-J.yaml --dry-run
-  gcx resources push -p alert-rules-J.yaml
-  ```
-  List rules to confirm: `gcx alert rules list`.
+- Confirms the generated burn-rate rules appeared: `gcx alert rules list`.
 
 Launch all journey agents simultaneously. Wait for all to complete.
 
 **Step 2 - sequential (depends on journeys existing):**
 
-Create a contact point targeting the IRM integration webhook (to be created in Phase 7). Use the Grafana provisioning API via `gcx api`:
+Create a contact point targeting the IRM integration webhook (to be created in Phase 7), using the native alert commands:
 
 ```bash
-# Create contact point
-gcx api /api/v1/provisioning/contact-points -X POST -d @contact-point.json
+# Create contact point (JSON/YAML file, or - for stdin)
+gcx alert contact-points create -f contact-point.yaml
 
 # Verify
-gcx api /api/v1/provisioning/contact-points
+gcx alert contact-points list
 
-# Create/update notification policy routing SLO alerts to that contact point
-gcx api /api/v1/provisioning/notification-policies -X PUT -d @notification-policy.json
+# Route SLO alerts to that contact point. `set` REPLACES the entire policy
+# tree, so export the current tree first as a restore point.
+gcx alert notification-policies get -o json > notification-policy-backup.json
+gcx alert notification-policies set -f notification-policy.yaml --force
 
 # Verify
-gcx api /api/v1/provisioning/notification-policies
+gcx alert notification-policies get
 ```
 
 **Step 3 - parallel with Step 2 (independent):**
 
-Create a mute timing via the provisioning API:
+Create a mute timing with the native command:
 ```bash
-gcx api /api/v1/provisioning/mute-timings -X POST -d @mute-timing.json
-gcx api /api/v1/provisioning/mute-timings
+gcx alert mute-timings create -f mute-timing.yaml
+gcx alert mute-timings list
 ```
 
 Launch mute-timings agent at the same time as Step 2. Mark task completed.
@@ -141,11 +144,11 @@ Discover the oncall command group (`gcx irm oncall --help`) and list integration
 
 Wait for both. Then **Step 2** (needs integration webhook URL from Agent A):
 
-Create a route via the API: `gcx api /api/v1/routes -X POST -d @route.yaml`, then `gcx irm oncall routes list` to confirm. Then update the Phase 4 contact point to use the IRM webhook URL:
+Create the route with the native command (`gcx irm oncall routes --help` for flags): `gcx irm oncall routes create -f route.yaml`, then `gcx irm oncall routes list` to confirm. Then update the Phase 4 contact point to use the IRM webhook URL:
 
 ```bash
-gcx api /api/v1/provisioning/contact-points/<uid> -X PUT -d @contact-point-updated.json
-gcx api /api/v1/provisioning/contact-points
+gcx alert contact-points update <uid> -f contact-point-updated.yaml
+gcx alert contact-points list
 ```
 
 Verify the webhook URL is correct. Mark task completed.

--- a/claude-plugin/skills/gcx-observability/references/phases-4-7-alerting.md
+++ b/claude-plugin/skills/gcx-observability/references/phases-4-7-alerting.md
@@ -94,7 +94,7 @@ Ensure full check type coverage across all endpoints - not just HTTP. Add any mi
 - TCP checks for database or service port connectivity
 - HTTP checks with relevant headers and methods (POST for write endpoints, not just GET)
 
-Ensure full metrics are collected on all checks (do not set `basicMetricsOnly: true`).
+Ensure full metrics are collected on all checks (do not set `basicMetricsOnly: true`). Trust the read-back, not the write: if `gcx synthetic-monitoring checks get <id> -o json` still shows `basicMetricsOnly: true` after an update, report that full metrics are unavailable for that check instead of claiming success or updating it again.
 
 Wait for all agents. Mark task completed.
 

--- a/claude-plugin/skills/gcx-observability/references/phases-8-11-finalize.md
+++ b/claude-plugin/skills/gcx-observability/references/phases-8-11-finalize.md
@@ -24,11 +24,9 @@ gcx resources get dashboards
 If the app folder already exists, capture its UID and skip creation. Skip any dashboard that already exists in the folder by title.
 
 **Step 1 - create folder** (needed before dashboards):
-Get an example folder manifest and customize it:
-```bash
-gcx resources examples Folder
-```
-Write folder YAML, then push:
+Folders don't ship a `resources examples` template. Check the server's schema
+(`gcx resources schemas folders`) and write a minimal manifest — `metadata.name`
+(a stable slug) plus `spec.title` is enough. Then push:
 ```bash
 gcx resources push -p folder.yaml --dry-run
 gcx resources push -p folder.yaml
@@ -45,8 +43,11 @@ Generate dashboards covering:
 - k6 load test results
 
 Each agent:
-1. Gets a dashboard example: `gcx resources examples Dashboard`
-2. Customizes the dashboard JSON with appropriate panels and queries
+1. Starts from the live schema (`gcx resources schemas dashboards`) — dashboards
+   don't ship a `resources examples` template. Set the target folder via the
+   `grafana.app/folder` metadata annotation (the folder UID captured in Step 1).
+   The `create-dashboard` skill covers authoring in depth if it is available.
+2. Customizes the dashboard spec with appropriate panels and queries
 3. Writes `dashboard-<name>.yaml`
 4. Pushes: `gcx resources push -p dashboard-<name>.yaml --dry-run` then `gcx resources push -p dashboard-<name>.yaml`
 5. Verifies: `gcx resources get dashboards` filtered by folder UID
@@ -71,7 +72,9 @@ gcx traces adaptive --help
 
 - **Agent A** - adaptive metrics:
   Discover the adaptive-metrics commands (`gcx metrics adaptive --help`).
-  List recommendations, review with user, sync rules if approved, list to confirm they were applied.
+  Review recommendations with the user (the recommendations group uses
+  `show`/`diff`, not `list`), sync rules if approved, then confirm they were
+  applied.
 
 - **Agent B** - adaptive logs:
   Discover the adaptive-logs commands (`gcx logs adaptive --help`).
@@ -92,7 +95,7 @@ Mark task in_progress.
 **Pre-check - check if export already exists:**
 List files in the export directory (default: `./grafana/`). If the directory exists and contains YAML files, run a dry-run push to check for drift:
 ```bash
-gcx resources push ./grafana/ --dry-run
+gcx resources push -p ./grafana/ --dry-run
 ```
 If no drift is detected, the export is up to date - skip and report to the user.
 
@@ -109,13 +112,13 @@ Ask the user where in their repo to place the export (default: `./grafana/`).
 - **Agent B** - prepare CI snippet while export runs:
   Generate a ready-to-paste GitHub Actions step or Makefile target that runs:
   ```bash
-  gcx resources push ./grafana/ --dry-run
+  gcx resources push -p ./grafana/ --dry-run
   ```
   This detects drift between the repo and live Grafana.
 
 Wait for Agent A. Then verify round-trip:
 ```bash
-gcx resources push ./grafana/ --dry-run
+gcx resources push -p ./grafana/ --dry-run
 ls ./grafana/
 ```
 

--- a/claude-plugin/skills/gcx-observability/references/phases-8-11-finalize.md
+++ b/claude-plugin/skills/gcx-observability/references/phases-8-11-finalize.md
@@ -92,33 +92,60 @@ Wait for all three. Report savings estimates and cardinality reduction. Mark tas
 
 Mark task in_progress.
 
+**Pick the managed kind set first.** The GitOps directory is an apply-capable
+set, not an archive: it holds only explicitly selected resource kinds that
+both pull successfully *and* pass `gcx resources push --dry-run` (read-only
+kinds can pull fine yet still fail apply, so "it pulled" is not enough). Use
+the same kind selectors for the export, the push preflight, and the drift
+re-pull. If the user also wants a full-stack archival snapshot, pull it to a
+separate directory — and never run the archival directory through the apply
+preflight.
+
 **Pre-check - check if export already exists:**
-List files in the export directory (default: `./grafana/`). If the directory exists and contains YAML files, run a dry-run push to check for drift:
-```bash
-gcx resources push -p ./grafana/ --dry-run
-```
-If no drift is detected, the export is up to date - skip and report to the user.
+List files in the export directory (default: `./grafana/`). If it already
+contains an export, run the drift check under Agent B instead of re-exporting;
+if it shows no differences, the export is up to date - skip and report to the
+user.
 
 Ask the user where in their repo to place the export (default: `./grafana/`).
 
 **Parallel:**
 
 - **Agent A** - export (run_in_background: true, can be slow):
-  Pull all resources to the chosen directory:
+  Pull the managed kinds to the chosen directory, pinned to YAML (the default
+  output format varies by mode), then confirm the result is apply-capable.
+  Pass each kind as its own selector argument — space-separated, never
+  comma-joined (`slos checks` below is an illustrative managed set):
   ```bash
-  gcx resources pull -p ./grafana/
-  ```
-
-- **Agent B** - prepare CI snippet while export runs:
-  Generate a ready-to-paste GitHub Actions step or Makefile target that runs:
-  ```bash
+  gcx resources pull slos checks -p ./grafana/ -o yaml
   gcx resources push -p ./grafana/ --dry-run
   ```
-  This detects drift between the repo and live Grafana.
+  If a kind errors on pull or fails the dry-run, move it out of the managed
+  set (the archival snapshot is the place for it) and repeat until both steps
+  pass cleanly.
 
-Wait for Agent A. Then verify round-trip:
+- **Agent B** - prepare CI snippet while export runs:
+  Generate a ready-to-paste GitHub Actions step or Makefile target with two
+  separate steps over the same managed kind selectors:
+  ```bash
+  # Validation preflight: simulates create/update of the checked-in manifests
+  # against the live stack. It catches manifests that no longer apply; it does
+  # NOT compare live state against the repo.
+  gcx resources push -p ./grafana/ --dry-run
+
+  # Drift check: re-pull the managed kinds — the same selector set as the
+  # export, each kind as its own argument — into a fresh, empty temp
+  # directory and diff; a reused directory with stale files would show
+  # false drift.
+  tmp="$(mktemp -d)"
+  gcx resources pull slos checks -p "$tmp" -o yaml
+  diff -r ./grafana/ "$tmp"
+  ```
+  Any pull error, skipped kind, or preflight failure makes the check
+  incomplete — report it as such, not as drift.
+
+Wait for Agent A. Then report the managed kind set to the user:
 ```bash
-gcx resources push -p ./grafana/ --dry-run
 ls ./grafana/
 ```
 


### PR DESCRIPTION
## Summary

- correct `create-dashboard` folder placement, dashboard API-version handling, datasource proxy lookup, and snapshot guidance
- align `gcx-demo` narration with the commands and fields the CLI actually exposes
- replace unsupported `gcx-observability` workflows with valid native commands, make SLO alerting explicit, distinguish apply preflight from drift detection, and verify persisted Synthetic Monitoring settings
- remove phantom `diagnose-entity-graph` detection claims and route configuration, plugin, onboarding, and permission failures accurately

## Why

The remaining Category C evaluation in grafana/gcx-internal#8 found factual drift between four bundled skills and the current CLI/product behavior. The highest-impact cases were:

- `spec.folderUID` was taught for dashboards even though folder placement uses the `grafana.app/folder` metadata annotation
- convention-mining examples assumed the server-preferred dashboard API had the classic `panels`/`templating` shape
- the observability workflow included unsupported resource push forms and treated the read-only AlertRule adapter as an authoring path
- `resources push --dry-run` was described as drift detection even though it is an apply/validation preflight
- Synthetic Monitoring updates were trusted without reading back `basicMetricsOnly`, which can revert server-side
- Knowledge Graph guidance claimed `gcx kg diagnose` detects service-name collisions and environment-scope splits, but those checks do not exist in the CLI

These errors can waste commands, silently place resources incorrectly, or give agents confidence in checks they never actually performed. The fixes keep executable claims tied to the current command tree and make unsupported or manual checks explicit.

## Evaluation evidence

The live-stack evaluation used 14 executor runs and 15 blind judge passes across the four skills, with deterministic fact and safety checks around every measured run.

- `create-dashboard`: greenfield quality tied a strong no-skill baseline; the skill's snapshot loop materially improved a deliberately broken dashboard in a blind before/after comparison
- `gcx-demo`: judge quality tied at ceiling while the skill used 34% fewer tokens, 37% less time, and 59% fewer command lines on the measured tour; its connectivity hard-stop also passed deterministically
- `gcx-observability`: idempotency and partial-resume contracts passed, but the suite correctly remained `iterate`; its failures exposed product-side drift and follow-up skill gaps addressed here
- `diagnose-entity-graph`: both configurations diagnosed the not-onboarded stack correctly; skill guidance reached the answer with 3 vs 16 gcx invocations, while live KG diagnostic usefulness remains unmeasured without a KG-enabled stack

A final offline forward test compared the observability carry-forward text with the amended text. Frozen grading was 11/12 vs 5/12; artifact review read 12/12 vs 4/12 on the targeted semantic anchors. It confirmed that the new guidance transferred the corrected GitOps and `basicMetricsOnly` semantics. This is scoped evidence, not a claim that every generated artifact was otherwise perfect.

## Validation

- `mise exec -- go test ./cmd/gcx/root/ -run 'TestSkillsGcxInvocationsMatchCommandTree|TestValidateInvocation' -count=1`
- `mise run validate-skills`
- `GCX_AGENT_MODE=false mise run gate` (lint, full tests, build)
- reference generation produced no diff
- `git diff --check origin/main...HEAD`
- evaluation-identifier and stack-detail leakage sweep

`GCX_AGENT_MODE=false mise run all` reached the documentation build, but local `mkdocs` is unavailable; CI remains the documentation-build authority for this PR.

## Scope and compliance

The diff is confined to the canonical portable bundle under `claude-plugin/skills/`. It changes no product code, CLI interface, packages, configuration model, or architecture, so no root or architecture documentation updates are required.
