### PR TITLE
feat(telemetry): export usage events as flat JSON over HTTP in enabled mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ internal/
 ├── notifier/    Update notifications (skills + gcx version checks; XDG state, throttling, message rendering — wired into root PersistentPostRun)
 ├── skills/      Portable Agent Skills installer primitives (BundledSkillNames, Install, Update — extracted from cmd/gcx/skills)
 ├── strcase/     String case conversion (snake_case, kebab-case, PascalCase)
-├── telemetry/   Anonymous usage stats library (wide-event model, GCX_TELEMETRY/DO_NOT_TRACK mode resolution, device ID, CI detection; wired into the CLI lifecycle via cmd/gcx/root PersistentPreRun + cmd/gcx exitWith)
+├── telemetry/   Anonymous usage stats library (wide-event model, device ID, CI detection, flat-JSON HTTP export to usage-stats; wired into the CLI lifecycle via cmd/gcx/root PersistentPreRun + cmd/gcx exitWith)
 ├── xdg/         XDG Base Directory paths (config home, state home, config dirs)
 └── shared/      Shared utilities (date handling, duration, etc.) to be shared across integrations.
 ```

--- a/cmd/gcx/telemetry.go
+++ b/cmd/gcx/telemetry.go
@@ -40,14 +40,13 @@ func emitUsageEvent(cmd *cobra.Command, start time.Time, exitCode int) {
 		return
 	}
 
-	mode := telemetry.ResolveMode(diagnosticsTelemetryValue)
-	if mode != telemetry.ModeLog {
-		// TODO: We'll handle ModeEnabled in a followup PR
-		return
-	}
-
-	if data, err := json.Marshal(buildUsageEvent(info, start, exitCode)); err == nil {
-		fmt.Fprintln(os.Stderr, string(data))
+	switch telemetry.ResolveMode(diagnosticsTelemetryValue) {
+	case telemetry.ModeLog:
+		if data, err := json.Marshal(buildUsageEvent(info, start, exitCode)); err == nil {
+			fmt.Fprintln(os.Stderr, string(data))
+		}
+	case telemetry.ModeEnabled:
+		telemetry.Export(buildUsageEvent(info, start, exitCode))
 	}
 }
 
@@ -68,8 +67,8 @@ func buildUsageEvent(info *root.TelemetryInfo, start time.Time, exitCode int) te
 		IsAgent: agent.IsAgentMode(),
 		Agent:   agent.Name(),
 		// TargetKind needs the resolved config context; resolving it requires
-		// a keychain-free context loader, which lands with the OTLP export
-		// stage. Empty until then.
+		// a keychain-free context loader, which is still a follow-up. Empty
+		// until then.
 	}
 
 	// The provider is the top-level command, the first segment of the path.

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -105,7 +105,7 @@ gcx/
 │   ├── secrets/              # Redaction of sensitive config fields
 │   ├── skills/               # Portable Agent Skills installer primitives (Install, Update, Bundled/InstalledBundledSkillNames)
 │   ├── strcase/              # String case conversion (snake_case, kebab-case, PascalCase)
-│   ├── telemetry/            # Anonymous usage stats library (event model, mode resolution, device ID, CI detection)
+│   ├── telemetry/            # Anonymous usage stats library (event model, mode resolution, device ID, CI detection, flat-JSON HTTP export)
 │   ├── terminal/             # TTY detection: IsPiped(), NoTruncate(), Detect()
 │   ├── testutils/            # Shared test helpers (not exposed externally)
 │   ├── resources/            # Core resource abstraction layer

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -24,6 +24,10 @@ Telemetry controls anonymous usage telemetry for this invocation:
 nothing). Takes precedence over DO_NOT_TRACK and the
 `diagnostics.telemetry` config field.
 
+## `GCX_TELEMETRY_ENDPOINT`
+
+Endpoint overrides the URL usage telemetry is sent to.
+
 ## `GRAFANA_CLOUD_API_URL`
 
 APIUrl is the base URL for all Grafana Cloud API (GCOM) resource calls

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -1,7 +1,7 @@
 package telemetry
 
-// ServiceName identifies gcx in the event envelope and as the OTLP resource
-// service.name; the usage-stats receiver dispatches on it.
+// ServiceName identifies gcx in the event envelope; the usage-stats receiver
+// dispatches on it.
 const ServiceName = "gcx"
 
 // Outcome values for Event.Outcome.
@@ -13,8 +13,8 @@ const (
 )
 
 // Event is the flat wide event describing one gcx invocation. Field names
-// follow the usage-stats JSON schema (snake_case); the same fields travel as
-// OTLP span/resource attributes on the wire.
+// follow the usage-stats JSON schema (snake_case); the json encoding of this
+// struct is exactly what travels on the wire (see Export).
 //
 // Privacy invariant: no field may carry argument or flag values, resource
 // names, hostnames, or anything else that identifies a person, an

--- a/internal/telemetry/export.go
+++ b/internal/telemetry/export.go
@@ -1,0 +1,54 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/grafana/gcx/internal/httputils"
+)
+
+// defaultEndpoint is the usage-stats receiver. GCX_TELEMETRY_ENDPOINT
+// overrides it, for pointing test builds at a dev deployment.
+const defaultEndpoint = "https://stats.grafana.org/gcx-usage-report"
+
+// exportTimeout caps the whole export request. Telemetry must never
+// noticeably delay CLI exit, so this is deliberately tight: the payload is
+// one small JSON document and the receiver replies before doing any work.
+const exportTimeout = time.Second
+
+// Export posts the event to the usage-stats receiver as a flat JSON body.
+// The Event json tags are the wire contract (pinned by TestEventFieldInventory
+// and by the receiver's own tests); the receiver stamps receipt time itself,
+// so the payload carries no timestamp. Export never reports failure:
+// telemetry is fire-and-forget and must not affect the command's outcome. A
+// lost event is fine — the shared client may retry transient failures, but
+// exportTimeout caps the whole exchange.
+func Export(event Event) {
+	endpoint := defaultEndpoint
+	if override := os.Getenv(envEndpoint); override != "" {
+		endpoint = override
+	}
+	export(event, endpoint)
+}
+
+func export(event Event, endpoint string) {
+	body, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := httputils.NewClient(httputils.ClientOpts{Timeout: exportTimeout})
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
+}

--- a/internal/telemetry/export_internal_test.go
+++ b/internal/telemetry/export_internal_test.go
@@ -1,0 +1,120 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testEvent() Event {
+	return Event{
+		Service:           ServiceName,
+		Version:           "v1.2.3",
+		OS:                "darwin",
+		Arch:              "arm64",
+		DeviceID:          "36d988e3-971e-4566-b0ca-7416f85b0da2",
+		DeviceIDPersisted: true,
+		Command:           "dashboards list",
+		Flags:             "output",
+		Provider:          "dashboards",
+		Outcome:           OutcomeOK,
+		ExitCode:          0,
+		DurationMS:        1059,
+		IsTTY:             true,
+		OutputFormat:      "table",
+	}
+}
+
+// The event must round-trip the wire: what the receiver decodes from our POST
+// body is field-for-field what the log mode would have printed.
+func TestExportPostsJSONToEndpointOverride(t *testing.T) {
+	requests := make(chan *http.Request, 1)
+	bodies := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests <- r
+		bodies <- body
+	}))
+	defer server.Close()
+	t.Setenv(envEndpoint, server.URL+"/gcx-usage-report")
+
+	event := testEvent()
+	Export(event)
+
+	select {
+	case r := <-requests:
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/gcx-usage-report", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+	case <-time.After(5 * time.Second):
+		t.Fatal("no request received")
+	}
+
+	body := <-bodies
+	var decoded Event
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	assert.Equal(t, event, decoded)
+
+	// parse_error_* fields mirror their omitempty tags: absent from the body
+	// unless set.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	for _, key := range []string{
+		"parse_error_kind", "parse_error_parent", "parse_error_token",
+		"attempted_command", "parse_error_flags", "parse_error_nearest",
+		"parse_error_distance",
+	} {
+		assert.NotContains(t, raw, key)
+	}
+}
+
+// parse_error_* fields travel when set, including distance -1 ("no near
+// match"), which omitempty must not drop.
+func TestExportCarriesParseErrorFields(t *testing.T) {
+	bodies := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies <- body
+	}))
+	defer server.Close()
+	t.Setenv(envEndpoint, server.URL)
+
+	event := testEvent()
+	event.Outcome = OutcomeParseError
+	event.ParseErrorKind = "unknown_command"
+	event.ParseErrorToken = "<redacted>"
+	event.ParseErrorDistance = -1
+	Export(event)
+
+	select {
+	case body := <-bodies:
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(body, &raw))
+		assert.Equal(t, "unknown_command", raw["parse_error_kind"])
+		assert.Equal(t, "<redacted>", raw["parse_error_token"])
+		assert.InDelta(t, float64(-1), raw["parse_error_distance"], 0)
+	case <-time.After(5 * time.Second):
+		t.Fatal("no request received")
+	}
+}
+
+// Export must never fail loudly, however broken the endpoint.
+func TestExportSwallowsFailures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Setenv(envEndpoint, server.URL)
+	Export(testEvent())
+
+	server.Close()
+	Export(testEvent())
+
+	t.Setenv(envEndpoint, "://not a url")
+	Export(testEvent())
+}

--- a/internal/telemetry/export_internal_test.go
+++ b/internal/telemetry/export_internal_test.go
@@ -118,3 +118,23 @@ func TestExportSwallowsFailures(t *testing.T) {
 	t.Setenv(envEndpoint, "://not a url")
 	Export(testEvent())
 }
+
+// exportTimeout is the ceiling on how long telemetry can hold up CLI exit: a
+// receiver that accepts the request and never replies must not block Export
+// past it.
+func TestExportReturnsPromptlyWhenReceiverHangs(t *testing.T) {
+	// Hold every response until the test ends. Released before server.Close()
+	// (defers run LIFO) so Close's wait for in-flight handlers can finish.
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+	t.Setenv(envEndpoint, server.URL)
+
+	start := time.Now()
+	Export(testEvent())
+	// Generous slack over exportTimeout to avoid flakes on loaded machines.
+	assert.Less(t, time.Since(start), 3*exportTimeout)
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -43,6 +43,9 @@ type Env struct {
 	// "true" (cross-tool DO_NOT_TRACK convention). Overridden by
 	// GCX_TELEMETRY.
 	DoNotTrack string `env:"DO_NOT_TRACK"`
+
+	// Endpoint overrides the URL usage telemetry is sent to.
+	Endpoint string `env:"GCX_TELEMETRY_ENDPOINT"`
 }
 
 // ResolveMode resolves the telemetry mode for this invocation. Precedence,
@@ -54,12 +57,13 @@ func ResolveMode(configValue func() string) Mode {
 	return resolveMode(os.Getenv, configValue)
 }
 
-// Env var names used by resolveMode. envConsistencyTest asserts they match
+// Env var names read by this package. envConsistencyTest asserts they match
 // the Env struct tags the docs generator reads, so the documented names
 // cannot drift from the resolved ones.
 const (
 	envTelemetry  = "GCX_TELEMETRY"
 	envDoNotTrack = "DO_NOT_TRACK"
+	envEndpoint   = "GCX_TELEMETRY_ENDPOINT"
 )
 
 func resolveMode(getenv func(string) string, configValue func() string) Mode {

--- a/internal/telemetry/telemetry_internal_test.go
+++ b/internal/telemetry/telemetry_internal_test.go
@@ -94,7 +94,7 @@ func TestResolveMode(t *testing.T) {
 	}
 }
 
-// The Env struct tags are what the docs generator publishes; resolveMode
+// The Env struct tags are what the docs generator publishes; the package
 // reads the constants. If they drift, the docs advertise a variable that
 // does nothing while the real one is undocumented.
 func TestEnvTagsMatchResolvedNames(t *testing.T) {
@@ -106,5 +106,6 @@ func TestEnvTagsMatchResolvedNames(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"Telemetry":  envTelemetry,
 		"DoNotTrack": envDoNotTrack,
+		"Endpoint":   envEndpoint,
 	}, tags)
 }


### PR DESCRIPTION
Part of https://github.com/grafana/gcx-internal/issues/2, follow on from #978.

This is an alternative to #1002, : instead of encoding the event as an OTLP span, it emits the JSON-encoded telemetry vent directly.

## Summary

- need `GCX_TELEMETRY=enabled` for now, as its default off until the receiver is ready. It posts to `https://stats.grafana.org/gcx-usage-report` or wherever `GCX_TELEMETRY_ENDPOINT` is set to.
- 1s timeout on export, all errors ignored. telemetry should not cause an error or noticeably slow the CLI. We can delegate the export to another process if it's obviously too slow.

Example payload:

```json
{"service":"gcx","version":"v0.4.4","os":"darwin","arch":"arm64","device_id":"36d988e3-971e-4566-b0ca-7416f85b0da2","device_id_persisted":true,"command":"providers list","flags":"","provider":"providers","outcome":"ok","exit_code":0,"error_kind":"","duration_ms":17,"is_tty":true,"is_ci":false,"ci_provider":"","is_agent":false,"agent":"","target_kind":"","output_format":"table"}
```

Not included: we still dont have `target_kind` (needs the keychain-free context loader) and parse-failure events (#578).


Run locally with e.g. (if you have the stats service running locally) 

```
GCX_TELEMETRY=enabled GCX_TELEMETRY_ENDPOINT=http://localhost:9051/gcx-usage-report ./bin/gcx datasources list
```