### PR TITLE
fix(login): request full cloud scopes in login cloud followup

### DIFF
--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -28,17 +28,7 @@ func (opts *loginOpts) bindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.cloudToken, "cloud-token", "", "Cloud Access Policy token (skips interactive OAuth flow)")
 	flags.StringVar(&opts.oauthURL, "oauth-url", "https://grafana.com", "Base URL for the OAuth login flow (used only by this command)")
 	flags.StringVar(&opts.apiURL, "api-url", "https://grafana.com", "Base URL for Grafana Cloud API resource calls (stacks etc.)")
-	// The grafana.com API scopes gcx needs across all commands: stacks
-	// (discovery + management), the signal write scopes for minting the
-	// Synthetic Monitoring token (metrics/logs/traces:write), and Fleet
-	// Management.
-	flags.StringSliceVar(&opts.scopes, "scope", []string{
-		"stacks:read", "stacks:write", "stacks:delete",
-		"metrics:write",
-		"logs:write",
-		"traces:write",
-		"fleet-management:read", "fleet-management:write",
-	}, "OAuth2 scopes to request")
+	flags.StringSliceVar(&opts.scopes, "scope", auth.DefaultGCOMScopes(), "OAuth2 scopes to request")
 }
 
 func (opts *loginOpts) Validate() error {

--- a/cmd/gcx/cloud/command_test.go
+++ b/cmd/gcx/cloud/command_test.go
@@ -1,0 +1,18 @@
+//nolint:testpackage // white-box: loginCmd is unexported
+package cloud
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// `gcx cloud login` and the `gcx login` cloud followup must request the same
+// scope set (auth.DefaultGCOMScopes) so tokens from either path are equivalent.
+func TestLoginScopeFlagDefaultMatchesDefaultGCOMScopes(t *testing.T) {
+	scopes, err := loginCmd().Flags().GetStringSlice("scope")
+	require.NoError(t, err)
+	assert.Equal(t, auth.DefaultGCOMScopes(), scopes)
+}

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -21,13 +21,19 @@ import (
 // DefaultGCOMClientID is the OAuth2 client ID registered in GCOM for gcx.
 const DefaultGCOMClientID = "gcx"
 
-// DefaultGCOMScopes returns the OAuth2 scopes requested when logging in to the
-// Grafana Cloud platform API (grafana.com) for stack management. A fresh slice
-// is returned on each call so callers (e.g. a Cobra flag default) can mutate
-// their copy without affecting others.
+// DefaultGCOMScopes returns the grafana.com API scopes gcx needs across all
+// commands: stacks (discovery + management), the signal write scopes for
+// minting the Synthetic Monitoring token (metrics/logs/traces:write), and
+// Fleet Management. Both `gcx cloud login` and the `gcx login` cloud followup
+// request this set. A fresh slice is returned on each call so callers (e.g. a
+// Cobra flag default) can mutate their copy without affecting others.
 func DefaultGCOMScopes() []string {
 	return []string{
 		"stacks:read", "stacks:write", "stacks:delete",
+		"metrics:write",
+		"logs:write",
+		"traces:write",
+		"fleet-management:read", "fleet-management:write",
 	}
 }
 

--- a/internal/auth/gcom_test.go
+++ b/internal/auth/gcom_test.go
@@ -1,0 +1,27 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+// The `gcx login` cloud followup requests DefaultGCOMScopes directly, so this
+// pins the full scope set gcx needs across all commands - not just stacks.
+func TestDefaultGCOMScopes(t *testing.T) {
+	want := []string{
+		"stacks:read", "stacks:write", "stacks:delete",
+		"metrics:write",
+		"logs:write",
+		"traces:write",
+		"fleet-management:read", "fleet-management:write",
+	}
+	assert.Equal(t, want, auth.DefaultGCOMScopes())
+
+	// Callers may mutate their copy (e.g. Cobra flag defaults); a fresh slice
+	// must be returned each call.
+	got := auth.DefaultGCOMScopes()
+	got[0] = "mutated"
+	assert.Equal(t, want, auth.DefaultGCOMScopes())
+}


### PR DESCRIPTION
## Summary

- `gcx login`'s cloud followup requested only `stacks:read/write/delete` (via `auth.DefaultGCOMScopes`), while `gcx cloud login` hardcoded the full 8-scope set as its `--scope` default. Tokens minted by the followup then lacked the signal write scopes (needed for minting the SM token) and fleet-management scopes.
- Expands `DefaultGCOMScopes()` to the full set and points `gcx cloud login`'s `--scope` default at it, so both paths share one definition.
- New tests pin the scope set (`internal/auth`) and assert the flag default equals `DefaultGCOMScopes()` (`cmd/gcx/cloud`), guarding against re-divergence.

No reference-doc changes needed: the rendered `--scope` default value is unchanged.

Noticed while reviewing, left out of scope: `gcx cloud login --scope ""` passes `Validate` (len 1 slice with an empty string) and fails server-side instead of at the CLI — pre-existing, happy to fix separately if we care.
