### PR TITLE
Add Azure datasource onboarding engine

### DIFF
--- a/internal/docs/links.go
+++ b/internal/docs/links.go
@@ -101,6 +101,12 @@ const (
 	// slugs become <slug>.grafana.net subdomains and accept lowercase
 	// characters only).
 	CloudAPI = "https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api.md"
+
+	// PrivateDataSourceConnect documents Private Data source Connect (PDC), the
+	// Grafana Cloud path for querying data sources that are not publicly
+	// reachable. Suggested during Azure onboarding when a discovered resource
+	// has public network access disabled.
+	PrivateDataSourceConnect = "https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect.md"
 )
 
 // All returns every documentation URL in the registry. Used by the
@@ -127,5 +133,6 @@ func All() []string {
 		IRMInvoice,
 		AnonymousUsageStats,
 		CloudAPI,
+		PrivateDataSourceConnect,
 	}
 }

--- a/internal/onboard/azure/adx.go
+++ b/internal/onboard/azure/adx.go
@@ -1,0 +1,76 @@
+package azure
+
+import (
+	"context"
+	"strings"
+
+	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/onboard"
+)
+
+// adxSpec provisions the Azure Data Explorer datasource. It uses the unified
+// azureCredentials schema and additionally grants the minted principal
+// AllDatabasesViewer on the target cluster.
+type adxSpec struct{}
+
+func (adxSpec) Token() string { return TokenADX }
+func (adxSpec) Kind() string  { return KindADX }
+
+func (adxSpec) RoleOptions() []RoleOption {
+	return []RoleOption{
+		{Label: "Reader on subscription + AllDatabasesViewer on cluster", Roles: []string{"Reader"}},
+	}
+}
+
+func (s adxSpec) AcquireAndBuild(ctx context.Context, in SpecInput) (Provisioned, error) {
+	cred, err := acquireCredential(ctx, in)
+	if err != nil {
+		return Provisioned{}, err
+	}
+
+	// Grant the minted principal viewer access to the cluster's databases.
+	assignment := onboardAssignmentName(cred.AppID)
+	rg, cluster := in.Extra["rg"], in.Extra["cluster"]
+	onboard.Progressf(in.Progress, "  granting AllDatabasesViewer on cluster %q...", cluster)
+	if err := in.CLI.GrantADXClusterViewer(ctx,
+		rg, cluster, assignment, cred.AppID, in.Account.TenantID); err != nil {
+		return Provisioned{}, err
+	}
+	if in.Rollback != nil {
+		in.Rollback.Add("delete ADX cluster assignment "+assignment, func(ctx context.Context) error {
+			return in.CLI.DeleteADXClusterAssignment(ctx, rg, cluster, assignment)
+		})
+	}
+
+	return Provisioned{Request: s.payload(in.Name, in.Account, cred, in.Extra["clusterUrl"]), AppID: cred.AppID}, nil
+}
+
+func (adxSpec) payload(name string, acct Account, cred SPCredential, clusterURL string) datasources.Datasource {
+	return datasources.Datasource{
+		Name:   name,
+		Type:   KindADX,
+		Access: "proxy",
+		JSONData: map[string]any{
+			"clusterUrl": clusterURL,
+			"azureCredentials": map[string]any{
+				"authType":   "clientsecret",
+				"azureCloud": armCloud(acct.CloudName),
+				"tenantId":   cred.Tenant,
+				"clientId":   cred.AppID,
+			},
+		},
+		SecureJSONData: map[string]string{
+			"azureClientSecret": cred.Password,
+		},
+	}
+}
+
+// onboardAssignmentName derives a stable, unique-per-app principal assignment
+// name for the cluster grant.
+func onboardAssignmentName(appID string) string {
+	short := strings.ReplaceAll(appID, "-", "")
+	if len(short) > 12 {
+		short = short[:12]
+	}
+	return "gcx-" + short
+}

--- a/internal/onboard/azure/azuremonitor.go
+++ b/internal/onboard/azure/azuremonitor.go
@@ -1,0 +1,77 @@
+package azure
+
+import (
+	"context"
+	"strings"
+
+	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/onboard"
+)
+
+// azureMonitorSpec provisions the Azure Monitor datasource. It uses the flat
+// credential schema (tenantId/clientId/subscriptionId + secureJsonData.clientSecret).
+type azureMonitorSpec struct{}
+
+func (azureMonitorSpec) Token() string { return TokenAzureMonitor }
+func (azureMonitorSpec) Kind() string  { return KindAzureMonitor }
+
+func (azureMonitorSpec) RoleOptions() []RoleOption {
+	// Reader (*/read) already covers metrics, Resource Graph, and Log Analytics
+	// queries: in the default workspace access-control mode ("Use resource or
+	// workspace permissions") a subscription-scoped read grant authorizes all
+	// log reads, so a separate Log Analytics Reader is redundant here. It would
+	// only matter for workspaces set to "Require workspace permissions", which
+	// ignore subscription-scoped grants and need a workspace-scoped assignment
+	// instead — out of scope for this subscription-level onboarding.
+	return []RoleOption{
+		{Label: "Default — Reader (metrics, logs, Resource Graph)", Roles: []string{"Reader"}},
+		{Label: "Metrics only — Monitoring Reader", Roles: []string{"Monitoring Reader"}},
+	}
+}
+
+func (s azureMonitorSpec) AcquireAndBuild(ctx context.Context, in SpecInput) (Provisioned, error) {
+	cred, err := acquireCredential(ctx, in)
+	if err != nil {
+		return Provisioned{}, err
+	}
+	return Provisioned{Request: s.payload(in.Name, in.Account, cred), AppID: cred.AppID}, nil
+}
+
+func (azureMonitorSpec) payload(name string, acct Account, cred SPCredential) datasources.Datasource {
+	return datasources.Datasource{
+		Name:   name,
+		Type:   KindAzureMonitor,
+		Access: "proxy",
+		JSONData: map[string]any{
+			"azureAuthType":  "clientsecret",
+			"cloudName":      monitorCloud(acct.CloudName),
+			"tenantId":       cred.Tenant,
+			"clientId":       cred.AppID,
+			"subscriptionId": acct.SubID,
+		},
+		SecureJSONData: map[string]string{
+			"clientSecret": cred.Password,
+		},
+	}
+}
+
+// acquireCredential mints a new gcx-owned app registration (service principal +
+// secret + least-privilege role assignment) for the datasource.
+func acquireCredential(ctx context.Context, in SpecInput) (SPCredential, error) {
+	onboard.Progressf(in.Progress, "  minting Azure app registration (this can take ~10-20s)...")
+	cred, err := in.CLI.CreateOwnedAppRegistration(ctx, AppRegistrationRequest{
+		Name:        in.Name,
+		Roles:       in.Roles,
+		Scopes:      in.Scopes,
+		CallerOID:   in.CallerOID,
+		Tenant:      in.Account.TenantID,
+		Description: in.attribution().roleDescription(in.Name),
+		ExpiryDays:  in.ExpiryDays,
+		AddUndo:     in.Rollback.Add,
+	})
+	if err != nil {
+		return SPCredential{}, err
+	}
+	onboard.Progressf(in.Progress, "  app registration ready (clientId %s, roles: %s)", cred.AppID, strings.Join(in.Roles, ", "))
+	return cred, nil
+}

--- a/internal/onboard/azure/cleanup.go
+++ b/internal/onboard/azure/cleanup.go
@@ -1,0 +1,176 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/grafana/gcx/internal/onboard"
+	"github.com/grafana/gcx/internal/output"
+)
+
+// CleanupInput scopes and controls a cleanup sweep.
+type CleanupInput struct {
+	// CallerOID, when set, restricts app-registration removal to artifacts
+	// tagged with this owner object ID, so a shared tenant never has one user's
+	// cleanup delete another user's app registrations.
+	CallerOID string
+	// Stack, when set, restricts app-registration removal to artifacts tagged
+	// with this Grafana stack slug.
+	Stack string
+	// DryRun lists what would be removed without deleting anything.
+	DryRun bool
+}
+
+// Cleanup removes gcx-created artifacts: datasources whose name starts with the
+// gcx- prefix, and app registrations that are tagged gcx-managed (and, when a
+// caller/stack is known, owned by this caller and scoped to this stack). It is
+// best-effort — individual failures are warned and skipped. With DryRun set it
+// reports what would be removed without deleting anything.
+//
+// App registrations are enumerated up-front so ADX cluster principal
+// assignments can be scoped to the ones this caller actually owns (see
+// cleanupADXAssignments): the assignment name embeds the owning app, so
+// deletions never revoke another owner's cluster access in a shared tenant.
+func Cleanup(ctx context.Context, deps RunDeps, in CleanupInput) (onboard.Result, error) {
+	// A real cleanup deletes credentials and role grants, so it must be scoped
+	// to the caller. Without a caller OID, ownedByCaller/attributableToCaller
+	// degrades to "any gcx-managed app", which in a shared tenant would delete
+	// other owners' artifacts. Refuse rather than widen the sweep. --dry-run is
+	// read-only and stays allowed.
+	if !in.DryRun && in.CallerOID == "" {
+		return onboard.Result{}, fmt.Errorf(
+			"%w: no signed-in Azure user object ID was resolved (e.g. a service-principal or managed-identity login); re-run as a user, or preview with --dry-run",
+			ErrUnscopedDestructive)
+	}
+
+	prefix := onboard.NamePrefix + "-"
+	var cleaned []onboard.CleanupResult
+
+	onboard.Progressf(deps.Progress, "Listing gcx-created Grafana datasources...")
+	list, err := deps.DS.List(ctx)
+	if err != nil {
+		return onboard.Result{}, err
+	}
+	for _, d := range list {
+		if !strings.HasPrefix(d.Name, prefix) {
+			continue
+		}
+		if in.DryRun {
+			cleaned = append(cleaned, onboard.CleanupResult{Kind: "datasource", Name: d.Name, ID: d.UID, Planned: true})
+			continue
+		}
+		onboard.Progressf(deps.Progress, "  deleting datasource %q...", d.Name)
+		if err := deps.DS.Delete(ctx, d.UID); err != nil {
+			warn(deps.ErrOut, "failed to delete datasource "+d.Name+": "+err.Error())
+			continue
+		}
+		cleaned = append(cleaned, onboard.CleanupResult{Kind: "datasource", Name: d.Name, ID: d.UID})
+	}
+
+	// Enumerate app registrations first so ADX assignment cleanup can be scoped
+	// to the apps this caller owns.
+	onboard.Progressf(deps.Progress, "Listing gcx-created Azure app registrations...")
+	apps, err := deps.CLI.ListAppsByPrefix(ctx, prefix)
+	if err != nil {
+		return onboard.Result{}, err
+	}
+	var owned []AppSummary
+	ownedAssignments := map[string]bool{}
+	for _, a := range apps {
+		if !ownedByCaller(a, in) {
+			if deps.Log != nil {
+				deps.Log.Debug("skipping app registration not attributable to this caller/stack",
+					"appId", a.AppID, "displayName", a.DisplayName)
+			}
+			continue
+		}
+		owned = append(owned, a)
+		ownedAssignments[onboardAssignmentName(a.AppID)] = true
+	}
+
+	// Remove gcx-created ADX cluster principal assignments backing our owned
+	// apps. They outlive the app registration, so clean them before deleting the
+	// apps. Best-effort: discovery failures (e.g. no kusto extension or no ADX
+	// clusters) are warned and skipped.
+	cleaned = append(cleaned, cleanupADXAssignments(ctx, deps, ownedAssignments, in.DryRun)...)
+
+	for _, a := range owned {
+		if in.DryRun {
+			cleaned = append(cleaned, onboard.CleanupResult{Kind: "app-registration", Name: a.DisplayName, ID: a.AppID, Planned: true})
+			continue
+		}
+		onboard.Progressf(deps.Progress, "  deleting app registration %q...", a.DisplayName)
+		if err := deps.CLI.DeleteAppRegistration(ctx, a.AppID); err != nil {
+			warn(deps.ErrOut, "failed to delete app registration "+a.DisplayName+": "+err.Error())
+			continue
+		}
+		cleaned = append(cleaned, onboard.CleanupResult{Kind: "app-registration", Name: a.DisplayName, ID: a.AppID})
+	}
+
+	return onboard.Result{Provider: "azure", Cleaned: cleaned, DryRun: in.DryRun}, nil
+}
+
+// ownedByCaller reports whether an app registration is safe for this caller to
+// remove: it must carry the gcx-managed tag, and — when the caller object ID
+// and/or stack are known — its owner/stack tags must match. This guards a
+// shared tenant against one caller's cleanup deleting another caller's or
+// stack's app registrations.
+func ownedByCaller(a AppSummary, in CleanupInput) bool {
+	return attributableToCaller(a.Tags, in.CallerOID, in.Stack)
+}
+
+// cleanupADXAssignments removes the cluster principal assignments that back the
+// caller's owned app registrations, across all ADX clusters in the active
+// subscription. owned holds the assignment names derived from those apps
+// (onboardAssignmentName); only assignments in this set are deleted, so a shared
+// cluster's other gcx owners are never affected.
+//
+// The trade-off is that an orphaned assignment whose app registration has
+// already been deleted cannot be attributed to this caller and is therefore
+// left in place — the safe choice, since ownership can no longer be proven.
+func cleanupADXAssignments(ctx context.Context, deps RunDeps, owned map[string]bool, dryRun bool) []onboard.CleanupResult {
+	if len(owned) == 0 {
+		return nil
+	}
+
+	onboard.Progressf(deps.Progress, "Listing ADX clusters for gcx-created assignments...")
+	clusters, err := deps.CLI.ListKustoClusters(ctx)
+	if err != nil {
+		warn(deps.ErrOut, "skipping ADX assignment cleanup: "+err.Error())
+		return nil
+	}
+
+	var cleaned []onboard.CleanupResult
+	for _, cl := range clusters {
+		assigns, err := deps.CLI.ListADXClusterAssignments(ctx, cl.RG, cl.Name)
+		if err != nil {
+			warn(deps.ErrOut, "skipping assignments on cluster "+cl.Name+": "+err.Error())
+			continue
+		}
+		for _, a := range assigns {
+			short := adxAssignmentShortName(a.Name)
+			if !owned[short] {
+				continue
+			}
+			if dryRun {
+				cleaned = append(cleaned, onboard.CleanupResult{Kind: "adx-assignment", Name: short, ID: cl.Name, Planned: true})
+				continue
+			}
+			onboard.Progressf(deps.Progress, "  deleting ADX assignment %q on cluster %q...", short, cl.Name)
+			if err := deps.CLI.DeleteADXClusterAssignment(ctx, cl.RG, cl.Name, short); err != nil {
+				warn(deps.ErrOut, "failed to delete ADX assignment "+short+": "+err.Error())
+				continue
+			}
+			cleaned = append(cleaned, onboard.CleanupResult{Kind: "adx-assignment", Name: short, ID: cl.Name})
+		}
+	}
+	return cleaned
+}
+
+func warn(w io.Writer, msg string) {
+	if w != nil {
+		output.EmitWarn(w, msg)
+	}
+}

--- a/internal/onboard/azure/cleanup_test.go
+++ b/internal/onboard/azure/cleanup_test.go
@@ -1,0 +1,187 @@
+//nolint:testpackage // white-box test exercises unexported cleanup helpers
+package azure
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"testing"
+)
+
+func TestCleanup_RemovesOnlyOwnedADXAssignments(t *testing.T) {
+	// onboardAssignmentName("abc123") == "gcx-abc123", so the caller's owned app
+	// backs the assignment "gcx-abc123". A second gcx assignment ("gcx-deadbeef")
+	// belongs to no owned app and must be left alone, as must a non-gcx one.
+	runner := &scriptedRunner{
+		handler: func(args []string) ([]byte, []byte, error) {
+			switch {
+			case hasPrefix(args, []string{"ad", "app", "list"}):
+				return []byte(`[{"appId":"abc123","displayName":"gcx-adx","tags":["gcx:managed","gcx:owner=me"]}]`), nil, nil
+			case hasPrefix(args, []string{"kusto", "cluster", "list"}):
+				return []byte(`[{"name":"adx1","uri":"https://adx1.kusto.windows.net","resourceGroup":"rg1","state":"Running"}]`), nil, nil
+			case hasPrefix(args, []string{"kusto", "cluster-principal-assignment", "list"}):
+				return []byte(`[{"name":"adx1/gcx-abc123"},{"name":"adx1/gcx-deadbeef"},{"name":"adx1/someone-else"}]`), nil, nil
+			default:
+				return nil, nil, nil
+			}
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+
+	// Datasource API: no datasources to remove.
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+
+	res, err := Cleanup(context.Background(), RunDeps{CLI: cli, DS: ds}, CleanupInput{CallerOID: "me"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var gotAssignment bool
+	for _, c := range res.Cleaned {
+		if c.Kind == "adx-assignment" {
+			gotAssignment = true
+			if c.Name != "gcx-abc123" {
+				t.Fatalf("unexpected assignment name %q", c.Name)
+			}
+		}
+	}
+	if !gotAssignment {
+		t.Fatal("expected the caller's owned ADX assignment to be cleaned up")
+	}
+
+	// Only the owned assignment may be deleted; the other gcx app's assignment
+	// and the unrelated one must be untouched.
+	var deletedOwned, deletedOtherGcx, deletedUnrelated bool
+	for _, call := range runner.calls {
+		if !hasPrefix(call, []string{"kusto", "cluster-principal-assignment", "delete"}) {
+			continue
+		}
+		switch {
+		case slices.Contains(call, "gcx-abc123"):
+			deletedOwned = true
+		case slices.Contains(call, "gcx-deadbeef"):
+			deletedOtherGcx = true
+		case slices.Contains(call, "someone-else"):
+			deletedUnrelated = true
+		}
+	}
+	if !deletedOwned {
+		t.Fatal("expected the caller's owned assignment to be deleted")
+	}
+	if deletedOtherGcx {
+		t.Fatal("must not delete a gcx assignment backing another owner's app")
+	}
+	if deletedUnrelated {
+		t.Fatal("must not delete an unrelated assignment")
+	}
+}
+
+func TestCleanup_RefusesWithoutCallerScope(t *testing.T) {
+	// A real (non-dry-run) cleanup with no caller OID must refuse rather than
+	// sweep every gcx-managed app in the tenant.
+	runner := &scriptedRunner{handler: func(args []string) ([]byte, []byte, error) {
+		if hasPrefix(args, []string{"ad", "app", "list"}) {
+			return []byte(`[]`), nil, nil
+		}
+		return nil, nil, nil
+	}}
+	cli := NewCLIWithRunner(runner)
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		t.Error("cleanup must not mutate anything in this test")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	_, err := Cleanup(context.Background(), RunDeps{CLI: cli, DS: ds}, CleanupInput{})
+	if !errors.Is(err, ErrUnscopedDestructive) {
+		t.Fatalf("expected ErrUnscopedDestructive, got %v", err)
+	}
+
+	// A dry-run with no caller OID is still allowed (read-only).
+	if _, err := Cleanup(context.Background(), RunDeps{CLI: cli, DS: ds}, CleanupInput{DryRun: true}); err != nil {
+		t.Fatalf("dry-run cleanup should be allowed without a caller OID, got %v", err)
+	}
+}
+
+func TestCleanup_OnlyRemovesGcxManagedAppsForCaller(t *testing.T) {
+	runner := &scriptedRunner{
+		handler: func(args []string) ([]byte, []byte, error) {
+			switch {
+			case hasPrefix(args, []string{"ad", "app", "list"}):
+				// Three gcx-prefixed apps: ours, another owner's, and an untagged one.
+				return []byte(`[
+					{"appId":"mine","displayName":"gcx-mine","tags":["gcx:managed","gcx:owner=me"]},
+					{"appId":"theirs","displayName":"gcx-theirs","tags":["gcx:managed","gcx:owner=someone-else"]},
+					{"appId":"legacy","displayName":"gcx-legacy","tags":[]}
+				]`), nil, nil
+			case hasPrefix(args, []string{"kusto", "cluster", "list"}):
+				return []byte(`[]`), nil, nil
+			default:
+				return nil, nil, nil
+			}
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+
+	res, err := Cleanup(context.Background(), RunDeps{CLI: cli, DS: ds}, CleanupInput{CallerOID: "me"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.Cleaned) != 1 || res.Cleaned[0].ID != "mine" {
+		t.Fatalf("expected only the caller's gcx-managed app to be cleaned, got %+v", res.Cleaned)
+	}
+	for _, c := range runner.calls {
+		if hasPrefix(c, []string{"ad", "app", "delete"}) {
+			if slices.Contains(c, "theirs") || slices.Contains(c, "legacy") {
+				t.Fatalf("must not delete apps not attributable to the caller: %v", c)
+			}
+		}
+	}
+}
+
+func TestCleanup_DryRunDeletesNothing(t *testing.T) {
+	runner := &scriptedRunner{
+		handler: func(args []string) ([]byte, []byte, error) {
+			switch {
+			case hasPrefix(args, []string{"ad", "app", "list"}):
+				return []byte(`[{"appId":"mine","displayName":"gcx-mine","tags":["gcx:managed"]}]`), nil, nil
+			case hasPrefix(args, []string{"kusto", "cluster", "list"}):
+				return []byte(`[]`), nil, nil
+			default:
+				return nil, nil, nil
+			}
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"uid":"u1","name":"gcx-azure-monitor","type":"grafana-azure-monitor-datasource"}]`))
+	}))
+
+	res, err := Cleanup(context.Background(), RunDeps{CLI: cli, DS: ds}, CleanupInput{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.DryRun {
+		t.Fatal("expected result to be marked as a dry run")
+	}
+	for _, c := range res.Cleaned {
+		if !c.Planned {
+			t.Fatalf("dry-run entries must be marked planned, got %+v", c)
+		}
+	}
+	for _, c := range runner.calls {
+		if hasPrefix(c, []string{"ad", "app", "delete"}) {
+			t.Fatal("must not delete any app during --dry-run")
+		}
+	}
+}

--- a/internal/onboard/azure/cli.go
+++ b/internal/onboard/azure/cli.go
@@ -1,0 +1,575 @@
+// Package azure implements `gcx setup datasources azure`: it discovers Azure resources
+// via the local `az` CLI, mints gcx-owned app registrations per suggested
+// datasource, and provisions the matching Grafana datasource.
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/grafana/gcx/internal/cloudcli"
+	"github.com/grafana/grafana-app-sdk/logging"
+)
+
+const azInstallDocs = "https://learn.microsoft.com/cli/azure/install-azure-cli"
+
+// Attribution tag keys applied to gcx-created app registrations. They make
+// gcx-owned artifacts reliably discoverable and let --cleanup/rotate scope to
+// this caller and stack instead of matching on the fragile name prefix alone.
+const (
+	// TagManaged marks an app registration as created and owned by gcx.
+	TagManaged = "gcx:managed"
+	// tagStackPrefix is followed by the Grafana stack slug the artifact serves.
+	tagStackPrefix = "gcx:stack="
+	// tagOwnerPrefix is followed by the object ID of the caller who created it.
+	tagOwnerPrefix = "gcx:owner="
+	// tagDatasourcePrefix is followed by the UID of the datasource it backs.
+	tagDatasourcePrefix = "gcx:datasource-uid="
+)
+
+// Attribution carries the metadata gcx stamps onto created artifacts (tags on
+// app registrations, descriptions on role assignments) so they can be
+// attributed to gcx, this caller, and a specific Grafana datasource.
+type Attribution struct {
+	Stack         string // Grafana stack slug (may be empty)
+	OwnerOID      string // caller object ID
+	DatasourceUID string // UID of the datasource the credential backs
+}
+
+// Tags renders the attribution as the app-registration tag set.
+func (a Attribution) Tags() []string {
+	tags := []string{TagManaged}
+	if a.Stack != "" {
+		tags = append(tags, tagStackPrefix+a.Stack)
+	}
+	if a.OwnerOID != "" {
+		tags = append(tags, tagOwnerPrefix+a.OwnerOID)
+	}
+	if a.DatasourceUID != "" {
+		tags = append(tags, tagDatasourcePrefix+a.DatasourceUID)
+	}
+	return tags
+}
+
+// roleDescription renders a human-readable role-assignment description used for
+// attribution on `az role assignment create`.
+func (a Attribution) roleDescription(datasourceName string) string {
+	parts := []string{"created-by=gcx", "datasource=" + datasourceName}
+	if a.Stack != "" {
+		parts = append(parts, "stack="+a.Stack)
+	}
+	if a.OwnerOID != "" {
+		parts = append(parts, "owner="+a.OwnerOID)
+	}
+	return strings.Join(parts, "; ")
+}
+
+// hasManagedTag reports whether the given tag set marks a gcx-managed artifact.
+func hasManagedTag(tags []string) bool {
+	return slices.Contains(tags, TagManaged)
+}
+
+// tagValue returns the value of the first tag with the given prefix, or "".
+func tagValue(tags []string, prefix string) string {
+	for _, t := range tags {
+		if v, ok := strings.CutPrefix(t, prefix); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// attributableToCaller reports whether an app registration with the given tags
+// is safe for this caller/stack to act on (cleanup or rotate): it must be
+// gcx-managed, and — when a caller object ID and/or stack slug are known — its
+// owner/stack tags must not belong to a different caller or stack. This guards
+// a shared tenant against cross-user or cross-stack mutation.
+func attributableToCaller(tags []string, callerOID, stack string) bool {
+	if !hasManagedTag(tags) {
+		return false
+	}
+	if callerOID != "" {
+		if owner := tagValue(tags, tagOwnerPrefix); owner != "" && owner != callerOID {
+			return false
+		}
+	}
+	if stack != "" {
+		if s := tagValue(tags, tagStackPrefix); s != "" && s != stack {
+			return false
+		}
+	}
+	return true
+}
+
+// ErrInsufficientPrivilege indicates the signed-in `az` identity lacks the
+// directory or RBAC permissions required to mint an app registration, assign a
+// role, or grant ADX access. The command layer maps this to an actionable
+// error explaining the roles an administrator must grant.
+var ErrInsufficientPrivilege = errors.New("insufficient Azure privileges")
+
+// ErrUnscopedDestructive indicates a destructive sweep (rotate or cleanup) was
+// requested without a resolved caller object ID to scope it. attributableToCaller
+// treats an empty caller OID as "skip the owner check", so proceeding would let
+// the sweep touch every gcx-managed artifact in a shared tenant regardless of
+// owner. gcx refuses instead. It never blocks --dry-run, which mutates nothing.
+var ErrUnscopedDestructive = errors.New("cannot scope destructive operation without a caller identity")
+
+// CLI is a thin wrapper around the `az` binary.
+type CLI struct {
+	tool cloudcli.Tool
+}
+
+// NewCLI returns a CLI backed by the real `az` binary.
+func NewCLI() *CLI {
+	return &CLI{tool: cloudcli.New("az", "Azure CLI", azInstallDocs)}
+}
+
+// NewCLIWithRunner returns a CLI backed by an injected runner (tests).
+func NewCLIWithRunner(r cloudcli.Runner) *CLI {
+	return &CLI{tool: cloudcli.New("az", "Azure CLI", azInstallDocs).WithRunner(r)}
+}
+
+// Ensure verifies the `az` binary is available.
+func (c *CLI) Ensure() error { return c.tool.Ensure() }
+
+// Account holds the fields from `az account show`/`az account list`.
+type Account struct {
+	TenantID  string `json:"tenantId"`
+	SubID     string `json:"id"`
+	Name      string `json:"name"`
+	CloudName string `json:"environmentName"` // AzureCloud / AzureUSGovernment / AzureChinaCloud
+	IsDefault bool   `json:"isDefault"`
+}
+
+// CurrentAccount returns the active subscription (`az account show`).
+func (c *CLI) CurrentAccount(ctx context.Context) (Account, error) {
+	var a Account
+	if err := c.tool.RunJSON(ctx, &a, "account", "show", "-o", "json"); err != nil {
+		return Account{}, err
+	}
+	return a, nil
+}
+
+// ListSubscriptions returns all enabled subscriptions (`az account list`).
+func (c *CLI) ListSubscriptions(ctx context.Context) ([]Account, error) {
+	var a []Account
+	if err := c.tool.RunJSON(ctx, &a, "account", "list", "--only-show-errors", "-o", "json"); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// SetSubscription sets the active `az` subscription. Resource discovery
+// (kusto/cosmos list) operates on the active subscription, so the orchestrator
+// switches subscription before discovering and provisioning per subscription,
+// then restores the original.
+func (c *CLI) SetSubscription(ctx context.Context, subID string) error {
+	if _, stderr, err := c.tool.Run(ctx, "account", "set", "--subscription", subID, "--only-show-errors"); err != nil {
+		return azError("set active subscription "+subID, err, stderr)
+	}
+	return nil
+}
+
+// SignedInUserObjectID returns the object ID of the signed-in user, used to set
+// app/SP ownership at creation time.
+func (c *CLI) SignedInUserObjectID(ctx context.Context) (string, error) {
+	var id string
+	if err := c.tool.RunJSON(ctx, &id, "ad", "signed-in-user", "show", "--query", "id", "-o", "json"); err != nil {
+		return "", classifyAuthErr(err)
+	}
+	return id, nil
+}
+
+// SPCredential carries the credentials a datasource needs to authenticate.
+type SPCredential struct {
+	AppID    string
+	Password string
+	Tenant   string
+}
+
+// AppExists reports whether an app registration with the given display name
+// already exists in the directory.
+func (c *CLI) AppExists(ctx context.Context, displayName string) (bool, error) {
+	var ids []string
+	err := c.tool.RunJSON(ctx, &ids,
+		"ad", "app", "list", "--display-name", displayName,
+		"--query", "[].appId", "--only-show-errors", "-o", "json")
+	if err != nil {
+		return false, classifyAuthErr(err)
+	}
+	return len(ids) > 0, nil
+}
+
+// AppSummary identifies a gcx-created app registration for cleanup and rotation.
+type AppSummary struct {
+	AppID       string   `json:"appId"`
+	DisplayName string   `json:"displayName"`
+	Tags        []string `json:"tags"`
+}
+
+// ListAppsByPrefix lists app registrations whose display name starts with the
+// given prefix, including their tags so callers can further scope by
+// gcx-managed/owner/stack attribution (used by --cleanup and rotate).
+func (c *CLI) ListAppsByPrefix(ctx context.Context, prefix string) ([]AppSummary, error) {
+	var apps []AppSummary
+	filter := fmt.Sprintf("startswith(displayName,'%s')", prefix)
+	err := c.tool.RunJSON(ctx, &apps,
+		"ad", "app", "list", "--filter", filter,
+		"--query", "[].{appId:appId,displayName:displayName,tags:tags}",
+		"--only-show-errors", "-o", "json")
+	if err != nil {
+		return nil, classifyAuthErr(err)
+	}
+	return apps, nil
+}
+
+// AppTags returns the tags on the app registration identified by appID.
+func (c *CLI) AppTags(ctx context.Context, appID string) ([]string, error) {
+	var tags []string
+	err := c.tool.RunJSON(ctx, &tags,
+		"ad", "app", "show", "--id", appID,
+		"--query", "tags", "--only-show-errors", "-o", "json")
+	if err != nil {
+		return nil, classifyAuthErr(err)
+	}
+	return tags, nil
+}
+
+// SetAppTags replaces the tags on the app registration identified by appID via
+// Microsoft Graph (the `az ad app` surface has no direct tags flag). The app is
+// addressed by its appId using the Graph alternate-key syntax so callers do not
+// need the object ID.
+func (c *CLI) SetAppTags(ctx context.Context, appID string, tags []string) error {
+	body, err := json.Marshal(map[string]any{"tags": tags})
+	if err != nil {
+		return fmt.Errorf("marshal tags: %w", err)
+	}
+	uri := fmt.Sprintf("https://graph.microsoft.com/v1.0/applications(appId='%s')", appID)
+	if _, stderr, err := c.tool.Run(ctx, "rest", "--method", "PATCH",
+		"--uri", uri, "--headers", "Content-Type=application/json",
+		"--body", string(body), "--only-show-errors"); err != nil {
+		return azError("set tags on app registration "+appID, err, stderr)
+	}
+	logging.FromContext(ctx).Info("tagged app registration", "appId", appID, "tags", strings.Join(tags, ","))
+	return nil
+}
+
+// AppRegistrationRequest carries the inputs for minting a gcx-owned app
+// registration.
+type AppRegistrationRequest struct {
+	Name      string   // display name (also the datasource name)
+	Roles     []string // Azure RBAC roles to assign over Scopes
+	Scopes    []string // role-assignment scopes
+	CallerOID string   // signed-in user object ID (owner)
+	Tenant    string   // tenant ID echoed back on the credential
+	// Description is attached to each role assignment for attribution.
+	Description string
+	// ExpiryDays, when > 0, sets an explicit end date on the minted client
+	// secret. When 0 the Azure default lifetime applies.
+	ExpiryDays int
+	// AddUndo registers rollback steps for each created object. May be nil.
+	AddUndo func(desc string, undo func(ctx context.Context) error)
+}
+
+// CreateOwnedAppRegistration builds an app registration + service principal with
+// the caller set as owner AT CREATION TIME (each owner-add runs immediately
+// after the object is created, as a required step), then assigns the requested
+// roles over scopes and mints a client secret. We deliberately avoid the
+// one-shot `az ad sp create-for-rbac` so ownership is never deferred.
+//
+// Every created object is registered with req.AddUndo so a caller can roll back
+// on a later failure.
+func (c *CLI) CreateOwnedAppRegistration(ctx context.Context, req AppRegistrationRequest) (SPCredential, error) {
+	log := logging.FromContext(ctx)
+
+	// 1. App registration.
+	var app struct {
+		AppID string `json:"appId"`
+		ID    string `json:"id"`
+	}
+	if err := c.tool.RunJSON(ctx, &app, "ad", "app", "create",
+		"--display-name", req.Name, "--only-show-errors", "-o", "json"); err != nil {
+		return SPCredential{}, classifyAuthErr(err)
+	}
+	log.Info("created app registration", "name", req.Name, "appId", app.AppID, "objectId", app.ID)
+	if req.AddUndo != nil {
+		appID := app.AppID
+		req.AddUndo("delete app registration "+req.Name, func(ctx context.Context) error {
+			return c.DeleteAppRegistration(ctx, appID)
+		})
+	}
+
+	// 2. Owner on the app registration — immediately, required. Creating the app
+	//    already sets the signed-in user as owner, so tolerate the benign
+	//    "already exists" case (idempotent).
+	if _, stderr, err := c.tool.Run(ctx, "ad", "app", "owner", "add",
+		"--id", app.AppID, "--owner-object-id", req.CallerOID, "--only-show-errors"); err != nil && !ownerAlreadyExists(stderr) {
+		return SPCredential{}, azError("add owner to app registration "+req.Name, err, stderr)
+	}
+	log.Info("set app registration owner", "appId", app.AppID, "ownerObjectId", req.CallerOID)
+
+	// 3. Service principal.
+	var sp struct {
+		ID string `json:"id"`
+	}
+	if err := c.tool.RunJSON(ctx, &sp, "ad", "sp", "create",
+		"--id", app.AppID, "--only-show-errors", "-o", "json"); err != nil {
+		return SPCredential{}, classifyAuthErr(err)
+	}
+	log.Info("created service principal", "appId", app.AppID, "spObjectId", sp.ID)
+
+	// 4. Owner on the service principal — immediately, required.
+	//    There is no native `az ad sp owner add`; use Graph via `az rest`.
+	if err := c.addSPOwner(ctx, sp.ID, req.CallerOID); err != nil {
+		return SPCredential{}, err
+	}
+	log.Info("set service principal owner", "spObjectId", sp.ID, "ownerObjectId", req.CallerOID)
+
+	// 5. Role assignments over scopes, stamped with an attribution description.
+	for _, role := range req.Roles {
+		for _, scope := range req.Scopes {
+			args := []string{"role", "assignment", "create",
+				"--assignee", app.AppID, "--role", role, "--scope", scope, "--only-show-errors"}
+			if req.Description != "" {
+				args = append(args, "--description", req.Description)
+			}
+			if _, stderr, err := c.tool.Run(ctx, args...); err != nil {
+				return SPCredential{}, azError(fmt.Sprintf("assign role %q on %s", role, scope), err, stderr)
+			}
+			log.Info("assigned role", "appId", app.AppID, "role", role, "scope", scope)
+		}
+	}
+
+	// 6. Client secret (shown once).
+	cred, err := c.resetSecret(ctx, app.AppID, req.ExpiryDays)
+	if err != nil {
+		return SPCredential{}, err
+	}
+	log.Info("minted client secret", "appId", app.AppID)
+
+	return SPCredential{AppID: app.AppID, Password: cred.Password, Tenant: req.Tenant}, nil
+}
+
+// secretReset is the subset of `az ad app credential reset` output gcx needs.
+type secretReset struct {
+	Password string `json:"password"`
+	KeyID    string `json:"keyId"`
+}
+
+// resetSecret appends a new client secret to the app registration and returns
+// it. When expiryDays > 0 an explicit end date is set so the secret has a
+// bounded lifetime.
+func (c *CLI) resetSecret(ctx context.Context, appID string, expiryDays int) (secretReset, error) {
+	args := []string{"ad", "app", "credential", "reset", "--id", appID, "--append", "--only-show-errors", "-o", "json"}
+	if expiryDays > 0 {
+		end := time.Now().UTC().AddDate(0, 0, expiryDays).Format("2006-01-02T15:04:05Z")
+		args = append(args, "--end-date", end)
+	}
+	var cred secretReset
+	if err := c.tool.RunJSON(ctx, &cred, args...); err != nil {
+		return secretReset{}, classifyAuthErr(err)
+	}
+	return cred, nil
+}
+
+// RotateSecret mints a fresh client secret on the app registration (appending a
+// new credential) and returns the new secret plus its key ID. The caller is
+// responsible for updating the consuming datasource and then, once that
+// succeeds, pruning the older secrets via PruneSecretsExcept.
+func (c *CLI) RotateSecret(ctx context.Context, appID string, expiryDays int) (SPCredentialRotation, error) {
+	cred, err := c.resetSecret(ctx, appID, expiryDays)
+	if err != nil {
+		return SPCredentialRotation{}, err
+	}
+	logging.FromContext(ctx).Info("rotated client secret", "appId", appID, "keyId", cred.KeyID)
+	return SPCredentialRotation{Secret: cred.Password, KeyID: cred.KeyID}, nil
+}
+
+// SPCredentialRotation is the result of minting a fresh client secret: the new
+// secret value and the key ID that identifies it (so the caller can prune the
+// superseded credentials).
+type SPCredentialRotation struct {
+	Secret string
+	KeyID  string
+}
+
+// appCredential is one password credential on an app registration.
+type appCredential struct {
+	KeyID string `json:"keyId"`
+}
+
+// PruneSecretsExcept deletes every password credential on the app registration
+// except the one identified by keepKeyID. Best-effort: individual delete
+// failures are returned joined so the caller can warn. It is used after a
+// successful rotation to retire the superseded secret(s).
+func (c *CLI) PruneSecretsExcept(ctx context.Context, appID, keepKeyID string) error {
+	var creds []appCredential
+	if err := c.tool.RunJSON(ctx, &creds, "ad", "app", "credential", "list",
+		"--id", appID, "--only-show-errors", "-o", "json"); err != nil {
+		return classifyAuthErr(err)
+	}
+	var errs []error
+	for _, cr := range creds {
+		if cr.KeyID == "" || cr.KeyID == keepKeyID {
+			continue
+		}
+		if _, stderr, err := c.tool.Run(ctx, "ad", "app", "credential", "delete",
+			"--id", appID, "--key-id", cr.KeyID, "--only-show-errors"); err != nil {
+			errs = append(errs, azError("delete superseded secret "+cr.KeyID, err, stderr))
+			continue
+		}
+		logging.FromContext(ctx).Info("pruned superseded client secret", "appId", appID, "keyId", cr.KeyID)
+	}
+	return errors.Join(errs...)
+}
+
+// addSPOwner adds an owner to a service principal via Microsoft Graph (az rest),
+// since the CLI has no native `az ad sp owner add`.
+//
+// Creating the service principal (`az ad sp create`) already adds the signed-in
+// user as an owner, so this POST commonly returns Request_BadRequest reporting
+// the owner reference already exists. That is the desired end state, so we treat
+// it as success (idempotent).
+func (c *CLI) addSPOwner(ctx context.Context, spObjectID, ownerOID string) error {
+	body := fmt.Sprintf(`{"@odata.id":"https://graph.microsoft.com/v1.0/directoryObjects/%s"}`, ownerOID)
+	uri := "https://graph.microsoft.com/v1.0/servicePrincipals/" + spObjectID + "/owners/$ref"
+	if _, stderr, err := c.tool.Run(ctx, "rest", "--method", "POST",
+		"--uri", uri, "--headers", "Content-Type=application/json",
+		"--body", body, "--only-show-errors"); err != nil {
+		if ownerAlreadyExists(stderr) {
+			return nil
+		}
+		return azError("add owner to service principal", err, stderr)
+	}
+	return nil
+}
+
+// ownerAlreadyExists reports whether a Graph "add owner" failure is the benign
+// case where the owner reference is already present.
+func ownerAlreadyExists(stderr []byte) bool {
+	s := strings.ToLower(string(stderr))
+	return strings.Contains(s, "already exist") && strings.Contains(s, "owners")
+}
+
+// GrantADXClusterViewer grants the app principal AllDatabasesViewer on a Kusto
+// cluster via the control-plane API. This avoids enumerating databases and does
+// not require Kusto data-plane admin rights (only ARM Owner/Contributor on the
+// cluster). assignmentName must be unique within the cluster.
+func (c *CLI) GrantADXClusterViewer(ctx context.Context, rg, cluster, assignmentName, appID, tenant string) error {
+	if _, stderr, err := c.tool.Run(ctx, "kusto", "cluster-principal-assignment", "create",
+		"--cluster-name", cluster, "--resource-group", rg,
+		"--principal-assignment-name", assignmentName,
+		"--principal-id", appID, "--principal-type", "App",
+		"--role", "AllDatabasesViewer", "--tenant-id", tenant, "--only-show-errors"); err != nil {
+		return azError("grant AllDatabasesViewer on cluster "+cluster, err, stderr)
+	}
+	logging.FromContext(ctx).Info("granted ADX cluster viewer",
+		"cluster", cluster, "resourceGroup", rg, "appId", appID, "assignment", assignmentName)
+	return nil
+}
+
+// ADXPrincipalAssignment identifies a Kusto cluster principal assignment. The
+// ARM Name is "<cluster>/<assignmentName>"; use adxAssignmentShortName to
+// extract the assignment name for delete.
+type ADXPrincipalAssignment struct {
+	Name string `json:"name"`
+}
+
+// ListADXClusterAssignments lists the cluster principal assignments on a Kusto
+// cluster (used by --cleanup to find gcx-created grants).
+func (c *CLI) ListADXClusterAssignments(ctx context.Context, rg, cluster string) ([]ADXPrincipalAssignment, error) {
+	var out []ADXPrincipalAssignment
+	if err := c.tool.RunJSON(ctx, &out, "kusto", "cluster-principal-assignment", "list",
+		"--cluster-name", cluster, "--resource-group", rg, "--only-show-errors", "-o", "json"); err != nil {
+		return nil, classifyAuthErr(err)
+	}
+	return out, nil
+}
+
+// DeleteADXClusterAssignment removes a cluster principal assignment, used by
+// rollback and cleanup.
+func (c *CLI) DeleteADXClusterAssignment(ctx context.Context, rg, cluster, assignmentName string) error {
+	if _, stderr, err := c.tool.Run(ctx, "kusto", "cluster-principal-assignment", "delete",
+		"--cluster-name", cluster, "--resource-group", rg,
+		"--principal-assignment-name", assignmentName, "--yes", "--only-show-errors"); err != nil {
+		return azError("delete ADX principal assignment "+assignmentName, err, stderr)
+	}
+	logging.FromContext(ctx).Info("deleted ADX cluster assignment", "cluster", cluster, "assignment", assignmentName)
+	return nil
+}
+
+// adxAssignmentShortName extracts the assignment name from an ARM child name of
+// the form "<cluster>/<assignmentName>".
+func adxAssignmentShortName(armName string) string {
+	if i := strings.LastIndex(armName, "/"); i >= 0 {
+		return armName[i+1:]
+	}
+	return armName
+}
+
+// DeleteAppRegistration removes an app registration (and its service principal),
+// used by rollback and cleanup.
+func (c *CLI) DeleteAppRegistration(ctx context.Context, appID string) error {
+	if _, stderr, err := c.tool.Run(ctx, "ad", "app", "delete", "--id", appID, "--only-show-errors"); err != nil {
+		return fmt.Errorf("failed to delete app registration %q: %w: %s", appID, err, strings.TrimSpace(string(stderr)))
+	}
+	logging.FromContext(ctx).Info("deleted app registration", "appId", appID)
+	return nil
+}
+
+// authMarkers identify authorization failures in `az` error output.
+var authMarkers = []string{ //nolint:gochecknoglobals
+	"authorizationfailed",
+	"insufficient privileges",
+	"does not have authorization",
+	"forbidden",
+	"403",
+	"authorization_requestdenied",
+	"privilege",
+}
+
+func isAuthErr(text string) bool {
+	lower := strings.ToLower(text)
+	for _, m := range authMarkers {
+		if strings.Contains(lower, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyAuthErr classifies a RunJSON error (which already embeds the az
+// stderr in its message) and wraps ErrInsufficientPrivilege when it looks like
+// an authorization failure.
+func classifyAuthErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if isAuthErr(err.Error()) {
+		return fmt.Errorf("%w: %w", ErrInsufficientPrivilege, err)
+	}
+	return err
+}
+
+// azError builds a descriptive error from a Run-based `az` failure. It ALWAYS
+// includes the captured stderr so users see the underlying `az` message instead
+// of a bare "exit status 1", and classifies authorization failures as
+// ErrInsufficientPrivilege so the command layer can surface actionable guidance.
+func azError(desc string, err error, stderr []byte) error {
+	detail := strings.TrimSpace(string(stderr))
+	if isAuthErr(err.Error() + " " + detail) {
+		if detail == "" {
+			detail = err.Error()
+		}
+		return fmt.Errorf("%s: %w: %s", desc, ErrInsufficientPrivilege, detail)
+	}
+	if detail != "" {
+		return fmt.Errorf("%s: %w: %s", desc, err, detail)
+	}
+	return fmt.Errorf("%s: %w", desc, err)
+}

--- a/internal/onboard/azure/cli_test.go
+++ b/internal/onboard/azure/cli_test.go
@@ -1,0 +1,176 @@
+//nolint:testpackage // white-box tests exercise unexported CLI sequencing helpers
+package azure
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// scriptedRunner returns canned stdout/err based on the leading args and
+// records the order of calls. It is safe for concurrent use so it can back the
+// parallel provisioning path under the race detector.
+type scriptedRunner struct {
+	mu      sync.Mutex
+	calls   [][]string
+	handler func(args []string) (stdout, stderr []byte, err error)
+	lookErr error
+}
+
+func (s *scriptedRunner) LookPath(string) error { return s.lookErr }
+
+func (s *scriptedRunner) Run(_ context.Context, _ string, args ...string) ([]byte, []byte, error) {
+	s.mu.Lock()
+	s.calls = append(s.calls, args)
+	s.mu.Unlock()
+	if s.handler != nil {
+		return s.handler(args)
+	}
+	return nil, nil, nil
+}
+
+func hasPrefix(args, prefix []string) bool {
+	if len(args) < len(prefix) {
+		return false
+	}
+	for i := range prefix {
+		if args[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCreateOwnedAppRegistration_SetsOwnersAtCreationTime(t *testing.T) {
+	runner := &scriptedRunner{
+		handler: func(args []string) ([]byte, []byte, error) {
+			switch {
+			case hasPrefix(args, []string{"ad", "app", "create"}):
+				return []byte(`{"appId":"app-123","id":"obj-1"}`), nil, nil
+			case hasPrefix(args, []string{"ad", "sp", "create"}):
+				return []byte(`{"id":"sp-1"}`), nil, nil
+			case hasPrefix(args, []string{"ad", "app", "credential", "reset"}):
+				return []byte(`{"password":"s3cret"}`), nil, nil
+			default:
+				return nil, nil, nil
+			}
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+
+	cred, err := cli.CreateOwnedAppRegistration(context.Background(), AppRegistrationRequest{
+		Name:      "gcx-azure-monitor",
+		Roles:     []string{"Reader", "Monitoring Reader"},
+		Scopes:    []string{"/subscriptions/sub-1"},
+		CallerOID: "caller-oid",
+		Tenant:    "tenant-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cred.AppID != "app-123" || cred.Password != "s3cret" || cred.Tenant != "tenant-1" {
+		t.Fatalf("unexpected credential: %+v", cred)
+	}
+
+	// Verify ordering: app create -> app owner add -> sp create -> sp owner (rest)
+	// -> role assignments -> credential reset.
+	idx := func(prefix ...string) int {
+		for i, c := range runner.calls {
+			if hasPrefix(c, prefix) {
+				return i
+			}
+		}
+		return -1
+	}
+	appCreate := idx("ad", "app", "create")
+	appOwner := idx("ad", "app", "owner", "add")
+	spCreate := idx("ad", "sp", "create")
+	spOwner := idx("rest", "--method", "POST")
+	roleAssign := idx("role", "assignment", "create")
+	credReset := idx("ad", "app", "credential", "reset")
+
+	ordered := appCreate < appOwner && appOwner < spCreate && spCreate < spOwner &&
+		spOwner < roleAssign && roleAssign < credReset
+	if !ordered {
+		t.Fatalf("unexpected call ordering: appCreate=%d appOwner=%d spCreate=%d spOwner=%d roleAssign=%d credReset=%d",
+			appCreate, appOwner, spCreate, spOwner, roleAssign, credReset)
+	}
+
+	// Both roles should be assigned over the single scope.
+	roleAssignments := 0
+	for _, c := range runner.calls {
+		if hasPrefix(c, []string{"role", "assignment", "create"}) {
+			roleAssignments++
+		}
+	}
+	if roleAssignments != 2 {
+		t.Fatalf("expected 2 role assignments, got %d", roleAssignments)
+	}
+}
+
+func TestCreateOwnedAppRegistration_RegistersRollback(t *testing.T) {
+	runner := &scriptedRunner{
+		handler: func(args []string) ([]byte, []byte, error) {
+			if hasPrefix(args, []string{"ad", "app", "create"}) {
+				return []byte(`{"appId":"app-xyz","id":"obj-1"}`), nil, nil
+			}
+			// Fail at owner add to ensure the rollback was already registered.
+			if hasPrefix(args, []string{"ad", "app", "owner", "add"}) {
+				return nil, []byte("AuthorizationFailed"), errors.New("exit 1")
+			}
+			return nil, nil, nil
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+
+	var undos []string
+	addUndo := func(desc string, _ func(ctx context.Context) error) { undos = append(undos, desc) }
+
+	_, err := cli.CreateOwnedAppRegistration(context.Background(), AppRegistrationRequest{
+		Name:      "gcx-adx-foo",
+		Roles:     []string{"Reader"},
+		Scopes:    []string{"/subscriptions/sub-1"},
+		CallerOID: "caller-oid",
+		Tenant:    "tenant-1",
+		AddUndo:   addUndo,
+	})
+	if !errors.Is(err, ErrInsufficientPrivilege) {
+		t.Fatalf("expected ErrInsufficientPrivilege, got %v", err)
+	}
+	if len(undos) != 1 || !strings.Contains(undos[0], "gcx-adx-foo") {
+		t.Fatalf("expected rollback registered for the app reg, got %v", undos)
+	}
+}
+
+func TestGrantADXClusterViewer_ClassifiesAuthFailure(t *testing.T) {
+	runner := &scriptedRunner{
+		handler: func([]string) ([]byte, []byte, error) {
+			return nil, []byte("ERROR: AuthorizationFailed"), errors.New("exit 1")
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+
+	err := cli.GrantADXClusterViewer(context.Background(), "rg", "cluster", "gcx-assign", "app-1", "tenant-1")
+	if !errors.Is(err, ErrInsufficientPrivilege) {
+		t.Fatalf("expected ErrInsufficientPrivilege, got %v", err)
+	}
+}
+
+func TestAppExists(t *testing.T) {
+	runner := &scriptedRunner{
+		handler: func([]string) ([]byte, []byte, error) {
+			return []byte(`["app-1"]`), nil, nil
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+
+	exists, err := cli.AppExists(context.Background(), "gcx-azure-monitor")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected app to exist")
+	}
+}

--- a/internal/onboard/azure/cosmos.go
+++ b/internal/onboard/azure/cosmos.go
@@ -1,0 +1,49 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/gcx/internal/datasources"
+)
+
+// cosmosSpec provisions the Azure Cosmos DB datasource (Enterprise plugin).
+// Cosmos DB does not support service-principal auth, so gcx does not mint an
+// app registration; it fetches the account's primary key instead. The Grafana
+// instance must have the grafana-azurecosmosdb-datasource Enterprise plugin
+// installed for the created datasource to function.
+type cosmosSpec struct{}
+
+func (cosmosSpec) Token() string             { return TokenCosmos }
+func (cosmosSpec) Kind() string              { return KindCosmos }
+func (cosmosSpec) RoleOptions() []RoleOption { return nil }
+
+func (s cosmosSpec) AcquireAndBuild(ctx context.Context, in SpecInput) (Provisioned, error) {
+	rg := in.Extra["rg"]
+	account := in.Extra["account"]
+	endpoint := in.Extra["endpoint"]
+	if rg == "" || account == "" {
+		return Provisioned{}, fmt.Errorf("cosmos: missing account/resource-group for %q", in.Name)
+	}
+
+	key, err := in.CLI.CosmosPrimaryKey(ctx, rg, account)
+	if err != nil {
+		return Provisioned{}, err
+	}
+
+	return Provisioned{Request: s.payload(in.Name, endpoint, key)}, nil
+}
+
+func (cosmosSpec) payload(name, endpoint, key string) datasources.Datasource {
+	return datasources.Datasource{
+		Name:   name,
+		Type:   KindCosmos,
+		Access: "proxy",
+		JSONData: map[string]any{
+			"accountEndpoint": endpoint,
+		},
+		SecureJSONData: map[string]string{
+			"accountKey": key,
+		},
+	}
+}

--- a/internal/onboard/azure/discover.go
+++ b/internal/onboard/azure/discover.go
@@ -1,0 +1,83 @@
+package azure
+
+import (
+	"context"
+	"strings"
+)
+
+// KustoCluster is a discovered Azure Data Explorer cluster.
+type KustoCluster struct {
+	Name string `json:"name"`
+	URI  string `json:"uri"`
+	RG   string `json:"resourceGroup"`
+	// State is the cluster runtime state (e.g. "Running", "Stopped",
+	// "Starting"). Provisioning requires a running cluster.
+	State string `json:"state"`
+	// PublicNetworkAccess is the cluster's public network access setting
+	// ("Enabled"/"Disabled"). "Disabled" means Grafana Cloud can only reach the
+	// cluster via Private Data source Connect (PDC).
+	PublicNetworkAccess string `json:"publicNetworkAccess"`
+}
+
+// IsRunning reports whether the cluster is in a state that supports
+// provisioning (role/principal assignment and live queries).
+func (c KustoCluster) IsRunning() bool {
+	return strings.EqualFold(c.State, "Running")
+}
+
+// isPrivate reports whether an Azure resource's publicNetworkAccess value
+// indicates the resource is not publicly reachable. An empty value is treated
+// as public (the common default) so we never emit a spurious PDC hint.
+func isPrivate(publicNetworkAccess string) bool {
+	return strings.EqualFold(publicNetworkAccess, "Disabled")
+}
+
+// IsPrivate reports whether the cluster has public network access disabled.
+func (c KustoCluster) IsPrivate() bool { return isPrivate(c.PublicNetworkAccess) }
+
+// ListKustoClusters discovers ADX clusters via `az kusto cluster list`. The
+// command requires the `kusto` az extension (auto-installed by az on first use)
+// and Reader access; callers should treat an error as "no ADX clusters".
+func (c *CLI) ListKustoClusters(ctx context.Context) ([]KustoCluster, error) {
+	var clusters []KustoCluster
+	if err := c.tool.RunJSON(ctx, &clusters, "kusto", "cluster", "list", "--only-show-errors", "-o", "json"); err != nil {
+		return nil, err
+	}
+	return clusters, nil
+}
+
+// CosmosAccount is a discovered Azure Cosmos DB account.
+type CosmosAccount struct {
+	Name             string `json:"name"`
+	RG               string `json:"resourceGroup"`
+	DocumentEndpoint string `json:"documentEndpoint"`
+	// PublicNetworkAccess is the account's public network access setting
+	// ("Enabled"/"Disabled"). "Disabled" means Grafana Cloud can only reach the
+	// account via Private Data source Connect (PDC).
+	PublicNetworkAccess string `json:"publicNetworkAccess"`
+}
+
+// IsPrivate reports whether the account has public network access disabled.
+func (a CosmosAccount) IsPrivate() bool { return isPrivate(a.PublicNetworkAccess) }
+
+// ListCosmosAccounts discovers Cosmos DB accounts via `az cosmosdb list`.
+func (c *CLI) ListCosmosAccounts(ctx context.Context) ([]CosmosAccount, error) {
+	var accounts []CosmosAccount
+	if err := c.tool.RunJSON(ctx, &accounts, "cosmosdb", "list", "--only-show-errors", "-o", "json"); err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
+// CosmosPrimaryKey fetches the primary master key for a Cosmos account.
+func (c *CLI) CosmosPrimaryKey(ctx context.Context, rg, account string) (string, error) {
+	var keys struct {
+		PrimaryMasterKey string `json:"primaryMasterKey"`
+	}
+	if err := c.tool.RunJSON(ctx, &keys, "cosmosdb", "keys", "list",
+		"--name", account, "--resource-group", rg, "--type", "keys",
+		"--only-show-errors", "-o", "json"); err != nil {
+		return "", classifyAuthErr(err)
+	}
+	return keys.PrimaryMasterKey, nil
+}

--- a/internal/onboard/azure/payload_test.go
+++ b/internal/onboard/azure/payload_test.go
@@ -1,0 +1,95 @@
+//nolint:testpackage // white-box tests exercise unexported payload builders
+package azure
+
+import "testing"
+
+func TestAzureMonitorPayload_FlatSchema(t *testing.T) {
+	acct := Account{TenantID: "t-1", SubID: "sub-1", CloudName: "AzureCloud"}
+	cred := SPCredential{AppID: "app-1", Password: "secret", Tenant: "t-1"}
+
+	req := azureMonitorSpec{}.payload("gcx-azure-monitor", acct, cred)
+
+	if req.Type != KindAzureMonitor {
+		t.Fatalf("type = %q", req.Type)
+	}
+	if req.JSONData["azureAuthType"] != "clientsecret" {
+		t.Fatalf("azureAuthType = %v", req.JSONData["azureAuthType"])
+	}
+	if req.JSONData["cloudName"] != "azuremonitor" {
+		t.Fatalf("cloudName = %v", req.JSONData["cloudName"])
+	}
+	if req.JSONData["clientId"] != "app-1" || req.JSONData["tenantId"] != "t-1" || req.JSONData["subscriptionId"] != "sub-1" {
+		t.Fatalf("unexpected jsonData: %v", req.JSONData)
+	}
+	if req.SecureJSONData["clientSecret"] != "secret" {
+		t.Fatalf("clientSecret = %q", req.SecureJSONData["clientSecret"])
+	}
+	// Flat schema must NOT nest azureCredentials.
+	if _, ok := req.JSONData["azureCredentials"]; ok {
+		t.Fatal("azure monitor payload must use the flat schema")
+	}
+}
+
+func TestADXPayload_NestedAzureCredentials(t *testing.T) {
+	acct := Account{TenantID: "t-1", SubID: "sub-1", CloudName: "AzureUSGovernment"}
+	cred := SPCredential{AppID: "app-1", Password: "secret", Tenant: "t-1"}
+
+	req := adxSpec{}.payload("gcx-adx-foo", acct, cred, "https://foo.kusto.windows.net")
+
+	if req.Type != KindADX {
+		t.Fatalf("type = %q", req.Type)
+	}
+	if req.JSONData["clusterUrl"] != "https://foo.kusto.windows.net" {
+		t.Fatalf("clusterUrl = %v", req.JSONData["clusterUrl"])
+	}
+	creds, ok := req.JSONData["azureCredentials"].(map[string]any)
+	if !ok {
+		t.Fatalf("azureCredentials missing or wrong type: %v", req.JSONData["azureCredentials"])
+	}
+	if creds["authType"] != "clientsecret" {
+		t.Fatalf("authType = %v", creds["authType"])
+	}
+	if creds["azureCloud"] != "AzureUSGovernment" {
+		t.Fatalf("azureCloud = %v", creds["azureCloud"])
+	}
+	if req.SecureJSONData["azureClientSecret"] != "secret" {
+		t.Fatalf("azureClientSecret = %q", req.SecureJSONData["azureClientSecret"])
+	}
+}
+
+func TestCloudNameMapping(t *testing.T) {
+	cases := []struct {
+		env         string
+		wantMonitor string
+		wantARM     string
+	}{
+		{"AzureCloud", "azuremonitor", "AzureCloud"},
+		{"AzureUSGovernment", "govazuremonitor", "AzureUSGovernment"},
+		{"AzureChinaCloud", "chinaazuremonitor", "AzureChinaCloud"},
+		{"", "azuremonitor", "AzureCloud"},
+	}
+	for _, c := range cases {
+		if got := monitorCloud(c.env); got != c.wantMonitor {
+			t.Errorf("monitorCloud(%q) = %q, want %q", c.env, got, c.wantMonitor)
+		}
+		if got := armCloud(c.env); got != c.wantARM {
+			t.Errorf("armCloud(%q) = %q, want %q", c.env, got, c.wantARM)
+		}
+	}
+}
+
+func TestArtifactName(t *testing.T) {
+	cases := []struct {
+		stack, token, resource string
+		want                   string
+	}{
+		{"mystack", "azure-monitor", "", "gcx-mystack-azure-monitor"},
+		{"", "azure-monitor", "", "gcx-azure-monitor"},
+		{"mystack", "adx", "My Cluster", "gcx-mystack-adx-my-cluster"},
+	}
+	for _, c := range cases {
+		if got := artifactName(c.stack, c.token, c.resource); got != c.want {
+			t.Errorf("artifactName(%q,%q,%q) = %q, want %q", c.stack, c.token, c.resource, got, c.want)
+		}
+	}
+}

--- a/internal/onboard/azure/plan.go
+++ b/internal/onboard/azure/plan.go
@@ -1,0 +1,93 @@
+package azure
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/grafana/gcx/internal/onboard"
+	"github.com/grafana/grafana-app-sdk/logging"
+)
+
+// PlanInput controls suggestion building.
+type PlanInput struct {
+	CLI           *CLI
+	Stack         string // naming label (e.g. stack slug) used in artifact names
+	Account       Account
+	IncludeCosmos bool
+	Log           logging.Logger
+}
+
+// BuildPlan discovers Azure resources and returns the datasources gcx suggests
+// creating. Azure Monitor is always suggested; ADX is suggested per discovered
+// cluster (one datasource per cluster); Cosmos DB is suggested per account only
+// when opted in.
+func BuildPlan(ctx context.Context, in PlanInput) []Suggestion {
+	sub := "/subscriptions/" + in.Account.SubID
+	out := []Suggestion{{
+		Spec:   azureMonitorSpec{},
+		Name:   artifactName(in.Stack, TokenAzureMonitor, ""),
+		Label:  "Azure Monitor (" + in.Account.Name + ")",
+		Scopes: []string{sub},
+	}}
+
+	clusters, err := in.CLI.ListKustoClusters(ctx)
+	if err != nil && in.Log != nil {
+		in.Log.Debug("ADX discovery skipped", "error", err.Error())
+	}
+	for _, cl := range clusters {
+		s := Suggestion{
+			Spec:           adxSpec{},
+			Name:           artifactName(in.Stack, TokenADX, cl.Name),
+			Label:          "Azure Data Explorer — " + cl.Name,
+			Scopes:         []string{sub},
+			Extra:          map[string]string{"clusterUrl": cl.URI, "rg": cl.RG, "cluster": cl.Name},
+			PrivateNetwork: cl.IsPrivate(),
+		}
+		if !cl.IsRunning() {
+			s.Disabled = true
+			state := cl.State
+			if state == "" {
+				state = "not running"
+			}
+			s.DisabledReason = "cluster is " + strings.ToLower(state) + "; start it to provision"
+		}
+		out = append(out, s)
+	}
+
+	if in.IncludeCosmos {
+		accounts, err := in.CLI.ListCosmosAccounts(ctx)
+		if err != nil && in.Log != nil {
+			in.Log.Debug("Cosmos discovery skipped", "error", err.Error())
+		}
+		for _, a := range accounts {
+			out = append(out, Suggestion{
+				Spec:           cosmosSpec{},
+				Name:           artifactName(in.Stack, TokenCosmos, a.Name),
+				Label:          "Azure Cosmos DB — " + a.Name + " (requires Enterprise plugin)",
+				Extra:          map[string]string{"endpoint": a.DocumentEndpoint, "rg": a.RG, "account": a.Name},
+				PrivateNetwork: a.IsPrivate(),
+			})
+		}
+	}
+
+	return out
+}
+
+var nameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9-]+`)
+
+// artifactName builds a stable, gcx-prefixed name for an app registration /
+// datasource: gcx-<stack>-<token>[-<resource>], lower-cased and sanitized.
+func artifactName(stack, token, resource string) string {
+	parts := []string{onboard.NamePrefix}
+	if stack != "" {
+		parts = append(parts, stack)
+	}
+	parts = append(parts, token)
+	if resource != "" {
+		parts = append(parts, resource)
+	}
+	name := strings.ToLower(strings.Join(parts, "-"))
+	name = nameSanitizer.ReplaceAllString(name, "-")
+	return strings.Trim(name, "-")
+}

--- a/internal/onboard/azure/plan_test.go
+++ b/internal/onboard/azure/plan_test.go
@@ -1,0 +1,152 @@
+//nolint:testpackage // white-box tests exercise unexported plan builders
+package azure
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestBuildPlan_AzureMonitorAlwaysAndADXPerCluster(t *testing.T) {
+	runner := &scriptedRunner{
+		handler: func(args []string) ([]byte, []byte, error) {
+			if hasPrefix(args, []string{"kusto", "cluster", "list"}) {
+				return []byte(`[{"name":"adx1","uri":"https://adx1.kusto.windows.net","resourceGroup":"rg1","state":"Running"}]`), nil, nil
+			}
+			return nil, nil, nil
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+
+	plan := BuildPlan(context.Background(), PlanInput{
+		CLI:     cli,
+		Stack:   "mystack",
+		Account: Account{SubID: "sub-1", Name: "Sub One"},
+	})
+
+	if len(plan) != 2 {
+		t.Fatalf("expected 2 suggestions (azure monitor + 1 adx), got %d", len(plan))
+	}
+	if plan[0].Spec.Token() != TokenAzureMonitor {
+		t.Fatalf("first suggestion = %q, want azure-monitor", plan[0].Spec.Token())
+	}
+	if plan[1].Spec.Token() != TokenADX {
+		t.Fatalf("second suggestion = %q, want adx", plan[1].Spec.Token())
+	}
+	if plan[1].Extra["clusterUrl"] != "https://adx1.kusto.windows.net" {
+		t.Fatalf("adx clusterUrl = %q", plan[1].Extra["clusterUrl"])
+	}
+	if plan[1].Name != "gcx-mystack-adx-adx1" {
+		t.Fatalf("adx name = %q", plan[1].Name)
+	}
+	if plan[1].Disabled {
+		t.Fatalf("running ADX cluster should be selectable, got Disabled=true (%q)", plan[1].DisabledReason)
+	}
+}
+
+func TestBuildPlan_StoppedADXClusterIsDisabled(t *testing.T) {
+	runner := &scriptedRunner{
+		handler: func(args []string) ([]byte, []byte, error) {
+			if hasPrefix(args, []string{"kusto", "cluster", "list"}) {
+				return []byte(`[{"name":"adx-stopped","uri":"https://adx-stopped.kusto.windows.net","resourceGroup":"rg1","state":"Stopped"}]`), nil, nil
+			}
+			return nil, nil, nil
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+
+	plan := BuildPlan(context.Background(), PlanInput{CLI: cli, Account: Account{SubID: "sub-1"}})
+	if len(plan) != 2 {
+		t.Fatalf("expected 2 suggestions (azure monitor + 1 adx), got %d", len(plan))
+	}
+	adx := plan[1]
+	if adx.Spec.Token() != TokenADX {
+		t.Fatalf("second suggestion = %q, want adx", adx.Spec.Token())
+	}
+	if !adx.Disabled {
+		t.Fatal("stopped ADX cluster should be Disabled")
+	}
+	if adx.DisabledReason == "" {
+		t.Fatal("disabled suggestion should carry a reason")
+	}
+}
+
+func TestBuildPlan_ADXDiscoveryErrorIsTolerated(t *testing.T) {
+	runner := &scriptedRunner{
+		handler: func(args []string) ([]byte, []byte, error) {
+			if hasPrefix(args, []string{"kusto", "cluster", "list"}) {
+				return nil, []byte("extension not installed"), errors.New("exit 1")
+			}
+			return nil, nil, nil
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+
+	plan := BuildPlan(context.Background(), PlanInput{CLI: cli, Account: Account{SubID: "sub-1"}})
+	if len(plan) != 1 {
+		t.Fatalf("expected only azure monitor when ADX discovery fails, got %d", len(plan))
+	}
+}
+
+func TestBuildPlan_PrivateNetworkFlaggedOnADXAndCosmos(t *testing.T) {
+	runner := &scriptedRunner{
+		handler: func(args []string) ([]byte, []byte, error) {
+			switch {
+			case hasPrefix(args, []string{"kusto", "cluster", "list"}):
+				return []byte(`[{"name":"adx-priv","uri":"https://adx-priv.kusto.windows.net","resourceGroup":"rg1","state":"Running","publicNetworkAccess":"Disabled"}]`), nil, nil
+			case hasPrefix(args, []string{"cosmosdb", "list"}):
+				return []byte(`[{"name":"cosmos-pub","resourceGroup":"rg1","documentEndpoint":"https://cosmos-pub.documents.azure.com","publicNetworkAccess":"Enabled"}]`), nil, nil
+			}
+			return nil, nil, nil
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+
+	plan := BuildPlan(context.Background(), PlanInput{CLI: cli, Account: Account{SubID: "sub-1"}, IncludeCosmos: true})
+
+	var adx, cosmos *Suggestion
+	for i := range plan {
+		switch plan[i].Spec.Token() {
+		case TokenADX:
+			adx = &plan[i]
+		case TokenCosmos:
+			cosmos = &plan[i]
+		}
+	}
+	if adx == nil || cosmos == nil {
+		t.Fatalf("expected both ADX and Cosmos suggestions, got %d total", len(plan))
+	}
+	if !adx.PrivateNetwork {
+		t.Error("ADX cluster with publicNetworkAccess=Disabled should set PrivateNetwork")
+	}
+	if cosmos.PrivateNetwork {
+		t.Error("Cosmos account with publicNetworkAccess=Enabled should not set PrivateNetwork")
+	}
+}
+
+func TestBuildPlan_IncludeCosmos(t *testing.T) {
+	runner := &scriptedRunner{
+		handler: func(args []string) ([]byte, []byte, error) {
+			if hasPrefix(args, []string{"cosmosdb", "list"}) {
+				return []byte(`[{"name":"cosmos1","resourceGroup":"rg1","documentEndpoint":"https://cosmos1.documents.azure.com"}]`), nil, nil
+			}
+			return nil, nil, nil
+		},
+	}
+	cli := NewCLIWithRunner(runner)
+
+	plan := BuildPlan(context.Background(), PlanInput{CLI: cli, Account: Account{SubID: "sub-1"}, IncludeCosmos: true})
+
+	var found bool
+	for _, s := range plan {
+		if s.Spec.Token() == TokenCosmos {
+			found = true
+			if s.Extra["endpoint"] != "https://cosmos1.documents.azure.com" {
+				t.Fatalf("cosmos endpoint = %q", s.Extra["endpoint"])
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected a cosmos suggestion when IncludeCosmos is set")
+	}
+}

--- a/internal/onboard/azure/rotate.go
+++ b/internal/onboard/azure/rotate.go
@@ -1,0 +1,235 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/onboard"
+)
+
+// RotateInput scopes and controls a secret-rotation sweep.
+type RotateInput struct {
+	// CallerOID and Stack restrict rotation to app registrations attributable to
+	// this caller/stack (verified against the gcx-managed tags), so a shared
+	// tenant never rotates another caller's or stack's credentials.
+	CallerOID string
+	Stack     string
+	// ExpiryDays, when > 0, sets an explicit end date on the newly minted
+	// secret.
+	ExpiryDays int
+	// DryRun lists what would be rotated without minting or updating anything.
+	DryRun bool
+	// SkipHealth skips the post-rotation datasource health verification.
+	SkipHealth bool
+	// IncludeUIDs, when non-empty, restricts rotation to datasources with these
+	// UIDs (used by the interactive picker). Nil/empty means every gcx-managed
+	// Azure datasource is a candidate.
+	IncludeUIDs []string
+}
+
+// Rotate mints a fresh client secret for each gcx-managed Azure datasource,
+// updates the datasource to use it, and retires the superseded secret. It only
+// touches datasources whose backing app registration is tagged gcx-managed and
+// attributable to this caller/stack; key-based datasources (Cosmos DB) and
+// datasources using supplied credentials are reported as skipped.
+func Rotate(ctx context.Context, deps RunDeps, in RotateInput) (onboard.Result, error) {
+	// A real rotation mints and prunes secrets, so it must be scoped to the
+	// caller. Without a caller OID, attributableToCaller degrades to "any
+	// gcx-managed app", which in a shared tenant would rotate (and prune) other
+	// owners' credentials. Refuse rather than widen the sweep. --dry-run is
+	// read-only and stays allowed.
+	if !in.DryRun && in.CallerOID == "" {
+		return onboard.Result{}, fmt.Errorf(
+			"%w: no signed-in Azure user object ID was resolved (e.g. a service-principal or managed-identity login); re-run as a user, or preview with --dry-run",
+			ErrUnscopedDestructive)
+	}
+
+	prefix := onboard.NamePrefix + "-"
+
+	only := uidSet(in.IncludeUIDs)
+
+	onboard.Progressf(deps.Progress, "Listing gcx-created Grafana datasources...")
+	list, err := deps.DS.List(ctx)
+	if err != nil {
+		return onboard.Result{}, err
+	}
+
+	results := make([]onboard.DatasourceResult, 0)
+	for _, item := range list {
+		if !strings.HasPrefix(item.Name, prefix) {
+			continue
+		}
+		if only != nil && !only[item.UID] {
+			continue
+		}
+
+		// The /api/datasources list omits jsonData, so fetch the full datasource
+		// to read the backing client ID and to preserve jsonData on update.
+		d, err := deps.DS.GetByUID(ctx, item.UID)
+		if err != nil {
+			warn(deps.ErrOut, fmt.Sprintf("skipping %q: could not read datasource details: %v", item.Name, err))
+			results = append(results, skipRotate(item, "could not read datasource details"))
+			continue
+		}
+
+		appID, field := credentialRef(d)
+		if appID == "" {
+			results = append(results, skipRotate(d, "no rotatable service-principal credential"))
+			continue
+		}
+
+		tags, err := deps.CLI.AppTags(ctx, appID)
+		if err != nil {
+			warn(deps.ErrOut, fmt.Sprintf("skipping %q: could not read app registration tags: %v", d.Name, err))
+			results = append(results, skipRotate(d, "could not verify gcx ownership"))
+			continue
+		}
+		if !attributableToCaller(tags, in.CallerOID, in.Stack) {
+			results = append(results, skipRotate(d, "app registration is not gcx-managed by this caller/stack"))
+			continue
+		}
+
+		if in.DryRun {
+			r := skipRotate(d, "would rotate secret")
+			r.Status = onboard.StatusPlanned
+			r.Credential = &onboard.CloudCredential{ID: appID}
+			results = append(results, r)
+			continue
+		}
+
+		res, err := rotateOne(ctx, deps, in, d, appID, field)
+		if err != nil {
+			return onboard.Result{}, err
+		}
+		results = append(results, res)
+	}
+
+	return onboard.Result{Provider: "azure", Datasources: results, DryRun: in.DryRun}, nil
+}
+
+// rotateOne rotates the secret for a single datasource: mint a new secret,
+// update the datasource to use it, then prune the superseded secret.
+func rotateOne(
+	ctx context.Context,
+	deps RunDeps,
+	in RotateInput,
+	d *datasources.Datasource,
+	appID, field string,
+) (onboard.DatasourceResult, error) {
+	onboard.Progressf(deps.Progress, "→ rotating secret for %q...", d.Name)
+	rot, err := deps.CLI.RotateSecret(ctx, appID, in.ExpiryDays)
+	if err != nil {
+		return onboard.DatasourceResult{}, fmt.Errorf("failed to rotate secret for %q: %w", d.Name, err)
+	}
+
+	// Update the datasource to use the new secret before retiring the old one,
+	// so a failure here leaves the still-valid previous secret in place.
+	update := *d
+	update.SecureJSONData = map[string]string{field: rot.Secret}
+	update.SecureJSONFields = nil
+	if _, err := deps.DS.Update(ctx, d.UID, &update); err != nil {
+		return onboard.DatasourceResult{}, fmt.Errorf(
+			"rotated the credential for app %q but failed to update datasource %q; the previous secret is still valid: %w",
+			appID, d.Name, err)
+	}
+
+	// Retire the superseded secret(s). Best-effort: the datasource already uses
+	// the new secret, so a prune failure is a warning, not a run failure.
+	if err := deps.CLI.PruneSecretsExcept(ctx, appID, rot.KeyID); err != nil {
+		warn(deps.ErrOut, fmt.Sprintf("rotated %q but could not remove the old secret(s): %v", d.Name, err))
+	}
+	onboard.Progressf(deps.Progress, "  rotated secret for %q", d.Name)
+
+	result := onboard.DatasourceResult{
+		Name: d.Name, Type: d.Type, UID: d.UID, Status: onboard.StatusRotated,
+		Credential: &onboard.CloudCredential{ID: appID},
+	}
+	if !in.SkipHealth {
+		applyHealth(ctx, deps, &result, d.UID)
+	}
+	return result, nil
+}
+
+// skipRotate builds a skipped result row with a note.
+func skipRotate(d *datasources.Datasource, note string) onboard.DatasourceResult {
+	return onboard.DatasourceResult{
+		Name: d.Name, Type: d.Type, UID: d.UID, Status: onboard.StatusSkipped, Note: note,
+	}
+}
+
+// credentialRef returns the app (client) ID backing a gcx datasource and the
+// secureJsonData field that holds its client secret, based on the datasource
+// type. It returns ("", "") for datasources without a rotatable
+// service-principal secret (e.g. key-based Cosmos DB or an unknown type).
+//
+// The client ID is read from whichever schema the datasource uses: gcx writes
+// the flat Azure Monitor schema (top-level clientId), but Grafana may normalize
+// it into the shared azureCredentials object, so both are checked.
+func credentialRef(d *datasources.Datasource) (string, string) {
+	switch d.Type {
+	case KindAzureMonitor:
+		id := stringField(d.JSONData, "clientId")
+		if id == "" {
+			id = stringField(azureCredentials(d), "clientId")
+		}
+		if id == "" {
+			return "", ""
+		}
+		return id, azureSecretField(d, "clientSecret")
+	case KindADX:
+		id := stringField(azureCredentials(d), "clientId")
+		if id == "" {
+			return "", ""
+		}
+		return id, azureSecretField(d, "azureClientSecret")
+	default:
+		return "", ""
+	}
+}
+
+// azureCredentials extracts the nested azureCredentials object from a
+// datasource's jsonData, or nil when absent.
+func azureCredentials(d *datasources.Datasource) map[string]any {
+	if creds, ok := d.JSONData["azureCredentials"].(map[string]any); ok {
+		return creds
+	}
+	return nil
+}
+
+// azureSecretField returns the secureJsonData key currently holding the client
+// secret, preferring whichever key the datasource already reports as set so
+// rotation overwrites the exact field Grafana expects. It falls back to the
+// type's default key when nothing is reported.
+func azureSecretField(d *datasources.Datasource, fallback string) string {
+	for _, k := range []string{"azureClientSecret", "clientSecret"} {
+		if d.SecureJSONFields[k] {
+			return k
+		}
+	}
+	return fallback
+}
+
+// uidSet builds a lookup set from the include list, or nil when empty (meaning
+// "no restriction").
+func uidSet(uids []string) map[string]bool {
+	if len(uids) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(uids))
+	for _, u := range uids {
+		set[u] = true
+	}
+	return set
+}
+
+func stringField(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/internal/onboard/azure/rotate_test.go
+++ b/internal/onboard/azure/rotate_test.go
@@ -1,0 +1,205 @@
+//nolint:testpackage // white-box tests exercise the rotate orchestrator
+package azure
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/onboard"
+)
+
+// isByUID reports whether the request targets the single-datasource by-uid GET
+// (which returns jsonData) rather than the list (which omits it).
+func isByUID(r *http.Request) bool {
+	return strings.Contains(r.URL.Path, "/uid/")
+}
+
+// rotateHandler answers the az calls a rotation makes: tag read, credential
+// reset (append), credential list, credential delete.
+func rotateHandler(tags string) func(args []string) ([]byte, []byte, error) {
+	return func(args []string) ([]byte, []byte, error) {
+		switch {
+		case hasPrefix(args, []string{"ad", "app", "show"}):
+			return []byte(tags), nil, nil
+		case hasPrefix(args, []string{"ad", "app", "credential", "reset"}):
+			return []byte(`{"password":"new-secret","keyId":"key-new"}`), nil, nil
+		case hasPrefix(args, []string{"ad", "app", "credential", "list"}):
+			return []byte(`[{"keyId":"key-old"},{"keyId":"key-new"}]`), nil, nil
+		default:
+			return nil, nil, nil
+		}
+	}
+}
+
+func TestRotate_RotatesGcxManagedDatasource(t *testing.T) {
+	runner := &scriptedRunner{handler: rotateHandler(`["gcx:managed","gcx:owner=owner-oid"]`)}
+	cli := NewCLIWithRunner(runner)
+
+	var updated bool
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && isByUID(r):
+			_, _ = w.Write([]byte(`{"uid":"uid-1","name":"gcx-azure-monitor","type":"grafana-azure-monitor-datasource","jsonData":{"clientId":"app-1"}}`))
+		case r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`[{"uid":"uid-1","name":"gcx-azure-monitor","type":"grafana-azure-monitor-datasource"}]`))
+		case r.Method == http.MethodPut:
+			updated = true
+			_, _ = w.Write([]byte(`{"datasource":{"uid":"uid-1","name":"gcx-azure-monitor","type":"grafana-azure-monitor-datasource"}}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+
+	res, err := Rotate(context.Background(), RunDeps{CLI: cli, DS: ds},
+		RotateInput{CallerOID: "owner-oid", SkipHealth: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !updated {
+		t.Fatal("expected the datasource to be updated with the new secret")
+	}
+	if len(res.Datasources) != 1 || res.Datasources[0].Status != onboard.StatusRotated {
+		t.Fatalf("expected one rotated datasource, got %+v", res.Datasources)
+	}
+
+	// The superseded secret (key-old) must be pruned, the new one (key-new) kept.
+	var deletedOld, deletedNew bool
+	for _, c := range runner.calls {
+		if hasPrefix(c, []string{"ad", "app", "credential", "delete"}) {
+			if slices.Contains(c, "key-old") {
+				deletedOld = true
+			}
+			if slices.Contains(c, "key-new") {
+				deletedNew = true
+			}
+		}
+	}
+	if !deletedOld {
+		t.Fatal("expected the old secret to be pruned")
+	}
+	if deletedNew {
+		t.Fatal("must not prune the newly minted secret")
+	}
+}
+
+func TestRotate_SkipsNonGcxManagedApp(t *testing.T) {
+	// The app registration carries no gcx-managed tag: rotation must not touch it.
+	runner := &scriptedRunner{handler: rotateHandler(`["someone-else"]`)}
+	cli := NewCLIWithRunner(runner)
+
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && isByUID(r):
+			_, _ = w.Write([]byte(`{"uid":"uid-1","name":"gcx-azure-monitor","type":"grafana-azure-monitor-datasource","jsonData":{"clientId":"app-1"}}`))
+		case r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`[{"uid":"uid-1","name":"gcx-azure-monitor","type":"grafana-azure-monitor-datasource"}]`))
+		default:
+			t.Errorf("did not expect a datasource write for a non-gcx-managed app")
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+
+	res, err := Rotate(context.Background(), RunDeps{CLI: cli, DS: ds}, RotateInput{CallerOID: "owner-oid"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Datasources) != 1 || res.Datasources[0].Status != onboard.StatusSkipped {
+		t.Fatalf("expected the datasource to be skipped, got %+v", res.Datasources)
+	}
+	for _, c := range runner.calls {
+		if hasPrefix(c, []string{"ad", "app", "credential", "reset"}) {
+			t.Fatal("must not reset a secret on a non-gcx-managed app")
+		}
+	}
+}
+
+func TestRotate_DryRunChangesNothing(t *testing.T) {
+	runner := &scriptedRunner{handler: rotateHandler(`["gcx:managed"]`)}
+	cli := NewCLIWithRunner(runner)
+
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && isByUID(r):
+			_, _ = w.Write([]byte(`{"uid":"uid-1","name":"gcx-adx","type":"` + KindADX + `","jsonData":{"azureCredentials":{"clientId":"app-1"}}}`))
+		case r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`[{"uid":"uid-1","name":"gcx-adx","type":"` + KindADX + `"}]`))
+		default:
+			t.Errorf("did not expect a datasource write during rotate --dry-run")
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+
+	res, err := Rotate(context.Background(), RunDeps{CLI: cli, DS: ds}, RotateInput{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.DryRun || len(res.Datasources) != 1 || res.Datasources[0].Status != onboard.StatusPlanned {
+		t.Fatalf("expected a planned dry-run result, got %+v", res)
+	}
+	for _, c := range runner.calls {
+		if hasPrefix(c, []string{"ad", "app", "credential", "reset"}) {
+			t.Fatal("must not mint a secret during --dry-run")
+		}
+	}
+}
+
+func TestRotate_RefusesWithoutCallerScope(t *testing.T) {
+	// A real (non-dry-run) rotation with no caller OID must refuse rather than
+	// sweep and prune every gcx-managed app's secrets in the tenant.
+	runner := &scriptedRunner{handler: func([]string) ([]byte, []byte, error) { return nil, nil, nil }}
+	cli := NewCLIWithRunner(runner)
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("rotate must refuse before touching the datasource API")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	_, err := Rotate(context.Background(), RunDeps{CLI: cli, DS: ds}, RotateInput{})
+	if !errors.Is(err, ErrUnscopedDestructive) {
+		t.Fatalf("expected ErrUnscopedDestructive, got %v", err)
+	}
+}
+
+func TestCredentialRef(t *testing.T) {
+	cases := []struct {
+		name      string
+		ds        map[string]any
+		dsType    string
+		wantApp   string
+		wantField string
+	}{
+		{
+			name:      "azure monitor flat clientId",
+			dsType:    KindAzureMonitor,
+			ds:        map[string]any{"clientId": "app-am"},
+			wantApp:   "app-am",
+			wantField: "clientSecret",
+		},
+		{
+			name:      "adx nested clientId",
+			dsType:    KindADX,
+			ds:        map[string]any{"azureCredentials": map[string]any{"clientId": "app-adx"}},
+			wantApp:   "app-adx",
+			wantField: "azureClientSecret",
+		},
+		{
+			name:      "cosmos has no rotatable secret",
+			dsType:    KindCosmos,
+			ds:        map[string]any{},
+			wantApp:   "",
+			wantField: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			app, field := credentialRef(&datasources.Datasource{Type: c.dsType, JSONData: c.ds})
+			if app != c.wantApp || field != c.wantField {
+				t.Fatalf("credentialRef = (%q,%q), want (%q,%q)", app, field, c.wantApp, c.wantField)
+			}
+		})
+	}
+}

--- a/internal/onboard/azure/run.go
+++ b/internal/onboard/azure/run.go
@@ -1,0 +1,534 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/docs"
+	"github.com/grafana/gcx/internal/onboard"
+	"github.com/grafana/gcx/internal/plugins"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"golang.org/x/sync/errgroup"
+)
+
+// ErrPluginUnavailable indicates the datasource plugin a selection needs is not
+// installed and could not be installed (e.g. a missing Enterprise plugin, or
+// the user declined installation). It is non-fatal to the overall run: the
+// affected datasource is skipped while the others still provision.
+var ErrPluginUnavailable = errors.New("required datasource plugin is unavailable")
+
+// RunDeps holds the collaborators the orchestrator needs.
+type RunDeps struct {
+	CLI    *CLI
+	DS     *datasources.Client
+	Log    logging.Logger
+	ErrOut io.Writer
+	// Progress receives human-readable narration for long-running steps. When
+	// nil (e.g. agent mode), progress is suppressed.
+	Progress io.Writer
+	// ConfirmRollback, when set, is asked whether to revert the listed steps
+	// after a mid-run failure. It receives the step descriptions in revert
+	// order. When nil (non-interactive/agent), gcx reverts automatically.
+	ConfirmRollback func(steps []string) (bool, error)
+	// Plugins checks/installs required datasource plugins. When nil, the plugin
+	// pre-flight is skipped.
+	Plugins *plugins.Client
+	// ConfirmInstallPlugin, when set, is asked whether to install a missing
+	// required plugin. When nil (non-interactive/agent), gcx installs it
+	// automatically.
+	ConfirmInstallPlugin func(pluginID string) (bool, error)
+	// HealthAttempts and HealthBackoff tune the post-create health check retry
+	// used to tolerate RBAC-propagation lag. Zero values fall back to defaults.
+	HealthAttempts int
+	HealthBackoff  time.Duration
+}
+
+const (
+	defaultHealthAttempts = 4
+	defaultHealthBackoff  = 2 * time.Second
+)
+
+func (d RunDeps) healthAttempts() int {
+	if d.HealthAttempts > 0 {
+		return d.HealthAttempts
+	}
+	return defaultHealthAttempts
+}
+
+func (d RunDeps) healthBackoff() time.Duration {
+	if d.HealthBackoff > 0 {
+		return d.HealthBackoff
+	}
+	return defaultHealthBackoff
+}
+
+// Selection is a chosen suggestion plus the resolved role set to assign.
+type Selection struct {
+	Suggestion Suggestion
+	Roles      []string // resolved roles for app-registration specs (nil for key-based)
+}
+
+// ProvisionInput carries the resolved inputs for a provisioning run.
+type ProvisionInput struct {
+	Account     Account
+	CallerOID   string
+	Selections  []Selection
+	Interactive bool
+	Stack       string // Grafana stack slug, stamped onto artifacts for attribution
+	ExpiryDays  int    // optional minted-secret expiry in days (0 = Azure default)
+	DryRun      bool   // preview only: mint/create nothing
+	SkipHealth  bool   // skip the post-create datasource health verification
+	// Concurrency bounds how many datasources are minted/created in parallel.
+	// Zero uses defaultProvisionConcurrency. Interactive runs are always serial
+	// (see effectiveConcurrency) so prompts and progress stay ordered.
+	Concurrency int
+}
+
+// defaultProvisionConcurrency bounds parallel minting when the caller does not
+// set ProvisionInput.Concurrency. It is deliberately modest: each job shells out
+// to `az` (which shares an on-disk MSAL token cache) and issues Azure ARM
+// writes, so a small fan-out avoids token-cache contention and ARM throttling
+// while still overlapping the slow RBAC-propagation health waits.
+const defaultProvisionConcurrency = 4
+
+// effectiveConcurrency resolves the parallelism for a run, clamped to the number
+// of jobs. Interactive runs stay serial so narration and prompts remain ordered
+// and readable.
+func effectiveConcurrency(in ProvisionInput, jobs int) int {
+	limit := in.Concurrency
+	if limit <= 0 {
+		limit = defaultProvisionConcurrency
+	}
+	if in.Interactive {
+		limit = 1
+	}
+	if limit > jobs {
+		limit = jobs
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	return limit
+}
+
+// mintJob is a selection that survived the serial planning pass and needs its
+// credentials minted and datasource created in the parallel pass. name is the
+// pre-resolved, collision-free artifact name, so parallel workers never race on
+// name resolution.
+type mintJob struct {
+	idx  int
+	sel  Selection
+	name string
+}
+
+// Provision creates each selected datasource, minting gcx-owned app
+// registrations as needed. On any failure it rolls back all artifacts created
+// during the run (datasources and app registrations) and returns the error.
+//
+// It is idempotent: a selection whose gcx-managed datasource already exists is
+// reused (reported as "existing") rather than duplicated. With DryRun set it
+// resolves the plan and reports what would be created without any side effects.
+//
+// Provisioning runs in two passes. The first (serial) pass resolves already-
+// existing, dry-run, and skipped datasources, runs the plugin pre-flight (which
+// may prompt interactively), and reserves a unique name for each datasource
+// that will be minted. The second pass mints credentials and creates the
+// datasources with bounded parallelism (see effectiveConcurrency), overlapping
+// the slow Azure/Grafana calls. Result ordering matches the input selections.
+func Provision(ctx context.Context, deps RunDeps, in ProvisionInput) (onboard.Result, error) {
+	rb := &onboard.Rollback{}
+
+	existing, err := existingDatasourcesByName(ctx, deps.DS)
+	if err != nil {
+		return onboard.Result{}, fmt.Errorf("failed to list existing datasources: %w", err)
+	}
+
+	// rollback handles the accumulated undo steps after a mid-run failure. It
+	// asks the user (when a confirmer is set) whether to revert, listing what
+	// will be undone; otherwise it reverts automatically. The revert itself is
+	// both logged and narrated step-by-step.
+	rollback := func() {
+		if rb.Len() == 0 {
+			return
+		}
+		onboard.Progressf(deps.Progress, "An error occurred after creating %d artifact(s).", rb.Len())
+		if !shouldRollback(deps, rb) {
+			onboard.Progressf(deps.Progress, "Keeping created artifacts. Remove them later with: gcx setup datasources azure --cleanup")
+			return
+		}
+		rb.Run(ctx, deps.Log, deps.Progress)
+	}
+
+	results := make([]onboard.DatasourceResult, len(in.Selections))
+	jobs, err := planJobs(ctx, deps, in, existing, results)
+	if err != nil {
+		return onboard.Result{}, err
+	}
+
+	if len(jobs) > 0 {
+		limit := effectiveConcurrency(in, len(jobs))
+		if limit > 1 {
+			onboard.Progressf(deps.Progress, "Provisioning %d datasource(s), up to %d in parallel...", len(jobs), limit)
+		}
+		// Each created artifact registers its rollback step synchronously, right
+		// after the `az`/Grafana call that created it returns (see
+		// CreateOwnedAppRegistration and provisionOne). So when errgroup cancels
+		// gctx on the first failure, any sibling that already created something
+		// has already recorded its undo and will be reverted by rollback() below.
+		// The only unrecoverable window is a job canceled after Azure/Grafana
+		// committed an object server-side but before the create call returned its
+		// id — a narrow race whose rare orphan is still reclaimable with
+		// `--cleanup` (name prefix + gcx:managed tag).
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(limit)
+		for _, job := range jobs {
+			g.Go(func() error {
+				res, err := provisionOne(gctx, deps, in, job, rb)
+				if err != nil {
+					return err
+				}
+				// Each job owns a distinct index, so concurrent writes to
+				// separate elements are safe without a lock.
+				results[job.idx] = res
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			rollback()
+			return onboard.Result{}, err
+		}
+	}
+
+	return onboard.Result{Provider: "azure", Datasources: results, DryRun: in.DryRun}, nil
+}
+
+// planJobs runs the serial planning pass: it fills results[i] for every
+// selection that is already existing, dry-run-planned, or skipped, and returns
+// the remaining selections (with reserved, collision-free names) that must be
+// minted in the parallel pass. It is kept serial because it may prompt (plugin
+// install) and because name reservation must not race.
+func planJobs(
+	ctx context.Context,
+	deps RunDeps,
+	in ProvisionInput,
+	existing map[string]*datasources.Datasource,
+	results []onboard.DatasourceResult,
+) ([]mintJob, error) {
+	// ensurePluginOnce memoizes the plugin pre-flight per plugin kind for the
+	// span of this run: several datasources of the same kind (e.g. two ADX
+	// clusters) share a single install prompt/attempt instead of re-prompting
+	// for each one.
+	ensured := map[string]error{}
+	ensurePluginOnce := func(kind string) error {
+		if e, ok := ensured[kind]; ok {
+			return e
+		}
+		e := ensurePlugin(ctx, deps, kind)
+		ensured[kind] = e
+		return e
+	}
+
+	// reserved tracks names claimed by earlier selections in this run so two
+	// jobs never resolve to the same minted name before either exists.
+	reserved := map[string]bool{}
+	var jobs []mintJob
+	for i, sel := range in.Selections {
+		base := sel.Suggestion.Name
+
+		// Idempotency: reuse an existing gcx-managed datasource for this resource
+		// instead of creating a "-2" duplicate.
+		if d := existing[strings.ToLower(base)]; d != nil {
+			onboard.Progressf(deps.Progress, "→ %s already exists (uid %s); skipping", d.Name, d.UID)
+			result := onboard.DatasourceResult{
+				Name: d.Name, Type: d.Type, UID: d.UID, Status: onboard.StatusExisting,
+			}
+			applyPrivateHint(in, sel, &result)
+			results[i] = result
+			continue
+		}
+
+		if in.DryRun {
+			onboard.Progressf(deps.Progress, "→ would create %s", sel.Suggestion.Label)
+			result := plannedResult(sel, base)
+			applyPrivateHint(in, sel, &result)
+			results[i] = result
+			continue
+		}
+
+		// Pre-flight the datasource plugin before minting any credentials, so we
+		// never create Azure artifacts for a datasource that can't be created. A
+		// missing/uninstallable plugin fails only this datasource (nothing has
+		// been minted yet): record it as skipped and carry on with the others.
+		if err := ensurePluginOnce(sel.Suggestion.Spec.Kind()); err != nil {
+			if errors.Is(err, ErrPluginUnavailable) {
+				onboard.Progressf(deps.Progress, "  skipping %s: %v", sel.Suggestion.Label, err)
+				warn(deps.ErrOut, fmt.Sprintf("skipping %s: %v", sel.Suggestion.Label, err))
+				results[i] = skippedResult(sel, base, err)
+				continue
+			}
+			// Nothing has been minted yet in this pass, so there is nothing to
+			// roll back — surface the hard error directly.
+			return nil, err
+		}
+
+		name, err := onboard.EnsureUniqueName(base, func(n string) (bool, error) {
+			key := strings.ToLower(n)
+			if existing[key] != nil || reserved[key] {
+				return true, nil
+			}
+			return deps.CLI.AppExists(ctx, n)
+		})
+		if err != nil {
+			return nil, err
+		}
+		reserved[strings.ToLower(name)] = true
+		jobs = append(jobs, mintJob{idx: i, sel: sel, name: name})
+	}
+	return jobs, nil
+}
+
+// provisionOne mints credentials (as needed) and creates a single datasource,
+// then tags the backing app registration and verifies datasource health. It is
+// safe to run concurrently for distinct jobs: the name is pre-resolved, the
+// rollback accumulator is concurrency-safe, and no shared maps are mutated.
+func provisionOne(
+	ctx context.Context,
+	deps RunDeps,
+	in ProvisionInput,
+	job mintJob,
+	rb *onboard.Rollback,
+) (onboard.DatasourceResult, error) {
+	sel, name := job.sel, job.name
+	onboard.Progressf(deps.Progress, "→ %s", sel.Suggestion.Label)
+
+	prov, err := sel.Suggestion.Spec.AcquireAndBuild(ctx, SpecInput{
+		CLI:         deps.CLI,
+		Account:     in.Account,
+		Name:        name,
+		Roles:       sel.Roles,
+		Scopes:      sel.Suggestion.Scopes,
+		CallerOID:   in.CallerOID,
+		Extra:       sel.Suggestion.Extra,
+		Stack:       in.Stack,
+		ExpiryDays:  in.ExpiryDays,
+		Rollback:    rb,
+		Interactive: in.Interactive,
+		Progress:    deps.Progress,
+		Log:         deps.Log,
+	})
+	if err != nil {
+		return onboard.DatasourceResult{}, err
+	}
+
+	onboard.Progressf(deps.Progress, "  creating Grafana datasource %q...", name)
+	ds, err := deps.DS.Create(ctx, &prov.Request)
+	if err != nil {
+		return onboard.DatasourceResult{}, fmt.Errorf("failed to create datasource %q: %w", name, err)
+	}
+	onboard.Progressf(deps.Progress, "  created datasource %q (uid %s)", name, ds.UID)
+
+	uid := ds.UID
+	rb.Add("delete datasource "+name, func(ctx context.Context) error {
+		return deps.DS.Delete(ctx, uid)
+	})
+
+	// Stamp the app registration with the datasource UID so cleanup and rotation
+	// can correlate credentials to datasources reliably (only when gcx minted
+	// the credential — supplied creds are not ours to tag).
+	if prov.AppID != "" {
+		attr := Attribution{Stack: in.Stack, OwnerOID: in.CallerOID, DatasourceUID: uid}
+		if err := deps.CLI.SetAppTags(ctx, prov.AppID, attr.Tags()); err != nil {
+			return onboard.DatasourceResult{}, fmt.Errorf("failed to tag app registration %q: %w", prov.AppID, err)
+		}
+	}
+
+	result := onboard.DatasourceResult{
+		Name: name, Type: ds.Type, UID: uid, Status: onboard.StatusCreated,
+	}
+	if prov.AppID != "" {
+		result.Credential = &onboard.CloudCredential{ID: prov.AppID}
+	}
+	if !in.SkipHealth {
+		applyHealth(ctx, deps, &result, uid)
+	}
+	applyPrivateHint(in, sel, &result)
+	return result, nil
+}
+
+// plannedResult builds the --dry-run preview row for a selection.
+func plannedResult(sel Selection, base string) onboard.DatasourceResult {
+	return onboard.DatasourceResult{
+		Name:   base,
+		Type:   sel.Suggestion.Spec.Kind(),
+		Status: onboard.StatusPlanned,
+		Credential: &onboard.CloudCredential{
+			Roles:  sel.Roles,
+			Scopes: sel.Suggestion.Scopes,
+		},
+	}
+}
+
+// applyPrivateHint attaches an advisory Private Data source Connect (PDC) hint
+// when the backing resource has public network access disabled. It is gated to
+// Grafana Cloud stacks (a non-empty stack slug): PDC is a Cloud feature, and a
+// self-managed Grafana may already sit inside the resource's network. The hint
+// is purely informational — the datasource and its credentials are still
+// created; it only tells the user extra connectivity setup is likely needed.
+func applyPrivateHint(in ProvisionInput, sel Selection, r *onboard.DatasourceResult) {
+	if !sel.Suggestion.PrivateNetwork || in.Stack == "" {
+		return
+	}
+	r.Hint = "public network access is disabled on this resource; your Grafana Cloud stack can only query it via Private Data source Connect (PDC)"
+	r.HintDocs = docs.PrivateDataSourceConnect
+}
+
+// skippedResult builds the row for a selection that was intentionally not
+// provisioned (e.g. its plugin was unavailable), carrying a short reason.
+func skippedResult(sel Selection, base string, cause error) onboard.DatasourceResult {
+	return onboard.DatasourceResult{
+		Name:   base,
+		Type:   sel.Suggestion.Spec.Kind(),
+		Status: onboard.StatusSkipped,
+		Note:   cause.Error(),
+	}
+}
+
+// applyHealth runs the health check (with retry) and records the outcome on the
+// result. Health failures never fail the run — a datasource can be briefly
+// unhealthy while Azure RBAC propagates — but they are surfaced to the user.
+func applyHealth(ctx context.Context, deps RunDeps, result *onboard.DatasourceResult, uid string) {
+	onboard.Progressf(deps.Progress, "  verifying datasource health...")
+	h := checkHealth(ctx, deps, uid)
+	if h == nil {
+		return
+	}
+	result.Health = h.Status
+	if !strings.EqualFold(h.Status, "ok") {
+		result.HealthMessage = h.Message
+		onboard.Progressf(deps.Progress, "  health: %s — %s", h.Status, h.Message)
+	} else {
+		onboard.Progressf(deps.Progress, "  health: OK")
+	}
+}
+
+// checkHealth polls the datasource health endpoint, retrying with backoff to
+// tolerate RBAC-propagation lag, until it reports OK or attempts are exhausted.
+func checkHealth(ctx context.Context, deps RunDeps, uid string) *datasources.HealthResult {
+	attempts := deps.healthAttempts()
+	var last *datasources.HealthResult
+	for i := range attempts {
+		h, err := deps.DS.Health(ctx, uid)
+		switch {
+		case err != nil:
+			last = &datasources.HealthResult{UID: uid, Status: "UNKNOWN", Message: err.Error()}
+		default:
+			last = h
+			if strings.EqualFold(h.Status, "ok") {
+				return h
+			}
+		}
+		if i < attempts-1 {
+			select {
+			case <-ctx.Done():
+				return last
+			case <-time.After(deps.healthBackoff()):
+			}
+		}
+	}
+	return last
+}
+
+// corePlugins are datasource plugins bundled with Grafana; they are always
+// present and must be skipped by the plugin pre-flight.
+var corePlugins = map[string]bool{ //nolint:gochecknoglobals
+	KindAzureMonitor: true,
+}
+
+func isCorePlugin(pluginID string) bool {
+	return corePlugins[pluginID]
+}
+
+// ensurePlugin verifies the datasource plugin is installed, installing it
+// (after confirmation in interactive mode) when missing. A check that cannot be
+// performed (e.g. insufficient permissions to read /api/plugins) is treated as
+// non-blocking so provisioning can still proceed.
+func ensurePlugin(ctx context.Context, deps RunDeps, pluginID string) error {
+	if deps.Plugins == nil || pluginID == "" || isCorePlugin(pluginID) {
+		return nil
+	}
+
+	installed, err := deps.Plugins.IsInstalled(ctx, pluginID)
+	if err != nil {
+		if deps.Log != nil {
+			deps.Log.Debug("plugin check skipped", "plugin", pluginID, "error", err.Error())
+		}
+		return nil
+	}
+	if installed {
+		return nil
+	}
+
+	onboard.Progressf(deps.Progress, "  required plugin %q is not installed", pluginID)
+
+	install := true
+	if deps.ConfirmInstallPlugin != nil {
+		ok, cerr := deps.ConfirmInstallPlugin(pluginID)
+		if cerr != nil {
+			return cerr
+		}
+		install = ok
+	}
+	if !install {
+		return fmt.Errorf("%w: %q is not installed; install it and re-run, or accept installation when prompted", ErrPluginUnavailable, pluginID)
+	}
+
+	onboard.Progressf(deps.Progress, "  installing plugin %q...", pluginID)
+	if err := deps.Plugins.Install(ctx, pluginID, ""); err != nil {
+		return fmt.Errorf("%w: failed to install %q: %w", ErrPluginUnavailable, pluginID, err)
+	}
+	if deps.Log != nil {
+		deps.Log.Info("installed plugin", "plugin", pluginID)
+	}
+	onboard.Progressf(deps.Progress, "  installed plugin %q", pluginID)
+	return nil
+}
+
+// shouldRollback decides whether to revert. With no confirmer (non-interactive
+// /agent) it reverts automatically. With a confirmer it asks the user; a
+// confirmation error falls back to reverting so artifacts are never silently
+// left behind.
+func shouldRollback(deps RunDeps, rb *onboard.Rollback) bool {
+	if deps.ConfirmRollback == nil {
+		return true
+	}
+	ok, err := deps.ConfirmRollback(rb.Descriptions())
+	if err != nil {
+		if deps.Log != nil {
+			deps.Log.Warn("rollback confirmation failed; reverting to be safe", "error", err.Error())
+		}
+		return true
+	}
+	if !ok && deps.Log != nil {
+		deps.Log.Info("user declined rollback; keeping artifacts", "steps", rb.Len())
+	}
+	return ok
+}
+
+// existingDatasourcesByName indexes the current datasources by lower-cased name
+// so the orchestrator can detect (and reuse) already-onboarded resources.
+func existingDatasourcesByName(ctx context.Context, ds *datasources.Client) (map[string]*datasources.Datasource, error) {
+	list, err := ds.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byName := make(map[string]*datasources.Datasource, len(list))
+	for _, d := range list {
+		byName[strings.ToLower(d.Name)] = d
+	}
+	return byName, nil
+}

--- a/internal/onboard/azure/run_test.go
+++ b/internal/onboard/azure/run_test.go
@@ -1,0 +1,717 @@
+//nolint:testpackage // white-box tests exercise the orchestrator with unexported specs
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/docs"
+	"github.com/grafana/gcx/internal/onboard"
+	"github.com/grafana/gcx/internal/plugins"
+	"k8s.io/client-go/rest"
+)
+
+func newDSClient(t *testing.T, handler http.Handler) *datasources.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	cfg := config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}}
+	client, err := datasources.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("failed to create datasource client: %v", err)
+	}
+	return client
+}
+
+func mintHandler() func(args []string) ([]byte, []byte, error) {
+	return func(args []string) ([]byte, []byte, error) {
+		switch {
+		case hasPrefix(args, []string{"ad", "app", "list"}):
+			return []byte(`[]`), nil, nil
+		case hasPrefix(args, []string{"ad", "app", "create"}):
+			return []byte(`{"appId":"app-1","id":"obj-1"}`), nil, nil
+		case hasPrefix(args, []string{"ad", "sp", "create"}):
+			return []byte(`{"id":"sp-1"}`), nil, nil
+		case hasPrefix(args, []string{"ad", "app", "credential", "reset"}):
+			return []byte(`{"password":"sek"}`), nil, nil
+		default:
+			return nil, nil, nil
+		}
+	}
+}
+
+// mintHandlerDistinct is like mintHandler but returns a per-name appId derived
+// from the `ad app create --display-name` value, so a test can correlate each
+// minted app registration with its rollback delete.
+func mintHandlerDistinct() func(args []string) ([]byte, []byte, error) {
+	return func(args []string) ([]byte, []byte, error) {
+		switch {
+		case hasPrefix(args, []string{"ad", "app", "list"}):
+			return []byte(`[]`), nil, nil
+		case hasPrefix(args, []string{"ad", "app", "create"}):
+			name := flagValue(args, "--display-name")
+			return []byte(`{"appId":"app-` + name + `","id":"obj-` + name + `"}`), nil, nil
+		case hasPrefix(args, []string{"ad", "sp", "create"}):
+			return []byte(`{"id":"sp-1"}`), nil, nil
+		case hasPrefix(args, []string{"ad", "app", "credential", "reset"}):
+			return []byte(`{"password":"sek"}`), nil, nil
+		default:
+			return nil, nil, nil
+		}
+	}
+}
+
+// flagValue returns the argument following the named flag, or "" when absent.
+func flagValue(args []string, flag string) string {
+	for i := range args {
+		if args[i] == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func TestProvision_HappyPath(t *testing.T) {
+	runner := &scriptedRunner{handler: mintHandler()}
+	cli := NewCLIWithRunner(runner)
+
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"datasource":{"uid":"uid-1","name":"gcx-azure-monitor","type":"grafana-azure-monitor-datasource"}}`))
+	}))
+
+	res, err := Provision(context.Background(), RunDeps{CLI: cli, DS: ds},
+		ProvisionInput{
+			Account:    Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID:  "oid",
+			SkipHealth: true,
+			Selections: []Selection{{
+				Suggestion: Suggestion{Spec: azureMonitorSpec{}, Name: "gcx-azure-monitor", Scopes: []string{"/subscriptions/sub-1"}},
+				Roles:      []string{"Reader", "Monitoring Reader"},
+			}},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Datasources) != 1 {
+		t.Fatalf("expected 1 datasource, got %d", len(res.Datasources))
+	}
+	d := res.Datasources[0]
+	if d.UID != "uid-1" || d.Credential == nil || d.Credential.ID != "app-1" {
+		t.Fatalf("unexpected result: %+v", d)
+	}
+	if d.Status != onboard.StatusCreated {
+		t.Fatalf("expected status %q, got %q", onboard.StatusCreated, d.Status)
+	}
+}
+
+func TestProvision_InstallsMissingPlugin(t *testing.T) {
+	runner := &scriptedRunner{handler: mintHandler()}
+	cli := NewCLIWithRunner(runner)
+
+	// Grafana server: datasource API + plugin API. The (non-core) ADX plugin is
+	// reported missing (404) until it is installed.
+	var installed bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/plugins/"+KindADX+"/install":
+			installed = true
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/api/plugins/"+KindADX+"/settings":
+			if installed {
+				_, _ = w.Write([]byte(`{"id":"` + KindADX + `"}`))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/datasources":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			_, _ = w.Write([]byte(`{"datasource":{"uid":"uid-1","name":"gcx-adx","type":"` + KindADX + `"}}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+	cfg := config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}}
+	ds, err := datasources.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("ds client: %v", err)
+	}
+	pl, err := plugins.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("plugins client: %v", err)
+	}
+
+	_, err = Provision(context.Background(), RunDeps{CLI: cli, DS: ds, Plugins: pl},
+		ProvisionInput{
+			Account:    Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID:  "oid",
+			SkipHealth: true,
+			Selections: []Selection{{
+				Suggestion: Suggestion{
+					Spec:   adxSpec{},
+					Name:   "gcx-adx",
+					Scopes: []string{"/subscriptions/sub-1"},
+					Extra:  map[string]string{"clusterUrl": "https://adx1.kusto.windows.net", "rg": "rg1", "cluster": "adx1"},
+				},
+				Roles: []string{"Reader"},
+			}},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !installed {
+		t.Fatal("expected missing plugin to be auto-installed (no confirmer set)")
+	}
+}
+
+func TestProvision_UnavailablePluginSkipsOnlyThatDatasource(t *testing.T) {
+	runner := &scriptedRunner{handler: mintHandler()}
+	cli := NewCLIWithRunner(runner)
+
+	// Grafana server: the (non-core) ADX plugin is missing and its install
+	// fails, so the ADX datasource must be skipped — while the core Azure
+	// Monitor datasource still provisions.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/plugins/"+KindADX+"/install":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"enterprise plugin not licensed"}`))
+		case r.URL.Path == "/api/plugins/"+KindADX+"/settings":
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/datasources":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			_, _ = w.Write([]byte(`{"datasource":{"uid":"uid-am","name":"gcx-azure-monitor","type":"` + KindAzureMonitor + `"}}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+	cfg := config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}}
+	ds, err := datasources.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("ds client: %v", err)
+	}
+	pl, err := plugins.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("plugins client: %v", err)
+	}
+
+	res, err := Provision(context.Background(), RunDeps{CLI: cli, DS: ds, Plugins: pl},
+		ProvisionInput{
+			Account:    Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID:  "oid",
+			SkipHealth: true,
+			Selections: []Selection{
+				{
+					Suggestion: Suggestion{Spec: azureMonitorSpec{}, Name: "gcx-azure-monitor", Scopes: []string{"/subscriptions/sub-1"}},
+					Roles:      []string{"Reader"},
+				},
+				{
+					Suggestion: Suggestion{
+						Spec:   adxSpec{},
+						Name:   "gcx-adx",
+						Scopes: []string{"/subscriptions/sub-1"},
+						Extra:  map[string]string{"clusterUrl": "https://adx1.kusto.windows.net", "rg": "rg1", "cluster": "adx1"},
+					},
+					Roles: []string{"Reader"},
+				},
+			},
+		})
+	if err != nil {
+		t.Fatalf("expected no top-level error when a plugin is unavailable, got %v", err)
+	}
+	if len(res.Datasources) != 2 {
+		t.Fatalf("expected 2 result rows, got %d: %+v", len(res.Datasources), res.Datasources)
+	}
+	if res.Datasources[0].Status != onboard.StatusCreated {
+		t.Fatalf("expected azure monitor to be created, got %+v", res.Datasources[0])
+	}
+	if res.Datasources[1].Status != onboard.StatusSkipped || res.Datasources[1].Note == "" {
+		t.Fatalf("expected ADX to be skipped with a note, got %+v", res.Datasources[1])
+	}
+	// The skipped ADX datasource must not have minted or left an app registration.
+	for _, c := range runner.calls {
+		if hasPrefix(c, []string{"ad", "app", "delete"}) {
+			t.Fatal("did not expect a rollback delete when a datasource is softly skipped")
+		}
+	}
+}
+
+func TestProvision_PluginPreflightDedupedPerKind(t *testing.T) {
+	runner := &scriptedRunner{handler: mintHandler()}
+	cli := NewCLIWithRunner(runner)
+
+	// Two ADX datasources, plugin missing. The install attempt must happen at
+	// most once for the shared plugin kind — not once per datasource.
+	var installs int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/plugins/"+KindADX+"/install":
+			installs++
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"enterprise plugin not licensed"}`))
+		case r.URL.Path == "/api/plugins/"+KindADX+"/settings":
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/datasources":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(server.Close)
+	cfg := config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}}
+	ds, err := datasources.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("ds client: %v", err)
+	}
+	pl, err := plugins.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("plugins client: %v", err)
+	}
+
+	var confirms int
+	adx := func(name string) Selection {
+		return Selection{
+			Suggestion: Suggestion{
+				Spec:   adxSpec{},
+				Name:   name,
+				Scopes: []string{"/subscriptions/sub-1"},
+				Extra:  map[string]string{"clusterUrl": "https://" + name + ".kusto.windows.net", "rg": "rg1", "cluster": name},
+			},
+			Roles: []string{"Reader"},
+		}
+	}
+
+	res, err := Provision(context.Background(), RunDeps{
+		CLI: cli, DS: ds, Plugins: pl,
+		ConfirmInstallPlugin: func(string) (bool, error) { confirms++; return true, nil },
+	}, ProvisionInput{
+		Account:    Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+		CallerOID:  "oid",
+		SkipHealth: true,
+		Selections: []Selection{adx("gcx-adx1"), adx("gcx-adx2")},
+	})
+	if err != nil {
+		t.Fatalf("expected no top-level error, got %v", err)
+	}
+	if len(res.Datasources) != 2 ||
+		res.Datasources[0].Status != onboard.StatusSkipped ||
+		res.Datasources[1].Status != onboard.StatusSkipped {
+		t.Fatalf("expected both ADX datasources skipped, got %+v", res.Datasources)
+	}
+	if installs != 1 {
+		t.Fatalf("expected exactly one install attempt for the shared plugin kind, got %d", installs)
+	}
+	if confirms != 1 {
+		t.Fatalf("expected exactly one install prompt for the shared plugin kind, got %d", confirms)
+	}
+}
+
+func TestEnsurePlugin_SkipsCoreAzureMonitor(t *testing.T) {
+	// A plugins client pointed at a server that fails every request; the core
+	// Azure Monitor plugin must be skipped without any call being made.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("plugin API should not be called for a core datasource")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	pl, err := plugins.NewClient(config.NamespacedRESTConfig{Config: rest.Config{Host: server.URL}})
+	if err != nil {
+		t.Fatalf("plugins client: %v", err)
+	}
+
+	if err := ensurePlugin(context.Background(), RunDeps{Plugins: pl}, KindAzureMonitor); err != nil {
+		t.Fatalf("expected core plugin to be skipped, got %v", err)
+	}
+}
+
+func TestProvision_RollsBackAppRegOnDatasourceFailure(t *testing.T) {
+	runner := &scriptedRunner{handler: mintHandler()}
+	cli := NewCLIWithRunner(runner)
+
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	}))
+
+	_, err := Provision(context.Background(), RunDeps{CLI: cli, DS: ds},
+		ProvisionInput{
+			Account:    Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID:  "oid",
+			SkipHealth: true,
+			Selections: []Selection{{
+				Suggestion: Suggestion{Spec: azureMonitorSpec{}, Name: "gcx-azure-monitor", Scopes: []string{"/subscriptions/sub-1"}},
+				Roles:      []string{"Reader"},
+			}},
+		})
+	if err == nil {
+		t.Fatal("expected error when datasource creation fails")
+	}
+
+	var deleted bool
+	for _, c := range runner.calls {
+		if hasPrefix(c, []string{"ad", "app", "delete"}) {
+			deleted = true
+		}
+	}
+	if !deleted {
+		t.Fatal("expected app registration to be deleted during rollback")
+	}
+}
+
+func TestProvision_IdempotentReusesExistingDatasource(t *testing.T) {
+	runner := &scriptedRunner{handler: mintHandler()}
+	cli := NewCLIWithRunner(runner)
+
+	// The datasource already exists; a re-run must reuse it (no create, no mint).
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`[{"uid":"uid-existing","name":"gcx-azure-monitor","type":"grafana-azure-monitor-datasource"}]`))
+			return
+		}
+		t.Errorf("did not expect a write to the datasource API on an idempotent re-run, got %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	res, err := Provision(context.Background(), RunDeps{CLI: cli, DS: ds},
+		ProvisionInput{
+			Account:    Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID:  "oid",
+			SkipHealth: true,
+			Selections: []Selection{{
+				Suggestion: Suggestion{Spec: azureMonitorSpec{}, Name: "gcx-azure-monitor", Scopes: []string{"/subscriptions/sub-1"}},
+				Roles:      []string{"Reader"},
+			}},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Datasources) != 1 || res.Datasources[0].Status != onboard.StatusExisting {
+		t.Fatalf("expected one existing datasource, got %+v", res.Datasources)
+	}
+	if res.Datasources[0].UID != "uid-existing" {
+		t.Fatalf("expected existing uid, got %q", res.Datasources[0].UID)
+	}
+	for _, c := range runner.calls {
+		if hasPrefix(c, []string{"ad", "app", "create"}) {
+			t.Fatal("did not expect any app registration to be minted on an idempotent re-run")
+		}
+	}
+}
+
+func TestProvision_DryRunMintsNothing(t *testing.T) {
+	runner := &scriptedRunner{handler: mintHandler()}
+	cli := NewCLIWithRunner(runner)
+
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		t.Errorf("did not expect a datasource write during --dry-run")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	res, err := Provision(context.Background(), RunDeps{CLI: cli, DS: ds},
+		ProvisionInput{
+			Account:   Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID: "oid",
+			DryRun:    true,
+			Selections: []Selection{{
+				Suggestion: Suggestion{Spec: azureMonitorSpec{}, Name: "gcx-azure-monitor", Scopes: []string{"/subscriptions/sub-1"}},
+				Roles:      []string{"Reader", "Monitoring Reader"},
+			}},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.DryRun {
+		t.Fatal("expected result to be marked as a dry run")
+	}
+	if len(res.Datasources) != 1 || res.Datasources[0].Status != onboard.StatusPlanned {
+		t.Fatalf("expected one planned datasource, got %+v", res.Datasources)
+	}
+	if cred := res.Datasources[0].Credential; cred == nil || len(cred.Roles) != 2 {
+		t.Fatalf("expected planned roles to be surfaced, got %+v", res.Datasources[0].Credential)
+	}
+	for _, c := range runner.calls {
+		if hasPrefix(c, []string{"ad", "app", "create"}) {
+			t.Fatal("did not expect any Azure mutation during --dry-run")
+		}
+	}
+}
+
+func TestProvision_TagsAppRegistrationWithDatasourceUID(t *testing.T) {
+	runner := &scriptedRunner{handler: mintHandler()}
+	cli := NewCLIWithRunner(runner)
+
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"datasource":{"uid":"uid-42","name":"gcx-azure-monitor","type":"grafana-azure-monitor-datasource"}}`))
+	}))
+
+	_, err := Provision(context.Background(), RunDeps{CLI: cli, DS: ds},
+		ProvisionInput{
+			Account:    Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID:  "owner-oid",
+			Stack:      "mystack",
+			SkipHealth: true,
+			Selections: []Selection{{
+				Suggestion: Suggestion{Spec: azureMonitorSpec{}, Name: "gcx-azure-monitor", Scopes: []string{"/subscriptions/sub-1"}},
+				Roles:      []string{"Reader"},
+			}},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var tagged bool
+	for _, c := range runner.calls {
+		if hasPrefix(c, []string{"rest", "--method", "PATCH"}) {
+			joined := strings.Join(c, " ")
+			if !strings.Contains(joined, tagDatasourcePrefix+"uid-42") ||
+				!strings.Contains(joined, tagOwnerPrefix+"owner-oid") ||
+				!strings.Contains(joined, tagStackPrefix+"mystack") ||
+				!strings.Contains(joined, TagManaged) {
+				t.Fatalf("tag PATCH missing expected attribution: %s", joined)
+			}
+			tagged = true
+		}
+	}
+	if !tagged {
+		t.Fatal("expected the app registration to be tagged with attribution after datasource creation")
+	}
+}
+
+func TestProvision_ParallelPreservesOrderAndCreatesAll(t *testing.T) {
+	runner := &scriptedRunner{handler: mintHandler()}
+	cli := NewCLIWithRunner(runner)
+
+	// Datasource create echoes back the requested name/type, so each parallel
+	// job produces a distinct, correctly-ordered result row.
+	var created int32
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		var req struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		atomic.AddInt32(&created, 1)
+		_, _ = w.Write([]byte(`{"datasource":{"uid":"uid-` + req.Name + `","name":"` + req.Name + `","type":"` + req.Type + `"}}`))
+	}))
+
+	sels := make([]Selection, 0, 5)
+	for _, n := range []string{"gcx-azure-monitor-a", "gcx-azure-monitor-b", "gcx-azure-monitor-c", "gcx-azure-monitor-d", "gcx-azure-monitor-e"} {
+		sels = append(sels, Selection{
+			Suggestion: Suggestion{Spec: azureMonitorSpec{}, Name: n, Scopes: []string{"/subscriptions/sub-1"}},
+			Roles:      []string{"Reader"},
+		})
+	}
+
+	res, err := Provision(context.Background(), RunDeps{CLI: cli, DS: ds},
+		ProvisionInput{
+			Account:     Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID:   "oid",
+			SkipHealth:  true,
+			Concurrency: 4,
+			Selections:  sels,
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if int(created) != len(sels) {
+		t.Fatalf("expected %d datasources created, got %d", len(sels), created)
+	}
+	if len(res.Datasources) != len(sels) {
+		t.Fatalf("expected %d result rows, got %d", len(sels), len(res.Datasources))
+	}
+	// Result order must match input selection order regardless of completion order.
+	for i, sel := range sels {
+		if res.Datasources[i].Name != sel.Suggestion.Name {
+			t.Fatalf("result[%d] = %q, want %q (order not preserved)", i, res.Datasources[i].Name, sel.Suggestion.Name)
+		}
+		if res.Datasources[i].Status != onboard.StatusCreated {
+			t.Fatalf("result[%d] status = %q, want created", i, res.Datasources[i].Status)
+		}
+	}
+}
+
+func TestProvision_ParallelRollsBackAllCreatedOnFailure(t *testing.T) {
+	runner := &scriptedRunner{handler: mintHandlerDistinct()}
+	cli := NewCLIWithRunner(runner)
+
+	// One of several parallel datasource creations fails; every app
+	// registration minted during the run must be rolled back (deleted) so a
+	// mid-parallel failure never leaves orphaned credentials behind.
+	const failName = "gcx-azure-monitor-c"
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`[]`))
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			var req struct {
+				Name string `json:"name"`
+				Type string `json:"type"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == failName {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"boom"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"datasource":{"uid":"uid-` + req.Name + `","name":"` + req.Name + `","type":"` + req.Type + `"}}`))
+		}
+	}))
+
+	sels := make([]Selection, 0, 5)
+	for _, n := range []string{"gcx-azure-monitor-a", "gcx-azure-monitor-b", failName, "gcx-azure-monitor-d", "gcx-azure-monitor-e"} {
+		sels = append(sels, Selection{
+			Suggestion: Suggestion{Spec: azureMonitorSpec{}, Name: n, Scopes: []string{"/subscriptions/sub-1"}},
+			Roles:      []string{"Reader"},
+		})
+	}
+
+	_, err := Provision(context.Background(), RunDeps{CLI: cli, DS: ds},
+		ProvisionInput{
+			Account:     Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID:   "oid",
+			SkipHealth:  true,
+			Concurrency: 4,
+			Selections:  sels,
+		})
+	if err == nil {
+		t.Fatal("expected a run error when one parallel datasource creation fails")
+	}
+
+	// Every app registration that was created must have a matching rollback
+	// delete. Provision has returned, so all workers are joined and reading the
+	// recorded calls is race-free.
+	created := map[string]bool{}
+	deleted := map[string]bool{}
+	for _, c := range runner.calls {
+		switch {
+		case hasPrefix(c, []string{"ad", "app", "create"}):
+			created["app-"+flagValue(c, "--display-name")] = true
+		case hasPrefix(c, []string{"ad", "app", "delete"}):
+			deleted[flagValue(c, "--id")] = true
+		}
+	}
+	if len(created) < 2 {
+		t.Fatalf("expected several app registrations to be minted in parallel, got %d", len(created))
+	}
+	for appID := range created {
+		if !deleted[appID] {
+			t.Fatalf("app registration %q was created but not rolled back; deleted=%v", appID, deleted)
+		}
+	}
+}
+
+func TestProvision_PrivateNetworkAddsPDCHint(t *testing.T) {
+	newDS := func(t *testing.T) *datasources.Client {
+		t.Helper()
+		return newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"datasource":{"uid":"uid-1","name":"gcx-azure-monitor","type":"grafana-azure-monitor-datasource"}}`))
+		}))
+	}
+
+	sel := Selection{
+		Suggestion: Suggestion{
+			Spec:           azureMonitorSpec{},
+			Name:           "gcx-azure-monitor",
+			Scopes:         []string{"/subscriptions/sub-1"},
+			PrivateNetwork: true,
+		},
+		Roles: []string{"Reader"},
+	}
+
+	// Cloud stack (non-empty Stack) → advisory PDC hint with docs link.
+	runner := &scriptedRunner{handler: mintHandler()}
+	res, err := Provision(context.Background(), RunDeps{CLI: NewCLIWithRunner(runner), DS: newDS(t)},
+		ProvisionInput{
+			Account:    Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID:  "oid",
+			Stack:      "mystack",
+			SkipHealth: true,
+			Selections: []Selection{sel},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d := res.Datasources[0]; d.Hint == "" || d.HintDocs != docs.PrivateDataSourceConnect {
+		t.Fatalf("expected PDC hint with docs link on a private resource for a cloud stack, got %+v", d)
+	}
+
+	// Self-managed target (empty Stack) → no PDC hint (PDC is Cloud-only).
+	runner = &scriptedRunner{handler: mintHandler()}
+	res, err = Provision(context.Background(), RunDeps{CLI: NewCLIWithRunner(runner), DS: newDS(t)},
+		ProvisionInput{
+			Account:    Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID:  "oid",
+			SkipHealth: true,
+			Selections: []Selection{sel},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d := res.Datasources[0]; d.Hint != "" || d.HintDocs != "" {
+		t.Fatalf("did not expect a PDC hint for a self-managed target, got %+v", d)
+	}
+}
+
+func TestProvision_HealthCheckRecordsStatus(t *testing.T) {
+	runner := &scriptedRunner{handler: mintHandler()}
+	cli := NewCLIWithRunner(runner)
+
+	ds := newDSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/health"):
+			_, _ = w.Write([]byte(`{"status":"OK","message":"ok"}`))
+		case r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			_, _ = w.Write([]byte(`{"datasource":{"uid":"uid-1","name":"gcx-azure-monitor","type":"grafana-azure-monitor-datasource"}}`))
+		}
+	}))
+
+	res, err := Provision(context.Background(), RunDeps{CLI: cli, DS: ds, HealthAttempts: 1},
+		ProvisionInput{
+			Account:   Account{TenantID: "t1", SubID: "sub-1", CloudName: "AzureCloud"},
+			CallerOID: "oid",
+			Selections: []Selection{{
+				Suggestion: Suggestion{Spec: azureMonitorSpec{}, Name: "gcx-azure-monitor", Scopes: []string{"/subscriptions/sub-1"}},
+				Roles:      []string{"Reader"},
+			}},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := res.Datasources[0].Health; !strings.EqualFold(got, "OK") {
+		t.Fatalf("expected health OK, got %q", got)
+	}
+}

--- a/internal/onboard/azure/spec.go
+++ b/internal/onboard/azure/spec.go
@@ -1,0 +1,129 @@
+package azure
+
+import (
+	"context"
+	"io"
+
+	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/onboard"
+	"github.com/grafana/grafana-app-sdk/logging"
+)
+
+// Friendly datasource tokens accepted by --types and shown in the picker.
+const (
+	TokenAzureMonitor = "azure-monitor"
+	TokenADX          = "adx"
+	TokenCosmos       = "cosmos"
+)
+
+// TypeTokens returns the datasource tokens accepted by --types, in display
+// order. It is the authoritative set the command layer validates --types
+// against so an unrecognised value fails fast instead of silently matching
+// nothing.
+func TypeTokens() []string {
+	return []string{TokenAzureMonitor, TokenADX, TokenCosmos}
+}
+
+// Grafana plugin IDs.
+const (
+	KindAzureMonitor = "grafana-azure-monitor-datasource"
+	KindADX          = "grafana-azure-data-explorer-datasource"
+	KindCosmos       = "grafana-azurecosmosdb-datasource"
+)
+
+// RoleOption is a selectable set of Azure RBAC roles for a datasource, ordered
+// from most-capable default to tighter alternatives.
+type RoleOption struct {
+	Label string
+	Roles []string
+}
+
+// SpecInput carries everything a spec needs to acquire credentials and build a
+// datasource create request.
+type SpecInput struct {
+	CLI         *CLI
+	Account     Account
+	Name        string            // resolved, collision-free datasource + app name
+	Roles       []string          // selected role set (for app-registration specs)
+	Scopes      []string          // role-assignment scopes
+	CallerOID   string            // signed-in user object ID (owner)
+	Extra       map[string]string // spec-specific (e.g. ADX clusterUrl/rg/cluster)
+	Stack       string            // Grafana stack slug for attribution
+	ExpiryDays  int               // optional minted-secret expiry (0 = default)
+	Rollback    *onboard.Rollback
+	Interactive bool
+	Progress    io.Writer // human-readable narration for long-running steps (nil = suppressed)
+	Log         logging.Logger
+}
+
+// attribution builds the Attribution stamp for artifacts this spec creates. The
+// datasource UID is filled in later (after the datasource exists) by the
+// orchestrator.
+func (in SpecInput) attribution() Attribution {
+	return Attribution{Stack: in.Stack, OwnerOID: in.CallerOID}
+}
+
+// Provisioned is the result of a spec acquiring credentials.
+type Provisioned struct {
+	Request datasources.Datasource
+	AppID   string // empty when no app registration was minted (key-based specs)
+}
+
+// DatasourceSpec owns credential acquisition and payload construction for one
+// datasource type.
+type DatasourceSpec interface {
+	// Token is the friendly identifier used by --only and the picker.
+	Token() string
+	// Kind is the Grafana plugin ID.
+	Kind() string
+	// RoleOptions are the selectable role sets (default first). May be empty for
+	// key-based datasources.
+	RoleOptions() []RoleOption
+	// AcquireAndBuild mints/acquires credentials, performs any extra grants, and
+	// returns the datasource create request.
+	AcquireAndBuild(ctx context.Context, in SpecInput) (Provisioned, error)
+}
+
+// Suggestion is one datasource gcx proposes to create.
+type Suggestion struct {
+	Spec   DatasourceSpec
+	Name   string            // gcx-<stack>-<token>[-<resource>] base name
+	Label  string            // human label shown in the picker
+	Scopes []string          // role-assignment scopes
+	Extra  map[string]string // passed through to the spec
+	// Disabled marks a suggestion that is shown but cannot be provisioned (e.g.
+	// a stopped ADX cluster). DisabledReason explains why.
+	Disabled       bool
+	DisabledReason string
+	// PrivateNetwork marks a resource whose public network access is disabled,
+	// so a Grafana Cloud stack can only reach it via Private Data source
+	// Connect (PDC). Surfaced as an advisory hint on the result; it never
+	// blocks provisioning (the datasource and credentials are still created).
+	PrivateNetwork bool
+}
+
+// monitorCloud maps an `az` environmentName to the Azure Monitor datasource's
+// cloudName value.
+func monitorCloud(env string) string {
+	switch env {
+	case "AzureUSGovernment":
+		return "govazuremonitor"
+	case "AzureChinaCloud":
+		return "chinaazuremonitor"
+	default:
+		return "azuremonitor"
+	}
+}
+
+// armCloud maps an `az` environmentName to the unified azureCredentials
+// azureCloud value (used by ADX/SQL/newer plugins).
+func armCloud(env string) string {
+	switch env {
+	case "AzureUSGovernment":
+		return "AzureUSGovernment"
+	case "AzureChinaCloud":
+		return "AzureChinaCloud"
+	default:
+		return "AzureCloud"
+	}
+}


### PR DESCRIPTION
## Summary

Adds the Azure provider for cloud datasource onboarding — the engine that discovers Azure resources and provisions Grafana datasources backed by gcx-owned, least-privilege app registrations. No CLI surface yet (that lands in the next PR); this is the library the command wires into.

- **Discovery**: enumerate subscriptions, Kusto (ADX) clusters, and Cosmos DB accounts via the `az` CLI; detect private-network resources.
- **Planning**: build datasource suggestions (Azure Monitor, ADX per cluster, Cosmos DB).
- **Provisioning**: mint a gcx-owned app registration with attribution tags (`gcx:managed`, `gcx:stack`, `gcx:owner`, `gcx:datasource-uid`), assign least-privilege roles, and create the datasource.
- **Idempotent**: reuses existing gcx-managed datasources instead of duplicating.
- **Bounded parallelism** with rollback on failure; **dry-run**; **health verification** with backoff for RBAC propagation.
- **Owner/stack-scoped cleanup and secret rotation** — destructive operations refuse to run without a resolved caller identity so they can never touch another owner's artifacts in a shared tenant.
- **PDC advisory hint** for privately-networked resources (Cloud stacks) — detect and hint, no auto-provisioning.

## Files

- `internal/onboard/azure/*.go` (+ tests): `cli`, `discover`, `plan`, `spec`, `azuremonitor`, `adx`, `cosmos`, `run`, `cleanup`, `rotate`
- `internal/docs/links.go` — adds the Private Data source Connect docs link consumed by `run.go`

## Stack

1. #1101
2. #1102
3. #1103
4. **this PR** — Azure datasource onboarding engine *(base: `andreas/onboard-3-core`)*
5. #1105

## Test plan

- [ ] `go test ./internal/onboard/...`
- [ ] `go build ./...`