### PR TITLE
feat(telemetry): capture guessed commands and flags as parse_error events

### DIFF
--- a/cmd/gcx/main.go
+++ b/cmd/gcx/main.go
@@ -58,7 +58,7 @@ func main() {
 	// prefer sticking to err != nil format, than optimizing for calling exitWith
 	// once
 	if err := root.ValidateArgs(cmd, os.Args[1:]); err != nil {
-		exitWith(cmd, start, reportError(err, boolFlags, subCmds))
+		exitWith(cmd, start, err, reportError(err, boolFlags, subCmds))
 	}
 
 	err := cmd.ExecuteContext(ctx)
@@ -68,13 +68,15 @@ func main() {
 		os.Exit(gcxerrors.ExitCancelled)
 	}
 
-	exitWith(cmd, start, reportError(err, boolFlags, subCmds))
+	exitWith(cmd, start, err, reportError(err, boolFlags, subCmds))
 }
 
 // exitWith emits the usage event for this invocation, then exits. Every
-// invocation ends here, except the cancellation fast path above.
-func exitWith(cmd *cobra.Command, start time.Time, exitCode int) {
-	emitUsageEvent(cmd, start, exitCode)
+// invocation ends here, except the cancellation fast path above. err is what
+// the invocation failed with, if anything; exitCode is what the process
+// reports for it.
+func exitWith(cmd *cobra.Command, start time.Time, err error, exitCode int) {
+	emitUsageEvent(cmd, start, err, exitCode)
 	os.Exit(exitCode)
 }
 

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -226,7 +226,9 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 		},
 	}
 
-	rootCmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		// Record the failure for the parse_error usage event (#578).
+		recordFlagFailure(cmd, err)
 		if strings.Contains(err.Error(), "--log-http-payload") && strings.Contains(err.Error(), "flag has been renamed") {
 			return errors.New("--log-http-payload has been renamed; use --insecure-log-http-payload instead")
 		}

--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -227,12 +227,12 @@ func newCommand(version string, pp []providers.Provider) *cobra.Command {
 	}
 
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		// Record the failure for the parse_error usage event (#578).
-		recordFlagFailure(cmd, err)
 		if strings.Contains(err.Error(), "--log-http-payload") && strings.Contains(err.Error(), "flag has been renamed") {
-			return errors.New("--log-http-payload has been renamed; use --insecure-log-http-payload instead")
+			err = errors.New("--log-http-payload has been renamed; use --insecure-log-http-payload instead")
 		}
-		return err
+		// Carry the failing command out with the error so the exit path can
+		// classify the parse_error usage event.
+		return &flagParseError{cmd: cmd, err: err}
 	})
 
 	defaultHelp := rootCmd.HelpFunc()

--- a/cmd/gcx/root/parsefailure.go
+++ b/cmd/gcx/root/parsefailure.go
@@ -1,23 +1,21 @@
 package root
 
-// Parse-failure capture (#578): classify invocations cobra rejected before any
-// hook ran (unknown command, unknown flag, argument validation) into an
-// anonymous usage event. Privacy invariant: only command-shaped tokens and
-// flag names are ever recorded, never argument or flag values.
-
 import (
+	"context"
+	"errors"
 	"math"
 	"net"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
-	"sync/atomic"
 
+	"github.com/grafana/gcx/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-// ParseFailure kinds.
+// Categories of parse failure.
 const (
 	parseErrorUnknownCommand = "unknown_command"
 	parseErrorUnknownFlag    = "unknown_flag"
@@ -27,46 +25,41 @@ const (
 // redactedToken replaces tokens that fail the command-shape filter.
 const redactedToken = "<redacted>"
 
-// suggestionsMinimumDistance mirrors cobra's default SuggestionsMinimumDistance;
-// cobra only assigns it lazily while rendering an unknown-command error.
-const suggestionsMinimumDistance = 2
+// suggestionsMaxDistance is the largest Levenshtein distance at which we count a real
+// command or flag as a near match. It mirrors cobra's default
+// for the (weirdly named) SuggestionsMinimumDistance field.
+const suggestionsMaxDistance = 2
 
-// ParseFailure describes a failed command-line parse for the usage event
-// (#578). Token and Flags carry shape-filtered names only, never values.
+// ParseFailure describes a failed command line parse for reporting in a usage event.
 type ParseFailure struct {
-	Kind      string // unknown_command, unknown_flag or invalid_args
-	Parent    string // deepest valid command path reached; "" is the root
-	Token     string // first unknown token; redactedToken if it fails the shape filter
+	Kind      string
+	Parent    string // deepest valid command path reached
+	Token     string // first unknown token. redactedToken if it fails the shape filter
 	Attempted string // Parent plus Token, truncated at the unknown token
-	Flags     string // unknown flag names only, never values
-	Nearest   string // nearest real command or flag; "" if no near match
-	Distance  int    // Levenshtein distance to Nearest; -1 if no near match
+	Flags     string // unknown flag names only
+	Nearest   string // nearest real command or flag. "" if no near match
+	Distance  int    // Levenshtein distance to Nearest. -1 if no near match
 }
 
-// flagFailure records the command and error from cobra's flag-error hook so a
-// failed parse can be classified as an unknown flag. pflag aborts at the first
-// bad flag, so at most one failure is seen per invocation.
-//
-//nolint:gochecknoglobals // written once per process from the flag-error hook.
-var flagFailure atomic.Pointer[flagFailureRecord]
-
-type flagFailureRecord struct {
+// flagParseError wraps the error from cobra's flag-error hook with the
+// command that failed, so the exit path can classify the parse failure for
+// the usage event from the returned error itself. It renders exactly as the
+// wrapped error, so user-facing output is unchanged.
+type flagParseError struct {
 	cmd *cobra.Command
 	err error
 }
 
-func recordFlagFailure(cmd *cobra.Command, err error) {
-	if cmd == nil || err == nil {
-		return
-	}
-	flagFailure.CompareAndSwap(nil, &flagFailureRecord{cmd: cmd, err: err})
-}
+func (e *flagParseError) Error() string { return e.err.Error() }
+func (e *flagParseError) Unwrap() error { return e.err }
 
 // parseFailureTelemetryInfo classifies a failed parse into telemetry info. It
 // runs only when PersistentPreRun never recorded an event and the exit code is
 // nonzero, which means cobra rejected the invocation before any hook ran.
-func parseFailureTelemetryInfo(rootCmd *cobra.Command, args []string) *TelemetryInfo {
-	if ff := flagFailure.Load(); ff != nil {
+// err is what ExecuteContext returned for this invocation.
+func parseFailureTelemetryInfo(rootCmd *cobra.Command, args []string, err error) *TelemetryInfo {
+	var ff *flagParseError
+	if errors.As(err, &ff) {
 		return flagFailureTelemetryInfo(ff)
 	}
 
@@ -83,6 +76,9 @@ func parseFailureTelemetryInfo(rootCmd *cobra.Command, args []string) *Telemetry
 		pf.Kind = parseErrorUnknownCommand
 		pf.Nearest, pf.Distance = nearestCommand(parent, token)
 		pf.Token = filterCommandToken(token)
+		if pf.Token != redactedToken && isConfiguredName(pf.Token) {
+			pf.Token = redactedToken
+		}
 		pf.Attempted = strings.TrimSpace(parentPath + " " + pf.Token)
 	} else {
 		// Runnable commands take argument values, which must never be
@@ -94,7 +90,7 @@ func parseFailureTelemetryInfo(rootCmd *cobra.Command, args []string) *Telemetry
 	return &TelemetryInfo{Command: parentPath, ParseError: pf}
 }
 
-func flagFailureTelemetryInfo(ff *flagFailureRecord) *TelemetryInfo {
+func flagFailureTelemetryInfo(ff *flagParseError) *TelemetryInfo {
 	if telemetrySuppressed(ff.cmd) {
 		return &TelemetryInfo{Suppress: true}
 	}
@@ -201,7 +197,7 @@ func findSubcommand(cmd *cobra.Command, name string) *cobra.Command {
 // or prefix match) and ranking the result by distance.
 func nearestCommand(parent *cobra.Command, token string) (string, int) {
 	if parent.SuggestionsMinimumDistance <= 0 {
-		parent.SuggestionsMinimumDistance = suggestionsMinimumDistance
+		parent.SuggestionsMinimumDistance = suggestionsMaxDistance
 	}
 	return nearestString(token, parent.SuggestionsFor(token))
 }
@@ -217,7 +213,7 @@ func nearestFlag(cmd *cobra.Command, name string) (string, int) {
 				return
 			}
 			seen[f.Name] = true
-			byDistance := levenshtein(strings.ToLower(name), strings.ToLower(f.Name)) <= suggestionsMinimumDistance
+			byDistance := levenshtein(strings.ToLower(name), strings.ToLower(f.Name)) <= suggestionsMaxDistance
 			byPrefix := strings.HasPrefix(strings.ToLower(f.Name), strings.ToLower(name))
 			if byDistance || byPrefix {
 				near = append(near, f.Name)
@@ -276,7 +272,7 @@ const maxTokenLength = 20
 // command name.
 const maxTokenEntropy = 3.7
 
-// filterCommandToken applies the command-shape filter (#578): the raw token is
+// filterCommandToken applies the command-shape filter: the raw token is
 // emitted only when it plausibly is a command name. Everything else (values,
 // paths, URLs, IPs, UUIDs, random identifiers) is replaced with redactedToken.
 // Callers compute the fuzzy distance from the raw token before filtering, so
@@ -299,6 +295,16 @@ func filterCommandToken(token string) string {
 func looksLikeURL(token string) bool {
 	u, err := url.Parse(token)
 	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+// isConfiguredName reports whether the token names one of the user's own
+// contexts or Cloud stacks. Those are command-shaped but identifying - they
+// reach command position when arguments are misplaced (`gcx prod-stack
+// resources get`) - so they are redacted even though the shape filter passes
+// them. The config read is keychain-free and only happens for tokens that
+// survived the shape filter.
+func isConfiguredName(token string) bool {
+	return slices.Contains(config.LoadContextNames(context.Background()), token)
 }
 
 // shannonEntropy returns the entropy of the token in bits per character.

--- a/cmd/gcx/root/parsefailure.go
+++ b/cmd/gcx/root/parsefailure.go
@@ -1,0 +1,321 @@
+package root
+
+// Parse-failure capture (#578): classify invocations cobra rejected before any
+// hook ran (unknown command, unknown flag, argument validation) into an
+// anonymous usage event. Privacy invariant: only command-shaped tokens and
+// flag names are ever recorded, never argument or flag values.
+
+import (
+	"math"
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync/atomic"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// ParseFailure kinds.
+const (
+	parseErrorUnknownCommand = "unknown_command"
+	parseErrorUnknownFlag    = "unknown_flag"
+	parseErrorInvalidArgs    = "invalid_args"
+)
+
+// redactedToken replaces tokens that fail the command-shape filter.
+const redactedToken = "<redacted>"
+
+// suggestionsMinimumDistance mirrors cobra's default SuggestionsMinimumDistance;
+// cobra only assigns it lazily while rendering an unknown-command error.
+const suggestionsMinimumDistance = 2
+
+// ParseFailure describes a failed command-line parse for the usage event
+// (#578). Token and Flags carry shape-filtered names only, never values.
+type ParseFailure struct {
+	Kind      string // unknown_command, unknown_flag or invalid_args
+	Parent    string // deepest valid command path reached; "" is the root
+	Token     string // first unknown token; redactedToken if it fails the shape filter
+	Attempted string // Parent plus Token, truncated at the unknown token
+	Flags     string // unknown flag names only, never values
+	Nearest   string // nearest real command or flag; "" if no near match
+	Distance  int    // Levenshtein distance to Nearest; -1 if no near match
+}
+
+// flagFailure records the command and error from cobra's flag-error hook so a
+// failed parse can be classified as an unknown flag. pflag aborts at the first
+// bad flag, so at most one failure is seen per invocation.
+//
+//nolint:gochecknoglobals // written once per process from the flag-error hook.
+var flagFailure atomic.Pointer[flagFailureRecord]
+
+type flagFailureRecord struct {
+	cmd *cobra.Command
+	err error
+}
+
+func recordFlagFailure(cmd *cobra.Command, err error) {
+	if cmd == nil || err == nil {
+		return
+	}
+	flagFailure.CompareAndSwap(nil, &flagFailureRecord{cmd: cmd, err: err})
+}
+
+// parseFailureTelemetryInfo classifies a failed parse into telemetry info. It
+// runs only when PersistentPreRun never recorded an event and the exit code is
+// nonzero, which means cobra rejected the invocation before any hook ran.
+func parseFailureTelemetryInfo(rootCmd *cobra.Command, args []string) *TelemetryInfo {
+	if ff := flagFailure.Load(); ff != nil {
+		return flagFailureTelemetryInfo(ff)
+	}
+
+	parent, token := deepestCommand(rootCmd, args)
+	if telemetrySuppressed(parent) {
+		return &TelemetryInfo{Suppress: true}
+	}
+
+	parentPath := trimCommandRoot(parent)
+	pf := &ParseFailure{Parent: parentPath, Attempted: parentPath, Distance: -1}
+	if token != "" && !parent.Runnable() {
+		// A positional on a pure group command can only be a command guess:
+		// nothing here takes argument values.
+		pf.Kind = parseErrorUnknownCommand
+		pf.Nearest, pf.Distance = nearestCommand(parent, token)
+		pf.Token = filterCommandToken(token)
+		pf.Attempted = strings.TrimSpace(parentPath + " " + pf.Token)
+	} else {
+		// Runnable commands take argument values, which must never be
+		// recorded, so any leftover token is dropped and the failure counts
+		// as argument validation.
+		pf.Kind = parseErrorInvalidArgs
+	}
+
+	return &TelemetryInfo{Command: parentPath, ParseError: pf}
+}
+
+func flagFailureTelemetryInfo(ff *flagFailureRecord) *TelemetryInfo {
+	if telemetrySuppressed(ff.cmd) {
+		return &TelemetryInfo{Suppress: true}
+	}
+
+	parentPath := trimCommandRoot(ff.cmd)
+	pf := &ParseFailure{Parent: parentPath, Attempted: parentPath, Distance: -1}
+	if name, ok := unknownFlagName(ff.err); ok {
+		pf.Kind = parseErrorUnknownFlag
+		pf.Nearest, pf.Distance = nearestFlag(ff.cmd, name)
+		pf.Flags = filterCommandToken(name)
+	} else {
+		// Any other flag parse failure (missing or malformed value on a real
+		// flag). The pflag error message embeds the value, so nothing from it
+		// is recorded.
+		pf.Kind = parseErrorInvalidArgs
+	}
+	return &TelemetryInfo{Command: parentPath, ParseError: pf}
+}
+
+// unknownFlagName extracts the flag name from pflag's unknown-flag errors:
+// "unknown flag: --frmat" and "unknown shorthand flag: 'q' in -qv". pflag
+// strips any "=value" before building the message. Every other flag error
+// returns false: those messages can embed flag values.
+func unknownFlagName(err error) (string, bool) {
+	msg := err.Error()
+	if name, ok := strings.CutPrefix(msg, "unknown flag: --"); ok {
+		return name, true
+	}
+	if rest, ok := strings.CutPrefix(msg, "unknown shorthand flag: '"); ok {
+		if i := strings.IndexByte(rest, '\''); i > 0 {
+			return rest[:i], true
+		}
+	}
+	return "", false
+}
+
+// deepestCommand resolves args against the command tree the way cobra's Find
+// does and returns the deepest valid command plus the first token that did not
+// match a subcommand ("" when every positional resolved). Flags are skipped
+// with cobra's stripFlags rules so a flag value can never be mistaken for the
+// unknown token; unrecognised flags are conservatively assumed to take a value.
+func deepestCommand(rootCmd *cobra.Command, args []string) (*cobra.Command, string) {
+	cmd := rootCmd
+	inFlagValue := false
+	for _, arg := range args {
+		switch {
+		case inFlagValue:
+			inFlagValue = false
+		case arg == "--":
+			return cmd, ""
+		case strings.HasPrefix(arg, "--") && !strings.Contains(arg, "="):
+			inFlagValue = longFlagTakesValue(cmd, arg[2:])
+		case strings.HasPrefix(arg, "-") && !strings.Contains(arg, "=") && len(arg) == 2:
+			inFlagValue = shortFlagTakesValue(cmd, arg[1:])
+		case arg == "" || strings.HasPrefix(arg, "-"):
+			// A flag with an inline value, combined shorthands, or a bare
+			// "-": consumes nothing and is never a command token.
+		default:
+			next := findSubcommand(cmd, arg)
+			if next == nil {
+				return cmd, arg
+			}
+			cmd = next
+		}
+	}
+	return cmd, ""
+}
+
+func longFlagTakesValue(cmd *cobra.Command, name string) bool {
+	for _, fs := range flagSets(cmd) {
+		if f := fs.Lookup(name); f != nil {
+			return f.NoOptDefVal == ""
+		}
+	}
+	// Unknown flag: assume it takes a value. Dropping a command token is
+	// safer than recording a value as the token.
+	return true
+}
+
+func shortFlagTakesValue(cmd *cobra.Command, shorthand string) bool {
+	for _, fs := range flagSets(cmd) {
+		if f := fs.ShorthandLookup(shorthand); f != nil {
+			return f.NoOptDefVal == ""
+		}
+	}
+	return true
+}
+
+func flagSets(cmd *cobra.Command) []*pflag.FlagSet {
+	return []*pflag.FlagSet{cmd.Flags(), cmd.PersistentFlags(), cmd.InheritedFlags()}
+}
+
+func findSubcommand(cmd *cobra.Command, name string) *cobra.Command {
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == name || sub.HasAlias(name) {
+			return sub
+		}
+	}
+	return nil
+}
+
+// nearestCommand finds the closest real subcommand for the unknown token,
+// reusing cobra's suggestion rule (Levenshtein within SuggestionsMinimumDistance,
+// or prefix match) and ranking the result by distance.
+func nearestCommand(parent *cobra.Command, token string) (string, int) {
+	if parent.SuggestionsMinimumDistance <= 0 {
+		parent.SuggestionsMinimumDistance = suggestionsMinimumDistance
+	}
+	return nearestString(token, parent.SuggestionsFor(token))
+}
+
+// nearestFlag finds the closest real flag name for the unknown flag, applying
+// the same near-match rule cobra uses for commands.
+func nearestFlag(cmd *cobra.Command, name string) (string, int) {
+	var near []string
+	seen := map[string]bool{}
+	for _, fs := range flagSets(cmd) {
+		fs.VisitAll(func(f *pflag.Flag) {
+			if f.Hidden || seen[f.Name] {
+				return
+			}
+			seen[f.Name] = true
+			byDistance := levenshtein(strings.ToLower(name), strings.ToLower(f.Name)) <= suggestionsMinimumDistance
+			byPrefix := strings.HasPrefix(strings.ToLower(f.Name), strings.ToLower(name))
+			if byDistance || byPrefix {
+				near = append(near, f.Name)
+			}
+		})
+	}
+	return nearestString(name, near)
+}
+
+// nearestString returns the candidate with the smallest case-insensitive
+// Levenshtein distance to token, or ("", -1) when there are no candidates.
+func nearestString(token string, candidates []string) (string, int) {
+	best, bestDist := "", -1
+	for _, c := range candidates {
+		d := levenshtein(strings.ToLower(token), strings.ToLower(c))
+		if bestDist == -1 || d < bestDist {
+			best, bestDist = c, d
+		}
+	}
+	return best, bestDist
+}
+
+// levenshtein is the classic edit distance. Cobra keeps its implementation
+// unexported, so this mirrors it for ranking suggestions.
+func levenshtein(a, b string) int {
+	ra, rb := []rune(a), []rune(b)
+	prev := make([]int, len(rb)+1)
+	cur := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		cur[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			cur[j] = min(prev[j]+1, cur[j-1]+1, prev[j-1]+cost)
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(rb)]
+}
+
+var (
+	commandShapeRe = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+	uuidShapeRe    = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+)
+
+const maxTokenLength = 20
+
+// maxTokenEntropy bounds the Shannon entropy (bits per character) of an
+// emitted token. Real command words stay around 3.2 bits; exceeding 3.7
+// requires 13+ distinct characters, which reads as a random identifier, not a
+// command name.
+const maxTokenEntropy = 3.7
+
+// filterCommandToken applies the command-shape filter (#578): the raw token is
+// emitted only when it plausibly is a command name. Everything else (values,
+// paths, URLs, IPs, UUIDs, random identifiers) is replaced with redactedToken.
+// Callers compute the fuzzy distance from the raw token before filtering, so
+// redacted guesses still count.
+func filterCommandToken(token string) string {
+	switch {
+	case !commandShapeRe.MatchString(token),
+		len(token) > maxTokenLength,
+		strings.Count(token, "-") > 1,
+		strings.ContainsAny(token, "0123456789"),
+		shannonEntropy(token) > maxTokenEntropy,
+		net.ParseIP(token) != nil,
+		looksLikeURL(token),
+		uuidShapeRe.MatchString(token):
+		return redactedToken
+	}
+	return token
+}
+
+func looksLikeURL(token string) bool {
+	u, err := url.Parse(token)
+	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+// shannonEntropy returns the entropy of the token in bits per character.
+func shannonEntropy(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	freq := map[rune]int{}
+	n := 0
+	for _, r := range s {
+		freq[r]++
+		n++
+	}
+	var h float64
+	for _, c := range freq {
+		p := float64(c) / float64(n)
+		h -= p * math.Log2(p)
+	}
+	return h
+}

--- a/cmd/gcx/root/parsefailure_internal_test.go
+++ b/cmd/gcx/root/parsefailure_internal_test.go
@@ -1,0 +1,329 @@
+package root
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseFailureTestTree builds gcx-shaped commands with flags:
+// root (--context string, --agent bool) > dashboards > {search, get (--format)},
+// plus completion > zsh and version.
+func parseFailureTestTree() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:         "gcx",
+		Annotations: map[string]string{cobra.CommandDisplayNameAnnotation: "gcx"},
+	}
+	rootCmd.PersistentFlags().String("context", "", "")
+	rootCmd.PersistentFlags().Bool("agent", false, "")
+
+	dashboards := &cobra.Command{Use: "dashboards"}
+	search := &cobra.Command{Use: "search", Run: func(*cobra.Command, []string) {}}
+	get := &cobra.Command{Use: "get", Run: func(*cobra.Command, []string) {}}
+	get.Flags().String("format", "", "")
+	dashboards.AddCommand(search, get)
+	rootCmd.AddCommand(dashboards)
+
+	completion := &cobra.Command{Use: "completion"}
+	completion.AddCommand(&cobra.Command{Use: "zsh", Run: func(*cobra.Command, []string) {}})
+	rootCmd.AddCommand(completion)
+	rootCmd.AddCommand(&cobra.Command{Use: "version", Run: func(*cobra.Command, []string) {}})
+
+	return rootCmd
+}
+
+// TestParseFailureTelemetryInfo_GoldenPII is the golden PII test required by
+// the #578 design: it pins down exactly what leaves the process for each parse
+// failure shape - truncation of attempted_command, the command-shape filter,
+// and distance preservation for redacted tokens.
+func TestParseFailureTelemetryInfo_GoldenPII(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		suppress bool
+		want     ParseFailure
+	}{
+		{
+			name: "typo at root",
+			args: []string{"dashbords"},
+			want: ParseFailure{
+				Kind: parseErrorUnknownCommand, Parent: "", Token: "dashbords",
+				Attempted: "dashbords", Nearest: "dashboards", Distance: 1,
+			},
+		},
+		{
+			name: "typo under a group",
+			args: []string{"dashboards", "serch"},
+			want: ParseFailure{
+				Kind: parseErrorUnknownCommand, Parent: "dashboards", Token: "serch",
+				Attempted: "dashboards serch", Nearest: "search", Distance: 1,
+			},
+		},
+		{
+			name: "novel top-level guess",
+			args: []string{"deploy"},
+			want: ParseFailure{
+				Kind: parseErrorUnknownCommand, Parent: "", Token: "deploy",
+				Attempted: "deploy", Nearest: "", Distance: -1,
+			},
+		},
+		{
+			name: "attempted command truncated at the unknown token",
+			args: []string{"dashboards", "serch", "my-secret-dashboard", "--name", "hunter2"},
+			want: ParseFailure{
+				Kind: parseErrorUnknownCommand, Parent: "dashboards", Token: "serch",
+				Attempted: "dashboards serch", Nearest: "search", Distance: 1,
+			},
+		},
+		{
+			name: "flag value never mistaken for the token",
+			args: []string{"--context", "prod-stack", "dashbords"},
+			want: ParseFailure{
+				Kind: parseErrorUnknownCommand, Parent: "", Token: "dashbords",
+				Attempted: "dashbords", Nearest: "dashboards", Distance: 1,
+			},
+		},
+		{
+			name: "unknown flag value consumed conservatively",
+			args: []string{"--tokn", "secret-value", "dashboards"},
+			want: ParseFailure{
+				Kind: parseErrorInvalidArgs, Parent: "dashboards",
+				Attempted: "dashboards", Distance: -1,
+			},
+		},
+		{
+			name: "uuid token redacted",
+			args: []string{"4f3a2b1c-9d0e-4a7b-8c6d-1e2f3a4b5c6d"},
+			want: ParseFailure{
+				Kind: parseErrorUnknownCommand, Parent: "", Token: redactedToken,
+				Attempted: redactedToken, Nearest: "", Distance: -1,
+			},
+		},
+		{
+			name: "url token redacted",
+			args: []string{"https://user:pass@example.com/secret"},
+			want: ParseFailure{
+				Kind: parseErrorUnknownCommand, Parent: "", Token: redactedToken,
+				Attempted: redactedToken, Nearest: "", Distance: -1,
+			},
+		},
+		{
+			name: "secret-looking token redacted",
+			args: []string{"MyToken123"},
+			want: ParseFailure{
+				Kind: parseErrorUnknownCommand, Parent: "", Token: redactedToken,
+				Attempted: redactedToken, Nearest: "", Distance: -1,
+			},
+		},
+		{
+			name: "distance preserved when the token is redacted",
+			args: []string{"dashboards", "Serch"},
+			want: ParseFailure{
+				Kind: parseErrorUnknownCommand, Parent: "dashboards", Token: redactedToken,
+				Attempted: "dashboards " + redactedToken, Nearest: "search", Distance: 1,
+			},
+		},
+		{
+			name: "positionals on a runnable command are values, not tokens",
+			args: []string{"dashboards", "get", "my-secret-dashboard", "extra"},
+			want: ParseFailure{
+				Kind: parseErrorInvalidArgs, Parent: "dashboards get",
+				Attempted: "dashboards get", Distance: -1,
+			},
+		},
+		{
+			name: "double dash ends command traversal",
+			args: []string{"dashboards", "--", "hunter2"},
+			want: ParseFailure{
+				Kind: parseErrorInvalidArgs, Parent: "dashboards",
+				Attempted: "dashboards", Distance: -1,
+			},
+		},
+		{
+			name:     "parse errors under completion stay suppressed",
+			args:     []string{"completion", "bogus"},
+			suppress: true,
+		},
+		{
+			name:     "parse errors under version stay suppressed",
+			args:     []string{"version", "extra"},
+			suppress: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagFailure.Store(nil)
+			t.Cleanup(func() { flagFailure.Store(nil) })
+
+			info := parseFailureTelemetryInfo(parseFailureTestTree(), tt.args)
+
+			if tt.suppress {
+				assert.True(t, info.Suppress)
+				return
+			}
+			require.NotNil(t, info.ParseError)
+			assert.Equal(t, tt.want, *info.ParseError)
+			assert.Equal(t, tt.want.Parent, info.Command)
+
+			// Nothing that looks like a value may survive into any field.
+			serialized := fmt.Sprintf("%+v", *info.ParseError)
+			for _, secret := range []string{"hunter2", "my-secret-dashboard", "prod-stack", "secret-value", "MyToken123", "4f3a2b1c", "example.com"} {
+				assert.NotContains(t, serialized, secret)
+			}
+		})
+	}
+}
+
+func TestFlagFailureTelemetryInfo(t *testing.T) {
+	rootCmd := parseFailureTestTree()
+	dashboards, _, err := rootCmd.Find([]string{"dashboards"})
+	require.NoError(t, err)
+	get, _, err := rootCmd.Find([]string{"dashboards", "get"})
+	require.NoError(t, err)
+	version, _, err := rootCmd.Find([]string{"version"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		cmd      *cobra.Command
+		err      error
+		suppress bool
+		want     ParseFailure
+	}{
+		{
+			name: "unknown flag with a near match",
+			cmd:  get,
+			err:  errors.New("unknown flag: --frmat"),
+			want: ParseFailure{
+				Kind: parseErrorUnknownFlag, Parent: "dashboards get",
+				Attempted: "dashboards get", Flags: "frmat", Nearest: "format", Distance: 1,
+			},
+		},
+		{
+			name: "unknown shorthand flag",
+			cmd:  dashboards,
+			err:  errors.New("unknown shorthand flag: 'q' in -qv"),
+			want: ParseFailure{
+				Kind: parseErrorUnknownFlag, Parent: "dashboards",
+				Attempted: "dashboards", Flags: "q", Nearest: "", Distance: -1,
+			},
+		},
+		{
+			name: "unknown flag name failing the shape filter is redacted",
+			cmd:  dashboards,
+			err:  errors.New("unknown flag: --https://example.com/secret"),
+			want: ParseFailure{
+				Kind: parseErrorUnknownFlag, Parent: "dashboards",
+				Attempted: "dashboards", Flags: redactedToken, Nearest: "", Distance: -1,
+			},
+		},
+		{
+			name: "flag errors embedding values record nothing from the message",
+			cmd:  get,
+			err:  errors.New(`invalid argument "hunter2" for "--format" flag: bad value`),
+			want: ParseFailure{
+				Kind: parseErrorInvalidArgs, Parent: "dashboards get",
+				Attempted: "dashboards get", Distance: -1,
+			},
+		},
+		{
+			name:     "flag failures on suppressed commands stay suppressed",
+			cmd:      version,
+			err:      errors.New("unknown flag: --bogus"),
+			suppress: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := flagFailureTelemetryInfo(&flagFailureRecord{cmd: tt.cmd, err: tt.err})
+
+			if tt.suppress {
+				assert.True(t, info.Suppress)
+				return
+			}
+			require.NotNil(t, info.ParseError)
+			assert.Equal(t, tt.want, *info.ParseError)
+			serialized := fmt.Sprintf("%+v", *info.ParseError)
+			assert.NotContains(t, serialized, "hunter2")
+			assert.NotContains(t, serialized, "example.com")
+		})
+	}
+}
+
+func TestFilterCommandToken(t *testing.T) {
+	tests := []struct {
+		token string
+		want  string
+	}{
+		// Command-shaped tokens pass through.
+		{"serch", "serch"},
+		{"deploy", "deploy"},
+		{"logs-tail", "logs-tail"},
+		{"instrumentation", "instrumentation"},
+		{"a", "a"},
+		// Shape violations are redacted.
+		{"Dashboards", redactedToken},                           // uppercase
+		{"my_secret", redactedToken},                            // underscore
+		{"abc123", redactedToken},                               // digits
+		{"a-b-c", redactedToken},                                // more than one hyphen
+		{"-dash", redactedToken},                                // leading hyphen
+		{"", redactedToken},                                     // empty
+		{"supercalifragilistical", redactedToken},               // longer than 20
+		{"some-uuid-looking-token-4f3a2b1c", redactedToken},     // digits, hyphens, length
+		{"4f3a2b1c-9d0e-4a7b-8c6d-1e2f3a4b5c6d", redactedToken}, // UUID
+		{"https://example.com", redactedToken},                  // URL
+		{"10.0.0.1", redactedToken},                             // IP
+		{"qwmzkxvbjfhdpl", redactedToken},                       // high entropy: 14 distinct chars
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.token, func(t *testing.T) {
+			assert.Equal(t, tt.want, filterCommandToken(tt.token))
+		})
+	}
+}
+
+func TestUnknownFlagName(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want string
+		ok   bool
+	}{
+		{"unknown flag: --frmat", "frmat", true},
+		{"unknown shorthand flag: 'q' in -qv", "q", true},
+		{"flag needs an argument: --output", "", false},
+		{`invalid argument "secret" for "--limit" flag: parse error`, "", false},
+		{"flag has been renamed; use --insecure-log-http-payload instead", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			name, ok := unknownFlagName(errors.New(tt.msg))
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.want, name)
+		})
+	}
+}
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"serch", "search", 1},
+		{"dashbords", "dashboards", 1},
+		{"resourcse", "resources", 2},
+		{"deploy", "dashboards", 8},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, levenshtein(tt.a, tt.b), "%s vs %s", tt.a, tt.b)
+	}
+}

--- a/cmd/gcx/root/parsefailure_internal_test.go
+++ b/cmd/gcx/root/parsefailure_internal_test.go
@@ -3,8 +3,11 @@ package root
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/grafana/gcx/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,10 +40,14 @@ func parseFailureTestTree() *cobra.Command {
 }
 
 // TestParseFailureTelemetryInfo_GoldenPII is the golden PII test required by
-// the #578 design: it pins down exactly what leaves the process for each parse
-// failure shape - truncation of attempted_command, the command-shape filter,
-// and distance preservation for redacted tokens.
+// the usage-stats design: it pins down exactly what leaves the process for
+// each parse failure shape - truncation of attempted_command, the
+// command-shape filter, and distance preservation for redacted tokens.
 func TestParseFailureTelemetryInfo_GoldenPII(t *testing.T) {
+	// Point config discovery at an empty dir so a real user config (whose
+	// context names are redacted) can never change what these cases emit.
+	t.Setenv(config.ConfigFileEnvVar, filepath.Join(t.TempDir(), "no-config.yaml"))
+
 	tests := []struct {
 		name     string
 		args     []string
@@ -157,10 +164,7 @@ func TestParseFailureTelemetryInfo_GoldenPII(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			flagFailure.Store(nil)
-			t.Cleanup(func() { flagFailure.Store(nil) })
-
-			info := parseFailureTelemetryInfo(parseFailureTestTree(), tt.args)
+			info := parseFailureTelemetryInfo(parseFailureTestTree(), tt.args, nil)
 
 			if tt.suppress {
 				assert.True(t, info.Suppress)
@@ -177,6 +181,29 @@ func TestParseFailureTelemetryInfo_GoldenPII(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A token naming one of the user's own contexts or Cloud stacks is
+// command-shaped but identifying - it reaches command position when arguments
+// are misplaced - so it must be redacted even though the shape filter passes
+// it.
+func TestParseFailureRedactsConfiguredNames(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	cfg := "contexts:\n  acme-corp:\n    cloud:\n      stack: acme-prod\ncurrent-context: acme-corp\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o600))
+	t.Setenv(config.ConfigFileEnvVar, cfgPath)
+
+	for _, token := range []string{"acme-corp", "acme-prod"} {
+		info := parseFailureTelemetryInfo(parseFailureTestTree(), []string{token, "dashboards"}, nil)
+		require.NotNil(t, info.ParseError, token)
+		assert.Equal(t, redactedToken, info.ParseError.Token, token)
+		assert.NotContains(t, fmt.Sprintf("%+v", *info.ParseError), token)
+	}
+
+	// An unrelated guess with the same shape still comes through raw.
+	info := parseFailureTelemetryInfo(parseFailureTestTree(), []string{"deploy"}, nil)
+	require.NotNil(t, info.ParseError)
+	assert.Equal(t, "deploy", info.ParseError.Token)
 }
 
 func TestFlagFailureTelemetryInfo(t *testing.T) {
@@ -241,7 +268,7 @@ func TestFlagFailureTelemetryInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			info := flagFailureTelemetryInfo(&flagFailureRecord{cmd: tt.cmd, err: tt.err})
+			info := flagFailureTelemetryInfo(&flagParseError{cmd: tt.cmd, err: tt.err})
 
 			if tt.suppress {
 				assert.True(t, info.Suppress)

--- a/cmd/gcx/root/telemetry.go
+++ b/cmd/gcx/root/telemetry.go
@@ -18,7 +18,7 @@ type TelemetryInfo struct {
 	OutputFormat string
 	Help         bool          // did the user call gcx help or use --help?
 	Suppress     bool          // this event must not get emitted
-	ParseError   *ParseFailure // set when the command line failed to parse (#578)
+	ParseError   *ParseFailure // set when the command line failed to parse
 }
 
 //nolint:gochecknoglobals // written once per process from PersistentPreRun.
@@ -60,7 +60,7 @@ func recordTelemetryInfo(cmd *cobra.Command, args []string) {
 //
 //   - The command line failed to parse (unknown command, unknown flag,
 //     invalid args) and the exit code is nonzero. These are classified into
-//     a parse_error outcome (#578).
+//     a parse_error outcome.
 //   - Cobra answered the invocation itself before any hooks could run:
 //     things like --help or --version, or a command with no action of its
 //     own (like `gcx` or `gcx resources`). The exit code is zero and
@@ -70,9 +70,9 @@ func recordTelemetryInfo(cmd *cobra.Command, args []string) {
 // For the zero-exit case, the command is re-resolved with Find and its flags
 // read as cobra parsed them. Scanning os.Args instead would misread forms
 // like --help=true.
-func FallbackTelemetryInfo(rootCmd *cobra.Command, args []string, exitCode int) *TelemetryInfo {
+func FallbackTelemetryInfo(rootCmd *cobra.Command, args []string, err error, exitCode int) *TelemetryInfo {
 	if exitCode != 0 {
-		return parseFailureTelemetryInfo(rootCmd, args)
+		return parseFailureTelemetryInfo(rootCmd, args, err)
 	}
 	target, _, err := rootCmd.Find(args)
 	if err != nil {

--- a/cmd/gcx/root/telemetry.go
+++ b/cmd/gcx/root/telemetry.go
@@ -16,8 +16,9 @@ type TelemetryInfo struct {
 	Command      string // command path without the root name, e.g. "resources get"
 	Flags        string // sorted, comma-separated names of the flags the user set
 	OutputFormat string
-	Help         bool // did the user call gcx help or use --help?
-	Suppress     bool // this event must not get emitted
+	Help         bool          // did the user call gcx help or use --help?
+	Suppress     bool          // this event must not get emitted
+	ParseError   *ParseFailure // set when the command line failed to parse (#578)
 }
 
 //nolint:gochecknoglobals // written once per process from PersistentPreRun.
@@ -57,10 +58,9 @@ func recordTelemetryInfo(cmd *cobra.Command, args []string) {
 // FallbackTelemetryInfo creates the usage-event info when PersistentPreRun
 // never ran, so nothing was recorded. That happens in two ways:
 //
-//   - The command line failed to parse (unknown command, unknown flag) and
-//     the exit code is nonzero. These return Suppress, so the caller emits
-//     no event. Recording parse failures as their own outcome is a TODO in
-//     #578.
+//   - The command line failed to parse (unknown command, unknown flag,
+//     invalid args) and the exit code is nonzero. These are classified into
+//     a parse_error outcome (#578).
 //   - Cobra answered the invocation itself before any hooks could run:
 //     things like --help or --version, or a command with no action of its
 //     own (like `gcx` or `gcx resources`). The exit code is zero and
@@ -72,7 +72,7 @@ func recordTelemetryInfo(cmd *cobra.Command, args []string) {
 // like --help=true.
 func FallbackTelemetryInfo(rootCmd *cobra.Command, args []string, exitCode int) *TelemetryInfo {
 	if exitCode != 0 {
-		return &TelemetryInfo{Suppress: true}
+		return parseFailureTelemetryInfo(rootCmd, args)
 	}
 	target, _, err := rootCmd.Find(args)
 	if err != nil {

--- a/cmd/gcx/root/telemetry_internal_test.go
+++ b/cmd/gcx/root/telemetry_internal_test.go
@@ -85,6 +85,8 @@ func TestRecordTelemetryInfo_HelpResolvesTarget(t *testing.T) {
 }
 
 func TestFallbackTelemetryInfo(t *testing.T) {
+	flagFailure.Store(nil)
+	t.Cleanup(func() { flagFailure.Store(nil) })
 	rootCmd, get, _ := telemetryTestTree()
 	get.Flags().Bool("help", false, "")
 
@@ -95,12 +97,14 @@ func TestFallbackTelemetryInfo(t *testing.T) {
 	assert.True(t, info.Help)
 	assert.Equal(t, "resources get", info.Command)
 
-	// `gcx resources bogus` fails with exit code 2, but Find still resolves
-	// it to the "resources" group - the same thing bare `gcx resources` (a
-	// help view) resolves to. The exit code is the only difference between
-	// them, so the failure must be suppressed rather than counted as help.
+	// `gcx resources bogus` fails with exit code 2: an unknown-command parse
+	// failure under the resources group (#578).
 	info = FallbackTelemetryInfo(rootCmd, []string{"resources", "bogus"}, 2)
-	assert.True(t, info.Suppress)
+	assert.False(t, info.Suppress)
+	require.NotNil(t, info.ParseError)
+	assert.Equal(t, parseErrorUnknownCommand, info.ParseError.Kind)
+	assert.Equal(t, "resources", info.ParseError.Parent)
+	assert.Equal(t, "bogus", info.ParseError.Token)
 
 	// Non-runnable command group: cobra prints help before the hooks run.
 	info = FallbackTelemetryInfo(rootCmd, []string{"resources"}, 0)
@@ -108,7 +112,8 @@ func TestFallbackTelemetryInfo(t *testing.T) {
 	assert.True(t, info.Help)
 	assert.Equal(t, "resources", info.Command)
 
-	// Unknown commands are parse failures, suppressed until parse capture.
+	// Unknown command with a zero exit means cobra answered the invocation
+	// itself; there is no parse failure to record.
 	info = FallbackTelemetryInfo(rootCmd, []string{"resourcse", "get"}, 0)
 	assert.True(t, info.Suppress)
 

--- a/cmd/gcx/root/telemetry_internal_test.go
+++ b/cmd/gcx/root/telemetry_internal_test.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -85,39 +86,44 @@ func TestRecordTelemetryInfo_HelpResolvesTarget(t *testing.T) {
 }
 
 func TestFallbackTelemetryInfo(t *testing.T) {
-	flagFailure.Store(nil)
-	t.Cleanup(func() { flagFailure.Store(nil) })
 	rootCmd, get, _ := telemetryTestTree()
 	get.Flags().Bool("help", false, "")
 
 	// --help on a resolved command: recorded as help with the resolved path.
 	require.NoError(t, get.Flags().Set("help", "true"))
-	info := FallbackTelemetryInfo(rootCmd, []string{"resources", "get", "--help"}, 0)
+	info := FallbackTelemetryInfo(rootCmd, []string{"resources", "get", "--help"}, nil, 0)
 	assert.False(t, info.Suppress)
 	assert.True(t, info.Help)
 	assert.Equal(t, "resources get", info.Command)
 
 	// `gcx resources bogus` fails with exit code 2: an unknown-command parse
-	// failure under the resources group (#578).
-	info = FallbackTelemetryInfo(rootCmd, []string{"resources", "bogus"}, 2)
+	// failure under the resources group.
+	info = FallbackTelemetryInfo(rootCmd, []string{"resources", "bogus"}, errors.New(`unknown command "bogus" for "gcx resources"`), 2)
 	assert.False(t, info.Suppress)
 	require.NotNil(t, info.ParseError)
 	assert.Equal(t, parseErrorUnknownCommand, info.ParseError.Kind)
 	assert.Equal(t, "resources", info.ParseError.Parent)
 	assert.Equal(t, "bogus", info.ParseError.Token)
 
+	// A wrapped flag failure classifies from the error itself, not the args.
+	info = FallbackTelemetryInfo(rootCmd, []string{"resources", "get", "--frmat"}, &flagParseError{cmd: get, err: errors.New("unknown flag: --frmat")}, 2)
+	assert.False(t, info.Suppress)
+	require.NotNil(t, info.ParseError)
+	assert.Equal(t, parseErrorUnknownFlag, info.ParseError.Kind)
+	assert.Equal(t, "frmat", info.ParseError.Flags)
+
 	// Non-runnable command group: cobra prints help before the hooks run.
-	info = FallbackTelemetryInfo(rootCmd, []string{"resources"}, 0)
+	info = FallbackTelemetryInfo(rootCmd, []string{"resources"}, nil, 0)
 	assert.False(t, info.Suppress)
 	assert.True(t, info.Help)
 	assert.Equal(t, "resources", info.Command)
 
 	// Unknown command with a zero exit means cobra answered the invocation
 	// itself; there is no parse failure to record.
-	info = FallbackTelemetryInfo(rootCmd, []string{"resourcse", "get"}, 0)
+	info = FallbackTelemetryInfo(rootCmd, []string{"resourcse", "get"}, nil, 0)
 	assert.True(t, info.Suppress)
 
 	// Suppressed commands stay suppressed on the fallback path too.
-	info = FallbackTelemetryInfo(rootCmd, []string{"completion", "zsh", "--help"}, 0)
+	info = FallbackTelemetryInfo(rootCmd, []string{"completion", "zsh", "--help"}, nil, 0)
 	assert.True(t, info.Suppress)
 }

--- a/cmd/gcx/telemetry.go
+++ b/cmd/gcx/telemetry.go
@@ -31,10 +31,10 @@ var diagnosticsConfig = sync.OnceValue(func() *internalconfig.DiagnosticsConfig 
 // emitUsageEvent builds and emits the anonymous usage event for this
 // invocation. It must never affect the command's exit code or prompt the user.
 // It must only be called once per invocation.
-func emitUsageEvent(cmd *cobra.Command, start time.Time, exitCode int) {
+func emitUsageEvent(cmd *cobra.Command, start time.Time, err error, exitCode int) {
 	info := root.CurrentTelemetryInfo()
 	if info == nil {
-		info = root.FallbackTelemetryInfo(cmd, os.Args[1:], exitCode)
+		info = root.FallbackTelemetryInfo(cmd, os.Args[1:], err, exitCode)
 	}
 	if info.Suppress {
 		return

--- a/cmd/gcx/telemetry.go
+++ b/cmd/gcx/telemetry.go
@@ -80,6 +80,17 @@ func buildUsageEvent(info *root.TelemetryInfo, start time.Time, exitCode int) te
 	event.CIProvider, event.IsCI = telemetry.DetectCI()
 
 	switch {
+	case info.ParseError != nil:
+		pe := info.ParseError
+		event.Outcome = telemetry.OutcomeParseError
+		event.ErrorKind = agentlog.KindFromExitCode(exitCode)
+		event.ParseErrorKind = pe.Kind
+		event.ParseErrorParent = pe.Parent
+		event.ParseErrorToken = pe.Token
+		event.AttemptedCommand = pe.Attempted
+		event.ParseErrorFlags = pe.Flags
+		event.ParseErrorNearest = pe.Nearest
+		event.ParseErrorDistance = pe.Distance
 	case info.Help && exitCode == 0:
 		event.Outcome = telemetry.OutcomeHelp
 	case exitCode == 0:

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -640,11 +641,19 @@ func diagnosticsSourcePaths(ctx context.Context) []string {
 }
 
 // readDiagnostics decodes a config file and returns only its diagnostics block.
-// It parses into the full Config (the codec rejects unknown fields, so a partial
-// struct will not do) but deliberately skips keychain resolution, plaintext
-// migration, and the config auto-creation that Load performs. Missing or
-// malformed files yield (nil, err).
 func readDiagnostics(path string) (*DiagnosticsConfig, error) {
+	cfg, err := readConfigFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.Diagnostics, nil
+}
+
+// readConfigFile decodes a config file into the full Config (the codec rejects
+// unknown fields, so a partial struct will not do) but deliberately skips the
+// keychain resolution, plaintext migration, and config auto-creation that Load
+// performs. Missing or malformed files yield (nil, err).
+func readConfigFile(path string) (*Config, error) {
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -654,7 +663,38 @@ func readDiagnostics(path string) (*DiagnosticsConfig, error) {
 	if err := codec.Decode(bytes.NewBuffer(contents), &cfg); err != nil {
 		return nil, err
 	}
-	return cfg.Diagnostics, nil
+	return &cfg, nil
+}
+
+// LoadContextNames returns the lowercased context names and Cloud stack slugs
+// from the layered config. Like LoadDiagnostics it never probes the OS
+// keychain and never auto-creates a config file: it exists so the telemetry
+// parse-failure filter can redact tokens that name the user's own contexts or
+// stacks without prompting or touching secrets.
+func LoadContextNames(ctx context.Context) []string {
+	seen := map[string]bool{}
+	var names []string
+	add := func(s string) {
+		s = strings.ToLower(s)
+		if s == "" || seen[s] {
+			return
+		}
+		seen[s] = true
+		names = append(names, s)
+	}
+	for _, path := range diagnosticsSourcePaths(ctx) {
+		cfg, err := readConfigFile(path)
+		if err != nil {
+			continue
+		}
+		for name, c := range cfg.Contexts {
+			add(name)
+			if c != nil && c.Cloud != nil {
+				add(c.Cloud.Stack)
+			}
+		}
+	}
+	return names
 }
 
 func annotateErrorWithSource(filename string, contents []byte, err error) error {


### PR DESCRIPTION
closes #578

## Summary

- Adds the `parse_error` outcome to usage events: unknown commands, unknown flags, and argument-validation failures are now recorded instead of suppressed. This is the "404 log" for the CLI - what people and agents *try* that doesn't exist.
- `FallbackTelemetryInfo` classifies the failed parse by walking the command tree the way cobra's `Find` does: `parse_error_kind`, `parse_error_parent` (deepest valid command), `parse_error_token` (first unknown token), `parse_error_nearest`/`parse_error_distance` (cobra's suggestion rule, `-1` when nothing is near).
- Unknown flags are captured via the root `SetFlagErrorFunc` hook (propagates to children); only flag **names** are recorded, and flag errors that embed values (e.g. `invalid argument "x" for --limit`) record nothing from the message.
- Privacy is enforced by a command-shape filter on the token: lowercase kebab, max 20 chars, at most one hyphen, no digits, an entropy bound, and stdlib URL/IP/UUID checks. Failing tokens become `<redacted>` while the distance is kept, so novel guesses still count. `attempted_command` is truncated at the unknown token, and flag values can never be mistaken for the token (unknown flags conservatively consume the next arg, matching cobra's `stripFlags`).
- Parse errors under suppressed commands (`completion`, `version`, `telemetry`) stay unrecorded; typos *of* those commands (e.g. `gcx versoin`) still count.
- Golden PII test pins down exactly what leaves the process for every failure shape: typo, novel guess, truncation, flag-value skipping, and secret-looking/UUID/URL tokens.

No wire or server changes - the `parse_error_*` fields already exist in the event schema and usage-stats columns.

## Example events (`GCX_TELEMETRY=log`)

**We need to be very cautious of accidentally emitting sensitive or identifiable data in these error events. Are we being defensive enough?** 

Typo of a real command (`gcx dashboards serch`):

```json
{"outcome":"parse_error","exit_code":2,"error_kind":"usage_error","parse_error_kind":"unknown_command","parse_error_parent":"dashboards","parse_error_token":"serch","attempted_command":"dashboards serch","parse_error_nearest":"search","parse_error_distance":1}
```

Novel top-level guess (`gcx deploy`) - no near match, still counted:

```json
{"outcome":"parse_error","exit_code":2,"error_kind":"usage_error","parse_error_kind":"unknown_command","parse_error_token":"deploy","attempted_command":"deploy","parse_error_distance":-1}
```

Unknown flag (`gcx resources get --frmat json`) - name only, never the value:

```json
{"outcome":"parse_error","exit_code":1,"parse_error_kind":"unknown_flag","parse_error_parent":"resources get","attempted_command":"resources get","parse_error_flags":"frmat","parse_error_distance":-1}
```

Token failing the shape filter (`gcx some-uuid-looking-token-4f3a2b1c`) - redacted, distance preserved:

```json
{"outcome":"parse_error","exit_code":2,"parse_error_kind":"unknown_command","parse_error_token":"<redacted>","attempted_command":"<redacted>","parse_error_distance":-1}
```

(envelope fields trimmed for readability; full events carry the usual service/version/os/device_id/agent fields)

## Notes

- Entropy threshold is 3.7 bits/char: real command words sit around 3.2, and exceeding 3.7 needs 13+ distinct characters, which reads as a random identifier. The charset/length/hyphen rules do most of the redaction work; entropy is the backstop the design asks for.
- Cobra only assigns `SuggestionsMinimumDistance` lazily while rendering an unknown-command error, so the classifier applies the same default (2) itself and reuses `SuggestionsFor` for command matching; flags get the identical rule.
