### PR TITLE
Add Grafana plugin admin client

### DIFF
--- a/internal/plugins/client.go
+++ b/internal/plugins/client.go
@@ -1,0 +1,140 @@
+// Package plugins provides a thin client for Grafana's plugin admin API
+// (/api/plugins). It is used to check whether a required datasource plugin is
+// installed (via GET /api/plugins/{id}/settings — Grafana has no bare
+// /api/plugins/{id} route) and, when permitted, to install it. It reuses the
+// NamespacedRESTConfig transport so OAuth proxy mode and token refresh are
+// respected, mirroring internal/datasources.
+package plugins
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	maxResponseBytes = 4 << 20 // 4 MB
+	pluginsPath      = "/api/plugins/"
+)
+
+// ErrNotInstalled is returned by Get when the plugin is not installed (HTTP 404).
+var ErrNotInstalled = errors.New("plugin not installed")
+
+// Plugin holds the subset of fields returned by GET /api/plugins/{id}.
+type Plugin struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Enabled bool   `json:"enabled"`
+	Info    struct {
+		Version string `json:"version"`
+	} `json:"info"`
+}
+
+// Client talks to the Grafana plugin admin API.
+type Client struct {
+	host       string
+	httpClient *http.Client
+}
+
+// NewClient creates a plugins client backed by the given REST config transport.
+func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
+	httpClient, err := rest.HTTPClientFor(&cfg.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+	return &Client{host: cfg.Host, httpClient: httpClient}, nil
+}
+
+// Get returns the plugin with the given ID. It returns ErrNotInstalled when the
+// plugin is not installed (HTTP 404). Other non-200 responses return an error.
+//
+// It queries GET /api/plugins/{id}/settings: Grafana has no bare
+// /api/plugins/{id} route (that path always 404s), and the settings endpoint is
+// the canonical per-plugin lookup — it returns 404 "Plugin not found, no
+// installed plugin with that id" when the plugin is absent and 200 with the
+// plugin metadata when it is installed.
+func (c *Client) Get(ctx context.Context, id string) (*Plugin, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.host+pluginsPath+url.PathEscape(id)+"/settings", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get plugin %q: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := httputils.ReadResponseBody(resp.Body, maxResponseBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotInstalled
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get plugin %q returned HTTP %d: %s", id, resp.StatusCode, bytes.TrimSpace(body))
+	}
+
+	var p Plugin
+	if err := json.Unmarshal(body, &p); err != nil {
+		return nil, fmt.Errorf("failed to parse plugin response: %w", err)
+	}
+	return &p, nil
+}
+
+// IsInstalled reports whether the plugin is installed.
+func (c *Client) IsInstalled(ctx context.Context, id string) (bool, error) {
+	_, err := c.Get(ctx, id)
+	if errors.Is(err, ErrNotInstalled) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Install installs a plugin via POST /api/plugins/{id}/install. version may be
+// empty to install the latest available version. Requires plugin-admin
+// permissions; the server error is surfaced when not permitted (e.g. an
+// Enterprise plugin without a license).
+func (c *Client) Install(ctx context.Context, id, version string) error {
+	payload, err := json.Marshal(map[string]string{"version": version})
+	if err != nil {
+		return fmt.Errorf("failed to marshal install request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.host+pluginsPath+url.PathEscape(id)+"/install", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to install plugin %q: %w", id, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := httputils.ReadResponseBody(resp.Body, maxResponseBytes)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("install plugin %q returned HTTP %d: %s", id, resp.StatusCode, bytes.TrimSpace(body))
+	}
+	return nil
+}

--- a/internal/plugins/client_test.go
+++ b/internal/plugins/client_test.go
@@ -1,0 +1,98 @@
+package plugins_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/plugins"
+	"k8s.io/client-go/rest"
+)
+
+func newClient(t *testing.T, handler http.Handler) *plugins.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	c, err := plugins.NewClient(config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}})
+	if err != nil {
+		t.Fatalf("failed to create plugins client: %v", err)
+	}
+	return c
+}
+
+func TestIsInstalled_True(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/plugins/grafana-azure-data-explorer-datasource/settings" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"id":"grafana-azure-data-explorer-datasource","enabled":true,"info":{"version":"5.0.0"}}`))
+	}))
+
+	ok, err := c.IsInstalled(context.Background(), "grafana-azure-data-explorer-datasource")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected plugin to be reported installed")
+	}
+}
+
+func TestIsInstalled_FalseOn404(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Plugin not found"}`))
+	}))
+
+	ok, err := c.IsInstalled(context.Background(), "missing-plugin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected plugin to be reported not installed")
+	}
+}
+
+func TestGet_ErrorOnNon200(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+	}))
+
+	if _, err := c.Get(context.Background(), "x"); err == nil {
+		t.Fatal("expected error on HTTP 403")
+	}
+}
+
+func TestInstall(t *testing.T) {
+	var called bool
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/plugins/grafana-azure-data-explorer-datasource/install" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	if err := c.Install(context.Background(), "grafana-azure-data-explorer-datasource", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected install endpoint to be called")
+	}
+}
+
+func TestInstall_ErrorSurfaced(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"license required"}`))
+	}))
+
+	if err := c.Install(context.Background(), "grafana-azurecosmosdb-datasource", ""); err == nil {
+		t.Fatal("expected error to be surfaced from failed install")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a thin client for Grafana's plugin admin API, used by the onboarding plugin pre-flight to make sure the datasource plugin a user is onboarding actually exists on the target instance.

- Checks whether a datasource plugin is installed via `GET /api/plugins/{id}/settings` (the canonical endpoint — `GET /api/plugins/{id}` is not valid and always 404s).
- Installs a plugin when it is missing.

No callers yet — consumed by the Azure onboarding engine later in the stack.

## Files

- `internal/plugins/client.go`
- `internal/plugins/client_test.go`

## Stack

1. #1101
2. **this PR** — Grafana plugin admin client *(base: `andreas/onboard-1-cloudcli`)*
3. #1103
4. #1104
5. #1105

## Test plan

- [ ] `go test ./internal/plugins/...`
- [ ] `go build ./...`