### PR TITLE
chore: update sigil app plugin ID to grafana-agento11y-app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ internal/
 │   ├── metrics/    Metrics signal provider (Prometheus queries + Adaptive Metrics commands)
 │   ├── appo11y/    App Observability provider (overrides, settings — singleton resources; services discovery via target_info)
 │   ├── profiles/   Profiles signal provider (Pyroscope queries + adaptive stub)
-│   ├── aio11y/     AI Observability provider (conversations, agents, generations, evaluators, rules, hook-rules (guards), templates, scores, judge, saved-conversations, collections, experiments — via grafana-sigil-app plugin API)
+│   ├── aio11y/     AI Observability provider (conversations, agents, generations, evaluators, rules, hook-rules (guards), templates, scores, judge, saved-conversations, collections, experiments — via grafana-agento11y-app plugin API)
 │   ├── slo/        SLO provider (definitions, reports)
 │   ├── synth/      Synthetic Monitoring provider (checks, probes)
 │   └── traces/     Traces signal provider (Tempo queries + Adaptive Traces commands)

--- a/claude-plugin/skills/agento11y-instrument/SKILL.md
+++ b/claude-plugin/skills/agento11y-instrument/SKILL.md
@@ -146,7 +146,7 @@ that and verify against the local instance instead. The rest of this step is the
    the value uses `Basic%20…` — keep it as given.)
 
    **`AGENTO11Y_*` (generation ingest) — the plugin Connection page.** `AGENTO11Y_ENDPOINT` and the
-   token come from `https://<stack>.grafana.net/plugins/grafana-sigil-app` → Connection tab. When the
+   token come from `https://<stack>.grafana.net/plugins/grafana-agento11y-app` → Connection tab. When the
    developer creates the token via **"Create a token in Cloud Access Policies"**, tell them the scopes:
    **`sigil:write`, `metrics:write`, `traces:write`, `logs:write`**. UI heads-up: `sigil` is not in
    the default resource list — add it via **"Add scope"** (then tick Write); the scope is still

--- a/claude-plugin/skills/agento11y-instrument/references/instrumentation.md
+++ b/claude-plugin/skills/agento11y-instrument/references/instrumentation.md
@@ -145,7 +145,7 @@ the stack's OTLP tile, `https://grafana.com/orgs/<org-slug>/stacks/<stack-id>/ot
 Only if you already have a raw token and instance-id and must build the header yourself, do it with
 `printf '%s' '<otlp-instance-id>:<glc_token>' | base64 | tr -d '\n'` — a trailing newline breaks the
 header. (The tile is also reachable from the plugin **Connection page**,
-`https://<stack>.grafana.net/plugins/grafana-sigil-app`.)
+`https://<stack>.grafana.net/plugins/grafana-agento11y-app`.)
 
 For the full reference — per-provider wrapper usage, every framework adapter, the complete telemetry
 field list, workflow-step schema, `set_result` field completeness, and content-capture modes — fetch

--- a/claude-plugin/skills/agento11y-test-starter/SKILL.md
+++ b/claude-plugin/skills/agento11y-test-starter/SKILL.md
@@ -444,7 +444,7 @@ If they accept:
    actually calls their agent.
 2. Preflight the environment and stop with a clear ask if anything is missing. **When you ask, tell
    the developer exactly where each value is** — for a Cloud stack they all live on the plugin
-   **Connection page**, `https://<your-stack>.grafana.net/plugins/grafana-sigil-app`:
+   **Connection page**, `https://<your-stack>.grafana.net/plugins/grafana-agento11y-app`:
    - `AGENTO11Y_ENDPOINT` = the **API URL** on that page. If unset, ask — never invent one.
    - `AGENTO11Y_AUTH_TENANT_ID` = the **Instance ID** on that page.
    - `AGENTO11Y_AUTH_TOKEN` — always required (the SDK raises before any request if it is empty).

--- a/internal/providers/aio11y/aio11yhttp/client.go
+++ b/internal/providers/aio11y/aio11yhttp/client.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const pluginBasePath = "/api/plugins/grafana-sigil-app/resources"
+const pluginBasePath = "/api/plugins/grafana-agento11y-app/resources"
 
 // Client is a base HTTP client for the Agent Observability plugin API.
 type Client struct {

--- a/internal/providers/aio11y/aio11yhttp/client_test.go
+++ b/internal/providers/aio11y/aio11yhttp/client_test.go
@@ -41,7 +41,7 @@ type testItem struct {
 
 func TestClient_DoRequest(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/query/test", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/query/test", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))

--- a/internal/providers/aio11y/eval/collections/client_test.go
+++ b/internal/providers/aio11y/eval/collections/client_test.go
@@ -93,7 +93,7 @@ func TestClient_Get_NotFound(t *testing.T) {
 func TestClient_Create(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/collections", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/collections", r.URL.Path)
 
 		body, _ := io.ReadAll(r.Body)
 		var raw map[string]any
@@ -208,7 +208,7 @@ func TestClient_RemoveMember(t *testing.T) {
 
 func TestStaticDescriptor(t *testing.T) {
 	d := collections.StaticDescriptor()
-	assert.Equal(t, "sigil.ext.grafana.app", d.GroupVersion.Group)
+	assert.Equal(t, "agento11y.ext.grafana.app", d.GroupVersion.Group)
 	assert.Equal(t, "v1alpha1", d.GroupVersion.Version)
 	assert.Equal(t, "Collection", d.Kind)
 	assert.Equal(t, "collections", d.Plural)

--- a/internal/providers/aio11y/eval/collections/resource_adapter.go
+++ b/internal/providers/aio11y/eval/collections/resource_adapter.go
@@ -18,7 +18,7 @@ import (
 func StaticDescriptor() resources.Descriptor {
 	return resources.Descriptor{
 		GroupVersion: schema.GroupVersion{
-			Group:   "sigil.ext.grafana.app",
+			Group:   "agento11y.ext.grafana.app",
 			Version: "v1alpha1",
 		},
 		Kind:     "Collection",

--- a/internal/providers/aio11y/eval/evaluators/resource_adapter.go
+++ b/internal/providers/aio11y/eval/evaluators/resource_adapter.go
@@ -18,7 +18,7 @@ import (
 func StaticDescriptor() resources.Descriptor {
 	return resources.Descriptor{
 		GroupVersion: schema.GroupVersion{
-			Group:   "sigil.ext.grafana.app",
+			Group:   "agento11y.ext.grafana.app",
 			Version: "v1alpha1",
 		},
 		Kind:     "Evaluator",

--- a/internal/providers/aio11y/eval/experiments/client_test.go
+++ b/internal/providers/aio11y/eval/experiments/client_test.go
@@ -40,7 +40,7 @@ func newTestClient(t *testing.T, handler http.Handler) *experiments.Client {
 func TestClient_List(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/experiments", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments", r.URL.Path)
 
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(w, map[string]any{
@@ -70,7 +70,7 @@ func TestClient_List_TransportError(t *testing.T) {
 func TestClient_ListSuites(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/test-suites", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/test-suites", r.URL.Path)
 
 		writeJSON(w, map[string]any{
 			"items": []experiments.TestSuite{
@@ -88,7 +88,7 @@ func TestClient_ListSuites(t *testing.T) {
 func TestClient_GetSuite(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/test-suites/suite-1", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/suite-1", r.URL.Path)
 
 		writeJSON(w, experiments.TestSuite{
 			SuiteID: "suite-1",
@@ -110,14 +110,14 @@ func TestClient_CreateSuiteVersionAndPublish(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls = append(calls, r.Method+" "+r.URL.EscapedPath())
 		switch r.URL.EscapedPath() {
-		case "/api/plugins/grafana-sigil-app/resources/eval/test-suites/suite-1/versions":
+		case "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/suite-1/versions":
 			assert.Equal(t, http.MethodPost, r.Method)
 			body, _ := io.ReadAll(r.Body)
 			var raw map[string]any
 			assert.NoError(t, json.Unmarshal(body, &raw))
 			assert.Equal(t, "draft", raw["changelog"])
 			writeJSON(w, experiments.TestSuiteVersion{SuiteID: "suite-1", Version: "v2"})
-		case "/api/plugins/grafana-sigil-app/resources/eval/test-suites/suite-1/versions/v2:publish":
+		case "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/suite-1/versions/v2:publish":
 			assert.Equal(t, http.MethodPost, r.Method)
 			writeJSON(w, experiments.TestSuiteVersion{SuiteID: "suite-1", Version: "v2", Published: true})
 		default:
@@ -133,27 +133,27 @@ func TestClient_CreateSuiteVersionAndPublish(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, published.Published)
 	assert.Equal(t, []string{
-		"POST /api/plugins/grafana-sigil-app/resources/eval/test-suites/suite-1/versions",
-		"POST /api/plugins/grafana-sigil-app/resources/eval/test-suites/suite-1/versions/v2:publish",
+		"POST /api/plugins/grafana-agento11y-app/resources/eval/test-suites/suite-1/versions",
+		"POST /api/plugins/grafana-agento11y-app/resources/eval/test-suites/suite-1/versions/v2:publish",
 	}, calls)
 }
 
 func TestClient_Cases(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-sigil-app/resources/eval/test-suites/suite-1/versions/v1/test-cases":
+		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/suite-1/versions/v1/test-cases":
 			writeJSON(w, map[string]any{"items": []experiments.TestCase{{TestCaseID: "case-1", SuiteID: "suite-1", SuiteVersion: "v1"}}})
-		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-sigil-app/resources/eval/test-suites/suite-1/versions/v1/test-cases/case-1":
+		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/suite-1/versions/v1/test-cases/case-1":
 			writeJSON(w, experiments.TestCase{TestCaseID: "case-1"})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/plugins/grafana-sigil-app/resources/eval/test-suites/suite-1/versions/v1/test-cases":
+		case r.Method == http.MethodPost && r.URL.Path == "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/suite-1/versions/v1/test-cases":
 			body, _ := io.ReadAll(r.Body)
 			assert.Contains(t, string(body), `"test_case_id":"case-1"`)
 			writeJSON(w, experiments.TestCase{TestCaseID: "case-1"})
-		case r.Method == http.MethodPatch && r.URL.Path == "/api/plugins/grafana-sigil-app/resources/eval/test-suites/suite-1/versions/v1/test-cases/case-1":
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/suite-1/versions/v1/test-cases/case-1":
 			body, _ := io.ReadAll(r.Body)
 			assert.Contains(t, string(body), `"name":"renamed"`)
 			writeJSON(w, experiments.TestCase{TestCaseID: "case-1", Name: "renamed"})
-		case r.Method == http.MethodDelete && r.URL.Path == "/api/plugins/grafana-sigil-app/resources/eval/test-suites/suite-1/versions/v1/test-cases/case-1":
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/plugins/grafana-agento11y-app/resources/eval/test-suites/suite-1/versions/v1/test-cases/case-1":
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			http.NotFound(w, r)
@@ -182,7 +182,7 @@ func TestClient_Cases(t *testing.T) {
 func TestClient_Get(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/experiments/r-1", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments/r-1", r.URL.Path)
 
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(w, experiments.Experiment{
@@ -203,21 +203,21 @@ func TestClient_Get(t *testing.T) {
 func TestClient_Trials(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-sigil-app/resources/eval/experiments/exp-1/trials":
+		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-agento11y-app/resources/eval/experiments/exp-1/trials":
 			writeJSON(w, map[string]any{"items": []experiments.TestCaseTrial{{TrialID: "trial-1", ExperimentID: "exp-1", TestCaseID: "case-1", Attempt: 1}}})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/plugins/grafana-sigil-app/resources/eval/experiments/exp-1/trials":
+		case r.Method == http.MethodPost && r.URL.Path == "/api/plugins/grafana-agento11y-app/resources/eval/experiments/exp-1/trials":
 			body, _ := io.ReadAll(r.Body)
 			assert.Contains(t, string(body), `"test_case_id":"case-1"`)
 			writeJSON(w, experiments.TestCaseTrial{TrialID: "trial-1", ExperimentID: "exp-1", TestCaseID: "case-1", Attempt: 1})
-		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-sigil-app/resources/eval/test-case-trials/trial-1":
+		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-agento11y-app/resources/eval/test-case-trials/trial-1":
 			writeJSON(w, experiments.TestCaseTrial{TrialID: "trial-1", ExperimentID: "exp-1", TestCaseID: "case-1", Attempt: 1})
-		case r.Method == http.MethodPatch && r.URL.Path == "/api/plugins/grafana-sigil-app/resources/eval/test-case-trials/trial-1":
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/plugins/grafana-agento11y-app/resources/eval/test-case-trials/trial-1":
 			body, _ := io.ReadAll(r.Body)
 			assert.Contains(t, string(body), `"status":"completed"`)
 			writeJSON(w, experiments.TestCaseTrial{TrialID: "trial-1", Status: "completed"})
-		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-sigil-app/resources/eval/test-case-trials/trial-1/scores":
+		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-agento11y-app/resources/eval/test-case-trials/trial-1/scores":
 			writeJSON(w, map[string]any{"items": []experiments.ScoreItem{{ScoreID: "score-1", TrialID: "trial-1", ScoreKey: "final"}}})
-		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-sigil-app/resources/eval/test-case-trials/trial-1/artifacts":
+		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-agento11y-app/resources/eval/test-case-trials/trial-1/artifacts":
 			writeJSON(w, map[string]any{"items": []experiments.Artifact{{ArtifactID: "art-1", ParentKind: "test_case_trial", ParentID: "trial-1", Name: "output.json", Kind: "json"}}})
 		default:
 			http.NotFound(w, r)
@@ -274,7 +274,7 @@ func TestClient_Get_TransportError(t *testing.T) {
 func TestClient_Create(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/experiments", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments", r.URL.Path)
 
 		body, _ := io.ReadAll(r.Body)
 		var raw map[string]any
@@ -319,7 +319,7 @@ func TestClient_Create_TransportError(t *testing.T) {
 func TestClient_Update_PATCH(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/experiments/r-1", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments/r-1", r.URL.Path)
 
 		body, _ := io.ReadAll(r.Body)
 		var raw map[string]any
@@ -366,7 +366,7 @@ func TestClient_Update_TransportError(t *testing.T) {
 func TestClient_Cancel(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/experiments/r-1:cancel", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments/r-1:cancel", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -379,7 +379,7 @@ func TestClient_Cancel_EscapesColonInRunID(t *testing.T) {
 	// to see the wire bytes.
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/experiments/r%3Afoo:cancel", r.URL.EscapedPath())
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments/r%3Afoo:cancel", r.URL.EscapedPath())
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -407,7 +407,7 @@ func TestClient_Cancel_TransportError(t *testing.T) {
 func TestClient_ListScores(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/experiments/r-1/scores", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments/r-1/scores", r.URL.Path)
 
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(w, map[string]any{
@@ -454,7 +454,7 @@ func TestClient_ListScores_TransportError(t *testing.T) {
 func TestClient_GetReport(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-sigil-app/resources/eval/experiments/r-1/report", r.URL.Path)
+		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments/r-1/report", r.URL.Path)
 
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(w, map[string]any{

--- a/internal/providers/aio11y/eval/guards/resource_adapter.go
+++ b/internal/providers/aio11y/eval/guards/resource_adapter.go
@@ -18,7 +18,7 @@ import (
 func StaticDescriptor() resources.Descriptor {
 	return resources.Descriptor{
 		GroupVersion: schema.GroupVersion{
-			Group:   "sigil.ext.grafana.app",
+			Group:   "agento11y.ext.grafana.app",
 			Version: "v1alpha1",
 		},
 		Kind:     "HookRule",

--- a/internal/providers/aio11y/eval/rules/resource_adapter.go
+++ b/internal/providers/aio11y/eval/rules/resource_adapter.go
@@ -18,7 +18,7 @@ import (
 func StaticDescriptor() resources.Descriptor {
 	return resources.Descriptor{
 		GroupVersion: schema.GroupVersion{
-			Group:   "sigil.ext.grafana.app",
+			Group:   "agento11y.ext.grafana.app",
 			Version: "v1alpha1",
 		},
 		Kind:     "EvalRule",

--- a/internal/providers/aio11y/integration_test.go
+++ b/internal/providers/aio11y/integration_test.go
@@ -47,11 +47,11 @@ func newBase(t *testing.T, handler http.Handler) *aio11yhttp.Client {
 	return base
 }
 
-// fakePluginMux returns a mux mimicking the grafana-sigil-app plugin API.
+// fakePluginMux returns a mux mimicking the grafana-agento11y-app plugin API.
 func fakePluginMux() *http.ServeMux {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/query/conversations",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/query/conversations",
 		func(w http.ResponseWriter, _ *http.Request) {
 			writeJSON(w, map[string]any{
 				"items": []map[string]any{
@@ -61,7 +61,7 @@ func fakePluginMux() *http.ServeMux {
 			})
 		})
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/query/conversations/conv-1",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/query/conversations/conv-1",
 		func(w http.ResponseWriter, _ *http.Request) {
 			writeJSON(w, map[string]any{
 				"conversation_id": "conv-1",
@@ -71,7 +71,7 @@ func fakePluginMux() *http.ServeMux {
 			})
 		})
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/query/conversations/search",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/query/conversations/search",
 		func(w http.ResponseWriter, _ *http.Request) {
 			writeJSON(w, map[string]any{
 				"conversations": []map[string]any{
@@ -83,7 +83,7 @@ func fakePluginMux() *http.ServeMux {
 			})
 		})
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/query/agents",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/query/agents",
 		func(w http.ResponseWriter, _ *http.Request) {
 			writeJSON(w, map[string]any{
 				"items": []map[string]any{
@@ -94,7 +94,7 @@ func fakePluginMux() *http.ServeMux {
 			})
 		})
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/query/agents/lookup",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/query/agents/lookup",
 		func(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, map[string]any{
 				"agent_name": r.URL.Query().Get("name"), "effective_version": "sha256:abc123",
@@ -102,7 +102,7 @@ func fakePluginMux() *http.ServeMux {
 			})
 		})
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/query/agents/versions",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/query/agents/versions",
 		func(w http.ResponseWriter, _ *http.Request) {
 			writeJSON(w, map[string]any{
 				"items": []map[string]any{
@@ -113,7 +113,7 @@ func fakePluginMux() *http.ServeMux {
 			})
 		})
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/eval/evaluators",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/eval/evaluators",
 		func(w http.ResponseWriter, _ *http.Request) {
 			writeJSON(w, map[string]any{
 				"items": []map[string]any{
@@ -122,7 +122,7 @@ func fakePluginMux() *http.ServeMux {
 			})
 		})
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/eval/evaluators/eval-1",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/eval/evaluators/eval-1",
 		func(w http.ResponseWriter, _ *http.Request) {
 			writeJSON(w, map[string]any{
 				"evaluator_id": "eval-1", "version": "1.0", "kind": "llm_judge",
@@ -132,7 +132,7 @@ func fakePluginMux() *http.ServeMux {
 			})
 		})
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/eval/rules",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/eval/rules",
 		func(w http.ResponseWriter, _ *http.Request) {
 			writeJSON(w, map[string]any{
 				"items": []map[string]any{
@@ -143,7 +143,7 @@ func fakePluginMux() *http.ServeMux {
 		})
 
 	hookRulesCalls := 0
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/eval/hook-rules",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/eval/hook-rules",
 		func(w http.ResponseWriter, _ *http.Request) {
 			hookRulesCalls++
 			if hookRulesCalls == 1 {
@@ -165,7 +165,7 @@ func fakePluginMux() *http.ServeMux {
 			})
 		})
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/eval:test",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/eval:test",
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -182,7 +182,7 @@ func fakePluginMux() *http.ServeMux {
 			})
 		})
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/eval/templates",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/eval/templates",
 		func(w http.ResponseWriter, _ *http.Request) {
 			writeJSON(w, map[string]any{
 				"items": []map[string]any{
@@ -192,7 +192,7 @@ func fakePluginMux() *http.ServeMux {
 			})
 		})
 
-	mux.HandleFunc("/api/plugins/grafana-sigil-app/resources/eval/templates/tpl-1/versions",
+	mux.HandleFunc("/api/plugins/grafana-agento11y-app/resources/eval/templates/tpl-1/versions",
 		func(w http.ResponseWriter, _ *http.Request) {
 			writeJSON(w, map[string]any{
 				"items": []map[string]any{

--- a/internal/providers/aio11y/provider.go
+++ b/internal/providers/aio11y/provider.go
@@ -23,7 +23,7 @@ func init() { //nolint:gochecknoinits // Self-registration pattern (like databas
 }
 
 // AIO11yProvider manages Grafana Agent Observability resources
-// (backed by the upstream `grafana-sigil-app` plugin). The CLI command is
+// (backed by the upstream `grafana-agento11y-app` plugin). The CLI command is
 // `agento11y`; the Go package name is retained for internal stability.
 type AIO11yProvider struct{}
 
@@ -155,28 +155,28 @@ func (p *AIO11yProvider) TypedRegistrations() []adapter.Registration {
 			Descriptor:  evalDesc,
 			GVK:         evalDesc.GroupVersionKind(),
 			Schema:      evaluators.EvaluatorSchema(),
-			URLTemplate: "/a/grafana-sigil-app/evaluators/{name}",
+			URLTemplate: "/a/grafana-agento11y-app/evaluators/{name}",
 		},
 		{
 			Factory:     rules.NewLazyFactory(),
 			Descriptor:  ruleDesc,
 			GVK:         ruleDesc.GroupVersionKind(),
 			Schema:      rules.RuleSchema(),
-			URLTemplate: "/a/grafana-sigil-app/rules/{name}",
+			URLTemplate: "/a/grafana-agento11y-app/rules/{name}",
 		},
 		{
 			Factory:     guards.NewLazyFactory(),
 			Descriptor:  guardDesc,
 			GVK:         guardDesc.GroupVersionKind(),
 			Schema:      guards.HookRuleSchema(),
-			URLTemplate: "/a/grafana-sigil-app/guards/{name}",
+			URLTemplate: "/a/grafana-agento11y-app/guards/{name}",
 		},
 		{
 			Factory:     collections.NewLazyFactory(),
 			Descriptor:  collectionDesc,
 			GVK:         collectionDesc.GroupVersionKind(),
 			Schema:      collections.CollectionSchema(),
-			URLTemplate: "/a/grafana-sigil-app/collections/{name}",
+			URLTemplate: "/a/grafana-agento11y-app/collections/{name}",
 		},
 	}
 }

--- a/internal/providers/aio11y/provider_test.go
+++ b/internal/providers/aio11y/provider_test.go
@@ -42,6 +42,30 @@ func TestAIO11yProvider_Commands(t *testing.T) {
 	}
 }
 
+func TestAIO11yProvider_TypedRegistrations(t *testing.T) {
+	registrations := (&aio11y.AIO11yProvider{}).TypedRegistrations()
+
+	tests := []struct {
+		kind        string
+		urlTemplate string
+	}{
+		{kind: "Evaluator", urlTemplate: "/a/grafana-agento11y-app/evaluators/{name}"},
+		{kind: "EvalRule", urlTemplate: "/a/grafana-agento11y-app/rules/{name}"},
+		{kind: "HookRule", urlTemplate: "/a/grafana-agento11y-app/guards/{name}"},
+		{kind: "Collection", urlTemplate: "/a/grafana-agento11y-app/collections/{name}"},
+	}
+
+	require.Len(t, registrations, len(tests))
+	for i, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			registration := registrations[i]
+			assert.Equal(t, "agento11y.ext.grafana.app", registration.GVK.Group)
+			assert.Equal(t, tt.kind, registration.GVK.Kind)
+			assert.Equal(t, tt.urlTemplate, registration.URLTemplate)
+		})
+	}
+}
+
 func commandNames(cmd *cobra.Command) []string {
 	names := make([]string, 0, len(cmd.Commands()))
 	for _, sub := range cmd.Commands() {


### PR DESCRIPTION
The Grafana app plugin is renamed from `grafana-sigil-app` to `grafana-agento11y-app` as part of the agento11y rename.