### PR TITLE
Add provider-agnostic onboarding core

### DIFF
--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -102,6 +102,7 @@ gcx/
 │   │   ├── loki/             # Loki HTTP client (log + metric queries)
 │   │   └── clickhouse/       # ClickHouse HTTP client
 │   ├── signals/              # Shared signal command and datasource-provider mounting (metrics/logs/traces/profiles)
+│   ├── onboard/              # Cloud datasource onboarding core (result types, naming/collision, rollback, shared progress)
 │   ├── notifier/             # Skills update notifier (XDG state, throttle, message rendering)
 │   ├── secrets/              # Redaction of sensitive config fields
 │   ├── skills/               # Portable Agent Skills installer primitives (Install, Update, Bundled/InstalledBundledSkillNames)

--- a/internal/onboard/onboard.go
+++ b/internal/onboard/onboard.go
@@ -1,0 +1,228 @@
+// Package onboard contains the provider-agnostic core for the
+// `gcx setup datasources <cloud>` command family: result types surfaced to users, a
+// stable naming/collision helper, and a best-effort rollback accumulator used
+// to undo partially-created cloud and Grafana artifacts on failure.
+package onboard
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"slices"
+	"sync"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+)
+
+// NamePrefix is prepended to every artifact gcx creates (app registrations,
+// datasources). It makes gcx-created objects attributable and lets `--cleanup`
+// find them reliably.
+const NamePrefix = "gcx"
+
+// Datasource lifecycle statuses reported in DatasourceResult.Status.
+const (
+	// StatusCreated marks a datasource newly created by this run.
+	StatusCreated = "created"
+	// StatusExisting marks a gcx-managed datasource that already existed and was
+	// reused (idempotent re-run) rather than duplicated.
+	StatusExisting = "existing"
+	// StatusPlanned marks a datasource that would be created (--dry-run); nothing
+	// was minted or created.
+	StatusPlanned = "planned"
+	// StatusRotated marks a datasource whose backing credential was rotated.
+	StatusRotated = "rotated"
+	// StatusSkipped marks a datasource that was intentionally not acted on (e.g.
+	// not gcx-managed during rotate, or an unsupported type).
+	StatusSkipped = "skipped"
+)
+
+// DatasourceResult describes a single provisioned datasource. Fields common to
+// every cloud live at the top level; cloud-specific identity and IAM details are
+// grouped under Credential so the shape stays applicable as the GCP and AWS
+// providers are added alongside Azure.
+type DatasourceResult struct {
+	Name string `json:"name" yaml:"name"`
+	Type string `json:"type" yaml:"type"`
+	UID  string `json:"uid,omitempty" yaml:"uid,omitempty"`
+	// Status is one of the Status* constants describing what happened to this
+	// datasource in the run (created, existing, planned, rotated, skipped).
+	Status string `json:"status,omitempty" yaml:"status,omitempty"`
+	// Health is the datasource health status reported by Grafana after a
+	// create/rotate (e.g. "OK", "ERROR", "UNKNOWN"). Empty when the health check
+	// was skipped or not applicable.
+	Health string `json:"health,omitempty" yaml:"health,omitempty"`
+	// HealthMessage carries the health-check detail when Health is not OK.
+	HealthMessage string `json:"healthMessage,omitempty" yaml:"healthMessage,omitempty"`
+	// Credential describes the managed cloud identity and the access granted to
+	// it. Nil for datasources that use no gcx-managed identity (e.g. key-based
+	// Cosmos DB) or when nothing identity-related applies to this row.
+	Credential *CloudCredential `json:"credential,omitempty" yaml:"credential,omitempty"`
+	// Note carries a short human-readable explanation for skipped/planned rows.
+	Note string `json:"note,omitempty" yaml:"note,omitempty"`
+	// Hint is an advisory, non-blocking suggestion about this datasource (e.g.
+	// the backing resource is not publicly reachable, so Private Data source
+	// Connect is likely needed). It never affects the run outcome.
+	Hint string `json:"hint,omitempty" yaml:"hint,omitempty"`
+	// HintDocs is a documentation URL backing Hint, so users and agents can
+	// follow up. Empty when there is no hint.
+	HintDocs string `json:"hintDocs,omitempty" yaml:"hintDocs,omitempty"`
+}
+
+// CloudCredential describes the cloud identity gcx provisions for a datasource
+// and the access granted to it. It is provider-agnostic so it applies to Azure
+// (app registration + RBAC), GCP (service account + IAM), and AWS (IAM role +
+// policies) alike.
+type CloudCredential struct {
+	// ID is the identity the datasource authenticates as: an Azure application
+	// (client) ID, a GCP service-account email, or an AWS role ARN. Empty for a
+	// --dry-run preview (nothing minted yet) or key-based datasources.
+	ID string `json:"id,omitempty" yaml:"id,omitempty"`
+	// Roles are the cloud IAM roles bound to the identity (Azure RBAC roles, GCP
+	// IAM roles, AWS policies). Populated for --dry-run previews so the user can
+	// see the access that would be granted.
+	Roles []string `json:"roles,omitempty" yaml:"roles,omitempty"`
+	// Scopes are the resources the roles are bound over (Azure ARM scopes, GCP
+	// projects/resources, AWS resource ARNs). Populated for --dry-run previews.
+	Scopes []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+}
+
+// CleanupResult describes one artifact removed (or, in --dry-run, that would be
+// removed) by `--cleanup`.
+type CleanupResult struct {
+	Kind string `json:"kind" yaml:"kind"` // "datasource" or "app-registration"
+	Name string `json:"name" yaml:"name"`
+	ID   string `json:"id,omitempty" yaml:"id,omitempty"`
+	// Planned marks a would-remove entry from a --dry-run cleanup; nothing was
+	// actually deleted.
+	Planned bool `json:"planned,omitempty" yaml:"planned,omitempty"`
+}
+
+// Result is the structured outcome of an onboard run, rendered by the output
+// codecs.
+type Result struct {
+	Provider    string             `json:"provider" yaml:"provider"`
+	Datasources []DatasourceResult `json:"datasources,omitempty" yaml:"datasources,omitempty"`
+	Cleaned     []CleanupResult    `json:"cleaned,omitempty" yaml:"cleaned,omitempty"`
+	// DryRun reports that this result is a preview: no cloud or Grafana
+	// artifacts were created, modified, or deleted.
+	DryRun bool `json:"dryRun,omitempty" yaml:"dryRun,omitempty"`
+}
+
+// EnsureUniqueName returns base if available, otherwise base-2, base-3, … until
+// taken reports the name as free. taken should return true when a name is
+// already in use anywhere it must be unique (e.g. both the cloud directory and
+// Grafana). It returns an error if taken errors or no free name is found.
+func EnsureUniqueName(base string, taken func(name string) (bool, error)) (string, error) {
+	const maxAttempts = 100
+	name := base
+	for i := 2; i <= maxAttempts+1; i++ {
+		used, err := taken(name)
+		if err != nil {
+			return "", err
+		}
+		if !used {
+			return name, nil
+		}
+		name = fmt.Sprintf("%s-%d", base, i)
+	}
+	return "", fmt.Errorf("could not find a unique name for %q after %d attempts", base, maxAttempts)
+}
+
+// Rollback accumulates undo steps registered as artifacts are created, and runs
+// them in reverse (LIFO) order. Steps are best-effort: a failing step is logged
+// and does not stop the remaining steps.
+//
+// It is safe for concurrent use: Add may be called from multiple goroutines
+// (e.g. parallel provisioning), so a mutex guards the step slice.
+type Rollback struct {
+	mu    sync.Mutex
+	steps []step
+}
+
+type step struct {
+	desc string
+	undo func(ctx context.Context) error
+}
+
+// Add registers an undo step. desc is a short human description used in logs.
+func (r *Rollback) Add(desc string, undo func(ctx context.Context) error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.steps = append(r.steps, step{desc: desc, undo: undo})
+}
+
+// Len reports how many undo steps are registered.
+func (r *Rollback) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.steps)
+}
+
+// Descriptions returns the step descriptions in the order they would be
+// reverted (reverse of registration / LIFO). Used to list pending reverts to
+// the user before running them.
+func (r *Rollback) Descriptions() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, 0, len(r.steps))
+	for _, s := range slices.Backward(r.steps) {
+		out = append(out, s.desc)
+	}
+	return out
+}
+
+// Run executes all registered undo steps in reverse order, best-effort. Each
+// step is both logged (Info/Warn, audit trail) and narrated to progress (stderr,
+// visible without -v) as it is reverted, so the user can see exactly what is
+// being undone. progress may be nil to suppress narration.
+func (r *Rollback) Run(ctx context.Context, log logging.Logger, progress io.Writer) {
+	r.mu.Lock()
+	steps := slices.Clone(r.steps)
+	r.mu.Unlock()
+
+	if len(steps) == 0 {
+		return
+	}
+	if log != nil {
+		log.Info("rolling back created artifacts", "steps", len(steps))
+	}
+	narrate(progress, fmt.Sprintf("Reverting %d change(s):", len(steps)))
+
+	for _, s := range slices.Backward(steps) {
+		if log != nil {
+			log.Info("rollback step", "step", s.desc)
+		}
+		if err := s.undo(ctx); err != nil {
+			if log != nil {
+				log.Warn("rollback step failed", "step", s.desc, "error", err.Error())
+			}
+			narrate(progress, fmt.Sprintf("  ✗ %s — %v", s.desc, err))
+			continue
+		}
+		if log != nil {
+			log.Info("rollback step done", "step", s.desc)
+		}
+		narrate(progress, "  ✓ "+s.desc)
+	}
+
+	if log != nil {
+		log.Info("rollback complete", "steps", len(steps))
+	}
+	narrate(progress, "Revert complete.")
+}
+
+// Progressf writes a human-readable progress line to w, appending a newline. It
+// is a no-op when w is nil, letting callers disable narration (e.g. agent mode,
+// where structured output is the contract) by passing a nil writer. Progress is
+// informational narration for long-running cloud and Grafana calls — it is never
+// the result.
+func Progressf(w io.Writer, format string, a ...any) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, format+"\n", a...)
+}
+
+func narrate(w io.Writer, msg string) {
+	Progressf(w, "%s", msg)
+}

--- a/internal/onboard/onboard_test.go
+++ b/internal/onboard/onboard_test.go
@@ -1,0 +1,101 @@
+package onboard_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/onboard"
+)
+
+func TestEnsureUniqueName(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		used map[string]bool
+		want string
+	}{
+		{name: "free", base: "gcx-azure-monitor", used: nil, want: "gcx-azure-monitor"},
+		{name: "first taken", base: "gcx-azure-monitor", used: map[string]bool{"gcx-azure-monitor": true}, want: "gcx-azure-monitor-2"},
+		{
+			name: "first two taken",
+			base: "gcx-adx",
+			used: map[string]bool{"gcx-adx": true, "gcx-adx-2": true},
+			want: "gcx-adx-3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := onboard.EnsureUniqueName(tt.base, func(n string) (bool, error) {
+				return tt.used[n], nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureUniqueName_PropagatesError(t *testing.T) {
+	want := errors.New("boom")
+	_, err := onboard.EnsureUniqueName("x", func(string) (bool, error) { return false, want })
+	if !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+}
+
+func TestRollback_RunsInReverseOrder(t *testing.T) {
+	var order []string
+	rb := &onboard.Rollback{}
+	rb.Add("first", func(context.Context) error { order = append(order, "first"); return nil })
+	rb.Add("second", func(context.Context) error { order = append(order, "second"); return nil })
+	rb.Add("third", func(context.Context) error { order = append(order, "third"); return nil })
+
+	rb.Run(context.Background(), nil, nil)
+
+	want := []string{"third", "second", "first"}
+	if len(order) != len(want) {
+		t.Fatalf("got %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("got %v, want %v", order, want)
+		}
+	}
+}
+
+func TestRollback_DescriptionsAreInRevertOrder(t *testing.T) {
+	rb := &onboard.Rollback{}
+	rb.Add("first", func(context.Context) error { return nil })
+	rb.Add("second", func(context.Context) error { return nil })
+	rb.Add("third", func(context.Context) error { return nil })
+
+	got := rb.Descriptions()
+	want := []string{"third", "second", "first"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestRollback_ContinuesAfterFailingStep(t *testing.T) {
+	var ran int
+	rb := &onboard.Rollback{}
+	rb.Add("ok-1", func(context.Context) error { ran++; return nil })
+	rb.Add("fail", func(context.Context) error { return errors.New("nope") })
+	rb.Add("ok-2", func(context.Context) error { ran++; return nil })
+
+	rb.Run(context.Background(), nil, nil)
+
+	if ran != 2 {
+		t.Fatalf("expected both non-failing steps to run, got %d", ran)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the provider-agnostic core for cloud datasource onboarding — the shared vocabulary and mechanics that the Azure provider (and future GCP/AWS providers) build on.

- Result types: `Result`, `DatasourceResult`, `CloudCredential`, `CleanupResult` (cloud-neutral; no Azure-specific fields).
- A **concurrency-safe** rollback accumulator (runs undo steps LIFO; safe for parallel provisioning).
- Unique-name resolution and shared progress narration.

No callers yet — consumed by the Azure onboarding engine later in the stack.

## Files

- `internal/onboard/onboard.go`
- `internal/onboard/onboard_test.go`

## Stack

1. #1101
2. #1102
3. **this PR** — provider-agnostic onboarding core *(base: `andreas/onboard-2-plugins`)*
4. #1104
5. #1105

## Test plan

- [ ] `go test ./internal/onboard/...`
- [ ] `go build ./...`