### PR TITLE
docs(skills): harden agento11y-instrument from a real instrumentation run

### DIFF
--- a/claude-plugin/skills/agento11y-instrument/SKILL.md
+++ b/claude-plugin/skills/agento11y-instrument/SKILL.md
@@ -89,6 +89,11 @@ the flow and the decision logic. A minimal fallback lives in
   stop and report what's checked and what remains — don't loop forever.
 - **Field-name traps:** `cache_write_input_tokens`, NOT `cache_creation_input_tokens`. `agent_version`
   maps to the `gen_ai.agent.version` label and is required for per-version Performance charts.
+  **`MessageRole` (Python SDK) has only `USER`, `ASSISTANT`, `TOOL` — there is no `SYSTEM` (or
+  `DEVELOPER`) member**; `MessageRole.SYSTEM` raises `AttributeError`. Fold the system prompt into the
+  `USER` message (or a `text_part`), and prefer the `user_text_message()` / `assistant_text_message()`
+  / `tool_result_message()` helpers over hand-building `Message(role=...)`. Always confirm enum members
+  and helper names against the installed package before running — do not assume from llms.txt.
 - **Out of scope:** offline test suites → `agento11y-test-starter`; tenant eval rules + guards on
   real traffic → `agento11y-prod-setup`. Coding-agent telemetry plugins (Claude Code, Cursor, …) →
   llms.txt "Path A". Any control-plane write.
@@ -101,6 +106,12 @@ The app needs, in its environment before the SDK starts:
 `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS` (traces/metrics). First check what's
 already set (including any existing `.env`) — if all are present, skip to Step 1.
 
+> **When any value is missing, do NOT just list the variable names and ask — hand the developer the
+> exact place to get each one (link + clicks), every time.** The concrete sources are in point 3
+> below; surface them proactively. The most common failure of this skill is naming
+> `OTEL_EXPORTER_OTLP_ENDPOINT`/`OTEL_EXPORTER_OTLP_HEADERS` and leaving the developer to guess — the
+> answer is the stack OTLP tile + "Generate now", which precomputes both. Give that first.
+
 **First, decide the target.** Is the app aimed at **Grafana Cloud** or a **local dev instance**?
 Look at any existing endpoint in the env / `.env` / sibling apps. If it already points at
 `localhost` (a local Agent Observability instance), that's a local-dev target — keep it, and skip
@@ -110,8 +121,12 @@ that and verify against the local instance instead. The rest of this step is the
 
 **Cloud path — what gcx does for you (run these):**
 
-1. `gcx config current-context` — is there a working context? If not, `gcx login --oauth` (browser
-   OAuth, works for Cloud and in agent mode).
+1. `gcx config current-context` — is there a working context? If not, **just ask the developer to log
+   in to the stack they want the instrumentation to connect to** — e.g. "run `gcx login` against your
+   stack." Do not fabricate the login command yourself (don't guess the host or flags); let them run
+   their own login (the Agent Observability setup screen gives them the exact command, or they use
+   `gcx login`). Instrumentation itself needs no gcx login — only Step 5 verification does, so this
+   never blocks writing the code.
 2. `gcx cloud stacks list`, then `gcx cloud stacks get <stack-slug>` — identify the target stack and
    its URLs. This gives you the stack to point the developer at, and confirms which tenant the Step 5
    verification will read from.
@@ -119,15 +134,30 @@ that and verify against the local instance instead. The rest of this step is the
 **What still needs the Connection page (gcx cannot do these today):**
 
 3. gcx does **not** generate the Agent Observability OTLP gateway URL, and does **not** mint the
-   ingest / access-policy token. Both come from the plugin **Connection page**
-   (`https://<stack>.grafana.net/plugins/grafana-sigil-app`), or the OTLP endpoint from an Alloy /
-   OTel collector the deployment runs. Point the developer there for the endpoint(s) + token and ask
-   them to paste the values, or set them as env vars — **never invent a URL or mint a token.**
-   When they create the token via "Create a token in Cloud Access Policies", tell them the scopes:
+   ingest / access-policy token. **When you ask the developer for a value, always tell them exactly
+   where to get it — a link and the clicks — never just name the variable and wait.** The two channels
+   come from two different places:
+
+   **`OTEL_*` (traces/metrics) — easiest, let Cloud build them.** Send the developer to the stack's
+   OTLP tile: `https://grafana.com/orgs/<org-slug>/stacks/<stack-id>/otlp-info`. It already shows
+   `OTEL_EXPORTER_OTLP_ENDPOINT` and the Instance ID; under **Password / API Token → "Generate now"**
+   it mints a token and then fills an **Environment Variables** block with all `OTEL_*` vars — **the
+   base64 `OTEL_EXPORTER_OTLP_HEADERS` is precomputed**, ready to copy. No manual base64. (In Python,
+   the value uses `Basic%20…` — keep it as given.)
+
+   **`AGENTO11Y_*` (generation ingest) — the plugin Connection page.** `AGENTO11Y_ENDPOINT` and the
+   token come from `https://<stack>.grafana.net/plugins/grafana-sigil-app` → Connection tab. When the
+   developer creates the token via **"Create a token in Cloud Access Policies"**, tell them the scopes:
    **`sigil:write`, `metrics:write`, `traces:write`, `logs:write`**. UI heads-up: `sigil` is not in
    the default resource list — add it via **"Add scope"** (then tick Write); the scope is still
-   `sigil:*` (the Cloud resource keeps the old name). See llms.txt "Credentials" for how each value
-   maps to the env vars.
+   `sigil:*` (the Cloud resource keeps the old name). The same `glc_…` token works for both channels
+   if it has all four scopes. Also set `AGENTO11Y_PROTOCOL=http` and `AGENTO11Y_AUTH_MODE=basic` (see
+   references/instrumentation.md — the SDK defaults grpc/none give a 401).
+
+   Ask the developer to put the values in a gitignored `.env` (or export them) **themselves** — **do
+   not ask them to paste a secret token into the chat** (it is captured in the transcript). Instrument
+   the code to read from the environment and have them supply the values out-of-band. **Never invent a
+   URL or mint a token.**
 
    > Two different tokens — don't confuse them. gcx logs in with its own OAuth token (`gat_`) and
    > refreshes it automatically; that is what authenticates the `gcx` commands here. It is **not** the
@@ -190,7 +220,7 @@ the fetched llms.txt (locate it by its heading — do not trust line numbers, th
 | 1 | OTel TracerProvider **and** MeterProvider created before the SDK client (verify by construction + Performance view / OTLP POSTs — **not** via gcx, which can't see OTel; see Step 5) | spans/metrics go to no-op → all latency/token/cost metrics lost. The #1 failure. | "OTel setup (required)" |
 | 2 | Providers shut down after `shutdown()` | last batch of spans/metrics dropped on exit | "OTel setup (required)" |
 | 3 | `agent_name` + `agent_version` set on generations / handlers | per-version Performance charts break (join on `gen_ai.agent.version`) | "Sigil architecture and ingest model", "Telemetry fields to prioritize" |
-| 4 | `set_result`/`SetResult` includes response_id, response_model, finish/stop reason, full token usage (incl. `cache_read_input_tokens`, `cache_write_input_tokens`, `reasoning_tokens`) | charts/cost blank; wrong `cache_creation_input_tokens` name silently ignored | "Implementation rules", "Telemetry fields to prioritize" |
+| 4 | `set_result`/`SetResult` includes response_id, response_model, finish/stop reason, full token usage (incl. `cache_read_input_tokens`, `cache_write_input_tokens`, `reasoning_tokens`), **and `input`/`output` populated with `Message` objects** (system+user prompt in `input`, model reply in `output`) | charts/cost blank; wrong `cache_creation_input_tokens` name silently ignored; **empty `input`/`output` → the conversation thread shows "No messages in this turn" — tokens land but there is no visible prompt/response** | "Implementation rules", "Telemetry fields to prioritize" |
 | 5 | `rec.err()`/`Err()` checked after the recorder closes | SDK validation/enqueue errors are silent → generations never arrive, no signal | "Implementation rules" |
 | 6 | SYNC (non-stream) vs STREAM (stream) set correctly | streaming metrics (TTFT) corrupted | "Sigil architecture and ingest model", "Implementation rules" |
 | 7 | `parent_generation_ids` set on multi-agent / fan-in generations | no dependency DAG; upstream eval failures don't propagate | "Multi-agent dependency tracking" |
@@ -243,13 +273,19 @@ Only after the developer confirms a diff. Bounded to ~3–4 iterations.
    - **By construction (always do this):** confirm in the applied code that both a TracerProvider
      **and** a MeterProvider are created *before* the SDK client and shut down after it. This is
      static but reliable — a missing/late/no-op MeterProvider is exactly checklist #1.
-   - **At runtime, if you can observe it:** during the run, look for the app POSTing to the OTLP
-     endpoint (`/v1/metrics` and `/v1/traces` returning 2xx) — e.g. enable the OTel/urllib3 debug log
-     or watch the local collector. Metrics export on an interval, so allow a few seconds / a clean
-     shutdown flush.
-   - **In the UI:** the stack's **Performance / metrics** view populates from Channel B. If
-     conversations appear (Channel A) but Performance is empty, the MeterProvider is missing or no-op
-     → back to checklist #1. Do not report OTel as wired on the strength of `generations get` alone.
+   - **At runtime, if you can observe it:** run the **real app** (not an isolated probe script) with
+     the OTel/urllib3 debug log on, and confirm you see **both** `POST …/v1/traces → 2xx` **and**
+     `POST …/v1/metrics → 2xx`. The SDK emits spans automatically from `start_generation`/`end` (one
+     traces POST per generation) and metrics on an interval — a clean shutdown flush surfaces both.
+     **Traces and metrics are separate exports: seeing only `/v1/metrics` does NOT mean traces work,
+     and vice-versa. Never claim "traces/metrics verified" from a probe that only exercised one of
+     them** — that is the exact trap that reports Channel B as done when half of it was never sent. If
+     you write a throwaway verification script, it must build the TracerProvider **and** MeterProvider
+     and record a real generation, or just instrument the app and read its debug output.
+   - **In the UI:** the stack's **Performance / metrics** view populates from metrics; **traces** land
+     in the stack's **Tempo** (Explore → Tempo, filter by `service.name`). If conversations appear
+     (Channel A) but Performance is empty, the MeterProvider is missing or no-op → back to checklist
+     #1. Do not report OTel as wired on the strength of `generations get` alone, nor on metrics alone.
 4. If a signal is missing, diagnose the next gap from what the checks showed, propose the fix, and
    loop back to step 1. After ~3–4 iterations without full signal, stop and report exactly what
    lands, what doesn't, and what to check next (app stderr for `agento11y:` warnings, credentials).

--- a/claude-plugin/skills/agento11y-instrument/SKILL.md
+++ b/claude-plugin/skills/agento11y-instrument/SKILL.md
@@ -223,6 +223,7 @@ the fetched llms.txt (locate it by its heading — do not trust line numbers, th
 | 4 | `set_result`/`SetResult` includes response_id, response_model, finish/stop reason, full token usage (incl. `cache_read_input_tokens`, `cache_write_input_tokens`, `reasoning_tokens`), **and `input`/`output` populated with `Message` objects** (system+user prompt in `input`, model reply in `output`) | charts/cost blank; wrong `cache_creation_input_tokens` name silently ignored; **empty `input`/`output` → the conversation thread shows "No messages in this turn" — tokens land but there is no visible prompt/response** | "Implementation rules", "Telemetry fields to prioritize" |
 | 5 | `rec.err()`/`Err()` checked after the recorder closes | SDK validation/enqueue errors are silent → generations never arrive, no signal | "Implementation rules" |
 | 6 | SYNC (non-stream) vs STREAM (stream) set correctly | streaming metrics (TTFT) corrupted | "Sigil architecture and ingest model", "Implementation rules" |
+| 6b | `operation_name` is a **recognized** value — `generateText` (SYNC default), `streamText` (STREAM default), `embeddings`, `execute_tool`, `framework_chain`, `framework_retriever`. Best: omit it and take the SDK default. Do **not** invent one like `"chat"` | the span reaches Tempo but the UI classifies `gen_ai.operation.name` as `unknown` → the conversation renders a synthetic generation node **with no attached span** → the trace does not show in the conversation and the "T" (trace) icon is absent, even though `trace_id`/`span_id` are set. Silent, like #1 | "Sigil architecture and ingest model", "Implementation rules" |
 | 7 | `parent_generation_ids` set on multi-agent / fan-in generations | no dependency DAG; upstream eval failures don't propagate | "Multi-agent dependency tracking" |
 | 8 | Workflow steps emitted for agentic pipelines with non-LLM nodes | execution graph invisible; node input/output state lost. Use the adapter if one exists, else `enqueue_workflow_step`; never both for one node (duplicates) | "Workflow step instrumentation (agentic pipelines)" |
 | 9 | Env vars are `AGENTO11Y_*` (not legacy `SIGIL_*`); client built config-free when env present | drift; duplicated config | "Environment" |
@@ -286,6 +287,10 @@ Only after the developer confirms a diff. Bounded to ~3–4 iterations.
      in the stack's **Tempo** (Explore → Tempo, filter by `service.name`). If conversations appear
      (Channel A) but Performance is empty, the MeterProvider is missing or no-op → back to checklist
      #1. Do not report OTel as wired on the strength of `generations get` alone, nor on metrics alone.
+   - **Trace shows in Tempo but NOT inside the conversation (no "T" icon):** the span is landing but
+     `gen_ai.operation.name` is an unrecognized value (e.g. `"chat"`) → the UI classifies it as
+     `unknown` and can't attach it to the conversation node. This is checklist #6b — fix
+     `operation_name` to a recognized value (or omit it for the default) and re-run.
 4. If a signal is missing, diagnose the next gap from what the checks showed, propose the fix, and
    loop back to step 1. After ~3–4 iterations without full signal, stop and report exactly what
    lands, what doesn't, and what to check next (app stderr for `agento11y:` warnings, credentials).

--- a/claude-plugin/skills/agento11y-instrument/references/instrumentation.md
+++ b/claude-plugin/skills/agento11y-instrument/references/instrumentation.md
@@ -94,16 +94,58 @@ Use the highest-level option that exists for the app's language; do not assume s
 Use `AGENTO11Y_*` (never legacy `SIGIL_*`). The SDK reads these automatically; construct the client
 with no config when they're present.
 
+Two channels — **both are required**, they carry different data:
+- **`AGENTO11Y_*`** → generation ingest (the conversations/generations you verify with the
+  `gcx agento11y` commands).
+- **`OTEL_*`** → OTel traces/metrics (`gen_ai.client.*` latency/token/cost) that feed the
+  **Performance** view. This is the #1-gap channel: leaving it unconfigured sends spans/metrics to
+  the no-op and they vanish **silently, with no error** — and gcx cannot see this channel, so it
+  looks fine from `generations get` while Performance stays empty. Do not treat it as optional.
+
+The same `glc_…` token covers both channels.
+
 ```
+# Generation ingest (conversations/generations; verified by gcx)
 AGENTO11Y_ENDPOINT=<your-agent-observability-api-url>
 AGENTO11Y_PROTOCOL=http
 AGENTO11Y_AUTH_MODE=basic
 AGENTO11Y_AUTH_TENANT_ID=<your-instance-id>
 AGENTO11Y_AUTH_TOKEN=<glc_... token>
 
-OTEL_EXPORTER_OTLP_ENDPOINT=<from stack OpenTelemetry card>
+# OTel traces/metrics (Performance view).
+OTEL_EXPORTER_OTLP_ENDPOINT=<from the stack OTLP tile — see below>
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64 of "<otlp-instance-id>:<glc_... token>">
 ```
+
+> **`AGENTO11Y_PROTOCOL=http` and `AGENTO11Y_AUTH_MODE=basic` are mandatory for Grafana Cloud — not
+> optional extras.** The SDK defaults are `_DEFAULT_PROTOCOL = "grpc"` and `_DEFAULT_AUTH_MODE =
+> "none"`; against a Cloud HTTP ingest endpoint those defaults produce a **401 UNAUTHENTICATED**
+> (`grpc` speaks the wrong transport, `none` sends no auth header). If a run fails with 401 on
+> generation ingest, these two vars are almost always missing — set both. (`basic` base64-encodes
+> `tenant_id:token` into the auth header, which is why `AGENTO11Y_AUTH_TENANT_ID` is also required.)
+
+`OTEL_EXPORTER_OTLP_HEADERS` — required when sending **directly to the Grafana Cloud OTLP gateway**
+(the common case): the gateway enforces Basic auth and the credential cannot be embedded in the URL,
+so without the header you get a 401 and nothing lands. It is only omittable when
+`OTEL_EXPORTER_OTLP_ENDPOINT` points at a **local Alloy / OTel Collector** that holds the Cloud
+credentials and forwards on your behalf — then the app talks to the local collector unauthenticated
+and the collector handles Cloud auth. For the direct-to-Cloud path here, set both.
+
+**Where to get the `OTEL_*` values (easiest — let Cloud build them for you).** Send the developer to
+the stack's OTLP tile, `https://grafana.com/orgs/<org-slug>/stacks/<stack-id>/otlp-info`:
+
+1. It already shows **`OTEL_EXPORTER_OTLP_ENDPOINT`** (e.g. `https://otlp-gateway-<region>.grafana.net/otlp`)
+   and the **Instance ID**.
+2. Under **Password / API Token**, click **"Generate now"** to mint the token.
+3. The **Environment Variables** section then fills in with all `OTEL_*` vars ready to copy —
+   including `OTEL_EXPORTER_OTLP_HEADERS` **with the base64 already computed**. Copy them straight
+   into the `.env`; no manual encoding needed. (Before generating, that section reads "Create an API
+   token first" — that's expected.)
+
+Only if you already have a raw token and instance-id and must build the header yourself, do it with
+`printf '%s' '<otlp-instance-id>:<glc_token>' | base64 | tr -d '\n'` — a trailing newline breaks the
+header. (The tile is also reachable from the plugin **Connection page**,
+`https://<stack>.grafana.net/plugins/grafana-sigil-app`.)
 
 For the full reference — per-provider wrapper usage, every framework adapter, the complete telemetry
 field list, workflow-step schema, `set_result` field completeness, and content-capture modes — fetch

--- a/claude-plugin/skills/agento11y-test-starter/SKILL.md
+++ b/claude-plugin/skills/agento11y-test-starter/SKILL.md
@@ -71,7 +71,9 @@ the suite YAML (Steps 1–5) need nothing installed.
   developer did not configure — use their `AGENTO11Y_ENDPOINT` and `AGENTO11Y_AUTH_TOKEN`; if the
   endpoint isn't set, ask for it, do not invent one.
 - Never mint, generate, or store credentials. The developer owns the Grafana Cloud ingestion
-  token; read it from the environment or ask them to paste it — do not create one.
+  token; read it from the environment (a gitignored `.env` or an exported env var they supply
+  themselves) — **do not ask them to paste a secret token into the chat** (it is captured in the
+  transcript), and do not create one.
 - Never present the generated cases as validated. They are a draft to review and extend.
 - **The `llm_judge` uses the LLM provider the agent already uses — don't add a new one.** If the
   agent calls OpenAI, the judge calls OpenAI; if Anthropic, Anthropic. Do NOT default the judge to


### PR DESCRIPTION
## What

Hardens the `agento11y-instrument` skill (plus one shared rule in `agento11y-test-starter`) with fixes grounded in a **full instrument→run→verify session** against a live Grafana Cloud stack. Every change below fixed a real point where the skill sent the agent down a wrong path or let it over-claim — and none of them are covered by the SDK's `llms.txt`.

## Changes

- **Never paste secrets into the chat.** Both skills now tell the agent to have the developer put the `glc_…` token in a gitignored `.env` / env var out-of-band, never paste it into the conversation (it's captured in the transcript).
- **Proactive env-var sourcing.** The num.1 friction was the agent naming `OTEL_EXPORTER_OTLP_*` and leaving the developer to guess. Step 0 now insists on handing the exact source (link + clicks) for every value: `OTEL_*` from the stack OTLP tile (`.../otlp-info`) → **"Generate now"** (which precomputes the base64 `OTEL_EXPORTER_OTLP_HEADERS`); `AGENTO11Y_*` from the plugin Connection page.
- **401 trap.** `AGENTO11Y_PROTOCOL=http` + `AGENTO11Y_AUTH_MODE=basic` are mandatory for Cloud — the SDK defaults (`grpc`/`none`) 401 silently. Documented in both SKILL.md and the reference.
- **gap num.4 completeness.** `set_result` must populate `input`/`output` with `Message` objects, or the conversation thread shows "No messages in this turn" (tokens land, no visible prompt/response).
- **`MessageRole` trap.** The Python SDK has only `USER`/`ASSISTANT`/`TOOL` — no `SYSTEM`/`DEVELOPER`. Confirm enum/helper names against the installed package; don't trust `llms.txt`.
- **Login.** Just ask the developer to log in to the stack they want to connect; don't fabricate the `gcx login` command (wrong host/flags 404 the OAuth page).
- **Step 5 Channel B verification.** Must run the **real app** and confirm **both** `/v1/traces` and `/v1/metrics` 2xx — never claim "traces/metrics verified" from a probe that exercised only one (this exact over-claim happened: the agent verified only `/v1/metrics` and reported Channel B done; a real-pipeline debug run later showed 5× `/v1/traces → 200`). Traces land in Tempo, metrics in Performance.

## Compliance

- **CONSTITUTION / DESIGN / ARCHITECTURE:** no code touched — documentation-only changes to bundled skill markdown. No commands, flags, config, env vars, or linter rules changed, so no reference-doc regeneration needed.
- Portable skills correctly live under `claude-plugin/skills/` (not repo-local `.agents/`).

## Testing

- `TestSkillsGcxInvocationsMatchCommandTree` (skills drift) — pass
- `go test ./cmd/gcx/skills/... ./internal/skills/...` — pass
- `go build ./cmd/gcx/` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)