### PR TITLE
fix(ux): follow-ups from alert ruler live testing

### DIFF
--- a/internal/agent/command_skills.go
+++ b/internal/agent/command_skills.go
@@ -18,16 +18,19 @@ var commandSkills = map[string][]string{
 	"gcx slo":                  {"slo-manage", "slo-investigate", "slo-optimize", "slo-check-status"},
 	"gcx synthetic-monitoring": {"synth-manage-checks", "synth-investigate-check", "synth-check-status"},
 	"gcx alert":                {"investigate-alert"},
-	"gcx irm":                  {"oncall-triage"},
-	"gcx logs":                 {"debug-with-grafana"},
-	"gcx metrics":              {"debug-with-grafana"},
-	"gcx traces":               {"debug-with-grafana"},
-	"gcx profiles":             {"debug-with-grafana"},
-	"gcx datasources":          {"debug-with-grafana"},
-	"gcx kg":                   {"diagnose-entity-graph"},
-	"gcx aio11y":               {"aio11y"},
-	"gcx setup":                {"setup-gcx"},
-	"gcx login":                {"setup-gcx"},
+	// Empty override: ruler config management is not what investigate-alert
+	// covers, so suppress the inherited footer on the ruler subtree.
+	"gcx alert ruler": {},
+	"gcx irm":         {"oncall-triage"},
+	"gcx logs":        {"debug-with-grafana"},
+	"gcx metrics":     {"debug-with-grafana"},
+	"gcx traces":      {"debug-with-grafana"},
+	"gcx profiles":    {"debug-with-grafana"},
+	"gcx datasources": {"debug-with-grafana"},
+	"gcx kg":          {"diagnose-entity-graph"},
+	"gcx aio11y":      {"aio11y"},
+	"gcx setup":       {"setup-gcx"},
+	"gcx login":       {"setup-gcx"},
 }
 
 // SkillsForCommand returns the bundled skill names mapped to the nearest mapped

--- a/internal/gcxerrors/detailed.go
+++ b/internal/gcxerrors/detailed.go
@@ -68,8 +68,10 @@ func (e DetailedError) Error() string {
 	blue := color.New(color.FgBlue).SprintFunc()
 
 	buffer.WriteString(red("Error: ") + e.Summary + "\n")
+	hasSections := false
 
 	if e.Details != "" {
+		hasSections = true
 		lines := strings.Split(e.Details, "\n")
 		buffer.WriteString("│\n")
 		for _, line := range lines {
@@ -86,6 +88,7 @@ func (e DetailedError) Error() string {
 	}
 
 	if showParent {
+		hasSections = true
 		fmt.Fprintf(&buffer, "│\n├─ %s\n│\n", blue("Details:"))
 		for line := range strings.SplitSeq(formattedParent, "\n") {
 			buffer.WriteString("│ " + line + "\n")
@@ -93,6 +96,7 @@ func (e DetailedError) Error() string {
 	}
 
 	if len(e.Suggestions) != 0 {
+		hasSections = true
 		fmt.Fprintf(&buffer, "│\n├─ %s\n│\n", blue("Suggestions:"))
 
 		for _, suggestion := range e.Suggestions {
@@ -101,10 +105,15 @@ func (e DetailedError) Error() string {
 	}
 
 	if e.DocsLink != "" {
+		hasSections = true
 		fmt.Fprintf(&buffer, "│\n├─ %s\n│\n│ %s\n", blue("Learn more:"), e.DocsLink)
 	}
 
-	buffer.WriteString("│\n└─\n")
+	// A summary with no sections renders as a single line; the box
+	// scaffolding would frame nothing.
+	if hasSections {
+		buffer.WriteString("│\n└─\n")
+	}
 
 	return buffer.String()
 }

--- a/internal/gcxerrors/detailed_test.go
+++ b/internal/gcxerrors/detailed_test.go
@@ -37,6 +37,22 @@ func TestDetailedError_Error_OmitsDuplicateParentDetails(t *testing.T) {
 	assert.NotContains(t, rendered, "├─ Details:")
 }
 
+func TestDetailedError_Error_SummaryOnlyHasNoScaffolding(t *testing.T) {
+	oldNoColor := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = oldNoColor })
+
+	err := gcxerrors.DetailedError{
+		Summary: "1 of 1 rule group(s) failed to apply",
+	}
+
+	rendered := err.Error()
+
+	assert.Equal(t, "Error: 1 of 1 rule group(s) failed to apply\n", rendered)
+	assert.NotContains(t, rendered, "│")
+	assert.NotContains(t, rendered, "└─")
+}
+
 func TestDetailedError_Error_KeepsDistinctParentDetails(t *testing.T) {
 	oldNoColor := color.NoColor
 	color.NoColor = true

--- a/internal/providers/alert/ruler_commands.go
+++ b/internal/providers/alert/ruler_commands.go
@@ -320,7 +320,11 @@ func (c *RulerGroupsTableCodec) Encode(w io.Writer, v any) error {
 	}
 	t := style.NewTable("NAMESPACE", "GROUP", "INTERVAL", "RULES")
 	for _, g := range views {
-		t.Row(g.Namespace, g.Group, g.Interval, strconv.Itoa(g.Rules))
+		interval := g.Interval
+		if interval == "" {
+			interval = "-"
+		}
+		t.Row(g.Namespace, g.Group, interval, strconv.Itoa(g.Rules))
 	}
 	return t.Render(w)
 }

--- a/internal/providers/alert/ruler_commands_test.go
+++ b/internal/providers/alert/ruler_commands_test.go
@@ -213,6 +213,7 @@ func TestRulerGroupsTableCodec_Encode(t *testing.T) {
 	var buf bytes.Buffer
 	err := codec.Encode(&buf, []alert.RulerGroupView{
 		{Namespace: "ns-a", Group: "g1", Interval: "1m", Rules: 3},
+		{Namespace: "ns-a", Group: "g2", Rules: 1},
 	})
 	require.NoError(t, err)
 
@@ -220,6 +221,14 @@ func TestRulerGroupsTableCodec_Encode(t *testing.T) {
 	assert.Contains(t, output, "GROUP")
 	assert.Contains(t, output, "g1")
 	assert.Contains(t, output, "1m")
+	// Groups without an explicit interval render a placeholder, not a blank cell.
+	g2Line := ""
+	for line := range strings.SplitSeq(output, "\n") {
+		if strings.Contains(line, "g2") {
+			g2Line = line
+		}
+	}
+	assert.Contains(t, g2Line, "-")
 
 	require.Error(t, codec.Encode(&buf, 42))
 }

--- a/internal/providers/confirm.go
+++ b/internal/providers/confirm.go
@@ -14,7 +14,7 @@ import (
 
 // ErrAgentModeRequiresForce is returned when agent mode is active but --force
 // was not passed. Exported so callers with custom prompts can check for it.
-var ErrAgentModeRequiresForce = errors.New("destructive operation requires --force in agent mode")
+var ErrAgentModeRequiresForce = errors.New("destructive operation in agent mode: use --force to proceed")
 
 // CheckDestructiveBypass runs the bypass chain for destructive operations.
 // Returns (true, nil) if the operation should proceed without prompting
@@ -66,7 +66,8 @@ func ConfirmDestructive(in io.Reader, out io.Writer, force bool, prompt string) 
 
 	answer, err := bufio.NewReader(in).ReadString('\n')
 	if err != nil {
-		return false, fmt.Errorf("read confirmation: %w", err)
+		// Typically EOF on a closed/non-interactive stdin (scripts, CI).
+		return false, fmt.Errorf("confirmation unavailable (no interactive input): use --force to proceed: %w", err)
 	}
 
 	answer = strings.TrimSpace(strings.ToLower(answer))

--- a/internal/providers/httperror.go
+++ b/internal/providers/httperror.go
@@ -14,10 +14,12 @@ const maxErrorBodyBytes = 1 << 20 // 1 MiB
 // ErrorResponse is the common JSON error-body shape returned by Grafana Cloud
 // product plugin APIs. They disagree on the field name for the human-readable
 // message, so all three variants are captured and read in preference order.
+// TraceID, when present, is surfaced for supportability.
 type ErrorResponse struct {
 	Error   string `json:"error"`
 	Message string `json:"message"`
 	Msg     string `json:"msg"`
+	TraceID string `json:"traceID"`
 }
 
 // message returns the first populated field: Error, then Message, then Msg.
@@ -50,6 +52,9 @@ func FormatError(statusCode int, body []byte) error {
 	var errResp ErrorResponse
 	if err := json.Unmarshal(body, &errResp); err == nil {
 		if msg := errResp.message(); msg != "" {
+			if errResp.TraceID != "" {
+				return fmt.Errorf("request failed with status %d: %s (traceID %s)", statusCode, msg, errResp.TraceID)
+			}
 			return fmt.Errorf("request failed with status %d: %s", statusCode, msg)
 		}
 	}

--- a/internal/providers/httperror_test.go
+++ b/internal/providers/httperror_test.go
@@ -1,0 +1,72 @@
+package providers_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatError(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		body string
+		want string
+	}{
+		{
+			name: "json message",
+			code: 400,
+			body: `{"message":"bad request data"}`,
+			want: "request failed with status 400: bad request data",
+		},
+		{
+			name: "json message with traceID",
+			code: 400,
+			body: `{"message":"bad request data","traceID":"abc123"}`,
+			want: "request failed with status 400: bad request data (traceID abc123)",
+		},
+		{
+			name: "error field preferred over message",
+			code: 500,
+			body: `{"error":"boom","message":"ignored"}`,
+			want: "request failed with status 500: boom",
+		},
+		{
+			name: "raw body fallback",
+			code: 502,
+			body: "upstream unavailable",
+			want: "request failed with status 502: upstream unavailable",
+		},
+		{
+			name: "empty body",
+			code: 503,
+			body: "",
+			want: "request failed with status 503",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := providers.FormatError(tt.code, []byte(tt.body))
+			require.Error(t, err)
+			assert.Equal(t, tt.want, err.Error())
+		})
+	}
+}
+
+func TestConfirmDestructive_NonInteractiveEOF(t *testing.T) {
+	// Empty stdin (no newline): the read fails with EOF and the error must
+	// tell the user how to proceed rather than leaking a bare read error.
+	var out strings.Builder
+	ok, err := providers.ConfirmDestructive(strings.NewReader(""), &out, false, "Delete it?")
+	if err == nil {
+		// Agent mode or GCX_AUTO_APPROVE can bypass the prompt in some test
+		// environments; only assert the message when the prompt path ran.
+		t.Skipf("prompt bypassed (ok=%v)", ok)
+	}
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), "use --force")
+}

--- a/internal/providers/httperror_test.go
+++ b/internal/providers/httperror_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,15 +59,19 @@ func TestFormatError(t *testing.T) {
 }
 
 func TestConfirmDestructive_NonInteractiveEOF(t *testing.T) {
+	// Pin the env so the interactive prompt path always runs: agent sessions
+	// (CLAUDECODE) would otherwise take the agent-mode error path, and
+	// GCX_AUTO_APPROVE would bypass the prompt entirely.
+	t.Setenv("GCX_AGENT_MODE", "false")
+	t.Setenv("GCX_AUTO_APPROVE", "false")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
 	// Empty stdin (no newline): the read fails with EOF and the error must
 	// tell the user how to proceed rather than leaking a bare read error.
 	var out strings.Builder
 	ok, err := providers.ConfirmDestructive(strings.NewReader(""), &out, false, "Delete it?")
-	if err == nil {
-		// Agent mode or GCX_AUTO_APPROVE can bypass the prompt in some test
-		// environments; only assert the message when the prompt path ran.
-		t.Skipf("prompt bypassed (ok=%v)", ok)
-	}
+	require.Error(t, err)
 	assert.False(t, ok)
 	assert.Contains(t, err.Error(), "use --force")
 }


### PR DESCRIPTION
## What

Follow-up PR for the UX issues surfaced during deep live testing of #981 and #982 against a real Grafana Cloud stack. Stacked on #982 (`feat/alert-ruler`) because two fixes touch the ruler subtree — retarget to `main` after #982 merges.

### Fixes

1. **Empty error box** — `DetailedError` with only a summary (no details/parent/suggestions/docs link) rendered an empty `│ … └─` box scaffold. It now renders as a single `Error: <summary>` line. (Seen on `alert ruler groups apply` partial-failure summaries.)
2. **Grafana traceID surfaced** — `FormatError` now appends the `traceID` from Grafana JSON error bodies: `request failed with status 400: bad request data (traceID abc123)`. Helps support correlate failures.
3. **Non-interactive confirmation** — `ConfirmDestructive` on a closed stdin previously printed the `[y/N]` prompt and died with `read confirmation: EOF`. It now returns `confirmation unavailable (no interactive input): use --force to proceed`. Piped `echo y |` workflows still work. The agent-mode error message likewise gains the actionable `use --force to proceed` phrasing.
   - Side effect: the `aio11y` `AbortsWithoutForce` tests, which assert on `use --force`, now pass inside agent sessions (`CLAUDECODE` set) where they previously failed on message mismatch.
4. **Help footer noise** — the `gcx alert ruler` subtree no longer inherits the `Related skill(s): investigate-alert` footer (empty override in the command-skills registry); ruler config management isn't what that skill covers. `gcx alert` itself keeps it.
5. **Blank INTERVAL cell** — `alert ruler groups list` renders `-` for groups without an explicit interval.

### Deliberately not addressed

- Header-only rendering of empty list tables (consistent with the rest of gcx; JSON output is a correct `[]`).
- Stripping `grafana.com/updatedBy`/`updateTimestamp` annotations on `resources pull` — a resources-pipeline behavior change that needs its own discussion.
- Duplicate datasource-UID lookups reported in early testing — already fixed in #982 (single lookup, verified with `-vvv`).

## Verification

- New unit tests: summary-only `DetailedError` rendering, `FormatError` traceID matrix, `ConfirmDestructive` EOF message, `-` interval placeholder.
- Verified against a built binary: ruler help shows no skill footer while `gcx alert` keeps it; destructive command without `--force` on non-TTY prints the actionable message and deletes nothing.
- `mise run lint` 0 issues; full race suite green (including `aio11y` under an agent session); no reference-doc drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)