### PR TITLE
fix(config): let env credentials override keychain failures

### DIFF
--- a/internal/config/envparse.go
+++ b/internal/config/envparse.go
@@ -58,6 +58,7 @@ func ParseEnvIntoContext(ctx *Context) error {
 		return err
 	}
 	CleanupAfterEnvParse(ctx)
+	clearRuntimeCredentialRejections(ctx)
 	if ctx.StackEntry != nil {
 		// PrepareForEnvParse may have created Grafana for a named stack that had
 		// no persisted Grafana block. Keep binding checks on the detached stack
@@ -69,6 +70,16 @@ func ParseEnvIntoContext(ctx *Context) error {
 		ctx.envStackSlug = slug
 	}
 	return nil
+}
+
+func clearRuntimeCredentialRejections(ctx *Context) {
+	for _, owner := range contextOwners(ctx) {
+		for _, field := range owner.fields {
+			if ctx.runtimeSecretOverrides[field] {
+				owner.clearReject(field)
+			}
+		}
+	}
 }
 
 // detachStackRuntimeView makes the selected context safe for process-local

--- a/internal/config/envparse_internal_test.go
+++ b/internal/config/envparse_internal_test.go
@@ -94,13 +94,11 @@ func TestParseEnvIntoContextDetachesSharedStackRuntimeView(t *testing.T) {
 	assert.Equal(t, []byte("persisted-ca-snapshot"), originalTLS.credentialCAFile.contents)
 	assert.Equal(t, []string{"dashboards.grafana.app"}, originalStack.Resources.AssumeServerDryRun)
 
-	// Owner provenance and rejection evidence survive on the runtime clone, but
-	// its map is independent so later binding enforcement cannot mutate disk state.
+	// Owner provenance survives on the runtime clone. The nonblank environment
+	// token clears its rejection only on that clone so validation can proceed.
 	assert.Equal(t, originalStack.Name, selected.StackEntry.Name)
 	assert.Equal(t, originalStack.sourceIdentity, selected.StackEntry.sourceIdentity)
 	assert.Equal(t, originalStack.sourceLayer, selected.StackEntry.sourceLayer)
-	require.Error(t, selected.StackEntry.credentialRejection(credentials.FieldGrafanaToken))
-	selected.StackEntry.clearCredentialRejection(credentials.FieldGrafanaToken)
 	require.NoError(t, selected.StackEntry.credentialRejection(credentials.FieldGrafanaToken))
 	require.Error(t, originalStack.credentialRejection(credentials.FieldGrafanaToken))
 

--- a/internal/config/keychain_bound_internal_test.go
+++ b/internal/config/keychain_bound_internal_test.go
@@ -541,6 +541,33 @@ func TestBoundKeychainUnavailableReferenceIsPreservedUntilExplicitUnset(t *testi
 	assert.Contains(t, store.deletes, account)
 }
 
+func TestBoundKeychainUnavailableGrafanaTokenCanBeOverriddenByEnvironment(t *testing.T) {
+	store := newBoundTestStore()
+	useBoundTestStore(t, store)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	cfg := boundStackTestConfig("https://example.invalid", "stored-token")
+	cfg.Stacks["default"].Grafana.StackID = 12345
+	require.NoError(t, Write(t.Context(), ExplicitConfigFile(path), cfg))
+
+	store.getErr = credentials.ErrUnavailable
+	store.gets = nil
+	t.Setenv("GRAFANA_TOKEN", "env-token")
+
+	loaded, err := Load(t.Context(), ExplicitConfigFile(path),
+		func(cfg *Config) error {
+			return ParseEnvIntoContext(cfg.Contexts["default"])
+		},
+		func(cfg *Config) error {
+			return cfg.GetCurrentContext().Validate(t.Context())
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "env-token", loaded.Contexts["default"].Grafana.APIToken)
+	assert.Empty(t, loaded.Stacks["default"].Grafana.APIToken,
+		"the environment override must not mutate the persisted stack view")
+	require.Error(t, loaded.Stacks["default"].credentialRejection(credentials.FieldGrafanaToken))
+}
+
 func TestBoundKeychainWholeOwnerDeletionRemovesExactAccount(t *testing.T) {
 	store := newBoundTestStore()
 	useBoundTestStore(t, store)


### PR DESCRIPTION
## Summary

- clear stale keychain-read rejection evidence when a nonblank environment credential supplies the effective runtime value
- limit the clearing to detached runtime owners so persisted stack and cloud entries retain their rejection state
- add regression coverage for an unavailable keychain entry rescued by `GRAFANA_TOKEN`

## Root cause

Keychain loading recorded an unreadable credential as rejected, but validation ran before the later binding pass that could clear that rejection for an explicit environment override. `ParseEnvIntoContext` now clears the matching rejection immediately after parsing nonblank credential overrides, on the already-detached runtime view.

## Testing

- `go test ./...`
- `go vet ./...`
- `golangci-lint run -c .golangci.yaml` (v2.12.2)
- `go run ./cmd/gcx/ dev lint test ./internal/linter/bundle/gcx/`
- `go run ./scripts/validate-skills`
- `go build -buildvcs=false -o bin/gcx ./cmd/gcx/`
- regenerated all reference documentation with no drift
- `mkdocs build -f mkdocs.yml`

Fixes #1060
