### PR TITLE
Verify keychain credential writes

### DIFF
--- a/internal/config/keychain.go
+++ b/internal/config/keychain.go
@@ -1350,6 +1350,20 @@ func (txn *keychainWriteTransaction) stageBoundSet(binding credentials.Binding, 
 				account: boundRef.Account, previouslySet: false,
 				owner: owner, field: field,
 			})
+			stored, err := txn.store.Get(boundRef.Account)
+			if err != nil {
+				txn.log.Warn("could not verify keychain entry after write",
+					"owner", owner,
+					"field", string(field),
+					"error", err.Error())
+				return credentials.BoundReference{}, false, fmt.Errorf("verify keychain entry for %q field %q after write: %w", owner, field, err)
+			}
+			if stored != value {
+				txn.log.Warn("keychain entry did not round-trip after write",
+					"owner", owner,
+					"field", string(field))
+				return credentials.BoundReference{}, false, fmt.Errorf("verify keychain entry for %q field %q after write: stored value did not match", owner, field)
+			}
 			return boundRef, true, nil
 		}
 		if errors.Is(err, credentials.ErrUnavailable) {

--- a/internal/config/keychain_bound_internal_test.go
+++ b/internal/config/keychain_bound_internal_test.go
@@ -16,19 +16,20 @@ import (
 )
 
 type boundTestStore struct {
-	entries       map[string]string
-	getErr        error
-	setErr        error
-	setErrValue   string
-	setFailAt     int
-	setCalls      int
-	deleteErr     error
-	deleteThenErr bool
-	deleteFailAt  int
-	deleteCalls   int
-	gets          []string
-	sets          []string
-	deletes       []string
+	entries        map[string]string
+	getErr         error
+	getErrAfterSet error
+	setErr         error
+	setErrValue    string
+	setFailAt      int
+	setCalls       int
+	deleteErr      error
+	deleteThenErr  bool
+	deleteFailAt   int
+	deleteCalls    int
+	gets           []string
+	sets           []string
+	deletes        []string
 }
 
 type boundTestLogger struct {
@@ -56,6 +57,9 @@ func (s *boundTestStore) Get(key string) (string, error) {
 	s.gets = append(s.gets, key)
 	if s.getErr != nil {
 		return "", s.getErr
+	}
+	if s.getErrAfterSet != nil && s.setCalls > 0 {
+		return "", s.getErrAfterSet
 	}
 	value, ok := s.entries[key]
 	if !ok {
@@ -1089,6 +1093,12 @@ func TestBoundKeychainGenericStoreFailuresLeaveDiskAndCallerUntouched(t *testing
 				store.setFailAt = 2
 			},
 		},
+		{
+			name: "write is not retrievable",
+			setup: func(store *boundTestStore) {
+				store.getErrAfterSet = credentials.ErrNotFound
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1104,6 +1114,9 @@ func TestBoundKeychainGenericStoreFailuresLeaveDiskAndCallerUntouched(t *testing
 
 			err := Write(context.Background(), ExplicitConfigFile(path), cfg)
 			require.Error(t, err)
+			if tt.name == "write is not retrievable" {
+				require.ErrorContains(t, err, "verify keychain entry")
+			}
 			raw, readErr := os.ReadFile(path)
 			require.NoError(t, readErr)
 			assert.Equal(t, original, raw)


### PR DESCRIPTION
## Summary

- verify a new keychain credential can be read back before replacing plaintext config with its sentinel
- roll back the staged write and leave the YAML unchanged when the keychain reports a successful write but cannot resolve the new entry
- add regression coverage for the successful-`Set`/missing-`Get` failure mode

## Validation

- `go test ./internal/config`
