### PR TITLE
feat(output): list truncation contract with honest caps and agent-legible metadata

### DIFF
--- a/cmd/gcx/datasources/list.go
+++ b/cmd/gcx/datasources/list.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
@@ -30,7 +31,9 @@ func (opts *listOpts) setup(flags *pflag.FlagSet) {
 
 	flags.StringVarP(&opts.Type, "type", "t", "", "Filter by datasource type (e.g., prometheus, loki)")
 	flags.StringVar(&opts.Name, "name", "", "Filter by datasource name (case-insensitive substring match)")
-	flags.IntVar(&opts.Limit, "limit", 50, "Maximum number of datasources to return")
+	// Cheaply complete source (no server-side limit exists), so the default
+	// is the full set; a default cap would only hide data.
+	opts.IO.BindListLimit(flags, &opts.Limit, "datasources", 0)
 }
 
 func (opts *listOpts) Validate() error {
@@ -109,13 +112,20 @@ func listCmd() *cobra.Command {
 				})
 			}
 
-			if opts.Limit > 0 && len(infos) > opts.Limit {
-				infos = infos[:opts.Limit]
-			}
+			// The full set is already in hand (the /api/datasources transport
+			// has no server-side limit), so the limit is purely a display trim
+			// and the observed total is exact. Truncation is machine-legible
+			// (list_meta in the envelope) and human-legible (stderr hint).
+			infos, meta := cmdio.TruncateCompleteList(infos, opts.Limit)
+			meta = cmdio.AttachListMeta(meta, os.Args)
 
 			// Pattern 13: single shape for all formats. The table codec extracts
 			// .Datasources to render rows; JSON/YAML serialize the envelope.
-			return opts.IO.Encode(cmd.OutOrStdout(), &datasourceListResult{Datasources: infos})
+			if err := opts.IO.Encode(cmd.OutOrStdout(), &datasourceListResult{Datasources: infos, ListMeta: meta}); err != nil {
+				return err
+			}
+			cmdio.EmitListTruncationHint(cmd.ErrOrStderr(), meta)
+			return nil
 		},
 	}
 
@@ -139,6 +149,10 @@ type datasourceInfo struct {
 // extracts .Datasources to render rows (Pattern 13: format-agnostic data).
 type datasourceListResult struct {
 	Datasources []*datasourceInfo `json:"datasources" yaml:"datasources"`
+	// ListMeta is attached only when the output is a truncated page, so
+	// agents cannot mistake a page for the complete set. Reserved key —
+	// see docs/design/output.md § List Truncation Contract.
+	ListMeta *cmdio.ListMeta `json:"list_meta,omitempty" yaml:"list_meta,omitempty"`
 }
 
 type datasourceTableCodec struct{}

--- a/cmd/gcx/datasources/list_test.go
+++ b/cmd/gcx/datasources/list_test.go
@@ -9,12 +9,24 @@ import (
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/datasources"
+	"github.com/grafana/gcx/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func executeDatasourceCommand(t *testing.T, args []string) (string, error) {
 	t.Helper()
+	stdout, _, err := executeDatasourceCommandStreams(t, args)
+	return stdout, err
+}
+
+func executeDatasourceCommandStreams(t *testing.T, args []string) (string, string, error) {
+	t.Helper()
+
+	// Pin agent-mode detection off so TTY hint shapes and table-default
+	// output are asserted deterministically even when the test itself runs
+	// inside an agent harness (e.g. CLAUDECODE=1).
+	testutils.SetAgentMode(t, false)
 
 	root := helperRoot(datasources.Command())
 	var stdout, stderr bytes.Buffer
@@ -26,7 +38,7 @@ func executeDatasourceCommand(t *testing.T, args []string) (string, error) {
 	if err != nil {
 		t.Logf("stderr: %s", stderr.String())
 	}
-	return stdout.String(), err
+	return stdout.String(), stderr.String(), err
 }
 
 // newDatasourceServer serves the given items from /api/datasources. It mimics a
@@ -201,13 +213,116 @@ func TestListExplicitLimitTrimsDatasources(t *testing.T) {
 	server := newDatasourceListServer(t, 60)
 	defer server.Close()
 
+	// The hint's continuation command derives from the real argv, preserving
+	// the user's flags; pin it for determinism.
+	testutils.PinArgv(t, "gcx", "datasources", "list", "--limit", "10")
+
 	configFile := newConfigFileForServer(t, server.URL)
-	stdout, err := executeDatasourceCommand(t, []string{"datasources", "list", "--config", configFile, "--limit", "10", "-o", "json"})
+	stdout, stderr, err := executeDatasourceCommandStreams(t, []string{"datasources", "list", "--config", configFile, "--limit", "10", "-o", "json"})
 	require.NoError(t, err)
 
 	var result struct {
 		Datasources []map[string]any `json:"datasources"`
+		ListMeta    *struct {
+			Truncated bool   `json:"truncated"`
+			Returned  int    `json:"returned"`
+			Total     *int   `json:"total"`
+			Continue  string `json:"continue"`
+		} `json:"list_meta"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
 	assert.Len(t, result.Datasources, 10)
+
+	// Truncation is machine-legible in the payload: the source is fully
+	// fetched, so the total is the observed count.
+	require.NotNil(t, result.ListMeta)
+	assert.True(t, result.ListMeta.Truncated)
+	assert.Equal(t, 10, result.ListMeta.Returned)
+	require.NotNil(t, result.ListMeta.Total)
+	assert.Equal(t, 60, *result.ListMeta.Total)
+	assert.Equal(t, "gcx datasources list --limit 0", result.ListMeta.Continue)
+
+	// ...and human-legible on stderr, in the maintainer-approved sentence
+	// shape (not a "<summary>: <command>" splice).
+	assert.Contains(t, stderr, "hint: showing first 10 of 60. See all results with: gcx datasources list --limit 0")
+}
+
+// TestListDefaultReturnsAllWithoutMeta locks the cheaply-complete-source
+// default: no --limit means the full set (default 0), with no truncation
+// metadata and no hint.
+func TestListDefaultReturnsAllWithoutMeta(t *testing.T) {
+	server := newDatasourceListServer(t, 60)
+	defer server.Close()
+
+	configFile := newConfigFileForServer(t, server.URL)
+	stdout, stderr, err := executeDatasourceCommandStreams(t, []string{"datasources", "list", "--config", configFile, "-o", "json"})
+	require.NoError(t, err)
+
+	var result struct {
+		Datasources []map[string]any `json:"datasources"`
+		ListMeta    *map[string]any  `json:"list_meta"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Len(t, result.Datasources, 60)
+	assert.Nil(t, result.ListMeta, "complete set must not carry list_meta")
+	assert.NotContains(t, stderr, "showing first")
+}
+
+// TestListTruncatedFieldSelection is the end-to-end guard for PR988 defect
+// (b): `--limit 1 --json uid` on a truncated result must return the real uid
+// per item plus the list_meta signal — never {"uid": null}.
+func TestListTruncatedFieldSelection(t *testing.T) {
+	server := newDatasourceListServer(t, 60)
+	defer server.Close()
+
+	configFile := newConfigFileForServer(t, server.URL)
+	stdout, err := executeDatasourceCommand(t, []string{"datasources", "list", "--config", configFile, "--limit", "1", "--json", "uid"})
+	require.NoError(t, err)
+
+	var result struct {
+		UID         any              `json:"uid"`
+		Datasources []map[string]any `json:"datasources"`
+		ListMeta    *struct {
+			Truncated bool `json:"truncated"`
+			Total     *int `json:"total"`
+		} `json:"list_meta"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Nil(t, result.UID, "must not extract fields from the envelope itself")
+	require.Len(t, result.Datasources, 1)
+	assert.Equal(t, "ds-00", result.Datasources[0]["uid"])
+	require.NotNil(t, result.ListMeta, "truncation signal must survive --json field selection")
+	assert.True(t, result.ListMeta.Truncated)
+	require.NotNil(t, result.ListMeta.Total)
+	assert.Equal(t, 60, *result.ListMeta.Total)
+}
+
+// TestListTruncatedFieldDiscovery is the end-to-end guard for PR988 defect
+// (c): `--limit 1 --json list` on a truncated result must discover item
+// fields, not list_meta.* or the wrapper key.
+func TestListTruncatedFieldDiscovery(t *testing.T) {
+	server := newDatasourceListServer(t, 60)
+	defer server.Close()
+
+	configFile := newConfigFileForServer(t, server.URL)
+	stdout, err := executeDatasourceCommand(t, []string{"datasources", "list", "--config", configFile, "--limit", "1", "--json", "list"})
+	require.NoError(t, err)
+
+	for _, field := range []string{"uid", "name", "type", "url"} {
+		assert.Contains(t, stdout, field, "item field %q must be discovered", field)
+	}
+	assert.NotContains(t, stdout, "datasources", "wrapper key must not be listed")
+	assert.NotContains(t, stdout, "list_meta", "reserved truncation metadata must be excluded from discovery")
+}
+
+// TestListNegativeLimitRejected locks the binder validation: --limit must be
+// >= 0 (0 means all results are returned).
+func TestListNegativeLimitRejected(t *testing.T) {
+	server := newDatasourceListServer(t, 2)
+	defer server.Close()
+
+	configFile := newConfigFileForServer(t, server.URL)
+	_, err := executeDatasourceCommand(t, []string{"datasources", "list", "--config", configFile, "--limit", "-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --limit -1")
 }

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -424,15 +424,18 @@ Only the reserved `list_meta` key gets this treatment; envelopes with other
 extra keys keep the pre-existing selection behavior.
 
 These guarantees hold for typed envelope structs and for envelopes assembled
-as dynamic `map[string]any` values — for dynamic maps, the reserved entry
+as dynamic `map[string]any` values — for dynamic maps, the reserved key
 itself is the opt-in signal: a map without `list_meta` keeps whole-object
 selection and as-is discovery even when it happens to be items-shaped, so raw
-passthrough payloads (`gcx api`) are unaffected by the reservation. An empty
-dynamic envelope has no element type to reflect on, so discovery degrades to
-the envelope's own keys (never `list_meta.*`). `unstructured.UnstructuredList`
-values are not part of the contract yet — no producer attaches truncation
-metadata to unstructured lists; that lands with the resources-pipeline
-migration (see the research doc's remaining-migration section).
+passthrough payloads (`gcx api`) are unaffected by the reservation. Dynamic
+maps may hold native Go values (a `*ListMeta`, a typed item slice) — envelope
+handling JSON-normalizes the map first, so producers don't have to
+pre-flatten to the JSON-decoded representation. An empty dynamic envelope has
+no element type to reflect on, so discovery degrades to the envelope's own
+keys (never `list_meta.*`). `unstructured.UnstructuredList` values are not
+part of the contract yet — no producer attaches truncation metadata to
+unstructured lists; that lands with the resources-pipeline migration (see the
+research doc's remaining-migration section).
 
 ### 15.6 Reference migrations
 

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -280,3 +280,160 @@ specified format regardless of the server's response format.
 
 Files are written as `plural.version.group/name.{ext}` where `{ext}`
 matches the chosen format (`.yaml` or `.json`).
+
+---
+
+## 15. List Truncation Contract [PROPOSED — #387 Track C]
+
+> **Status: proposed.** Implemented as an opt-in shared contract in
+> `internal/output/listmeta.go` and migrated to two exemplar commands
+> (`datasources list`, `irm oncall alert-groups list`).
+> Not yet a repo-wide requirement; see
+> `docs/research/2026-07-17-global-limit-investigation.md` for the migration
+> plan and open questions.
+
+List commands must never truncate silently. All truncation flows through the
+shared helpers in `internal/output/listmeta.go` — do not roll per-command
+hint strings or ad-hoc slicing.
+
+### 15.1 The `--limit` flag
+
+Uncapped list commands register `--limit` through the shared binder:
+
+```go
+opts.IO.BindListLimit(flags, &opts.Limit, "<subject>", <default>)
+```
+
+which produces exactly this wording and rejects negative values via
+`Options.Validate()`:
+
+```
+Maximum number of <subject> to return. 0 means all results are returned
+```
+
+**Capped-source exception:** commands whose fetch is bounded by a client-side
+safety cap (e.g. `irm oncall alert-groups list`, capped at 1000) must NOT use
+the binder — "0 means all" would be dishonest there. They keep a bespoke flag
+description that discloses the cap, and disclose the cap at runtime via
+`ListMeta.Cap` plus the cap-variant hint (below). `--limit 0` on a capped
+source means "as much as the cap allows", and the output must say so.
+
+The binder is deliberately minimal: commands still pass the limit to their
+clients for server-side pushdown where the API supports it.
+
+### 15.2 Machine-readable payload signal: `list_meta`
+
+`list_meta` is a **reserved envelope key**. A truncated page carries it in
+the items envelope; **absence means the output is the complete result set**:
+
+```json
+{
+  "items": [ ... ],
+  "list_meta": {"truncated": true, "returned": 50, "continue": "gcx ... list --limit 100"}
+}
+```
+
+Fields (`internal/output.ListMeta`):
+
+| Field | Presence | Meaning |
+|---|---|---|
+| `truncated` | always (when attached) | Always `true`; a `list_meta` is only attached to partial pages |
+| `returned` | always | Items in this page |
+| `total` | only when observed | Size of the complete set — never guessed. Fully-fetched sources, or a paginated source whose pagination happened to end (drained) while trimming to the bound |
+| `cap` | only when the safety cap was the bound | The cap value; raising `--limit` cannot retrieve more |
+| `continue` | when a runnable continuation exists | Command derived from the real invocation argv (filters survive); empty for cap-bounded pages |
+
+Attach it to the envelope struct with exactly this key and `omitempty`
+(required — a `null list_meta` on complete sets would defeat the
+absence-means-complete rule and confuse the discovery path):
+
+```go
+ListMeta *cmdio.ListMeta `json:"list_meta,omitempty" yaml:"list_meta,omitempty"`
+```
+
+Bare-array list outputs (no envelope) cannot carry the signal; they get the
+stderr hint only and should migrate to an envelope when their consumers can
+absorb the shape change (`alert rules list` is the tracked example).
+
+### 15.3 Constructors by source shape
+
+Never drain a source just to count it. Pick the constructor matching the
+source, then finalize with `AttachListMeta(meta, os.Args)`:
+
+| Source shape | Helper | Total |
+|---|---|---|
+| Cheaply complete (no server-side limit; full set already fetched) | `TruncateCompleteList(items, limit)` | observed |
+| Paginated, API reports more-pages (continue token / next cursor) | `PagedListMeta(returned, limit, serverHasMore, safetyCap)` | unknown |
+| Paginated, no more-pages signal | over-fetch by one (`limit+1` on the wire), then `TruncatePagedList(items, limit)` | unknown |
+
+`PagedListMeta` honors `serverHasMore` **even when `limit <= 0`**: a fetch
+bounded by a safety cap is still a partial page. This is the fix for the
+PR988 defect where `--limit 0` silently returned a hard-capped page as if it
+were complete. `serverHasMore` must also be true when the final page
+**overshot** the bound and in-hand items were trimmed, even without a next
+cursor — dropped items are truncation evidence. In that drained-overshoot
+case the total was genuinely observed, and the command may attach it to the
+constructed meta when honest (always on a cap-bounded page; otherwise only
+when `--limit 0` can really retrieve it) — observed, never guessed
+(`irm oncall alert-groups list` is the reference implementation).
+
+The cap-recording rule fires at `limit >= safetyCap`, including
+`limit == safetyCap` exactly: a doubled `--limit` continuation could never
+return more than the cap allows, so the cap variant (refine filters, no
+continuation) is used there.
+
+### 15.4 Human-readable stderr hint
+
+Emit via `EmitListTruncationHint(cmd.ErrOrStderr(), meta)` after the payload
+encode, with `meta` finalized by `AttachListMeta` — the single derivation
+point for the continuation, so the stderr hint and the payload's
+`list_meta.continue` can never disagree. It routes through `EmitHint` (agent
+mode emits the JSONL `class:"hint"` form with the continuation in `command`).
+No-op when `meta` is nil. TTY templates:
+
+```
+hint: showing first 5 of 219. See all results with: gcx datasources list --limit 0          # total known
+hint: showing first 50; more results are available. See more with: gcx ... list --limit 100  # total unknown (doubled limit)
+hint: showing first 1000 (safety cap). Refine filters to narrow the result set               # cap was the bound
+```
+
+Rules baked into the helper:
+
+1. The continuation command is derived from the real argv with any prior
+   `--limit` stripped — the user's filter flags always survive. Never a
+   hardcoded string.
+2. `--limit 0` is only suggested when the total was observed (the full set is
+   genuinely retrievable). Unknown totals get a doubled limit — never a
+   promise that `--limit 0` retrieves everything when a cap may exist.
+3. The cap variant suggests no `--limit` at all: a bigger limit cannot beat
+   the cap.
+
+### 15.5 `--json` guarantees
+
+The reserved key is transparent to field selection and discovery
+(`internal/output/field_select.go`, `format.go`):
+
+- `--json field1,field2` on a truncated envelope selects from the **items**
+  and **re-attaches** `list_meta` to the output — the truncation signal
+  survives selection.
+- `--json list` / `--json ?` discovery samples the first item; `list_meta.*`
+  paths are never listed, and the reserved field on the envelope struct does
+  not break empty-envelope discovery.
+
+Only the reserved `list_meta` key gets this treatment; envelopes with other
+extra keys keep the pre-existing selection behavior.
+
+### 15.6 Reference migrations
+
+- `cmd/gcx/datasources/list.go` — cheaply complete source, binder,
+  default `--limit 0`, known total.
+- `internal/providers/irm/oncall_commands_extra.go` (alert-groups list) —
+  paginated source, both server-reported (`PagedListMeta` with safety cap)
+  and over-fetch-by-one (`TruncatePagedList`, alternate-implementation
+  fallback path) variants.
+
+`alert rules list` is deliberately not migrated yet: its JSON/YAML output is
+a bare array (no envelope to carry `list_meta`) and its `--limit` counts
+different units per format (flattened rules in the table, groups in JSON).
+The envelope and unit decisions are tracked in
+`docs/research/2026-07-17-global-limit-investigation.md` §6–7.

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -423,6 +423,17 @@ The reserved key is transparent to field selection and discovery
 Only the reserved `list_meta` key gets this treatment; envelopes with other
 extra keys keep the pre-existing selection behavior.
 
+These guarantees hold for typed envelope structs and for envelopes assembled
+as dynamic `map[string]any` values — for dynamic maps, the reserved entry
+itself is the opt-in signal: a map without `list_meta` keeps whole-object
+selection and as-is discovery even when it happens to be items-shaped, so raw
+passthrough payloads (`gcx api`) are unaffected by the reservation. An empty
+dynamic envelope has no element type to reflect on, so discovery degrades to
+the envelope's own keys (never `list_meta.*`). `unstructured.UnstructuredList`
+values are not part of the contract yet — no producer attaches truncation
+metadata to unstructured lists; that lands with the resources-pipeline
+migration (see the research doc's remaining-migration section).
+
 ### 15.6 Reference migrations
 
 - `cmd/gcx/datasources/list.go` — cheaply complete source, binder,

--- a/docs/reference/cli/gcx_datasources_list.md
+++ b/docs/reference/cli/gcx_datasources_list.md
@@ -38,7 +38,7 @@ gcx datasources list [flags]
   -h, --help             help for list
       --jq string        jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string      Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int        Maximum number of datasources to return (default 50)
+      --limit int        Maximum number of datasources to return. 0 means all results are returned
       --name string      Filter by datasource name (case-insensitive substring match)
   -o, --output string    Output format. One of: agents, json, table, yaml (default "table")
   -t, --type string      Filter by datasource type (e.g., prometheus, loki)

--- a/docs/research/2026-07-17-global-limit-investigation.md
+++ b/docs/research/2026-07-17-global-limit-investigation.md
@@ -1,0 +1,286 @@
+# Global `--limit` Investigation & List Truncation Contract (#387 Track C)
+
+> **Status: proposal / experiment record.** This documents the investigation
+> behind the `--limit` + truncation-hint contract prototyped on branch
+> `test/387-e2e-feasibility`, including why a root-level persistent `--limit`
+> was rejected, how PR #988's defects are fixed, and what migration remains.
+> Nothing here is a settled repo-wide requirement until #387 lands.
+>
+> The first production PR extracts everything below EXCEPT the
+> `alert rules list` partial migration, which stays prototype-only on the
+> feasibility branch pending the envelope/unit decisions (§ 5–7) — rows and
+> proofs below that exist only on the prototype are marked as such.
+
+## 1. Problem
+
+The command-surface audit (#387) found `--limit` semantics scattered across
+~64 local flag registrations (a fresh grep of `Var(&…, "limit"` finds 64
+non-test registrations; the audit inventory counted 67 including variants),
+with three systemic defects:
+
+1. **Silent truncation** — many list commands slice client-side with no
+   signal on stdout or stderr (`adapter.TruncateSlice` callers, `datasources
+   list` at the old `list.go:112-114`).
+2. **Inconsistent `0` semantics** — `0` variously means "all", "server
+   default", "invalid", or "all up to a hidden cap".
+3. **No machine-readable contract** — an agent reading `-o json` output
+   cannot distinguish a truncated page from the complete set.
+
+PR #988 attempted a fix and was found broken in maintainer review (§ 4).
+
+## 2. Root-level persistent `--limit`: investigated and REJECTED
+
+A single `--limit` persistent flag on the root command looks attractive but
+fails on three grounds:
+
+### 2.1 Shadowing mechanics
+
+Cobra merges persistent flags into each command's flag set at execution time;
+`pflag.FlagSet.AddFlagSet` **silently skips** flags whose name already exists
+in the target set. Every one of the ~64 existing local `--limit` flags would
+shadow the root flag, so the "global" flag would apply only to commands that
+never declared one — including dozens of non-list commands (`login`, `push`,
+mutation verbs) where it is meaningless help pollution. A global default also
+could not vary per command (list commands legitimately differ: 0, 20, 50…).
+
+### 2.2 Semantic outliers (same name, different meaning)
+
+At least six existing `--limit` families are not "number of list rows" and
+must never be captured by a uniform contract:
+
+| Command family | Location | Semantics |
+|---|---|---|
+| Loki queries | `internal/datasources/loki/query.go:130`, `cmd/gcx/datasources/query.go:214` | Max **log lines** returned by the Loki engine, not list rows |
+| SQL datasources (ClickHouse/Athena) | `internal/datasources/clickhouse/query.go:130`, `internal/datasources/athena/query.go:132`, clamp in `internal/query/sql/types.go:44-56` | Rewrites/append a SQL `LIMIT` clause; existing user `LIMIT` values are silently clamped to 1000 |
+| Dashboards list | `internal/providers/dashboards/crud.go:50` | K8s **page size** paired with `--continue` cursor pagination ("0 fetches all pages") |
+| Incidents list / activity | `internal/providers/irm/incidents_commands_impl.go:43` (list: `--limit` < 1 is **invalid**, lines 56-57), `:507` + `internal/providers/irm/incidents_client.go:399-402` (activity: `0` is silently **coerced to 50** server-side) | `0` is not "all" on either path |
+| Incidents contexts | `internal/providers/irm/incidents_commands_impl.go:747` | `0` = **server default**, not "all" |
+| Resources get | `cmd/gcx/resources/get.go:123` | Per-resource-type K8s page size across multiple types |
+
+### 2.3 Capped sources
+
+`irm oncall alert-groups list` bounds even `--limit 0` with a 1000-item
+runaway cap (`alertGroupListHardCap`, `oncall_commands_extra.go`). A global
+"0 means all results are returned" promise would be a lie there.
+
+### 2.4 Chosen architecture
+
+An **opt-in shared binder + uniform contract**, migrated incrementally:
+
+- `(o *Options) BindListLimit(flags, p, subject, def)` registers `--limit`
+  with the maintainer-approved wording ("Maximum number of `<subject>` to
+  return. 0 means all results are returned") and hooks `>= 0` validation into
+  `Options.Validate()` (already called by every list command).
+- Truncation metadata + hints live in `internal/output/listmeta.go`
+  (`ListMeta`, `TruncateCompleteList`, `TruncatePagedList`, `PagedListMeta`,
+  `AttachListMeta`, `EmitListTruncationHint`).
+- Capped sources skip the binder (bespoke wording disclosing the cap) but
+  participate in the metadata contract via `ListMeta.Cap`.
+- Semantic outliers (§ 2.2) are explicitly out of scope.
+
+See `docs/design/output.md` § 15 for the normative contract text.
+
+## 3. The contract in one page
+
+- Reserved envelope key `list_meta`; **absence == complete set**.
+- `ListMeta{truncated, returned, total?, cap?, continue?}`; `total` only when
+  observed, `cap` only when the safety cap was the bound, `continue` always
+  derived from real argv (filters survive).
+- Constructors by source shape: cheaply-complete → `TruncateCompleteList`
+  (total observed); paginated with more-pages signal → `PagedListMeta`
+  (honors `serverHasMore` even at `limit<=0`); paginated without signal →
+  over-fetch `limit+1` + `TruncatePagedList`.
+- Hints (TTY): known total → "showing first N of M. See all results with:
+  `<cmd> --limit 0`"; unknown total → "showing first N; more results are
+  available. See more with: `<cmd> --limit 2N`"; cap → "showing first N
+  (safety cap). Refine filters to narrow the result set" (no `--limit`
+  suggestion).
+- `--json` selection re-attaches `list_meta`; discovery excludes it.
+
+## 4. PR #988 post-mortem: four defects, root causes, fixes
+
+PR #988 introduced `list_meta` + a hint helper and migrated `datasources
+list` and `alert-groups list`. Maintainer review found four problems; all are
+verified against HEAD and fixed here:
+
+### (a) Hint wording and hardcoded continue command
+
+- **Symptom:** `hint: showing first 1 of 219: gcx datasources list --limit 0`
+  — a "summary: command" splice; and the suggested command dropped the user's
+  filter flags (`--type prometheus` etc.) because PR988 passed a **constant**
+  command string per call site.
+- **Root cause:** `EmitHint`'s TTY shape is `hint: <summary>: <command>`
+  (`internal/output/format.go`), and PR988 fed it a bare count summary plus a
+  hardcoded command.
+- **Fix:** `EmitListTruncationHint` folds a connective into the TTY summary
+  ("showing first 5 of 219. See all results with") so the line reads as a
+  sentence, and the continuation is always derived from `os.Args` via
+  `BuildListLimitCommand` (extending `internal/output/pagination.go`'s
+  `stripFlag`/`shellJoin` used by the dashboards `--continue` hint) — prior
+  `--limit`/`--limit=` spellings stripped, all other flags preserved.
+- **Proof:** `TestEmitListTruncationHint` (exact TTY strings incl. the
+  filter-preservation case), `TestBuildListLimitCommand`,
+  `TestListExplicitLimitTrimsDatasources` (end-to-end stderr assert), and —
+  prototype-only, on the feasibility branch —
+  `TestRulesList_HintPreservesFilterFlags`.
+
+### (b) `--limit 1 --json uid` returned `{"uid": null}`
+
+- **Symptom:** field selection on a truncated page extracted from the
+  envelope instead of the items — only when truncated (worst case).
+- **Root cause:** `singleKeyItems` (`internal/output/field_select.go`)
+  requires **exactly one** top-level key; adding `list_meta` makes two, so
+  the single-key-envelope path fails and `extractFields` runs on the
+  envelope.
+- **Fix:** `singleKeyItems` now ignores a reserved `list_meta` sibling
+  (object-valued only; scoped — any other second key keeps HEAD behavior),
+  and the selection output **re-attaches** `list_meta`. The `items`-keyed
+  path also carries `list_meta` through instead of dropping it.
+- **Proof:** `TestFieldSelectionOnTruncatedEnvelope` (Dafydd's exact repro:
+  `{"datasources":[...],"list_meta":{...}}` + `--json uid` →
+  `{"datasources":[{"uid":"ds-01"}],"list_meta":{...}}`),
+  `TestFieldSelectionOnTruncatedItemsEnvelope`,
+  `TestSingleKeyEnvelopeWithUnrelatedSecondKey` (scoping guard),
+  `TestListTruncatedFieldSelection` (end-to-end through the real command).
+
+### (c) `--json list` discovery listed `list_meta.*` instead of item fields
+
+- **Root cause:** same arity bug in `sampleFromObject`
+  (`internal/output/format.go`) — the envelope no longer matched the
+  single-key shape, so discovery sampled the envelope map itself.
+- **Fix:** the tolerant `singleKeyItems` fixes the populated case;
+  `reflectSingleSliceField` skips the reserved `list_meta`-tagged struct
+  field so **empty**-envelope discovery keeps working on structs that carry
+  the metadata field.
+- **Proof:** `TestDiscoveryOnTruncatedEnvelope`,
+  `TestDiscoveryOnEmptyEnvelopeWithListMetaField`,
+  `TestListTruncatedFieldDiscovery` (end-to-end).
+
+### (d) `alert-groups list --limit 0` silently capped at 1000 with no meta
+
+- **Symptom:** the rich path caps `--limit 0` at `alertGroupListHardCap=1000`
+  (`effectiveCap` fallback in `listAlertGroupsRaw`); PR988's `PagedListMeta`
+  short-circuited on `limit <= 0`, so a hard-capped page carried **no**
+  `list_meta` — violating its own "absence == complete" rule exactly where
+  it matters most.
+- **Fix:** `PagedListMeta(returned, limit, serverHasMore, safetyCap)` honors
+  `serverHasMore` even at `limit <= 0` and records `Cap` when the cap (not a
+  larger user limit) is the binding ceiling (`limit <= 0 || limit >= cap` —
+  `limit == cap` counts, since a doubled continuation could never beat the
+  cap). The hint
+  switches to the cap variant and never suggests `--limit 0`. The legacy
+  fallback path (which genuinely drains fully at `--limit 0`, no cap) now
+  over-fetches `limit+1` and uses `TruncatePagedList`; at `--limit 0` it
+  stays metadata-free, keeping the two paths individually honest.
+  Naming correction: this fallback is NOT a production "SA-token" mode —
+  the production loader always returns `*OnCallClient`, which implements
+  the rich interface (`internal/providers/irm/config.go`,
+  `interfaces.go`); the fallback is reachable only by alternate
+  `OnCallAPI` implementations (e.g. test doubles) today.
+- **Proof:** `TestPagedListMeta` ("limit zero capped by safety cap is
+  truncated with cap"), `TestAlertGroupList_RichPath_LimitZeroHitsSafetyCap`,
+  `TestAlertGroupList_LegacyPath_LimitZeroDrainsFully`,
+  `TestAlertGroupList_LegacyPath_OverFetchDetectsTruncation`.
+
+## 5. Behavior changes vs pre-contract HEAD
+
+All rows below ship in the first production PR except the last, which is
+prototype-only (feasibility branch).
+
+| Change | Where |
+|---|---|
+| `datasources list` default `--limit` 50 → **0** (full set; maintainer's own review suggestion — the source is fully fetched anyway) | `cmd/gcx/datasources/list.go` |
+| `datasources list` truncation now emits `list_meta` + stderr hint (was silent slice) | same |
+| `datasources list` rejects negative `--limit` via the binder (was accepted, treated as unlimited); `alert-groups list` rejects it with bespoke capped-source wording | binder validation in `Options.Validate`; `alertGroupListOpts.Validate` |
+| `alert-groups list` rich path: `list_meta` on truncated pages; `--limit 0` capped fetch now reports `cap:1000` + "safety cap" hint (was silent, indistinguishable from complete) | `internal/providers/irm/oncall_commands_extra.go` |
+| `alert-groups list` rich-path hint wording: "showing first N results: … --limit 2N" → "showing first N; more results are available. See more with: `<argv-derived> --limit 2N`" (filters now survive) | same |
+| `alert-groups list` legacy path: wire limit is now `limit+1` (over-fetch); truncated pages gain `list_meta` + hint (was silent) | same |
+| `--json` selection/discovery: reserved `list_meta` key handled per § 15.5 (no behavior change for envelopes without it) | `internal/output/field_select.go`, `format.go` |
+| PROTOTYPE-ONLY (not landed): `alert rules list` **hint-only partial migration** — truncation hints on stderr for table and JSON paths (was silent `adapter.TruncateSlice`); flag type `int64` → `int`; wording via binder. NOT a completed contract exemplar: the JSON/YAML payload is a bare array (no `list_meta`), and `--limit` keeps its pre-existing unit mismatch (table counts flattened **rules**, JSON counts **groups** — `--limit 50` over 2×100-rule groups truncates the table to 50 rules but returns all 200 rules as JSON). The envelope/unit decision is recorded in § 6 and § 7; kept out of the first production truncation PR | `internal/providers/alert/rules_commands.go` (feasibility branch only) |
+
+Non-changes (parity kept): `alert-groups list` keeps its bespoke flag wording
+(discloses the cap), its default limit 50, the 1000 hard cap itself, and the
+note/filter/nav-hint ordering; `alert rules list` keeps default 50 and its
+bare-array JSON shape.
+
+## 6. Remaining migration (~40 list commands)
+
+Mechanical migrations (cheaply complete sources currently using
+`adapter.TruncateSlice` or ad-hoc slicing): `alert` groups/templates/
+contact-points/mute-timings, `slo` reports, `k6` projects/tests/runs/envvars/
+schedules/zones, `fleet` pipelines/collectors, `kg` search, adaptive-telemetry
+rules/segments/exemptions (logs/metrics/traces), synth checks/probes, and the
+resource-adapter `TruncateSlice` call sites.
+
+Needs per-command decisions:
+
+- **`irm oncall` TypedCRUD lists** (schedules, integrations, escalation
+  chains, webhooks, users, teams, …) have **no `--limit` at all** and drain
+  the paginated public API fully. Adding the binder there is additive (new
+  flag, default 0 keeps behavior); over-fetch `limit+1` gives the truncation
+  signal.
+- **`incidents list`** rejects `--limit 0` today (`>= 1` validation) — adopting
+  the contract is a breaking flag-semantics change; needs a deprecation note.
+- **`incidents activity`** coerces `0 → 50` in the client; the client must
+  learn a real "all" spelling first.
+- **`dashboards list`** already has cursor pagination with a
+  `BuildPaginationCommand` hint; converging it on `list_meta` (with
+  `continue` carrying the cursor command) is a shape addition, not a rewrite.
+- **Bare-array outputs** (`alert rules list`, and any list emitting `[...]`)
+  cannot carry `list_meta` until they move to envelopes; `alert rules list`
+  is deferred because the bundled `investigate-alert` skill documents
+  `gcx alert rules list -o json | jq '.[]…'` (claude-plugin is owned by
+  parallel work and the shape change must land together with the skill
+  update).
+- **`irm oncall alert-groups` bulk-by-filter actions** — `resolveBulkTargets`
+  (`internal/providers/irm/oncall_actions.go`) enumerates targets via
+  `ListAlertGroupsRaw(ctx, filters, 0)` and discards the returned page info,
+  so a sweep whose filter matches more than the 1000-item hard cap silently
+  operates on the first 1000 groups. Needs a per-command decision — a bulk
+  mutation probably ought to **refuse** on a capped enumeration rather than
+  warn.
+
+## 7. Open questions
+
+1. **Should `list_meta` ride only the agents codec?** Currently it is part of
+   the JSON/YAML payload for all consumers. Argument for: humans piping
+   `-o json` to `jq '.datasources[]'` are unaffected either way (key is
+   additive); argument against agents-only: scripts deserve the completeness
+   signal too, and split shapes complicate testing. Current implementation:
+   all structured formats. Needs a maintainer call.
+2. **Retire `adapter.TruncateSlice` centrally?** Once list commands migrate,
+   the remaining callers are resource adapters (`List(ctx, limit)` paths)
+   where truncation is applied below the command layer and no envelope
+   exists. Either the adapter layer returns `(items, truncated bool)` or the
+   resources-get pipeline grows its own contract; out of Track C scope.
+3. **Capped-source binder variant** — a `BindListLimitCapped(..., cap)` with
+   wording like "0 means as many as the safety cap (N) allows" would let
+   capped sources join the binder; deferred until a second capped source
+   appears.
+4. **`table` output and `list_meta`** — tables ignore the field by design
+   (the stderr hint covers humans). If `wide` output ever needs a footer row
+   ("… 50 of 219 shown"), that is a codec concern, not a contract change.
+5. **argv fidelity in tests** — continuation commands derive from `os.Args`,
+   which tests must pin (`testutils.PinArgv`). A future
+   `cmd.CommandPath()`-based derivation could avoid the global, at the cost
+   of reconstructing flag spellings; rejected for now to stay aligned with
+   the `BuildPaginationCommand(os.Args, …)` precedent.
+6. **Explicit source shape vs Total-presence inference** —
+   `listContinueCommand` infers "the full set is retrievable via
+   `--limit 0`" from the mere presence of `Total`, which forces capped
+   sources to withhold an honestly-observed total above the cap (see the
+   guard in `alert-groups list`). Making the cap or source shape an explicit
+   input to `AttachListMeta` would let observed totals always ride;
+   deferred until a second capped source needs it.
+
+## 8. Validation record (2026-07-17, feasibility branch)
+
+- `go test ./internal/output/... ./cmd/gcx/datasources/... ./internal/providers/irm/... ./internal/providers/alert/...` — pass
+  (also pass with `GCX_AGENT_MODE=true` forced, guarding agent-harness envs).
+- `go build -buildvcs=false -o bin/gcx ./cmd/gcx/` — pass.
+- Hint strings locked by exact-match assertions in
+  `internal/output/listmeta_test.go::TestEmitListTruncationHint`.
+
+The production extraction (everything except the `alert rules list` rows) is
+re-validated in its own PR: full `go test -race ./...`, lint, reference-drift,
+and a live main-vs-branch E2E comparison.

--- a/docs/research/2026-07-17-global-limit-investigation.md
+++ b/docs/research/2026-07-17-global-limit-investigation.md
@@ -253,6 +253,10 @@ Needs per-command decisions:
    where truncation is applied below the command layer and no envelope
    exists. Either the adapter layer returns `(items, truncated bool)` or the
    resources-get pipeline grows its own contract; out of Track C scope.
+   The `--json` selection/discovery paths for `unstructured.UnstructuredList`
+   likewise do not carry `list_meta` yet — deliberate, since no producer
+   attaches it to unstructured lists; wire it up together with this
+   migration.
 3. **Capped-source binder variant** — a `BindListLimitCapped(..., cap)` with
    wording like "0 means as many as the safety cap (N) allows" would let
    capped sources join the binder; deferred until a second capped source

--- a/internal/output/field_select.go
+++ b/internal/output/field_select.go
@@ -106,13 +106,19 @@ func (c *FieldSelectCodec) Encode(dst goio.Writer, value any) error {
 
 	case map[string]any:
 		// A dynamic map is treated as a list envelope only when it carries
-		// the reserved list_meta entry — attaching the reserved key is the
-		// producer's opt-in to the contract. All other maps keep whole-object
-		// selection, so raw passthrough payloads (e.g. gcx api responses that
-		// happen to be items-shaped) are unaffected.
-		if hasListMetaEntry(v) {
-			if out, ok := c.envelopeFieldSelection(v); ok {
-				return c.json.Encode(dst, out)
+		// the reserved list_meta key — attaching the key is the producer's
+		// opt-in to the contract. The map may hold native Go values (a
+		// *ListMeta, a []map[string]any or typed item slice), so envelope
+		// handling runs on a JSON-normalized copy; the key-presence check
+		// happens before normalization so native metadata values opt in too,
+		// and the reserved shape is validated after. Maps without the key —
+		// raw passthrough payloads (e.g. gcx api responses that happen to be
+		// items-shaped) — keep whole-object selection on the original value.
+		if _, ok := v[ListMetaKey]; ok {
+			if m, err := toMap(v); err == nil && hasListMetaEntry(m) {
+				if out, ok := c.envelopeFieldSelection(m); ok {
+					return c.json.Encode(dst, out)
+				}
 			}
 		}
 		return c.json.Encode(dst, extractFields(v, c.fields))

--- a/internal/output/field_select.go
+++ b/internal/output/field_select.go
@@ -135,18 +135,23 @@ func (c *FieldSelectCodec) Encode(dst goio.Writer, value any) error {
 			for i, item := range items {
 				extracted[i] = extractFields(item, c.fields)
 			}
-			return c.json.Encode(dst, listFieldSelectionOutput(extracted, paginationMetadataFromObjectMap(m)))
+			out := listFieldSelectionOutput(extracted, paginationMetadataFromObjectMap(m))
+			attachListMetaEntry(out, m)
+			return c.json.Encode(dst, out)
 		}
 
-		// Single-key list envelope (e.g. {"datasources": [...]}): apply field
-		// selection per item and preserve the wrapper key. No pagination
-		// metadata by construction (the envelope has exactly one key).
+		// Single-key list envelope (e.g. {"datasources": [...]}, optionally
+		// with a reserved list_meta sibling): apply field selection per item
+		// and preserve the wrapper key. Truncation metadata is re-attached so
+		// the signal survives field selection.
 		if key, items, ok := singleKeyItems(m); ok {
 			extracted := make([]map[string]any, len(items))
 			for i, item := range items {
 				extracted[i] = extractFields(item, c.fields)
 			}
-			return c.json.Encode(dst, map[string]any{key: extracted})
+			out := map[string]any{key: extracted}
+			attachListMetaEntry(out, m)
+			return c.json.Encode(dst, out)
 		}
 
 		return c.json.Encode(dst, extractFields(m, c.fields))
@@ -232,6 +237,15 @@ func listFieldSelectionOutput(items []map[string]any, metadata map[string]any) m
 	return out
 }
 
+// attachListMetaEntry copies the reserved ListMetaKey truncation-metadata
+// object from the source envelope into the field-selection output, so a
+// truncated page stays machine-legible under --json field selection.
+func attachListMetaEntry(out, src map[string]any) {
+	if lm, ok := src[ListMetaKey].(map[string]any); ok {
+		out[ListMetaKey] = lm
+	}
+}
+
 func paginationMetadataFromUnstructuredList(list unstructured.UnstructuredList) map[string]any {
 	metadata := make(map[string]any, 3)
 	if token := list.GetContinue(); token != "" {
@@ -277,15 +291,20 @@ func paginationMetadataValuePresent(value any) bool {
 }
 
 // singleKeyItems reports whether m is a single-key list envelope: exactly one
-// key whose value is an array of objects (or an empty array). Provider list
-// commands wrap their items under such keys (e.g. {"datasources": [...]}).
+// key whose value is an array of objects (or an empty array), optionally
+// accompanied by the reserved ListMetaKey truncation-metadata object.
+// Provider list commands wrap their items under such keys (e.g.
+// {"datasources": [...]} or {"datasources": [...], "list_meta": {...}}).
 // Callers must check the k8s "items" shape first — that path carries
 // pagination metadata and a fixed output shape.
 func singleKeyItems(m map[string]any) (string, []map[string]any, bool) {
-	if len(m) != 1 {
+	if nonListMetaKeyCount(m) != 1 {
 		return "", nil, false
 	}
 	for key, raw := range m {
+		if isListMetaEntry(key, raw) {
+			continue
+		}
 		arr, ok := raw.([]any)
 		if !ok {
 			return "", nil, false
@@ -298,6 +317,36 @@ func singleKeyItems(m map[string]any) (string, []map[string]any, bool) {
 		return key, items, true
 	}
 	return "", nil, false
+}
+
+// nonListMetaKeyCount counts m's keys excluding a reserved ListMetaKey entry
+// (see isListMetaEntry). Used to recognize list envelopes regardless of
+// whether truncation metadata rides alongside the items key.
+func nonListMetaKeyCount(m map[string]any) int {
+	n := 0
+	for key, val := range m {
+		if isListMetaEntry(key, val) {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// isListMetaEntry reports whether the key/value pair is the reserved
+// truncation-metadata sibling: the ListMetaKey key holding an object (or an
+// explicit null). Any other value shape under the key is not treated as
+// metadata, so unrelated payloads that happen to use the name keep their
+// pre-reservation behavior.
+func isListMetaEntry(key string, val any) bool {
+	if key != ListMetaKey {
+		return false
+	}
+	if val == nil {
+		return true
+	}
+	_, ok := val.(map[string]any)
+	return ok
 }
 
 // toSliceOfMaps converts an any value to []map[string]any. Values that are

--- a/internal/output/field_select.go
+++ b/internal/output/field_select.go
@@ -105,6 +105,16 @@ func (c *FieldSelectCodec) Encode(dst goio.Writer, value any) error {
 		return c.json.Encode(dst, extractFields(v.Object, c.fields))
 
 	case map[string]any:
+		// A dynamic map is treated as a list envelope only when it carries
+		// the reserved list_meta entry — attaching the reserved key is the
+		// producer's opt-in to the contract. All other maps keep whole-object
+		// selection, so raw passthrough payloads (e.g. gcx api responses that
+		// happen to be items-shaped) are unaffected.
+		if hasListMetaEntry(v) {
+			if out, ok := c.envelopeFieldSelection(v); ok {
+				return c.json.Encode(dst, out)
+			}
+		}
 		return c.json.Encode(dst, extractFields(v, c.fields))
 
 	default:
@@ -125,37 +135,50 @@ func (c *FieldSelectCodec) Encode(dst goio.Writer, value any) error {
 			return c.json.Encode(dst, extracted)
 		}
 
-		// If the value serialized to an object with an "items" array treat it
-		// as a collection (covers the printItems struct used in get.go). Preserve
-		// pagination metadata from the list envelope even when item fields are
-		// selected, so callers can detect and fetch additional pages.
-		if raw, ok := m["items"]; ok {
-			items := toSliceOfMaps(raw)
-			extracted := make([]map[string]any, len(items))
-			for i, item := range items {
-				extracted[i] = extractFields(item, c.fields)
-			}
-			out := listFieldSelectionOutput(extracted, paginationMetadataFromObjectMap(m))
-			attachListMetaEntry(out, m)
-			return c.json.Encode(dst, out)
-		}
-
-		// Single-key list envelope (e.g. {"datasources": [...]}, optionally
-		// with a reserved list_meta sibling): apply field selection per item
-		// and preserve the wrapper key. Truncation metadata is re-attached so
-		// the signal survives field selection.
-		if key, items, ok := singleKeyItems(m); ok {
-			extracted := make([]map[string]any, len(items))
-			for i, item := range items {
-				extracted[i] = extractFields(item, c.fields)
-			}
-			out := map[string]any{key: extracted}
-			attachListMetaEntry(out, m)
+		if out, ok := c.envelopeFieldSelection(m); ok {
 			return c.json.Encode(dst, out)
 		}
 
 		return c.json.Encode(dst, extractFields(m, c.fields))
 	}
+}
+
+// envelopeFieldSelection applies per-item field selection when m is a list
+// envelope, returning the selected output and true. Two envelope shapes are
+// recognized:
+//
+//   - an "items"-keyed map (covers the printItems struct used in get.go and
+//     the k8s list shape) — pagination metadata from the envelope is
+//     preserved so callers can detect and fetch additional pages;
+//   - a single-key list envelope (e.g. {"datasources": [...]}), optionally
+//     with a reserved list_meta sibling.
+//
+// The reserved list_meta truncation-metadata entry is re-attached in both
+// cases so the signal survives field selection. Returns false for any other
+// shape (the caller falls back to whole-object selection).
+func (c *FieldSelectCodec) envelopeFieldSelection(m map[string]any) (map[string]any, bool) {
+	if raw, ok := m["items"]; ok {
+		items := toSliceOfMaps(raw)
+		extracted := make([]map[string]any, len(items))
+		for i, item := range items {
+			extracted[i] = extractFields(item, c.fields)
+		}
+		out := listFieldSelectionOutput(extracted, paginationMetadataFromObjectMap(m))
+		attachListMetaEntry(out, m)
+		return out, true
+	}
+
+	if key, items, ok := singleKeyItems(m); ok {
+		extracted := make([]map[string]any, len(items))
+		for i, item := range items {
+			extracted[i] = extractFields(item, c.fields)
+		}
+		out := map[string]any{key: extracted}
+		attachListMetaEntry(out, m)
+		return out, true
+	}
+
+	return nil, false
 }
 
 func (c *FieldSelectCodec) Decode(src goio.Reader, value any) error {
@@ -347,6 +370,15 @@ func isListMetaEntry(key string, val any) bool {
 	}
 	_, ok := val.(map[string]any)
 	return ok
+}
+
+// hasListMetaEntry reports whether m carries the reserved truncation-metadata
+// sibling (see isListMetaEntry). Producers opt into the list-envelope
+// treatment of dynamic maps by attaching the reserved key; maps without it
+// keep their pre-reservation behavior.
+func hasListMetaEntry(m map[string]any) bool {
+	val, ok := m[ListMetaKey]
+	return ok && isListMetaEntry(ListMetaKey, val)
 }
 
 // toSliceOfMaps converts an any value to []map[string]any. Values that are

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -47,6 +47,7 @@ type Options struct {
 	jsonFieldValidator  func(fields []string) error // optional; invoked before field extraction when --json is used
 	jqQuery             *gojq.Query                 // compiled --jq query; nil when flag not set
 	jsonFieldsHintShown bool
+	listLimit           *int // registered by BindListLimit; Validate enforces >= 0
 }
 
 // SetJSONFieldValidator registers an optional validator invoked before field
@@ -101,6 +102,10 @@ func (opts *Options) Validate() error {
 	codec := opts.codecFor(opts.OutputFormat)
 	if codec == nil {
 		return fmt.Errorf("unknown output format '%s'. Valid formats are: %s", opts.OutputFormat, strings.Join(opts.allowedCodecs(), ", "))
+	}
+
+	if opts.listLimit != nil && *opts.listLimit < 0 {
+		return fmt.Errorf("invalid --limit %d: must be >= 0 (0 means all results are returned)", *opts.listLimit)
 	}
 
 	if err := opts.applyJSONFlag(); err != nil {
@@ -363,6 +368,10 @@ func reflectFields(t reflect.Type) []string {
 // from a marshaled object: the first element of an "items" array or of a
 // single-key list envelope (e.g. {"datasources": [...]}), reflected item
 // fields for an envelope with no rows, or the object itself.
+//
+// The reserved ListMetaKey ("list_meta") truncation-metadata sibling is
+// transparent to discovery: envelopes are recognized with or without it, the
+// sample is always an item, and list_meta.* paths are never listed.
 func sampleFromObject(m map[string]any, value any) map[string]any {
 	// If the object has an "items" array, use the first element.
 	if raw, ok := m["items"]; ok {
@@ -370,14 +379,14 @@ func sampleFromObject(m map[string]any, value any) map[string]any {
 			return items[0]
 		}
 	}
-	// Single-key list envelope: sample the first item so discovery lists
-	// item-level fields.
+	// Single-key list envelope (optionally with a list_meta sibling): sample
+	// the first item so discovery lists item-level fields.
 	if _, items, ok := singleKeyItems(m); ok && len(items) > 0 {
 		return items[0]
 	}
 	// Single-key envelope with no rows (empty or nil slice): reflect on the
 	// wrapper struct's sole slice field so discovery still works.
-	if len(m) == 1 {
+	if nonListMetaKeyCount(m) == 1 {
 		if fields := reflectSingleSliceField(reflect.TypeOf(value)); len(fields) > 0 {
 			return nullFieldMap(fields)
 		}
@@ -400,7 +409,9 @@ func nullFieldMap(fields []string) map[string]any {
 // a struct's sole exported field, which must be a slice of structs. Returns
 // nil unless t (after pointer unwrapping) is a struct with exactly one
 // exported non-json:"-" field of slice kind. Used to discover item fields of
-// an empty single-key list envelope.
+// an empty single-key list envelope. A field carrying the reserved
+// ListMetaKey json tag (truncation metadata) does not count against the
+// single-field shape.
 func reflectSingleSliceField(t reflect.Type) []string {
 	if t == nil {
 		return nil
@@ -416,6 +427,9 @@ func reflectSingleSliceField(t reflect.Type) []string {
 	exported := 0
 	for f := range t.Fields() {
 		if !f.IsExported() || f.Tag.Get("json") == "-" {
+			continue
+		}
+		if name, _, _ := strings.Cut(f.Tag.Get("json"), ","); name == ListMetaKey {
 			continue
 		}
 		exported++

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -298,6 +298,14 @@ func marshalToSampleMap(value any) (map[string]any, error) {
 		}
 		return nil, errors.New("cannot discover fields from empty UnstructuredList")
 	case map[string]any:
+		// A dynamic map carrying the reserved list_meta entry is a list
+		// envelope: sample item fields exactly like the marshalled-struct
+		// path, so list_meta.* paths are never listed. All other maps stay
+		// as-is — raw passthrough payloads (e.g. gcx api responses) keep
+		// discovering their own fields.
+		if hasListMetaEntry(v) {
+			return sampleFromObject(v, value), nil
+		}
 		return v, nil
 	}
 
@@ -391,7 +399,27 @@ func sampleFromObject(m map[string]any, value any) map[string]any {
 			return nullFieldMap(fields)
 		}
 	}
-	return m
+	// Not an envelope shape (or an empty dynamic envelope with no element
+	// type to reflect on): sample the object itself, minus the reserved
+	// truncation-metadata entry — list_meta.* paths are never discoverable.
+	return withoutListMetaEntry(m)
+}
+
+// withoutListMetaEntry returns m without its reserved truncation-metadata
+// entry (see isListMetaEntry). Returns m unchanged when no reserved entry is
+// present.
+func withoutListMetaEntry(m map[string]any) map[string]any {
+	if !hasListMetaEntry(m) {
+		return m
+	}
+	out := make(map[string]any, len(m)-1)
+	for k, v := range m {
+		if isListMetaEntry(k, v) {
+			continue
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // nullFieldMap builds a discovery sample map whose keys are the given field

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -298,13 +298,18 @@ func marshalToSampleMap(value any) (map[string]any, error) {
 		}
 		return nil, errors.New("cannot discover fields from empty UnstructuredList")
 	case map[string]any:
-		// A dynamic map carrying the reserved list_meta entry is a list
+		// A dynamic map carrying the reserved list_meta key is a list
 		// envelope: sample item fields exactly like the marshalled-struct
-		// path, so list_meta.* paths are never listed. All other maps stay
-		// as-is — raw passthrough payloads (e.g. gcx api responses) keep
-		// discovering their own fields.
-		if hasListMetaEntry(v) {
-			return sampleFromObject(v, value), nil
+		// path, so list_meta.* paths are never listed. The map may hold
+		// native Go values (a *ListMeta, typed item slices), so sampling
+		// runs on a JSON-normalized copy, with the reserved shape validated
+		// after normalization. All other maps stay as-is — raw passthrough
+		// payloads (e.g. gcx api responses) keep discovering their own
+		// fields.
+		if _, ok := v[ListMetaKey]; ok {
+			if m, err := toMap(v); err == nil && hasListMetaEntry(m) {
+				return sampleFromObject(m, value), nil
+			}
 		}
 		return v, nil
 	}

--- a/internal/output/listmeta.go
+++ b/internal/output/listmeta.go
@@ -19,6 +19,12 @@ import (
 //   - a single-key list envelope is still recognized as such when the
 //     reserved key rides alongside it.
 //
+// These guarantees cover typed envelope structs and dynamic map[string]any
+// envelopes (whose values may be native Go types — they are JSON-normalized
+// before envelope handling). unstructured.UnstructuredList output does not
+// participate in the contract yet: no producer attaches truncation metadata
+// to unstructured lists (see docs/design/output.md § 15.5).
+//
 // Commands must attach the metadata with exactly this key and `omitempty`:
 //
 //	ListMeta *cmdio.ListMeta `json:"list_meta,omitempty" yaml:"list_meta,omitempty"`

--- a/internal/output/listmeta.go
+++ b/internal/output/listmeta.go
@@ -1,0 +1,223 @@
+package output
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/spf13/pflag"
+)
+
+// ListMetaKey is the reserved envelope key under which list commands attach
+// truncation metadata. The field-selection and discovery paths in this
+// package treat the key specially:
+//
+//   - `--json field1,field2` selection re-attaches the metadata object to the
+//     output, so the truncation signal survives field selection;
+//   - `--json list` / `--json ?` discovery samples the first item and never
+//     lists `list_meta.*` paths;
+//   - a single-key list envelope is still recognized as such when the
+//     reserved key rides alongside it.
+//
+// Commands must attach the metadata with exactly this key and `omitempty`:
+//
+//	ListMeta *cmdio.ListMeta `json:"list_meta,omitempty" yaml:"list_meta,omitempty"`
+const ListMetaKey = "list_meta"
+
+// ListMeta is machine-readable truncation metadata for list envelopes.
+//
+// A nil ListMeta (field absent from the payload) means the output IS the
+// complete result set — presence is the truncation signal, so an agent
+// reading stdout cannot mistake a page for the whole set. Table codecs
+// ignore the field; the paired stderr hint comes from
+// [EmitListTruncationHint].
+type ListMeta struct {
+	// Truncated is always true — a ListMeta is only attached when the output
+	// is a partial page. Serialized explicitly (no omitempty) so agents can
+	// key on it.
+	Truncated bool `json:"truncated" yaml:"truncated"`
+	// Returned is the number of items in this page.
+	Returned int `json:"returned" yaml:"returned"`
+	// Total is the size of the complete result set, present only when the
+	// command actually observed it (fully-fetched source). Absent (nil)
+	// means unknown — never a guess.
+	Total *int `json:"total,omitempty" yaml:"total,omitempty"`
+	// Cap is the safety cap that bounded the fetch, set only when the cap —
+	// not the user's --limit — was the effective bound. When Cap is set,
+	// raising --limit (including --limit 0) cannot retrieve more results;
+	// the result set must be narrowed with filters instead.
+	Cap int `json:"cap,omitempty" yaml:"cap,omitempty"`
+	// Continue is the runnable command that retrieves more results. It is
+	// always derived from the real invocation argv (see [AttachListMeta]) so
+	// the user's filter flags survive — never a hardcoded string. Empty for
+	// cap-bounded pages, where no larger --limit can help.
+	Continue string `json:"continue,omitempty" yaml:"continue,omitempty"`
+}
+
+// TruncateCompleteList applies a client-side display limit to a fully-fetched
+// list (a "cheaply complete" source: the API has no server-side limit, so the
+// command already holds everything). Returns the page and, when items were
+// dropped, a ListMeta with the observed total. limit <= 0 means unlimited:
+// the input is returned unchanged with nil metadata.
+func TruncateCompleteList[T any](items []T, limit int) ([]T, *ListMeta) {
+	if limit <= 0 || len(items) <= limit {
+		return items, nil
+	}
+	total := len(items)
+	return items[:limit], &ListMeta{
+		Truncated: true,
+		Returned:  limit,
+		Total:     &total,
+	}
+}
+
+// TruncatePagedList applies a display limit to items over-fetched by one from
+// a paginated source. Callers request limit+1 from the API and pass the full
+// response: a spare item proves more data exists without draining the source,
+// so Total stays unknown. limit <= 0 means unlimited: the input is returned
+// unchanged with nil metadata (the caller drained the source).
+func TruncatePagedList[T any](items []T, limit int) ([]T, *ListMeta) {
+	if limit <= 0 || len(items) <= limit {
+		return items, nil
+	}
+	return items[:limit], &ListMeta{
+		Truncated: true,
+		Returned:  limit,
+	}
+}
+
+// PagedListMeta builds truncation metadata for a paginated source whose API
+// reports directly whether more pages exist (a continue token / next cursor).
+// serverHasMore is honored even when limit <= 0: a fetch bounded by a
+// client-side safety cap is still a partial page, and reporting it as
+// complete would violate the contract ("absence of list_meta == complete
+// set"). safetyCap is the cap value (0 if the caller has none); Cap is
+// recorded when the cap — not a larger user limit — is the binding ceiling
+// (limit <= 0 or limit >= safetyCap). limit == safetyCap counts: a doubled
+// --limit continuation could never return more than the cap allows, so the
+// cap variant (refine filters, no continuation) is the honest signal there.
+// Returns nil only when the page is genuinely complete. Total stays
+// unknown — the source was not drained.
+func PagedListMeta(returned, limit int, serverHasMore bool, safetyCap int) *ListMeta {
+	if !serverHasMore {
+		return nil
+	}
+	meta := &ListMeta{
+		Truncated: true,
+		Returned:  returned,
+	}
+	if safetyCap > 0 && (limit <= 0 || limit >= safetyCap) {
+		meta.Cap = safetyCap
+	}
+	return meta
+}
+
+// AttachListMeta finalizes truncation metadata for embedding in a list
+// envelope: it derives the runnable continuation command from the invocation
+// argv (typically os.Args), preserving the user's filter flags, and returns
+// the metadata for assignment into the envelope's reserved `list_meta` field.
+// Nil-safe: returns nil for a complete result set.
+func AttachListMeta(meta *ListMeta, argv []string) *ListMeta {
+	if meta == nil {
+		return nil
+	}
+	meta.Continue = listContinueCommand(meta, argv)
+	return meta
+}
+
+// listContinueCommand renders the runnable command that retrieves more
+// results for a truncated page:
+//
+//   - total observed (fully-fetched source): `<argv> --limit 0` — the full
+//     set is genuinely retrievable;
+//   - total unknown (undrained paginated source): `<argv> --limit <2N>` — a
+//     doubled limit is a safe next step that never promises --limit 0
+//     retrieves everything (a safety cap may exist upstream);
+//   - cap-bounded page: no continuation — a larger --limit cannot help.
+//
+// The command is always derived from argv with any prior --limit stripped
+// (see [BuildListLimitCommand]), so filters survive verbatim.
+func listContinueCommand(meta *ListMeta, argv []string) string {
+	if meta == nil || !meta.Truncated || len(argv) == 0 {
+		return ""
+	}
+	switch {
+	case meta.Cap > 0:
+		return ""
+	case meta.Total != nil:
+		return BuildListLimitCommand(argv, 0)
+	case meta.Returned > 0:
+		return BuildListLimitCommand(argv, 2*meta.Returned)
+	default:
+		return ""
+	}
+}
+
+// EmitListTruncationHint writes the standardized truncation hint for a list
+// page to w (stderr). No-op when meta is nil (complete result set). Routes
+// through [EmitHint], so agent mode emits the JSONL class:"hint" form with
+// the continuation in the `command` field. The continuation is read from
+// meta.Continue, populated by [AttachListMeta] — the single derivation point,
+// so the stderr hint and the payload's list_meta.continue can never disagree.
+//
+// TTY shapes:
+//
+//	total known:   "hint: showing first 5 of 219. See all results with: gcx datasources list --limit 0"
+//	total unknown: "hint: showing first 50; more results are available. See more with: gcx irm oncall alert-groups list --limit 100"
+//	cap bounded:   "hint: showing first 1000 (safety cap). Refine filters to narrow the result set"
+func EmitListTruncationHint(w io.Writer, meta *ListMeta) {
+	if meta == nil || !meta.Truncated {
+		return
+	}
+
+	if meta.Cap > 0 {
+		EmitHint(w, fmt.Sprintf("showing first %d (safety cap). Refine filters to narrow the result set", meta.Returned), "")
+		return
+	}
+
+	cont := meta.Continue
+
+	summary := fmt.Sprintf("showing first %d; more results are available", meta.Returned)
+	connective := "See more with"
+	if meta.Total != nil {
+		summary = fmt.Sprintf("showing first %d of %d", meta.Returned, *meta.Total)
+		connective = "See all results with"
+	}
+
+	if cont == "" {
+		// No runnable continuation (empty argv at AttachListMeta time) — emit
+		// the bare summary rather than a dangling connective.
+		EmitHint(w, summary, "")
+		return
+	}
+
+	// Agent mode carries the continuation in the structured `command` field,
+	// so the summary stays bare. On a TTY, EmitHint renders
+	// "hint: <summary>: <command>" — fold the connective into the summary so
+	// the line reads as a sentence instead of a double-colon splice.
+	if agent.IsAgentMode() {
+		EmitHint(w, summary, cont)
+		return
+	}
+	EmitHint(w, summary+". "+connective, cont)
+}
+
+// BindListLimit registers the standard --limit flag for a list command with
+// the uniform contract wording ("0 means all results are returned").
+// Validation (limit >= 0) is enforced by [Options.Validate], which every
+// list command already calls, so no extra per-command wiring is needed.
+//
+// The binder is deliberately minimal: it only registers the flag and hooks
+// validation. Commands still pass the limit to their clients for server-side
+// pushdown where the API supports it, and choose the truncation constructor
+// matching their source shape (see [TruncateCompleteList],
+// [TruncatePagedList], [PagedListMeta]).
+//
+// Sources bounded by a client-side safety cap must NOT use this binder — the
+// "0 means all" promise would be dishonest there. Keep a bespoke flag
+// description that discloses the cap, and report the cap via
+// [PagedListMeta].
+func (opts *Options) BindListLimit(flags *pflag.FlagSet, p *int, subject string, def int) {
+	flags.IntVar(p, "limit", def, fmt.Sprintf("Maximum number of %s to return. 0 means all results are returned", subject))
+	opts.listLimit = p
+}

--- a/internal/output/listmeta_selection_test.go
+++ b/internal/output/listmeta_selection_test.go
@@ -1,0 +1,171 @@
+package output_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// truncatedEnvelope mirrors the shape list commands emit for a truncated
+// page: a single items key plus the reserved list_meta sibling.
+type truncatedEnvelope struct {
+	Datasources []dsRow         `json:"datasources"`
+	ListMeta    *cmdio.ListMeta `json:"list_meta,omitempty"`
+}
+
+type dsRow struct {
+	UID  string `json:"uid"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+func newTruncatedEnvelope() *truncatedEnvelope {
+	total := 219
+	return &truncatedEnvelope{
+		Datasources: []dsRow{{UID: "ds-01", Name: "Datasource 01", Type: "prometheus"}},
+		ListMeta: &cmdio.ListMeta{
+			Truncated: true,
+			Returned:  1,
+			Total:     &total,
+			Continue:  "gcx datasources list --limit 0",
+		},
+	}
+}
+
+func encodeWithJSONFlag(t *testing.T, jsonFlag string, value any) string {
+	t.Helper()
+	opts := &cmdio.Options{}
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.BindFlags(flags)
+	require.NoError(t, flags.Set("json", jsonFlag))
+	require.NoError(t, opts.Validate())
+
+	var buf bytes.Buffer
+	require.NoError(t, opts.Encode(&buf, value))
+	return buf.String()
+}
+
+// TestFieldSelectionOnTruncatedEnvelope reproduces PR988 defect (b): with a
+// list_meta sibling present, `--limit 1 --json uid` must still select from
+// the ITEMS ({"datasources":[{"uid":"ds-01"}]}), not treat the envelope as a
+// single object and return {"uid": null} — and the truncation signal must
+// survive selection.
+func TestFieldSelectionOnTruncatedEnvelope(t *testing.T) {
+	out := encodeWithJSONFlag(t, "uid", newTruncatedEnvelope())
+
+	var result struct {
+		UID         any              `json:"uid"`
+		Datasources []map[string]any `json:"datasources"`
+		ListMeta    *cmdio.ListMeta  `json:"list_meta"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+
+	assert.Nil(t, result.UID, "envelope must not be treated as a single object")
+	require.Len(t, result.Datasources, 1)
+	assert.Equal(t, "ds-01", result.Datasources[0]["uid"], "selection must run per item")
+
+	require.NotNil(t, result.ListMeta, "list_meta must be re-attached after field selection")
+	assert.True(t, result.ListMeta.Truncated)
+	assert.Equal(t, 1, result.ListMeta.Returned)
+	require.NotNil(t, result.ListMeta.Total)
+	assert.Equal(t, 219, *result.ListMeta.Total)
+}
+
+// TestFieldSelectionOnCompleteEnvelope guards the non-truncated case: no
+// list_meta in, none out — absence remains the completeness signal.
+func TestFieldSelectionOnCompleteEnvelope(t *testing.T) {
+	env := &truncatedEnvelope{Datasources: []dsRow{{UID: "ds-01", Name: "n", Type: "prometheus"}}}
+	out := encodeWithJSONFlag(t, "uid", env)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.NotContains(t, result, "list_meta")
+	assert.Contains(t, result, "datasources")
+}
+
+// TestFieldSelectionOnTruncatedItemsEnvelope covers the k8s-style
+// {"items": [...], "list_meta": {...}} shape used by e.g. `irm oncall
+// alert-groups list`: item selection keeps the truncation metadata.
+func TestFieldSelectionOnTruncatedItemsEnvelope(t *testing.T) {
+	type itemsEnvelope struct {
+		Items    []dsRow         `json:"items"`
+		ListMeta *cmdio.ListMeta `json:"list_meta,omitempty"`
+	}
+	env := &itemsEnvelope{
+		Items:    []dsRow{{UID: "AG1", Name: "g", Type: "t"}},
+		ListMeta: &cmdio.ListMeta{Truncated: true, Returned: 1, Continue: "gcx irm oncall alert-groups list --limit 2"},
+	}
+
+	out := encodeWithJSONFlag(t, "uid", env)
+
+	var result struct {
+		Items    []map[string]any `json:"items"`
+		ListMeta *cmdio.ListMeta  `json:"list_meta"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.Len(t, result.Items, 1)
+	assert.Equal(t, "AG1", result.Items[0]["uid"])
+	require.NotNil(t, result.ListMeta, "list_meta must survive selection on items envelopes")
+	assert.True(t, result.ListMeta.Truncated)
+}
+
+// TestDiscoveryOnTruncatedEnvelope reproduces PR988 defect (c): `--json list`
+// on a truncated envelope must discover ITEM fields (uid, name, type), not
+// the envelope keys or list_meta.* paths.
+func TestDiscoveryOnTruncatedEnvelope(t *testing.T) {
+	out := encodeWithJSONFlag(t, "list", newTruncatedEnvelope())
+
+	fields := strings.Fields(out)
+	assert.Contains(t, fields, "uid")
+	assert.Contains(t, fields, "name")
+	assert.Contains(t, fields, "type")
+	assert.NotContains(t, fields, "datasources", "wrapper key must not be listed")
+	for _, f := range fields {
+		assert.False(t, strings.HasPrefix(f, "list_meta"),
+			"reserved truncation metadata must be excluded from discovery, got %q", f)
+	}
+}
+
+// TestDiscoveryOnEmptyEnvelopeWithListMetaField guards the reflection
+// fallback: an EMPTY envelope whose struct carries the reserved ListMeta
+// field (nil, omitted from JSON) must still discover item fields via the
+// sole slice field — the metadata field must not break the single-slice
+// shape detection.
+func TestDiscoveryOnEmptyEnvelopeWithListMetaField(t *testing.T) {
+	out := encodeWithJSONFlag(t, "list", &truncatedEnvelope{Datasources: []dsRow{}})
+
+	fields := strings.Fields(out)
+	assert.Contains(t, fields, "uid")
+	assert.Contains(t, fields, "name")
+	assert.NotContains(t, fields, "datasources")
+	assert.NotContains(t, fields, "list_meta")
+}
+
+// TestSingleKeyEnvelopeWithUnrelatedSecondKey pins the scoping of the fix:
+// only the reserved list_meta key is tolerated. Envelopes with any other
+// extra key keep their pre-existing (whole-object selection) behavior — that
+// generalization is tracked separately for human review.
+func TestSingleKeyEnvelopeWithUnrelatedSecondKey(t *testing.T) {
+	codec := cmdio.NewFieldSelectCodec([]string{"uid"})
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, struct {
+		Datasources []dsRow        `json:"datasources"`
+		Summary     map[string]any `json:"summary"`
+	}{
+		Datasources: []dsRow{{UID: "ds-01"}},
+		Summary:     map[string]any{"count": 1},
+	}))
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+	// Two non-reserved keys: not a single-key envelope, so selection applies
+	// to the whole object (uid resolves to null) — unchanged from HEAD.
+	assert.Contains(t, result, "uid")
+	assert.Nil(t, result["uid"])
+}

--- a/internal/output/listmeta_selection_test.go
+++ b/internal/output/listmeta_selection_test.go
@@ -317,3 +317,101 @@ func TestDiscoveryOnDynamicMapNonReservedListMeta(t *testing.T) {
 	fields := strings.Fields(out)
 	assert.Contains(t, fields, "list_meta", "non-reserved shape keeps pre-reservation discovery")
 }
+
+// nativeEnvelope builds a dynamic envelope the way a Go producer naturally
+// would — a *ListMeta value and a native []map[string]any items slice, NOT
+// the JSON-decoded representation ([]any + map[string]any) that dynamicEnvelope
+// uses. Envelope handling must JSON-normalize these before selection.
+func nativeEnvelope(itemsKey string) map[string]any {
+	return map[string]any{
+		itemsKey: []map[string]any{
+			{"uid": "ds-01", "name": "Datasource 01", "type": "prometheus"},
+		},
+		"list_meta": &cmdio.ListMeta{Truncated: true, Returned: 1},
+	}
+}
+
+// TestFieldSelectionOnNativeMapEnvelope: native Go values (a *ListMeta, a
+// []map[string]any slice) must get the same envelope treatment as the
+// JSON-decoded representation — the key-presence gate fires before
+// normalization, so a native metadata value opts in too.
+func TestFieldSelectionOnNativeMapEnvelope(t *testing.T) {
+	for _, key := range []string{"items", "datasources"} {
+		out := encodeWithJSONFlag(t, "uid", nativeEnvelope(key))
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &result))
+		assert.NotContains(t, result, "uid", "envelope must not be treated as a single object")
+
+		items, ok := result[key].([]any)
+		require.True(t, ok, "wrapper key %q must survive selection, got %v", key, result)
+		require.Len(t, items, 1, "the native item row must not be dropped")
+		row, ok := items[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "ds-01", row["uid"])
+
+		meta, ok := result["list_meta"].(map[string]any)
+		require.True(t, ok, "native *ListMeta must be re-attached as the normalized object")
+		assert.Equal(t, true, meta["truncated"])
+	}
+}
+
+// TestFieldSelectionOnHybridMapEnvelope pins the row-dropping regression: a
+// JSON-decoded list_meta object alongside a NATIVE []map[string]any items
+// slice passed the reserved-key gate but toSliceOfMaps (which only accepts
+// []any) returned no rows — selection emitted {"items": [], "list_meta": ...},
+// silently discarding data. Normalizing the whole map fixes the slice too.
+func TestFieldSelectionOnHybridMapEnvelope(t *testing.T) {
+	env := map[string]any{
+		"items":     []map[string]any{{"uid": "ds-01"}},
+		"list_meta": map[string]any{"truncated": true, "returned": float64(1)},
+	}
+	out := encodeWithJSONFlag(t, "uid", env)
+
+	var result struct {
+		Items    []map[string]any `json:"items"`
+		ListMeta *cmdio.ListMeta  `json:"list_meta"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.Len(t, result.Items, 1, "native items slice must not be silently dropped")
+	assert.Equal(t, "ds-01", result.Items[0]["uid"])
+	require.NotNil(t, result.ListMeta)
+	assert.True(t, result.ListMeta.Truncated)
+}
+
+// TestFieldSelectionOnNativeTypedItemsEnvelope: a typed item slice (what a
+// command holding []Row naturally has in hand) is normalized like any other
+// native value.
+func TestFieldSelectionOnNativeTypedItemsEnvelope(t *testing.T) {
+	env := map[string]any{
+		"datasources": []dsRow{{UID: "ds-01", Name: "n", Type: "prometheus"}},
+		"list_meta":   &cmdio.ListMeta{Truncated: true, Returned: 1},
+	}
+	out := encodeWithJSONFlag(t, "uid", env)
+
+	var result struct {
+		Datasources []map[string]any `json:"datasources"`
+		ListMeta    *cmdio.ListMeta  `json:"list_meta"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.Len(t, result.Datasources, 1)
+	assert.Equal(t, "ds-01", result.Datasources[0]["uid"])
+	require.NotNil(t, result.ListMeta)
+}
+
+// TestDiscoveryOnNativeMapEnvelope: discovery must normalize native values
+// the same way — item fields listed, never the wrapper key or list_meta.*.
+func TestDiscoveryOnNativeMapEnvelope(t *testing.T) {
+	for _, key := range []string{"items", "datasources"} {
+		out := encodeWithJSONFlag(t, "list", nativeEnvelope(key))
+
+		fields := strings.Fields(out)
+		assert.Contains(t, fields, "uid")
+		assert.Contains(t, fields, "name")
+		assert.NotContains(t, fields, key, "wrapper key %q must not be listed", key)
+		for _, f := range fields {
+			assert.False(t, strings.HasPrefix(f, "list_meta"),
+				"reserved truncation metadata must be excluded from discovery, got %q", f)
+		}
+	}
+}

--- a/internal/output/listmeta_selection_test.go
+++ b/internal/output/listmeta_selection_test.go
@@ -169,3 +169,151 @@ func TestSingleKeyEnvelopeWithUnrelatedSecondKey(t *testing.T) {
 	assert.Contains(t, result, "uid")
 	assert.Nil(t, result["uid"])
 }
+
+// dynamicEnvelope builds the map-shaped equivalent of a truncated list
+// envelope — what a command would produce if it assembled its output as
+// map[string]any instead of a typed struct. The reserved list_meta entry is
+// the producer's opt-in to the envelope treatment on this fast path.
+func dynamicEnvelope(itemsKey string) map[string]any {
+	return map[string]any{
+		itemsKey: []any{
+			map[string]any{"uid": "ds-01", "name": "Datasource 01", "type": "prometheus"},
+		},
+		"list_meta": map[string]any{
+			"truncated": true,
+			"returned":  float64(1),
+		},
+	}
+}
+
+// TestFieldSelectionOnDynamicMapItemsEnvelope covers the direct map[string]any
+// fast path in the codec's type switch, which bypasses the marshal step: an
+// items-keyed map with a reserved list_meta entry must select per item and
+// re-attach the metadata, exactly like the typed-struct path.
+func TestFieldSelectionOnDynamicMapItemsEnvelope(t *testing.T) {
+	out := encodeWithJSONFlag(t, "uid", dynamicEnvelope("items"))
+
+	var result struct {
+		UID      any              `json:"uid"`
+		Items    []map[string]any `json:"items"`
+		ListMeta *cmdio.ListMeta  `json:"list_meta"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Nil(t, result.UID, "envelope must not be treated as a single object")
+	require.Len(t, result.Items, 1)
+	assert.Equal(t, "ds-01", result.Items[0]["uid"])
+	require.NotNil(t, result.ListMeta, "list_meta must survive selection on dynamic map envelopes")
+	assert.True(t, result.ListMeta.Truncated)
+}
+
+// TestFieldSelectionOnDynamicMapSingleKeyEnvelope is the provider-envelope
+// variant of the direct-map fast path.
+func TestFieldSelectionOnDynamicMapSingleKeyEnvelope(t *testing.T) {
+	out := encodeWithJSONFlag(t, "uid", dynamicEnvelope("datasources"))
+
+	var result struct {
+		UID         any              `json:"uid"`
+		Datasources []map[string]any `json:"datasources"`
+		ListMeta    *cmdio.ListMeta  `json:"list_meta"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Nil(t, result.UID)
+	require.Len(t, result.Datasources, 1)
+	assert.Equal(t, "ds-01", result.Datasources[0]["uid"])
+	require.NotNil(t, result.ListMeta)
+	assert.True(t, result.ListMeta.Truncated)
+}
+
+// TestFieldSelectionOnDynamicMapWithoutListMeta pins the pre-reservation
+// behavior of the direct-map fast path: WITHOUT the reserved entry, even an
+// items-shaped map keeps whole-object selection. Raw passthrough payloads
+// (gcx api) must not change behavior because a response happens to be
+// items-shaped.
+func TestFieldSelectionOnDynamicMapWithoutListMeta(t *testing.T) {
+	env := map[string]any{
+		"items": []any{map[string]any{"uid": "a"}},
+	}
+	out := encodeWithJSONFlag(t, "uid", env)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Contains(t, result, "uid")
+	assert.Nil(t, result["uid"], "whole-object selection is the pinned behavior for maps without list_meta")
+}
+
+// TestFieldSelectionOnDynamicMapNonReservedListMeta: a list_meta key whose
+// value is not an object (or null) is genuine payload data, not the reserved
+// entry — the map keeps whole-object selection (consistent with
+// isListMetaEntry's scoping).
+func TestFieldSelectionOnDynamicMapNonReservedListMeta(t *testing.T) {
+	env := map[string]any{
+		"items":     []any{map[string]any{"uid": "a"}},
+		"list_meta": "not-an-object",
+	}
+	out := encodeWithJSONFlag(t, "uid", env)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Contains(t, result, "uid")
+	assert.Nil(t, result["uid"])
+}
+
+// TestDiscoveryOnDynamicMapEnvelope covers the direct-map fast path in
+// discovery: an envelope map with the reserved entry must discover item
+// fields only — never the wrapper key or list_meta.* paths.
+func TestDiscoveryOnDynamicMapEnvelope(t *testing.T) {
+	for _, key := range []string{"items", "datasources"} {
+		out := encodeWithJSONFlag(t, "list", dynamicEnvelope(key))
+
+		fields := strings.Fields(out)
+		assert.Contains(t, fields, "uid")
+		assert.Contains(t, fields, "name")
+		assert.NotContains(t, fields, key, "wrapper key %q must not be listed", key)
+		for _, f := range fields {
+			assert.False(t, strings.HasPrefix(f, "list_meta"),
+				"reserved truncation metadata must be excluded from discovery, got %q", f)
+		}
+	}
+}
+
+// TestDiscoveryOnDynamicMapWithoutListMeta pins the pre-reservation discovery
+// behavior for plain maps: their own fields are listed as-is.
+func TestDiscoveryOnDynamicMapWithoutListMeta(t *testing.T) {
+	out := encodeWithJSONFlag(t, "list", map[string]any{"foo": "bar", "count": float64(2)})
+
+	fields := strings.Fields(out)
+	assert.Contains(t, fields, "foo")
+	assert.Contains(t, fields, "count")
+}
+
+// TestDiscoveryOnEmptyDynamicMapEnvelope pins the empty-envelope decision for
+// dynamic maps: unlike a typed struct there is no element type to reflect on,
+// so discovery degrades to the envelope's own keys — but the reserved
+// list_meta entry must never surface as discoverable fields.
+func TestDiscoveryOnEmptyDynamicMapEnvelope(t *testing.T) {
+	env := map[string]any{
+		"datasources": []any{},
+		"list_meta":   map[string]any{"truncated": true, "returned": float64(0)},
+	}
+	out := encodeWithJSONFlag(t, "list", env)
+
+	fields := strings.Fields(out)
+	assert.Contains(t, fields, "datasources", "reduced result: the envelope key is all that is known")
+	for _, f := range fields {
+		assert.False(t, strings.HasPrefix(f, "list_meta"),
+			"reserved truncation metadata must be excluded from discovery, got %q", f)
+	}
+}
+
+// TestDiscoveryOnDynamicMapNonReservedListMeta: a non-object list_meta value
+// is genuine data and stays discoverable — the reservation only claims the
+// object-valued shape.
+func TestDiscoveryOnDynamicMapNonReservedListMeta(t *testing.T) {
+	out := encodeWithJSONFlag(t, "list", map[string]any{
+		"items":     []any{map[string]any{"uid": "a"}},
+		"list_meta": "not-an-object",
+	})
+
+	fields := strings.Fields(out)
+	assert.Contains(t, fields, "list_meta", "non-reserved shape keeps pre-reservation discovery")
+}

--- a/internal/output/listmeta_test.go
+++ b/internal/output/listmeta_test.go
@@ -1,0 +1,476 @@
+package output_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/testutils"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func assertListMeta(t *testing.T, got, want *cmdio.ListMeta) {
+	t.Helper()
+	if want == nil {
+		assert.Nil(t, got)
+		return
+	}
+	require.NotNil(t, got)
+	assert.Equal(t, want.Truncated, got.Truncated, "Truncated")
+	assert.Equal(t, want.Returned, got.Returned, "Returned")
+	assert.Equal(t, want.Cap, got.Cap, "Cap")
+	assert.Equal(t, want.Continue, got.Continue, "Continue")
+	if want.Total == nil {
+		assert.Nil(t, got.Total, "Total must be absent (never guessed)")
+	} else {
+		require.NotNil(t, got.Total)
+		assert.Equal(t, *want.Total, *got.Total, "Total")
+	}
+}
+
+func TestTruncateCompleteList(t *testing.T) {
+	items := []string{"a", "b", "c", "d"}
+
+	tests := []struct {
+		name      string
+		limit     int
+		wantItems []string
+		wantMeta  *cmdio.ListMeta
+	}{
+		{
+			name:      "limit zero returns all with nil meta",
+			limit:     0,
+			wantItems: items,
+		},
+		{
+			name:      "negative limit returns all with nil meta",
+			limit:     -1,
+			wantItems: items,
+		},
+		{
+			name:      "under limit returns all with nil meta",
+			limit:     10,
+			wantItems: items,
+		},
+		{
+			name:      "exactly at limit returns all with nil meta",
+			limit:     4,
+			wantItems: items,
+		},
+		{
+			name:      "over limit truncates with observed total",
+			limit:     2,
+			wantItems: []string{"a", "b"},
+			wantMeta:  &cmdio.ListMeta{Truncated: true, Returned: 2, Total: new(4)},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, meta := cmdio.TruncateCompleteList(items, tc.limit)
+			assert.Equal(t, tc.wantItems, got)
+			assertListMeta(t, meta, tc.wantMeta)
+		})
+	}
+}
+
+func TestTruncatePagedList(t *testing.T) {
+	// Over-fetch-by-one: the caller requested limit+1 items from the API.
+	tests := []struct {
+		name      string
+		items     []string
+		limit     int
+		wantItems []string
+		wantMeta  *cmdio.ListMeta
+	}{
+		{
+			name:      "limit zero means drained source, nil meta",
+			items:     []string{"a", "b", "c"},
+			limit:     0,
+			wantItems: []string{"a", "b", "c"},
+		},
+		{
+			name:      "short page proves source drained",
+			items:     []string{"a", "b"},
+			limit:     3,
+			wantItems: []string{"a", "b"},
+		},
+		{
+			name:      "exactly limit items means no spare row, no truncation",
+			items:     []string{"a", "b", "c"},
+			limit:     3,
+			wantItems: []string{"a", "b", "c"},
+		},
+		{
+			name:      "spare row proves more exist, total stays unknown",
+			items:     []string{"a", "b", "c", "d"},
+			limit:     3,
+			wantItems: []string{"a", "b", "c"},
+			wantMeta:  &cmdio.ListMeta{Truncated: true, Returned: 3},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, meta := cmdio.TruncatePagedList(tc.items, tc.limit)
+			assert.Equal(t, tc.wantItems, got)
+			assertListMeta(t, meta, tc.wantMeta)
+		})
+	}
+}
+
+func TestPagedListMeta(t *testing.T) {
+	tests := []struct {
+		name          string
+		returned      int
+		limit         int
+		serverHasMore bool
+		safetyCap     int
+		want          *cmdio.ListMeta
+	}{
+		{
+			name:          "server reports no more pages, nil meta",
+			returned:      50,
+			limit:         50,
+			serverHasMore: false,
+			safetyCap:     1000,
+			want:          nil,
+		},
+		{
+			name:          "limit zero and no more pages is genuinely complete",
+			returned:      120,
+			limit:         0,
+			serverHasMore: false,
+			safetyCap:     1000,
+			want:          nil,
+		},
+		{
+			name:          "user limit bound the page, no cap recorded",
+			returned:      50,
+			limit:         50,
+			serverHasMore: true,
+			safetyCap:     1000,
+			want:          &cmdio.ListMeta{Truncated: true, Returned: 50},
+		},
+		{
+			// PR988 regression: `--limit 0` capped by the safety cap must
+			// report a truncated page — a hard-capped fetch is NOT the
+			// complete set.
+			name:          "limit zero capped by safety cap is truncated with cap",
+			returned:      1000,
+			limit:         0,
+			serverHasMore: true,
+			safetyCap:     1000,
+			want:          &cmdio.ListMeta{Truncated: true, Returned: 1000, Cap: 1000},
+		},
+		{
+			name:          "limit above the cap means the cap was the bound",
+			returned:      1000,
+			limit:         5000,
+			serverHasMore: true,
+			safetyCap:     1000,
+			want:          &cmdio.ListMeta{Truncated: true, Returned: 1000, Cap: 1000},
+		},
+		{
+			// Boundary: at limit == cap a doubled --limit continuation could
+			// never return more than the cap allows — the page must use the
+			// cap variant (Cap set, no continuation), not advertise a dead
+			// continuation.
+			name:          "limit equal to the cap means the cap is the ceiling",
+			returned:      1000,
+			limit:         1000,
+			serverHasMore: true,
+			safetyCap:     1000,
+			want:          &cmdio.ListMeta{Truncated: true, Returned: 1000, Cap: 1000},
+		},
+		{
+			name:          "no safety cap configured, limit zero with more pages",
+			returned:      200,
+			limit:         0,
+			serverHasMore: true,
+			safetyCap:     0,
+			want:          &cmdio.ListMeta{Truncated: true, Returned: 200},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cmdio.PagedListMeta(tc.returned, tc.limit, tc.serverHasMore, tc.safetyCap)
+			assertListMeta(t, got, tc.want)
+		})
+	}
+}
+
+func TestAttachListMeta(t *testing.T) {
+	argv := []string{"gcx", "datasources", "list", "--type", "prometheus", "--limit", "5"}
+
+	tests := []struct {
+		name         string
+		meta         *cmdio.ListMeta
+		argv         []string
+		wantContinue string
+	}{
+		{
+			name: "nil meta stays nil",
+			meta: nil,
+			argv: argv,
+		},
+		{
+			name:         "known total derives --limit 0 preserving filters",
+			meta:         &cmdio.ListMeta{Truncated: true, Returned: 5, Total: new(219)},
+			argv:         argv,
+			wantContinue: "gcx datasources list --type prometheus --limit 0",
+		},
+		{
+			name:         "unknown total derives doubled limit preserving filters",
+			meta:         &cmdio.ListMeta{Truncated: true, Returned: 5},
+			argv:         argv,
+			wantContinue: "gcx datasources list --type prometheus --limit 10",
+		},
+		{
+			name:         "limit=value spelling is stripped too",
+			meta:         &cmdio.ListMeta{Truncated: true, Returned: 3, Total: new(9)},
+			argv:         []string{"gcx", "alert", "rules", "list", "--limit=3", "--folder", "abc"},
+			wantContinue: "gcx alert rules list --folder abc --limit 0",
+		},
+		{
+			name:         "cap-bounded page has no runnable continuation",
+			meta:         &cmdio.ListMeta{Truncated: true, Returned: 1000, Cap: 1000},
+			argv:         argv,
+			wantContinue: "",
+		},
+		{
+			name:         "empty argv yields no continuation",
+			meta:         &cmdio.ListMeta{Truncated: true, Returned: 5, Total: new(219)},
+			argv:         nil,
+			wantContinue: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cmdio.AttachListMeta(tc.meta, tc.argv)
+			if tc.meta == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantContinue, got.Continue)
+		})
+	}
+}
+
+func TestEmitListTruncationHint(t *testing.T) {
+	// The continuation is read from meta.Continue, which [AttachListMeta]
+	// populates from the invocation argv (covered by TestAttachListMeta);
+	// argv column here shows the invocation each fixture corresponds to.
+	tests := []struct {
+		name      string
+		meta      *cmdio.ListMeta
+		argv      []string
+		agentMode bool
+		want      string
+	}{
+		{
+			name: "nil meta emits nothing",
+			meta: nil,
+			argv: []string{"gcx", "datasources", "list"},
+			want: "",
+		},
+		{
+			// Maintainer-approved TTY shape (PR988 review): a sentence, not a
+			// "<summary>: <command>" splice.
+			name: "total known TTY",
+			meta: &cmdio.ListMeta{Truncated: true, Returned: 5, Total: new(219)},
+			argv: []string{"gcx", "datasources", "list", "--limit", "5"},
+			want: "hint: showing first 5 of 219. See all results with: gcx datasources list --limit 0\n",
+		},
+		{
+			name: "total known TTY preserves filter flags in continuation",
+			meta: &cmdio.ListMeta{Truncated: true, Returned: 1, Total: new(219)},
+			argv: []string{"gcx", "datasources", "list", "--type", "prometheus", "--limit", "1"},
+			want: "hint: showing first 1 of 219. See all results with: gcx datasources list --type prometheus --limit 0\n",
+		},
+		{
+			// Unknown total: never promise --limit 0 retrieves everything —
+			// suggest a doubled limit instead.
+			name: "total unknown TTY suggests doubled limit",
+			meta: &cmdio.ListMeta{Truncated: true, Returned: 50},
+			argv: []string{"gcx", "irm", "oncall", "alert-groups", "list", "--limit", "50"},
+			want: "hint: showing first 50; more results are available. See more with: gcx irm oncall alert-groups list --limit 100\n",
+		},
+		{
+			// Cap variant: no --limit suggestion at all — a bigger limit
+			// cannot beat the safety cap.
+			name: "cap bounded TTY suggests refining filters",
+			meta: &cmdio.ListMeta{Truncated: true, Returned: 1000, Cap: 1000},
+			argv: []string{"gcx", "irm", "oncall", "alert-groups", "list", "--limit", "0"},
+			want: "hint: showing first 1000 (safety cap). Refine filters to narrow the result set\n",
+		},
+		{
+			name:      "agent mode emits JSONL hint with bare summary",
+			meta:      &cmdio.ListMeta{Truncated: true, Returned: 5, Total: new(219)},
+			argv:      []string{"gcx", "datasources", "list", "--limit", "5"},
+			agentMode: true,
+			want:      `{"class":"hint","summary":"showing first 5 of 219","command":"gcx datasources list --limit 0"}` + "\n",
+		},
+		{
+			name:      "agent mode cap variant",
+			meta:      &cmdio.ListMeta{Truncated: true, Returned: 1000, Cap: 1000},
+			argv:      []string{"gcx", "irm", "oncall", "alert-groups", "list"},
+			agentMode: true,
+			want:      `{"class":"hint","summary":"showing first 1000 (safety cap). Refine filters to narrow the result set"}` + "\n",
+		},
+		{
+			name: "empty continuation falls back to bare summary",
+			meta: &cmdio.ListMeta{Truncated: true, Returned: 5, Total: new(219)},
+			argv: nil,
+			want: "hint: showing first 5 of 219\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testutils.SetAgentMode(t, tc.agentMode)
+
+			var buf bytes.Buffer
+			cmdio.EmitListTruncationHint(&buf, cmdio.AttachListMeta(tc.meta, tc.argv))
+			assert.Equal(t, tc.want, buf.String())
+		})
+	}
+}
+
+// TestEmitListTruncationHint_LimitEqualsCap pipes the full helper chain —
+// PagedListMeta → AttachListMeta → EmitListTruncationHint — for the
+// limit == safetyCap boundary: the page must emit the refine-filters cap
+// variant, never a doubled --limit continuation that cannot return more.
+func TestEmitListTruncationHint_LimitEqualsCap(t *testing.T) {
+	testutils.SetAgentMode(t, false)
+
+	meta := cmdio.AttachListMeta(
+		cmdio.PagedListMeta(1000, 1000, true, 1000),
+		[]string{"gcx", "irm", "oncall", "alert-groups", "list", "--limit", "1000"})
+	require.NotNil(t, meta)
+	assert.Equal(t, 1000, meta.Cap)
+	assert.Empty(t, meta.Continue, "cap-bounded page must not carry a continuation")
+
+	var buf bytes.Buffer
+	cmdio.EmitListTruncationHint(&buf, meta)
+	assert.Equal(t, "hint: showing first 1000 (safety cap). Refine filters to narrow the result set\n", buf.String())
+	assert.NotContains(t, buf.String(), "--limit 2000", "doubled-limit continuation would be dead at the cap")
+}
+
+// TestListMetaJSONShape locks the wire shape agents key on: truncated is
+// always explicit; total and cap are omitted (never guessed) when unknown.
+func TestListMetaJSONShape(t *testing.T) {
+	tests := []struct {
+		name string
+		meta *cmdio.ListMeta
+		want string
+	}{
+		{
+			name: "total known",
+			meta: &cmdio.ListMeta{Truncated: true, Returned: 2, Total: new(4), Continue: "gcx datasources list --limit 0"},
+			want: `{"truncated":true,"returned":2,"total":4,"continue":"gcx datasources list --limit 0"}`,
+		},
+		{
+			name: "total unknown is omitted",
+			meta: &cmdio.ListMeta{Truncated: true, Returned: 50, Continue: "gcx things list --limit 100"},
+			want: `{"truncated":true,"returned":50,"continue":"gcx things list --limit 100"}`,
+		},
+		{
+			name: "cap variant carries cap and no continue",
+			meta: &cmdio.ListMeta{Truncated: true, Returned: 1000, Cap: 1000},
+			want: `{"truncated":true,"returned":1000,"cap":1000}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.meta)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, string(b))
+		})
+	}
+}
+
+func TestBuildListLimitCommand(t *testing.T) {
+	tests := []struct {
+		name  string
+		argv  []string
+		limit int
+		want  string
+	}{
+		{
+			name:  "strips separate --limit value",
+			argv:  []string{"gcx", "datasources", "list", "--limit", "5", "--type", "prometheus"},
+			limit: 0,
+			want:  "gcx datasources list --type prometheus --limit 0",
+		},
+		{
+			name:  "strips --limit=value spelling",
+			argv:  []string{"gcx", "datasources", "list", "--limit=5"},
+			limit: 10,
+			want:  "gcx datasources list --limit 10",
+		},
+		{
+			name:  "appends when no prior limit",
+			argv:  []string{"gcx", "alert", "rules", "list"},
+			limit: 0,
+			want:  "gcx alert rules list --limit 0",
+		},
+		{
+			name:  "quotes unsafe args",
+			argv:  []string{"gcx", "datasources", "list", "--name", "my datasource"},
+			limit: 0,
+			want:  "gcx datasources list --name 'my datasource' --limit 0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, cmdio.BuildListLimitCommand(tc.argv, tc.limit))
+		})
+	}
+}
+
+func TestBindListLimitValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+		want    int
+	}{
+		{name: "default applies", args: nil, want: 50},
+		{name: "zero means all", args: []string{"--limit", "0"}, want: 0},
+		{name: "positive value", args: []string{"--limit", "7"}, want: 7},
+		{name: "negative rejected", args: []string{"--limit", "-1"}, wantErr: "invalid --limit -1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &cmdio.Options{}
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			opts.BindFlags(flags)
+			var limit int
+			opts.BindListLimit(flags, &limit, "widgets", 50)
+
+			flag := flags.Lookup("limit")
+			require.NotNil(t, flag)
+			assert.Equal(t, "Maximum number of widgets to return. 0 means all results are returned", flag.Usage)
+
+			require.NoError(t, flags.Parse(tc.args))
+			err := opts.Validate()
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, limit)
+		})
+	}
+}

--- a/internal/output/pagination.go
+++ b/internal/output/pagination.go
@@ -18,6 +18,17 @@ func BuildPaginationCommand(argv []string, limit int64, continueToken string) st
 	return shellJoin(args)
 }
 
+// BuildListLimitCommand returns a runnable list command derived from the
+// original argv: any existing --limit flag is stripped and the supplied limit
+// is appended. All other flags (filters, output format, config) survive
+// verbatim, so the suggestion stays faithful to the user's query — never a
+// hardcoded command string.
+func BuildListLimitCommand(argv []string, limit int) string {
+	args := stripFlag(argv, "--limit")
+	args = append(args, "--limit", strconv.Itoa(limit))
+	return shellJoin(args)
+}
+
 func stripFlag(argv []string, flag string) []string {
 	out := make([]string, 0, len(argv))
 	for i := 0; i < len(argv); i++ {

--- a/internal/providers/irm/interfaces.go
+++ b/internal/providers/irm/interfaces.go
@@ -14,10 +14,12 @@ import (
 // and alertGroupListFilters are package-private to irm.
 type RichAlertGroupReader interface {
 	// ListAlertGroupsRaw fetches paginated alert groups from the internal API
-	// and returns the per-item raw JSON plus a serverHasMore flag indicating
-	// whether the server reported additional pages when we stopped early due
-	// to the caller-supplied cap.
-	ListAlertGroupsRaw(ctx context.Context, filters alertGroupListFilters, limit int) ([]json.RawMessage, bool, error)
+	// and returns the per-item raw JSON plus page info describing how the
+	// fetch ended: whether items beyond the returned page exist (the fetch
+	// stopped at the effective bound with a next cursor, or in-hand items
+	// exceeded the bound) and, when the source was fully drained, the
+	// observed total.
+	ListAlertGroupsRaw(ctx context.Context, filters alertGroupListFilters, limit int) ([]json.RawMessage, alertGroupPageInfo, error)
 
 	// GetAlertGroupRich fetches a single alert group by ID and returns the
 	// rich shape. Identity fields (PK, StartedAt) are on rich.Metadata;
@@ -40,7 +42,7 @@ type RichAlertGroupReader interface {
 
 // ListAlertGroupsRaw is the exported method wrapper that delegates to the
 // package-level listAlertGroupsRaw free function, satisfying RichAlertGroupReader.
-func (c *OnCallClient) ListAlertGroupsRaw(ctx context.Context, filters alertGroupListFilters, limit int) ([]json.RawMessage, bool, error) {
+func (c *OnCallClient) ListAlertGroupsRaw(ctx context.Context, filters alertGroupListFilters, limit int) ([]json.RawMessage, alertGroupPageInfo, error) {
 	return listAlertGroupsRaw(ctx, c, filters, limit)
 }
 

--- a/internal/providers/irm/oncall_alertgroup_list_test.go
+++ b/internal/providers/irm/oncall_alertgroup_list_test.go
@@ -1,0 +1,238 @@
+//nolint:testpackage // white-box tests require access to unexported IRM types and helpers
+package irm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/testutils"
+)
+
+// fakeRichListAPI drives the rich alert-groups list path (internal API). It
+// records the wire limit so tests can prove server-side pushdown.
+type fakeRichListAPI struct {
+	OnCallAPI
+
+	items    []json.RawMessage
+	page     alertGroupPageInfo
+	gotLimit int
+}
+
+func (f *fakeRichListAPI) ListAlertGroupsRaw(_ context.Context, _ alertGroupListFilters, limit int) ([]json.RawMessage, alertGroupPageInfo, error) {
+	f.gotLimit = limit
+	return f.items, f.page, nil
+}
+
+func (f *fakeRichListAPI) GetAlertGroupRich(context.Context, string) (*AlertGroupRich, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeRichListAPI) ListAlertIDs(context.Context, string, int) ([]string, int, error) {
+	return nil, 0, nil
+}
+
+func (f *fakeRichListAPI) GetAlertRich(context.Context, string) (*alertAPI, *AlertRich, error) {
+	return nil, nil, errors.New("not implemented")
+}
+
+func (f *fakeRichListAPI) ResolveTeams(context.Context) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+// fakeLegacyListAPI drives the alternate-implementation fallback list path.
+// It intentionally does NOT implement RichAlertGroupReader, so the command
+// takes the legacy branch. The applied ListConfig is recorded to observe the
+// wire limit.
+type fakeLegacyListAPI struct {
+	OnCallAPI
+
+	items  []AlertGroup
+	gotCfg ListConfig
+}
+
+func (f *fakeLegacyListAPI) ListAlertGroups(_ context.Context, opts ...ListOption) ([]AlertGroup, error) {
+	for _, o := range opts {
+		o(&f.gotCfg)
+	}
+	if f.gotCfg.Limit > 0 && len(f.items) > f.gotCfg.Limit {
+		return f.items[:f.gotCfg.Limit], nil
+	}
+	return f.items, nil
+}
+
+// alertGroupListPayload is the decoded stdout shape asserted by these tests.
+type alertGroupListPayload struct {
+	Items    []map[string]any `json:"items"`
+	ListMeta *cmdio.ListMeta  `json:"list_meta"`
+}
+
+func runAlertGroupList(t *testing.T, client OnCallAPI, args ...string) (alertGroupListPayload, string) {
+	t.Helper()
+	resetAgentMode(t)
+	testutils.PinArgv(t, append([]string{"gcx", "irm", "oncall", "alert-groups", "list"}, args...)...)
+
+	cmd := newAlertGroupListCommand(&fakeLoader{client: client})
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(append([]string{"-o", "json"}, args...))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("alert-groups list: %v\nstderr=%s", err, stderr.String())
+	}
+
+	var payload alertGroupListPayload
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid JSON on stdout: %v\nraw=%s", err, stdout.String())
+	}
+	return payload, stderr.String()
+}
+
+func rawAlertGroups(n int) []json.RawMessage {
+	items := make([]json.RawMessage, 0, n)
+	for i := range n {
+		items = append(items, json.RawMessage(fmt.Sprintf(
+			`{"pk":"AG%d","alerts_count":1,"started_at":"2026-01-01T00:00:00Z"}`, i)))
+	}
+	return items
+}
+
+func TestAlertGroupList_RichPath_UserLimitTruncates(t *testing.T) {
+	fake := &fakeRichListAPI{items: rawAlertGroups(2), page: alertGroupPageInfo{HasMore: true}}
+	payload, stderr := runAlertGroupList(t, fake, "--limit", "2")
+
+	if fake.gotLimit != 2 {
+		t.Errorf("wire limit = %d, want 2 (rich path passes the limit server-side)", fake.gotLimit)
+	}
+	if len(payload.Items) != 2 {
+		t.Fatalf("items = %d, want 2", len(payload.Items))
+	}
+	meta := payload.ListMeta
+	if meta == nil || !meta.Truncated || meta.Returned != 2 {
+		t.Fatalf("list_meta = %+v, want truncated page of 2", meta)
+	}
+	if meta.Total != nil {
+		t.Errorf("list_meta.total = %d, want absent (source not drained)", *meta.Total)
+	}
+	if meta.Cap != 0 {
+		t.Errorf("list_meta.cap = %d, want 0 (the user's limit, not the safety cap, was the bound)", meta.Cap)
+	}
+	// The continuation derives from argv (filters would survive) and doubles
+	// the limit — it never promises --limit 0 retrieves everything, because
+	// the safety cap exists upstream.
+	if meta.Continue != "gcx irm oncall alert-groups list --limit 4" {
+		t.Errorf("list_meta.continue = %q, want doubled-limit continuation", meta.Continue)
+	}
+	want := "hint: showing first 2; more results are available. See more with: gcx irm oncall alert-groups list --limit 4"
+	if !strings.Contains(stderr, want) {
+		t.Errorf("stderr missing truncation hint %q:\n%s", want, stderr)
+	}
+}
+
+// TestAlertGroupList_RichPath_LimitZeroHitsSafetyCap locks the PR988-review
+// defect (d) fix: `--limit 0` bounded by the runaway cap must report a
+// truncated page with the cap disclosed — never a silent 1000-item "complete"
+// set — and must NOT suggest --limit 0 (it cannot beat the cap).
+func TestAlertGroupList_RichPath_LimitZeroHitsSafetyCap(t *testing.T) {
+	fake := &fakeRichListAPI{items: rawAlertGroups(3), page: alertGroupPageInfo{HasMore: true}}
+	payload, stderr := runAlertGroupList(t, fake, "--limit", "0")
+
+	if fake.gotLimit != 0 {
+		t.Errorf("wire limit = %d, want 0", fake.gotLimit)
+	}
+	meta := payload.ListMeta
+	if meta == nil || !meta.Truncated {
+		t.Fatalf("list_meta = %+v, want truncated (hard-capped page is NOT the complete set)", meta)
+	}
+	if meta.Cap != alertGroupListHardCap {
+		t.Errorf("list_meta.cap = %d, want %d (the safety cap was the bound)", meta.Cap, alertGroupListHardCap)
+	}
+	if meta.Continue != "" {
+		t.Errorf("list_meta.continue = %q, want empty (no --limit can beat the cap)", meta.Continue)
+	}
+	want := "hint: showing first 3 (safety cap). Refine filters to narrow the result set"
+	if !strings.Contains(stderr, want) {
+		t.Errorf("stderr missing cap-variant hint %q:\n%s", want, stderr)
+	}
+	if strings.Contains(stderr, "--limit 0") {
+		t.Errorf("cap-variant hint must not suggest --limit 0:\n%s", stderr)
+	}
+}
+
+func TestAlertGroupList_RichPath_Complete(t *testing.T) {
+	fake := &fakeRichListAPI{items: rawAlertGroups(2), page: alertGroupPageInfo{}}
+	payload, stderr := runAlertGroupList(t, fake, "--limit", "50")
+
+	if payload.ListMeta != nil {
+		t.Errorf("list_meta = %+v, want absent for a complete result set", payload.ListMeta)
+	}
+	if strings.Contains(stderr, "showing first") {
+		t.Errorf("unexpected truncation hint on stderr:\n%s", stderr)
+	}
+}
+
+func TestAlertGroupList_LegacyPath_OverFetchDetectsTruncation(t *testing.T) {
+	items := []AlertGroup{
+		{PK: "AG1", AlertsCount: 1},
+		{PK: "AG2", AlertsCount: 1},
+		{PK: "AG3", AlertsCount: 1},
+		{PK: "AG4", AlertsCount: 1},
+	}
+	fake := &fakeLegacyListAPI{items: items}
+	payload, stderr := runAlertGroupList(t, fake, "--limit", "3")
+
+	if fake.gotCfg.Limit != 4 {
+		t.Errorf("wire limit = %d, want 4 (over-fetch by one)", fake.gotCfg.Limit)
+	}
+	if len(payload.Items) != 3 {
+		t.Fatalf("items = %d, want 3 (display limit)", len(payload.Items))
+	}
+	meta := payload.ListMeta
+	if meta == nil || !meta.Truncated || meta.Returned != 3 || meta.Total != nil || meta.Cap != 0 {
+		t.Fatalf("list_meta = %+v, want truncated page of 3 with unknown total and no cap", meta)
+	}
+	want := "hint: showing first 3; more results are available. See more with: gcx irm oncall alert-groups list --limit 6"
+	if !strings.Contains(stderr, want) {
+		t.Errorf("stderr missing truncation hint %q:\n%s", want, stderr)
+	}
+}
+
+func TestAlertGroupList_LegacyPath_LimitZeroDrainsFully(t *testing.T) {
+	items := []AlertGroup{{PK: "AG1"}, {PK: "AG2"}, {PK: "AG3"}}
+	fake := &fakeLegacyListAPI{items: items}
+	payload, stderr := runAlertGroupList(t, fake, "--limit", "0")
+
+	if fake.gotCfg.Limit != 0 {
+		t.Errorf("wire limit = %d, want 0 (unlimited — no cap on the legacy path)", fake.gotCfg.Limit)
+	}
+	if len(payload.Items) != 3 {
+		t.Fatalf("items = %d, want all 3", len(payload.Items))
+	}
+	if payload.ListMeta != nil {
+		t.Errorf("list_meta = %+v, want absent for --limit 0 (drained source)", payload.ListMeta)
+	}
+	if strings.Contains(stderr, "showing first") {
+		t.Errorf("unexpected truncation hint on stderr:\n%s", stderr)
+	}
+}
+
+func TestAlertGroupList_LegacyPath_ShortPageIsComplete(t *testing.T) {
+	items := []AlertGroup{{PK: "AG1"}, {PK: "AG2"}}
+	fake := &fakeLegacyListAPI{items: items}
+	payload, stderr := runAlertGroupList(t, fake, "--limit", "3")
+
+	if len(payload.Items) != 2 {
+		t.Fatalf("items = %d, want 2", len(payload.Items))
+	}
+	if payload.ListMeta != nil {
+		t.Errorf("list_meta = %+v, want absent: no spare row means no more data", payload.ListMeta)
+	}
+	if strings.Contains(stderr, "showing first") {
+		t.Errorf("unexpected truncation hint on stderr:\n%s", stderr)
+	}
+}

--- a/internal/providers/irm/oncall_alertgroup_listraw_test.go
+++ b/internal/providers/irm/oncall_alertgroup_listraw_test.go
@@ -1,0 +1,281 @@
+//nolint:testpackage // white-box tests drive the unexported pagination loop
+package irm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// alertGroupPage is one page served by newPagedAlertGroupsServer: a batch of
+// raw alert-group items plus whether a `next` cursor points at the following
+// page.
+type alertGroupPage struct {
+	items   []json.RawMessage
+	hasNext bool
+}
+
+// pagedServerState records what the fake OnCall backend observed.
+type pagedServerState struct {
+	requests     int
+	firstPerPage string
+}
+
+// newPagedAlertGroupsServer serves the OnCall internal alertgroups endpoint
+// through the plugin-proxy path shape the real client uses. Pages are
+// addressed by the `page` query parameter (1-based; absent means page 1) and
+// the `next` cursor is an absolute URL containing the `/api/internal/v1/`
+// marker so ExtractNextPath re-routes follow-ups through the proxy path,
+// exactly as the production backend does.
+func newPagedAlertGroupsServer(t *testing.T, pages []alertGroupPage) (*httptest.Server, *pagedServerState) {
+	t.Helper()
+	state := &pagedServerState{}
+
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+	mux.HandleFunc(BasePath+"/teams/", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"results":[],"next":null}`))
+	})
+	mux.HandleFunc(BasePath+"/alertgroups/", func(w http.ResponseWriter, r *http.Request) {
+		state.requests++
+		if state.requests == 1 {
+			state.firstPerPage = r.URL.Query().Get("perpage")
+		}
+		pageNum := 1
+		if p := r.URL.Query().Get("page"); p != "" {
+			n, err := strconv.Atoi(p)
+			if err != nil {
+				t.Errorf("invalid page param %q", p)
+			}
+			pageNum = n
+		}
+		if pageNum < 1 || pageNum > len(pages) {
+			t.Errorf("requested page %d out of range (have %d pages)", pageNum, len(pages))
+			http.Error(w, "no such page", http.StatusNotFound)
+			return
+		}
+		page := pages[pageNum-1]
+		var next *string
+		if page.hasNext {
+			u := fmt.Sprintf("%s/oncall/api/internal/v1/alertgroups/?page=%d", srv.URL, pageNum+1)
+			next = &u
+		}
+		body, err := json.Marshal(map[string]any{"results": page.items, "next": next})
+		if err != nil {
+			t.Fatalf("marshal page: %v", err)
+		}
+		_, _ = w.Write(body)
+	})
+
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, state
+}
+
+func onCallClientFor(srv *httptest.Server) *OnCallClient {
+	return &OnCallClient{HTTPClient: srv.Client(), Host: srv.URL}
+}
+
+// TestListAlertGroupsRaw_MultiPageDrain drives the real pagination loop
+// across two pages to a natural end: everything is returned, no truncation
+// evidence, no observed total (nothing was trimmed).
+func TestListAlertGroupsRaw_MultiPageDrain(t *testing.T) {
+	srv, state := newPagedAlertGroupsServer(t, []alertGroupPage{
+		{items: rawAlertGroups(2), hasNext: true},
+		{items: rawAlertGroups(2)},
+	})
+
+	out, info, err := listAlertGroupsRaw(context.Background(), onCallClientFor(srv), alertGroupListFilters{}, 0)
+	if err != nil {
+		t.Fatalf("listAlertGroupsRaw: %v", err)
+	}
+	if len(out) != 4 {
+		t.Errorf("items = %d, want 4 (both pages)", len(out))
+	}
+	if info.HasMore {
+		t.Error("HasMore = true, want false (pagination ended before the bound)")
+	}
+	if info.Total != nil {
+		t.Errorf("Total = %d, want nil (nothing trimmed)", *info.Total)
+	}
+	if state.requests != 2 {
+		t.Errorf("requests = %d, want 2", state.requests)
+	}
+	if state.firstPerPage != strconv.Itoa(alertGroupListPerPageMax) {
+		t.Errorf("first perpage = %q, want %d (limit 0 uses the per-page max)", state.firstPerPage, alertGroupListPerPageMax)
+	}
+}
+
+// TestListAlertGroupsRaw_OvershootWithNextCursor: the final page overshoots
+// the effective cap AND reports a next cursor — truncated, total unknown.
+func TestListAlertGroupsRaw_OvershootWithNextCursor(t *testing.T) {
+	srv, state := newPagedAlertGroupsServer(t, []alertGroupPage{
+		{items: rawAlertGroups(2), hasNext: true},
+		{items: rawAlertGroups(2), hasNext: true},
+	})
+
+	out, info, err := listAlertGroupsRaw(context.Background(), onCallClientFor(srv), alertGroupListFilters{}, 3)
+	if err != nil {
+		t.Fatalf("listAlertGroupsRaw: %v", err)
+	}
+	if len(out) != 3 {
+		t.Errorf("items = %d, want 3 (trimmed to the limit)", len(out))
+	}
+	if !info.HasMore {
+		t.Error("HasMore = false, want true (next cursor on the stopping page)")
+	}
+	if info.Total != nil {
+		t.Errorf("Total = %d, want nil (source not drained)", *info.Total)
+	}
+	if state.firstPerPage != "3" {
+		t.Errorf("first perpage = %q, want 3 (min(limit, perPageMax))", state.firstPerPage)
+	}
+}
+
+// TestListAlertGroupsRaw_OvershootWithoutNextCursor locks the H1 fix: the
+// final page overshoots the effective cap and reports NO next cursor —
+// items are dropped in-hand, so that IS truncation evidence, and because
+// pagination ended the total is genuinely observed.
+func TestListAlertGroupsRaw_OvershootWithoutNextCursor(t *testing.T) {
+	srv, _ := newPagedAlertGroupsServer(t, []alertGroupPage{
+		{items: rawAlertGroups(2), hasNext: true},
+		{items: rawAlertGroups(2)},
+	})
+
+	out, info, err := listAlertGroupsRaw(context.Background(), onCallClientFor(srv), alertGroupListFilters{}, 3)
+	if err != nil {
+		t.Fatalf("listAlertGroupsRaw: %v", err)
+	}
+	if len(out) != 3 {
+		t.Errorf("items = %d, want 3 (trimmed to the limit)", len(out))
+	}
+	if !info.HasMore {
+		t.Error("HasMore = false, want true — the overshooting final page dropped items in-hand (H1 regression)")
+	}
+	if info.Total == nil {
+		t.Fatal("Total = nil, want 4 (source fully drained, total observed)")
+	}
+	if *info.Total != 4 {
+		t.Errorf("Total = %d, want 4", *info.Total)
+	}
+}
+
+// TestListAlertGroupsRaw_CapAlignedExactFit: pagination ends exactly at the
+// effective cap — the page IS the complete set; no truncation metadata.
+func TestListAlertGroupsRaw_CapAlignedExactFit(t *testing.T) {
+	srv, _ := newPagedAlertGroupsServer(t, []alertGroupPage{
+		{items: rawAlertGroups(2), hasNext: true},
+		{items: rawAlertGroups(2)},
+	})
+
+	out, info, err := listAlertGroupsRaw(context.Background(), onCallClientFor(srv), alertGroupListFilters{}, 4)
+	if err != nil {
+		t.Fatalf("listAlertGroupsRaw: %v", err)
+	}
+	if len(out) != 4 {
+		t.Errorf("items = %d, want 4", len(out))
+	}
+	if info.HasMore {
+		t.Error("HasMore = true, want false (exact fit is a complete set)")
+	}
+	if info.Total != nil {
+		t.Errorf("Total = %d, want nil (no truncation)", *info.Total)
+	}
+}
+
+// TestAlertGroupList_RichPath_EndToEndHTTP_DrainedOvershoot exercises the
+// full command path — real OnCallClient, real listAlertGroupsRaw pagination
+// against an httptest backend, list_meta attachment, stderr hint — for the
+// drained-overshoot case fixed by H1: the observed total is reported and the
+// continuation honestly promises --limit 0.
+func TestAlertGroupList_RichPath_EndToEndHTTP_DrainedOvershoot(t *testing.T) {
+	srv, state := newPagedAlertGroupsServer(t, []alertGroupPage{
+		{items: rawAlertGroups(2), hasNext: true},
+		{items: rawAlertGroups(2)},
+	})
+
+	payload, stderr := runAlertGroupList(t, onCallClientFor(srv), "--limit", "3")
+
+	if state.requests != 2 {
+		t.Errorf("requests = %d, want 2 (real pagination loop)", state.requests)
+	}
+	if len(payload.Items) != 3 {
+		t.Fatalf("items = %d, want 3", len(payload.Items))
+	}
+	meta := payload.ListMeta
+	if meta == nil || !meta.Truncated || meta.Returned != 3 {
+		t.Fatalf("list_meta = %+v, want truncated page of 3", meta)
+	}
+	if meta.Total == nil || *meta.Total != 4 {
+		t.Fatalf("list_meta.total = %v, want 4 (drained source, observed total)", meta.Total)
+	}
+	if meta.Cap != 0 {
+		t.Errorf("list_meta.cap = %d, want 0 (the user's limit was the bound)", meta.Cap)
+	}
+	if meta.Continue != "gcx irm oncall alert-groups list --limit 0" {
+		t.Errorf("list_meta.continue = %q, want --limit 0 (total observed and retrievable)", meta.Continue)
+	}
+	want := "hint: showing first 3 of 4. See all results with: gcx irm oncall alert-groups list --limit 0"
+	if !strings.Contains(stderr, want) {
+		t.Errorf("stderr missing known-total truncation hint %q:\n%s", want, stderr)
+	}
+}
+
+// TestAlertGroupList_RichPath_UnretrievableTotalNotAttached pins the honesty
+// guard on the drained-overshoot total: when the observed total exceeds the
+// hard cap and the cap was not the bound, attaching it would derive a
+// "--limit 0 retrieves everything" continuation that the cap makes a lie —
+// so the total stays unknown and the doubled-limit continuation is used.
+func TestAlertGroupList_RichPath_UnretrievableTotalNotAttached(t *testing.T) {
+	total := alertGroupListHardCap + 500
+	fake := &fakeRichListAPI{
+		items: rawAlertGroups(2),
+		page:  alertGroupPageInfo{HasMore: true, Total: &total},
+	}
+	payload, _ := runAlertGroupList(t, fake, "--limit", "950")
+
+	meta := payload.ListMeta
+	if meta == nil || !meta.Truncated {
+		t.Fatalf("list_meta = %+v, want truncated", meta)
+	}
+	if meta.Total != nil {
+		t.Errorf("list_meta.total = %d, want absent (total above the hard cap is not retrievable)", *meta.Total)
+	}
+	if meta.Continue != "gcx irm oncall alert-groups list --limit 4" {
+		t.Errorf("list_meta.continue = %q, want doubled-limit continuation", meta.Continue)
+	}
+}
+
+// TestAlertGroupList_RichPath_CapBoundedDrainedTotalAttached: a cap-bounded
+// page carries no continuation, so an observed total is always honest to
+// attach — the agent learns both the ceiling and the real set size.
+func TestAlertGroupList_RichPath_CapBoundedDrainedTotalAttached(t *testing.T) {
+	total := alertGroupListHardCap + 5
+	fake := &fakeRichListAPI{
+		items: rawAlertGroups(3),
+		page:  alertGroupPageInfo{HasMore: true, Total: &total},
+	}
+	payload, stderr := runAlertGroupList(t, fake, "--limit", "0")
+
+	meta := payload.ListMeta
+	if meta == nil || !meta.Truncated {
+		t.Fatalf("list_meta = %+v, want truncated", meta)
+	}
+	if meta.Cap != alertGroupListHardCap {
+		t.Errorf("list_meta.cap = %d, want %d", meta.Cap, alertGroupListHardCap)
+	}
+	if meta.Total == nil || *meta.Total != total {
+		t.Fatalf("list_meta.total = %v, want %d (observed on the drained source)", meta.Total, total)
+	}
+	if meta.Continue != "" {
+		t.Errorf("list_meta.continue = %q, want empty (no --limit can beat the cap)", meta.Continue)
+	}
+	if !strings.Contains(stderr, "safety cap") {
+		t.Errorf("stderr missing cap-variant hint:\n%s", stderr)
+	}
+}

--- a/internal/providers/irm/oncall_commands_extra.go
+++ b/internal/providers/irm/oncall_commands_extra.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -75,10 +76,19 @@ func (o *alertGroupListOpts) setup(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.IncludeChildGroups, "include-child-groups", false, "Include child groups (drops the is_root filter while keeping the status default)")
 }
 
-// Validate is a stub to satisfy the CONSTITUTION-required
-// opts/setup/Validate/constructor quartet. The flag set has no cross-field
-// invariants beyond what opts.IO.Validate() already enforces.
-func (o *alertGroupListOpts) Validate() error { return nil }
+// Validate rejects negative --limit values before any config or network work,
+// mirroring the shape of the shared BindListLimit validation
+// (internal/output/format.go) with capped-source wording: this command binds
+// --limit bespoke instead of using the binder because --limit 0 is bounded by
+// a client-side safety cap (alertGroupListHardCap), so neither the flag help
+// nor this error may promise "0 means all results are returned"
+// (docs/design/output.md § 15.1).
+func (o *alertGroupListOpts) Validate() error {
+	if o.Limit < 0 {
+		return fmt.Errorf("invalid --limit %d: must be >= 0 (0 means as many results as the safety cap allows)", o.Limit)
+	}
+	return nil
+}
 
 // stateNameToInt translates a user-facing state name into the OnCall internal
 // API integer wire encoding. Accepted: firing|new, acknowledged|ack,
@@ -127,7 +137,8 @@ func newAlertGroupsCommand(loader OnCallConfigLoader) *cobra.Command {
 // alertGroupListFilters is the resolved set of filters applied to the
 // alertgroups list endpoint. Built from alertGroupListOpts after default
 // resolution; passed through both the OAuth-proxy path (listAlertGroupsRaw)
-// and the SA-token legacy path (listAlertGroupsLegacy).
+// and the alternate-implementation fallback (listAlertGroupsLegacy — e.g.
+// test doubles; not reachable via the production loader today).
 type alertGroupListFilters struct {
 	MaxAge             string
 	Statuses           []int
@@ -229,7 +240,7 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 				return listAlertGroupsLegacy(cmd, opts, filters, client, namespace)
 			}
 
-			rawItems, serverHasMore, err := reader.ListAlertGroupsRaw(cmd.Context(), filters, opts.Limit)
+			rawItems, pageInfo, err := reader.ListAlertGroupsRaw(cmd.Context(), filters, opts.Limit)
 			if err != nil {
 				return err
 			}
@@ -249,9 +260,28 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 				envs = append(envs, env)
 			}
 
+			// Truncation metadata: pageInfo.HasMore is true whenever the
+			// fetch stopped at the effective bound — the user's --limit or
+			// the runaway safety cap (alertGroupListHardCap) — with
+			// truncation evidence in hand (a next cursor, or a final page
+			// that overshot the bound). PagedListMeta honors it even at
+			// --limit 0 and records the cap when it was the binding ceiling,
+			// so a hard-capped "give me all" page is never reported as the
+			// complete set.
+			meta := cmdio.PagedListMeta(len(envs), opts.Limit, pageInfo.HasMore, alertGroupListHardCap)
+			// Drained-overshoot case: pagination ended, so the total was
+			// genuinely observed. Attach it when honest — always for a
+			// cap-bounded page (it carries no continuation), otherwise only
+			// when the full set is actually retrievable via --limit 0 (a
+			// total above the hard cap would make that continuation a lie).
+			if meta != nil && pageInfo.Total != nil && (meta.Cap > 0 || *pageInfo.Total <= alertGroupListHardCap) {
+				meta.Total = pageInfo.Total
+			}
+			meta = cmdio.AttachListMeta(meta, os.Args)
+
 			// List envelope MUST be `{"items": [...]}` (never bare
 			// array, never null). Empty result is `{"items": []}`.
-			if err := opts.IO.Encode(cmd.OutOrStdout(), alertGroupItemsEnvelope{Items: envs}); err != nil {
+			if err := opts.IO.Encode(cmd.OutOrStdout(), alertGroupItemsEnvelope{Items: envs, ListMeta: meta}); err != nil {
 				return err
 			}
 
@@ -271,13 +301,15 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 				emitNote(stderr, "default filter excludes resolved and child groups; pass --all or --include-child-groups to broaden")
 			}
 
-			// Hint emission (locked shape, D2 round 14): only when the user
-			// accepted truncation (--limit > 0), the result hit the limit
-			// exactly, AND the server confirmed more pages exist. Otherwise
-			// silent.
-			if opts.Limit > 0 && len(envs) == opts.Limit && serverHasMore {
-				emitAlertGroupListLimitHint(stderr, opts.Limit)
-			}
+			// Truncation hint: the standardized shape shared by all list
+			// commands (see docs/design/output.md § List Truncation
+			// Contract), emitted only when the metadata says the page is
+			// partial. Replaces the bespoke D2-round-14 doubled-limit hint —
+			// the shared helper suggests the same doubled limit for a
+			// user-bounded page, renders the argv-derived continuation from
+			// AttachListMeta (so filter flags survive), and switches to the
+			// "refine filters" variant when the safety cap was the bound.
+			cmdio.EmitListTruncationHint(stderr, meta)
 
 			// Filter-summary hint (D2 round 17): silent only when --all is
 			// passed AND no other filter flag is in effect (the "show me
@@ -297,21 +329,6 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 	}
 	opts.setup(cmd.Flags())
 	return cmd
-}
-
-// emitAlertGroupListLimitHint surfaces the D2-round-14 truncation hint on
-// stderr when alert-groups list returns exactly `limit` rows AND the server
-// reported a non-empty `next` cursor. Format mirrors the locked shape and
-// surfaces a runnable command (a doubled-limit fetch
-// is a sensible next step that avoids committing to --limit 0):
-//
-//	TTY:    "hint: showing first N results: gcx irm oncall alert-groups list --limit M"
-//	agent:  {"class":"hint","summary":"showing first N results","command":"gcx irm oncall alert-groups list --limit M"}
-func emitAlertGroupListLimitHint(stderr io.Writer, limit int) {
-	suggested := limit * 2
-	emitHint(stderr,
-		fmt.Sprintf("showing first %d results", limit),
-		fmt.Sprintf("gcx irm oncall alert-groups list --limit %d", suggested))
 }
 
 // alertGroupListFilterMaxLen caps the rendered filter summary at a generous
@@ -468,7 +485,9 @@ func emitListAlertsLinkHints(stderr io.Writer, ruleUID string) {
 	emitHint(stderr, "see live instances", "gcx alert instances list --rule "+safe)
 }
 
-// listAlertGroupsLegacy is the SA-token-mode fallback that goes through the
+// listAlertGroupsLegacy is the alternate-implementation fallback (e.g. test
+// doubles; not reachable via the production loader today, which always
+// returns *OnCallClient — see config.go) that goes through the
 // public-API client (which doesn't return the rich shape). The public API
 // supports a smaller filter set than the internal API; unsupported filters
 // are passed through to the public client which silently ignores them, and
@@ -493,7 +512,11 @@ func listAlertGroupsLegacy(cmd *cobra.Command, opts *alertGroupListOpts, filters
 		listOpts = append(listOpts, WithIntegrations(filters.Integrations...))
 	}
 	if opts.Limit > 0 {
-		listOpts = append(listOpts, WithLimit(opts.Limit))
+		// Over-fetch by one: the public API has no more-pages signal, so a
+		// spare item is the cheap proof that the page is partial — without
+		// draining the source just to count it. --limit 0 keeps draining
+		// fully on this path (no safety cap here) and stays metadata-free.
+		listOpts = append(listOpts, WithLimit(opts.Limit+1))
 	}
 
 	// Surface unsupported-filter warnings once at the command edge — the
@@ -525,6 +548,10 @@ func listAlertGroupsLegacy(cmd *cobra.Command, opts *alertGroupListOpts, filters
 	if err != nil {
 		return err
 	}
+	// A spare (limit+1) row proves more data exists; Total stays unknown —
+	// the source was not drained.
+	items, meta := cmdio.TruncatePagedList(items, opts.Limit)
+	meta = cmdio.AttachListMeta(meta, os.Args)
 	// SA-token mode doesn't get the rich shape (no internal API access). The
 	// envelope type is the same — most status fields stay empty (omitempty);
 	// only AlertsCount/Status (decoded) are populated from the public payload.
@@ -550,8 +577,13 @@ func listAlertGroupsLegacy(cmd *cobra.Command, opts *alertGroupListOpts, filters
 		})
 	}
 	// Wrap in the items envelope on every list path, including the
-	// SA-token fallback.
-	return opts.IO.Encode(cmd.OutOrStdout(), alertGroupItemsEnvelope{Items: envs})
+	// alternate-implementation fallback (e.g. test doubles; not reachable
+	// via the production loader today).
+	if err := opts.IO.Encode(cmd.OutOrStdout(), alertGroupItemsEnvelope{Items: envs, ListMeta: meta}); err != nil {
+		return err
+	}
+	cmdio.EmitListTruncationHint(cmd.ErrOrStderr(), meta)
+	return nil
 }
 
 // alertGroupListHardCap bounds the maximum number of items returned by
@@ -564,25 +596,46 @@ const alertGroupListHardCap = 1000
 // fitting the default limit (50) into a single request.
 const alertGroupListPerPageMax = 100
 
+// alertGroupPageInfo reports how a paginated alert-group fetch ended.
+type alertGroupPageInfo struct {
+	// HasMore is true when items beyond the returned page exist: the fetch
+	// stopped at the effective bound (the caller's limit or the hard cap)
+	// with the server reporting a next cursor, or the in-hand items of the
+	// final page exceeded the bound and were trimmed.
+	HasMore bool
+	// Total is the observed size of the complete result set. It is set only
+	// when the source was fully drained (pagination ended with no next
+	// cursor) yet more items were in hand than the bound allowed — the one
+	// case where the loop actually observes the full count. Nil means
+	// unknown; never a guess.
+	Total *int
+}
+
 // listAlertGroupsRaw issues the paginated GET against alertgroups/?... and
-// returns the per-item raw JSON for downstream rich conversion plus a
-// `hasMore` flag indicating whether the server reported additional pages
-// when we stopped early due to the caller-supplied cap.
+// returns the per-item raw JSON for downstream rich conversion plus page
+// info describing how the fetch ended (see alertGroupPageInfo).
 //
 // limit semantics:
 //   - limit > 0  → fetch up to `limit` items; perpage=min(limit, perPageMax).
 //   - limit == 0 → fetch up to alertGroupListHardCap items; perpage=perPageMax.
 //
-// hasMore is true only when the result was truncated by `limit` AND the page
-// that triggered the stop reported a non-empty `next` cursor. It stays false
-// when the server's pagination naturally ends or when only the hardCap kicks
-// in (the latter is silent — `--limit 0` callers opted into "give me all").
-func listAlertGroupsRaw(ctx context.Context, c *OnCallClient, filters alertGroupListFilters, limit int) ([]json.RawMessage, bool, error) {
+// HasMore is true whenever the fetch stopped at the effective bound — the
+// caller-supplied limit or the runaway hard cap — with truncation evidence
+// in hand: the stopping page reported a non-empty `next` cursor, or the
+// in-hand items exceeded the bound (a final overshooting page proves
+// truncation even without a cursor). It stays false only when the server's
+// pagination ends at or before the bound. Nothing is silenced here; each
+// caller decides how to surface the page info. The list command emits
+// list_meta plus stderr hints; resolveBulkTargets (oncall_actions.go)
+// currently discards it, so a hard-capped bulk-by-filter sweep is still
+// silent — tracked for a per-command decision in
+// docs/research/2026-07-17-global-limit-investigation.md § 6.
+func listAlertGroupsRaw(ctx context.Context, c *OnCallClient, filters alertGroupListFilters, limit int) ([]json.RawMessage, alertGroupPageInfo, error) {
 	params := url.Values{}
 	if filters.MaxAge != "" {
 		dur, err := parseDuration(filters.MaxAge)
 		if err != nil {
-			return nil, false, fmt.Errorf("invalid --max-age value %q: %w", filters.MaxAge, err)
+			return nil, alertGroupPageInfo{}, fmt.Errorf("invalid --max-age value %q: %w", filters.MaxAge, err)
 		}
 		const layout = "2006-01-02T15:04:05"
 		start := time.Now().UTC().Add(-dur).Format(layout)
@@ -634,29 +687,29 @@ func listAlertGroupsRaw(ctx context.Context, c *OnCallClient, filters alertGroup
 	}
 
 	var (
-		out           []json.RawMessage
-		next          = path
-		serverHasMore bool
+		out  []json.RawMessage
+		next = path
+		info alertGroupPageInfo
 	)
 	for next != "" {
 		resp, err := c.DoRequest(ctx, http.MethodGet, next, nil)
 		if err != nil {
-			return nil, false, fmt.Errorf("irm: list alert groups: %w", err)
+			return nil, alertGroupPageInfo{}, fmt.Errorf("irm: list alert groups: %w", err)
 		}
 		body, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
-			return nil, false, err
+			return nil, alertGroupPageInfo{}, err
 		}
 		if resp.StatusCode != http.StatusOK {
-			return nil, false, fmt.Errorf("irm: list alert groups: HTTP %d: %s", resp.StatusCode, string(body))
+			return nil, alertGroupPageInfo{}, fmt.Errorf("irm: list alert groups: HTTP %d: %s", resp.StatusCode, string(body))
 		}
 		var page struct {
 			Results []json.RawMessage `json:"results"`
 			Next    *string           `json:"next"`
 		}
 		if err := json.Unmarshal(body, &page); err != nil {
-			return nil, false, fmt.Errorf("irm: decode alert groups: %w", err)
+			return nil, alertGroupPageInfo{}, fmt.Errorf("irm: decode alert groups: %w", err)
 		}
 		out = append(out, page.Results...)
 		pageNext := ""
@@ -664,8 +717,17 @@ func listAlertGroupsRaw(ctx context.Context, c *OnCallClient, filters alertGroup
 			pageNext = *page.Next
 		}
 		if len(out) >= effectiveCap {
+			// Truncation evidence comes from either signal: the stopping page
+			// reported a next cursor, or the final page overshot the bound and
+			// in-hand items are about to be dropped. Evaluate BEFORE trimming.
+			info.HasMore = pageNext != "" || len(out) > effectiveCap
+			if pageNext == "" && len(out) > effectiveCap {
+				// Pagination ended naturally, so the source was fully drained
+				// and the total is genuinely observed — not a guess.
+				total := len(out)
+				info.Total = &total
+			}
 			out = out[:effectiveCap]
-			serverHasMore = pageNext != ""
 			break
 		}
 		if pageNext == "" {
@@ -673,16 +735,14 @@ func listAlertGroupsRaw(ctx context.Context, c *OnCallClient, filters alertGroup
 		}
 		np, err := ExtractNextPath(pageNext)
 		if err != nil {
-			return nil, false, err
+			return nil, alertGroupPageInfo{}, err
 		}
 		next = np
 	}
 
-	// serverHasMore is true only when the cap (caller-supplied or hardCap)
-	// truncated us AND the server reported a non-empty `next` cursor on the
-	// page we stopped on. The caller decides whether to surface a hint based
-	// on its own --limit semantics.
-	return out, serverHasMore, nil
+	// The caller decides how to surface the page info (list_meta + hints)
+	// based on its own --limit semantics.
+	return out, info, nil
 }
 
 func parseDuration(s string) (time.Duration, error) {
@@ -1427,6 +1487,10 @@ type alertEnvelope struct {
 // `internal/output/format.go::marshalToSampleMap`).
 type alertGroupItemsEnvelope struct {
 	Items []alertGroupEnvelope `json:"items" yaml:"items"`
+	// ListMeta is attached only when the output is a truncated page, so
+	// agents cannot mistake a page for the complete set. Reserved key —
+	// see docs/design/output.md § List Truncation Contract.
+	ListMeta *cmdio.ListMeta `json:"list_meta,omitempty" yaml:"list_meta,omitempty"`
 }
 
 // alertItemsEnvelope is the list envelope for `alert-groups list-alerts`.

--- a/internal/providers/irm/oncall_commands_extra_test.go
+++ b/internal/providers/irm/oncall_commands_extra_test.go
@@ -89,6 +89,51 @@ func TestStringifyAlertGroupListFilters(t *testing.T) {
 	}
 }
 
+// TestAlertGroupListOptsValidate covers the negative --limit rejection: it
+// must fire at validation time — before any config or network work — with the
+// capped-source wording (never "0 means all results are returned": --limit 0
+// on this command is bounded by alertGroupListHardCap).
+func TestAlertGroupListOptsValidate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		limit   int
+		wantErr string // exact error message; empty means Validate must pass
+	}{
+		{
+			name:    "negative limit rejected",
+			limit:   -1,
+			wantErr: "invalid --limit -1: must be >= 0 (0 means as many results as the safety cap allows)",
+		},
+		{
+			name:    "large negative limit rejected",
+			limit:   -50,
+			wantErr: "invalid --limit -50: must be >= 0 (0 means as many results as the safety cap allows)",
+		},
+		{name: "zero limit accepted", limit: 0},
+		{name: "default limit accepted", limit: alertGroupListDefaultLimit},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			opts := &alertGroupListOpts{Limit: tc.limit}
+			err := opts.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("Validate() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestAlertGroupListHasExplicitFilter — silent-on-`--all` decision predicate.
 func TestAlertGroupListHasExplicitFilter(t *testing.T) {
 	t.Parallel()

--- a/internal/testutils/agent.go
+++ b/internal/testutils/agent.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"os"
+	"testing"
 
 	"github.com/grafana/gcx/internal/agent"
 )
@@ -23,4 +24,32 @@ func init() { //nolint:gochecknoinits
 	}
 
 	agent.ResetForTesting()
+}
+
+// SetAgentMode pins agent-mode detection for the duration of a test, so TTY
+// and agent-mode output shapes can be asserted deterministically even when
+// the test runs inside an agent harness (e.g. CLAUDECODE=1). The cleanup is
+// registered before t.Setenv so it runs after the env restore (LIFO),
+// re-detecting from the original environment. Incompatible with t.Parallel
+// (t.Setenv enforces this).
+func SetAgentMode(t *testing.T, enabled bool) {
+	t.Helper()
+	t.Cleanup(agent.ResetForTesting)
+	if enabled {
+		t.Setenv("GCX_AGENT_MODE", "true")
+	} else {
+		t.Setenv("GCX_AGENT_MODE", "false")
+	}
+	agent.ResetForTesting()
+}
+
+// PinArgv fixes os.Args for the duration of a test so behavior derived from
+// the real invocation argv (e.g. list truncation continuation commands) is
+// deterministic under `go test`. os.Args is process-global and the swap is
+// unsynchronized — do not combine with t.Parallel.
+func PinArgv(t *testing.T, argv ...string) {
+	t.Helper()
+	old := os.Args
+	os.Args = argv
+	t.Cleanup(func() { os.Args = old })
 }


### PR DESCRIPTION
This is the groundwork PR for #1031, the output workstream of #387 (split out of the naming train per the #994 review discussion). It supersedes the approach in #988 — same goals, and it fixes the four defects that PR's review found. The investigation behind it, including why a root-level persistent `--limit` was rejected, rides along as `docs/research/2026-07-17-global-limit-investigation.md`; the contract itself is documented as `docs/design/output.md` §15, marked PROPOSED until #387 settles it repo-wide.

The contract in short: a truncated list page carries a reserved `list_meta` key in its envelope — `{truncated, returned, total?, cap?, continue?}` — and absence means the output is the complete result set, so an agent reading `-o json` can't mistake a page for the whole set. `total` appears only when actually observed, never guessed. `cap` appears only when a client-side safety cap, not the user's `--limit`, was the bound. `continue` is a runnable command derived from the real invocation argv, so the user's filter flags survive — never a hardcoded string. The stderr hint uses the sentence shape from the #988 review ("showing first 5 of 219. See all results with: gcx datasources list --limit 0"); unknown totals get a doubled limit instead of a `--limit 0` promise, and cap-bounded pages say "safety cap" and suggest refining filters, because no `--limit` can beat the cap. `--json` field selection and discovery are now tolerant of the reserved key: selection re-attaches `list_meta` (this was the `{"uid": null}` break), discovery samples item fields and never lists `list_meta.*`. Any other second envelope key keeps today's behavior, pinned by test.

Two commands migrate as the reference implementations:

- `datasources list` — cheaply complete source. The silent client-side slice is gone; default `--limit` goes 50 → 0 (the full set is fetched from the API regardless, so a default cap only hid data — and the reviewer on #988 didn't object to 0 there); truncation now reports `list_meta` plus the hint, and negative `--limit` is rejected at validation.
- `irm oncall alert-groups list` — paginated source with a 1000-item runaway cap. `--limit 0` bounded by the cap now reports `{cap: 1000}` and the refine-filters hint instead of returning 1000 items indistinguishable from a complete set (the exact case flagged in #988 review). The pagination loop also counts a final page that overshoots the bound with no next cursor as truncation evidence — previously that truncated silently — and attaches the observed total only when the suggested continuation can honestly retrieve it. Negative `--limit` is rejected, and the non-rich fallback path over-fetches by one so truncation is detectable there too.

Deliberately out of scope, so review doesn't go looking for it:

- The shared `--limit` rollout across the remaining ~40 list commands stays out — that's the stretch item on #1031. Several sites need per-command decisions first (incidents list rejects `--limit 0` today, incidents activity coerces 0 to 50 in the client, dashboards list has cursor pagination to converge with).
- `alert rules list` is not migrated. Its JSON output is a bare array with no envelope to carry `list_meta`, and its `--limit` counts different units per format (flattened rules in the table, groups in JSON). The adjudicated review of the feasibility work said to keep it out of the first production truncation PR; the envelope and unit decisions are recorded in the investigation doc.

Verified locally: gofmt clean, lint clean, `go test -race -count=1 ./...` green (with `GCX_AGENT_MODE=false`), reference docs regenerated with `GCX_AGENT_MODE=false` and drift-clean. The diff also went through an adversarial multi-lens review workflow before going up; the confirmed findings were fixed (the capped command's validation error no longer borrows the "0 means all" wording, the research doc no longer describes prototype-only changes as landed, a dead second derivation path in the hint helper was removed so `AttachListMeta` is the single source of the continuation, and the os.Args/agent-mode test helpers moved to `internal/testutils` instead of being copy-pasted per package).

Live end-to-end comparison against a real Grafana Cloud stack, origin/main binary vs this branch with identical args (details in a comment below): the `datasources list` truncation behavior is exactly as promised — honest counts, `list_meta` in the payload, the hint sentence on stderr, filters surviving in the continuation, discovery and selection clean — and untouched commands (including `alert rules list`) are byte-identical modulo server-side evaluation timestamps that also differ between two runs of the same main binary. The IRM cap and overshoot paths could not be forced live without creating tenant alert groups, which I didn't do; they're covered by httptest-driven tests that drive the real pagination loop end to end, and the live runs verified the empty-complete-set parity and the negative-limit rejection. mkdocs isn't installed locally so the docs build runs in CI.

Sequencing: this merges after the #387 naming train (#1009 and the batches), one rebase expected. It also crosses `internal/output/format.go` with the output-safe-corrections branch from the same workstream — whichever lands second rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
