### PR TITLE
fix(profiles): support UTF-8 label names

### DIFF
--- a/internal/query/pyroscope/client.go
+++ b/internal/query/pyroscope/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/grafana/gcx/internal/config"
@@ -17,6 +18,8 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 	"k8s.io/client-go/rest"
 )
+
+const utf8LabelNamesCapability = "allow-utf8-labelnames=true"
 
 // Client is a client for executing Pyroscope queries via Grafana's datasource API.
 type Client struct {
@@ -30,11 +33,34 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
+	httpClient.Transport = &clientCapabilitiesTransport{base: httpClient.Transport}
 
 	return &Client{
 		restConfig: cfg,
 		httpClient: httpClient,
 	}, nil
+}
+
+// clientCapabilitiesTransport advertises Pyroscope features supported by gcx.
+type clientCapabilitiesTransport struct {
+	base http.RoundTripper
+}
+
+func (t *clientCapabilitiesTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	clone := req.Clone(req.Context())
+	for _, value := range clone.Header.Values("Accept") {
+		if strings.Contains(value, utf8LabelNamesCapability) {
+			return base.RoundTrip(clone)
+		}
+	}
+	clone.Header.Add("Accept", "*/*;"+utf8LabelNamesCapability)
+
+	return base.RoundTrip(clone)
 }
 
 // Query executes a Pyroscope profile query against the specified datasource.

--- a/internal/query/pyroscope/client_test.go
+++ b/internal/query/pyroscope/client_test.go
@@ -216,6 +216,34 @@ func TestClient_SelectSeries(t *testing.T) {
 	}
 }
 
+func TestClient_LabelNames_UTF8CapabilityAndResponse(t *testing.T) {
+	const utf8LabelName = "\u90e8\u7f72"
+	selector := `{"` + utf8LabelName + `"="frontend"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "querier.v1.QuerierService/LabelNames")
+		assert.Equal(t, []string{"*/*;allow-utf8-labelnames=true"}, r.Header.Values("Accept"))
+
+		var body map[string]any
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			return
+		}
+		assert.Equal(t, []any{selector}, body["matchers"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"names":["service_name","` + utf8LabelName + `"]}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	resp, err := client.LabelNames(context.Background(), "test-uid", pyroscope.LabelNamesRequest{
+		Matchers: []string{selector},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"service_name", utf8LabelName}, resp.Names)
+}
+
 func TestClient_Query_RequestFields(t *testing.T) {
 	emptyFlamegraph := `{"flamegraph":{"names":[],"levels":[],"total":"0","maxSelf":"0"}}`
 


### PR DESCRIPTION
## Summary
- advertise Pyroscope UTF-8 label-name support on every datasource request
- preserve existing Accept header values while avoiding duplicate capability values
- verify UTF-8 label-name selectors and responses round-trip unchanged

## Testing
- `OPENCODE=0 GCX_AGENT_MODE=false go test ./...`
- `mise run lint`

Closes https://github.com/grafana/pyroscope-squad/issues/864

Related: https://github.com/grafana/pyroscope/pull/4442