### PR TITLE
docs(traces): mark --llm flag experimental and document Accept header

### DIFF
--- a/docs/reference/cli/gcx_datasources_tempo_get.md
+++ b/docs/reference/cli/gcx_datasources_tempo_get.md
@@ -48,7 +48,7 @@ gcx datasources tempo get TRACE_ID [flags]
   -h, --help                help for get
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --llm                 [experimental] Request LLM-friendly trace format
+      --llm                 [experimental] Request LLM-friendly trace format by sending the 'Accept: application/vnd.grafana.llm' header. Falls back to default JSON
       --open                Open the retrieved trace in Grafana Explore
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr

--- a/docs/reference/cli/gcx_datasources_tempo_get.md
+++ b/docs/reference/cli/gcx_datasources_tempo_get.md
@@ -12,6 +12,10 @@ Use --share-link to print a Grafana Explore URL for the trace, or --open to
 open it in your browser after retrieval succeeds. Share links require an
 explicit time range via --since or --from/--to.
 
+Experimental: --llm requests the trace in a new LLM-friendly JSON format by
+sending the "Accept: application/vnd.grafana.llm" header. Datasources that do
+not support this format return the standard response.
+
 ```
 gcx datasources tempo get TRACE_ID [flags]
 ```
@@ -44,7 +48,7 @@ gcx datasources tempo get TRACE_ID [flags]
   -h, --help                help for get
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --llm                 Request LLM-friendly trace format
+      --llm                 [experimental] Request LLM-friendly trace format
       --open                Open the retrieved trace in Grafana Explore
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr

--- a/docs/reference/cli/gcx_datasources_tempo_labels.md
+++ b/docs/reference/cli/gcx_datasources_tempo_labels.md
@@ -53,7 +53,7 @@ gcx datasources tempo labels [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-      --llm                 [experimental] Request LLM-friendly label values format by sending the 'Accept: application/vnd.grafana.llm' header (requires --label). Falls back to default JSON
+      --llm                 [experimental] Request LLM-friendly label values format by sending the 'Accept: application/vnd.grafana.llm' header. Falls back to default JSON (requires --label)
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)

--- a/docs/reference/cli/gcx_datasources_tempo_labels.md
+++ b/docs/reference/cli/gcx_datasources_tempo_labels.md
@@ -53,7 +53,7 @@ gcx datasources tempo labels [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-      --llm                 [experimental] Request LLM-friendly label values format (requires --label)
+      --llm                 [experimental] Request LLM-friendly label values format by sending the 'Accept: application/vnd.grafana.llm' header (requires --label). Falls back to default JSON
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)

--- a/docs/reference/cli/gcx_datasources_tempo_labels.md
+++ b/docs/reference/cli/gcx_datasources_tempo_labels.md
@@ -11,6 +11,10 @@ When -l is omitted, returns all label names.
 
 Datasource is resolved from -d flag or datasources.tempo in your context.
 
+Experimental: --llm requests label values in a new LLM-friendly JSON format by
+sending the "Accept: application/vnd.grafana.llm" header. Datasources that do
+not support this format return the standard response.
+
 ```
 gcx datasources tempo labels [flags]
 ```
@@ -49,7 +53,7 @@ gcx datasources tempo labels [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-      --llm                 Request LLM-friendly label values format (requires --label)
+      --llm                 [experimental] Request LLM-friendly label values format (requires --label)
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)

--- a/docs/reference/cli/gcx_traces_get.md
+++ b/docs/reference/cli/gcx_traces_get.md
@@ -42,7 +42,7 @@ gcx traces get TRACE_ID [flags]
   -h, --help                help for get
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --llm                 [experimental] Request LLM-friendly trace format
+      --llm                 [experimental] Request LLM-friendly trace format by sending the 'Accept: application/vnd.grafana.llm' header. Falls back to default JSON
       --open                Open the retrieved trace in Grafana Explore
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr

--- a/docs/reference/cli/gcx_traces_get.md
+++ b/docs/reference/cli/gcx_traces_get.md
@@ -12,6 +12,10 @@ Use --share-link to print a Grafana Explore URL for the trace, or --open to
 open it in your browser after retrieval succeeds. Share links require an
 explicit time range via --since or --from/--to.
 
+Experimental: --llm requests the trace in a new LLM-friendly JSON format by
+sending the "Accept: application/vnd.grafana.llm" header. Datasources that do
+not support this format return the standard response.
+
 ```
 gcx traces get TRACE_ID [flags]
 ```
@@ -38,7 +42,7 @@ gcx traces get TRACE_ID [flags]
   -h, --help                help for get
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --llm                 Request LLM-friendly trace format
+      --llm                 [experimental] Request LLM-friendly trace format
       --open                Open the retrieved trace in Grafana Explore
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr

--- a/docs/reference/cli/gcx_traces_labels.md
+++ b/docs/reference/cli/gcx_traces_labels.md
@@ -11,6 +11,10 @@ When -l is omitted, returns all label names.
 
 Datasource is resolved from -d flag or datasources.tempo in your context.
 
+Experimental: --llm requests label values in a new LLM-friendly JSON format by
+sending the "Accept: application/vnd.grafana.llm" header. Datasources that do
+not support this format return the standard response.
+
 ```
 gcx traces labels [flags]
 ```
@@ -37,7 +41,7 @@ gcx traces labels [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-      --llm                 Request LLM-friendly label values format (requires --label)
+      --llm                 [experimental] Request LLM-friendly label values format (requires --label)
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)

--- a/docs/reference/cli/gcx_traces_labels.md
+++ b/docs/reference/cli/gcx_traces_labels.md
@@ -41,7 +41,7 @@ gcx traces labels [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-      --llm                 [experimental] Request LLM-friendly label values format (requires --label)
+      --llm                 [experimental] Request LLM-friendly label values format by sending the 'Accept: application/vnd.grafana.llm' header (requires --label). Falls back to default JSON
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)

--- a/docs/reference/cli/gcx_traces_labels.md
+++ b/docs/reference/cli/gcx_traces_labels.md
@@ -41,7 +41,7 @@ gcx traces labels [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
-      --llm                 [experimental] Request LLM-friendly label values format by sending the 'Accept: application/vnd.grafana.llm' header (requires --label). Falls back to default JSON
+      --llm                 [experimental] Request LLM-friendly label values format by sending the 'Accept: application/vnd.grafana.llm' header. Falls back to default JSON (requires --label)
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
   -q, --query string        TraceQL query to filter labels
       --scope string        Tag scope filter (resource, span, event, link, instrumentation)

--- a/internal/datasources/tempo/get.go
+++ b/internal/datasources/tempo/get.go
@@ -31,7 +31,7 @@ func (opts *getOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.tempo is configured)")
-	flags.BoolVar(&opts.LLM, "llm", false, "[experimental] Request LLM-friendly trace format")
+	flags.BoolVar(&opts.LLM, "llm", false, "[experimental] Request LLM-friendly trace format by sending the 'Accept: application/vnd.grafana.llm' header. Falls back to default JSON")
 	opts.Share.Setup(flags, "retrieved trace")
 	opts.SetupTimeFlags(flags)
 }

--- a/internal/datasources/tempo/get.go
+++ b/internal/datasources/tempo/get.go
@@ -31,7 +31,7 @@ func (opts *getOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.tempo is configured)")
-	flags.BoolVar(&opts.LLM, "llm", false, "Request LLM-friendly trace format")
+	flags.BoolVar(&opts.LLM, "llm", false, "[experimental] Request LLM-friendly trace format")
 	opts.Share.Setup(flags, "retrieved trace")
 	opts.SetupTimeFlags(flags)
 }
@@ -55,7 +55,11 @@ TRACE_ID is the hex-encoded trace identifier to retrieve.
 Datasource is resolved from -d flag or datasources.tempo in your context.
 Use --share-link to print a Grafana Explore URL for the trace, or --open to
 open it in your browser after retrieval succeeds. Share links require an
-explicit time range via --since or --from/--to.`,
+explicit time range via --since or --from/--to.
+
+Experimental: --llm requests the trace in a new LLM-friendly JSON format by
+sending the "Accept: application/vnd.grafana.llm" header. Datasources that do
+not support this format return the standard response.`,
 		Example: `
   # Get LLM-friendly output for agent analysis
   gcx datasources tempo get abc123def456 --llm -o json

--- a/internal/datasources/tempo/tags.go
+++ b/internal/datasources/tempo/tags.go
@@ -33,7 +33,7 @@ func (opts *labelsOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&opts.Label, "label", "l", "", "Get values for this label (omit to list all labels)")
 	flags.StringVar(&opts.Scope, "scope", "", "Tag scope filter (resource, span, event, link, instrumentation)")
 	flags.StringVarP(&opts.Query, "query", "q", "", "TraceQL query to filter labels")
-	flags.BoolVar(&opts.LLM, "llm", false, "[experimental] Request LLM-friendly label values format (requires --label)")
+	flags.BoolVar(&opts.LLM, "llm", false, "[experimental] Request LLM-friendly label values format by sending the 'Accept: application/vnd.grafana.llm' header (requires --label). Falls back to default JSON")
 }
 
 func (opts *labelsOpts) Validate() error {

--- a/internal/datasources/tempo/tags.go
+++ b/internal/datasources/tempo/tags.go
@@ -33,7 +33,7 @@ func (opts *labelsOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&opts.Label, "label", "l", "", "Get values for this label (omit to list all labels)")
 	flags.StringVar(&opts.Scope, "scope", "", "Tag scope filter (resource, span, event, link, instrumentation)")
 	flags.StringVarP(&opts.Query, "query", "q", "", "TraceQL query to filter labels")
-	flags.BoolVar(&opts.LLM, "llm", false, "Request LLM-friendly label values format (requires --label)")
+	flags.BoolVar(&opts.LLM, "llm", false, "[experimental] Request LLM-friendly label values format (requires --label)")
 }
 
 func (opts *labelsOpts) Validate() error {
@@ -60,7 +60,11 @@ func LabelsCmd(loader *providers.ConfigLoader) *cobra.Command {
 When -l/--label is provided, returns values for that label.
 When -l is omitted, returns all label names.
 
-Datasource is resolved from -d flag or datasources.tempo in your context.`,
+Datasource is resolved from -d flag or datasources.tempo in your context.
+
+Experimental: --llm requests label values in a new LLM-friendly JSON format by
+sending the "Accept: application/vnd.grafana.llm" header. Datasources that do
+not support this format return the standard response.`,
 		Example: `
   # List all labels
   gcx datasources tempo labels -d UID

--- a/internal/datasources/tempo/tags.go
+++ b/internal/datasources/tempo/tags.go
@@ -33,7 +33,7 @@ func (opts *labelsOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&opts.Label, "label", "l", "", "Get values for this label (omit to list all labels)")
 	flags.StringVar(&opts.Scope, "scope", "", "Tag scope filter (resource, span, event, link, instrumentation)")
 	flags.StringVarP(&opts.Query, "query", "q", "", "TraceQL query to filter labels")
-	flags.BoolVar(&opts.LLM, "llm", false, "[experimental] Request LLM-friendly label values format by sending the 'Accept: application/vnd.grafana.llm' header (requires --label). Falls back to default JSON")
+	flags.BoolVar(&opts.LLM, "llm", false, "[experimental] Request LLM-friendly label values format by sending the 'Accept: application/vnd.grafana.llm' header. Falls back to default JSON (requires --label)")
 }
 
 func (opts *labelsOpts) Validate() error {


### PR DESCRIPTION
## Summary

- mark the `--llm` flag on `traces get` / `traces labels` (and the `datasources tempo` equivalents) as `[experimental]` in the flag help, and explain the mechanism: it requests a new LLM-friendly JSON format by sending the `Accept: application/vnd.grafana.llm` header, falling back to the standard response if unsupported
- same explanation added to the long help of both commands
- regenerate CLI reference docs

Before:

```
      --llm                 Request LLM-friendly trace format
```

After:

```
      --llm                 [experimental] Request LLM-friendly trace format by sending the 'Accept: application/vnd.grafana.llm' header. Falls back to default JSON
```

plus in the long help:

```
Experimental: --llm requests the trace in a new LLM-friendly JSON format by
sending the "Accept: application/vnd.grafana.llm" header. Datasources that do
not support this format return the standard response.
```
