### PR TITLE
feat(profiles)!: rename profile-types to list-profile-types at both mounts

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -123,10 +123,14 @@ agent mode detection, behavior changes, and opt-out mechanisms.
   does not obey standard list/get/create/update/delete semantics (e.g.,
   composite keys, scope-required lookups, query-only endpoints), do not
   register it as an adapter. Keep it in the provider command tree only, but
-  use alternative verbs (`show`, `describe`, `search`) — never `get`, `list`,
-  `create`, `update`, `delete`. This avoids user confusion: adapter verbs
-  (`resources get`) and provider verbs should not overlap for resources that
-  behave differently across the two paths.
+  use alternative verbs (`show`, `describe`, `search`) or an
+  `<operation>-<subject>` compound that honestly describes the behavior
+  (e.g. `list-profile-types`, `list-tables` for commands that genuinely
+  enumerate a collection) — never bare `get`, `list`, `create`, `update`,
+  `delete`. This avoids user confusion: adapter verbs (`resources get`) and
+  provider verbs should not overlap for resources that behave differently
+  across the two paths; a compound such as `list-profile-types` does not
+  collide with any adapter verb.
 - **Sub-resources nest under their parent command.** If a resource cannot
   be listed or addressed without a parent ID (e.g. alerts require an
   alert group), it is a sub-resource. Sub-resources must not be registered as standalone typed

--- a/claude-plugin/skills/create-dashboard/SKILL.md
+++ b/claude-plugin/skills/create-dashboard/SKILL.md
@@ -127,7 +127,7 @@ gcx datasources list -o json
 | Prometheus | `gcx datasources prometheus labels -d <uid> --label __name__` | `gcx datasources prometheus labels -d <uid> --label <label>` |
 | Loki | `gcx datasources loki labels -d <uid>` | `gcx datasources loki labels -d <uid> --label <label>` |
 | Tempo | `gcx datasources tempo labels -d <uid>` | `gcx datasources tempo labels -d <uid> -l <attr> --llm -o json [--scope span\|resource] [-q '<traceql>']` |
-| Pyroscope | `gcx datasources pyroscope profile-types -d <uid>` then `labels -d <uid>` | `gcx datasources pyroscope labels -d <uid> --label <label>` |
+| Pyroscope | `gcx datasources pyroscope list-profile-types -d <uid>` then `labels -d <uid>` | `gcx datasources pyroscope labels -d <uid> --label <label>` |
 
 Prometheus also has `gcx datasources prometheus metadata -d <uid>` for metric type and help text.
 For Prometheus scoped label lookups, fall back to `gcx api "/api/datasources/proxy/uid/<uid>/api/v1/label/<label>/values?match[]=<selector>"` — use the datasource `uid` from `gcx datasources list`; the list output has no numeric id.

--- a/claude-plugin/skills/manage-dashboards/SKILL.md
+++ b/claude-plugin/skills/manage-dashboards/SKILL.md
@@ -76,7 +76,7 @@ Use JSON/YAML for programmatic work and table/wide output for human summaries.
 | Loki label values | `gcx datasources loki labels -d <uid> --label <label>` |
 | Tempo attribute names | `gcx datasources tempo labels -d <uid>` |
 | Tempo attribute values | `gcx datasources tempo labels -d <uid> -l resource.service.name --llm -o json` |
-| Pyroscope profile types | `gcx datasources pyroscope profile-types -d <uid>` |
+| Pyroscope profile types | `gcx datasources pyroscope list-profile-types -d <uid>` |
 | Pyroscope label values | `gcx datasources pyroscope labels -d <uid> --label service_name` |
 | Other datasource types | Check `gcx datasources <type> --help` for dedicated subcommands before using `gcx api` |
 | List dashboards | `gcx dashboards list -o wide` |

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -435,7 +435,7 @@ func queryErrorHelpCommand(apiErr *queryerror.APIError) string {
 		case "query":
 			return "gcx profiles query --help"
 		case "profile types query":
-			return "gcx profiles profile-types --help"
+			return "gcx profiles list-profile-types --help"
 		case "label names query", "label values query":
 			return "gcx profiles labels --help"
 		case "series query":

--- a/cmd/gcx/root/command_test.go
+++ b/cmd/gcx/root/command_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	claudeplugin "github.com/grafana/gcx/claude-plugin"
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/cmd/gcx/root"
 	"github.com/grafana/gcx/internal/agent"
 	internalconfig "github.com/grafana/gcx/internal/config"
@@ -161,6 +162,29 @@ func TestValidateArgs_NestedGroupRejectsUnexpectedArgs(t *testing.T) {
 	require.ErrorContains(t, err, "Available Commands:")
 	require.ErrorContains(t, err, "show")
 	require.ErrorContains(t, err, "versions")
+}
+
+func TestValidateArgs_UnknownCommandIncludesSuggestForHint(t *testing.T) {
+	listProfileTypesCmd := &cobra.Command{
+		Use:        "list-profile-types",
+		SuggestFor: []string{"profile-types"},
+		Short:      "List available profile types.",
+		RunE:       func(_ *cobra.Command, _ []string) error { return nil },
+	}
+	profilesCmd := &cobra.Command{Use: "profiles", Short: "Query profiles."}
+	profilesCmd.AddCommand(listProfileTypesCmd)
+
+	rootCmd := root.NewCommandForTest("v0.0.0-test", []providers.Provider{
+		&mockProvider{name: "profiles", commands: []*cobra.Command{profilesCmd}},
+	})
+
+	err := root.ValidateArgs(rootCmd, []string{"profiles", "profile-types"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, `unknown command "profile-types" for "gcx profiles"`)
+
+	var usageErr *fail.UsageError
+	require.ErrorAs(t, err, &usageErr)
+	assert.Contains(t, usageErr.Suggestions, "Did you mean 'gcx profiles list-profile-types'?")
 }
 
 func TestValidateArgs_AllowsHelpAndCompletionCommands(t *testing.T) {

--- a/cmd/gcx/root/validation.go
+++ b/cmd/gcx/root/validation.go
@@ -57,6 +57,9 @@ func ValidateArgs(rootCmd *cobra.Command, args []string) error {
 	commandPath := strings.TrimSpace(cmd.CommandPath())
 	suggestions := []string{}
 	if commandPath != "" {
+		for _, name := range cmd.SuggestionsFor(positionals[0]) {
+			suggestions = append(suggestions, fmt.Sprintf("Did you mean '%s %s'?", commandPath, name))
+		}
 		suggestions = append(suggestions, fmt.Sprintf("Run '%s --help' for full usage and examples", commandPath))
 	}
 
@@ -102,11 +105,17 @@ func formatUnknownGroupCommand(cmd *cobra.Command, unknown string) string {
 	if cmd.HasAvailableSubCommands() {
 		fmt.Fprintln(&b)
 		fmt.Fprintln(&b, "Available Commands:")
+		width := 16
+		for _, sub := range cmd.Commands() {
+			if sub.IsAvailableCommand() && sub.Name() != "help" && len(sub.Name()) > width {
+				width = len(sub.Name())
+			}
+		}
 		for _, sub := range cmd.Commands() {
 			if !sub.IsAvailableCommand() || sub.Name() == "help" {
 				continue
 			}
-			fmt.Fprintf(&b, "  %-16s %s\n", sub.Name(), sub.Short)
+			fmt.Fprintf(&b, "  %-*s %s\n", width, sub.Name(), sub.Short)
 		}
 	}
 

--- a/docs/adrs/signal-provider-ux/001-cross-signal-command-consistency.md
+++ b/docs/adrs/signal-provider-ux/001-cross-signal-command-consistency.md
@@ -66,14 +66,14 @@ operation, and a `metrics` command where the backend supports a distinct
 time-series-over-time query with a different response shape:
 
 ```
-gcx metrics                       gcx logs                        gcx profiles                    gcx traces
-+-- query EXPR      (-d)          +-- query EXPR      (-d)        +-- query EXPR      (-d)        +-- query TRACEQL      (-d)
-|                                 +-- metrics EXPR    (-d)        +-- metrics EXPR    (-d)        |   (also: search)
-+-- labels          (-d)          +-- labels          (-d)        +-- labels          (-d)        +-- metrics TRACEQL    (-d)
-+-- metadata        (-d)          +-- series          (-d)        +-- profile-types   (-d)        +-- labels             (-d)
-|                                 |                               |                               |   (also: tags)
-'-- adaptive/                     '-- adaptive/                   '-- adaptive (stub)             +-- get TRACE_ID       (-d)
-                                                                                                  '-- adaptive/
+gcx metrics                       gcx logs                        gcx profiles                       gcx traces
++-- query EXPR      (-d)          +-- query EXPR      (-d)        +-- query EXPR         (-d)        +-- query TRACEQL      (-d)
+|                                 +-- metrics EXPR    (-d)        +-- metrics EXPR       (-d)        |   (also: search)
++-- labels          (-d)          +-- labels          (-d)        +-- labels             (-d)        +-- metrics TRACEQL    (-d)
++-- metadata        (-d)          +-- series          (-d)        +-- list-profile-types (-d)        +-- labels             (-d)
+|                                 |                               |                                  |   (also: tags)
+'-- adaptive/                     '-- adaptive/                   '-- adaptive (stub)                +-- get TRACE_ID       (-d)
+                                                                                                     '-- adaptive/
 ```
 
 `metrics query` keeps a single command because Prometheus instant vs range is

--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -84,7 +84,7 @@ gcx (root)
 ├── profiles                 [internal/providers/profiles/provider.go] (registered via providers.Register)
 │   ├── query                [DATASOURCE_UID] EXPR --profile-type TYPE [--from] [--to] [--since] [--max-nodes] [--profile-id UUID]... [--span-id ID]... [--trace-id ID]... [--stacktrace-selector FN]... [-o]
 │   ├── labels               [--datasource/-d UID] [--label/-l NAME]
-│   ├── profile-types        [--datasource/-d UID]
+│   ├── list-profile-types   [--datasource/-d UID]
 │   ├── series               [DATASOURCE_UID] EXPR --profile-type TYPE [--top] [--group-by] [--limit]
 │   └── adaptive             (stub — "not yet available")
 │

--- a/docs/reference/cli/gcx_datasources_pyroscope.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope.md
@@ -25,7 +25,7 @@ Query Pyroscope datasources
 * [gcx datasources](gcx_datasources.md)	 - Manage and query Grafana datasources
 * [gcx datasources pyroscope exemplars](gcx_datasources_pyroscope_exemplars.md)	 - Query profile or span exemplars from a Pyroscope datasource
 * [gcx datasources pyroscope labels](gcx_datasources_pyroscope_labels.md)	 - List labels or label values
+* [gcx datasources pyroscope list-profile-types](gcx_datasources_pyroscope_list-profile-types.md)	 - List available profile types
 * [gcx datasources pyroscope metrics](gcx_datasources_pyroscope_metrics.md)	 - Query profile time-series data from a Pyroscope datasource
-* [gcx datasources pyroscope profile-types](gcx_datasources_pyroscope_profile-types.md)	 - List available profile types
 * [gcx datasources pyroscope query](gcx_datasources_pyroscope_query.md)	 - Execute a profiling query against a Pyroscope datasource
 

--- a/docs/reference/cli/gcx_datasources_pyroscope_list-profile-types.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_list-profile-types.md
@@ -1,4 +1,4 @@
-## gcx datasources pyroscope profile-types
+## gcx datasources pyroscope list-profile-types
 
 List available profile types
 
@@ -6,8 +6,10 @@ List available profile types
 
 List available profile types from a Pyroscope datasource.
 
+If gcx auto-discovers the datasource from your Grafana Cloud stack, the discovered datasource UID may be saved to your gcx configuration for future commands.
+
 ```
-gcx datasources pyroscope profile-types [flags]
+gcx datasources pyroscope list-profile-types [flags]
 ```
 
 ### Examples
@@ -15,17 +17,17 @@ gcx datasources pyroscope profile-types [flags]
 ```
 
 	# List profile types (use datasource UID, not name)
-	gcx datasources pyroscope profile-types -d UID
+	gcx datasources pyroscope list-profile-types -d UID
 
 	# Output as JSON
-	gcx datasources pyroscope profile-types -d UID -o json
+	gcx datasources pyroscope list-profile-types -d UID -o json
 ```
 
 ### Options
 
 ```
   -d, --datasource string   Datasource UID (required unless default-pyroscope-datasource is configured)
-  -h, --help                help for profile-types
+  -h, --help                help for list-profile-types
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")

--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -75,7 +75,7 @@ gcx datasources pyroscope query [EXPR] [flags]
       --pprof-overwrite               Overwrite the output file if it already exists (only with -o pprof)
       --pprof-path string             Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)
-      --profile-type string           Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
+      --profile-type string           Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles list-profile-types' to list available (required)
       --since string                  Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --span-id strings               Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)
       --stacktrace-selector strings   Only query locations with these function names, starting from the root (repeatable)

--- a/docs/reference/cli/gcx_profiles.md
+++ b/docs/reference/cli/gcx_profiles.md
@@ -26,7 +26,7 @@ Query Pyroscope datasources and manage continuous profiling
 * [gcx profiles adaptive](gcx_profiles_adaptive.md)	 - Manage Adaptive Profiles (not yet available)
 * [gcx profiles exemplars](gcx_profiles_exemplars.md)	 - Query profile or span exemplars from a Pyroscope datasource
 * [gcx profiles labels](gcx_profiles_labels.md)	 - List labels or label values
+* [gcx profiles list-profile-types](gcx_profiles_list-profile-types.md)	 - List available profile types
 * [gcx profiles metrics](gcx_profiles_metrics.md)	 - Query profile time-series data from a Pyroscope datasource
-* [gcx profiles profile-types](gcx_profiles_profile-types.md)	 - List available profile types
 * [gcx profiles query](gcx_profiles_query.md)	 - Execute a profiling query against a Pyroscope datasource
 

--- a/docs/reference/cli/gcx_profiles_list-profile-types.md
+++ b/docs/reference/cli/gcx_profiles_list-profile-types.md
@@ -1,4 +1,4 @@
-## gcx profiles profile-types
+## gcx profiles list-profile-types
 
 List available profile types
 
@@ -6,8 +6,10 @@ List available profile types
 
 List available profile types from a Pyroscope datasource.
 
+If gcx auto-discovers the datasource from your Grafana Cloud stack, the discovered datasource UID may be saved to your gcx configuration for future commands.
+
 ```
-gcx profiles profile-types [flags]
+gcx profiles list-profile-types [flags]
 ```
 
 ### Examples
@@ -15,17 +17,17 @@ gcx profiles profile-types [flags]
 ```
 
   # List profile types (use datasource UID, not name)
-  gcx profiles profile-types -d UID
+  gcx profiles list-profile-types -d UID
 
   # Output as JSON
-  gcx profiles profile-types -d UID -o json
+  gcx profiles list-profile-types -d UID -o json
 ```
 
 ### Options
 
 ```
   -d, --datasource string   Datasource UID (required unless default-pyroscope-datasource is configured)
-  -h, --help                help for profile-types
+  -h, --help                help for list-profile-types
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -67,7 +67,7 @@ gcx profiles query [EXPR] [flags]
       --pprof-overwrite               Overwrite the output file if it already exists (only with -o pprof)
       --pprof-path string             Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)
-      --profile-type string           Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)
+      --profile-type string           Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles list-profile-types' to list available (required)
       --since string                  Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --span-id strings               Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)
       --stacktrace-selector strings   Only query locations with these function names, starting from the root (repeatable)

--- a/docs/reference/migration-gap-analysis.md
+++ b/docs/reference/migration-gap-analysis.md
@@ -182,7 +182,7 @@ We are migrating from the old `grafana-cloud-cli` to the new `gcx` codebase. Thi
 | `gcx metrics query/range` | PromQL queries (standalone) | **Exists** (`gcx metrics query`, `gcx metrics labels`, `gcx metrics metadata`) |
 | `gcx logs query` | LogQL queries (standalone) | **Exists** (`gcx logs query`, `gcx logs labels`, `gcx logs series`) |
 | `gcx traces query/search` | TraceQL queries (standalone) | **Exists** (`gcx traces search`, `gcx traces get`, `gcx traces tags`, `gcx traces tag-values`, `gcx traces metrics`) |
-| `gcx profiles types/flamegraph/series/label-values` | Pyroscope queries (standalone) | **Exists** (`gcx profiles query`, `gcx profiles labels`, `gcx profiles profile-types`, `gcx profiles series`) |
+| `gcx profiles types/flamegraph/series/label-values` | Pyroscope queries (standalone) | **Exists** (`gcx profiles query`, `gcx profiles labels`, `gcx profiles list-profile-types`, `gcx profiles series`) |
 | `gcx telemetry status` | Pipeline health and ingest rate | **Missing** |
 | `gcx telemetry cardinality` | Metric cardinality analysis | **Missing** |
 | `gcx telemetry diff` | Before/after cardinality comparison | **Missing** |

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -491,11 +491,11 @@ var commandAnnotations = map[string]annotation{
 	// -----------------------------------------------------------------------
 	// Profiles provider
 	// -----------------------------------------------------------------------
-	"gcx profiles adaptive":      {Cost: "small"},
-	"gcx profiles labels":        {Cost: "small"},
-	"gcx profiles metrics":       {Cost: "large", Hint: "'{service_name=\"frontend\"}' --profile-type cpu --since 1h -o json"},
-	"gcx profiles profile-types": {Cost: "small"},
-	"gcx profiles query":         {Cost: "large", Hint: "'{service_name=\"frontend\"}' --profile-type cpu --since 1h -o json | Docs: " + docs.PyroscopeQueries},
+	"gcx profiles adaptive":           {Cost: "small"},
+	"gcx profiles labels":             {Cost: "small"},
+	"gcx profiles list-profile-types": {Cost: "small"},
+	"gcx profiles metrics":            {Cost: "large", Hint: "'{service_name=\"frontend\"}' --profile-type cpu --since 1h -o json"},
+	"gcx profiles query":              {Cost: "large", Hint: "'{service_name=\"frontend\"}' --profile-type cpu --since 1h -o json | Docs: " + docs.PyroscopeQueries},
 
 	// -----------------------------------------------------------------------
 	// Agent Observability provider

--- a/internal/datasources/providers/pyroscope.go
+++ b/internal/datasources/providers/pyroscope.go
@@ -12,7 +12,7 @@ func init() { //nolint:gochecknoinits // Self-registration pattern (like databas
 		"Query Pyroscope datasources",
 		pyroscope.QueryCmd,
 		pyroscope.LabelsCmd,
-		pyroscope.ProfileTypesCmd,
+		pyroscope.ListProfileTypesCmd,
 		pyroscope.MetricsCmd,
 		pyroscope.ExemplarsCmd,
 	))

--- a/internal/datasources/pyroscope/list_profile_types.go
+++ b/internal/datasources/pyroscope/list_profile_types.go
@@ -32,19 +32,23 @@ func (opts *profileTypesOpts) Validate() error {
 	return opts.IO.Validate()
 }
 
-func ProfileTypesCmd(loader *providers.ConfigLoader) *cobra.Command {
+func ListProfileTypesCmd(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &profileTypesOpts{}
 
 	cmd := &cobra.Command{
-		Use:   "profile-types",
-		Short: "List available profile types",
-		Long:  "List available profile types from a Pyroscope datasource.",
+		Use:        "list-profile-types",
+		SuggestFor: []string{"profile-types"},
+		Short:      "List available profile types",
+		Long: "List available profile types from a Pyroscope datasource.\n\n" +
+			"If gcx auto-discovers the datasource from your Grafana Cloud stack, " +
+			"the discovered datasource UID may be saved to your gcx configuration " +
+			"for future commands.",
 		Example: `
 	# List profile types (use datasource UID, not name)
-	gcx datasources pyroscope profile-types -d UID
+	gcx datasources pyroscope list-profile-types -d UID
 
 	# Output as JSON
-	gcx datasources pyroscope profile-types -d UID -o json`,
+	gcx datasources pyroscope list-profile-types -d UID -o json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.Validate(); err != nil {
 				return err
@@ -81,7 +85,7 @@ func ProfileTypesCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 	cmd.Annotations = map[string]string{
 		agent.AnnotationTokenCost: "small",
-		agent.AnnotationLLMHint:   "gcx datasources pyroscope profile-types -d UID -o json",
+		agent.AnnotationLLMHint:   "gcx datasources pyroscope list-profile-types -d UID -o json",
 	}
 
 	opts.setup(cmd.Flags())

--- a/internal/datasources/pyroscope/query.go
+++ b/internal/datasources/pyroscope/query.go
@@ -49,7 +49,7 @@ func (opts *pyroscopeQueryOpts) setup(flags *pflag.FlagSet) {
 	opts.shared.Setup(flags, true)
 
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.pyroscope is configured)")
-	flags.StringVar(&opts.ProfileType, "profile-type", "", "Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles profile-types' to list available (required)")
+	flags.StringVar(&opts.ProfileType, "profile-type", "", "Profile type ID (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'); use 'gcx profiles list-profile-types' to list available (required)")
 	flags.Int64Var(&opts.MaxNodes, "max-nodes", 0, fmt.Sprintf("Maximum nodes in flame graph (default 0/unlimited for pprof output, %d for all other formats)", defaultMaxNodes))
 	flags.StringSliceVar(&opts.ProfileIDs, "profile-id", nil, "Drill down to specific profile UUIDs from exemplar queries (repeatable)")
 	flags.StringSliceVar(&opts.SpanIDs, "span-id", nil, "Only query profiles with these 16-character hex span IDs (repeatable; unavailable with -o pprof)")

--- a/internal/providers/profiles/provider.go
+++ b/internal/providers/profiles/provider.go
@@ -77,15 +77,15 @@ func (p *Provider) descriptor() signals.Descriptor {
   gcx profiles labels -d UID -o json`,
 			},
 			{
-				Build:     dspyroscope.ProfileTypesCmd,
+				Build:     dspyroscope.ListProfileTypesCmd,
 				TokenCost: "small",
-				LLMHint:   "gcx profiles profile-types -d abc123 -o json",
+				LLMHint:   "gcx profiles list-profile-types -d abc123 -o json",
 				Example: `
   # List profile types (use datasource UID, not name)
-  gcx profiles profile-types -d UID
+  gcx profiles list-profile-types -d UID
 
   # Output as JSON
-  gcx profiles profile-types -d UID -o json`,
+  gcx profiles list-profile-types -d UID -o json`,
 			},
 			{
 				Build:     dspyroscope.MetricsCmd,

--- a/internal/providers/profiles/provider_test.go
+++ b/internal/providers/profiles/provider_test.go
@@ -32,7 +32,7 @@ func TestProviderRegistration(t *testing.T) {
 			subNames = append(subNames, sub.Name())
 		}
 
-		for _, expected := range []string{"query", "labels", "profile-types", "metrics", "adaptive"} {
+		for _, expected := range []string{"query", "labels", "list-profile-types", "metrics", "adaptive"} {
 			assert.Contains(t, subNames, expected, "missing subcommand %q", expected)
 		}
 	})


### PR DESCRIPTION
This is the first rename from the #387 naming workstream. Dafydd decided the rename on 2026-07-17, and after simonswine's review feedback both maintainers agreed on the `list-profile-types` spelling (2026-07-21) — it matches the `--profile-type` flag, the Pyroscope API (`QuerierService/ProfileTypes`) and profilecli vocabulary, and stays unambiguous if Pyroscope grows other type-like facets later. Since #994 is an alignment record that won't merge, this PR is self-contained: it carries the rename plus the one CONSTITUTION.md clause change it needs.

Migration mapping:

| old | new |
|---|---|
| `gcx profiles profile-types` | `gcx profiles list-profile-types` |
| `gcx datasources pyroscope profile-types` | `gcx datasources pyroscope list-profile-types` |

Both mounts share one command builder, so the rename itself is a single Use-string change plus every place the old path appeared in active text: the help examples, the --profile-type flag help that points at it, the agent llm_hint annotations, the path-keyed cost registry, the error-help suggestion in cmd/gcx/fail, the two bundled dashboard skills, the cli-layer tree diagram, the cross-signal ADR surface diagram, the migration gap analysis row, and the regenerated CLI reference. Per review feedback the command file is also renamed to list_profile_types.go (builder: ListProfileTypesCmd). CHANGELOG and the 2026-04-14 UX plan doc keep the old name on purpose, they're historical records.

Per the pre-v1 clean-start policy there is no deprecated alias and no forwarder. Instead of an alias, the old spelling now gets a clear error (also from review feedback): the command declares SuggestFor, and the unknown-command usage error surfaces it, so `gcx profiles profile-types` fails with exit 2 plus "Did you mean 'gcx profiles list-profile-types'?" in the suggestions. Behavior, flags, positional args, output schema and exit codes of the command itself are all unchanged.

One thing reviewers should look at closely: this PR amends CONSTITUTION.md. The Provider Architecture clause said provider-only resources must use alternative verbs and "never `get`, `list`, `create`, `update`, `delete`", which read literally would have made this rename a documented violation. The amendment narrows the prohibition to the bare verbs and allows an <operation>-<subject> compound that honestly describes the behavior (list-profile-types, list-tables for genuine enumerations). That matches what the tree already ships (clickhouse and athena list-tables, the cloudwatch list-metrics family, and the sub-resource clause already blesses alert-groups list-alerts), and it's the smallest change that makes the decided rename legal. It deliberately does not import the operation-semantics ADR from #994.

While touching the command I also added one sentence to its help text: when gcx auto-discovers the datasource from your Grafana Cloud stack, the discovered datasource UID may be saved to your config. That's existing ResolveAndSaveDatasource behavior, not a change; the help just says so now. The same behavior exists in the other datasource commands — a family-wide disclosure is a recorded follow-up, this PR doesn't expand it.

Note for #1026: that PR adds time-range flags to this same command; whichever lands second rebases, and I'm happy to help with that rebase either way.

Verified locally: built the binary and ran both new paths (help renders with the disclosure at both mounts), confirmed both old paths fail with exit 2 and the did-you-mean suggestion (in both the styled and agent-mode JSON error output), gofmt clean, lint clean, go test -race -count=1 ./... passes, reference-drift passes. mkdocs isn't installed on my machine so the docs build runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)