### PR TITLE
feat(profiles): add time-range flags to labels and profile-types

### DIFF
--- a/docs/reference/cli/gcx_datasources_pyroscope_labels.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_labels.md
@@ -20,6 +20,9 @@ gcx datasources pyroscope labels [flags]
 	# Get values for a specific label
 	gcx datasources pyroscope labels -d UID --label service_name
 
+	# Search a wider window than the default last hour
+	gcx datasources pyroscope labels -d UID --since 24h
+
 	# Output as JSON
 	gcx datasources pyroscope labels -d UID -o json
 ```
@@ -28,11 +31,14 @@ gcx datasources pyroscope labels [flags]
 
 ```
   -d, --datasource string   Datasource UID (required unless default-pyroscope-datasource is configured)
+      --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for labels
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
+      --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_pyroscope_list-profile-types.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_list-profile-types.md
@@ -19,6 +19,9 @@ gcx datasources pyroscope list-profile-types [flags]
 	# List profile types (use datasource UID, not name)
 	gcx datasources pyroscope list-profile-types -d UID
 
+	# Search a wider window than the default last hour
+	gcx datasources pyroscope list-profile-types -d UID --since 24h
+
 	# Output as JSON
 	gcx datasources pyroscope list-profile-types -d UID -o json
 ```
@@ -27,10 +30,13 @@ gcx datasources pyroscope list-profile-types [flags]
 
 ```
   -d, --datasource string   Datasource UID (required unless default-pyroscope-datasource is configured)
+      --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for list-profile-types
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
+      --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_profiles_labels.md
+++ b/docs/reference/cli/gcx_profiles_labels.md
@@ -28,11 +28,14 @@ gcx profiles labels [flags]
 
 ```
   -d, --datasource string   Datasource UID (required unless default-pyroscope-datasource is configured)
+      --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for labels
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -l, --label string        Get values for this label (omit to list all labels)
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
+      --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_profiles_list-profile-types.md
+++ b/docs/reference/cli/gcx_profiles_list-profile-types.md
@@ -27,10 +27,13 @@ gcx profiles list-profile-types [flags]
 
 ```
   -d, --datasource string   Datasource UID (required unless default-pyroscope-datasource is configured)
+      --from string         Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
   -h, --help                help for list-profile-types
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string       Output format. One of: agents, json, table, yaml (default "table")
+      --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
+      --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```
 
 ### Options inherited from parent commands

--- a/internal/datasources/pyroscope/hints.go
+++ b/internal/datasources/pyroscope/hints.go
@@ -1,0 +1,23 @@
+package pyroscope
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/query/pyroscope"
+)
+
+// emitEmptyWindowHint reports the time window that produced an empty metadata
+// result. Without it, an empty tenant and a tenant whose data sits just outside
+// the implicit default window are indistinguishable from the output alone.
+func emitEmptyWindowHint(w io.Writer, what string, start, end time.Time, explicitRange bool) {
+	effStart, effEnd := pyroscope.DefaultTimeRange(start, end)
+	window := fmt.Sprintf("%s to %s", effStart.UTC().Format(time.RFC3339), effEnd.UTC().Format(time.RFC3339))
+	if explicitRange {
+		cmdio.EmitHint(w, fmt.Sprintf("no %s found in window %s — widen the range with --since or --from/--to", what, window), "")
+		return
+	}
+	cmdio.EmitHint(w, fmt.Sprintf("no %s found in the default window (last 1h: %s) — pass --since (e.g. --since 24h) or --from/--to to search further back", what, window), "")
+}

--- a/internal/datasources/pyroscope/hints_test.go
+++ b/internal/datasources/pyroscope/hints_test.go
@@ -1,0 +1,46 @@
+package pyroscope //nolint:testpackage // white-box test of unexported emitEmptyWindowHint
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmitEmptyWindowHint(t *testing.T) {
+	start := time.Date(2026, 7, 16, 14, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	t.Run("explicit range names the window", func(t *testing.T) {
+		var buf strings.Builder
+		emitEmptyWindowHint(&buf, "labels", start, end, true)
+
+		assert.Contains(t, buf.String(), "no labels found in window 2026-07-16T14:00:00Z to 2026-07-16T15:00:00Z")
+		assert.Contains(t, buf.String(), "--since")
+	})
+
+	t.Run("default window is called out as such", func(t *testing.T) {
+		var buf strings.Builder
+		emitEmptyWindowHint(&buf, "profile types", time.Time{}, time.Time{}, false)
+
+		out := buf.String()
+		assert.Contains(t, out, "no profile types found in the default window (last 1h")
+		assert.Contains(t, out, "--since")
+	})
+}
+
+func TestMetadataCommandsExposeTimeFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{"labels", LabelsCmd(nil)},
+		{"list-profile-types", ListProfileTypesCmd(nil)},
+	} {
+		for _, flag := range []string{"since", "from", "to"} {
+			assert.NotNil(t, tc.cmd.Flags().Lookup(flag), "%s should expose --%s", tc.name, flag)
+		}
+	}
+}

--- a/internal/datasources/pyroscope/labels.go
+++ b/internal/datasources/pyroscope/labels.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/grafana/gcx/internal/agent"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
@@ -16,6 +17,8 @@ import (
 )
 
 type pyroscopeLabelsOpts struct {
+	dsquery.TimeRangeOpts
+
 	IO         cmdio.Options
 	Datasource string
 	Label      string
@@ -28,10 +31,14 @@ func (opts *pyroscopeLabelsOpts) setup(flags *pflag.FlagSet) {
 
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless default-pyroscope-datasource is configured)")
 	flags.StringVarP(&opts.Label, "label", "l", "", "Get values for this label (omit to list all labels)")
+	opts.SetupTimeFlags(flags)
 }
 
 func (opts *pyroscopeLabelsOpts) Validate() error {
-	return opts.IO.Validate()
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	return opts.ValidateTimeRange()
 }
 
 func LabelsCmd(loader *providers.ConfigLoader) *cobra.Command {
@@ -47,6 +54,9 @@ func LabelsCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 	# Get values for a specific label
 	gcx datasources pyroscope labels -d UID --label service_name
+
+	# Search a wider window than the default last hour
+	gcx datasources pyroscope labels -d UID --since 24h
 
 	# Output as JSON
 	gcx datasources pyroscope labels -d UID -o json`,
@@ -72,25 +82,41 @@ func LabelsCmd(loader *providers.ConfigLoader) *cobra.Command {
 				return fmt.Errorf("failed to create client: %w", err)
 			}
 
+			start, end, err := opts.ParseTimeRange(time.Now())
+			if err != nil {
+				return err
+			}
+
 			if opts.Label != "" {
 				resp, err := client.LabelValues(ctx, datasourceUID, pyroscope.LabelValuesRequest{
-					Name: opts.Label,
+					Name:  opts.Label,
+					Start: start,
+					End:   end,
 				})
 				if err != nil {
 					return fmt.Errorf("failed to get label values: %w", err)
 				}
 
+				if len(resp.Names) == 0 {
+					emitEmptyWindowHint(cmd.ErrOrStderr(), fmt.Sprintf("values for label %q", opts.Label), start, end, opts.IsRange())
+				}
 				if opts.IO.OutputFormat == "table" {
 					return pyroscope.FormatLabelsTable(cmd.OutOrStdout(), resp.Names)
 				}
 				return opts.IO.Encode(cmd.OutOrStdout(), resp)
 			}
 
-			resp, err := client.LabelNames(ctx, datasourceUID, pyroscope.LabelNamesRequest{})
+			resp, err := client.LabelNames(ctx, datasourceUID, pyroscope.LabelNamesRequest{
+				Start: start,
+				End:   end,
+			})
 			if err != nil {
 				return fmt.Errorf("failed to get labels: %w", err)
 			}
 
+			if len(resp.Names) == 0 {
+				emitEmptyWindowHint(cmd.ErrOrStderr(), "labels", start, end, opts.IsRange())
+			}
 			if opts.IO.OutputFormat == "table" {
 				return pyroscope.FormatLabelsTable(cmd.OutOrStdout(), resp.Names)
 			}
@@ -100,7 +126,7 @@ func LabelsCmd(loader *providers.ConfigLoader) *cobra.Command {
 
 	cmd.Annotations = map[string]string{
 		agent.AnnotationTokenCost: "small",
-		agent.AnnotationLLMHint:   "gcx datasources pyroscope labels -d UID -o json",
+		agent.AnnotationLLMHint:   "gcx datasources pyroscope labels -d UID --since 1h -o json",
 	}
 
 	opts.setup(cmd.Flags())

--- a/internal/datasources/pyroscope/list_profile_types.go
+++ b/internal/datasources/pyroscope/list_profile_types.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/grafana/gcx/internal/agent"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
@@ -16,6 +17,8 @@ import (
 )
 
 type profileTypesOpts struct {
+	dsquery.TimeRangeOpts
+
 	IO         cmdio.Options
 	Datasource string
 }
@@ -26,10 +29,14 @@ func (opts *profileTypesOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless default-pyroscope-datasource is configured)")
+	opts.SetupTimeFlags(flags)
 }
 
 func (opts *profileTypesOpts) Validate() error {
-	return opts.IO.Validate()
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	return opts.ValidateTimeRange()
 }
 
 func ListProfileTypesCmd(loader *providers.ConfigLoader) *cobra.Command {
@@ -46,6 +53,9 @@ func ListProfileTypesCmd(loader *providers.ConfigLoader) *cobra.Command {
 		Example: `
 	# List profile types (use datasource UID, not name)
 	gcx datasources pyroscope list-profile-types -d UID
+
+	# Search a wider window than the default last hour
+	gcx datasources pyroscope list-profile-types -d UID --since 24h
 
 	# Output as JSON
 	gcx datasources pyroscope list-profile-types -d UID -o json`,
@@ -71,11 +81,22 @@ func ListProfileTypesCmd(loader *providers.ConfigLoader) *cobra.Command {
 				return fmt.Errorf("failed to create client: %w", err)
 			}
 
-			resp, err := client.ProfileTypes(ctx, datasourceUID, pyroscope.ProfileTypesRequest{})
+			start, end, err := opts.ParseTimeRange(time.Now())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.ProfileTypes(ctx, datasourceUID, pyroscope.ProfileTypesRequest{
+				Start: start,
+				End:   end,
+			})
 			if err != nil {
 				return fmt.Errorf("failed to get profile types: %w", err)
 			}
 
+			if len(resp.ProfileTypes) == 0 {
+				emitEmptyWindowHint(cmd.ErrOrStderr(), "profile types", start, end, opts.IsRange())
+			}
 			if opts.IO.OutputFormat == "table" {
 				return pyroscope.FormatProfileTypesTable(cmd.OutOrStdout(), resp)
 			}


### PR DESCRIPTION
`labels` and `profile-types` query a fixed last-1h window: the time flags every other profiles subcommand has (`--since`/`--from`/`--to`) aren't registered on them, and an empty result says nothing about the window that was searched — `{"names":null}`, exit 0. A tenant with no data and a tenant whose data sits 61 minutes in the past are indistinguishable from the output, and there's no way to widen the search even after diagnosing the cause.

In an internal profiling-agent benchmark this was the largest single source of wasted agent steps: agents ran `labels`/`profile-types` against data anchored a few hours back, got silent empties, retried with `-v 3` and `--log-http-payload` (neither reveals the window), guessed `--from`/`--to` (unknown flag on these two subcommands), and eventually fell back to raw curl against the datasource proxy.

Changes:
- register the shared `TimeRangeOpts` flags (`--since`/`--from`/`--to`) on both commands and pass the range through — the request structs already had `Start`/`End` fields, they were just never populated
- on an empty result, emit a stderr hint naming the effective window:

```
$ gcx profiles labels -d <uid>
{"names":null}
hint: no labels found in the default window (last 1h: 2026-07-16T19:29:40Z to 2026-07-16T20:29:40Z) — pass --since (e.g. --since 24h) or --from/--to to search further back
```

Agent mode gets the typed `{"class":"hint",...}` JSONL form; stdout payloads are unchanged in both modes, as is the default window when no flags are passed.

Notes:
- verified end-to-end against a Pyroscope holding only 5h-old data: `--since 6h` returns the labels/values/types that are silently dropped today
- will rebase once #1009 (`profile-types` → `list-profile-types`) lands; these changes are orthogonal to the rename