### PR TITLE
fix(kg): route KG write API through the asserts plugin proxy

### DIFF
--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -56,7 +56,14 @@ const (
 	// Entity and relationship deletes use these collection paths with identity
 	// in the query string (type/name are not path segments), so names containing
 	// '/' are addressable without Tomcat rejecting encoded solidus.
-	kgWriteAPIBase     = "/apis/kg.grafana.com/v1alpha1/namespaces/%s"
+	//
+	// Routed through the asserts plugin's resource proxy: the plugin backend
+	// forwards unmatched resource paths to the asserts cell gateway with the
+	// stack's Basic auth, and the gateway maps /apis/kg.grafana.com/* to the
+	// KG api-server. The bare /apis/kg.grafana.com group is not registered
+	// with Grafana's API aggregator, so it is not reachable on the stack URL
+	// directly.
+	kgWriteAPIBase     = pluginResourcePath + "/apis/kg.grafana.com/v1alpha1/namespaces/%s"
 	kgEntitiesPathFmt  = kgWriteAPIBase + "/entities"
 	kgRelationshipsFmt = kgWriteAPIBase + "/relationships"
 )

--- a/internal/providers/kg/client_test.go
+++ b/internal/providers/kg/client_test.go
@@ -789,7 +789,7 @@ func TestClient_UpsertEntity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodPost, r.Method)
-				assert.Contains(t, r.URL.Path, "/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/entities")
+				assert.Contains(t, r.URL.Path, "/api/plugins/grafana-asserts-app/resources/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/entities")
 				var got kg.EntityWriteRequest
 				assert.NoError(t, json.NewDecoder(r.Body).Decode(&got))
 				assert.Equal(t, "myapp", got.Domain)
@@ -823,7 +823,7 @@ func TestClient_DeleteEntity(t *testing.T) {
 	t.Run("sends identity as query params on collection path", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodDelete, r.Method)
-			assert.Equal(t, "/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/entities", r.URL.Path)
+			assert.Equal(t, "/api/plugins/grafana-asserts-app/resources/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/entities", r.URL.Path)
 			q := r.URL.Query()
 			assert.Equal(t, "myapp", q.Get("domain"))
 			assert.Equal(t, "Service", q.Get("type"))
@@ -838,7 +838,7 @@ func TestClient_DeleteEntity(t *testing.T) {
 	t.Run("allows slash in name via query params", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodDelete, r.Method)
-			assert.Equal(t, "/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/entities", r.URL.Path)
+			assert.Equal(t, "/api/plugins/grafana-asserts-app/resources/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/entities", r.URL.Path)
 			assert.Equal(t, "foo/bar", r.URL.Query().Get("name"))
 			w.WriteHeader(http.StatusNoContent)
 		}))
@@ -862,7 +862,7 @@ func TestClient_DeleteEntity(t *testing.T) {
 func TestClient_DeleteRelationship(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Equal(t, "/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/relationships", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-asserts-app/resources/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/relationships", r.URL.Path)
 		q := r.URL.Query()
 		assert.Equal(t, "CALLS", q.Get("type"))
 		assert.Equal(t, "myapp", q.Get("from.domain"))


### PR DESCRIPTION
## Problem

`gcx kg entities create` (and the other KG write commands) fail against real stacks with a bare `404`:

```
Error: Knowledge Graph API resource not found
│ kg: upsert entity
│ 404 page not found
```

KG entity/relationship writes were addressed to an API path that isn't served on the Grafana stack URL, so the request 404s before reaching the KG backend. It only worked when port-forwarding directly to the backend.

## Approach

Route the write client through the asserts plugin's resource proxy (`/api/plugins/grafana-asserts-app/resources/...`) — the same path the KG provider already uses for suppressions and model rules. Synchronous upsert semantics (created vs updated status), `ttlSeconds`, and the query-param DELETE design are unchanged; only the base path moves.

The change is one constant (`kgWriteAPIBase`) plus an explanatory comment.

## Out of scope

- Broader KG write surface beyond entities/relationships (follow-up).

## Test coverage

- Updated the path assertions in `client_test.go`; confirmed RED against the old constant, then GREEN.
- `TestClient_*`, `TestEntities*`, `TestRelationships*`, `TestScopeFlags*` pass; kg package lints clean; build OK.
- Verified end-to-end against a dev stack: entity create (scoped + unscoped), relationship create/delete, and scoped entity delete all succeed with correct created/updated status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)