### PR TITLE
added telemetry to datasources query command

### DIFF
--- a/cmd/gcx/telemetry.go
+++ b/cmd/gcx/telemetry.go
@@ -86,6 +86,8 @@ func buildUsageEvent(info *root.TelemetryInfo, start time.Time, exitCode int) te
 	event.DeviceID, event.DeviceIDPersisted = telemetry.DeviceID()
 	event.CIProvider, event.IsCI = telemetry.DetectCI()
 
+	event.DatasourcePluginType = telemetry.CapturedDatasourcePluginType
+
 	switch {
 	case info.Help && exitCode == 0:
 		event.Outcome = telemetry.OutcomeHelp

--- a/docs/sources/anonymous-usage-statistics.md
+++ b/docs/sources/anonymous-usage-statistics.md
@@ -49,6 +49,12 @@ Each `gcx` event contains the following properties:
 | `target_kind` | Whether the target Grafana is `cloud` or `self-hosted`. Empty when no effective Grafana target could be resolved. Deliberately coarse — never the URL, hostname, or stack slug. | `cloud` |
 | `output_format` | The output format the command used. | `table`, `json` |
 
+When the command targets a datasource, this additional field is set:
+
+| Field | Description | Example |
+| :---- | :---- | :---- |
+| `datasource_plugin_type` | The Grafana datasource plugin type that was resolved. Never the datasource UID, name, or query expression. | `prometheus`, `loki`, `grafana-pyroscope-datasource` |
+
 When the invocation fails to parse, these additional fields are set. They capture what was attempted so the team can understand the differences between what users expect and what exists:
 
 | Field | Description | Example |

--- a/internal/datasources/query/resolve.go
+++ b/internal/datasources/query/resolve.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/datasources"
+	"github.com/grafana/gcx/internal/telemetry"
 	"github.com/grafana/grafana-app-sdk/logging"
 )
 
@@ -149,6 +150,7 @@ func ResolveValidateAndSaveDatasource(ctx context.Context, saver DatasourceSaver
 		}
 	}
 
+	telemetry.RecordDatasourceQueryType(dsType)
 	return resolved.UID, dsType, nil
 }
 
@@ -225,6 +227,7 @@ func GetDatasourceType(ctx context.Context, cfg config.NamespacedRESTConfig, uid
 		return "", fmt.Errorf("failed to get datasource %q: %w", uid, err)
 	}
 
+	telemetry.RecordDatasourceQueryType(ds.Type)
 	return ds.Type, nil
 }
 

--- a/internal/telemetry/datasources.go
+++ b/internal/telemetry/datasources.go
@@ -1,0 +1,14 @@
+package telemetry
+
+// CapturedDatasourcePluginType is the datasource plugin type recorded by a
+// query command's RunE, read once at exit by buildUsageEvent. Empty when no
+// query command ran.
+//
+//nolint:gochecknoglobals
+var CapturedDatasourcePluginType string
+
+// RecordDatasourceQueryType records the datasource plugin type for the
+// usage event. The raw plugin ID is stored as-is.
+func RecordDatasourceQueryType(rawPluginID string) {
+	CapturedDatasourcePluginType = rawPluginID
+}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -50,6 +50,10 @@ type Event struct {
 	TargetKind   string `json:"target_kind"`
 	OutputFormat string `json:"output_format"`
 
+	// The datasource plugin type resolved during datasource commands.
+	// Empty for non-datasource commands.
+	DatasourcePluginType string `json:"datasource_plugin_type,omitempty"`
+
 	// Parse-failure capture, set only when Outcome is OutcomeParseError.
 	ParseErrorKind     string `json:"parse_error_kind,omitempty"`
 	ParseErrorParent   string `json:"parse_error_parent,omitempty"`

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -21,6 +21,12 @@ func wantAlwaysPresent() []string {
 	}
 }
 
+func wantDatasourceQueryOnly() []string {
+	return []string{
+		"datasource_plugin_type",
+	}
+}
+
 func wantParseErrorOnly() []string {
 	return []string{
 		"parse_error_kind", "parse_error_parent", "parse_error_token",
@@ -39,44 +45,62 @@ func marshalKeys(t *testing.T, ev telemetry.Event) map[string]any {
 
 func TestEventFieldInventory(t *testing.T) {
 	full := telemetry.Event{
-		Service:            telemetry.ServiceName,
-		Version:            "0.4.1",
-		OS:                 "linux",
-		Arch:               "arm64",
-		DeviceID:           "00000000-0000-4000-8000-000000000000",
-		DeviceIDPersisted:  true,
-		Command:            "dashboards push",
-		Flags:              "dry-run,folder",
-		Provider:           "dashboards",
-		Outcome:            telemetry.OutcomeParseError,
-		ExitCode:           2,
-		ErrorKind:          "usage_error",
-		DurationMS:         1234,
-		IsTTY:              true,
-		IsCI:               true,
-		CIProvider:         "github_actions",
-		IsAgent:            true,
-		Agent:              "claude-code",
-		TargetKind:         "cloud",
-		OutputFormat:       "json",
-		ParseErrorKind:     "unknown_command",
-		ParseErrorParent:   "dashboards",
-		ParseErrorToken:    "serch",
-		AttemptedCommand:   "dashboards serch",
-		ParseErrorFlags:    "verbsoe",
-		ParseErrorNearest:  "search",
-		ParseErrorDistance: 2,
+		Service:              telemetry.ServiceName,
+		Version:              "0.4.1",
+		OS:                   "linux",
+		Arch:                 "arm64",
+		DeviceID:             "00000000-0000-4000-8000-000000000000",
+		DeviceIDPersisted:    true,
+		Command:              "dashboards push",
+		Flags:                "dry-run,folder",
+		Provider:             "dashboards",
+		Outcome:              telemetry.OutcomeParseError,
+		ExitCode:             2,
+		ErrorKind:            "usage_error",
+		DurationMS:           1234,
+		IsTTY:                true,
+		IsCI:                 true,
+		CIProvider:           "github_actions",
+		IsAgent:              true,
+		Agent:                "claude-code",
+		TargetKind:           "cloud",
+		OutputFormat:         "json",
+		DatasourcePluginType: "prometheus",
+		ParseErrorKind:       "unknown_command",
+		ParseErrorParent:     "dashboards",
+		ParseErrorToken:      "serch",
+		AttemptedCommand:     "dashboards serch",
+		ParseErrorFlags:      "verbsoe",
+		ParseErrorNearest:    "search",
+		ParseErrorDistance:   2,
 	}
 
 	got := marshalKeys(t, full)
-	want := append(wantAlwaysPresent(), wantParseErrorOnly()...)
+	want := append(wantAlwaysPresent(), wantDatasourceQueryOnly()...)
+	want = append(want, wantParseErrorOnly()...)
 	assert.ElementsMatch(t, want, keys(got), "full event must emit exactly the documented field set")
 }
 
 func TestEventOmitsParseFieldsWhenUnset(t *testing.T) {
 	got := marshalKeys(t, telemetry.Event{Outcome: telemetry.OutcomeOK})
 	assert.ElementsMatch(t, wantAlwaysPresent(), keys(got),
-		"non-parse-error events must omit parse_error_* and keep all other fields, even zero-valued")
+		"non-query, non-parse-error events must omit datasource_plugin_type and parse_error_* and keep all other fields, even zero-valued")
+}
+
+func TestEventOmitsDatasourcePluginTypeWhenUnset(t *testing.T) {
+	got := marshalKeys(t, telemetry.Event{Outcome: telemetry.OutcomeOK})
+	assert.NotContains(t, keys(got), "datasource_plugin_type",
+		"non-query events must omit datasource_plugin_type")
+}
+
+func TestEventCarriesDatasourcePluginType(t *testing.T) {
+	got := marshalKeys(t, telemetry.Event{
+		Outcome:              telemetry.OutcomeOK,
+		DatasourcePluginType: "loki",
+	})
+	want := append(wantAlwaysPresent(), wantDatasourceQueryOnly()...)
+	assert.ElementsMatch(t, want, keys(got),
+		"query events must include datasource_plugin_type and omit parse_error_*")
 }
 
 func TestEventNoNearMatchDistanceSurvives(t *testing.T) {

--- a/internal/telemetry/export_internal_test.go
+++ b/internal/telemetry/export_internal_test.go
@@ -64,11 +64,11 @@ func TestExportPostsJSONToEndpointOverride(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &decoded))
 	assert.Equal(t, event, decoded)
 
-	// parse_error_* fields mirror their omitempty tags: absent from the body
-	// unless set.
+	// omitempty fields mirror their tags: absent from the body unless set.
 	var raw map[string]any
 	require.NoError(t, json.Unmarshal(body, &raw))
 	for _, key := range []string{
+		"datasource_plugin_type",
 		"parse_error_kind", "parse_error_parent", "parse_error_token",
 		"attempted_command", "parse_error_flags", "parse_error_nearest",
 		"parse_error_distance",


### PR DESCRIPTION
This pull request adds telemetry support for capturing the datasource plugin type used in query commands. This enables more granular and privacy-conscious analytics about which datasource plugins are being used, without exposing sensitive information. The implementation includes code changes to capture, store, and export this new field, as well as updates to documentation and test coverage.

**Telemetry capture and export:**

- Added a new field `DatasourcePluginType` to the telemetry `Event` struct, populated when a datasource command is executed. This field is included in exported telemetry data only for relevant commands. [[1]](diffhunk://#diff-6ea5ea075c668dd5db713f6156972f85a3696956cea693e0c2dc22b754c6ae9cR53-R56) [[2]](diffhunk://#diff-01e57e4b5fb2cd80841f31031c9a859b84705095f0cc95fb075fb65e0256c2ddR89-R90)
- Introduced `CapturedDatasourcePluginType` and `RecordDatasourceQueryType` in `internal/telemetry/datasources.go` to record the datasource plugin type during command execution.
- Updated the query resolution logic in `internal/datasources/query/resolve.go` to call `RecordDatasourceQueryType` whenever a datasource type is resolved.

**Documentation:**

- Documented the new `datasource_plugin_type` field in the anonymous usage statistics documentation, clarifying its purpose and providing examples.

**Testing:**

- Enhanced test coverage to verify the correct presence or absence of the `datasource_plugin_type` field in exported events, including new test cases and assertions. 

## demo

```sh
➜  gcx git:(datasources/raw-query-telemetry) GCX_TELEMETRY=log ./bin/gcx datasources query yugabyte-ds-m --query '{ "rawSql" : "SELECT * FROM world_data LIMIT 2", "format" : 1 }'
┌──────────────────────────────────────────────┬────────────┬─────┬─────────┬───────────────┬──────────────
│ BASE_COUNTRY                                 │ BIRTH_RATE │ CO2 │ GDP     │ DATE_TIME     │ TIMESTAMP_VAL
├──────────────────────────────────────────────┼────────────┼─────┼─────────┼───────────────┼──────────────
│ {"Name":"Turkmenistan","Capital":"Ashgabat"} │ 2          │ 412 │ 3136939 │ 1785256006000 │ 1785256006487
│ {"Name":"Sudan","Capital":"Khartum"}         │ 0          │ 892 │ 988147  │ 1785112896000 │ 1785112896487
└──────────────────────────────────────────────┴────────────┴─────┴─────────┴───────────────┴──────────────
{
"service":"gcx",
"version":"(devel)",
"os":"darwin",
"arch":"arm64",
"device_id":"964cfbf1-1143-45c5-952c-0eb3ce7e6f15",
"device_id_persisted":true,
"command":"datasources query",
"flags":"query",
"provider":"datasources",
"outcome":"ok",
"exit_code":0,
"error_kind":"",
"duration_ms":1061,
"is_tty":true,
"is_ci":false,
"ci_provider":"",
"is_agent":false,
"agent":"",
"target_kind":"cloud",
"output_format":"table",
"datasource_plugin_type":"grafana-yugabyte-datasource"
}
```