### PR TITLE
fix(output): descend into single-key list envelopes for --json discovery and selection

### DIFF
--- a/cmd/gcx/datasources/list_test.go
+++ b/cmd/gcx/datasources/list_test.go
@@ -166,6 +166,37 @@ func TestListDefaultReturnsAllDatasources(t *testing.T) {
 	assert.Len(t, result.Datasources, 60)
 }
 
+func TestListJSONFieldDiscoveryAndSelection(t *testing.T) {
+	server := newDatasourceListServer(t, 2)
+	defer server.Close()
+
+	configFile := newConfigFileForServer(t, server.URL)
+
+	t.Run("--json list discovers item fields", func(t *testing.T) {
+		stdout, err := executeDatasourceCommand(t, []string{"datasources", "list", "--config", configFile, "--json", "list"})
+		require.NoError(t, err)
+
+		for _, field := range []string{"uid", "name", "type", "url"} {
+			assert.Contains(t, stdout, field, "item field %q must be discovered", field)
+		}
+		assert.NotContains(t, stdout, "datasources", "wrapper key must not be listed")
+	})
+
+	t.Run("--json uid,name selects per item", func(t *testing.T) {
+		stdout, err := executeDatasourceCommand(t, []string{"datasources", "list", "--config", configFile, "--json", "uid,name"})
+		require.NoError(t, err)
+
+		var result struct {
+			Datasources []map[string]any `json:"datasources"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+		require.Len(t, result.Datasources, 2)
+		assert.Equal(t, "ds-00", result.Datasources[0]["uid"])
+		assert.Equal(t, "Datasource 00", result.Datasources[0]["name"])
+		assert.NotContains(t, result.Datasources[0], "type")
+	})
+}
+
 func TestListExplicitLimitTrimsDatasources(t *testing.T) {
 	server := newDatasourceListServer(t, 60)
 	defer server.Close()

--- a/internal/output/encode_json_fields_test.go
+++ b/internal/output/encode_json_fields_test.go
@@ -171,6 +171,93 @@ func TestEncode_JSONFields_ArbitrarySlice(t *testing.T) {
 	assert.NotContains(t, got[0], "extra")
 }
 
+func TestEncode_JSONFields_SingleKeyEnvelope(t *testing.T) {
+	// Provider list commands wrap their items under a single non-"items" key
+	// (e.g. {"datasources": [...]}). Field selection must descend into the
+	// array and preserve the wrapper key.
+	type item struct {
+		UID  string `json:"uid"`
+		Name string `json:"name"`
+		Type string `json:"type"`
+	}
+	type envelope struct {
+		Datasources []item `json:"datasources"`
+	}
+
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{
+			name: "populated envelope selects per item and preserves wrapper key",
+			value: &envelope{Datasources: []item{
+				{UID: "a", Name: "prom", Type: "prometheus"},
+				{UID: "b", Name: "logs", Type: "loki"},
+			}},
+			want: `{"datasources":[{"uid":"a","name":"prom"},{"uid":"b","name":"logs"}]}`,
+		},
+		{
+			name:  "empty envelope preserves wrapper key with empty array",
+			value: &envelope{Datasources: []item{}},
+			want:  `{"datasources":[]}`,
+		},
+		{
+			name: "single-key scalar array is not an envelope",
+			value: struct {
+				Tags []string `json:"tags"`
+			}{Tags: []string{"a", "b"}},
+			want: `{"uid":null,"name":null}`,
+		},
+		{
+			name: "single-key object value is not an envelope",
+			value: struct {
+				Spec map[string]any `json:"spec"`
+			}{Spec: map[string]any{"uid": "x"}},
+			want: `{"uid":null,"name":null}`,
+		},
+		{
+			name: "multi-key object gets flat extraction",
+			value: struct {
+				UID   string `json:"uid"`
+				Name  string `json:"name"`
+				Other string `json:"other"`
+			}{UID: "a", Name: "n", Other: "o"},
+			want: `{"uid":"a","name":"n"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := optsWithJSONFields(t, []string{"uid", "name"})
+			var buf bytes.Buffer
+			require.NoError(t, opts.Encode(&buf, tt.value))
+			assert.JSONEq(t, tt.want, buf.String())
+		})
+	}
+}
+
+func TestEncode_JSONDiscovery_SingleKeyEnvelope(t *testing.T) {
+	// Discovery on a single-key list envelope must list item-level fields,
+	// not the wrapper key.
+	type item struct {
+		UID  string `json:"uid"`
+		Name string `json:"name"`
+	}
+	type envelope struct {
+		Datasources []item `json:"datasources"`
+	}
+
+	opts := optsWithJSONDiscovery(t)
+	var buf bytes.Buffer
+	require.NoError(t, opts.Encode(&buf, &envelope{Datasources: []item{{UID: "a", Name: "x"}}}))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	assert.Contains(t, lines, "uid")
+	assert.Contains(t, lines, "name")
+	assert.NotContains(t, lines, "datasources")
+}
+
 func TestEncode_JSONDiscovery_PrintsFieldNames(t *testing.T) {
 	opts := optsWithJSONDiscovery(t)
 

--- a/internal/output/field_select.go
+++ b/internal/output/field_select.go
@@ -34,7 +34,10 @@ func (e UnknownFieldSelectionError) Error() string {
 // For a single object the output is a flat JSON object containing only the
 // selected fields. For k8s unstructured collections (UnstructuredList) or
 // objects with an "items" field, the output is {"items": [...]}. For plain
-// Go slices, the output preserves the array shape ([...]).
+// Go slices, the output preserves the array shape ([...]). Single-key list
+// envelopes (an object whose only key holds an array of objects, e.g.
+// {"datasources": [...]}) get per-item selection with the wrapper key
+// preserved.
 //
 // Missing fields produce a null value rather than being omitted.
 type FieldSelectCodec struct {
@@ -133,6 +136,17 @@ func (c *FieldSelectCodec) Encode(dst goio.Writer, value any) error {
 				extracted[i] = extractFields(item, c.fields)
 			}
 			return c.json.Encode(dst, listFieldSelectionOutput(extracted, paginationMetadataFromObjectMap(m)))
+		}
+
+		// Single-key list envelope (e.g. {"datasources": [...]}): apply field
+		// selection per item and preserve the wrapper key. No pagination
+		// metadata by construction (the envelope has exactly one key).
+		if key, items, ok := singleKeyItems(m); ok {
+			extracted := make([]map[string]any, len(items))
+			for i, item := range items {
+				extracted[i] = extractFields(item, c.fields)
+			}
+			return c.json.Encode(dst, map[string]any{key: extracted})
 		}
 
 		return c.json.Encode(dst, extractFields(m, c.fields))
@@ -260,6 +274,30 @@ func paginationMetadataValuePresent(value any) bool {
 		return s != ""
 	}
 	return true
+}
+
+// singleKeyItems reports whether m is a single-key list envelope: exactly one
+// key whose value is an array of objects (or an empty array). Provider list
+// commands wrap their items under such keys (e.g. {"datasources": [...]}).
+// Callers must check the k8s "items" shape first — that path carries
+// pagination metadata and a fixed output shape.
+func singleKeyItems(m map[string]any) (string, []map[string]any, bool) {
+	if len(m) != 1 {
+		return "", nil, false
+	}
+	for key, raw := range m {
+		arr, ok := raw.([]any)
+		if !ok {
+			return "", nil, false
+		}
+		items := toSliceOfMaps(arr)
+		if len(items) != len(arr) {
+			// Elements are not all objects (scalar or mixed array).
+			return "", nil, false
+		}
+		return key, items, true
+	}
+	return "", nil, false
 }
 
 // toSliceOfMaps converts an any value to []map[string]any. Values that are

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -304,13 +304,7 @@ func marshalToSampleMap(value any) (map[string]any, error) {
 	// Try as object first.
 	var m map[string]any
 	if err := json.Unmarshal(data, &m); err == nil {
-		// If the object has an "items" array, use the first element.
-		if raw, ok := m["items"]; ok {
-			if items := toSliceOfMaps(raw); len(items) > 0 {
-				return items[0], nil
-			}
-		}
-		return m, nil
+		return sampleFromObject(m, value), nil
 	}
 
 	// Try as array — use first element.
@@ -325,11 +319,7 @@ func marshalToSampleMap(value any) (map[string]any, error) {
 	// Reflection fallback: enumerate exported struct fields from the Go type.
 	// Handles empty typed slices where there is no data to sample.
 	if fields := reflectFields(reflect.TypeOf(value)); len(fields) > 0 {
-		result := make(map[string]any, len(fields))
-		for _, f := range fields {
-			result[f] = nil
-		}
-		return result, nil
+		return nullFieldMap(fields), nil
 	}
 
 	return nil, fmt.Errorf("cannot discover fields from %T: not a JSON object or array", value)
@@ -367,6 +357,76 @@ func reflectFields(t reflect.Type) []string {
 		fields = append(fields, name)
 	}
 	return fields
+}
+
+// sampleFromObject picks the representative sample map for field discovery
+// from a marshaled object: the first element of an "items" array or of a
+// single-key list envelope (e.g. {"datasources": [...]}), reflected item
+// fields for an envelope with no rows, or the object itself.
+func sampleFromObject(m map[string]any, value any) map[string]any {
+	// If the object has an "items" array, use the first element.
+	if raw, ok := m["items"]; ok {
+		if items := toSliceOfMaps(raw); len(items) > 0 {
+			return items[0]
+		}
+	}
+	// Single-key list envelope: sample the first item so discovery lists
+	// item-level fields.
+	if _, items, ok := singleKeyItems(m); ok && len(items) > 0 {
+		return items[0]
+	}
+	// Single-key envelope with no rows (empty or nil slice): reflect on the
+	// wrapper struct's sole slice field so discovery still works.
+	if len(m) == 1 {
+		if fields := reflectSingleSliceField(reflect.TypeOf(value)); len(fields) > 0 {
+			return nullFieldMap(fields)
+		}
+	}
+	return m
+}
+
+// nullFieldMap builds a discovery sample map whose keys are the given field
+// names, each mapped to nil. Used when there is no data row to sample and the
+// field set has to come from reflection instead.
+func nullFieldMap(fields []string) map[string]any {
+	result := make(map[string]any, len(fields))
+	for _, f := range fields {
+		result[f] = nil
+	}
+	return result
+}
+
+// reflectSingleSliceField returns the JSON field names of the element type of
+// a struct's sole exported field, which must be a slice of structs. Returns
+// nil unless t (after pointer unwrapping) is a struct with exactly one
+// exported non-json:"-" field of slice kind. Used to discover item fields of
+// an empty single-key list envelope.
+func reflectSingleSliceField(t reflect.Type) []string {
+	if t == nil {
+		return nil
+	}
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+
+	var sliceType reflect.Type
+	exported := 0
+	for f := range t.Fields() {
+		if !f.IsExported() || f.Tag.Get("json") == "-" {
+			continue
+		}
+		exported++
+		if f.Type.Kind() == reflect.Slice {
+			sliceType = f.Type
+		}
+	}
+	if exported != 1 || sliceType == nil {
+		return nil
+	}
+	return reflectFields(sliceType)
 }
 
 // We have to return an interface here.

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -299,6 +299,46 @@ func TestEncodeDiscovery_EmptyTypedSlice(t *testing.T) {
 	assert.NotContains(t, out, "Selection", "json:\"-\" fields must be excluded")
 }
 
+func TestEncodeDiscovery_EmptySingleKeyEnvelope(t *testing.T) {
+	// A single-key list envelope with no rows (nil or empty slice) must still
+	// discover item-level fields via reflection on the element type.
+	type row struct {
+		UID    string `json:"uid"`
+		Status string `json:"status,omitempty"`
+		Hidden string `json:"-"` // excluded by json:"-"
+	}
+	type envelope struct {
+		Results []row `json:"results"`
+	}
+
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "nil slice", value: &envelope{}},
+		{name: "empty slice", value: &envelope{Results: []row{}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &cmdio.Options{}
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			opts.BindFlags(flags)
+			require.NoError(t, flags.Set("json", "list"))
+			require.NoError(t, opts.Validate())
+
+			var buf bytes.Buffer
+			require.NoError(t, opts.Encode(&buf, tt.value))
+
+			out := buf.String()
+			assert.Contains(t, out, "uid", "field 'uid' must appear in discovered fields")
+			assert.Contains(t, out, "status", "field 'status' must appear")
+			assert.NotContains(t, out, "results", "wrapper key must not appear")
+			assert.NotContains(t, out, "Hidden", "json:\"-\" fields must be excluded")
+		})
+	}
+}
+
 // dummyCodec satisfies format.Codec for testing.
 type dummyCodec struct{}
 


### PR DESCRIPTION
## Summary
- `gcx datasources list --json list` printed only the wrapper key `datasources` instead of the item-level field names (reported in Slack), and `--json uid,name` returned all-null values.
- Root cause: the `--json` discovery path (`marshalToSampleMap`) and selection path (`FieldSelectCodec.Encode`) special-cased only the k8s `items` wrapper key; envelopes keyed otherwise (`datasources`, `results`, `types`) were treated as single objects.
- Fix: generalize both paths via a shared `singleKeyItems` helper — an object with exactly one key holding an array of objects is treated as a list envelope. Discovery samples the first item (reflection fallback on the wrapper's sole slice field for empty lists); selection extracts per item and preserves the wrapper key.

Before / after:

```
$ gcx datasources list --json list
datasources                          # before
access default name readOnly type uid url   # after (one per line)

$ gcx datasources list --json uid,name
{"name": null, "uid": null}          # before
{"datasources": [{"uid": "...", "name": "..."}, ...]}   # after
```

## Changes
- `internal/output/field_select.go` — new `singleKeyItems` helper; `FieldSelectCodec.Encode` descends into single-key envelopes preserving the wrapper key; doc comment updated.
- `internal/output/format.go` — object branch of `marshalToSampleMap` extracted into `sampleFromObject`, which now also handles single-key envelopes; `reflectSingleSliceField` + `nullFieldMap` helpers for empty/nil envelopes.
- Tests: table-driven coverage in `internal/output` (selection, discovery, empty/nil envelope, scalar-array/map-value/multi-key non-envelopes) and end-to-end `--json list` / `--json uid,name` in `cmd/gcx/datasources/list_test.go`.

The k8s `items` path (with pagination metadata) is unchanged; bare slices, scalar arrays, map values, and multi-key objects keep their previous behavior. Also fixes `datasources health` (`results`) and `datasources schema` (`types`), which share the envelope shape.

**Behavior note:** selecting the wrapper key itself (`--json datasources`) previously echoed the whole array; it now yields per-item nulls like any non-item field — use `--jq '.datasources'` for that.

## Test Plan
- [x] Tests pass locally (`GCX_AGENT_MODE=false mise run all`)
- [x] New tests cover the change (failing-first TDD)
- [x] Lints clean
- [x] Verified live against a stack: discovery lists item fields; selection returns real values; `providers list --json list` (bare slice) and k8s `items` paths unchanged
- [ ] Architecture docs: n/a (no new packages, no command/flag surface change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)