### PR TITLE
feat(telemetry): export usage events over OTLP in enabled mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ internal/
 ├── notifier/    Update notifications (skills + gcx version checks; XDG state, throttling, message rendering — wired into root PersistentPostRun)
 ├── skills/      Portable Agent Skills installer primitives (BundledSkillNames, Install, Update — extracted from cmd/gcx/skills)
 ├── strcase/     String case conversion (snake_case, kebab-case, PascalCase)
-├── telemetry/   Anonymous usage stats library (wide-event model, GCX_TELEMETRY/DO_NOT_TRACK mode resolution, device ID, CI detection; wired into the CLI lifecycle via cmd/gcx/root PersistentPreRun + cmd/gcx exitWith)
+├── telemetry/   Anonymous usage stats library (wide-event model, GCX_TELEMETRY/DO_NOT_TRACK mode resolution, device ID, CI detection, OTLP export to usage-stats; wired into the CLI lifecycle via cmd/gcx/root PersistentPreRun + cmd/gcx exitWith)
 ├── xdg/         XDG Base Directory paths (config home, state home, config dirs)
 └── shared/      Shared utilities (date handling, duration, etc.) to be shared across integrations.
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ internal/
 ├── notifier/    Update notifications (skills + gcx version checks; XDG state, throttling, message rendering — wired into root PersistentPostRun)
 ├── skills/      Portable Agent Skills installer primitives (BundledSkillNames, Install, Update — extracted from cmd/gcx/skills)
 ├── strcase/     String case conversion (snake_case, kebab-case, PascalCase)
-├── telemetry/   Anonymous usage stats library (wide-event model, GCX_TELEMETRY/DO_NOT_TRACK mode resolution, device ID, CI detection, OTLP export to usage-stats; wired into the CLI lifecycle via cmd/gcx/root PersistentPreRun + cmd/gcx exitWith)
+├── telemetry/   Anonymous usage stats library (wide-event model, device ID, CI detection, OTLP export to usage-stats; wired into the CLI lifecycle via cmd/gcx/root PersistentPreRun + cmd/gcx exitWith)
 ├── xdg/         XDG Base Directory paths (config home, state home, config dirs)
 └── shared/      Shared utilities (date handling, duration, etc.) to be shared across integrations.
 ```

--- a/cmd/gcx/telemetry.go
+++ b/cmd/gcx/telemetry.go
@@ -40,14 +40,13 @@ func emitUsageEvent(cmd *cobra.Command, start time.Time, exitCode int) {
 		return
 	}
 
-	mode := telemetry.ResolveMode(diagnosticsTelemetryValue)
-	if mode != telemetry.ModeLog {
-		// TODO: We'll handle ModeEnabled in a followup PR
-		return
-	}
-
-	if data, err := json.Marshal(buildUsageEvent(info, start, exitCode)); err == nil {
-		fmt.Fprintln(os.Stderr, string(data))
+	switch telemetry.ResolveMode(diagnosticsTelemetryValue) {
+	case telemetry.ModeLog:
+		if data, err := json.Marshal(buildUsageEvent(info, start, exitCode)); err == nil {
+			fmt.Fprintln(os.Stderr, string(data))
+		}
+	case telemetry.ModeEnabled:
+		telemetry.Export(buildUsageEvent(info, start, exitCode), start)
 	}
 }
 
@@ -68,8 +67,8 @@ func buildUsageEvent(info *root.TelemetryInfo, start time.Time, exitCode int) te
 		IsAgent: agent.IsAgentMode(),
 		Agent:   agent.Name(),
 		// TargetKind needs the resolved config context; resolving it requires
-		// a keychain-free context loader, which lands with the OTLP export
-		// stage. Empty until then.
+		// a keychain-free context loader, which is still a follow-up. Empty
+		// until then.
 	}
 
 	// The provider is the top-level command, the first segment of the path.

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -105,7 +105,7 @@ gcx/
 │   ├── secrets/              # Redaction of sensitive config fields
 │   ├── skills/               # Portable Agent Skills installer primitives (Install, Update, Bundled/InstalledBundledSkillNames)
 │   ├── strcase/              # String case conversion (snake_case, kebab-case, PascalCase)
-│   ├── telemetry/            # Anonymous usage stats library (event model, mode resolution, device ID, CI detection)
+│   ├── telemetry/            # Anonymous usage stats library (event model, mode resolution, device ID, CI detection, OTLP export)
 │   ├── terminal/             # TTY detection: IsPiped(), NoTruncate(), Detect()
 │   ├── testutils/            # Shared test helpers (not exposed externally)
 │   ├── resources/            # Core resource abstraction layer

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -26,8 +26,7 @@ nothing). Takes precedence over DO_NOT_TRACK and the
 
 ## `GCX_TELEMETRY_ENDPOINT`
 
-Endpoint overrides the URL usage telemetry is sent to, for pointing
-test builds at a non-production receiver.
+Endpoint overrides the URL usage telemetry is sent to.
 
 ## `GRAFANA_CLOUD_API_URL`
 

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -24,6 +24,11 @@ Telemetry controls anonymous usage telemetry for this invocation:
 nothing). Takes precedence over DO_NOT_TRACK and the
 `diagnostics.telemetry` config field.
 
+## `GCX_TELEMETRY_ENDPOINT`
+
+Endpoint overrides the URL usage telemetry is sent to, for pointing
+test builds at a non-production receiver.
+
 ## `GRAFANA_CLOUD_API_URL`
 
 APIUrl is the base URL for all Grafana Cloud API (GCOM) resource calls

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/common v0.69.0
 	github.com/zalando/go-keyring v0.2.8
+	go.opentelemetry.io/proto/otlp v1.10.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -448,6 +448,8 @@ go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYr
 go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
+go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
+go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/internal/telemetry/otlp.go
+++ b/internal/telemetry/otlp.go
@@ -113,9 +113,8 @@ func spanAttributes(event Event) []*commonpb.KeyValue {
 		{"parse_error_flags", event.ParseErrorFlags},
 		{"parse_error_nearest", event.ParseErrorNearest},
 	} {
-		key, value := kv.key, kv.value
-		if value != "" {
-			attrs = append(attrs, stringAttr(key, value))
+		if kv.value != "" {
+			attrs = append(attrs, stringAttr(kv.key, kv.value))
 		}
 	}
 	if event.ParseErrorDistance != 0 {

--- a/internal/telemetry/otlp.go
+++ b/internal/telemetry/otlp.go
@@ -28,9 +28,10 @@ const exportTimeout = time.Second
 // It never reports failure: telemetry is fire-and-forget and must not affect
 // the command's outcome. No retries — a lost event is fine.
 func Export(event Event, start time.Time) {
-	endpoint := os.Getenv(envEndpoint)
-	if endpoint == "" {
-		endpoint = defaultEndpoint
+	endpoint := defaultEndpoint
+	override := os.Getenv(envEndpoint)
+	if override != "" {
+		endpoint = override
 	}
 	export(event, start, endpoint)
 }
@@ -53,12 +54,10 @@ func export(event Event, start time.Time, endpoint string) {
 	_ = resp.Body.Close()
 }
 
-// encodeTracesData lays the event out on the wire as the receiver expects:
-// exactly one root span whose resource carries the envelope fields and whose
-// attributes carry the event fields; the span start/end times carry the
-// duration. TracesData is wire-identical to the OTLP/HTTP
-// ExportTraceServiceRequest, without importing the collector packages (whose
-// generated code depends on grpc).
+// encodeTracesData writes the vent into a trace structure. The usage-stats
+// receiver expects one root span. Use TracesData instead of
+// ExportTraceServiceRequest in otlp/collector/trace/v1 to save import package
+// weight (it saves about 6MB).
 func encodeTracesData(event Event, start time.Time) *tracepb.TracesData {
 	end := start.Add(time.Duration(event.DurationMS) * time.Millisecond)
 	span := &tracepb.Span{

--- a/internal/telemetry/otlp.go
+++ b/internal/telemetry/otlp.go
@@ -1,0 +1,145 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// defaultEndpoint is the usage-stats OTLP receiver. GCX_TELEMETRY_ENDPOINT
+// overrides it, for pointing test builds at a dev deployment.
+const defaultEndpoint = "https://stats.grafana.org/v1/traces"
+
+// exportTimeout caps the whole export request. Telemetry must never
+// noticeably delay CLI exit, so this is deliberately tight: the payload is a
+// single tiny span and the receiver replies before doing any work.
+const exportTimeout = time.Second
+
+// Export sends the event to the usage-stats receiver as one OTLP root span.
+// It never reports failure: telemetry is fire-and-forget and must not affect
+// the command's outcome. No retries — a lost event is fine.
+func Export(event Event, start time.Time) {
+	endpoint := os.Getenv(envEndpoint)
+	if endpoint == "" {
+		endpoint = defaultEndpoint
+	}
+	export(event, start, endpoint)
+}
+
+func export(event Event, start time.Time, endpoint string) {
+	body, err := proto.Marshal(encodeTracesData(event, start))
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	client := &http.Client{Timeout: exportTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+// encodeTracesData lays the event out on the wire as the receiver expects:
+// exactly one root span whose resource carries the envelope fields and whose
+// attributes carry the event fields; the span start/end times carry the
+// duration. TracesData is wire-identical to the OTLP/HTTP
+// ExportTraceServiceRequest, without importing the collector packages (whose
+// generated code depends on grpc).
+func encodeTracesData(event Event, start time.Time) *tracepb.TracesData {
+	end := start.Add(time.Duration(event.DurationMS) * time.Millisecond)
+	span := &tracepb.Span{
+		TraceId:           randomID(16),
+		SpanId:            randomID(8),
+		Name:              strings.TrimSpace(ServiceName + " " + event.Command),
+		StartTimeUnixNano: uint64(start.UnixNano()),
+		EndTimeUnixNano:   uint64(end.UnixNano()),
+		Attributes:        spanAttributes(event),
+	}
+	return &tracepb.TracesData{
+		ResourceSpans: []*tracepb.ResourceSpans{{
+			Resource: &resourcepb.Resource{
+				Attributes: []*commonpb.KeyValue{
+					stringAttr("service.name", event.Service),
+					stringAttr("service.version", event.Version),
+					stringAttr("os.type", event.OS),
+					stringAttr("host.arch", event.Arch),
+				},
+			},
+			ScopeSpans: []*tracepb.ScopeSpans{{Spans: []*tracepb.Span{span}}},
+		}},
+	}
+}
+
+// spanAttributes flattens the event fields into span attributes, mirroring
+// the JSON encoding: parse_error_* fields travel only when set, matching
+// their omitempty tags.
+func spanAttributes(event Event) []*commonpb.KeyValue {
+	attrs := []*commonpb.KeyValue{
+		stringAttr("device_id", event.DeviceID),
+		boolAttr("device_id_persisted", event.DeviceIDPersisted),
+		stringAttr("command", event.Command),
+		stringAttr("flags", event.Flags),
+		stringAttr("provider", event.Provider),
+		stringAttr("outcome", event.Outcome),
+		intAttr("exit_code", int64(event.ExitCode)),
+		stringAttr("error_kind", event.ErrorKind),
+		boolAttr("is_tty", event.IsTTY),
+		boolAttr("is_ci", event.IsCI),
+		stringAttr("ci_provider", event.CIProvider),
+		boolAttr("is_agent", event.IsAgent),
+		stringAttr("agent", event.Agent),
+		stringAttr("target_kind", event.TargetKind),
+		stringAttr("output_format", event.OutputFormat),
+	}
+	for _, kv := range []struct{ key, value string }{
+		{"parse_error_kind", event.ParseErrorKind},
+		{"parse_error_parent", event.ParseErrorParent},
+		{"parse_error_token", event.ParseErrorToken},
+		{"attempted_command", event.AttemptedCommand},
+		{"parse_error_flags", event.ParseErrorFlags},
+		{"parse_error_nearest", event.ParseErrorNearest},
+	} {
+		key, value := kv.key, kv.value
+		if value != "" {
+			attrs = append(attrs, stringAttr(key, value))
+		}
+	}
+	if event.ParseErrorDistance != 0 {
+		attrs = append(attrs, intAttr("parse_error_distance", int64(event.ParseErrorDistance)))
+	}
+	return attrs
+}
+
+// randomID returns n random bytes for a trace or span ID. The IDs only need
+// to be unique-ish; they correlate nothing, by design.
+func randomID(n int) []byte {
+	id := make([]byte, n)
+	_, _ = rand.Read(id)
+	return id
+}
+
+func stringAttr(key, value string) *commonpb.KeyValue {
+	return &commonpb.KeyValue{Key: key, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: value}}}
+}
+
+func boolAttr(key string, value bool) *commonpb.KeyValue {
+	return &commonpb.KeyValue{Key: key, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_BoolValue{BoolValue: value}}}
+}
+
+func intAttr(key string, value int64) *commonpb.KeyValue {
+	return &commonpb.KeyValue{Key: key, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: value}}}
+}

--- a/internal/telemetry/otlp.go
+++ b/internal/telemetry/otlp.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/gcx/internal/httputils"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
@@ -26,7 +27,8 @@ const exportTimeout = time.Second
 
 // Export sends the event to the usage-stats receiver as one OTLP root span.
 // It never reports failure: telemetry is fire-and-forget and must not affect
-// the command's outcome. No retries — a lost event is fine.
+// the command's outcome. A lost event is fine — the shared client may retry
+// transient failures, but exportTimeout caps the whole exchange.
 func Export(event Event, start time.Time) {
 	endpoint := defaultEndpoint
 	override := os.Getenv(envEndpoint)
@@ -46,7 +48,7 @@ func export(event Event, start time.Time, endpoint string) {
 		return
 	}
 	req.Header.Set("Content-Type", "application/x-protobuf")
-	client := &http.Client{Timeout: exportTimeout}
+	client := httputils.NewClient(httputils.ClientOpts{Timeout: exportTimeout})
 	resp, err := client.Do(req)
 	if err != nil {
 		return
@@ -54,7 +56,7 @@ func export(event Event, start time.Time, endpoint string) {
 	_ = resp.Body.Close()
 }
 
-// encodeTracesData writes the vent into a trace structure. The usage-stats
+// encodeTracesData writes the event into a trace structure. The usage-stats
 // receiver expects one root span. Use TracesData instead of
 // ExportTraceServiceRequest in otlp/collector/trace/v1 to save import package
 // weight (it saves about 6MB).

--- a/internal/telemetry/otlp_internal_test.go
+++ b/internal/telemetry/otlp_internal_test.go
@@ -1,0 +1,179 @@
+package telemetry
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func testEvent() Event {
+	return Event{
+		Service:           ServiceName,
+		Version:           "v1.2.3",
+		OS:                "darwin",
+		Arch:              "arm64",
+		DeviceID:          "36d988e3-971e-4566-b0ca-7416f85b0da2",
+		DeviceIDPersisted: true,
+		Command:           "dashboards list",
+		Flags:             "output",
+		Provider:          "dashboards",
+		Outcome:           OutcomeOK,
+		ExitCode:          0,
+		DurationMS:        1059,
+		IsTTY:             true,
+		OutputFormat:      "table",
+	}
+}
+
+// The event must round-trip the wire: what the receiver decodes from our
+// marshalled bytes is field-for-field what the log mode would have printed.
+func TestEncodeTracesDataRoundTrip(t *testing.T) {
+	event := testEvent()
+	start := time.Now()
+
+	body, err := proto.Marshal(encodeTracesData(event, start))
+	require.NoError(t, err)
+
+	decoded := &tracepb.TracesData{}
+	require.NoError(t, proto.Unmarshal(body, decoded))
+
+	require.Len(t, decoded.GetResourceSpans(), 1)
+	rs := decoded.GetResourceSpans()[0]
+	assert.Equal(t, map[string]any{
+		"service.name":    ServiceName,
+		"service.version": "v1.2.3",
+		"os.type":         "darwin",
+		"host.arch":       "arm64",
+	}, attrValues(t, rs.GetResource().GetAttributes()))
+
+	require.Len(t, rs.GetScopeSpans(), 1)
+	require.Len(t, rs.GetScopeSpans()[0].GetSpans(), 1)
+	span := rs.GetScopeSpans()[0].GetSpans()[0]
+
+	assert.Len(t, span.GetTraceId(), 16)
+	assert.Len(t, span.GetSpanId(), 8)
+	assert.Equal(t, "gcx dashboards list", span.GetName())
+	// The receiver derives duration_ms from the span timestamps; they must
+	// reproduce the event's DurationMS exactly.
+	assert.Equal(t, uint64(start.UnixNano()), span.GetStartTimeUnixNano())
+	end := start.Add(time.Duration(event.DurationMS) * time.Millisecond)
+	assert.Equal(t, uint64(end.UnixNano()), span.GetEndTimeUnixNano())
+
+	assert.Equal(t, map[string]any{
+		"device_id":           event.DeviceID,
+		"device_id_persisted": true,
+		"command":             "dashboards list",
+		"flags":               "output",
+		"provider":            "dashboards",
+		"outcome":             OutcomeOK,
+		"exit_code":           int64(0),
+		"error_kind":          "",
+		"is_tty":              true,
+		"is_ci":               false,
+		"ci_provider":         "",
+		"is_agent":            false,
+		"agent":               "",
+		"target_kind":         "",
+		"output_format":       "table",
+	}, attrValues(t, span.GetAttributes()))
+}
+
+// parse_error_* attributes mirror the JSON omitempty tags: absent unless set,
+// with distance -1 ("no near match") surviving.
+func TestEncodeTracesDataParseErrorAttributes(t *testing.T) {
+	event := testEvent()
+	attrs := attrValues(t, spanAttributes(event))
+	for _, key := range []string{
+		"parse_error_kind", "parse_error_parent", "parse_error_token",
+		"attempted_command", "parse_error_flags", "parse_error_nearest",
+		"parse_error_distance",
+	} {
+		assert.NotContains(t, attrs, key)
+	}
+
+	event.ParseErrorKind = "unknown_command"
+	event.ParseErrorToken = "<redacted>"
+	event.ParseErrorDistance = -1
+	attrs = attrValues(t, spanAttributes(event))
+	assert.Equal(t, "unknown_command", attrs["parse_error_kind"])
+	assert.Equal(t, "<redacted>", attrs["parse_error_token"])
+	assert.Equal(t, int64(-1), attrs["parse_error_distance"])
+}
+
+func TestExportPostsProtobufToEndpointOverride(t *testing.T) {
+	requests := make(chan *http.Request, 1)
+	bodies := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests <- r
+		bodies <- body
+	}))
+	defer server.Close()
+	t.Setenv(envEndpoint, server.URL)
+
+	Export(testEvent(), time.Now())
+
+	select {
+	case r := <-requests:
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/x-protobuf", r.Header.Get("Content-Type"))
+	case <-time.After(5 * time.Second):
+		t.Fatal("no request received")
+	}
+	decoded := &tracepb.TracesData{}
+	require.NoError(t, proto.Unmarshal(<-bodies, decoded))
+	require.Len(t, decoded.GetResourceSpans(), 1)
+}
+
+// Export must never fail loudly, however broken the endpoint.
+func TestExportSwallowsFailures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Setenv(envEndpoint, server.URL)
+	Export(testEvent(), time.Now())
+
+	server.Close()
+	Export(testEvent(), time.Now())
+
+	t.Setenv(envEndpoint, "://not a url")
+	Export(testEvent(), time.Now())
+}
+
+// The exporter deliberately uses only the OTLP message packages; the
+// collector packages would pull google.golang.org/grpc into a build that has
+// none. TracesData is wire-identical to ExportTraceServiceRequest, so
+// nothing is lost.
+func TestGrpcStaysOutOfGoMod(t *testing.T) {
+	gomod, err := os.ReadFile("../../go.mod")
+	require.NoError(t, err)
+	assert.NotContains(t, string(gomod), "google.golang.org/grpc")
+}
+
+func attrValues(t *testing.T, kvs []*commonpb.KeyValue) map[string]any {
+	t.Helper()
+	m := make(map[string]any, len(kvs))
+	for _, kv := range kvs {
+		require.NotContains(t, m, kv.GetKey(), "duplicate attribute key")
+		switch v := kv.GetValue().GetValue().(type) {
+		case *commonpb.AnyValue_StringValue:
+			m[kv.GetKey()] = v.StringValue
+		case *commonpb.AnyValue_BoolValue:
+			m[kv.GetKey()] = v.BoolValue
+		case *commonpb.AnyValue_IntValue:
+			m[kv.GetKey()] = v.IntValue
+		default:
+			t.Fatalf("unexpected attribute type for %q", kv.GetKey())
+		}
+	}
+	return m
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -43,6 +43,10 @@ type Env struct {
 	// "true" (cross-tool DO_NOT_TRACK convention). Overridden by
 	// GCX_TELEMETRY.
 	DoNotTrack string `env:"DO_NOT_TRACK"`
+
+	// Endpoint overrides the URL usage telemetry is sent to, for pointing
+	// test builds at a non-production receiver.
+	Endpoint string `env:"GCX_TELEMETRY_ENDPOINT"`
 }
 
 // ResolveMode resolves the telemetry mode for this invocation. Precedence,
@@ -54,12 +58,13 @@ func ResolveMode(configValue func() string) Mode {
 	return resolveMode(os.Getenv, configValue)
 }
 
-// Env var names used by resolveMode. envConsistencyTest asserts they match
+// Env var names read by this package. envConsistencyTest asserts they match
 // the Env struct tags the docs generator reads, so the documented names
 // cannot drift from the resolved ones.
 const (
 	envTelemetry  = "GCX_TELEMETRY"
 	envDoNotTrack = "DO_NOT_TRACK"
+	envEndpoint   = "GCX_TELEMETRY_ENDPOINT"
 )
 
 func resolveMode(getenv func(string) string, configValue func() string) Mode {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -44,8 +44,7 @@ type Env struct {
 	// GCX_TELEMETRY.
 	DoNotTrack string `env:"DO_NOT_TRACK"`
 
-	// Endpoint overrides the URL usage telemetry is sent to, for pointing
-	// test builds at a non-production receiver.
+	// Endpoint overrides the URL usage telemetry is sent to.
 	Endpoint string `env:"GCX_TELEMETRY_ENDPOINT"`
 }
 

--- a/internal/telemetry/telemetry_internal_test.go
+++ b/internal/telemetry/telemetry_internal_test.go
@@ -94,7 +94,7 @@ func TestResolveMode(t *testing.T) {
 	}
 }
 
-// The Env struct tags are what the docs generator publishes; resolveMode
+// The Env struct tags are what the docs generator publishes; the package
 // reads the constants. If they drift, the docs advertise a variable that
 // does nothing while the real one is undocumented.
 func TestEnvTagsMatchResolvedNames(t *testing.T) {
@@ -106,5 +106,6 @@ func TestEnvTagsMatchResolvedNames(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"Telemetry":  envTelemetry,
 		"DoNotTrack": envDoNotTrack,
+		"Endpoint":   envEndpoint,
 	}, tags)
 }


### PR DESCRIPTION
Part of https://github.com/grafana/gcx-internal/issues/2, follow on from #978. 

## Summary

- `GCX_TELEMETRY=enabled` now exports the usage event to the usage-stats receiver as an OTLP/HTTP trace: one root span per invocation, encoded as protobuf. It posts to `https://stats.grafana.org/v1/traces` by default.
- hand-rolled `TracesData` construction, to avoid heavy imports for minimal benefit: the only new dependency is the OTLP proto message package.
- 1s timeout on export, with all errors ignored. telemetry should not cause an error or noticeably slow the CLI. We can delegate the export to another process if its obviously too slow.
- `GCX_TELEMETRY_ENDPOINT` overrides the export endpoint, documented in the env-var reference
- default mode remains disabled until the receiving endpoint is ready.

Not included:  we still dont have `target_kind` (needs the keychain-free context loader) and parse-failure events (#578).