### PR TITLE
fix(output): honest output handling for pull/edit and typed hints (#387 output track)

### DIFF
--- a/cmd/gcx/resources/edit.go
+++ b/cmd/gcx/resources/edit.go
@@ -39,6 +39,12 @@ func (opts *editOpts) setup(flags *pflag.FlagSet) {
 	// Bind all the flags
 	opts.IO.BindFlags(flags)
 	opts.flags = flags
+
+	// Validate rejects every use of --json/--jq (below), so hide both from
+	// help — advertising flags the command always refuses is the same
+	// dishonesty as advertising the rejected agents format.
+	_ = flags.MarkHidden("json")
+	_ = flags.MarkHidden("jq")
 }
 
 func (opts *editOpts) Validate() error {

--- a/cmd/gcx/resources/edit.go
+++ b/cmd/gcx/resources/edit.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
@@ -16,16 +17,54 @@ import (
 
 type editOpts struct {
 	IO cmdio.Options
+
+	// flags is the bound flag set, kept so Validate can reject flags that
+	// cannot round-trip through the editor (--json, --jq).
+	flags *pflag.FlagSet
 }
 
 func (opts *editOpts) setup(flags *pflag.FlagSet) {
+	// OutputFormat doubles as the editor temp-file extension, the encoder
+	// for the buffer handed to the editor, and the decode format for the
+	// round-trip read-back — pin the default so agent mode does not flip it
+	// to the agents codec (not decodable by the FSReader, and large
+	// resources would open as a spill-summary envelope). An explicit
+	// -o json|yaml from the user still wins.
+	opts.IO.PinDefaultFormat("json")
+
+	// Validate rejects -o agents (below), so never advertise it in the
+	// format menu (usage string and unknown-format error listings).
+	opts.IO.HideFormat("agents")
+
 	// Bind all the flags
 	opts.IO.BindFlags(flags)
+	opts.flags = flags
 }
 
 func (opts *editOpts) Validate() error {
 	if err := opts.IO.Validate(); err != nil {
 		return err
+	}
+
+	// The agents display codec cannot round-trip: the FSReader has no
+	// "agents" decoder, so the edited buffer could never be read back —
+	// the command would fail only after the user finished editing.
+	if opts.IO.OutputFormat == "agents" {
+		return errors.New("output format 'agents' cannot be used with edit: the edited file could not be read back. Use -o json or -o yaml")
+	}
+
+	// --json (field selection/discovery) and --jq (transformation) shape
+	// the encoded buffer handed to the editor, which the command then
+	// decodes back as the resource — a field-selected or jq-transformed
+	// document cannot round-trip. Reject upfront, mirroring the agents
+	// rejection above.
+	if opts.flags != nil {
+		if f := opts.flags.Lookup("json"); f != nil && f.Changed {
+			return errors.New("--json cannot be used with edit: field-selected output cannot round-trip through the editor. Use -o json or -o yaml")
+		}
+		if f := opts.flags.Lookup("jq"); f != nil && f.Changed {
+			return errors.New("--jq cannot be used with edit: transformed output cannot round-trip through the editor. Use -o json or -o yaml")
+		}
 	}
 
 	return nil
@@ -58,6 +97,10 @@ The edition will be cancelled if no changes are written to the file or if the fi
 	EDITOR=nvim gcx resources edit dashboard/foo
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
 			ctx := cmd.Context()
 			edit := editorFromEnv()
 

--- a/cmd/gcx/resources/edit.go
+++ b/cmd/gcx/resources/edit.go
@@ -2,10 +2,10 @@ package resources
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources"
@@ -55,8 +55,10 @@ func (opts *editOpts) Validate() error {
 	// The agents display codec cannot round-trip: the FSReader has no
 	// "agents" decoder, so the edited buffer could never be read back —
 	// the command would fail only after the user finished editing.
+	// UsageError classifies the rejection as invalid usage (exit 2,
+	// DESIGN.md taxonomy).
 	if opts.IO.OutputFormat == "agents" {
-		return errors.New("output format 'agents' cannot be used with edit: the edited file could not be read back. Use -o json or -o yaml")
+		return &fail.UsageError{Message: "output format 'agents' cannot be used with edit: the edited file could not be read back. Use -o json or -o yaml"}
 	}
 
 	// --json (field selection/discovery) and --jq (transformation) shape
@@ -66,10 +68,10 @@ func (opts *editOpts) Validate() error {
 	// rejection above.
 	if opts.flags != nil {
 		if f := opts.flags.Lookup("json"); f != nil && f.Changed {
-			return errors.New("--json cannot be used with edit: field-selected output cannot round-trip through the editor. Use -o json or -o yaml")
+			return &fail.UsageError{Message: "--json cannot be used with edit: field-selected output cannot round-trip through the editor. Use -o json or -o yaml"}
 		}
 		if f := opts.flags.Lookup("jq"); f != nil && f.Changed {
-			return errors.New("--jq cannot be used with edit: transformed output cannot round-trip through the editor. Use -o json or -o yaml")
+			return &fail.UsageError{Message: "--jq cannot be used with edit: transformed output cannot round-trip through the editor. Use -o json or -o yaml"}
 		}
 	}
 

--- a/cmd/gcx/resources/export_test.go
+++ b/cmd/gcx/resources/export_test.go
@@ -1,5 +1,12 @@
 package resources
 
+import (
+	"io"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
 // Exported aliases for unexported types, available to external test packages only.
 
 // TableCodecForTest wraps tableCodec for use in _test packages.
@@ -12,3 +19,30 @@ func NewTableCodecForTest(wide bool) *tableCodec {
 
 // TabCodecForTest wraps tabCodec for use in _test packages.
 type TabCodecForTest = tabCodec
+
+// NewPullOptsForTest constructs pullOpts with flags bound for format tests.
+func NewPullOptsForTest(flags *pflag.FlagSet) *pullOpts {
+	opts := &pullOpts{}
+	opts.setup(flags)
+	return opts
+}
+
+// NewEditOptsForTest constructs editOpts with flags bound for format tests.
+func NewEditOptsForTest(flags *pflag.FlagSet) *editOpts {
+	opts := &editOpts{}
+	opts.setup(flags)
+	return opts
+}
+
+// NewGetOptsForTest constructs getOpts with flags bound for output-path tests.
+func NewGetOptsForTest(flags *pflag.FlagSet) *getOpts {
+	opts := &getOpts{}
+	opts.setup(flags)
+	return opts
+}
+
+// WriteGetOutputForTest exposes the unexported writeGetOutput (the RunE
+// output tail: encode + truncation hint + partial-failure error).
+func WriteGetOutputForTest(stdout, stderr io.Writer, opts *getOpts, res *FetchResponse, output unstructured.UnstructuredList) error {
+	return writeGetOutput(stdout, stderr, opts, res, output)
+}

--- a/cmd/gcx/resources/export_test.go
+++ b/cmd/gcx/resources/export_test.go
@@ -42,7 +42,9 @@ func NewGetOptsForTest(flags *pflag.FlagSet) *getOpts {
 }
 
 // WriteGetOutputForTest exposes the unexported writeGetOutput (the RunE
-// output tail: encode + truncation hint + partial-failure error).
+// output tail: encode + truncation hint; the partial-failure error fires on
+// the non-field-select path, while the --json field-select path delegates
+// partial-failure handling to writeFieldSelect).
 func WriteGetOutputForTest(stdout, stderr io.Writer, opts *getOpts, res *FetchResponse, output unstructured.UnstructuredList) error {
 	return writeGetOutput(stdout, stderr, opts, res, output)
 }

--- a/cmd/gcx/resources/get.go
+++ b/cmd/gcx/resources/get.go
@@ -277,53 +277,75 @@ func getCmd(configOpts *cmdconfig.Options) *cobra.Command {
 				return deeplink.Open(url)
 			}
 
-			// --json field1,field2: use FieldSelectCodec for output.
-			if len(opts.IO.JSONFields) > 0 {
-				return writeFieldSelect(cmd.OutOrStdout(), opts, res, output)
-			}
-
-			var encodeErr error
-			if opts.IO.OutputFormat != "text" && opts.IO.OutputFormat != "wide" {
-				// Avoid printing a list of results if a single resource is being pulled,
-				// and we are not using the table output format.
-				if res.IsSingleTarget && len(output.Items) == 1 {
-					encodeErr = opts.IO.Encode(cmd.OutOrStdout(), output.Items[0].Object)
-				} else {
-					// For JSON / YAML output we don't want to have "object" keys in the output,
-					// so use the custom printItems type instead.
-					formatted := printItems{
-						Items: make([]map[string]any, len(output.Items)),
-					}
-					for i, item := range output.Items {
-						formatted.Items[i] = item.Object
-					}
-					encodeErr = opts.IO.Encode(cmd.OutOrStdout(), formatted)
-				}
-			} else {
-				encodeErr = opts.IO.Encode(cmd.OutOrStdout(), output)
-			}
-
-			if encodeErr != nil {
-				return encodeErr
-			}
-
-			if res.PullSummary.IsTruncated() {
-				fmt.Fprintf(cmd.ErrOrStderr(),
-					"Showing first %d items per resource type. Use --limit=0 to fetch all.\n",
-					opts.Limit)
-			}
-
-			if opts.OnError.FailOnErrors() && res.PullSummary.FailedCount() > 0 {
-				return fmt.Errorf("%d resource(s) failed to get", res.PullSummary.FailedCount())
-			}
-
-			return nil
+			return writeGetOutput(cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, res, output)
 		},
 	}
 
 	opts.setup(cmd.Flags())
 
 	return cmd
+}
+
+// writeGetOutput renders the fetched resources to stdout in the resolved
+// output mode (--json field selection, single object, list envelope, or
+// table) and surfaces the truncation hint on stderr. Split from RunE so the
+// output path is testable without a live server.
+func writeGetOutput(stdout, stderr io.Writer, opts *getOpts, res *FetchResponse, output unstructured.UnstructuredList) error {
+	// --json field1,field2: use FieldSelectCodec for output. The truncation
+	// hint must fire on this path too — field-selected output is truncated by
+	// the same per-resource-type limit as every other mode.
+	if len(opts.IO.JSONFields) > 0 {
+		err := writeFieldSelect(stdout, opts, res, output)
+		emitGetTruncationHint(stderr, opts, res)
+		return err
+	}
+
+	var encodeErr error
+	if opts.IO.OutputFormat != "text" && opts.IO.OutputFormat != "wide" {
+		// Avoid printing a list of results if a single resource is being pulled,
+		// and we are not using the table output format.
+		if res.IsSingleTarget && len(output.Items) == 1 {
+			encodeErr = opts.IO.Encode(stdout, output.Items[0].Object)
+		} else {
+			// For JSON / YAML output we don't want to have "object" keys in the output,
+			// so use the custom printItems type instead.
+			formatted := printItems{
+				Items: make([]map[string]any, len(output.Items)),
+			}
+			for i, item := range output.Items {
+				formatted.Items[i] = item.Object
+			}
+			encodeErr = opts.IO.Encode(stdout, formatted)
+		}
+	} else {
+		encodeErr = opts.IO.Encode(stdout, output)
+	}
+
+	if encodeErr != nil {
+		return encodeErr
+	}
+
+	emitGetTruncationHint(stderr, opts, res)
+
+	if opts.OnError.FailOnErrors() && res.PullSummary.FailedCount() > 0 {
+		return fmt.Errorf("%d resource(s) failed to get", res.PullSummary.FailedCount())
+	}
+
+	return nil
+}
+
+// emitGetTruncationHint surfaces the per-resource-type truncation hint on
+// stderr. K8s per-resource-type paging: the limit applies to each resource
+// type independently, so this is not a list_meta envelope case — a typed
+// hint keeps it agent-legible (JSONL {"class":"hint"} in agent mode,
+// "hint: ..." on a TTY).
+func emitGetTruncationHint(stderr io.Writer, opts *getOpts, res *FetchResponse) {
+	if res == nil || res.PullSummary == nil || !res.PullSummary.IsTruncated() {
+		return
+	}
+	cmdio.EmitHint(stderr,
+		fmt.Sprintf("showing first %d items per resource type; use --limit=0 to fetch all", opts.Limit),
+		"")
 }
 
 // writeFieldSelect handles --json field1,field2 output for the get command.

--- a/cmd/gcx/resources/get.go
+++ b/cmd/gcx/resources/get.go
@@ -293,11 +293,14 @@ func getCmd(configOpts *cmdconfig.Options) *cobra.Command {
 func writeGetOutput(stdout, stderr io.Writer, opts *getOpts, res *FetchResponse, output unstructured.UnstructuredList) error {
 	// --json field1,field2: use FieldSelectCodec for output. The truncation
 	// hint must fire on this path too — field-selected output is truncated by
-	// the same per-resource-type limit as every other mode.
+	// the same per-resource-type limit as every other mode — but, as on the
+	// path below, only after a successful encode.
 	if len(opts.IO.JSONFields) > 0 {
-		err := writeFieldSelect(stdout, opts, res, output)
+		if err := writeFieldSelect(stdout, opts, res, output); err != nil {
+			return err
+		}
 		emitGetTruncationHint(stderr, opts, res)
-		return err
+		return nil
 	}
 
 	var encodeErr error

--- a/cmd/gcx/resources/get_truncation_hint_test.go
+++ b/cmd/gcx/resources/get_truncation_hint_test.go
@@ -1,0 +1,127 @@
+package resources_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/resources"
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/resources/remote"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// TestGetTruncationHint: the per-resource-type truncation hint must fire on
+// every output path of `resources get` — including --json field selection,
+// which returns through writeFieldSelect instead of the shared encode tail.
+// Regression test for the #387 Track B correction pass: previously the
+// JSONFields branch returned before the hint, so `--json <field>` silently
+// dropped the truncation notice.
+func TestGetTruncationHint(t *testing.T) {
+	item := unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "dashboard.grafana.app/v1alpha1",
+		"kind":       "Dashboard",
+		"metadata":   map[string]any{"name": "alpha"},
+	}}
+
+	tests := []struct {
+		name      string
+		agentMode bool
+		jsonField string // --json value; empty = explicit -o json output
+		truncated bool
+		wantHint  bool
+	}{
+		{
+			name:      "json field selection + truncation emits JSONL hint in agent mode",
+			agentMode: true,
+			jsonField: "metadata.name",
+			truncated: true,
+			wantHint:  true,
+		},
+		{
+			name:      "json field selection + truncation emits hint-prefixed line on a TTY",
+			agentMode: false,
+			jsonField: "metadata.name",
+			truncated: true,
+			wantHint:  true,
+		},
+		{
+			name:      "json field selection without truncation stays silent",
+			agentMode: true,
+			jsonField: "metadata.name",
+			truncated: false,
+			wantHint:  false,
+		},
+		{
+			name:      "plain -o json + truncation still emits the hint",
+			agentMode: false,
+			truncated: true,
+			wantHint:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agent.SetFlag(tc.agentMode)
+			t.Cleanup(func() { agent.SetFlag(false) })
+
+			flags := pflag.NewFlagSet("get", pflag.ContinueOnError)
+			opts := resources.NewGetOptsForTest(flags)
+			if tc.jsonField != "" {
+				if err := flags.Set("json", tc.jsonField); err != nil {
+					t.Fatalf("set --json: %v", err)
+				}
+			} else if err := flags.Set("output", "json"); err != nil {
+				t.Fatalf("set -o json: %v", err)
+			}
+			if err := opts.Validate(); err != nil {
+				t.Fatalf("Validate() = %v, want nil", err)
+			}
+
+			summary := &remote.OperationSummary{}
+			if tc.truncated {
+				summary.RecordTruncated()
+			}
+			res := &resources.FetchResponse{PullSummary: summary}
+			output := unstructured.UnstructuredList{Items: []unstructured.Unstructured{item}}
+
+			var stdout, stderr bytes.Buffer
+			opts.IO.ErrWriter = &stderr
+			if err := resources.WriteGetOutputForTest(&stdout, &stderr, opts, res, output); err != nil {
+				t.Fatalf("writeGetOutput() = %v, want nil", err)
+			}
+			if stdout.Len() == 0 {
+				t.Fatal("stdout empty, want encoded output")
+			}
+
+			if !tc.wantHint {
+				if stderr.Len() != 0 {
+					t.Fatalf("stderr = %q, want empty (no truncation)", stderr.String())
+				}
+				return
+			}
+
+			line := strings.TrimSpace(stderr.String())
+			if line == "" {
+				t.Fatal("stderr empty, want truncation hint")
+			}
+			const wantSummary = "showing first 50 items per resource type; use --limit=0 to fetch all"
+			if tc.agentMode {
+				var event map[string]any
+				if err := json.Unmarshal([]byte(line), &event); err != nil {
+					t.Fatalf("agent-mode hint must be JSONL, got %q (%v)", line, err)
+				}
+				if event["class"] != "hint" {
+					t.Fatalf("hint class = %v, want %q", event["class"], "hint")
+				}
+				if event["summary"] != wantSummary {
+					t.Fatalf("hint summary = %v, want %q", event["summary"], wantSummary)
+				}
+			} else if line != "hint: "+wantSummary {
+				t.Fatalf("TTY hint = %q, want %q", line, "hint: "+wantSummary)
+			}
+		})
+	}
+}

--- a/cmd/gcx/resources/pull.go
+++ b/cmd/gcx/resources/pull.go
@@ -44,6 +44,12 @@ func (opts *pullOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 	opts.flags = flags
 
+	// Validate rejects every use of --json/--jq (below), so hide both from
+	// help — advertising flags the command always refuses is the same
+	// dishonesty as advertising the rejected agents format.
+	_ = flags.MarkHidden("json")
+	_ = flags.MarkHidden("jq")
+
 	bindOnErrorFlag(flags, &opts.OnError)
 	flags.StringVarP(&opts.Path, "path", "p", defaultResourcesPath, "Path on disk in which the resources will be written")
 	flags.BoolVar(

--- a/cmd/gcx/resources/pull.go
+++ b/cmd/gcx/resources/pull.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/gcxerrors"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/resources/local"
@@ -67,9 +68,10 @@ func (opts *pullOpts) Validate() error {
 
 	// The agents codec is a display codec: it writes compact JSON and, above
 	// the spill threshold, a spill-summary envelope instead of the payload.
-	// Neither belongs in a resource file on disk.
+	// Neither belongs in a resource file on disk. UsageError classifies the
+	// rejection as invalid usage (exit 2, DESIGN.md taxonomy).
 	if opts.IO.OutputFormat == "agents" {
-		return errors.New("output format 'agents' cannot be used with pull: it writes display envelopes, not resource content. Use -o json or -o yaml")
+		return &fail.UsageError{Message: "output format 'agents' cannot be used with pull: it writes display envelopes, not resource content. Use -o json or -o yaml"}
 	}
 
 	// --json (field selection/discovery) and --jq (transformation) shape the
@@ -80,10 +82,10 @@ func (opts *pullOpts) Validate() error {
 	// the edit rejections.
 	if opts.flags != nil {
 		if f := opts.flags.Lookup("json"); f != nil && f.Changed {
-			return errors.New("--json cannot be used with pull: field-selected output cannot round-trip as a resource file. Use -o json or -o yaml")
+			return &fail.UsageError{Message: "--json cannot be used with pull: field-selected output cannot round-trip as a resource file. Use -o json or -o yaml"}
 		}
 		if f := opts.flags.Lookup("jq"); f != nil && f.Changed {
-			return errors.New("--jq cannot be used with pull: transformed output cannot round-trip as a resource file. Use -o json or -o yaml")
+			return &fail.UsageError{Message: "--jq cannot be used with pull: transformed output cannot round-trip as a resource file. Use -o json or -o yaml"}
 		}
 	}
 

--- a/cmd/gcx/resources/pull.go
+++ b/cmd/gcx/resources/pull.go
@@ -22,11 +22,27 @@ type pullOpts struct {
 	OnError        OnErrorMode
 	IncludeManaged bool
 	Path           string
+
+	// flags is the bound flag set, kept so Validate can reject flags that
+	// cannot round-trip as on-disk resource files (--json, --jq).
+	flags *pflag.FlagSet
 }
 
 func (opts *pullOpts) setup(flags *pflag.FlagSet) {
+	// OutputFormat doubles as the on-disk file extension and the encoder for
+	// pulled resources — pin the default so agent mode does not flip it to
+	// the agents codec (which would write `<name>.agents` files, with
+	// spill-summary envelopes instead of content for large resources).
+	// An explicit -o json|yaml from the user still wins.
+	opts.IO.PinDefaultFormat("json")
+
+	// Validate rejects -o agents (below), so never advertise it in the
+	// format menu (usage string and unknown-format error listings).
+	opts.IO.HideFormat("agents")
+
 	// Bind all the flags
 	opts.IO.BindFlags(flags)
+	opts.flags = flags
 
 	bindOnErrorFlag(flags, &opts.OnError)
 	flags.StringVarP(&opts.Path, "path", "p", defaultResourcesPath, "Path on disk in which the resources will be written")
@@ -41,6 +57,28 @@ func (opts *pullOpts) setup(flags *pflag.FlagSet) {
 func (opts *pullOpts) Validate() error {
 	if err := opts.IO.Validate(); err != nil {
 		return err
+	}
+
+	// The agents codec is a display codec: it writes compact JSON and, above
+	// the spill threshold, a spill-summary envelope instead of the payload.
+	// Neither belongs in a resource file on disk.
+	if opts.IO.OutputFormat == "agents" {
+		return errors.New("output format 'agents' cannot be used with pull: it writes display envelopes, not resource content. Use -o json or -o yaml")
+	}
+
+	// --json (field selection/discovery) and --jq (transformation) shape the
+	// encoded document, but pull writes resource files that push reads back —
+	// a field-selected or jq-transformed document is not the resource and
+	// cannot round-trip. pull encodes via opts.IO.Codec() directly, which
+	// would silently ignore both flags; reject upfront instead, mirroring
+	// the edit rejections.
+	if opts.flags != nil {
+		if f := opts.flags.Lookup("json"); f != nil && f.Changed {
+			return errors.New("--json cannot be used with pull: field-selected output cannot round-trip as a resource file. Use -o json or -o yaml")
+		}
+		if f := opts.flags.Lookup("jq"); f != nil && f.Changed {
+			return errors.New("--jq cannot be used with pull: transformed output cannot round-trip as a resource file. Use -o json or -o yaml")
+		}
 	}
 
 	if opts.Path == "" {

--- a/cmd/gcx/resources/pull_edit_format_test.go
+++ b/cmd/gcx/resources/pull_edit_format_test.go
@@ -1,13 +1,34 @@
 package resources_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/cmd/gcx/resources"
 	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/gcxerrors"
 	"github.com/spf13/pflag"
 )
+
+// assertUsageErrorExitCode pins the DESIGN.md exit-code taxonomy for the new
+// pull/edit rejections: they are usage errors (bad flag combinations), so the
+// error must classify through cmd/gcx/fail as exit 2, not the generic exit 1.
+func assertUsageErrorExitCode(t *testing.T, err error) {
+	t.Helper()
+	usageErr := &fail.UsageError{}
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("Validate() error = %T, want *fail.UsageError", err)
+	}
+	detailed := fail.ErrorToDetailedError(err)
+	if detailed.ExitCode == nil {
+		t.Fatal("converted DetailedError has no ExitCode, want 2 (usage error)")
+	}
+	if *detailed.ExitCode != gcxerrors.ExitUsageError {
+		t.Fatalf("converted exit code = %d, want %d (usage error)", *detailed.ExitCode, gcxerrors.ExitUsageError)
+	}
+}
 
 // The pull and edit commands use OutputFormat as the on-disk file extension,
 // the encoder, and (for edit) the round-trip decode format. Their default must
@@ -122,6 +143,7 @@ func TestPullAndEditRejectAgentsOutputFormat(t *testing.T) {
 			if !strings.Contains(err.Error(), "agents") {
 				t.Fatalf("Validate() error = %q, want mention of 'agents'", err.Error())
 			}
+			assertUsageErrorExitCode(t, err)
 		})
 	}
 }
@@ -176,6 +198,7 @@ func TestPullAndEditRejectJSONAndJQ(t *testing.T) {
 				if !strings.Contains(err.Error(), "round-trip") {
 					t.Fatalf("Validate() error = %q, want round-trip rationale", err.Error())
 				}
+				assertUsageErrorExitCode(t, err)
 			})
 		}
 	}

--- a/cmd/gcx/resources/pull_edit_format_test.go
+++ b/cmd/gcx/resources/pull_edit_format_test.go
@@ -202,5 +202,17 @@ func TestPullAndEditDoNotAdvertiseAgentsFormat(t *testing.T) {
 				t.Errorf("%s -o usage missing %q: %q", name, want, usage)
 			}
 		}
+
+		// --json/--jq are rejected on every use (TestPullAndEditRejectJSONAndJQ),
+		// so help must not advertise them either.
+		for _, rejected := range []string{"json", "jq"} {
+			f := flags.Lookup(rejected)
+			if f == nil {
+				t.Fatalf("%s --%s flag not bound", name, rejected)
+			}
+			if !f.Hidden {
+				t.Errorf("%s --%s is always rejected but still advertised in help", name, rejected)
+			}
+		}
 	}
 }

--- a/cmd/gcx/resources/pull_edit_format_test.go
+++ b/cmd/gcx/resources/pull_edit_format_test.go
@@ -1,0 +1,206 @@
+package resources_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/resources"
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/spf13/pflag"
+)
+
+// The pull and edit commands use OutputFormat as the on-disk file extension,
+// the encoder, and (for edit) the round-trip decode format. Their default must
+// therefore stay pinned to json in agent mode — the agents display codec would
+// write `<name>.agents` files containing spill-summary envelopes instead of
+// resource content. Regression tests for #387 Track B.
+
+func TestPullDefaultFormatInAgentMode(t *testing.T) {
+	tests := []struct {
+		name           string
+		agentMode      bool
+		explicitOutput string // simulates -o flag; empty = use default
+		wantFormat     string
+	}{
+		{
+			name:       "agent mode default stays json",
+			agentMode:  true,
+			wantFormat: "json",
+		},
+		{
+			name:       "non-agent mode default is json",
+			agentMode:  false,
+			wantFormat: "json",
+		},
+		{
+			name:           "explicit -o yaml still wins in agent mode",
+			agentMode:      true,
+			explicitOutput: "yaml",
+			wantFormat:     "yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agent.SetFlag(tc.agentMode)
+			t.Cleanup(func() { agent.SetFlag(false) })
+
+			flags := pflag.NewFlagSet("pull", pflag.ContinueOnError)
+			opts := resources.NewPullOptsForTest(flags)
+
+			if tc.explicitOutput != "" {
+				if err := flags.Set("output", tc.explicitOutput); err != nil {
+					t.Fatalf("set -o %s: %v", tc.explicitOutput, err)
+				}
+			}
+
+			if opts.IO.OutputFormat != tc.wantFormat {
+				t.Fatalf("pull output format = %q, want %q", opts.IO.OutputFormat, tc.wantFormat)
+			}
+			if err := opts.Validate(); err != nil {
+				t.Fatalf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestEditDefaultFormatInAgentMode(t *testing.T) {
+	agent.SetFlag(true)
+	t.Cleanup(func() { agent.SetFlag(false) })
+
+	flags := pflag.NewFlagSet("edit", pflag.ContinueOnError)
+	opts := resources.NewEditOptsForTest(flags)
+
+	if opts.IO.OutputFormat != "json" {
+		t.Fatalf("edit output format in agent mode = %q, want %q", opts.IO.OutputFormat, "json")
+	}
+	if err := opts.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestPullAndEditRejectAgentsOutputFormat(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(func() { agent.SetFlag(false) })
+
+	tests := []struct {
+		name     string
+		validate func(t *testing.T) error
+	}{
+		{
+			name: "pull rejects -o agents",
+			validate: func(t *testing.T) error {
+				t.Helper()
+				flags := pflag.NewFlagSet("pull", pflag.ContinueOnError)
+				opts := resources.NewPullOptsForTest(flags)
+				if err := flags.Set("output", "agents"); err != nil {
+					t.Fatalf("set -o agents: %v", err)
+				}
+				return opts.Validate()
+			},
+		},
+		{
+			name: "edit rejects -o agents",
+			validate: func(t *testing.T) error {
+				t.Helper()
+				flags := pflag.NewFlagSet("edit", pflag.ContinueOnError)
+				opts := resources.NewEditOptsForTest(flags)
+				if err := flags.Set("output", "agents"); err != nil {
+					t.Fatalf("set -o agents: %v", err)
+				}
+				return opts.Validate()
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.validate(t)
+			if err == nil {
+				t.Fatal("Validate() = nil, want agents rejection error")
+			}
+			if !strings.Contains(err.Error(), "agents") {
+				t.Fatalf("Validate() error = %q, want mention of 'agents'", err.Error())
+			}
+		})
+	}
+}
+
+// TestPullAndEditRejectJSONAndJQ: --json (field selection/discovery) and
+// --jq (transformation) shape the encoded document, but both commands
+// round-trip that document as the resource — edit decodes the editor buffer
+// back, and pull writes resource files that push reads back. A
+// field-selected or jq-transformed document is not the resource, so both
+// flags must fail validation upfront, before any fetch or editor launch.
+// For pull the flags were previously advertised but silently ignored (it
+// encodes via opts.IO.Codec() directly).
+func TestPullAndEditRejectJSONAndJQ(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(func() { agent.SetFlag(false) })
+
+	validators := map[string]func(flags *pflag.FlagSet) func() error{
+		"pull": func(flags *pflag.FlagSet) func() error {
+			return resources.NewPullOptsForTest(flags).Validate
+		},
+		"edit": func(flags *pflag.FlagSet) func() error {
+			return resources.NewEditOptsForTest(flags).Validate
+		},
+	}
+
+	flagCases := []struct {
+		name  string
+		flag  string
+		value string
+	}{
+		{name: "rejects --json field selection", flag: "json", value: "metadata.name"},
+		{name: "rejects --json discovery", flag: "json", value: "list"},
+		{name: "rejects --jq", flag: "jq", value: ".metadata"},
+	}
+
+	for cmdName, newValidate := range validators {
+		for _, tc := range flagCases {
+			t.Run(cmdName+" "+tc.name, func(t *testing.T) {
+				flags := pflag.NewFlagSet(cmdName, pflag.ContinueOnError)
+				validate := newValidate(flags)
+				if err := flags.Set(tc.flag, tc.value); err != nil {
+					t.Fatalf("set --%s: %v", tc.flag, err)
+				}
+
+				err := validate()
+				if err == nil {
+					t.Fatalf("Validate() = nil, want --%s rejection error", tc.flag)
+				}
+				if !strings.Contains(err.Error(), "--"+tc.flag) {
+					t.Fatalf("Validate() error = %q, want mention of --%s", err.Error(), tc.flag)
+				}
+				if !strings.Contains(err.Error(), "round-trip") {
+					t.Fatalf("Validate() error = %q, want round-trip rationale", err.Error())
+				}
+			})
+		}
+	}
+}
+
+// TestPullAndEditDoNotAdvertiseAgentsFormat: both commands reject -o agents
+// at validation time, so their -o usage menu must not advertise it.
+func TestPullAndEditDoNotAdvertiseAgentsFormat(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(func() { agent.SetFlag(false) })
+
+	pullFlags := pflag.NewFlagSet("pull", pflag.ContinueOnError)
+	resources.NewPullOptsForTest(pullFlags)
+	editFlags := pflag.NewFlagSet("edit", pflag.ContinueOnError)
+	resources.NewEditOptsForTest(editFlags)
+
+	for name, flags := range map[string]*pflag.FlagSet{"pull": pullFlags, "edit": editFlags} {
+		usage := flags.Lookup("output").Usage
+		if strings.Contains(usage, "agents") {
+			t.Errorf("%s -o usage still advertises the rejected agents format: %q", name, usage)
+		}
+		for _, want := range []string{"json", "yaml"} {
+			if !strings.Contains(usage, want) {
+				t.Errorf("%s -o usage missing %q: %q", name, want, usage)
+			}
+		}
+	}
+}

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -274,9 +274,26 @@ When agent mode is active:
 
 ## 14. Pull Format Consistency
 
-`pull` accepts a `--format` flag (values: `yaml`, `json`; default: `yaml`)
-that enforces consistent file format on disk. All pulled files use the
-specified format regardless of the server's response format.
+`resources pull` uses the standard `-o/--output` flag (values: `json`,
+`yaml`; default: `json`) to enforce a consistent file format on disk. All
+pulled files use the specified format regardless of the server's response
+format.
 
-Files are written as `plural.version.group/name.{ext}` where `{ext}`
-matches the chosen format (`.yaml` or `.json`).
+Files are written as `plural.version.group/name.{ext}` where `{ext}` is the
+chosen format name (`.json` or `.yaml`).
+
+Because the output format doubles as the on-disk file extension and the
+encoder, file-writing commands pin their default with
+`Options.PinDefaultFormat`: agent mode must not flip their default to the
+`agents` display codec (which would write `<name>.agents` files containing
+spill-summary envelopes for large resources). `resources pull` and
+`resources edit` reject an explicit `-o agents` at validation time for the
+same reason.
+
+> **Doc/code divergence (open):** this section originally specified a
+> dedicated `--format` flag with a `yaml` default. The implementation ships
+> the standard `-o` flag with a `json` default. Whether the on-disk default
+> should converge on `yaml` is an open decision recorded in the #387
+> output-format audit
+> (`docs/research/2026-07-17-output-format-consistency-audit.md`) and
+> presented for sign-off in issue #1030.

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -291,9 +291,11 @@ spill-summary envelopes for large resources). `resources pull` and
 same reason.
 
 > **Doc/code divergence (open):** this section originally specified a
-> dedicated `--format` flag with a `yaml` default. The implementation ships
-> the standard `-o` flag with a `json` default. Whether the on-disk default
-> should converge on `yaml` is an open decision recorded in the #387
-> output-format audit
-> (`docs/research/2026-07-17-output-format-consistency-audit.md`) and
-> presented for sign-off in issue #1030.
+> dedicated `--format` flag with a `yaml` default, and
+> `CONSTITUTION.md` § Push/Pull Philosophy still says pull writes YAML by
+> default. The implementation ships the standard `-o` flag with a `json`
+> default and always has. This section describes the shipped behavior;
+> whether to ratify `json` (and amend the Constitution) or migrate the
+> default to `yaml` is an open decision recorded in the #387 output-format
+> audit (`docs/research/2026-07-17-output-format-consistency-audit.md`)
+> and presented for sign-off in issue #1030.

--- a/docs/reference/cli/gcx_resources_edit.md
+++ b/docs/reference/cli/gcx_resources_edit.md
@@ -39,7 +39,7 @@ gcx resources edit RESOURCE_SELECTOR [flags]
   -h, --help            help for edit
       --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string   Output format. One of: agents, json, yaml (default "json")
+  -o, --output string   Output format. One of: json, yaml (default "json")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_resources_edit.md
+++ b/docs/reference/cli/gcx_resources_edit.md
@@ -37,8 +37,6 @@ gcx resources edit RESOURCE_SELECTOR [flags]
 
 ```
   -h, --help            help for edit
-      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
-      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string   Output format. One of: json, yaml (default "json")
 ```
 

--- a/docs/reference/cli/gcx_resources_pull.md
+++ b/docs/reference/cli/gcx_resources_pull.md
@@ -70,7 +70,7 @@ gcx resources pull [RESOURCE_SELECTOR]... [flags]
                             ignore — continue processing all resources and exit 0
                             fail   — continue processing all resources and exit 1 if any failed (default)
                             abort  — stop on the first error and exit 1 (default "fail")
-  -o, --output string     Output format. One of: agents, json, yaml (default "json")
+  -o, --output string     Output format. One of: json, yaml (default "json")
   -p, --path string       Path on disk in which the resources will be written (default "./resources")
 ```
 

--- a/docs/reference/cli/gcx_resources_pull.md
+++ b/docs/reference/cli/gcx_resources_pull.md
@@ -64,8 +64,6 @@ gcx resources pull [RESOURCE_SELECTOR]... [flags]
 ```
   -h, --help              help for pull
       --include-managed   Include resources managed by tools other than gcx
-      --jq string         jq expression to apply to JSON output. Mutually exclusive with --json.
-      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --on-error string   How to handle errors during resource operations:
                             ignore — continue processing all resources and exit 0
                             fail   — continue processing all resources and exit 1 if any failed (default)

--- a/docs/research/2026-07-17-output-format-consistency-audit.md
+++ b/docs/research/2026-07-17-output-format-consistency-audit.md
@@ -211,7 +211,9 @@ the truncation notice.
 
 **Now:** the RunE output tail is extracted into `writeGetOutput`, and the
 `emitGetTruncationHint` helper fires on every output path including field
-selection (hint after encode, before the captured error is returned). Test:
+selection (after a successful encode only, matching the non-field-select
+path — no "showing first N items" claim when the output actually failed).
+Test:
 `TestGetTruncationHint` in
 `cmd/gcx/resources/get_truncation_hint_test.go` (JSONL hint in agent mode,
 `hint: ` line on a TTY, silence when not truncated, plain-output
@@ -228,9 +230,18 @@ flags were dropped.
 **Now:** pull's `Validate()` rejects both flags upfront with round-trip
 errors exactly mirroring the edit rejections (§5 item 3): a field-selected
 or jq-transformed document is not the resource and cannot round-trip as an
-on-disk resource file that push reads back. Test:
-`TestPullAndEditRejectJSONAndJQ` in
-`cmd/gcx/resources/pull_edit_format_test.go` (covers both commands).
+on-disk resource file that push reads back. Since every use is rejected,
+both flags are also hidden from pull/edit help (`pflag.MarkHidden`) — the
+same honesty rule as hiding the rejected `agents` format (§6.3). And
+because pull/edit pin their default (§4.4), the agent-mode Encode nudge
+that recommends `--json`/`--jq` is suppressed for pinned-default commands —
+a command must not recommend flags its own validation refuses (the nudge
+targets stdout consumers; pinned commands encode into files or editor
+buffers). Tests: `TestPullAndEditRejectJSONAndJQ` and
+`TestPullAndEditDoNotAdvertiseAgentsFormat` in
+`cmd/gcx/resources/pull_edit_format_test.go` (cover both commands),
+`TestEncode_AgentModeHint` in `internal/output/format_test.go` (pinned
+suppression case).
 
 ---
 
@@ -258,7 +269,9 @@ successful non-agent stdout payload.
    rejections from §4.9 too).
 4. **`resources pull` now rejects `--json`/`--jq` outright** (new
    validation error, §4.9). Previously both flags were advertised but
-   silently ignored — pull encodes via `opts.IO.Codec()` directly.
+   silently ignored — pull encodes via `opts.IO.Codec()` directly. Both
+   flags are hidden from pull/edit help, and the agent-mode Encode nudge
+   recommending them is suppressed for pinned-default commands (§4.9).
 5. **Agent-mode hints became JSONL** for `kg entities list` (both hints) and
    `resources get` truncation; `resources get`'s TTY notice gained the
    `hint: ` prefix. The kg `--limit` hint also moved from process stderr to

--- a/docs/research/2026-07-17-output-format-consistency-audit.md
+++ b/docs/research/2026-07-17-output-format-consistency-audit.md
@@ -9,8 +9,8 @@
 > sign-off in issue #1030. The corrections were first implemented and
 > adversarially reviewed on an internal feasibility branch, then extracted
 > onto main; a related list-truncation contract ("Track C") explored on
-> that branch has **not** landed and is referenced below only as a
-> proposal.
+> that branch is tracked separately as issue #1031 / PR #1033 and is
+> referenced below only as a proposal.
 
 ## 1. Purpose
 
@@ -81,7 +81,8 @@ is a paginated backend page truncated client-side with
 `adapter.TruncateSlice`, and the `>=` trigger fires even when the page is
 exactly `--limit` long — it does not prove truncation, so no stronger
 machine-readable claim would be honest here. Migrating kg search to a
-proven-truncation envelope is part of the proposed (unlanded) Track C work.
+proven-truncation envelope is part of the proposed Track C work
+(issue #1031 / PR #1033).
 
 The sibling per-type pagination hint in `searchByTypes` (same defect
 class: typed on a TTY, invisible as JSONL) was converted the same way. TTY
@@ -255,7 +256,13 @@ successful non-agent stdout payload.
    `.agents` files with display/spill envelopes; `edit -o agents` always
    failed, but only after the user finished editing. The usage menus no
    longer advertise `agents` for these two commands (implemented via
-   `Options.HideFormat`; see §6.3).
+   `Options.HideFormat`; see §6.3). The rejections are typed
+   `fail.UsageError` → exit 2 per the DESIGN.md taxonomy (as are the
+   §4.9/§5.3 `--json`/`--jq` rejections). Note the pre-existing repo-wide
+   gap left untouched: the shared `Options.Validate()` errors (unknown
+   `-o` format, `--json`/`-o` conflicts) and pull's `--path is required`
+   all exit 1 today — reclassifying those is an existing-behavior change
+   across every command, out of scope here.
 2. **Agent-mode default for `pull`/`edit` is now `json`** (was `agents`).
    Non-agent default unchanged (`json` before and after).
 3. **`resources edit` now runs `Validate()` and rejects `--json`/`--jq`
@@ -300,8 +307,8 @@ implemented**, for three reasons:
    `TestEmitListPaginationHintStructuredOutput` asserts empty output for
    json/yaml/agents) — overriding a considered, tested decision without an
    owner nod is what this section is for.
-2. The proposed Track C list-truncation contract (feasibility work, not
-   landed) queues `dashboards list` for a per-command decision: converge it
+2. The proposed Track C list-truncation contract (issue #1031 / PR #1033)
+   queues `dashboards list` for a per-command decision: converge it
    on a machine-readable truncation envelope with the cursor command in a
    `continue` field. Un-gating the legacy ad-hoc hint now would be churn
    ahead of that sanctioned fix.
@@ -379,7 +386,8 @@ the largest coherence gap found and is squarely ADR territory.
 
 ### 7.5 `cloud stacks` internal split
 
-`internal/providers/stacks/commands.go`: list/create/update/regions default
+`internal/providers/stacks/commands.go`: list/create/update/list-regions
+(`regions` before the #387 naming train, PR #1019) default
 `table` (lines 32/140/234/415) but get defaults `yaml` (line 85). A mutation
 (`create`/`update`) defaulting to a *table* while `get` shows yaml means the
 create → inspect loop changes shape mid-flow. Small fix, but it is an
@@ -427,13 +435,19 @@ different menu). Left as a finding.
 
 ### 7.10 `resources pull` on-disk default: json (shipped) vs yaml (designed)
 
-§14's original text wanted yaml as the on-disk default. The implementation
-has always defaulted to json, and §4.4 pinned that (unchanged) default.
-Switching to yaml is a one-line change but breaks every workflow that
-assumes `.json` files from a bare `gcx resources pull` (including
-`push`-side globbing and any user tooling). **Question:** converge on yaml
-(K8s-manifest convention, matches `resources get`'s yaml-ish leanings in
-7.1(b)) or ratify json? Needs an owner call plus a migration note either way.
+§14's original text wanted yaml as the on-disk default — and so does
+`CONSTITUTION.md` § Push/Pull Philosophy ("`pull` … writes a consistent
+format (default: YAML)"), which the compliance hierarchy treats as a hard
+invariant. The implementation has always defaulted to json, and §4.4 pinned
+that (unchanged) default, so the shipped behavior violates the Constitution
+as written and has since the flag existed. Switching to yaml is a one-line
+change but breaks every workflow that assumes `.json` files from a bare
+`gcx resources pull` (including `push`-side globbing and any user tooling).
+**Question:** converge on yaml (K8s-manifest convention, matches
+`resources get`'s yaml-ish leanings in 7.1(b)) or ratify json and amend the
+Constitution? Needs an owner call plus a migration note either way; until
+then §14 knowingly documents behavior that conflicts with the Constitution
+text.
 
 ### 7.11 `alert groups status`: status exists only in the table codec
 
@@ -451,6 +465,7 @@ Owner decision.
 | Doc claim | Reality | Status |
 |---|---|---|
 | §14: pull has `--format`, default yaml | `-o`, default json | **Fixed** (doc rewritten, §4.6); yaml-default intent → 7.10 |
+| CONSTITUTION § Push/Pull Philosophy: pull default YAML | default json, always has been | DECISION NEEDED (7.10 — ratify json + amend, or migrate to yaml) |
 | §1.3: list/get default `text` | 131 table / 40 json / 49 yaml / 27 text | DECISION NEEDED (7.7) |
 | §1.3: push/pull/delete "status messages only" | pull has data-bearing `-o`; IRM has MutationResult | DECISION NEEDED (7.4) |
 | §1.4: status messages → stdout | 109 stdout vs 63 stderr | DECISION NEEDED (7.8) |

--- a/docs/research/2026-07-17-output-format-consistency-audit.md
+++ b/docs/research/2026-07-17-output-format-consistency-audit.md
@@ -1,0 +1,462 @@
+# Output-Format Consistency Audit & Corrections (#387 output track)
+
+> **Status: audit record + proposal, not accepted policy.** This documents
+> the output-format consistency review run for the #387 output workstream:
+> the full inconsistency inventory with evidence, the safe corrections that
+> ship in the PR carrying this document, and the items that need a
+> maintainer decision before anything else changes. Nothing in the
+> DECISION NEEDED sections is settled — those decisions are presented for
+> sign-off in issue #1030. The corrections were first implemented and
+> adversarially reviewed on an internal feasibility branch, then extracted
+> onto main; a related list-truncation contract ("Track C") explored on
+> that branch has **not** landed and is referenced below only as a
+> proposal.
+
+## 1. Purpose
+
+`docs/design/output.md` prescribes one output model; the code ships several.
+An evidence-cited audit of output mechanics found (a) untyped diagnostics
+invisible to agents, (b) an agent-mode default that corrupts file-writing
+commands, (c) an unpredictable `text`/`table` spelling split, and (d) design
+docs describing flags and defaults that do not exist. The mandate for this
+track: implement only the safe, well-supported corrections; record
+everything that needs an owner decision here and in issue #1030.
+
+## 2. Method
+
+Every claim below was re-verified against `origin/main` at extraction time
+(not taken from the earlier feasibility-branch audit on faith) by reading
+the cited files and re-running the counts. Corrections were implemented
+with table-driven tests where practical and validated with `go test`
+(full suite, race detection), `golangci-lint`, regenerated reference docs,
+and behavior demos comparing a main-built binary against a branch-built
+binary (see §9).
+
+## 3. Census (re-measured on origin/main, non-test code)
+
+| Measurement | Value |
+|---|---|
+| `RegisterCustomCodec("table", …)` call sites | 156 |
+| `RegisterCustomCodec("text", …)` call sites | 28 |
+| `DefaultFormat("table")` | 131 |
+| `DefaultFormat("json")` | 40 |
+| `DefaultFormat("yaml")` | 49 |
+| `DefaultFormat("text")` | 27 |
+| `DefaultFormat("graph")` | 3 |
+| `DefaultFormat("pretty")` | 1 |
+| `cmdio.Success` → stdout / stderr | 77 / 39 |
+| `cmdio.Warning` → stdout / stderr | 10 / 8 |
+| `cmdio.Info` → stdout / stderr | 21 / 16 |
+| `cmdio.Error` → stdout / stderr | 1 / 0 |
+| Status-message stream total | 109 stdout vs 63 stderr — no discernible rule |
+
+An earlier pass measured the per-`get`-command default split at roughly
+37 yaml / 14 table / 7 json / 6 text (with the alert provider splitting
+internally between table and json). That split is consistent with the
+`DefaultFormat` census above and with the per-provider spot checks in §7,
+but was not re-derived command-by-command here.
+
+Commands registering **both** spellings on one options instance: only
+`internal/providers/assistant/mcpservers/commands.go:291-292`, and both
+names point at the same codec type (`ListTableCodec`). No command registers
+the two names with genuinely different **tabular** codecs — but commands do
+register non-tabular codecs under one of the two names (e.g. help-tree's
+prose codec named `text`), which is what sank the §4.5 synonym attempt.
+
+---
+
+## 4. IMPLEMENTED — safe corrections in this PR
+
+### 4.1 `kg entities list` truncation hint was invisible to agents
+
+**Was:** `internal/providers/kg/commands.go` wrote a raw
+`fmt.Fprintf(os.Stderr, "hint: …")` — bypassing the command's redirected
+stderr (`cmd.ErrOrStderr()`) and emitting no JSONL `{"class":"hint"}` record
+in agent mode.
+
+**Now:** routed through `output.EmitHint(cmd.ErrOrStderr(), …)` with the same
+informational content (limit reached; raise `--limit` or pass `--limit 0`).
+The hint deliberately stays a plain "may be truncated" notice: the kg source
+is a paginated backend page truncated client-side with
+`adapter.TruncateSlice`, and the `>=` trigger fires even when the page is
+exactly `--limit` long — it does not prove truncation, so no stronger
+machine-readable claim would be honest here. Migrating kg search to a
+proven-truncation envelope is part of the proposed (unlanded) Track C work.
+
+The sibling per-type pagination hint in `searchByTypes` (same defect
+class: typed on a TTY, invisible as JSONL) was converted the same way. TTY
+output is byte-identical for both (the messages already began with
+`"hint: "`).
+
+### 4.2 `resources get` truncation notice was untyped
+
+**Was:** `cmd/gcx/resources/get.go` wrote a plain
+`fmt.Fprintf(cmd.ErrOrStderr(), "Showing first %d items per resource type. …")`
+— invisible as JSONL to agents.
+
+**Now:** routed through `output.EmitHint` keeping the per-resource-type
+meaning intact ("showing first N items per resource type; use --limit=0 to
+fetch all"). This is K8s per-type paging — the limit applies to each
+resource type independently, so no list-level truncation metadata was
+bolted on. TTY delta: the line now carries the standard `hint: ` prefix and
+lowercase phrasing.
+
+### 4.3 IRM OnCall: stale comment + dead assignments
+
+`internal/providers/irm/oncall_commands.go:35-38` claimed the alert-groups
+tree "defaults to `text` (table)" while the code initialized
+`defaultFmt := "table"` and redundantly re-assigned `"table"` in the
+`alert-groups` and `alerts` switch cases. Comment rewritten to match reality
+(everything defaults to `table`), the dead variable and both redundant
+assignments removed, `DefaultFormat("table")` called directly. No behavior
+change; IRM package tests green.
+
+### 4.4 Agent-mode default corrupted file-writing commands (real bug)
+
+**Was:** `resources pull` set no `DefaultFormat`, so
+`BindFlags`' agent-mode branch (`internal/output/format.go`) flipped its
+default to `agents`. Pull uses `OutputFormat` as **both** the on-disk file
+extension and the encoder (`cmd/gcx/resources/pull.go` →
+`local.GroupResourcesByKind(opts.IO.OutputFormat, …)`,
+`internal/resources/local/writer.go`): agent invocations wrote
+`<name>.agents` files, and any resource whose payload exceeded the 100 KiB
+spill threshold got a spill-summary envelope written **into the resource
+file** (`internal/output/agents.go`). `resources edit` had the same default
+dependence across its encode → editor → decode round-trip, and its agent-mode
+round-trip could never succeed (the `FSReader` has no `agents` decoder —
+`internal/resources/local/reader.go`, `format.Codecs()` is json/yaml only).
+
+**Now:**
+
+- `Options.PinDefaultFormat(name)` added to `internal/output/format.go`:
+  sets the default and exempts the command from the agent-mode override.
+  Explicit `-o` still wins (cobra flag precedence unchanged).
+- `pull` and `edit` pin `json` — their current non-agent effective default,
+  so non-agent behavior is unchanged; agent-mode default is now `json`.
+- `pull` and `edit` reject an explicit `-o agents` at validation time with a
+  clear error (see §5 behavior changes). For `edit` this converts a
+  guaranteed post-editing failure (decode error after the user's edits are
+  lost) into an upfront validation error.
+- `edit`'s `RunE` never called `opts.Validate()` at all (pre-existing
+  options-pattern defect) — the call was added.
+- `docs/design/output.md` §14 updated to document the pinning rule.
+
+Tests: `internal/output/format_options_test.go`
+(`TestBindFlags_PinDefaultFormat`) and
+`cmd/gcx/resources/pull_edit_format_test.go` (agent-mode default regression
+for pull and edit; `-o agents` rejection for both; explicit `-o yaml`
+override still honored).
+
+### 4.5 `-o text` / `-o table` synonym — attempted, then REVERTED (DEFERRED)
+
+**Was:** 156 call sites register the tabular codec as `table`, 28 as `text`
+(§3); users cannot predict the spelling — `slo definitions list -o text`
+errors, `resources get -o table` errors.
+
+**Attempted (on the feasibility branch):** a resolution-time alias in
+`Options.Validate()` rewriting `OutputFormat` between the two spellings
+when the requested one resolved to no codec but the sibling was registered.
+
+**Reverted — DEFERRED; the alias does not ship.** The alias was presented
+as a safe correction but changed **non-tabular** commands: any command that
+registers a codec under one of the two names for output that is not a table
+gained an unintended `-o` spelling for it. Verified example:
+`gcx help-tree version -o table` emitted the prose tree text, because
+help-tree registers its prose codec under the name `"text"` — the alias
+routed `-o table` to prose. The resolution-failure guard only scopes the
+alias to commands that register exactly one of the two names; it cannot
+know whether that codec is genuinely tabular.
+
+The underlying 156-`table` / 28-`text` split (census in §3) still needs
+fixing, but it requires either (a) an owner decision on the canonical
+spelling with a call-site migration — the same ADR as 7.1 / §8's
+doc-vs-code divergence — or (b) an aliasing mechanism scoped to genuinely
+tabular codecs (e.g. opt-in registration metadata), not a name-based
+rewrite. Deferred to issue #1030; both spellings behave exactly as before
+this PR.
+
+### 4.6 `docs/design/output.md` §14 was factually false
+
+The section claimed pull has a `--format` flag (yaml|json, default yaml).
+Reality: the standard `-o` flag with an implicit `json` default
+(`docs/reference/cli/gcx_resources_pull.md` agrees). Rewritten to describe
+actual behavior including the §4.4 pinning rule. The original yaml-default
+design intent is **not** silently adopted — recorded as an open divergence
+(§7.10, issue #1030).
+
+### 4.7 Agents-codec spill hint broke the JSONL stderr contract
+
+**Was:** `internal/output/agents.go` wrote the spill notice as a raw
+`fmt.Fprintf(c.errWriter, "hint: response too large…")`. The agents codec
+runs almost exclusively in agent mode (it *is* the agent-mode default), so
+its own diagnostic violated the FR-104 typed-class JSONL stderr contract on
+exactly the consumer that depends on it.
+
+**Now:** routed through the same-package `EmitHint` with identical
+informational content (payload size, spill file path, `-o json` escape
+hatch; the command argument is empty — the summary already embeds the file
+path). TTY output keeps the `hint: `-prefixed line byte-compatible with the
+previous shape; agent mode now emits `{"class":"hint","summary":…}`. Tests:
+`TestAgentsCodec_Spill_EmitsStderrHint` (TTY prefix) and
+`TestAgentsCodec_Spill_AgentModeHintIsJSONL` in
+`internal/output/agents_test.go`.
+
+### 4.8 `resources get` truncation hint skipped under `--json`
+
+**Was:** the §4.2 typed truncation hint fired only on the shared encode
+tail of `cmd/gcx/resources/get.go`; the `--json field1,field2` branch
+returned early through `writeFieldSelect`, so field-selecting consumers —
+disproportionately agents, the audience the hint exists for — silently lost
+the truncation notice.
+
+**Now:** the RunE output tail is extracted into `writeGetOutput`, and the
+`emitGetTruncationHint` helper fires on every output path including field
+selection (hint after encode, before the captured error is returned). Test:
+`TestGetTruncationHint` in
+`cmd/gcx/resources/get_truncation_hint_test.go` (JSONL hint in agent mode,
+`hint: ` line on a TTY, silence when not truncated, plain-output
+regression).
+
+### 4.9 `resources pull` advertised but silently ignored `--json`/`--jq`
+
+**Was:** pull encodes resource files via `opts.IO.Codec()` directly, so the
+`--json` and `--jq` flags bound by `BindFlags` were advertised in help but
+had no effect — worse than an error, because a user asking for
+field-selected output got full resource files with no indication their
+flags were dropped.
+
+**Now:** pull's `Validate()` rejects both flags upfront with round-trip
+errors exactly mirroring the edit rejections (§5 item 3): a field-selected
+or jq-transformed document is not the resource and cannot round-trip as an
+on-disk resource file that push reads back. Test:
+`TestPullAndEditRejectJSONAndJQ` in
+`cmd/gcx/resources/pull_edit_format_test.go` (covers both commands).
+
+---
+
+## 5. Behavior changes shipped (enumerated)
+
+All are stderr-only, validation-time, or agent-mode-only; none change a
+successful non-agent stdout payload.
+
+1. **`resources pull` / `resources edit` reject `-o agents`** (new
+   validation error). Previously `pull -o agents` "worked" — wrote
+   `.agents` files with display/spill envelopes; `edit -o agents` always
+   failed, but only after the user finished editing. The usage menus no
+   longer advertise `agents` for these two commands (implemented via
+   `Options.HideFormat`; see §6.3).
+2. **Agent-mode default for `pull`/`edit` is now `json`** (was `agents`).
+   Non-agent default unchanged (`json` before and after).
+3. **`resources edit` now runs `Validate()` and rejects `--json`/`--jq`
+   outright** — unknown `-o` values fail before fetching/opening the
+   editor. Note: merely activating `Validate()` was NOT safe for
+   `--json`/`--jq` — validation would have *accepted* well-formed uses and
+   let field-selected/jq-transformed output into the editor buffer, which
+   edit then round-trips back as the resource. Both flags are now rejected
+   with a round-trip error (`cmd/gcx/resources/edit.go`;
+   `TestPullAndEditRejectJSONAndJQ`, which covers the matching pull
+   rejections from §4.9 too).
+4. **`resources pull` now rejects `--json`/`--jq` outright** (new
+   validation error, §4.9). Previously both flags were advertised but
+   silently ignored — pull encodes via `opts.IO.Codec()` directly.
+5. **Agent-mode hints became JSONL** for `kg entities list` (both hints) and
+   `resources get` truncation; `resources get`'s TTY notice gained the
+   `hint: ` prefix. The kg `--limit` hint also moved from process stderr to
+   the command's `cmd.ErrOrStderr()`.
+6. **The agents-codec spill notice became a typed JSONL hint in agent
+   mode** (§4.7); the TTY line keeps its `hint: ` prefix.
+7. **`resources get --json <fields>` now emits the truncation hint**
+   (§4.8) — stderr-only; previously the field-select path dropped it.
+8. **The `-o text`/`-o table` resolution-time synonym does not ship**
+   (§4.5): on the feasibility branch it changed non-tabular commands
+   (verified: `help-tree version -o table` rendered prose) and was
+   reverted. Both spellings behave exactly as on main before this PR; the
+   split is DEFERRED to an owner decision (issue #1030).
+
+## 6. RECOMMENDED — safe but visible; needs a nod (not implemented)
+
+### 6.1 `dashboards list` pagination hint gated to table/wide only
+
+`internal/providers/dashboards/crud.go:119,135-137`
+(`shouldEmitListPaginationHint`) suppresses the continue-token hint exactly
+for the json/agents consumers who most need it. **Judgment call: not
+implemented**, for three reasons:
+
+1. The suppression is deliberate and pinned by an explicit test
+   (`internal/providers/dashboards/pagination_test.go:91`,
+   `TestEmitListPaginationHintStructuredOutput` asserts empty output for
+   json/yaml/agents) — overriding a considered, tested decision without an
+   owner nod is what this section is for.
+2. The proposed Track C list-truncation contract (feasibility work, not
+   landed) queues `dashboards list` for a per-command decision: converge it
+   on a machine-readable truncation envelope with the cursor command in a
+   `continue` field. Un-gating the legacy ad-hoc hint now would be churn
+   ahead of that sanctioned fix.
+3. The right end state is a truncation envelope plus an unconditional typed
+   hint, not the current bespoke hint emitted more often.
+
+The blast radius of un-gating would be trivial (stderr-only), so if the
+owner prefers the interim fix over waiting for the migration, it is a
+two-line change plus a test update.
+
+### 6.2 kg per-type server-error warning is untyped
+
+`internal/providers/kg/commands.go` (`searchByTypes`, the
+`"warning: skipping entity type …"` write) still uses a raw `Fprintf`.
+Routing through `output.EmitWarn` would make it agent-legible but changes the
+TTY prefix from `warning:` to `warn:` — left for a nod.
+
+### 6.3 Rejected `agents` format still advertised in pull/edit usage
+
+After §4.4, `-o agents` was rejected but `Output format. One of: agents,
+json, yaml` still appeared in pull/edit help (the menu comes from
+`allowedCodecs()` merging builtins). **Since implemented in this PR**:
+`Options.HideFormat(name)` removes a format from the advertised menu (usage
+string and unknown-format error listings) without unregistering it; pull and
+edit hide `agents`. Resolution is untouched, so the commands' own bespoke
+rejection errors still fire on an explicit `-o agents`
+(`TestPullAndEditDoNotAdvertiseAgentsFormat`, `TestHideFormat`).
+
+## 7. DECISION NEEDED — recorded, not implemented (see issue #1030)
+
+### 7.1 `get`-command default-format convergence
+
+Split on main: slo/k6/fleet get → yaml; dashboards/synth/faro get → table;
+the alert provider splits internally (rules/groups list → table, several
+single-object reads → json). See §3 census. **Question:** what is the
+canonical default for `get <name>` — the human table (per output.md §1.3) or
+the full serialized object (yaml/json)? **Options:** (a) table everywhere,
+detail via `-o yaml`; (b) yaml for single-object get, table for list; (c)
+leave and document. Needs an ADR-level call; blast radius is every scripted
+consumer of a changed default.
+
+### 7.2 Adaptive-telemetry family divergence
+
+Within one product family: adaptive logs get → table, adaptive metrics get →
+json, adaptive traces get → yaml; creates split json vs yaml
+(`internal/providers/logs/adaptive/commands.go` alone mixes
+`DefaultFormat("table")` and `DefaultFormat("json")` across subcommands —
+lines 79/131/541 vs 629/677/881/932). Same question as 7.1 scoped to the
+signal providers, which also advertise themselves as one consistent family.
+
+### 7.3 `--json` list-shape divergence and sibling-key dropping
+
+Three list shapes coexist under `-o json`: bare array, `{"items":[…]}`, and
+`{"<wrapper>":[…]}`. Field selection over single-key envelopes drops sibling
+keys: `appo11y operations` loses `service`/`window`/`metrics_mode`/
+`span_kinds` under `--json`; `assistant conversation get`'s transcript
+`{"chat","messages"}` shape defeats selection entirely. The general sibling
+policy (preserve all non-items siblings? canonicalize on `items`?) is
+unresolved. **Question:** one canonical list envelope pre-GA, or grandfather
+the three shapes?
+
+### 7.4 Mutation-output generations + status-stream anarchy
+
+Three generations coexist: `resources push`/`delete` have **no `-o` at all**
+(pull only grew one as a file-format selector); IRM ships a structured
+`MutationResult` envelope; adaptive commands echo the mutated object to
+stdout plus `cmdio.Success` to stderr. `cmdio.Success/Warning/Info`
+(`internal/output/messages.go`) are not agent-aware (no JSONL class), and
+the 109/63 stdout-vs-stderr split (§3) follows no rule — output.md §12 even
+prescribes both ("summary to stdout" and "Success for progress"). §12's
+summary-table/JSON-summary design is implemented almost nowhere.
+**Question:** adopt §12 as written, adopt IRM's `MutationResult` as the
+repo-wide envelope, or codify the status-message stream rule first? This is
+the largest coherence gap found and is squarely ADR territory.
+
+### 7.5 `cloud stacks` internal split
+
+`internal/providers/stacks/commands.go`: list/create/update/regions default
+`table` (lines 32/140/234/415) but get defaults `yaml` (line 85). A mutation
+(`create`/`update`) defaulting to a *table* while `get` shows yaml means the
+create → inspect loop changes shape mid-flow. Small fix, but it is an
+instance of 7.1/7.4 and should follow that decision.
+
+### 7.6 One-off format names + undocumented `agents` in every menu
+
+`pretty` (`cmd/gcx/linter/lint.go:50`), `raw`
+(`internal/datasources/loki/query.go:124`), `pprof`
+(`internal/datasources/pyroscope/query.go:48`) are single-command format
+names. `agents` appears in every `-o` menu but is documented only in
+output.md §1.1.1 (not in the CLI reference conceptually). **Question:**
+allow domain formats freely, or reserve a namespace (`raw`, `pprof` arguably
+carry real semantics; `pretty` duplicates what `table`/`text` mean
+elsewhere)? Should `agents` be hidden from menus or documented properly?
+
+### 7.7 output.md §1.3 default-format table vs reality
+
+§1.3 says list/get default `text` with table codec, and "push, pull, delete:
+status messages only". Reality: §3 census (131 table / 40 json / 49 yaml /
+27 text defaults), and pull has had a data-bearing `-o` for its file format
+all along. The doc prescribes a policy the code never followed — either the
+policy is right (then ~100 commands are defects) or the doc must be
+rewritten to the real model. Policy decision, not a typo; ties to 7.1.
+
+### 7.8 output.md §1.4 "status messages go to stdout" vs reality
+
+§1.4 prescribes stdout for all `cmdio` status messages; the code splits
+109/63 (§3). Whichever way the rule lands (kubectl convention would be:
+data → stdout, diagnostics → stderr), ~40% of call sites move. Same ADR as
+7.4.
+
+### 7.9 `gcx config path`: agent mode flips default to `json`, not `agents`
+
+Root cause (investigated): `cmd/gcx/config/path.go:20-76` predates/bypasses
+the shared options — it hand-rolls its own `-o` flag (line 74) with a local
+`defaultFormat := "table"` flipped to `"json"` under `agent.IsAgentMode()`
+(lines 70-73), and encodes via a locally constructed
+`cmdio.Options{OutputFormat: …}` (line 57). The `agents` codec is never
+reachable (menu: `json, table, yaml`), so `json` is the intentional
+hand-rolled stand-in. **Not** a trivial local bug: the proper fix is
+migrating the command to `cmdio.Options.BindFlags`, which visibly changes
+its surface (adds `--json`/`--jq`, the agents codec and spill, and a
+different menu). Left as a finding.
+
+### 7.10 `resources pull` on-disk default: json (shipped) vs yaml (designed)
+
+§14's original text wanted yaml as the on-disk default. The implementation
+has always defaulted to json, and §4.4 pinned that (unchanged) default.
+Switching to yaml is a one-line change but breaks every workflow that
+assumes `.json` files from a bare `gcx resources pull` (including
+`push`-side globbing and any user tooling). **Question:** converge on yaml
+(K8s-manifest convention, matches `resources get`'s yaml-ish leanings in
+7.1(b)) or ratify json? Needs an owner call plus a migration note either way.
+
+### 7.11 `alert groups status`: status exists only in the table codec
+
+The status columns are synthesized inside the table codec only
+(`internal/providers/alert/groups_commands.go:231` ff.,
+`GroupsStatusTableCodec`); `-o json`/`-o yaml` output of `groups status` is
+byte-identical to `groups list` — the very data the command exists to show
+is absent from structured output. Pattern 13 violation ("codecs control
+display, not data"); fixing it means adding the status field to the
+underlying value (a payload shape change for existing json consumers).
+Owner decision.
+
+## 8. Doc-vs-code contract divergences (summary)
+
+| Doc claim | Reality | Status |
+|---|---|---|
+| §14: pull has `--format`, default yaml | `-o`, default json | **Fixed** (doc rewritten, §4.6); yaml-default intent → 7.10 |
+| §1.3: list/get default `text` | 131 table / 40 json / 49 yaml / 27 text | DECISION NEEDED (7.7) |
+| §1.3: push/pull/delete "status messages only" | pull has data-bearing `-o`; IRM has MutationResult | DECISION NEEDED (7.4) |
+| §1.4: status messages → stdout | 109 stdout vs 63 stderr | DECISION NEEDED (7.8) |
+| §11: "register a `text` table codec, DefaultFormat(`text`)" | 156 register `table`, 28 `text` | DEFERRED (§4.5 — synonym reverted; broke non-tabular commands); canonical spelling → same ADR as 7.1 |
+| §12: mutation summary tables + JSON summary shape | implemented almost nowhere | DECISION NEEDED (7.4) |
+
+## 9. Validation record
+
+- `gofmt` clean on all touched files.
+- `GCX_AGENT_MODE=false go test -race ./...` — full suite green.
+- `mise run lint` — 0 issues.
+- `GCX_AGENT_MODE=false mise run reference` — regenerated, drift-clean
+  (`gcx_resources_pull.md` / `gcx_resources_edit.md` pick up the hidden
+  `agents` menu entry).
+- Live-binary comparison (main binary vs this branch, identical args,
+  same context): pull/edit reject `-o agents` and `--json`/`--jq`
+  pre-connection; pull/edit `--help` under agent mode shows
+  `(default "json")` and no `agents` menu entry; `resources get --limit N`
+  emits `{"class":"hint","summary":"showing first N items per resource
+  type; …"}` on stderr in agent mode and `hint: …` on a TTY, including
+  under `--json <field>`; JSON stdout payloads byte-identical to main for
+  every compared command.

--- a/internal/output/agents.go
+++ b/internal/output/agents.go
@@ -95,10 +95,15 @@ func (c *agentsCodec) spill(dst io.Writer, value any, payload []byte) error {
 		s.TotalItems = &n
 	}
 
-	fmt.Fprintf(c.errWriter,
-		"hint: response too large for stdout (%d bytes) — read %s for full data, or use -o json to force inline\n",
-		len(payload), f.Name(),
-	)
+	// Typed hint diagnostic: on a TTY this renders the familiar
+	// "hint: ..." line; in agent mode it must be a JSONL
+	// {"class":"hint",...} record so the stderr stream stays
+	// machine-parseable (FR-104). The command argument is empty because the
+	// summary already embeds the spill file path.
+	emitHint(c.errWriter,
+		fmt.Sprintf("response too large for stdout (%d bytes) — read %s for full data, or use -o json to force inline",
+			len(payload), f.Name()),
+		"")
 
 	out := json.NewEncoder(dst)
 	out.SetEscapeHTML(false)

--- a/internal/output/agents_test.go
+++ b/internal/output/agents_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/gcx/internal/agent"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -220,6 +221,10 @@ func TestAgentsCodec_Spill_EmitsStderrHint(t *testing.T) {
 	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
 	t.Setenv("TMPDIR", t.TempDir())
 
+	// TTY mode: the hint stays a plain "hint: ..." line.
+	agent.SetFlag(false)
+	t.Cleanup(func() { agent.SetFlag(false) })
+
 	var errBuf bytes.Buffer
 	codec := cmdio.NewAgentsCodecWithErrWriter(&errBuf)
 
@@ -228,11 +233,42 @@ func TestAgentsCodec_Spill_EmitsStderrHint(t *testing.T) {
 
 	hint := errBuf.String()
 	require.NotEmpty(t, hint, "spill must emit a hint to errWriter")
+	assert.True(t, strings.HasPrefix(hint, "hint: "), "TTY-mode hint must keep the hint: prefix, got %q", hint)
 
 	var summary map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
 	spillPath, _ := summary["spilled_to"].(string)
 	assert.Contains(t, hint, spillPath, "hint must reference the spill file path")
+}
+
+// TestAgentsCodec_Spill_AgentModeHintIsJSONL pins the stderr contract in agent
+// mode: diagnostics must be JSONL records with a typed class (FR-104), never
+// raw prose — a bare "hint: ..." line would break agent stderr parsing.
+func TestAgentsCodec_Spill_AgentModeHintIsJSONL(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
+	t.Setenv("TMPDIR", t.TempDir())
+
+	agent.SetFlag(true)
+	t.Cleanup(func() { agent.SetFlag(false) })
+
+	var errBuf bytes.Buffer
+	codec := cmdio.NewAgentsCodecWithErrWriter(&errBuf)
+
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, map[string]any{"name": "alpha"}))
+
+	line := strings.TrimSpace(errBuf.String())
+	require.NotEmpty(t, line, "spill must emit a hint to errWriter")
+
+	var event map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &event), "agent-mode hint must be a JSONL record, got %q", line)
+	assert.Equal(t, "hint", event["class"])
+
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+	spillPath, _ := summary["spilled_to"].(string)
+	sum, _ := event["summary"].(string)
+	assert.Contains(t, sum, spillPath, "hint summary must reference the spill file path")
 }
 
 func TestAgentsCodec_NoSpill_NoStderrHint(t *testing.T) {

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -43,6 +43,8 @@ type Options struct {
 
 	customCodecs        map[string]format.Codec
 	defaultFormat       string
+	defaultFormatPinned bool
+	hiddenFormats       map[string]bool // formats removed from the advertised menu (see HideFormat)
 	flags               *pflag.FlagSet
 	jsonFieldValidator  func(fields []string) error // optional; invoked before field extraction when --json is used
 	jqQuery             *gojq.Query                 // compiled --jq query; nil when flag not set
@@ -72,6 +74,35 @@ func (opts *Options) DefaultFormat(name string) {
 	opts.defaultFormat = name
 }
 
+// PinDefaultFormat sets the command's default output format and exempts it
+// from the agent-mode "agents" default override applied in BindFlags.
+//
+// File-writing commands (resources pull, resources edit) must use this:
+// their OutputFormat doubles as the on-disk file extension and the encoder,
+// so silently flipping the default to the agents codec in agent mode would
+// write `<name>.agents` files — and, for payloads above the spill threshold,
+// write a spill-summary envelope instead of the resource content. An explicit
+// -o flag from the user still wins over the pinned default.
+func (opts *Options) PinDefaultFormat(name string) {
+	opts.defaultFormat = name
+	opts.defaultFormatPinned = true
+}
+
+// HideFormat removes a format name from the advertised format menu — the
+// -o usage string built by BindFlags and the "Valid formats are: ..."
+// error listings — without unregistering the codec. Resolution is
+// unaffected: an explicit -o <name> still reaches the codec, so the
+// command's own Validate keeps owning the rejection with a
+// context-specific error. Used by commands that reject a built-in display
+// codec (resources pull and edit reject `agents`), so the menu never
+// advertises a format the command will refuse. Call before BindFlags.
+func (opts *Options) HideFormat(name string) {
+	if opts.hiddenFormats == nil {
+		opts.hiddenFormats = make(map[string]bool)
+	}
+	opts.hiddenFormats[name] = true
+}
+
 func (opts *Options) BindFlags(flags *pflag.FlagSet) {
 	defaultFormat := "json"
 	if opts.defaultFormat != "" {
@@ -79,8 +110,10 @@ func (opts *Options) BindFlags(flags *pflag.FlagSet) {
 	}
 
 	// Agent mode: override any per-command default with the agents codec.
-	// Explicit -o flag from user still takes precedence (via cobra flag parsing).
-	if agent.IsAgentMode() {
+	// Explicit -o flag from user still takes precedence (via cobra flag
+	// parsing). Commands whose default was pinned via PinDefaultFormat
+	// (file-writing commands) are exempt from the override.
+	if agent.IsAgentMode() && !opts.defaultFormatPinned {
 		defaultFormat = string(agentsFormat)
 	}
 
@@ -459,6 +492,13 @@ func (opts *Options) allowedCodecs() []string {
 	}
 	for name := range opts.customCodecs {
 		all[name] = struct{}{}
+	}
+
+	// Drop menu-hidden formats (see HideFormat). Custom codecs registered
+	// under a hidden name stay hidden too — the command asked for the name
+	// to disappear from the menu, whatever backs it.
+	for name := range opts.hiddenFormats {
+		delete(all, name)
 	}
 
 	allowedCodecs := slices.Collect(maps.Keys(all))

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -253,11 +253,15 @@ func (opts *Options) Encode(dst io.Writer, value any) error {
 	// not realize --jq exists for transformation (group_by, filter, count).
 	// Suppressed when --jq is already in use (caller already has the more
 	// powerful tool) or when --json list is requested (discovery output is
-	// not a transformation target). Emitted once per invocation to stderr
-	// (never pollutes stdout) as JSONL {"class":"hint",...} via emitHint
-	// (FR-104). Suppressed outside agent mode to avoid noise on TTYs.
+	// not a transformation target). Also suppressed for pinned-default
+	// (file-writing) commands: their encode fills a file or editor buffer,
+	// not stdout, and they reject --json/--jq — recommending those flags
+	// would contradict the command's own validation. Emitted once per
+	// invocation to stderr (never pollutes stdout) as JSONL
+	// {"class":"hint",...} via emitHint (FR-104). Suppressed outside agent
+	// mode to avoid noise on TTYs.
 	isJSONLike := codec.Format() == format.JSON || codec.Format() == agentsFormat
-	if !opts.jsonFieldsHintShown && agent.IsAgentMode() && isJSONLike && !opts.JSONDiscovery && opts.jqQuery == nil {
+	if !opts.jsonFieldsHintShown && agent.IsAgentMode() && isJSONLike && !opts.JSONDiscovery && opts.jqQuery == nil && !opts.defaultFormatPinned {
 		opts.jsonFieldsHintShown = true
 		w := opts.ErrWriter
 		if w == nil {

--- a/internal/output/format_options_test.go
+++ b/internal/output/format_options_test.go
@@ -1,0 +1,96 @@
+package output_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/agent"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHideFormat covers the advertised-menu suppression used by commands
+// that reject a built-in display codec (resources pull/edit reject agents):
+// the hidden name disappears from the usage string and the unknown-format
+// error listing, while resolution stays intact so the command's own
+// Validate owns the rejection.
+func TestHideFormat(t *testing.T) {
+	agent.SetFlag(false)
+	t.Cleanup(func() { agent.SetFlag(false) })
+
+	opts := &cmdio.Options{}
+	opts.HideFormat("agents")
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.BindFlags(flags)
+
+	// Usage string menu drops the hidden format.
+	usage := flags.Lookup("output").Usage
+	assert.NotContains(t, usage, "agents")
+	assert.Contains(t, usage, "json")
+	assert.Contains(t, usage, "yaml")
+
+	// Unknown-format error listing drops it too.
+	opts.OutputFormat = "bogus"
+	err := opts.Validate()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "agents")
+	assert.Contains(t, err.Error(), "json")
+
+	// Resolution is unaffected: an explicit -o agents still validates here;
+	// the command's own Validate is responsible for rejecting it.
+	opts.OutputFormat = "agents"
+	require.NoError(t, opts.Validate())
+}
+
+// TestBindFlags_PinDefaultFormat covers the file-writing-command opt-out:
+// a pinned default survives the agent-mode "agents" override, while an
+// explicit -o flag from the user still wins.
+func TestBindFlags_PinDefaultFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		agentMode      bool
+		pin            string
+		explicitOutput string // simulates -o flag; empty = use default
+		wantFormat     string
+	}{
+		{
+			name:       "agent mode keeps pinned default",
+			agentMode:  true,
+			pin:        "json",
+			wantFormat: "json",
+		},
+		{
+			name:           "explicit -o overrides pinned default in agent mode",
+			agentMode:      true,
+			pin:            "json",
+			explicitOutput: "yaml",
+			wantFormat:     "yaml",
+		},
+		{
+			name:       "non-agent mode uses pinned default",
+			agentMode:  false,
+			pin:        "json",
+			wantFormat: "json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agent.SetFlag(tc.agentMode)
+			t.Cleanup(func() { agent.SetFlag(false) })
+
+			opts := &cmdio.Options{}
+			opts.PinDefaultFormat(tc.pin)
+
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			opts.BindFlags(flags)
+
+			if tc.explicitOutput != "" {
+				require.NoError(t, flags.Set("output", tc.explicitOutput))
+			}
+
+			assert.Equal(t, tc.wantFormat, opts.OutputFormat)
+		})
+	}
+}

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -206,12 +206,19 @@ func TestEncode_AgentModeHint(t *testing.T) {
 		agentMode bool
 		jsonField string // if set, pass --json flag
 		jqExpr    string // if set, pass --jq flag
+		pinned    bool   // if set, pin the default format (file-writing command)
 		wantHint  bool
 	}{
 		{
 			name:      "agent mode without --json or --jq: emits hint",
 			agentMode: true,
 			wantHint:  true,
+		},
+		{
+			name:      "agent mode + pinned default (file-writing command): hint suppressed",
+			agentMode: true,
+			pinned:    true,
+			wantHint:  false,
 		},
 		{
 			name:      "agent mode + --json field selection: hint still fires (nudges toward --jq)",
@@ -245,6 +252,9 @@ func TestEncode_AgentModeHint(t *testing.T) {
 
 			var errBuf bytes.Buffer
 			opts := &cmdio.Options{ErrWriter: &errBuf}
+			if tc.pinned {
+				opts.PinDefaultFormat("json")
+			}
 			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 			opts.BindFlags(flags)
 

--- a/internal/providers/irm/oncall_commands.go
+++ b/internal/providers/irm/oncall_commands.go
@@ -32,10 +32,9 @@ type listOpts struct {
 
 func (o *listOpts) setup(flags *pflag.FlagSet, resource string) {
 	o.Resource = resource
-	// Default codec name for CRUD list/get/list-alerts. The alert-groups
-	// command tree defaults to `text` (table); other OnCall resources
-	// continue to default to `table` per the existing convention.
-	defaultFmt := "table"
+	// Every OnCall resource command built here defaults to the `table`
+	// codec; the switch below registers the matching table/wide codecs per
+	// resource type.
 	switch resource {
 	case "integrations":
 		o.IO.RegisterCustomCodec("table", &integrationTableCodec{})
@@ -58,11 +57,8 @@ func (o *listOpts) setup(flags *pflag.FlagSet, resource string) {
 		o.IO.RegisterCustomCodec("table", &webhookTableCodec{})
 		o.IO.RegisterCustomCodec("wide", &webhookTableCodec{Wide: true})
 	case "alert-groups":
-		// alert-groups list registers a `table` codec — uniform with the
-		// CRUD-data-command default model in CONSTITUTION/DESIGN.
 		o.IO.RegisterCustomCodec("table", &alertGroupTableCodec{})
 		o.IO.RegisterCustomCodec("wide", &alertGroupTableCodec{Wide: true})
-		defaultFmt = "table"
 	case "users":
 		o.IO.RegisterCustomCodec("table", &userTableCodec{})
 		o.IO.RegisterCustomCodec("wide", &userTableCodec{Wide: true})
@@ -73,11 +69,9 @@ func (o *listOpts) setup(flags *pflag.FlagSet, resource string) {
 	case "slack-channels":
 		o.IO.RegisterCustomCodec("table", &slackChannelTableCodec{})
 	case "alerts":
-		// Same table-codec default applies to `alert-groups list-alerts <group-id>`,
-		// which dispatches via the "alerts" case here.
+		// `alert-groups list-alerts <group-id>` dispatches via this case.
 		o.IO.RegisterCustomCodec("table", &alertTableCodec{})
 		o.IO.RegisterCustomCodec("wide", &alertTableCodec{Wide: true})
-		defaultFmt = "table"
 	case "organizations":
 		o.IO.RegisterCustomCodec("table", &organizationTableCodec{})
 	case "resolution-notes":
@@ -87,7 +81,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet, resource string) {
 		o.IO.RegisterCustomCodec("table", &shiftSwapTableCodec{})
 		o.IO.RegisterCustomCodec("wide", &shiftSwapTableCodec{Wide: true})
 	}
-	o.IO.DefaultFormat(defaultFmt)
+	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)
 }
 

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -372,9 +372,10 @@ func searchByTypes(ctx context.Context, cmd *cobra.Command, client *Client, enti
 			return nil, fmt.Errorf("search entity type %s: %w", et, err)
 		}
 		if page.MaxLimitHit || (!page.LastPage && len(page.Entities) > 0) {
-			fmt.Fprintf(cmd.ErrOrStderr(),
-				"hint: more results available for type %q (page %d returned %d) — use --page %d or narrow with --property/--namespace\n",
-				et, pageNum, len(page.Entities), pageNum+1)
+			cmdio.EmitHint(cmd.ErrOrStderr(),
+				fmt.Sprintf("more results available for type %q (page %d returned %d) — use --page %d or narrow with --property/--namespace",
+					et, pageNum, len(page.Entities), pageNum+1),
+				"")
 		}
 		allResults = append(allResults, page.Entities...)
 	}
@@ -1465,7 +1466,9 @@ analysis, use 'gcx kg entities inspect' instead.`,
 			}
 			results = adapter.TruncateSlice(results, listOpts.Limit)
 			if listOpts.Limit > 0 && int64(len(results)) >= listOpts.Limit {
-				fmt.Fprintf(os.Stderr, "hint: --limit of %d reached — results may be truncated; raise --limit or pass --limit 0 for all\n", listOpts.Limit)
+				cmdio.EmitHint(cmd.ErrOrStderr(),
+					fmt.Sprintf("--limit of %d reached — results may be truncated; raise --limit or pass --limit 0 for all", listOpts.Limit),
+					"")
 			}
 			return listOpts.IO.Encode(cmd.OutOrStdout(), results)
 		},


### PR DESCRIPTION
This is the safe-corrections extraction from the #387 output-format audit, tracked in #1030. The full audit record rides along as docs/research/2026-07-17-output-format-consistency-audit.md. The bar for inclusion was: makes existing behavior honest without changing any non-agent default format or any successful non-agent stdout payload.

What's in:

- resources pull and edit no longer let agent mode flip their default to the agents display codec. Their output format doubles as the on-disk file extension, the encoder, and (for edit) the round-trip decode format, so agent invocations wrote `<name>.agents` files — and resources over the 100KiB spill threshold got a spill-summary envelope written into the resource file instead of the resource. Both now pin json (their existing non-agent default, unchanged) via the new Options.PinDefaultFormat, reject an explicit -o agents at validation time, and hide agents from their format menus via the new Options.HideFormat, so help never advertises a format the command refuses.
- edit now actually calls its own Validate() (it never did), and both pull and edit reject --json/--jq upfront. pull advertised both flags but silently ignored them; a field-selected or jq-transformed document can't round-trip through the editor or as a resource file that push reads back. The rejections are typed usage errors (exit 2 per the DESIGN.md taxonomy).
- The truncation and pagination hints in kg entities list, resources get, and the agents codec's own spill notice now go through output.EmitHint — a "hint: ..." line on a TTY, a {"class":"hint"} JSONL record in agent mode. kg also stops writing to raw os.Stderr past the command's redirected stream, and resources get now emits its truncation hint on the --json field-selection path too, which previously dropped it for exactly the field-selecting consumers the hint exists for.
- IRM oncall list options: a stale comment and dead defaultFmt reassignments removed. No behavior change.
- docs/design/output.md §14 rewritten: it documented a --format flag on pull (yaml default) that never existed. It now describes the real -o flag and json default; the yaml design intent is recorded as an open decision, not silently adopted.

Deliberate behavior changes a reviewer should sign off on explicitly — this list is complete, no need to read #1030 to review this PR:

1. The agent-mode default for pull and edit changes from agents to json. Non-agent defaults are untouched, but this one is a real default change — it's in the safe bucket because the old default was writing display envelopes into resource files, not because nothing moved.
2. Previously-tolerated invocations now fail: pull -o agents used to exit 0 and write .agents files; pull --json/--jq were advertised but silently ignored; edit --json/--jq were inert because edit never validated. All six combinations now exit 2 with a clear error before any fetch or editor launch. Any automation that passed these flags by accident will start failing loudly.
3. The resources get truncation notice changed wording and stream shape: "Showing first N items per resource type." became a typed hint ("hint: showing first N items per resource type; ..." on a TTY, JSONL in agent mode). Anything grepping the old literal stops matching. That's the point of the FR-104 conversion, but it's not byte-neutral on stderr.

One decision surfaces here that lives outside the PR: CONSTITUTION.md's Push/Pull Philosophy says pull writes YAML by default. We traced that line — it was added 2026-03-25 in PR #17 as codified design intent, and on that same day the code already defaulted pull to json. The sentence has never matched shipped behavior at any point in the repo's history (same shape as the output.md §14 `--format` flag this PR fixes: documented, never implemented). This PR documents the shipped json behavior in §14 with the conflict called out inline, and changes nothing either way. The call needed from a maintainer: ratify json — follow-up is a one-line Constitution amendment PR we'll put up on a nod — or schedule a yaml migration as its own breaking change (it would break every workflow reading `.json` files from a bare pull). Either answer is fine for this PR; it doesn't block merge.

Follow-ups after merge, for the record: one rebase here once the naming train lands (kg/irm overlap, ours to do); the Constitution amendment or yaml-migration PR per the decision above; and PR #1033's rebase absorbs the output.md overlap (its workstream). The rest of the audit's breaking default-format questions are queued in #1030 and none of them touch this PR.

What's deliberately out, so the boundary is visible in review: every breaking default-format change the audit surfaced — get-default convergence, the adaptive family's table/json/yaml split, cloud stacks get vs its siblings, the pull json-vs-yaml on-disk default, the text/table canonical spelling (a resolution-time alias was tried on the feasibility branch and reverted after it leaked help-tree's prose codec into -o table), and the output.md §1.3 policy-vs-reality call. Those are presented as a decision table in #1030 and none of them are implemented here. Also out: the list-truncation contract (Track C), which is its own workstream in #1031 / PR #1033 — nothing here depends on it, and this PR should merge before #1033 (both touch output.md and format.go; #1033's rebase absorbs the overlap).

Verification: gofmt clean, golangci-lint 0 issues, go test -race -count=1 ./... green, reference docs regenerated with GCX_AGENT_MODE=false and drift-clean (the two pull/edit CLI pages pick up the menu changes).

The diff also went through an adversarial multi-agent review at xhigh effort before any E2E. Four confirmed findings landed as the second commit: pull/edit now hide the always-rejected --json/--jq from help (same honesty rule as hiding the agents format — the Validate rejections still fire on explicit use), the agent-mode field-selection nudge is suppressed for pinned file-writing commands (edit's own stderr was recommending exactly the flags edit rejects), get's --json path emits the truncation hint only after a successful encode like the other paths, and a test-helper comment that overstated writeGetOutput's contract was corrected. A second review handoff produced the third commit: the six rejections were plain errors and exited 1; they're now fail.UsageError and exit 2, with tests asserting the converted exit code. Left as recorded findings rather than fixed here: the shared Options.Validate errors (unknown -o format, --json/-o conflicts) and pull's --path check exit 1 everywhere today — reclassifying those is a repo-wide existing-behavior change; and writeFieldSelect's agent-mode partial-failure envelope declares exit_code 4 in the payload but the process exits 0 (pre-existing on main). The remaining review suggestions (a combined DisallowFormat API, deduplicating the twin pull/edit Validate blocks, unifying the stderr plumbing in writeGetOutput) are real but would be redesign, which this PR intentionally isn't.

E2E, against a live stack with a main-built binary vs this branch, identical args, scratch config, read-only throughout: get and pull JSON stdout plus pulled file trees are byte-identical; every hint is stderr-only, and the agent-mode stderr stream is now pure JSONL where main interleaved raw prose; agent-mode pull writes .json where main wrote .agents; pull -o agents, pull/edit --json/--jq all fail fast with exit 2 where main exited 0 (main demonstrably wrote a `<name>.agents` display-envelope file and silently ignored --json). The kg hint path couldn't be exercised live (Asserts isn't enabled on the test stack; both binaries fail byte-identically there) — it's pinned by unit tests, and its TTY text was already hint:-prefixed, so TTY output is byte-identical by construction.

Sequencing: this should merge after the #387 naming train (#1009 is already in; the batch PRs #1013-#1019 remain) to avoid churn on shared provider files — kg/commands.go and irm/oncall_commands.go are touched by both tracks, so one rebase here is expected — and before #1033 as noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
