### PR TITLE
feat(alert)!: drop create/update/apply aliases from templates upsert

### DIFF
--- a/internal/providers/alert/templates_commands.go
+++ b/internal/providers/alert/templates_commands.go
@@ -152,7 +152,6 @@ func newTemplatesUpsertCommand(loader GrafanaConfigLoader) *cobra.Command {
 
 The provisioning API uses a single PUT endpoint keyed by template name,
 so the same command handles both create and update.`,
-		Aliases: []string{"create", "update", "apply"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err


### PR DESCRIPTION
This drops the `create`, `update`, and `apply` aliases from `gcx alert templates upsert`. The upsert command itself is untouched.

The provisioning API behind this command is a single PUT keyed by template name, so all three aliases were doing silent upserts — someone typing `gcx alert templates create` could overwrite an existing template without any warning. `upsert` is the honest name for what actually happens.

Dafydd approved this in the operation-semantics review, decision D6: https://github.com/grafana/gcx/pull/994#discussion_r3615377995

Migration: `gcx alert templates create|update|apply` are removed, use `gcx alert templates upsert`. Pre-v1 policy is clean removal, so no deprecation shims or forwarders.

While at it I swept every `Aliases:` declaration in the repo. This was the only command aliasing CRUD verbs onto an upsert. The closest relatives are `kg entities create` and `kg relationships create`, which are upserts under the hood (they call UpsertEntity/UpsertRelationship) but are named `create` with no aliases. Left those alone, possible follow-up for a kg batch.

Nothing else referenced the alias spellings — no skills, no tests, no agent annotations — and generated reference docs are unchanged (cobra's markdown generator doesn't emit alias sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
