### PR TITLE
fix(cloud): drop status, createdAt, updatedAt from stack regions output

### DIFF
--- a/internal/cloud/gcom.go
+++ b/internal/cloud/gcom.go
@@ -77,13 +77,10 @@ type StackInfo struct {
 // Region describes a Grafana Cloud stack region as returned by the GCOM API.
 type Region struct {
 	ID          int    `json:"id"`
-	Status      string `json:"status"`
 	Slug        string `json:"slug"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Provider    string `json:"provider"`
-	CreatedAt   string `json:"createdAt,omitempty"`
-	UpdatedAt   string `json:"updatedAt,omitempty"`
 }
 
 // CreateStackRequest is the request body for creating a new Grafana Cloud stack.

--- a/internal/cloud/gcom_test.go
+++ b/internal/cloud/gcom_test.go
@@ -546,8 +546,8 @@ func TestGCOMClient_DeleteStack_DeleteProtection(t *testing.T) {
 
 func TestGCOMClient_ListRegions_Success(t *testing.T) {
 	want := []cloud.Region{
-		{ID: 1, Slug: "us", Name: "GCP US Central", Description: "United States", Provider: "gcp", Status: "active"},
-		{ID: 2, Slug: "eu", Name: "GCP Belgium", Description: "Europe", Provider: "gcp", Status: "active"},
+		{ID: 1, Slug: "us", Name: "GCP US Central", Description: "United States", Provider: "gcp"},
+		{ID: 2, Slug: "eu", Name: "GCP Belgium", Description: "Europe", Provider: "gcp"},
 	}
 
 	var capturedPath string

--- a/internal/providers/stacks/format.go
+++ b/internal/providers/stacks/format.go
@@ -117,9 +117,9 @@ func (c *regionTableCodec) Encode(w io.Writer, v any) error {
 		return errors.New("invalid data type for table codec: expected []cloud.Region")
 	}
 
-	tbl := style.NewTable("SLUG", "NAME", "DESCRIPTION", "PROVIDER", "STATUS")
+	tbl := style.NewTable("SLUG", "NAME", "DESCRIPTION", "PROVIDER")
 	for _, r := range regions {
-		tbl.Row(r.Slug, r.Name, r.Description, r.Provider, r.Status)
+		tbl.Row(r.Slug, r.Name, r.Description, r.Provider)
 	}
 	return tbl.Render(w)
 }

--- a/internal/providers/stacks/format_test.go
+++ b/internal/providers/stacks/format_test.go
@@ -65,8 +65,8 @@ func TestStackTableCodec_Encode_InvalidType(t *testing.T) {
 
 func TestRegionTableCodec_Encode(t *testing.T) {
 	out, err := stacks.ExportEncodeRegionTable([]cloud.Region{
-		{Slug: "us", Name: "US Central", Description: "United States", Provider: "gcp", Status: "active"},
-		{Slug: "eu", Name: "Belgium", Description: "Europe", Provider: "gcp", Status: "active"},
+		{Slug: "us", Name: "US Central", Description: "United States", Provider: "gcp"},
+		{Slug: "eu", Name: "Belgium", Description: "Europe", Provider: "gcp"},
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
Prep for #1044, which we can't merge yet (waiting on an oauth scope for the new `/api/v1/stack-regions` endpoint). This lands the output-shape half now so the command surface and result shapes don't change when #1044 applies: drop `status`, `createdAt` and `updatedAt` from `cloud.Region` (the v1 endpoint won't return them; the old endpoint's extra fields are ignored on unmarshal) and remove the STATUS column from `gcx cloud stacks list-regions`. The endpoint itself is unchanged.

Once this merges, #1044 rebases down to just the endpoint swap and a doc line - zero user-visible change at that point.

Before:

```
SLUG                 NAME               DESCRIPTION                   PROVIDER  STATUS
prod-us-west-0       AWS US West        AWS US West                   aws       active
us                   GCP US Central     United States                 gcp       active
```

After:

```
SLUG                 NAME               DESCRIPTION                   PROVIDER
prod-us-west-0       AWS US West        AWS US West                   aws
us                   GCP US Central     United States                 gcp
```