### PR TITLE
docs(readme): update agent skills list sample output

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,11 +273,11 @@ For example: OpenAI Codex, OpenCode, and Pi. View the skills shipped in the bund
 
 ```sh
 gcx agent skills list
-22 skill(s) bundled with gcx
+21 skill(s) bundled with gcx
 
 SKILL                      INSTALLED    DESCRIPTION
 create-dashboard           yes          Design and create dashboards with datasource discovery and snapshot-based visual iteration.
-explore-datasources        yes          Discover what datasources, metrics, labels, and log streams are available in a Grafana instance.
+debug-with-grafana         yes          Structured workflow for investigating application problems with Grafana observability data.
 ....
 ```
 


### PR DESCRIPTION
the sample `gcx agent skills list` output in the README still showed 22 bundled skills and an `explore-datasources` row — the bundle is now 21 skills after #963. Follow-up to a review nit on #977.