### PR TITLE
chore(release): v0.6.0 changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "gcx",
       "source": "./claude-plugin",
       "description": "Debug, explore, and instrument with Grafana using gcx CLI",
-      "version": "0.5.0"
+      "version": "0.6.0"
     }
   ]
 }

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,22 +1,35 @@
-- Register the Assistant as a first-class provider, moving `mcp-servers` into the resources pipeline
-- **Breaking:** rename the `aio11y` command tree and skills to `agento11y`
-- **Breaking:** rename the `agento11y-eval-starter` skill to `agento11y-test-starter`
-- Add `agento11y-instrument` skill (setup → instrument → verify loop)
-- Add `agento11y-prod-setup` skill for production evals and guards
-- Bundle the `agento11y-test-starter` starter skill
-- **Breaking:** remove the `explore-datasources` skill
-- Retune skill descriptions and fix API drift in aio11y, SLO, and Synthetics guidance
-- Export anonymous usage events as flat JSON over HTTP when telemetry is enabled
-- Add profiles span and trace selectors; include trace IDs in exemplars
-- Fix profiles `--top` totals to exclude the pre-window boundary point
-- Add KG `prom-rules schema` command and `--dry-run` to suppressions create
-- Route KG write API through the Asserts plugin proxy
-- Fix KG entity/relationship deletes to use the collection-path API
-- Support Dashboard V2 in the resource linter
-- Descend into single-key list envelopes for `--json` discovery and selection
-- Include an output-shape hint in `--jq` runtime errors
-- Request full cloud scopes in the `login cloud` followup flow
-- Derive SDK imports for generated `dev import` code from actual usage
-- Disclose per-product Grafana Cloud costs in docs and help text
-- Clarify gcx works with OSS and Enterprise, not just Cloud
-- Mark the traces `--llm` flag experimental and document its Accept header
+Here are the CHANGELOG bullets for **v0.6.0**:
+
+```markdown
+### Breaking changes
+
+- Naming convergence: verb-first subcommand renames across all providers
+  (e.g. `versions`→`list-versions`, `create`→`upsert`, `summary`→`stats`)
+- Config split into separate stacks, cloud entries, and contexts (auto-migrates)
+- Agent output contract: one JSON document per finite command
+- Profiles: `profile-types` renamed to `list-profile-types` at both mounts
+- Alert: dropped `create`/`update`/`apply` aliases from templates `upsert`
+
+### Features
+
+- Telemetry: first-run notice and default-on anonymous usage stats
+- Output: list truncation contract with honest caps and agent-legible metadata
+- aio11y: experiments v2 shapes and commands, plus conversation annotations
+- kg: `--dry-run` for model-rules and prom-rules upsert
+- Profiles: time-range flags for `labels` and `list-profile-types`
+
+### Fixes
+
+- Cloud: stop misreporting invalid stack slugs as "slug already taken"
+- appo11y: honor `--config` across the direct command tree
+- aio11y: honor `--config` in direct agento11y CRUD commands
+- irm: decode expanded webhook integration filters
+
+### Docs
+
+- Added anonymous usage statistics page; fixed usage-stats command examples
+```
+
+A few notes on the grouping:
+- I folded the seven `naming convergence batch (#387)` commits (assistant, irm, cli, kg, datasources, k6, agento11y) into one breaking-change bullet since they're a single coordinated effort.
+- Pure-docs/plan commits (`docs(plans)`, `docs(skills)`) are internal maintenance, so I omitted them from the user-facing changelog.

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,6 +1,3 @@
-Here are the CHANGELOG bullets for **v0.6.0**:
-
-```markdown
 ### Breaking changes
 
 - Naming convergence: verb-first subcommand renames across all providers
@@ -28,8 +25,3 @@ Here are the CHANGELOG bullets for **v0.6.0**:
 ### Docs
 
 - Added anonymous usage statistics page; fixed usage-stats command examples
-```
-
-A few notes on the grouping:
-- I folded the seven `naming convergence batch (#387)` commits (assistant, irm, cli, kg, datasources, k6, agento11y) into one breaking-change bullet since they're a single coordinated effort.
-- Pure-docs/plan commits (`docs(plans)`, `docs(skills)`) are internal maintenance, so I omitted them from the user-facing changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+## v0.6.0 (2026-07-24)
+
+Here are the CHANGELOG bullets for **v0.6.0**:
+
+```markdown
+### Breaking changes
+
+- Naming convergence: verb-first subcommand renames across all providers
+  (e.g. `versions`→`list-versions`, `create`→`upsert`, `summary`→`stats`)
+- Config split into separate stacks, cloud entries, and contexts (auto-migrates)
+- Agent output contract: one JSON document per finite command
+- Profiles: `profile-types` renamed to `list-profile-types` at both mounts
+- Alert: dropped `create`/`update`/`apply` aliases from templates `upsert`
+
+### Features
+
+- Telemetry: first-run notice and default-on anonymous usage stats
+- Output: list truncation contract with honest caps and agent-legible metadata
+- aio11y: experiments v2 shapes and commands, plus conversation annotations
+- kg: `--dry-run` for model-rules and prom-rules upsert
+- Profiles: time-range flags for `labels` and `list-profile-types`
+
+### Fixes
+
+- Cloud: stop misreporting invalid stack slugs as "slug already taken"
+- appo11y: honor `--config` across the direct command tree
+- aio11y: honor `--config` in direct agento11y CRUD commands
+- irm: decode expanded webhook integration filters
+
+### Docs
+
+- Added anonymous usage statistics page; fixed usage-stats command examples
+```
+
+A few notes on the grouping:
+- I folded the seven `naming convergence batch (#387)` commits (assistant, irm, cli, kg, datasources, k6, agento11y) into one breaking-change bullet since they're a single coordinated effort.
+- Pure-docs/plan commits (`docs(plans)`, `docs(skills)`) are internal maintenance, so I omitted them from the user-facing changelog.
+
+
 ## v0.5.0 (2026-07-21)
 
 - Register the Assistant as a first-class provider, moving `mcp-servers` into the resources pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## v0.6.0 (2026-07-24)
 
-Here are the CHANGELOG bullets for **v0.6.0**:
-
-```markdown
 ### Breaking changes
 
 - Naming convergence: verb-first subcommand renames across all providers
@@ -30,12 +27,6 @@ Here are the CHANGELOG bullets for **v0.6.0**:
 ### Docs
 
 - Added anonymous usage statistics page; fixed usage-stats command examples
-```
-
-A few notes on the grouping:
-- I folded the seven `naming convergence batch (#387)` commits (assistant, irm, cli, kg, datasources, k6, agento11y) into one breaking-change bullet since they're a single coordinated effort.
-- Pure-docs/plan commits (`docs(plans)`, `docs(skills)`) are internal maintenance, so I omitted them from the user-facing changelog.
-
 
 ## v0.5.0 (2026-07-21)
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcx",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Debug, explore, and instrument with Grafana using gcx CLI",
   "keywords": ["grafana", "observability", "monitoring", "prometheus", "loki", "dashboards"],
   "author": {


### PR DESCRIPTION
## Summary

Release v0.6.0: changelog entry, release notes, and Claude plugin version bump (0.5.0 → 0.6.0), generated via `mise run tag -- minor`.

After merge, tag the commit on main to trigger GoReleaser:

```bash
git checkout main && git pull
git tag v0.6.0
git push origin v0.6.0
```

Made with [Cursor](https://cursor.com)