### PR TITLE
fix(irm): decode expanded webhook integration filters

### DIFF
--- a/internal/providers/irm/oncall_client_test.go
+++ b/internal/providers/irm/oncall_client_test.go
@@ -489,6 +489,87 @@ func TestListWebhookPresets(t *testing.T) {
 	}
 }
 
+func TestListWebhooksIntegrationFilterShapes(t *testing.T) {
+	t.Parallel()
+
+	client := newTestOnCallClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := irm.BasePath + "/webhooks/"
+		if r.URL.Path != wantPath {
+			t.Errorf("got path %q, want %q", r.URL.Path, wantPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"id":"webhook-1","name":"Legacy","is_webhook_enabled":true,"integration_filter":["integration-1"]},
+			{"id":"webhook-2","name":"Expanded","is_webhook_enabled":true,"integration_filter":[{"id":"integration-2","name":"Grafana Alerts"}]}
+		]`))
+	}))
+
+	webhooks, err := client.ListWebhooks(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []irm.WebhookIntegrationFilter{{"integration-1"}, {"integration-2"}}
+	if len(webhooks) != len(want) {
+		t.Fatalf("got %d webhooks, want %d", len(webhooks), len(want))
+	}
+	for i := range webhooks {
+		if !reflect.DeepEqual(webhooks[i].IntegrationFilter, want[i]) {
+			t.Errorf("webhook %d integration filter: got %v, want %v", i, webhooks[i].IntegrationFilter, want[i])
+		}
+	}
+}
+
+func TestWebhookIntegrationFilterJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    irm.WebhookIntegrationFilter
+		wantErr string
+	}{
+		{name: "id strings", input: `["integration-1","integration-2"]`, want: irm.WebhookIntegrationFilter{"integration-1", "integration-2"}},
+		{name: "expanded objects", input: `[{"id":"integration-1","name":"Primary"}]`, want: irm.WebhookIntegrationFilter{"integration-1"}},
+		{name: "mixed entries", input: `["integration-1",{"id":"integration-2","name":"Secondary"}]`, want: irm.WebhookIntegrationFilter{"integration-1", "integration-2"}},
+		{name: "empty", input: `[]`, want: irm.WebhookIntegrationFilter{}},
+		{name: "null", input: `null`, want: nil},
+		{name: "object missing id", input: `[{"name":"Primary"}]`, wantErr: "missing id"},
+		{name: "invalid entry", input: `[42]`, wantErr: "cannot unmarshal number"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got irm.WebhookIntegrationFilter
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("got error %v, want error containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+			encoded, err := json.Marshal(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var encodedIDs []string
+			if err := json.Unmarshal(encoded, &encodedIDs); err != nil {
+				t.Fatalf("marshaled filter should contain only IDs, got %s: %v", encoded, err)
+			}
+			if !reflect.DeepEqual(encodedIDs, []string(tt.want)) {
+				t.Errorf("marshaled filter: got %v, want %v", encodedIDs, tt.want)
+			}
+		})
+	}
+}
+
 func TestListRouteFilterTypes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/providers/irm/oncall_types.go
+++ b/internal/providers/irm/oncall_types.go
@@ -2,6 +2,8 @@ package irm
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -313,26 +315,70 @@ type Route struct {
 	FilteringLabels     any    `json:"filtering_labels,omitempty"`
 }
 
+// WebhookIntegrationFilter is the list of integration IDs that may trigger a
+// webhook. The public and older internal APIs return ID strings, while newer
+// Cloud IRM internal APIs expand each entry to an object containing id and
+// name. Normalize both response shapes to IDs so manifests and write requests
+// retain the portable string-array representation.
+type WebhookIntegrationFilter []string
+
+func (f *WebhookIntegrationFilter) UnmarshalJSON(data []byte) error {
+	var entries []json.RawMessage
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return fmt.Errorf("decode webhook integration filter: %w", err)
+	}
+	if entries == nil {
+		*f = nil
+		return nil
+	}
+
+	filter := make(WebhookIntegrationFilter, 0, len(entries))
+	for i, entry := range entries {
+		var id string
+		if err := json.Unmarshal(entry, &id); err == nil {
+			if id == "" {
+				return fmt.Errorf("decode webhook integration filter entry %d: empty id", i)
+			}
+			filter = append(filter, id)
+			continue
+		}
+
+		var ref struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(entry, &ref); err != nil {
+			return fmt.Errorf("decode webhook integration filter entry %d: %w", i, err)
+		}
+		if ref.ID == "" {
+			return fmt.Errorf("decode webhook integration filter entry %d: missing id", i)
+		}
+		filter = append(filter, ref.ID)
+	}
+
+	*f = filter
+	return nil
+}
+
 //nolint:recvcheck
 type Webhook struct {
-	ID                  string   `json:"id,omitempty"`
-	Name                string   `json:"name"`
-	URL                 string   `json:"url,omitempty"`
-	HTTPMethod          string   `json:"http_method,omitempty"`
-	TriggerType         any      `json:"trigger_type,omitempty"`
-	IsWebhookEnabled    bool     `json:"is_webhook_enabled"`
-	IsLegacy            bool     `json:"is_legacy,omitempty"`
-	Team                any      `json:"team,omitempty"`
-	Data                string   `json:"data,omitempty"`
-	Username            string   `json:"username,omitempty"`
-	Password            string   `json:"password,omitempty"`
-	AuthorizationHeader string   `json:"authorization_header,omitempty"`
-	Headers             string   `json:"headers,omitempty"`
-	TriggerTemplate     string   `json:"trigger_template,omitempty"`
-	IntegrationFilter   []string `json:"integration_filter,omitempty"`
-	ForwardAll          bool     `json:"forward_all,omitempty"`
-	Preset              string   `json:"preset,omitempty"`
-	Labels              any      `json:"labels,omitempty"`
+	ID                  string                   `json:"id,omitempty"`
+	Name                string                   `json:"name"`
+	URL                 string                   `json:"url,omitempty"`
+	HTTPMethod          string                   `json:"http_method,omitempty"`
+	TriggerType         any                      `json:"trigger_type,omitempty"`
+	IsWebhookEnabled    bool                     `json:"is_webhook_enabled"`
+	IsLegacy            bool                     `json:"is_legacy,omitempty"`
+	Team                any                      `json:"team,omitempty"`
+	Data                string                   `json:"data,omitempty"`
+	Username            string                   `json:"username,omitempty"`
+	Password            string                   `json:"password,omitempty"`
+	AuthorizationHeader string                   `json:"authorization_header,omitempty"`
+	Headers             string                   `json:"headers,omitempty"`
+	TriggerTemplate     string                   `json:"trigger_template,omitempty"`
+	IntegrationFilter   WebhookIntegrationFilter `json:"integration_filter,omitempty"`
+	ForwardAll          bool                     `json:"forward_all,omitempty"`
+	Preset              string                   `json:"preset,omitempty"`
+	Labels              any                      `json:"labels,omitempty"`
 }
 
 //nolint:recvcheck


### PR DESCRIPTION
## Summary

- accept both integration ID strings and expanded `{id, name}` objects in Cloud IRM webhook responses
- normalize expanded references to IDs so manifests and create/update requests retain the portable string-array format
- add regression coverage for legacy, expanded, mixed, empty, null, invalid, and marshal-round-trip cases

## Why

The Cloud IRM internal webhook endpoint can expand `integration_filter` entries into objects. The existing `[]string` response model fails to decode those webhooks, causing `gcx irm oncall webhooks list` to fail before producing output.

## Reproduction

Before this fix, listing webhooks against a stack that returns expanded integration references fails immediately:

```console
$ gcx irm oncall webhooks list
Error: Irm: decode webhook

json: cannot unmarshal object into Go struct field Webhook.integration_filter of type string
```

## Test plan

- [x] `go test ./internal/providers/irm/...`
- [x] `go test ./...`
- [x] `golangci-lint run -c .golangci.yaml`
- [x] `GCX_AGENT_MODE=false mise run --jobs=1 reference-drift`
- [x] build and verify `gcx irm oncall webhooks list -o json` against a Grafana Cloud IRM stack
- [ ] local MkDocs render (the local Python environment does not have `mkdocs-material`; CI will run the documentation build)
