### PR TITLE
feat(telemetry): first-run notice and default-on usage stats

### DIFF
--- a/cmd/gcx/telemetry.go
+++ b/cmd/gcx/telemetry.go
@@ -40,7 +40,14 @@ func emitUsageEvent(cmd *cobra.Command, start time.Time, exitCode int) {
 		return
 	}
 
-	switch telemetry.ResolveMode(diagnosticsTelemetryValue) {
+	mode := telemetry.ResolveMode(diagnosticsTelemetryValue)
+
+	// One-time opt-out notice for interactive users; the command's own output
+	// has already been written by this point.
+	_, isCI := telemetry.DetectCI()
+	telemetry.MaybeShowFirstRunNotice(os.Stderr, mode, terminal.StdoutIsTerminal(), isCI, agent.IsAgentMode())
+
+	switch mode {
 	case telemetry.ModeLog:
 		if data, err := json.Marshal(buildUsageEvent(info, start, exitCode)); err == nil {
 			fmt.Fprintln(os.Stderr, string(data))

--- a/cmd/gcx/telemetry.go
+++ b/cmd/gcx/telemetry.go
@@ -43,9 +43,11 @@ func emitUsageEvent(cmd *cobra.Command, start time.Time, exitCode int) {
 	mode := telemetry.ResolveMode(diagnosticsTelemetryValue)
 
 	// One-time opt-out notice for interactive users; the command's own output
-	// has already been written by this point.
+	// has already been written by this point. Gated on stderr's TTY state
+	// because that is where the notice goes: piped stdout must not hide it,
+	// and discarded stderr must not consume the one-shot flag.
 	_, isCI := telemetry.DetectCI()
-	telemetry.MaybeShowFirstRunNotice(os.Stderr, mode, terminal.StdoutIsTerminal(), isCI, agent.IsAgentMode())
+	telemetry.MaybeShowFirstRunNotice(os.Stderr, mode, terminal.StderrIsTerminal(), isCI, agent.IsAgentMode())
 
 	switch mode {
 	case telemetry.ModeLog:

--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -193,7 +193,7 @@ diagnostics:
   log-dir: string
   # Telemetry controls anonymous usage telemetry: "enabled", "disabled",
   # or "log" (prints to stderr). Enabled by default. Overridden by the
-  # GCX_TELEMETRY and DO_NOT_TRACK environment variables.
+  # GCX_TELEMETRY environment variable.
   telemetry: string
 
 ```

--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -192,8 +192,8 @@ diagnostics:
   # Default: $XDG_STATE_HOME/gcx/ (platform-specific).
   log-dir: string
   # Telemetry controls anonymous usage telemetry: "enabled", "disabled",
-  # or "log" (prints to stderr). Overridden by the GCX_TELEMETRY and
-  # DO_NOT_TRACK environment variables.
+  # or "log" (prints to stderr). Enabled by default. Overridden by the
+  # GCX_TELEMETRY and DO_NOT_TRACK environment variables.
   telemetry: string
 
 ```

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -21,8 +21,8 @@ disables the notifier (NO_COLOR convention).
 
 Telemetry controls anonymous usage telemetry for this invocation:
 "enabled", "disabled", or "log" (print the event to stderr and send
-nothing). Takes precedence over DO_NOT_TRACK and the
-`diagnostics.telemetry` config field.
+nothing). Telemetry is enabled by default. Takes precedence over
+DO_NOT_TRACK and the `diagnostics.telemetry` config field.
 
 ## `GCX_TELEMETRY_ENDPOINT`
 

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -21,8 +21,9 @@ disables the notifier (NO_COLOR convention).
 
 Telemetry controls anonymous usage telemetry for this invocation:
 "enabled", "disabled", or "log" (print the event to stderr and send
-nothing). Telemetry is enabled by default. Takes precedence over
-the `diagnostics.telemetry` config field.
+nothing). Telemetry is enabled by default. Any other non-empty value
+disables telemetry. Takes precedence over the `diagnostics.telemetry`
+config field.
 
 ## `GCX_TELEMETRY_ENDPOINT`
 

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -22,7 +22,7 @@ disables the notifier (NO_COLOR convention).
 Telemetry controls anonymous usage telemetry for this invocation:
 "enabled", "disabled", or "log" (print the event to stderr and send
 nothing). Telemetry is enabled by default. Takes precedence over
-DO_NOT_TRACK and the `diagnostics.telemetry` config field.
+the `diagnostics.telemetry` config field.
 
 ## `GCX_TELEMETRY_ENDPOINT`
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -134,7 +134,7 @@ type DiagnosticsConfig struct {
 
 	// Telemetry controls anonymous usage telemetry: "enabled", "disabled",
 	// or "log" (prints to stderr). Enabled by default. Overridden by the
-	// GCX_TELEMETRY and DO_NOT_TRACK environment variables.
+	// GCX_TELEMETRY environment variable.
 	Telemetry string `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -133,8 +133,8 @@ type DiagnosticsConfig struct {
 	LogDir string `json:"log-dir,omitempty" yaml:"log-dir,omitempty"`
 
 	// Telemetry controls anonymous usage telemetry: "enabled", "disabled",
-	// or "log" (prints to stderr). Overridden by the GCX_TELEMETRY and
-	// DO_NOT_TRACK environment variables.
+	// or "log" (prints to stderr). Enabled by default. Overridden by the
+	// GCX_TELEMETRY and DO_NOT_TRACK environment variables.
 	Telemetry string `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`
 }
 

--- a/internal/docs/links.go
+++ b/internal/docs/links.go
@@ -90,6 +90,11 @@ const (
 	// field mapping. Referenced by the loader's automatic migration on both
 	// success and failure.
 	ConfigMigration = "https://grafana.com/docs/grafana/latest/as-code/observability-as-code/grafana-cli/gcx/migrate-configuration.md"
+
+	// AnonymousUsageStats documents gcx's anonymous usage statistics: what is
+	// collected and how to opt out. Referenced by the first-run telemetry
+	// notice.
+	AnonymousUsageStats = "https://grafana.com/docs/grafana/latest/as-code/observability-as-code/grafana-cli/gcx/anonymous-usage-statistics.md"
 )
 
 // All returns every documentation URL in the registry. Used by the
@@ -114,5 +119,6 @@ func All() []string {
 		SyntheticMonitoringInvoice,
 		PerformanceTestingInvoice,
 		IRMInvoice,
+		AnonymousUsageStats,
 	}
 }

--- a/internal/telemetry/deviceid.go
+++ b/internal/telemetry/deviceid.go
@@ -11,10 +11,16 @@ import (
 
 const deviceIDFileName = "device-id"
 
-// DeviceIDPath returns the full path of the persistent device ID file.
-// Deleting the file resets the ID.
+// DeviceIDPath returns the full path of the persistent device ID file, or ""
+// when no state home is known (HOME and XDG_STATE_HOME both unset), so the ID
+// file cannot land relative to the current directory. Deleting the file
+// resets the ID.
 func DeviceIDPath() string {
-	return filepath.Join(xdg.StateHome(), "gcx", deviceIDFileName)
+	stateHome := xdg.StateHome()
+	if stateHome == "" {
+		return ""
+	}
+	return filepath.Join(stateHome, "gcx", deviceIDFileName)
 }
 
 // DeviceID returns the anonymous per-install device ID and whether it is
@@ -34,6 +40,10 @@ func DeviceID() (string, bool) {
 		return "", false
 	}
 	id := fresh.String()
+	// No known state home: nowhere sensible to persist, so stay ephemeral.
+	if path == "" {
+		return id, false
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return id, false
 	}

--- a/internal/telemetry/deviceid_test.go
+++ b/internal/telemetry/deviceid_test.go
@@ -43,6 +43,17 @@ func TestDeviceIDRewritesCorruptFile(t *testing.T) {
 	assert.Equal(t, id+"\n", string(data), "corrupt file must be replaced with the fresh ID")
 }
 
+func TestDeviceIDEphemeralWhenStateHomeUnknown(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", "")
+	assert.Empty(t, telemetry.DeviceIDPath(), "unknown state home must not yield a relative path")
+
+	id, persisted := telemetry.DeviceID()
+	assert.False(t, persisted, "unknown state home must yield an ephemeral ID")
+	_, err := uuid.Parse(id)
+	require.NoError(t, err)
+}
+
 func TestDeviceIDEphemeralWhenStateDirUnwritable(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("permission checks do not apply to root")

--- a/internal/telemetry/export.go
+++ b/internal/telemetry/export.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/grafana/gcx/internal/httputils"
+	"github.com/grafana/gcx/internal/version"
 )
 
 // defaultEndpoint is the usage-stats receiver. GCX_TELEMETRY_ENDPOINT
@@ -25,8 +25,9 @@ const exportTimeout = time.Second
 // and by the receiver's own tests); the receiver stamps receipt time itself,
 // so the payload carries no timestamp. Export never reports failure:
 // telemetry is fire-and-forget and must not affect the command's outcome. A
-// lost event is fine — the shared client may retry transient failures, but
-// exportTimeout caps the whole exchange.
+// lost event is fine: the export is a single attempt with no retries, so an
+// unreachable endpoint costs one fast failure rather than the full
+// exportTimeout, which caps the whole exchange.
 func Export(event Event) {
 	endpoint := defaultEndpoint
 	if override := os.Getenv(envEndpoint); override != "" {
@@ -45,7 +46,11 @@ func export(event Event, endpoint string) {
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := httputils.NewClient(httputils.ClientOpts{Timeout: exportTimeout})
+	req.Header.Set("User-Agent", version.UserAgent())
+	// Deliberately not the shared httputils client: its retry transport would
+	// burn the whole exportTimeout budget on an unreachable endpoint, and this
+	// runs synchronously before exit on every telemetry-enabled invocation.
+	client := &http.Client{Timeout: exportTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return

--- a/internal/telemetry/export_internal_test.go
+++ b/internal/telemetry/export_internal_test.go
@@ -5,9 +5,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/grafana/gcx/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,6 +54,7 @@ func TestExportPostsJSONToEndpointOverride(t *testing.T) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/gcx-usage-report", r.URL.Path)
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, version.UserAgent(), r.Header.Get("User-Agent"))
 	case <-time.After(5 * time.Second):
 		t.Fatal("no request received")
 	}
@@ -117,6 +120,23 @@ func TestExportSwallowsFailures(t *testing.T) {
 
 	t.Setenv(envEndpoint, "://not a url")
 	Export(testEvent())
+}
+
+// A retryable failure (503) must produce exactly one request: the export runs
+// synchronously before CLI exit, so retries would delay every invocation
+// whenever the receiver is unavailable.
+func TestExportMakesSingleAttempt(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	t.Setenv(envEndpoint, server.URL)
+
+	Export(testEvent())
+
+	assert.EqualValues(t, 1, attempts.Load())
 }
 
 // exportTimeout is the ceiling on how long telemetry can hold up CLI exit: a

--- a/internal/telemetry/firstrun.go
+++ b/internal/telemetry/firstrun.go
@@ -14,9 +14,9 @@ const firstRunNoticeFileName = "telemetry-notice-shown"
 
 // firstRunNotice is the one-time message telling interactive users that
 // anonymous usage stats are on and how to opt out.
-const firstRunNotice = `gcx collects anonymous usage statistics: command paths, flag names, and outcomes - never argument values, resource names, or hosts.
-Opt out: set GCX_TELEMETRY=disabled, or diagnostics.telemetry: disabled in the gcx config file.
-Details: ` + docs.AnonymousUsageStats + "\n"
+const firstRunNotice = `gcx collects anonymous usage statistics so we can make gcx better. We do not collect potentially identifiable or sensitive information like argument or flag values or resource names.
+You can opt out by setting GCX_TELEMETRY=disabled, or putting diagnostics.telemetry: disabled in your gcx config file.
+Find out more at ` + docs.AnonymousUsageStats + "\n"
 
 // FirstRunNoticePath returns the flag file that records the notice was shown.
 func FirstRunNoticePath() string {

--- a/internal/telemetry/firstrun.go
+++ b/internal/telemetry/firstrun.go
@@ -18,9 +18,15 @@ const firstRunNotice = `gcx collects anonymous usage statistics so we can make g
 You can opt out by setting GCX_TELEMETRY=disabled, or putting diagnostics.telemetry: disabled in your gcx config file.
 Find out more at ` + docs.AnonymousUsageStats + "\n"
 
-// FirstRunNoticePath returns the flag file that records the notice was shown.
+// FirstRunNoticePath returns the flag file that records the notice was shown,
+// or "" when no state home is known (HOME and XDG_STATE_HOME both unset), so
+// the flag file cannot land relative to the current directory.
 func FirstRunNoticePath() string {
-	return filepath.Join(xdg.StateHome(), "gcx", firstRunNoticeFileName)
+	stateHome := xdg.StateHome()
+	if stateHome == "" {
+		return ""
+	}
+	return filepath.Join(stateHome, "gcx", firstRunNoticeFileName)
 }
 
 // MaybeShowFirstRunNotice writes the one-time telemetry notice to w. It is
@@ -35,6 +41,11 @@ func MaybeShowFirstRunNotice(w io.Writer, mode Mode, isTTY, isCI, isAgent bool) 
 
 func maybeShowFirstRunNotice(w io.Writer, mode Mode, isTTY, isCI, isAgent bool, path string) {
 	if mode != ModeEnabled || !isTTY || isCI || isAgent {
+		return
+	}
+	// No known state home: without the flag file the notice would repeat on
+	// every invocation, so skip it, matching the unwritable-dir behaviour.
+	if path == "" {
 		return
 	}
 	if _, err := os.Stat(path); err == nil {

--- a/internal/telemetry/firstrun.go
+++ b/internal/telemetry/firstrun.go
@@ -14,9 +14,9 @@ const firstRunNoticeFileName = "telemetry-notice-shown"
 
 // firstRunNotice is the one-time message telling interactive users that
 // anonymous usage stats are on and how to opt out.
-const firstRunNotice = "gcx collects anonymous usage statistics: command paths, flag names, and outcomes - never argument values, resource names, or hosts.\n" +
-	"Opt out: set GCX_TELEMETRY=disabled, or diagnostics.telemetry: disabled in the gcx config file.\n" +
-	"Details: " + docs.AnonymousUsageStats + "\n"
+const firstRunNotice = `gcx collects anonymous usage statistics: command paths, flag names, and outcomes - never argument values, resource names, or hosts.
+Opt out: set GCX_TELEMETRY=disabled, or diagnostics.telemetry: disabled in the gcx config file.
+Details: ` + docs.AnonymousUsageStats + "\n"
 
 // FirstRunNoticePath returns the flag file that records the notice was shown.
 func FirstRunNoticePath() string {

--- a/internal/telemetry/firstrun.go
+++ b/internal/telemetry/firstrun.go
@@ -15,7 +15,9 @@ const firstRunNoticeFileName = "telemetry-notice-shown"
 // firstRunNotice is the one-time message telling interactive users that
 // anonymous usage stats are on and how to opt out.
 const firstRunNotice = `gcx collects anonymous usage statistics so we can make gcx better. We do not collect potentially identifiable or sensitive information like argument or flag values or resource names.
-You can opt out by setting GCX_TELEMETRY=disabled, or putting diagnostics.telemetry: disabled in your gcx config file.
+You can opt out by setting GCX_TELEMETRY=disabled, or adding to your gcx config file:
+  diagnostics:
+    telemetry: disabled
 Find out more at ` + docs.AnonymousUsageStats + "\n"
 
 // FirstRunNoticePath returns the flag file that records the notice was shown,

--- a/internal/telemetry/firstrun.go
+++ b/internal/telemetry/firstrun.go
@@ -1,0 +1,52 @@
+package telemetry
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/gcx/internal/docs"
+	"github.com/grafana/gcx/internal/xdg"
+)
+
+const firstRunNoticeFileName = "telemetry-notice-shown"
+
+// firstRunNotice is the one-time message telling interactive users that
+// anonymous usage stats are on and how to opt out.
+const firstRunNotice = "gcx collects anonymous usage statistics: command paths, flag names, and outcomes - never argument values, resource names, or hosts.\n" +
+	"Opt out: set GCX_TELEMETRY=disabled, or diagnostics.telemetry: disabled in the gcx config file.\n" +
+	"Details: " + docs.AnonymousUsageStats + "\n"
+
+// FirstRunNoticePath returns the flag file that records the notice was shown.
+func FirstRunNoticePath() string {
+	return filepath.Join(xdg.StateHome(), "gcx", firstRunNoticeFileName)
+}
+
+// MaybeShowFirstRunNotice writes the one-time telemetry notice to w. It is
+// shown only when telemetry is actually enabled and the run is interactive
+// (a TTY, not CI, not an agent), at most once per install, gated by a flag
+// file under the XDG state dir. All file I/O is best-effort: when the flag
+// file cannot be written the notice is skipped rather than repeated on every
+// invocation.
+func MaybeShowFirstRunNotice(w io.Writer, mode Mode, isTTY, isCI, isAgent bool) {
+	maybeShowFirstRunNotice(w, mode, isTTY, isCI, isAgent, FirstRunNoticePath())
+}
+
+func maybeShowFirstRunNotice(w io.Writer, mode Mode, isTTY, isCI, isAgent bool, path string) {
+	if mode != ModeEnabled || !isTTY || isCI || isAgent {
+		return
+	}
+	if _, err := os.Stat(path); err == nil {
+		return
+	}
+	// Record before showing: when the state dir is unwritable, skipping the
+	// notice beats printing it on every invocation.
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return
+	}
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		return
+	}
+	fmt.Fprint(w, firstRunNotice)
+}

--- a/internal/telemetry/firstrun.go
+++ b/internal/telemetry/firstrun.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/grafana/gcx/internal/docs"
 	"github.com/grafana/gcx/internal/xdg"
@@ -13,12 +14,16 @@ import (
 const firstRunNoticeFileName = "telemetry-notice-shown"
 
 // firstRunNotice is the one-time message telling interactive users that
-// anonymous usage stats are on and how to opt out.
-const firstRunNotice = `gcx collects anonymous usage statistics so we can make gcx better. We do not collect potentially identifiable or sensitive information like argument or flag values or resource names.
+// anonymous usage stats are on and how to opt out. The docs link is the
+// rendered page (trailing slash), not the raw-markdown .md URL the registry
+// serves to agents.
+//
+//nolint:gochecknoglobals // constant-like; var only because TrimSuffix is not const-able.
+var firstRunNotice = `gcx collects anonymous usage statistics so we can make gcx better. We do not collect potentially identifiable or sensitive information like argument or flag values or resource names.
 You can opt out by setting GCX_TELEMETRY=disabled, or adding to your gcx config file:
   diagnostics:
     telemetry: disabled
-Find out more at ` + docs.AnonymousUsageStats + "\n"
+Find out more at ` + strings.TrimSuffix(docs.AnonymousUsageStats, ".md") + "/\n"
 
 // FirstRunNoticePath returns the flag file that records the notice was shown,
 // or "" when no state home is known (HOME and XDG_STATE_HOME both unset), so

--- a/internal/telemetry/firstrun_internal_test.go
+++ b/internal/telemetry/firstrun_internal_test.go
@@ -1,0 +1,82 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFirstRunNoticeShownOnceThenSuppressed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gcx", firstRunNoticeFileName)
+
+	var first strings.Builder
+	maybeShowFirstRunNotice(&first, ModeEnabled, true, false, false, path)
+	assert.Equal(t, firstRunNotice, first.String())
+	assert.Contains(t, first.String(), "GCX_TELEMETRY=disabled")
+	assert.Contains(t, first.String(), "diagnostics.telemetry")
+	assert.Contains(t, first.String(), "https://grafana.com/docs/")
+	assert.NotContains(t, first.String(), "—", "notice must not contain em-dashes")
+
+	_, err := os.Stat(path)
+	require.NoError(t, err, "showing the notice must write the flag file")
+
+	var second strings.Builder
+	maybeShowFirstRunNotice(&second, ModeEnabled, true, false, false, path)
+	assert.Empty(t, second.String(), "flag file must suppress the notice")
+}
+
+func TestFirstRunNoticeSuppressedWhenNotInteractive(t *testing.T) {
+	tests := []struct {
+		name                 string
+		isTTY, isCI, isAgent bool
+	}{
+		{name: "piped stdout", isTTY: false},
+		{name: "CI environment", isTTY: true, isCI: true},
+		{name: "agent mode", isTTY: true, isAgent: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "gcx", firstRunNoticeFileName)
+
+			var out strings.Builder
+			maybeShowFirstRunNotice(&out, ModeEnabled, tc.isTTY, tc.isCI, tc.isAgent, path)
+			assert.Empty(t, out.String())
+
+			_, err := os.Stat(path)
+			assert.True(t, os.IsNotExist(err), "suppressed runs must not consume the one-time flag")
+		})
+	}
+}
+
+func TestFirstRunNoticeSuppressedWhenModeNotEnabled(t *testing.T) {
+	for _, mode := range []Mode{ModeDisabled, ModeLog} {
+		t.Run(string(mode), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "gcx", firstRunNoticeFileName)
+
+			var out strings.Builder
+			maybeShowFirstRunNotice(&out, mode, true, false, false, path)
+			assert.Empty(t, out.String())
+
+			_, err := os.Stat(path)
+			assert.True(t, os.IsNotExist(err))
+		})
+	}
+}
+
+func TestFirstRunNoticeSkippedWhenStateDirUnwritable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission checks do not apply to root")
+	}
+	readonly := filepath.Join(t.TempDir(), "readonly")
+	require.NoError(t, os.MkdirAll(readonly, 0o500))
+	path := filepath.Join(readonly, "gcx", firstRunNoticeFileName)
+
+	var out strings.Builder
+	maybeShowFirstRunNotice(&out, ModeEnabled, true, false, false, path)
+	assert.Empty(t, out.String(), "unwritable flag file must skip the notice, not repeat it")
+}

--- a/internal/telemetry/firstrun_internal_test.go
+++ b/internal/telemetry/firstrun_internal_test.go
@@ -21,6 +21,7 @@ func TestFirstRunNoticeShownOnceThenSuppressed(t *testing.T) {
 	// strict config parser would reject verbatim.
 	assert.Contains(t, first.String(), "  diagnostics:\n    telemetry: disabled")
 	assert.Contains(t, first.String(), "https://grafana.com/docs/")
+	assert.NotContains(t, first.String(), ".md", "notice must link the rendered page, not raw markdown")
 	assert.NotContains(t, first.String(), "—", "notice must not contain em-dashes")
 
 	_, err := os.Stat(path)

--- a/internal/telemetry/firstrun_internal_test.go
+++ b/internal/telemetry/firstrun_internal_test.go
@@ -17,7 +17,9 @@ func TestFirstRunNoticeShownOnceThenSuppressed(t *testing.T) {
 	maybeShowFirstRunNotice(&first, ModeEnabled, true, false, false, path)
 	assert.Equal(t, firstRunNotice, first.String())
 	assert.Contains(t, first.String(), "GCX_TELEMETRY=disabled")
-	assert.Contains(t, first.String(), "diagnostics.telemetry")
+	// The config opt-out must be paste-ready YAML, not an inline key that the
+	// strict config parser would reject verbatim.
+	assert.Contains(t, first.String(), "  diagnostics:\n    telemetry: disabled")
 	assert.Contains(t, first.String(), "https://grafana.com/docs/")
 	assert.NotContains(t, first.String(), "—", "notice must not contain em-dashes")
 

--- a/internal/telemetry/firstrun_internal_test.go
+++ b/internal/telemetry/firstrun_internal_test.go
@@ -34,7 +34,7 @@ func TestFirstRunNoticeSuppressedWhenNotInteractive(t *testing.T) {
 		name                 string
 		isTTY, isCI, isAgent bool
 	}{
-		{name: "piped stdout", isTTY: false},
+		{name: "non-terminal stderr", isTTY: false},
 		{name: "CI environment", isTTY: true, isCI: true},
 		{name: "agent mode", isTTY: true, isAgent: true},
 	}

--- a/internal/telemetry/firstrun_internal_test.go
+++ b/internal/telemetry/firstrun_internal_test.go
@@ -68,6 +68,16 @@ func TestFirstRunNoticeSuppressedWhenModeNotEnabled(t *testing.T) {
 	}
 }
 
+func TestFirstRunNoticeSkippedWhenStateHomeUnknown(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", "")
+	assert.Empty(t, FirstRunNoticePath(), "unknown state home must not yield a relative path")
+
+	var out strings.Builder
+	maybeShowFirstRunNotice(&out, ModeEnabled, true, false, false, FirstRunNoticePath())
+	assert.Empty(t, out.String(), "unknown state home must skip the notice, not repeat it")
+}
+
 func TestFirstRunNoticeSkippedWhenStateDirUnwritable(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("permission checks do not apply to root")

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -25,9 +25,10 @@ const (
 )
 
 // defaultMode is the resolved mode when no env var or config setting applies.
-// It stays disabled until privacy/legal and usage-stats owner sign-off clear;
-// flipping to ModeEnabled is deliberately a one-line change gated on those.
-const defaultMode = ModeDisabled
+// Telemetry is opt-out: enabled by default, disabled via GCX_TELEMETRY,
+// DO_NOT_TRACK, or the diagnostics.telemetry config value. Interactive users
+// are told about this once via the first-run notice (firstrun.go).
+const defaultMode = ModeEnabled
 
 // Env documents the environment variables that control telemetry. The env
 // tags are read by scripts/env-vars-reference (docs generation); resolution
@@ -35,8 +36,8 @@ const defaultMode = ModeDisabled
 type Env struct {
 	// Telemetry controls anonymous usage telemetry for this invocation:
 	// "enabled", "disabled", or "log" (print the event to stderr and send
-	// nothing). Takes precedence over DO_NOT_TRACK and the
-	// `diagnostics.telemetry` config field.
+	// nothing). Telemetry is enabled by default. Takes precedence over
+	// DO_NOT_TRACK and the `diagnostics.telemetry` config field.
 	Telemetry string `env:"GCX_TELEMETRY"`
 
 	// DoNotTrack disables anonymous usage telemetry when set to "1" or

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -36,8 +36,9 @@ const defaultMode = ModeEnabled
 type Env struct {
 	// Telemetry controls anonymous usage telemetry for this invocation:
 	// "enabled", "disabled", or "log" (print the event to stderr and send
-	// nothing). Telemetry is enabled by default. Takes precedence over
-	// the `diagnostics.telemetry` config field.
+	// nothing). Telemetry is enabled by default. Any other non-empty value
+	// disables telemetry. Takes precedence over the `diagnostics.telemetry`
+	// config field.
 	Telemetry string `env:"GCX_TELEMETRY"`
 
 	// DoNotTrack disables anonymous usage telemetry when set to "1" or
@@ -51,9 +52,10 @@ type Env struct {
 
 // ResolveMode resolves the telemetry mode for this invocation. Precedence,
 // highest first: GCX_TELEMETRY, DO_NOT_TRACK, the diagnostics.telemetry
-// config value, the built-in default. Unrecognised values fall through to
-// the next level. configValue is a func so callers only pay the config-file
-// read when the environment doesn't already decide the mode.
+// config value, the built-in default. Empty values fall through to the next
+// level; unrecognised non-empty values resolve to disabled. configValue is a
+// func so callers only pay the config-file read when the environment doesn't
+// already decide the mode.
 func ResolveMode(configValue func() string) Mode {
 	return resolveMode(os.Getenv, configValue)
 }
@@ -81,12 +83,17 @@ func resolveMode(getenv func(string) string, configValue func() string) Mode {
 }
 
 func parseMode(s string) (Mode, bool) {
+	if s == "" {
+		return "", false
+	}
 	m := Mode(strings.ToLower(s))
 	switch m {
 	case ModeEnabled, ModeDisabled, ModeLog:
 		return m, true
 	default:
-		return "", false
+		// Unrecognised non-empty values fail toward privacy: with enabled as
+		// the default, a typo in an opt-out setting must not silently opt in.
+		return ModeDisabled, true
 	}
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -37,7 +37,7 @@ type Env struct {
 	// Telemetry controls anonymous usage telemetry for this invocation:
 	// "enabled", "disabled", or "log" (print the event to stderr and send
 	// nothing). Telemetry is enabled by default. Takes precedence over
-	// DO_NOT_TRACK and the `diagnostics.telemetry` config field.
+	// the `diagnostics.telemetry` config field.
 	Telemetry string `env:"GCX_TELEMETRY"`
 
 	// DoNotTrack disables anonymous usage telemetry when set to "1" or

--- a/internal/telemetry/telemetry_internal_test.go
+++ b/internal/telemetry/telemetry_internal_test.go
@@ -44,10 +44,26 @@ func TestResolveMode(t *testing.T) {
 			want: ModeEnabled,
 		},
 		{
-			name:        "unrecognised GCX_TELEMETRY falls through to config",
+			name:        "unrecognised GCX_TELEMETRY disables",
 			env:         map[string]string{"GCX_TELEMETRY": "on"},
 			configValue: "enabled",
-			want:        ModeEnabled,
+			want:        ModeDisabled,
+		},
+		{
+			name: "GCX_TELEMETRY=off disables",
+			env:  map[string]string{"GCX_TELEMETRY": "off"},
+			want: ModeDisabled,
+		},
+		{
+			name: "GCX_TELEMETRY=false disables",
+			env:  map[string]string{"GCX_TELEMETRY": "false"},
+			want: ModeDisabled,
+		},
+		{
+			name:        "empty GCX_TELEMETRY falls through to config",
+			env:         map[string]string{"GCX_TELEMETRY": ""},
+			configValue: "log",
+			want:        ModeLog,
 		},
 		{
 			name:        "DO_NOT_TRACK=1 overrides config enabled",
@@ -80,9 +96,9 @@ func TestResolveMode(t *testing.T) {
 			want:        ModeLog,
 		},
 		{
-			name:        "unrecognised config value falls through to default",
+			name:        "unrecognised config value disables",
 			configValue: "on",
-			want:        ModeEnabled,
+			want:        ModeDisabled,
 		},
 	}
 

--- a/internal/telemetry/telemetry_internal_test.go
+++ b/internal/telemetry/telemetry_internal_test.go
@@ -19,8 +19,8 @@ func TestResolveMode(t *testing.T) {
 		want        Mode
 	}{
 		{
-			name: "no env, no config: built-in default",
-			want: defaultMode,
+			name: "no env, no config: enabled by default",
+			want: ModeEnabled,
 		},
 		{
 			name: "GCX_TELEMETRY=enabled",
@@ -82,7 +82,7 @@ func TestResolveMode(t *testing.T) {
 		{
 			name:        "unrecognised config value falls through to default",
 			configValue: "on",
-			want:        defaultMode,
+			want:        ModeEnabled,
 		},
 	}
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -34,6 +34,11 @@ func StdoutIsTerminal() bool {
 	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
+// StderrIsTerminal reports whether stderr is connected to a real terminal.
+func StderrIsTerminal() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
 // StdoutWidth returns the current stdout terminal width, or 0 when unknown.
 func StdoutWidth() int {
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))


### PR DESCRIPTION

## Summary

- Do a one-time  notice to stderr telling interactive users thattelemetry is on and how to opt out.
- flip the telemetry default from `disabled` to `enabled`
- record the default in the config and env-var reference docs; the public docs page (#985) already documents enabled-by-default

## details

Renders as:

```
gcx collects anonymous usage statistics: command paths, flag names, and outcomes - never argument values, resource names, or hosts.
Opt out: set GCX_TELEMETRY=disabled, or diagnostics.telemetry: disabled in the gcx config file.
Details: https://grafana.com/docs/grafana/latest/as-code/observability-as-code/grafana-cli/gcx/anonymous-usage-statistics.md
```

If the state dir is unwritable the notice is skipped entirely.

The docs URL is added to the `internal/docs` registry (`.md` per the registry invariant); the page merged in #985 but hasn't synced to the website yet, so the link 404s until the next docs sync.

we don't show the message in non-interactive environments, as it just adds noise
