### PR TITLE
fix(cloud): migrate stack regions to /api/v1/stack-regions

### DIFF
--- a/docs/reference/grafana-cloud-api-tiers.md
+++ b/docs/reference/grafana-cloud-api-tiers.md
@@ -45,7 +45,7 @@ above any individual stack.
 ```
 /api/orgs/{slug}                          org + members
 /api/stacks, /api/instances/{id}          stack lifecycle
-/api/stack-regions                        region catalog
+/api/v1/stack-regions                     region catalog
 /api/v1/accesspolicies, /api/v1/tokens    IAM for Cloud itself
 /api/plugins, /api/instances/{id}/plugins plugin catalog + install
 /api/stacks/{id}/integrations             prebuilt integrations installer

--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	instancesPath    = "/api/instances/"
-	stackRegionsPath = "/api/stack-regions"
+	stackRegionsPath = "/api/v1/stack-regions"
 	orgsPath         = "/api/orgs/"
 )
 
@@ -77,13 +77,10 @@ type StackInfo struct {
 // Region describes a Grafana Cloud stack region as returned by the GCOM API.
 type Region struct {
 	ID          int    `json:"id"`
-	Status      string `json:"status"`
 	Slug        string `json:"slug"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Provider    string `json:"provider"`
-	CreatedAt   string `json:"createdAt,omitempty"`
-	UpdatedAt   string `json:"updatedAt,omitempty"`
 }
 
 // CreateStackRequest is the request body for creating a new Grafana Cloud stack.
@@ -352,7 +349,7 @@ func (c *GCOMClient) DeleteStack(ctx context.Context, slug string) error {
 	return nil
 }
 
-// ListRegions calls GET /api/stack-regions on the GCOM API and returns
+// ListRegions calls GET /api/v1/stack-regions on the GCOM API and returns
 // the available regions for stack creation.
 func (c *GCOMClient) ListRegions(ctx context.Context) ([]Region, error) {
 	endpoint, err := c.buildURL(stackRegionsPath)

--- a/internal/cloud/gcom_test.go
+++ b/internal/cloud/gcom_test.go
@@ -486,8 +486,8 @@ func TestGCOMClient_DeleteStack_DeleteProtection(t *testing.T) {
 
 func TestGCOMClient_ListRegions_Success(t *testing.T) {
 	want := []cloud.Region{
-		{ID: 1, Slug: "us", Name: "GCP US Central", Description: "United States", Provider: "gcp", Status: "active"},
-		{ID: 2, Slug: "eu", Name: "GCP Belgium", Description: "Europe", Provider: "gcp", Status: "active"},
+		{ID: 1, Slug: "us", Name: "GCP US Central", Description: "United States", Provider: "gcp"},
+		{ID: 2, Slug: "eu", Name: "GCP Belgium", Description: "Europe", Provider: "gcp"},
 	}
 
 	var capturedPath string
@@ -506,8 +506,8 @@ func TestGCOMClient_ListRegions_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if capturedPath != "/api/stack-regions" {
-		t.Errorf("expected path /api/stack-regions, got %q", capturedPath)
+	if capturedPath != "/api/v1/stack-regions" {
+		t.Errorf("expected path /api/v1/stack-regions, got %q", capturedPath)
 	}
 	if len(got) != 2 {
 		t.Fatalf("expected 2 regions, got %d", len(got))

--- a/internal/providers/stacks/format.go
+++ b/internal/providers/stacks/format.go
@@ -74,9 +74,9 @@ func (c *regionTableCodec) Encode(w io.Writer, v any) error {
 		return errors.New("invalid data type for table codec: expected []cloud.Region")
 	}
 
-	tbl := style.NewTable("SLUG", "NAME", "DESCRIPTION", "PROVIDER", "STATUS")
+	tbl := style.NewTable("SLUG", "NAME", "DESCRIPTION", "PROVIDER")
 	for _, r := range regions {
-		tbl.Row(r.Slug, r.Name, r.Description, r.Provider, r.Status)
+		tbl.Row(r.Slug, r.Name, r.Description, r.Provider)
 	}
 	return tbl.Render(w)
 }

--- a/internal/providers/stacks/format_test.go
+++ b/internal/providers/stacks/format_test.go
@@ -65,8 +65,8 @@ func TestStackTableCodec_Encode_InvalidType(t *testing.T) {
 
 func TestRegionTableCodec_Encode(t *testing.T) {
 	out, err := stacks.ExportEncodeRegionTable([]cloud.Region{
-		{Slug: "us", Name: "US Central", Description: "United States", Provider: "gcp", Status: "active"},
-		{Slug: "eu", Name: "Belgium", Description: "Europe", Provider: "gcp", Status: "active"},
+		{Slug: "us", Name: "US Central", Description: "United States", Provider: "gcp"},
+		{Slug: "eu", Name: "Belgium", Description: "Europe", Provider: "gcp"},
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
- [ ] Needs the new `/api/v1/stack-regions` endpoint to have an oauth scope attached to it

## Summary

- point the GCOM client's `ListRegions` at `GET /api/v1/stack-regions` (was `/api/stack-regions`)
- drop `status`, `createdAt` and `updatedAt` from `cloud.Region` — the v1 endpoint no longer returns them (`sortOrder` was also removed upstream but gcx never read it)
- remove the STATUS column from the `gcx cloud stacks list-regions` table
- update the API-tiers reference doc

## Why

The grafana.com team is migrating region endpoints to v1 and wants clients off `/api/stack-regions` to ease its phase-out. The v1 endpoint is live in all environments with the same auth. Verified against the grafana-com OpenAPI spec and live responses: v1 keeps the `{"items": [...]}` envelope (minus pagination metadata gcx never used) and drops `createdAt`, `updatedAt`, `sortOrder` — and also `status`, which the Slack thread didn't mention but which gcx did surface.

## User-visible change

The STATUS column is gone from the table (it was `active` for every region — v1 only returns visible regions), and `status`/`createdAt`/`updatedAt` no longer appear in `-o json` output.

Before:

```
SLUG                 NAME               DESCRIPTION                   PROVIDER  STATUS
prod-us-west-0       AWS US West        AWS US West                   aws       active
us                   GCP US Central     United States                 gcp       active
...
```

After (verified live against grafana.com):

```
SLUG                 NAME               DESCRIPTION                   PROVIDER
prod-us-west-0       AWS US West        AWS US West                   aws
us                   GCP US Central     United States                 gcp
...
```