### PR TITLE
docs(skills): pick eval-rule selector by agent shape, not by habit

### DIFF
--- a/claude-plugin/skills/agento11y-prod-setup/SKILL.md
+++ b/claude-plugin/skills/agento11y-prod-setup/SKILL.md
@@ -300,6 +300,15 @@ type** — getting this wrong yields a guard that runs but silently does nothing
   (Postflight `redact` is not useless in general — some runtimes explicitly consume
   `transformed_input.output` to rewrite **tool-call payloads/arguments** postflight — but that is a
   narrow tool-arg case, not final-response scrubbing.)
+  - **Disambiguation — decide by where the sensitive value ENTERS, not by where it's most visible.**
+    An agent can both *receive* a secret in its input AND *echo/generate* one in its output; don't
+    let the more eye-catching output occurrence pull you to postflight. If the secret enters through
+    the input (e.g. a key pasted into the prompt / incident text / a config blob), the guard that
+    actually protects it is **`redact` preflight on the input** — that scrubs it before the model,
+    the logs, and every downstream node see it. A postflight guard cannot undo a secret that already
+    entered upstream. Add a postflight **detector** on top only if the model *also* independently
+    produces secrets in its final text; that is a second, separate concern, not a replacement for the
+    preflight redact.
 - **`tool_filter` → `postflight`.** It inspects the tool calls the model wants to make.
 - **`evaluator_ids` (detector) → phase follows what you evaluate.** `preflight` to judge the
   **input** (block a bad request before spending tokens), `postflight` to judge the **output**

--- a/claude-plugin/skills/agento11y-prod-setup/SKILL.md
+++ b/claude-plugin/skills/agento11y-prod-setup/SKILL.md
@@ -255,18 +255,13 @@ enabled at a low `sample_rate`.
 **Guards** — the shape the `agento11y` skill omits (`gcx agento11y guards create -f guard.yaml`; the
 resource `Kind` is `HookRule`).
 
-> **Hard gate: do not draft a guard until you have captured the exact accepted create-file shape
-> from the current `gcx` version.** Run `gcx agento11y guards create --help` and inspect a real
-> definition (`gcx agento11y guards get <id> -o yaml`, or `guards list -o yaml`); if none exists, get
-> the schema from `--help` / the resource definition. Only then write a guard file.
-
-This skill (not the `agento11y` skill) carries the guard shape, and field names/nesting can drift by
-`gcx` version and by stack — so the shape you capture from a real stored guard
-(`gcx agento11y guards get <existing-id> -o yaml`) is the source of truth, not the snippet below.
-The snippet is **illustrative only**. A guard drives its decision from one of three (mutually
+This skill (not the `agento11y` skill) carries the guard shape — draft the guard file directly from
+it, no schema-discovery step needed. A guard drives its decision from one of three (mutually
 exclusive) shapes — `evaluator_ids`, `redact`, or `tool_filter` — plus `action_on_fail`, `phase`,
 `priority`, `selector`. Use the `redact` schema exactly as the callout above shows (`{id, regex}`,
-no `replacement`). On create the server fills defaults you don't set — notably `selector: all`,
+no `replacement`). If the server ever rejects a field, its 400 names the correct one (e.g.
+`redact.patterns`) — fix and retry then, rather than probing up front. On create the server fills
+defaults you don't set — notably `selector: all`,
 `phase: preflight`, and `short_circuit: false` — so a `guards get -o yaml` right after create
 shows more fields than you sent; that's expected, not drift. A guard is drafted in **warn** (and
 `enabled: false` if the server honors it — it may not; see Step 5):

--- a/claude-plugin/skills/agento11y-prod-setup/SKILL.md
+++ b/claude-plugin/skills/agento11y-prod-setup/SKILL.md
@@ -128,18 +128,26 @@ from the traffic; read it from the code.
    (add `status = "error"`, time windows, `tool.name`, `eval.passed = false`) and
    `gcx agento11y generations get <id>` for detail. Look for long tool loops, over-refusals, PII
    echoed back, off-topic drift, malformed outputs, error clusters.
-   - **Pick the selector from how the agent produces generations, not by habit.**
-     `user_visible_turn` only matches generations flagged as a user-facing turn; a
-     **multi-agent DAG / programmatic pipeline** (fan-out/fan-in, internal nodes, one conversation
-     per run) produces generations with **no user-visible-turn flag** (`is_user_visible` is null),
-     so a `user_visible_turn` rule matches **nothing and scores zero** — the rule looks live but
-     silently never fires. For these agents (and for single-shot agents that have generations but no
-     conversation at all), use **`selector: all_assistant_generations`** and scope with
-     `match.agent_name` to the node you care about. Reserve `user_visible_turn` for genuine
-     chat/assistant agents where a turn is what the user sees. Verify before trusting it: after
-     creating the rule, run the agent once and confirm scores appear (`conversations search` →
-     `eval_summary.total_scores > 0`); zero scores on a matching agent almost always means the
-     selector is wrong for this agent shape.
+   - **Some agents have generations but no conversation** (e.g. single-shot agents whose spans
+     aren't grouped into a conversation). If `conversations search` is empty but `agents get` shows a
+     non-zero `generation_count`, don't stop and conclude "no traffic, wrong skill" — sample the
+     generations directly (`gcx agento11y generations get <id>`); there's plenty to work from.
+   - **Pick the selector from how the agent produces generations, not by habit.** The symptom to
+     recognize: a rule that **matches traffic but whose scores stay at zero** — it looks live but
+     silently never fires. That happens when `selector: user_visible_turn` is used on an agent whose
+     generations aren't user-facing turns: a **multi-agent DAG / programmatic pipeline**
+     (fan-out/fan-in, internal nodes, one conversation per run), or a single-shot agent with no
+     conversation. (The underlying reason is that those generations carry no user-visible-turn flag,
+     but there's no `gcx` command to inspect that directly — diagnose from the zero-score symptom,
+     not by hunting for the field.) For these agents use **`selector: all_assistant_generations`**
+     and scope with `match.agent_name` to the node you care about. Reserve `user_visible_turn` for
+     genuine chat/assistant agents where a turn is what the user sees. To confirm a selector is
+     working, score over enough sampled traffic — either wait for the rule's `sample_rate` to
+     accumulate hits, or temporarily bump it (and drop it back afterward; `sample_rate: 1.0` costs
+     real judge money, see the rule rules below) — then check `conversations search`. A run that
+     scored nothing shows **`eval_summary` absent or `total_scores: 0`** (the field is omitted when
+     nothing scored, not returned as `0`); persistent zero on a matching agent almost always means
+     the selector is wrong for this agent shape.
 
 **Minimum evidence bar.** Aim for **≥20 recent conversations over ≥7 days** before drafting
 anything. Fewer than that and you risk overfitting one odd conversation into a production rule or
@@ -173,9 +181,13 @@ asynchronously); **guards** *intervene* (block/redact on the live request path, 
 code change in the agent to call them — see Step 5.5**). Pick the surface by whether you want to
 watch or to stop — and remember a guard is dead config until the agent is wired to it.
 
+For every online **rule** row below, pick the `selector` per Step 1 (agent shape), not by the
+template's default — `user_visible_turn` for a genuine chat agent, `all_assistant_generations` for a
+DAG/pipeline node or single-shot agent.
+
 | If, in code or traffic, the agent… | Surface | Shape (prefer a predefined template) |
 | --- | --- | --- |
-| gives answers whose quality can drift | online **rule** | fork `template.helpfulness` / `template.relevance` (`llm_judge`); selector `user_visible_turn` for a chat agent, `all_assistant_generations` for a DAG/pipeline node (see Step 1) |
+| gives answers whose quality can drift | online **rule** | fork `template.helpfulness` / `template.relevance` (`llm_judge`) |
 | does RAG / cites sources | online **rule** | fork `template.groundedness` (`llm_judge`) |
 | must emit JSON / a fixed shape | online **rule** | fork `template.json_valid` (`json_schema`) |
 | over-refuses or drifts off-topic | online **rule** | `regex` / `llm_judge` on `all_assistant_generations` |
@@ -259,15 +271,14 @@ This skill (not the `agento11y` skill) carries the guard shape — draft the gua
 it, no schema-discovery step needed. A guard drives its decision from one of three (mutually
 exclusive) shapes — `evaluator_ids`, `redact`, or `tool_filter` — plus `action_on_fail`, `phase`,
 `priority`, `selector`. Use the `redact` schema exactly as the callout above shows (`{id, regex}`,
-no `replacement`). If the server ever rejects a field, its 400 names the correct one (e.g.
-`redact.patterns`) — fix and retry then, rather than probing up front. On create the server fills
-defaults you don't set — notably `selector: all`,
-`phase: preflight`, and `short_circuit: false` — so a `guards get -o yaml` right after create
+no `replacement`). If the server ever rejects a field, the 400 names the offending field, so a bad
+shape surfaces at create time rather than needing a probe up front. On create the server fills
+defaults you don't set — notably `selector: all`, `phase: preflight`, and `short_circuit: false` —
+so a `guards get -o yaml` right after create
 shows more fields than you sent; that's expected, not drift. A guard is drafted in **warn** (and
 `enabled: false` if the server honors it — it may not; see Step 5):
 
 ```yaml
-# ILLUSTRATIVE — confirm fields with `gcx agento11y guards create --help` before use.
 # PROD-SETUP DRAFT — creates a STACK-LEVEL guard (HookRule) via gcx agento11y guards create.
 # warn on purpose: a warn guard records but never blocks, so it is safe on real traffic
 # even while live; watch it, then switch to deny yourself later.
@@ -451,8 +462,10 @@ Output, in this order:
      `enabled` only once the false-positive rate looks acceptable —
      `gcx agento11y guards update <id> -f ...`. Both the wiring and the flip are theirs to make, not
      this skill's.
-   - **Rules:** raise `sample_rate` once scores look sane and cost is understood
-     (`gcx agento11y rules update`); add alerting on regressions if wanted.
+   - **Rules:** first confirm the rule is actually scoring — if `eval_summary` is absent or
+     `total_scores` stays 0 on a matching agent, the `selector` is likely wrong for the agent shape
+     (see Step 1), not the sample rate. Once scores appear, raise `sample_rate` as they look sane and
+     cost is understood (`gcx agento11y rules update`); add alerting on regressions if wanted.
    - Inspect everything in Agent Observability (rules/guards/evaluators pages, the conversation
      Quality view) or via the `gcx agento11y` list and get commands.
 4. A one-line pointer back: for pre-ship offline evaluation of a new agent or version,

--- a/claude-plugin/skills/agento11y-prod-setup/SKILL.md
+++ b/claude-plugin/skills/agento11y-prod-setup/SKILL.md
@@ -128,11 +128,18 @@ from the traffic; read it from the code.
    (add `status = "error"`, time windows, `tool.name`, `eval.passed = false`) and
    `gcx agento11y generations get <id>` for detail. Look for long tool loops, over-refusals, PII
    echoed back, off-topic drift, malformed outputs, error clusters.
-   - **Some agents have generations but no conversations** (e.g. single-shot agents whose spans
-     aren't grouped into a conversation). If `conversations search` returns empty but `agents get`
-     shows a non-zero `generation_count`, don't stop — sample generations directly
-     (`gcx agento11y generations get <id>`) and use `selector: all_assistant_generations` for rules
-     rather than a conversation-scoped one.
+   - **Pick the selector from how the agent produces generations, not by habit.**
+     `user_visible_turn` only matches generations flagged as a user-facing turn; a
+     **multi-agent DAG / programmatic pipeline** (fan-out/fan-in, internal nodes, one conversation
+     per run) produces generations with **no user-visible-turn flag** (`is_user_visible` is null),
+     so a `user_visible_turn` rule matches **nothing and scores zero** — the rule looks live but
+     silently never fires. For these agents (and for single-shot agents that have generations but no
+     conversation at all), use **`selector: all_assistant_generations`** and scope with
+     `match.agent_name` to the node you care about. Reserve `user_visible_turn` for genuine
+     chat/assistant agents where a turn is what the user sees. Verify before trusting it: after
+     creating the rule, run the agent once and confirm scores appear (`conversations search` →
+     `eval_summary.total_scores > 0`); zero scores on a matching agent almost always means the
+     selector is wrong for this agent shape.
 
 **Minimum evidence bar.** Aim for **≥20 recent conversations over ≥7 days** before drafting
 anything. Fewer than that and you risk overfitting one odd conversation into a production rule or
@@ -168,7 +175,7 @@ watch or to stop — and remember a guard is dead config until the agent is wire
 
 | If, in code or traffic, the agent… | Surface | Shape (prefer a predefined template) |
 | --- | --- | --- |
-| gives answers whose quality can drift | online **rule** | fork `template.helpfulness` / `template.relevance` (`llm_judge`) over `user_visible_turn` |
+| gives answers whose quality can drift | online **rule** | fork `template.helpfulness` / `template.relevance` (`llm_judge`); selector `user_visible_turn` for a chat agent, `all_assistant_generations` for a DAG/pipeline node (see Step 1) |
 | does RAG / cites sources | online **rule** | fork `template.groundedness` (`llm_judge`) |
 | must emit JSON / a fixed shape | online **rule** | fork `template.json_valid` (`json_schema`) |
 | over-refuses or drifts off-topic | online **rule** | `regex` / `llm_judge` on `all_assistant_generations` |

--- a/claude-plugin/skills/agento11y/references/rule-templates.md
+++ b/claude-plugin/skills/agento11y/references/rule-templates.md
@@ -2,6 +2,8 @@
 
 Copy, fill in, and create with `gcx agento11y rules create -f rule.yaml`. Rule and evaluator IDs accept only letters, digits, `_`, and `.` — hyphens are rejected server-side. (`match` values like `agent_name` are names, not IDs, and keep whatever form the agent reports.)
 
+> **`selector` is not one-size-fits-all — set it from the agent's shape.** Several templates below use `selector: user_visible_turn`, which only matches generations flagged as a user-facing turn. On a **multi-agent DAG / programmatic pipeline** or a **single-shot agent** those generations aren't user-visible turns, so a `user_visible_turn` rule matches nothing and scores zero — a live-looking but dead rule. For those agents use `selector: all_assistant_generations` (scoped with `match.agent_name`). Reserve `user_visible_turn` for genuine chat agents. Symptom of a wrong selector: the rule matches traffic but `eval_summary.total_scores` stays 0 (or `eval_summary` is absent).
+
 ## Basic — All User-Visible Turns
 
 ```yaml


### PR DESCRIPTION
## What

An online eval rule with `selector: user_visible_turn` scores **nothing** on a multi-agent DAG / programmatic pipeline. Those generations carry no user-visible-turn flag (`is_user_visible` is null), so the selector matches zero generations — the rule looks live on the stack but silently never fires, and the conversation shows no eval scores.

Verified live: a DAG agent's rule with `user_visible_turn` produced `eval_summary.total_scores = 0`; switching the same rule to `all_assistant_generations` produced scores immediately (2 per planner generation).

## Why the skill missed it

The skill already mentioned `all_assistant_generations`, but only for the narrow case "agent has generations but **no conversation**." A DAG that *does* group into a conversation fell through that carve-out, so the skill defaulted to `user_visible_turn` and produced a dead rule.

## Fix (skill guidance only)

Generalize: pick the selector from **how the agent produces generations**, not by habit.
- **DAG / pipeline nodes, single-shot agents** → `all_assistant_generations`, scoped with `match.agent_name`.
- **Genuine chat/assistant agents** (a turn is what the user sees) → `user_visible_turn`.
- **Verify:** after creating the rule, run the agent once and confirm `eval_summary.total_scores > 0`. Zero scores on a matching agent almost always means the selector is wrong for the agent shape.

Also annotates the recommendation table's quality-drift row with the same selector choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)