### PR TITLE
feat(assistant): preserve full v2 investigation summaries and total in list output

### DIFF
--- a/internal/assistant/investigations/client_v2.go
+++ b/internal/assistant/investigations/client_v2.go
@@ -30,10 +30,9 @@ func (c *Client) CreateLodestone(ctx context.Context, req CreateLodestoneRequest
 	return assistanthttp.DoEnvelopeRequest[CreateLodestoneResponse](c.base, ctx, http.MethodPost, v2InvestigationsBase, req, "create investigation")
 }
 
-// ListLodestone returns v2 investigation summaries. The envelope is the same
-// shape as the v1 summary endpoint, so the existing InvestigationSummary type
-// and ListTableCodec are reused.
-func (c *Client) ListLodestone(ctx context.Context, opts ListLodestoneOptions) ([]InvestigationSummary, error) {
+// ListLodestone returns the v2 investigation collection: rich summaries plus
+// the total matching count for offset-based pagination.
+func (c *Client) ListLodestone(ctx context.Context, opts ListLodestoneOptions) (*LodestoneList, error) {
 	params := url.Values{}
 	if opts.State != "" {
 		params.Set("state", opts.State)
@@ -89,17 +88,15 @@ func (c *Client) ListLodestone(ctx context.Context, opts ListLodestoneOptions) (
 		return nil, assistanthttp.HandleErrorResponse(resp)
 	}
 	var envelope struct {
-		Data struct {
-			Investigations []InvestigationSummary `json:"investigations"`
-		} `json:"data"`
+		Data LodestoneList `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
 		return nil, fmt.Errorf("decode list response: %w", err)
 	}
 	if envelope.Data.Investigations == nil {
-		return []InvestigationSummary{}, nil
+		envelope.Data.Investigations = []LodestoneInvestigationSummary{}
 	}
-	return envelope.Data.Investigations, nil
+	return &envelope.Data, nil
 }
 
 // ResolveByID maps a user-supplied investigation identifier to both forms

--- a/internal/assistant/investigations/client_v2_test.go
+++ b/internal/assistant/investigations/client_v2_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/grafana/gcx/internal/assistant/investigations"
 	"github.com/stretchr/testify/assert"
@@ -87,17 +88,110 @@ func TestListLodestone(t *testing.T) {
 				tt.assertReq(t, r)
 				writeJSON(w, map[string]any{
 					"data": map[string]any{
-						"investigations": []investigations.InvestigationSummary{
-							{ID: "inv-1", Title: "x", State: "in_progress"},
+						"investigations": []map[string]any{
+							{"id": "inv-1", "title": "x", "state": "in_progress"},
 						},
+						"total": 42,
 					},
 				})
 			}))
 			out, err := client.ListLodestone(t.Context(), tt.opts)
 			require.NoError(t, err)
-			assert.Len(t, out, tt.wantCount)
+			assert.Len(t, out.Investigations, tt.wantCount)
+			assert.Equal(t, int64(42), out.Total)
 		})
 	}
+}
+
+// TestListLodestone_LosslessSummary pins the full v2 summary shape: every
+// field the server emits must survive the decode so json/yaml output is
+// lossless (gcx#997).
+func TestListLodestone_LosslessSummary(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"data": map[string]any{
+				"investigations": []map[string]any{{
+					"id":          "inv-1",
+					"title":       "High latency",
+					"description": "p99 spiked",
+					"state":       "in_progress",
+					"chatId":      "chat-1",
+					"variant":     "lodestone",
+					"createdAt":   "2026-07-01T10:00:00Z",
+					"updatedAt":   "2026-07-01T12:00:00Z",
+					"tokensUsed":  1234,
+					"source": map[string]any{
+						"type": "user", "value": "https://hook", "prompt": "check latency",
+						"chatId": "chat-1", "userId": "admin",
+					},
+					"agents": []map[string]any{{
+						"id": "agent-1", "name": "lead", "task": "investigate",
+						"finalMessage": "done", "status": "completed", "audience": "user",
+						"createdAt": "2026-07-01T10:00:00Z", "updatedAt": "2026-07-01T11:00:00Z",
+						"tokensPerSecondHistory": []float64{10.5, 12.0},
+						"tokenCounter":           int64(999),
+						"outputPreview":          "tail of output",
+					}},
+					"progress": map[string]any{
+						"pending": 1, "inProgress": 2, "completed": 3, "canceled": 4, "total": 10,
+					},
+					"completionQuality": "degraded",
+					"degradedReason":    "token budget exhausted",
+					"labels":            map[string]string{"env": "prod"},
+					"ownerUserId":       "owner-1",
+					"activeLoopCount":   2,
+				}},
+				"total": 1,
+			},
+		})
+	}))
+
+	out, err := client.ListLodestone(t.Context(), investigations.ListLodestoneOptions{})
+	require.NoError(t, err)
+	require.Len(t, out.Investigations, 1)
+	assert.Equal(t, int64(1), out.Total)
+
+	s := out.Investigations[0]
+	assert.Equal(t, "inv-1", s.ID)
+	assert.Equal(t, "High latency", s.Title)
+	assert.Equal(t, "p99 spiked", s.Description)
+	assert.Equal(t, "in_progress", s.State)
+	assert.Equal(t, "chat-1", s.ChatID)
+	assert.Equal(t, "lodestone", s.Variant)
+	assert.Equal(t, "2026-07-01T10:00:00Z", s.CreatedAt.Format(time.RFC3339))
+	assert.Equal(t, "2026-07-01T12:00:00Z", s.UpdatedAt.Format(time.RFC3339))
+	require.NotNil(t, s.TokensUsed)
+	assert.Equal(t, 1234, *s.TokensUsed)
+	require.NotNil(t, s.Source)
+	assert.Equal(t, investigations.LodestoneSource{
+		Type: "user", Value: "https://hook", Prompt: "check latency",
+		ChatID: "chat-1", UserID: "admin",
+	}, *s.Source)
+	require.Len(t, s.Agents, 1)
+	a := s.Agents[0]
+	assert.Equal(t, "agent-1", a.ID)
+	assert.Equal(t, "lead", a.Name)
+	assert.Equal(t, "investigate", a.Task)
+	require.NotNil(t, a.FinalMessage)
+	assert.Equal(t, "done", *a.FinalMessage)
+	assert.Equal(t, "completed", a.Status)
+	assert.Equal(t, "user", a.Audience)
+	assert.Equal(t, []float64{10.5, 12.0}, a.TokensPerSecondHistory)
+	require.NotNil(t, a.TokenCounter)
+	assert.Equal(t, int64(999), *a.TokenCounter)
+	require.NotNil(t, a.OutputPreview)
+	assert.Equal(t, "tail of output", *a.OutputPreview)
+	require.NotNil(t, s.Progress)
+	assert.Equal(t, investigations.LodestoneTodoProgress{
+		Pending: 1, InProgress: 2, Completed: 3, Canceled: 4, Total: 10,
+	}, *s.Progress)
+	require.NotNil(t, s.CompletionQuality)
+	assert.Equal(t, "degraded", *s.CompletionQuality)
+	require.NotNil(t, s.DegradedReason)
+	assert.Equal(t, "token budget exhausted", *s.DegradedReason)
+	assert.Equal(t, map[string]string{"env": "prod"}, s.Labels)
+	assert.Equal(t, "owner-1", s.OwnerUserID)
+	assert.Equal(t, 2, s.ActiveLoopCount)
 }
 
 func TestResolveByID(t *testing.T) {

--- a/internal/assistant/investigations/commands.go
+++ b/internal/assistant/investigations/commands.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/grafana/gcx/internal/assistant/assistanthttp"
 	"github.com/grafana/gcx/internal/deeplink"
@@ -208,7 +209,7 @@ func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 			if err := opts.validateForV2(); err != nil {
 				return err
 			}
-			summaries, err := client.ListLodestone(cmd.Context(), ListLodestoneOptions{
+			list, err := client.ListLodestone(cmd.Context(), ListLodestoneOptions{
 				State:         opts.State,
 				Q:             opts.Q,
 				Scope:         opts.Scope,
@@ -226,7 +227,7 @@ func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return opts.IO.Encode(cmd.OutOrStdout(), summaries)
+			return opts.IO.Encode(cmd.OutOrStdout(), list)
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -657,7 +658,8 @@ func newApprovalsCommand(loader *providers.ConfigLoader) *cobra.Command {
 
 // --- table codecs ---
 
-// ListTableCodec renders []InvestigationSummary as a table.
+// ListTableCodec renders []InvestigationSummary (v1) or *LodestoneList (v2)
+// as a table with the same columns for both API versions.
 type ListTableCodec struct {
 	Wide bool
 }
@@ -670,11 +672,6 @@ func (c *ListTableCodec) Format() format.Format {
 }
 
 func (c *ListTableCodec) Encode(w io.Writer, v any) error {
-	summaries, ok := v.([]InvestigationSummary)
-	if !ok {
-		return errors.New("invalid data type for table codec: expected []InvestigationSummary")
-	}
-
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
 	if c.Wide {
 		fmt.Fprintln(tw, "ID\tTITLE\tSTATUS\tCREATED BY\tCREATED\tUPDATED")
@@ -682,24 +679,41 @@ func (c *ListTableCodec) Encode(w io.Writer, v any) error {
 		fmt.Fprintln(tw, "ID\tTITLE\tSTATUS\tUPDATED")
 	}
 
-	for _, s := range summaries {
-		title := truncate(s.Title, 40)
-		updated := assistanthttp.FormatTime(s.UpdatedAt)
-
-		if c.Wide {
-			created := assistanthttp.FormatTime(s.CreatedAt)
+	switch list := v.(type) {
+	case []InvestigationSummary:
+		for _, s := range list {
 			createdBy := "-"
 			if s.Source != nil && s.Source.UserID != "" {
 				createdBy = s.Source.UserID
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-				s.ID, title, s.State, createdBy, created, updated)
-		} else {
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
-				s.ID, title, s.State, updated)
+			c.writeRow(tw, s.ID, s.Title, s.State, createdBy, s.CreatedAt, s.UpdatedAt)
 		}
+	case *LodestoneList:
+		for _, s := range list.Investigations {
+			createdBy := s.OwnerUserID
+			if s.Source != nil && s.Source.UserID != "" {
+				createdBy = s.Source.UserID
+			}
+			if createdBy == "" {
+				createdBy = "-"
+			}
+			c.writeRow(tw, s.ID, s.Title, s.State, createdBy, s.CreatedAt, s.UpdatedAt)
+		}
+	default:
+		return errors.New("invalid data type for table codec: expected []InvestigationSummary or *LodestoneList")
 	}
 	return tw.Flush()
+}
+
+func (c *ListTableCodec) writeRow(w io.Writer, id, title, state, createdBy string, createdAt, updatedAt time.Time) {
+	title = truncate(title, 40)
+	updated := assistanthttp.FormatTime(updatedAt)
+	if c.Wide {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			id, title, state, createdBy, assistanthttp.FormatTime(createdAt), updated)
+	} else {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", id, title, state, updated)
+	}
 }
 
 func (c *ListTableCodec) Decode(_ io.Reader, _ any) error {

--- a/internal/assistant/investigations/commands_test.go
+++ b/internal/assistant/investigations/commands_test.go
@@ -60,12 +60,57 @@ func TestListTableCodec_Encode(t *testing.T) {
 		codec := &investigations.ListTableCodec{}
 		err := codec.Encode(&bytes.Buffer{}, "wrong")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "expected []InvestigationSummary")
+		assert.Contains(t, err.Error(), "expected []InvestigationSummary or *LodestoneList")
 	})
 
 	t.Run("decode unsupported", func(t *testing.T) {
 		codec := &investigations.ListTableCodec{}
 		require.Error(t, codec.Decode(nil, nil))
+	})
+}
+
+func TestListTableCodec_EncodeLodestone(t *testing.T) {
+	list := &investigations.LodestoneList{
+		Investigations: []investigations.LodestoneInvestigationSummary{
+			{
+				ID:        "inv-1",
+				Title:     "High CPU investigation",
+				State:     "in_progress",
+				ChatID:    "chat-1",
+				Source:    &investigations.LodestoneSource{UserID: "admin"},
+				CreatedAt: time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC),
+			},
+			{
+				ID:          "inv-2",
+				State:       "completed",
+				OwnerUserID: "owner-2",
+			},
+		},
+		Total: 2,
+	}
+
+	t.Run("table", func(t *testing.T) {
+		codec := &investigations.ListTableCodec{}
+		var buf bytes.Buffer
+		require.NoError(t, codec.Encode(&buf, list))
+		out := buf.String()
+		assert.Contains(t, out, "ID")
+		assert.Contains(t, out, "STATUS")
+		assert.NotContains(t, out, "CREATED BY")
+		assert.Contains(t, out, "inv-1")
+		assert.Contains(t, out, "High CPU investigation")
+		assert.Contains(t, out, "inv-2")
+	})
+
+	t.Run("wide falls back to owner when source is absent", func(t *testing.T) {
+		codec := &investigations.ListTableCodec{Wide: true}
+		var buf bytes.Buffer
+		require.NoError(t, codec.Encode(&buf, list))
+		out := buf.String()
+		assert.Contains(t, out, "CREATED BY")
+		assert.Contains(t, out, "admin")   // inv-1: source.userId wins
+		assert.Contains(t, out, "owner-2") // inv-2: ownerUserId fallback
 	})
 }
 

--- a/internal/assistant/investigations/types_v2.go
+++ b/internal/assistant/investigations/types_v2.go
@@ -1,5 +1,7 @@
 package investigations
 
+import "time"
+
 // --- v2 (Lodestone) types ---
 //
 // Lodestone is the single-agent successor to the legacy investigations
@@ -37,6 +39,75 @@ type ListLodestoneOptions struct {
 	Offset        int
 	Label         string
 	IncludeLegacy bool
+}
+
+// LodestoneList is the collection envelope from GET /api/v2/investigations.
+// Total is the number of matching investigations across all pages, for
+// offset-based pagination.
+type LodestoneList struct {
+	Investigations []LodestoneInvestigationSummary `json:"investigations"`
+	Total          int64                           `json:"total"`
+}
+
+// LodestoneInvestigationSummary is a v2 list item. It mirrors the server's
+// summary shape field-for-field so no data is dropped from json/yaml output.
+// The deprecated `confidence` field (always null server-side) is omitted.
+type LodestoneInvestigationSummary struct {
+	ID          string    `json:"id"`
+	Title       string    `json:"title,omitempty"`
+	Description string    `json:"description,omitempty"`
+	State       string    `json:"state"`
+	ChatID      string    `json:"chatId,omitempty"`
+	Variant     string    `json:"variant,omitempty"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	// TokensUsed is the summed input+output+cache token count of the backing
+	// chat. Only populated for view=full.
+	TokensUsed        *int                   `json:"tokensUsed,omitempty"`
+	Source            *LodestoneSource       `json:"source,omitempty"`
+	Agents            []LodestoneAgent       `json:"agents,omitempty"`
+	Progress          *LodestoneTodoProgress `json:"progress,omitempty"`
+	CompletionQuality *string                `json:"completionQuality,omitempty"`
+	DegradedReason    *string                `json:"degradedReason,omitempty"`
+	Labels            map[string]string      `json:"labels,omitempty"`
+	OwnerUserID       string                 `json:"ownerUserId,omitempty"`
+	ActiveLoopCount   int                    `json:"activeLoopCount,omitempty"`
+}
+
+// LodestoneSource identifies what created an investigation
+// (type: url|user|assistant).
+type LodestoneSource struct {
+	Type   string `json:"type,omitempty"`
+	Value  string `json:"value,omitempty"`
+	Prompt string `json:"prompt,omitempty"`
+	ChatID string `json:"chatId,omitempty"`
+	UserID string `json:"userId,omitempty"`
+}
+
+// LodestoneAgent is per-agent progress data attached to a summary
+// (view=full only).
+type LodestoneAgent struct {
+	ID                     string    `json:"id"`
+	Name                   string    `json:"name,omitempty"`
+	Task                   string    `json:"task,omitempty"`
+	FinalMessage           *string   `json:"finalMessage,omitempty"`
+	Status                 string    `json:"status,omitempty"`
+	Audience               string    `json:"audience,omitempty"`
+	CreatedAt              string    `json:"createdAt,omitempty"`
+	UpdatedAt              string    `json:"updatedAt,omitempty"`
+	TokensPerSecondHistory []float64 `json:"tokensPerSecondHistory,omitempty"`
+	TokenCounter           *int64    `json:"tokenCounter,omitempty"`
+	OutputPreview          *string   `json:"outputPreview,omitempty"`
+}
+
+// LodestoneTodoProgress is the todo completion breakdown attached to a
+// summary (view=full only).
+type LodestoneTodoProgress struct {
+	Pending    int `json:"pending"`
+	InProgress int `json:"inProgress"`
+	Completed  int `json:"completed"`
+	Canceled   int `json:"canceled"`
+	Total      int `json:"total"`
 }
 
 // LodestoneState is the response from GET /investigations/lodestone/{chatId}/state.


### PR DESCRIPTION
## Summary

First slice of #997 (v2 create/read parity): make `gcx assistant investigations list` lossless on v2 stacks.

The v2 list endpoint returns rich summaries plus a collection `total`, but gcx decoded them into the v1 `InvestigationSummary` struct, silently dropping `chatId`, description, variant, labels, owner, active-loop count, token usage, completion quality, degradation reason, agent/progress data, and richer source metadata — including from `-o json`/`-o yaml`, since output is rendered from the typed value.

## Changes

- New `LodestoneList` envelope (`investigations` + `total`) and `LodestoneInvestigationSummary` mirroring the server's v2 summary shape field-for-field, with `LodestoneSource`, `LodestoneAgent`, and `LodestoneTodoProgress` supporting types.
- `ListLodestone` decodes into the new envelope; the `list` command encodes it directly, so json/yaml output now carries every server field plus the pagination `total`.
- `ListTableCodec` renders both API versions with the same columns; `wide` falls back to `ownerUserId` when `source.userId` is absent.
- The deprecated `confidence` field (always null server-side) is intentionally omitted.
- v1 list behavior and output shape are unchanged.

Note: json/yaml output for v2 list changes from a bare array to the `{investigations, total}` envelope — this is the intended shape to preserve `total`.

## Testing

- `TestListLodestone_LosslessSummary` pins the full v2 summary shape end-to-end through the HTTP decode.
- Codec tests cover the v2 envelope for table/wide, including the owner fallback.
- `GCX_AGENT_MODE=false mise run all` passes (lint, full test suite with race detection, build, docs); no reference-doc drift.

Part of #997 — remaining bullets (list input flags, chatId in get, profiles, evidence, wait ergonomics) will follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)