### PR TITLE
fix(profiles): exclude pre-window boundary point from --top totals

### DIFF
--- a/internal/datasources/pyroscope/series.go
+++ b/internal/datasources/pyroscope/series.go
@@ -172,10 +172,11 @@ Datasource is resolved from -d flag or datasources.pyroscope in your context.`,
 			}
 
 			if opts.Top {
-				topResp := pyroscope.AggregateTopSeries(resp, opts.ProfileType, groupBy, int(opts.Limit))
+				topResp := pyroscope.AggregateTopSeries(resp, opts.ProfileType, groupBy, int(opts.Limit), start.UnixMilli())
 				return opts.shared.IO.Encode(cmd.OutOrStdout(), topResp)
 			}
 
+			resp.StepSeconds = stepSeconds
 			return opts.shared.IO.Encode(cmd.OutOrStdout(), resp)
 		},
 	}

--- a/internal/query/pyroscope/formatter_test.go
+++ b/internal/query/pyroscope/formatter_test.go
@@ -157,6 +157,9 @@ func TestAggregateTopSeries(t *testing.T) {
 			{
 				Labels: []pyroscope.LabelPair{{Name: "service_name", Value: "frontend"}},
 				Points: []pyroscope.TimePoint{
+					// boundary point at the window start aggregates pre-window
+					// data and must not count towards the total
+					tp(999, 500),
 					tp(100, 1000),
 					tp(200, 2000),
 				},
@@ -170,7 +173,7 @@ func TestAggregateTopSeries(t *testing.T) {
 		},
 	}
 
-	top := pyroscope.AggregateTopSeries(resp, "process_cpu:cpu:nanoseconds:cpu:nanoseconds", []string{"service_name"}, 10)
+	top := pyroscope.AggregateTopSeries(resp, "process_cpu:cpu:nanoseconds:cpu:nanoseconds", []string{"service_name"}, 10, 500)
 
 	assert.Equal(t, "process_cpu:cpu:nanoseconds:cpu:nanoseconds", top.ProfileType)
 	assert.Equal(t, []string{"service_name"}, top.GroupBy)
@@ -196,7 +199,7 @@ func TestAggregateTopSeries_Limit(t *testing.T) {
 		},
 	}
 
-	top := pyroscope.AggregateTopSeries(resp, "test", []string{"s"}, 2)
+	top := pyroscope.AggregateTopSeries(resp, "test", []string{"s"}, 2, 0)
 	assert.Len(t, top.Series, 2)
 	assert.Equal(t, "c", top.Series[0].Labels["s"])
 	assert.Equal(t, "b", top.Series[1].Labels["s"])

--- a/internal/query/pyroscope/types.go
+++ b/internal/query/pyroscope/types.go
@@ -185,7 +185,11 @@ type HeatmapSlot struct {
 
 // SelectSeriesResponse represents the response from a SelectSeries query.
 type SelectSeriesResponse struct {
-	Series []TimeSeries `json:"series"`
+	// StepSeconds is the bucket duration of the returned points. It is not
+	// part of the server response; the CLI sets it from the resolved step so
+	// consumers don't have to infer the bucket size from timestamp spacing.
+	StepSeconds float64      `json:"stepSeconds,omitempty"`
+	Series      []TimeSeries `json:"series"`
 }
 
 // TimeSeries represents a single time series with labels and data points.
@@ -256,8 +260,14 @@ type TopSeriesEntry struct {
 }
 
 // AggregateTopSeries converts a SelectSeriesResponse into a ranked TopSeriesResponse
-// by summing all points per series and sorting by total descending.
-func AggregateTopSeries(resp *SelectSeriesResponse, profileType string, groupBy []string, limit int) *TopSeriesResponse {
+// by summing points per series and sorting by total descending.
+//
+// Points at or before startMs are excluded: SelectSeries widens the fetch range
+// backwards by one step so charts render a complete first bucket, which places a
+// boundary point at the window start aggregating (start-step, start] — data
+// entirely before the requested window. With step set to the full range (--top
+// mode), summing that point would add one whole extra window to every total.
+func AggregateTopSeries(resp *SelectSeriesResponse, profileType string, groupBy []string, limit int, startMs int64) *TopSeriesResponse {
 	type entry struct {
 		labels map[string]string
 		total  float64
@@ -267,6 +277,9 @@ func AggregateTopSeries(resp *SelectSeriesResponse, profileType string, groupBy 
 	for _, s := range resp.Series {
 		var total float64
 		for _, p := range s.Points {
+			if p.TimestampMs() <= startMs {
+				continue
+			}
 			total += p.FloatValue()
 		}
 		lbls := make(map[string]string, len(s.Labels))


### PR DESCRIPTION
`gcx profiles metrics --top` reports totals ~2x larger than the flamegraph (`gcx profiles query`) or the merged pprof for the same selector and window.

`SelectSeries` intentionally widens the fetch range backwards by one step so the first chart bucket renders complete ([v2 read path](https://github.com/grafana/pyroscope/blob/main/pkg/frontend/readpath/queryfrontend/query_select_time_series.go#L48-L49), [v1 querier](https://github.com/grafana/pyroscope/blob/main/pkg/querier/querier.go#L1076-L1078)). The response therefore contains a boundary point at `t = start` aggregating `(start-step, start]` — data entirely before the requested window. `--top` sets `step = to - from` and `AggregateTopSeries` summed every point, so every total included one full extra window of data: with steady load that's ~2x, otherwise it's off by whatever the previous window did. Same bug and fix as `profilecli query top` (grafana/pyroscope#5359).

Verified against a dev cluster (`memory:alloc_space:bytes:space:bytes`; `pprof` = sum of samples from `profilecli query profile --output=pprof`, which is byte-identical to `flamegraph.total` from `gcx profiles query`):

| service | window | `--top` before | pprof / flamegraph | `--top` after |
|---|---|---:|---:|---:|
| service_a | 1h | 10,545,255,203,083 | 4,996,847,743,652 | 4,996,847,743,652 |
| service_a | 30m | 4,996,847,743,652 | 2,425,444,876,615 | 2,425,444,876,615 |
| service_a | 5m | 763,007,184,463 | 464,597,092,865 | 464,597,092,865 |
| service_b | 1h | 10,202,242,286,762 | 4,937,857,998,914 | 4,937,857,998,914 |
| service_c | 1h | 11,676,932,718,597 | 5,964,171,658,765 | 5,964,171,658,765 |

Note the service_a 30m "before" value: it equals the true 1h total exactly — the extra summed bucket is precisely the 30m preceding the window. Same behavior for `process_cpu` (2.01x over a 30m window).

Also echoes the resolved `stepSeconds` in `metrics` JSON output: points come pre-summed per step bucket, but the output never stated the bucket duration, and LLM agents consuming it have misread 300s buckets as per-minute values (exact 5x errors).
