### PR TITLE
feat(telemetry): wire usage event lifecycle with log mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ internal/
 │   ├── mcpservers/     MCP server integration HTTP client (offset-paginated list/get/create/update/delete, OAuth initiate/validate, user vs tenant scope headers)
 │   └── mcpserver/      MCPServer manifest domain type + `TypedCRUD[MCPServer]` adapter wiring (identity, natural key, schema/example) + per-header write-intent mapping (overwrite/preserve/remove, fromEnv/fromFile) — consumed by `internal/providers/assistant` (adapter registration + the mcp-servers CRUD commands, which route create/update/delete through this TypedCRUD)
 ├── agent/       Agent mode detection, command annotations, known-resource registry with operation hints
-├── agentlog/    Agent invocation failure logger (opt-in JSONL disk log, XDG state dir — wired into handleError in cmd/gcx/main.go)
+├── agentlog/    Agent invocation failure logger (opt-in JSONL disk log, XDG state dir — wired into reportError in cmd/gcx/main.go)
 ├── style/       Terminal styling (Grafana Neon Dark theme, TableBuilder, ASCII banner, glamour help)
 ├── terminal/    TTY/pipe detection (IsPiped, NoTruncate, Detect) for output suppression
 ├── linter/      Linting engine (Rego rules, report aggregation, PromQL validator)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ internal/
 ├── notifier/    Update notifications (skills + gcx version checks; XDG state, throttling, message rendering — wired into root PersistentPostRun)
 ├── skills/      Portable Agent Skills installer primitives (BundledSkillNames, Install, Update — extracted from cmd/gcx/skills)
 ├── strcase/     String case conversion (snake_case, kebab-case, PascalCase)
-├── telemetry/   Anonymous usage stats library (wide-event model, GCX_TELEMETRY/DO_NOT_TRACK mode resolution, device ID, CI detection — not yet wired into the CLI)
+├── telemetry/   Anonymous usage stats library (wide-event model, GCX_TELEMETRY/DO_NOT_TRACK mode resolution, device ID, CI detection; wired into the CLI lifecycle via cmd/gcx/root PersistentPreRun + cmd/gcx exitWith)
 ├── xdg/         XDG Base Directory paths (config home, state home, config dirs)
 └── shared/      Shared utilities (date handling, duration, etc.) to be shared across integrations.
 ```

--- a/cmd/gcx/main.go
+++ b/cmd/gcx/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/gcx/cmd/gcx/root"
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/agentlog"
-	internalconfig "github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/gcxerrors"
 	appversion "github.com/grafana/gcx/internal/version"
 	"github.com/spf13/cobra"
@@ -32,8 +31,13 @@ var (
 )
 
 func main() {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer stop()
+	// used to measure command execution time
+	start := time.Now()
+
+	// stop is deliberately not deferred: every path out of main ends in
+	// os.Exit (exitWith or the cancellation fast path), so a defer would
+	// never run, and signal-handler cleanup is moot at process exit.
+	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)
 
 	// Pre-parse --agent flag before Cobra sees it. This must happen before
 	// root.Command() because io.Options.BindFlags() reads agent.IsAgentMode()
@@ -50,11 +54,28 @@ func main() {
 	cmd := root.Command(formattedVersion)
 	boolFlags := collectBoolFlags(cmd)
 	subCmds := collectSubCmds(cmd)
+
+	// prefer sticking to err != nil format, than optimizing for calling exitWith
+	// once
 	if err := root.ValidateArgs(cmd, os.Args[1:]); err != nil {
-		handleError(err, boolFlags, subCmds)
+		exitWith(cmd, start, reportError(err, boolFlags, subCmds))
 	}
 
-	handleError(cmd.ExecuteContext(ctx), boolFlags, subCmds)
+	err := cmd.ExecuteContext(ctx)
+
+	// quick exit on context canceled
+	if errors.Is(err, context.Canceled) {
+		os.Exit(gcxerrors.ExitCancelled)
+	}
+
+	exitWith(cmd, start, reportError(err, boolFlags, subCmds))
+}
+
+// exitWith emits the usage event for this invocation, then exits. Every
+// invocation ends here, except the cancellation fast path above.
+func exitWith(cmd *cobra.Command, start time.Time, exitCode int) {
+	emitUsageEvent(cmd, start, exitCode)
+	os.Exit(exitCode)
 }
 
 // preParseAgentFlag scans os.Args for --agent / --agent=true / --agent=false
@@ -78,21 +99,18 @@ func preParseAgentFlag() {
 	}
 }
 
-func handleError(err error, boolFlags map[string]struct{}, subCmds map[string]bool) {
+// reportError prints the error (if any) to the right stream for the consumer,
+// appends the agent invocation log entry, and returns the process exit code.
+// It never exits; context cancellation is already handled in main before this
+// is called.
+func reportError(err error, boolFlags map[string]struct{}, subCmds map[string]bool) int {
 	if err == nil {
-		return
-	}
-
-	// Fast-path: context cancellation (e.g., SIGINT).
-	// Skip detailed error formatting — exit cleanly and quickly.
-	if errors.Is(err, context.Canceled) {
-		os.Exit(gcxerrors.ExitCancelled)
+		return 0
 	}
 
 	detailedErr := fail.ErrorToDetailedError(err)
 	if detailedErr == nil {
-		os.Exit(1)
-		return // unreachable; hint for static analysis
+		return 1
 	}
 
 	exitCode := 1
@@ -122,7 +140,7 @@ func handleError(err error, boolFlags map[string]struct{}, subCmds map[string]bo
 		fmt.Fprintln(os.Stderr, detailedErr.Error())
 	}
 
-	os.Exit(exitCode)
+	return exitCode
 }
 
 // collectBoolFlags walks the full command tree and returns a set of all boolean
@@ -170,11 +188,10 @@ func collectSubCmds(cmd *cobra.Command) map[string]bool {
 }
 
 // loadDiagnosticsConfig reads diagnostics settings from the layered gcx config.
-// It runs on every invocation, so it uses LoadDiagnostics, which reads only the
-// diagnostics block — no context parsing, no keychain probe, no config auto-
-// creation. A missing or malformed config simply yields a disabled config.
+// It runs on every invocation, so it uses a memoized result to avoid excessive
+// reads.
 func loadDiagnosticsConfig() agentlog.Config {
-	d := internalconfig.LoadDiagnostics(context.Background())
+	d := diagnosticsConfig()
 	if d == nil || !d.AgentInvocationLog {
 		return agentlog.Config{}
 	}

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -61,7 +61,7 @@ import (
 
 // jsonFlagActive is set to true in PersistentPreRun when the resolved command
 // has a --json flag that was explicitly changed by the user. This ensures
-// handleError() in main.go emits JSON errors only for commands that actually
+// reportError() in main.go emits JSON errors only for commands that actually
 // support --json, avoiding false positives from naive os.Args pre-scanning.
 //
 //nolint:gochecknoglobals
@@ -93,19 +93,11 @@ func shouldNotifySkills(cmd *cobra.Command) bool {
 }
 
 func isNonInteractiveCommand(cmd *cobra.Command) bool {
-	switch cmd.Name() {
-	case "help", "completion", "__complete", "__completeNoDesc":
+	if cmd.Name() == "help" || isShellPlumbingCommand(cmd.Name()) {
 		return true
 	}
 
-	if flag := cmd.Flags().Lookup("help"); flag != nil && flag.Changed && flag.Value.String() == "true" {
-		return true
-	}
-	if flag := cmd.Flags().Lookup("version"); flag != nil && flag.Changed && flag.Value.String() == "true" {
-		return true
-	}
-
-	return false
+	return boolFlagSet(cmd, "help") || boolFlagSet(cmd, "version")
 }
 
 func hasInteractiveTextOutput(cmd *cobra.Command) bool {
@@ -157,7 +149,7 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true, // We want to print errors ourselves
 		Version:       version,
-		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			jsonFlagActive.Store(false)
 			// Track whether --json was explicitly set on the resolved command.
 			// Only mark active when the command actually declares a --json flag,
@@ -219,6 +211,8 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 			}
 
 			cmd.SetContext(ctx)
+
+			recordTelemetryInfo(cmd, args)
 		},
 		PersistentPostRun: func(cmd *cobra.Command, _ []string) {
 			if !shouldNotifySkills(cmd) {

--- a/cmd/gcx/root/telemetry.go
+++ b/cmd/gcx/root/telemetry.go
@@ -1,0 +1,156 @@
+package root
+
+import (
+	"sort"
+	"strings"
+	"sync/atomic"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// TelemetryInfo contains the usage stats properties that PersistentPreRun
+// records for an anonymous usage event. No argument or flag values must be
+// stored.
+type TelemetryInfo struct {
+	Command      string // command path without the root name, e.g. "resources get"
+	Flags        string // sorted, comma-separated names of the flags the user set
+	OutputFormat string
+	Help         bool // did the user call gcx help or use --help?
+	Suppress     bool // this event must not get emitted
+}
+
+//nolint:gochecknoglobals // written once per process from PersistentPreRun.
+var telemetryInfo atomic.Pointer[TelemetryInfo]
+
+// CurrentTelemetryInfo returns the telemetry info for the current invocation.
+func CurrentTelemetryInfo() *TelemetryInfo {
+	return telemetryInfo.Load()
+}
+
+// recordTelemetryInfo writes telemetryInfo from the current command and args.
+func recordTelemetryInfo(cmd *cobra.Command, args []string) {
+	isHelp := cmd.Name() == "help"
+
+	// For `gcx help <path>` the resolved command is help itself; record the
+	// command the user asked about instead.
+	//
+	// `gcx help resources get` records "resources get", not "help"
+	target := cmd
+	if isHelp {
+		if found, _, err := cmd.Root().Find(args); err == nil {
+			target = found
+		}
+	}
+
+	telemetryInfo.Store(&TelemetryInfo{
+		Command:      trimCommandRoot(target),
+		Flags:        changedFlagNames(cmd),
+		OutputFormat: resolvedOutputFormat(cmd),
+		Help:         isHelp,
+		// Suppression applies to the help target too: `gcx help telemetry`
+		// must stay as unrecorded as `gcx telemetry --help`.
+		Suppress: telemetrySuppressed(cmd) || telemetrySuppressed(target),
+	})
+}
+
+// FallbackTelemetryInfo creates the usage-event info when PersistentPreRun
+// never ran, so nothing was recorded. That happens in two ways:
+//
+//   - The command line failed to parse (unknown command, unknown flag) and
+//     the exit code is nonzero. These return Suppress, so the caller emits
+//     no event. Recording parse failures as their own outcome is a TODO in
+//     #578.
+//   - Cobra answered the invocation itself before any hooks could run:
+//     things like --help or --version, or a command with no action of its
+//     own (like `gcx` or `gcx resources`). The exit code is zero and
+//     cobra printed the help screen (or the version string) as the
+//     command's only output.
+//
+// For the zero-exit case, the command is re-resolved with Find and its flags
+// read as cobra parsed them. Scanning os.Args instead would misread forms
+// like --help=true.
+func FallbackTelemetryInfo(rootCmd *cobra.Command, args []string, exitCode int) *TelemetryInfo {
+	if exitCode != 0 {
+		return &TelemetryInfo{Suppress: true}
+	}
+	target, _, err := rootCmd.Find(args)
+	if err != nil {
+		return &TelemetryInfo{Suppress: true}
+	}
+	if telemetrySuppressed(target) {
+		return &TelemetryInfo{Suppress: true}
+	}
+	if boolFlagSet(target, "help") || !target.Runnable() {
+		return &TelemetryInfo{Command: trimCommandRoot(target), Help: true}
+	}
+	return &TelemetryInfo{Suppress: true}
+}
+
+// trimCommandRoot returns the command path without the root name, e.g.
+// "resources get" for `gcx resources get`. The root prefix is its own
+// CommandPath, which honours the display-name annotation where Name does not.
+func trimCommandRoot(cmd *cobra.Command) string {
+	return strings.TrimSpace(strings.TrimPrefix(cmd.CommandPath(), cmd.Root().CommandPath()))
+}
+
+// changedFlagNames returns the names of the flags the user set, sorted and
+// comma-separated. Names only: values may identify people or resources.
+func changedFlagNames(cmd *cobra.Command) string {
+	var names []string
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		names = append(names, f.Name)
+	})
+	sort.Strings(names)
+	return strings.Join(names, ",")
+}
+
+// knownOutputFormats guards the privacy invariant: --output is a rendering
+// format on most commands, but on some it is a filesystem path (`gcx dev
+// linter new --output <dir>`), so only enumerated formats are ever recorded.
+//
+//nolint:gochecknoglobals
+var knownOutputFormats = map[string]bool{
+	"agents": true, "compact": true, "graph": true, "json": true,
+	"pretty": true, "table": true, "text": true, "wide": true, "yaml": true,
+}
+
+func resolvedOutputFormat(cmd *cobra.Command) string {
+	if f := cmd.Flags().Lookup("output"); f != nil {
+		if v := strings.ToLower(f.Value.String()); knownOutputFormats[v] {
+			return v
+		}
+		return ""
+	}
+	if boolFlagSet(cmd, "json") {
+		return "json"
+	}
+	return ""
+}
+
+// isShellPlumbingCommand reports whether name is a shell-integration command:
+// completion and cobra's hidden completion helpers.
+func isShellPlumbingCommand(name string) bool {
+	switch name {
+	case "completion", cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd:
+		return true
+	}
+	return false
+}
+
+// telemetrySuppressed reports whether the invocation must emit nothing: shell
+// plumbing, version, and the telemetry command itself. The ancestor chain is
+// checked, so subcommands like `completion zsh` are suppressed too.
+func telemetrySuppressed(cmd *cobra.Command) bool {
+	for c := cmd; c.HasParent(); c = c.Parent() {
+		if isShellPlumbingCommand(c.Name()) || c.Name() == "version" || c.Name() == "telemetry" {
+			return true
+		}
+	}
+	return boolFlagSet(cmd, "version")
+}
+
+func boolFlagSet(cmd *cobra.Command, name string) bool {
+	f := cmd.Flags().Lookup(name)
+	return f != nil && f.Changed && f.Value.String() == "true"
+}

--- a/cmd/gcx/root/telemetry_internal_test.go
+++ b/cmd/gcx/root/telemetry_internal_test.go
@@ -1,0 +1,118 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// telemetryTestTree builds gcx-shaped commands: root (with the display-name
+// annotation the real root carries) > resources > get, plus completion > zsh.
+func telemetryTestTree() (*cobra.Command, *cobra.Command, *cobra.Command) {
+	rootCmd := &cobra.Command{
+		Use:         "gcx",
+		Annotations: map[string]string{cobra.CommandDisplayNameAnnotation: "gcx"},
+	}
+	resources := &cobra.Command{Use: "resources"}
+	get := &cobra.Command{Use: "get", Run: func(*cobra.Command, []string) {}}
+	resources.AddCommand(get)
+	rootCmd.AddCommand(resources)
+
+	completion := &cobra.Command{Use: "completion"}
+	zsh := &cobra.Command{Use: "zsh", Run: func(*cobra.Command, []string) {}}
+	completion.AddCommand(zsh)
+	rootCmd.AddCommand(completion)
+
+	return rootCmd, get, zsh
+}
+
+func TestTrimCommandRoot(t *testing.T) {
+	rootCmd, get, _ := telemetryTestTree()
+
+	assert.Equal(t, "resources get", trimCommandRoot(get))
+	assert.Empty(t, trimCommandRoot(rootCmd))
+}
+
+func TestChangedFlagNames_SortedNamesOnly(t *testing.T) {
+	_, get, _ := telemetryTestTree()
+	get.Flags().String("output", "", "")
+	get.Flags().Bool("dry-run", false, "")
+	require.NoError(t, get.Flags().Set("output", "secret-value"))
+	require.NoError(t, get.Flags().Set("dry-run", "true"))
+
+	names := changedFlagNames(get)
+
+	assert.Equal(t, "dry-run,output", names)
+	assert.NotContains(t, names, "secret-value", "flag values must never be recorded")
+}
+
+func TestTelemetrySuppressed(t *testing.T) {
+	rootCmd, get, zsh := telemetryTestTree()
+
+	assert.False(t, telemetrySuppressed(get))
+	assert.True(t, telemetrySuppressed(zsh), "completion subcommands are suppressed via the ancestor chain")
+
+	version := &cobra.Command{Use: "version"}
+	rootCmd.AddCommand(version)
+	assert.True(t, telemetrySuppressed(version))
+
+	telemetryCmd := &cobra.Command{Use: "telemetry"}
+	rootCmd.AddCommand(telemetryCmd)
+	assert.True(t, telemetrySuppressed(telemetryCmd), "opting out must never itself be recorded")
+}
+
+func TestRecordTelemetryInfo_HelpResolvesTarget(t *testing.T) {
+	telemetryInfo.Store(nil)
+	t.Cleanup(func() { telemetryInfo.Store(nil) })
+	rootCmd, _, _ := telemetryTestTree()
+	help := &cobra.Command{Use: "help"}
+	rootCmd.AddCommand(help)
+
+	recordTelemetryInfo(help, []string{"resources", "get"})
+
+	info := CurrentTelemetryInfo()
+	require.NotNil(t, info)
+	assert.True(t, info.Help)
+	assert.Equal(t, "resources get", info.Command)
+
+	// Suppression follows the help target: asking for help about a suppressed
+	// command must stay as unrecorded as running it.
+	recordTelemetryInfo(help, []string{"completion", "zsh"})
+	require.NotNil(t, CurrentTelemetryInfo())
+	assert.True(t, CurrentTelemetryInfo().Suppress)
+}
+
+func TestFallbackTelemetryInfo(t *testing.T) {
+	rootCmd, get, _ := telemetryTestTree()
+	get.Flags().Bool("help", false, "")
+
+	// --help on a resolved command: recorded as help with the resolved path.
+	require.NoError(t, get.Flags().Set("help", "true"))
+	info := FallbackTelemetryInfo(rootCmd, []string{"resources", "get", "--help"}, 0)
+	assert.False(t, info.Suppress)
+	assert.True(t, info.Help)
+	assert.Equal(t, "resources get", info.Command)
+
+	// `gcx resources bogus` fails with exit code 2, but Find still resolves
+	// it to the "resources" group - the same thing bare `gcx resources` (a
+	// help view) resolves to. The exit code is the only difference between
+	// them, so the failure must be suppressed rather than counted as help.
+	info = FallbackTelemetryInfo(rootCmd, []string{"resources", "bogus"}, 2)
+	assert.True(t, info.Suppress)
+
+	// Non-runnable command group: cobra prints help before the hooks run.
+	info = FallbackTelemetryInfo(rootCmd, []string{"resources"}, 0)
+	assert.False(t, info.Suppress)
+	assert.True(t, info.Help)
+	assert.Equal(t, "resources", info.Command)
+
+	// Unknown commands are parse failures, suppressed until parse capture.
+	info = FallbackTelemetryInfo(rootCmd, []string{"resourcse", "get"}, 0)
+	assert.True(t, info.Suppress)
+
+	// Suppressed commands stay suppressed on the fallback path too.
+	info = FallbackTelemetryInfo(rootCmd, []string{"completion", "zsh", "--help"}, 0)
+	assert.True(t, info.Suppress)
+}

--- a/cmd/gcx/telemetry.go
+++ b/cmd/gcx/telemetry.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/grafana/gcx/cmd/gcx/root"
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/agentlog"
+	internalconfig "github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/telemetry"
+	"github.com/grafana/gcx/internal/terminal"
+	appversion "github.com/grafana/gcx/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// diagnosticsConfig memoizes the layered config read shared by agentlog setup
+// at startup and telemetry mode resolution at exit.
+//
+//nolint:gochecknoglobals
+var diagnosticsConfig = sync.OnceValue(func() *internalconfig.DiagnosticsConfig {
+	return internalconfig.LoadDiagnostics(context.Background())
+})
+
+// emitUsageEvent builds and emits the anonymous usage event for this
+// invocation. It must never affect the command's exit code or prompt the user.
+// It must only be called once per invocation.
+func emitUsageEvent(cmd *cobra.Command, start time.Time, exitCode int) {
+	info := root.CurrentTelemetryInfo()
+	if info == nil {
+		info = root.FallbackTelemetryInfo(cmd, os.Args[1:], exitCode)
+	}
+	if info.Suppress {
+		return
+	}
+
+	mode := telemetry.ResolveMode(diagnosticsTelemetryValue)
+	if mode != telemetry.ModeLog {
+		// TODO: We'll handle ModeEnabled in a followup PR
+		return
+	}
+
+	if data, err := json.Marshal(buildUsageEvent(info, start, exitCode)); err == nil {
+		fmt.Fprintln(os.Stderr, string(data))
+	}
+}
+
+func buildUsageEvent(info *root.TelemetryInfo, start time.Time, exitCode int) telemetry.Event {
+	event := telemetry.Event{
+		Service: telemetry.ServiceName,
+		Version: appversion.Get(),
+		OS:      runtime.GOOS,
+		Arch:    runtime.GOARCH,
+
+		Command:      info.Command,
+		Flags:        info.Flags,
+		ExitCode:     exitCode,
+		DurationMS:   time.Since(start).Milliseconds(),
+		OutputFormat: info.OutputFormat,
+
+		IsTTY:   terminal.StdoutIsTerminal(),
+		IsAgent: agent.IsAgentMode(),
+		Agent:   agent.Name(),
+		// TargetKind needs the resolved config context; resolving it requires
+		// a keychain-free context loader, which lands with the OTLP export
+		// stage. Empty until then.
+	}
+
+	// The provider is the top-level command, the first segment of the path.
+	if fields := strings.Fields(info.Command); len(fields) > 0 {
+		event.Provider = fields[0]
+	}
+
+	event.DeviceID, event.DeviceIDPersisted = telemetry.DeviceID()
+	event.CIProvider, event.IsCI = telemetry.DetectCI()
+
+	switch {
+	case info.Help && exitCode == 0:
+		event.Outcome = telemetry.OutcomeHelp
+	case exitCode == 0:
+		event.Outcome = telemetry.OutcomeOK
+	default:
+		event.Outcome = telemetry.OutcomeRuntimeError
+		event.ErrorKind = agentlog.KindFromExitCode(exitCode)
+	}
+
+	return event
+}
+
+func diagnosticsTelemetryValue() string {
+	if d := diagnosticsConfig(); d != nil {
+		return d.Telemetry
+	}
+	return ""
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -48,8 +48,9 @@ type Env struct {
 // ResolveMode resolves the telemetry mode for this invocation. Precedence,
 // highest first: GCX_TELEMETRY, DO_NOT_TRACK, the diagnostics.telemetry
 // config value, the built-in default. Unrecognised values fall through to
-// the next level.
-func ResolveMode(configValue string) Mode {
+// the next level. configValue is a func so callers only pay the config-file
+// read when the environment doesn't already decide the mode.
+func ResolveMode(configValue func() string) Mode {
 	return resolveMode(os.Getenv, configValue)
 }
 
@@ -61,14 +62,14 @@ const (
 	envDoNotTrack = "DO_NOT_TRACK"
 )
 
-func resolveMode(getenv func(string) string, configValue string) Mode {
+func resolveMode(getenv func(string) string, configValue func() string) Mode {
 	if m, ok := parseMode(getenv(envTelemetry)); ok {
 		return m
 	}
 	if isDoNotTrack(getenv(envDoNotTrack)) {
 		return ModeDisabled
 	}
-	if m, ok := parseMode(configValue); ok {
+	if m, ok := parseMode(configValue()); ok {
 		return m
 	}
 	return defaultMode

--- a/internal/telemetry/telemetry_internal_test.go
+++ b/internal/telemetry/telemetry_internal_test.go
@@ -88,7 +88,7 @@ func TestResolveMode(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := resolveMode(fakeGetenv(tc.env), tc.configValue)
+			got := resolveMode(fakeGetenv(tc.env), func() string { return tc.configValue })
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
Part of https://github.com/grafana/gcx-internal/issues/2

follow on from https://github.com/grafana/gcx/pull/944

## Summary

- wires the internal telemetry library from #944 into the CLI lifecycle
- `GCX_TELEMETRY=log` prints the event JSON to stderr. nothing is exported yet

behaviours:
  - suppression: `completion`,`version` and`telemetry` commands do not emit events.
  - `--help`, `gcx help <path>`, `gcx`, and e.g. `gcx resources` record `outcome=help` with the resolved target path
  - parse failures (e.g. `gcx invalid command`) emit nothing, this is a TODO in #578 
  - user cancellation exits fast with no event

## Examples

```
// valid
GCX_TELEMETRY=log ./bin/gcx commands >/dev/null
{"service":"gcx","version":"(devel)","os":"darwin","arch":"arm64","device_id":"36d9...","device_id_persisted":true,"command":"commands","flags":"","provider":"commands","outcome":"ok","exit_code":0,"error_kind":"","duration_ms":24,"is_tty":false,"is_ci":false,"ci_provider":"","is_agent":false,"agent":"","target_kind":"","output_format":"json"}

// valid, multiple args
GCX_TELEMETRY=log ./bin/gcx dashboards list >/dev/null
{"service":"gcx","version":"(devel)","os":"darwin","arch":"arm64","device_id":"36d9...","device_id_persisted":true,"command":"dashboards list","flags":"","provider":"dashboards","outcome":"ok","exit_code":0,"error_kind":"","duration_ms":1059,"is_tty":false,"is_ci":false,"ci_provider":"","is_agent":false,"agent":"","target_kind":"","output_format":"table"}

// help
GCX_TELEMETRY=log ./bin/gcx help dashboards list >/dev/null
{"service":"gcx","version":"(devel)","os":"darwin","arch":"arm64","device_id":"36d9...","device_id_persisted":true,"command":"dashboards list","flags":"","provider":"dashboards","outcome":"help","exit_code":0,"error_kind":"","duration_ms":18,"is_tty":false,"is_ci":false,"ci_provider":"","is_agent":false,"agent":"","target_kind":"","output_format":""}

// help, invalid command => command is "help"
GCX_TELEMETRY=log ./bin/gcx help foo bar >/dev/null
{"service":"gcx","version":"(devel)","os":"darwin","arch":"arm64","device_id":"36d9...","device_id_persisted":true,"command":"help","flags":"","provider":"help","outcome":"help","exit_code":0,"error_kind":"","duration_ms":10,"is_tty":false,"is_ci":false,"ci_provider":"","is_agent":false,"agent":"","target_kind":"","output_format":""}

// --help
GCX_TELEMETRY=log ./bin/gcx datasources list --help >/dev/null
{"service":"gcx","version":"(devel)","os":"darwin","arch":"arm64","device_id":"36d988e3-971e-4566-b0ca-7416f85b0da2","device_id_persisted":true,"command":"datasources list","flags":"","provider":"datasources","outcome":"help","exit_code":0,"error_kind":"","duration_ms":4,"is_tty":false,"is_ci":false,"ci_provider":"","is_agent":false,"agent":"","target_kind":"","output_format":""}

//  --help on invalid command => no telemetry (for now - we will add parse failure events)
GCX_TELEMETRY=log ./bin/gcx foo bar--help >/dev/null
<error only>
```


## Notes

- the`target_kind` property in the usage event is empty. We'll fix that in a later stage, when we can avoid reading the OS keychain.
- default is currently `disabled`
