### PR TITLE
add data-sources codeowners for internal/datasources

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,9 +33,7 @@
 /internal/datasources/influxdb/ @grafana/grafana-gcx @grafana/data-sources
 /internal/datasources/loki/ @grafana/grafana-gcx @grafana/loki-team
 /internal/datasources/prometheus/ @grafana/grafana-gcx @grafana/cortex-team
-/internal/datasources/providers/ @grafana/grafana-gcx @grafana/data-sources
 /internal/datasources/pyroscope/ @grafana/grafana-gcx @grafana/pyroscope-team
-/internal/datasources/query/ @grafana/grafana-gcx @grafana/data-sources
 /internal/datasources/tempo/ @grafana/grafana-gcx @grafana/tempo
 
 /internal/query/loki/ @grafana/grafana-gcx @grafana/loki-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,9 +26,16 @@
 /internal/providers/profiles/ @grafana/grafana-gcx @grafana/pyroscope-team
 /internal/providers/traces/ @grafana/grafana-gcx @grafana/tempo
 
+/internal/datasources/athena/ @grafana/grafana-gcx @grafana/data-sources
+/internal/datasources/clickhouse/ @grafana/grafana-gcx @grafana/data-sources
+/internal/datasources/cloudwatch/ @grafana/grafana-gcx @grafana/data-sources
+/internal/datasources/infinity/ @grafana/grafana-gcx @grafana/data-sources
+/internal/datasources/influxdb/ @grafana/grafana-gcx @grafana/data-sources
 /internal/datasources/loki/ @grafana/grafana-gcx @grafana/loki-team
 /internal/datasources/prometheus/ @grafana/grafana-gcx @grafana/cortex-team
+/internal/datasources/providers/ @grafana/grafana-gcx @grafana/data-sources
 /internal/datasources/pyroscope/ @grafana/grafana-gcx @grafana/pyroscope-team
+/internal/datasources/query/ @grafana/grafana-gcx @grafana/data-sources
 /internal/datasources/tempo/ @grafana/grafana-gcx @grafana/tempo
 
 /internal/query/loki/ @grafana/grafana-gcx @grafana/loki-team


### PR DESCRIPTION
Adds `@grafana/data-sources` as code owners for the per-datasource directories under `internal/datasources/` that were only covered by the `*` fallback: `athena`, `clickhouse`, `cloudwatch`, `infinity`, `influxdb`. Dirs with existing team owners (loki, prometheus, pyroscope, tempo) are untouched, and the `providers`/`query` plumbing packages stay with gcx.