### PR TITLE
fix(aio11y): honor --config in direct agento11y CRUD commands

### DIFF
--- a/cmd/gcx/root/aio11y_config_routing_test.go
+++ b/cmd/gcx/root/aio11y_config_routing_test.go
@@ -7,10 +7,16 @@ package root_test
 // only the Agent Observability provider mounted, points two recording HTTP
 // servers A and B at distinct config files, and asserts every plugin-API
 // request lands on the server the user selected — and none on the other.
-// Distinct stack-ids give each config a deterministic namespace
-// (stacks-11111 vs stacks-22222) without any /bootdata discovery round-trip,
-// which also lets the collections-update case assert the output envelope's
-// namespace comes from the selected config.
+// Every fixed verb gets its own routing case because each subcommand
+// constructor captures the loader independently: a verb-local regression
+// cannot be caught by a neighboring verb's case.
+//
+// The two configs also differ in stack-id and token, so two same-shaped
+// mixed-path defect classes stay observable: distinct stack-ids give each
+// config a deterministic namespace (stacks-11111 vs stacks-22222, no
+// /bootdata round-trip) for the collections-update envelope assertion, and
+// distinct tokens let the recorder assert requests carry the selected
+// config's credentials, not the other config's or the environment's.
 
 import (
 	"bytes"
@@ -29,20 +35,30 @@ import (
 	"github.com/grafana/gcx/cmd/gcx/root"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/aio11y"
+	"github.com/grafana/gcx/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// recorder captures every request that reaches a test server.
-type recorder struct {
-	mu   sync.Mutex
-	hits []string
+type hit struct {
+	method string
+	path   string
+	auth   string
 }
 
-func (r *recorder) record(method, path string) {
+func (h hit) String() string { return h.method + " " + h.path + " [" + h.auth + "]" }
+
+// recorder captures every request that reaches a test server, including the
+// Authorization header so credential routing is as observable as URL routing.
+type recorder struct {
+	mu   sync.Mutex
+	hits []hit
+}
+
+func (r *recorder) record(req *http.Request) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.hits = append(r.hits, method+" "+path)
+	r.hits = append(r.hits, hit{method: req.Method, path: req.URL.Path, auth: req.Header.Get("Authorization")})
 }
 
 func (r *recorder) count() int {
@@ -51,10 +67,10 @@ func (r *recorder) count() int {
 	return len(r.hits)
 }
 
-func (r *recorder) all() []string {
+func (r *recorder) all() []hit {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return append([]string(nil), r.hits...)
+	return slices.Clone(r.hits)
 }
 
 func (r *recorder) reset() {
@@ -63,21 +79,35 @@ func (r *recorder) reset() {
 	r.hits = nil
 }
 
-func (r *recorder) contains(methodAndPath string) bool {
+func (r *recorder) contains(method, path string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return slices.Contains(r.hits, methodAndPath)
+	return slices.ContainsFunc(r.hits, func(h hit) bool { return h.method == method && h.path == path })
+}
+
+// wrongAuth returns the hits whose Authorization header differs from want.
+func (r *recorder) wrongAuth(want string) []hit {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var bad []hit
+	for _, h := range r.hits {
+		if h.auth != want {
+			bad = append(bad, h)
+		}
+	}
+	return bad
 }
 
 // newPluginServer starts a recording server that answers the grafana-sigil-app
-// plugin API well enough for every CRUD command to succeed: lists return an
-// empty page, deletes return {}, and mutations return one canned object whose
-// keys satisfy all four definition decoders (unknown fields are ignored).
+// plugin API well enough for every CRUD command to succeed: lists and gets
+// return an empty page/object, deletes return {}, and mutations return one
+// canned object whose keys satisfy all four definition decoders (unknown
+// fields are ignored).
 func newPluginServer(t *testing.T) (*httptest.Server, *recorder) {
 	t.Helper()
 	rec := &recorder{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		rec.record(req.Method, req.URL.Path)
+		rec.record(req)
 		w.Header().Set("Content-Type", "application/json")
 		switch req.Method {
 		case http.MethodGet:
@@ -92,29 +122,7 @@ func newPluginServer(t *testing.T) (*httptest.Server, *recorder) {
 	return srv, rec
 }
 
-// sandboxEnv isolates the test from the developer's real config and
-// environment: config discovery is confined to a temp HOME, every GRAFANA_*
-// and GCX_CONFIG variable is cleared (t.Setenv registers restoration), agent
-// mode is pinned off, and telemetry is disabled.
-func sandboxEnv(t *testing.T) string {
-	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
-	t.Setenv("GCX_AGENT_MODE", "false")
-	t.Setenv("GCX_TELEMETRY", "disabled")
-	for _, kv := range os.Environ() {
-		k, _, _ := strings.Cut(kv, "=")
-		if strings.HasPrefix(k, "GRAFANA_") || k == "GCX_CONFIG" {
-			t.Setenv(k, os.Getenv(k))
-			os.Unsetenv(k)
-		}
-	}
-	return home
-}
-
-func writeConfigFile(t *testing.T, path, server string, stackID int64) string {
+func writeConfigFile(t *testing.T, path, server, token string, stackID int64) string {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	cfg := fmt.Sprintf(`version: 1
@@ -122,13 +130,13 @@ stacks:
   main:
     grafana:
       server: %s
-      token: test-token
+      token: %s
       stack-id: %d
 contexts:
   default:
     stack: main
 current-context: default
-`, server, stackID)
+`, server, token, stackID)
 	require.NoError(t, os.WriteFile(path, []byte(cfg), 0o600))
 	return path
 }
@@ -137,9 +145,9 @@ func defaultConfigPath(home string) string {
 	return filepath.Join(home, ".config", "gcx", "config.yaml")
 }
 
-// runAIO11y executes the real root command tree with only the Agent Observability
-// provider mounted. A fresh tree per invocation keeps cobra flag state from
-// leaking between cases.
+// runAIO11y executes the real root command tree with only the Agent
+// Observability provider mounted. A fresh tree per invocation keeps cobra
+// flag state from leaking between cases.
 func runAIO11y(t *testing.T, args ...string) (string, string, error) {
 	t.Helper()
 	cmd := root.NewCommandForTest("test", []providers.Provider{&aio11y.AIO11yProvider{}})
@@ -163,34 +171,45 @@ const pluginBase = "/api/plugins/grafana-sigil-app/resources"
 
 // TestAIO11y_ExplicitConfigWinsOverDefault is the core #951 regression: a
 // valid config exists at the default location (server A) and the user passes
-// --config for server B. Every read and mutation must reach B and never A —
-// before the fix, all of these silently ran against A.
+// --config for server B. Every fixed verb must reach B, carrying B's token,
+// and never touch A — before the fix, all of these silently ran against A.
+// Collections update has its own dedicated test below (envelope namespace).
 func TestAIO11y_ExplicitConfigWinsOverDefault(t *testing.T) {
-	home := sandboxEnv(t)
+	home := testutils.SandboxConfigEnv(t)
 	srvA, recA := newPluginServer(t)
 	srvB, recB := newPluginServer(t)
-	writeConfigFile(t, defaultConfigPath(home), srvA.URL, 11111)
-	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, 22222)
+	writeConfigFile(t, defaultConfigPath(home), srvA.URL, "token-a", 11111)
+	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, "token-b", 22222)
 
 	evaluatorFile := writeSpecFile(t, "evaluator.yaml", "evaluator_id: e-1\nkind: llm_judge\n")
 	ruleFile := writeSpecFile(t, "rule.yaml", "rule_id: r-1\nenabled: true\n")
 	guardFile := writeSpecFile(t, "guard.yaml", "rule_id: g-1\nphase: preflight\n")
 
 	cases := []struct {
-		name string
-		args []string
-		hit  string
+		name   string
+		args   []string
+		method string
+		path   string
 	}{
 		// Flag before the subcommand, matching the exact #951 repro position.
-		{"evaluators list, --config first", []string{"--config", cfgB, "agento11y", "evaluators", "list", "-o", "json"}, "GET " + pluginBase + "/eval/evaluators"},
-		{"evaluators upsert", []string{"agento11y", "evaluators", "upsert", "-f", evaluatorFile, "-o", "json", "--config", cfgB}, "POST " + pluginBase + "/eval/evaluators"},
-		{"evaluators delete", []string{"agento11y", "evaluators", "delete", "e-1", "--force", "--config", cfgB}, "DELETE " + pluginBase + "/eval/evaluators/e-1"},
-		{"rules list", []string{"agento11y", "rules", "list", "-o", "json", "--config", cfgB}, "GET " + pluginBase + "/eval/rules"},
-		{"rules create", []string{"agento11y", "rules", "create", "-f", ruleFile, "-o", "json", "--config", cfgB}, "POST " + pluginBase + "/eval/rules"},
-		{"guards list", []string{"agento11y", "guards", "list", "-o", "json", "--config", cfgB}, "GET " + pluginBase + "/eval/hook-rules"},
-		{"guards create", []string{"agento11y", "guards", "create", "-f", guardFile, "-o", "json", "--config", cfgB}, "POST " + pluginBase + "/eval/hook-rules"},
-		{"collections list", []string{"agento11y", "collections", "list", "-o", "json", "--config", cfgB}, "GET " + pluginBase + "/eval/collections"},
-		{"collections create", []string{"agento11y", "collections", "create", "--name", "suite", "-o", "json", "--config", cfgB}, "POST " + pluginBase + "/eval/collections"},
+		{"evaluators list, --config first", []string{"--config", cfgB, "agento11y", "evaluators", "list", "-o", "json"}, "GET", "/eval/evaluators"},
+		{"evaluators get", []string{"agento11y", "evaluators", "get", "e-1", "-o", "json", "--config", cfgB}, "GET", "/eval/evaluators/e-1"},
+		{"evaluators upsert", []string{"agento11y", "evaluators", "upsert", "-f", evaluatorFile, "-o", "json", "--config", cfgB}, "POST", "/eval/evaluators"},
+		{"evaluators delete", []string{"agento11y", "evaluators", "delete", "e-1", "--force", "--config", cfgB}, "DELETE", "/eval/evaluators/e-1"},
+		{"rules list", []string{"agento11y", "rules", "list", "-o", "json", "--config", cfgB}, "GET", "/eval/rules"},
+		{"rules get", []string{"agento11y", "rules", "get", "r-1", "-o", "json", "--config", cfgB}, "GET", "/eval/rules/r-1"},
+		{"rules create", []string{"agento11y", "rules", "create", "-f", ruleFile, "-o", "json", "--config", cfgB}, "POST", "/eval/rules"},
+		{"rules update", []string{"agento11y", "rules", "update", "r-1", "-f", ruleFile, "-o", "json", "--config", cfgB}, "PATCH", "/eval/rules/r-1"},
+		{"rules delete", []string{"agento11y", "rules", "delete", "r-1", "--force", "--config", cfgB}, "DELETE", "/eval/rules/r-1"},
+		{"guards list", []string{"agento11y", "guards", "list", "-o", "json", "--config", cfgB}, "GET", "/eval/hook-rules"},
+		{"guards get", []string{"agento11y", "guards", "get", "g-1", "-o", "json", "--config", cfgB}, "GET", "/eval/hook-rules/g-1"},
+		{"guards create", []string{"agento11y", "guards", "create", "-f", guardFile, "-o", "json", "--config", cfgB}, "POST", "/eval/hook-rules"},
+		{"guards update", []string{"agento11y", "guards", "update", "g-1", "-f", guardFile, "-o", "json", "--config", cfgB}, "PUT", "/eval/hook-rules/g-1"},
+		{"guards delete", []string{"agento11y", "guards", "delete", "g-1", "--force", "--config", cfgB}, "DELETE", "/eval/hook-rules/g-1"},
+		{"collections list", []string{"agento11y", "collections", "list", "-o", "json", "--config", cfgB}, "GET", "/eval/collections"},
+		{"collections get", []string{"agento11y", "collections", "get", "c-1", "-o", "json", "--config", cfgB}, "GET", "/eval/collections/c-1"},
+		{"collections create", []string{"agento11y", "collections", "create", "--name", "suite", "-o", "json", "--config", cfgB}, "POST", "/eval/collections"},
+		{"collections delete", []string{"agento11y", "collections", "delete", "c-1", "--force", "--config", cfgB}, "DELETE", "/eval/collections/c-1"},
 	}
 
 	for _, tc := range cases {
@@ -199,23 +218,38 @@ func TestAIO11y_ExplicitConfigWinsOverDefault(t *testing.T) {
 			recB.reset()
 			_, stderr, err := runAIO11y(t, tc.args...)
 			require.NoError(t, err, "stderr: %s", stderr)
-			assert.True(t, recB.contains(tc.hit), "expected %q on --config server B, got %v", tc.hit, recB.all())
+			assert.True(t, recB.contains(tc.method, pluginBase+tc.path),
+				"expected %s %s on --config server B, got %v", tc.method, pluginBase+tc.path, recB.all())
+			assert.Empty(t, recB.wrongAuth("Bearer token-b"),
+				"every request to --config server B must carry B's token")
 			assert.Zero(t, recA.count(), "default-config server A must receive no requests, got %v", recA.all())
 		})
 	}
 }
 
 // TestAIO11y_ExplicitConfigWinsOverGCXConfigEnv: GCX_CONFIG points at server A,
-// --config at server B. The explicit flag has higher precedence.
+// --config at server B. The explicit flag has higher precedence. The positive
+// control proves GCX_CONFIG is honored at all in this harness, so the
+// precedence cases cannot pass vacuously.
 func TestAIO11y_ExplicitConfigWinsOverGCXConfigEnv(t *testing.T) {
-	sandboxEnv(t)
+	testutils.SandboxConfigEnv(t)
 	srvA, recA := newPluginServer(t)
 	srvB, recB := newPluginServer(t)
-	cfgA := writeConfigFile(t, filepath.Join(t.TempDir(), "a.yaml"), srvA.URL, 11111)
-	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, 22222)
+	cfgA := writeConfigFile(t, filepath.Join(t.TempDir(), "a.yaml"), srvA.URL, "token-a", 11111)
+	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, "token-b", 22222)
 	t.Setenv("GCX_CONFIG", cfgA)
 
 	ruleFile := writeSpecFile(t, "rule.yaml", "rule_id: r-1\nenabled: true\n")
+
+	t.Run("positive control: GCX_CONFIG alone routes to A", func(t *testing.T) {
+		recA.reset()
+		recB.reset()
+		_, stderr, err := runAIO11y(t, "agento11y", "evaluators", "list", "-o", "json")
+		require.NoError(t, err, "stderr: %s", stderr)
+		assert.Positive(t, recA.count(), "expected requests on the GCX_CONFIG server")
+		assert.Empty(t, recA.wrongAuth("Bearer token-a"), "GCX_CONFIG requests must carry A's token")
+		assert.Zero(t, recB.count(), "server B must receive no requests, got %v", recB.all())
+	})
 
 	for _, tc := range []struct {
 		name string
@@ -230,6 +264,7 @@ func TestAIO11y_ExplicitConfigWinsOverGCXConfigEnv(t *testing.T) {
 			_, stderr, err := runAIO11y(t, tc.args...)
 			require.NoError(t, err, "stderr: %s", stderr)
 			assert.Positive(t, recB.count(), "expected requests on --config server B")
+			assert.Empty(t, recB.wrongAuth("Bearer token-b"), "requests must carry B's token")
 			assert.Zero(t, recA.count(), "GCX_CONFIG server A must receive no requests, got %v", recA.all())
 		})
 	}
@@ -240,9 +275,9 @@ func TestAIO11y_ExplicitConfigWinsOverGCXConfigEnv(t *testing.T) {
 // sufficient. Before the fix these commands failed with "Invalid
 // configuration" from the auto-created empty default config.
 func TestAIO11y_ExplicitConfigWithoutDefault(t *testing.T) {
-	sandboxEnv(t)
+	testutils.SandboxConfigEnv(t)
 	srvB, recB := newPluginServer(t)
-	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, 22222)
+	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, "token-b", 22222)
 
 	guardFile := writeSpecFile(t, "guard.yaml", "rule_id: g-1\nphase: preflight\n")
 
@@ -269,17 +304,18 @@ func TestAIO11y_ExplicitConfigWithoutDefault(t *testing.T) {
 // config, so its namespace came from the wrong stack. Routing-only assertions
 // cannot catch this; the namespace assertion can.
 func TestAIO11y_CollectionsUpdateEnvelopeNamespace(t *testing.T) {
-	home := sandboxEnv(t)
+	home := testutils.SandboxConfigEnv(t)
 	srvA, recA := newPluginServer(t)
 	srvB, recB := newPluginServer(t)
-	writeConfigFile(t, defaultConfigPath(home), srvA.URL, 11111)
-	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, 22222)
+	writeConfigFile(t, defaultConfigPath(home), srvA.URL, "token-a", 11111)
+	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, "token-b", 22222)
 
 	stdout, stderr, err := runAIO11y(t, "agento11y", "collections", "update", "c-1", "--name", "renamed", "-o", "json", "--config", cfgB)
 	require.NoError(t, err, "stderr: %s", stderr)
 
-	assert.True(t, recB.contains("PATCH "+pluginBase+"/eval/collections/c-1"),
+	assert.True(t, recB.contains(http.MethodPatch, pluginBase+"/eval/collections/c-1"),
 		"expected PATCH on --config server B, got %v", recB.all())
+	assert.Empty(t, recB.wrongAuth("Bearer token-b"), "the PATCH must carry B's token")
 	assert.Zero(t, recA.count(), "default-config server A must receive no requests, got %v", recA.all())
 
 	var envelope struct {
@@ -293,9 +329,9 @@ func TestAIO11y_CollectionsUpdateEnvelopeNamespace(t *testing.T) {
 }
 
 // TestAIO11y_ContextFlagSmoke guards what #1012 fixed: --context selects
-// between contexts of the discovered default config.
+// between contexts of the discovered default config, credentials included.
 func TestAIO11y_ContextFlagSmoke(t *testing.T) {
-	home := sandboxEnv(t)
+	home := testutils.SandboxConfigEnv(t)
 	srvA, recA := newPluginServer(t)
 	srvB, recB := newPluginServer(t)
 	path := defaultConfigPath(home)
@@ -324,24 +360,26 @@ current-context: a
 	_, stderr, err := runAIO11y(t, "--context", "b", "agento11y", "evaluators", "list", "-o", "json")
 	require.NoError(t, err, "stderr: %s", stderr)
 	assert.Positive(t, recB.count(), "expected requests on context b's server")
+	assert.Empty(t, recB.wrongAuth("Bearer token-b"), "requests must carry context b's token")
 	assert.Zero(t, recA.count(), "context a's server must receive no requests, got %v", recA.all())
 }
 
 // TestAIO11y_EnvVarSmoke guards the env-override path that always worked for
 // #951's reporter: GRAFANA_SERVER/GRAFANA_TOKEN override an existing config
-// file. (The env-only path with no config file at all is broken on main for
-// every ConfigLoader-based provider — "$.stacks.default.grafana: node not
-// found" — which is a separate pre-existing defect, out of scope here.)
+// file, credentials included. (The env-only path with no config file at all
+// is broken on main for every ConfigLoader-based provider — tracked
+// separately in #1049 — and is out of scope here.)
 func TestAIO11y_EnvVarSmoke(t *testing.T) {
-	home := sandboxEnv(t)
+	home := testutils.SandboxConfigEnv(t)
 	srvA, recA := newPluginServer(t)
 	srvB, recB := newPluginServer(t)
-	writeConfigFile(t, defaultConfigPath(home), srvA.URL, 11111)
+	writeConfigFile(t, defaultConfigPath(home), srvA.URL, "token-a", 11111)
 	t.Setenv("GRAFANA_SERVER", srvB.URL)
 	t.Setenv("GRAFANA_TOKEN", "env-token")
 
 	_, stderr, err := runAIO11y(t, "agento11y", "evaluators", "list", "-o", "json")
 	require.NoError(t, err, "stderr: %s", stderr)
 	assert.Positive(t, recB.count(), "expected requests on the env-var server")
+	assert.Empty(t, recB.wrongAuth("Bearer env-token"), "requests must carry the env token, not the config file's")
 	assert.Zero(t, recA.count(), "config-file server A must receive no requests, got %v", recA.all())
 }

--- a/cmd/gcx/root/aio11y_config_routing_test.go
+++ b/cmd/gcx/root/aio11y_config_routing_test.go
@@ -1,0 +1,347 @@
+package root_test
+
+// Regression tests for issue #951: explicit --config must reach the direct
+// `gcx agento11y` CRUD commands (evaluators, rules, guards, collections).
+//
+// Each case builds the real root command tree (root.NewCommandForTest) with
+// only the Agent Observability provider mounted, points two recording HTTP
+// servers A and B at distinct config files, and asserts every plugin-API
+// request lands on the server the user selected — and none on the other.
+// Distinct stack-ids give each config a deterministic namespace
+// (stacks-11111 vs stacks-22222) without any /bootdata discovery round-trip,
+// which also lets the collections-update case assert the output envelope's
+// namespace comes from the selected config.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/root"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/providers/aio11y"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recorder captures every request that reaches a test server.
+type recorder struct {
+	mu   sync.Mutex
+	hits []string
+}
+
+func (r *recorder) record(method, path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hits = append(r.hits, method+" "+path)
+}
+
+func (r *recorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.hits)
+}
+
+func (r *recorder) all() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.hits...)
+}
+
+func (r *recorder) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hits = nil
+}
+
+func (r *recorder) contains(methodAndPath string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Contains(r.hits, methodAndPath)
+}
+
+// newPluginServer starts a recording server that answers the grafana-sigil-app
+// plugin API well enough for every CRUD command to succeed: lists return an
+// empty page, deletes return {}, and mutations return one canned object whose
+// keys satisfy all four definition decoders (unknown fields are ignored).
+func newPluginServer(t *testing.T) (*httptest.Server, *recorder) {
+	t.Helper()
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		rec.record(req.Method, req.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"items": []}`))
+		case http.MethodDelete:
+			_, _ = w.Write([]byte(`{}`))
+		default: // POST, PUT, PATCH
+			_, _ = w.Write([]byte(`{"evaluator_id":"e-1","rule_id":"r-1","collection_id":"c-1","name":"n","kind":"llm_judge"}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+// sandboxEnv isolates the test from the developer's real config and
+// environment: config discovery is confined to a temp HOME, every GRAFANA_*
+// and GCX_CONFIG variable is cleared (t.Setenv registers restoration), agent
+// mode is pinned off, and telemetry is disabled.
+func sandboxEnv(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
+	t.Setenv("GCX_AGENT_MODE", "false")
+	t.Setenv("GCX_TELEMETRY", "disabled")
+	for _, kv := range os.Environ() {
+		k, _, _ := strings.Cut(kv, "=")
+		if strings.HasPrefix(k, "GRAFANA_") || k == "GCX_CONFIG" {
+			t.Setenv(k, os.Getenv(k))
+			os.Unsetenv(k)
+		}
+	}
+	return home
+}
+
+func writeConfigFile(t *testing.T, path, server string, stackID int64) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	cfg := fmt.Sprintf(`version: 1
+stacks:
+  main:
+    grafana:
+      server: %s
+      token: test-token
+      stack-id: %d
+contexts:
+  default:
+    stack: main
+current-context: default
+`, server, stackID)
+	require.NoError(t, os.WriteFile(path, []byte(cfg), 0o600))
+	return path
+}
+
+func defaultConfigPath(home string) string {
+	return filepath.Join(home, ".config", "gcx", "config.yaml")
+}
+
+// runAIO11y executes the real root command tree with only the Agent Observability
+// provider mounted. A fresh tree per invocation keeps cobra flag state from
+// leaking between cases.
+func runAIO11y(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	cmd := root.NewCommandForTest("test", []providers.Provider{&aio11y.AIO11yProvider{}})
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetArgs(args)
+	err := cmd.ExecuteContext(context.Background())
+	return stdout.String(), stderr.String(), err
+}
+
+func writeSpecFile(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+const pluginBase = "/api/plugins/grafana-sigil-app/resources"
+
+// TestAIO11y_ExplicitConfigWinsOverDefault is the core #951 regression: a
+// valid config exists at the default location (server A) and the user passes
+// --config for server B. Every read and mutation must reach B and never A —
+// before the fix, all of these silently ran against A.
+func TestAIO11y_ExplicitConfigWinsOverDefault(t *testing.T) {
+	home := sandboxEnv(t)
+	srvA, recA := newPluginServer(t)
+	srvB, recB := newPluginServer(t)
+	writeConfigFile(t, defaultConfigPath(home), srvA.URL, 11111)
+	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, 22222)
+
+	evaluatorFile := writeSpecFile(t, "evaluator.yaml", "evaluator_id: e-1\nkind: llm_judge\n")
+	ruleFile := writeSpecFile(t, "rule.yaml", "rule_id: r-1\nenabled: true\n")
+	guardFile := writeSpecFile(t, "guard.yaml", "rule_id: g-1\nphase: preflight\n")
+
+	cases := []struct {
+		name string
+		args []string
+		hit  string
+	}{
+		// Flag before the subcommand, matching the exact #951 repro position.
+		{"evaluators list, --config first", []string{"--config", cfgB, "agento11y", "evaluators", "list", "-o", "json"}, "GET " + pluginBase + "/eval/evaluators"},
+		{"evaluators upsert", []string{"agento11y", "evaluators", "upsert", "-f", evaluatorFile, "-o", "json", "--config", cfgB}, "POST " + pluginBase + "/eval/evaluators"},
+		{"evaluators delete", []string{"agento11y", "evaluators", "delete", "e-1", "--force", "--config", cfgB}, "DELETE " + pluginBase + "/eval/evaluators/e-1"},
+		{"rules list", []string{"agento11y", "rules", "list", "-o", "json", "--config", cfgB}, "GET " + pluginBase + "/eval/rules"},
+		{"rules create", []string{"agento11y", "rules", "create", "-f", ruleFile, "-o", "json", "--config", cfgB}, "POST " + pluginBase + "/eval/rules"},
+		{"guards list", []string{"agento11y", "guards", "list", "-o", "json", "--config", cfgB}, "GET " + pluginBase + "/eval/hook-rules"},
+		{"guards create", []string{"agento11y", "guards", "create", "-f", guardFile, "-o", "json", "--config", cfgB}, "POST " + pluginBase + "/eval/hook-rules"},
+		{"collections list", []string{"agento11y", "collections", "list", "-o", "json", "--config", cfgB}, "GET " + pluginBase + "/eval/collections"},
+		{"collections create", []string{"agento11y", "collections", "create", "--name", "suite", "-o", "json", "--config", cfgB}, "POST " + pluginBase + "/eval/collections"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			recA.reset()
+			recB.reset()
+			_, stderr, err := runAIO11y(t, tc.args...)
+			require.NoError(t, err, "stderr: %s", stderr)
+			assert.True(t, recB.contains(tc.hit), "expected %q on --config server B, got %v", tc.hit, recB.all())
+			assert.Zero(t, recA.count(), "default-config server A must receive no requests, got %v", recA.all())
+		})
+	}
+}
+
+// TestAIO11y_ExplicitConfigWinsOverGCXConfigEnv: GCX_CONFIG points at server A,
+// --config at server B. The explicit flag has higher precedence.
+func TestAIO11y_ExplicitConfigWinsOverGCXConfigEnv(t *testing.T) {
+	sandboxEnv(t)
+	srvA, recA := newPluginServer(t)
+	srvB, recB := newPluginServer(t)
+	cfgA := writeConfigFile(t, filepath.Join(t.TempDir(), "a.yaml"), srvA.URL, 11111)
+	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, 22222)
+	t.Setenv("GCX_CONFIG", cfgA)
+
+	ruleFile := writeSpecFile(t, "rule.yaml", "rule_id: r-1\nenabled: true\n")
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"read", []string{"agento11y", "evaluators", "list", "-o", "json", "--config", cfgB}},
+		{"mutation", []string{"agento11y", "rules", "create", "-f", ruleFile, "-o", "json", "--config", cfgB}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recA.reset()
+			recB.reset()
+			_, stderr, err := runAIO11y(t, tc.args...)
+			require.NoError(t, err, "stderr: %s", stderr)
+			assert.Positive(t, recB.count(), "expected requests on --config server B")
+			assert.Zero(t, recA.count(), "GCX_CONFIG server A must receive no requests, got %v", recA.all())
+		})
+	}
+}
+
+// TestAIO11y_ExplicitConfigWithoutDefault reproduces the original #951 error
+// path: no config exists at the default location, and --config alone must be
+// sufficient. Before the fix these commands failed with "Invalid
+// configuration" from the auto-created empty default config.
+func TestAIO11y_ExplicitConfigWithoutDefault(t *testing.T) {
+	sandboxEnv(t)
+	srvB, recB := newPluginServer(t)
+	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, 22222)
+
+	guardFile := writeSpecFile(t, "guard.yaml", "rule_id: g-1\nphase: preflight\n")
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"evaluators list", []string{"agento11y", "evaluators", "list", "-o", "json", "--config", cfgB}},
+		{"guards create", []string{"agento11y", "guards", "create", "-f", guardFile, "-o", "json", "--config", cfgB}},
+		{"collections update", []string{"agento11y", "collections", "update", "c-1", "--name", "renamed", "-o", "json", "--config", cfgB}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recB.reset()
+			_, stderr, err := runAIO11y(t, tc.args...)
+			require.NoError(t, err, "stderr: %s", stderr)
+			assert.Positive(t, recB.count(), "expected requests on --config server B")
+		})
+	}
+}
+
+// TestAIO11y_CollectionsUpdateEnvelopeNamespace covers the mixed-path defect
+// in collections update: the PATCH already routed through the bound loader,
+// but the output envelope was built from a TypedCRUD loaded off the default
+// config, so its namespace came from the wrong stack. Routing-only assertions
+// cannot catch this; the namespace assertion can.
+func TestAIO11y_CollectionsUpdateEnvelopeNamespace(t *testing.T) {
+	home := sandboxEnv(t)
+	srvA, recA := newPluginServer(t)
+	srvB, recB := newPluginServer(t)
+	writeConfigFile(t, defaultConfigPath(home), srvA.URL, 11111)
+	cfgB := writeConfigFile(t, filepath.Join(t.TempDir(), "b.yaml"), srvB.URL, 22222)
+
+	stdout, stderr, err := runAIO11y(t, "agento11y", "collections", "update", "c-1", "--name", "renamed", "-o", "json", "--config", cfgB)
+	require.NoError(t, err, "stderr: %s", stderr)
+
+	assert.True(t, recB.contains("PATCH "+pluginBase+"/eval/collections/c-1"),
+		"expected PATCH on --config server B, got %v", recB.all())
+	assert.Zero(t, recA.count(), "default-config server A must receive no requests, got %v", recA.all())
+
+	var envelope struct {
+		Metadata struct {
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &envelope), "stdout: %s", stdout)
+	assert.Equal(t, "stacks-22222", envelope.Metadata.Namespace,
+		"output envelope namespace must come from the --config stack, not the default config")
+}
+
+// TestAIO11y_ContextFlagSmoke guards what #1012 fixed: --context selects
+// between contexts of the discovered default config.
+func TestAIO11y_ContextFlagSmoke(t *testing.T) {
+	home := sandboxEnv(t)
+	srvA, recA := newPluginServer(t)
+	srvB, recB := newPluginServer(t)
+	path := defaultConfigPath(home)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	cfg := fmt.Sprintf(`version: 1
+stacks:
+  stack-a:
+    grafana:
+      server: %s
+      token: token-a
+      stack-id: 11111
+  stack-b:
+    grafana:
+      server: %s
+      token: token-b
+      stack-id: 22222
+contexts:
+  a:
+    stack: stack-a
+  b:
+    stack: stack-b
+current-context: a
+`, srvA.URL, srvB.URL)
+	require.NoError(t, os.WriteFile(path, []byte(cfg), 0o600))
+
+	_, stderr, err := runAIO11y(t, "--context", "b", "agento11y", "evaluators", "list", "-o", "json")
+	require.NoError(t, err, "stderr: %s", stderr)
+	assert.Positive(t, recB.count(), "expected requests on context b's server")
+	assert.Zero(t, recA.count(), "context a's server must receive no requests, got %v", recA.all())
+}
+
+// TestAIO11y_EnvVarSmoke guards the env-override path that always worked for
+// #951's reporter: GRAFANA_SERVER/GRAFANA_TOKEN override an existing config
+// file. (The env-only path with no config file at all is broken on main for
+// every ConfigLoader-based provider — "$.stacks.default.grafana: node not
+// found" — which is a separate pre-existing defect, out of scope here.)
+func TestAIO11y_EnvVarSmoke(t *testing.T) {
+	home := sandboxEnv(t)
+	srvA, recA := newPluginServer(t)
+	srvB, recB := newPluginServer(t)
+	writeConfigFile(t, defaultConfigPath(home), srvA.URL, 11111)
+	t.Setenv("GRAFANA_SERVER", srvB.URL)
+	t.Setenv("GRAFANA_TOKEN", "env-token")
+
+	_, stderr, err := runAIO11y(t, "agento11y", "evaluators", "list", "-o", "json")
+	require.NoError(t, err, "stderr: %s", stderr)
+	assert.Positive(t, recB.count(), "expected requests on the env-var server")
+	assert.Zero(t, recA.count(), "config-file server A must receive no requests, got %v", recA.all())
+}

--- a/internal/providers/aio11y/eval/collections/commands.go
+++ b/internal/providers/aio11y/eval/collections/commands.go
@@ -38,11 +38,11 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "Manage named groups of saved conversations.",
 	}
 	cmd.AddCommand(
-		newListCommand(),
-		newGetCommand(),
-		newCreateCommand(),
+		newListCommand(loader),
+		newGetCommand(loader),
+		newCreateCommand(loader),
 		newUpdateCommand(loader),
-		newDeleteCommand(),
+		newDeleteCommand(loader),
 		newListConversationsCommand(loader),
 		newAddConversationsCommand(loader),
 		newRemoveConversationCommand(loader),
@@ -65,7 +65,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of collections to return (0 for no limit)")
 }
 
-func newListCommand() *cobra.Command {
+func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &listOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -76,7 +76,7 @@ func newListCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -121,7 +121,7 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newGetCommand() *cobra.Command {
+func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &getOpts{}
 	cmd := &cobra.Command{
 		Use:   "get <collection-id>",
@@ -133,7 +133,7 @@ func newGetCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -209,7 +209,7 @@ func readCollectionFile(path string, stdin io.Reader) (*Collection, error) {
 	return &col, nil
 }
 
-func newCreateCommand() *cobra.Command {
+func newCreateCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &createOpts{}
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -236,7 +236,7 @@ func newCreateCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -298,7 +298,7 @@ func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -342,7 +342,7 @@ func (o *deleteOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newDeleteCommand() *cobra.Command {
+func newDeleteCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &deleteOpts{}
 	cmd := &cobra.Command{
 		Use:   "delete COLLECTION-ID...",
@@ -362,7 +362,7 @@ func newDeleteCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/aio11y/eval/collections/commands.go
+++ b/internal/providers/aio11y/eval/collections/commands.go
@@ -33,9 +33,6 @@ func newClient(cmd *cobra.Command, loader *providers.ConfigLoader) (*Client, err
 
 // Commands returns the collections command group.
 func Commands(loader *providers.ConfigLoader) *cobra.Command {
-	if loader == nil {
-		loader = &providers.ConfigLoader{}
-	}
 	cmd := &cobra.Command{
 		Use:   "collections",
 		Short: "Manage named groups of saved conversations.",

--- a/internal/providers/aio11y/eval/collections/commands.go
+++ b/internal/providers/aio11y/eval/collections/commands.go
@@ -33,6 +33,9 @@ func newClient(cmd *cobra.Command, loader *providers.ConfigLoader) (*Client, err
 
 // Commands returns the collections command group.
 func Commands(loader *providers.ConfigLoader) *cobra.Command {
+	if loader == nil {
+		loader = &providers.ConfigLoader{}
+	}
 	cmd := &cobra.Command{
 		Use:   "collections",
 		Short: "Manage named groups of saved conversations.",
@@ -298,15 +301,11 @@ func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx, loader)
+			crud, client, err := newCRUDAndClient(ctx, loader)
 			if err != nil {
 				return err
 			}
 
-			client, err := newClient(cmd, loader)
-			if err != nil {
-				return err
-			}
 			updated, err := client.Update(ctx, args[0], req)
 			if err != nil {
 				return err

--- a/internal/providers/aio11y/eval/collections/commands_test.go
+++ b/internal/providers/aio11y/eval/collections/commands_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/collections"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,7 +64,7 @@ func TestTableCodec_Format(t *testing.T) {
 }
 
 func TestCommands_HasMembershipCompounds(t *testing.T) {
-	cmd := collections.Commands(&providers.ConfigLoader{})
+	cmd := collections.Commands(nil)
 
 	for _, sub := range []string{"list-conversations", "add-conversations", "remove-conversation"} {
 		c, _, err := cmd.Find([]string{sub})
@@ -82,7 +81,7 @@ func TestCommands_HasMembershipCompounds(t *testing.T) {
 }
 
 func TestCreateCommand_RejectsConflictingFlags(t *testing.T) {
-	cmd := collections.Commands(&providers.ConfigLoader{})
+	cmd := collections.Commands(nil)
 	cmd.SetArgs([]string{"create", "-f", "x.yaml", "--name", "x"})
 
 	var stdout, stderr bytes.Buffer
@@ -95,7 +94,7 @@ func TestCreateCommand_RejectsConflictingFlags(t *testing.T) {
 }
 
 func TestCreateCommand_RequiresInput(t *testing.T) {
-	cmd := collections.Commands(&providers.ConfigLoader{})
+	cmd := collections.Commands(nil)
 	cmd.SetArgs([]string{"create"})
 
 	var stdout, stderr bytes.Buffer
@@ -108,7 +107,7 @@ func TestCreateCommand_RequiresInput(t *testing.T) {
 }
 
 func TestUpdateCommand_RequiresAtLeastOneFlag(t *testing.T) {
-	cmd := collections.Commands(&providers.ConfigLoader{})
+	cmd := collections.Commands(nil)
 	cmd.SetArgs([]string{"update", "c-1"})
 
 	var stdout, stderr bytes.Buffer
@@ -121,7 +120,7 @@ func TestUpdateCommand_RequiresAtLeastOneFlag(t *testing.T) {
 }
 
 func TestAddConversationsCommand_NeedsTwoArgs(t *testing.T) {
-	cmd := collections.Commands(&providers.ConfigLoader{})
+	cmd := collections.Commands(nil)
 	cmd.SetArgs([]string{"add-conversations", "c-1"})
 
 	var stdout, stderr bytes.Buffer
@@ -134,7 +133,7 @@ func TestAddConversationsCommand_NeedsTwoArgs(t *testing.T) {
 }
 
 func TestDeleteCommand_AbortsWithoutForce(t *testing.T) {
-	cmd := collections.Commands(&providers.ConfigLoader{})
+	cmd := collections.Commands(nil)
 	cmd.SetArgs([]string{"delete", "c-1"})
 
 	var stdout, stderr bytes.Buffer

--- a/internal/providers/aio11y/eval/collections/commands_test.go
+++ b/internal/providers/aio11y/eval/collections/commands_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/aio11y/eval/collections"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,7 +65,7 @@ func TestTableCodec_Format(t *testing.T) {
 }
 
 func TestCommands_HasMembershipCompounds(t *testing.T) {
-	cmd := collections.Commands(nil)
+	cmd := collections.Commands(&providers.ConfigLoader{})
 
 	for _, sub := range []string{"list-conversations", "add-conversations", "remove-conversation"} {
 		c, _, err := cmd.Find([]string{sub})
@@ -81,7 +82,7 @@ func TestCommands_HasMembershipCompounds(t *testing.T) {
 }
 
 func TestCreateCommand_RejectsConflictingFlags(t *testing.T) {
-	cmd := collections.Commands(nil)
+	cmd := collections.Commands(&providers.ConfigLoader{})
 	cmd.SetArgs([]string{"create", "-f", "x.yaml", "--name", "x"})
 
 	var stdout, stderr bytes.Buffer
@@ -94,7 +95,7 @@ func TestCreateCommand_RejectsConflictingFlags(t *testing.T) {
 }
 
 func TestCreateCommand_RequiresInput(t *testing.T) {
-	cmd := collections.Commands(nil)
+	cmd := collections.Commands(&providers.ConfigLoader{})
 	cmd.SetArgs([]string{"create"})
 
 	var stdout, stderr bytes.Buffer
@@ -107,7 +108,7 @@ func TestCreateCommand_RequiresInput(t *testing.T) {
 }
 
 func TestUpdateCommand_RequiresAtLeastOneFlag(t *testing.T) {
-	cmd := collections.Commands(nil)
+	cmd := collections.Commands(&providers.ConfigLoader{})
 	cmd.SetArgs([]string{"update", "c-1"})
 
 	var stdout, stderr bytes.Buffer
@@ -120,7 +121,7 @@ func TestUpdateCommand_RequiresAtLeastOneFlag(t *testing.T) {
 }
 
 func TestAddConversationsCommand_NeedsTwoArgs(t *testing.T) {
-	cmd := collections.Commands(nil)
+	cmd := collections.Commands(&providers.ConfigLoader{})
 	cmd.SetArgs([]string{"add-conversations", "c-1"})
 
 	var stdout, stderr bytes.Buffer
@@ -133,7 +134,7 @@ func TestAddConversationsCommand_NeedsTwoArgs(t *testing.T) {
 }
 
 func TestDeleteCommand_AbortsWithoutForce(t *testing.T) {
-	cmd := collections.Commands(nil)
+	cmd := collections.Commands(&providers.ConfigLoader{})
 	cmd.SetArgs([]string{"delete", "c-1"})
 
 	var stdout, stderr bytes.Buffer

--- a/internal/providers/aio11y/eval/collections/nil_loader_test.go
+++ b/internal/providers/aio11y/eval/collections/nil_loader_test.go
@@ -1,0 +1,63 @@
+package collections_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/aio11y/eval/collections"
+	"github.com/grafana/gcx/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommands_NilLoader_EndToEnd is the teeth for the nil-loader contract:
+// unlike the flag-validation tests in commands_test.go, which return before
+// RunE ever touches the loader, this runs a verb all the way through
+// ConfigLoader.LoadGrafanaConfig and an HTTP round-trip. A nil loader must
+// behave like a zero-value one (default config discovery); removing the
+// nil-receiver handling in providers.ConfigLoader fails this test.
+func TestCommands_NilLoader_EndToEnd(t *testing.T) {
+	home := testutils.SandboxConfigEnv(t)
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items": []}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfgPath := filepath.Join(home, ".config", "gcx", "config.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o755))
+	cfg := fmt.Sprintf(`version: 1
+stacks:
+  main:
+    grafana:
+      server: %s
+      token: test-token
+      stack-id: 11111
+contexts:
+  default:
+    stack: main
+current-context: default
+`, srv.URL)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o600))
+
+	cmd := collections.Commands(nil)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetArgs([]string{"list", "-o", "json"})
+
+	require.NoError(t, cmd.ExecuteContext(context.Background()), "stderr: %s", stderr.String())
+	assert.Positive(t, hits.Load(), "nil-loader command must route via default config discovery")
+}

--- a/internal/providers/aio11y/eval/collections/resource_adapter.go
+++ b/internal/providers/aio11y/eval/collections/resource_adapter.go
@@ -58,14 +58,26 @@ func stripFields() []string {
 // a zero-value loader and inherit the selection (config file and context name)
 // threaded through ctx by the resources command.
 func NewTypedCRUD(ctx context.Context, loader *providers.ConfigLoader) (*adapter.TypedCRUD[Collection], string, error) {
+	crud, _, err := newCRUDAndClient(ctx, loader)
+	if err != nil {
+		return nil, "", err
+	}
+	return crud, crud.Namespace, nil
+}
+
+// newCRUDAndClient builds the collections client and its envelope CRUD from a
+// single config load, so callers that need both (the update command routes its
+// PATCH through the client but renders via the CRUD) cannot end up with the
+// two halves pointing at different stacks.
+func newCRUDAndClient(ctx context.Context, loader *providers.ConfigLoader) (*adapter.TypedCRUD[Collection], *Client, error) {
 	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to load REST config for Agent Observability collections: %w", err)
+		return nil, nil, fmt.Errorf("failed to load REST config for Agent Observability collections: %w", err)
 	}
 
 	base, err := aio11yhttp.NewClient(cfg)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to create Agent Observability HTTP client: %w", err)
+		return nil, nil, fmt.Errorf("failed to create Agent Observability HTTP client: %w", err)
 	}
 	client := NewClient(base)
 
@@ -95,7 +107,7 @@ func NewTypedCRUD(ctx context.Context, loader *providers.ConfigLoader) (*adapter
 		StripFields: stripFields(),
 		Descriptor:  StaticDescriptor(),
 	}
-	return crud, cfg.Namespace, nil
+	return crud, client, nil
 }
 
 // NewLazyFactory returns an adapter.Factory for Agent Observability collections.

--- a/internal/providers/aio11y/eval/collections/resource_adapter.go
+++ b/internal/providers/aio11y/eval/collections/resource_adapter.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	internalconfig "github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/aio11y/aio11yhttp"
 	"github.com/grafana/gcx/internal/resources"
@@ -55,10 +54,10 @@ func stripFields() []string {
 // description in the pulled YAML — Collection.Description has `omitempty`, so
 // it round-trips as zero — does not clear the server-side value. To explicitly
 // clear a description, use `gcx agento11y collections update <id> --description ""`.
-func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[Collection], string, error) {
-	var loader providers.ConfigLoader
-	loader.SetContextName(internalconfig.ContextNameFromCtx(ctx))
-
+// The loader carries the command's --config selection; adapter factories pass
+// a zero-value loader and inherit the selection (config file and context name)
+// threaded through ctx by the resources command.
+func NewTypedCRUD(ctx context.Context, loader *providers.ConfigLoader) (*adapter.TypedCRUD[Collection], string, error) {
 	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load REST config for Agent Observability collections: %w", err)
@@ -102,7 +101,8 @@ func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[Collection], string, 
 // NewLazyFactory returns an adapter.Factory for Agent Observability collections.
 func NewLazyFactory() adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
-		crud, _, err := NewTypedCRUD(ctx)
+		var loader providers.ConfigLoader
+		crud, _, err := NewTypedCRUD(ctx, &loader)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/providers/aio11y/eval/evaluators/commands.go
+++ b/internal/providers/aio11y/eval/evaluators/commands.go
@@ -22,14 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// Commands returns the evaluators command group. A nil loader falls back to
-// a zero-value loader (default discovery + ctx threading), preserving the
-// behavior external callers relied on before the loader was threaded through
-// every subcommand.
+// Commands returns the evaluators command group. A nil loader is valid and
+// behaves like a zero-value loader (see providers.ConfigLoader).
 func Commands(loader *providers.ConfigLoader) *cobra.Command {
-	if loader == nil {
-		loader = &providers.ConfigLoader{}
-	}
 	cmd := &cobra.Command{
 		Use:   "evaluators",
 		Short: "Manage evaluator definitions (LLM judge, regex, heuristic).",

--- a/internal/providers/aio11y/eval/evaluators/commands.go
+++ b/internal/providers/aio11y/eval/evaluators/commands.go
@@ -29,10 +29,10 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "Manage evaluator definitions (LLM judge, regex, heuristic).",
 	}
 	cmd.AddCommand(
-		newListCommand(),
-		newGetCommand(),
-		newCreateCommand(),
-		newDeleteCommand(),
+		newListCommand(loader),
+		newGetCommand(loader),
+		newCreateCommand(loader),
+		newDeleteCommand(loader),
 		newTestCommand(loader),
 	)
 	return cmd
@@ -53,7 +53,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of evaluators to return (0 for no limit)")
 }
 
-func newListCommand() *cobra.Command {
+func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &listOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -64,7 +64,7 @@ func newListCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, namespace, err := NewTypedCRUD(ctx)
+			crud, namespace, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -109,7 +109,7 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newGetCommand() *cobra.Command {
+func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &getOpts{}
 	cmd := &cobra.Command{
 		Use:   "get <evaluator-id>",
@@ -121,7 +121,7 @@ func newGetCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, namespace, err := NewTypedCRUD(ctx)
+			crud, namespace, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -162,7 +162,7 @@ func (o *createOpts) Validate() error {
 	return o.IO.Validate()
 }
 
-func newCreateCommand() *cobra.Command {
+func newCreateCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &createOpts{}
 	cmd := &cobra.Command{
 		Use:   "upsert",
@@ -187,7 +187,7 @@ func newCreateCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -224,7 +224,7 @@ func (o *deleteOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newDeleteCommand() *cobra.Command {
+func newDeleteCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &deleteOpts{}
 	cmd := &cobra.Command{
 		Use:   "delete ID...",
@@ -244,7 +244,7 @@ func newDeleteCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/aio11y/eval/evaluators/commands.go
+++ b/internal/providers/aio11y/eval/evaluators/commands.go
@@ -22,8 +22,14 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// Commands returns the evaluators command group.
+// Commands returns the evaluators command group. A nil loader falls back to
+// a zero-value loader (default discovery + ctx threading), preserving the
+// behavior external callers relied on before the loader was threaded through
+// every subcommand.
 func Commands(loader *providers.ConfigLoader) *cobra.Command {
+	if loader == nil {
+		loader = &providers.ConfigLoader{}
+	}
 	cmd := &cobra.Command{
 		Use:   "evaluators",
 		Short: "Manage evaluator definitions (LLM judge, regex, heuristic).",

--- a/internal/providers/aio11y/eval/evaluators/resource_adapter.go
+++ b/internal/providers/aio11y/eval/evaluators/resource_adapter.go
@@ -41,9 +41,10 @@ func evalStripFields() []string {
 }
 
 // NewTypedCRUD creates a TypedCRUD for Agent Observability evaluators.
-func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.EvaluatorDefinition], string, error) {
-	var loader providers.ConfigLoader
-
+// The loader carries the command's --config selection; adapter factories pass
+// a zero-value loader and inherit the selection threaded through ctx by the
+// resources command.
+func NewTypedCRUD(ctx context.Context, loader *providers.ConfigLoader) (*adapter.TypedCRUD[eval.EvaluatorDefinition], string, error) {
 	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load REST config for Agent Observability evaluators: %w", err)
@@ -78,7 +79,8 @@ func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.EvaluatorDefinit
 // NewLazyFactory returns an adapter.Factory for Agent Observability evaluators.
 func NewLazyFactory() adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
-		crud, _, err := NewTypedCRUD(ctx)
+		var loader providers.ConfigLoader
+		crud, _, err := NewTypedCRUD(ctx, &loader)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/providers/aio11y/eval/guards/commands.go
+++ b/internal/providers/aio11y/eval/guards/commands.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Commands returns the guards command group.
-func Commands() *cobra.Command {
+func Commands(loader *providers.ConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "guards",
 		Short: "Manage synchronous policy guards (hook rules) that evaluate generations on the request path.",
@@ -34,11 +34,11 @@ They can deny, warn, or transform a generation based on evaluators, regex patter
 Unlike eval rules (gcx agento11y rules), guards run inline on the request path and short-circuit by default.`,
 	}
 	cmd.AddCommand(
-		newListCommand(),
-		newGetCommand(),
-		newCreateCommand(),
-		newUpdateCommand(),
-		newDeleteCommand(),
+		newListCommand(loader),
+		newGetCommand(loader),
+		newCreateCommand(loader),
+		newUpdateCommand(loader),
+		newDeleteCommand(loader),
 	)
 	return cmd
 }
@@ -58,7 +58,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of hook rules to return (0 for no limit)")
 }
 
-func newListCommand() *cobra.Command {
+func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &listOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -69,7 +69,7 @@ func newListCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, namespace, err := NewTypedCRUD(ctx)
+			crud, namespace, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -114,7 +114,7 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newGetCommand() *cobra.Command {
+func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &getOpts{}
 	cmd := &cobra.Command{
 		Use:   "get <rule-id>",
@@ -126,7 +126,7 @@ func newGetCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, namespace, err := NewTypedCRUD(ctx)
+			crud, namespace, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -167,7 +167,7 @@ func (o *createOpts) Validate() error {
 	return o.IO.Validate()
 }
 
-func newCreateCommand() *cobra.Command {
+func newCreateCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &createOpts{}
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -191,7 +191,7 @@ func newCreateCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -230,7 +230,7 @@ func (o *updateOpts) Validate() error {
 	return o.IO.Validate()
 }
 
-func newUpdateCommand() *cobra.Command {
+func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &updateOpts{}
 	cmd := &cobra.Command{
 		Use:   "update <rule-id>",
@@ -249,7 +249,7 @@ func newUpdateCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -286,7 +286,7 @@ func (o *deleteOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newDeleteCommand() *cobra.Command {
+func newDeleteCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &deleteOpts{}
 	cmd := &cobra.Command{
 		Use:   "delete ID...",
@@ -306,7 +306,7 @@ func newDeleteCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/aio11y/eval/guards/commands.go
+++ b/internal/providers/aio11y/eval/guards/commands.go
@@ -25,6 +25,9 @@ import (
 
 // Commands returns the guards command group.
 func Commands(loader *providers.ConfigLoader) *cobra.Command {
+	if loader == nil {
+		loader = &providers.ConfigLoader{}
+	}
 	cmd := &cobra.Command{
 		Use:   "guards",
 		Short: "Manage synchronous policy guards (hook rules) that evaluate generations on the request path.",

--- a/internal/providers/aio11y/eval/guards/commands.go
+++ b/internal/providers/aio11y/eval/guards/commands.go
@@ -25,9 +25,6 @@ import (
 
 // Commands returns the guards command group.
 func Commands(loader *providers.ConfigLoader) *cobra.Command {
-	if loader == nil {
-		loader = &providers.ConfigLoader{}
-	}
 	cmd := &cobra.Command{
 		Use:   "guards",
 		Short: "Manage synchronous policy guards (hook rules) that evaluate generations on the request path.",

--- a/internal/providers/aio11y/eval/guards/resource_adapter.go
+++ b/internal/providers/aio11y/eval/guards/resource_adapter.go
@@ -40,9 +40,10 @@ func hookRuleStripFields() []string {
 }
 
 // NewTypedCRUD creates a TypedCRUD for Agent Observability hook rules.
-func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.HookRuleDefinition], string, error) {
-	var loader providers.ConfigLoader
-
+// The loader carries the command's --config selection; adapter factories pass
+// a zero-value loader and inherit the selection threaded through ctx by the
+// resources command.
+func NewTypedCRUD(ctx context.Context, loader *providers.ConfigLoader) (*adapter.TypedCRUD[eval.HookRuleDefinition], string, error) {
 	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load REST config for Agent Observability hook rules: %w", err)
@@ -76,7 +77,8 @@ func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.HookRuleDefiniti
 // NewLazyFactory returns an adapter.Factory for Agent Observability hook rules.
 func NewLazyFactory() adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
-		crud, _, err := NewTypedCRUD(ctx)
+		var loader providers.ConfigLoader
+		crud, _, err := NewTypedCRUD(ctx, &loader)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/providers/aio11y/eval/rules/commands.go
+++ b/internal/providers/aio11y/eval/rules/commands.go
@@ -24,17 +24,17 @@ import (
 )
 
 // Commands returns the rules command group.
-func Commands() *cobra.Command {
+func Commands(loader *providers.ConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rules",
 		Short: "Manage rules that route generations to evaluators.",
 	}
 	cmd.AddCommand(
-		newListCommand(),
-		newGetCommand(),
-		newCreateCommand(),
-		newUpdateCommand(),
-		newDeleteCommand(),
+		newListCommand(loader),
+		newGetCommand(loader),
+		newCreateCommand(loader),
+		newUpdateCommand(loader),
+		newDeleteCommand(loader),
 	)
 	return cmd
 }
@@ -54,7 +54,7 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	flags.Int64Var(&o.Limit, "limit", 50, "Maximum number of rules to return (0 for no limit)")
 }
 
-func newListCommand() *cobra.Command {
+func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &listOpts{}
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -65,7 +65,7 @@ func newListCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, namespace, err := NewTypedCRUD(ctx)
+			crud, namespace, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -110,7 +110,7 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newGetCommand() *cobra.Command {
+func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &getOpts{}
 	cmd := &cobra.Command{
 		Use:   "get <rule-id>",
@@ -122,7 +122,7 @@ func newGetCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, namespace, err := NewTypedCRUD(ctx)
+			crud, namespace, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -163,7 +163,7 @@ func (o *createOpts) Validate() error {
 	return o.IO.Validate()
 }
 
-func newCreateCommand() *cobra.Command {
+func newCreateCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &createOpts{}
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -187,7 +187,7 @@ func newCreateCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -226,7 +226,7 @@ func (o *updateOpts) Validate() error {
 	return o.IO.Validate()
 }
 
-func newUpdateCommand() *cobra.Command {
+func newUpdateCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &updateOpts{}
 	cmd := &cobra.Command{
 		Use:   "update <rule-id>",
@@ -245,7 +245,7 @@ func newUpdateCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}
@@ -282,7 +282,7 @@ func (o *deleteOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 }
 
-func newDeleteCommand() *cobra.Command {
+func newDeleteCommand(loader *providers.ConfigLoader) *cobra.Command {
 	opts := &deleteOpts{}
 	cmd := &cobra.Command{
 		Use:   "delete ID...",
@@ -302,7 +302,7 @@ func newDeleteCommand() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-			crud, _, err := NewTypedCRUD(ctx)
+			crud, _, err := NewTypedCRUD(ctx, loader)
 			if err != nil {
 				return err
 			}

--- a/internal/providers/aio11y/eval/rules/commands.go
+++ b/internal/providers/aio11y/eval/rules/commands.go
@@ -25,9 +25,6 @@ import (
 
 // Commands returns the rules command group.
 func Commands(loader *providers.ConfigLoader) *cobra.Command {
-	if loader == nil {
-		loader = &providers.ConfigLoader{}
-	}
 	cmd := &cobra.Command{
 		Use:   "rules",
 		Short: "Manage rules that route generations to evaluators.",

--- a/internal/providers/aio11y/eval/rules/commands.go
+++ b/internal/providers/aio11y/eval/rules/commands.go
@@ -25,6 +25,9 @@ import (
 
 // Commands returns the rules command group.
 func Commands(loader *providers.ConfigLoader) *cobra.Command {
+	if loader == nil {
+		loader = &providers.ConfigLoader{}
+	}
 	cmd := &cobra.Command{
 		Use:   "rules",
 		Short: "Manage rules that route generations to evaluators.",

--- a/internal/providers/aio11y/eval/rules/resource_adapter.go
+++ b/internal/providers/aio11y/eval/rules/resource_adapter.go
@@ -40,9 +40,10 @@ func ruleStripFields() []string {
 }
 
 // NewTypedCRUD creates a TypedCRUD for Agent Observability evaluation rules.
-func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.RuleDefinition], string, error) {
-	var loader providers.ConfigLoader
-
+// The loader carries the command's --config selection; adapter factories pass
+// a zero-value loader and inherit the selection threaded through ctx by the
+// resources command.
+func NewTypedCRUD(ctx context.Context, loader *providers.ConfigLoader) (*adapter.TypedCRUD[eval.RuleDefinition], string, error) {
 	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load REST config for Agent Observability rules: %w", err)
@@ -76,7 +77,8 @@ func NewTypedCRUD(ctx context.Context) (*adapter.TypedCRUD[eval.RuleDefinition],
 // NewLazyFactory returns an adapter.Factory for Agent Observability evaluation rules.
 func NewLazyFactory() adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
-		crud, _, err := NewTypedCRUD(ctx)
+		var loader providers.ConfigLoader
+		crud, _, err := NewTypedCRUD(ctx, &loader)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/providers/aio11y/provider.go
+++ b/internal/providers/aio11y/provider.go
@@ -68,13 +68,13 @@ func (p *AIO11yProvider) Commands() []*cobra.Command {
 		agent.AnnotationLLMHint:   `gcx agento11y evaluators list -o json; gcx agento11y evaluators get <id> -o yaml; gcx agento11y evaluators upsert -f def.yaml -o json; gcx agento11y evaluators test -e <id> -g <gen-id> -o json; gcx agento11y evaluators delete <id> --force`,
 	}
 
-	rulesCmd := rules.Commands()
+	rulesCmd := rules.Commands(loader)
 	rulesCmd.Annotations = map[string]string{
 		agent.AnnotationTokenCost: "low",
 		agent.AnnotationLLMHint:   `gcx agento11y rules list -o json; gcx agento11y rules get <id> -o yaml; gcx agento11y rules create -f rule.yaml -o json; gcx agento11y rules update <id> -f patch.yaml -o json; gcx agento11y rules delete <id> --force`,
 	}
 
-	guardsCmd := guards.Commands()
+	guardsCmd := guards.Commands(loader)
 	guardsCmd.Annotations = map[string]string{
 		agent.AnnotationTokenCost: "low",
 		agent.AnnotationLLMHint:   `gcx agento11y guards list -o json; gcx agento11y guards get <id> -o yaml; gcx agento11y guards create -f guard.yaml -o json; gcx agento11y guards update <id> -f guard.yaml -o json; gcx agento11y guards delete <id> --force`,

--- a/internal/providers/configloader.go
+++ b/internal/providers/configloader.go
@@ -119,13 +119,19 @@ func (c CloudRESTConfig) ProviderConfig(name string) map[string]string {
 // ConfigLoader is a minimal config loading helper shared across providers.
 // It avoids importing cmd/gcx/config (which would create an import cycle
 // via internal/providers).
+//
+// A nil *ConfigLoader is valid for every load path and behaves exactly like
+// a zero-value loader (GCX_CONFIG, layered discovery, and ctx threading):
+// provider Commands constructors take a flag-bound loader, and external
+// callers — package tests in particular — pass nil. Only BindFlags and the
+// setters require a non-nil receiver.
 type ConfigLoader struct {
 	configFile string
 	ctxName    string
 }
 
 func (l *ConfigLoader) resolvedContextName(ctx context.Context) string {
-	if l.ctxName != "" {
+	if l != nil && l.ctxName != "" {
 		return l.ctxName
 	}
 	return config.ContextNameFromCtx(ctx)
@@ -137,7 +143,7 @@ func (l *ConfigLoader) resolvedContextName(ctx context.Context) string {
 // immutable context selection. An empty result retains GCX_CONFIG and layered
 // discovery in config.LoadLayered.
 func (l *ConfigLoader) resolvedConfigFile(ctx context.Context) string {
-	if l.configFile != "" {
+	if l != nil && l.configFile != "" {
 		return l.configFile
 	}
 	return config.ConfigFileFromCtx(ctx)
@@ -643,10 +649,7 @@ func (l *ConfigLoader) SaveDatasourceUID(ctx context.Context, kind, uid string) 
 		return err
 	}
 
-	ctxName := l.ctxName
-	if ctxName == "" {
-		ctxName = config.ContextNameFromCtx(ctx)
-	}
+	ctxName := l.resolvedContextName(ctx)
 	if ctxName == "" {
 		ctxName = loaded.CurrentContext
 	}

--- a/internal/providers/configloader_test.go
+++ b/internal/providers/configloader_test.go
@@ -1582,3 +1582,37 @@ current-context: prod
 	assert.Equal(t, 7, cloudCfg.Stack.ID)
 	assert.NotEqual(t, "prod-stack", cloudCfg.Stack.Slug)
 }
+
+// TestConfigLoader_NilLoaderBehavesLikeZeroValue pins the nil-receiver
+// contract at the choke point: every provider Commands constructor accepts a
+// *ConfigLoader that external callers (package tests in particular) pass as
+// nil, and the resolved* fallbacks must treat that exactly like a zero-value
+// loader instead of panicking. Removing the nil checks in
+// resolvedContextName/resolvedConfigFile fails this test.
+func TestConfigLoader_NilLoaderBehavesLikeZeroValue(t *testing.T) {
+	isolateConfigSources(t)
+	cfgFile := writeConfigFile(t, `
+version: 1
+stacks:
+  main:
+    grafana:
+      server: http://127.0.0.1:3000
+      token: test-token
+      stack-id: 11111
+contexts:
+  default:
+    stack: main
+current-context: default
+`)
+	t.Setenv(internalconfig.ConfigFileEnvVar, cfgFile)
+
+	var nilLoader *providers.ConfigLoader
+	got, err := nilLoader.LoadGrafanaConfig(context.Background())
+	require.NoError(t, err)
+
+	want, err := (&providers.ConfigLoader{}).LoadGrafanaConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, want.Host, got.Host)
+	assert.Equal(t, want.Namespace, got.Namespace)
+	assert.Equal(t, "stacks-11111", got.Namespace)
+}

--- a/internal/providers/configloader_test.go
+++ b/internal/providers/configloader_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/gcx/internal/cloud"
 	internalconfig "github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/testutils"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1589,8 +1590,11 @@ current-context: prod
 // nil, and the resolved* fallbacks must treat that exactly like a zero-value
 // loader instead of panicking. Removing the nil checks in
 // resolvedContextName/resolvedConfigFile fails this test.
+//
+// SandboxConfigEnv rather than isolateConfigSources: the namespace assertion
+// is hard-coded, so ambient GRAFANA_STACK_ID/GRAFANA_SERVER must be cleared.
 func TestConfigLoader_NilLoaderBehavesLikeZeroValue(t *testing.T) {
-	isolateConfigSources(t)
+	testutils.SandboxConfigEnv(t)
 	cfgFile := writeConfigFile(t, `
 version: 1
 stacks:

--- a/internal/testutils/configsandbox.go
+++ b/internal/testutils/configsandbox.go
@@ -1,0 +1,40 @@
+package testutils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// SandboxConfigEnv isolates a test from every config-discovery input so that
+// only config files the test writes itself can be found: HOME and the XDG
+// config/state homes point at a temp dir, XDG_CONFIG_DIRS points at an empty
+// temp dir (system layer), the working directory moves to an empty temp dir
+// (cwd-local .gcx.yaml layer), every GRAFANA_* env var and GCX_CONFIG are
+// cleared (t.Setenv registers restoration), telemetry is disabled, and
+// agent-mode detection is pinned off via SetAgentMode — a plain
+// t.Setenv("GCX_AGENT_MODE", ...) would be dead code because internal/agent
+// caches detection at init() time.
+//
+// Returns the sandbox HOME. Incompatible with t.Parallel (t.Setenv/t.Chdir
+// enforce this).
+func SandboxConfigEnv(t *testing.T) string {
+	t.Helper()
+	SetAgentMode(t, false)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
+	t.Setenv("XDG_CONFIG_DIRS", t.TempDir())
+	t.Setenv("GCX_TELEMETRY", "disabled")
+	t.Chdir(t.TempDir())
+	for _, kv := range os.Environ() {
+		k, _, _ := strings.Cut(kv, "=")
+		if strings.HasPrefix(k, "GRAFANA_") || k == "GCX_CONFIG" {
+			t.Setenv(k, os.Getenv(k))
+			os.Unsetenv(k)
+		}
+	}
+	return home
+}


### PR DESCRIPTION
Fixes #951.

The evaluators, rules, guards, and collections CRUD subcommands were building their clients from zero-value ConfigLoaders instead of the flag-bound loader the provider creates, so an explicit --config parsed fine and was then silently ignored. With a valid default config that means reads and mutations (delete, upsert) ran against the default context's stack while you thought you were targeting the --config one. #1012 fixed the resources tier by threading the selection through context, and it fixed default discovery and --context, but the direct agento11y command tree never consulted its bound loader.

The fix is the shape the SLO provider already uses: NewTypedCRUD takes the loader explicitly, commands pass the bound one, and the lazy adapter factories pass a local zero-value loader so the resources-tier path keeps inheriting the context threading unchanged. rules.Commands and guards.Commands gain the loader parameter they were missing, and collections update now builds its output envelope from the selected config too (before this its PATCH went to the right stack but the envelope namespace came from the default config, and the command failed outright when no default config existed).

Tests: cmd/gcx/root/aio11y_config_routing_test.go runs the real root command tree in-process against two recording servers. Config at the default location points at server A, --config points at server B, and every read and mutation for all four resource kinds must land on B with zero requests on A. Also covers --config beating GCX_CONFIG, --config with no default config present, the collections update envelope namespace (distinct stack-ids make the namespaces assertable), flag-before-subcommand position, and green smoke tests for the --context and env-override paths #1012 fixed. All the routing cases were written first and confirmed failing on unfixed main; the two smokes passed before and after.

Two adjacent findings that are deliberately not in this PR: the appo11y provider has the same defect (it binds --config to a loader it never passes to any subcommand, affecting services, overrides, and settings), and env-only auth (GRAFANA_SERVER/GRAFANA_TOKEN with no config file at all) currently fails for every ConfigLoader-based provider with a "$.stacks.default.grafana: node not found" error. Both reproduce on main without this change; issues to follow.

No CLI surface changes, so no reference drift. mise run gate is green locally; the docs step needs mkdocs which isn't installed here, CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)