### PR TITLE
fix(config): separate health from resource discovery

### DIFF
--- a/cmd/gcx/config/check_test.go
+++ b/cmd/gcx/config/check_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/grafana/gcx/internal/gcxerrors"
@@ -68,6 +69,7 @@ current-context: first
 	assert.Equal(t, 2, strings.Count(output, "Configuration:"), output)
 	assert.Equal(t, 2, strings.Count(output, "Connectivity:"), output)
 	assert.Equal(t, 2, strings.Count(output, "Grafana version:"), output)
+	assert.Equal(t, 2, strings.Count(output, "Resource discovery:"), output)
 }
 
 func TestCheckCommandPreservesCancellation(t *testing.T) {
@@ -95,7 +97,7 @@ current-context: target
 	assert.NotErrorIs(t, err, gcxerrors.ErrAlreadyReported)
 }
 
-func TestCheckCommandExitStatusTracksConnectivityAndVersion(t *testing.T) {
+func TestCheckCommandExitStatusTracksConnectivityVersionAndDiscovery(t *testing.T) {
 	clearConfigCheckEnvironment(t)
 
 	tests := []struct {
@@ -103,6 +105,7 @@ func TestCheckCommandExitStatusTracksConnectivityAndVersion(t *testing.T) {
 		handler    http.HandlerFunc
 		wantErr    bool
 		wantOutput string
+		wantExtra  string
 	}{
 		{
 			name: "success",
@@ -120,7 +123,7 @@ func TestCheckCommandExitStatusTracksConnectivityAndVersion(t *testing.T) {
 			wantOutput: "Connectivity:",
 		},
 		{
-			name: "version request failure",
+			name: "health request failure",
 			handler: checkServerHandler(func(w http.ResponseWriter) {
 				http.Error(w, `{"message":"health unavailable"}`, http.StatusServiceUnavailable)
 			}),
@@ -134,6 +137,7 @@ func TestCheckCommandExitStatusTracksConnectivityAndVersion(t *testing.T) {
 			}),
 			wantErr:    true,
 			wantOutput: "gcx requires Grafana 12.0.0 or later",
+			wantExtra:  "Resource discovery: skipped",
 		},
 	}
 
@@ -162,6 +166,9 @@ current-context: target
 				require.NoError(t, err)
 			}
 			assert.Contains(t, output, tc.wantOutput)
+			if tc.wantExtra != "" {
+				assert.Contains(t, output, tc.wantExtra)
+			}
 		})
 	}
 }
@@ -179,5 +186,190 @@ func checkServerHandler(health func(http.ResponseWriter)) http.HandlerFunc {
 		default:
 			http.NotFound(w, r)
 		}
+	}
+}
+
+// requestObservation records a single HTTP request observed by the fake
+// Grafana server so tests can assert on probe order, request counts, and the
+// bearer credential sent to each endpoint.
+type requestObservation struct {
+	path string
+	auth string
+}
+
+// newCheckProbeServer returns an httptest server whose /api/health and /apis
+// behavior are driven by the given handlers, recording every request. It is
+// safe for concurrent HTTP handler goroutines.
+func newCheckProbeServer(t *testing.T, health, apis func(http.ResponseWriter)) (*httptest.Server, func() []requestObservation) {
+	t.Helper()
+	var mu sync.Mutex
+	var observations []requestObservation
+	record := func(r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		observations = append(observations, requestObservation{
+			path: r.URL.Path,
+			auth: r.Header.Get("Authorization"),
+		})
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/health":
+			if health != nil {
+				health(w)
+				return
+			}
+		case "/apis":
+			if apis != nil {
+				apis(w)
+				return
+			}
+		case "/api":
+			_, _ = w.Write([]byte(`{"kind":"APIVersions","apiVersion":"v1","versions":[]}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+	getObservations := func() []requestObservation {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]requestObservation(nil), observations...)
+	}
+	return server, getObservations
+}
+
+func writeCheckProbeConfig(t *testing.T, serverURL string) string {
+	t.Helper()
+	return writeCheckConfig(t, fmt.Sprintf(`version: 1
+stacks:
+  target:
+    grafana:
+      server: %q
+      org-id: 1
+      auth-method: token
+contexts:
+  target:
+    stack: target
+current-context: target
+`, serverURL))
+}
+
+func TestCheckHealthProbePrecedesResourceDiscovery(t *testing.T) {
+	clearConfigCheckEnvironment(t)
+
+	tests := []struct {
+		name          string
+		health        func(http.ResponseWriter)
+		apis          func(http.ResponseWriter)
+		wantErr       bool
+		wantExit      int
+		wantOutputs   []string
+		wantHealth    int
+		wantDiscovery int
+	}{
+		{
+			name: "health ok version 12 discovery 401",
+			health: func(w http.ResponseWriter) {
+				_, _ = w.Write([]byte(`{"version":"12.0.0"}`))
+			},
+			apis: func(w http.ResponseWriter) {
+				http.Error(w, `{"message":"unauthorized"}`, http.StatusUnauthorized)
+			},
+			wantErr:  true,
+			wantExit: gcxerrors.ExitAuthFailure,
+			wantOutputs: []string{
+				"Connectivity: online",
+				"Grafana version: 12.0.0",
+				"Resource discovery: unavailable",
+				"Unauthorized - code 401",
+				"Make sure that the configured credentials have enough permissions",
+			},
+			wantHealth:    1,
+			wantDiscovery: 1,
+		},
+		{
+			name: "fully successful",
+			health: func(w http.ResponseWriter) {
+				_, _ = w.Write([]byte(`{"version":"12.0.0"}`))
+			},
+			apis: func(w http.ResponseWriter) {
+				_, _ = w.Write([]byte(`{"kind":"APIGroupList","apiVersion":"v1","groups":[]}`))
+			},
+			wantErr: false,
+			wantOutputs: []string{
+				"Connectivity: online",
+				"Grafana version: 12.0.0",
+				"Resource discovery: available",
+			},
+			wantHealth:    1,
+			wantDiscovery: 1,
+		},
+		{
+			name: "health failure skips discovery",
+			health: func(w http.ResponseWriter) {
+				http.Error(w, `{"message":"unauthorized"}`, http.StatusUnauthorized)
+			},
+			wantErr:  true,
+			wantExit: gcxerrors.ExitGeneralError,
+			wantOutputs: []string{
+				"Connectivity:",
+				"Grafana version: skipped",
+				"Resource discovery: skipped",
+			},
+			wantHealth:    1,
+			wantDiscovery: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GRAFANA_TOKEN", "test-token")
+			server, getObs := newCheckProbeServer(t, tc.health, tc.apis)
+			path := writeCheckProbeConfig(t, server.URL)
+
+			output, err := runConfigCmd(t, "check", "--config", path)
+			if tc.wantErr {
+				require.ErrorIs(t, err, gcxerrors.ErrAlreadyReported)
+				exitCode, ok := gcxerrors.AlreadyReportedExitCode(err)
+				require.True(t, ok, "failure must retain the already-reported exit code: %v", err)
+				assert.Equal(t, tc.wantExit, exitCode)
+			} else {
+				require.NoError(t, err)
+			}
+			for _, want := range tc.wantOutputs {
+				assert.Contains(t, output, want)
+			}
+
+			obs := getObs()
+			healthCount := 0
+			discoveryCount := 0
+			seenHealth := false
+			discoveryBeforeHealth := false
+			for _, o := range obs {
+				switch o.path {
+				case "/api/health":
+					healthCount++
+					seenHealth = true
+					assert.Equal(t, "Bearer test-token", o.auth, "health must be bearer-authenticated")
+				case "/api":
+					assert.Equal(t, "Bearer test-token", o.auth, "core resource discovery must be bearer-authenticated")
+					if !seenHealth {
+						discoveryBeforeHealth = true
+					}
+				case "/apis":
+					discoveryCount++
+					assert.Equal(t, "Bearer test-token", o.auth, "discovery must be bearer-authenticated")
+					if !seenHealth {
+						discoveryBeforeHealth = true
+					}
+				}
+			}
+			assert.Equal(t, tc.wantHealth, healthCount, "unexpected /api/health request count")
+			assert.Equal(t, tc.wantDiscovery, discoveryCount, "unexpected /apis request count")
+			assert.False(t, discoveryBeforeHealth, "resource discovery probed before /api/health")
+		})
 	}
 }

--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -710,7 +710,8 @@ func checkContext(ctx context.Context, cfg *config.Config, gCtx *config.Context,
 	if err := gCtx.Validate(ctx); err != nil {
 		cmdio.Error(stdout, "Configuration: %s", cmdio.Red(summarizeError(err)))
 		cmdio.Warning(stdout, "Connectivity: %s", cmdio.Yellow("skipped"))
-		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped")+"\n")
+		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped"))
+		cmdio.Warning(stdout, "Resource discovery: %s", cmdio.Yellow("skipped")+"\n")
 
 		printSuggestions(err)
 		return err
@@ -724,7 +725,8 @@ func checkContext(ctx context.Context, cfg *config.Config, gCtx *config.Context,
 		// future validation/transport drift rather than an expected branch.
 		cmdio.Error(stdout, "Configuration: %s", cmdio.Red(err.Error()))
 		cmdio.Warning(stdout, "Connectivity: %s", cmdio.Yellow("skipped"))
-		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped")+"\n")
+		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped"))
+		cmdio.Warning(stdout, "Resource discovery: %s", cmdio.Yellow("skipped")+"\n")
 		return err
 	}
 	switch {
@@ -746,45 +748,57 @@ func checkContext(ctx context.Context, cfg *config.Config, gCtx *config.Context,
 	if err != nil {
 		cmdio.Error(stdout, "Configuration: %s", cmdio.Red(err.Error()))
 		cmdio.Warning(stdout, "Connectivity: %s", cmdio.Yellow("skipped"))
-		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped")+"\n")
+		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped"))
+		cmdio.Warning(stdout, "Resource discovery: %s", cmdio.Yellow("skipped")+"\n")
 		return err
 	}
 	restCfg.WireTokenPersistence(ctx, source, gCtx.Name, gCtx.Stack, cfg.Sources)
 
-	if _, err := discovery.NewDefaultRegistry(ctx, restCfg); err != nil {
+	// Use one authenticated /api/health probe for both base Grafana connectivity
+	// and the reported version, so a healthy Grafana 12 server is never reported
+	// as a connectivity failure because its K8s-style /apis endpoint is unavailable.
+	version, raw, err := grafana.GetVersion(ctx, gCtx)
+	if err != nil {
 		cmdio.Error(stdout, "Connectivity: %s", cmdio.Red(summarizeError(err)))
-		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped")+"\n")
+		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("skipped"))
+		cmdio.Warning(stdout, "Resource discovery: %s", cmdio.Yellow("skipped")+"\n")
 		printSuggestions(err)
 		return err
 	}
 
 	cmdio.Success(stdout, "Connectivity: %s", cmdio.Green("online"))
 
-	version, raw, err := grafana.GetVersion(ctx, gCtx)
-	if err != nil {
-		cmdio.Error(stdout, "Grafana version: %s", cmdio.Red(summarizeError(err))+"\n")
-		printSuggestions(err)
-		return err
-	}
-
 	switch {
 	case version == nil && raw == "" && isCloud:
 		// Grafana Cloud (dev/ops) environments don't expose the version
 		// field via /api/health. Report the platform instead of a cryptic
 		// "hidden by server" line.
-		cmdio.Success(stdout, "Grafana version: %s", cmdio.Green("Grafana Cloud")+"\n")
+		cmdio.Success(stdout, "Grafana version: %s", cmdio.Green("Grafana Cloud"))
 	case version == nil && raw == "":
-		cmdio.Warning(stdout, "Grafana version: %s\n", cmdio.Yellow("hidden by server (anonymous /api/health)"))
+		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("hidden by server (anonymous /api/health)"))
 	case version == nil:
-		cmdio.Warning(stdout, "Grafana version: %s\n", cmdio.Yellow("unparseable: "+raw))
+		cmdio.Warning(stdout, "Grafana version: %s", cmdio.Yellow("unparseable: "+raw))
 	case version.Major() < 12:
 		err := &grafana.VersionIncompatibleError{Version: version}
-		cmdio.Error(stdout, "Grafana version: %s", cmdio.Red(err.Error())+"\n")
+		cmdio.Error(stdout, "Grafana version: %s", cmdio.Red(err.Error()))
+		cmdio.Warning(stdout, "Resource discovery: %s", cmdio.Yellow("skipped")+"\n")
 		printSuggestions(err)
 		return err
 	default:
-		cmdio.Success(stdout, "Grafana version: %s", cmdio.Green(version.String())+"\n")
+		cmdio.Success(stdout, "Grafana version: %s", cmdio.Green(version.String()))
 	}
+
+	// Probe Kubernetes /apis resource discovery separately from base
+	// connectivity. A Grafana 12 server can be fully reachable (/api/health
+	// 200) while its K8s-style /apis endpoint is unavailable (e.g. 401), so
+	// discovery failures are reported on their own line — never as base
+	// connectivity.
+	if _, err := discovery.NewDefaultRegistry(ctx, restCfg); err != nil {
+		cmdio.Error(stdout, "Resource discovery: %s", cmdio.Red("unavailable: "+summarizeError(err))+"\n")
+		printSuggestions(err)
+		return err
+	}
+	cmdio.Success(stdout, "Resource discovery: %s", cmdio.Green("available")+"\n")
 
 	return nil
 }

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -131,10 +131,12 @@ Use these commands to check the configuration:
 gcx config check
 ```
 
-The check covers every configured context before returning. It exits non-zero
-when the current context is invalid or any context fails configuration,
-authentication setup, connectivity, or Grafana version checks, so it is safe to
-use as a deployment gate.
+The check covers every configured context before returning. It uses the
+authenticated Grafana health endpoint for connectivity and version, then
+reports Kubernetes-style resource discovery separately. It exits non-zero when
+the current context is invalid or any context fails configuration,
+authentication setup, connectivity, version, or resource discovery checks, so
+it is safe to use as a deployment gate.
 
 List existing contexts:
 


### PR DESCRIPTION
## Summary

- use authenticated `/api/health` to report base Grafana connectivity and version before resource discovery
- report Kubernetes-style API discovery separately, preserving its classified error, suggestions, and nonzero exit
- skip discovery after a failed health probe or an incompatible Grafana version
- document the `config check` contract and add ordered, bearer-authenticated `httptest` coverage

Previously, `gcx config check` treated `/apis` discovery as the connectivity check. A Grafana server could be healthy and report a supported version while returning 401 for `/apis`; the command then described the server as offline/unauthorized and hid its version.

After this change, that case reports connectivity online and the detected version, followed by a distinct resource-discovery failure. Discovery remains required, so the command still exits nonzero.

## Verification

- `go test ./cmd/gcx/config ./internal/grafana ./internal/config`
- `go test -race -count=1 ./...`
- `GCX_AGENT_MODE=false mise run all`
