### PR TITLE
feat(kg): add --dry-run to model-rules/prom-rules upsert

### DIFF
--- a/docs/reference/cli/gcx_kg_model-rules_upsert.md
+++ b/docs/reference/cli/gcx_kg_model-rules_upsert.md
@@ -6,11 +6,24 @@ Upload model rules from a YAML file.
 gcx kg model-rules upsert [flags]
 ```
 
+### Examples
+
+```
+  gcx kg model-rules upsert -f model-rules.yaml
+
+  # Validate against the backend and preview the diff without uploading:
+  gcx kg model-rules upsert -f model-rules.yaml --dry-run
+```
+
 ### Options
 
 ```
-  -f, --file string   Input file (YAML)
-  -h, --help          help for upsert
+      --dry-run         Validate against the backend and show a diff without uploading.
+  -f, --file string     Input file (YAML), or '-' for stdin.
+  -h, --help            help for upsert
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_kg_prom-rules_upsert.md
+++ b/docs/reference/cli/gcx_kg_prom-rules_upsert.md
@@ -6,11 +6,24 @@ Upload Knowledge Graph Custom Prometheus rules from a YAML file.
 gcx kg prom-rules upsert [flags]
 ```
 
+### Examples
+
+```
+  gcx kg prom-rules upsert -f rules.yaml
+
+  # Validate against the backend and preview the diff without uploading:
+  gcx kg prom-rules upsert -f rules.yaml --dry-run
+```
+
 ### Options
 
 ```
-  -f, --file string   Input file (YAML)
-  -h, --help          help for upsert
+      --dry-run         Validate against the backend and show a diff without uploading.
+  -f, --file string     Input file (YAML), or '-' for stdin.
+  -h, --help            help for upsert
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,9 +39,11 @@ const (
 	rulesPath                = pluginResourcePath + "/asserts/api-server/v1/config/prom-rules"
 	ruleByNameFmt            = rulesPath + "/%s"
 	rulesSchemaPath          = rulesPath + "/schema"
+	rulesValidateSyncPath    = rulesPath + "-validate-sync"
 	modelRulesPath           = pluginResourcePath + "/asserts/api-server/v1/config/model-rules"
 	modelRulesByNameFmt      = modelRulesPath + "/%s"
 	modelRulesSchemaPath     = modelRulesPath + "/schema"
+	modelRulesValidatePath   = modelRulesPath + "-validate"
 	suppressionPath          = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alert"
 	suppressionByNameFmt     = suppressionPath + "/%s"
 	suppressionsPath         = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alerts"
@@ -436,28 +439,34 @@ func (c *Client) GetSuppressions(ctx context.Context) (*Suppressions, error) {
 	return &result, nil
 }
 
-// SuppressionFieldError is a single field-level validation failure reported by
-// the disabled-alerts-validate endpoint, e.g. field "disabledAlertConfigs[0].name",
+// ConfigFieldError is a single field-level validation failure reported by a
+// KG config validate endpoint, e.g. field "disabledAlertConfigs[0].name",
 // message "Missing Rule Name".
-type SuppressionFieldError struct {
+type ConfigFieldError struct {
 	Field   string
 	Message string
 }
 
-// SuppressionsValidationError is returned by ValidateSuppressions when the
-// backend rejects the payload (HTTP 422). It carries the per-field errors from
-// the server-side validator so callers can render them without a round-trip to
-// the write endpoint.
-type SuppressionsValidationError struct {
+// ConfigValidationError is returned by the Validate* methods when the backend
+// rejects a config payload (HTTP 422). It carries the per-field errors from the
+// server-side validator so callers can render them without a round-trip to the
+// write endpoint. Kind identifies the config family (e.g. "suppressions",
+// "model rules", "prom rules") for the default message.
+type ConfigValidationError struct {
 	StatusCode int
+	Kind       string
 	Message    string
-	Errors     []SuppressionFieldError
+	Errors     []ConfigFieldError
 }
 
-func (e *SuppressionsValidationError) Error() string {
+func (e *ConfigValidationError) Error() string {
 	msg := e.Message
 	if msg == "" {
-		msg = "suppressions configuration is invalid"
+		kind := e.Kind
+		if kind == "" {
+			kind = "configuration"
+		}
+		msg = kind + " configuration is invalid"
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "kg: %s", msg)
@@ -468,13 +477,20 @@ func (e *SuppressionsValidationError) Error() string {
 }
 
 // HTTPStatusCode implements the interface used by internal/fail for rich errors.
-func (e *SuppressionsValidationError) HTTPStatusCode() int { return e.StatusCode }
+func (e *ConfigValidationError) HTTPStatusCode() int { return e.StatusCode }
 
 // APIServiceName implements the interface used by internal/fail for rich errors.
-func (e *SuppressionsValidationError) APIServiceName() string { return "Knowledge Graph" }
+func (e *ConfigValidationError) APIServiceName() string { return "Knowledge Graph" }
 
 // APIUserMessage implements the interface used by internal/fail for rich errors.
-func (e *SuppressionsValidationError) APIUserMessage() string { return e.Error() }
+func (e *ConfigValidationError) APIUserMessage() string { return e.Error() }
+
+// SuppressionFieldError and SuppressionsValidationError are retained as aliases
+// so existing callers and tests keep compiling; new code uses the generic types.
+type (
+	SuppressionFieldError       = ConfigFieldError
+	SuppressionsValidationError = ConfigValidationError
+)
 
 // ValidateSuppressions checks a suppression configuration against the backend's
 // server-side validator without persisting anything, via the validate-only
@@ -486,11 +502,35 @@ func (c *Client) ValidateSuppressions(ctx context.Context, s *Suppressions) erro
 	if err != nil {
 		return fmt.Errorf("kg: marshal request body: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.host+suppressionsValidatePath, bytes.NewReader(b))
+	return c.validateConfig(ctx, suppressionsValidatePath, "application/json", b, "suppressions")
+}
+
+// ValidateModelRules checks a model rules configuration against the backend's
+// synchronous validate-only endpoint without persisting anything. It accepts the
+// same YAML payload as create. It returns nil when valid, a
+// *ConfigValidationError on HTTP 422 (with per-field errors), or an *APIError for
+// other failures.
+func (c *Client) ValidateModelRules(ctx context.Context, yamlContent string) error {
+	return c.validateConfig(ctx, modelRulesValidatePath, "application/x-yaml", []byte(yamlContent), "model rules")
+}
+
+// ValidatePromRules checks a Custom Prometheus rules configuration against the
+// backend's synchronous validate-only endpoint (prom-rules-validate-sync, distinct
+// from the orphaned async prom-rules-validate) without persisting anything. It
+// accepts the same YAML payload as create.
+func (c *Client) ValidatePromRules(ctx context.Context, yamlContent string) error {
+	return c.validateConfig(ctx, rulesValidateSyncPath, "application/x-yaml", []byte(yamlContent), "prom rules")
+}
+
+// validateConfig POSTs a payload to a validate-only endpoint and maps the
+// response: nil on 2xx, a *ConfigValidationError on 422 (per-field errors), or a
+// generic *APIError otherwise. kind names the config family for error messages.
+func (c *Client) validateConfig(ctx context.Context, path, contentType string, body []byte, kind string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.host+path, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentType)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -499,7 +539,7 @@ func (c *Client) ValidateSuppressions(ctx context.Context, s *Suppressions) erro
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnprocessableEntity {
-		return parseSuppressionsValidationError(resp)
+		return parseConfigValidationError(resp, kind)
 	}
 	if resp.StatusCode >= 400 {
 		return readError(resp)
@@ -507,10 +547,10 @@ func (c *Client) ValidateSuppressions(ctx context.Context, s *Suppressions) erro
 	return nil
 }
 
-// parseSuppressionsValidationError parses the ApiError envelope returned by the
-// validate endpoint on HTTP 422 (fields message + subErrors[]{field,message}).
-// If the body is not the expected envelope, it falls back to a generic APIError.
-func parseSuppressionsValidationError(resp *http.Response) error {
+// parseConfigValidationError parses the ApiError envelope returned by a validate
+// endpoint on HTTP 422 (fields message + subErrors[]{field,message}). If the body
+// is not the expected envelope, it falls back to a generic APIError.
+func parseConfigValidationError(resp *http.Response, kind string) error {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return &APIError{StatusCode: resp.StatusCode}
@@ -523,9 +563,9 @@ func parseSuppressionsValidationError(resp *http.Response) error {
 		} `json:"subErrors"`
 	}
 	if jsonErr := json.Unmarshal(body, &env); jsonErr == nil && len(env.SubErrors) > 0 {
-		verr := &SuppressionsValidationError{StatusCode: resp.StatusCode, Message: env.Message}
+		verr := &ConfigValidationError{StatusCode: resp.StatusCode, Kind: kind, Message: env.Message}
 		for _, se := range env.SubErrors {
-			verr.Errors = append(verr.Errors, SuppressionFieldError{Field: se.Field, Message: se.Message})
+			verr.Errors = append(verr.Errors, ConfigFieldError{Field: se.Field, Message: se.Message})
 		}
 		return verr
 	}
@@ -537,6 +577,45 @@ func parseSuppressionsValidationError(resp *http.Response) error {
 		apiErr.rawBody = string(body)
 	}
 	return apiErr
+}
+
+// getModelRulesForDiff fetches a model rules config by name for dry-run diffing,
+// returning found=false (nil error) when the config does not exist — either a 404
+// or an empty object — so the caller can render it as an "add".
+func (c *Client) getModelRulesForDiff(ctx context.Context, name string) (*ModelRules, bool, error) {
+	var m ModelRules
+	err := c.getJSON(ctx, fmt.Sprintf(modelRulesByNameFmt, url.PathEscape(name)), &m)
+	if err != nil {
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("kg: get model rules %q: %w", name, err)
+	}
+	if m.Name == "" {
+		return nil, false, nil
+	}
+	return &m, true, nil
+}
+
+// getPromRuleForDiff fetches a Custom Prometheus rules config by name for dry-run
+// diffing, returning found=false (nil error) when the config does not exist. The
+// backend returns an empty object (200) rather than 404 for a missing name, so an
+// empty result is treated as not-found.
+func (c *Client) getPromRuleForDiff(ctx context.Context, name string) (*Rule, bool, error) {
+	var f Rule
+	err := c.getJSON(ctx, fmt.Sprintf(ruleByNameFmt, url.PathEscape(name)), &f)
+	if err != nil {
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("kg: get rule %q: %w", name, err)
+	}
+	if f.Name == "" && len(f.Groups) == 0 {
+		return nil, false, nil
+	}
+	return &f, true, nil
 }
 
 // GetRelabelRules fetches the relabel rule group of the given type.

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "sigs.k8s.io/yaml"
 )
 
 // ---------------------------------------------------------------------------
@@ -520,32 +521,16 @@ func newRulesCommand(loader RESTConfigLoader) *cobra.Command {
 	}
 	getOpts.setup(getCmd.Flags())
 
-	var createFile string
-	createCmd := &cobra.Command{
-		Use:   "upsert",
-		Short: "Upload Knowledge Graph Custom Prometheus rules from a YAML file.",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			data, err := readFileOrStdin(cmd, createFile)
-			if err != nil {
-				return fmt.Errorf("failed to read file: %w", err)
-			}
-			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
-			if err != nil {
-				return err
-			}
-			client, err := NewClient(cfg)
-			if err != nil {
-				return err
-			}
-			if err := client.UploadPromRules(cmd.Context(), string(data)); err != nil {
-				return err
-			}
-			cmdio.Success(cmd.OutOrStdout(), "Knowledge Graph rules uploaded")
-			return nil
-		},
-	}
-	createCmd.Flags().StringVarP(&createFile, "file", "f", "", "Input file (YAML)")
-	_ = createCmd.MarkFlagRequired("file")
+	createCmd := newRulesUpsertCommand(loader,
+		"Upload Knowledge Graph Custom Prometheus rules from a YAML file.",
+		`  gcx kg prom-rules upsert -f rules.yaml
+
+  # Validate against the backend and preview the diff without uploading:
+  gcx kg prom-rules upsert -f rules.yaml --dry-run`,
+		"Knowledge Graph rules uploaded",
+		runPromRulesDryRun,
+		(*Client).UploadPromRules,
+	)
 
 	deleteCmd := &cobra.Command{
 		Use:   "delete <name>",
@@ -724,32 +709,16 @@ func newModelRulesCommand(loader RESTConfigLoader) *cobra.Command {
 		Short: "Manage model rules in the Knowledge Graph.",
 	}
 
-	var fileFlag string
-	createCmd := &cobra.Command{
-		Use:   "upsert",
-		Short: "Upload model rules from a YAML file.",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			data, err := readFileOrStdin(cmd, fileFlag)
-			if err != nil {
-				return fmt.Errorf("failed to read file: %w", err)
-			}
-			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
-			if err != nil {
-				return err
-			}
-			client, err := NewClient(cfg)
-			if err != nil {
-				return err
-			}
-			if err := client.UploadModelRules(cmd.Context(), string(data)); err != nil {
-				return err
-			}
-			cmdio.Success(cmd.OutOrStdout(), "Model rules uploaded")
-			return nil
-		},
-	}
-	createCmd.Flags().StringVarP(&fileFlag, "file", "f", "", "Input file (YAML)")
-	_ = createCmd.MarkFlagRequired("file")
+	createCmd := newRulesUpsertCommand(loader,
+		"Upload model rules from a YAML file.",
+		`  gcx kg model-rules upsert -f model-rules.yaml
+
+  # Validate against the backend and preview the diff without uploading:
+  gcx kg model-rules upsert -f model-rules.yaml --dry-run`,
+		"Model rules uploaded",
+		runModelRulesDryRun,
+		(*Client).UploadModelRules,
+	)
 
 	listOpts := &modelRulesListOpts{}
 	listCmd := &cobra.Command{
@@ -1228,6 +1197,262 @@ func unifiedYAMLDiff(remote, local string) (string, error) {
 		ToFile:   "local",
 		Context:  3,
 	})
+}
+
+// ---------------------------------------------------------------------------
+// model-rules / prom-rules upsert --dry-run
+//
+// These mirror the suppressions dry-run (validate-then-diff), but model-rules
+// and prom-rules manage a single named config per file rather than a batch, so
+// the result describes one config: add, modify, or no-op. See runSuppressionsDryRun.
+//
+// Note the deliberate YAML-library split: suppressions parse/diff with
+// gopkg.in/yaml.v3 because Suppression carries yaml: tags and only simple types.
+// The rule types here carry only json: tags (PromRule.Duration maps the YAML key
+// "for") and ModelRules embeds json.RawMessage, both of which yaml.v3 mishandles,
+// so the rules path uses sigs.k8s.io/yaml (YAML->JSON->struct) for correctness.
+// ---------------------------------------------------------------------------
+
+type rulesCreateOpts struct {
+	File   string
+	DryRun bool
+	IO     cmdio.Options
+}
+
+func (o *rulesCreateOpts) setup(flags *pflag.FlagSet) {
+	flags.StringVarP(&o.File, "file", "f", "", "Input file (YAML), or '-' for stdin.")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Validate against the backend and show a diff without uploading.")
+	o.IO.RegisterCustomCodec("text", &RulesDryRunTextCodec{})
+	o.IO.DefaultFormat("text")
+	o.IO.BindFlags(flags)
+}
+
+// newRulesUpsertCommand builds the shared `upsert` command for the model-rules
+// and prom-rules groups: both read a single named config from a YAML file (or
+// stdin) and both support --dry-run (validate + client-side diff, no writes).
+// dryRun runs the validate/diff path; upload performs the real PUT; successMsg is
+// printed after a real upsert.
+func newRulesUpsertCommand(
+	loader RESTConfigLoader,
+	short, example, successMsg string,
+	dryRun func(cmd *cobra.Command, ioOpts *cmdio.Options, client *Client, data []byte) error,
+	upload func(client *Client, ctx context.Context, yamlContent string) error,
+) *cobra.Command {
+	opts := &rulesCreateOpts{}
+	createCmd := &cobra.Command{
+		Use:     "upsert",
+		Short:   short,
+		Example: example,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if opts.DryRun {
+				if err := opts.IO.Validate(); err != nil {
+					return err
+				}
+			}
+			data, err := readFileOrStdin(cmd, opts.File)
+			if err != nil {
+				return fmt.Errorf("failed to read file: %w", err)
+			}
+			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(cfg)
+			if err != nil {
+				return err
+			}
+			if opts.DryRun {
+				return dryRun(cmd, &opts.IO, client, data)
+			}
+			if err := upload(client, cmd.Context(), string(data)); err != nil {
+				return err
+			}
+			cmdio.Success(cmd.OutOrStdout(), "%s", successMsg)
+			return nil
+		},
+	}
+	opts.setup(createCmd.Flags())
+	_ = createCmd.MarkFlagRequired("file")
+	return createCmd
+}
+
+// RulesDryRunResult is the structured result of a model-rules / prom-rules
+// `upsert --dry-run`. Unlike suppressions (a batch), these commands manage a
+// single named config per file, so the result describes one config. It is
+// rendered as a unified diff in the default text format and as this struct under
+// -o json/yaml (and the agents format). Reaching this result implies validation
+// passed. Action is one of:
+//   - "add"    — absent remotely; `upsert` will add it.
+//   - "modify" — present remotely but differing; `upsert` will update it.
+//   - "none"   — present remotely and identical; `upsert` is a no-op.
+type RulesDryRunResult struct {
+	Valid   bool   `json:"valid" yaml:"valid"`
+	Changed bool   `json:"changed" yaml:"changed"`
+	Action  string `json:"action" yaml:"action"`
+	Name    string `json:"name" yaml:"name"`
+	Diff    string `json:"diff,omitempty" yaml:"diff,omitempty"`
+}
+
+// runModelRulesDryRun validates the model rules file against the backend's
+// synchronous validator and, if valid, reports what `upsert` would add or modify
+// versus the current remote config. It never writes. A diagnostic banner goes to
+// stderr; the result (diff in text mode, struct under -o json/yaml) to stdout.
+func runModelRulesDryRun(cmd *cobra.Command, ioOpts *cmdio.Options, client *Client, data []byte) error {
+	ctx := cmd.Context()
+
+	var local ModelRules
+	if err := k8syaml.Unmarshal(data, &local); err != nil {
+		return fmt.Errorf("failed to parse model-rules file: %w", err)
+	}
+	if local.Name == "" {
+		return errors.New("model-rules file has no name")
+	}
+
+	if err := client.ValidateModelRules(ctx, string(data)); err != nil {
+		return err
+	}
+
+	remote, found, err := client.getModelRulesForDiff(ctx, local.Name)
+	if err != nil {
+		return err
+	}
+
+	localYAML, err := normalizeK8sYAMLForDiff(modelRulesForDiff(local))
+	if err != nil {
+		return fmt.Errorf("render local model rules: %w", err)
+	}
+	var remoteYAML string
+	if found {
+		remoteYAML, err = normalizeK8sYAMLForDiff(modelRulesForDiff(*remote))
+		if err != nil {
+			return fmt.Errorf("render remote model rules: %w", err)
+		}
+	}
+
+	result, err := buildRulesDryRunResult(local.Name, remoteYAML, localYAML, found)
+	if err != nil {
+		return err
+	}
+	reportRulesDryRun(cmd, "model rules", result)
+	return ioOpts.Encode(cmd.OutOrStdout(), result)
+}
+
+// runPromRulesDryRun is the prom-rules counterpart to runModelRulesDryRun.
+func runPromRulesDryRun(cmd *cobra.Command, ioOpts *cmdio.Options, client *Client, data []byte) error {
+	ctx := cmd.Context()
+
+	var local Rule
+	if err := k8syaml.Unmarshal(data, &local); err != nil {
+		return fmt.Errorf("failed to parse prom-rules file: %w", err)
+	}
+	if local.Name == "" {
+		return errors.New("prom-rules file has no name")
+	}
+
+	if err := client.ValidatePromRules(ctx, string(data)); err != nil {
+		return err
+	}
+
+	remote, found, err := client.getPromRuleForDiff(ctx, local.Name)
+	if err != nil {
+		return err
+	}
+
+	localYAML, err := normalizeK8sYAMLForDiff(local)
+	if err != nil {
+		return fmt.Errorf("render local prom-rules: %w", err)
+	}
+	var remoteYAML string
+	if found {
+		remoteYAML, err = normalizeK8sYAMLForDiff(*remote)
+		if err != nil {
+			return fmt.Errorf("render remote prom-rules: %w", err)
+		}
+	}
+
+	result, err := buildRulesDryRunResult(local.Name, remoteYAML, localYAML, found)
+	if err != nil {
+		return err
+	}
+	reportRulesDryRun(cmd, "prom-rules", result)
+	return ioOpts.Encode(cmd.OutOrStdout(), result)
+}
+
+// buildRulesDryRunResult compares a single local config's canonical YAML against
+// its remote counterpart. found is false (remoteYAML "") when the config does not
+// exist remotely, which `create` would add. Reaching this implies validation
+// passed.
+func buildRulesDryRunResult(name, remoteYAML, localYAML string, found bool) (RulesDryRunResult, error) {
+	result := RulesDryRunResult{Valid: true, Name: name}
+	switch {
+	case !found:
+		result.Action = "add"
+		result.Changed = true
+	case remoteYAML != localYAML:
+		result.Action = "modify"
+		result.Changed = true
+	default:
+		result.Action = "none"
+		return result, nil
+	}
+
+	diff, err := unifiedYAMLDiff(remoteYAML, localYAML)
+	if err != nil {
+		return RulesDryRunResult{}, fmt.Errorf("render rules diff: %w", err)
+	}
+	result.Diff = diff
+	return result, nil
+}
+
+// reportRulesDryRun writes the stderr banner summarizing a rules dry-run.
+func reportRulesDryRun(cmd *cobra.Command, kind string, result RulesDryRunResult) {
+	if result.Changed {
+		cmdio.Info(cmd.ErrOrStderr(), "[dry-run] %s are valid; would %s %q (remote -> local)", kind, result.Action, result.Name)
+	} else {
+		cmdio.Info(cmd.ErrOrStderr(), "[dry-run] %s are valid; no changes to %q", kind, result.Name)
+	}
+}
+
+// modelRulesForDiff returns a copy of m with system-managed fields cleared, so
+// dry-run comparison and diffing consider only the user-authored fields.
+// managedBy is set by the backend (e.g. "terraform"), not the input file, so
+// including it would flag unchanged configs as modified.
+func modelRulesForDiff(m ModelRules) ModelRules {
+	m.ManagedBy = ""
+	return m
+}
+
+// normalizeK8sYAMLForDiff marshals a value to canonical YAML via sigs.k8s.io/yaml
+// (struct->JSON->YAML) so json-tagged fields and json.RawMessage render correctly
+// and two configs with equivalent content compare and diff cleanly.
+func normalizeK8sYAMLForDiff(v any) (string, error) {
+	out, err := k8syaml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// RulesDryRunTextCodec renders a rules dry-run result as its unified diff (or
+// nothing when there are no changes, keeping stdout empty for pipe consumers).
+type RulesDryRunTextCodec struct{}
+
+func (c *RulesDryRunTextCodec) Format() format.Format { return "text" }
+
+func (c *RulesDryRunTextCodec) Encode(w io.Writer, v any) error {
+	result, ok := v.(RulesDryRunResult)
+	if !ok {
+		return errors.New("invalid data type for text codec: expected RulesDryRunResult")
+	}
+	if result.Diff == "" {
+		return nil
+	}
+	_, err := io.WriteString(w, result.Diff)
+	return err
+}
+
+func (c *RulesDryRunTextCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("text format does not support decoding")
 }
 
 type suppressionsListOpts struct {

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -150,6 +150,16 @@ func NewSuppressionsCommand(loader RESTConfigLoader) *cobra.Command {
 	return newSuppressionsCommand(loader)
 }
 
+// NewModelRulesCommand exposes the model-rules command group for tests.
+func NewModelRulesCommand(loader RESTConfigLoader) *cobra.Command {
+	return newModelRulesCommand(loader)
+}
+
+// NewPromRulesCommand exposes the prom-rules command group for tests.
+func NewPromRulesCommand(loader RESTConfigLoader) *cobra.Command {
+	return newRulesCommand(loader)
+}
+
 func NewRelationshipsDeleteCommand(loader RESTConfigLoader) *cobra.Command {
 	return newRelationshipsDeleteCommand(loader)
 }

--- a/internal/providers/kg/rules_dryrun_test.go
+++ b/internal/providers/kg/rules_dryrun_test.go
@@ -1,0 +1,309 @@
+package kg_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/kg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rulesDryRunHandler routes the three endpoints a rules dry-run touches:
+// POST <validateSuffix> (validate-only), GET <getSubstr> (fetch current config,
+// remoteBody is an empty object when it does not exist), and PUT <writeSuffix>
+// (the real write — recorded in writeHit so tests can assert dry-run never
+// writes).
+func rulesDryRunHandler(t *testing.T, validateSuffix, getSubstr, writeSuffix string, validateStatus int, validateBody, remoteBody string, writeHit *bool) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, validateSuffix):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(validateStatus)
+			if validateBody != "" {
+				_, _ = w.Write([]byte(validateBody))
+			}
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, getSubstr):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(remoteBody))
+		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, writeSuffix):
+			*writeHit = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func modelRulesDryRunHandler(t *testing.T, validateStatus int, validateBody, remoteBody string, writeHit *bool) http.HandlerFunc {
+	t.Helper()
+	return rulesDryRunHandler(t, "model-rules-validate", "/model-rules/", "model-rules", validateStatus, validateBody, remoteBody, writeHit)
+}
+
+func promRulesDryRunHandler(t *testing.T, validateStatus int, validateBody, remoteBody string, writeHit *bool) http.HandlerFunc {
+	t.Helper()
+	return rulesDryRunHandler(t, "prom-rules-validate-sync", "/prom-rules/", "prom-rules", validateStatus, validateBody, remoteBody, writeHit)
+}
+
+const localModelRulesYAML = `name: my-model
+entities:
+- name: Service
+`
+
+// --- model-rules -----------------------------------------------------------
+
+func TestModelRulesCreate_DryRun_Invalid(t *testing.T) {
+	writeHit := false
+	body := `{"message":"Invalid model rules configuration","subErrors":[` +
+		`{"field":"entities[0].name","message":"Missing Entity Name"}]}`
+	server := httptest.NewServer(modelRulesDryRunHandler(t, http.StatusUnprocessableEntity, body, "{}", &writeHit))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	cmd := kg.NewModelRulesCommand(writeLoaderFor(server))
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"upsert", "-f", "-", "--dry-run"})
+	cmd.SetIn(bytes.NewBufferString(localModelRulesYAML))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Missing Entity Name")
+	assert.Empty(t, stdout.String(), "no diff on stdout for invalid input")
+	assert.False(t, writeHit, "dry-run must not write")
+}
+
+func TestModelRulesCreate_DryRun_Add(t *testing.T) {
+	writeHit := false
+	// Empty object => config does not exist remotely => "add".
+	server := httptest.NewServer(modelRulesDryRunHandler(t, http.StatusOK, "", "{}", &writeHit))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	cmd := kg.NewModelRulesCommand(writeLoaderFor(server))
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"upsert", "-f", "-", "--dry-run", "-o", "json"})
+	cmd.SetIn(bytes.NewBufferString(localModelRulesYAML))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, cmd.Execute())
+
+	var got kg.RulesDryRunResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	assert.True(t, got.Valid)
+	assert.True(t, got.Changed)
+	assert.Equal(t, "add", got.Action)
+	assert.Equal(t, "my-model", got.Name)
+	assert.Contains(t, got.Diff, "+++ local")
+	assert.Contains(t, got.Diff, "Service")
+	assert.Contains(t, stderr.String(), "[dry-run]")
+	assert.False(t, writeHit, "dry-run must not write")
+}
+
+func TestModelRulesCreate_DryRun_Modify(t *testing.T) {
+	writeHit := false
+	remote := kg.ModelRules{Name: "my-model", Entities: json.RawMessage(`[{"name":"Database"}]`)}
+	remoteBody, err := json.Marshal(remote)
+	require.NoError(t, err)
+	server := httptest.NewServer(modelRulesDryRunHandler(t, http.StatusOK, "", string(remoteBody), &writeHit))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	cmd := kg.NewModelRulesCommand(writeLoaderFor(server))
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"upsert", "-f", "-", "--dry-run", "-o", "text"})
+	cmd.SetIn(bytes.NewBufferString(localModelRulesYAML))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, stderr.String(), "[dry-run]")
+	assert.Contains(t, stderr.String(), "modify")
+	assert.Contains(t, stdout.String(), "--- remote")
+	assert.Contains(t, stdout.String(), "+++ local")
+	assert.Contains(t, stdout.String(), "Service")
+	assert.Contains(t, stdout.String(), "Database")
+	assert.False(t, writeHit, "dry-run must not write")
+}
+
+func TestModelRulesCreate_DryRun_NoChanges(t *testing.T) {
+	writeHit := false
+	remote := kg.ModelRules{Name: "my-model", Entities: json.RawMessage(`[{"name":"Service"}]`)}
+	remoteBody, err := json.Marshal(remote)
+	require.NoError(t, err)
+	server := httptest.NewServer(modelRulesDryRunHandler(t, http.StatusOK, "", string(remoteBody), &writeHit))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	cmd := kg.NewModelRulesCommand(writeLoaderFor(server))
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"upsert", "-f", "-", "--dry-run", "-o", "text"})
+	cmd.SetIn(bytes.NewBufferString(localModelRulesYAML))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, stderr.String(), "no changes")
+	assert.Empty(t, stdout.String(), "no diff on stdout when there are no changes")
+	assert.False(t, writeHit, "dry-run must not write")
+}
+
+// System-managed fields (managedBy) are populated by the backend, not the input
+// file, so a config whose user fields match remote must report no change even
+// when remote carries a managedBy the file omits.
+func TestModelRulesCreate_DryRun_SystemFieldsIgnored(t *testing.T) {
+	writeHit := false
+	remote := kg.ModelRules{Name: "my-model", Entities: json.RawMessage(`[{"name":"Service"}]`), ManagedBy: "terraform"}
+	remoteBody, err := json.Marshal(remote)
+	require.NoError(t, err)
+	server := httptest.NewServer(modelRulesDryRunHandler(t, http.StatusOK, "", string(remoteBody), &writeHit))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	cmd := kg.NewModelRulesCommand(writeLoaderFor(server))
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"upsert", "-f", "-", "--dry-run", "-o", "json"})
+	cmd.SetIn(bytes.NewBufferString(localModelRulesYAML))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, cmd.Execute())
+
+	var got kg.RulesDryRunResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	assert.False(t, got.Changed, "managedBy is system-managed and must not count as a change")
+	assert.Equal(t, "none", got.Action)
+	assert.Empty(t, got.Diff)
+	assert.False(t, writeHit, "dry-run must not write")
+}
+
+// --- prom-rules ------------------------------------------------------------
+
+// localPromRulesYAML uses `for:` — the JSON-tag-only field that yaml.v3 would
+// mishandle — so the no-change test doubles as a guard on the sigs.k8s.io/yaml
+// parse path.
+const localPromRulesYAML = `name: my-rules
+groups:
+- name: g1
+  rules:
+  - alert: HighErrors
+    expr: rate(errors[5m]) > 0
+    for: 5m
+`
+
+func TestPromRulesCreate_DryRun_Invalid(t *testing.T) {
+	writeHit := false
+	body := `{"message":"Invalid prom rules configuration","subErrors":[` +
+		`{"field":"groups[0].rules[0].expr","message":"Invalid PromQL"}]}`
+	server := httptest.NewServer(promRulesDryRunHandler(t, http.StatusUnprocessableEntity, body, "{}", &writeHit))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	cmd := kg.NewPromRulesCommand(writeLoaderFor(server))
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"upsert", "-f", "-", "--dry-run"})
+	cmd.SetIn(bytes.NewBufferString(localPromRulesYAML))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid PromQL")
+	assert.Empty(t, stdout.String(), "no diff on stdout for invalid input")
+	assert.False(t, writeHit, "dry-run must not write")
+}
+
+func TestPromRulesCreate_DryRun_Add(t *testing.T) {
+	writeHit := false
+	// Backend returns an empty object (200) for a missing name => "add".
+	server := httptest.NewServer(promRulesDryRunHandler(t, http.StatusOK, "", "{}", &writeHit))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	cmd := kg.NewPromRulesCommand(writeLoaderFor(server))
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"upsert", "-f", "-", "--dry-run", "-o", "json"})
+	cmd.SetIn(bytes.NewBufferString(localPromRulesYAML))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, cmd.Execute())
+
+	var got kg.RulesDryRunResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	assert.True(t, got.Valid)
+	assert.True(t, got.Changed)
+	assert.Equal(t, "add", got.Action)
+	assert.Equal(t, "my-rules", got.Name)
+	// `for:` must survive parsing (proves the sigs.k8s.io/yaml path honors JSON tags).
+	assert.Contains(t, got.Diff, "for: 5m")
+	assert.False(t, writeHit, "dry-run must not write")
+}
+
+func TestPromRulesCreate_DryRun_Modify(t *testing.T) {
+	writeHit := false
+	remote := kg.Rule{Name: "my-rules", Groups: []kg.RuleGroup{{
+		Name:  "g1",
+		Rules: []kg.PromRule{{Alert: "HighErrors", Expr: "rate(errors[5m]) > 0", Duration: "10m"}},
+	}}}
+	remoteBody, err := json.Marshal(remote)
+	require.NoError(t, err)
+	server := httptest.NewServer(promRulesDryRunHandler(t, http.StatusOK, "", string(remoteBody), &writeHit))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	cmd := kg.NewPromRulesCommand(writeLoaderFor(server))
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"upsert", "-f", "-", "--dry-run", "-o", "text"})
+	cmd.SetIn(bytes.NewBufferString(localPromRulesYAML))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, stderr.String(), "modify")
+	assert.Contains(t, stdout.String(), "-    for: 10m")
+	assert.Contains(t, stdout.String(), "+    for: 5m")
+	assert.False(t, writeHit, "dry-run must not write")
+}
+
+func TestPromRulesCreate_DryRun_NoChanges(t *testing.T) {
+	writeHit := false
+	remote := kg.Rule{Name: "my-rules", Groups: []kg.RuleGroup{{
+		Name:  "g1",
+		Rules: []kg.PromRule{{Alert: "HighErrors", Expr: "rate(errors[5m]) > 0", Duration: "5m"}},
+	}}}
+	remoteBody, err := json.Marshal(remote)
+	require.NoError(t, err)
+	server := httptest.NewServer(promRulesDryRunHandler(t, http.StatusOK, "", string(remoteBody), &writeHit))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	cmd := kg.NewPromRulesCommand(writeLoaderFor(server))
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"upsert", "-f", "-", "--dry-run", "-o", "text"})
+	cmd.SetIn(bytes.NewBufferString(localPromRulesYAML))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, stderr.String(), "no changes")
+	assert.Empty(t, stdout.String(), "identical config (including for:) must produce no diff")
+	assert.False(t, writeHit, "dry-run must not write")
+}


### PR DESCRIPTION
## Summary

Adds `--dry-run` to the KG `model-rules upsert` and `prom-rules upsert` commands.
With `--dry-run`, the command runs the backend's synchronous validator and, if valid,
prints a unified diff of what a real `upsert` would add or modify against the current
remote config — **without writing anything**. Reaching the diff implies validation passed;
validation failures surface the backend's field-level errors and exit non-zero.

This mirrors the validate-then-diff pattern already shipped for `kg suppressions upsert`
(#1015), and brings all three KG write commands into one consistent surface:

| Command | Verb | `--dry-run` |
|---|---|---|
| `kg suppressions upsert` | `upsert` | ✅ (pre-existing) |
| `kg model-rules upsert` | `upsert` | ✅ (this PR) |
| `kg prom-rules upsert` | `upsert` | ✅ (this PR) |

## Backend dependency

Depends on the two already-merged, already-deployed backend PRs (asserts-adi validate
endpoints + cell-gateway routes). E2E-validated live against `assertsdemo01`:

- New rule → `model rules are valid; would add …` + full add diff
- Modify existing rule → `would modify …` + minimal diff
- Empty name → rejected client-side, exit 1
- Malformed PromQL → backend **HTTP 422** with parser-precise location, exit 1
- prom-rules new rule → `prom-rules are valid; would add …` + diff
- Confirmed nothing persisted (all dry-run)

## Naming

Rebased onto `main` after #1015's `create` → `upsert` naming convergence. Resolution
kept this PR's dry-run feature and adopted the `upsert` verb, so model-rules/prom-rules
now match the convention suppressions already established (shared `newRulesUpsertCommand`
helper for the two single-config commands).

## ⚠️ Open question for the team: prom-rules `get` ↔ `upsert` round-trip (NOT fixed here)

Surfaced during E2E; **out of scope for this PR**, flagging for direction. `prom-rules`
cannot round-trip its own `get` output back into `upsert` (the natural pull → edit →
dry-run → apply loop):

| | `get -o yaml` emits | `upsert -f` consumes | round-trips? |
|---|---|---|---|
| `model-rules` | flat (`name`/`relations`) | flat `ModelRules` | ✅ |
| `prom-rules`  | K8s envelope (`apiVersion`/`kind`/`metadata`/`spec`) | flat `Rule` (`name`/`groups`) | ❌ (`Prom-rules file has no name`) |

Note this is a `get`↔`upsert` **shape** mismatch, not a validate-vs-upload one — validate
and upload receive the identical flat bytes. Both `Rule` and `ModelRules` are registered
resource-tier types with two-way converters, so this is a KG-provider-local choice.

**Options (follow-up, not blocking):**
- **A — fix consumer (non-breaking):** unwrap a K8s envelope via the existing
  `RuleFromResource` in `runPromRulesDryRun` + `UploadPromRules` before the flat fallback.
  Restores round-trip; `get` output unchanged.
- **B — fix producer (root cause, breaking):** pick one canonical `get` shape for both
  commands.

Recommendation: A as a follow-up issue; B as a separate consistency discussion. **Preference?**

## Testing

- `GCX_AGENT_MODE=false mise run gate` — lint 0 issues, full suite passes, build OK
- `GCX_AGENT_MODE=false mise run reference-drift` — clean
- 309 lines of new table tests in `internal/providers/kg/rules_dryrun_test.go`
