### PR TITLE
feat(profiles): add series discovery

### DIFF
--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -400,7 +400,7 @@ func queryErrorLanguage(apiErr *queryerror.APIError) string {
 			return "PromQL"
 		}
 	case "pyroscope":
-		if apiErr.Operation == "query" || apiErr.Operation == "series query" {
+		if apiErr.Operation == "query" || apiErr.Operation == "series query" || apiErr.Operation == "profile series query" {
 			return "Pyroscope selector"
 		}
 	case "tempo":
@@ -419,6 +419,9 @@ func queryErrorStringLiteralExample(apiErr *queryerror.APIError) string {
 	case "prometheus":
 		return `Try a quoted selector value, e.g. gcx metrics query 'up{job="grafana"}'`
 	case "pyroscope":
+		if apiErr.Operation == "profile series query" {
+			return `Try a quoted selector value, e.g. gcx profiles series '{service_name="frontend"}'`
+		}
 		return `Try a quoted selector value, e.g. gcx profiles query '{service_name="frontend"}' --profile-type <PROFILE_TYPE>`
 	case "tempo":
 		return `Try a quoted string literal, e.g. gcx traces query '{ resource.service.name = "checkout" }'`
@@ -459,6 +462,8 @@ func queryErrorHelpCommand(apiErr *queryerror.APIError) string {
 			return "gcx profiles labels --help"
 		case "series query":
 			return "gcx profiles metrics --help"
+		case "profile series query":
+			return "gcx profiles series --help"
 		case "profile exemplars query":
 			return "gcx profiles exemplars profile --help"
 		case "span exemplars query":

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -160,6 +160,22 @@ func TestErrorToDetailedError_QueryParseError(t *testing.T) {
 	assert.Nil(t, got.ExitCode)
 }
 
+func TestErrorToDetailedError_ProfileSeriesQuery(t *testing.T) {
+	got := fail.ErrorToDetailedError(queryerror.New(
+		"pyroscope",
+		"profile series query",
+		400,
+		"parse error: expecting string",
+		"downstream",
+	))
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Invalid Pyroscope selector query", got.Summary)
+	assert.Contains(t, got.Suggestions, `Try a quoted selector value, e.g. gcx profiles series '{service_name="frontend"}'`)
+	assert.Contains(t, got.Suggestions, "Run 'gcx profiles series --help' for usage and examples")
+	assert.Equal(t, docs.PyroscopeQueries, got.DocsLink)
+}
+
 func TestErrorToDetailedError_QueryAuthFailure(t *testing.T) {
 	got := fail.ErrorToDetailedError(queryerror.New("prometheus", "query", 401, "unauthorized", ""))
 

--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -454,6 +454,7 @@
  "gcx profiles list-profile-types": "finite",
  "gcx profiles metrics": "finite",
  "gcx profiles query": "finite",
+ "gcx profiles series": "finite",
  "gcx providers list": "finite",
  "gcx resources delete": "finite",
  "gcx resources edit": "interactive",

--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -86,7 +86,8 @@ gcx (root)
 │   ├── query                [DATASOURCE_UID] EXPR --profile-type TYPE [--from] [--to] [--since] [--max-nodes] [--profile-id UUID]... [--span-id ID]... [--trace-id ID]... [--stacktrace-selector FN]... [-o]
 │   ├── labels               [--datasource/-d UID] [--label/-l NAME]
 │   ├── list-profile-types   [--datasource/-d UID]
-│   ├── series               [DATASOURCE_UID] EXPR --profile-type TYPE [--top] [--group-by] [--limit]
+│   ├── metrics              [SELECTOR] --profile-type TYPE [--top] [--group-by] [--limit]
+│   ├── series               [SELECTOR] [--datasource/-d UID] [--match SELECTOR]... [--label-name LABEL]... [--from] [--to] [--since]
 │   └── adaptive             (stub — "not yet available")
 │
 ├── providers                [cmd/gcx/providers/command.go]
@@ -566,7 +567,7 @@ print available fields via `DiscoverFields()` and exit early (exit 0).
 
 Built-in codecs: `json` and `yaml` (always available). Commands register additional ones (e.g. `text`, `wide`, `graph`) by calling `RegisterCustomCodec` before `BindFlags`.
 
-The `graph` codec is a special-purpose output format available on per-kind `query` subcommands (`metrics query`, `logs query`, `profiles series`, etc.) and `synth checks status`. It renders Prometheus or Loki query results (or check status metrics) as a terminal line chart using `ntcharts` and `lipgloss` (via `internal/graph`). Terminal width is detected at render time via `golang.org/x/term`.
+The `graph` codec is a special-purpose output format available on per-kind `query` subcommands (`metrics query`, `logs query`, `profiles metrics`, etc.) and `synth checks status`. It renders Prometheus or Loki query results (or check status metrics) as a terminal line chart using `ntcharts` and `lipgloss` (via `internal/graph`). Terminal width is detected at render time via `golang.org/x/term`.
 
 The `wide` codec is available on `slo definitions list`, `slo reports list`, and `synth checks status`. It shows additional detail columns compared to the default `text` table codec.
 

--- a/docs/reference/cli/gcx_profiles.md
+++ b/docs/reference/cli/gcx_profiles.md
@@ -29,4 +29,5 @@ Query Pyroscope datasources and manage continuous profiling
 * [gcx profiles list-profile-types](gcx_profiles_list-profile-types.md)	 - List available profile types
 * [gcx profiles metrics](gcx_profiles_metrics.md)	 - Query profile time-series data from a Pyroscope datasource
 * [gcx profiles query](gcx_profiles_query.md)	 - Execute a profiling query against a Pyroscope datasource
+* [gcx profiles series](gcx_profiles_series.md)	 - List unique profile label sets
 

--- a/docs/reference/cli/gcx_profiles_series.md
+++ b/docs/reference/cli/gcx_profiles_series.md
@@ -1,0 +1,65 @@
+## gcx profiles series
+
+List unique profile label sets
+
+### Synopsis
+
+List unique profile label sets from a Pyroscope datasource.
+
+The command uses Pyroscope's Series endpoint and does not require a profile
+type. SELECTOR is optional; use --match for repeatable selectors. By default,
+the response includes every label.
+
+Use --label-name to request only the labels needed for discovery. This reduces
+the response size and can significantly speed up queries with high-cardinality
+labels. For example, use --label-name service_name --label-name namespace to
+discover services and namespaces without fetching pod, instance, or custom
+labels.
+
+```
+gcx profiles series [SELECTOR] [flags]
+```
+
+### Examples
+
+```
+
+  # List unique profile label sets without a profile type
+  gcx profiles series -d UID --since 1h
+
+  # Scope to a service and return selected labels
+  gcx profiles series -d UID '{service_name="frontend"}' \
+    --label-name service_name --label-name namespace --label-name pod --since 24h
+```
+
+### Options
+
+```
+  -d, --datasource string    Datasource UID (required unless datasources.pyroscope is configured)
+      --from string          Start time (RFC3339, Unix timestamp, or relative like 'now-1h')
+  -h, --help                 help for series
+      --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --label-name strings   Label name to return (repeatable; limit labels to reduce response size and speed up discovery)
+      --match stringArray    Profile label selector (repeatable)
+  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+      --since string         Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
+      --to string            End time (RFC3339, Unix timestamp, or relative like 'now')
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx profiles](gcx_profiles.md)	 - Query Pyroscope datasources and manage continuous profiling
+

--- a/internal/datasources/pyroscope/series_discovery.go
+++ b/internal/datasources/pyroscope/series_discovery.go
@@ -1,0 +1,157 @@
+package pyroscope
+
+import (
+	"errors"
+	"io"
+	"time"
+
+	"github.com/grafana/gcx/internal/agent"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	pyroscope "github.com/grafana/gcx/internal/query/pyroscope"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type profileSeriesOpts struct {
+	TimeRange  dsquery.TimeRangeOpts
+	IO         cmdio.Options
+	Datasource string
+	Matchers   []string
+	LabelNames []string
+}
+
+func (opts *profileSeriesOpts) setup(flags *pflag.FlagSet) {
+	opts.IO.RegisterCustomCodec("table", &profileSeriesTableCodec{})
+	opts.IO.RegisterCustomCodec("wide", &profileSeriesWideCodec{})
+	opts.IO.DefaultFormat("table")
+	opts.IO.BindFlags(flags)
+
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.pyroscope is configured)")
+	flags.StringArrayVar(&opts.Matchers, "match", nil, "Profile label selector (repeatable)")
+	flags.StringSliceVar(&opts.LabelNames, "label-name", nil, "Label name to return (repeatable; limit labels to reduce response size and speed up discovery)")
+	opts.TimeRange.SetupTimeFlags(flags)
+}
+
+func (opts *profileSeriesOpts) Validate() error {
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	return opts.TimeRange.ValidateTimeRange()
+}
+
+// SeriesCmd lists unique profile label sets without requiring a profile type.
+func SeriesCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &profileSeriesOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "series [SELECTOR]",
+		Short: "List unique profile label sets",
+		Long: `List unique profile label sets from a Pyroscope datasource.
+
+The command uses Pyroscope's Series endpoint and does not require a profile
+type. SELECTOR is optional; use --match for repeatable selectors. By default,
+the response includes every label.
+
+Use --label-name to request only the labels needed for discovery. This reduces
+the response size and can significantly speed up queries with high-cardinality
+labels. For example, use --label-name service_name --label-name namespace to
+discover services and namespaces without fetching pod, instance, or custom
+labels.`,
+		Args: cobra.RangeArgs(0, 1),
+		Example: `
+  # List service and workload combinations from the last hour
+  gcx profiles series -d UID --since 1h
+
+	# Faster discovery: request only the labels needed
+	gcx profiles series -d UID '{service_name="checkout"}' \
+		--label-name service_name --label-name namespace --label-name pod --since 7d
+
+  # Use multiple selectors and JSON output
+  gcx profiles series -d UID \
+    --match '{namespace="payments"}' --match '{namespace="checkout"}' \
+    --since 24h -o json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			selectors := append([]string{}, opts.Matchers...)
+			if len(args) == 1 {
+				selectors = append(selectors, args[0])
+			}
+
+			ctx := cmd.Context()
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
+			if err != nil {
+				return err
+			}
+			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "pyroscope")
+			if err != nil {
+				return err
+			}
+
+			start, end, err := opts.TimeRange.ParseTimeRange(time.Now())
+			if err != nil {
+				return err
+			}
+			client, err := pyroscope.NewClient(cfg)
+			if err != nil {
+				return err
+			}
+			resp, err := client.Series(ctx, datasourceUID, pyroscope.SeriesRequest{
+				Matchers:   selectors,
+				LabelNames: opts.LabelNames,
+				Start:      start,
+				End:        end,
+			})
+			if err != nil {
+				return err
+			}
+			if len(resp.LabelsSet) == 0 {
+				emitEmptyWindowHint(cmd.ErrOrStderr(), "profile series", start, end, opts.TimeRange.IsRange())
+			}
+			return opts.IO.Encode(cmd.OutOrStdout(), resp)
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "small",
+		agent.AnnotationLLMHint:   "gcx profiles series -d UID --since 1h -o json",
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+type profileSeriesTableCodec struct{}
+
+func (c *profileSeriesTableCodec) Format() format.Format { return "table" }
+
+func (c *profileSeriesTableCodec) Encode(w io.Writer, data any) error {
+	resp, ok := data.(*pyroscope.SeriesResponse)
+	if !ok {
+		return errors.New("invalid data type for profile series table codec")
+	}
+	return pyroscope.FormatProfileSeriesTable(w, resp)
+}
+
+func (c *profileSeriesTableCodec) Decode(io.Reader, any) error {
+	return errors.New("profile series table codec does not support decoding")
+}
+
+type profileSeriesWideCodec struct{}
+
+func (c *profileSeriesWideCodec) Format() format.Format { return "wide" }
+
+func (c *profileSeriesWideCodec) Encode(w io.Writer, data any) error {
+	resp, ok := data.(*pyroscope.SeriesResponse)
+	if !ok {
+		return errors.New("invalid data type for profile series wide codec")
+	}
+	return pyroscope.FormatProfileSeriesWide(w, resp)
+}
+
+func (c *profileSeriesWideCodec) Decode(io.Reader, any) error {
+	return errors.New("profile series wide codec does not support decoding")
+}

--- a/internal/providers/profiles/provider.go
+++ b/internal/providers/profiles/provider.go
@@ -77,6 +77,18 @@ func (p *Provider) descriptor() signals.Descriptor {
   gcx profiles labels -d UID -o json`,
 			},
 			{
+				Build:     dspyroscope.SeriesCmd,
+				TokenCost: "small",
+				LLMHint:   "gcx profiles series -d abc123 --since 1h -o json",
+				Example: `
+  # List unique profile label sets without a profile type
+  gcx profiles series -d UID --since 1h
+
+  # Scope to a service and return selected labels
+  gcx profiles series -d UID '{service_name="frontend"}' \
+    --label-name service_name --label-name namespace --label-name pod --since 24h`,
+			},
+			{
 				Build:     dspyroscope.ListProfileTypesCmd,
 				TokenCost: "small",
 				LLMHint:   "gcx profiles list-profile-types -d abc123 -o json",

--- a/internal/providers/profiles/provider_test.go
+++ b/internal/providers/profiles/provider_test.go
@@ -32,7 +32,7 @@ func TestProviderRegistration(t *testing.T) {
 			subNames = append(subNames, sub.Name())
 		}
 
-		for _, expected := range []string{"query", "labels", "list-profile-types", "metrics", "adaptive"} {
+		for _, expected := range []string{"query", "labels", "series", "list-profile-types", "metrics", "adaptive"} {
 			assert.Contains(t, subNames, expected, "missing subcommand %q", expected)
 		}
 	})

--- a/internal/query/pyroscope/client.go
+++ b/internal/query/pyroscope/client.go
@@ -252,6 +252,54 @@ func (c *Client) LabelValues(ctx context.Context, datasourceUID string, req Labe
 	return &result, nil
 }
 
+// Series returns unique profile label sets from the datasource.
+func (c *Client) Series(ctx context.Context, datasourceUID string, req SeriesRequest) (*SeriesResponse, error) {
+	apiPath := c.buildResourcePath(datasourceUID, "querier.v1.QuerierService/Series")
+
+	start, end := DefaultTimeRange(req.Start, req.End)
+	bodyMap := map[string]any{
+		"start": strconv.FormatInt(start.UnixMilli(), 10),
+		"end":   strconv.FormatInt(end.UnixMilli(), 10),
+	}
+	if len(req.Matchers) > 0 {
+		bodyMap["matchers"] = req.Matchers
+	}
+	if len(req.LabelNames) > 0 {
+		bodyMap["labelNames"] = req.LabelNames
+	}
+
+	body, err := json.Marshal(bodyMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal series request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.restConfig.Host+apiPath, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create series request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute series request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := httputils.ReadResponseBody(resp.Body, httputils.DefaultResponseLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read series response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, queryerror.FromBody("pyroscope", "profile series query", resp.StatusCode, respBody)
+	}
+
+	var result SeriesResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse series response: %w", err)
+	}
+	return &result, nil
+}
+
 // SelectSeries executes a SelectSeries query to get profile time-series data.
 func (c *Client) SelectSeries(ctx context.Context, datasourceUID string, req SelectSeriesRequest) (*SelectSeriesResponse, error) {
 	apiPath := c.buildResourcePath(datasourceUID, "querier.v1.QuerierService/SelectSeries")

--- a/internal/query/pyroscope/client_test.go
+++ b/internal/query/pyroscope/client_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/query/pyroscope"
+	"github.com/grafana/gcx/internal/queryerror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -214,6 +215,72 @@ func TestClient_SelectSeries(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClient_Series(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "querier.v1.QuerierService/Series")
+		var body map[string]any
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			return
+		}
+		assert.Equal(t, []any{`{service_name="frontend"}`}, body["matchers"])
+		assert.Equal(t, []any{"service_name", "namespace", "pod", "__name__"}, body["labelNames"])
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"labelsSet": [
+				{"labels": [
+					{"name": "service_name", "value": "frontend"},
+					{"name": "namespace", "value": "default"}
+				]}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	resp, err := client.Series(context.Background(), "test-uid", pyroscope.SeriesRequest{
+		Matchers:   []string{`{service_name="frontend"}`},
+		LabelNames: []string{"service_name", "namespace", "pod", "__name__"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.LabelsSet, 1)
+	assert.Equal(t, "frontend", resp.LabelsSet[0].Labels[0].Value)
+}
+
+func TestClient_Series_OmitsLabelNamesWhenUnset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			return
+		}
+		assert.NotContains(t, body, "labelNames", "an omitted projection must return complete label sets")
+		_, _ = w.Write([]byte(`{"labelsSet":[]}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	_, err := client.Series(context.Background(), "test-uid", pyroscope.SeriesRequest{})
+	require.NoError(t, err)
+}
+
+func TestClient_Series_NonOKUsesProfileSeriesOperation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"invalid selector"}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	_, err := client.Series(context.Background(), "test-uid", pyroscope.SeriesRequest{})
+	require.Error(t, err)
+
+	var apiErr *queryerror.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, "profile series query", apiErr.Operation)
 }
 
 func TestClient_Query_RequestFields(t *testing.T) {

--- a/internal/query/pyroscope/formatter.go
+++ b/internal/query/pyroscope/formatter.go
@@ -63,6 +63,55 @@ func FormatLabelsTable(w io.Writer, labels []string) error {
 	return t.Render(w)
 }
 
+// FormatProfileSeriesTable formats unique profile label sets as one row each.
+func FormatProfileSeriesTable(w io.Writer, resp *SeriesResponse) error {
+	t := style.NewTable("SERIES", "LABELS")
+	for i, set := range resp.LabelsSet {
+		t.Row(strconv.Itoa(i+1), formatLabelSet(set))
+	}
+	return t.Render(w)
+}
+
+// FormatProfileSeriesWide formats unique profile label sets with one label per column.
+func FormatProfileSeriesWide(w io.Writer, resp *SeriesResponse) error {
+	labelNames := make(map[string]struct{})
+	for _, set := range resp.LabelsSet {
+		for _, label := range set.Labels {
+			labelNames[label.Name] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(labelNames))
+	for name := range labelNames {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	columns := append([]string{"SERIES"}, names...)
+	t := style.NewTable(columns...)
+	for i, set := range resp.LabelsSet {
+		values := make(map[string]string, len(set.Labels))
+		for _, label := range set.Labels {
+			values[label.Name] = label.Value
+		}
+		row := make([]string, 1, len(columns))
+		row[0] = strconv.Itoa(i + 1)
+		for _, name := range names {
+			row = append(row, values[name])
+		}
+		t.Row(row...)
+	}
+	return t.Render(w)
+}
+
+func formatLabelSet(set Labels) string {
+	labels := append([]LabelPair(nil), set.Labels...)
+	sort.Slice(labels, func(i, j int) bool { return labels[i].Name < labels[j].Name })
+	parts := make([]string, 0, len(labels))
+	for _, label := range labels {
+		parts = append(parts, label.Name+"="+strconv.Quote(label.Value))
+	}
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
 // ExtractTopFunctions extracts the top N functions by self time from a flame graph.
 func ExtractTopFunctions(fg *Flamegraph, limit int) []FunctionSample {
 	if fg == nil || len(fg.Levels) == 0 {

--- a/internal/query/pyroscope/formatter_test.go
+++ b/internal/query/pyroscope/formatter_test.go
@@ -88,6 +88,39 @@ func TestFormatSeriesTable(t *testing.T) {
 	}
 }
 
+func TestFormatProfileSeries(t *testing.T) {
+	resp := &pyroscope.SeriesResponse{
+		LabelsSet: []pyroscope.Labels{
+			{Labels: []pyroscope.LabelPair{
+				{Name: "namespace", Value: "prod"},
+				{Name: "service_name", Value: "api"},
+			}},
+		},
+	}
+
+	var table bytes.Buffer
+	require.NoError(t, pyroscope.FormatProfileSeriesTable(&table, resp))
+	assert.Contains(t, table.String(), "{namespace=\"prod\",service_name=\"api\"}")
+
+	var wide bytes.Buffer
+	require.NoError(t, pyroscope.FormatProfileSeriesWide(&wide, resp))
+	assert.Contains(t, wide.String(), "namespace")
+	assert.Contains(t, wide.String(), "service_name")
+	assert.Contains(t, wide.String(), "prod")
+}
+
+func TestFormatProfileSeriesTableEscapesLabelValues(t *testing.T) {
+	resp := &pyroscope.SeriesResponse{
+		LabelsSet: []pyroscope.Labels{{Labels: []pyroscope.LabelPair{
+			{Name: "path", Value: `C:\\profiles\"quoted\"`},
+		}}},
+	}
+
+	var table bytes.Buffer
+	require.NoError(t, pyroscope.FormatProfileSeriesTable(&table, resp))
+	assert.Contains(t, table.String(), `{path="C:\\\\profiles\\\"quoted\\\""}`)
+}
+
 func TestFormatTopSeriesTable(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/query/pyroscope/types.go
+++ b/internal/query/pyroscope/types.go
@@ -100,6 +100,25 @@ type LabelValuesResponse struct {
 	Names []string `json:"names"` // Pyroscope uses "names" for both labels and values
 }
 
+// SeriesRequest represents a request to list unique profile label sets.
+// Unlike SelectSeriesRequest, it does not require a profile type.
+type SeriesRequest struct {
+	Matchers   []string
+	LabelNames []string
+	Start      time.Time
+	End        time.Time
+}
+
+// SeriesResponse represents unique profile label sets returned by Pyroscope.
+type SeriesResponse struct {
+	LabelsSet []Labels `json:"labelsSet"`
+}
+
+// Labels is one unique profile label set.
+type Labels struct {
+	Labels []LabelPair `json:"labels"`
+}
+
 // FunctionSample represents a function in the flame graph with computed stats.
 type FunctionSample struct {
 	Name       string


### PR DESCRIPTION
## Summary
- add `gcx profiles series` for Pyroscope profile label-set discovery without a profile type
- provide table, wide, JSON, YAML, and agent output plus selector error guidance
- return complete label sets by default; promote `--label-name` projection to reduce response size and speed up high-cardinality discovery

