### PR TITLE
feat(skills)!: rename agento11y-eval-starter to agento11y-test-starter + align with rebranding

### DIFF
--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -84,7 +84,7 @@ canonical portable skill bundle.
 | `agento11y` | Browse conversations, manage evaluators and rules, set up online evaluation for LLM quality scoring (Agent Observability) |
 | `agento11y-instrument` | Set up and instrument a developer's own LLM app to send generations to Agent Observability, verifying data lands via gcx |
 | `agento11y-prod-setup` | Set up production evaluation and guardrails (online eval rules + guards) for a deployed agent, grounded in its code and live traffic, applied via gcx with confirmation |
-| `agento11y-eval-starter` | Decide which evaluations an agent needs before it ships and scaffold a starter offline test suite (Agent Observability suite YAML + runner stub) from the agent's own code |
+| `agento11y-test-starter` | Build a starter offline test suite for an agent before it ships — test cases (Agent Observability suite YAML + runner stub) plus how to score them, grounded in the agent's own code |
 | `synth-check-status` | Check Synthetic Monitoring health, status, and trends |
 | `synth-investigate-check` | Diagnose why a Synthetic Monitoring check is failing |
 | `synth-manage-checks` | Create, update, pull, push, and delete Synthetic Monitoring checks |

--- a/claude-plugin/skills/agento11y-instrument/SKILL.md
+++ b/claude-plugin/skills/agento11y-instrument/SKILL.md
@@ -15,8 +15,8 @@ description: >
   completeness, SYNC vs STREAM, parent_generation_ids DAG links, and workflow-step coverage.
   Recommends changes citing file:line and, only with explicit confirmation, applies minimal
   diffs that don't change app behavior. Pulls SDK reference from sigil-sdk's llms.txt rather
-  than restating it, and hands off to `agento11y-eval-starter` once data flows. It does NOT
-  set up evaluations, rules, or guards (that is `agento11y-eval-starter` / `agento11y-prod-setup`);
+  than restating it, and hands off to `agento11y-test-starter` once data flows. It does NOT
+  set up evaluations, rules, or guards (that is `agento11y-test-starter` / `agento11y-prod-setup`);
   does NOT install coding-agent telemetry plugins (that is llms.txt "Path A"); does NOT mint
   or store credentials or invent endpoints. Trigger on phrases like "instrument my app",
   "send my agent's traces to Grafana", "set up AI observability for my app", "my generations
@@ -88,7 +88,7 @@ the flow and the decision logic. A minimal fallback lives in
   stop and report what's checked and what remains — don't loop forever.
 - **Field-name traps:** `cache_write_input_tokens`, NOT `cache_creation_input_tokens`. `agent_version`
   maps to the `gen_ai.agent.version` label and is required for per-version Performance charts.
-- **Out of scope:** evaluations / rules / guards → `agento11y-eval-starter` (offline) and
+- **Out of scope:** evaluations / rules / guards → `agento11y-test-starter` (offline) and
   `agento11y-prod-setup` (production). Coding-agent telemetry plugins (Claude Code, Cursor, …) →
   llms.txt "Path A". Any control-plane write.
 - **If a required input is missing** (entrypoint, framework, endpoint, gcx auth), ask — don't guess.
@@ -122,7 +122,11 @@ that and verify against the local instance instead. The rest of this step is the
    (`https://<stack>.grafana.net/plugins/grafana-sigil-app`), or the OTLP endpoint from an Alloy /
    OTel collector the deployment runs. Point the developer there for the endpoint(s) + token and ask
    them to paste the values, or set them as env vars — **never invent a URL or mint a token.**
-   See llms.txt "Credentials" for exactly which values the page emits and how they map to the env vars.
+   When they create the token via "Create a token in Cloud Access Policies", tell them the scopes:
+   **`sigil:write`, `metrics:write`, `traces:write`, `logs:write`**. UI heads-up: `sigil` is not in
+   the default resource list — add it via **"Add scope"** (then tick Write); the scope is still
+   `sigil:*` (the Cloud resource keeps the old name). See llms.txt "Credentials" for how each value
+   maps to the env vars.
 
    > Two different tokens — don't confuse them. gcx logs in with its own OAuth token (`gat_`) and
    > refreshes it automatically; that is what authenticates the `gcx` commands here. It is **not** the
@@ -143,8 +147,9 @@ Find and read, recording `file:line` for each:
 1. The generation entrypoint(s) — where the model is invoked.
 2. How the LLM client is constructed (which provider: OpenAI / Anthropic / Gemini / other).
 3. The app bootstrap / init — where an OTel `TracerProvider` / `MeterProvider` would be created.
-4. Any existing Agent Observability SDK imports (`sigil_sdk` / `@grafana/sigil-sdk-js` / the Go
-   `sigil` package) or `AGENTO11Y_*` usage.
+4. Any existing Agent Observability SDK imports (`agento11y` / `@grafana/agento11y` / the Go
+   `agento11y` package — or the legacy `sigil_sdk` / `@grafana/sigil-sdk-js` / Go `sigil` names in
+   older code) or `AGENTO11Y_*` usage.
 
 Detect:
 - **Language** — from the manifest / extensions (`pyproject.toml`/`.py`, `package.json`/`.ts`,
@@ -226,7 +231,7 @@ Only after the developer confirms a diff. Bounded to ~3–4 iterations.
      (both `--from`/`--to` required, RFC3339) then `gcx agento11y conversations get <conversation-id>`
      or `gcx agento11y generations get <generation-id>` — tokens, finish reason, and cost populated.
      This proves generation ingest + `set_result` are wired. **It does NOT prove OTel is wired.**
-   - **Local-dev target:** gcx can't read a local instance — confirm the app printed no `sigil:`
+   - **Local-dev target:** gcx can't read a local instance — confirm the app printed no `agento11y:`
      export errors and check the local instance / its UI for the new conversation.
 
    **Channel B — OTel spans/metrics** (the TracerProvider/MeterProvider → OTLP exporter →
@@ -246,12 +251,12 @@ Only after the developer confirms a diff. Bounded to ~3–4 iterations.
      → back to checklist #1. Do not report OTel as wired on the strength of `generations get` alone.
 4. If a signal is missing, diagnose the next gap from what the checks showed, propose the fix, and
    loop back to step 1. After ~3–4 iterations without full signal, stop and report exactly what
-   lands, what doesn't, and what to check next (app stderr for `sigil:` warnings, credentials).
+   lands, what doesn't, and what to check next (app stderr for `agento11y:` warnings, credentials).
 
 ## Step 6 — Hand off
 
 Once generations land and metrics populate, instrumentation is done — that's the prerequisite for
-everything else. Point the developer at the next step: `agento11y-eval-starter` to decide **what to
+everything else. Point the developer at the next step: `agento11y-test-starter` to decide **what to
 evaluate** offline before shipping, and `agento11y-prod-setup` to set up online eval rules and guards
 once there's real traffic.
 

--- a/claude-plugin/skills/agento11y-instrument/SKILL.md
+++ b/claude-plugin/skills/agento11y-instrument/SKILL.md
@@ -16,7 +16,8 @@ description: >
   Recommends changes citing file:line and, only with explicit confirmation, applies minimal
   diffs that don't change app behavior. Pulls SDK reference from sigil-sdk's llms.txt rather
   than restating it, and hands off to `agento11y-test-starter` once data flows. It does NOT
-  set up evaluations, rules, or guards (that is `agento11y-test-starter` / `agento11y-prod-setup`);
+  write test suites or set up tenant evaluations, rules, or guards — offline test suites are
+  `agento11y-test-starter`, tenant eval rules + guards are `agento11y-prod-setup`;
   does NOT install coding-agent telemetry plugins (that is llms.txt "Path A"); does NOT mint
   or store credentials or invent endpoints. Trigger on phrases like "instrument my app",
   "send my agent's traces to Grafana", "set up AI observability for my app", "my generations
@@ -88,8 +89,8 @@ the flow and the decision logic. A minimal fallback lives in
   stop and report what's checked and what remains — don't loop forever.
 - **Field-name traps:** `cache_write_input_tokens`, NOT `cache_creation_input_tokens`. `agent_version`
   maps to the `gen_ai.agent.version` label and is required for per-version Performance charts.
-- **Out of scope:** evaluations / rules / guards → `agento11y-test-starter` (offline) and
-  `agento11y-prod-setup` (production). Coding-agent telemetry plugins (Claude Code, Cursor, …) →
+- **Out of scope:** offline test suites → `agento11y-test-starter`; tenant eval rules + guards on
+  real traffic → `agento11y-prod-setup`. Coding-agent telemetry plugins (Claude Code, Cursor, …) →
   llms.txt "Path A". Any control-plane write.
 - **If a required input is missing** (entrypoint, framework, endpoint, gcx auth), ask — don't guess.
 
@@ -256,9 +257,11 @@ Only after the developer confirms a diff. Bounded to ~3–4 iterations.
 ## Step 6 — Hand off
 
 Once generations land and metrics populate, instrumentation is done — that's the prerequisite for
-everything else. Point the developer at the next step: `agento11y-test-starter` to decide **what to
-evaluate** offline before shipping, and `agento11y-prod-setup` to set up online eval rules and guards
-once there's real traffic.
+everything else. Point the developer at the next step: `agento11y-test-starter` to build an
+**offline test suite** for the agent (useful before shipping *and* for regression-testing new
+versions once it's live), and `agento11y-prod-setup` to set up **online eval rules + guards** on
+real traffic once it's deployed. The split is offline test suite vs online rules/guards — not
+before-traffic vs after-traffic.
 
 ## Note — keeping this skill in sync
 

--- a/claude-plugin/skills/agento11y-prod-setup/SKILL.md
+++ b/claude-plugin/skills/agento11y-prod-setup/SKILL.md
@@ -19,7 +19,7 @@ allowed-tools: Bash, Read, Write, Edit
 
 # Agent Observability — production evals & guards setup
 
-The production counterpart to `agento11y-eval-starter` (which runs pre-ship, on code alone,
+The production counterpart to `agento11y-test-starter` (which runs pre-ship, on code alone,
 producing an offline test suite). This skill runs **after** ship, when the agent has real
 traffic, and sets up the two production surfaces the starter deliberately leaves out:
 
@@ -65,7 +65,7 @@ the `agento11y` skill and to `gcx agento11y <sub> --help` rather than restating 
   (`gcx agento11y evaluators list`, `rules list`, `guards list`) and never recommend a duplicate.
   Compare by **semantic equivalence**, not just id/name — see Step 2.
 - This skill **does** create tenant-level objects — that is its job, the one thing that separates
-  it from `agento11y-eval-starter`. But every creation is **explicit and confirmed**: show the exact
+  it from `agento11y-test-starter`. But every creation is **explicit and confirmed**: show the exact
   YAML, get a yes, then create it with the matching `gcx agento11y` command. A yes for one object
   is not a yes for the next.
 - New guards are always drafted **`enabled: false`** and **`action_on_fail: "warn"`** — even
@@ -107,7 +107,7 @@ sign the active context is not their prod stack.)
 
 Two evidence sources. Do both; every later recommendation cites one of them.
 
-**Code** (as `agento11y-eval-starter` Step 1). Find and record file:line for: the entrypoint, the
+**Code** (as `agento11y-test-starter` Step 1). Find and record file:line for: the entrypoint, the
 system prompt, the tool/function definitions, and how it handles user data. This tells you what
 *could* go wrong. **The code is the authoritative source for the system prompt and tools** —
 content capture is often off in production, so the ingested traffic frequently has an empty
@@ -135,7 +135,7 @@ anything. Fewer than that and you risk overfitting one odd conversation into a p
 guard: if the window is thin, either stop and say so, or proceed but mark every recommendation
 **low-confidence** and lean on drafts (disabled guards, low `sample_rate`) rather than anything
 that intervenes. A recommendation from a single conversation is a hypothesis, not a rule. If the
-agent has essentially no traffic, stop — this is the wrong skill; `agento11y-eval-starter` (offline
+agent has essentially no traffic, stop — this is the wrong skill; `agento11y-test-starter` (offline
 suite) is the right one until traffic exists.
 
 ## Step 2 — Inventory what already exists
@@ -162,11 +162,11 @@ surface by whether you want to watch or to stop.
 
 | If, in code or traffic, the agent… | Surface | Shape (prefer a predefined template) |
 | --- | --- | --- |
-| gives answers whose quality can drift | online **rule** | fork `sigil.helpfulness` / `sigil.relevance` (`llm_judge`) over `user_visible_turn` |
-| does RAG / cites sources | online **rule** | fork `sigil.groundedness` (`llm_judge`) |
-| must emit JSON / a fixed shape | online **rule** | fork `sigil.json_valid` (`json_schema`) |
+| gives answers whose quality can drift | online **rule** | fork `template.helpfulness` / `template.relevance` (`llm_judge`) over `user_visible_turn` |
+| does RAG / cites sources | online **rule** | fork `template.groundedness` (`llm_judge`) |
+| must emit JSON / a fixed shape | online **rule** | fork `template.json_valid` (`json_schema`) |
 | over-refuses or drifts off-topic | online **rule** | `regex` / `llm_judge` on `all_assistant_generations` |
-| public-facing text | online **rule** | fork `sigil.toxicity` / `sigil.pii` (`llm_judge`) |
+| public-facing text | online **rule** | fork `template.toxicity` / `template.pii` (`llm_judge`) |
 | echoes user data with PII/secrets | **guard** | `transform` (regex → `[REDACTED:...]`) |
 | can call dangerous tools (shell, delete, write) | **guard** | `tool_filter` with `blocked_names` globs (e.g. `Bash(*rm*)`) |
 | is subject to prompt-injection / hard policy | **guard** | `llm_judge` evaluator; draft `warn`, later promotable to `deny` |
@@ -319,4 +319,4 @@ Output, in this order:
    - Inspect everything in Agent Observability (rules/guards/evaluators pages, the conversation
      Quality view) or via the `gcx agento11y` list and get commands.
 4. A one-line pointer back: for pre-ship offline evaluation of a new agent or version,
-   `agento11y-eval-starter` is the counterpart; for control-plane mechanics, the `agento11y` skill.
+   `agento11y-test-starter` is the counterpart; for control-plane mechanics, the `agento11y` skill.

--- a/claude-plugin/skills/agento11y-test-starter/SKILL.md
+++ b/claude-plugin/skills/agento11y-test-starter/SKILL.md
@@ -6,7 +6,7 @@ description: >
   task), writes a labeled draft suite of test cases (happy/edge/adversarial) grounded in real
   lines, and recommends how to score each case (the evaluators/judges the offline runner uses).
   Assesses how runnable the agent is: for an easily-invoked agent it generates a runner stub
-  (run_experiment.py) with one hole to fill and can optionally run it (only with permission, only
+  (run_experiment.py) with two holes to fill and can optionally run it (only with permission, only
   against the endpoint the developer configured); for agents needing a harness or full runtime it
   points to the existing eval infra. It runs OFFLINE and never creates tenant-level evaluators,
   rules, or guards — that is `agento11y-prod-setup`, for a deployed agent with real traffic.
@@ -33,7 +33,7 @@ Always produce:
 Then, depending on how runnable the agent is (Step 1):
 
 3. For an easily-invoked agent, a **runner stub** (`run_experiment.py`) that wires the suite
-   to the SDK with one hole to fill — and optionally run it (Step 6), only with permission.
+   to the SDK with two holes to fill — and optionally run it (Step 6), only with permission.
    For an agent that needs a harness or full runtime, point to the existing eval infra instead
    of a runner that can't actually call it.
 
@@ -53,7 +53,9 @@ agent has a clean function seam or needs a harness / full stack. For deeper run-
 The generated runner imports the Agent Observability SDK. Install it in the agent's environment
 before running (Step 6):
 
-- **Python:** `pip install agento11y` (the experiments API lives in `agento11y.experiments`)
+- **Python:** `pip install agento11y python-dotenv` (the experiments API lives in
+  `agento11y.experiments`; the runner uses `python-dotenv` to load the agent's `.env`, and it is
+  not a dependency of `agento11y`)
 - **Go:** add `github.com/grafana/agento11y/go`
 
 Only needed to *run* the suite (Step 6). Reading the agent, recommending evaluators, and writing
@@ -66,21 +68,19 @@ the suite YAML (Steps 1–5) need nothing installed.
   does not create tenant-level evaluators/rules/guards — but only do it via Step 6.)
 - Do not rewrite the agent's prompt, optimize, or redeploy.
 - Never run the experiment without asking first (Step 6). Never run against a target the
-  developer did not configure — use their `AGENTO11Y_ENDPOINT` (+ token for Cloud); if it isn't set,
-  ask for it, do not invent an endpoint.
-- Never mint, generate, or store credentials. For a Cloud target the developer owns the ingestion
-  token; read it from the environment or ask them to paste it — do not create one. (A local dev
-  target has no token — see "Two targets" below.)
+  developer did not configure — use their `AGENTO11Y_ENDPOINT` and `AGENTO11Y_AUTH_TOKEN`; if the
+  endpoint isn't set, ask for it, do not invent one.
+- Never mint, generate, or store credentials. The developer owns the Grafana Cloud ingestion
+  token; read it from the environment or ask them to paste it — do not create one.
 - Never present the generated cases as validated. They are a draft to review and extend.
 - **The `llm_judge` uses the LLM provider the agent already uses — don't add a new one.** If the
   agent calls OpenAI, the judge calls OpenAI; if Anthropic, Anthropic. Do NOT default the judge to
   `litellm` (or any other provider SDK) when the app doesn't already depend on it — that adds a
   dependency and a second provider just for scoring. Reuse the agent's existing client/SDK.
-- **Two targets: Grafana Cloud and local dev.** Detect which the agent is aimed at from any existing
-  `AGENTO11Y_ENDPOINT` / `.env` / sibling apps; don't assume Cloud. A **local dev instance** (e.g.
-  `AGENTO11Y_ENDPOINT=http://localhost:8080`, tenant `anonymous`) needs **no auth token** — publish
-  with just the endpoint. A **Cloud** target needs `AGENTO11Y_AUTH_TOKEN` (the ingestion key from
-  the Connection page). Never invent an endpoint or mint a token for either.
+- **The target is Grafana Cloud.** Publishing scores needs `AGENTO11Y_ENDPOINT` **and**
+  `AGENTO11Y_AUTH_TOKEN` (the ingestion key from the Connection page) — the SDK raises before
+  making any request if the token is empty, so both are always required. Read the endpoint from an
+  existing `AGENTO11Y_ENDPOINT` / `.env` / sibling app; never invent one or mint a token.
 - If a required input is missing (entrypoint, prompt, tools), ask the developer — don't guess.
 
 ## Step 1 — Read the agent
@@ -264,13 +264,16 @@ For an **easy Python/Go** agent, write `evals/run_experiment.py`. It must:
 
 - Load the suite with `TestSuite.from_yaml(...)`.
 - Open an experiment (`agento11y.experiment(...)`) and one `trial` per case.
-- Call the agent through a single clearly-marked function `run_agent(case)` — **this is the
-  one hole the developer fills**; wire it to the real entrypoint you found in Step 1.
+- Call the agent through a single clearly-marked function `run_agent(case)` — **the first of the
+  two holes the developer fills**; wire it to the real entrypoint you found in Step 1.
 - Include ONE recommended evaluator sketched end-to-end (prefer an `llm_judge` — a real model
   call that returns a JSON `{score, passed, explanation}`), so they see the shape and can copy
   it for the others. Reference the rest by name in a comment; do not stub all of them. **The
   judge's model call must use the provider the agent already uses** (reuse its OpenAI/Anthropic
-  client or SDK) — do not pull in `litellm` or another provider just for the judge.
+  client or SDK) — do not pull in `litellm` or another provider just for the judge. The one model
+  call inside the judge is **the second hole** — leave it as an explicit `NotImplementedError` so a
+  developer who only fills `run_agent` gets a clear "fill the judge call" error, not a `NameError`
+  on an undefined helper.
 - Record I/O (`trial.record_io(...)`) and emit `trial.final_score(...)` with the evaluator.
 
 Keep the header verbatim, and be honest in it about what still needs doing:
@@ -281,10 +284,11 @@ Keep the header verbatim, and be honest in it about what still needs doing:
 
 Runs <agent> over evals/<agent>-starter.yaml as an Agent Observability experiment and publishes scores.
 
-You still need to: (1) fill run_agent(case) to call YOUR agent; (2) tune the sketched
-judge; (3) set real credentials — `AGENTO11Y_ENDPOINT` (+ `AGENTO11Y_AUTH_TOKEN` for a Cloud stack;
-a local endpoint needs no token) and the agent's provider key. The SDK stores scores; it does not
-run the agent or the judge.
+You still need to: (1) fill run_agent(case) to call YOUR agent (first hole); (2) fill the model
+call inside judge_<evaluator> using the agent's own provider client, then tune it (second hole);
+(3) set real credentials — `AGENTO11Y_ENDPOINT` and `AGENTO11Y_AUTH_TOKEN` (your Grafana Cloud
+ingestion key) and the agent's provider key. The SDK stores scores; it does not run the agent or
+the judge.
 
 Set AGENTO11Y_INGEST_ACTOR to a stable value: the run and its trials must share one actor, or
 trial creation fails with "401: experiment is owned by another actor".
@@ -302,7 +306,7 @@ SUITE = Path(__file__).parent / "<agent>-starter.yaml"
 
 
 def run_agent(case: agento11y.TestCase) -> str:
-    """THE ONE HOLE YOU FILL — call your agent for this case, return its output text."""
+    """FIRST HOLE YOU FILL — call your agent for this case, return its output text."""
     raise NotImplementedError("wire this to your agent entrypoint (see Step 1 refs)")
 
 
@@ -325,12 +329,16 @@ def judge_<evaluator>(case_input, output) -> tuple[float, bool, str]:
         f"Input:\n{case_input}\n\nOutput:\n{output}"
     )
     model = os.getenv("GRADER_MODEL") or os.getenv("MODEL_NAME")  # a LIVE model id; no default (dead ids 404)
-    # Reuse the agent's client (e.g. `from agent import client` for Anthropic/OpenAI). Give it enough
-    # max_tokens (~600) that the JSON verdict is never truncated mid-object. Example (Anthropic):
-    #   text = client.messages.create(model=model, max_tokens=600,
-    #                                  messages=[{"role": "user", "content": prompt}]).content[0].text
-    # Example (OpenAI): client.chat.completions.create(...).choices[0].message.content
-    text = _grade_with_agent_client(model, prompt)  # wire to the agent's provider; max_tokens>=600
+    # SECOND HOLE YOU FILL — call the model using the SAME client the agent uses (do NOT add a new
+    # provider). Import it from the agent module and make ONE call that returns the reply text into
+    # `text`. Give it enough max_tokens (~600) that the JSON verdict is never truncated mid-object.
+    #   Anthropic: from agent import client
+    #     text = client.messages.create(model=model, max_tokens=600,
+    #                                    messages=[{"role": "user", "content": prompt}]).content[0].text
+    #   OpenAI:    from agent import client
+    #     text = client.chat.completions.create(model=model, max_tokens=600,
+    #                                            messages=[{"role": "user", "content": prompt}]).choices[0].message.content
+    raise NotImplementedError("call the agent's provider client here and assign the reply to `text`")
     d = _parse_judge_json(text)
     score = max(0.0, min(1.0, float(d.get("score", 0.0))))
     return score, bool(d.get("passed", score >= 0.6)), str(d.get("explanation", ""))
@@ -408,9 +416,10 @@ Output, in this order:
 2. The paths to the two written files (`evals/<agent>-starter.yaml` and
    `evals/run_experiment.py`), and a one-line reminder to review the edge/adversarial cases
    and add real ones.
-3. The three things they still do to run it: fill `run_agent(case)`, tune the sketched judge
-   (and add the other recommended evaluators the same way), and set credentials
-   (`AGENTO11Y_ENDPOINT` + the provider key; plus `AGENTO11Y_AUTH_TOKEN` for a Cloud target).
+3. The three things they still do to run it: fill `run_agent(case)` (first hole); fill the judge's
+   model call using the agent's own provider client, then tune it and add the other recommended
+   evaluators the same way (second hole); and set credentials (`AGENTO11Y_ENDPOINT` +
+   `AGENTO11Y_AUTH_TOKEN` + the provider key).
    State the boundary explicitly: this skill only
    bootstraps the first run; for anything past that — binding an already-instrumented agent's
    real generations, auditable LLM-judge grading, cross-process verifiers, repeated-sampling
@@ -436,9 +445,8 @@ If they accept:
    **Connection page**, `https://<your-stack>.grafana.net/plugins/grafana-sigil-app`:
    - `AGENTO11Y_ENDPOINT` = the **API URL** on that page. If unset, ask — never invent one.
    - `AGENTO11Y_AUTH_TENANT_ID` = the **Instance ID** on that page.
-   - `AGENTO11Y_AUTH_TOKEN` **only for a Cloud target**. For a **local dev** endpoint
-     (`localhost`), there is no token — skip it (tenant `anonymous`). For Cloud, the developer
-     creates it via **"Create a token in Cloud Access Policies"** on the Connection page. Tell them
+   - `AGENTO11Y_AUTH_TOKEN` — always required (the SDK raises before any request if it is empty).
+     The developer creates it via **"Create a token in Cloud Access Policies"** on the Connection page. Tell them
      the exact scopes: **`sigil:write`, `metrics:write`, `traces:write`, `logs:write`**. Heads-up on
      the UI: `sigil` is **not** in the default resource list — they must add it via **"Add scope"**
      (then tick Write); `metrics`/`traces`/`logs` are already listed (tick Write). The scope is still

--- a/claude-plugin/skills/agento11y-test-starter/SKILL.md
+++ b/claude-plugin/skills/agento11y-test-starter/SKILL.md
@@ -1,22 +1,29 @@
 ---
-name: agento11y-eval-starter
+name: agento11y-test-starter
 description: >
-  Use early in an AI-agent project — before ship, before real traffic — to decide which
-  evaluations to set up and to scaffold a starter experiment. Reads the agent's own code (system
-  prompt, tools, task), recommends specific evaluators with reasons that cite real lines, and writes
-  a labeled draft test suite as an Agent Observability suite YAML. It also assesses how runnable the agent is: for
-  an easily-invoked agent it generates a runner stub (run_experiment.py) with one hole to fill and
-  can optionally run it (only with permission, only against the endpoint the developer configured);
-  for agents that need a harness or a full runtime it points to the existing eval infra instead of
-  emitting a runner that can't call the agent. It never creates tenant-level evaluators, rules, or
-  guards.
+  Use early in an AI-agent project — before ship, before real traffic — to build a starter
+  test suite for the agent and run it offline. Reads the agent's own code (system prompt, tools,
+  task), writes a labeled draft suite of test cases (happy/edge/adversarial) grounded in real
+  lines, and recommends how to score each case (the evaluators/judges the offline runner uses).
+  Assesses how runnable the agent is: for an easily-invoked agent it generates a runner stub
+  (run_experiment.py) with one hole to fill and can optionally run it (only with permission, only
+  against the endpoint the developer configured); for agents needing a harness or full runtime it
+  points to the existing eval infra. It runs OFFLINE and never creates tenant-level evaluators,
+  rules, or guards — that is `agento11y-prod-setup`, for a deployed agent with real traffic.
+  Trigger on phrases like "how do I test my agent before shipping", "write test cases for my
+  agent", "set up tests for my agent", "check my agent before prod", "I have no traffic yet, how
+  do I evaluate it", "test my agent offline".
 ---
 
-# agento11y eval starter
+# agento11y test starter
 
-Help a developer who has an AI agent but no evaluation set up yet. The hard part isn't
-running an experiment — it's knowing **what to evaluate** and having **cases to test
-against** before there's any traffic. Answer both, grounded in the agent's actual code.
+Help a developer test an AI agent **before it ships** — while there is no real traffic yet. The
+hard part isn't running the test — it's having **cases to test against** and knowing **how to
+score them**, grounded in the agent's actual code.
+
+> Scope: this is the **pre-production, offline** skill — it writes test cases and a local runner,
+> and never touches the tenant. Once the agent is deployed and has real traffic, setting up online
+> eval rules + guards on that traffic is a different skill, `agento11y-prod-setup`.
 
 Always produce:
 
@@ -41,6 +48,17 @@ agent has a clean function seam or needs a harness / full stack. For deeper run-
 > (`python/skills/agento11y-experiments/`), not in this gcx bundle yet — install it from there for
 > now. Consolidating it into the gcx bundle is pending.
 
+## Prerequisites
+
+The generated runner imports the Agent Observability SDK. Install it in the agent's environment
+before running (Step 6):
+
+- **Python:** `pip install agento11y` (the experiments API lives in `agento11y.experiments`)
+- **Go:** add `github.com/grafana/agento11y/go`
+
+Only needed to *run* the suite (Step 6). Reading the agent, recommending evaluators, and writing
+the suite YAML (Steps 1–5) need nothing installed.
+
 ## Rules
 
 - Do not create, enable, or modify evaluators, rules, or guards in any Agent Observability tenant. No
@@ -48,13 +66,21 @@ agent has a clean function seam or needs a harness / full stack. For deeper run-
   does not create tenant-level evaluators/rules/guards — but only do it via Step 6.)
 - Do not rewrite the agent's prompt, optimize, or redeploy.
 - Never run the experiment without asking first (Step 6). Never run against a target the
-  developer did not configure — use their `AGENTO11Y_ENDPOINT` + credentials (Grafana Cloud); if
-  they are not set, ask for them, do not invent an endpoint.
-- Never mint, generate, or store credentials. The developer owns their Grafana Cloud
-  ingestion token; read it from the environment or ask them to paste it — do not create one.
+  developer did not configure — use their `AGENTO11Y_ENDPOINT` (+ token for Cloud); if it isn't set,
+  ask for it, do not invent an endpoint.
+- Never mint, generate, or store credentials. For a Cloud target the developer owns the ingestion
+  token; read it from the environment or ask them to paste it — do not create one. (A local dev
+  target has no token — see "Two targets" below.)
 - Never present the generated cases as validated. They are a draft to review and extend.
-- Agent Observability is a Grafana Cloud product. Do not hardcode or assume any endpoint (no `localhost`);
-  the developer supplies their Cloud endpoint and token.
+- **The `llm_judge` uses the LLM provider the agent already uses — don't add a new one.** If the
+  agent calls OpenAI, the judge calls OpenAI; if Anthropic, Anthropic. Do NOT default the judge to
+  `litellm` (or any other provider SDK) when the app doesn't already depend on it — that adds a
+  dependency and a second provider just for scoring. Reuse the agent's existing client/SDK.
+- **Two targets: Grafana Cloud and local dev.** Detect which the agent is aimed at from any existing
+  `AGENTO11Y_ENDPOINT` / `.env` / sibling apps; don't assume Cloud. A **local dev instance** (e.g.
+  `AGENTO11Y_ENDPOINT=http://localhost:8080`, tenant `anonymous`) needs **no auth token** — publish
+  with just the endpoint. A **Cloud** target needs `AGENTO11Y_AUTH_TOKEN` (the ingestion key from
+  the Connection page). Never invent an endpoint or mint a token for either.
 - If a required input is missing (entrypoint, prompt, tools), ask the developer — don't guess.
 
 ## Step 1 — Read the agent
@@ -65,6 +91,19 @@ Find and read these in the target repo, and record the file path and line range 
 2. The system prompt / instructions.
 3. The tool / function definitions the agent can call.
 4. One or two real user requests and what a correct answer looks like.
+5. **The LLM provider and the model** — two distinct things; read them off how the client is
+   constructed and cite the line:
+   - **Provider** (who serves the LLM) → which SDK/client the judge reuses: e.g.
+     `from openai import OpenAI` → OpenAI; `from anthropic import Anthropic` → Anthropic.
+   - **Model** (the specific id, e.g. `gpt-4o-mini`, `claude-sonnet-5`) → the `MODEL_NAME` the runner uses.
+   State both explicitly, and have the judge use the **same provider** as the agent (never a
+   different one). If you can't tell from the code, ask; don't default to a provider the app doesn't use.
+   - **Do NOT assume where the provider API key lives.** The app already loads it *somehow* — an env
+     var, a `.env` (`load_dotenv()`), a secret manager, an explicit `client(api_key=...)`. The
+     runner should reuse the **same mechanism** (it already calls `load_dotenv()`, and provider SDKs
+     read their standard env var themselves). Don't hardcode a key, and don't tell the developer to
+     "set `OPENAI_API_KEY`" as if that's the only way — if the run can't find the key, ask them how
+     their app loads it and mirror that.
 
 Every recommendation must cite one of these locations.
 
@@ -124,7 +163,7 @@ Evaluator ids are yours to choose — pick clear, stable ids. Be concrete about 
 each one means, because it is not an Agent Observability control-plane action here: in the offline SDK flow
 an evaluator is **code the developer writes in the runner** (Step 4). An `llm_judge` is a
 function that calls a model and returns a score; a `deterministic` one is a plain code check.
-`sigil.Evaluator(evaluator_id=..., kind=...)` is only the label attached to the score, not the
+`agento11y.Evaluator(evaluator_id=..., kind=...)` is only the label attached to the score, not the
 logic. (Forking a predefined template is a separate online-eval path, not needed here.)
 
 This skill targets the **offline** phase: run these evaluators as offline experiments against
@@ -160,7 +199,7 @@ as a harness case in its notes, or leave it out.
 ```yaml
 # STARTER DRAFT — review before use. Generated from your agent code (<file:line refs>).
 # NOT validated. Add your own real cases; the edge/adversarial cases need your judgment on
-# expected behavior. Loads with sigil TestSuite.from_yaml(...).
+# expected behavior. Loads with agento11y.TestSuite.from_yaml(...).
 suite_id: <agent>-starter
 name: <Agent> starter suite
 version: 1.0.0
@@ -213,7 +252,7 @@ What you generate depends on the runnability you assessed in Step 1:
 
 Also branch on **language** (the experiments SDK is Python/Go only):
 
-- **Python or Go agent** → native runner (`run_experiment.py`, or the Go `sigil` package).
+- **Python or Go agent** → native runner (`run_experiment.py`, or the Go `agento11y` package).
 - **TS / Java / .NET agent** → there is no experiments SDK in that language. Deliver
   recommendations + YAML (they are language-neutral), and be honest about the run path: the
   runner must be Python or Go calling the agent across a process boundary (e.g. a Python
@@ -224,25 +263,28 @@ Also branch on **language** (the experiments SDK is Python/Go only):
 For an **easy Python/Go** agent, write `evals/run_experiment.py`. It must:
 
 - Load the suite with `TestSuite.from_yaml(...)`.
-- Open an experiment (`sigil.experiment(...)`) and one `trial` per case.
+- Open an experiment (`agento11y.experiment(...)`) and one `trial` per case.
 - Call the agent through a single clearly-marked function `run_agent(case)` — **this is the
   one hole the developer fills**; wire it to the real entrypoint you found in Step 1.
 - Include ONE recommended evaluator sketched end-to-end (prefer an `llm_judge` — a real model
   call that returns a JSON `{score, passed, explanation}`), so they see the shape and can copy
-  it for the others. Reference the rest by name in a comment; do not stub all of them.
+  it for the others. Reference the rest by name in a comment; do not stub all of them. **The
+  judge's model call must use the provider the agent already uses** (reuse its OpenAI/Anthropic
+  client or SDK) — do not pull in `litellm` or another provider just for the judge.
 - Record I/O (`trial.record_io(...)`) and emit `trial.final_score(...)` with the evaluator.
 
 Keep the header verbatim, and be honest in it about what still needs doing:
 
 ```python
 #!/usr/bin/env python3
-"""STARTER RUNNER — generated by agento11y-eval-starter, review before use.
+"""STARTER RUNNER — generated by agento11y-test-starter, review before use.
 
 Runs <agent> over evals/<agent>-starter.yaml as an Agent Observability experiment and publishes scores.
 
 You still need to: (1) fill run_agent(case) to call YOUR agent; (2) tune the sketched
-judge; (3) set real credentials — AGENTO11Y_ENDPOINT + AGENTO11Y_AUTH_TOKEN for your Grafana Cloud
-stack. The SDK stores scores; it does not run the agent or the judge.
+judge; (3) set real credentials — `AGENTO11Y_ENDPOINT` (+ `AGENTO11Y_AUTH_TOKEN` for a Cloud stack;
+a local endpoint needs no token) and the agent's provider key. The SDK stores scores; it does not
+run the agent or the judge.
 
 Set AGENTO11Y_INGEST_ACTOR to a stable value: the run and its trials must share one actor, or
 trial creation fails with "401: experiment is owned by another actor".
@@ -253,33 +295,78 @@ trial creation fails with "401: experiment is owned by another actor".
 import json, os, time
 from pathlib import Path
 from dotenv import load_dotenv
-from sigil_sdk import experiments as sigil
+from agento11y import experiments as agento11y
 
 load_dotenv()
 SUITE = Path(__file__).parent / "<agent>-starter.yaml"
 
 
-def run_agent(case: sigil.TestCase) -> str:
+def run_agent(case: agento11y.TestCase) -> str:
     """THE ONE HOLE YOU FILL — call your agent for this case, return its output text."""
     raise NotImplementedError("wire this to your agent entrypoint (see Step 1 refs)")
 
 
 def judge_<evaluator>(case_input, output) -> tuple[float, bool, str]:
-    """Sketched llm_judge — a model call returning (score 0-1, passed, explanation). Tune it."""
-    import litellm
-    prompt = f"Grade <what this evaluator checks>. Return JSON {{\"score\":0-1,\"passed\":bool,\"explanation\":\"...\"}}.\n\nInput:\n{case_input}\n\nOutput:\n{output}"
+    """Sketched llm_judge — a model call returning (score 0-1, passed, explanation). Tune it.
+
+    Uses the SAME provider client the agent uses (imported below from the agent module) — do NOT
+    swap in litellm or another provider. Adapt the call to your provider's API.
+
+    IMPORTANT for grounding/relevance judges: the judge must SEE what the agent saw. If the agent
+    retrieves context (RAG), re-run its retriever here and put the passages in the prompt —
+    otherwise the judge marks correct, cited answers as "unverifiable" and scores them low. Import
+    the agent's own retriever (e.g. `from agent import retrieve`) and include its output.
+    """
+    prompt = (
+        'Grade <what this evaluator checks>. Reply with ONLY a JSON object, no prose, no markdown '
+        'fences, explanation LAST and short: {"score": <0-1 float>, "passed": <bool>, "explanation": "<one sentence>"}.\n\n'
+        # For a grounding judge, prepend the retrieved context here:
+        # f"CONTEXT:\n{retrieved_passages}\n\n"
+        f"Input:\n{case_input}\n\nOutput:\n{output}"
+    )
     model = os.getenv("GRADER_MODEL") or os.getenv("MODEL_NAME")  # a LIVE model id; no default (dead ids 404)
-    text = litellm.completion(model=model, messages=[{"role": "user", "content": prompt}],
-                              temperature=0, max_tokens=300).choices[0].message.content or "{}"
-    s, e = text.find("{"), text.rfind("}")
-    d = json.loads(text[s:e + 1]) if s >= 0 else {}
+    # Reuse the agent's client (e.g. `from agent import client` for Anthropic/OpenAI). Give it enough
+    # max_tokens (~600) that the JSON verdict is never truncated mid-object. Example (Anthropic):
+    #   text = client.messages.create(model=model, max_tokens=600,
+    #                                  messages=[{"role": "user", "content": prompt}]).content[0].text
+    # Example (OpenAI): client.chat.completions.create(...).choices[0].message.content
+    text = _grade_with_agent_client(model, prompt)  # wire to the agent's provider; max_tokens>=600
+    d = _parse_judge_json(text)
     score = max(0.0, min(1.0, float(d.get("score", 0.0))))
     return score, bool(d.get("passed", score >= 0.6)), str(d.get("explanation", ""))
 
 
+def _parse_judge_json(text: str) -> dict:
+    """Robustly pull the JSON verdict out of a model reply (handles prose / ```json fences)."""
+    if not text:
+        return {}
+    t = text.strip()
+    if "```" in t:  # strip a ```json ... ``` fence if present
+        t = t.split("```")[1].removeprefix("json").strip() if t.count("```") >= 2 else t
+    try:
+        return json.loads(t)
+    except json.JSONDecodeError:
+        pass
+    # Fallback: scan for the first balanced {...} object rather than first-brace/last-brace.
+    depth = 0; start = -1
+    for i, ch in enumerate(t):
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                try:
+                    return json.loads(t[start:i + 1])
+                except json.JSONDecodeError:
+                    start = -1
+    return {}  # unparseable → caller treats as score 0; investigate the raw reply
+
+
 def main() -> None:
-    suite = sigil.TestSuite.from_yaml(str(SUITE))
-    verifier = sigil.Evaluator(evaluator_id="<evaluator>", version="draft-0", kind="llm_judge")
+    suite = agento11y.TestSuite.from_yaml(str(SUITE))
+    verifier = agento11y.Evaluator(evaluator_id="<evaluator>", version="draft-0", kind="llm_judge")
     candidate = {
         "agent_name": "<agent>",
         # Always send a declared agent_version. Without it Agent Observability auto-derives a version from
@@ -290,7 +377,7 @@ def main() -> None:
         "git_sha": os.getenv("GIT_SHA", ""),
         "model_name": os.getenv("MODEL_NAME", ""),
     }
-    with sigil.experiment(name="<agent> starter", experiment_id=f"<agent>-starter-{int(time.time())}",
+    with agento11y.experiment(name="<agent> starter", experiment_id=f"<agent>-starter-{int(time.time())}",
                           suite=suite, candidate=candidate, tags=["starter"],
                           actor=os.getenv("AGENTO11Y_INGEST_ACTOR", "ingest:sdk/python")) as exp:
         for case in suite.test_cases:
@@ -323,7 +410,8 @@ Output, in this order:
    and add real ones.
 3. The three things they still do to run it: fill `run_agent(case)`, tune the sketched judge
    (and add the other recommended evaluators the same way), and set credentials
-   (`AGENTO11Y_ENDPOINT` + `AGENTO11Y_AUTH_TOKEN`). State the boundary explicitly: this skill only
+   (`AGENTO11Y_ENDPOINT` + the provider key; plus `AGENTO11Y_AUTH_TOKEN` for a Cloud target).
+   State the boundary explicitly: this skill only
    bootstraps the first run; for anything past that — binding an already-instrumented agent's
    real generations, auditable LLM-judge grading, cross-process verifiers, repeated-sampling
    metrics — the `agento11y-experiments` skill is the reference.
@@ -343,12 +431,21 @@ If they accept:
 
 1. Help fill `run_agent(case)` — wire it to the real entrypoint from Step 1, so the runner
    actually calls their agent.
-2. Preflight the environment and stop with a clear ask if anything is missing:
-   - `AGENTO11Y_ENDPOINT` + `AGENTO11Y_AUTH_TOKEN`. If either is unset, ask the developer for it
-     proactively — `AGENTO11Y_AUTH_TOKEN` is their Grafana Cloud ingestion API key (Cloud portal →
-     stack → API keys), `AGENTO11Y_ENDPOINT` their stack endpoint. **Never mint, generate, or
-     fabricate a token yourself, and never invent an endpoint** — the developer owns the
-     credential and supplies it; you only read it from the environment or ask for it.
+2. Preflight the environment and stop with a clear ask if anything is missing. **When you ask, tell
+   the developer exactly where each value is** — for a Cloud stack they all live on the plugin
+   **Connection page**, `https://<your-stack>.grafana.net/plugins/grafana-sigil-app`:
+   - `AGENTO11Y_ENDPOINT` = the **API URL** on that page. If unset, ask — never invent one.
+   - `AGENTO11Y_AUTH_TENANT_ID` = the **Instance ID** on that page.
+   - `AGENTO11Y_AUTH_TOKEN` **only for a Cloud target**. For a **local dev** endpoint
+     (`localhost`), there is no token — skip it (tenant `anonymous`). For Cloud, the developer
+     creates it via **"Create a token in Cloud Access Policies"** on the Connection page. Tell them
+     the exact scopes: **`sigil:write`, `metrics:write`, `traces:write`, `logs:write`**. Heads-up on
+     the UI: `sigil` is **not** in the default resource list — they must add it via **"Add scope"**
+     (then tick Write); `metrics`/`traces`/`logs` are already listed (tick Write). The scope is still
+     `sigil:*` (the Cloud resource keeps the old name). **Never mint or fabricate a token** — the
+     developer creates and supplies it; you only read it from the environment or ask.
+   - The **provider API key from Step 1** (e.g. `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`) — name the
+     exact env var, since both the agent and the judge need it. Ask for it; never mint it.
    - `MODEL_NAME` is a live model (dead model ids fail with a 404 not_found).
    - A stable `AGENTO11Y_INGEST_ACTOR` so run and trials share one actor (else `401: owned by
      another actor`).
@@ -360,5 +457,10 @@ If they accept:
    Start with 1–2 cases as a smoke run before the full suite.
 4. Show the per-case scores and the `exp.url`, and note this published one experiment's
    scores (no tenant evaluators/rules/guards were created).
+5. **Don't oversell a clean sweep.** If every case passes on the first run, say so honestly: that
+   usually means the suite isn't hard enough to discriminate yet, not that the agent is flawless.
+   Nudge toward (a) wiring the recommended **deterministic** evaluators (they catch contract
+   violations an `llm_judge` forgives — e.g. an exact-string check vs a paraphrase), and (b) adding
+   a case that actually stresses the agent's likely real failure mode.
 
 If they decline, stop after the summary.

--- a/claude-plugin/skills/agento11y/references/evaluator-examples.md
+++ b/claude-plugin/skills/agento11y/references/evaluator-examples.md
@@ -70,7 +70,7 @@ directly valid `create` input.
 Scores via a configured judge model. The `user_prompt` must inject the
 content being judged with template variables — `{{assistant_response}}` for
 the reply, `{{latest_user_message}}` for the user turn (the convention the
-built-in `sigil.*` judge templates use); without them the judge never sees
+built-in `template.*` judge templates use); without them the judge never sees
 the generation. Pick `provider`/`model` from what the stack actually has:
 
 ```bash


### PR DESCRIPTION
Renames the pre-ship skill and refocuses it on **testing an agent before it ships**, and brings all `agento11y` skills up to date with the `sigil → agento11y` rebranding that landed in grafana/sigil-sdk.

## Rename + refocus (`agento11y-eval-starter` → `agento11y-test-starter`)
- **"eval-starter" collided with `agento11y-prod-setup`** — on an ambiguous prompt like "evaluate this agent", the trigger pulled the wrong skill. This skill writes a **test suite to run an agent offline pre-ship**; "test" says that clearly and cedes "evaluate" to prod-setup. Adds explicit trigger phrases + a scope boundary pointing at `agento11y-prod-setup` for the tenant-level / online case.
- Cross-references updated in `agento11y-instrument` and `agento11y-prod-setup`.

## Rebranding alignment (SDK renamed in sigil-sdk)
- Generated runner imports `from agento11y import experiments` (was `sigil_sdk`).
- `instrument`: detects `agento11y` / `@grafana/agento11y` / Go `agento11y` package (legacy `sigil_sdk` names still noted); log prefix `agento11y:`.
- `prod-setup` + `agento11y`: predefined template ids `sigil.*` → `template.*` (backend grafana/sigil#1296).
- **Kept as-is (still `sigil`):** repo `grafana/sigil-sdk`, plugin `grafana-sigil-app`, `SIGIL_*` legacy env.

## Fixes surfaced by testing the skill end-to-end (local + a Cloud stack)
- **Provider/model detection** (Step 1): read provider + model off the code; the judge reuses the agent's own provider client — **never litellm** or a new provider dependency.
- **Don't assume where the API key lives** (env / `.env` / secret manager) — reuse the app's mechanism.
- **Two targets: Cloud vs local dev** — a local endpoint needs no auth token.
- **Prerequisites**: `pip install agento11y`.
- **Token guidance**: exact scopes (`sigil:write`, `metrics/traces/logs:write`) + the "Add scope" UI step (`sigil` isn't in the default resource list).
- **Robust judge**: balanced-brace JSON parsing + fence stripping + `max_tokens` headroom so the verdict never truncates; grounding judges must see the retrieved context; don't oversell an all-pass first run.

## Testing
Validated end-to-end: instrumented + tested two agents (a LangGraph pipeline and a RAG agent) against **a local instance and a Cloud stack** — experiments published with scores in both. Skills-drift, `validate-skills`, and command-skills tests pass.

> [!WARNING]
> **BREAKING CHANGE:** the skill is now `agento11y-test-starter` (was `agento11y-eval-starter`).

## Coordination
A follow-up grafana/sigil-sdk PR updates `llms.txt` Path C to route to `agento11y-test-starter` (install via gcx) — the earlier draft #400 predates the rebranding on main and will be redone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)