### PR TITLE
chore(release): v0.5.0 changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "gcx",
       "source": "./claude-plugin",
       "description": "Debug, explore, and instrument with Grafana using gcx CLI",
-      "version": "0.4.4"
+      "version": "0.5.0"
     }
   ]
 }

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -4,7 +4,7 @@
 - Add `agento11y-instrument` skill (setup → instrument → verify loop)
 - Add `agento11y-prod-setup` skill for production evals and guards
 - Bundle the `agento11y-test-starter` starter skill
-- Remove the `explore-datasources` skill
+- **Breaking:** remove the `explore-datasources` skill
 - Retune skill descriptions and fix API drift in aio11y, SLO, and Synthetics guidance
 - Export anonymous usage events as flat JSON over HTTP when telemetry is enabled
 - Add profiles span and trace selectors; include trace IDs in exemplars

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,25 +1,30 @@
-- Add full CRUD lifecycle for datasources (create, update, delete, health, schemas)
-- Add `--name` filter to `datasources list`
-- Parallelize per-plugin-group datasource list fetch for speed
-- Add CRUD verbs and discovery for IRM OnCall resources
-- Fix IRM build break from a semantic merge conflict
-- Add OAuth login flow for `gcx cloud login` (grafana.com), marked experimental
-- Expand OAuth scopes; drop k6 from write scopes; fix login help text/doc links
-- Add anonymous usage stats core library (telemetry, not yet wired in)
-- Add fail-safe client-side dry-run for APIs that ignore `dryRun`
-- Add metrics cardinality analysis commands
-- Add filter, group-by, and label discovery to appo11y services commands
-- Add `assistant mcp-servers` command group
-- Add knowledge graph entity & relationship write commands (gated, experimental)
-- Add `x-client-id` header to Synthetic Monitoring requests
-- Fix logs: distinguish structured metadata from indexed stream labels
-- Skip `/bootdata` namespace validation when stack-id is set (faster config load)
-- Dedupe HTTP client construction/error parsing across providers
-- Dedupe Prometheus/Loki/CloudWatch onto shared query transport
-- Dedupe aio11y marshal/status-check/decode pattern
-- Dedupe datasources config-loading boilerplate
-- Add drift check ensuring bundled skills match real gcx commands
-- Switch lint to Go module mode, dropping the `vendor/` requirement
-- Update Go dependencies
-- Fix docs links in README, CLI help text, and OAuth login docs
-- Use main branch for deploy previews; update SM CODEOWNERS
+Here are the CHANGELOG bullets for v0.5.0:
+
+```markdown
+- Register the Assistant as a first-class provider, moving `mcp-servers` into the resources pipeline
+- Rename the `aio11y` command tree and skills to `agento11y`
+- Rename the `agento11y-eval-starter` skill to `agento11y-test-starter`
+- Add `agento11y-instrument` skill (setup → instrument → verify loop)
+- Add `agento11y-prod-setup` skill for production evals and guards
+- Bundle the `agento11y-test-starter` starter skill
+- Remove the `explore-datasources` skill
+- Retune skill descriptions and fix API drift in aio11y, SLO, and Synthetics guidance
+- Export anonymous usage events as flat JSON over HTTP when telemetry is enabled
+- Add profiles span and trace selectors; include trace IDs in exemplars
+- Fix profiles `--top` totals to exclude the pre-window boundary point
+- Add KG `prom-rules schema` command and `--dry-run` to suppressions create
+- Route KG write API through the Asserts plugin proxy
+- Fix KG entity/relationship deletes to use the collection-path API
+- Support Dashboard V2 in the resource linter
+- Descend into single-key list envelopes for `--json` discovery and selection
+- Include an output-shape hint in `--jq` runtime errors
+- Request full cloud scopes in the `login cloud` followup flow
+- Derive SDK imports for generated `dev import` code from actual usage
+- Disclose per-product Grafana Cloud costs in docs and help text
+- Clarify gcx works with OSS and Enterprise, not just Cloud
+- Mark the traces `--llm` flag experimental and document its Accept header
+```
+
+A couple of notes:
+- Commit `f8f6ac98` is marked breaking (`!`) — the skill rename `agento11y-eval-starter` → `agento11y-test-starter`, as is `9d193ca7` (`aio11y` → `agento11y`). You may want a **BREAKING CHANGES** callout for those two renames since users have to update command/skill names.
+- I collapsed the several skill-guidance fix commits (`e7388082`, `b67d9512`, `35e80d99`, `f595093d`) into one bullet to stay concise; expand if you'd rather list them separately.

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,9 +1,6 @@
-Here are the CHANGELOG bullets for v0.5.0:
-
-```markdown
 - Register the Assistant as a first-class provider, moving `mcp-servers` into the resources pipeline
-- Rename the `aio11y` command tree and skills to `agento11y`
-- Rename the `agento11y-eval-starter` skill to `agento11y-test-starter`
+- **Breaking:** rename the `aio11y` command tree and skills to `agento11y`
+- **Breaking:** rename the `agento11y-eval-starter` skill to `agento11y-test-starter`
 - Add `agento11y-instrument` skill (setup → instrument → verify loop)
 - Add `agento11y-prod-setup` skill for production evals and guards
 - Bundle the `agento11y-test-starter` starter skill
@@ -23,8 +20,3 @@ Here are the CHANGELOG bullets for v0.5.0:
 - Disclose per-product Grafana Cloud costs in docs and help text
 - Clarify gcx works with OSS and Enterprise, not just Cloud
 - Mark the traces `--llm` flag experimental and document its Accept header
-```
-
-A couple of notes:
-- Commit `f8f6ac98` is marked breaking (`!`) — the skill rename `agento11y-eval-starter` → `agento11y-test-starter`, as is `9d193ca7` (`aio11y` → `agento11y`). You may want a **BREAKING CHANGES** callout for those two renames since users have to update command/skill names.
-- I collapsed the several skill-guidance fix commits (`e7388082`, `b67d9512`, `35e80d99`, `f595093d`) into one bullet to stay concise; expand if you'd rather list them separately.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add `agento11y-instrument` skill (setup → instrument → verify loop)
 - Add `agento11y-prod-setup` skill for production evals and guards
 - Bundle the `agento11y-test-starter` starter skill
-- Remove the `explore-datasources` skill
+- **Breaking:** remove the `explore-datasources` skill
 - Retune skill descriptions and fix API drift in aio11y, SLO, and Synthetics guidance
 - Export anonymous usage events as flat JSON over HTTP when telemetry is enabled
 - Add profiles span and trace selectors; include trace IDs in exemplars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+## v0.5.0 (2026-07-21)
+
+Here are the CHANGELOG bullets for v0.5.0:
+
+```markdown
+- Register the Assistant as a first-class provider, moving `mcp-servers` into the resources pipeline
+- Rename the `aio11y` command tree and skills to `agento11y`
+- Rename the `agento11y-eval-starter` skill to `agento11y-test-starter`
+- Add `agento11y-instrument` skill (setup → instrument → verify loop)
+- Add `agento11y-prod-setup` skill for production evals and guards
+- Bundle the `agento11y-test-starter` starter skill
+- Remove the `explore-datasources` skill
+- Retune skill descriptions and fix API drift in aio11y, SLO, and Synthetics guidance
+- Export anonymous usage events as flat JSON over HTTP when telemetry is enabled
+- Add profiles span and trace selectors; include trace IDs in exemplars
+- Fix profiles `--top` totals to exclude the pre-window boundary point
+- Add KG `prom-rules schema` command and `--dry-run` to suppressions create
+- Route KG write API through the Asserts plugin proxy
+- Fix KG entity/relationship deletes to use the collection-path API
+- Support Dashboard V2 in the resource linter
+- Descend into single-key list envelopes for `--json` discovery and selection
+- Include an output-shape hint in `--jq` runtime errors
+- Request full cloud scopes in the `login cloud` followup flow
+- Derive SDK imports for generated `dev import` code from actual usage
+- Disclose per-product Grafana Cloud costs in docs and help text
+- Clarify gcx works with OSS and Enterprise, not just Cloud
+- Mark the traces `--llm` flag experimental and document its Accept header
+```
+
+A couple of notes:
+- Commit `f8f6ac98` is marked breaking (`!`) — the skill rename `agento11y-eval-starter` → `agento11y-test-starter`, as is `9d193ca7` (`aio11y` → `agento11y`). You may want a **BREAKING CHANGES** callout for those two renames since users have to update command/skill names.
+- I collapsed the several skill-guidance fix commits (`e7388082`, `b67d9512`, `35e80d99`, `f595093d`) into one bullet to stay concise; expand if you'd rather list them separately.
+
+
 ## v0.4.4 (2026-07-10)
 
 - Add full CRUD lifecycle for datasources (create, update, delete, health, schemas)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 ## v0.5.0 (2026-07-21)
 
-Here are the CHANGELOG bullets for v0.5.0:
-
-```markdown
 - Register the Assistant as a first-class provider, moving `mcp-servers` into the resources pipeline
-- Rename the `aio11y` command tree and skills to `agento11y`
-- Rename the `agento11y-eval-starter` skill to `agento11y-test-starter`
+- **Breaking:** rename the `aio11y` command tree and skills to `agento11y`
+- **Breaking:** rename the `agento11y-eval-starter` skill to `agento11y-test-starter`
 - Add `agento11y-instrument` skill (setup → instrument → verify loop)
 - Add `agento11y-prod-setup` skill for production evals and guards
 - Bundle the `agento11y-test-starter` starter skill
@@ -25,11 +22,6 @@ Here are the CHANGELOG bullets for v0.5.0:
 - Disclose per-product Grafana Cloud costs in docs and help text
 - Clarify gcx works with OSS and Enterprise, not just Cloud
 - Mark the traces `--llm` flag experimental and document its Accept header
-```
-
-A couple of notes:
-- Commit `f8f6ac98` is marked breaking (`!`) — the skill rename `agento11y-eval-starter` → `agento11y-test-starter`, as is `9d193ca7` (`aio11y` → `agento11y`). You may want a **BREAKING CHANGES** callout for those two renames since users have to update command/skill names.
-- I collapsed the several skill-guidance fix commits (`e7388082`, `b67d9512`, `35e80d99`, `f595093d`) into one bullet to stay concise; expand if you'd rather list them separately.
 
 
 ## v0.4.4 (2026-07-10)

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcx",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Debug, explore, and instrument with Grafana using gcx CLI",
   "keywords": ["grafana", "observability", "monitoring", "prometheus", "loki", "dashboards"],
   "author": {


### PR DESCRIPTION
## Summary
- Prepare gcx v0.5.0 release notes and changelog.
- Bump Claude plugin metadata to 0.5.0.
- Call out the breaking command/skill renames for agento11y.

## Test plan
- Release script completed successfully with `mise run tag -- minor`.
- Manually cleaned generated changelog/release notes formatting.