### PR TITLE
enhancement(telemetry): populate target_kind in usage events

### DIFF
--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -381,6 +381,10 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 	if flags.AllowServerOverride {
 		opts.AllowOverride = true
 	}
+	// Record the target before the gates below, so a login rejected by the
+	// server-override preflight still reports the server it was aimed at rather
+	// than the one the existing context happens to hold.
+	captureLoginTargetKind(&opts)
 	if err := preflightServerOverride(&opts, persistedSourceCtx, isInteractive); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			fmt.Fprintln(cmd.ErrOrStderr(), "Aborted.")
@@ -448,6 +452,22 @@ func enforceAutoLocalCredentialPolicy(opts *login.Options, sourceCtx *config.Con
 	return nil
 }
 
+// captureLoginTargetKind records the telemetry target kind for this login.
+// A resolved target — forced by --cloud or established by detection inside
+// login.Run — is authoritative. Until one exists the requested server's
+// hostname is the only signal available, normalized the same way Run
+// normalizes it so a schemeless cloud URL is not read as self-hosted.
+func captureLoginTargetKind(opts *login.Options) {
+	switch opts.Target {
+	case login.TargetCloud:
+		config.CaptureTargetKind(config.TargetKindCloud)
+	case login.TargetOnPrem:
+		config.CaptureTargetKind(config.TargetKindSelfHosted)
+	case login.TargetUnknown:
+		config.CaptureTargetKindForServer(login.NormalizeServerURL(opts.Server))
+	}
+}
+
 func runLoginLoop(
 	cmd *cobra.Command,
 	flags *loginOpts,
@@ -465,6 +485,11 @@ func runLoginLoop(
 			}
 		}
 		result, err := login.Run(cmd.Context(), opts)
+		// Run resolves opts.Target by detection when it was not forced, and the
+		// resolution survives the sentinel retries below. It outranks anything
+		// derived from the URL: a custom domain fronting a Cloud stack is only
+		// recognisable once detection has run.
+		captureLoginTargetKind(opts)
 		if err == nil {
 			if shouldWarnRuntimeOnlyDestination(runtimeDestinationFromEnvironment, result) {
 				warnRuntimeOnlyDestination(cmd.ErrOrStderr())

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -725,6 +725,11 @@ func loadLoginSourceContext(ctx context.Context, flags *loginOpts, contextName s
 	selectionServer := requestedLoginServer(flags.Server, nil)
 	sourceCtx, resolvedName := resolveSourceContext(cfg, contextName, selectionServer)
 	if sourceCtx == nil {
+		// No configured context describes the requested server, so the reload
+		// below is skipped and the telemetry kind captured by the load above
+		// still describes whichever context was current. Reclassify from the
+		// requested server, which is the target this login is about to create.
+		config.CaptureTargetKindForServer(selectionServer)
 		return cfg, sourceCtx, resolvedName, nil
 	}
 

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -161,6 +161,12 @@ Auth sources (for non-interactive use):
 //nolint:gocyclo,maintidx // Login deliberately keeps trust preflight, auth selection, and retry setup in one auditable flow.
 func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 	ctx := cmd.Context()
+	// The auto-discovered-config credential rejection below is the earliest gate
+	// that can end a login, and it runs before any config is read — so there is
+	// nothing but the flags to go on. Record what they ask for here; the
+	// context-derived capture after the load refines it for logins that get that
+	// far, and login.Run's detection overrides both.
+	captureRequestedLoginTargetKind(flags, nil)
 	preflightTarget, targetIsDeterministic, err := flags.Config.PreflightLoginMutationTarget()
 	if err != nil {
 		return err

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -189,6 +189,12 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 	if err != nil {
 		return err
 	}
+	// Every gate between here and login.Run — mutation planning, auto-local
+	// credential policy, binding verification, the server-override preflight —
+	// can reject the login before detection ever runs. Record what the
+	// invocation asked for now, so those refusals report the target the user
+	// aimed at instead of the one the current context happens to hold.
+	captureRequestedLoginTargetKind(flags, sourceCtx)
 	mutationTarget, err := flags.Config.PlanLoginMutation(cfg, contextName, config.LoginMutationUnified)
 	if err != nil {
 		return err
@@ -381,10 +387,6 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 	if flags.AllowServerOverride {
 		opts.AllowOverride = true
 	}
-	// Record the target before the gates below, so a login rejected by the
-	// server-override preflight still reports the server it was aimed at rather
-	// than the one the existing context happens to hold.
-	captureLoginTargetKind(&opts)
 	if err := preflightServerOverride(&opts, persistedSourceCtx, isInteractive); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			fmt.Fprintln(cmd.ErrOrStderr(), "Aborted.")
@@ -450,6 +452,19 @@ func enforceAutoLocalCredentialPolicy(opts *login.Options, sourceCtx *config.Con
 		}
 	}
 	return nil
+}
+
+// captureRequestedLoginTargetKind records the target the invocation asked for,
+// before any gate that could reject the login. --cloud and --server name a
+// target explicitly and outrank the context the preceding config load
+// classified; with neither, that context is the target and its classification
+// stands.
+func captureRequestedLoginTargetKind(flags *loginOpts, sourceCtx *config.Context) {
+	if flags.Cloud {
+		config.CaptureTargetKind(config.TargetKindCloud)
+		return
+	}
+	config.CaptureTargetKindForServer(login.NormalizeServerURL(requestedLoginServer(flags.Server, sourceCtx)))
 }
 
 // captureLoginTargetKind records the telemetry target kind for this login.
@@ -752,9 +767,14 @@ func loadLoginSourceContext(ctx context.Context, flags *loginOpts, contextName s
 	if sourceCtx == nil {
 		// No configured context describes the requested server, so the reload
 		// below is skipped and the telemetry kind captured by the load above
-		// still describes whichever context was current. Reclassify from the
-		// requested server, which is the target this login is about to create.
-		config.CaptureTargetKindForServer(selectionServer)
+		// still describes whichever context was current.
+		if selectionServer == "" {
+			// A new context with no server yet: nothing about the target is
+			// known, and an unrelated context must not stand in for it.
+			config.ClearCapturedTargetKind()
+		} else {
+			config.CaptureTargetKindForServer(selectionServer)
+		}
 		return cfg, sourceCtx, resolvedName, nil
 	}
 

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -828,6 +828,31 @@ func TestLoadLoginSourceContextAppliesEnvToPositionalTarget(t *testing.T) {
 	assert.Equal(t, "target-env-token", sourceCtx.Grafana.APIToken)
 }
 
+func TestLoadLoginSourceContextClassifiesUnmatchedServerForTelemetry(t *testing.T) {
+	unsetEnvForTest(t, "GRAFANA_SERVER")
+	unsetEnvForTest(t, "GRAFANA_CLOUD_STACK")
+	unsetEnvForTest(t, "GRAFANA_STACK_ID")
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	seed := config.Config{}
+	seed.SetStack("onprem", config.StackConfig{Grafana: &config.GrafanaConfig{Server: "http://localhost:3000", OrgID: 1}})
+	seed.SetContext("onprem", true, config.Context{Stack: "onprem"})
+	require.NoError(t, config.Write(t.Context(), config.ExplicitConfigFile(path), seed))
+
+	// Logging in to a cloud stack no context describes: the load above classifies
+	// the current self-hosted context and the reload that would correct it is
+	// skipped, so telemetry has to be reclassified from the requested server or
+	// this cloud login is counted as self-hosted.
+	flags := &loginOpts{
+		Config: configcmd.Options{ConfigFile: path},
+		Server: "https://newstack.grafana.net",
+	}
+	_, sourceCtx, _, err := loadLoginSourceContext(t.Context(), flags, "")
+	require.NoError(t, err)
+	require.Nil(t, sourceCtx)
+	assert.Equal(t, "cloud", config.CapturedTargetKind())
+}
+
 func TestPersistedLoginSourceContextIgnoresRuntimeEnvironmentOverrides(t *testing.T) {
 	t.Setenv("GRAFANA_SERVER", "https://runtime.invalid")
 	t.Setenv("GRAFANA_CLOUD_API_URL", "https://grafana-ops.com")

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -1597,16 +1597,21 @@ contexts:
 }
 
 func TestLoginRejectsFreshCredentialsForAutoLocalBeforeNetwork(t *testing.T) {
+	// wantKind is the telemetry target kind the rejection must report. This gate
+	// runs before any config is read, so only the flags can supply it: --server
+	// points at the local test server, and --cloud outranks it.
 	tests := []struct {
-		name string
-		env  string
-		args []string
+		name     string
+		env      string
+		args     []string
+		wantKind string
 	}{
-		{name: "Grafana token flag", args: []string{"--token", "fresh-grafana-token"}},
-		{name: "Grafana token environment", env: "GRAFANA_TOKEN"},
-		{name: "Grafana OAuth", args: []string{"--oauth"}},
-		{name: "Cloud token flag", args: []string{"--cloud-token", "fresh-cloud-token"}},
-		{name: "Cloud token environment", env: "GRAFANA_CLOUD_TOKEN"},
+		{name: "Grafana token flag", args: []string{"--token", "fresh-grafana-token"}, wantKind: "self-hosted"},
+		{name: "Grafana token environment", env: "GRAFANA_TOKEN", wantKind: "self-hosted"},
+		{name: "Grafana OAuth", args: []string{"--oauth"}, wantKind: "self-hosted"},
+		{name: "Cloud token flag", args: []string{"--cloud-token", "fresh-cloud-token"}, wantKind: "self-hosted"},
+		{name: "Cloud token environment", env: "GRAFANA_CLOUD_TOKEN", wantKind: "self-hosted"},
+		{name: "Cloud target forced", args: []string{"--cloud", "--cloud-token", "fresh-cloud-token"}, wantKind: "cloud"},
 	}
 
 	for _, tt := range tests {
@@ -1615,6 +1620,14 @@ func TestLoginRejectsFreshCredentialsForAutoLocalBeforeNetwork(t *testing.T) {
 			if tt.env != "" {
 				t.Setenv(tt.env, "fresh-environment-token")
 			}
+
+			// Seed the opposite kind, so reporting the requested one cannot be a
+			// leftover value from an earlier case.
+			seed := config.TargetKindCloud
+			if tt.wantKind == "cloud" {
+				seed = config.TargetKindSelfHosted
+			}
+			config.CaptureTargetKind(seed)
 
 			var requests atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
@@ -1651,6 +1664,8 @@ current-context: default
 			require.ErrorContains(t, err, "auto-discovered repository config")
 			require.ErrorContains(t, err, "--config "+localPath)
 			assert.Zero(t, requests.Load(), "fresh credentials must fail before target detection or validation")
+			assert.Equal(t, tt.wantKind, config.CapturedTargetKind(),
+				"the earliest rejection gate must still report the requested target")
 			raw, readErr := os.ReadFile(localPath)
 			require.NoError(t, readErr)
 			assert.Equal(t, original, raw)

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -905,6 +905,102 @@ func TestCaptureLoginTargetKindKeepsKindWhenNothingIsKnown(t *testing.T) {
 	assert.Equal(t, "cloud", config.CapturedTargetKind())
 }
 
+func TestLoginNewContextWithoutServerReportsNoTarget(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	unsetEnvForTest(t, "GRAFANA_SERVER")
+	unsetEnvForTest(t, "GRAFANA_TOKEN")
+	unsetEnvForTest(t, "GRAFANA_CLOUD_API_URL")
+	unsetEnvForTest(t, "GRAFANA_CLOUD_OAUTH_URL")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	seed := config.Config{}
+	seed.SetStack("onprem", config.StackConfig{Grafana: &config.GrafanaConfig{Server: "http://localhost:3000", OrgID: 1}})
+	seed.SetContext("dev", true, config.Context{Stack: "onprem"})
+	require.NoError(t, config.Write(t.Context(), config.ExplicitConfigFile(path), seed))
+
+	cmd := Command()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"brand-new-context", "--config", path, "--yes"})
+
+	// A brand-new context with no --server: nothing is known about the target,
+	// so the self-hosted context that happens to be current must not be
+	// reported in its place.
+	err := cmd.ExecuteContext(t.Context())
+	require.ErrorContains(t, err, "server")
+	assert.Empty(t, config.CapturedTargetKind())
+}
+
+func TestLoginRejectedStoredTokenReportsRequestedTarget(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	unsetEnvForTest(t, "GRAFANA_SERVER")
+	unsetEnvForTest(t, "GRAFANA_TOKEN")
+	unsetEnvForTest(t, "GRAFANA_CLOUD_API_URL")
+	unsetEnvForTest(t, "GRAFANA_CLOUD_OAUTH_URL")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	seed := config.Config{}
+	seed.SetStack("onprem", config.StackConfig{
+		Grafana: &config.GrafanaConfig{Server: "http://localhost:3000", OrgID: 1, APIToken: "stored"},
+	})
+	seed.SetContext("dev", true, config.Context{Stack: "onprem"})
+	require.NoError(t, config.Write(t.Context(), config.ExplicitConfigFile(path), seed))
+
+	cmd := Command()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"dev", "--server", "https://newstack.grafana.net", "--config", path, "--yes"})
+
+	// The stored token cannot be reused for the new destination, which returns
+	// well before target detection. The event must still describe the cloud
+	// stack that was requested, not the self-hosted server being replaced.
+	err := cmd.ExecuteContext(t.Context())
+	require.ErrorContains(t, err, "Stored Grafana token cannot be reused")
+	assert.Equal(t, "cloud", config.CapturedTargetKind())
+}
+
+func TestRunLoginLoopReportsDetectedCloudTargetOnCustomDomain(t *testing.T) {
+	// Seeded with the kind the hostname implies, so only a value taken from the
+	// resolved target can satisfy this.
+	config.CaptureTargetKind(config.TargetKindSelfHosted)
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(t.Context())
+
+	detected := false
+	opts := &internallogin.Options{
+		Inputs: internallogin.Inputs{
+			Server:      "https://grafana.mycorp.example",
+			ContextName: "dev",
+		},
+		// A Cloud stack behind a custom domain — invisible to any hostname
+		// heuristic, and the reason the recapture after login.Run exists.
+		Hooks: internallogin.Hooks{
+			DetectFn: func(context.Context, string) (internallogin.Target, error) {
+				detected = true
+				return internallogin.TargetCloud, nil
+			},
+		},
+	}
+
+	// Non-interactive, and a Cloud target with no cloud credential, so Run
+	// returns a missing-input error before attempting any network call.
+	err := runLoginLoop(cmd, &loginOpts{}, opts, nil, nil, false, nil, false)
+	require.Error(t, err)
+	require.True(t, detected, "detection did not run; the test no longer covers the recapture")
+	assert.Equal(t, "cloud", config.CapturedTargetKind())
+}
+
 func TestLoginRejectedByServerOverridePreflightReportsRequestedTarget(t *testing.T) {
 	t.Setenv("GCX_AGENT_MODE", "false")
 	unsetEnvForTest(t, "GRAFANA_SERVER")

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -853,6 +853,116 @@ func TestLoadLoginSourceContextClassifiesUnmatchedServerForTelemetry(t *testing.
 	assert.Equal(t, "cloud", config.CapturedTargetKind())
 }
 
+func TestCaptureLoginTargetKind(t *testing.T) {
+	// Each case is seeded with the opposite kind, so a helper that recorded
+	// nothing would read back the seed and fail rather than pass by accident.
+	tests := []struct {
+		name string
+		seed config.TargetKind
+		opts internallogin.Options
+		want string
+	}{
+		{
+			name: "resolved cloud target wins over the URL",
+			// --cloud, or detection recognising a Cloud stack behind a custom
+			// domain: the hostname alone would read as self-hosted.
+			seed: config.TargetKindSelfHosted,
+			opts: internallogin.Options{Inputs: internallogin.Inputs{Target: internallogin.TargetCloud, Server: "https://grafana.mycorp.example"}},
+			want: "cloud",
+		},
+		{
+			name: "resolved on-prem target wins over the URL",
+			seed: config.TargetKindCloud,
+			opts: internallogin.Options{Inputs: internallogin.Inputs{Target: internallogin.TargetOnPrem, Server: "https://mystack.grafana.net"}},
+			want: "self-hosted",
+		},
+		{
+			name: "undetected target falls back to the server hostname",
+			seed: config.TargetKindSelfHosted,
+			opts: internallogin.Options{Inputs: internallogin.Inputs{Server: "https://mystack.grafana.net"}},
+			want: "cloud",
+		},
+		{
+			name: "schemeless server is normalized before classifying",
+			seed: config.TargetKindSelfHosted,
+			opts: internallogin.Options{Inputs: internallogin.Inputs{Server: "mystack.grafana.net"}},
+			want: "cloud",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.CaptureTargetKind(tt.seed)
+			captureLoginTargetKind(&tt.opts)
+			assert.Equal(t, tt.want, config.CapturedTargetKind())
+		})
+	}
+}
+
+func TestCaptureLoginTargetKindKeepsKindWhenNothingIsKnown(t *testing.T) {
+	config.CaptureTargetKind(config.TargetKindCloud)
+	captureLoginTargetKind(&internallogin.Options{})
+	assert.Equal(t, "cloud", config.CapturedTargetKind())
+}
+
+func TestLoginRejectedByServerOverridePreflightReportsRequestedTarget(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	unsetEnvForTest(t, "GRAFANA_SERVER")
+	unsetEnvForTest(t, "GRAFANA_CLOUD_API_URL")
+	unsetEnvForTest(t, "GRAFANA_CLOUD_OAUTH_URL")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	seed := config.Config{}
+	seed.SetStack("default", config.StackConfig{Grafana: &config.GrafanaConfig{Server: "https://old.example.invalid"}})
+	seed.SetContext("default", true, config.Context{Stack: "default"})
+	require.NoError(t, config.Write(t.Context(), config.ExplicitConfigFile(path), seed))
+
+	cmd := Command()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"default", "--server", "https://newstack.grafana.net", "--token", "fresh", "--config", path, "--yes"})
+
+	// The preflight rejects re-pointing the context, so the login never reaches
+	// detection. Telemetry must still describe the cloud stack the user aimed at
+	// rather than the self-hosted server the existing context holds.
+	err := cmd.ExecuteContext(t.Context())
+	require.ErrorContains(t, err, "--allow-server-override")
+	assert.Equal(t, "cloud", config.CapturedTargetKind())
+}
+
+func TestLoginForcedCloudTargetOnCustomDomainReportsCloud(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "false")
+	unsetEnvForTest(t, "GRAFANA_SERVER")
+	unsetEnvForTest(t, "GRAFANA_CLOUD_API_URL")
+	unsetEnvForTest(t, "GRAFANA_CLOUD_OAUTH_URL")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	seed := config.Config{}
+	seed.SetStack("default", config.StackConfig{Grafana: &config.GrafanaConfig{Server: "http://localhost:3000"}})
+	seed.SetContext("default", true, config.Context{Stack: "default"})
+	require.NoError(t, config.Write(t.Context(), config.ExplicitConfigFile(path), seed))
+
+	cmd := Command()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"default", "--cloud", "--server", "https://grafana.mycorp.example", "--token", "fresh", "--config", path, "--yes"})
+
+	// --cloud forces the target, so a hostname that looks nothing like Cloud must
+	// not be classified from the URL. The preflight stops the login before any
+	// network call.
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Equal(t, "cloud", config.CapturedTargetKind())
+}
+
 func TestPersistedLoginSourceContextIgnoresRuntimeEnvironmentOverrides(t *testing.T) {
 	t.Setenv("GRAFANA_SERVER", "https://runtime.invalid")
 	t.Setenv("GRAFANA_CLOUD_API_URL", "https://grafana-ops.com")

--- a/cmd/gcx/telemetry.go
+++ b/cmd/gcx/telemetry.go
@@ -75,9 +75,8 @@ func buildUsageEvent(info *root.TelemetryInfo, start time.Time, exitCode int) te
 		IsTTY:   terminal.StdoutIsTerminal(),
 		IsAgent: agent.IsAgentMode(),
 		Agent:   agent.Name(),
-		// TargetKind needs the resolved config context; resolving it requires
-		// a keychain-free context loader, which is still a follow-up. Empty
-		// until then.
+		// Keychain-free classification: only ever "cloud", "self-managed", or "".
+		TargetKind: internalconfig.LoadTargetKind(context.Background()),
 	}
 
 	// The provider is the top-level command, the first segment of the path.

--- a/cmd/gcx/telemetry.go
+++ b/cmd/gcx/telemetry.go
@@ -72,11 +72,10 @@ func buildUsageEvent(info *root.TelemetryInfo, start time.Time, exitCode int) te
 		DurationMS:   time.Since(start).Milliseconds(),
 		OutputFormat: info.OutputFormat,
 
-		IsTTY:   terminal.StdoutIsTerminal(),
-		IsAgent: agent.IsAgentMode(),
-		Agent:   agent.Name(),
-		// Keychain-free classification: only ever "cloud", "self-managed", or "".
-		TargetKind: internalconfig.LoadTargetKind(context.Background()),
+		IsTTY:      terminal.StdoutIsTerminal(),
+		IsAgent:    agent.IsAgentMode(),
+		Agent:      agent.Name(),
+		TargetKind: internalconfig.CapturedTargetKind(),
 	}
 
 	// The provider is the top-level command, the first segment of the path.

--- a/docs/sources/anonymous-usage-statistics.md
+++ b/docs/sources/anonymous-usage-statistics.md
@@ -44,7 +44,7 @@ Each `gcx` event contains the following properties:
 | `ci_provider` | Which CI system was detected, from a fixed list of known names. `gcx` reads well-known CI environment variables to detect the provider but never sends their values. | `github_actions` |
 | `is_agent` | Whether an AI coding agent drove the invocation. | `true` |
 | `agent` | The name of the agent harness, if one was detected. | `claude-code` |
-| `target_kind` | Whether the target Grafana is `cloud` or `self-hosted`. Empty when the invocation had no Grafana target to classify, such as a command that only reads or writes config. Deliberately coarse — never the URL, hostname, or stack slug. | `cloud` |
+| `target_kind` | Whether the target Grafana is `cloud` or `self-hosted`. Empty when no effective Grafana target could be resolved. Deliberately coarse — never the URL, hostname, or stack slug. | `cloud` |
 | `output_format` | The output format the command used. | `table`, `json` |
 
 When the invocation fails to parse, these additional fields are set. They capture what was attempted so the team can understand the differences between what users expect and what exists:

--- a/docs/sources/anonymous-usage-statistics.md
+++ b/docs/sources/anonymous-usage-statistics.md
@@ -44,7 +44,7 @@ Each `gcx` event contains the following properties:
 | `ci_provider` | Which CI system was detected, from a fixed list of known names. `gcx` reads well-known CI environment variables to detect the provider but never sends their values. | `github_actions` |
 | `is_agent` | Whether an AI coding agent drove the invocation. | `true` |
 | `agent` | The name of the agent harness, if one was detected. | `claude-code` |
-| `target_kind` | Whether the target Grafana is `cloud` or `self-managed`. Deliberately coarse — never the URL, hostname, or stack slug. | `cloud` |
+| `target_kind` | Whether the target Grafana is `cloud` or `self-hosted`. Empty when the invocation had no Grafana target to classify, such as a command that only reads or writes config. Deliberately coarse — never the URL, hostname, or stack slug. | `cloud` |
 | `output_format` | The output format the command used. | `table`, `json` |
 
 When the invocation fails to parse, these additional fields are set. They capture what was attempted so the team can understand the differences between what users expect and what exists:

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1048,12 +1048,16 @@ func configWriteTarget(filename, canonicalSource string, allowSymlink bool) (str
 // If no config files are found, creates a default user config (preserving current behavior).
 // If explicitFile is set (--config flag) or GCX_CONFIG env var is set,
 // bypasses layering entirely and loads that single file.
-// Every successful load also records the current context's telemetry target kind.
+// Every load also records the effective context's telemetry target kind.
 func LoadLayered(ctx context.Context, explicitFile string, overrides ...Override) (Config, error) {
 	cfg, err := loadLayered(ctx, explicitFile, overrides...)
-	if err == nil {
-		captureTargetKind(&cfg)
-	}
+	// Capture regardless of err: the override and credential-binding failure
+	// paths below return a fully merged config, so the target is known even
+	// though the command will fail. Gating on success attributed those failures
+	// to no target at all, making a resolved-but-invalid config indistinguishable
+	// from an absent one. Failures that stop before merge return Config{}, which
+	// still classifies as "".
+	captureTargetKind(&cfg)
 	return cfg, err
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1051,13 +1051,21 @@ func configWriteTarget(filename, canonicalSource string, allowSymlink bool) (str
 // Every load also records the effective context's telemetry target kind.
 func LoadLayered(ctx context.Context, explicitFile string, overrides ...Override) (Config, error) {
 	cfg, err := loadLayered(ctx, explicitFile, overrides...)
-	// Capture regardless of err: the override and credential-binding failure
-	// paths below return a fully merged config, so the target is known even
-	// though the command will fail. Gating on success attributed those failures
-	// to no target at all, making a resolved-but-invalid config indistinguishable
-	// from an absent one. Failures that stop before merge return Config{}, which
-	// still classifies as "".
-	captureTargetKind(&cfg)
+	// Capture even when err is non-nil: the validation and credential-binding
+	// override paths below return a fully merged config, so the target is known
+	// even though the command will fail. Gating on success attributed those
+	// failures to no target at all, making a resolved-but-invalid config
+	// indistinguishable from an absent one. Failures that stop before merge
+	// return Config{}, which still classifies as unknown.
+	//
+	// Context selection failing is the exception. cfg.CurrentContext then still
+	// names whichever context was current before --context was applied, and that
+	// is not what the invocation targeted — classifying it would report a
+	// confidently wrong kind where the honest answer is that no target was ever
+	// resolved.
+	if !errors.Is(err, ErrContextNotFound) {
+		captureTargetKind(&cfg)
+	}
 	return cfg, err
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1048,7 +1048,16 @@ func configWriteTarget(filename, canonicalSource string, allowSymlink bool) (str
 // If no config files are found, creates a default user config (preserving current behavior).
 // If explicitFile is set (--config flag) or GCX_CONFIG env var is set,
 // bypasses layering entirely and loads that single file.
+// Every successful load also records the current context's telemetry target kind.
 func LoadLayered(ctx context.Context, explicitFile string, overrides ...Override) (Config, error) {
+	cfg, err := loadLayered(ctx, explicitFile, overrides...)
+	if err == nil {
+		captureTargetKind(&cfg)
+	}
+	return cfg, err
+}
+
+func loadLayered(ctx context.Context, explicitFile string, overrides ...Override) (Config, error) {
 	// --config flag bypasses layering.
 	if explicitFile != "" {
 		return loadExplicit(ctx, explicitFile, overrides...)

--- a/internal/config/targetkind.go
+++ b/internal/config/targetkind.go
@@ -1,165 +1,36 @@
 package config
 
-import (
-	"bytes"
-	"context"
-	"maps"
-	"net/url"
-	"os"
-	"strings"
+import "sync/atomic"
 
-	"github.com/grafana/gcx/internal/format"
-)
-
-// Target kind values reported by LoadTargetKind. Deliberately coarse: never
-// the URL, hostname, or stack slug.
 const (
 	targetKindCloud       = "cloud"
 	targetKindSelfManaged = "self-managed"
 )
 
-// LoadTargetKind classifies the current context's Grafana target as "cloud"
-// or "self-managed" for anonymous usage telemetry. Like LoadDiagnostics it
-// reads the layered config without building the full Config: it never probes
-// the OS keychain, never prompts, and never auto-creates a config file.
-// Returns "" when no target is resolvable (no config, no current context,
-// malformed files).
-func LoadTargetKind(ctx context.Context) string {
-	view := newTargetKindView()
-	for _, path := range diagnosticsSourcePaths(ctx) {
-		layer, err := readTargetKindLayer(path)
-		if err != nil {
-			continue
-		}
-		view.merge(layer)
-	}
-	return view.classify()
+// capturedTargetKind holds the targetKind for the invocation. It is updated when each layer of the config is read. It is read once at exit by the usage-stats emitter.
+//
+//nolint:gochecknoglobals
+var capturedTargetKind atomic.Value
+
+// CapturedTargetKind returns target kind of the config loaded by the command invocation.
+func CapturedTargetKind() string {
+	kind, _ := capturedTargetKind.Load().(string)
+	return kind
 }
 
-// targetKindStack carries the per-stack fields Context.IsCloud consults.
-type targetKindStack struct {
-	slug    string
-	stackID int64
-	server  string
+// captureTargetKind writes the current config layer's classification to the capturedTargetKind atomic value.
+func captureTargetKind(cfg *Config) {
+	capturedTargetKind.Store(targetKindForContext(cfg.GetCurrentContext()))
 }
 
-// targetKindView is the minimal layered-config view needed to classify the
-// current context: the context→stack references and per-stack cloud signals.
-type targetKindView struct {
-	currentContext string
-	contextStacks  map[string]string
-	stacks         map[string]targetKindStack
-}
-
-func newTargetKindView() *targetKindView {
-	return &targetKindView{
-		contextStacks: map[string]string{},
-		stacks:        map[string]targetKindStack{},
-	}
-}
-
-// merge folds a higher-precedence layer into the view, mirroring MergeConfigs:
-// current-context is last-non-empty-wins, stack entries are atomic per name,
-// and a context's stack reference is only overridden by a non-empty one.
-func (view *targetKindView) merge(layer *targetKindView) {
-	if layer.currentContext != "" {
-		view.currentContext = layer.currentContext
-	}
-	maps.Copy(view.stacks, layer.stacks)
-	for name, stack := range layer.contextStacks {
-		if stack != "" {
-			view.contextStacks[name] = stack
-		}
-	}
-}
-
-// classify applies the Context.IsCloud signals to the resolved current
-// context. GRAFANA_CLOUD_STACK and GRAFANA_SERVER are honoured directly
-// (as a full load's env parsing would) so env-only detached contexts are
-// classified too.
-func (view *targetKindView) classify() string {
-	stack := view.stacks[view.contextStacks[view.currentContext]]
-	slug := os.Getenv("GRAFANA_CLOUD_STACK")
-	if slug == "" {
-		slug = stack.slug
-	}
-	server := os.Getenv("GRAFANA_SERVER")
-	if server == "" {
-		server = stack.server
-	}
-	if slug != "" || stack.stackID != 0 {
+func targetKindForContext(context *Context) string {
+	switch {
+	case context == nil:
+		return ""
+	case context.IsCloud():
 		return targetKindCloud
-	}
-	if server == "" {
+	case context.Grafana == nil || context.Grafana.Server == "":
 		return ""
 	}
-	if parsed, err := url.Parse(server); err == nil && IsGrafanaCloudHost(strings.ToLower(parsed.Hostname())) {
-		return targetKindCloud
-	}
 	return targetKindSelfManaged
-}
-
-// readTargetKindLayer decodes one config file into a view, following
-// readDiagnostics: full-struct decode, but no keychain resolution, no
-// migration, no auto-creation. Legacy-format files are read through the
-// legacy struct, where each context carries its own grafana block and cloud
-// stack slug. Missing or malformed files yield (nil, err).
-func readTargetKindLayer(path string) (*targetKindView, error) {
-	contents, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	if err := validateDeclaredConfigVersion(path, contents); err != nil {
-		return nil, err
-	}
-	layer := newTargetKindView()
-	codec := &format.YAMLCodec{BytesAsBase64: true}
-	if isLegacyConfig(contents) {
-		var lc legacyConfig
-		if err := codec.Decode(bytes.NewBuffer(contents), &lc); err != nil {
-			return nil, err
-		}
-		layer.currentContext = lc.CurrentContext
-		for name, lctx := range lc.Contexts {
-			if lctx == nil {
-				continue
-			}
-			stack := targetKindStack{}
-			if lctx.Cloud != nil {
-				stack.slug = lctx.Cloud.Stack
-			}
-			if lctx.Grafana != nil {
-				stack.stackID = lctx.Grafana.StackID
-				stack.server = lctx.Grafana.Server
-			}
-			// Mirror the in-memory migration: each legacy context becomes a
-			// same-named stack referenced by the context.
-			layer.stacks[name] = stack
-			layer.contextStacks[name] = name
-		}
-		return layer, nil
-	}
-	var cfg Config
-	if err := codec.Decode(bytes.NewBuffer(contents), &cfg); err != nil {
-		return nil, err
-	}
-	layer.currentContext = cfg.CurrentContext
-	for name, stack := range cfg.Stacks {
-		if stack == nil {
-			continue
-		}
-		entry := targetKindStack{slug: stack.Slug}
-		if stack.Grafana != nil {
-			entry.stackID = stack.Grafana.StackID
-			entry.server = stack.Grafana.Server
-		}
-		layer.stacks[name] = entry
-	}
-	for name, c := range cfg.Contexts {
-		if c == nil {
-			continue
-		}
-		layer.contextStacks[name] = c.Stack
-	}
-	return layer, nil
 }

--- a/internal/config/targetkind.go
+++ b/internal/config/targetkind.go
@@ -57,6 +57,17 @@ func CaptureTargetKind(kind TargetKind) {
 	capturedTargetKind.Store(string(kind))
 }
 
+// ClearCapturedTargetKind resets the captured kind to unknown.
+//
+// gcx login uses it once it has resolved neither a context nor a server: the
+// kind the config load took from whichever context happened to be current
+// describes a target this invocation is not aiming at, and reporting nothing is
+// the honest answer. Prefer CaptureTargetKind for a kind that is merely
+// undecided — that leaves an established value alone rather than erasing it.
+func ClearCapturedTargetKind() {
+	capturedTargetKind.Store(string(TargetKindUnknown))
+}
+
 // CaptureTargetKindForServer records the target kind implied by a Grafana server
 // URL, for the point in gcx login before target detection has run and where no
 // configured context describes the requested server. Without it the value

--- a/internal/config/targetkind.go
+++ b/internal/config/targetkind.go
@@ -3,8 +3,8 @@ package config
 import "sync/atomic"
 
 const (
-	targetKindCloud       = "cloud"
-	targetKindSelfManaged = "self-hosted"
+	targetKindCloud      = "cloud"
+	targetKindSelfHosted = "self-hosted"
 )
 
 // capturedTargetKind holds the targetKind for the invocation. It is updated when each layer of the config is read. It is read once at exit by the usage-stats emitter.
@@ -32,5 +32,5 @@ func targetKindForContext(context *Context) string {
 	case context.Grafana == nil || context.Grafana.Server == "":
 		return ""
 	}
-	return targetKindSelfManaged
+	return targetKindSelfHosted
 }

--- a/internal/config/targetkind.go
+++ b/internal/config/targetkind.go
@@ -1,0 +1,165 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"maps"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/grafana/gcx/internal/format"
+)
+
+// Target kind values reported by LoadTargetKind. Deliberately coarse: never
+// the URL, hostname, or stack slug.
+const (
+	targetKindCloud       = "cloud"
+	targetKindSelfManaged = "self-managed"
+)
+
+// LoadTargetKind classifies the current context's Grafana target as "cloud"
+// or "self-managed" for anonymous usage telemetry. Like LoadDiagnostics it
+// reads the layered config without building the full Config: it never probes
+// the OS keychain, never prompts, and never auto-creates a config file.
+// Returns "" when no target is resolvable (no config, no current context,
+// malformed files).
+func LoadTargetKind(ctx context.Context) string {
+	view := newTargetKindView()
+	for _, path := range diagnosticsSourcePaths(ctx) {
+		layer, err := readTargetKindLayer(path)
+		if err != nil {
+			continue
+		}
+		view.merge(layer)
+	}
+	return view.classify()
+}
+
+// targetKindStack carries the per-stack fields Context.IsCloud consults.
+type targetKindStack struct {
+	slug    string
+	stackID int64
+	server  string
+}
+
+// targetKindView is the minimal layered-config view needed to classify the
+// current context: the context→stack references and per-stack cloud signals.
+type targetKindView struct {
+	currentContext string
+	contextStacks  map[string]string
+	stacks         map[string]targetKindStack
+}
+
+func newTargetKindView() *targetKindView {
+	return &targetKindView{
+		contextStacks: map[string]string{},
+		stacks:        map[string]targetKindStack{},
+	}
+}
+
+// merge folds a higher-precedence layer into the view, mirroring MergeConfigs:
+// current-context is last-non-empty-wins, stack entries are atomic per name,
+// and a context's stack reference is only overridden by a non-empty one.
+func (view *targetKindView) merge(layer *targetKindView) {
+	if layer.currentContext != "" {
+		view.currentContext = layer.currentContext
+	}
+	maps.Copy(view.stacks, layer.stacks)
+	for name, stack := range layer.contextStacks {
+		if stack != "" {
+			view.contextStacks[name] = stack
+		}
+	}
+}
+
+// classify applies the Context.IsCloud signals to the resolved current
+// context. GRAFANA_CLOUD_STACK and GRAFANA_SERVER are honoured directly
+// (as a full load's env parsing would) so env-only detached contexts are
+// classified too.
+func (view *targetKindView) classify() string {
+	stack := view.stacks[view.contextStacks[view.currentContext]]
+	slug := os.Getenv("GRAFANA_CLOUD_STACK")
+	if slug == "" {
+		slug = stack.slug
+	}
+	server := os.Getenv("GRAFANA_SERVER")
+	if server == "" {
+		server = stack.server
+	}
+	if slug != "" || stack.stackID != 0 {
+		return targetKindCloud
+	}
+	if server == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(server); err == nil && IsGrafanaCloudHost(strings.ToLower(parsed.Hostname())) {
+		return targetKindCloud
+	}
+	return targetKindSelfManaged
+}
+
+// readTargetKindLayer decodes one config file into a view, following
+// readDiagnostics: full-struct decode, but no keychain resolution, no
+// migration, no auto-creation. Legacy-format files are read through the
+// legacy struct, where each context carries its own grafana block and cloud
+// stack slug. Missing or malformed files yield (nil, err).
+func readTargetKindLayer(path string) (*targetKindView, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateDeclaredConfigVersion(path, contents); err != nil {
+		return nil, err
+	}
+	layer := newTargetKindView()
+	codec := &format.YAMLCodec{BytesAsBase64: true}
+	if isLegacyConfig(contents) {
+		var lc legacyConfig
+		if err := codec.Decode(bytes.NewBuffer(contents), &lc); err != nil {
+			return nil, err
+		}
+		layer.currentContext = lc.CurrentContext
+		for name, lctx := range lc.Contexts {
+			if lctx == nil {
+				continue
+			}
+			stack := targetKindStack{}
+			if lctx.Cloud != nil {
+				stack.slug = lctx.Cloud.Stack
+			}
+			if lctx.Grafana != nil {
+				stack.stackID = lctx.Grafana.StackID
+				stack.server = lctx.Grafana.Server
+			}
+			// Mirror the in-memory migration: each legacy context becomes a
+			// same-named stack referenced by the context.
+			layer.stacks[name] = stack
+			layer.contextStacks[name] = name
+		}
+		return layer, nil
+	}
+	var cfg Config
+	if err := codec.Decode(bytes.NewBuffer(contents), &cfg); err != nil {
+		return nil, err
+	}
+	layer.currentContext = cfg.CurrentContext
+	for name, stack := range cfg.Stacks {
+		if stack == nil {
+			continue
+		}
+		entry := targetKindStack{slug: stack.Slug}
+		if stack.Grafana != nil {
+			entry.stackID = stack.Grafana.StackID
+			entry.server = stack.Grafana.Server
+		}
+		layer.stacks[name] = entry
+	}
+	for name, c := range cfg.Contexts {
+		if c == nil {
+			continue
+		}
+		layer.contextStacks[name] = c.Stack
+	}
+	return layer, nil
+}

--- a/internal/config/targetkind.go
+++ b/internal/config/targetkind.go
@@ -7,7 +7,18 @@ const (
 	targetKindSelfHosted = "self-hosted"
 )
 
-// capturedTargetKind holds the targetKind for the invocation. It is updated when each layer of the config is read. It is read once at exit by the usage-stats emitter.
+// capturedTargetKind holds the target kind for the invocation. LoadLayered
+// stores it once per call, from the effective context after all layers are
+// merged and every override (context selection, env vars) has been applied —
+// not once per layer. When a command loads config more than once, the last
+// load wins, which is the most specific view of what the command actually
+// targeted. It is read once at exit by the usage-stats emitter.
+//
+// It stays "" for paths that never reach LoadLayered, notably the LoadForWrite
+// shortcuts for --config and --file. Those load a single named layer instead of
+// the merged view, so classifying from them could report a kind the invocation
+// never targeted; an absent value is preferable to a wrong one, and config
+// writes do not talk to a Grafana instance anyway.
 //
 //nolint:gochecknoglobals
 var capturedTargetKind atomic.Value
@@ -18,11 +29,32 @@ func CapturedTargetKind() string {
 	return kind
 }
 
-// captureTargetKind writes the current config layer's classification to the capturedTargetKind atomic value.
+// captureTargetKind classifies the config's effective context and records it.
 func captureTargetKind(cfg *Config) {
 	capturedTargetKind.Store(targetKindForContext(cfg.GetCurrentContext()))
 }
 
+// CaptureTargetKindForServer records the target kind for a Grafana server URL
+// that no configured context describes yet — gcx login building a new context
+// from --server. Without it the value captured by the preceding config load
+// would describe whichever context happened to be current, mislabelling the
+// login target in either direction. An empty server carries no signal, so it
+// leaves any kind already captured for this invocation in place.
+func CaptureTargetKindForServer(server string) {
+	if server == "" {
+		return
+	}
+	capturedTargetKind.Store(targetKindForContext(&Context{Grafana: &GrafanaConfig{Server: server}}))
+}
+
+// targetKindForContext classifies a context as cloud or self-hosted for
+// telemetry. It reports "" when no Grafana target can be determined.
+//
+// A context holding only a cloud entry (an org-wide GCOM credential, no stack
+// slug and no Grafana server) is deliberately "" rather than cloud: target_kind
+// describes the Grafana instance a command talked to, and such a context names
+// no instance. Commands against the Cloud control plane alone are therefore
+// unclassified by design.
 func targetKindForContext(context *Context) string {
 	switch {
 	case context == nil:

--- a/internal/config/targetkind.go
+++ b/internal/config/targetkind.go
@@ -4,7 +4,7 @@ import "sync/atomic"
 
 const (
 	targetKindCloud       = "cloud"
-	targetKindSelfManaged = "self-managed"
+	targetKindSelfManaged = "self-hosted"
 )
 
 // capturedTargetKind holds the targetKind for the invocation. It is updated when each layer of the config is read. It is read once at exit by the usage-stats emitter.

--- a/internal/config/targetkind.go
+++ b/internal/config/targetkind.go
@@ -2,9 +2,15 @@ package config
 
 import "sync/atomic"
 
+// TargetKind classifies the Grafana instance a command targeted. The values are
+// the ones sent in the usage-stats event.
+type TargetKind string
+
 const (
-	targetKindCloud      = "cloud"
-	targetKindSelfHosted = "self-hosted"
+	// TargetKindUnknown means no Grafana target could be determined.
+	TargetKindUnknown    TargetKind = ""
+	TargetKindCloud      TargetKind = "cloud"
+	TargetKindSelfHosted TargetKind = "self-hosted"
 )
 
 // capturedTargetKind holds the target kind for the invocation. LoadLayered
@@ -14,11 +20,11 @@ const (
 // load wins, which is the most specific view of what the command actually
 // targeted. It is read once at exit by the usage-stats emitter.
 //
-// It stays "" for paths that never reach LoadLayered, notably the LoadForWrite
-// shortcuts for --config and --file. Those load a single named layer instead of
-// the merged view, so classifying from them could report a kind the invocation
-// never targeted; an absent value is preferable to a wrong one, and config
-// writes do not talk to a Grafana instance anyway.
+// It stays unset for paths that never reach LoadLayered, notably the
+// LoadForWrite shortcuts for --config and --file. Those load a single named
+// layer instead of the merged view, so classifying from them could report a
+// kind the invocation never targeted, and an absent value is preferable to a
+// wrong one.
 //
 //nolint:gochecknoglobals
 var capturedTargetKind atomic.Value
@@ -30,39 +36,61 @@ func CapturedTargetKind() string {
 }
 
 // captureTargetKind classifies the config's effective context and records it.
+// Unlike CaptureTargetKind it records TargetKindUnknown too: a load that
+// resolved no context is itself the answer for that invocation.
 func captureTargetKind(cfg *Config) {
-	capturedTargetKind.Store(targetKindForContext(cfg.GetCurrentContext()))
+	capturedTargetKind.Store(string(targetKindForContext(cfg.GetCurrentContext())))
 }
 
-// CaptureTargetKindForServer records the target kind for a Grafana server URL
-// that no configured context describes yet — gcx login building a new context
-// from --server. Without it the value captured by the preceding config load
-// would describe whichever context happened to be current, mislabelling the
-// login target in either direction. An empty server carries no signal, so it
-// leaves any kind already captured for this invocation in place.
+// CaptureTargetKind records a target kind the caller determined for itself.
+// gcx login resolves its target by probing the server and by honouring --cloud,
+// both of which outrank the hostname guess in CaptureTargetKindForServer, so it
+// reports the resolved value through here.
+//
+// TargetKindUnknown is ignored rather than stored: a detection that came back
+// undecided is no reason to erase a kind already established for this
+// invocation.
+func CaptureTargetKind(kind TargetKind) {
+	if kind == TargetKindUnknown {
+		return
+	}
+	capturedTargetKind.Store(string(kind))
+}
+
+// CaptureTargetKindForServer records the target kind implied by a Grafana server
+// URL, for the point in gcx login before target detection has run and where no
+// configured context describes the requested server. Without it the value
+// captured by the preceding config load would describe whichever context
+// happened to be current, mislabelling the login target in either direction.
+//
+// This is a hostname guess and nothing more; a custom domain fronting a Cloud
+// stack looks self-hosted here. Callers that later learn the real target must
+// report it through CaptureTargetKind. An empty server carries no signal and
+// leaves any kind already captured in place.
 func CaptureTargetKindForServer(server string) {
 	if server == "" {
 		return
 	}
-	capturedTargetKind.Store(targetKindForContext(&Context{Grafana: &GrafanaConfig{Server: server}}))
+	CaptureTargetKind(targetKindForContext(&Context{Grafana: &GrafanaConfig{Server: server}}))
 }
 
 // targetKindForContext classifies a context as cloud or self-hosted for
-// telemetry. It reports "" when no Grafana target can be determined.
+// telemetry. It reports TargetKindUnknown when no Grafana target can be
+// determined.
 //
 // A context holding only a cloud entry (an org-wide GCOM credential, no stack
-// slug and no Grafana server) is deliberately "" rather than cloud: target_kind
-// describes the Grafana instance a command talked to, and such a context names
-// no instance. Commands against the Cloud control plane alone are therefore
-// unclassified by design.
-func targetKindForContext(context *Context) string {
+// slug and no Grafana server) is deliberately unknown rather than cloud:
+// target_kind describes the Grafana instance a command talked to, and such a
+// context names no instance. Commands against the Cloud control plane alone are
+// therefore unclassified by design.
+func targetKindForContext(context *Context) TargetKind {
 	switch {
 	case context == nil:
-		return ""
+		return TargetKindUnknown
 	case context.IsCloud():
-		return targetKindCloud
+		return TargetKindCloud
 	case context.Grafana == nil || context.Grafana.Server == "":
-		return ""
+		return TargetKindUnknown
 	}
-	return targetKindSelfHosted
+	return TargetKindSelfHosted
 }

--- a/internal/config/targetkind_test.go
+++ b/internal/config/targetkind_test.go
@@ -364,10 +364,9 @@ contexts:
 current-context: dev
 `)
 
-	// Stands in for a kind established earlier in the invocation, so the
-	// assertion distinguishes "left alone" from "overwritten with the stale
-	// context's kind".
-	config.CaptureTargetKind(config.TargetKindCloud)
+	// Start from a genuinely unset value so the assertion below is about the
+	// label being absent, not about some earlier value happening to survive.
+	config.ClearCapturedTargetKind()
 
 	// --context naming a context that does not exist fails selection without
 	// changing CurrentContext, so the merged config still describes the
@@ -379,15 +378,15 @@ current-context: dev
 
 	_, err := config.LoadLayered(t.Context(), "", selectMissing, testEnvOverride)
 	require.ErrorIs(t, err, config.ErrContextNotFound)
-	assert.Equal(t, "cloud", config.CapturedTargetKind())
+	assert.Empty(t, config.CapturedTargetKind())
 }
 
 func TestCapturedTargetKind_CloudCredentialOnlyContextIsUnclassified(t *testing.T) {
 	userDir, _ := isolatedLoaderEnv(t)
 	scrubTargetKindEnv(t)
 
-	// Seeded so an implementation that captures nothing here cannot pass on a
-	// leftover empty value from an earlier test.
+	// Seeded with a kind, so passing requires the load to actively record
+	// "unknown" rather than inherit an empty value from an earlier test.
 	config.CaptureTargetKind(config.TargetKindCloud)
 
 	// A cloud entry on its own is an org-wide GCOM credential: no stack slug, no

--- a/internal/config/targetkind_test.go
+++ b/internal/config/targetkind_test.go
@@ -1,0 +1,198 @@
+package config_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadTargetKind(t *testing.T) {
+	cloudConfig := "stacks:\n" +
+		"  prod:\n" +
+		"    grafana:\n" +
+		"      server: https://mystack.grafana.net\n" +
+		"contexts:\n" +
+		"  dev:\n" +
+		"    stack: prod\n" +
+		"current-context: dev\n"
+
+	tests := []struct {
+		name  string
+		user  string // user-layer config content, "" for none
+		local string // repo-local .gcx.yaml content, "" for none
+		env   map[string]string
+		want  string
+	}{
+		{
+			name: "no config",
+			want: "",
+		},
+		{
+			name: "cloud server URL",
+			user: cloudConfig,
+			want: "cloud",
+		},
+		{
+			name: "self-managed server",
+			user: "stacks:\n" +
+				"  onprem:\n" +
+				"    grafana:\n" +
+				"      server: https://grafana.internal.example.com\n" +
+				"contexts:\n" +
+				"  dev:\n" +
+				"    stack: onprem\n" +
+				"current-context: dev\n",
+			want: "self-managed",
+		},
+		{
+			name: "explicit stack slug",
+			user: "stacks:\n" +
+				"  prod:\n" +
+				"    slug: mystack\n" +
+				"contexts:\n" +
+				"  dev:\n" +
+				"    stack: prod\n" +
+				"current-context: dev\n",
+			want: "cloud",
+		},
+		{
+			name: "stack id on custom domain",
+			user: "stacks:\n" +
+				"  prod:\n" +
+				"    grafana:\n" +
+				"      server: https://grafana.example.com\n" +
+				"      stack-id: 12345\n" +
+				"contexts:\n" +
+				"  dev:\n" +
+				"    stack: prod\n" +
+				"current-context: dev\n",
+			want: "cloud",
+		},
+		{
+			name: "no current context",
+			user: "stacks:\n" +
+				"  prod:\n" +
+				"    grafana:\n" +
+				"      server: https://mystack.grafana.net\n" +
+				"contexts:\n" +
+				"  dev:\n" +
+				"    stack: prod\n",
+			want: "",
+		},
+		{
+			name: "malformed config",
+			user: "{{{ not yaml",
+			want: "",
+		},
+		{
+			name: "env-only GRAFANA_CLOUD_STACK",
+			env:  map[string]string{"GRAFANA_CLOUD_STACK": "mystack"},
+			want: "cloud",
+		},
+		{
+			name: "env-only self-managed GRAFANA_SERVER",
+			env:  map[string]string{"GRAFANA_SERVER": "http://localhost:3000"},
+			want: "self-managed",
+		},
+		{
+			name: "env-only cloud GRAFANA_SERVER",
+			env:  map[string]string{"GRAFANA_SERVER": "https://mystack.grafana.net"},
+			want: "cloud",
+		},
+		{
+			name: "legacy config cloud",
+			user: "contexts:\n" +
+				"  dev:\n" +
+				"    grafana:\n" +
+				"      server: https://mystack.grafana.net\n" +
+				"current-context: dev\n",
+			want: "cloud",
+		},
+		{
+			name: "legacy config cloud via cloud stack slug",
+			user: "contexts:\n" +
+				"  dev:\n" +
+				"    grafana:\n" +
+				"      server: https://grafana.internal.example.com\n" +
+				"    cloud:\n" +
+				"      stack: mystack\n" +
+				"current-context: dev\n",
+			want: "cloud",
+		},
+		{
+			name: "legacy config self-managed",
+			user: "contexts:\n" +
+				"  dev:\n" +
+				"    grafana:\n" +
+				"      server: http://localhost:3000\n" +
+				"      token: abc\n" +
+				"current-context: dev\n",
+			want: "self-managed",
+		},
+		{
+			name: "local layer switches current context",
+			user: cloudConfig,
+			local: "stacks:\n" +
+				"  onprem:\n" +
+				"    grafana:\n" +
+				"      server: http://localhost:3000\n" +
+				"contexts:\n" +
+				"  local:\n" +
+				"    stack: onprem\n" +
+				"current-context: local\n",
+			want: "self-managed",
+		},
+		{
+			name: "local context references user-layer stack",
+			user: "stacks:\n" +
+				"  prod:\n" +
+				"    grafana:\n" +
+				"      server: https://mystack.grafana.net\n" +
+				"contexts:\n" +
+				"  dev:\n" +
+				"    stack: prod\n",
+			local: "contexts:\n" +
+				"  dev: {}\n" +
+				"current-context: dev\n",
+			want: "cloud",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userDir, workDir := isolatedLoaderEnv(t)
+			t.Setenv("GRAFANA_CLOUD_STACK", "")
+			t.Setenv("GRAFANA_SERVER", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			if tt.user != "" {
+				writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"), tt.user)
+			}
+			if tt.local != "" {
+				writeLoaderConfig(t, filepath.Join(workDir, ".gcx.yaml"), tt.local)
+			}
+
+			assert.Equal(t, tt.want, config.LoadTargetKind(t.Context()))
+		})
+	}
+}
+
+func TestLoadTargetKind_ExplicitConfigFile(t *testing.T) {
+	userDir, _ := isolatedLoaderEnv(t)
+	t.Setenv("GRAFANA_CLOUD_STACK", "")
+	t.Setenv("GRAFANA_SERVER", "")
+
+	// The discoverable user layer says cloud; the explicit file must bypass it.
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
+		"stacks:\n  prod:\n    slug: mystack\ncontexts:\n  dev:\n    stack: prod\ncurrent-context: dev\n")
+
+	explicit := filepath.Join(t.TempDir(), "explicit.yaml")
+	writeLoaderConfig(t, explicit,
+		"stacks:\n  onprem:\n    grafana:\n      server: http://localhost:3000\ncontexts:\n  dev:\n    stack: onprem\ncurrent-context: dev\n")
+	t.Setenv("GCX_CONFIG", explicit)
+
+	assert.Equal(t, "self-managed", config.LoadTargetKind(t.Context()))
+}

--- a/internal/config/targetkind_test.go
+++ b/internal/config/targetkind_test.go
@@ -329,6 +329,12 @@ contexts:
 current-context: dev
 `)
 
+	// Seed a different kind first. Without this the assertion passes against an
+	// implementation that captures nothing on the error path, because an earlier
+	// test in this package leaves "self-hosted" in the process-wide value and the
+	// stale reading is indistinguishable from a fresh one.
+	config.CaptureTargetKind(config.TargetKindCloud)
+
 	// Commands run context validation as an override (providers.LoadGrafanaConfig),
 	// so a config that resolves but fails validation — a self-hosted stack with no
 	// org-id, for instance — reaches this path with a fully merged config. The
@@ -343,9 +349,46 @@ current-context: dev
 	assert.Equal(t, "self-hosted", config.CapturedTargetKind())
 }
 
+func TestCapturedTargetKind_ContextSelectionFailureLeavesTargetUnreported(t *testing.T) {
+	userDir, _ := isolatedLoaderEnv(t)
+	scrubTargetKindEnv(t)
+
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"), `
+stacks:
+  onprem:
+    grafana:
+      server: http://localhost:3000
+contexts:
+  dev:
+    stack: onprem
+current-context: dev
+`)
+
+	// Stands in for a kind established earlier in the invocation, so the
+	// assertion distinguishes "left alone" from "overwritten with the stale
+	// context's kind".
+	config.CaptureTargetKind(config.TargetKindCloud)
+
+	// --context naming a context that does not exist fails selection without
+	// changing CurrentContext, so the merged config still describes the
+	// previously current self-hosted context. That context is not what the
+	// invocation targeted and must not be reported as though it were.
+	selectMissing := func(*config.Config) error {
+		return config.ContextNotFound("does-not-exist")
+	}
+
+	_, err := config.LoadLayered(t.Context(), "", selectMissing, testEnvOverride)
+	require.ErrorIs(t, err, config.ErrContextNotFound)
+	assert.Equal(t, "cloud", config.CapturedTargetKind())
+}
+
 func TestCapturedTargetKind_CloudCredentialOnlyContextIsUnclassified(t *testing.T) {
 	userDir, _ := isolatedLoaderEnv(t)
 	scrubTargetKindEnv(t)
+
+	// Seeded so an implementation that captures nothing here cannot pass on a
+	// leftover empty value from an earlier test.
+	config.CaptureTargetKind(config.TargetKindCloud)
 
 	// A cloud entry on its own is an org-wide GCOM credential: no stack slug, no
 	// Grafana server, so it names no Grafana instance to classify. Pinned so the

--- a/internal/config/targetkind_test.go
+++ b/internal/config/targetkind_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -311,4 +312,79 @@ current-context: dev
 	_, err := config.LoadLayered(t.Context(), explicit, testEnvOverride)
 	require.NoError(t, err)
 	assert.Equal(t, "self-hosted", config.CapturedTargetKind())
+}
+
+func TestCapturedTargetKind_FailedOverrideStillRecordsTarget(t *testing.T) {
+	userDir, _ := isolatedLoaderEnv(t)
+	scrubTargetKindEnv(t)
+
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"), `
+stacks:
+  onprem:
+    grafana:
+      server: http://localhost:3000
+contexts:
+  dev:
+    stack: onprem
+current-context: dev
+`)
+
+	// Commands run context validation as an override (providers.LoadGrafanaConfig),
+	// so a config that resolves but fails validation — a self-hosted stack with no
+	// org-id, for instance — reaches this path with a fully merged config. The
+	// target is known and must be recorded, otherwise those invocations look
+	// identical to ones that had no config at all.
+	failValidation := func(*config.Config) error {
+		return errors.New("missing stacks.onprem.grafana.org-id")
+	}
+
+	_, err := config.LoadLayered(t.Context(), "", testEnvOverride, failValidation)
+	require.Error(t, err)
+	assert.Equal(t, "self-hosted", config.CapturedTargetKind())
+}
+
+func TestCapturedTargetKind_CloudCredentialOnlyContextIsUnclassified(t *testing.T) {
+	userDir, _ := isolatedLoaderEnv(t)
+	scrubTargetKindEnv(t)
+
+	// A cloud entry on its own is an org-wide GCOM credential: no stack slug, no
+	// Grafana server, so it names no Grafana instance to classify. Pinned so the
+	// empty value stays a decision rather than becoming an accident.
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"), `
+cloud:
+  grafana-com:
+    token: abc
+contexts:
+  dev:
+    cloud: grafana-com
+current-context: dev
+`)
+
+	_, err := config.LoadLayered(t.Context(), "", testEnvOverride)
+	require.NoError(t, err)
+	assert.Empty(t, config.CapturedTargetKind())
+}
+
+func TestCaptureTargetKindForServer(t *testing.T) {
+	tests := []struct {
+		name   string
+		server string
+		want   string
+	}{
+		{name: "cloud host", server: "https://mystack.grafana.net", want: "cloud"},
+		{name: "self-hosted host", server: "http://localhost:3000", want: "self-hosted"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.CaptureTargetKindForServer(tt.server)
+			assert.Equal(t, tt.want, config.CapturedTargetKind())
+		})
+	}
+}
+
+func TestCaptureTargetKindForServer_EmptyServerKeepsCapturedKind(t *testing.T) {
+	config.CaptureTargetKindForServer("https://mystack.grafana.net")
+	config.CaptureTargetKindForServer("")
+	assert.Equal(t, "cloud", config.CapturedTargetKind())
 }

--- a/internal/config/targetkind_test.go
+++ b/internal/config/targetkind_test.go
@@ -1,14 +1,40 @@
 package config_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestLoadTargetKind(t *testing.T) {
+// scrubTargetKindEnv unsets the env vars that influence classification.
+// Set-but-empty is not enough: the real env parsing uses LookupEnv, so an
+// empty GRAFANA_SERVER would clear the config-file server instead.
+func scrubTargetKindEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{"GRAFANA_SERVER", "GRAFANA_CLOUD_STACK", "GRAFANA_STACK_ID"} {
+		t.Setenv(key, "") // register restoration of the real value
+		require.NoError(t, os.Unsetenv(key))
+	}
+}
+
+// testEnvOverride mirrors the env override every command load path applies
+// (providers.envOverride / cloudEnvOverride): ensure a current context exists
+// and parse GRAFANA_* env vars into it.
+func testEnvOverride(cfg *config.Config) error {
+	if cfg.CurrentContext == "" {
+		cfg.CurrentContext = config.DefaultContextName
+	}
+	if !cfg.HasContext(cfg.CurrentContext) {
+		cfg.SetContext(cfg.CurrentContext, true, config.Context{})
+	}
+	return config.ParseEnvIntoContext(cfg.Contexts[cfg.CurrentContext])
+}
+
+func TestCapturedTargetKind(t *testing.T) {
 	cloudConfig := "stacks:\n" +
 		"  prod:\n" +
 		"    grafana:\n" +
@@ -82,11 +108,6 @@ func TestLoadTargetKind(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "malformed config",
-			user: "{{{ not yaml",
-			want: "",
-		},
-		{
 			name: "env-only GRAFANA_CLOUD_STACK",
 			env:  map[string]string{"GRAFANA_CLOUD_STACK": "mystack"},
 			want: "cloud",
@@ -99,6 +120,14 @@ func TestLoadTargetKind(t *testing.T) {
 		{
 			name: "env-only cloud GRAFANA_SERVER",
 			env:  map[string]string{"GRAFANA_SERVER": "https://mystack.grafana.net"},
+			want: "cloud",
+		},
+		{
+			name: "env GRAFANA_STACK_ID marks custom domain as cloud",
+			env: map[string]string{
+				"GRAFANA_SERVER":   "https://grafana.mycorp.com",
+				"GRAFANA_STACK_ID": "12345",
+			},
 			want: "cloud",
 		},
 		{
@@ -158,13 +187,27 @@ func TestLoadTargetKind(t *testing.T) {
 				"current-context: dev\n",
 			want: "cloud",
 		},
+		{
+			name: "legacy cloud-auth-only local layer keeps user-layer stack ref",
+			user: "stacks:\n" +
+				"  prod:\n" +
+				"    slug: mystack\n" +
+				"contexts:\n" +
+				"  dev:\n" +
+				"    stack: prod\n" +
+				"current-context: dev\n",
+			local: "contexts:\n" +
+				"  dev:\n" +
+				"    cloud:\n" +
+				"      token: abc\n",
+			want: "cloud",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			userDir, workDir := isolatedLoaderEnv(t)
-			t.Setenv("GRAFANA_CLOUD_STACK", "")
-			t.Setenv("GRAFANA_SERVER", "")
+			scrubTargetKindEnv(t)
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
@@ -175,15 +218,45 @@ func TestLoadTargetKind(t *testing.T) {
 				writeLoaderConfig(t, filepath.Join(workDir, ".gcx.yaml"), tt.local)
 			}
 
-			assert.Equal(t, tt.want, config.LoadTargetKind(t.Context()))
+			_, err := config.LoadLayered(t.Context(), "", testEnvOverride)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, config.CapturedTargetKind())
 		})
 	}
 }
 
-func TestLoadTargetKind_ExplicitConfigFile(t *testing.T) {
+func TestCapturedTargetKind_ContextOverride(t *testing.T) {
 	userDir, _ := isolatedLoaderEnv(t)
-	t.Setenv("GRAFANA_CLOUD_STACK", "")
-	t.Setenv("GRAFANA_SERVER", "")
+	scrubTargetKindEnv(t)
+
+	// current-context says cloud; a --context style override selects the
+	// self-managed context and must win.
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
+		"stacks:\n"+
+			"  prod:\n"+
+			"    slug: mystack\n"+
+			"  onprem:\n"+
+			"    grafana:\n"+
+			"      server: http://localhost:3000\n"+
+			"contexts:\n"+
+			"  dev:\n"+
+			"    stack: prod\n"+
+			"  local:\n"+
+			"    stack: onprem\n"+
+			"current-context: dev\n")
+
+	selectLocal := func(cfg *config.Config) error {
+		cfg.CurrentContext = "local"
+		return nil
+	}
+	_, err := config.LoadLayered(t.Context(), "", selectLocal, testEnvOverride)
+	require.NoError(t, err)
+	assert.Equal(t, "self-managed", config.CapturedTargetKind())
+}
+
+func TestCapturedTargetKind_ExplicitConfigFile(t *testing.T) {
+	userDir, _ := isolatedLoaderEnv(t)
+	scrubTargetKindEnv(t)
 
 	// The discoverable user layer says cloud; the explicit file must bypass it.
 	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
@@ -192,7 +265,8 @@ func TestLoadTargetKind_ExplicitConfigFile(t *testing.T) {
 	explicit := filepath.Join(t.TempDir(), "explicit.yaml")
 	writeLoaderConfig(t, explicit,
 		"stacks:\n  onprem:\n    grafana:\n      server: http://localhost:3000\ncontexts:\n  dev:\n    stack: onprem\ncurrent-context: dev\n")
-	t.Setenv("GCX_CONFIG", explicit)
 
-	assert.Equal(t, "self-managed", config.LoadTargetKind(t.Context()))
+	_, err := config.LoadLayered(t.Context(), explicit, testEnvOverride)
+	require.NoError(t, err)
+	assert.Equal(t, "self-managed", config.CapturedTargetKind())
 }

--- a/internal/config/targetkind_test.go
+++ b/internal/config/targetkind_test.go
@@ -61,7 +61,7 @@ func TestCapturedTargetKind(t *testing.T) {
 			want: "cloud",
 		},
 		{
-			name: "self-managed server",
+			name: "self-hosted server",
 			user: "stacks:\n" +
 				"  onprem:\n" +
 				"    grafana:\n" +
@@ -70,7 +70,7 @@ func TestCapturedTargetKind(t *testing.T) {
 				"  dev:\n" +
 				"    stack: onprem\n" +
 				"current-context: dev\n",
-			want: "self-managed",
+			want: "self-hosted",
 		},
 		{
 			name: "explicit stack slug",
@@ -113,9 +113,9 @@ func TestCapturedTargetKind(t *testing.T) {
 			want: "cloud",
 		},
 		{
-			name: "env-only self-managed GRAFANA_SERVER",
+			name: "env-only self-hosted GRAFANA_SERVER",
 			env:  map[string]string{"GRAFANA_SERVER": "http://localhost:3000"},
-			want: "self-managed",
+			want: "self-hosted",
 		},
 		{
 			name: "env-only cloud GRAFANA_SERVER",
@@ -151,14 +151,14 @@ func TestCapturedTargetKind(t *testing.T) {
 			want: "cloud",
 		},
 		{
-			name: "legacy config self-managed",
+			name: "legacy config self-hosted",
 			user: "contexts:\n" +
 				"  dev:\n" +
 				"    grafana:\n" +
 				"      server: http://localhost:3000\n" +
 				"      token: abc\n" +
 				"current-context: dev\n",
-			want: "self-managed",
+			want: "self-hosted",
 		},
 		{
 			name: "local layer switches current context",
@@ -171,7 +171,7 @@ func TestCapturedTargetKind(t *testing.T) {
 				"  local:\n" +
 				"    stack: onprem\n" +
 				"current-context: local\n",
-			want: "self-managed",
+			want: "self-hosted",
 		},
 		{
 			name: "local context references user-layer stack",
@@ -230,7 +230,7 @@ func TestCapturedTargetKind_ContextOverride(t *testing.T) {
 	scrubTargetKindEnv(t)
 
 	// current-context says cloud; a --context style override selects the
-	// self-managed context and must win.
+	// self-hosted context and must win.
 	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
 		"stacks:\n"+
 			"  prod:\n"+
@@ -251,7 +251,7 @@ func TestCapturedTargetKind_ContextOverride(t *testing.T) {
 	}
 	_, err := config.LoadLayered(t.Context(), "", selectLocal, testEnvOverride)
 	require.NoError(t, err)
-	assert.Equal(t, "self-managed", config.CapturedTargetKind())
+	assert.Equal(t, "self-hosted", config.CapturedTargetKind())
 }
 
 func TestCapturedTargetKind_ExplicitConfigFile(t *testing.T) {
@@ -268,5 +268,5 @@ func TestCapturedTargetKind_ExplicitConfigFile(t *testing.T) {
 
 	_, err := config.LoadLayered(t.Context(), explicit, testEnvOverride)
 	require.NoError(t, err)
-	assert.Equal(t, "self-managed", config.CapturedTargetKind())
+	assert.Equal(t, "self-hosted", config.CapturedTargetKind())
 }

--- a/internal/config/targetkind_test.go
+++ b/internal/config/targetkind_test.go
@@ -35,14 +35,16 @@ func testEnvOverride(cfg *config.Config) error {
 }
 
 func TestCapturedTargetKind(t *testing.T) {
-	cloudConfig := "stacks:\n" +
-		"  prod:\n" +
-		"    grafana:\n" +
-		"      server: https://mystack.grafana.net\n" +
-		"contexts:\n" +
-		"  dev:\n" +
-		"    stack: prod\n" +
-		"current-context: dev\n"
+	cloudConfig := `
+stacks:
+  prod:
+    grafana:
+      server: https://mystack.grafana.net
+contexts:
+  dev:
+    stack: prod
+current-context: dev
+`
 
 	tests := []struct {
 		name  string
@@ -62,49 +64,57 @@ func TestCapturedTargetKind(t *testing.T) {
 		},
 		{
 			name: "self-hosted server",
-			user: "stacks:\n" +
-				"  onprem:\n" +
-				"    grafana:\n" +
-				"      server: https://grafana.internal.example.com\n" +
-				"contexts:\n" +
-				"  dev:\n" +
-				"    stack: onprem\n" +
-				"current-context: dev\n",
+			user: `
+stacks:
+  onprem:
+    grafana:
+      server: https://grafana.internal.example.com
+contexts:
+  dev:
+    stack: onprem
+current-context: dev
+`,
 			want: "self-hosted",
 		},
 		{
 			name: "explicit stack slug",
-			user: "stacks:\n" +
-				"  prod:\n" +
-				"    slug: mystack\n" +
-				"contexts:\n" +
-				"  dev:\n" +
-				"    stack: prod\n" +
-				"current-context: dev\n",
+			user: `
+stacks:
+  prod:
+    slug: mystack
+contexts:
+  dev:
+    stack: prod
+current-context: dev
+`,
 			want: "cloud",
 		},
 		{
 			name: "stack id on custom domain",
-			user: "stacks:\n" +
-				"  prod:\n" +
-				"    grafana:\n" +
-				"      server: https://grafana.example.com\n" +
-				"      stack-id: 12345\n" +
-				"contexts:\n" +
-				"  dev:\n" +
-				"    stack: prod\n" +
-				"current-context: dev\n",
+			user: `
+stacks:
+  prod:
+    grafana:
+      server: https://grafana.example.com
+      stack-id: 12345
+contexts:
+  dev:
+    stack: prod
+current-context: dev
+`,
 			want: "cloud",
 		},
 		{
 			name: "no current context",
-			user: "stacks:\n" +
-				"  prod:\n" +
-				"    grafana:\n" +
-				"      server: https://mystack.grafana.net\n" +
-				"contexts:\n" +
-				"  dev:\n" +
-				"    stack: prod\n",
+			user: `
+stacks:
+  prod:
+    grafana:
+      server: https://mystack.grafana.net
+contexts:
+  dev:
+    stack: prod
+`,
 			want: "",
 		},
 		{
@@ -132,74 +142,90 @@ func TestCapturedTargetKind(t *testing.T) {
 		},
 		{
 			name: "legacy config cloud",
-			user: "contexts:\n" +
-				"  dev:\n" +
-				"    grafana:\n" +
-				"      server: https://mystack.grafana.net\n" +
-				"current-context: dev\n",
+			user: `
+contexts:
+  dev:
+    grafana:
+      server: https://mystack.grafana.net
+current-context: dev
+`,
 			want: "cloud",
 		},
 		{
 			name: "legacy config cloud via cloud stack slug",
-			user: "contexts:\n" +
-				"  dev:\n" +
-				"    grafana:\n" +
-				"      server: https://grafana.internal.example.com\n" +
-				"    cloud:\n" +
-				"      stack: mystack\n" +
-				"current-context: dev\n",
+			user: `
+contexts:
+  dev:
+    grafana:
+      server: https://grafana.internal.example.com
+    cloud:
+      stack: mystack
+current-context: dev
+`,
 			want: "cloud",
 		},
 		{
 			name: "legacy config self-hosted",
-			user: "contexts:\n" +
-				"  dev:\n" +
-				"    grafana:\n" +
-				"      server: http://localhost:3000\n" +
-				"      token: abc\n" +
-				"current-context: dev\n",
+			user: `
+contexts:
+  dev:
+    grafana:
+      server: http://localhost:3000
+      token: abc
+current-context: dev
+`,
 			want: "self-hosted",
 		},
 		{
 			name: "local layer switches current context",
 			user: cloudConfig,
-			local: "stacks:\n" +
-				"  onprem:\n" +
-				"    grafana:\n" +
-				"      server: http://localhost:3000\n" +
-				"contexts:\n" +
-				"  local:\n" +
-				"    stack: onprem\n" +
-				"current-context: local\n",
+			local: `
+stacks:
+  onprem:
+    grafana:
+      server: http://localhost:3000
+contexts:
+  local:
+    stack: onprem
+current-context: local
+`,
 			want: "self-hosted",
 		},
 		{
 			name: "local context references user-layer stack",
-			user: "stacks:\n" +
-				"  prod:\n" +
-				"    grafana:\n" +
-				"      server: https://mystack.grafana.net\n" +
-				"contexts:\n" +
-				"  dev:\n" +
-				"    stack: prod\n",
-			local: "contexts:\n" +
-				"  dev: {}\n" +
-				"current-context: dev\n",
+			user: `
+stacks:
+  prod:
+    grafana:
+      server: https://mystack.grafana.net
+contexts:
+  dev:
+    stack: prod
+`,
+			local: `
+contexts:
+  dev: {}
+current-context: dev
+`,
 			want: "cloud",
 		},
 		{
 			name: "legacy cloud-auth-only local layer keeps user-layer stack ref",
-			user: "stacks:\n" +
-				"  prod:\n" +
-				"    slug: mystack\n" +
-				"contexts:\n" +
-				"  dev:\n" +
-				"    stack: prod\n" +
-				"current-context: dev\n",
-			local: "contexts:\n" +
-				"  dev:\n" +
-				"    cloud:\n" +
-				"      token: abc\n",
+			user: `
+stacks:
+  prod:
+    slug: mystack
+contexts:
+  dev:
+    stack: prod
+current-context: dev
+`,
+			local: `
+contexts:
+  dev:
+    cloud:
+      token: abc
+`,
 			want: "cloud",
 		},
 	}
@@ -231,19 +257,20 @@ func TestCapturedTargetKind_ContextOverride(t *testing.T) {
 
 	// current-context says cloud; a --context style override selects the
 	// self-hosted context and must win.
-	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
-		"stacks:\n"+
-			"  prod:\n"+
-			"    slug: mystack\n"+
-			"  onprem:\n"+
-			"    grafana:\n"+
-			"      server: http://localhost:3000\n"+
-			"contexts:\n"+
-			"  dev:\n"+
-			"    stack: prod\n"+
-			"  local:\n"+
-			"    stack: onprem\n"+
-			"current-context: dev\n")
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"), `
+stacks:
+  prod:
+    slug: mystack
+  onprem:
+    grafana:
+      server: http://localhost:3000
+contexts:
+  dev:
+    stack: prod
+  local:
+    stack: onprem
+current-context: dev
+`)
 
 	selectLocal := func(cfg *config.Config) error {
 		cfg.CurrentContext = "local"
@@ -259,12 +286,27 @@ func TestCapturedTargetKind_ExplicitConfigFile(t *testing.T) {
 	scrubTargetKindEnv(t)
 
 	// The discoverable user layer says cloud; the explicit file must bypass it.
-	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"),
-		"stacks:\n  prod:\n    slug: mystack\ncontexts:\n  dev:\n    stack: prod\ncurrent-context: dev\n")
+	writeLoaderConfig(t, filepath.Join(userDir, "gcx", "config.yaml"), `
+stacks:
+  prod:
+    slug: mystack
+contexts:
+  dev:
+    stack: prod
+current-context: dev
+`)
 
 	explicit := filepath.Join(t.TempDir(), "explicit.yaml")
-	writeLoaderConfig(t, explicit,
-		"stacks:\n  onprem:\n    grafana:\n      server: http://localhost:3000\ncontexts:\n  dev:\n    stack: onprem\ncurrent-context: dev\n")
+	writeLoaderConfig(t, explicit, `
+stacks:
+  onprem:
+    grafana:
+      server: http://localhost:3000
+contexts:
+  dev:
+    stack: onprem
+current-context: dev
+`)
 
 	_, err := config.LoadLayered(t.Context(), explicit, testEnvOverride)
 	require.NoError(t, err)


### PR DESCRIPTION
Part of https://github.com/grafana/gcx-internal/issues/2

## Summary

- populate `target_kind` in anonymous usage events, to show whether the config associated with the current gcx invocation was interacting with a self-hosted or cloud grafana instance.
- it uses all layers of config used in the invocation to capture the target kind