### PR TITLE
feat(agento11y): adding conversation annotations

### DIFF
--- a/docs/reference/cli/gcx_agento11y_conversations_annotate.md
+++ b/docs/reference/cli/gcx_agento11y_conversations_annotate.md
@@ -1,0 +1,46 @@
+## gcx agento11y conversations annotate
+
+Annotate a conversation.
+
+```
+gcx agento11y conversations annotate <conversation-id> [flags]
+```
+
+### Examples
+
+```
+  gcx agento11y conversations annotate conv-123 --body "Needs review"
+  gcx agento11y conversations annotate conv-123 --type TRIAGE_STATUS --body "Escalated" --tag status=needs_review
+```
+
+### Options
+
+```
+      --annotation-id string   Annotation ID; generated when omitted
+      --body string            Annotation body
+      --generation-id string   Generation ID to attach the annotation to
+  -h, --help                   help for annotate
+      --jq string              jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string            Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --metadata-json string   Metadata object as JSON
+  -o, --output string          Output format. One of: agents, json, yaml (default "json")
+      --tag stringArray        Tag in key=value form (repeatable)
+      --type string            Annotation type: NOTE, LABEL, TRIAGE_STATUS, ROOT_CAUSE, or FOLLOW_UP (default "NOTE")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx agento11y conversations](gcx_agento11y_conversations.md)	 - Query Agent Observability conversations.
+

--- a/docs/reference/cli/gcx_agento11y_conversations_list-annotations.md
+++ b/docs/reference/cli/gcx_agento11y_conversations_list-annotations.md
@@ -1,11 +1,20 @@
-## gcx agento11y conversations
+## gcx agento11y conversations list-annotations
 
-Query Agent Observability conversations.
+List annotations for a conversation.
+
+```
+gcx agento11y conversations list-annotations <conversation-id> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for conversations
+      --cursor string   Pagination cursor from a previous response
+  -h, --help            help for list-annotations
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int       Number of annotations to request (default 50)
+  -o, --output string   Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands
@@ -22,10 +31,5 @@ Query Agent Observability conversations.
 
 ### SEE ALSO
 
-* [gcx agento11y](gcx_agento11y.md)	 - Manage Grafana Agent Observability resources
-* [gcx agento11y conversations annotate](gcx_agento11y_conversations_annotate.md)	 - Annotate a conversation.
-* [gcx agento11y conversations get](gcx_agento11y_conversations_get.md)	 - Get a single conversation with all generations.
-* [gcx agento11y conversations list](gcx_agento11y_conversations_list.md)	 - List conversations.
-* [gcx agento11y conversations list-annotations](gcx_agento11y_conversations_list-annotations.md)	 - List annotations for a conversation.
-* [gcx agento11y conversations search](gcx_agento11y_conversations_search.md)	 - Search conversations with filters.
+* [gcx agento11y conversations](gcx_agento11y_conversations.md)	 - Query Agent Observability conversations.
 

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -504,9 +504,11 @@ var commandAnnotations = map[string]annotation{
 	"gcx agento11y agents list":     {Cost: "small"},
 	"gcx agento11y agents versions": {Cost: "small"},
 
-	"gcx agento11y conversations get":    {Cost: "medium", Hint: "<conversation-id> -o json"},
-	"gcx agento11y conversations list":   {Cost: "small"},
-	"gcx agento11y conversations search": {Cost: "medium", Hint: "--from 2024-01-01 --to 2024-01-31 -o json"},
+	"gcx agento11y conversations annotate":         {Cost: "small"},
+	"gcx agento11y conversations get":              {Cost: "medium", Hint: "<conversation-id> -o json"},
+	"gcx agento11y conversations list":             {Cost: "small"},
+	"gcx agento11y conversations list-annotations": {Cost: "small"},
+	"gcx agento11y conversations search":           {Cost: "medium", Hint: "--from 2024-01-01 --to 2024-01-31 -o json"},
 
 	"gcx agento11y evaluators create": {Cost: "small"},
 	"gcx agento11y evaluators delete": {Cost: "small"},

--- a/internal/providers/aio11y/conversations/client.go
+++ b/internal/providers/aio11y/conversations/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
 )
@@ -53,7 +54,7 @@ func (c *Client) Search(ctx context.Context, req SearchRequest) (*SearchResponse
 func (c *Client) ListAnnotations(ctx context.Context, conversationID string, limit int, cursor string) (*ConversationAnnotationsResponse, error) {
 	query := url.Values{}
 	if limit > 0 {
-		query.Set("limit", fmt.Sprintf("%d", limit))
+		query.Set("limit", strconv.Itoa(limit))
 	}
 	if cursor != "" {
 		query.Set("cursor", cursor)

--- a/internal/providers/aio11y/conversations/client.go
+++ b/internal/providers/aio11y/conversations/client.go
@@ -13,6 +13,7 @@ const (
 	conversationsPath      = "/query/conversations"
 	conversationByIDFmt    = conversationsPath + "/%s"
 	conversationSearchPath = conversationsPath + "/search"
+	annotationsByIDFmt     = conversationByIDFmt + "/annotations"
 )
 
 // Client is an HTTP client for Agent Observability conversation endpoints.
@@ -46,4 +47,35 @@ func (c *Client) Search(ctx context.Context, req SearchRequest) (*SearchResponse
 		return nil, err
 	}
 	return &searchResp, nil
+}
+
+// ListAnnotations returns annotation events attached to a conversation.
+func (c *Client) ListAnnotations(ctx context.Context, conversationID string, limit int, cursor string) (*ConversationAnnotationsResponse, error) {
+	query := url.Values{}
+	if limit > 0 {
+		query.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	if cursor != "" {
+		query.Set("cursor", cursor)
+	}
+
+	path := fmt.Sprintf(annotationsByIDFmt, url.PathEscape(conversationID))
+	if encoded := query.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	resp, err := aio11yhttp.DoJSON[any, ConversationAnnotationsResponse](ctx, c.base, http.MethodGet, path, nil, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CreateAnnotation creates an annotation event for a conversation.
+func (c *Client) CreateAnnotation(ctx context.Context, conversationID string, req CreateAnnotationRequest) (*CreateAnnotationResponse, error) {
+	resp, err := aio11yhttp.DoJSON[CreateAnnotationRequest, CreateAnnotationResponse](ctx, c.base, http.MethodPost, fmt.Sprintf(annotationsByIDFmt, url.PathEscape(conversationID)), &req, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }

--- a/internal/providers/aio11y/conversations/client_test.go
+++ b/internal/providers/aio11y/conversations/client_test.go
@@ -121,6 +121,85 @@ func TestClient_Search(t *testing.T) {
 	assert.Equal(t, "page2", resp.NextCursor)
 }
 
+func TestClient_ListAnnotations(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/query/conversations/conv-123/annotations")
+		assert.Equal(t, "25", r.URL.Query().Get("limit"))
+		assert.Equal(t, "42", r.URL.Query().Get("cursor"))
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, conversations.ConversationAnnotationsResponse{
+			Items: []conversations.ConversationAnnotation{
+				{
+					AnnotationID:   "ann-1",
+					ConversationID: "conv-123",
+					AnnotationType: "NOTE",
+					Body:           "Needs review",
+					OperatorID:     "alice",
+					CreatedAt:      now,
+				},
+			},
+			NextCursor: "99",
+		})
+	}))
+
+	resp, err := client.ListAnnotations(context.Background(), "conv-123", 25, "42")
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, "ann-1", resp.Items[0].AnnotationID)
+	assert.Equal(t, "99", resp.NextCursor)
+}
+
+func TestClient_CreateAnnotation(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "/query/conversations/conv-123/annotations")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Empty(t, r.Header.Get("X-Sigil-Operator-Id"))
+
+		var req conversations.CreateAnnotationRequest
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&req)) {
+			http.Error(w, "bad request body", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, "ann-1", req.AnnotationID)
+		assert.Equal(t, "TRIAGE_STATUS", req.AnnotationType)
+		assert.Equal(t, "Escalated", req.Body)
+		assert.Equal(t, "needs_review", req.Tags["status"])
+		assert.Equal(t, "cli", req.Metadata["source"])
+		assert.Equal(t, "gen-1", req.GenerationID)
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, conversations.CreateAnnotationResponse{
+			Annotation: conversations.ConversationAnnotation{
+				AnnotationID:   req.AnnotationID,
+				ConversationID: "conv-123",
+				AnnotationType: req.AnnotationType,
+				Body:           req.Body,
+				Tags:           req.Tags,
+				Metadata:       req.Metadata,
+				GenerationID:   req.GenerationID,
+				OperatorID:     "alice",
+			},
+			Summary: conversations.AnnotationSummary{AnnotationCount: 1, LatestAnnotationType: req.AnnotationType},
+		})
+	}))
+
+	resp, err := client.CreateAnnotation(context.Background(), "conv-123", conversations.CreateAnnotationRequest{
+		AnnotationID:   "ann-1",
+		AnnotationType: "TRIAGE_STATUS",
+		Body:           "Escalated",
+		Tags:           map[string]string{"status": "needs_review"},
+		Metadata:       map[string]any{"source": "cli"},
+		GenerationID:   "gen-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ann-1", resp.Annotation.AnnotationID)
+	assert.Equal(t, 1, resp.Summary.AnnotationCount)
+}
+
 func TestClient_Get_NotFound(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "not found", http.StatusNotFound)

--- a/internal/providers/aio11y/conversations/commands.go
+++ b/internal/providers/aio11y/conversations/commands.go
@@ -432,10 +432,10 @@ func newAnnotateCommand(loader *providers.ConfigLoader) *cobra.Command {
 }
 
 func parseAnnotationTags(raw []string) (map[string]string, error) {
-	if len(raw) == 0 {
-		return nil, nil
-	}
 	tags := make(map[string]string, len(raw))
+	if len(raw) == 0 {
+		return tags, nil
+	}
 	for _, t := range raw {
 		k, v, ok := strings.Cut(t, "=")
 		if !ok {
@@ -452,10 +452,10 @@ func parseAnnotationTags(raw []string) (map[string]string, error) {
 }
 
 func parseAnnotationMetadata(raw string) (map[string]any, error) {
+	metadata := map[string]any{}
 	if strings.TrimSpace(raw) == "" {
-		return nil, nil
+		return metadata, nil
 	}
-	var metadata map[string]any
 	if err := json.Unmarshal([]byte(raw), &metadata); err != nil {
 		return nil, fmt.Errorf("invalid --metadata-json: %w", err)
 	}

--- a/internal/providers/aio11y/conversations/commands.go
+++ b/internal/providers/aio11y/conversations/commands.go
@@ -1,13 +1,16 @@
 package conversations
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
@@ -36,6 +39,8 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 		newListCommand(loader),
 		newGetCommand(loader),
 		newSearchCommand(loader),
+		newListAnnotationsCommand(loader),
+		newAnnotateCommand(loader),
 	)
 	return cmd
 }
@@ -291,6 +296,236 @@ func (c *SearchTableCodec) Encode(w io.Writer, v any) error {
 
 func (c *SearchTableCodec) Decode(_ io.Reader, _ any) error {
 	return errors.New("table format does not support decoding")
+}
+
+// --- annotations ---
+
+type annotationsListOpts struct {
+	IO     cmdio.Options
+	Limit  int
+	Cursor string
+}
+
+func (o *annotationsListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &AnnotationsTableCodec{})
+	o.IO.RegisterCustomCodec("wide", &AnnotationsTableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.IntVar(&o.Limit, "limit", 50, "Number of annotations to request")
+	flags.StringVar(&o.Cursor, "cursor", "", "Pagination cursor from a previous response")
+}
+
+func (o *annotationsListOpts) Validate() error {
+	if o.Limit <= 0 {
+		return errors.New("--limit must be greater than 0")
+	}
+	return o.IO.Validate()
+}
+
+func newListAnnotationsCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &annotationsListOpts{}
+	cmd := &cobra.Command{
+		Use:   "list-annotations <conversation-id>",
+		Short: "List annotations for a conversation.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			resp, err := client.ListAnnotations(cmd.Context(), args[0], opts.Limit, opts.Cursor)
+			if err != nil {
+				return err
+			}
+			if opts.IO.OutputFormat == "table" || opts.IO.OutputFormat == "wide" {
+				return opts.IO.Encode(cmd.OutOrStdout(), resp.Items)
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), resp)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type annotationsAddOpts struct {
+	IO             cmdio.Options
+	AnnotationID   string
+	AnnotationType string
+	Body           string
+	GenerationID   string
+	Tags           []string
+	MetadataJSON   string
+}
+
+func (o *annotationsAddOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("json")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.AnnotationID, "annotation-id", "", "Annotation ID; generated when omitted")
+	flags.StringVar(&o.AnnotationType, "type", "NOTE", "Annotation type: NOTE, LABEL, TRIAGE_STATUS, ROOT_CAUSE, or FOLLOW_UP")
+	flags.StringVar(&o.Body, "body", "", "Annotation body")
+	flags.StringVar(&o.GenerationID, "generation-id", "", "Generation ID to attach the annotation to")
+	flags.StringArrayVar(&o.Tags, "tag", nil, "Tag in key=value form (repeatable)")
+	flags.StringVar(&o.MetadataJSON, "metadata-json", "", "Metadata object as JSON")
+}
+
+func (o *annotationsAddOpts) Validate() error {
+	if strings.TrimSpace(o.Body) == "" {
+		return errors.New("--body is required")
+	}
+	switch strings.TrimSpace(o.AnnotationType) {
+	case "NOTE", "LABEL", "TRIAGE_STATUS", "ROOT_CAUSE", "FOLLOW_UP":
+	default:
+		return errors.New("--type must be one of NOTE, LABEL, TRIAGE_STATUS, ROOT_CAUSE, or FOLLOW_UP")
+	}
+	return o.IO.Validate()
+}
+
+func newAnnotateCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &annotationsAddOpts{}
+	cmd := &cobra.Command{
+		Use:   "annotate <conversation-id>",
+		Short: "Annotate a conversation.",
+		Example: `  gcx agento11y conversations annotate conv-123 --body "Needs review"
+  gcx agento11y conversations annotate conv-123 --type TRIAGE_STATUS --body "Escalated" --tag status=needs_review`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			tags, err := parseAnnotationTags(opts.Tags)
+			if err != nil {
+				return err
+			}
+			metadata, err := parseAnnotationMetadata(opts.MetadataJSON)
+			if err != nil {
+				return err
+			}
+			annotationID := strings.TrimSpace(opts.AnnotationID)
+			if annotationID == "" {
+				annotationID = "ann-" + uuid.NewString()
+			}
+
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			resp, err := client.CreateAnnotation(cmd.Context(), args[0], CreateAnnotationRequest{
+				AnnotationID:   annotationID,
+				AnnotationType: strings.TrimSpace(opts.AnnotationType),
+				Body:           strings.TrimSpace(opts.Body),
+				Tags:           tags,
+				Metadata:       metadata,
+				GenerationID:   strings.TrimSpace(opts.GenerationID),
+			})
+			if err != nil {
+				return err
+			}
+			cmdio.Success(cmd.ErrOrStderr(), "Added annotation %s", resp.Annotation.AnnotationID)
+			return opts.IO.Encode(cmd.OutOrStdout(), resp)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func parseAnnotationTags(raw []string) (map[string]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	tags := make(map[string]string, len(raw))
+	for _, t := range raw {
+		k, v, ok := strings.Cut(t, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid --tag %q: expected key=value", t)
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k == "" {
+			return nil, fmt.Errorf("invalid --tag %q: empty key", t)
+		}
+		tags[k] = v
+	}
+	return tags, nil
+}
+
+func parseAnnotationMetadata(raw string) (map[string]any, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(raw), &metadata); err != nil {
+		return nil, fmt.Errorf("invalid --metadata-json: %w", err)
+	}
+	if metadata == nil {
+		return nil, errors.New("--metadata-json must be a JSON object")
+	}
+	return metadata, nil
+}
+
+// AnnotationsTableCodec renders conversation annotations.
+type AnnotationsTableCodec struct {
+	Wide bool
+}
+
+func (c *AnnotationsTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *AnnotationsTableCodec) Encode(w io.Writer, v any) error {
+	annotations, ok := v.([]ConversationAnnotation)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []ConversationAnnotation")
+	}
+
+	var t *style.TableBuilder
+	if c.Wide {
+		t = style.NewTable("ID", "TYPE", "BODY", "TAGS", "OPERATOR", "GENERATION", "CREATED")
+	} else {
+		t = style.NewTable("ID", "TYPE", "BODY", "OPERATOR", "CREATED")
+	}
+
+	for _, annotation := range annotations {
+		body := aio11yhttp.Truncate(annotation.Body, 56)
+		operator := firstNonEmpty(annotation.OperatorName, annotation.OperatorLogin, annotation.OperatorID, "-")
+		created := aio11yhttp.FormatTime(annotation.CreatedAt)
+		if c.Wide {
+			t.Row(annotation.AnnotationID, annotation.AnnotationType, body, formatTags(annotation.Tags), operator, firstNonEmpty(annotation.GenerationID, "-"), created)
+		} else {
+			t.Row(annotation.AnnotationID, annotation.AnnotationType, body, operator, created)
+		}
+	}
+	return t.Render(w)
+}
+
+func (c *AnnotationsTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+func formatTags(tags map[string]string) string {
+	if len(tags) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(tags))
+	for k, v := range tags {
+		parts = append(parts, k+"="+v)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func parseTimeRange(from, to string) (*SearchTimeRange, error) {

--- a/internal/providers/aio11y/conversations/commands_test.go
+++ b/internal/providers/aio11y/conversations/commands_test.go
@@ -159,3 +159,90 @@ func TestSearchTableCodec_WrongType(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "expected []SearchResult")
 }
+
+func TestAnnotationsTableCodec_Encode(t *testing.T) {
+	now := time.Date(2026, 4, 2, 18, 30, 0, 0, time.UTC)
+	items := []conversations.ConversationAnnotation{
+		{
+			AnnotationID:   "ann-1",
+			AnnotationType: "NOTE",
+			Body:           "Needs review",
+			Tags:           map[string]string{"status": "needs_review", "team": "sre"},
+			OperatorName:   "Alice",
+			GenerationID:   "gen-1",
+			CreatedAt:      now,
+		},
+	}
+
+	tests := []struct {
+		name string
+		wide bool
+		want []string
+	}{
+		{
+			name: "table format",
+			wide: false,
+			want: []string{"ID", "TYPE", "BODY", "OPERATOR", "CREATED", "ann-1", "NOTE", "Needs review", "Alice", "2026-04-02 18:30"},
+		},
+		{
+			name: "wide includes tags and generation",
+			wide: true,
+			want: []string{"TAGS", "GENERATION", "status=needs_review, team=sre", "gen-1"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			codec := &conversations.AnnotationsTableCodec{Wide: tc.wide}
+			var buf bytes.Buffer
+			require.NoError(t, codec.Encode(&buf, items))
+
+			output := buf.String()
+			for _, s := range tc.want {
+				assert.Contains(t, output, s)
+			}
+		})
+	}
+}
+
+func TestAnnotationsTableCodec_WrongType(t *testing.T) {
+	codec := &conversations.AnnotationsTableCodec{}
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, "not-a-slice")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected []ConversationAnnotation")
+}
+
+func TestCommands_HasAnnotationCommands(t *testing.T) {
+	cmd := conversations.Commands(nil)
+
+	for _, sub := range []string{"list-annotations", "annotate"} {
+		c, _, err := cmd.Find([]string{sub})
+		require.NoError(t, err)
+		assert.Equal(t, sub, c.Name())
+	}
+}
+
+func TestAnnotateCommand_RequiresBody(t *testing.T) {
+	cmd := conversations.Commands(nil)
+	cmd.SetArgs([]string{"annotate", "conv-1"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--body is required")
+}
+
+func TestAnnotateCommand_RejectsInvalidTag(t *testing.T) {
+	cmd := conversations.Commands(nil)
+	cmd.SetArgs([]string{"annotate", "conv-1", "--body", "note", "--tag", "not-a-tag"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --tag")
+}
+
+func TestAnnotateCommand_RejectsInvalidMetadataJSON(t *testing.T) {
+	cmd := conversations.Commands(nil)
+	cmd.SetArgs([]string{"annotate", "conv-1", "--body", "note", "--metadata-json", "[]"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --metadata-json")
+}

--- a/internal/providers/aio11y/conversations/types.go
+++ b/internal/providers/aio11y/conversations/types.go
@@ -40,6 +40,50 @@ type SearchResult struct {
 // nested objects (model is an object, input/output vary by provider).
 type ConversationDetail map[string]any
 
+// ConversationAnnotation is an annotation event attached to a conversation.
+type ConversationAnnotation struct {
+	AnnotationID   string            `json:"annotation_id"`
+	ConversationID string            `json:"conversation_id"`
+	GenerationID   string            `json:"generation_id,omitempty"`
+	AnnotationType string            `json:"annotation_type"`
+	Body           string            `json:"body,omitempty"`
+	Tags           map[string]string `json:"tags,omitempty"`
+	Metadata       map[string]any    `json:"metadata,omitempty"`
+	OperatorID     string            `json:"operator_id"`
+	OperatorLogin  string            `json:"operator_login,omitempty"`
+	OperatorName   string            `json:"operator_name,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
+}
+
+// ConversationAnnotationsResponse is the paginated annotation list response.
+type ConversationAnnotationsResponse struct {
+	Items      []ConversationAnnotation `json:"items"`
+	NextCursor string                   `json:"next_cursor,omitempty"`
+}
+
+// CreateAnnotationRequest is the request body for POST /query/conversations/{id}/annotations.
+type CreateAnnotationRequest struct {
+	AnnotationID   string            `json:"annotation_id"`
+	AnnotationType string            `json:"annotation_type"`
+	Body           string            `json:"body"`
+	Tags           map[string]string `json:"tags,omitempty"`
+	Metadata       map[string]any    `json:"metadata,omitempty"`
+	GenerationID   string            `json:"generation_id,omitempty"`
+}
+
+// CreateAnnotationResponse is the response from creating a conversation annotation.
+type CreateAnnotationResponse struct {
+	Annotation ConversationAnnotation `json:"annotation"`
+	Summary    AnnotationSummary      `json:"summary"`
+}
+
+// AnnotationSummary holds conversation annotation aggregates.
+type AnnotationSummary struct {
+	AnnotationCount      int       `json:"annotation_count"`
+	LatestAnnotationType string    `json:"latest_annotation_type,omitempty"`
+	LatestAnnotatedAt    time.Time `json:"latest_annotated_at"`
+}
+
 // RatingSummary holds conversation rating aggregates.
 type RatingSummary struct {
 	TotalCount   int    `json:"total_count"`


### PR DESCRIPTION
## Notes

Updating gcx with conversation annotation commands for Grafana Agent Observability.

This adds support for the Sigil conversation annotation API via:

```bash
gcx agento11y conversations annotate <conversation-id>
gcx agento11y conversations list-annotations <conversation-id>
```

## Tests

Verified with local `gcx`:

```bash
./bin/gcx version
./bin/gcx agento11y conversations --help
./bin/gcx agento11y conversations annotate --help
./bin/gcx agento11y conversations list-annotations --help
```

Confirmed the new `annotate` and `list-annotations` commands are present.

### Automated checks

```bash
go test -mod=readonly ./internal/providers/aio11y/conversations ./cmd/gcx/root -run 'TestConsistency|Test.*'
go test -mod=readonly ./internal/providers/aio11y/...
GOFLAGS=-mod=readonly GCX_AGENT_MODE=false mise run reference
go build -mod=readonly -buildvcs=false -o bin/gcx ./cmd/gcx/
git diff --check
```

Verified command behavior, generated docs, and build all pass.
