### PR TITLE
fix(docs): stop prescribing Editor/Admin for service-account tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Opens a browser for OAuth, then saves the access token, refresh token, and proxy
 gcx login my-grafana --server https://your-instance.grafana.net --token glsa_xxx --yes
 ```
 
-Use a [Grafana service account token](https://grafana.com/docs/grafana/latest/administration/service-accounts/) with **Editor** or **Admin** role. It works for both Cloud and on-premises and is recommended for automation. On-premises stacks can also use basic authentication or configured mTLS client certificates.
+Use a [Grafana service account token](https://grafana.com/docs/grafana/latest/administration/service-accounts/) with a role matching what the token needs to do: **Viewer** is enough for querying (metrics, logs, traces, profiles) and reading dashboards or folders; pushing, editing, or deleting resources needs **Editor** or **Admin**. For tighter scoping, a custom role granting `datasources:read` and `datasources:query` on specific datasources also works. Tokens work for both Cloud and on-premises and are recommended for automation. On-premises stacks can also use basic authentication or configured mTLS client certificates.
 
 **Grafana Cloud product APIs (SLO, Synthetic Monitoring, IRM, etc.):**
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Opens a browser for OAuth, then saves the access token, refresh token, and proxy
 gcx login my-grafana --server https://your-instance.grafana.net --token glsa_xxx --yes
 ```
 
-Use a [Grafana service account token](https://grafana.com/docs/grafana/latest/administration/service-accounts/) with a role matching what the token needs to do: **Viewer** is enough for querying (metrics, logs, traces, profiles) and reading dashboards or folders; pushing, editing, or deleting resources needs **Editor** or **Admin**. For tighter scoping, a custom role granting `datasources:read` and `datasources:query` on specific datasources also works. Tokens work for both Cloud and on-premises and are recommended for automation. On-premises stacks can also use basic authentication or configured mTLS client certificates.
+Use a [Grafana service account token](https://grafana.com/docs/grafana/latest/administration/service-accounts/) with a role matching what the token needs to do: **Viewer** is enough for querying (metrics, logs, traces, profiles) and reading dashboards or folders; **Editor** covers pushing and editing dashboards and folders; managing datasource configuration needs **Admin**. On Grafana Cloud and Enterprise, RBAC custom roles can scope query access tighter (for example `datasources:read` plus `datasources:query` on specific datasources). Tokens work for both Cloud and on-premises and are recommended for automation. On-premises stacks can also use basic authentication or configured mTLS client certificates.
 
 **Grafana Cloud product APIs (SLO, Synthetic Monitoring, IRM, etc.):**
 

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -788,7 +788,6 @@ func convertLoginValidationErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Details: k8sErr.Cause.Error(),
 			Suggestions: []string{
 				"Confirm the Grafana stack is on version 12 or later",
-				"Confirm the Grafana token has the role required to call /apis (Admin or Editor)",
 				"Check network/proxy access to " + k8sErr.Server,
 			},
 			DocsLink: docs.GrafanaInstallation,
@@ -867,7 +866,6 @@ func convertHealthCheckError(err *login.HealthCheckError) *gcxerrors.DetailedErr
 			Suggestions: []string{
 				"Confirm the Grafana service-account token belongs to the target stack",
 				"Confirm the token has not expired or been revoked",
-				"Confirm the service-account role grants Admin or Editor as required",
 				reauthSuggestion,
 			},
 			DocsLink: docs.ServiceAccounts,

--- a/docs/architecture/auth-system.md
+++ b/docs/architecture/auth-system.md
@@ -86,8 +86,8 @@ inspect populated credential fields to invent their own precedence.
 
 Service account tokens are static bearer credentials issued by a Grafana
 instance. Users provision them through the Grafana UI under Administration →
-Service accounts; the token carries the scope of its account (Editor, Admin,
-or custom role). Tokens are prefixed `glsa_`.
+Service accounts; the token carries the scope of its account (Viewer, Editor,
+Admin, or custom role). Tokens are prefixed `glsa_`.
 
 gcx stores them in `GrafanaConfig.APIToken` (`datapolicy:"secret"`, redacted
 in `gcx config view`). The REST config builder in `internal/config/rest.go`

--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -76,7 +76,7 @@ gcx login my-grafana --server https://your-instance.grafana.net
 # At the prompt, pick "Service account token" and paste your token.
 ```
 
-Use a [Grafana service account token](https://grafana.com/docs/grafana/latest/administration/service-accounts/) with a role matching what the token needs to do: **Viewer** is enough for querying (metrics, logs, traces, profiles) and reading dashboards or folders; pushing, editing, or deleting resources needs **Editor** or **Admin**. For tighter scoping, a custom role granting `datasources:read` and `datasources:query` on specific datasources also works.
+Use a [Grafana service account token](https://grafana.com/docs/grafana/latest/administration/service-accounts/) with a role matching what the token needs to do: **Viewer** is enough for querying (metrics, logs, traces, profiles) and reading dashboards or folders; **Editor** covers pushing and editing dashboards and folders; managing datasource configuration needs **Admin**. On Grafana Cloud and Enterprise, RBAC custom roles can scope query access tighter (for example `datasources:read` plus `datasources:query` on specific datasources).
 
 For on-premises instances, gcx defaults the organization ID to 1 if you do not specify one — the common case for single-tenant Grafana OSS. If you need a different org ID, set it with `gcx config set stacks.<name>.grafana.org-id N` after login (on the context's stack entry).
 

--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -76,7 +76,7 @@ gcx login my-grafana --server https://your-instance.grafana.net
 # At the prompt, pick "Service account token" and paste your token.
 ```
 
-Use a [Grafana service account token](https://grafana.com/docs/grafana/latest/administration/service-accounts/) with **Editor** or **Admin** role.
+Use a [Grafana service account token](https://grafana.com/docs/grafana/latest/administration/service-accounts/) with a role matching what the token needs to do: **Viewer** is enough for querying (metrics, logs, traces, profiles) and reading dashboards or folders; pushing, editing, or deleting resources needs **Editor** or **Admin**. For tighter scoping, a custom role granting `datasources:read` and `datasources:query` on specific datasources also works.
 
 For on-premises instances, gcx defaults the organization ID to 1 if you do not specify one — the common case for single-tenant Grafana OSS. If you need a different org ID, set it with `gcx config set stacks.<name>.grafana.org-id N` after login (on the context's stack entry).
 


### PR DESCRIPTION
An enterprise user told us in an interview that they hold gcx back from their teams because it "requires a token with Editor or Admin role", citing #764 and our own docs. They were planning to design custom elevated roles just to hand gcx to AI agents for read-only telemetry work. That requirement doesn't exist anymore: the Viewer 403 behind #764 was worked around in #891 (shipped in v0.4.3, fallback to /api/ds/query on any non-200), and nothing in gcx checks the token's role. The remaining "Editor or Admin" wording in our copy is what keeps sending people toward overprivileged tokens, so this fixes the copy.

What changed:

- README and docs/reference/login.md now describe role selection by workflow: Viewer covers querying (metrics, logs, traces, profiles) and dashboard/folder reads; Editor covers pushing and editing dashboards and folders; datasource configuration is Admin-only (fixed:datasources:writer belongs to the Admin basic role). On Cloud/Enterprise, RBAC custom roles can scope query access tighter (datasources:read + datasources:query on specific datasources) — that path is per Grafana's RBAC docs, not something our live test exercised.
- docs/architecture/auth-system.md's service-account role list now includes Viewer.
- The k8s discovery failure suggestion no longer claims /apis needs Admin or Editor. A Viewer token can call /apis. Note /api/health on Cloud answers 200 even to invalid tokens, so a genuinely bad token does reach the discovery step — but its 401/403 surfaces as a k8s StatusError, which convertAPIErrors handles before the login-validation converter runs, so those users still get auth-specific messaging. This suggestion list is reached for the remaining causes (version < 12, proxies), which the other suggestions already cover.
- The /api/health 401/403 suggestion no longer tells users to escalate the role. That status there means the token itself was rejected (invalid, expired, wrong stack), so advising a role upgrade was misleading.

How we verified (2026-07-24):

- Live, on a Grafana Cloud stack (Grafana 13.2.0) with a service account whose only role is Viewer, running gcx built from main: gcx login succeeds (health, /apis discovery, version detection), gcx config check is green, metrics/logs/traces/profiles queries all return data, resources get works for dashboards and folders, and a resources push correctly fails with 403. The k8s query API accepted the Viewer token directly, so on current cloud stacks the #891 fallback isn't even exercised.
- Tests: TestQuery_FallsBackOn403 in internal/query/prometheus and internal/query/loki simulate the original #764 scenario (403 from the k8s query API, query served via /api/ds/query) and pass, which covers stacks whose server side still rejects Viewers.
- Code: a repo-wide search shows the only Editor/Admin mentions were the copy fixed here, plus the setup-gcx skill which already gives the correct per-workflow guidance and is left unchanged. A follow-up adversarial review (one finder per correctness angle, independent verifiers per location) confirmed the suggestion removals are safe and caught the Editor-vs-Admin imprecision for datasource writes, the unscoped custom-role claim, and the stale auth-system.md sentence — all fixed in the second commit.

Refs #764 — intentionally not closing it yet; we'd like the reporter (or anyone) to confirm on a current version first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)