### PR TITLE
feat(datasources): raw query

### DIFF
--- a/cmd/gcx/datasources/query.go
+++ b/cmd/gcx/datasources/query.go
@@ -1,17 +1,29 @@
 package datasources
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
+	"github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/query/clickhouse"
+	"github.com/grafana/gcx/internal/query/dataframe"
+	"github.com/grafana/gcx/internal/query/grafanaquery"
 	"github.com/grafana/gcx/internal/query/influxdb"
 	"github.com/grafana/gcx/internal/query/loki"
 	"github.com/grafana/gcx/internal/query/prometheus"
 	"github.com/grafana/gcx/internal/query/pyroscope"
+	"github.com/grafana/gcx/internal/queryerror"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +34,7 @@ func QueryCmd() *cobra.Command {
 	var profileType string
 	var maxNodes int64
 	var limit int
+	var rawQuery string
 
 	cmd := &cobra.Command{
 		Use:   "query DATASOURCE_UID [EXPR]",
@@ -33,7 +46,12 @@ EXPR is the query expression appropriate for the datasource type.
 
 The datasource type is detected via the Grafana API and the appropriate query
 client is used automatically. This is the escape hatch for datasource types
-that do not have a dedicated subcommand.`,
+that do not have a dedicated subcommand.
+
+Use --query to provide a raw query JSON object for any datasource type,
+bypassing type-specific logic. The object is merged into the Grafana datasource
+query envelope — datasource UID, type, refId, and time range are injected
+automatically. Use @file to read from a file or @- for stdin.`,
 		Example: `
   # Auto-detect and query any supported datasource
   gcx datasources query ds-001 'up{job="grafana"}' --from now-1h --to now
@@ -43,15 +61,45 @@ that do not have a dedicated subcommand.`,
 
   # Pyroscope via auto-detect
   gcx datasources query pyro-001 '{service_name="frontend"}' \
-    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --from now-1h --to now`,
+    --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --from now-1h --to now
+
+  # Raw query JSON (plugin-agnostic) — Infinity example
+  gcx datasources query infinity-01 --query '{
+    "type": "json", "source": "url",
+    "url": "https://api.example.com/data",
+    "format": "table", "root_selector": "$.items"
+  }' --since 30m
+
+  # Raw query from file
+  gcx datasources query ds-001 --query @query.json --since 1h
+
+  # Raw query from stdin
+  cat query.json | gcx datasources query ds-001 --query @- --since 1h`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := shared.Validate(); err != nil {
 				return err
 			}
 
+			queryFlagSet := cmd.Flags().Changed("query")
+
+			// Default empty --query to "{}".
+			if queryFlagSet && rawQuery == "" {
+				rawQuery = "{}"
+			}
+
+			// --query is mutually exclusive with EXPR and --expr.
+			if queryFlagSet {
+				if len(args) > 1 {
+					return errors.New("--query is mutually exclusive with a positional EXPR argument")
+				}
+				if shared.Expr != "" {
+					return errors.New("--query is mutually exclusive with --expr")
+				}
+			}
+
 			// Reject "both positional and --expr" before any HTTP call.
-			if len(args) > 1 && shared.Expr != "" {
+			if !queryFlagSet && len(args) > 1 && shared.Expr != "" {
 				return errors.New("provide the expression as a positional argument or via --expr, not both")
 			}
 
@@ -63,147 +111,12 @@ that do not have a dedicated subcommand.`,
 				return err
 			}
 
-			rawType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			dsType := dsquery.NormalizeKind(rawType)
-
-			if dsType == "cloudwatch" {
-				return errors.New("CloudWatch queries are structured (namespace, metric, dimensions, region, statistic, period); " +
-					"the generic `gcx datasources query <uid> <expr>` form can't carry them — " +
-					"use `gcx datasources cloudwatch query --namespace ... --metric ... --region ...` instead")
+			// Raw query path: skip type-specific dispatch.
+			if queryFlagSet {
+				return executeRawQuery(ctx, cmd, cfg, datasourceUID, rawQuery, shared)
 			}
 
-			expr, err := shared.ResolveExpr(args, 1)
-			if err != nil {
-				return err
-			}
-
-			now := time.Now()
-			start, end, step, err := shared.ParseTimes(now)
-			if err != nil {
-				return err
-			}
-
-			switch dsType {
-			case "prometheus":
-				client, err := prometheus.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				req := prometheus.QueryRequest{
-					Query: expr,
-					Start: start,
-					End:   end,
-					Step:  step,
-				}
-
-				resp, err := client.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "loki":
-				client, err := loki.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				req := loki.QueryRequest{
-					Query: expr,
-					Start: start,
-					End:   end,
-					Step:  step,
-					Limit: limit,
-				}
-
-				resp, err := client.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "pyroscope":
-				if profileType == "" {
-					return errors.New("--profile-type is required for pyroscope queries")
-				}
-
-				client, err := pyroscope.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				req := pyroscope.QueryRequest{
-					LabelSelector: expr,
-					ProfileTypeID: profileType,
-					Start:         start,
-					End:           end,
-					MaxNodes:      maxNodes,
-				}
-
-				resp, err := client.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "influxdb":
-				influxClient, err := influxdb.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				modeStr, err := dsquery.GetInfluxDBMode(ctx, cfg, datasourceUID)
-				if err != nil {
-					return fmt.Errorf("failed to detect influxdb mode: %w", err)
-				}
-
-				req := influxdb.QueryRequest{
-					Query: expr,
-					Start: start,
-					End:   end,
-					Step:  step,
-					Mode:  influxdb.Mode(modeStr),
-				}
-
-				resp, err := influxClient.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "clickhouse":
-				client, err := clickhouse.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				req := clickhouse.QueryRequest{
-					RawSQL: clickhouse.EnforceLimit(expr, 100, 1000),
-					Start:  start,
-					End:    end,
-				}
-				if step > 0 {
-					req.IntervalMs = step.Milliseconds()
-				}
-
-				resp, err := client.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			default:
-				return fmt.Errorf("datasource type %q is not supported (supported: prometheus, loki, pyroscope, influxdb, clickhouse)", dsType)
-			}
+			return executeTypedQuery(ctx, cmd, cfg, datasourceUID, args, shared, profileType, maxNodes, limit)
 		},
 	}
 
@@ -212,6 +125,285 @@ that do not have a dedicated subcommand.`,
 	cmd.Flags().StringVar(&profileType, "profile-type", "", "Profile type ID for pyroscope queries (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds')")
 	cmd.Flags().Int64Var(&maxNodes, "max-nodes", 1024, "Maximum nodes in flame graph (pyroscope only)")
 	cmd.Flags().IntVar(&limit, "limit", dsquery.DefaultLokiLimit, "Maximum number of log lines to return for loki queries (0 means no limit)")
+	cmd.Flags().StringVar(&rawQuery, "query", "", "Raw query JSON object (plugin-agnostic); use @file for file, @- for stdin")
 
 	return cmd
+}
+
+// executeTypedQuery handles auto-detect dispatch for known datasource types.
+func executeTypedQuery(
+	ctx context.Context,
+	cmd *cobra.Command,
+	cfg config.NamespacedRESTConfig,
+	datasourceUID string,
+	args []string,
+	shared *dsquery.SharedOpts,
+	profileType string,
+	maxNodes int64,
+	limit int,
+) error {
+	rawType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
+	if err != nil {
+		return err
+	}
+	dsType := dsquery.NormalizeKind(rawType)
+
+	// Short-circuit unsupported types before requiring an expression, so the
+	// user sees a helpful hint instead of "expression is required".
+	switch dsType {
+	case "prometheus", "loki", "pyroscope", "influxdb", "clickhouse":
+		// supported — fall through to expression resolution
+	case "cloudwatch":
+		return errors.New("CloudWatch queries are structured (namespace, metric, dimensions, region, statistic, period); " +
+			"the generic `gcx datasources query <uid> <expr>` form can't carry them — " +
+			"use `gcx datasources cloudwatch query --namespace ... --metric ... --region ...` instead")
+	default:
+		return fmt.Errorf("datasource type %q is not supported by auto-detect (supported: prometheus, loki, pyroscope, influxdb, clickhouse); "+
+			"use --query to provide a raw query JSON for this datasource type", dsType)
+	}
+
+	expr, err := shared.ResolveExpr(args, 1)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	start, end, step, err := shared.ParseTimes(now)
+	if err != nil {
+		return err
+	}
+
+	switch dsType {
+	case "prometheus":
+		client, err := prometheus.NewClient(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+
+		req := prometheus.QueryRequest{
+			Query: expr,
+			Start: start,
+			End:   end,
+			Step:  step,
+		}
+
+		resp, err := client.Query(ctx, datasourceUID, req)
+		if err != nil {
+			return fmt.Errorf("query failed: %w", err)
+		}
+
+		return shared.IO.Encode(cmd.OutOrStdout(), resp)
+
+	case "loki":
+		client, err := loki.NewClient(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+
+		req := loki.QueryRequest{
+			Query: expr,
+			Start: start,
+			End:   end,
+			Step:  step,
+			Limit: limit,
+		}
+
+		resp, err := client.Query(ctx, datasourceUID, req)
+		if err != nil {
+			return fmt.Errorf("query failed: %w", err)
+		}
+
+		return shared.IO.Encode(cmd.OutOrStdout(), resp)
+
+	case "pyroscope":
+		if profileType == "" {
+			return errors.New("--profile-type is required for pyroscope queries")
+		}
+
+		client, err := pyroscope.NewClient(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+
+		req := pyroscope.QueryRequest{
+			LabelSelector: expr,
+			ProfileTypeID: profileType,
+			Start:         start,
+			End:           end,
+			MaxNodes:      maxNodes,
+		}
+
+		resp, err := client.Query(ctx, datasourceUID, req)
+		if err != nil {
+			return fmt.Errorf("query failed: %w", err)
+		}
+
+		return shared.IO.Encode(cmd.OutOrStdout(), resp)
+
+	case "influxdb":
+		influxClient, err := influxdb.NewClient(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+
+		modeStr, err := dsquery.GetInfluxDBMode(ctx, cfg, datasourceUID)
+		if err != nil {
+			return fmt.Errorf("failed to detect influxdb mode: %w", err)
+		}
+
+		req := influxdb.QueryRequest{
+			Query: expr,
+			Start: start,
+			End:   end,
+			Step:  step,
+			Mode:  influxdb.Mode(modeStr),
+		}
+
+		resp, err := influxClient.Query(ctx, datasourceUID, req)
+		if err != nil {
+			return fmt.Errorf("query failed: %w", err)
+		}
+
+		return shared.IO.Encode(cmd.OutOrStdout(), resp)
+
+	case "clickhouse":
+		client, err := clickhouse.NewClient(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+
+		req := clickhouse.QueryRequest{
+			RawSQL: clickhouse.EnforceLimit(expr, 100, 1000),
+			Start:  start,
+			End:    end,
+		}
+		if step > 0 {
+			req.IntervalMs = step.Milliseconds()
+		}
+
+		resp, err := client.Query(ctx, datasourceUID, req)
+		if err != nil {
+			return fmt.Errorf("query failed: %w", err)
+		}
+
+		return shared.IO.Encode(cmd.OutOrStdout(), resp)
+
+	default:
+		// Unreachable: unsupported types are rejected before expression resolution.
+		return fmt.Errorf("unsupported datasource type %q; use --query", dsType)
+	}
+}
+
+// executeRawQuery executes a plugin-agnostic raw query. The user-provided JSON
+// is merged into the Grafana datasource query envelope with the datasource UID,
+// plugin type, refId, and time range injected automatically.
+func executeRawQuery(
+	ctx context.Context,
+	cmd *cobra.Command,
+	cfg config.NamespacedRESTConfig,
+	datasourceUID string,
+	rawQueryInput string,
+	shared *dsquery.SharedOpts,
+) error {
+	queryJSON, err := resolveQueryJSON(cmd, rawQueryInput)
+	if err != nil {
+		return err
+	}
+
+	var queryObj map[string]any
+	if err := json.Unmarshal([]byte(queryJSON), &queryObj); err != nil {
+		return fmt.Errorf("invalid --query JSON: %w", err)
+	}
+
+	// Look up the datasource type so the query envelope is well-formed.
+	rawType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
+	if err != nil {
+		return err
+	}
+
+	// Build the full query object: inject refId and datasource, then merge
+	// user-provided fields (user fields override defaults like refId).
+	fullQuery := map[string]any{
+		"refId": "A",
+		"datasource": map[string]any{
+			"type": rawType,
+			"uid":  datasourceUID,
+		},
+	}
+	maps.Copy(fullQuery, queryObj)
+
+	// Resolve time range.
+	now := time.Now()
+	start, end, _, err := shared.ParseTimes(now)
+	if err != nil {
+		return err
+	}
+
+	var from, to string
+	if !start.IsZero() && !end.IsZero() {
+		from = strconv.FormatInt(start.UnixMilli(), 10)
+		to = strconv.FormatInt(end.UnixMilli(), 10)
+	} else {
+		from = "now-1h"
+		to = "now"
+	}
+
+	bodyMap := map[string]any{
+		"queries": []any{fullQuery},
+		"from":    from,
+		"to":      to,
+	}
+
+	body, err := json.Marshal(bodyMap)
+	if err != nil {
+		return fmt.Errorf("failed to marshal query request: %w", err)
+	}
+
+	client, err := grafanaquery.NewClient(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create query client: %w", err)
+	}
+
+	respBody, err := client.Execute(ctx, body, rawType, "query")
+	if err != nil {
+		return err
+	}
+
+	var grafanaResp dataframe.Response
+	if err := json.Unmarshal(respBody, &grafanaResp); err != nil {
+		return fmt.Errorf("failed to parse query response: %w", err)
+	}
+
+	if result, ok := grafanaResp.Results["A"]; ok && result.Error != "" {
+		status := result.Status
+		if status == 0 {
+			status = http.StatusBadRequest
+		}
+		return queryerror.New(rawType, "query", status, result.Error, result.ErrorSource)
+	}
+
+	return shared.IO.Encode(cmd.OutOrStdout(), dataframe.ConvertResponse(&grafanaResp))
+}
+
+// resolveQueryJSON reads the raw query JSON from inline text, a file (@path),
+// or stdin (@-). It follows the same convention as `gcx api -d`.
+func resolveQueryJSON(cmd *cobra.Command, input string) (string, error) {
+	if input == "" {
+		return "", errors.New("--query value is empty")
+	}
+	if input == "@-" {
+		b, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return "", fmt.Errorf("failed to read query from stdin: %w", err)
+		}
+		return string(b), nil
+	}
+	if strings.HasPrefix(input, "@") {
+		b, err := os.ReadFile(input[1:])
+		if err != nil {
+			return "", fmt.Errorf("failed to read query file: %w", err)
+		}
+		return string(b), nil
+	}
+	return input, nil
 }

--- a/cmd/gcx/datasources/query.go
+++ b/cmd/gcx/datasources/query.go
@@ -322,7 +322,7 @@ func executeRawQuery(
 	}
 
 	// Build the full query object: inject refId and datasource, then merge
-	// user-provided fields (user fields override defaults like refId).
+	// user-provided fields (user fields may override refId).
 	fullQuery := map[string]any{
 		"refId": "A",
 		"datasource": map[string]any{
@@ -331,6 +331,14 @@ func executeRawQuery(
 		},
 	}
 	maps.Copy(fullQuery, queryObj)
+
+	// Read the effective refId after the merge — the user may have
+	// overridden it. Both the error check and response conversion must
+	// use the same key to avoid silently dropping results.
+	refId := "A"
+	if v, ok := fullQuery["refId"].(string); ok && v != "" {
+		refId = v
+	}
 
 	// Resolve time range.
 	now := time.Now()
@@ -374,7 +382,7 @@ func executeRawQuery(
 		return fmt.Errorf("failed to parse query response: %w", err)
 	}
 
-	if result, ok := grafanaResp.Results["A"]; ok && result.Error != "" {
+	if result, ok := grafanaResp.Results[refId]; ok && result.Error != "" {
 		status := result.Status
 		if status == 0 {
 			status = http.StatusBadRequest
@@ -382,7 +390,7 @@ func executeRawQuery(
 		return queryerror.New(rawType, "query", status, result.Error, result.ErrorSource)
 	}
 
-	return shared.IO.Encode(cmd.OutOrStdout(), dataframe.ConvertResponse(&grafanaResp))
+	return shared.IO.Encode(cmd.OutOrStdout(), dataframe.ConvertResponse(&grafanaResp, refId))
 }
 
 // resolveQueryJSON reads the raw query JSON from inline text, a file (@path),

--- a/cmd/gcx/datasources/query_test.go
+++ b/cmd/gcx/datasources/query_test.go
@@ -299,6 +299,212 @@ func TestGenericQueryCloudWatchShortCircuit(t *testing.T) {
 	}
 }
 
+// TestRawQueryFlagMutualExclusion verifies --query is mutually exclusive with
+// positional EXPR and --expr.
+func TestRawQueryFlagMutualExclusion(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		expectErr string
+	}{
+		{
+			name:      "--query + positional EXPR rejected",
+			args:      []string{"query", "uid", "some-expr", "--query", `{"type":"json"}`},
+			expectErr: "--query is mutually exclusive with a positional EXPR argument",
+		},
+		{
+			name:      "--query + --expr rejected",
+			args:      []string{"query", "uid", "--query", `{"type":"json"}`, "--expr", "up"},
+			expectErr: "--query is mutually exclusive with --expr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := executeQueryCommand(t, datasources.QueryCmd(), tt.args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectErr)
+		})
+	}
+}
+
+// TestRawQueryInvalidJSON verifies --query rejects malformed JSON.
+func TestRawQueryInvalidJSON(t *testing.T) {
+	server := newDatasourceTypeOnlyServer(t, "yesoreyeram-infinity-datasource")
+	defer server.Close()
+	configFile := newConfigFileForServer(t, server.URL)
+
+	err := executeQueryCommand(t, datasources.QueryCmd(), []string{
+		"query", "uid", "--query", `{invalid`, "--config", configFile,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --query JSON")
+}
+
+// TestRawQuerySendsCorrectBody verifies the raw query path sends a well-formed
+// Grafana query envelope with user fields merged.
+func TestRawQuerySendsCorrectBody(t *testing.T) {
+	var capturedBody map[string]any
+	server := newQueryCaptureServer(t, "yesoreyeram-infinity-datasource", func(_ string, body map[string]any) {
+		capturedBody = body
+	})
+	defer server.Close()
+
+	configFile := newConfigFileForServer(t, server.URL)
+
+	err := executeQueryCommand(t, datasources.QueryCmd(), []string{
+		"query", "uid",
+		"--query", `{"type":"json","source":"url","url":"https://example.com/api","format":"table"}`,
+		"--since", "1h",
+		"--config", configFile,
+		"-o", "json",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, capturedBody)
+
+	// Verify queries array is present.
+	queries, ok := capturedBody["queries"].([]any)
+	require.True(t, ok, "expected queries array")
+	require.Len(t, queries, 1)
+
+	query, ok := queries[0].(map[string]any)
+	require.True(t, ok)
+
+	// Verify injected fields.
+	assert.Equal(t, "A", query["refId"])
+	ds, ok := query["datasource"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "yesoreyeram-infinity-datasource", ds["type"])
+	assert.Equal(t, "uid", ds["uid"])
+
+	// Verify user-provided fields are merged.
+	assert.Equal(t, "json", query["type"])
+	assert.Equal(t, "url", query["source"])
+	assert.Equal(t, "https://example.com/api", query["url"])
+	assert.Equal(t, "table", query["format"])
+
+	// Verify time range is present.
+	start := parseUnixMillisField(t, capturedBody, "from")
+	end := parseUnixMillisField(t, capturedBody, "to")
+	assert.WithinDuration(t, end.Add(-time.Hour), start, time.Second)
+}
+
+// TestRawQueryFromFile verifies --query @file reads from a file.
+func TestRawQueryFromFile(t *testing.T) {
+	var capturedBody map[string]any
+	server := newQueryCaptureServer(t, "yesoreyeram-infinity-datasource", func(_ string, body map[string]any) {
+		capturedBody = body
+	})
+	defer server.Close()
+
+	configFile := newConfigFileForServer(t, server.URL)
+	queryFile := testutils.CreateTempFile(t, `{"type":"json","source":"url","format":"table"}`)
+
+	err := executeQueryCommand(t, datasources.QueryCmd(), []string{
+		"query", "uid",
+		"--query", "@" + queryFile,
+		"--since", "30m",
+		"--config", configFile,
+		"-o", "json",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, capturedBody)
+
+	queries, ok := capturedBody["queries"].([]any)
+	require.True(t, ok, "expected queries array")
+	query, ok := queries[0].(map[string]any)
+	require.True(t, ok, "expected query object")
+	assert.Equal(t, "json", query["type"])
+	assert.Equal(t, "url", query["source"])
+}
+
+// TestRawQueryFromStdin verifies --query @- reads from stdin.
+func TestRawQueryFromStdin(t *testing.T) {
+	var capturedBody map[string]any
+	server := newQueryCaptureServer(t, "yesoreyeram-infinity-datasource", func(_ string, body map[string]any) {
+		capturedBody = body
+	})
+	defer server.Close()
+
+	configFile := newConfigFileForServer(t, server.URL)
+
+	cmd := datasources.QueryCmd()
+	root := helperRoot(cmd)
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetIn(strings.NewReader(`{"type":"json","source":"inline","format":"table"}`))
+	root.SetArgs([]string{
+		"query", "uid",
+		"--query", "@-",
+		"--since", "1h",
+		"--config", configFile,
+		"-o", "json",
+	})
+
+	err := root.Execute()
+	require.NoError(t, err)
+	require.NotNil(t, capturedBody)
+
+	queries, ok := capturedBody["queries"].([]any)
+	require.True(t, ok, "expected queries array")
+	query, ok := queries[0].(map[string]any)
+	require.True(t, ok, "expected query object")
+	assert.Equal(t, "json", query["type"])
+	assert.Equal(t, "inline", query["source"])
+}
+
+// TestRawQueryFileNotFound verifies --query @nonexistent fails clearly.
+func TestRawQueryFileNotFound(t *testing.T) {
+	server := newDatasourceTypeOnlyServer(t, "yesoreyeram-infinity-datasource")
+	defer server.Close()
+	configFile := newConfigFileForServer(t, server.URL)
+
+	err := executeQueryCommand(t, datasources.QueryCmd(), []string{
+		"query", "uid", "--query", "@/nonexistent/query.json", "--config", configFile,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read query file")
+}
+
+// TestRawQueryDefaultTimeRange verifies that omitting --from/--to defaults
+// to "now-1h" / "now".
+func TestRawQueryDefaultTimeRange(t *testing.T) {
+	var capturedBody map[string]any
+	server := newQueryCaptureServer(t, "yesoreyeram-infinity-datasource", func(_ string, body map[string]any) {
+		capturedBody = body
+	})
+	defer server.Close()
+
+	configFile := newConfigFileForServer(t, server.URL)
+
+	err := executeQueryCommand(t, datasources.QueryCmd(), []string{
+		"query", "uid",
+		"--query", `{"type":"json"}`,
+		"--config", configFile,
+		"-o", "json",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, capturedBody)
+
+	assert.Equal(t, "now-1h", capturedBody["from"])
+	assert.Equal(t, "now", capturedBody["to"])
+}
+
+// TestRawQueryUnsupportedTypeHint verifies the error message for unsupported
+// datasource types now suggests --query.
+func TestRawQueryUnsupportedTypeHint(t *testing.T) {
+	server := newDatasourceTypeOnlyServer(t, "yesoreyeram-infinity-datasource")
+	defer server.Close()
+	configFile := newConfigFileForServer(t, server.URL)
+
+	err := executeQueryCommand(t, datasources.QueryCmd(), []string{
+		"query", "uid", "some-expr", "--config", configFile,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--query")
+}
+
 // Pins shared.Validate() running before any HTTP or short-circuit branch.
 func TestGenericQueryFlagValidationPrecedence(t *testing.T) {
 	tests := []struct {

--- a/docs/reference/cli/gcx_datasources_query.md
+++ b/docs/reference/cli/gcx_datasources_query.md
@@ -13,6 +13,11 @@ The datasource type is detected via the Grafana API and the appropriate query
 client is used automatically. This is the escape hatch for datasource types
 that do not have a dedicated subcommand.
 
+Use --query to provide a raw query JSON object for any datasource type,
+bypassing type-specific logic. The object is merged into the Grafana datasource
+query envelope — datasource UID, type, refId, and time range are injected
+automatically. Use @file to read from a file or @- for stdin.
+
 ```
 gcx datasources query DATASOURCE_UID [EXPR] [flags]
 ```
@@ -30,6 +35,19 @@ gcx datasources query DATASOURCE_UID [EXPR] [flags]
   # Pyroscope via auto-detect
   gcx datasources query pyro-001 '{service_name="frontend"}' \
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --from now-1h --to now
+
+  # Raw query JSON (plugin-agnostic) — Infinity example
+  gcx datasources query infinity-01 --query '{
+    "type": "json", "source": "url",
+    "url": "https://api.example.com/data",
+    "format": "table", "root_selector": "$.items"
+  }' --since 30m
+
+  # Raw query from file
+  gcx datasources query ds-001 --query @query.json --since 1h
+
+  # Raw query from stdin
+  cat query.json | gcx datasources query ds-001 --query @- --since 1h
 ```
 
 ### Options
@@ -46,6 +64,7 @@ gcx datasources query DATASOURCE_UID [EXPR] [flags]
       --max-nodes int         Maximum nodes in flame graph (pyroscope only) (default 1024)
   -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
       --profile-type string   Profile type ID for pyroscope queries (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds')
+      --query string          Raw query JSON object (plugin-agnostic); use @file for file, @- for stdin
       --since string          Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')
       --to string             End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/internal/datasources/query/codecs.go
+++ b/internal/datasources/query/codecs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/gcx/internal/query/athena"
 	"github.com/grafana/gcx/internal/query/clickhouse"
 	"github.com/grafana/gcx/internal/query/cloudwatch"
+	"github.com/grafana/gcx/internal/query/dataframe"
 	"github.com/grafana/gcx/internal/query/infinity"
 	"github.com/grafana/gcx/internal/query/influxdb"
 	"github.com/grafana/gcx/internal/query/loki"
@@ -55,6 +56,8 @@ func (c *queryTableCodec) Encode(w io.Writer, data any) error {
 		return athena.FormatStringList(w, resp.Items, resp.Header)
 	case *cloudwatch.QueryResponse:
 		return cloudwatch.FormatTable(w, resp)
+	case *dataframe.RawQueryResponse:
+		return dataframe.FormatTable(w, resp)
 	default:
 		return errors.New("invalid data type for query table codec")
 	}
@@ -88,6 +91,8 @@ func (c *queryWideCodec) Encode(w io.Writer, data any) error {
 		return athena.FormatStringList(w, resp.Items, resp.Header)
 	case *cloudwatch.QueryResponse:
 		return cloudwatch.FormatWide(w, resp)
+	case *dataframe.RawQueryResponse:
+		return dataframe.FormatTable(w, resp) // wide is the same as table for raw queries
 	default:
 		return errors.New("invalid data type for query wide codec")
 	}
@@ -152,6 +157,8 @@ func (c *queryGraphCodec) Encode(w io.Writer, data any) error {
 		return errors.New("graph output is not supported for ClickHouse describe-table; use -o table/json/yaml")
 	case athena.StringList:
 		return errors.New("graph output is not supported for Athena discovery; use -o table/json/yaml")
+	case *dataframe.RawQueryResponse:
+		return errors.New("graph output is not supported for raw queries; use -o table/json/yaml")
 	default:
 		return errors.New("invalid data type for graph codec")
 	}

--- a/internal/query/dataframe/raw.go
+++ b/internal/query/dataframe/raw.go
@@ -31,14 +31,14 @@ type RawColumn struct {
 }
 
 // ConvertResponse converts a Grafana data-frame Response into a
-// RawQueryResponse by pivoting every frame for refId "A" from
+// RawQueryResponse by pivoting every frame for the given refId from
 // column-oriented to row-oriented layout.
-func ConvertResponse(resp *Response) *RawQueryResponse {
+func ConvertResponse(resp *Response, refId string) *RawQueryResponse {
 	out := &RawQueryResponse{
 		Frames: []RawFrame{},
 	}
 
-	result, ok := resp.Results["A"]
+	result, ok := resp.Results[refId]
 	if !ok {
 		return out
 	}

--- a/internal/query/dataframe/raw.go
+++ b/internal/query/dataframe/raw.go
@@ -1,0 +1,149 @@
+package dataframe
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/gcx/internal/style"
+)
+
+// RawQueryResponse holds the result of a raw (plugin-agnostic) datasource
+// query. Each Grafana data frame becomes a separate RawFrame so multi-frame
+// responses are preserved end-to-end.
+type RawQueryResponse struct {
+	Frames []RawFrame `json:"frames"`
+}
+
+// RawFrame is a single data frame converted from column-oriented to
+// row-oriented layout.
+type RawFrame struct {
+	Name    string      `json:"name,omitempty"`
+	Columns []RawColumn `json:"columns"`
+	Rows    [][]any     `json:"rows"`
+}
+
+// RawColumn describes a single column in a raw query result.
+type RawColumn struct {
+	Name string `json:"name"`
+	Type string `json:"type,omitempty"`
+}
+
+// ConvertResponse converts a Grafana data-frame Response into a
+// RawQueryResponse by pivoting every frame for refId "A" from
+// column-oriented to row-oriented layout.
+func ConvertResponse(resp *Response) *RawQueryResponse {
+	out := &RawQueryResponse{
+		Frames: []RawFrame{},
+	}
+
+	result, ok := resp.Results["A"]
+	if !ok {
+		return out
+	}
+
+	for _, frame := range result.Frames {
+		if len(frame.Schema.Fields) == 0 {
+			continue
+		}
+
+		rf := RawFrame{
+			Name:    frame.Schema.Name,
+			Columns: make([]RawColumn, len(frame.Schema.Fields)),
+			Rows:    [][]any{},
+		}
+
+		for i, field := range frame.Schema.Fields {
+			rf.Columns[i] = RawColumn{Name: field.Name, Type: field.Type}
+		}
+
+		if len(frame.Data.Values) > 0 && len(frame.Data.Values[0]) > 0 {
+			numFields := len(frame.Schema.Fields)
+			numRows := len(frame.Data.Values[0])
+			for i := range numRows {
+				row := make([]any, numFields)
+				for colIdx, colValues := range frame.Data.Values {
+					if colIdx < numFields && i < len(colValues) {
+						row[colIdx] = colValues[i]
+					}
+				}
+				rf.Rows = append(rf.Rows, row)
+			}
+		}
+
+		out.Frames = append(out.Frames, rf)
+	}
+
+	return out
+}
+
+// FormatTable renders a RawQueryResponse as terminal tables.
+// Each frame is rendered as a separate table, with a heading when
+// there are multiple frames.
+func FormatTable(w io.Writer, resp *RawQueryResponse) error {
+	totalRows := 0
+	for _, f := range resp.Frames {
+		totalRows += len(f.Rows)
+	}
+	if totalRows == 0 {
+		fmt.Fprintln(w, "No data")
+		return nil
+	}
+
+	multiFrame := len(resp.Frames) > 1
+
+	for i, frame := range resp.Frames {
+		if len(frame.Columns) == 0 {
+			continue
+		}
+
+		if multiFrame {
+			if i > 0 {
+				fmt.Fprintln(w)
+			}
+			label := frame.Name
+			if label == "" {
+				label = fmt.Sprintf("Frame %d", i+1)
+			}
+			fmt.Fprintf(w, "── %s (%d rows) ──\n", label, len(frame.Rows))
+		}
+
+		headers := make([]string, len(frame.Columns))
+		for j, col := range frame.Columns {
+			headers[j] = strings.ToUpper(col.Name)
+		}
+
+		t := style.NewTable(headers...)
+		for _, row := range frame.Rows {
+			cells := make([]string, len(row))
+			for j, val := range row {
+				cells[j] = toString(val)
+			}
+			t.Row(cells...)
+		}
+
+		if err := t.Render(w); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func toString(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	case int64:
+		return strconv.FormatInt(val, 10)
+	case bool:
+		return strconv.FormatBool(val)
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}

--- a/internal/query/dataframe/raw_test.go
+++ b/internal/query/dataframe/raw_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestConvertResponse_EmptyResults(t *testing.T) {
 	resp := &dataframe.Response{Results: map[string]dataframe.Result{}}
-	out := dataframe.ConvertResponse(resp)
+	out := dataframe.ConvertResponse(resp, "A")
 	assert.Empty(t, out.Frames)
 }
 
@@ -21,7 +21,7 @@ func TestConvertResponse_NoRefIdA(t *testing.T) {
 			"B": {Frames: []dataframe.Frame{}},
 		},
 	}
-	out := dataframe.ConvertResponse(resp)
+	out := dataframe.ConvertResponse(resp, "A")
 	assert.Empty(t, out.Frames)
 }
 
@@ -49,7 +49,7 @@ func TestConvertResponse_SingleFrame(t *testing.T) {
 		},
 	}
 
-	out := dataframe.ConvertResponse(resp)
+	out := dataframe.ConvertResponse(resp, "A")
 
 	require.Len(t, out.Frames, 1)
 	frame := out.Frames[0]
@@ -101,7 +101,7 @@ func TestConvertResponse_MultiFrame(t *testing.T) {
 		},
 	}
 
-	out := dataframe.ConvertResponse(resp)
+	out := dataframe.ConvertResponse(resp, "A")
 
 	require.Len(t, out.Frames, 2)
 
@@ -119,6 +119,33 @@ func TestConvertResponse_MultiFrame(t *testing.T) {
 	require.Len(t, out.Frames[1].Rows, 2)
 	assert.Equal(t, []any{"requests", float64(100)}, out.Frames[1].Rows[0])
 	assert.Equal(t, []any{"errors", float64(5)}, out.Frames[1].Rows[1])
+}
+
+func TestConvertResponse_CustomRefId(t *testing.T) {
+	resp := &dataframe.Response{
+		Results: map[string]dataframe.Result{
+			"B": {
+				Frames: []dataframe.Frame{
+					{
+						Schema: dataframe.Schema{
+							Fields: []dataframe.Field{{Name: "val", Type: "number"}},
+						},
+						Data: dataframe.Data{Values: [][]any{{float64(99)}}},
+					},
+				},
+			},
+		},
+	}
+
+	// Requesting refId "A" should return empty.
+	outA := dataframe.ConvertResponse(resp, "A")
+	assert.Empty(t, outA.Frames)
+
+	// Requesting refId "B" should return the data.
+	outB := dataframe.ConvertResponse(resp, "B")
+	require.Len(t, outB.Frames, 1)
+	require.Len(t, outB.Frames[0].Rows, 1)
+	assert.Equal(t, []any{float64(99)}, outB.Frames[0].Rows[0])
 }
 
 func TestConvertResponse_EmptyData(t *testing.T) {
@@ -139,7 +166,7 @@ func TestConvertResponse_EmptyData(t *testing.T) {
 		},
 	}
 
-	out := dataframe.ConvertResponse(resp)
+	out := dataframe.ConvertResponse(resp, "A")
 	require.Len(t, out.Frames, 1)
 	require.Len(t, out.Frames[0].Columns, 1)
 	assert.Equal(t, "value", out.Frames[0].Columns[0].Name)
@@ -163,7 +190,7 @@ func TestConvertResponse_SkipsEmptySchemaFrames(t *testing.T) {
 		},
 	}
 
-	out := dataframe.ConvertResponse(resp)
+	out := dataframe.ConvertResponse(resp, "A")
 	require.Len(t, out.Frames, 1)
 	assert.Equal(t, "x", out.Frames[0].Columns[0].Name)
 }

--- a/internal/query/dataframe/raw_test.go
+++ b/internal/query/dataframe/raw_test.go
@@ -1,0 +1,259 @@
+package dataframe_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/dataframe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertResponse_EmptyResults(t *testing.T) {
+	resp := &dataframe.Response{Results: map[string]dataframe.Result{}}
+	out := dataframe.ConvertResponse(resp)
+	assert.Empty(t, out.Frames)
+}
+
+func TestConvertResponse_NoRefIdA(t *testing.T) {
+	resp := &dataframe.Response{
+		Results: map[string]dataframe.Result{
+			"B": {Frames: []dataframe.Frame{}},
+		},
+	}
+	out := dataframe.ConvertResponse(resp)
+	assert.Empty(t, out.Frames)
+}
+
+func TestConvertResponse_SingleFrame(t *testing.T) {
+	resp := &dataframe.Response{
+		Results: map[string]dataframe.Result{
+			"A": {
+				Frames: []dataframe.Frame{
+					{
+						Schema: dataframe.Schema{
+							Fields: []dataframe.Field{
+								{Name: "host", Type: "string"},
+								{Name: "status", Type: "number"},
+							},
+						},
+						Data: dataframe.Data{
+							Values: [][]any{
+								{"server-1", "server-2"},
+								{float64(200), float64(500)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out := dataframe.ConvertResponse(resp)
+
+	require.Len(t, out.Frames, 1)
+	frame := out.Frames[0]
+
+	require.Len(t, frame.Columns, 2)
+	assert.Equal(t, "host", frame.Columns[0].Name)
+	assert.Equal(t, "string", frame.Columns[0].Type)
+	assert.Equal(t, "status", frame.Columns[1].Name)
+	assert.Equal(t, "number", frame.Columns[1].Type)
+
+	require.Len(t, frame.Rows, 2)
+	assert.Equal(t, []any{"server-1", float64(200)}, frame.Rows[0])
+	assert.Equal(t, []any{"server-2", float64(500)}, frame.Rows[1])
+}
+
+func TestConvertResponse_MultiFrame(t *testing.T) {
+	resp := &dataframe.Response{
+		Results: map[string]dataframe.Result{
+			"A": {
+				Frames: []dataframe.Frame{
+					{
+						Schema: dataframe.Schema{
+							Name: "users",
+							Fields: []dataframe.Field{
+								{Name: "name", Type: "string"},
+							},
+						},
+						Data: dataframe.Data{
+							Values: [][]any{{"alice", "bob"}},
+						},
+					},
+					{
+						Schema: dataframe.Schema{
+							Name: "counts",
+							Fields: []dataframe.Field{
+								{Name: "metric", Type: "string"},
+								{Name: "value", Type: "number"},
+							},
+						},
+						Data: dataframe.Data{
+							Values: [][]any{
+								{"requests", "errors"},
+								{float64(100), float64(5)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out := dataframe.ConvertResponse(resp)
+
+	require.Len(t, out.Frames, 2)
+
+	// First frame.
+	assert.Equal(t, "users", out.Frames[0].Name)
+	require.Len(t, out.Frames[0].Columns, 1)
+	assert.Equal(t, "name", out.Frames[0].Columns[0].Name)
+	require.Len(t, out.Frames[0].Rows, 2)
+	assert.Equal(t, []any{"alice"}, out.Frames[0].Rows[0])
+	assert.Equal(t, []any{"bob"}, out.Frames[0].Rows[1])
+
+	// Second frame.
+	assert.Equal(t, "counts", out.Frames[1].Name)
+	require.Len(t, out.Frames[1].Columns, 2)
+	require.Len(t, out.Frames[1].Rows, 2)
+	assert.Equal(t, []any{"requests", float64(100)}, out.Frames[1].Rows[0])
+	assert.Equal(t, []any{"errors", float64(5)}, out.Frames[1].Rows[1])
+}
+
+func TestConvertResponse_EmptyData(t *testing.T) {
+	resp := &dataframe.Response{
+		Results: map[string]dataframe.Result{
+			"A": {
+				Frames: []dataframe.Frame{
+					{
+						Schema: dataframe.Schema{
+							Fields: []dataframe.Field{
+								{Name: "value", Type: "number"},
+							},
+						},
+						Data: dataframe.Data{Values: [][]any{}},
+					},
+				},
+			},
+		},
+	}
+
+	out := dataframe.ConvertResponse(resp)
+	require.Len(t, out.Frames, 1)
+	require.Len(t, out.Frames[0].Columns, 1)
+	assert.Equal(t, "value", out.Frames[0].Columns[0].Name)
+	assert.Empty(t, out.Frames[0].Rows)
+}
+
+func TestConvertResponse_SkipsEmptySchemaFrames(t *testing.T) {
+	resp := &dataframe.Response{
+		Results: map[string]dataframe.Result{
+			"A": {
+				Frames: []dataframe.Frame{
+					{Schema: dataframe.Schema{Fields: []dataframe.Field{}}},
+					{
+						Schema: dataframe.Schema{
+							Fields: []dataframe.Field{{Name: "x", Type: "number"}},
+						},
+						Data: dataframe.Data{Values: [][]any{{float64(1)}}},
+					},
+				},
+			},
+		},
+	}
+
+	out := dataframe.ConvertResponse(resp)
+	require.Len(t, out.Frames, 1)
+	assert.Equal(t, "x", out.Frames[0].Columns[0].Name)
+}
+
+func TestFormatTable_NoData(t *testing.T) {
+	resp := &dataframe.RawQueryResponse{Frames: []dataframe.RawFrame{}}
+	var buf bytes.Buffer
+	err := dataframe.FormatTable(&buf, resp)
+	require.NoError(t, err)
+	assert.Equal(t, "No data\n", buf.String())
+}
+
+func TestFormatTable_SingleFrame(t *testing.T) {
+	resp := &dataframe.RawQueryResponse{
+		Frames: []dataframe.RawFrame{
+			{
+				Columns: []dataframe.RawColumn{
+					{Name: "name", Type: "string"},
+					{Name: "value", Type: "number"},
+				},
+				Rows: [][]any{
+					{"alice", float64(42)},
+					{"bob", nil},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := dataframe.FormatTable(&buf, resp)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "NAME")
+	assert.Contains(t, output, "VALUE")
+	assert.Contains(t, output, "alice")
+	assert.Contains(t, output, "42")
+	assert.Contains(t, output, "bob")
+	// Single frame: no frame header.
+	assert.NotContains(t, output, "──")
+}
+
+func TestFormatTable_MultiFrame(t *testing.T) {
+	resp := &dataframe.RawQueryResponse{
+		Frames: []dataframe.RawFrame{
+			{
+				Name: "users",
+				Columns: []dataframe.RawColumn{
+					{Name: "name", Type: "string"},
+				},
+				Rows: [][]any{{"alice"}},
+			},
+			{
+				Name: "counts",
+				Columns: []dataframe.RawColumn{
+					{Name: "metric", Type: "string"},
+					{Name: "value", Type: "number"},
+				},
+				Rows: [][]any{{"requests", float64(100)}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := dataframe.FormatTable(&buf, resp)
+	require.NoError(t, err)
+
+	output := buf.String()
+	// Both frame headers present.
+	assert.Contains(t, output, "── users (1 rows) ──")
+	assert.Contains(t, output, "── counts (1 rows) ──")
+	// Data from both frames.
+	assert.Contains(t, output, "alice")
+	assert.Contains(t, output, "requests")
+	assert.Contains(t, output, "100")
+}
+
+func TestFormatTable_MultiFrameUnnamed(t *testing.T) {
+	resp := &dataframe.RawQueryResponse{
+		Frames: []dataframe.RawFrame{
+			{Columns: []dataframe.RawColumn{{Name: "a"}}, Rows: [][]any{{"x"}}},
+			{Columns: []dataframe.RawColumn{{Name: "b"}}, Rows: [][]any{{"y"}}},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := dataframe.FormatTable(&buf, resp)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "── Frame 1 (1 rows) ──")
+	assert.Contains(t, output, "── Frame 2 (1 rows) ──")
+}


### PR DESCRIPTION
## Summary

Adds a --query flag to gcx datasources query that accepts raw query JSON for any datasource type, bypassing auto-detect limitations. The user supplies the query body; gcx automatically injects the datasource UID, plugin type, refId, and time range into the Grafana query envelope.
Fixes the gap where unsupported datasource types (Infinity, custom plugins, etc.) could not be queried via the generic datasources query command.

## Motivation

The existing gcx datasources query <uid> <expr> command only supports a hardcoded set of datasource types (Prometheus, Loki, Pyroscope, InfluxDB, ClickHouse). Attempting to query other datasources—like Infinity, CloudWatch (via the generic command), or any custom plugin—fails with:
datasource type "infinity" is not supported by auto-detect
This forced users to drop down to gcx api /api/ds/query -d @body.json, losing the convenience of automatic datasource/time-range injection.

## Changes

### New --query flag

Accepts raw query JSON via:
- Inline: --query '{"type":"json","source":"url","format":"table"}'
- File: --query @query.json
- Stdin: --query @- (follows gcx api -d convention)
- Empty: --query "" or --query='' defaults to {}
The query object is merged into the Grafana query envelope. The datasource UID, plugin type, refId: "A", and time range (--from/--to/--since) are injected automatically.

### Multi-frame response handling

Previously, only the first data frame was returned. Now:
- RawQueryResponse wraps an array of RawFrames
- Each frame preserves its schema name, columns, and rows

### Improved unsupported-type error

When a datasource type isn't in the auto-detect list and no --query is provided, the error now immediately suggests --query:

```sh
datasource type "infinity" is not supported by auto-detect (supported: prometheus, loki, pyroscope, influxdb, clickhouse);
use --query to provide a raw query JSON for this datasource type
```

Previously, users saw the confusing "expression is required" error instead.

## Usage Examples

### Infinity datasource

#### Inline JSON

```sh
./bin/gcx datasources query grafanacloud-infinity --query '{
  "source": "url",
  "url": "https://dogapi.dog/api/v2/breeds",
  "parser": "backend",
  "root_selector": "$.data.attributes"
}' --since 30m -o table
```

#### From file

`./bin/gcx datasources query grafanacloud-infinity --query @query.json --since 1h`

#### From stdin

`cat query.json | gcx datasources query grafanacloud-infinity --query @- --from now-1h --to now`

#### Empty query (uses datasource's saved config)

`gcx datasources query grafanacloud-infinity --query='' --since 1h`

### Any custom plugin

```sh
gcx datasources query my-custom-ds-uid --query '{
  "customField": "value",
  "anotherField": 123
}' --from now-6h --to now -o json
```

## Sample screenshots ( yugabyte datasource )

<img width="1370" height="1014" alt="image" src="https://github.com/user-attachments/assets/efdb289f-4ee3-41ce-b01e-0d9254ca8314" />
