### PR TITLE
Add gcx setup datasources azure command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,17 +8,17 @@
 
 ## Documentation Map
 
-| File | Purpose |
-|------|---------|
-| [VISION.md](VISION.md) | Goals, product surface, roadmap themes, release timeline |
-| [CONSTITUTION.md](CONSTITUTION.md) | Invariants — things that cannot change without explicit human approval |
-| [ARCHITECTURE.md](ARCHITECTURE.md) | System overview (all 7 subsystems), pipeline diagrams, ADR index |
-| [DESIGN.md](DESIGN.md) | CLI UX design: command grammar, output model, exit codes |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | Dev setup, testing environment, contribution workflow |
+| File                                     | Purpose                                                                          |
+| ---------------------------------------- | -------------------------------------------------------------------------------- |
+| [VISION.md](VISION.md)                   | Goals, product surface, roadmap themes, release timeline                         |
+| [CONSTITUTION.md](CONSTITUTION.md)       | Invariants — things that cannot change without explicit human approval           |
+| [ARCHITECTURE.md](ARCHITECTURE.md)       | System overview (all 7 subsystems), pipeline diagrams, ADR index                 |
+| [DESIGN.md](DESIGN.md)                   | CLI UX design: command grammar, output model, exit codes                         |
+| [CONTRIBUTING.md](CONTRIBUTING.md)       | Dev setup, testing environment, contribution workflow                            |
 | [docs/architecture/](docs/architecture/) | Deep-dive architecture docs (patterns, resource model, CLI layer, data flows, …) |
-| [docs/design/](docs/design/) | Prescriptive UX implementation rules (output, errors, agent mode, naming, …) |
-| [docs/reference/](docs/reference/) | Provider guides, CLI reference, migration analysis |
-| [docs/_templates/](docs/_templates/) | Spec and planning templates (feature, bugfix, refactor, ADR, research) |
+| [docs/design/](docs/design/)             | Prescriptive UX implementation rules (output, errors, agent mode, naming, …)     |
+| [docs/reference/](docs/reference/)       | Provider guides, CLI reference, migration analysis                               |
+| [docs/\_templates/](docs/_templates/)    | Spec and planning templates (feature, bugfix, refactor, ADR, research)           |
 
 ## Architecture at a Glance
 
@@ -74,7 +74,7 @@ cmd/gcx/
   linter/       Linting (mounted under dev lint)
   commands/     Commands catalog (agent metadata)
   helptree/     Help tree for agent context
-  setup/        Onboarding (gcx setup status)
+  setup/        Setup command area (status; datasources/ — onboard cloud datasources: azure Azure Monitor + ADX + Cosmos, mints gcx-owned app registrations, provisions via legacy datasource API; azure rotate subcommand rotates gcx-minted secrets)
   instrumentation/  Instrumentation Hub commands (clusters, services, setup wizard, status)
   skills/       Portable Agent Skills installer for .agents-compatible tools (install/update/list/get/uninstall; get reads bundled SKILL.md or references without installing)
   dev/          Developer tools (import, scaffold, generate, lint, serve)
@@ -85,29 +85,30 @@ internal/        Non-public packages — full annotated map: docs/architecture/p
 
 ## What to Read Before You Start
 
-| Task | Read first | Then |
-|------|-----------|------|
-| **Adding a new command** | [DESIGN.md](DESIGN.md) (grammar, output model) | [docs/design/](docs/design/) for implementation rules, [ARCHITECTURE.md](ARCHITECTURE.md) § CLI layer |
-| **Adding a new provider** | [ARCHITECTURE.md](ARCHITECTURE.md) § Provider System | [docs/reference/provider-guide.md](docs/reference/provider-guide.md), [docs/design/provider-checklist.md](docs/design/provider-checklist.md) |
-| **Adding a signal provider command** | [ARCHITECTURE.md](ARCHITECTURE.md) § Signal Providers | Existing signal provider code for the SharedOpts pattern |
-| **Modifying resource handling** | [ARCHITECTURE.md](ARCHITECTURE.md) § Resources Pipeline | [docs/architecture/resource-model.md](docs/architecture/resource-model.md), [docs/architecture/data-flows.md](docs/architecture/data-flows.md) |
-| **Changing config or auth** | [ARCHITECTURE.md](ARCHITECTURE.md) § Configuration + § Auth | [docs/architecture/config-system.md](docs/architecture/config-system.md), [docs/architecture/client-api-layer.md](docs/architecture/client-api-layer.md) |
-| **Fixing a bug** | [ARCHITECTURE.md](ARCHITECTURE.md) for the relevant subsystem | Jump directly to the deep-dive doc for that domain |
-| **Planning a new feature** | [VISION.md](VISION.md) (does it belong?), [CONSTITUTION.md](CONSTITUTION.md) (can we build it within the rules?) | [DESIGN.md](DESIGN.md) for UX, [ARCHITECTURE.md](ARCHITECTURE.md) for structure |
-| **Reviewing a PR** | [Compliance Hierarchy](#compliance-hierarchy) below | Check all 4 levels in order |
+| Task                                 | Read first                                                                                                       | Then                                                                                                                                                     |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Adding a new command**             | [DESIGN.md](DESIGN.md) (grammar, output model)                                                                   | [docs/design/](docs/design/) for implementation rules, [ARCHITECTURE.md](ARCHITECTURE.md) § CLI layer                                                    |
+| **Adding a new provider**            | [ARCHITECTURE.md](ARCHITECTURE.md) § Provider System                                                             | [docs/reference/provider-guide.md](docs/reference/provider-guide.md), [docs/design/provider-checklist.md](docs/design/provider-checklist.md)             |
+| **Adding a signal provider command** | [ARCHITECTURE.md](ARCHITECTURE.md) § Signal Providers                                                            | Existing signal provider code for the SharedOpts pattern                                                                                                 |
+| **Modifying resource handling**      | [ARCHITECTURE.md](ARCHITECTURE.md) § Resources Pipeline                                                          | [docs/architecture/resource-model.md](docs/architecture/resource-model.md), [docs/architecture/data-flows.md](docs/architecture/data-flows.md)           |
+| **Changing config or auth**          | [ARCHITECTURE.md](ARCHITECTURE.md) § Configuration + § Auth                                                      | [docs/architecture/config-system.md](docs/architecture/config-system.md), [docs/architecture/client-api-layer.md](docs/architecture/client-api-layer.md) |
+| **Fixing a bug**                     | [ARCHITECTURE.md](ARCHITECTURE.md) for the relevant subsystem                                                    | Jump directly to the deep-dive doc for that domain                                                                                                       |
+| **Planning a new feature**           | [VISION.md](VISION.md) (does it belong?), [CONSTITUTION.md](CONSTITUTION.md) (can we build it within the rules?) | [DESIGN.md](DESIGN.md) for UX, [ARCHITECTURE.md](ARCHITECTURE.md) for structure                                                                          |
+| **Reviewing a PR**                   | [Compliance Hierarchy](#compliance-hierarchy) below                                                              | Check all 4 levels in order                                                                                                                              |
 
 ## Compliance Hierarchy
 
 Check work against these docs during planning, design, and implementation — in order of strictness.
 
-| # | Doc | Strictness | What to check | If violated |
-|---|-----|-----------|---------------|-------------|
-| 1 | [CONSTITUTION.md](CONSTITUTION.md) | **Hard invariant** — violation is a bug | Architecture invariants, dependency rules, provider registration, CLI grammar, typed resource requirements | Stop. Fix before proceeding. Violation requires explicit human approval to waive. |
-| 2 | [VISION.md](VISION.md) | **Strategic alignment** — violation is wasted work | Does this belong in gcx? Does it align with dual-purpose design, core beliefs, product surface? | Pause. Confirm direction with a human before investing more effort. |
-| 3 | [DESIGN.md](DESIGN.md) | **UX rules** — violation is a UX defect | Output model, exit codes, safety patterns, taste rules in [docs/design/](docs/design/) | Fix. New code must comply. |
-| 4 | [ARCHITECTURE.md](ARCHITECTURE.md) | **Structural guidance** — violation is tech debt | Pipeline placement, package boundaries, patterns in [docs/architecture/](docs/architecture/README.md) | Prefer compliance. Deviation is acceptable with rationale (document in commit or ADR). |
+| #   | Doc                                | Strictness                                         | What to check                                                                                              | If violated                                                                            |
+| --- | ---------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 1   | [CONSTITUTION.md](CONSTITUTION.md) | **Hard invariant** — violation is a bug            | Architecture invariants, dependency rules, provider registration, CLI grammar, typed resource requirements | Stop. Fix before proceeding. Violation requires explicit human approval to waive.      |
+| 2   | [VISION.md](VISION.md)             | **Strategic alignment** — violation is wasted work | Does this belong in gcx? Does it align with dual-purpose design, core beliefs, product surface?            | Pause. Confirm direction with a human before investing more effort.                    |
+| 3   | [DESIGN.md](DESIGN.md)             | **UX rules** — violation is a UX defect            | Output model, exit codes, safety patterns, taste rules in [docs/design/](docs/design/)                     | Fix. New code must comply.                                                             |
+| 4   | [ARCHITECTURE.md](ARCHITECTURE.md) | **Structural guidance** — violation is tech debt   | Pipeline placement, package boundaries, patterns in [docs/architecture/](docs/architecture/README.md)      | Prefer compliance. Deviation is acceptable with rationale (document in commit or ADR). |
 
 **When to check:**
+
 - **Planning/design**: Check VISION (2) and CONSTITUTION (1) — are we building the right thing, and can we build it within the rules?
 - **Implementation**: Check DESIGN (3) and ARCHITECTURE (4) — does the code follow UX rules and structural patterns?
 - **Pre-flight** (below): Final sweep across all four before pushing.

--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -469,6 +469,8 @@
  "gcx resources pull": "artifact",
  "gcx resources push": "finite",
  "gcx resources validate": "finite",
+ "gcx setup datasources azure": "finite",
+ "gcx setup datasources azure rotate": "finite",
  "gcx setup status": "finite",
  "gcx slo definitions delete": "finite",
  "gcx slo definitions get": "finite",

--- a/cmd/gcx/setup/command.go
+++ b/cmd/gcx/setup/command.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	datasourcescmd "github.com/grafana/gcx/cmd/gcx/setup/datasources"
 	fleetbase "github.com/grafana/gcx/internal/fleet"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
@@ -33,6 +34,7 @@ func Command() *cobra.Command {
 	loader.BindFlags(cmd.PersistentFlags())
 
 	cmd.AddCommand(newStatusCommand(loader))
+	cmd.AddCommand(datasourcescmd.Command())
 
 	return cmd
 }

--- a/cmd/gcx/setup/datasources/azure/command.go
+++ b/cmd/gcx/setup/datasources/azure/command.go
@@ -1,0 +1,158 @@
+package azure
+
+import (
+	"strings"
+
+	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/gcxerrors"
+	azonboard "github.com/grafana/gcx/internal/onboard/azure"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type azureOpts struct {
+	Config           cmdconfig.Options
+	IO               cmdio.Options
+	Subscription     []string
+	AllSubscriptions bool
+	Types            []string
+	Role             string
+	IncludeCosmos    bool
+	Cleanup          bool
+	DryRun           bool
+	SkipHealth       bool
+	SecretExpiry     int
+	Concurrency      int
+	Yes              bool
+	Force            bool
+}
+
+func (o *azureOpts) setup(flags *pflag.FlagSet) {
+	o.Config.BindFlags(flags)
+	o.IO.RegisterCustomCodec("text", &onboardTextCodec{})
+	o.IO.DefaultFormat("text")
+	o.IO.BindFlags(flags)
+
+	flags.StringSliceVar(&o.Subscription, "subscription", nil, "Subscription ID(s) to target (default: the active subscription, or interactive multi-select)")
+	flags.BoolVar(&o.AllSubscriptions, "all-subscriptions", false, "Onboard every discovered subscription non-interactively (otherwise --subscription is required when several exist)")
+	flags.StringSliceVar(&o.Types, "types", nil, "Restrict to datasource kinds: azure-monitor, adx, cosmos")
+	flags.StringVar(&o.Role, "role", "", "Override the default Azure role set (comma-separated role names, e.g. \"Monitoring Reader\")")
+	flags.BoolVar(&o.IncludeCosmos, "include-cosmos", false, "Include Azure Cosmos DB datasources (requires the Enterprise plugin licensed in Grafana)")
+	flags.BoolVar(&o.Cleanup, "cleanup", false, "Remove gcx-created Azure app registrations and their datasources")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview what would be created or removed without making any changes")
+	flags.BoolVar(&o.SkipHealth, "skip-health-check", false, "Skip the post-create datasource health verification")
+	flags.IntVar(&o.SecretExpiry, "secret-expiry-days", 0, "Set an expiry (in days) on minted client secrets (0 = Azure default). Rotate before expiry with the rotate subcommand")
+	flags.IntVar(&o.Concurrency, "concurrency", 0, "Maximum datasources to provision in parallel (0 = default; interactive runs are always serial)")
+	flags.BoolVar(&o.Yes, "yes", false, "Non-interactive: skip prompts and accept all suggestions")
+	flags.BoolVar(&o.Force, "force", false, "Confirm credential-minting side effects (required in agent mode); implies --yes")
+}
+
+func (o *azureOpts) Validate() error {
+	if err := o.validateTypes(); err != nil {
+		return err
+	}
+
+	// --dry-run never mutates, so it is always exempt from the agent-mode --force
+	// gate. Both provisioning (mints credentials) and cleanup (deletes cloud
+	// artifacts) mutate, so they require --force in agent mode, where gcx cannot
+	// prompt for confirmation.
+	if agent.IsAgentMode() && !o.Force && !o.DryRun {
+		if o.Cleanup {
+			return gcxerrors.DetailedError{
+				Summary: "setup datasources azure --cleanup deletes cloud artifacts; --force is required in agent mode",
+				Details: "Cleanup permanently removes gcx-created Azure app registrations, role assignments, and Grafana datasources.",
+				Suggestions: []string{
+					"Re-run with --cleanup --force",
+					"Or preview first with --cleanup --dry-run (nothing is deleted)",
+				},
+			}
+		}
+		return gcxerrors.DetailedError{
+			Summary: "setup datasources azure mints cloud credentials; --force is required in agent mode",
+			Details: "Provisioning creates Azure app registrations, role assignments, and Grafana datasources.",
+			Suggestions: []string{
+				"Re-run with --force [--subscription <id>] [--types azure-monitor]",
+				"Or preview first with --dry-run (no credentials are minted)",
+			},
+		}
+	}
+
+	return o.IO.Validate()
+}
+
+// validateTypes rejects unknown --types values up front so a typo (e.g.
+// "--types adxx") fails with the valid set rather than silently matching no
+// suggestions and reporting "nothing was created".
+func (o *azureOpts) validateTypes() error {
+	if len(o.Types) == 0 {
+		return nil
+	}
+	valid := make(map[string]bool, len(azonboard.TypeTokens()))
+	for _, t := range azonboard.TypeTokens() {
+		valid[t] = true
+	}
+	var unknown []string
+	for _, t := range o.Types {
+		norm := strings.ToLower(strings.TrimSpace(t))
+		if norm != "" && !valid[norm] {
+			unknown = append(unknown, t)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	return gcxerrors.DetailedError{
+		Summary: "unknown --types value(s): " + strings.Join(unknown, ", "),
+		Suggestions: []string{
+			"Valid types are: " + strings.Join(azonboard.TypeTokens(), ", "),
+		},
+	}
+}
+
+// Command returns the `gcx setup datasources azure` command.
+func Command() *cobra.Command {
+	opts := &azureOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "azure",
+		Short: "Onboard Azure datasources (Azure Monitor, Azure Data Explorer, and Azure CosmosDB)",
+		Long: "Discover Azure resources using your local `az` CLI session and provision the " +
+			"matching Grafana datasources. For each accepted datasource, gcx mints a dedicated, " +
+			"gcx-owned Azure app registration (service principal + secret + least-privilege role) " +
+			"with you set as owner, then creates the Grafana datasource wired to those credentials.",
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "small",
+			agent.AnnotationLLMHint: "Mints Azure credentials and creates datasources; requires --force in agent mode (or use --dry-run to preview without minting). " +
+				"Example: gcx setup datasources azure --force --types azure-monitor --subscription <sub-id> -o json. " +
+				"Clean up gcx-created artifacts with: gcx setup datasources azure --cleanup --force -o json. " +
+				"Rotate minted secrets with: gcx setup datasources azure rotate --force -o json",
+		},
+		Example: `
+  # Interactive: discover and pick datasources to create
+  gcx setup datasources azure
+
+  # Preview what would be created without minting anything
+  gcx setup datasources azure --dry-run
+
+  # Non-interactive: create the Azure Monitor datasource with a specified subscription
+  gcx setup datasources azure --force --types azure-monitor --subscription <sub-id>
+
+  # Tighten Azure Monitor permissions to metrics only
+  gcx setup datasources azure --types azure-monitor --role "Monitoring Reader"
+
+  # Remove everything gcx created
+  gcx setup datasources azure --cleanup --force`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			return runAzure(cmd, opts)
+		},
+	}
+
+	opts.setup(cmd.Flags())
+	cmd.AddCommand(rotateCommand())
+	return cmd
+}

--- a/cmd/gcx/setup/datasources/azure/command_test.go
+++ b/cmd/gcx/setup/datasources/azure/command_test.go
@@ -1,0 +1,142 @@
+//nolint:testpackage // white-box tests exercise unexported option validation
+package azure
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/spf13/pflag"
+)
+
+// newOpts builds an azureOpts with flags bound, mirroring command construction.
+// Agent-mode env must be set before calling so BindFlags resolves the right
+// default output codec.
+func newOpts(t *testing.T) *azureOpts {
+	t.Helper()
+	opts := &azureOpts{}
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.setup(fs)
+	return opts
+}
+
+func TestValidate_AgentModeRequiresForce(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "true")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	opts := newOpts(t)
+
+	err := opts.Validate()
+	if err == nil {
+		t.Fatal("expected error in agent mode without --force")
+	}
+	var de gcxerrors.DetailedError
+	if !errors.As(err, &de) {
+		t.Fatalf("expected DetailedError, got %T", err)
+	}
+}
+
+func TestValidate_AgentModeForceAllowed(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "true")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	opts := newOpts(t)
+	opts.Force = true
+	if err := opts.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_AgentModeCleanupRequiresForce(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "true")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	opts := newOpts(t)
+	opts.Cleanup = true
+
+	err := opts.Validate()
+	if err == nil {
+		t.Fatal("expected error for destructive cleanup in agent mode without --force")
+	}
+	var de gcxerrors.DetailedError
+	if !errors.As(err, &de) {
+		t.Fatalf("expected DetailedError, got %T", err)
+	}
+}
+
+func TestValidate_AgentModeCleanupForceAllowed(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "true")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	opts := newOpts(t)
+	opts.Cleanup = true
+	opts.Force = true
+	if err := opts.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_AgentModeCleanupDryRunAllowedWithoutForce(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "true")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	opts := newOpts(t)
+	opts.Cleanup = true
+	opts.DryRun = true
+	if err := opts.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_AgentModeDryRunAllowedWithoutForce(t *testing.T) {
+	t.Setenv("GCX_AGENT_MODE", "true")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	opts := newOpts(t)
+	opts.DryRun = true
+	if err := opts.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateTypes_RejectsUnknown(t *testing.T) {
+	opts := newOpts(t)
+	opts.Types = []string{"azure-monitor", "adxx"}
+
+	err := opts.validateTypes()
+	if err == nil {
+		t.Fatal("expected error for an unknown --types value")
+	}
+	var de gcxerrors.DetailedError
+	if !errors.As(err, &de) {
+		t.Fatalf("expected DetailedError, got %T", err)
+	}
+}
+
+func TestValidateTypes_AcceptsKnown(t *testing.T) {
+	opts := newOpts(t)
+	opts.Types = []string{"azure-monitor", " ADX ", "cosmos"}
+	if err := opts.validateTypes(); err != nil {
+		t.Fatalf("unexpected error for valid --types: %v", err)
+	}
+}
+
+func TestSplitRoles(t *testing.T) {
+	got := splitRoles(" Reader , Monitoring Reader ,")
+	want := []string{"Reader", "Monitoring Reader"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}

--- a/cmd/gcx/setup/datasources/azure/encoding.go
+++ b/cmd/gcx/setup/datasources/azure/encoding.go
@@ -1,0 +1,95 @@
+package azure
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/grafana/gcx/internal/docs"
+	"github.com/grafana/gcx/internal/format"
+	"github.com/grafana/gcx/internal/onboard"
+)
+
+// onboardTextCodec renders an onboard.Result as a human-friendly summary.
+type onboardTextCodec struct{}
+
+func (c *onboardTextCodec) Format() format.Format { return "text" }
+
+func (c *onboardTextCodec) Encode(w io.Writer, value any) error {
+	res, ok := value.(onboard.Result)
+	if !ok {
+		return fmt.Errorf("onboard text codec: unsupported type %T", value)
+	}
+
+	if len(res.Cleaned) > 0 || (res.DryRun && len(res.Datasources) == 0) {
+		return c.encodeCleaned(w, res)
+	}
+
+	if len(res.Datasources) == 0 {
+		fmt.Fprintln(w, "No datasources were created.")
+		return nil
+	}
+
+	if res.DryRun {
+		fmt.Fprintf(w, "Dry run — %d datasource(s) planned (nothing was created):\n", len(res.Datasources))
+	} else {
+		fmt.Fprintf(w, "%d datasource(s):\n", len(res.Datasources))
+	}
+	for _, d := range res.Datasources {
+		c.encodeDatasource(w, d)
+	}
+	return nil
+}
+
+func (c *onboardTextCodec) encodeCleaned(w io.Writer, res onboard.Result) error {
+	verb := "Removed"
+	if res.DryRun {
+		verb = "Would remove"
+	}
+	if len(res.Cleaned) == 0 {
+		fmt.Fprintf(w, "%s 0 gcx-created artifact(s).\n", verb)
+		return nil
+	}
+	fmt.Fprintf(w, "%s %d gcx-created artifact(s):\n", verb, len(res.Cleaned))
+	for _, cl := range res.Cleaned {
+		fmt.Fprintf(w, "  - %s %s\n", cl.Kind, cl.Name)
+	}
+	return nil
+}
+
+func (c *onboardTextCodec) encodeDatasource(w io.Writer, d onboard.DatasourceResult) {
+	fmt.Fprintf(w, "  - %s (%s)", d.Name, d.Type)
+	if d.UID != "" {
+		fmt.Fprintf(w, " uid=%s", d.UID)
+	}
+	if d.Credential != nil && d.Credential.ID != "" {
+		fmt.Fprintf(w, " id=%s", d.Credential.ID)
+	}
+	if d.Status != "" {
+		fmt.Fprintf(w, " [%s]", d.Status)
+	}
+	if d.Health != "" {
+		fmt.Fprintf(w, " health=%s", d.Health)
+	}
+	if d.Credential != nil && len(d.Credential.Roles) > 0 {
+		fmt.Fprintf(w, " roles=%s", strings.Join(d.Credential.Roles, ","))
+	}
+	if d.Note != "" {
+		fmt.Fprintf(w, " (%s)", d.Note)
+	}
+	fmt.Fprintln(w)
+	if d.HealthMessage != "" {
+		fmt.Fprintf(w, "      health: %s\n", d.HealthMessage)
+	}
+	if d.Hint != "" {
+		fmt.Fprintf(w, "      hint: %s\n", d.Hint)
+		if d.HintDocs != "" {
+			fmt.Fprintf(w, "      docs: %s\n", docs.HumanURL(d.HintDocs))
+		}
+	}
+}
+
+func (c *onboardTextCodec) Decode(io.Reader, any) error {
+	return errors.New("onboard text codec does not support decoding")
+}

--- a/cmd/gcx/setup/datasources/azure/output.go
+++ b/cmd/gcx/setup/datasources/azure/output.go
@@ -1,0 +1,27 @@
+package azure
+
+import (
+	"github.com/grafana/gcx/internal/config"
+	azonboard "github.com/grafana/gcx/internal/onboard/azure"
+)
+
+// subLabel renders a subscription for progress output, preferring its name.
+func subLabel(a azonboard.Account) string {
+	if a.Name != "" {
+		return a.Name
+	}
+	return a.SubID
+}
+
+// stackLabel derives the Grafana stack slug (used to label and attribute
+// created artifacts) from the resolved REST config.
+func stackLabel(restCfg config.NamespacedRESTConfig) string {
+	url := restCfg.GrafanaURL
+	if url == "" {
+		url = restCfg.Host
+	}
+	if slug, ok := config.StackSlugFromServerURL(url); ok && slug != "" {
+		return slug
+	}
+	return ""
+}

--- a/cmd/gcx/setup/datasources/azure/prompts.go
+++ b/cmd/gcx/setup/datasources/azure/prompts.go
@@ -1,0 +1,131 @@
+package azure
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/charmbracelet/huh"
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/onboard"
+	azonboard "github.com/grafana/gcx/internal/onboard/azure"
+	"github.com/grafana/gcx/internal/terminal"
+	"golang.org/x/term"
+)
+
+// canPrompt reports whether gcx can render an interactive TUI prompt: both
+// stdout and stdin must be TTYs and the process must not be in agent mode.
+func canPrompt() bool {
+	return terminal.StdoutIsTerminal() &&
+		term.IsTerminal(int(os.Stdin.Fd())) &&
+		!agent.IsAgentMode()
+}
+
+// isInteractive reports whether to render the TUI pickers. Both --yes and
+// --force imply "accept all suggestions", so either one (like a non-TTY or
+// agent mode) turns the picker off. This lets agent/CI callers provision with a
+// single --force flag instead of pairing it with --yes.
+func isInteractive(opts *azureOpts) bool {
+	return canPrompt() && !opts.Yes && !opts.Force
+}
+
+// pickSuggestions renders the interactive datasource multiselect. Disabled
+// suggestions (e.g. stopped ADX clusters) are shown unchecked and labelled
+// "(not selectable)"; a Validate guard refuses to submit if one is checked,
+// since huh has no native per-option disabling.
+func pickSuggestions(suggestions []azonboard.Suggestion) ([]azonboard.Suggestion, error) {
+	options := make([]huh.Option[int], 0, len(suggestions))
+	var picked []int
+	for i, s := range suggestions {
+		label := s.Label
+		if s.Disabled {
+			label += " (not selectable — " + s.DisabledReason + ")"
+		}
+		options = append(options, huh.NewOption(label, i).Selected(!s.Disabled))
+		if !s.Disabled {
+			picked = append(picked, i)
+		}
+	}
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewMultiSelect[int]().
+			Title("Datasources to create").
+			Options(options...).
+			Validate(func(sel []int) error {
+				for _, i := range sel {
+					if suggestions[i].Disabled {
+						return fmt.Errorf("%s is not selectable: %s", suggestions[i].Label, suggestions[i].DisabledReason)
+					}
+				}
+				return nil
+			}).
+			Value(&picked),
+	))
+	if err := form.Run(); err != nil {
+		return nil, err
+	}
+	chosen := make([]azonboard.Suggestion, 0, len(picked))
+	for _, i := range picked {
+		chosen = append(chosen, suggestions[i])
+	}
+	return chosen, nil
+}
+
+// confirmCleanup lists the gcx-created artifacts that will be permanently
+// removed and asks the user to confirm. It defaults to "Cancel" because the
+// action is destructive and irreversible.
+func confirmCleanup(errOut io.Writer, preview onboard.Result) (bool, error) {
+	fmt.Fprintf(errOut, "The following %d gcx-created artifact(s) will be permanently removed:\n", len(preview.Cleaned))
+	for _, c := range preview.Cleaned {
+		fmt.Fprintf(errOut, "  - %s %s\n", c.Kind, c.Name)
+	}
+	proceed := false
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewConfirm().
+			Title("Remove these artifacts? This cannot be undone.").
+			Affirmative("Remove").
+			Negative("Cancel").
+			Value(&proceed),
+	))
+	if err := form.Run(); err != nil {
+		return false, err
+	}
+	return proceed, nil
+}
+
+// confirmRollback lists the changes that can be reverted and asks the user
+// whether to undo them. Defaults to reverting.
+func confirmRollback(errOut io.Writer, steps []string) (bool, error) {
+	fmt.Fprintln(errOut, "The following changes were made before the error and can be reverted:")
+	for _, s := range steps {
+		fmt.Fprintf(errOut, "  - %s\n", s)
+	}
+	revert := true
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewConfirm().
+			Title("Revert these changes?").
+			Affirmative("Revert").
+			Negative("Keep them").
+			Value(&revert),
+	))
+	if err := form.Run(); err != nil {
+		return false, err
+	}
+	return revert, nil
+}
+
+// confirmInstallPlugin asks whether to install a missing required plugin.
+// Defaults to installing.
+func confirmInstallPlugin(pluginID string) (bool, error) {
+	install := true
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewConfirm().
+			Title(fmt.Sprintf("The %q plugin is required but not installed. Install it now?", pluginID)).
+			Affirmative("Install").
+			Negative("Skip").
+			Value(&install),
+	))
+	if err := form.Run(); err != nil {
+		return false, err
+	}
+	return install, nil
+}

--- a/cmd/gcx/setup/datasources/azure/provision.go
+++ b/cmd/gcx/setup/datasources/azure/provision.go
@@ -13,6 +13,7 @@ import (
 	azonboard "github.com/grafana/gcx/internal/onboard/azure"
 	cmdio "github.com/grafana/gcx/internal/output"
 	pluginsclient "github.com/grafana/gcx/internal/plugins"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 )
@@ -163,7 +164,15 @@ func runCleanup(
 		return opts.IO.Encode(cmd.OutOrStdout(), res)
 	}
 
-	if !opts.Force {
+	// Route through the shared destructive-bypass chain so --force,
+	// GCX_AUTO_APPROVE, and agent mode behave identically to every other
+	// destructive command (docs/design/safety.md § 3.2). Only when nothing
+	// bypasses do we fall back to the interactive preview + confirmation.
+	bypass, err := providers.CheckDestructiveBypass(opts.Force)
+	if err != nil {
+		return err
+	}
+	if !bypass {
 		proceed, err := confirmRemoval(cmd, opts, deps, callerOID, stack, progress, errOut)
 		if err != nil || !proceed {
 			return err

--- a/cmd/gcx/setup/datasources/azure/provision.go
+++ b/cmd/gcx/setup/datasources/azure/provision.go
@@ -1,0 +1,320 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/agent"
+	dsclient "github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/grafana/gcx/internal/onboard"
+	azonboard "github.com/grafana/gcx/internal/onboard/azure"
+	cmdio "github.com/grafana/gcx/internal/output"
+	pluginsclient "github.com/grafana/gcx/internal/plugins"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+)
+
+func runAzure(cmd *cobra.Command, opts *azureOpts) error {
+	ctx := cmd.Context()
+	log := logging.FromContext(ctx)
+	errOut := cmd.ErrOrStderr()
+
+	// Progress narration goes to stderr for humans; suppressed in agent mode
+	// where the structured result on stdout is the contract.
+	var progress io.Writer
+	if !agent.IsAgentMode() {
+		progress = errOut
+	}
+
+	onboard.Progressf(progress, "Checking for the Azure CLI (az)...")
+	cli := azonboard.NewCLI()
+	if err := cli.Ensure(); err != nil {
+		return err
+	}
+
+	onboard.Progressf(progress, "Connecting to Grafana...")
+	restCfg, err := opts.Config.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return err
+	}
+	ds, err := dsclient.NewClient(restCfg)
+	if err != nil {
+		return err
+	}
+	pluginsClient, err := pluginsclient.NewClient(restCfg)
+	if err != nil {
+		return err
+	}
+
+	deps := azonboard.RunDeps{CLI: cli, DS: ds, Plugins: pluginsClient, Log: log, ErrOut: errOut, Progress: progress}
+	stack := stackLabel(restCfg)
+
+	if opts.Cleanup {
+		return runCleanup(cmd, opts, deps, cli, stack, progress, errOut)
+	}
+
+	interactive := isInteractive(opts)
+
+	// In interactive mode, ask before reverting partial work on failure and
+	// before installing a missing required plugin.
+	if interactive {
+		deps.ConfirmRollback = func(steps []string) (bool, error) {
+			return confirmRollback(errOut, steps)
+		}
+		deps.ConfirmInstallPlugin = confirmInstallPlugin
+	}
+
+	// Resolve target subscriptions.
+	onboard.Progressf(progress, "Discovering Azure subscriptions...")
+	subs, err := resolveSubscriptions(ctx, cli, opts, interactive)
+	if err != nil {
+		return err
+	}
+	if len(subs) == 0 {
+		cmdio.EmitNote(errOut, "no subscriptions selected; nothing to do")
+		return opts.IO.Encode(cmd.OutOrStdout(), onboard.Result{Provider: "azure"})
+	}
+
+	// Resolve the caller object ID once (owner for minted artifacts). Tolerate
+	// failure when only previewing (--dry-run), which mints nothing that needs
+	// an owner.
+	onboard.Progressf(progress, "Resolving your Azure identity...")
+	callerOID, oidErr := cli.SignedInUserObjectID(ctx)
+	if oidErr != nil && !opts.DryRun {
+		return oidErr
+	}
+
+	// Preserve and restore the originally-active subscription.
+	original, _ := cli.CurrentAccount(ctx)
+	defer func() {
+		if original.SubID != "" {
+			_ = cli.SetSubscription(context.WithoutCancel(ctx), original.SubID)
+		}
+	}()
+
+	// Provision each subscription independently. A failure in one subscription
+	// is recorded but does not discard the artifacts already created in earlier
+	// subscriptions — those are always reported (fixing the cross-subscription
+	// orphan gap).
+	combined := onboard.Result{Provider: "azure", DryRun: opts.DryRun}
+	var subErrs []error
+	for _, sub := range subs {
+		res, err := provisionSubscription(ctx, deps, cli, opts, sub, original, stack, callerOID, interactive, errOut, log)
+		combined.Datasources = append(combined.Datasources, res.Datasources...)
+		if err != nil {
+			subErrs = append(subErrs, fmt.Errorf("subscription %q: %w", subLabel(sub), err))
+		}
+	}
+
+	// Always surface what was created, even when a later subscription failed.
+	if encErr := opts.IO.Encode(cmd.OutOrStdout(), combined); encErr != nil {
+		return encErr
+	}
+	if len(subErrs) > 0 {
+		return partialFailureError(combined, subErrs)
+	}
+	return nil
+}
+
+// runCleanup removes gcx-created Azure artifacts and datasources. Because this
+// is destructive, it requires confirmation unless --force is passed: in an
+// interactive session it previews exactly what will be removed and asks; in a
+// non-interactive session (piped/agent) it refuses and points at --force. A
+// --dry-run only previews and never needs confirmation.
+func runCleanup(
+	cmd *cobra.Command,
+	opts *azureOpts,
+	deps azonboard.RunDeps,
+	cli *azonboard.CLI,
+	stack string,
+	progress, errOut io.Writer,
+) error {
+	ctx := cmd.Context()
+
+	// Cleanup only touches app registrations attributable to this caller/stack
+	// (matched on the gcx:owner tag). A real cleanup therefore needs a resolved
+	// caller object ID; without one the sweep cannot be scoped and would risk
+	// deleting another owner's artifacts in a shared tenant. --dry-run is
+	// read-only, so a missing identity is tolerated there (the preview simply
+	// falls back to the gcx-managed tag).
+	callerOID, oidErr := cli.SignedInUserObjectID(ctx)
+	if !opts.DryRun && (oidErr != nil || callerOID == "") {
+		return gcxerrors.DetailedError{
+			Summary: "cannot resolve your Azure identity to scope the cleanup",
+			Details: "Cleanup permanently deletes app registrations and role grants you own, matched on the gcx:owner tag. Without a signed-in user object ID gcx cannot scope the removal and refuses to proceed.",
+			Parent:  oidErr,
+			Suggestions: []string{
+				"Sign in as a user (az login) rather than a service principal or managed identity, then re-run",
+				"Or preview what would be removed with --cleanup --dry-run",
+			},
+		}
+	}
+	in := azonboard.CleanupInput{CallerOID: callerOID, Stack: stack, DryRun: opts.DryRun}
+
+	if opts.DryRun {
+		onboard.Progressf(progress, "Previewing gcx-created Azure artifacts and datasources that would be removed...")
+		res, err := azonboard.Cleanup(ctx, deps, in)
+		if err != nil {
+			return err
+		}
+		return opts.IO.Encode(cmd.OutOrStdout(), res)
+	}
+
+	if !opts.Force {
+		proceed, err := confirmRemoval(cmd, opts, deps, callerOID, stack, progress, errOut)
+		if err != nil || !proceed {
+			return err
+		}
+	}
+
+	onboard.Progressf(progress, "Removing gcx-created Azure artifacts and datasources...")
+	res, err := azonboard.Cleanup(ctx, deps, in)
+	if err != nil {
+		return err
+	}
+	return opts.IO.Encode(cmd.OutOrStdout(), res)
+}
+
+// confirmRemoval previews the gcx-created artifacts a real cleanup would remove
+// and asks the user to confirm. It returns proceed=true only when the user
+// approved removing a non-empty set. On the refusal (non-interactive), empty,
+// and declined paths it returns proceed=false — encoding the appropriate result
+// itself — so the caller simply stops. A non-nil error is fatal.
+func confirmRemoval(
+	cmd *cobra.Command,
+	opts *azureOpts,
+	deps azonboard.RunDeps,
+	callerOID, stack string,
+	progress, errOut io.Writer,
+) (bool, error) {
+	if !canPrompt() {
+		return false, gcxerrors.DetailedError{
+			Summary: "cleanup permanently removes cloud artifacts and needs confirmation",
+			Details: "Deleting gcx-created Azure app registrations, role assignments, and Grafana datasources is irreversible, and this non-interactive session cannot prompt for confirmation.",
+			Suggestions: []string{
+				"Re-run with --cleanup --force to confirm the removal",
+				"Or preview first with --cleanup --dry-run (nothing is deleted)",
+			},
+		}
+	}
+
+	onboard.Progressf(progress, "Finding gcx-created Azure artifacts and datasources to remove...")
+	preview, err := azonboard.Cleanup(cmd.Context(), deps, azonboard.CleanupInput{CallerOID: callerOID, Stack: stack, DryRun: true})
+	if err != nil {
+		return false, err
+	}
+	if len(preview.Cleaned) == 0 {
+		cmdio.EmitNote(errOut, "no gcx-created artifacts found; nothing to remove")
+		return false, opts.IO.Encode(cmd.OutOrStdout(), preview)
+	}
+
+	confirmed, err := confirmCleanup(errOut, preview)
+	if err != nil {
+		return false, err
+	}
+	if !confirmed {
+		cmdio.EmitNote(errOut, "cleanup aborted; nothing was removed")
+		return false, opts.IO.Encode(cmd.OutOrStdout(), onboard.Result{Provider: "azure"})
+	}
+	return true, nil
+}
+
+// provisionSubscription switches to the subscription, discovers candidates, and
+// provisions the resolved selections. It returns whatever was created together
+// with any error, so the caller can report partial success across
+// subscriptions.
+func provisionSubscription(
+	ctx context.Context,
+	deps azonboard.RunDeps,
+	cli *azonboard.CLI,
+	opts *azureOpts,
+	sub, original azonboard.Account,
+	stack, callerOID string,
+	interactive bool,
+	errOut io.Writer,
+	log logging.Logger,
+) (onboard.Result, error) {
+	if err := cli.SetSubscription(ctx, sub.SubID); err != nil {
+		return onboard.Result{}, err
+	}
+	acct := normalizeAccount(sub, original)
+
+	onboard.Progressf(deps.Progress, "Scanning subscription %q for datasources...", subLabel(sub))
+	suggestions := azonboard.BuildPlan(ctx, azonboard.PlanInput{
+		CLI:           cli,
+		Stack:         stack,
+		Account:       acct,
+		IncludeCosmos: opts.IncludeCosmos,
+		Log:           log,
+	})
+	onboard.Progressf(deps.Progress, "  found %d candidate datasource(s)", len(suggestions))
+
+	selections, err := resolveSelections(suggestions, opts, interactive, errOut)
+	if err != nil {
+		return onboard.Result{}, err
+	}
+	if len(selections) == 0 {
+		return onboard.Result{}, nil
+	}
+
+	return provisionGuarded(ctx, deps, azonboard.ProvisionInput{
+		Account:     acct,
+		CallerOID:   callerOID,
+		Selections:  selections,
+		Interactive: interactive,
+		Stack:       stack,
+		ExpiryDays:  opts.SecretExpiry,
+		DryRun:      opts.DryRun,
+		SkipHealth:  opts.SkipHealth,
+		Concurrency: opts.Concurrency,
+	})
+}
+
+// provisionGuarded runs Provision and maps an insufficient-privilege failure to
+// an actionable DetailedError explaining the directory and RBAC roles gcx needs
+// to mint app registrations and assign roles.
+func provisionGuarded(ctx context.Context, deps azonboard.RunDeps, in azonboard.ProvisionInput) (onboard.Result, error) {
+	res, err := azonboard.Provision(ctx, deps, in)
+	if err == nil {
+		return res, nil
+	}
+	if !errors.Is(err, azonboard.ErrInsufficientPrivilege) {
+		return onboard.Result{}, err
+	}
+	return onboard.Result{}, gcxerrors.DetailedError{
+		Summary: "insufficient Azure privileges to mint app registrations or assign roles",
+		Details: "gcx needs directory privileges (e.g. Application Developer) to create app registrations, and Owner/User Access Administrator to assign roles.",
+		Parent:  err,
+		Suggestions: []string{
+			"Ask an administrator to grant the required roles, then re-run",
+		},
+	}
+}
+
+// partialFailureError wraps per-subscription errors, noting how many
+// datasources were still created/verified so the user is not left thinking the
+// whole run was lost.
+func partialFailureError(combined onboard.Result, subErrs []error) error {
+	created := 0
+	for _, d := range combined.Datasources {
+		if d.Status == onboard.StatusCreated || d.Status == onboard.StatusExisting {
+			created++
+		}
+	}
+	details := ""
+	if created > 0 {
+		details = fmt.Sprintf("%d datasource(s) were created or already existed and are reported above; the failure affected other subscriptions only.", created)
+	}
+	return gcxerrors.DetailedError{
+		Summary: "one or more subscriptions failed during onboarding",
+		Details: details,
+		Parent:  errors.Join(subErrs...),
+		Suggestions: []string{
+			"Review the errors below and re-run for the affected subscription(s) with --subscription <id>",
+			"Re-running is safe: already-created datasources are detected and reused, not duplicated",
+		},
+	}
+}

--- a/cmd/gcx/setup/datasources/azure/rotate.go
+++ b/cmd/gcx/setup/datasources/azure/rotate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -15,11 +14,10 @@ import (
 	"github.com/grafana/gcx/internal/onboard"
 	azonboard "github.com/grafana/gcx/internal/onboard/azure"
 	cmdio "github.com/grafana/gcx/internal/output"
-	"github.com/grafana/gcx/internal/terminal"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/term"
 )
 
 type rotateOpts struct {
@@ -135,10 +133,26 @@ func runRotate(cmd *cobra.Command, opts *rotateOpts) error {
 		}
 	}
 
-	// In interactive mode, let the user choose which datasources to rotate
-	// rather than sweeping every gcx-managed one.
+	// Rotation is destructive (mints and retires client secrets), so the
+	// mutating path routes through the shared bypass chain (--force,
+	// GCX_AUTO_APPROVE, agent mode) exactly like every other destructive command
+	// (docs/design/safety.md § 3.2). --dry-run mutates nothing and is exempt.
+	bypass := opts.Force
+	if !opts.DryRun {
+		var err error
+		bypass, err = providers.CheckDestructiveBypass(opts.Force)
+		if err != nil {
+			return err
+		}
+	}
+
+	// When nothing bypassed the prompt, an interactive session lets the user
+	// choose targets rather than sweeping every gcx-managed one; a
+	// non-interactive real rotation is refused instead of silently rotating
+	// everything. Bypassed (--force/GCX_AUTO_APPROVE) and dry-run runs sweep all.
 	var includeUIDs []string
-	if isRotateInteractive(opts) {
+	switch {
+	case !bypass && canPrompt():
 		selected, err := pickRotateTargets(ctx, ds)
 		if err != nil {
 			return err
@@ -148,6 +162,15 @@ func runRotate(cmd *cobra.Command, opts *rotateOpts) error {
 			return opts.IO.Encode(cmd.OutOrStdout(), onboard.Result{Provider: "azure"})
 		}
 		includeUIDs = selected
+	case !bypass && !opts.DryRun:
+		return gcxerrors.DetailedError{
+			Summary: "rotate mints new cloud credentials and needs confirmation",
+			Details: "Rotation mints a new client secret for each gcx-managed datasource and retires the old one, and this non-interactive session cannot prompt for which datasources to rotate.",
+			Suggestions: []string{
+				"Re-run with --force to rotate every gcx-managed Azure datasource",
+				"Or preview which datasources would rotate with --dry-run",
+			},
+		}
 	}
 
 	res, err := azonboard.Rotate(ctx, deps, azonboard.RotateInput{
@@ -162,16 +185,6 @@ func runRotate(cmd *cobra.Command, opts *rotateOpts) error {
 		return err
 	}
 	return opts.IO.Encode(cmd.OutOrStdout(), res)
-}
-
-// isRotateInteractive reports whether to render the rotate target picker.
-// --force (like a non-TTY or agent mode) turns the picker off and rotates every
-// gcx-managed datasource.
-func isRotateInteractive(opts *rotateOpts) bool {
-	return terminal.StdoutIsTerminal() &&
-		term.IsTerminal(int(os.Stdin.Fd())) &&
-		!opts.Force &&
-		!agent.IsAgentMode()
 }
 
 // pickRotateTargets lists gcx-managed, rotatable Azure datasources and returns

--- a/cmd/gcx/setup/datasources/azure/rotate.go
+++ b/cmd/gcx/setup/datasources/azure/rotate.go
@@ -1,0 +1,213 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/internal/agent"
+	dsclient "github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/grafana/gcx/internal/onboard"
+	azonboard "github.com/grafana/gcx/internal/onboard/azure"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/terminal"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/term"
+)
+
+type rotateOpts struct {
+	Config       cmdconfig.Options
+	IO           cmdio.Options
+	SecretExpiry int
+	SkipHealth   bool
+	DryRun       bool
+	Force        bool
+}
+
+func (o *rotateOpts) setup(flags *pflag.FlagSet) {
+	o.Config.BindFlags(flags)
+	o.IO.RegisterCustomCodec("text", &onboardTextCodec{})
+	o.IO.DefaultFormat("text")
+	o.IO.BindFlags(flags)
+
+	flags.IntVar(&o.SecretExpiry, "secret-expiry-days", 0, "Set an expiry (in days) on the newly minted client secrets (0 = Azure default)")
+	flags.BoolVar(&o.SkipHealth, "skip-health-check", false, "Skip the post-rotation datasource health verification")
+	flags.BoolVar(&o.DryRun, "dry-run", false, "Preview which datasources would have their secret rotated without changing anything")
+	flags.BoolVar(&o.Force, "force", false, "Confirm credential-mutating side effects (required in agent mode)")
+}
+
+func (o *rotateOpts) Validate() error {
+	if agent.IsAgentMode() && !o.Force && !o.DryRun {
+		return gcxerrors.DetailedError{
+			Summary: "rotate mints new cloud credentials; --force is required in agent mode",
+			Details: "Rotation mints a new client secret for each gcx-managed datasource, updates the datasource, and retires the old secret.",
+			Suggestions: []string{
+				"Re-run with --force",
+				"Or preview first with --dry-run (nothing is changed)",
+			},
+		}
+	}
+	return o.IO.Validate()
+}
+
+// rotateCommand returns the `gcx setup datasources azure rotate` subcommand.
+func rotateCommand() *cobra.Command {
+	opts := &rotateOpts{}
+	cmd := &cobra.Command{
+		Use:   "rotate",
+		Short: "Rotate client secrets for gcx-created Azure datasources",
+		Long: "Mint a fresh client secret for each gcx-managed Azure datasource, update the " +
+			"datasource to use it, and retire the superseded secret. Only datasources whose " +
+			"backing app registration is tagged gcx-managed (and attributable to you) are rotated; " +
+			"key-based datasources (Cosmos DB) are skipped.",
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "small",
+			agent.AnnotationLLMHint: "Rotates client secrets for gcx-created Azure datasources; requires --force in agent mode (or --dry-run to preview). " +
+				"Example: gcx setup datasources azure rotate --force -o json",
+		},
+		Example: `
+  # Preview which datasources would be rotated
+  gcx setup datasources azure rotate --dry-run
+
+  # Rotate all gcx-managed Azure datasource secrets
+  gcx setup datasources azure rotate --force`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			return runRotate(cmd, opts)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func runRotate(cmd *cobra.Command, opts *rotateOpts) error {
+	ctx := cmd.Context()
+	log := logging.FromContext(ctx)
+	errOut := cmd.ErrOrStderr()
+
+	var progress io.Writer
+	if !agent.IsAgentMode() {
+		progress = errOut
+	}
+
+	onboard.Progressf(progress, "Checking for the Azure CLI (az)...")
+	cli := azonboard.NewCLI()
+	if err := cli.Ensure(); err != nil {
+		return err
+	}
+
+	onboard.Progressf(progress, "Connecting to Grafana...")
+	restCfg, err := opts.Config.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return err
+	}
+	ds, err := dsclient.NewClient(restCfg)
+	if err != nil {
+		return err
+	}
+
+	deps := azonboard.RunDeps{CLI: cli, DS: ds, Log: log, ErrOut: errOut, Progress: progress}
+
+	// Rotation only touches app registrations attributable to this caller
+	// (matched on the gcx:owner tag). A real rotation therefore needs a resolved
+	// caller object ID; without one the sweep cannot be scoped and would risk
+	// rotating another owner's credentials in a shared tenant. --dry-run is
+	// read-only, so a missing identity is tolerated there.
+	callerOID, oidErr := cli.SignedInUserObjectID(ctx)
+	if !opts.DryRun && (oidErr != nil || callerOID == "") {
+		return gcxerrors.DetailedError{
+			Summary: "cannot resolve your Azure identity to scope the rotation",
+			Details: "Rotation mints and prunes client secrets only on app registrations you own, matched on the gcx:owner tag. Without a signed-in user object ID gcx cannot scope the sweep and refuses to proceed.",
+			Parent:  oidErr,
+			Suggestions: []string{
+				"Sign in as a user (az login) rather than a service principal or managed identity, then re-run",
+				"Or preview which datasources would rotate with --dry-run",
+			},
+		}
+	}
+
+	// In interactive mode, let the user choose which datasources to rotate
+	// rather than sweeping every gcx-managed one.
+	var includeUIDs []string
+	if isRotateInteractive(opts) {
+		selected, err := pickRotateTargets(ctx, ds)
+		if err != nil {
+			return err
+		}
+		if len(selected) == 0 {
+			onboard.Progressf(progress, "No datasources selected; nothing to rotate.")
+			return opts.IO.Encode(cmd.OutOrStdout(), onboard.Result{Provider: "azure"})
+		}
+		includeUIDs = selected
+	}
+
+	res, err := azonboard.Rotate(ctx, deps, azonboard.RotateInput{
+		CallerOID:   callerOID,
+		Stack:       stackLabel(restCfg),
+		ExpiryDays:  opts.SecretExpiry,
+		DryRun:      opts.DryRun,
+		SkipHealth:  opts.SkipHealth,
+		IncludeUIDs: includeUIDs,
+	})
+	if err != nil {
+		return err
+	}
+	return opts.IO.Encode(cmd.OutOrStdout(), res)
+}
+
+// isRotateInteractive reports whether to render the rotate target picker.
+// --force (like a non-TTY or agent mode) turns the picker off and rotates every
+// gcx-managed datasource.
+func isRotateInteractive(opts *rotateOpts) bool {
+	return terminal.StdoutIsTerminal() &&
+		term.IsTerminal(int(os.Stdin.Fd())) &&
+		!opts.Force &&
+		!agent.IsAgentMode()
+}
+
+// pickRotateTargets lists gcx-managed, rotatable Azure datasources and returns
+// the UIDs the user selects (default: all selected). Cosmos DB and other
+// key-based datasources are omitted since they have no rotatable secret.
+func pickRotateTargets(ctx context.Context, ds *dsclient.Client) ([]string, error) {
+	list, err := ds.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	prefix := onboard.NamePrefix + "-"
+
+	options := make([]huh.Option[string], 0)
+	var selected []string
+	for _, d := range list {
+		if !strings.HasPrefix(d.Name, prefix) || !rotatableType(d.Type) {
+			continue
+		}
+		options = append(options, huh.NewOption(fmt.Sprintf("%s (%s)", d.Name, d.Type), d.UID).Selected(true))
+		selected = append(selected, d.UID)
+	}
+	if len(options) == 0 {
+		return nil, nil
+	}
+
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewMultiSelect[string]().Title("Datasources to rotate").Options(options...).Value(&selected),
+	))
+	if err := form.Run(); err != nil {
+		return nil, err
+	}
+	return selected, nil
+}
+
+// rotatableType reports whether a datasource type uses a rotatable
+// service-principal secret (as opposed to key-based auth like Cosmos DB).
+func rotatableType(t string) bool {
+	return t == azonboard.KindAzureMonitor || t == azonboard.KindADX
+}

--- a/cmd/gcx/setup/datasources/azure/selection.go
+++ b/cmd/gcx/setup/datasources/azure/selection.go
@@ -1,0 +1,211 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	"github.com/grafana/gcx/internal/gcxerrors"
+	azonboard "github.com/grafana/gcx/internal/onboard/azure"
+	cmdio "github.com/grafana/gcx/internal/output"
+)
+
+// resolveSubscriptions returns the subscriptions to operate on.
+func resolveSubscriptions(ctx context.Context, cli *azonboard.CLI, opts *azureOpts, interactive bool) ([]azonboard.Account, error) {
+	all, err := cli.ListSubscriptions(ctx)
+	if err != nil || len(all) == 0 {
+		// Fall back to the current account.
+		cur, cerr := cli.CurrentAccount(ctx)
+		if cerr != nil {
+			if err != nil {
+				return nil, err
+			}
+			return nil, cerr
+		}
+		all = []azonboard.Account{cur}
+	}
+
+	if len(opts.Subscription) > 0 {
+		want := map[string]bool{}
+		for _, s := range opts.Subscription {
+			want[strings.ToLower(s)] = true
+		}
+		var filtered []azonboard.Account
+		for _, a := range all {
+			if want[strings.ToLower(a.SubID)] {
+				filtered = append(filtered, a)
+			}
+		}
+		if len(filtered) == 0 {
+			return nil, gcxerrors.DetailedError{
+				Summary:     "none of the requested subscriptions were found",
+				Suggestions: []string{"List subscriptions with: az account list -o table"},
+			}
+		}
+		return filtered, nil
+	}
+
+	if len(all) == 1 {
+		return all, nil
+	}
+
+	if !interactive {
+		// Non-interactive (agent/piped/--force/--yes) with several subscriptions
+		// and no explicit --subscription would silently fan out credential
+		// minting and datasource creation across every subscription. Refuse to
+		// do that implicitly — require an explicit target (or an explicit opt-in)
+		// to bound the blast radius. --dry-run is exempt because it mutates
+		// nothing, so previewing every subscription is safe and useful.
+		if opts.AllSubscriptions || opts.DryRun {
+			return all, nil
+		}
+		return nil, gcxerrors.DetailedError{
+			Summary: fmt.Sprintf("%d subscriptions were discovered; refusing to onboard all of them without confirmation", len(all)),
+			Details: "This non-interactive session cannot prompt for which subscriptions to target, and onboarding mints credentials and creates datasources in each one.",
+			Suggestions: []string{
+				"Target specific subscriptions with --subscription <id> (repeatable)",
+				"Or onboard every discovered subscription with --all-subscriptions",
+				"List subscriptions with: az account list -o table",
+			},
+		}
+	}
+
+	// Interactive multi-select, default all selected.
+	var opted []string
+	options := make([]huh.Option[string], 0, len(all))
+	for _, a := range all {
+		label := fmt.Sprintf("%s (%s)", a.Name, a.SubID)
+		options = append(options, huh.NewOption(label, a.SubID).Selected(true))
+		opted = append(opted, a.SubID)
+	}
+	sel := opted
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewMultiSelect[string]().Title("Subscriptions to onboard").Options(options...).Value(&sel),
+	))
+	if err := form.Run(); err != nil {
+		return nil, err
+	}
+	chosen := map[string]bool{}
+	for _, id := range sel {
+		chosen[id] = true
+	}
+	var out []azonboard.Account
+	for _, a := range all {
+		if chosen[a.SubID] {
+			out = append(out, a)
+		}
+	}
+	return out, nil
+}
+
+// resolveSelections filters suggestions by --types, lets the user choose
+// (interactive; default all selectable), and resolves the role set per
+// selection. Disabled suggestions (e.g. stopped ADX clusters) are shown in the
+// interactive picker but cannot be selected, and are skipped with a warning in
+// non-interactive mode.
+func resolveSelections(suggestions []azonboard.Suggestion, opts *azureOpts, interactive bool, errOut io.Writer) ([]azonboard.Selection, error) {
+	suggestions = filterByType(suggestions, opts.Types)
+	if len(suggestions) == 0 {
+		return nil, nil
+	}
+
+	var chosen []azonboard.Suggestion
+	if interactive {
+		picked, err := pickSuggestions(suggestions)
+		if err != nil {
+			return nil, err
+		}
+		chosen = picked
+	} else {
+		for _, s := range suggestions {
+			if s.Disabled {
+				cmdio.EmitWarn(errOut, fmt.Sprintf("skipping %s: %s", s.Label, s.DisabledReason))
+				continue
+			}
+			chosen = append(chosen, s)
+		}
+	}
+
+	selections := make([]azonboard.Selection, 0, len(chosen))
+	for _, s := range chosen {
+		if s.Disabled {
+			continue // defensive: never provision a disabled suggestion
+		}
+		roles, err := resolveRoles(s, opts, interactive)
+		if err != nil {
+			return nil, err
+		}
+		selections = append(selections, azonboard.Selection{Suggestion: s, Roles: roles})
+	}
+	return selections, nil
+}
+
+func resolveRoles(s azonboard.Suggestion, opts *azureOpts, interactive bool) ([]string, error) {
+	if opts.Role != "" {
+		return splitRoles(opts.Role), nil
+	}
+	options := s.Spec.RoleOptions()
+	if len(options) == 0 {
+		return nil, nil
+	}
+	if interactive && len(options) > 1 {
+		labels := make([]huh.Option[int], 0, len(options))
+		for i, ro := range options {
+			labels = append(labels, huh.NewOption(ro.Label, i))
+		}
+		idx := 0
+		form := huh.NewForm(huh.NewGroup(
+			huh.NewSelect[int]().Title("Permissions for " + s.Label).Options(labels...).Value(&idx),
+		))
+		if err := form.Run(); err != nil {
+			return nil, err
+		}
+		return options[idx].Roles, nil
+	}
+	return options[0].Roles, nil
+}
+
+func filterByType(suggestions []azonboard.Suggestion, types []string) []azonboard.Suggestion {
+	if len(types) == 0 {
+		return suggestions
+	}
+	want := map[string]bool{}
+	for _, o := range types {
+		want[strings.ToLower(strings.TrimSpace(o))] = true
+	}
+	var out []azonboard.Suggestion
+	for _, s := range suggestions {
+		if want[s.Spec.Token()] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func splitRoles(s string) []string {
+	parts := strings.Split(s, ",")
+	out := parts[:0]
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// normalizeAccount fills in fields missing from `az account list` (notably
+// environmentName) using the originally-active account as a fallback.
+func normalizeAccount(a, fallback azonboard.Account) azonboard.Account {
+	if a.CloudName == "" {
+		a.CloudName = fallback.CloudName
+	}
+	if a.CloudName == "" {
+		a.CloudName = "AzureCloud"
+	}
+	if a.TenantID == "" {
+		a.TenantID = fallback.TenantID
+	}
+	return a
+}

--- a/cmd/gcx/setup/datasources/command.go
+++ b/cmd/gcx/setup/datasources/command.go
@@ -1,0 +1,26 @@
+// Package datasources provides the `gcx setup datasources <cloud>` command
+// family, which discovers cloud resources via the native cloud CLI and
+// provisions matching Grafana datasources.
+package datasources
+
+import (
+	azurecmd "github.com/grafana/gcx/cmd/gcx/setup/datasources/azure"
+	"github.com/spf13/cobra"
+)
+
+// Command returns the `gcx setup datasources` command group.
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "datasources",
+		Short: "Set up cloud provider datasources",
+		Long: "Discover cloud resources using your local cloud CLI session and " +
+			"provision the matching Grafana datasources, minting dedicated, " +
+			"gcx-owned credentials per datasource.\n\n" +
+			"Azure is supported today (Azure Monitor, Azure Data Explorer, and Azure CosmosDB). " +
+			"AWS and GCP are planned.",
+	}
+
+	cmd.AddCommand(azurecmd.Command())
+
+	return cmd
+}

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -15,7 +15,8 @@ gcx/
 │       │   └── query/        # Auto-detecting query command (GenericCmd only)
 │       ├── commands/         # 'commands' catalog (agent metadata, resource types, live validation)
 │       ├── helptree/        # 'help-tree' compact text tree for agent context injection
-│       ├── setup/            # 'setup' command area (cross-product onboarding helpers)
+│       ├── setup/            # 'setup' command area (status; cross-product onboarding helpers)
+│       │   └── datasources/  #   onboard cloud datasources (azure: Azure Monitor + ADX + Cosmos; rotate subcommand rotates gcx-minted secrets)
 │       ├── instrumentation/  # 'instrumentation' provider command tree (setup wizard, status, clusters, services)
 │       │   ├── clusters/     #   cluster-level subcommands (list, get, configure, remove, wait, apps subtree)
 │       │   ├── services/     #   workload-level subcommands (list, get, include, exclude, clear)
@@ -35,6 +36,7 @@ gcx/
 │   ├── auth/                 # OAuth PKCE flow, token refresh transport
 │   │   └── adaptive/         # Shared adaptive telemetry auth (GCOM caching, Basic auth)
 │   ├── cloud/                # Grafana Cloud stack discovery via GCOM API
+│   ├── cloudcli/             # Generic cloud CLI exec wrapper (az/aws/gcloud — Ensure + Run/RunJSON, injectable runner for tests)
 │   ├── fleet/                # Shared fleet base client (HTTP, auth, config — shared by fleet provider and instrumentation provider)
 │   ├── config/               # Config loading, context management, auth types (auto-migrates plaintext token-shaped secrets into the OS keychain via internal/credentials)
 │   │   └── testdata/         # YAML fixtures for config unit tests
@@ -42,6 +44,7 @@ gcx/
 │   ├── format/               # JSON/YAML codec, format auto-detection
 │   ├── output/               # Output codec registry (json, yaml, text, wide), field selection, user-facing messages
 │   ├── grafana/              # Thin wrapper over grafana-openapi-client-go
+│   ├── plugins/              # Grafana plugin admin client (check/install datasource plugins — used by onboard pre-flight)
 │   ├── graph/                # Terminal chart rendering (ntcharts + lipgloss)
 │   ├── httputils/            # REST client helpers, request/response utilities
 │   ├── retry/                # Retry transport (429/5xx/connection errors, exponential backoff, Retry-After)
@@ -101,6 +104,8 @@ gcx/
 │   │   ├── loki/             # Loki HTTP client (log + metric queries)
 │   │   └── clickhouse/       # ClickHouse HTTP client
 │   ├── signals/              # Shared signal command and datasource-provider mounting (metrics/logs/traces/profiles)
+│   ├── onboard/              # Cloud datasource onboarding core (result types, naming/collision, rollback, shared progress)
+│   │   └── azure/            # Azure onboarding (az CLI wrapper, discover, plan, Azure Monitor + ADX + Cosmos payloads, orchestration, cleanup, rotate)
 │   ├── notifier/             # Skills update notifier (XDG state, throttle, message rendering)
 │   ├── secrets/              # Redaction of sensitive config fields
 │   ├── skills/               # Portable Agent Skills installer primitives (Install, Update, Bundled/InstalledBundledSkillNames)

--- a/docs/reference/cli/gcx_setup_datasources.md
+++ b/docs/reference/cli/gcx_setup_datasources.md
@@ -1,18 +1,24 @@
-## gcx setup
+## gcx setup datasources
 
-Onboard and configure Grafana Cloud products.
+Set up cloud provider datasources
+
+### Synopsis
+
+Discover cloud resources using your local cloud CLI session and provision the matching Grafana datasources, minting dedicated, gcx-owned credentials per datasource.
+
+Azure is supported today (Azure Monitor, Azure Data Explorer, and Azure CosmosDB). AWS and GCP are planned.
 
 ### Options
 
 ```
-      --config string   Path to the configuration file to use
-  -h, --help            help for setup
+  -h, --help   help for datasources
 ```
 
 ### Options inherited from parent commands
 
 ```
       --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
       --context string              Name of the context to use (overrides current-context in config)
       --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
       --no-color                    Disable color output
@@ -22,7 +28,6 @@ Onboard and configure Grafana Cloud products.
 
 ### SEE ALSO
 
-* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
-* [gcx setup datasources](gcx_setup_datasources.md)	 - Set up cloud provider datasources
-* [gcx setup status](gcx_setup_status.md)	 - Show aggregated setup status across all products.
+* [gcx setup](gcx_setup.md)	 - Onboard and configure Grafana Cloud products.
+* [gcx setup datasources azure](gcx_setup_datasources_azure.md)	 - Onboard Azure datasources (Azure Monitor, Azure Data Explorer, and Azure CosmosDB)
 

--- a/docs/reference/cli/gcx_setup_datasources_azure.md
+++ b/docs/reference/cli/gcx_setup_datasources_azure.md
@@ -1,0 +1,70 @@
+## gcx setup datasources azure
+
+Onboard Azure datasources (Azure Monitor, Azure Data Explorer, and Azure CosmosDB)
+
+### Synopsis
+
+Discover Azure resources using your local `az` CLI session and provision the matching Grafana datasources. For each accepted datasource, gcx mints a dedicated, gcx-owned Azure app registration (service principal + secret + least-privilege role) with you set as owner, then creates the Grafana datasource wired to those credentials.
+
+```
+gcx setup datasources azure [flags]
+```
+
+### Examples
+
+```
+
+  # Interactive: discover and pick datasources to create
+  gcx setup datasources azure
+
+  # Preview what would be created without minting anything
+  gcx setup datasources azure --dry-run
+
+  # Non-interactive: create the Azure Monitor datasource with a specified subscription
+  gcx setup datasources azure --force --types azure-monitor --subscription <sub-id>
+
+  # Tighten Azure Monitor permissions to metrics only
+  gcx setup datasources azure --types azure-monitor --role "Monitoring Reader"
+
+  # Remove everything gcx created
+  gcx setup datasources azure --cleanup --force
+```
+
+### Options
+
+```
+      --all-subscriptions        Onboard every discovered subscription non-interactively (otherwise --subscription is required when several exist)
+      --cleanup                  Remove gcx-created Azure app registrations and their datasources
+      --concurrency int          Maximum datasources to provision in parallel (0 = default; interactive runs are always serial)
+      --config string            Path to the configuration file to use
+      --context string           Name of the context to use
+      --dry-run                  Preview what would be created or removed without making any changes
+      --force                    Confirm credential-minting side effects (required in agent mode); implies --yes
+  -h, --help                     help for azure
+      --include-cosmos           Include Azure Cosmos DB datasources (requires the Enterprise plugin licensed in Grafana)
+      --jq string                jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string              Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string            Output format. One of: agents, json, text, yaml (default "text")
+      --role string              Override the default Azure role set (comma-separated role names, e.g. "Monitoring Reader")
+      --secret-expiry-days int   Set an expiry (in days) on minted client secrets (0 = Azure default). Rotate before expiry with the rotate subcommand
+      --skip-health-check        Skip the post-create datasource health verification
+      --subscription strings     Subscription ID(s) to target (default: the active subscription, or interactive multi-select)
+      --types strings            Restrict to datasource kinds: azure-monitor, adx, cosmos
+      --yes                      Non-interactive: skip prompts and accept all suggestions
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx setup datasources](gcx_setup_datasources.md)	 - Set up cloud provider datasources
+* [gcx setup datasources azure rotate](gcx_setup_datasources_azure_rotate.md)	 - Rotate client secrets for gcx-created Azure datasources
+

--- a/docs/reference/cli/gcx_setup_datasources_azure_rotate.md
+++ b/docs/reference/cli/gcx_setup_datasources_azure_rotate.md
@@ -1,0 +1,52 @@
+## gcx setup datasources azure rotate
+
+Rotate client secrets for gcx-created Azure datasources
+
+### Synopsis
+
+Mint a fresh client secret for each gcx-managed Azure datasource, update the datasource to use it, and retire the superseded secret. Only datasources whose backing app registration is tagged gcx-managed (and attributable to you) are rotated; key-based datasources (Cosmos DB) are skipped.
+
+```
+gcx setup datasources azure rotate [flags]
+```
+
+### Examples
+
+```
+
+  # Preview which datasources would be rotated
+  gcx setup datasources azure rotate --dry-run
+
+  # Rotate all gcx-managed Azure datasource secrets
+  gcx setup datasources azure rotate --force
+```
+
+### Options
+
+```
+      --config string            Path to the configuration file to use
+      --context string           Name of the context to use
+      --dry-run                  Preview which datasources would have their secret rotated without changing anything
+      --force                    Confirm credential-mutating side effects (required in agent mode)
+  -h, --help                     help for rotate
+      --jq string                jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string              Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string            Output format. One of: agents, json, text, yaml (default "text")
+      --secret-expiry-days int   Set an expiry (in days) on the newly minted client secrets (0 = Azure default)
+      --skip-health-check        Skip the post-rotation datasource health verification
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx setup datasources azure](gcx_setup_datasources_azure.md)	 - Onboard Azure datasources (Azure Monitor, Azure Data Explorer, and Azure CosmosDB)
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -68,6 +68,10 @@ var commandAnnotations = map[string]annotation{
 	"gcx config use-context":     {Cost: "small"},
 	"gcx config view":            {Cost: "medium", Hint: "--minify -o json"},
 
+	// setup datasources
+	"gcx setup datasources azure":        {Cost: "small", Hint: "Mints Azure credentials and creates datasources; requires --force in agent mode (or --dry-run to preview). Example: gcx setup datasources azure --force --types azure-monitor --subscription <sub-id> -o json. Clean up gcx-created artifacts with: gcx setup datasources azure --cleanup --force -o json"},
+	"gcx setup datasources azure rotate": {Cost: "small", Hint: "Rotates client secrets for gcx-created Azure datasources; requires --force in agent mode (or --dry-run to preview). Example: gcx setup datasources azure rotate --force -o json"},
+
 	// datasources
 	"gcx datasources get":   {Cost: "medium", Hint: "<uid> -o json"},
 	"gcx datasources list":  {Cost: "small"},


### PR DESCRIPTION
## Summary

Wires the Azure onboarding engine into the CLI and ships the user-facing surface + docs.

- New command group `gcx setup datasources` and `gcx setup datasources azure`, with a `rotate` subcommand and `--cleanup`.
- Interactive and non-interactive (`--yes` / `--force`) flows: subscription and datasource selection, confirmation prompts (including a cleanup confirmation guard), and `--concurrency` / `--dry-run` / `--skip-health` controls.
- `--types` validation, output codecs (text/json/yaml) rendering credentials, health, and PDC hints.
- Agent annotations, output classification, generated CLI reference, and doc updates (`AGENTS.md`, `project-structure.md`).

## Files

- `cmd/gcx/setup/datasources/**` (+ `cmd/gcx/setup/command.go`, `cmd/gcx/setup/datasources/command.go`)
- `internal/agent/command_annotations.go`, `cmd/gcx/root/testdata/output_classes.json`
- `docs/reference/cli/gcx_setup*.md`, `AGENTS.md`, `docs/architecture/project-structure.md`

## Stack

1. #1101
2. #1102
3. #1103
4. #1104
5. **this PR** — `gcx setup datasources azure` command + docs *(base: `andreas/onboard-4-azure-engine`)*


## Test plan

- [ ] `go test ./internal/onboard/... ./cmd/gcx/setup/...`
- [ ] `GCX_AGENT_MODE=false mise run all`