### PR TITLE
fix(aio11y): drop rule_id from rules update PATCH body

### DIFF
--- a/internal/providers/aio11y/eval/rules/client.go
+++ b/internal/providers/aio11y/eval/rules/client.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -48,9 +49,26 @@ func (c *Client) Create(ctx context.Context, rule *eval.RuleDefinition) (*eval.R
 	return &created, nil
 }
 
-// Update sends a full rule definition as a PATCH request.
+// Update sends a rule definition as a PATCH request.
+//
+// The rule id is taken from the URL path, so it must not also appear in the
+// body: the server decodes the PATCH body with DisallowUnknownFields and its
+// update DTO has no rule_id field, so a body carrying rule_id (even as an empty
+// string) fails with `unknown field "rule_id"`. RuleDefinition.RuleID has no
+// omitempty because it is required on create, so we can't just zero it — we
+// marshal to a map and drop the key entirely before sending.
 func (c *Client) Update(ctx context.Context, id string, rule *eval.RuleDefinition) (*eval.RuleDefinition, error) {
-	updated, err := aio11yhttp.DoJSON[eval.RuleDefinition, eval.RuleDefinition](ctx, c.base, http.MethodPatch, fmt.Sprintf(ruleByIDFmt, url.PathEscape(id)), rule, http.StatusOK)
+	raw, err := json.Marshal(rule)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal rule: %w", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, fmt.Errorf("failed to prepare rule body: %w", err)
+	}
+	delete(body, "rule_id")
+
+	updated, err := aio11yhttp.DoJSON[map[string]any, eval.RuleDefinition](ctx, c.base, http.MethodPatch, fmt.Sprintf(ruleByIDFmt, url.PathEscape(id)), &body, http.StatusOK)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/aio11y/eval/rules/client_test.go
+++ b/internal/providers/aio11y/eval/rules/client_test.go
@@ -166,8 +166,17 @@ func TestClient_Update(t *testing.T) {
 		assert.Equal(t, http.MethodPatch, r.Method)
 		assert.Contains(t, r.URL.Path, "/eval/rules/rule-1")
 
+		raw, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		// The id is in the URL path; it must NOT be in the PATCH body. The
+		// server decodes with DisallowUnknownFields and its update DTO has no
+		// rule_id field, so a body carrying rule_id fails with
+		// `unknown field "rule_id"`. Even though the caller passes RuleID, the
+		// client must strip it before sending.
+		assert.NotContains(t, string(raw), "rule_id", "PATCH body must not carry rule_id")
+
 		var def eval.RuleDefinition
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&def))
+		assert.NoError(t, json.Unmarshal(raw, &def))
 		assert.InDelta(t, 0.5, def.SampleRate, 0.001)
 
 		writeJSON(w, eval.RuleDefinition{


### PR DESCRIPTION
## What

`gcx agento11y rules update <id> -f <file>` always failed with:

```
invalid request body: unknown field "rule_id"
```

— even when the file had no `rule_id`. `Client.Update` marshalled the whole `RuleDefinition` as the PATCH body, and `RuleDefinition.RuleID` has no `omitempty` (it's required on create), so the body always carried a `rule_id`. The server decodes the PATCH body with `DisallowUnknownFields` and its update DTO has no `rule_id` field (the id comes from the URL path), so it rejected every update.

## Fix

Zeroing `RuleID` isn't enough — without `omitempty` it still serializes as `"rule_id":""`, which the server still rejects. Marshal the rule to a map and `delete` the `rule_id` key so it's absent from the body entirely. The id continues to travel in the URL path.

## Testing

- Added a regression assertion to `TestClient_Update`: the PATCH body must not contain `rule_id`. (Confirmed it fails without the fix.)
- `go test ./internal/providers/aio11y/eval/rules/` passes.
- **Verified end-to-end against a Cloud stack**: `rules update` now succeeds and a `sample_rate` change persists (before, every update 400'd).

## Impact

Users currently cannot change any field on an existing eval rule (sample_rate, match, evaluators…) via the CLI — the only workaround is delete + recreate. This restores `rules update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)