### PR TITLE
feat(profiles): add span and trace selectors

### DIFF
--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -82,7 +82,7 @@ gcx (root)
 │   └── adaptive             Adaptive Traces (policies, recommendations)
 │
 ├── profiles                 [internal/providers/profiles/provider.go] (registered via providers.Register)
-│   ├── query                [DATASOURCE_UID] EXPR --profile-type TYPE [--from] [--to] [--since] [--max-nodes] [--profile-id UUID]... [--stacktrace-selector FN]... [-o]
+│   ├── query                [DATASOURCE_UID] EXPR --profile-type TYPE [--from] [--to] [--since] [--max-nodes] [--profile-id UUID]... [--span-selector ID]... [--trace-id ID]... [--stacktrace-selector FN]... [-o]
 │   ├── labels               [--datasource/-d UID] [--label/-l NAME]
 │   ├── profile-types        [--datasource/-d UID]
 │   ├── series               [DATASOURCE_UID] EXPR --profile-type TYPE [--top] [--group-by] [--limit]

--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -82,7 +82,7 @@ gcx (root)
 │   └── adaptive             Adaptive Traces (policies, recommendations)
 │
 ├── profiles                 [internal/providers/profiles/provider.go] (registered via providers.Register)
-│   ├── query                [DATASOURCE_UID] EXPR --profile-type TYPE [--from] [--to] [--since] [--max-nodes] [--profile-id UUID]... [--span-selector ID]... [--trace-id ID]... [--stacktrace-selector FN]... [-o]
+│   ├── query                [DATASOURCE_UID] EXPR --profile-type TYPE [--from] [--to] [--since] [--max-nodes] [--profile-id UUID]... [--span-id ID]... [--trace-id ID]... [--stacktrace-selector FN]... [-o]
 │   ├── labels               [--datasource/-d UID] [--label/-l NAME]
 │   ├── profile-types        [--datasource/-d UID]
 │   ├── series               [DATASOURCE_UID] EXPR --profile-type TYPE [--top] [--group-by] [--limit]

--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -39,7 +39,7 @@ gcx datasources pyroscope query [EXPR] [flags]
   # Restrict the query to one or more trace spans
   gcx datasources pyroscope query '{service_name="frontend"}' \
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
-    --span-selector 00f067aa0ba902b7
+    --span-id 00f067aa0ba902b7
 
   # Restrict the query to samples from one or more traces
   gcx datasources pyroscope query '{service_name="frontend"}' \
@@ -77,7 +77,7 @@ gcx datasources pyroscope query [EXPR] [flags]
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)
       --profile-type string           Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
       --since string                  Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
-      --span-selector strings         Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)
+      --span-id strings               Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)
       --stacktrace-selector strings   Only query locations with these function names, starting from the root (repeatable)
       --step string                   Query step (e.g., '15s', '1m')
       --to string                     End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -36,6 +36,16 @@ gcx datasources pyroscope query [EXPR] [flags]
     --profile-id 550e8400-e29b-41d4-a716-446655440000 \
     --profile-id 7c9e6679-7425-40de-944b-e07fc1f90ae7
 
+  # Restrict the query to one or more trace spans
+  gcx datasources pyroscope query '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
+    --span-selector 00f067aa0ba902b7
+
+  # Restrict the query to samples from one or more traces
+  gcx datasources pyroscope query '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
+    --trace-id 4bf92f3577b34da6a3ce929d0e0e4736
+
   # Restrict the flamegraph to stacks rooted at a specific call site
   # (--stacktrace-selector is repeatable; pass it once per frame, root first)
   gcx datasources pyroscope query '{service_name="my-go-service"}' \
@@ -67,9 +77,11 @@ gcx datasources pyroscope query [EXPR] [flags]
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)
       --profile-type string           Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
       --since string                  Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
+      --span-selector strings         Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)
       --stacktrace-selector strings   Only query locations with these function names, starting from the root (repeatable)
       --step string                   Query step (e.g., '15s', '1m')
       --to string                     End time (RFC3339, Unix timestamp, or relative like 'now')
+      --trace-id strings              Only query samples with these 32-character hex trace IDs (repeatable)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -36,6 +36,16 @@ gcx profiles query [EXPR] [flags]
     --profile-id 550e8400-e29b-41d4-a716-446655440000 \
     --profile-id 7c9e6679-7425-40de-944b-e07fc1f90ae7
 
+  # Restrict the query to one or more trace spans
+  gcx profiles query '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
+    --span-selector 00f067aa0ba902b7
+
+  # Restrict the query to samples from one or more traces
+  gcx profiles query '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
+    --trace-id 4bf92f3577b34da6a3ce929d0e0e4736
+
   # Restrict the flamegraph to stacks rooted at a specific call site
   # (--stacktrace-selector is repeatable; pass it once per frame, root first)
   gcx profiles query '{service_name="my-go-service"}' \
@@ -59,9 +69,11 @@ gcx profiles query [EXPR] [flags]
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)
       --profile-type string           Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
       --since string                  Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
+      --span-selector strings         Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)
       --stacktrace-selector strings   Only query locations with these function names, starting from the root (repeatable)
       --step string                   Query step (e.g., '15s', '1m')
       --to string                     End time (RFC3339, Unix timestamp, or relative like 'now')
+      --trace-id strings              Only query samples with these 32-character hex trace IDs (repeatable)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -39,7 +39,7 @@ gcx profiles query [EXPR] [flags]
   # Restrict the query to one or more trace spans
   gcx profiles query '{service_name="frontend"}' \
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
-    --span-selector 00f067aa0ba902b7
+    --span-id 00f067aa0ba902b7
 
   # Restrict the query to samples from one or more traces
   gcx profiles query '{service_name="frontend"}' \
@@ -69,7 +69,7 @@ gcx profiles query [EXPR] [flags]
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)
       --profile-type string           Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
       --since string                  Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
-      --span-selector strings         Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)
+      --span-id strings               Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)
       --stacktrace-selector strings   Only query locations with these function names, starting from the root (repeatable)
       --step string                   Query step (e.g., '15s', '1m')
       --to string                     End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/internal/datasources/pyroscope/query.go
+++ b/internal/datasources/pyroscope/query.go
@@ -36,6 +36,8 @@ type pyroscopeQueryOpts struct {
 	ProfileType        string
 	MaxNodes           int64
 	ProfileIDs         []string
+	SpanIDs            []string
+	TraceIDs           []string
 	StacktraceSelector []string
 	PprofPath          string
 	PprofOverwrite     bool
@@ -50,6 +52,8 @@ func (opts *pyroscopeQueryOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.ProfileType, "profile-type", "", "Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)")
 	flags.Int64Var(&opts.MaxNodes, "max-nodes", 0, fmt.Sprintf("Maximum nodes in flame graph (default 0/unlimited for pprof output, %d for all other formats)", defaultMaxNodes))
 	flags.StringSliceVar(&opts.ProfileIDs, "profile-id", nil, "Drill down to specific profile UUIDs from exemplar queries (repeatable)")
+	flags.StringSliceVar(&opts.SpanIDs, "span-selector", nil, "Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)")
+	flags.StringSliceVar(&opts.TraceIDs, "trace-id", nil, "Only query samples with these 32-character hex trace IDs (repeatable)")
 	flags.StringSliceVar(&opts.StacktraceSelector, "stacktrace-selector", nil, "Only query locations with these function names, starting from the root (repeatable)")
 	flags.StringVar(&opts.PprofPath, "pprof-path", "", "Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)")
 	flags.BoolVar(&opts.PprofOverwrite, "pprof-overwrite", false, "Overwrite the output file if it already exists (only with -o pprof)")
@@ -70,6 +74,31 @@ func (opts *pyroscopeQueryOpts) Validate(flags *pflag.FlagSet) error {
 	for _, id := range opts.ProfileIDs {
 		if !isUUID(id) {
 			return fmt.Errorf("--profile-id must be a valid UUID (got %q)", id)
+		}
+	}
+	if len(opts.SpanIDs) > 0 && len(opts.StacktraceSelector) > 0 {
+		return errors.New("--span-selector and --stacktrace-selector cannot be used together")
+	}
+	if len(opts.SpanIDs) > 0 && len(opts.ProfileIDs) > 0 {
+		return errors.New("--span-selector and --profile-id cannot be used together")
+	}
+	if len(opts.TraceIDs) > 0 && len(opts.SpanIDs) > 0 {
+		return errors.New("--trace-id and --span-selector cannot be used together")
+	}
+	if len(opts.TraceIDs) > 0 && len(opts.ProfileIDs) > 0 {
+		return errors.New("--trace-id and --profile-id cannot be used together")
+	}
+	if len(opts.SpanIDs) > 0 && opts.shared.IO.OutputFormat == "pprof" {
+		return errors.New("--span-selector is not supported with -o pprof")
+	}
+	for _, id := range opts.SpanIDs {
+		if !isHexID(id, 16) {
+			return fmt.Errorf("--span-selector must be a 16-character hex span ID (got %q)", id)
+		}
+	}
+	for _, id := range opts.TraceIDs {
+		if !isHexID(id, 32) {
+			return fmt.Errorf("--trace-id must be a 32-character hex trace ID (got %q)", id)
 		}
 	}
 	return nil
@@ -127,6 +156,16 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
     --profile-id 550e8400-e29b-41d4-a716-446655440000 \
     --profile-id 7c9e6679-7425-40de-944b-e07fc1f90ae7
+
+  # Restrict the query to one or more trace spans
+  gcx datasources pyroscope query '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
+    --span-selector 00f067aa0ba902b7
+
+  # Restrict the query to samples from one or more traces
+  gcx datasources pyroscope query '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
+    --trace-id 4bf92f3577b34da6a3ce929d0e0e4736
 
   # Restrict the flamegraph to stacks rooted at a specific call site
   # (--stacktrace-selector is repeatable; pass it once per frame, root first)
@@ -190,6 +229,7 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 					Start:         start,
 					End:           end,
 					MaxNodes:      opts.MaxNodes,
+					TraceIDs:      opts.TraceIDs,
 				})
 				if err != nil {
 					return fmt.Errorf("pprof fetch failed: %w", err)
@@ -208,6 +248,8 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 				End:                end,
 				MaxNodes:           opts.resolveMaxNodes(cmd.Flags()),
 				ProfileIDs:         opts.ProfileIDs,
+				SpanIDs:            opts.SpanIDs,
+				TraceIDs:           opts.TraceIDs,
 				StackTraceSelector: opts.stackTraceSelector(),
 			}
 
@@ -245,6 +287,18 @@ func isUUID(s string) bool {
 				return false
 			}
 		} else if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+func isHexID(s string, length int) bool {
+	if len(s) != length {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 			return false
 		}
 	}

--- a/internal/datasources/pyroscope/query.go
+++ b/internal/datasources/pyroscope/query.go
@@ -52,7 +52,7 @@ func (opts *pyroscopeQueryOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.ProfileType, "profile-type", "", "Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)")
 	flags.Int64Var(&opts.MaxNodes, "max-nodes", 0, fmt.Sprintf("Maximum nodes in flame graph (default 0/unlimited for pprof output, %d for all other formats)", defaultMaxNodes))
 	flags.StringSliceVar(&opts.ProfileIDs, "profile-id", nil, "Drill down to specific profile UUIDs from exemplar queries (repeatable)")
-	flags.StringSliceVar(&opts.SpanIDs, "span-selector", nil, "Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)")
+	flags.StringSliceVar(&opts.SpanIDs, "span-id", nil, "Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)")
 	flags.StringSliceVar(&opts.TraceIDs, "trace-id", nil, "Only query samples with these 32-character hex trace IDs (repeatable)")
 	flags.StringSliceVar(&opts.StacktraceSelector, "stacktrace-selector", nil, "Only query locations with these function names, starting from the root (repeatable)")
 	flags.StringVar(&opts.PprofPath, "pprof-path", "", "Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)")
@@ -77,23 +77,23 @@ func (opts *pyroscopeQueryOpts) Validate(flags *pflag.FlagSet) error {
 		}
 	}
 	if len(opts.SpanIDs) > 0 && len(opts.StacktraceSelector) > 0 {
-		return errors.New("--span-selector and --stacktrace-selector cannot be used together")
+		return errors.New("--span-id and --stacktrace-selector cannot be used together")
 	}
 	if len(opts.SpanIDs) > 0 && len(opts.ProfileIDs) > 0 {
-		return errors.New("--span-selector and --profile-id cannot be used together")
+		return errors.New("--span-id and --profile-id cannot be used together")
 	}
 	if len(opts.TraceIDs) > 0 && len(opts.SpanIDs) > 0 {
-		return errors.New("--trace-id and --span-selector cannot be used together")
+		return errors.New("--trace-id and --span-id cannot be used together")
 	}
 	if len(opts.TraceIDs) > 0 && len(opts.ProfileIDs) > 0 {
 		return errors.New("--trace-id and --profile-id cannot be used together")
 	}
 	if len(opts.SpanIDs) > 0 && opts.shared.IO.OutputFormat == "pprof" {
-		return errors.New("--span-selector is not supported with -o pprof")
+		return errors.New("--span-id is not supported with -o pprof")
 	}
 	for _, id := range opts.SpanIDs {
 		if !isHexID(id, 16) {
-			return fmt.Errorf("--span-selector must be a 16-character hex span ID (got %q)", id)
+			return fmt.Errorf("--span-id must be a 16-character hex span ID (got %q)", id)
 		}
 	}
 	for _, id := range opts.TraceIDs {
@@ -160,7 +160,7 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
   # Restrict the query to one or more trace spans
   gcx datasources pyroscope query '{service_name="frontend"}' \
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
-    --span-selector 00f067aa0ba902b7
+    --span-id 00f067aa0ba902b7
 
   # Restrict the query to samples from one or more traces
   gcx datasources pyroscope query '{service_name="frontend"}' \

--- a/internal/datasources/pyroscope/query_test.go
+++ b/internal/datasources/pyroscope/query_test.go
@@ -1,0 +1,102 @@
+//nolint:testpackage // White-box tests cover query option validation.
+package pyroscope
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPyroscopeQueryOptsValidateSelectors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "span selector",
+			args: []string{"--span-selector", "00f067aa0ba902b7"},
+		},
+		{
+			name: "multiple span selectors",
+			args: []string{"--span-selector", "00f067aa0ba902b7", "--span-selector", "5a4fe264a9c987fe"},
+		},
+		{
+			name: "trace selector",
+			args: []string{"--trace-id", "4bf92f3577b34da6a3ce929d0e0e4736"},
+		},
+		{
+			name: "trace selector with pprof",
+			args: []string{"--trace-id", "4bf92f3577b34da6a3ce929d0e0e4736", "-o", "pprof"},
+		},
+		{
+			name: "trace selector with stacktrace selector",
+			args: []string{"--trace-id", "4bf92f3577b34da6a3ce929d0e0e4736", "--stacktrace-selector", "main.run"},
+		},
+		{
+			name:    "short span selector",
+			args:    []string{"--span-selector", "00f067aa"},
+			wantErr: "16-character hex span ID",
+		},
+		{
+			name:    "non-hex span selector",
+			args:    []string{"--span-selector", "00f067aa0ba902bg"},
+			wantErr: "16-character hex span ID",
+		},
+		{
+			name:    "short trace selector",
+			args:    []string{"--trace-id", "00f067aa0ba902b7"},
+			wantErr: "32-character hex trace ID",
+		},
+		{
+			name:    "non-hex trace selector",
+			args:    []string{"--trace-id", "4bf92f3577b34da6a3ce929d0e0e473g"},
+			wantErr: "32-character hex trace ID",
+		},
+		{
+			name:    "span and stacktrace selectors",
+			args:    []string{"--span-selector", "00f067aa0ba902b7", "--stacktrace-selector", "main.run"},
+			wantErr: "--span-selector and --stacktrace-selector cannot be used together",
+		},
+		{
+			name:    "span and profile selectors",
+			args:    []string{"--span-selector", "00f067aa0ba902b7", "--profile-id", "550e8400-e29b-41d4-a716-446655440000"},
+			wantErr: "--span-selector and --profile-id cannot be used together",
+		},
+		{
+			name:    "trace and span selectors",
+			args:    []string{"--trace-id", "4bf92f3577b34da6a3ce929d0e0e4736", "--span-selector", "00f067aa0ba902b7"},
+			wantErr: "--trace-id and --span-selector cannot be used together",
+		},
+		{
+			name:    "trace and profile selectors",
+			args:    []string{"--trace-id", "4bf92f3577b34da6a3ce929d0e0e4736", "--profile-id", "550e8400-e29b-41d4-a716-446655440000"},
+			wantErr: "--trace-id and --profile-id cannot be used together",
+		},
+		{
+			name:    "span selector with pprof",
+			args:    []string{"--span-selector", "00f067aa0ba902b7", "-o", "pprof"},
+			wantErr: "--span-selector is not supported with -o pprof",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &pyroscopeQueryOpts{}
+			flags := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+			opts.setup(flags)
+			args := append([]string{"--profile-type", "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}, tt.args...)
+			require.NoError(t, flags.Parse(args))
+
+			err := opts.Validate(flags)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/internal/datasources/pyroscope/query_test.go
+++ b/internal/datasources/pyroscope/query_test.go
@@ -16,12 +16,12 @@ func TestPyroscopeQueryOptsValidateSelectors(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "span selector",
-			args: []string{"--span-selector", "00f067aa0ba902b7"},
+			name: "span ID",
+			args: []string{"--span-id", "00f067aa0ba902b7"},
 		},
 		{
-			name: "multiple span selectors",
-			args: []string{"--span-selector", "00f067aa0ba902b7", "--span-selector", "5a4fe264a9c987fe"},
+			name: "multiple span IDs",
+			args: []string{"--span-id", "00f067aa0ba902b7", "--span-id", "5a4fe264a9c987fe"},
 		},
 		{
 			name: "trace selector",
@@ -36,13 +36,13 @@ func TestPyroscopeQueryOptsValidateSelectors(t *testing.T) {
 			args: []string{"--trace-id", "4bf92f3577b34da6a3ce929d0e0e4736", "--stacktrace-selector", "main.run"},
 		},
 		{
-			name:    "short span selector",
-			args:    []string{"--span-selector", "00f067aa"},
+			name:    "short span ID",
+			args:    []string{"--span-id", "00f067aa"},
 			wantErr: "16-character hex span ID",
 		},
 		{
-			name:    "non-hex span selector",
-			args:    []string{"--span-selector", "00f067aa0ba902bg"},
+			name:    "non-hex span ID",
+			args:    []string{"--span-id", "00f067aa0ba902bg"},
 			wantErr: "16-character hex span ID",
 		},
 		{
@@ -57,18 +57,18 @@ func TestPyroscopeQueryOptsValidateSelectors(t *testing.T) {
 		},
 		{
 			name:    "span and stacktrace selectors",
-			args:    []string{"--span-selector", "00f067aa0ba902b7", "--stacktrace-selector", "main.run"},
-			wantErr: "--span-selector and --stacktrace-selector cannot be used together",
+			args:    []string{"--span-id", "00f067aa0ba902b7", "--stacktrace-selector", "main.run"},
+			wantErr: "--span-id and --stacktrace-selector cannot be used together",
 		},
 		{
 			name:    "span and profile selectors",
-			args:    []string{"--span-selector", "00f067aa0ba902b7", "--profile-id", "550e8400-e29b-41d4-a716-446655440000"},
-			wantErr: "--span-selector and --profile-id cannot be used together",
+			args:    []string{"--span-id", "00f067aa0ba902b7", "--profile-id", "550e8400-e29b-41d4-a716-446655440000"},
+			wantErr: "--span-id and --profile-id cannot be used together",
 		},
 		{
 			name:    "trace and span selectors",
-			args:    []string{"--trace-id", "4bf92f3577b34da6a3ce929d0e0e4736", "--span-selector", "00f067aa0ba902b7"},
-			wantErr: "--trace-id and --span-selector cannot be used together",
+			args:    []string{"--trace-id", "4bf92f3577b34da6a3ce929d0e0e4736", "--span-id", "00f067aa0ba902b7"},
+			wantErr: "--trace-id and --span-id cannot be used together",
 		},
 		{
 			name:    "trace and profile selectors",
@@ -76,9 +76,9 @@ func TestPyroscopeQueryOptsValidateSelectors(t *testing.T) {
 			wantErr: "--trace-id and --profile-id cannot be used together",
 		},
 		{
-			name:    "span selector with pprof",
-			args:    []string{"--span-selector", "00f067aa0ba902b7", "-o", "pprof"},
-			wantErr: "--span-selector is not supported with -o pprof",
+			name:    "span ID with pprof",
+			args:    []string{"--span-id", "00f067aa0ba902b7", "-o", "pprof"},
+			wantErr: "--span-id is not supported with -o pprof",
 		},
 	}
 

--- a/internal/providers/profiles/provider.go
+++ b/internal/providers/profiles/provider.go
@@ -49,7 +49,7 @@ func (p *Provider) descriptor() signals.Descriptor {
   # Restrict the query to one or more trace spans
   gcx profiles query '{service_name="frontend"}' \
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
-    --span-selector 00f067aa0ba902b7
+    --span-id 00f067aa0ba902b7
 
   # Restrict the query to samples from one or more traces
   gcx profiles query '{service_name="frontend"}' \

--- a/internal/providers/profiles/provider.go
+++ b/internal/providers/profiles/provider.go
@@ -46,6 +46,16 @@ func (p *Provider) descriptor() signals.Descriptor {
     --profile-id 550e8400-e29b-41d4-a716-446655440000 \
     --profile-id 7c9e6679-7425-40de-944b-e07fc1f90ae7
 
+  # Restrict the query to one or more trace spans
+  gcx profiles query '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
+    --span-selector 00f067aa0ba902b7
+
+  # Restrict the query to samples from one or more traces
+  gcx profiles query '{service_name="frontend"}' \
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --since 1h \
+    --trace-id 4bf92f3577b34da6a3ce929d0e0e4736
+
   # Restrict the flamegraph to stacks rooted at a specific call site
   # (--stacktrace-selector is repeatable; pass it once per frame, root first)
   gcx profiles query '{service_name="my-go-service"}' \

--- a/internal/query/pyroscope/client.go
+++ b/internal/query/pyroscope/client.go
@@ -39,7 +39,11 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 
 // Query executes a Pyroscope profile query against the specified datasource.
 func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryRequest) (*QueryResponse, error) {
-	apiPath := c.buildResourcePath(datasourceUID, "querier.v1.QuerierService/SelectMergeStacktraces")
+	resourcePath := "querier.v1.QuerierService/SelectMergeStacktraces"
+	if len(req.SpanIDs) > 0 {
+		resourcePath = "querier.v1.QuerierService/SelectMergeSpanProfile"
+	}
+	apiPath := c.buildResourcePath(datasourceUID, resourcePath)
 
 	start, end := DefaultTimeRange(req.Start, req.End)
 
@@ -54,11 +58,18 @@ func (c *Client) Query(ctx context.Context, datasourceUID string, req QueryReque
 	if req.MaxNodes > 0 {
 		bodyMap["maxNodes"] = strconv.FormatInt(req.MaxNodes, 10)
 	}
-	if len(req.ProfileIDs) > 0 {
-		bodyMap["profileIdSelector"] = req.ProfileIDs
-	}
-	if req.StackTraceSelector != nil {
-		bodyMap["stackTraceSelector"] = req.StackTraceSelector
+	if len(req.SpanIDs) > 0 {
+		bodyMap["spanSelector"] = req.SpanIDs
+	} else {
+		if len(req.ProfileIDs) > 0 {
+			bodyMap["profileIdSelector"] = req.ProfileIDs
+		}
+		if len(req.TraceIDs) > 0 {
+			bodyMap["traceIdSelector"] = req.TraceIDs
+		}
+		if req.StackTraceSelector != nil {
+			bodyMap["stackTraceSelector"] = req.StackTraceSelector
+		}
 	}
 
 	body, err := json.Marshal(bodyMap)
@@ -382,6 +393,7 @@ func (c *Client) Pprof(ctx context.Context, datasourceUID string, req PprofReque
 	//   3: start (int64, ms since epoch)
 	//   4: end (int64, ms since epoch)
 	//   5: max_nodes (int64, optional)
+	//   8: trace_id_selector (repeated string)
 	var msg []byte
 	msg = protowire.AppendTag(msg, 1, protowire.BytesType)
 	msg = protowire.AppendString(msg, req.ProfileTypeID)
@@ -394,6 +406,10 @@ func (c *Client) Pprof(ctx context.Context, datasourceUID string, req PprofReque
 	if req.MaxNodes > 0 {
 		msg = protowire.AppendTag(msg, 5, protowire.VarintType)
 		msg = protowire.AppendVarint(msg, uint64(req.MaxNodes))
+	}
+	for _, traceID := range req.TraceIDs {
+		msg = protowire.AppendTag(msg, 8, protowire.BytesType)
+		msg = protowire.AppendString(msg, traceID)
 	}
 
 	apiPath := c.buildResourcePath(datasourceUID, "querier.v1.QuerierService/SelectMergeProfile")

--- a/internal/query/pyroscope/client_test.go
+++ b/internal/query/pyroscope/client_test.go
@@ -219,9 +219,10 @@ func TestClient_Query_RequestFields(t *testing.T) {
 	emptyFlamegraph := `{"flamegraph":{"names":[],"levels":[],"total":"0","maxSelf":"0"}}`
 
 	tests := []struct {
-		name   string
-		req    pyroscope.QueryRequest
-		assert func(t *testing.T, body map[string]any)
+		name     string
+		req      pyroscope.QueryRequest
+		wantPath string
+		assert   func(t *testing.T, body map[string]any)
 	}{
 		{
 			name: "optional fields omitted when unset",
@@ -231,10 +232,35 @@ func TestClient_Query_RequestFields(t *testing.T) {
 			},
 			assert: func(t *testing.T, body map[string]any) {
 				t.Helper()
-				for _, k := range []string{"profileIdSelector", "stackTraceSelector", "maxNodes"} {
+				for _, k := range []string{"profileIdSelector", "spanSelector", "traceIdSelector", "stackTraceSelector", "maxNodes"} {
 					_, present := body[k]
 					assert.False(t, present, "%s should be omitted when unset", k)
 				}
+			},
+		},
+		{
+			name: "spanSelector forwarded to span profile endpoint",
+			req: pyroscope.QueryRequest{
+				ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				LabelSelector: `{}`,
+				SpanIDs:       []string{"00f067aa0ba902b7", "5a4fe264a9c987fe"},
+			},
+			wantPath: "querier.v1.QuerierService/SelectMergeSpanProfile",
+			assert: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				assert.Equal(t, []any{"00f067aa0ba902b7", "5a4fe264a9c987fe"}, body["spanSelector"])
+			},
+		},
+		{
+			name: "traceIdSelector forwarded as JSON array",
+			req: pyroscope.QueryRequest{
+				ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				LabelSelector: `{}`,
+				TraceIDs:      []string{"4bf92f3577b34da6a3ce929d0e0e4736", "7c9e66797425440de944be07fc1f90ae"},
+			},
+			assert: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				assert.Equal(t, []any{"4bf92f3577b34da6a3ce929d0e0e4736", "7c9e66797425440de944be07fc1f90ae"}, body["traceIdSelector"])
 			},
 		},
 		{
@@ -286,7 +312,11 @@ func TestClient_Query_RequestFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				assert.Contains(t, r.URL.Path, "querier.v1.QuerierService/SelectMergeStacktraces")
+				wantPath := tt.wantPath
+				if wantPath == "" {
+					wantPath = "querier.v1.QuerierService/SelectMergeStacktraces"
+				}
+				assert.Contains(t, r.URL.Path, wantPath)
 				var body map[string]any
 				if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
 					return
@@ -389,6 +419,38 @@ func TestClient_Pprof(t *testing.T) {
 					}
 				}
 				assert.True(t, foundMaxNodes, "max_nodes field (5) should be present")
+				w.Header().Set("Content-Type", "application/proto")
+				_, _ = w.Write(fakeProfileProto)
+			},
+			wantGzip: true,
+		},
+		{
+			name: "trace_id_selector fields encoded when set",
+			req: pyroscope.PprofRequest{
+				ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				LabelSelector: `{}`,
+				TraceIDs:      []string{"4bf92f3577b34da6a3ce929d0e0e4736", "7c9e66797425440de944be07fc1f90ae"},
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				b := body
+				var traceIDs []string
+				for len(b) > 0 {
+					num, typ, n := protowire.ConsumeTag(b)
+					b = b[n:]
+					if num == 8 && typ == protowire.BytesType {
+						v, n := protowire.ConsumeString(b)
+						b = b[n:]
+						traceIDs = append(traceIDs, v)
+					} else {
+						n := protowire.ConsumeFieldValue(num, typ, b)
+						if n < 0 {
+							break
+						}
+						b = b[n:]
+					}
+				}
+				assert.Equal(t, []string{"4bf92f3577b34da6a3ce929d0e0e4736", "7c9e66797425440de944be07fc1f90ae"}, traceIDs)
 				w.Header().Set("Content-Type", "application/proto")
 				_, _ = w.Write(fakeProfileProto)
 			},

--- a/internal/query/pyroscope/types.go
+++ b/internal/query/pyroscope/types.go
@@ -7,7 +7,6 @@ import (
 )
 
 // QueryRequest represents a Pyroscope profile query request.
-// Field names mirror querier.v1.SelectMergeStacktracesRequest.
 type QueryRequest struct {
 	LabelSelector      string
 	ProfileTypeID      string
@@ -15,6 +14,8 @@ type QueryRequest struct {
 	End                time.Time
 	MaxNodes           int64
 	ProfileIDs         []string
+	SpanIDs            []string
+	TraceIDs           []string
 	StackTraceSelector *StackTraceSelector
 }
 
@@ -234,6 +235,7 @@ type PprofRequest struct {
 	Start         time.Time
 	End           time.Time
 	MaxNodes      int64
+	TraceIDs      []string
 }
 
 // PprofWriteResult is the structured output emitted after writing a pprof binary to disk.


### PR DESCRIPTION
## Summary

- add repeatable `--span-id` and `--trace-id` flags to Pyroscope profile queries
- route span-filtered flamegraph queries through `SelectMergeSpanProfile`
- forward trace selectors through both `SelectMergeStacktraces` JSON and `SelectMergeProfile` protobuf requests
- validate span/trace ID formats and profilecli-compatible selector exclusions
- update command examples, architecture docs, and generated CLI references

`--span-selector` is intentionally rejected with `-o pprof`: the span RPC returns a Pyroscope tree rather than a pprof profile, and gcx does not currently carry the server-side tree conversion code. Trace selectors support pprof output.

## Testing

- `GCX_AGENT_MODE=false mise run all` passes lint, all Go tests, linter rules, skill validation, reference generation, and build
- local MkDocs rendering was unavailable because `mkdocs` is not installed; CI will perform the documentation build