### PR TITLE
fix(profiles): include trace IDs in exemplars

### DIFF
--- a/docs/reference/cli/gcx_datasources_pyroscope_exemplars_span.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_exemplars_span.md
@@ -6,9 +6,9 @@ List span exemplars (profiles linked to trace spans)
 
 List span exemplars by calling SelectHeatmap with HEATMAP_QUERY_TYPE_SPAN.
 
-Each row is a span-linked profile sample identified by Span ID, which can be used to
-pivot to the associated trace in Tempo. Requires span-aware instrumentation upstream
-(e.g. otelpyroscope); without it the query returns an empty list.
+Each row is a span-linked profile sample identified by Span ID. When supplied by the
+server, Trace ID is also included for direct correlation with Tempo. Requires span-aware
+instrumentation upstream (e.g. otelpyroscope); without it the query returns an empty list.
 
 EXPR is the label selector (e.g. '{service_name="frontend"}').
 

--- a/docs/reference/cli/gcx_profiles_exemplars_span.md
+++ b/docs/reference/cli/gcx_profiles_exemplars_span.md
@@ -6,9 +6,9 @@ List span exemplars (profiles linked to trace spans)
 
 List span exemplars by calling SelectHeatmap with HEATMAP_QUERY_TYPE_SPAN.
 
-Each row is a span-linked profile sample identified by Span ID, which can be used to
-pivot to the associated trace in Tempo. Requires span-aware instrumentation upstream
-(e.g. otelpyroscope); without it the query returns an empty list.
+Each row is a span-linked profile sample identified by Span ID. When supplied by the
+server, Trace ID is also included for direct correlation with Tempo. Requires span-aware
+instrumentation upstream (e.g. otelpyroscope); without it the query returns an empty list.
 
 EXPR is the label selector (e.g. '{service_name="frontend"}').
 

--- a/internal/datasources/pyroscope/exemplars.go
+++ b/internal/datasources/pyroscope/exemplars.go
@@ -185,9 +185,9 @@ func exemplarsSpanCmd(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "List span exemplars (profiles linked to trace spans)",
 		Long: `List span exemplars by calling SelectHeatmap with HEATMAP_QUERY_TYPE_SPAN.
 
-Each row is a span-linked profile sample identified by Span ID, which can be used to
-pivot to the associated trace in Tempo. Requires span-aware instrumentation upstream
-(e.g. otelpyroscope); without it the query returns an empty list.
+Each row is a span-linked profile sample identified by Span ID. When supplied by the
+server, Trace ID is also included for direct correlation with Tempo. Requires span-aware
+instrumentation upstream (e.g. otelpyroscope); without it the query returns an empty list.
 
 EXPR is the label selector (e.g. '{service_name="frontend"}').`,
 		Example: `

--- a/internal/query/pyroscope/client_test.go
+++ b/internal/query/pyroscope/client_test.go
@@ -121,7 +121,7 @@ func TestClient_SelectSeries(t *testing.T) {
 							"value": 100,
 							"timestamp": "1000",
 							"exemplars": [
-								{"profileId": "p-1", "timestamp": "1100", "value": "5000", "spanId": "span-1"}
+								{"profileId": "p-1", "timestamp": "1100", "value": "5000", "spanId": "span-1", "traceId": "trace-1"}
 							]
 						}]
 					}]
@@ -201,13 +201,14 @@ func TestClient_SelectSeries(t *testing.T) {
 			assert.Len(t, resp.Series, tt.wantSeries)
 
 			// For the exemplars case, spot-check the decoded Exemplar payload:
-			// timestamp/value are json.Number, profileId/spanId propagate through.
+			// timestamp/value are json.Number; IDs propagate through.
 			if tt.name == "exemplarType forwarded and exemplars decoded" {
 				require.Len(t, resp.Series[0].Points, 1)
 				require.Len(t, resp.Series[0].Points[0].Exemplars, 1)
 				ex := resp.Series[0].Points[0].Exemplars[0]
 				assert.Equal(t, "p-1", ex.ProfileID)
 				assert.Equal(t, "span-1", ex.SpanID)
+				assert.Equal(t, "trace-1", ex.TraceID)
 				assert.Equal(t, int64(1100), ex.TimestampMs())
 				assert.Equal(t, int64(5000), ex.Int64Value())
 			}
@@ -472,7 +473,7 @@ func TestClient_SelectHeatmap(t *testing.T) {
 						"slots": [{
 							"timestamp": "1500",
 							"exemplars": [
-								{"spanId": "span-abc", "timestamp": "1600", "value": "12345"}
+								{"spanId": "span-abc", "traceId": "trace-abc", "timestamp": "1600", "value": "12345"}
 							]
 						}]
 					}]
@@ -538,6 +539,7 @@ func TestClient_SelectHeatmap(t *testing.T) {
 				require.Len(t, resp.Series[0].Slots[0].Exemplars, 1)
 				ex := resp.Series[0].Slots[0].Exemplars[0]
 				assert.Equal(t, "span-abc", ex.SpanID)
+				assert.Equal(t, "trace-abc", ex.TraceID)
 				assert.Equal(t, int64(1600), ex.TimestampMs())
 				assert.Equal(t, int64(12345), ex.Int64Value())
 			}

--- a/internal/query/pyroscope/exemplars.go
+++ b/internal/query/pyroscope/exemplars.go
@@ -25,6 +25,7 @@ type ProfileExemplar struct {
 	Timestamp time.Time         `json:"timestamp"`
 	Value     int64             `json:"value"`
 	SpanID    string            `json:"spanId,omitempty"`
+	TraceID   string            `json:"traceId,omitempty"`
 	Labels    map[string]string `json:"labels,omitempty"`
 }
 
@@ -40,6 +41,7 @@ type SpanExemplarsResult struct {
 // SpanExemplar is a single flattened span-exemplar entry.
 type SpanExemplar struct {
 	SpanID    string            `json:"spanId"`
+	TraceID   string            `json:"traceId,omitempty"`
 	Timestamp time.Time         `json:"timestamp"`
 	Value     int64             `json:"value"`
 	Labels    map[string]string `json:"labels,omitempty"`
@@ -65,6 +67,7 @@ func BuildProfileExemplarsResult(resp *SelectSeriesResponse, from, to time.Time,
 					Timestamp: time.UnixMilli(ex.TimestampMs()).UTC(),
 					Value:     ex.Int64Value(),
 					SpanID:    ex.SpanID,
+					TraceID:   ex.TraceID,
 					Labels:    mergeLabels(seriesLabels, ex.Labels),
 				})
 			}
@@ -104,6 +107,7 @@ func BuildSpanExemplarsResult(resp *SelectHeatmapResponse, from, to time.Time, p
 				}
 				entries = append(entries, SpanExemplar{
 					SpanID:    ex.SpanID,
+					TraceID:   ex.TraceID,
 					Timestamp: time.UnixMilli(ex.TimestampMs()).UTC(),
 					Value:     ex.Int64Value(),
 					Labels:    mergeLabels(seriesLabels, ex.Labels),
@@ -234,7 +238,18 @@ func FormatSpanExemplarsTable(w io.Writer, result *SpanExemplarsResult, maxLabel
 	}
 	cols := TopCardinalityLabelNames(labelMaps, maxLabelCols)
 
-	headers := make([]string, 0, 3+len(cols))
+	hasTraceID := false
+	for _, e := range result.Exemplars {
+		if e.TraceID != "" {
+			hasTraceID = true
+			break
+		}
+	}
+
+	headers := make([]string, 0, 4+len(cols))
+	if hasTraceID {
+		headers = append(headers, "TRACE ID")
+	}
 	headers = append(headers, "SPAN ID", "TIMESTAMP", "VALUE ("+strings.ToUpper(unit)+")")
 	for _, c := range cols {
 		headers = append(headers, strings.ToUpper(c))
@@ -249,11 +264,15 @@ func FormatSpanExemplarsTable(w io.Writer, result *SpanExemplarsResult, maxLabel
 	}
 
 	for _, e := range result.Exemplars {
-		row := []string{
+		row := make([]string, 0, len(headers))
+		if hasTraceID {
+			row = append(row, e.TraceID)
+		}
+		row = append(row,
 			e.SpanID,
 			e.Timestamp.UTC().Format(time.RFC3339),
 			formatHumanValue(float64(e.Value), unit),
-		}
+		)
 		for _, c := range cols {
 			row = append(row, e.Labels[c])
 		}

--- a/internal/query/pyroscope/exemplars_test.go
+++ b/internal/query/pyroscope/exemplars_test.go
@@ -31,7 +31,7 @@ func TestBuildProfileExemplarsResult(t *testing.T) {
 						Value:     num(1_000_000),
 						Timestamp: num(1500000),
 						Exemplars: []pyroscope.Exemplar{
-							{ProfileID: "p-1", Timestamp: num(1500100), Value: num(5_000_000), SpanID: "span-1"},
+							{ProfileID: "p-1", Timestamp: num(1500100), Value: num(5_000_000), SpanID: "span-1", TraceID: "trace-1"},
 							{ProfileID: "p-2", Timestamp: num(1500200), Value: num(10_000_000), SpanID: "span-2"},
 							{ProfileID: "p-3", Timestamp: num(1500300), Value: num(1_000_000), SpanID: "span-3"},
 						},
@@ -68,6 +68,7 @@ func TestBuildProfileExemplarsResult(t *testing.T) {
 		assert.Equal(t, int64(20_000_000), result.Exemplars[0].Value)
 		assert.Equal(t, "p-2", result.Exemplars[1].ProfileID)
 		assert.Equal(t, "p-1", result.Exemplars[2].ProfileID)
+		assert.Equal(t, "trace-1", result.Exemplars[2].TraceID)
 
 		// Internal labels filtered from merged labels.
 		for _, e := range result.Exemplars {
@@ -106,7 +107,7 @@ func TestBuildSpanExemplarsResult(t *testing.T) {
 					{
 						Timestamp: num(1500000),
 						Exemplars: []pyroscope.Exemplar{
-							{SpanID: "span-1", Timestamp: num(1500100), Value: num(5_000_000)},
+							{SpanID: "span-1", TraceID: "trace-1", Timestamp: num(1500100), Value: num(5_000_000)},
 							{SpanID: "", Timestamp: num(1500200), Value: num(50_000_000)}, // empty span, dropped
 							{SpanID: "span-3", Timestamp: num(1500300), Value: num(15_000_000)},
 						},
@@ -123,6 +124,7 @@ func TestBuildSpanExemplarsResult(t *testing.T) {
 		assert.Equal(t, "span-3", result.Exemplars[0].SpanID)
 		assert.Equal(t, int64(15_000_000), result.Exemplars[0].Value)
 		assert.Equal(t, "span-1", result.Exemplars[1].SpanID)
+		assert.Equal(t, "trace-1", result.Exemplars[1].TraceID)
 	})
 
 	t.Run("truncates to topN", func(t *testing.T) {
@@ -238,4 +240,46 @@ func TestFormatSpanExemplarsTable(t *testing.T) {
 		require.NoError(t, pyroscope.FormatSpanExemplarsTable(&buf, result, 3))
 		assert.Contains(t, buf.String(), "(no span exemplars)")
 	})
+
+	t.Run("includes trace id column when present", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := &pyroscope.SpanExemplarsResult{
+			ProfileType: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+			Exemplars: []pyroscope.SpanExemplar{
+				{SpanID: "span-1", TraceID: "trace-1", Timestamp: time.UnixMilli(1700000000000).UTC(), Value: 1000},
+				{SpanID: "span-2", Timestamp: time.UnixMilli(1700000001000).UTC(), Value: 500},
+			},
+		}
+		require.NoError(t, pyroscope.FormatSpanExemplarsTable(&buf, result, 0))
+		out := buf.String()
+		assert.Contains(t, out, "TRACE ID")
+		assert.Contains(t, out, "trace-1")
+		assert.Contains(t, out, "span-2")
+	})
+
+	t.Run("omits trace id column when absent", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := &pyroscope.SpanExemplarsResult{
+			ProfileType: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+			Exemplars: []pyroscope.SpanExemplar{
+				{SpanID: "span-1", Timestamp: time.UnixMilli(1700000000000).UTC(), Value: 1000},
+			},
+		}
+		require.NoError(t, pyroscope.FormatSpanExemplarsTable(&buf, result, 0))
+		assert.NotContains(t, buf.String(), "TRACE ID")
+	})
+}
+
+func TestExemplarResultsJSONIncludesTraceID(t *testing.T) {
+	profileJSON, err := json.Marshal(pyroscope.ProfileExemplarsResult{
+		Exemplars: []pyroscope.ProfileExemplar{{ProfileID: "p-1", TraceID: "trace-profile"}},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(profileJSON), `"traceId":"trace-profile"`)
+
+	spanJSON, err := json.Marshal(pyroscope.SpanExemplarsResult{
+		Exemplars: []pyroscope.SpanExemplar{{SpanID: "span-1", TraceID: "trace-span"}},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(spanJSON), `"traceId":"trace-span"`)
 }

--- a/internal/query/pyroscope/types.go
+++ b/internal/query/pyroscope/types.go
@@ -137,6 +137,7 @@ type Exemplar struct {
 	Timestamp json.Number `json:"timestamp"` // ms since epoch, encoded as string
 	ProfileID string      `json:"profileId,omitempty"`
 	SpanID    string      `json:"spanId,omitempty"`
+	TraceID   string      `json:"traceId,omitempty"`
 	Value     json.Number `json:"value"`
 	Labels    []LabelPair `json:"labels,omitempty"`
 }


### PR DESCRIPTION
## Summary

- decode and propagate Pyroscope exemplar `traceId` values
- include trace IDs in structured profile and span exemplar output
- show the span table `TRACE ID` column only when at least one value is present, preserving compatibility with older servers
- update generated CLI reference documentation

Ports the profilecli behavior from https://github.com/grafana/pyroscope/pull/5353.

## Testing

- `mise run lint`
- `go test ./...`
- `GCX_AGENT_MODE=false mise run reference`
- `mise run build`
- `mise run docs` not run locally because `mkdocs` is unavailable; CI will perform the docs build