### PR TITLE
docs(adr): command operation contract and pre-GA surface convergence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -192,6 +192,9 @@ Multiple auth mechanisms for different tiers.
 | [019](docs/adrs/oncall-alert-group-rich-shape/001-rich-shape-and-list-defaults.md) | Rich `AlertGroup` shape and actionable `alert-groups list` defaults | implemented |
 | [020](docs/adrs/sm-datasource-proxy/001-dual-mode-transport.md) | Synthetic Monitoring dual-mode transport: datasource proxy primary, direct SM API fallback | accepted |
 | [021](docs/adrs/assistant-provider/001-assistant-provider-and-mcp-servers-as-resources.md) | Assistant provider + MCP servers as resources | proposed |
+| [022](docs/adrs/login-consolidation/001-login-config-consolidation.md) | Login and config consolidation | accepted |
+| [023](docs/adrs/signal-provider-ux/001-cross-signal-command-consistency.md) | Cross-signal command consistency | accepted |
+| [024](docs/adrs/command-operation-contract/001-command-operation-semantics.md) | Command operation contract and pre-GA surface convergence | proposed |
 
 See [docs/adrs/](docs/adrs/) for all ADRs.
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -69,6 +69,12 @@ OnCall, Fleet Management, etc.) using product-specific REST APIs.
   being acted on (resource selectors, UIDs, expressions, file paths) is
   positional. How to act on it (output format, concurrency, dry-run, filters)
   is a flag.
+- **Every runnable command declares an approved operation contract.** The
+  final path token is the operation, an `<operation>-<subject>` compound,
+  or an approved shorthand/protocol exception from the governed vocabulary
+  (see [ADR: Command Operation Contract](docs/adrs/command-operation-contract/001-command-operation-semantics.md)
+  and [docs/design/naming.md §9.7](docs/design/naming.md)). The bare-verb
+  enumeration above is unchanged.
 
 ## Dual-Purpose Design
 
@@ -119,14 +125,18 @@ agent mode detection, behavior changes, and opt-out mechanisms.
   `ResourceAdapter` (via TypedCRUD) for data access, not raw API clients.
   Table/wide codecs may diverge — provider tables show domain-specific
   columns, generic tables show resource-management columns.
-- **Provider-only resources must not mimic adapter verbs.** If a resource
-  does not obey standard list/get/create/update/delete semantics (e.g.,
-  composite keys, scope-required lookups, query-only endpoints), do not
-  register it as an adapter. Keep it in the provider command tree only, but
-  use alternative verbs (`show`, `describe`, `search`) — never `get`, `list`,
-  `create`, `update`, `delete`. This avoids user confusion: adapter verbs
-  (`resources get`) and provider verbs should not overlap for resources that
-  behave differently across the two paths.
+- **Command operations follow the operation contract.** A command's
+  operation is determined by its user-visible subject, addressability,
+  result cardinality, and side effects — never by HTTP method, API path or
+  version, adapter registration, or transport (see
+  [ADR: Command Operation Contract](docs/adrs/command-operation-contract/001-command-operation-semantics.md)).
+  A genuine read-one is `get` and a genuine enumeration is `list`
+  regardless of whether the resource is adapter-registered. Resources that
+  do not obey entity semantics use the appropriate query/view/domain
+  operation from the governed vocabulary — not `get`/`list` in disguise,
+  and not ad-hoc synonyms. Adapter verbs (`resources get`) and provider
+  commands still must not overlap for resources that behave differently
+  across the two paths.
 - **Sub-resources nest under their parent command.** If a resource cannot
   be listed or addressed without a parent ID (e.g. alerts require an
   alert group), it is a sub-resource. Sub-resources must not be registered as standalone typed
@@ -134,6 +144,9 @@ agent mode detection, behavior changes, and opt-out mechanisms.
   as verbs under the parent command: `$PARENT $VERB-$CHILD $PARENT_ID`
   (e.g. `alert-groups list-alerts <id>`). Get-by-ID may still have a
   standalone adapter if the API supports direct ID lookup without a parent.
+  Addressability rules for selector, optional, variadic, and flag-supplied
+  identities are defined in the
+  [operation-contract ADR](docs/adrs/command-operation-contract/001-command-operation-semantics.md).
 - **Typed resource trajectory.** Provider domain types implement
   `ResourceIdentity` for self-describing identity and are wrapped by
   `TypedObject[T]` (embedded `metav1.ObjectMeta` + `TypeMeta` + `Spec T`)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,7 +24,7 @@ gcx logs query --from=1h
 gcx irm oncall schedules get my-schedule
 ```
 
-See [CONSTITUTION.md § CLI Grammar](CONSTITUTION.md#cli-grammar) for the authoritative rules (positional arguments, flags, extension commands, verb constraints).
+See [CONSTITUTION.md § CLI Grammar](CONSTITUTION.md#cli-grammar) for the authoritative rules (positional arguments, flags, extension commands, verb constraints), and the [ADR: Command Operation Contract](docs/adrs/command-operation-contract/001-command-operation-semantics.md) for operation semantics (vocabulary, addressability, surface forms). View-operation output defaults are governed separately from the format table below.
 
 ## Dual-Purpose Design
 
@@ -157,5 +157,5 @@ Prescriptive implementation rules live in [docs/design/](docs/design/), split by
 | [agent-mode.md](docs/design/agent-mode.md) | Agent mode detection, behavior changes, opt-out |
 | [provider-checklist.md](docs/design/provider-checklist.md) | Provider UX compliance (architecture patterns in [patterns.md](docs/architecture/patterns.md)) |
 | [help-text.md](docs/design/help-text.md) | Command descriptions, examples format |
-| [naming.md](docs/design/naming.md) | Resource kinds, file naming, config keys, flags |
+| [naming.md](docs/design/naming.md) | Resource kinds, file naming, config keys, flags, command operations |
 | [environment-variables.md](docs/design/environment-variables.md) | Canonical environment variable reference |

--- a/docs/adrs/command-operation-contract/001-command-operation-semantics.md
+++ b/docs/adrs/command-operation-contract/001-command-operation-semantics.md
@@ -1,0 +1,326 @@
+# ADR: Command Operation Contract and Pre-GA Surface Convergence
+
+**Created**: 2026-07-16
+**Status**: proposed
+**Supersedes**: none
+
+<!-- Status lifecycle: proposed -> accepted -> deprecated | superseded -->
+
+## Context
+
+gcx exposes ~487 runnable leaf commands across 16 providers. The command
+vocabulary evolved organically: the ~487 leaves end in 142 distinct final
+tokens, while the five standard CRUD verbs already cover 274 of them. The
+same user intent is spelled differently across providers (`get`, `show`,
+`inspect`, `describe-table`), some leaves are nouns whose behavior is not
+discoverable from the name (`kg meta logs`), and sub-resource addressing is
+inconsistent. For a CLI that is driven by both humans and AI agents — which
+discover the surface by walking `--help` as a decision tree and embed exact
+invocations in skills — this is a discoverability and automation-contract
+defect, not a cosmetic one.
+
+Prior art inside the repo: [CONSTITUTION.md § CLI Grammar](../../../CONSTITUTION.md)
+defines `$AREA $NOUN $VERB` and a closed bare-verb set; CONSTITUTION.md
+§ Provider Architecture currently *forbids* provider-only resources from
+using `get`/`list` (mandating `show`/`describe`/`search`), which review
+discussion has since turned against; the
+[cross-signal ADR](../signal-provider-ux/001-cross-signal-command-consistency.md)
+standardized the signal tier; the
+[UX-consistency design](../../plans/2026-04-14-ux-consistency-design.md)
+deferred verb taxonomy to a dedicated decision. A maintainer ruling
+(July 2026) established two rules of thumb: the last path word identifies
+the action, and the type of ID you pass commands the nesting. The
+[command-surface consistency audit](../../research/2026-07-01-command-surface-consistency-audit.md)
+inventoried the deviations.
+
+External forces: Grafana's App Platform structures its APIs as
+`/apis/<group>/<version>/namespaces/<ns>/<resource>[/<name>]` — collection
+routes for list/create, named-resource routes for get/update/delete — while
+the legacy `/api` surface is being migrated with no exact `/apis`
+replacement for every endpoint. Command names must survive that backend
+migration. Grafana's Git Sync documentation already instructs users to
+automate with `gcx resources pull`: command paths are automation contracts
+today. The Grafana App SDK models Get/List/Create/Update/Patch/Delete plus
+custom subresource routes; Grafana's MCP surface uses `list_*`/`get_*`/
+`query_*`/`search_*` and retains `describe_*` where the result is genuinely
+a schema/composite view.
+
+gcx has not shipped v1.0.0. This is the last cheap moment to converge the
+surface: after GA, command paths are stable interfaces and every rename is
+a breaking change.
+
+## Decision
+
+### 1. Transport-neutral operation contract
+
+A command operation is determined by its **user-visible subject,
+addressability, result cardinality, and side effects**. It MUST NOT depend
+on HTTP method, API path or version, provider-adapter registration, or
+transport.
+
+Consequences of this invariant: whether a resource happens to be registered
+as a typed adapter is irrelevant to its verb; a genuine read-one is `get`
+regardless of how it is implemented; command names must not change when a
+provider migrates from `/api` to `/apis`.
+
+### 2. The contract model
+
+Every active runnable command has a declared contract:
+
+| Field | Values | Meaning |
+|---|---|---|
+| Operation | `list`, `get`, `create`, `update`, `delete`, `patch` (reserved), `upsert`, `push`, `pull`, `query`, `search`, view ops (§5), domain ops (§6) | what it does |
+| Subject | free noun (`recommendations`, `alerts`, `labels`, …) | what it acts on |
+| Surface form | `canonical` \| `compound` \| `approved_shorthand` \| `protocol_exception` | how it is spelled |
+| Category | `entity` \| `manifest` \| `query` \| `view` \| `domain` \| `utility` | operation family |
+| Effect | `read_only` \| `mutating` \| `destructive` | side effects |
+| Addressing | `none` \| `singleton` \| `subject` \| `parent` \| `selector` | what identity it takes |
+| Result shape | `item` \| `collection` \| `item_or_collection` \| `report` \| `stream` \| `mutation` \| `none` | what comes back |
+| Lifecycle | `active` \| `deprecated` (+ replacement, earliest-eligible removal) | stability state |
+| Contract source | `explicit` \| `inferred` \| `unresolved` | where the contract came from |
+
+Category and Effect are deliberately separate: `query`/`view`/`domain`
+describe operation families; side effects are an orthogonal axis.
+`singleton` is an **addressing** concept, not a result shape. Logical
+cardinality is user-visible, not container-visible: a `get` result may
+contain nested arrays.
+
+Examples:
+
+- `slo definitions list` → {list, definitions, canonical, entity, read_only, none, collection}
+- `irm oncall alert-groups list-alerts <group-id>` → {list, alerts, compound, entity, read_only, parent, collection}
+- `metrics labels` → {list, labels, approved_shorthand, query, read_only, none, collection}
+- `kg entities inspect <entity>` → {inspect, entities, canonical, view, read_only, subject, report}
+- `resources get [RESOURCE_SELECTOR]...` → {get, resources, protocol_exception, entity, read_only, selector, item_or_collection}
+
+### 3. Entity operations (normal provider/product behavior)
+
+- `list` enumerates zero or more independently meaningful subjects.
+- `get` retrieves one addressable subject or singleton in its stable
+  structured representation.
+- `create` requires absence; `update` requires existence; `delete` removes
+  an existing subject.
+- `patch` is **reserved** for partial modification (the App SDK exposes it
+  separately from update); no command uses it until a real partial-update
+  surface exists.
+- `upsert` is permitted only when the backend genuinely provides
+  create-or-update semantics (single endpoint, no existence distinction).
+  Splitting a true upsert into `create`/`update` is rejected: it would
+  falsely promise existence checks and introduce read-then-write races.
+  Evidence: the alert notification-template provisioning API is a single
+  PUT keyed by template name.
+- `push`/`pull` are the manifest (GitOps) operations, unchanged.
+
+**Generic resource-tier exception (protocol family).** The Kubernetes-style
+resource family is an explicit exception: `gcx resources get
+[RESOURCE_SELECTOR]...` uses **selector addressing** and may return an item
+or a collection (`dashboards`, `dashboards/foo`, `dashboards/foo,bar`,
+multiple kinds). This mirrors kubectl and is already published in Grafana's
+Git Sync documentation. It is modeled as
+{get, protocol_exception, selector, item_or_collection} — the universal
+read-one definition explicitly does not apply to this family.
+
+### 4. Query operations and signal shorthands
+
+`query` executes a user-supplied data query; `search` performs discovery of
+matching subjects. Signal nouns — `labels`, `series`, `metrics`,
+`metadata` — are **approved surface shorthands** mapped to their real
+list/query semantics ({list|query, <noun>, approved_shorthand, query}).
+They are not independent semantic operations, and they are not violations:
+the shorthand set is closed and governed. This resolves the tension between
+the "last word identifies the action" rule and the ratified signal-tier
+command set.
+
+### 5. View operations
+
+View verbs are permitted only where the output contract **materially
+differs from ordinary retrieval**:
+
+- `status` — current condition or health
+- `timeline` — time-ordered events
+- `inspect` — composite diagnostic analysis involving related data
+- `diff` — comparison between states
+- `stats` — numeric aggregates
+- `report` — a cohesive analytical artifact
+- `describe` — a narrowly defined schema/composite view, admitted per
+  command where behavior supports it
+
+`show` is not canonical (it does not identify whether the result is an
+item, collection, or computed view). `summary` is not canonical; existing
+`summary` commands are classified during migration as `stats`, `status`, or
+`report` according to their real output. Neither `describe` nor `summary`
+is declared "universally nonstandard" — Grafana's MCP surface contains
+legitimate describe and qualified-summary operations; the rule is the
+materially-different-output test, applied per command.
+
+`kg entities inspect` is ratified as a valid diagnostic view (its output is
+an RCA timeline plus related entities; its own help text distinguishes it
+from property reads).
+
+### 6. Domain operations
+
+Domain verbs (`acknowledge`, `silence`, `escalate`, `open`, `close`,
+`resolve`, `restore`, `run`, `deploy`, `validate`, `sync`, …) remain valid
+where CRUD would misrepresent the behavior — you close an incident, you do
+not "update" it closed. Domain operations MUST be entries in a governed,
+reviewed vocabulary registry (a normal reviewed PR to the registry, not a
+constitutional amendment per verb). Inverse pairs (`unacknowledge`,
+`unsilence`, `unresolve`) are ratified together with their base verbs.
+
+### 7. Addressability
+
+The command path indicates the type of the first required positional
+identity:
+
+- Identity is the **parent's** → operation-subject compound under the
+  parent: `$PARENT $OPERATION-$CHILD $PARENT_ID`
+  (`alert-groups list-alerts <group-id>`).
+- Identity is the **child's** and the child has multiple operations → a
+  child resource group (`experiments trials get-scores <trial-id>`).
+- Catalog children with no parent identity may keep a noun group with
+  `list` (`incidents severities list`).
+- Selector, optional, variadic, multiple, or flag-supplied identities
+  cannot be derived from syntax and REQUIRE explicit contract metadata
+  (e.g. `instrumentation services get <cluster> <namespace> <service>`;
+  `slo definitions status [UUID]` returns one or many depending on the
+  optional argument).
+
+Syntax alone cannot prove an identity's resource type; explicit semantic
+metadata is the source of truth for ambiguous cases.
+
+### 8. Pre-GA surface convergence (normative)
+
+gcx v1.0.0 will ship a fully classified canonical command surface:
+
+- Every active runnable command MUST conform to this operation contract or
+  be an intentional canonical exception.
+- Commands whose names misrepresent their subject, addressability, result,
+  or side effects MUST be renamed or removed before v1.0.0.
+- The temporary legacy-contract baseline is migration scaffolding only and
+  MUST be empty before v1.0.0.
+- First-party documentation, examples, skills, annotations, and generated
+  references MUST use canonical paths.
+- Broad hidden forwarders MUST NOT ship in v1.0.0 merely to preserve
+  pre-GA naming. A noncanonical path may ship in v1 only through an
+  explicit, narrowly scoped maintainer-approved compatibility exception
+  carrying evidence of external dependency, replacement metadata, an
+  owner, and a removal policy.
+
+Migration does not mean blindly renaming every unusual command. Each
+current command resolves through exactly one of four outcomes:
+**keep and annotate** (already canonical), **ratify** (intentional
+canonical exception — recorded in this ADR's exception lists or the
+vocabulary registry), **rename** (name misrepresents the contract), or
+**remove** (obsolete or duplicated).
+
+Intentional canonical exceptions (closed lists): the bare top-level verbs
+already enumerated in CONSTITUTION.md § CLI Grammar; kubectl-parity
+`config` commands (`current-context`, `use-context`, `view`, `path`,
+`list-contexts`); CLI-utility commands (`version`, `commands`,
+`help-tree`, `api`); Cobra built-ins (`help`, `completion <shell>`); the
+resource-tier protocol family (§3); the signal shorthands (§4).
+
+### 9. Enforcement
+
+- **Local metadata ownership.** New commands declare their contract beside
+  their constructor or inherit it from a shared builder. A permanent
+  central path-keyed contract registry is rejected: a recent single-provider
+  rename churned 61+61 lines in the existing path-keyed annotation map —
+  path-keyed registries are rename hazards by construction.
+- **One shared resolver.** CI enforcement, the machine-readable command
+  catalog, and command-surface generation all consume the same resolution
+  logic; there is exactly one definition of a command's contract.
+- **Conservative inference, bootstrap only.** Inference from command syntax
+  exists to classify the existing tree cheaply and is limited to obvious
+  cases: a no-identity `list`; a `get` with exactly one simple required
+  positional; a no-argument `get` (singleton); a simple operation-subject
+  compound with exactly one required parent positional. Optional/variadic/
+  multiple/flag-supplied identities, selector syntax, alternatives in
+  `Use`, views, and domain actions are never inferred.
+- **Fail closed.** A command with unknown operation or unknown addressing
+  either carries explicit metadata or an exact-path entry in the temporary
+  legacy baseline; otherwise CI fails.
+- **Honest ratchet.** The legacy baseline is exact-path, carries rule
+  codes, an owner, and a rationale per entry, and may only shrink. A fixed
+  count ceiling prevents net growth but does not prove shrink-only
+  behavior on its own; shrink-only is enforced by review of baseline diffs
+  (optionally by a base-branch comparison in CI, outside the hermetic test
+  suite). The GA gate — an empty baseline — is the terminal guarantee.
+- **Versioned surface.** A deterministic, versioned command-surface JSON
+  document (paths, positional shapes, aliases, semantic contract fields,
+  lifecycle, hidden/deprecated mappings) is generated and drift-checked in
+  CI alongside the existing reference docs.
+- **Alias governance.** Permanent synonyms and deprecated compatibility
+  paths are distinct, explicitly declared concepts. Undeclared aliases that
+  misrepresent semantics (e.g. CRUD-named aliases on a true upsert) are
+  contract violations to resolve during migration.
+
+### 10. Compatibility policy
+
+Because v1.0.0 is the first stable boundary, **clean pre-GA
+canonicalization is the default**: pre-GA renames ship without
+compatibility shims unless a final v0.x migration release is planned, in
+which case a small, enumerated set of already-shipped paths may carry
+hidden forwarders with stderr warnings for that release only. Forwarders,
+where used: same-parent moves only for the generic mechanism; fresh
+command construction; the deprecation warning wraps Run/RunE and writes to
+stderr (never Cobra's built-in `Deprecated`, which writes through the
+command output stream and would corrupt structured stdout); structured
+stdout is preserved byte-for-byte; cross-parent moves require dedicated
+behavioral parity testing. Removal versions are the *earliest eligible*
+removal, not automatic deletion; removal additionally requires explicit
+approval and zero first-party references.
+
+After v1.0.0: command paths are stable interfaces; non-additive changes
+occur only at a major version with the same forwarder discipline.
+
+This supersedes the pre-GA clean-break stance of the cross-signal ADR for
+any path renamed under this contract going forward (that ADR's
+already-executed renames are unaffected).
+
+### Explicitly rejected
+
+- "The last word is always a verb" as the enforcement rule (word-shape
+  grammar): rejected in favor of declared operation semantics — it
+  misclassifies `status`, `labels`, and `list-trials`, and cannot express
+  subjects, addressing, or effects.
+- Universal `get`-returns-one-item: rejected; the resource-tier selector
+  family is a documented protocol exception.
+- `show`/`describe`/`search` as the mandated verbs for provider-only
+  resources (current CONSTITUTION text): rejected and replaced by this
+  contract.
+- A permanent central path-keyed contract registry: rejected (rename
+  hazard).
+- Nested noun groups as the default sub-resource shape (`alert-groups
+  alerts list`): rejected in favor of the addressability rule.
+- Splitting true upserts into create/update: rejected (races, false
+  existence semantics).
+- Broad v1 forwarders for pre-GA names: rejected (v1 ships canonical).
+
+### Out of scope
+
+Output-format defaults and codecs; typed-adapter (TypedCRUD) migrations;
+backend capability modeling (native/emulated/unsupported), pagination,
+rate limiting, retry/idempotency, and authentication standardization —
+tracked separately as client-platform work; k6 run-history consolidation
+except where a semantic rename requires it.
+
+## Consequences
+
+Easier: agents and humans can predict a command's behavior from its name
+and its machine-readable contract; new commands have one law to follow and
+one place to declare it; CI prevents regression; renames become mechanical
+(contract-verified) instead of debatable; the v1 surface is a real
+contract.
+
+Harder / costs: an initial migration census (~150–200 unresolved entries
+expected under conservative inference) must be burned down before v1.0.0;
+every provider owner reviews classifications for their commands; a handful
+of long-standing names change pre-GA (one-time breakage in a pre-stability
+period, softened by a final v0.x migration release if planned); the
+vocabulary registry adds a review step for genuinely new operations.
+
+Follow-up work: encode the contract in code (metadata package + shared
+resolver + CI ratchet + catalog + versioned surface); run the migration
+census; execute provider-sized rename batches; empty the baseline; add the
+GA gate.

--- a/docs/adrs/conventional-commits/001-pr-title-enforcement.md
+++ b/docs/adrs/conventional-commits/001-pr-title-enforcement.md
@@ -1,0 +1,93 @@
+# Conventional Commits via PR Title Enforcement
+
+**Created**: 2026-03-27
+**Status**: accepted
+**Bead**: none
+**Supersedes**: none
+
+## Context
+
+The gcx repo already follows Conventional Commits informally — recent history
+shows consistent use of `feat(scope):`, `fix:`, `docs:`, `ci:`, `chore:`,
+`build(deps):`. The goal is to codify and encourage the convention without
+blocking contributors unnecessarily.
+
+The repo is **squash-merge-only** with `PR_TITLE` as the squash commit title
+and `PR_BODY` as the commit body. Individual commits within a PR are discarded
+at merge time. This means PR title lint is the single meaningful enforcement
+point.
+
+Primary motivation is readability/consistency of the git log. Automated
+changelogs are a future option but not a driver today.
+
+## Decision
+
+Adopt a layered approach — four independent components that reinforce each
+other, all Go/shell-only (no Node.js dependencies):
+
+### 1. PR Title Lint (CI)
+
+A GitHub Actions workflow on `pull_request` events (`opened`, `edited`,
+`synchronize`) that checks the PR title against the Conventional Commits regex:
+
+```
+^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+
+```
+
+Two modes, controlled by a GitHub Actions variable `CC_ENFORCE`:
+- **`warn`** (default): Posts a warning annotation if the title doesn't match.
+  Does not block merge.
+- **`require`**: Fails the status check, blocks merge.
+
+Graduation path: flip `CC_ENFORCE` from `warn` to `require` when the team is
+comfortable.
+
+### 2. PR Template
+
+`.github/PULL_REQUEST_TEMPLATE.md` with a CC format reminder at the top and
+standard sections (Summary, Test plan).
+
+### 3. Git Commit Template
+
+`.gitmessage` at the repo root with CC format hints. A `make setup` target
+configures it for the local clone via `git config commit.template .gitmessage`.
+
+### 4. CLAUDE.md Convention Entry
+
+Add a convention entry so Claude Code and other AI agents format PR titles
+and commit messages using Conventional Commits.
+
+## Allowed Types
+
+| Type | Use for |
+|------|---------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `style` | Formatting, no logic change |
+| `refactor` | Code restructuring, no behavior change |
+| `perf` | Performance improvement |
+| `test` | Adding/updating tests |
+| `build` | Build system, dependencies |
+| `ci` | CI/CD configuration |
+| `chore` | Maintenance, tooling |
+| `revert` | Reverting a previous commit |
+
+Scope is optional but encouraged (e.g. `feat(slo):`, `fix(providers):`).
+
+## Alternatives Considered
+
+- **Git commit-msg hook**: Requires per-contributor setup, doesn't help agents
+  or GitHub web UI, bypassable with `--no-verify`. Irrelevant when squash-merge
+  discards individual commits.
+- **Full CI commit lint (every commit)**: Overkill when squash-merge makes only
+  the PR title matter. Annoying for WIP `fixup!` commits during development.
+- **Node.js commitlint**: Gold standard but adds a Node.js dependency to a
+  Go-only toolchain.
+
+## Consequences
+
+- PR titles become the single source of truth for commit messages.
+- The warn→require graduation path lets the team adopt incrementally.
+- Future automated changelog generation becomes straightforward since all
+  squash commits will follow CC format.

--- a/docs/adrs/signal-provider-ux/001-cross-signal-command-consistency.md
+++ b/docs/adrs/signal-provider-ux/001-cross-signal-command-consistency.md
@@ -1,7 +1,8 @@
 # Cross-Signal Command Consistency
 
 **Created**: 2026-04-03
-**Status**: proposed
+**Accepted**: 2026-07-16
+**Status**: accepted
 **Bead**: none
 **Supersedes**: none
 
@@ -157,6 +158,13 @@ only in what the API returns: a single data point vs a time series.
 ### 6. Aliases and clean breaks
 
 We are pre-GA -- no deprecated aliases, just clean renames where needed.
+
+> **Superseded for future renames** by the
+> [Command Operation Contract ADR §10](../command-operation-contract/001-command-operation-semantics.md):
+> clean pre-GA canonicalization remains the default, but if a final v0.x
+> migration release is planned, an enumerated set of already-shipped paths
+> may carry hidden forwarders for that release only. The renames already
+> executed under this ADR are unaffected.
 
 **Traces aliases (non-deprecated, kept permanently):**
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -16,5 +16,5 @@ New commands and providers **must comply with all rules documented here**.
 | [agent-mode.md](agent-mode.md) | Agent mode detection, behavior changes, opt-out |
 | [provider-checklist.md](provider-checklist.md) | Provider UX compliance (architecture patterns in [patterns.md](../architecture/patterns.md)) |
 | [help-text.md](help-text.md) | Command descriptions, examples format |
-| [naming.md](naming.md) | Resource kinds, file naming, config keys, flags |
+| [naming.md](naming.md) | Resource kinds, file naming, config keys, flags, command operations |
 | [environment-variables.md](environment-variables.md) | Canonical environment variable reference |

--- a/docs/design/naming.md
+++ b/docs/design/naming.md
@@ -1,6 +1,6 @@
 # Resource and API Naming
 
-> Naming conventions for resource kinds, file names, config keys, environment variables, flags, and URL path patterns.
+> Naming conventions for resource kinds, file names, config keys, environment variables, flags, URL path patterns, and command operations.
 
 ---
 
@@ -63,3 +63,44 @@ See [patterns.md § Provider ConfigLoader](../architecture/patterns.md#provider-
 
 For k6-related tools specifically, make sure to use "k6" (lowercase "k") and not "K6". This is only relevant for docstrings, documentation and other user-facing strings.
 Examples: "k6 Open Source", "k6 Cloud".
+
+### 9.7 Command Operations
+
+> Authoritative source: [ADR: Command Operation Contract](../adrs/command-operation-contract/001-command-operation-semantics.md).
+> This section is the working summary; the ADR defines the full model,
+> rationale, and rejected alternatives.
+
+A command's operation is determined by its **user-visible subject,
+addressability, result cardinality, and side effects** — never by HTTP
+method, API path or version, adapter registration, or transport.
+
+**The contract.** Every active runnable command declares (explicitly beside
+its constructor, via a shared builder, or — during migration only — by
+conservative inference): Operation, Subject, Surface form, Category,
+Effect, Addressing, and Result shape. See the ADR §2 for the field table.
+
+**Operation vocabulary (closed core, governed extensions):**
+
+| Family | Operations | Notes |
+|--------|-----------|-------|
+| Entity | `list`, `get`, `create`, `update`, `delete`, `upsert`, `patch` (reserved) | `get` = one addressable subject or singleton; `upsert` only for genuine create-or-update backends; `patch` reserved for partial modification |
+| Manifest | `push`, `pull` | GitOps tier, unchanged |
+| Query | `query`, `search` + approved shorthands `labels`, `series`, `metrics`, `metadata` | shorthands map to real list/query semantics |
+| View | `status`, `timeline`, `inspect`, `diff`, `stats`, `report`, `describe` (narrow, per command) | only where output materially differs from ordinary retrieval; `show` and `summary` are not canonical |
+| Domain | `acknowledge`, `silence`, `close`, `resolve`, `restore`, `sync`, … | governed registry; new domain verbs are a reviewed registry PR |
+| Utility | `version`, `login`, `logout`, … | closed exception lists in the ADR §8 |
+
+**Addressability.** The command path indicates the type of the first
+required positional identity: parent's ID → `$PARENT $OPERATION-$CHILD
+$PARENT_ID` compound; child's ID with multiple child operations → child
+group; no parent identity → noun group with `list` is legal. Selector,
+optional, variadic, multiple, or flag-supplied identities require explicit
+contract metadata — syntax alone cannot prove an identity's type.
+
+**Protocol exception.** `gcx resources get [RESOURCE_SELECTOR]...` is a
+kubectl-style protocol family: selector addressing, item-or-collection
+result. The universal read-one definition of `get` does not apply to it.
+
+**Ownership.** New commands declare contracts locally (constructor or
+shared builder). Path-keyed registries and `Use`-string inference are
+migration bootstrap only.

--- a/docs/design/provider-checklist.md
+++ b/docs/design/provider-checklist.md
@@ -20,6 +20,7 @@ UX requirements. All items are unless marked otherwise.
 
 ### UX Compliance
 
+- [ ] Every new command declares its operation contract (`commandmeta.Set` beside the constructor, or inherited from a shared builder) per [naming.md §9.7](naming.md) — operational views, query/search, and singleton categories in the exemption table below map onto the contract's view/query classes
 - [ ] All data-display commands support `-o json/yaml` (inherited from `io.Options`)
 - [ ] List/get commands register a `text` table codec as default format
 - [ ] List/get commands register a `wide` codec showing additional detail columns

--- a/docs/plans/2026-04-14-ux-consistency-design.md
+++ b/docs/plans/2026-04-14-ux-consistency-design.md
@@ -564,19 +564,22 @@ they're removed.
 
 ### Singleton resources use `show`, not `get`
 
-Resources with no ID and no list (e.g., `appo11y overrides`, `appo11y
-settings`) use `show` to distinguish from the adapter `get` which implies
-"by ID." This is codified as the **singleton rule** in the verb taxonomy.
+> **Superseded.** The singleton rule changed during ratification: under the
+> [Command Operation Contract ADR](../adrs/command-operation-contract/001-command-operation-semantics.md),
+> a no-argument read of a singleton is `get` with singleton *addressing* —
+> `show` is not a canonical operation. `appo11y overrides get` /
+> `settings get` are therefore already canonical.
 
 ### New verb taxonomy rules
 
-Three rules added to `docs/design/naming.md`:
-
-1. **Singleton rule**: Resources with no ID and no list use `show`
-2. **`open` disambiguation**: `browse` for browser navigation, explicit
-   state verbs (`activate`/`close`) for lifecycle changes
-3. **`show`/`list`/`get` decision tree**: `get` = by ID (adapter or not),
-   `list` = collection, `show` = singleton or aggregate view
+> **Correction (2026-07-16).** This section previously claimed three rules
+> were "added to `docs/design/naming.md`" — they never were (documentation
+> drift). The verb taxonomy is now ratified by the
+> [Command Operation Contract ADR](../adrs/command-operation-contract/001-command-operation-semantics.md)
+> and summarized in [naming.md §9.7](../design/naming.md). Outcomes differ
+> from the original sketch: singleton reads are `get` (not `show`); `show`
+> is not canonical; the `open`/`browse` disambiguation remains an open
+> migration-census question rather than a ratified rule.
 
 ---
 

--- a/docs/research/2026-07-01-command-surface-consistency-audit.md
+++ b/docs/research/2026-07-01-command-surface-consistency-audit.md
@@ -1,0 +1,117 @@
+# Research: Command Surface Consistency Audit
+
+**Created**: 2026-07-01
+**Confidence**: High (derived from the generated CLI reference + code inspection)
+**Sources**: 5
+
+## Executive Summary
+
+- Audited all ~470 leaf commands in `docs/reference/cli/` against four consistency goals: `$PRODUCT $RESOURCE $VERB` grammar, standard verbs (`list|get|create|update|delete`), the standardized `TypedCRUD` interface, and the output model (lists → table, individual items → YAML, agent/scripting → JSON).
+- **Grammar** and **verb** deviations are the bulk of the findings and are mode-independent. Most are mechanical renames; a few (signal providers) are deliberate exceptions that should be ratified in `CONSTITUTION.md` rather than "fixed".
+- **`TypedCRUD`** is broadly adopted; the notable bespoke holdouts are `dashboards`, `cloud stacks`, and `instrumentation`.
+- **Output**: `list` → table and agent-mode → JSON (`agents` codec) are already correct. The one systemic gap is that `get` / single-item commands default to `text`/table instead of YAML — a **non-agent-mode-only** defect rooted in one design-doc rule (`docs/design/output.md` §1.3) and one shared default call, not 62 separate bugs.
+
+This audit is the input for the pending verb-taxonomy and output-consistency implementation plans anticipated by [the UX Consistency design](../plans/2026-04-14-ux-consistency-design.md) (dimensions 4-5) and tracked under issue #387.
+
+## Scope and Method
+
+- Command inventory: the generated per-command reference under `docs/reference/cli/` (leaf = a command file with no `_`-prefixed children).
+- Rules checked against: `CONSTITUTION.md` §CLI Grammar (authoritative grammar + verb constraints), `DESIGN.md`, `docs/design/output.md` §1.3 (default format by command type).
+- `TypedCRUD` adoption determined by `grep` for `adapter.TypedCRUD[T]` usage per provider.
+- Output precedence confirmed in `internal/output/format.go:81-84` (`BindFlags` overrides the per-command default with the `agents` codec when `agent.IsAgentMode()`).
+
+### Rule clarifications used
+
+- The codebase's canonical verb set is effectively `list | get | create | update | delete | push | pull` — CONSTITUTION treats `push`/`pull`/`delete` as first-class CRUD verbs for the GitOps tier. Findings below flag against `list|get|create|update|delete` and note where CONSTITUTION already blesses an exception.
+- Output rules are **non-agent-mode** defaults. Agent mode always emits the `agents` codec (JSON, with temp-file spill above 100 KiB) regardless of command type. Precedence: explicit `-o` flag → agent-mode `agents` → per-command human default.
+- Individual-item target format is **YAML**. Today only `config view` defaults to YAML; every `get` defaults to table.
+
+## Findings
+
+### 1. Grammar — not `$PRODUCT $RESOURCE $VERB`
+
+| Command(s) | Problem | Suggested fix |
+|---|---|---|
+| `gcx api` | Bare noun, no verb; not in the closed bare-verb set (`login`,`setup`,`version`,`help`,`completion`) | Add a verb (`gcx api call ...`) or ratify as an explicit exception in CONSTITUTION |
+| `gcx metrics query\|labels\|series\|metadata` | `$PRODUCT $VERB`, no resource noun; `labels`/`series`/`metadata` are nouns-as-verbs | Accepted per ADR `signal-provider-ux/001` — ratify the exception in CONSTITUTION |
+| `gcx logs query\|labels\|series\|metrics` | Same | Same |
+| `gcx traces query\|labels\|metrics\|get` | Same; `traces get <id>` has an implicit resource | Same |
+| `gcx profiles query\|labels\|metrics\|profile-types` | Same | Same |
+| `gcx assistant dashboard`, `gcx assistant prompt` | `$PRODUCT $VERB`, no resource noun | Nest under a noun, or document as a verb-first exception |
+| `gcx kg open\|status\|summary` | `$PRODUCT $VERB`, bare verbs under the product | Fold under a noun (`kg graph open/status`) or ratify |
+| `gcx kg diagnose service\|labels` | Inverted `$PRODUCT $VERB $NOUN` | Re-order to `kg <noun> diagnose` |
+| `gcx kg meta all\|logs\|metrics\|traces\|profiles\|schema\|scopes` | Noun leaves, no verb | `kg meta <noun> get/list` |
+| `gcx kg insights chart\|sources` | Noun leaves, no verb | `kg insights <noun> get/list` |
+| `gcx k6 auth token` | `auth` isn't a resource | Rework (`k6 auth get-token` or config) |
+| `gcx k6 test-run status\|emit\|runs list` | `test-run` isn't a CRUD resource; mixed verb/noun leaves | Clarify the resource model |
+| `gcx datasources prometheus labels\|metadata`; `... loki labels\|series\|metrics`; `... tempo labels\|metrics`; `... pyroscope labels\|metrics\|profile-types`; `... influxdb field-keys\|measurements\|tag-keys\|tag-values` | Trailing noun stands in for a verb (`$PRODUCT $RESOURCE $NOUN`) | Treat as sub-resources with `list`, or ratify as a query-discovery exception |
+
+### 2. Non-standard verbs — should be `list|get|create|update|delete`
+
+| Command(s) | Current verb | Should be |
+|---|---|---|
+| `gcx datasources cloudwatch list-namespaces\|list-metrics\|list-dimensions\|list-regions\|list-accounts` | `list-X` compound | `cloudwatch <noun> list` |
+| `gcx datasources athena list-catalogs\|list-databases\|list-tables` | `list-X` | `athena <noun> list` |
+| `gcx datasources clickhouse list-tables` | `list-X` | `clickhouse tables list` |
+| `gcx appo11y services list-operations` | `list-X` | `services operations list` |
+| `gcx irm oncall alert-groups list-alerts` | `list-X` | `alert-groups alerts list` |
+| `gcx config list-contexts` | `list-X` | `config contexts list` (tooling — lower priority) |
+| `gcx datasources clickhouse describe-table`, `... athena describe-table` | `describe-X` | `get` |
+| `gcx kg entities inspect` | `inspect` | `get` |
+| `gcx logs adaptive patterns show`; `gcx metrics adaptive recommendations show`; `gcx traces adaptive recommendations show` | `show` | `get` |
+| `gcx frontend apps show-sourcemaps` | `show-X` | `frontend apps sourcemaps list` |
+| `gcx alert templates upsert` | `upsert` (only one in tree) | `create` / `update` |
+| `gcx alert notification-policies set\|reset` | `set`/`reset` | `update` (singleton) |
+| `gcx alert contact-points export`, `... mute-timings export`, `... notification-policies export` | `export` | fold into `get`/`pull` with a flag |
+| `gcx aio11y saved-conversations save` | `save` | `create` |
+| `gcx k6 load-tests update-script` | `update-script` | flag on `update` |
+| `gcx aio11y collections conversations add\|remove` | `add`/`remove` | `create`/`delete` (or accept as membership ops) |
+| `gcx frontend apps apply-sourcemap\|remove-sourcemap` | compound verbs | `frontend apps sourcemaps apply\|delete` |
+| `gcx instrumentation clusters configure\|remove`, `... clusters apps configure\|remove` | `configure`/`remove` | `create`/`update`/`delete` |
+| `gcx instrumentation services include\|exclude\|clear` | 3 domain verbs | `update`/`delete` (or document as a wizard exception) |
+| `gcx irm incidents open\|close`, `... incidents activity add` | `open`/`close`/`add` | `create`/`update`; `activity create` |
+| `gcx irm oncall alert-groups acknowledge\|unacknowledge\|resolve\|unresolve\|silence\|unsilence`, `gcx irm oncall escalate` | 7 state-transition verbs | Defensible as extensions per CONSTITUTION — verify each isn't expressible as `update`; note oncall has no CRUD at all |
+
+### 3. TypedCRUD gaps
+
+| Command group | Problem | Suggested fix |
+|---|---|---|
+| `gcx dashboards create\|update\|delete\|get\|list` | Bespoke CRUD, no `TypedCRUD[T]` (highest-value resource) | Migrate to TypedCRUD |
+| `gcx cloud stacks create\|update\|delete\|get\|list` | Bespoke CRUD | Migrate to TypedCRUD |
+| `gcx instrumentation clusters\|clusters apps\|services *` | Bespoke + non-standard verbs; doesn't fit the typed pattern | Rework toward TypedCRUD or document exception |
+| `gcx alert rules` (get/list only), `gcx alert instances` (list only) | Read-only while sibling `contact-points`/`mute-timings` are full CRUD — asymmetry | Confirm intended (likely API read-only) |
+| Most of `gcx irm oncall *`; `gcx aio11y templates\|generations\|conversations\|scores` | Read-only where CRUD might be expected | Confirm intended |
+
+### 4. Output model — non-agent-mode only (agent mode already forces JSON via the `agents` codec)
+
+| Command(s) | Problem | Suggested fix |
+|---|---|---|
+| **All `gcx <product> <resource> get`** (~62) + singleton getters (`appo11y overrides/settings get`, `alert notification-policies get`, …) | Default to `text`/table; should be YAML for individual items. Root cause: `output.md` §1.3 groups `get` with `list`, and commands call `DefaultFormat("text")` | Change `output.md` §1.3 (`get` → `yaml`); switch single-item commands to `DefaultFormat("yaml")`. One coordinated change, not 62 edits |
+| **All `gcx <product> <resource> list`** | Default to `text`/table — correct | None |
+| `gcx * query` (metrics/logs/traces/profiles + all `datasources * query`) | Non-tabular payload (series/streams/traces); table shape is synthetic | Confirm `-o json/yaml` is stable in both modes |
+| `gcx assistant prompt\|chat`, `... investigations narrative\|report\|document\|regenerate-report`, `gcx kg summary` | Prose/streaming, not resource-shaped | Confirm/limit format support |
+| `gcx dashboards snapshot` (PNG), `gcx kg open`, `gcx assistant dashboard` (deep-link), `gcx k6 test-run emit` | Binary / side-effecting, no data payload | Exempt explicitly |
+| `gcx metrics adaptive recommendations diff` | Diff output, not codec-driven | Exempt explicitly |
+
+Compliant (recorded so they are not re-litigated): `list` → table; `json`/`yaml`/`agents` free on all data commands; agent-mode JSON override.
+
+## Recommendations
+
+Highest-leverage, in order:
+
+1. **`list-X` → `X list`** across datasources (cloudwatch/athena/clickhouse), `appo11y services`, `irm oncall alert-groups`. Pure mechanical grammar win, low risk.
+2. **Normalize get-synonyms**: `describe-table`/`show`/`inspect` → `get`; `upsert`/`save`/`set` → `create`/`update`; `export` → `get`/`pull` with a flag.
+3. **Ratify the signal-provider exception** in CONSTITUTION (already ADR'd in `signal-provider-ux/001`) so `metrics query`-style commands don't read as violations.
+4. **Reconcile instrumentation's verb vocabulary** (`configure`/`remove`/`include`/`exclude`/`clear`) with standard CRUD, or document it as a deliberate wizard-style exception.
+5. **`get` → YAML (human mode)**: edit `output.md` §1.3 and switch single-item commands to `DefaultFormat("yaml")`. Decide first whether `get` with multiple positional IDs defaults YAML (multi-doc `---` stream) too — cleanest is "one command, one default".
+6. **Migrate `dashboards` and `cloud stacks` to TypedCRUD**.
+
+These map to dimensions 4-5 of [the UX Consistency design](../plans/2026-04-14-ux-consistency-design.md), which anticipated separate implementation plans for verb taxonomy and output consistency.
+
+## Sources
+
+1. `docs/reference/cli/` — generated per-command CLI reference (command inventory).
+2. `CONSTITUTION.md` §CLI Grammar — authoritative grammar and verb constraints.
+3. `docs/design/output.md` §1.3 — default format by command type.
+4. `internal/output/format.go:81-84` — agent-mode output override precedence.
+5. `docs/adrs/signal-provider-ux/001-cross-signal-command-consistency.md` — signal-provider command exceptions.

--- a/docs/research/2026-07-01-command-surface-consistency-audit.md
+++ b/docs/research/2026-07-01-command-surface-consistency-audit.md
@@ -4,6 +4,15 @@
 **Confidence**: High (derived from the generated CLI reference + code inspection)
 **Sources**: 5
 
+> **Preface (2026-07-16).** This audit predates the July 2026 sub-resource
+> ruling and the [Command Operation Contract ADR](../adrs/command-operation-contract/001-command-operation-semantics.md).
+> Its §2 recommendations to convert `list-X` compounds into nested noun
+> groups (e.g. `alert-groups list-alerts` → `alert-groups alerts list`) are
+> **superseded**: compounds of the form `$PARENT $OPERATION-$CHILD
+> $PARENT_ID` are the canonical shape for parent-addressed children. The
+> inventory and the remaining findings stand as the input to the migration
+> census.
+
 ## Executive Summary
 
 - Audited all ~470 leaf commands in `docs/reference/cli/` against four consistency goals: `$PRODUCT $RESOURCE $VERB` grammar, standard verbs (`list|get|create|update|delete`), the standardized `TypedCRUD` interface, and the output model (lists → table, individual items → YAML, agent/scripting → JSON).


### PR DESCRIPTION
## What

Decision ADR for #387 plus the full governing-doc reconciliation, opened as a **draft**: per the ADR lifecycle, this PR merges only after the maintainer decisions land and the ADR is flipped to `accepted` — so there is no window where CONSTITUTION points at an unsettled rule.

- **New ADR** `docs/adrs/command-operation-contract/001-command-operation-semantics.md` — a transport-neutral command operation contract (operation / subject / surface form / category / effect / addressing / result shape / lifecycle / source), the addressability rule (formalizing the July sub-resource ruling), the resource-tier selector exception (`resources get [RESOURCE_SELECTOR]...` is kubectl-style, verified in `cmd/gcx/resources/get.go`), signal nouns as approved shorthands, a narrowly-scoped view vocabulary, a governed domain-verb registry, true-upsert policy, and a **normative pre-GA convergence commitment**: v1.0.0 ships a fully classified canonical surface with an empty legacy baseline and no broad compatibility forwarders.
- **CONSTITUTION.md** — replaces the "never `get`/`list`; use `show`/`describe`/`search`" provider rule with the operation contract; adds the contract bullet to § CLI Grammar. (Constitutional change — requires explicit maintainer approval, hence the decision list below.)
- **DESIGN.md / docs/design/naming.md §9.7 / docs/design/README.md / provider-checklist.md** — working summaries and pointers reconciled to the ADR.
- **Signal-provider ADR** — flipped to `accepted` (it has been implemented since April) and its pre-GA clean-break section amended to defer to the new compatibility policy for future renames, so two accepted ADRs don't prescribe opposite migration policies.
- **ARCHITECTURE.md ADR table** — adds rows 022–024 (login-consolidation and signal-provider-ux were missing from the index; the new ADR is 024) and repairs ADR-006: `docs/adrs/conventional-commits/001-pr-title-enforcement.md` was **accidentally deleted** by an unrelated rebase in `4c754615` (#38) — restored verbatim from `0689aed2`.
- **UX-consistency plan D6** — corrects documentation drift: it claimed three verb rules were "added to naming.md" that never were, and the singleton-rule outcome changed (`get`, not `show`).
- **Command-surface audit** — cherry-picked from `dafydd-t/command-consistency-audit` (authorship preserved) with a preface noting its §2 `list-X → X list` recommendations are superseded by the July ruling.

## Maintainer decisions

The decision list (D1–D10) is posted on #387 with recommended answers. The load-bearing ones: **D6** (empty legacy baseline before v1.0.0) and **D7** (whether a final v0.x migration release exists — this decides forwarders vs clean renames for the pilot). Follow-up implementation (contract metadata + CI ratchet, then the adaptive `show → list` pilot, then provider batches) starts only after this merges as accepted.

## Verification

- `GCX_AGENT_MODE=false mise run reference` — zero drift (docs-only change).
- `GCX_AGENT_MODE=false mise run gate` — lint + tests + build green.
- `mkdocs` unavailable locally; docs build deferred to CI.
- Doc-maintenance gate: ADR-table row added; no `docs/architecture/` structural changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
