### PR TITLE
docs: fix usage-stats page phantom command and error_kind values

### DIFF
--- a/docs/sources/anonymous-usage-statistics.md
+++ b/docs/sources/anonymous-usage-statistics.md
@@ -37,7 +37,7 @@ Each `gcx` event contains the following properties:
 | `provider` | The resource provider the command belongs to. | `dashboards` |
 | `outcome` | How the invocation ended: `ok`, `runtime_error`, `parse_error`, or `help`. | `ok` |
 | `exit_code` | The process exit code. | `0` |
-| `error_kind` | A coarse error category when the command failed, such as `auth` or `validation`. Never an error message. | `auth` |
+| `error_kind` | A coarse error category when the command failed: `usage_error`, `auth_failure`, `partial_failure`, `version_incompatible`, or `error`. Never an error message. | `auth_failure` |
 | `duration_ms` | Total invocation duration in milliseconds. | `1234` |
 | `is_tty` | Whether `gcx` ran attached to an interactive terminal. | `false` |
 | `is_ci` | Whether a CI environment was detected. | `true` |
@@ -65,7 +65,6 @@ Some invocations never emit an event:
 
 - **Shell completion** — the completion machinery runs on every tab-press and carries no usage signal.  
 - **`gcx version`**  
-- **The `gcx telemetry` command itself** — the command that controls reporting doesn't report on itself.  
 - **Cancelled invocations** — pressing Ctrl-C emits nothing.
 
 ## Server-side enrichment


### PR DESCRIPTION
followup to #985: the page listed a `gcx telemetry` command that doesn't exist - reporting is controlled via `GCX_TELEMETRY`, `DO_NOT_TRACK`, or `diagnostics.telemetry`, all already covered in the Opt out section, so the phantom bullet is just removed. Also corrects the `error_kind` examples to the values the code actually emits (`usage_error`, `auth_failure`, `partial_failure`, `version_incompatible`, `error` - see `agentlog.KindFromExitCode`), since this page is a disclosure document and should match reality.