### PR TITLE
feat(agento11y): add experiments check for CI quality gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### New features
+
+- agento11y: add `gcx agento11y experiments check <run-id> --min-pass-rate <0..1>` for CI gates on offline evaluation runs. Exit 4 indicates a failed or canceled experiment, a pass rate below the threshold, insufficient verdict coverage, or no pass verdict. Use `--on-unknown=pass` for evaluators that emit only reward or numeric scores. Without `--min-pass-rate`, the gate checks completion and verdict coverage. `--wait` polls every five seconds until completion (default timeout: 10m); timeout exits 1.
+
 ### Fixes
 
 - instrumentation: app and service writes (`clusters apps configure`/`remove`, `services include`/`exclude`/`clear`) no longer fail with `otlp_url is required`.

--- a/claude-plugin/skills/agento11y/SKILL.md
+++ b/claude-plugin/skills/agento11y/SKILL.md
@@ -33,7 +33,7 @@ All commands live under `gcx agento11y`. Use `gcx agento11y <subcommand> --help`
 | `rules` | List, get, create, update, delete evaluation rules |
 | `templates` | List, get built-in evaluator templates |
 | `judge` | List judge providers and models |
-| `experiments` | List, get, create, update, cancel runs; `list-scores` and `report` |
+| `experiments` | List, get, create, update, cancel runs; `list-scores`, `get-report`, and `check` (CI quality gate: exits 4 when the run misses a threshold, ends with status failed or canceled, or produces no pass or fail verdict; `--wait` polls until the run finishes) |
 
 Delete commands (`evaluators delete`, `rules delete`) require `--force` to skip confirmation in agent mode (there is no `-f` shorthand on delete). List first to confirm the target ID:
 

--- a/cmd/gcx/root/agento11y_experiments_check_test.go
+++ b/cmd/gcx/root/agento11y_experiments_check_test.go
@@ -1,0 +1,374 @@
+package root_test
+
+// End-to-end tests for `gcx agento11y experiments check`. They drive the real
+// root command tree against a fake plugin API so the whole path is covered:
+// flag validation, the single report request, the finished-status guard, the
+// stdout document, and the error type the top-level reporter turns into an
+// exit code.
+//
+// Exit codes are asserted the way cmd/gcx/main.go derives them: an
+// EmittedError's Code wins, otherwise fail.ErrorToDetailedError decides.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/cmd/gcx/root"
+	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/providers/agento11y"
+	"github.com/grafana/gcx/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newReportServer serves one experiment report response and counts requests, so
+// a test can prove the command issues exactly one report call, or none at all
+// when a flag is invalid. A zero status means 200.
+func newReportServer(t *testing.T, status int, body string) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	if status == 0 {
+		status = http.StatusOK
+	}
+	var calls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if strings.HasSuffix(req.URL.Path, "/report") {
+			calls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		http.Error(w, "unexpected path "+req.URL.Path, http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+// exitCodeFor mirrors cmd/gcx/main.go reportError: EmittedError carries its
+// own code, anything else goes through the converter chain and defaults to 1.
+func exitCodeFor(err error) int {
+	if err == nil {
+		return 0
+	}
+	var emitted *gcxerrors.EmittedError
+	if errors.As(err, &emitted) {
+		return emitted.Code
+	}
+	detailed := fail.ErrorToDetailedError(err)
+	if detailed == nil || detailed.ExitCode == nil {
+		return 1
+	}
+	return *detailed.ExitCode
+}
+
+func runExperimentsCheck(t *testing.T, serverURL string, args ...string) (string, string, error) {
+	t.Helper()
+	home := testutils.SandboxConfigEnv(t)
+	writeConfigFile(t, defaultConfigPath(home), serverURL, "token-a", 11111)
+
+	cmd := root.NewCommandForTest("test", []providers.Provider{&agento11y.Agento11yProvider{}})
+	cmd.SetArgs(append([]string{"agento11y", "experiments", "check"}, args...))
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetIn(strings.NewReader(""))
+	err := cmd.ExecuteContext(context.Background())
+	return stdout.String(), stderr.String(), err
+}
+
+func TestExperimentsCheck_EndToEnd(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int // HTTP status of the report response, zero means 200
+		body         string
+		args         []string
+		wantExitCode int
+		wantVerdict  string // empty means no check document is expected
+		wantChecks   []string
+		wantErr      string
+		wantCalls    int64
+	}{
+		{
+			name:         "pass rate above the threshold exits zero",
+			body:         `{"experiment":{"experiment_id":"r-1","status":"completed"},"summary":{"test_case_count":20,"completed_count":20,"pass_rate":0.95,"pass_count":19,"pass_denominator":20}}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "-o", "json"},
+			wantExitCode: 0,
+			wantVerdict:  "pass",
+			wantChecks:   []string{"experiment_status", "min_pass_rate", "verdict_coverage"},
+			wantCalls:    1,
+		},
+		{
+			name:         "pass rate below the threshold exits four",
+			body:         `{"experiment":{"experiment_id":"r-1","status":"completed"},"summary":{"test_case_count":10,"completed_count":10,"pass_rate":0.8,"pass_count":8,"pass_denominator":10}}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "-o", "json"},
+			wantExitCode: gcxerrors.ExitPartialFailure,
+			wantVerdict:  "fail",
+			wantChecks:   []string{"experiment_status", "min_pass_rate", "verdict_coverage"},
+			wantCalls:    1,
+		},
+		{
+			name:         "perfect pass rate over a tenth of the suite exits four",
+			body:         `{"experiment":{"experiment_id":"r-1","status":"completed"},"summary":{"test_case_count":100,"trial_count":100,"completed_count":10,"failed_count":90,"pass_rate":1.0,"pass_count":10,"pass_denominator":10}}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "-o", "json"},
+			wantExitCode: gcxerrors.ExitPartialFailure,
+			wantVerdict:  "fail",
+			wantChecks:   []string{"experiment_status", "min_pass_rate", "verdict_coverage"},
+			wantCalls:    1,
+		},
+		{
+			// Same run, but the caller accepts a tenth of the suite, so the only
+			// graded threshold is the pass rate.
+			name:         "a lowered coverage threshold accepts the same run",
+			body:         `{"experiment":{"experiment_id":"r-1","status":"completed"},"summary":{"test_case_count":100,"trial_count":100,"completed_count":10,"failed_count":90,"pass_rate":1.0,"pass_count":10,"pass_denominator":10}}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "--min-verdict-coverage", "0.1", "-o", "json"},
+			wantExitCode: 0,
+			wantVerdict:  "pass",
+			wantChecks:   []string{"experiment_status", "min_pass_rate", "verdict_coverage"},
+			wantCalls:    1,
+		},
+		{
+			name:         "a zero coverage threshold drops the coverage check",
+			body:         `{"experiment":{"experiment_id":"r-1","status":"completed"},"summary":{"test_case_count":100,"completed_count":10,"failed_count":90,"pass_rate":1.0,"pass_count":10,"pass_denominator":10}}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "--min-verdict-coverage", "0", "-o", "json"},
+			wantExitCode: 0,
+			wantVerdict:  "pass",
+			wantChecks:   []string{"experiment_status", "min_pass_rate"},
+			wantCalls:    1,
+		},
+		{
+			name:         "absent pass rate exits four by default",
+			body:         `{"experiment":{"experiment_id":"r-1","status":"completed"},"summary":{"test_case_count":10,"completed_count":10,"pass_count":0,"pass_denominator":0}}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "-o", "json"},
+			wantExitCode: gcxerrors.ExitPartialFailure,
+			wantVerdict:  "fail",
+			wantChecks:   []string{"experiment_status", "min_pass_rate", "verdict_coverage"},
+			wantCalls:    1,
+		},
+		{
+			// A reward-only run: every trial completed and none produced a pass or
+			// fail verdict, so there is nothing to grade and the caller says so.
+			name:         "a reward-only run exits zero with the override",
+			body:         `{"experiment":{"experiment_id":"r-1","status":"completed"},"summary":{"test_case_count":10,"trial_count":10,"completed_count":10,"pass_count":0,"pass_denominator":0}}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "--on-unknown", "pass", "-o", "json"},
+			wantExitCode: 0,
+			wantVerdict:  "pass",
+			wantChecks:   []string{"experiment_status", "min_pass_rate", "verdict_coverage"},
+			wantCalls:    1,
+		},
+		{
+			// The regression this gate exists for: every trial of all 100 test cases
+			// failed, which looks like a reward-only run in pass_rate alone. The
+			// override must not wave it through, because no trial completed.
+			name:         "a run whose every trial failed exits four despite the override",
+			body:         `{"experiment":{"experiment_id":"r-1","status":"completed"},"summary":{"test_case_count":100,"trial_count":100,"completed_count":0,"failed_count":100,"pass_count":0,"pass_denominator":0}}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "--on-unknown", "pass", "-o", "json"},
+			wantExitCode: gcxerrors.ExitPartialFailure,
+			wantVerdict:  "fail",
+			wantChecks:   []string{"experiment_status", "min_pass_rate", "verdict_coverage"},
+			wantCalls:    1,
+		},
+		{
+			name:         "failed experiment exits four with a status check",
+			body:         `{"experiment":{"experiment_id":"r-1","status":"failed"},"summary":{"pass_rate":1,"pass_count":2,"pass_denominator":2}}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "-o", "json"},
+			wantExitCode: gcxerrors.ExitPartialFailure,
+			wantVerdict:  "fail",
+			wantChecks:   []string{"experiment_status"},
+			wantCalls:    1,
+		},
+		{
+			name:         "running experiment exits one and writes no document",
+			body:         `{"experiment":{"experiment_id":"r-1","status":"running"},"summary":{"pass_rate":1,"pass_count":1,"pass_denominator":1}}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "-o", "json"},
+			wantExitCode: 1,
+			wantErr:      `experiment r-1 reports status "running"`,
+			wantCalls:    1,
+		},
+		{
+			// A server failure is not a quality verdict, so it must not borrow the
+			// exit code of one, and no document may claim a run was graded.
+			name:         "a report request failure exits one and writes no document",
+			status:       http.StatusInternalServerError,
+			body:         `{"message":"boom"}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "-o", "json"},
+			wantExitCode: 1,
+			wantCalls:    1,
+		},
+		{
+			name:         "invalid threshold exits two without calling the API",
+			body:         `{}`,
+			args:         []string{"r-1", "--min-pass-rate", "1.1", "-o", "json"},
+			wantExitCode: gcxerrors.ExitUsageError,
+			wantErr:      "from 0 through 1",
+			wantCalls:    0,
+		},
+		{
+			name:         "invalid coverage threshold exits two without calling the API",
+			body:         `{}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "--min-verdict-coverage", "2", "-o", "json"},
+			wantExitCode: gcxerrors.ExitUsageError,
+			wantErr:      "invalid --min-verdict-coverage value 2",
+			wantCalls:    0,
+		},
+		{
+			// Cobra owns the arity rejection, and no converter maps it to the usage
+			// code, so it exits 1 like every other command in the CLI. What this row
+			// pins is that the rejection happens before the report request.
+			name:         "a missing run id is rejected without calling the API",
+			body:         `{}`,
+			args:         []string{"--min-pass-rate", "0.9", "-o", "json"},
+			wantExitCode: 1,
+			wantErr:      "accepts 1 arg",
+			wantCalls:    0,
+		},
+		{
+			// Without --min-pass-rate the gate is completion plus full coverage,
+			// and the document still names both assertions.
+			name:         "a bare invocation gates on completion and coverage",
+			body:         `{"experiment":{"experiment_id":"r-1","status":"completed"},"summary":{"test_case_count":10,"completed_count":10,"pass_rate":0.2,"pass_count":2,"pass_denominator":10}}`,
+			args:         []string{"r-1", "-o", "json"},
+			wantExitCode: 0,
+			wantVerdict:  "pass",
+			wantChecks:   []string{"experiment_status", "verdict_coverage"},
+			wantCalls:    1,
+		},
+		{
+			name:         "a timeout without wait exits two without calling the API",
+			body:         `{}`,
+			args:         []string{"r-1", "--timeout", "1m", "-o", "json"},
+			wantExitCode: gcxerrors.ExitUsageError,
+			wantErr:      "--timeout needs --wait",
+			wantCalls:    0,
+		},
+		{
+			name:         "unknown on-unknown mode exits two without calling the API",
+			body:         `{}`,
+			args:         []string{"r-1", "--min-pass-rate", "0.9", "--on-unknown", "ignore", "-o", "json"},
+			wantExitCode: gcxerrors.ExitUsageError,
+			wantErr:      `invalid --on-unknown value "ignore"`,
+			wantCalls:    0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, calls := newReportServer(t, tc.status, tc.body)
+			stdout, _, err := runExperimentsCheck(t, srv.URL, tc.args...)
+
+			assert.Equal(t, tc.wantExitCode, exitCodeFor(err), "exit code (err: %v)", err)
+			assert.Equal(t, tc.wantCalls, calls.Load(), "report requests")
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			}
+
+			if tc.wantVerdict == "" {
+				assert.NotContains(t, stdout, `"verdict"`, "no check document may be written")
+				return
+			}
+
+			var doc map[string]any
+			dec := json.NewDecoder(strings.NewReader(stdout))
+			require.NoError(t, dec.Decode(&doc), "stdout is not valid JSON:\n%s", stdout)
+			var second any
+			require.ErrorIs(t, dec.Decode(&second), io.EOF,
+				"stdout must contain exactly one JSON value:\n%s", stdout)
+			assert.Equal(t, tc.wantVerdict, doc["verdict"])
+			assert.Equal(t, "r-1", doc["experiment_id"])
+			// A failing check writes this document in place of a gcx.error, so a
+			// consumer needs the marker to tell the two apart.
+			assert.Equal(t, "gcx.agento11y.experiment_check", doc["type"])
+			assert.Equal(t, "1", doc["schema_version"])
+
+			checks, ok := doc["checks"].([]any)
+			require.True(t, ok, "checks must be an array: %v", doc["checks"])
+			names := make([]string, 0, len(checks))
+			for _, entry := range checks {
+				check, isObject := entry.(map[string]any)
+				require.True(t, isObject, "check must be an object: %v", entry)
+				name, isString := check["name"].(string)
+				require.True(t, isString, "check name must be a string: %v", check["name"])
+				names = append(names, name)
+			}
+			assert.Equal(t, tc.wantChecks, names)
+		})
+	}
+}
+
+// TestExperimentsCheck_TextDefaultIsHumanReadable covers the default output
+// path end to end: no -o flag, so the command renders its text codec.
+func TestExperimentsCheck_TextDefaultIsHumanReadable(t *testing.T) {
+	srv, _ := newReportServer(t, 0, `{"experiment":{"experiment_id":"r-1","status":"completed"},"summary":{"test_case_count":10,"completed_count":10,"pass_rate":0.8,"pass_count":8,"pass_denominator":10}}`)
+	stdout, stderr, err := runExperimentsCheck(t, srv.URL, "r-1", "--min-pass-rate", "0.9")
+
+	require.Error(t, err)
+	assert.Equal(t, gcxerrors.ExitPartialFailure, exitCodeFor(err))
+	assert.Contains(t, stdout, "Quality check:")
+	assert.Contains(t, stdout, "min_pass_rate")
+	assert.Contains(t, stderr, "warn:")
+}
+
+// newWaitServer serves the experiment GET the --wait loop polls, one scripted
+// status per request with the last one repeating, next to the report response
+// the grading step fetches.
+func newWaitServer(t *testing.T, statuses []string, reportBody string) (*httptest.Server, *atomic.Int64, *atomic.Int64) {
+	t.Helper()
+	var getCalls, reportCalls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(req.URL.Path, "/report") {
+			reportCalls.Add(1)
+			_, _ = w.Write([]byte(reportBody))
+			return
+		}
+		n := int(getCalls.Add(1)) - 1
+		if n >= len(statuses) {
+			n = len(statuses) - 1
+		}
+		_, _ = fmt.Fprintf(w, `{"experiment_id":"r-1","status":%q}`, statuses[n])
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &getCalls, &reportCalls
+}
+
+// TestExperimentsCheck_WaitGradesAFinishedRun covers the --wait path end to
+// end: the poll sees a finished run and the command grades it in the same
+// invocation. The status transition itself is pinned in the package's
+// TestWaitForFinished, where the poll interval is controllable.
+func TestExperimentsCheck_WaitGradesAFinishedRun(t *testing.T) {
+	srv, getCalls, reportCalls := newWaitServer(t, []string{"completed"},
+		`{"experiment":{"experiment_id":"r-1","status":"completed"},"summary":{"test_case_count":10,"completed_count":10,"pass_rate":0.95,"pass_count":9,"pass_denominator":10}}`)
+	stdout, _, err := runExperimentsCheck(t, srv.URL, "r-1", "--wait", "--min-pass-rate", "0.9", "-o", "json")
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), getCalls.Load(), "status polls")
+	assert.Equal(t, int64(1), reportCalls.Load(), "report requests")
+	assert.Contains(t, stdout, `"verdict": "pass"`)
+}
+
+// TestExperimentsCheck_WaitTimeoutExitsOne pins the CI contract of a wait that
+// gave up: exit 1, not the quality verdict's 4, and no check document, so a
+// consumer cannot mistake the timeout for a graded run.
+func TestExperimentsCheck_WaitTimeoutExitsOne(t *testing.T) {
+	srv, _, reportCalls := newWaitServer(t, []string{"running"}, `{}`)
+	stdout, stderr, err := runExperimentsCheck(t, srv.URL, "r-1", "--wait", "--timeout", "100ms", "--min-pass-rate", "0.9", "-o", "json")
+
+	require.Error(t, err)
+	assert.Equal(t, 1, exitCodeFor(err))
+	assert.Contains(t, err.Error(), "Timed out")
+	assert.Equal(t, int64(0), reportCalls.Load(), "a timed out wait must not grade")
+	assert.NotContains(t, stdout, `"verdict"`, "no check document may be written")
+	assert.Contains(t, stderr, `status "running"`, "the wait reports progress")
+}

--- a/cmd/gcx/root/consistency_test.go
+++ b/cmd/gcx/root/consistency_test.go
@@ -2,12 +2,14 @@ package root_test
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/root"
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
 )
 
 func isLeaf(cmd *cobra.Command) bool {
@@ -211,4 +213,55 @@ func TestConsistency_SkillMappingResolvesToCommands(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConsistency_LLMHintFlagsExist parses every LLM hint back against the real
+// command tree. A hint is the invocation an agent copies, so a flag that does
+// not exist sends the agent straight into a usage error.
+func TestConsistency_LLMHintFlagsExist(t *testing.T) {
+	rootCmd := buildRootCmd()
+
+	agent.WalkCommands(rootCmd, func(cmd *cobra.Command) {
+		hint := cmd.Annotations[agent.AnnotationLLMHint]
+		if hint == "" || cmd.Hidden {
+			return
+		}
+		t.Run(cmd.CommandPath(), func(t *testing.T) {
+			for invocation := range strings.SplitSeq(hint, ";") {
+				fields := strings.Fields(invocation)
+				if len(fields) == 0 || fields[0] != "gcx" {
+					continue
+				}
+				target, path := resolveHintCommand(t, rootCmd, fields[1:])
+				for _, field := range fields[1:] {
+					name, ok := strings.CutPrefix(field, "--")
+					if !ok {
+						continue
+					}
+					name = strings.SplitN(name, "=", 2)[0]
+					if target.Flags().Lookup(name) == nil {
+						t.Errorf("hint for %s uses unknown flag --%s (resolved command: gcx %s)",
+							cmd.CommandPath(), name, path)
+					}
+				}
+			}
+		})
+	})
+}
+
+// resolveHintCommand walks the leading non-flag words of a hint invocation down
+// the command tree, so a group-level hint is checked against the subcommand it
+// actually names.
+func resolveHintCommand(t *testing.T, rootCmd *cobra.Command, fields []string) (*cobra.Command, string) {
+	t.Helper()
+	words := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if strings.HasPrefix(field, "-") {
+			break
+		}
+		words = append(words, field)
+	}
+	target, _, err := rootCmd.Find(words)
+	require.NoError(t, err)
+	return target, strings.Join(words, " ")
 }

--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -27,6 +27,7 @@
  "gcx agento11y evaluators test": "finite",
  "gcx agento11y evaluators upsert": "finite",
  "gcx agento11y experiments cancel": "finite",
+ "gcx agento11y experiments check": "finite",
  "gcx agento11y experiments create": "finite",
  "gcx agento11y experiments get": "finite",
  "gcx agento11y experiments get-report": "finite",

--- a/docs/design/command-naming.md
+++ b/docs/design/command-naming.md
@@ -96,14 +96,23 @@ datasource discovery may persist configuration.
 ## View verbs
 
 Default to `get` for a straight read. Use a view verb such as `status`,
-`timeline`, `inspect`, `diff`, `stats`, `report`, or `describe` only when the
-result is a derived, composite, or diagnostic view rather than the subject's
-stored fields.
+`timeline`, `inspect`, `diff`, `stats`, `report`, `describe`, or `check` only
+when the result is a derived, composite, or diagnostic view rather than the
+subject's stored fields.
 
 For example, `gcx kg entities inspect` returns diagnostic analysis rather than
 only an entity record. `gcx datasources health` is an owner-approved keep from
 #1014 — it runs the Grafana product health check rather than reading the
 datasource record — and is not a pattern to copy.
+
+`check` is the gate verb: it asserts a policy against the subject and sets the
+exit code from the verdict, so a CI job can branch on the code alone. Use it
+only when all three hold: the caller supplies the thresholds or rules, the
+command writes one result document naming every assertion it made, and a
+failing verdict exits 4 (see [exit-codes.md](exit-codes.md) § 2.1). A read that
+returns findings without a caller-supplied policy is `inspect` or `status`, not
+`check`. Current uses: `gcx agento11y experiments check`, `gcx instrumentation
+check`, and `gcx config check` (which predates the exit-code rule).
 
 ## Domain verbs
 

--- a/docs/design/exit-codes.md
+++ b/docs/design/exit-codes.md
@@ -29,6 +29,15 @@ Constants defined in `internal/gcxerrors/exitcodes.go`.
   push, pull, delete, or validate operations have mixed success/failure results.
   Commands return a `PartialFailureError` when `--on-error=fail` (default) and
   `FailedCount > 0`.
+- Exit code 4 is also the failing verdict of a gate command. A gate command
+  grades a subject against thresholds the user passed, writes one result
+  document, and sets the exit code from the verdict, so a CI job can branch on
+  the code without parsing the document. `gcx instrumentation check` and
+  `gcx agento11y experiments check` do this: they return an `EmittedError`
+  carrying `ExitPartialFailure` once the document is on stdout. A gate command
+  must not use 1 for a failing verdict, because 1 is the catch-all and a CI job
+  cannot tell a breached threshold from a network failure. `gcx config check`
+  predates this rule and still returns 1; do not copy it.
 - Exit code 5 (cancelled) is set by `convertContextCanceled` (first in converter
   chain) and by a fast-path check in `handleError` for `context.Canceled`.
 - SIGINT is handled via `signal.NotifyContext` in `main.go`, which cancels the

--- a/docs/reference/cli/gcx_agento11y_experiments.md
+++ b/docs/reference/cli/gcx_agento11y_experiments.md
@@ -24,6 +24,7 @@ Manage eval experiment runs.
 
 * [gcx agento11y](gcx_agento11y.md)	 - Manage Grafana Agent Observability resources
 * [gcx agento11y experiments cancel](gcx_agento11y_experiments_cancel.md)	 - Cancel a running experiment.
+* [gcx agento11y experiments check](gcx_agento11y_experiments_check.md)	 - Grade a finished experiment against quality thresholds for CI.
 * [gcx agento11y experiments create](gcx_agento11y_experiments_create.md)	 - Create a new experiment from a JSON or YAML file.
 * [gcx agento11y experiments get](gcx_agento11y_experiments_get.md)	 - Get a single experiment by run ID.
 * [gcx agento11y experiments get-report](gcx_agento11y_experiments_get-report.md)	 - Get the aggregate report for an experiment.

--- a/docs/reference/cli/gcx_agento11y_experiments_check.md
+++ b/docs/reference/cli/gcx_agento11y_experiments_check.md
@@ -1,0 +1,98 @@
+## gcx agento11y experiments check
+
+Grade a finished experiment against quality thresholds for CI.
+
+### Synopsis
+
+Compare a finished experiment against quality thresholds and exit non-zero
+when the experiment falls short, so a CI job fails on a regression.
+
+The main threshold, --min-pass-rate, applies to the report's pass_rate: of the
+test cases that produced a verdict, the share that passed on the first
+completed attempt. The denominator counts test cases, not trials. For the
+all-trials figure, read rows[].summary.trial_pass_rate from get-report -o json.
+When --min-pass-rate is omitted, the pass rate is not checked; the gate is then
+the run's status plus, by default, full verdict coverage.
+
+A test case whose trials all failed produces no verdict, so it changes neither
+side of that fraction. Take a run where every trial failed for 90 of its 100
+test cases: if the surviving 10 all passed, the report says 100%.
+--min-verdict-coverage rejects that run by requiring a minimum share of the
+suite to have produced a verdict. It defaults to 1, the whole suite.
+
+With --wait the command polls the experiment every 5 seconds until it finishes,
+up to --timeout (default 10m; raise it for a long suite), and then grades it.
+Without --wait an unfinished experiment exits 1 immediately.
+
+Exit codes:
+  0  every threshold met
+  1  general error, including an experiment that has not finished yet and a
+     --wait that timed out
+  2  a flag value is invalid, or --timeout is used without --wait
+  4  the run missed a threshold; or the experiment finished with status failed
+     or canceled; or a check could not measure what it grades while
+     --on-unknown=fail (the default)
+
+A check that cannot measure what it grades reports the verdict unknown, and
+--on-unknown decides those runs: fail (the default) exits 4, and pass exits 0.
+Two cases reach it. An experiment whose evaluators emit only reward or numeric
+scores produces no pass or fail verdict, so there is no pass rate and no
+coverage to measure. A server that does not report the size of the suite leaves
+coverage unmeasurable on its own.
+
+```
+gcx agento11y experiments check <run-id> [flags]
+```
+
+### Examples
+
+```
+  # Fail the build when fewer than 90% of test cases pass
+  gcx agento11y experiments check <run-id> --min-pass-rate 0.9
+
+  # The run completed and every test case produced a verdict, no rate threshold
+  gcx agento11y experiments check <run-id>
+
+  # The harness is still running: wait for the run to finish, then gate
+  gcx agento11y experiments check <run-id> --wait --timeout 30m --min-pass-rate 0.9
+
+  # Machine-readable verdict for a CI step summary
+  gcx agento11y experiments check <run-id> --min-pass-rate 0.9 -o json
+
+  # Accept a run where a fifth of the test cases produced no verdict
+  gcx agento11y experiments check <run-id> --min-pass-rate 0.9 --min-verdict-coverage 0.8
+
+  # Reward-scored experiment: no pass or fail verdict exists, so do not fail on it
+  gcx agento11y experiments check <run-id> --min-pass-rate 0.9 --on-unknown pass
+```
+
+### Options
+
+```
+  -h, --help                         help for check
+      --jq string                    jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string                  Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --min-pass-rate float          Lowest acceptable pass rate, 0..1. When omitted, the pass rate is not checked. Zero accepts any measured rate; a rate that cannot be measured is still graded by --on-unknown. See --help for how pass_rate is measured.
+      --min-verdict-coverage float   Lowest acceptable share of test cases that produced a pass or fail verdict, 0..1. Set to 0 to skip this check. (default 1)
+      --on-unknown string            Verdict for a check that could not measure what it grades: fail (exit 4) or pass (exit 0). (default "fail")
+  -o, --output string                Output format. One of: agents, json, text, yaml (default "text")
+      --timeout duration             Maximum time to wait for the experiment to finish. Needs --wait. (default 10m0s)
+      --wait                         Poll every 5 seconds until the experiment finishes, then grade it.
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx agento11y experiments](gcx_agento11y_experiments.md)	 - Manage eval experiment runs.
+

--- a/docs/reference/cli/gcx_agento11y_experiments_check.md
+++ b/docs/reference/cli/gcx_agento11y_experiments_check.md
@@ -83,7 +83,7 @@ gcx agento11y experiments check <run-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, OPENCODE, PI_CODING_AGENT, or GCX_AGENT_MODE env vars.
       --config string               Path to the configuration file to use
       --context string              Name of the context to use (overrides current-context in config)
       --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -559,11 +559,17 @@ var commandAnnotations = map[string]annotation{
 	"gcx agento11y collections add-conversations":   {Cost: "small"},
 	"gcx agento11y collections remove-conversation": {Cost: "small"},
 
-	"gcx agento11y experiments list":        {Cost: "small"},
-	"gcx agento11y experiments get":         {Cost: "small"},
-	"gcx agento11y experiments create":      {Cost: "small"},
-	"gcx agento11y experiments update":      {Cost: "small"},
-	"gcx agento11y experiments cancel":      {Cost: "small"},
+	"gcx agento11y experiments list":   {Cost: "small"},
+	"gcx agento11y experiments get":    {Cost: "small"},
+	"gcx agento11y experiments create": {Cost: "small"},
+	"gcx agento11y experiments update": {Cost: "small"},
+	"gcx agento11y experiments cancel": {Cost: "small"},
+	"gcx agento11y experiments check": {
+		Cost: "small",
+		Hint: "<run-id> --min-pass-rate 0.9 -o json. Exit 4 means the run missed a threshold, ended with " +
+			"status failed or canceled, or produced no pass or fail verdict; add --on-unknown=pass to exit " +
+			"0 in that last case. Add --wait to poll until the run finishes.",
+	},
 	"gcx agento11y experiments list-scores": {Cost: "medium", Hint: "<run-id> --limit 50 -o json"},
 	"gcx agento11y experiments get-report":  {Cost: "medium", Hint: "<run-id> -o json"},
 	"gcx agento11y experiments list-trials": {

--- a/internal/providers/agento11y/eval/experiments/check.go
+++ b/internal/providers/agento11y/eval/experiments/check.go
@@ -175,9 +175,6 @@ func checkStatusError(runID, status string) error {
 // Thresholds are compared with strict less-than, so --min-pass-rate 0.9 accepts
 // exactly 0.9.
 func evaluateChecks(report *ExperimentReport, spec checkSpec) CheckResult {
-	if report == nil {
-		report = &ExperimentReport{}
-	}
 	run := report.Experiment
 	summary := report.Summary
 	result := newCheckResult(run, summary)

--- a/internal/providers/agento11y/eval/experiments/check.go
+++ b/internal/providers/agento11y/eval/experiments/check.go
@@ -1,0 +1,361 @@
+package experiments
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/gcx/internal/gcxerrors"
+)
+
+// Experiment lifecycle statuses used by the eval API. completed, failed and
+// canceled are the finished ones; any other value means the experiment is still
+// producing results, or the server sent a status this build does not know.
+const (
+	statusCompleted = "completed"
+	statusFailed    = "failed"
+	statusCanceled  = "canceled"
+)
+
+// Check names are stable identifiers for CI consumers, so they are part of the
+// output contract.
+const (
+	checkNameMinPassRate      = "min_pass_rate"
+	checkNameVerdictCoverage  = "verdict_coverage"
+	checkNameExperimentStatus = "experiment_status"
+)
+
+// Discriminators for the check document. A failing check writes this document
+// in place of a gcx.error, so the marker has to be on this shape too, otherwise
+// a CI consumer has to guess which of the two it received.
+const (
+	checkResultType          = "gcx.agento11y.experiment_check"
+	checkResultSchemaVersion = "1"
+)
+
+// Values of --on-unknown.
+const (
+	onUnknownFail = "fail"
+	onUnknownPass = "pass"
+)
+
+// CheckVerdict is the outcome of one Check, and of the CheckResult that
+// aggregates them.
+type CheckVerdict string
+
+const (
+	CheckVerdictPass    CheckVerdict = "pass"
+	CheckVerdictFail    CheckVerdict = "fail"
+	CheckVerdictUnknown CheckVerdict = "unknown"
+)
+
+// CheckResult is the document the check command writes to stdout, on both pass
+// and failure. Checks is a slice rather than one boolean so further thresholds
+// are additive.
+//
+// TestCaseCount, PassCount and PassDenominator carry no omitempty, for the
+// reason ExperimentReportSummary documents.
+type CheckResult struct {
+	Type             string       `json:"type"`
+	SchemaVersion    string       `json:"schema_version"`
+	ExperimentID     string       `json:"experiment_id"`
+	ExperimentStatus string       `json:"experiment_status"`
+	Verdict          CheckVerdict `json:"verdict"`
+	TestCaseCount    int          `json:"test_case_count"`
+	PassCount        int          `json:"pass_count"`
+	PassDenominator  int          `json:"pass_denominator"`
+	Checks           []Check      `json:"checks"`
+}
+
+// Check is one threshold or state assertion within a CheckResult. Threshold and
+// Actual are optional: a status check has no numbers, and a check that could not
+// measure anything has no actual value.
+type Check struct {
+	Name      string       `json:"name"`
+	Verdict   CheckVerdict `json:"verdict"`
+	Threshold *float64     `json:"threshold,omitempty"`
+	Actual    *float64     `json:"actual,omitempty"`
+	Observed  string       `json:"observed"`
+}
+
+// checkSpec is the resolved set of thresholds a check applies.
+type checkSpec struct {
+	// MinPassRate is the lowest acceptable experiment pass rate, 0 through 1.
+	// Nil means the caller did not pass --min-pass-rate, which skips the check.
+	MinPassRate *float64
+	// MinVerdictCoverage is the lowest acceptable share of test cases that
+	// produced a pass or fail verdict, 0 through 1. Zero disables the check.
+	MinVerdictCoverage float64
+	// OnUnknown is the --on-unknown value, which decides the overall verdict
+	// when a check cannot measure what it grades.
+	OnUnknown string
+}
+
+// newCheckResult starts a result for one experiment, with the discriminators and
+// the server's counts filled in and no checks yet.
+func newCheckResult(run Experiment, summary ExperimentReportSummary) CheckResult {
+	return CheckResult{
+		Type:             checkResultType,
+		SchemaVersion:    checkResultSchemaVersion,
+		ExperimentID:     run.ID(),
+		ExperimentStatus: run.Status,
+		TestCaseCount:    summary.TestCaseCount,
+		PassCount:        summary.PassCount,
+		PassDenominator:  summary.PassDenominator,
+		Checks:           []Check{},
+	}
+}
+
+func normalizeStatus(status string) string {
+	return strings.ToLower(strings.TrimSpace(status))
+}
+
+// isFinishedStatus reports whether the experiment reached a terminal status.
+// An unrecognized status counts as unfinished: the command refuses to grade a
+// run it does not understand rather than guess.
+func isFinishedStatus(status string) bool {
+	switch normalizeStatus(status) {
+	case statusCompleted, statusFailed, statusCanceled:
+		return true
+	}
+	return false
+}
+
+// validateOnUnknown rejects an --on-unknown value the command does not know. The
+// caller turns the error into a usage error, the way resolveMetricsMode is used
+// in internal/providers/appo11y/services.
+func validateOnUnknown(mode string) error {
+	switch mode {
+	case onUnknownFail, onUnknownPass:
+		return nil
+	default:
+		return fmt.Errorf("invalid --on-unknown value %q: must be %q or %q", mode, onUnknownFail, onUnknownPass)
+	}
+}
+
+// unknownVerdict maps --on-unknown onto the verdict an unmeasurable check
+// contributes. Any value other than pass, including the empty string, resolves
+// to failure, so a run this command could not grade never passes by accident.
+func unknownVerdict(mode string) CheckVerdict {
+	if mode == onUnknownPass {
+		return CheckVerdictPass
+	}
+	return CheckVerdictFail
+}
+
+// checkStatusError says why an unfinished experiment cannot be graded, and
+// returns nil when the experiment can be graded. It exits 1 rather than the 4 a
+// quality verdict carries, so a CI job can tell a regression from an experiment
+// that is still running.
+func checkStatusError(runID, status string) error {
+	if isFinishedStatus(status) {
+		return nil
+	}
+
+	reported := strings.TrimSpace(status)
+	if reported == "" {
+		reported = "(none)"
+	}
+	return &gcxerrors.DetailedError{
+		Summary: "Experiment has not finished",
+		Details: fmt.Sprintf("experiment %s reports status %q, and check grades only a finished experiment", runID, reported),
+		Suggestions: []string{
+			fmt.Sprintf("Watch the run with 'gcx agento11y experiments get %s' and retry once the status is %s", runID, statusCompleted),
+		},
+	}
+}
+
+// evaluateChecks compares an experiment report against the thresholds in spec
+// and returns the document the check command writes to stdout. It is pure: no
+// I/O, no clock, no network.
+//
+// The caller rejects an unfinished experiment first, because being unable to
+// grade a running experiment is a state error and not a quality verdict. See
+// checkStatusError.
+//
+// Thresholds are compared with strict less-than, so --min-pass-rate 0.9 accepts
+// exactly 0.9.
+func evaluateChecks(report *ExperimentReport, spec checkSpec) CheckResult {
+	if report == nil {
+		report = &ExperimentReport{}
+	}
+	run := report.Experiment
+	summary := report.Summary
+	result := newCheckResult(run, summary)
+
+	// The status check appears in every result, so the document names at least
+	// one assertion even when both thresholds are disabled.
+	status := statusCheck(run.Status)
+	result.Checks = append(result.Checks, status)
+
+	// A run that died halfway must not pass because the trials that did execute
+	// happened to clear the threshold.
+	//
+	// This branch grades only failed and canceled runs when the command calls it,
+	// because the RunE of check rejects every other unfinished status through
+	// checkStatusError first. Dropping that call would route an unfinished run
+	// here and turn its exit 1 into an exit 4.
+	if status.Verdict != CheckVerdictPass {
+		result.Verdict = CheckVerdictFail
+		return result
+	}
+
+	if spec.MinPassRate != nil {
+		result.Checks = append(result.Checks, evaluateMinPassRate(summary, *spec.MinPassRate))
+	}
+	if spec.MinVerdictCoverage > 0 {
+		result.Checks = append(result.Checks, evaluateVerdictCoverage(summary, spec.MinVerdictCoverage))
+	}
+	result.Verdict = aggregateVerdict(result.Checks, spec.OnUnknown)
+	return result
+}
+
+// statusCheck is the experiment_status assertion.
+func statusCheck(status string) Check {
+	check := Check{Name: checkNameExperimentStatus}
+	if normalizeStatus(status) == statusCompleted {
+		check.Verdict = CheckVerdictPass
+		check.Observed = fmt.Sprintf("experiment status is %q", status)
+		return check
+	}
+	check.Verdict = CheckVerdictFail
+	check.Observed = fmt.Sprintf("experiment status is %q, not %q", status, statusCompleted)
+	return check
+}
+
+// evaluateMinPassRate builds the min_pass_rate check. A nil pass rate is the
+// server saying no test case produced a pass or fail verdict, which is not a
+// measured 0%.
+func evaluateMinPassRate(summary ExperimentReportSummary, threshold float64) Check {
+	check := Check{Name: checkNameMinPassRate, Threshold: &threshold}
+
+	if summary.PassRate == nil {
+		check.Verdict = CheckVerdictUnknown
+		check.Observed = "no test case produced a pass or fail verdict"
+		return check
+	}
+
+	actual := *summary.PassRate
+	check.Actual = &actual
+	// A server older than the pass-count fields sends a rate with no counts. The
+	// rate is still authoritative, so grade it and say the counts are missing
+	// instead of inventing a 0/0.
+	if summary.PassDenominator > 0 {
+		check.Observed = fmt.Sprintf("%d of %d graded test cases passed on the first completed attempt (%s)",
+			summary.PassCount, summary.PassDenominator, formatRate(actual))
+	} else {
+		check.Observed = fmt.Sprintf("pass rate %s, and the server reported no pass counts", formatRate(actual))
+	}
+	check.Verdict = verdictForThreshold(actual, threshold)
+	return check
+}
+
+// evaluateVerdictCoverage builds the verdict_coverage check, which guards the
+// blind spot in pass_rate: a test case whose trials all failed produces no
+// verdict, so it leaves both sides of that fraction untouched. A run that lost
+// most of its suite can still report a perfect rate for the few test cases that
+// survived.
+//
+// A check that cannot measure coverage reports unknown instead of dropping out
+// of the result, so --on-unknown decides it and the CI log names the gate that
+// did not run.
+func evaluateVerdictCoverage(summary ExperimentReportSummary, threshold float64) Check {
+	check := Check{Name: checkNameVerdictCoverage, Threshold: &threshold}
+	lost := summary.FailedCount + summary.CanceledCount
+
+	switch {
+	case summary.TestCaseCount <= 0:
+		check.Verdict = CheckVerdictUnknown
+		check.Observed = "the server reported no test case count, so the share of graded test cases is unknown"
+		return check
+	case summary.PassDenominator == 0 && summary.CompletedCount > 0:
+		// Trials completed and still produced no verdict, so the evaluators emit
+		// only reward or numeric scores. Coverage of a verdict that no evaluator
+		// produces measures nothing.
+		check.Verdict = CheckVerdictUnknown
+		check.Observed = fmt.Sprintf("%d trials completed and none produced a pass or fail verdict, so coverage measures nothing", summary.CompletedCount)
+		return check
+	}
+
+	// A server that counts more verdicts than test cases pushes this above 1. The
+	// share is not clamped: the comparison against the threshold stays correct,
+	// and the odd percentage in the output is the evidence that the counts
+	// disagree.
+	actual := float64(summary.PassDenominator) / float64(summary.TestCaseCount)
+	check.Actual = &actual
+	check.Observed = fmt.Sprintf("%d of %d test cases produced a verdict (%s)",
+		summary.PassDenominator, summary.TestCaseCount, formatRate(actual))
+	if lost > 0 {
+		check.Observed += fmt.Sprintf("; %d trials failed or were canceled", lost)
+	}
+	check.Verdict = verdictForThreshold(actual, threshold)
+	return check
+}
+
+func verdictForThreshold(actual, threshold float64) CheckVerdict {
+	if actual < threshold {
+		return CheckVerdictFail
+	}
+	return CheckVerdictPass
+}
+
+// aggregateVerdict folds per-check outcomes into the verdict of the result. Any
+// failing check fails the result; otherwise an unknown check decides the outcome
+// through onUnknown. A check that set no verdict at all is treated as unknown,
+// so a future check that forgets to set one cannot turn into a silent pass.
+func aggregateVerdict(checks []Check, onUnknown string) CheckVerdict {
+	verdict := CheckVerdictPass
+	for _, c := range checks {
+		switch c.Verdict {
+		case CheckVerdictFail:
+			return CheckVerdictFail
+		case CheckVerdictPass:
+		default:
+			verdict = unknownVerdict(onUnknown)
+		}
+	}
+	return verdict
+}
+
+// checkFailureSummary renders the one-line stderr diagnostic for a non-passing
+// result. EmittedError suppresses the top-level reporter's stderr rendering, so
+// without this line a failing check prints nothing a human can read.
+func checkFailureSummary(result CheckResult) string {
+	id := result.ExperimentID
+	if id == "" {
+		id = "(unknown)"
+	}
+
+	details := make([]string, 0, len(result.Checks))
+	for _, c := range result.Checks {
+		if c.Verdict == CheckVerdictPass {
+			continue
+		}
+		details = append(details, checkDetail(c))
+	}
+	// Every non-passing result names the check that produced it, so this stands in
+	// only for a result built without one. Without it the line would end in a
+	// colon and say nothing.
+	if len(details) == 0 {
+		details = append(details, "no check reported a reason")
+	}
+	return fmt.Sprintf("quality check verdict %s for experiment %s: %s",
+		result.Verdict, id, strings.Join(details, "; "))
+}
+
+// checkDetail renders one check as a single line. Both stdout (the text codec)
+// and stderr (the failure diagnostic) use it, so a CI log shows one wording for
+// one check.
+func checkDetail(c Check) string {
+	detail := fmt.Sprintf("%s %s", c.Name, c.Verdict)
+	if c.Threshold != nil {
+		detail += fmt.Sprintf(" (threshold %s)", formatRate(*c.Threshold))
+	}
+	if c.Observed != "" {
+		detail += " - " + c.Observed
+	}
+	return detail
+}
+
+func formatRate(v float64) string {
+	return fmt.Sprintf("%.2f%%", v*100)
+}

--- a/internal/providers/agento11y/eval/experiments/check_contract_test.go
+++ b/internal/providers/agento11y/eval/experiments/check_contract_test.go
@@ -1,0 +1,326 @@
+package experiments //nolint:testpackage // Tests drive the unexported emitCheckResult seam and checkOpts wiring.
+
+// Contract tests for the emitCheckResult seam of `gcx agento11y experiments
+// check`: the command writes one document to stdout on both pass and failure,
+// and a failing verdict surfaces as an EmittedError carrying the partial-failure
+// exit code rather than a second document.
+//
+// The verdict matrix lives in check_test.go and the exit-code matrix in
+// cmd/gcx/root/agento11y_experiments_check_test.go. These rows cover only what
+// neither reaches: per-field JSON shape, format resolution, and a broken stdout.
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failWriter fails every write with err, simulating ENOSPC/EIO on stdout.
+type failWriter struct{ err error }
+
+func (f failWriter) Write([]byte) (int, error) { return 0, f.err }
+
+func newCheckOptsForTest(t *testing.T, output string, args ...string) *checkOpts {
+	t.Helper()
+	opts := &checkOpts{}
+	opts.IO.ErrWriter = io.Discard // silence the agent-mode --json/--jq hint
+	flags := pflag.NewFlagSet("check", pflag.ContinueOnError)
+	opts.setup(flags)
+	require.NoError(t, flags.Parse(args))
+	if output != "" {
+		require.NoError(t, flags.Set("output", output))
+	}
+	require.NoError(t, opts.Validate(nil))
+	return opts
+}
+
+func completedReport(passRate *float64, passCount, passDenominator int) *ExperimentReport {
+	return &ExperimentReport{
+		Experiment: Experiment{ExperimentID: "r-1", Status: statusCompleted},
+		Summary: ExperimentReportSummary{
+			PassRate:        passRate,
+			PassCount:       passCount,
+			PassDenominator: passDenominator,
+		},
+	}
+}
+
+func TestCheck_OutputContract(t *testing.T) {
+	tests := []struct {
+		name       string
+		report     *ExperimentReport
+		args       []string
+		wantErr    bool
+		wantStderr []string
+		wantChecks []map[string]any
+	}{
+		{
+			// A measured check carries both numbers, and a passing verdict writes
+			// the document with no diagnostic at all.
+			name:   "a measured pass carries threshold and actual",
+			report: completedReport(new(0.95), 19, 20),
+			args:   []string{"--min-pass-rate", "0.95", "--min-verdict-coverage", "0"},
+			wantChecks: []map[string]any{
+				{"name": "experiment_status", "verdict": "pass"},
+				{"name": "min_pass_rate", "verdict": "pass", "threshold": 0.95, "actual": 0.95},
+			},
+		},
+		{
+			// A bare invocation gates on completion and coverage alone, and the
+			// document still names both assertions.
+			name: "an omitted pass rate threshold emits no min_pass_rate check",
+			report: &ExperimentReport{
+				Experiment: Experiment{ExperimentID: "r-1", Status: statusCompleted},
+				Summary: ExperimentReportSummary{
+					PassRate: new(0.5), PassCount: 5, PassDenominator: 10,
+					TestCaseCount: 10, CompletedCount: 10,
+				},
+			},
+			wantChecks: []map[string]any{
+				{"name": "experiment_status", "verdict": "pass"},
+				{"name": "verdict_coverage", "verdict": "pass", "threshold": 1.0, "actual": 1.0},
+			},
+		},
+		{
+			// An unmeasurable check must omit actual rather than report 0, which a
+			// consumer would read as a measured zero.
+			name:       "an unmeasurable check omits actual",
+			report:     completedReport(nil, 0, 0),
+			args:       []string{"--min-pass-rate", "0.9", "--min-verdict-coverage", "0"},
+			wantErr:    true,
+			wantStderr: []string{"min_pass_rate", "no test case produced a pass or fail verdict"},
+			wantChecks: []map[string]any{
+				{"name": "experiment_status", "verdict": "pass"},
+				{"name": "min_pass_rate", "verdict": "unknown", "threshold": 0.9},
+			},
+		},
+		{
+			// Both graded checks reach the document, so a CI consumer sees the
+			// passing one next to the breach that failed the run.
+			name: "a coverage breach emits both checks",
+			report: &ExperimentReport{
+				Experiment: Experiment{ExperimentID: "r-1", Status: statusCompleted},
+				Summary: ExperimentReportSummary{
+					PassRate: new(1.0), PassCount: 10, PassDenominator: 10,
+					TestCaseCount: 100, CompletedCount: 10, FailedCount: 90,
+				},
+			},
+			args:       []string{"--min-pass-rate", "0.9"},
+			wantErr:    true,
+			wantStderr: []string{"verdict_coverage", "10 of 100"},
+			wantChecks: []map[string]any{
+				{"name": "experiment_status", "verdict": "pass"},
+				{"name": "min_pass_rate", "verdict": "pass", "threshold": 0.9, "actual": 1.0},
+				{"name": "verdict_coverage", "verdict": "fail", "threshold": 1.0, "actual": 0.1},
+			},
+		},
+		{
+			// A status check has no numbers to report, so both fields stay absent.
+			name: "a status check carries no numbers",
+			report: &ExperimentReport{
+				Experiment: Experiment{ExperimentID: "r-1", Status: statusFailed},
+				Summary:    ExperimentReportSummary{PassRate: new(1.0), PassCount: 2, PassDenominator: 2},
+			},
+			args:       []string{"--min-pass-rate", "0.9"},
+			wantErr:    true,
+			wantStderr: []string{"experiment_status"},
+			wantChecks: []map[string]any{
+				{"name": "experiment_status", "verdict": "fail"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agent.SetFlag(true)
+			t.Cleanup(agent.ResetForTesting)
+			opts := newCheckOptsForTest(t, "json", tc.args...)
+
+			var stdout, stderr bytes.Buffer
+			err := emitCheckResult(&stdout, &stderr, opts, evaluateChecks(tc.report, opts.spec()))
+
+			if tc.wantErr {
+				require.Error(t, err)
+				var emitted *gcxerrors.EmittedError
+				require.ErrorAs(t, err, &emitted, "want EmittedError, got %T", err)
+				assert.Equal(t, gcxerrors.ExitPartialFailure, emitted.Code)
+				for _, s := range tc.wantStderr {
+					assert.Contains(t, stderr.String(), s)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Empty(t, stderr.String())
+			}
+
+			doc := requireOneJSONValue(t, stdout.String())
+			assert.Equal(t, "gcx.agento11y.experiment_check", doc["type"], "consumers dispatch on type")
+			assert.Equal(t, "1", doc["schema_version"])
+			assert.Equal(t, "r-1", doc["experiment_id"])
+			assert.Equal(t, tc.report.Experiment.Status, doc["experiment_status"])
+			// Zero counts must survive encoding: pass_denominator == 0 next to
+			// test_case_count == 100 is the signal a whole suite was lost.
+			assert.Contains(t, doc, "pass_count")
+			assert.Contains(t, doc, "pass_denominator")
+			assert.Contains(t, doc, "test_case_count")
+
+			checks, ok := doc["checks"].([]any)
+			require.True(t, ok, "checks must be an array: %v", doc["checks"])
+			require.Len(t, checks, len(tc.wantChecks))
+			for i, want := range tc.wantChecks {
+				got, ok := checks[i].(map[string]any)
+				require.True(t, ok, "check must be an object: %v", checks[i])
+				for key, value := range want {
+					assert.Equal(t, value, got[key], "check %d field %q", i, key)
+				}
+				assert.NotEmpty(t, got["observed"], "check %d must say what it observed", i)
+				for _, key := range []string{"threshold", "actual"} {
+					if _, wanted := want[key]; !wanted {
+						assert.NotContains(t, got, key, "check %d must omit %s", i, key)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestCheck_DefaultFormat pins format resolution: an agent gets the machine
+// document with no flag, and a human gets the text rendering.
+func TestCheck_DefaultFormat(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentMode bool
+		want      []string
+		notWant   []string
+	}{
+		{
+			name:      "an agent defaults to the machine document",
+			agentMode: true,
+			want:      []string{"gcx.agento11y.experiment_check", "min_pass_rate"},
+			notWant:   []string{"Quality check:"},
+		},
+		{
+			name:      "a human defaults to text",
+			agentMode: false,
+			want:      []string{"Quality check:", "fail", "min_pass_rate"},
+			notWant:   []string{"schema_version"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agent.SetFlag(tc.agentMode)
+			t.Cleanup(agent.ResetForTesting)
+			opts := newCheckOptsForTest(t, "", "--min-pass-rate", "0.9")
+
+			var stdout, stderr bytes.Buffer
+			err := emitCheckResult(&stdout, &stderr, opts, evaluateChecks(completedReport(new(0.8), 8, 10), opts.spec()))
+
+			require.Error(t, err)
+			for _, s := range tc.want {
+				assert.Contains(t, stdout.String(), s)
+			}
+			for _, s := range tc.notWant {
+				assert.NotContains(t, stdout.String(), s)
+			}
+			// EmittedError suppresses the reporter's own rendering, so the command
+			// owes stderr a line in either mode. An agent gets it as a JSON
+			// warning, a human as a warn: prefix, and both carry the same summary.
+			assert.Contains(t, stderr.String(), "quality check verdict fail for experiment r-1")
+		})
+	}
+}
+
+// TestCheck_WriteFailureReturnsWriteError proves a broken stdout returns the
+// write error, not an EmittedError: the stream is already corrupt, so the
+// standard error path is the honest one.
+func TestCheck_WriteFailureReturnsWriteError(t *testing.T) {
+	agent.SetFlag(true)
+	t.Cleanup(agent.ResetForTesting)
+
+	writeErr := errors.New("disk full")
+	opts := newCheckOptsForTest(t, "json", "--min-pass-rate", "0.9")
+
+	var stderr bytes.Buffer
+	err := emitCheckResult(failWriter{err: writeErr}, &stderr, opts, evaluateChecks(completedReport(new(0.8), 8, 10), opts.spec()))
+
+	require.ErrorIs(t, err, writeErr)
+	var emitted *gcxerrors.EmittedError
+	assert.NotErrorAs(t, err, &emitted, "a failed write must not be reported as an emitted result")
+	assert.Empty(t, stderr.String())
+}
+
+func TestCheckOpts_Spec(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		wantPassRate  *float64
+		wantCoverage  float64
+		wantOnUnknown string
+	}{
+		{
+			name:          "the defaults gate the whole suite and fail on an ungraded run",
+			args:          []string{"--min-pass-rate", "0.75"},
+			wantPassRate:  new(0.75),
+			wantCoverage:  1,
+			wantOnUnknown: onUnknownFail,
+		},
+		{
+			name:          "every threshold can be overridden",
+			args:          []string{"--min-pass-rate", "0.75", "--min-verdict-coverage", "0.5", "--on-unknown", "pass"},
+			wantPassRate:  new(0.75),
+			wantCoverage:  0.5,
+			wantOnUnknown: onUnknownPass,
+		},
+		{
+			// An omitted --min-pass-rate disables the check. An explicit zero does
+			// not, so the two must resolve differently.
+			name:          "an omitted pass rate threshold resolves to nil",
+			args:          nil,
+			wantPassRate:  nil,
+			wantCoverage:  1,
+			wantOnUnknown: onUnknownFail,
+		},
+		{
+			name:          "an explicit zero pass rate threshold stays a threshold",
+			args:          []string{"--min-pass-rate", "0"},
+			wantPassRate:  new(0.0),
+			wantCoverage:  1,
+			wantOnUnknown: onUnknownFail,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := newCheckOptsForTest(t, "json", tc.args...).spec()
+
+			if tc.wantPassRate == nil {
+				assert.Nil(t, spec.MinPassRate)
+			} else {
+				require.NotNil(t, spec.MinPassRate)
+				assert.InDelta(t, *tc.wantPassRate, *spec.MinPassRate, 1e-9)
+			}
+			assert.InDelta(t, tc.wantCoverage, spec.MinVerdictCoverage, 1e-9)
+			assert.Equal(t, tc.wantOnUnknown, spec.OnUnknown)
+		})
+	}
+}
+
+func requireOneJSONValue(t *testing.T, stdout string) map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(stdout))
+	var doc map[string]any
+	require.NoError(t, dec.Decode(&doc), "stdout is not valid JSON:\n%s", stdout)
+	var second any
+	require.ErrorIs(t, dec.Decode(&second), io.EOF,
+		"stdout must contain exactly one JSON value:\n%s", stdout)
+	return doc
+}

--- a/internal/providers/agento11y/eval/experiments/check_test.go
+++ b/internal/providers/agento11y/eval/experiments/check_test.go
@@ -1,0 +1,613 @@
+package experiments //nolint:testpackage // Tests drive the unexported evaluateChecks, checkStatusError and checkFailureSummary helpers.
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func checkReport(status string, summary ExperimentReportSummary) *ExperimentReport {
+	return &ExperimentReport{
+		Experiment: Experiment{ExperimentID: "r-1", Status: status},
+		Summary:    summary,
+	}
+}
+
+// wantCheck is the expectation for one entry of CheckResult.Checks.
+type wantCheck struct {
+	name      string
+	verdict   CheckVerdict
+	threshold *float64
+	actual    *float64
+	// observed substrings the diagnostic must name. Every check must set a
+	// non-empty Observed, which the loop asserts separately.
+	observed []string
+}
+
+// statusPassed is the leading experiment_status entry every completed-run row
+// expects, because the status check appears in every result.
+func statusPassed() wantCheck {
+	return wantCheck{
+		name: checkNameExperimentStatus, verdict: CheckVerdictPass,
+		observed: []string{`"completed"`},
+	}
+}
+
+// checkCase is one row of the evaluateChecks tables below. The tables are split
+// by the check under test, and every row lists every check it expects, in order,
+// so no row can leave a second check unasserted.
+type checkCase struct {
+	name        string
+	report      *ExperimentReport
+	spec        checkSpec
+	wantVerdict CheckVerdict
+	wantChecks  []wantCheck
+}
+
+func runCheckCases(t *testing.T, cases []checkCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := evaluateChecks(tc.report, tc.spec)
+
+			assert.Equal(t, tc.wantVerdict, result.Verdict)
+			assert.Equal(t, tc.report.Summary.TestCaseCount, result.TestCaseCount)
+			assert.Equal(t, tc.report.Summary.PassCount, result.PassCount)
+			assert.Equal(t, tc.report.Summary.PassDenominator, result.PassDenominator)
+
+			require.Len(t, result.Checks, len(tc.wantChecks), "checks: %+v", result.Checks)
+			for i, want := range tc.wantChecks {
+				got := result.Checks[i]
+				assert.Equal(t, want.name, got.Name)
+				assert.Equal(t, want.verdict, got.Verdict, "verdict of %s", want.name)
+				assert.NotEmpty(t, got.Observed, "every check must say what it observed")
+				for _, s := range want.observed {
+					assert.Contains(t, got.Observed, s, "observed of %s", want.name)
+				}
+				assertRate(t, want.threshold, got.Threshold, "threshold of "+want.name)
+				assertRate(t, want.actual, got.Actual, "actual of "+want.name)
+			}
+		})
+	}
+}
+
+// TestEvaluateChecks_MinPassRate grades the pass rate alone, so every row here
+// disables the coverage check.
+func TestEvaluateChecks_MinPassRate(t *testing.T) {
+	runCheckCases(t, []checkCase{
+		{
+			name: "pass rate above threshold passes",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(0.95), PassCount: 19, PassDenominator: 20,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9)},
+			wantVerdict: CheckVerdictPass,
+			wantChecks: []wantCheck{statusPassed(), {
+				name: checkNameMinPassRate, verdict: CheckVerdictPass,
+				threshold: new(0.9), actual: new(0.95),
+				observed: []string{"19 of 20 graded test cases passed", "95.00%"},
+			}},
+		},
+		{
+			name: "pass rate exactly at threshold passes",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(0.9), PassCount: 9, PassDenominator: 10,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9)},
+			wantVerdict: CheckVerdictPass,
+			wantChecks: []wantCheck{statusPassed(), {
+				name: checkNameMinPassRate, verdict: CheckVerdictPass,
+				threshold: new(0.9), actual: new(0.9),
+			}},
+		},
+		{
+			name: "pass rate below threshold fails",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(0.8), PassCount: 8, PassDenominator: 10,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9)},
+			wantVerdict: CheckVerdictFail,
+			wantChecks: []wantCheck{statusPassed(), {
+				name: checkNameMinPassRate, verdict: CheckVerdictFail,
+				threshold: new(0.9), actual: new(0.8),
+			}},
+		},
+		{
+			name: "measured zero pass rate fails rather than reading as unknown",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(0.0), PassCount: 0, PassDenominator: 3,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.1)},
+			wantVerdict: CheckVerdictFail,
+			wantChecks: []wantCheck{statusPassed(), {
+				name: checkNameMinPassRate, verdict: CheckVerdictFail,
+				threshold: new(0.1), actual: new(0.0),
+			}},
+		},
+		{
+			// --min-pass-rate 0 gates on nothing, so any measured rate clears it.
+			name: "a zero threshold accepts a measured zero",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(0.0), PassCount: 0, PassDenominator: 3,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.0)},
+			wantVerdict: CheckVerdictPass,
+			wantChecks: []wantCheck{statusPassed(), {
+				name: checkNameMinPassRate, verdict: CheckVerdictPass,
+				threshold: new(0.0), actual: new(0.0),
+			}},
+		},
+		{
+			name:        "nil pass rate is unknown and fails by default",
+			report:      checkReport("completed", ExperimentReportSummary{}),
+			spec:        checkSpec{MinPassRate: new(0.9), OnUnknown: onUnknownFail},
+			wantVerdict: CheckVerdictFail,
+			wantChecks: []wantCheck{statusPassed(), {
+				name: checkNameMinPassRate, verdict: CheckVerdictUnknown, threshold: new(0.9),
+				observed: []string{"no test case produced a pass or fail verdict"},
+			}},
+		},
+		{
+			name:        "nil pass rate passes with the pass override",
+			report:      checkReport("completed", ExperimentReportSummary{}),
+			spec:        checkSpec{MinPassRate: new(0.9), OnUnknown: onUnknownPass},
+			wantVerdict: CheckVerdictPass,
+			wantChecks: []wantCheck{statusPassed(), {
+				name: checkNameMinPassRate, verdict: CheckVerdictUnknown, threshold: new(0.9),
+			}},
+		},
+		{
+			name:        "empty OnUnknown defaults to fail",
+			report:      checkReport("completed", ExperimentReportSummary{}),
+			spec:        checkSpec{MinPassRate: new(0.9)},
+			wantVerdict: CheckVerdictFail,
+			wantChecks: []wantCheck{statusPassed(), {
+				name: checkNameMinPassRate, verdict: CheckVerdictUnknown, threshold: new(0.9),
+			}},
+		},
+		{
+			// Without --min-pass-rate the rate is not a gate, so a measured zero
+			// cannot fail the run.
+			name: "an omitted threshold skips the pass rate check",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(0.0), PassCount: 0, PassDenominator: 3,
+			}),
+			spec:        checkSpec{},
+			wantVerdict: CheckVerdictPass,
+			wantChecks:  []wantCheck{statusPassed()},
+		},
+		{
+			// A server older than the pass-count fields sends a rate with no
+			// counts. The rate is the measurement, so it is graded.
+			name: "pass rate without counts is graded",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(0.95),
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9)},
+			wantVerdict: CheckVerdictPass,
+			wantChecks: []wantCheck{statusPassed(), {
+				name: checkNameMinPassRate, verdict: CheckVerdictPass,
+				threshold: new(0.9), actual: new(0.95),
+				observed: []string{"the server reported no pass counts"},
+			}},
+		},
+	})
+}
+
+// TestEvaluateChecks_VerdictCoverage grades the share of the suite that produced
+// a verdict, which is the blind spot pass_rate alone cannot see.
+func TestEvaluateChecks_VerdictCoverage(t *testing.T) {
+	runCheckCases(t, []checkCase{
+		{
+			name: "full verdict coverage passes",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(1.0), PassCount: 10, PassDenominator: 10,
+				TestCaseCount: 10, CompletedCount: 10,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 1},
+			wantVerdict: CheckVerdictPass,
+			wantChecks: []wantCheck{statusPassed(),
+				{name: checkNameMinPassRate, verdict: CheckVerdictPass, threshold: new(0.9), actual: new(1.0)},
+				{
+					name: checkNameVerdictCoverage, verdict: CheckVerdictPass,
+					threshold: new(1.0), actual: new(1.0),
+					observed: []string{"10 of 10 test cases produced a verdict", "100.00%"},
+				},
+			},
+		},
+		{
+			// Every trial failed for 90 test cases, so only the surviving 10 were
+			// graded and all of them passed.
+			name: "partial verdict coverage fails a perfect pass rate",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(1.0), PassCount: 10, PassDenominator: 10,
+				TestCaseCount: 100, TrialCount: 100, CompletedCount: 10, FailedCount: 85, CanceledCount: 5,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 1},
+			wantVerdict: CheckVerdictFail,
+			wantChecks: []wantCheck{statusPassed(),
+				{name: checkNameMinPassRate, verdict: CheckVerdictPass, threshold: new(0.9), actual: new(1.0)},
+				{
+					name: checkNameVerdictCoverage, verdict: CheckVerdictFail,
+					threshold: new(1.0), actual: new(0.1),
+					observed: []string{"10 of 100 test cases produced a verdict", "10.00%", "90 trials failed or were canceled"},
+				},
+			},
+		},
+		{
+			name: "both thresholds can fail at once",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(0.5), PassCount: 5, PassDenominator: 10,
+				TestCaseCount: 100, CompletedCount: 10, FailedCount: 90,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 1},
+			wantVerdict: CheckVerdictFail,
+			wantChecks: []wantCheck{statusPassed(),
+				{name: checkNameMinPassRate, verdict: CheckVerdictFail, threshold: new(0.9), actual: new(0.5)},
+				{name: checkNameVerdictCoverage, verdict: CheckVerdictFail, threshold: new(1.0), actual: new(0.1)},
+			},
+		},
+		{
+			name: "partial verdict coverage passes under a lowered threshold",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(1.0), PassCount: 8, PassDenominator: 8,
+				TestCaseCount: 10, CompletedCount: 8, FailedCount: 2,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 0.8},
+			wantVerdict: CheckVerdictPass,
+			wantChecks: []wantCheck{statusPassed(),
+				{name: checkNameMinPassRate, verdict: CheckVerdictPass, threshold: new(0.9), actual: new(1.0)},
+				{name: checkNameVerdictCoverage, verdict: CheckVerdictPass, threshold: new(0.8), actual: new(0.8)},
+			},
+		},
+		{
+			// An inconsistent payload can report more graded test cases than the
+			// suite holds. Coverage above the threshold still passes.
+			name: "coverage above one passes",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(1.0), PassCount: 12, PassDenominator: 12,
+				TestCaseCount: 10, CompletedCount: 12,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 1},
+			wantVerdict: CheckVerdictPass,
+			wantChecks: []wantCheck{statusPassed(),
+				{name: checkNameMinPassRate, verdict: CheckVerdictPass, threshold: new(0.9), actual: new(1.0)},
+				{name: checkNameVerdictCoverage, verdict: CheckVerdictPass, threshold: new(1.0), actual: new(1.2)},
+			},
+		},
+		{
+			name: "zero coverage threshold skips the coverage check",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(1.0), PassCount: 1, PassDenominator: 1, TestCaseCount: 100,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 0},
+			wantVerdict: CheckVerdictPass,
+			wantChecks: []wantCheck{statusPassed(),
+				{name: checkNameMinPassRate, verdict: CheckVerdictPass, threshold: new(0.9), actual: new(1.0)},
+			},
+		},
+		{
+			// The gate the caller asked for stays visible even when it cannot be
+			// measured, so --on-unknown decides it instead of it vanishing.
+			name:        "a missing suite size makes coverage unknown, not absent",
+			report:      checkReport("completed", ExperimentReportSummary{PassRate: new(1.0), PassCount: 2, PassDenominator: 2}),
+			spec:        checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 1, OnUnknown: onUnknownFail},
+			wantVerdict: CheckVerdictFail,
+			wantChecks: []wantCheck{statusPassed(),
+				{name: checkNameMinPassRate, verdict: CheckVerdictPass, threshold: new(0.9), actual: new(1.0)},
+				{
+					name: checkNameVerdictCoverage, verdict: CheckVerdictUnknown, threshold: new(1.0),
+					observed: []string{"no test case count"},
+				},
+			},
+		},
+		{
+			// Trials completed and still produced no verdict, so the evaluators
+			// emit only reward or numeric scores. Coverage of a verdict nothing
+			// produces measures nothing, so --on-unknown decides the run.
+			name: "a reward-only run is unknown on both checks",
+			report: checkReport("completed", ExperimentReportSummary{
+				TestCaseCount: 10, TrialCount: 10, CompletedCount: 10, PassDenominator: 0,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 1, OnUnknown: onUnknownPass},
+			wantVerdict: CheckVerdictPass,
+			wantChecks: []wantCheck{statusPassed(),
+				{name: checkNameMinPassRate, verdict: CheckVerdictUnknown, threshold: new(0.9)},
+				{
+					name: checkNameVerdictCoverage, verdict: CheckVerdictUnknown, threshold: new(1.0),
+					observed: []string{"10 trials completed and none produced a pass or fail verdict"},
+				},
+			},
+		},
+		{
+			// The run --on-unknown=pass must not wave through: nothing completed,
+			// so the missing pass rate is lost work rather than a reward-only
+			// scoring choice, and coverage is a measured 0%.
+			name: "a run whose every trial failed fails even with the pass override",
+			report: checkReport("completed", ExperimentReportSummary{
+				TestCaseCount: 100, TrialCount: 100, CompletedCount: 0, FailedCount: 100,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 1, OnUnknown: onUnknownPass},
+			wantVerdict: CheckVerdictFail,
+			wantChecks: []wantCheck{statusPassed(),
+				{name: checkNameMinPassRate, verdict: CheckVerdictUnknown, threshold: new(0.9)},
+				{
+					name: checkNameVerdictCoverage, verdict: CheckVerdictFail,
+					threshold: new(1.0), actual: new(0.0),
+					observed: []string{"0 of 100 test cases produced a verdict", "100 trials failed or were canceled"},
+				},
+			},
+		},
+	})
+}
+
+// TestEvaluateChecks_Status grades the experiment status, which short-circuits
+// every threshold: a run that died halfway must not pass because the trials that
+// did execute happened to clear it.
+func TestEvaluateChecks_Status(t *testing.T) {
+	runCheckCases(t, []checkCase{
+		{
+			// The server normalizes status, but so does this function, because a
+			// padded value must not slip past and fail a healthy run with exit 4.
+			name: "status case and padding are tolerated",
+			report: checkReport(" Completed ", ExperimentReportSummary{
+				PassRate: new(1.0), PassCount: 2, PassDenominator: 2,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9)},
+			wantVerdict: CheckVerdictPass,
+			wantChecks: []wantCheck{{name: checkNameExperimentStatus, verdict: CheckVerdictPass, observed: []string{"Completed"}}, {
+				name: checkNameMinPassRate, verdict: CheckVerdictPass,
+				threshold: new(0.9), actual: new(1.0),
+			}},
+		},
+		{
+			name: "failed status fails regardless of the pass rate",
+			report: checkReport("failed", ExperimentReportSummary{
+				PassRate: new(1.0), PassCount: 2, PassDenominator: 2,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9)},
+			wantVerdict: CheckVerdictFail,
+			wantChecks: []wantCheck{{
+				name: checkNameExperimentStatus, verdict: CheckVerdictFail,
+				observed: []string{`"failed"`, `"completed"`},
+			}},
+		},
+		{
+			name: "canceled status fails even with the unknown override",
+			report: checkReport("canceled", ExperimentReportSummary{
+				PassRate: new(1.0), PassDenominator: 2,
+			}),
+			spec:        checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 1, OnUnknown: onUnknownPass},
+			wantVerdict: CheckVerdictFail,
+			wantChecks: []wantCheck{{
+				name: checkNameExperimentStatus, verdict: CheckVerdictFail,
+			}},
+		},
+	})
+}
+
+func TestEvaluateChecks_Identity(t *testing.T) {
+	tests := []struct {
+		name        string
+		report      *ExperimentReport
+		wantID      string
+		wantStatus  string
+		wantVerdict CheckVerdict
+	}{
+		{
+			name:        "the experiment field carries the identity",
+			report:      checkReport("completed", ExperimentReportSummary{PassRate: new(0.5), PassCount: 1, PassDenominator: 2}),
+			wantID:      "r-1",
+			wantStatus:  "completed",
+			wantVerdict: CheckVerdictPass,
+		},
+		{
+			// Defence in depth: the command never reaches here with a nil report,
+			// and an empty status must still fail rather than grade nothing.
+			name:        "a nil report fails on status",
+			report:      nil,
+			wantVerdict: CheckVerdictFail,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := evaluateChecks(tc.report, checkSpec{MinPassRate: new(0.5)})
+
+			assert.Equal(t, tc.wantID, result.ExperimentID)
+			assert.Equal(t, tc.wantStatus, result.ExperimentStatus)
+			assert.Equal(t, tc.wantVerdict, result.Verdict)
+			// Consumers dispatch on these, so every result carries them.
+			assert.Equal(t, "gcx.agento11y.experiment_check", result.Type)
+			assert.Equal(t, "1", result.SchemaVersion)
+		})
+	}
+}
+
+func TestEvaluateChecks_ThresholdIsCopiedNotAliased(t *testing.T) {
+	spec := checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 1}
+	result := evaluateChecks(checkReport("completed", ExperimentReportSummary{
+		PassRate: new(0.95), PassCount: 19, PassDenominator: 20, TestCaseCount: 20, CompletedCount: 20,
+	}), spec)
+
+	thresholds := 0
+	for _, c := range result.Checks {
+		if c.Threshold == nil {
+			continue // the status check carries no threshold
+		}
+		thresholds++
+		*c.Threshold = 0
+	}
+	require.Equal(t, 2, thresholds)
+	assert.InDelta(t, 0.9, *spec.MinPassRate, 1e-9, "a check must not alias the caller's spec")
+	assert.InDelta(t, 1.0, spec.MinVerdictCoverage, 1e-9, "a check must not alias the caller's spec")
+}
+
+func TestCheckStatusError(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  string
+		wantErr []string
+	}{
+		{name: "completed can be graded", status: "completed"},
+		{name: "failed can be graded", status: "failed"},
+		{name: "canceled can be graded", status: "canceled"},
+		{name: "status case and padding are tolerated", status: " COMPLETED "},
+		{
+			name:    "running cannot be graded",
+			status:  "running",
+			wantErr: []string{"r-1", `"running"`},
+		},
+		{
+			name:    "unrecognized status cannot be graded",
+			status:  "queued",
+			wantErr: []string{"r-1", `"queued"`},
+		},
+		{
+			name:    "missing status cannot be graded",
+			status:  "",
+			wantErr: []string{"r-1", "(none)"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkStatusError("r-1", tc.status)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, s := range tc.wantErr {
+				assert.Contains(t, err.Error(), s)
+			}
+
+			var detailed *gcxerrors.DetailedError
+			require.ErrorAs(t, err, &detailed)
+			// The summary is fixed so an agent can dispatch on it, and the run id
+			// lives in the details instead.
+			assert.Equal(t, "Experiment has not finished", detailed.Summary)
+			require.NotEmpty(t, detailed.Suggestions, "an unfinished run needs a way forward")
+			assert.Contains(t, detailed.Suggestions[0], "gcx agento11y experiments get r-1")
+			// A nil exit code means 1. Exit 4 is the failing quality verdict, so
+			// "cannot grade yet" must not borrow it.
+			assert.Nil(t, detailed.ExitCode)
+			var emitted *gcxerrors.EmittedError
+			assert.NotErrorAs(t, err, &emitted, "no document was written, so nothing was emitted")
+		})
+	}
+}
+
+func TestCheckFailureSummary(t *testing.T) {
+	tests := []struct {
+		name    string
+		report  *ExperimentReport
+		spec    checkSpec
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "threshold breach names both numbers",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(0.8), PassCount: 8, PassDenominator: 10,
+			}),
+			spec: checkSpec{MinPassRate: new(0.9)},
+			want: []string{"r-1", "min_pass_rate", "80.00%", "90.00%"},
+		},
+		{
+			name:   "unknown verdict names the missing verdict",
+			report: checkReport("completed", ExperimentReportSummary{}),
+			spec:   checkSpec{MinPassRate: new(0.9)},
+			want:   []string{"r-1", "min_pass_rate", "unknown", "no test case produced a pass or fail verdict"},
+		},
+		{
+			// min_pass_rate passes here, so the diagnostic must name only the
+			// check that failed.
+			name: "coverage breach names the covered share and omits the passing check",
+			report: checkReport("completed", ExperimentReportSummary{
+				PassRate: new(1.0), PassCount: 10, PassDenominator: 10,
+				TestCaseCount: 100, CompletedCount: 10, FailedCount: 90,
+			}),
+			spec:    checkSpec{MinPassRate: new(0.9), MinVerdictCoverage: 1},
+			want:    []string{"r-1", "verdict_coverage", "10.00%", "10 of 100"},
+			notWant: []string{"min_pass_rate"},
+		},
+		{
+			name:   "failed status names the status",
+			report: checkReport("failed", ExperimentReportSummary{}),
+			spec:   checkSpec{MinPassRate: new(0.9)},
+			want:   []string{"r-1", "experiment_status", "failed"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			summary := checkFailureSummary(evaluateChecks(tc.report, tc.spec))
+			for _, s := range tc.want {
+				assert.Contains(t, summary, s)
+			}
+			for _, s := range tc.notWant {
+				assert.NotContains(t, summary, s)
+			}
+		})
+	}
+}
+
+func TestCheckFailureSummary_UnknownExperimentID(t *testing.T) {
+	summary := checkFailureSummary(CheckResult{Verdict: CheckVerdictFail})
+	assert.Contains(t, summary, "(unknown)")
+	// A result carrying no check still has to produce a readable line rather than
+	// one that ends in a colon.
+	assert.Contains(t, summary, "no check reported a reason")
+}
+
+func TestOnUnknown(t *testing.T) {
+	tests := []struct {
+		mode        string
+		wantErr     bool
+		wantVerdict CheckVerdict
+	}{
+		{mode: onUnknownFail, wantVerdict: CheckVerdictFail},
+		{mode: onUnknownPass, wantVerdict: CheckVerdictPass},
+		{mode: "", wantErr: true, wantVerdict: CheckVerdictFail},
+		{mode: "ignore", wantErr: true, wantVerdict: CheckVerdictFail},
+		{mode: "FAIL", wantErr: true, wantVerdict: CheckVerdictFail},
+	}
+
+	for _, tc := range tests {
+		t.Run("mode="+tc.mode, func(t *testing.T) {
+			err := validateOnUnknown(tc.mode)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "--on-unknown")
+			} else {
+				require.NoError(t, err)
+			}
+			// An unrecognized mode still resolves to fail, so a validation gap
+			// cannot turn into a silent pass.
+			assert.Equal(t, tc.wantVerdict, unknownVerdict(tc.mode))
+		})
+	}
+}
+
+// TestAggregateVerdict_UnsetCheckVerdictIsNotAPass guards the extension point: a
+// check appended later that forgets to set Verdict must not turn into a silent
+// exit 0.
+func TestAggregateVerdict_UnsetCheckVerdictIsNotAPass(t *testing.T) {
+	checks := []Check{{Name: checkNameMinPassRate, Verdict: CheckVerdictPass}, {Name: "future_check"}}
+
+	assert.Equal(t, CheckVerdictFail, aggregateVerdict(checks, onUnknownFail))
+	assert.Equal(t, CheckVerdictPass, aggregateVerdict(checks, onUnknownPass))
+}
+
+func assertRate(t *testing.T, want, got *float64, what string) {
+	t.Helper()
+	if want == nil {
+		assert.Nil(t, got, "%s must stay absent when nothing was measured", what)
+		return
+	}
+	require.NotNil(t, got, what)
+	assert.InDelta(t, *want, *got, 1e-9, what)
+}

--- a/internal/providers/agento11y/eval/experiments/check_test.go
+++ b/internal/providers/agento11y/eval/experiments/check_test.go
@@ -389,41 +389,16 @@ func TestEvaluateChecks_Status(t *testing.T) {
 }
 
 func TestEvaluateChecks_Identity(t *testing.T) {
-	tests := []struct {
-		name        string
-		report      *ExperimentReport
-		wantID      string
-		wantStatus  string
-		wantVerdict CheckVerdict
-	}{
-		{
-			name:        "the experiment field carries the identity",
-			report:      checkReport("completed", ExperimentReportSummary{PassRate: new(0.5), PassCount: 1, PassDenominator: 2}),
-			wantID:      "r-1",
-			wantStatus:  "completed",
-			wantVerdict: CheckVerdictPass,
-		},
-		{
-			// Defence in depth: the command never reaches here with a nil report,
-			// and an empty status must still fail rather than grade nothing.
-			name:        "a nil report fails on status",
-			report:      nil,
-			wantVerdict: CheckVerdictFail,
-		},
-	}
+	report := checkReport("completed", ExperimentReportSummary{PassRate: new(0.5), PassCount: 1, PassDenominator: 2})
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := evaluateChecks(tc.report, checkSpec{MinPassRate: new(0.5)})
+	result := evaluateChecks(report, checkSpec{MinPassRate: new(0.5)})
 
-			assert.Equal(t, tc.wantID, result.ExperimentID)
-			assert.Equal(t, tc.wantStatus, result.ExperimentStatus)
-			assert.Equal(t, tc.wantVerdict, result.Verdict)
-			// Consumers dispatch on these, so every result carries them.
-			assert.Equal(t, "gcx.agento11y.experiment_check", result.Type)
-			assert.Equal(t, "1", result.SchemaVersion)
-		})
-	}
+	assert.Equal(t, "r-1", result.ExperimentID)
+	assert.Equal(t, "completed", result.ExperimentStatus)
+	assert.Equal(t, CheckVerdictPass, result.Verdict)
+	// Consumers dispatch on these, so every result carries them.
+	assert.Equal(t, "gcx.agento11y.experiment_check", result.Type)
+	assert.Equal(t, "1", result.SchemaVersion)
 }
 
 func TestEvaluateChecks_ThresholdIsCopiedNotAliased(t *testing.T) {

--- a/internal/providers/agento11y/eval/experiments/commands.go
+++ b/internal/providers/agento11y/eval/experiments/commands.go
@@ -6,13 +6,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/goccy/go-yaml"
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/format"
+	"github.com/grafana/gcx/internal/gcxerrors"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/agento11y/agento11yhttp"
@@ -44,6 +48,7 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 		newCancelCommand(loader),
 		newListScoresCommand(loader),
 		newGetReportCommand(loader),
+		newCheckCommand(loader),
 		newListTrialsCommand(loader),
 		newTestSuitesCommand(loader),
 		newTrialsCommand(loader),
@@ -446,6 +451,212 @@ func newGetReportCommand(loader *providers.ConfigLoader) *cobra.Command {
 	}
 	opts.setup(cmd.Flags())
 	return cmd
+}
+
+// --- check ---
+
+type checkOpts struct {
+	IO                 cmdio.Options
+	MinPassRate        float64
+	MinVerdictCoverage float64
+	OnUnknown          string
+	Wait               bool
+	Timeout            time.Duration
+	// flags is the set setup bound, kept so Validate can ask which flags were
+	// passed at all: --min-pass-rate carries no gate when omitted, and its zero
+	// default is a real threshold, so the value alone cannot say which of the
+	// two the caller meant.
+	flags          *pflag.FlagSet
+	minPassRateSet bool
+}
+
+func (o *checkOpts) setup(flags *pflag.FlagSet) {
+	o.flags = flags
+	o.IO.RegisterCustomCodec("text", &CheckTextCodec{})
+	o.IO.DefaultFormat("text")
+	o.IO.BindFlags(flags)
+	flags.Float64Var(&o.MinPassRate, "min-pass-rate", 0,
+		"Lowest acceptable pass rate, 0..1. When omitted, the pass rate is not checked. "+
+			"Zero accepts any measured rate; a rate that cannot be measured is still graded "+
+			"by --on-unknown. See --help for how pass_rate is measured.")
+	flags.Float64Var(&o.MinVerdictCoverage, "min-verdict-coverage", 1,
+		"Lowest acceptable share of test cases that produced a pass or fail verdict, 0..1. "+
+			"Set to 0 to skip this check.")
+	// One line rather than the indented block --on-error uses: cobra appends its
+	// own (default "fail") to the last line, which would land beside the pass row
+	// and read as though pass were the default.
+	flags.StringVar(&o.OnUnknown, "on-unknown", onUnknownFail,
+		"Verdict for a check that could not measure what it grades: fail (exit 4) or pass (exit 0).")
+	flags.BoolVar(&o.Wait, "wait", false,
+		"Poll every 5 seconds until the experiment finishes, then grade it.")
+	flags.DurationVar(&o.Timeout, "timeout", 10*time.Minute,
+		"Maximum time to wait for the experiment to finish. Needs --wait.")
+}
+
+func (o *checkOpts) Validate(cmd *cobra.Command) error {
+	o.minPassRateSet = o.flags.Changed("min-pass-rate")
+	if err := validateRateFlag(cmd, "--min-pass-rate", o.MinPassRate); err != nil {
+		return err
+	}
+	if err := validateRateFlag(cmd, "--min-verdict-coverage", o.MinVerdictCoverage); err != nil {
+		return err
+	}
+	if err := validateOnUnknown(o.OnUnknown); err != nil {
+		return fail.NewCommandUsageError(cmd, "", err)
+	}
+	if o.flags.Changed("timeout") && !o.Wait {
+		return fail.NewCommandUsageError(cmd, "--timeout needs --wait", nil)
+	}
+	if o.Wait && o.Timeout <= 0 {
+		return fail.NewCommandUsageError(cmd,
+			fmt.Sprintf("invalid --timeout value %s: must be positive", o.Timeout), nil)
+	}
+	return o.IO.Validate()
+}
+
+// spec resolves the validated flags into the thresholds evaluateChecks applies.
+func (o *checkOpts) spec() checkSpec {
+	spec := checkSpec{
+		MinVerdictCoverage: o.MinVerdictCoverage,
+		OnUnknown:          o.OnUnknown,
+	}
+	if o.minPassRateSet {
+		rate := o.MinPassRate
+		spec.MinPassRate = &rate
+	}
+	return spec
+}
+
+// validateRateFlag rejects a rate outside 0 through 1. Go's float flag parser
+// accepts NaN and Inf, and a range comparison alone catches neither, so this
+// function rejects them explicitly.
+func validateRateFlag(cmd *cobra.Command, name string, value float64) error {
+	if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 || value > 1 {
+		return fail.NewCommandUsageError(cmd,
+			fmt.Sprintf("invalid %s value %v: must be a finite value from 0 through 1, for example %s 0.9", name, value, name),
+			nil)
+	}
+	return nil
+}
+
+func newCheckCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &checkOpts{}
+	cmd := &cobra.Command{
+		Use:   "check <run-id>",
+		Short: "Grade a finished experiment against quality thresholds for CI.",
+		Long: `Compare a finished experiment against quality thresholds and exit non-zero
+when the experiment falls short, so a CI job fails on a regression.
+
+The main threshold, --min-pass-rate, applies to the report's pass_rate: of the
+test cases that produced a verdict, the share that passed on the first
+completed attempt. The denominator counts test cases, not trials. For the
+all-trials figure, read rows[].summary.trial_pass_rate from get-report -o json.
+When --min-pass-rate is omitted, the pass rate is not checked; the gate is then
+the run's status plus, by default, full verdict coverage.
+
+A test case whose trials all failed produces no verdict, so it changes neither
+side of that fraction. Take a run where every trial failed for 90 of its 100
+test cases: if the surviving 10 all passed, the report says 100%.
+--min-verdict-coverage rejects that run by requiring a minimum share of the
+suite to have produced a verdict. It defaults to 1, the whole suite.
+
+With --wait the command polls the experiment every 5 seconds until it finishes,
+up to --timeout (default 10m; raise it for a long suite), and then grades it.
+Without --wait an unfinished experiment exits 1 immediately.
+
+Exit codes:
+  0  every threshold met
+  1  general error, including an experiment that has not finished yet and a
+     --wait that timed out
+  2  a flag value is invalid, or --timeout is used without --wait
+  4  the run missed a threshold; or the experiment finished with status failed
+     or canceled; or a check could not measure what it grades while
+     --on-unknown=fail (the default)
+
+A check that cannot measure what it grades reports the verdict unknown, and
+--on-unknown decides those runs: fail (the default) exits 4, and pass exits 0.
+Two cases reach it. An experiment whose evaluators emit only reward or numeric
+scores produces no pass or fail verdict, so there is no pass rate and no
+coverage to measure. A server that does not report the size of the suite leaves
+coverage unmeasurable on its own.`,
+		Example: `  # Fail the build when fewer than 90% of test cases pass
+  gcx agento11y experiments check <run-id> --min-pass-rate 0.9
+
+  # The run completed and every test case produced a verdict, no rate threshold
+  gcx agento11y experiments check <run-id>
+
+  # The harness is still running: wait for the run to finish, then gate
+  gcx agento11y experiments check <run-id> --wait --timeout 30m --min-pass-rate 0.9
+
+  # Machine-readable verdict for a CI step summary
+  gcx agento11y experiments check <run-id> --min-pass-rate 0.9 -o json
+
+  # Accept a run where a fifth of the test cases produced no verdict
+  gcx agento11y experiments check <run-id> --min-pass-rate 0.9 --min-verdict-coverage 0.8
+
+  # Reward-scored experiment: no pass or fail verdict exists, so do not fail on it
+  gcx agento11y experiments check <run-id> --min-pass-rate 0.9 --on-unknown pass`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(cmd); err != nil {
+				return err
+			}
+
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			if opts.Wait {
+				if err := waitForFinished(cmd.Context(), client, args[0], opts.Timeout, waitPollInterval, cmd.ErrOrStderr()); err != nil {
+					return err
+				}
+			}
+			report, err := client.GetReport(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+
+			// Refuse to grade an unfinished experiment: exit 1 and write no
+			// check document. See checkStatusError for why.
+			if err := checkStatusError(args[0], report.Experiment.Status); err != nil {
+				return err
+			}
+
+			return emitCheckResult(cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, evaluateChecks(report, opts.spec()))
+		},
+	}
+	opts.setup(cmd.Flags())
+	// The call fails only for a flag that does not exist, which cannot happen
+	// right after setup bound it.
+	if err := cmd.RegisterFlagCompletionFunc("on-unknown", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{onUnknownFail, onUnknownPass}, cobra.ShellCompDirectiveNoFileComp
+	}); err != nil {
+		panic(err)
+	}
+	return cmd
+}
+
+// emitCheckResult writes the single check document through the codec system,
+// then maps a non-passing verdict to the partial-failure exit code so the
+// process exit agrees with the verdict in the payload.
+//
+// The document is already on stdout, so the error is an EmittedError: the
+// top-level reporter honors the code and writes nothing more, which keeps the
+// one-JSON-value contract intact. EmittedError also suppresses the reporter's
+// stderr rendering, hence the explicit warn line.
+//
+// An encode failure returns the write error instead, because the stream is
+// already broken.
+func emitCheckResult(stdout, stderr io.Writer, opts *checkOpts, result CheckResult) error {
+	if err := opts.IO.Encode(stdout, result); err != nil {
+		return err
+	}
+	if result.Verdict == CheckVerdictPass {
+		return nil
+	}
+	summary := checkFailureSummary(result)
+	cmdio.EmitWarn(stderr, summary)
+	return gcxerrors.NewEmittedError(gcxerrors.ExitPartialFailure, errors.New(summary))
 }
 
 // --- test-suites ---
@@ -1538,5 +1749,55 @@ func coverageNote(coverage string) string {
 }
 
 func (c *ReportTextCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("text format does not support decoding")
+}
+
+// CheckTextCodec renders a check result as a compact summary followed by one
+// line per check, so a human reading CI logs sees the verdict first and the
+// evidence right below it.
+type CheckTextCodec struct{}
+
+func (c *CheckTextCodec) Format() format.Format {
+	return "text"
+}
+
+func (c *CheckTextCodec) Encode(w io.Writer, v any) error {
+	var r *CheckResult
+	switch val := v.(type) {
+	case *CheckResult:
+		r = val
+	case CheckResult:
+		r = &val
+	default:
+		return errors.New("invalid data type for check text codec: expected *CheckResult")
+	}
+	if r == nil {
+		return errors.New("invalid data type for check text codec: expected *CheckResult")
+	}
+
+	const labelFmt = "%-15s %s\n"
+	if r.ExperimentID != "" {
+		fmt.Fprintf(w, labelFmt, "Experiment:", r.ExperimentID)
+	}
+	if r.ExperimentStatus != "" {
+		fmt.Fprintf(w, labelFmt, "Status:", r.ExperimentStatus)
+	}
+	fmt.Fprintf(w, labelFmt, "Quality check:", string(r.Verdict))
+	if r.TestCaseCount > 0 {
+		fmt.Fprintf(w, labelFmt, "Test cases:", strconv.Itoa(r.TestCaseCount))
+	}
+
+	if len(r.Checks) == 0 {
+		return nil
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Checks:")
+	for _, check := range r.Checks {
+		fmt.Fprintf(w, "  %s\n", checkDetail(check))
+	}
+	return nil
+}
+
+func (c *CheckTextCodec) Decode(_ io.Reader, _ any) error {
 	return errors.New("text format does not support decoding")
 }

--- a/internal/providers/agento11y/eval/experiments/commands.go
+++ b/internal/providers/agento11y/eval/experiments/commands.go
@@ -505,11 +505,11 @@ func (o *checkOpts) Validate(cmd *cobra.Command) error {
 		return fail.NewCommandUsageError(cmd, "", err)
 	}
 	if o.flags.Changed("timeout") && !o.Wait {
-		return fail.NewCommandUsageError(cmd, "--timeout needs --wait", nil)
+		return fail.NewCommandUsageError(cmd, "--timeout needs --wait, for example --wait --timeout 30m", nil)
 	}
 	if o.Wait && o.Timeout <= 0 {
 		return fail.NewCommandUsageError(cmd,
-			fmt.Sprintf("invalid --timeout value %s: must be positive", o.Timeout), nil)
+			fmt.Sprintf("invalid --timeout value %s: must be positive, for example --timeout 30m", o.Timeout), nil)
 	}
 	return o.IO.Validate()
 }

--- a/internal/providers/agento11y/eval/experiments/commands_test.go
+++ b/internal/providers/agento11y/eval/experiments/commands_test.go
@@ -18,7 +18,7 @@ func TestCommands_HasExpectedLeaves(t *testing.T) {
 	cmd := experiments.Commands(nil)
 	require.Equal(t, "experiments", cmd.Name())
 
-	for _, sub := range []string{"list", "get", "create", "update", "cancel", "list-scores", "get-report", "list-trials", "test-suites", "trials"} {
+	for _, sub := range []string{"list", "get", "create", "update", "cancel", "list-scores", "get-report", "check", "list-trials", "test-suites", "trials"} {
 		c, _, err := cmd.Find([]string{sub})
 		require.NoError(t, err, "subcommand %q must exist", sub)
 		require.NotNil(t, c)
@@ -225,6 +225,196 @@ func TestReportCommand_RequiresArg(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "accepts 1 arg")
+}
+
+// TestCheckCommand_RejectsInvalidInvocation proves every rejection happens
+// before any client call: the command group is built with a nil loader, so a
+// request would fail loudly rather than silently pass. The exit code each
+// rejection carries is asserted end to end in cmd/gcx/root.
+func TestCheckCommand_RejectsInvalidInvocation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "missing run id",
+			args:    []string{"check"},
+			wantErr: "accepts 1 arg",
+		},
+		{
+			name:    "--timeout without --wait",
+			args:    []string{"check", "run-123", "--timeout", "1m"},
+			wantErr: "--timeout needs --wait",
+		},
+		{
+			name:    "--wait with a non-positive --timeout",
+			args:    []string{"check", "run-123", "--wait", "--timeout", "0s"},
+			wantErr: "invalid --timeout value 0s: must be positive",
+		},
+		{
+			name:    "--min-pass-rate above 1",
+			args:    []string{"check", "run-123", "--min-pass-rate", "1.1"},
+			wantErr: "invalid --min-pass-rate value 1.1",
+		},
+		{
+			name:    "--min-pass-rate below 0",
+			args:    []string{"check", "run-123", "--min-pass-rate", "-0.5"},
+			wantErr: "invalid --min-pass-rate value -0.5",
+		},
+		{
+			name:    "--min-pass-rate NaN",
+			args:    []string{"check", "run-123", "--min-pass-rate", "NaN"},
+			wantErr: "must be a finite value from 0 through 1",
+		},
+		{
+			name:    "--min-pass-rate Inf",
+			args:    []string{"check", "run-123", "--min-pass-rate", "Inf"},
+			wantErr: "must be a finite value from 0 through 1",
+		},
+		{
+			name:    "--min-verdict-coverage above 1",
+			args:    []string{"check", "run-123", "--min-pass-rate", "0.9", "--min-verdict-coverage", "2"},
+			wantErr: "invalid --min-verdict-coverage value 2",
+		},
+		{
+			name:    "--min-verdict-coverage below 0",
+			args:    []string{"check", "run-123", "--min-pass-rate", "0.9", "--min-verdict-coverage", "-1"},
+			wantErr: "invalid --min-verdict-coverage value -1",
+		},
+		{
+			name:    "--min-verdict-coverage NaN",
+			args:    []string{"check", "run-123", "--min-pass-rate", "0.9", "--min-verdict-coverage", "NaN"},
+			wantErr: "must be a finite value from 0 through 1",
+		},
+		{
+			name:    "unknown --on-unknown mode",
+			args:    []string{"check", "run-123", "--min-pass-rate", "0.9", "--on-unknown", "ignore"},
+			wantErr: `invalid --on-unknown value "ignore"`,
+		},
+		{
+			name:    "--on-unknown is case sensitive",
+			args:    []string{"check", "run-123", "--min-pass-rate", "0.9", "--on-unknown", "FAIL"},
+			wantErr: `invalid --on-unknown value "FAIL"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := experiments.Commands(nil)
+			cmd.SetArgs(tc.args)
+
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+			// The group under test has no SilenceUsage, so cobra prints its usage
+			// text here; what matters is that no check document does.
+			assert.NotContains(t, stdout.String(), `"verdict"`,
+				"no check document may be written for an invalid invocation")
+		})
+	}
+}
+
+func TestCheckTextCodec_Format(t *testing.T) {
+	assert.Equal(t, "text", string((&experiments.CheckTextCodec{}).Format()))
+}
+
+func TestCheckTextCodec_Encode(t *testing.T) {
+	threshold := 0.9
+	actual := 0.8
+
+	tests := []struct {
+		name   string
+		result any
+		want   []string
+	}{
+		{
+			name: "threshold check reports both numbers",
+			result: &experiments.CheckResult{
+				ExperimentID:     "r-1",
+				ExperimentStatus: "completed",
+				Verdict:          experiments.CheckVerdictFail,
+				TestCaseCount:    10,
+				PassCount:        8,
+				PassDenominator:  10,
+				Checks: []experiments.Check{{
+					Name:      "min_pass_rate",
+					Verdict:   experiments.CheckVerdictFail,
+					Threshold: &threshold,
+					Actual:    &actual,
+					Observed:  "pass rate 80.00% (8/10 test cases passed on the first completed attempt)",
+				}},
+			},
+			want: []string{
+				"Experiment:", "r-1", "Status:", "completed", "Quality check:", "fail",
+				"Test cases:", "10", "Checks:", "min_pass_rate fail", "threshold 90.00%", "80.00%",
+			},
+		},
+		{
+			name: "unknown verdict is rendered as a value, passed by value",
+			result: experiments.CheckResult{
+				ExperimentID:     "r-1",
+				ExperimentStatus: "completed",
+				Verdict:          experiments.CheckVerdictFail,
+				Checks: []experiments.Check{{
+					Name:      "min_pass_rate",
+					Verdict:   experiments.CheckVerdictUnknown,
+					Threshold: &threshold,
+					Observed:  "no test case produced a pass verdict",
+				}},
+			},
+			want: []string{"min_pass_rate unknown", "no test case produced a pass verdict"},
+		},
+		{
+			name: "status check has no numbers",
+			result: &experiments.CheckResult{
+				ExperimentID:     "r-1",
+				ExperimentStatus: "failed",
+				Verdict:          experiments.CheckVerdictFail,
+				Checks: []experiments.Check{{
+					Name:     "experiment_status",
+					Verdict:  experiments.CheckVerdictFail,
+					Observed: `experiment status is "failed", not "completed"`,
+				}},
+			},
+			want: []string{"Status:", "failed", "experiment_status fail", `not "completed"`},
+		},
+		{
+			name:   "no checks still reports the verdict",
+			result: &experiments.CheckResult{ExperimentID: "r-1", Verdict: experiments.CheckVerdictPass},
+			want:   []string{"Quality check:", "pass"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			codec := &experiments.CheckTextCodec{}
+			var buf bytes.Buffer
+			require.NoError(t, codec.Encode(&buf, tc.result))
+			out := buf.String()
+			for _, s := range tc.want {
+				assert.Contains(t, out, s)
+			}
+		})
+	}
+}
+
+func TestCheckTextCodec_WrongType(t *testing.T) {
+	codec := &experiments.CheckTextCodec{}
+	var buf bytes.Buffer
+	err := codec.Encode(&buf, "not-a-check-result")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected *CheckResult")
+}
+
+func TestCheckTextCodec_Decode(t *testing.T) {
+	err := (&experiments.CheckTextCodec{}).Decode(strings.NewReader("{}"), &experiments.CheckResult{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support decoding")
 }
 
 func TestTableCodec_Format(t *testing.T) {
@@ -510,6 +700,17 @@ func TestReportTextCodec_Encode(t *testing.T) {
 				CostCoverage: "partial", TokenCoverage: "partial",
 			},
 			want: []string{"Cost:           $1.2500 (coverage: partial)", "Tokens:         42 (coverage: partial)"},
+		},
+		{
+			// A measured zero renders as a number, where an unmeasured total
+			// renders as "-".
+			name: "cost and tokens measured as zero",
+			summary: experiments.ExperimentReportSummary{
+				TestCaseCount: 1, TrialCount: 1, CompletedCount: 1,
+				TotalCost: new(0.0), TotalTokens: new(int64(0)),
+				CostCoverage: "complete", TokenCoverage: "complete",
+			},
+			want: []string{"Cost:           $0.0000", "Tokens:         0"},
 		},
 		{
 			name:    "experiment failed",

--- a/internal/providers/agento11y/eval/experiments/wait.go
+++ b/internal/providers/agento11y/eval/experiments/wait.go
@@ -1,0 +1,87 @@
+package experiments
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/grafana/gcx/internal/gcxerrors"
+)
+
+// waitPollInterval is how often --wait polls the experiment, the same cadence
+// gcx instrumentation clusters wait uses.
+const waitPollInterval = 5 * time.Second
+
+// experimentGetter is the one client call the wait loop needs, split out so
+// tests can script a sequence of statuses.
+type experimentGetter interface {
+	Get(ctx context.Context, runID string) (*Experiment, error)
+}
+
+// waitForFinished polls the experiment until it reaches a terminal status
+// (completed, failed or canceled), the timeout elapses, or ctx is canceled.
+//
+// The first poll happens immediately and any error there returns right away, so
+// a wrong run ID or a broken token fails fast instead of spinning until the
+// timeout. A later poll error is treated as transient: the loop keeps polling
+// and the timeout error names the last one.
+//
+// Progress goes to stderr, one line per poll, so a CI log shows the wait is
+// alive. The timeout error is a plain DetailedError, so it exits 1 like every
+// other not-finished outcome, and no check document is written.
+func waitForFinished(ctx context.Context, client experimentGetter, runID string, timeout, interval time.Duration, stderr io.Writer) error {
+	start := time.Now()
+
+	run, err := client.Get(ctx, runID)
+	if err != nil {
+		return err
+	}
+	lastStatus := run.Status
+	if isFinishedStatus(lastStatus) {
+		return nil
+	}
+	emitWaitProgress(stderr, runID, lastStatus, start)
+
+	timeoutCh := time.After(timeout)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var lastPollErr error
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timeoutCh:
+			details := fmt.Sprintf("experiment %s still reports status %q after %s", runID, lastStatus, timeout)
+			if lastPollErr != nil {
+				details = fmt.Sprintf("%s; last poll error: %v", details, lastPollErr)
+			}
+			return &gcxerrors.DetailedError{
+				Summary: "Timed out waiting for the experiment to finish",
+				Details: details,
+				Suggestions: []string{
+					"Raise --timeout for a long suite",
+					fmt.Sprintf("Watch the run with 'gcx agento11y experiments get %s'", runID),
+				},
+			}
+		case <-ticker.C:
+			run, err := client.Get(ctx, runID)
+			if err != nil {
+				lastPollErr = err
+				continue
+			}
+			lastPollErr = nil
+			lastStatus = run.Status
+			if isFinishedStatus(lastStatus) {
+				return nil
+			}
+			emitWaitProgress(stderr, runID, lastStatus, start)
+		}
+	}
+}
+
+func emitWaitProgress(stderr io.Writer, runID, status string, start time.Time) {
+	fmt.Fprintf(stderr, "waiting: experiment %s status %q (elapsed %s)\n",
+		runID, status, time.Since(start).Truncate(time.Second))
+}

--- a/internal/providers/agento11y/eval/experiments/wait_test.go
+++ b/internal/providers/agento11y/eval/experiments/wait_test.go
@@ -1,0 +1,163 @@
+package experiments //nolint:testpackage // Tests drive the unexported waitForFinished helper.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedGetter returns one step per Get call and keeps returning the last
+// step once the script runs out.
+type scriptedGetter struct {
+	steps []scriptedStep
+	calls int
+}
+
+type scriptedStep struct {
+	status string
+	err    error
+}
+
+func (g *scriptedGetter) Get(_ context.Context, _ string) (*Experiment, error) {
+	step := g.steps[min(g.calls, len(g.steps)-1)]
+	g.calls++
+	if step.err != nil {
+		return nil, step.err
+	}
+	return &Experiment{ExperimentID: "r-1", Status: step.status}, nil
+}
+
+func TestWaitForFinished(t *testing.T) {
+	pollErr := errors.New("connection reset")
+	tests := []struct {
+		name    string
+		steps   []scriptedStep
+		timeout time.Duration
+		// wantErr substrings; nil means the wait must succeed.
+		wantErr []string
+		// wantStderr substrings the progress stream must carry.
+		wantStderr []string
+		// wantMinCalls guards against a loop that returns before it polled.
+		wantMinCalls int
+	}{
+		{
+			name:         "an already finished run returns without waiting",
+			steps:        []scriptedStep{{status: "completed"}},
+			timeout:      time.Second,
+			wantMinCalls: 1,
+		},
+		{
+			name: "a run that finishes while polling returns",
+			steps: []scriptedStep{
+				{status: "pending"},
+				{status: "running"},
+				{status: "completed"},
+			},
+			timeout:      time.Second,
+			wantStderr:   []string{`status "pending"`, `status "running"`},
+			wantMinCalls: 3,
+		},
+		{
+			// failed and canceled end the wait too: grading them is the check's
+			// job, and it fails them with exit 4 rather than spinning here.
+			name: "a failed run ends the wait",
+			steps: []scriptedStep{
+				{status: "running"},
+				{status: "failed"},
+			},
+			timeout:      time.Second,
+			wantMinCalls: 2,
+		},
+		{
+			name:         "a run that never finishes times out with its last status",
+			steps:        []scriptedStep{{status: "running"}},
+			timeout:      30 * time.Millisecond,
+			wantErr:      []string{"Timed out", "r-1", `"running"`, "30ms"},
+			wantMinCalls: 1,
+		},
+		{
+			// The first poll failing fast is what keeps a wrong run ID or a broken
+			// token from spinning until the timeout.
+			name:         "a first poll error returns immediately",
+			steps:        []scriptedStep{{err: pollErr}},
+			timeout:      time.Second,
+			wantErr:      []string{"connection reset"},
+			wantMinCalls: 1,
+		},
+		{
+			name: "a transient poll error does not end the wait",
+			steps: []scriptedStep{
+				{status: "running"},
+				{err: pollErr},
+				{status: "completed"},
+			},
+			timeout:      time.Second,
+			wantMinCalls: 3,
+		},
+		{
+			name: "a timeout names the last poll error",
+			steps: []scriptedStep{
+				{status: "running"},
+				{err: pollErr},
+			},
+			timeout:      40 * time.Millisecond,
+			wantErr:      []string{"Timed out", "last poll error", "connection reset"},
+			wantMinCalls: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			getter := &scriptedGetter{steps: tc.steps}
+			var stderr bytes.Buffer
+
+			err := waitForFinished(t.Context(), getter, "r-1", tc.timeout, time.Millisecond, &stderr)
+
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, s := range tc.wantErr {
+					assert.Contains(t, err.Error(), s)
+				}
+			}
+			assert.GreaterOrEqual(t, getter.calls, tc.wantMinCalls, "polls")
+			for _, s := range tc.wantStderr {
+				assert.Contains(t, stderr.String(), s)
+			}
+		})
+	}
+}
+
+// TestWaitForFinished_TimeoutIsAStateError pins the exit code contract: a
+// timeout is "not finished yet", the same class as running without --wait, so
+// it must exit 1 and not borrow the quality verdict's 4.
+func TestWaitForFinished_TimeoutIsAStateError(t *testing.T) {
+	getter := &scriptedGetter{steps: []scriptedStep{{status: "running"}}}
+
+	err := waitForFinished(t.Context(), getter, "r-1", 20*time.Millisecond, time.Millisecond, &bytes.Buffer{})
+
+	var detailed *gcxerrors.DetailedError
+	require.ErrorAs(t, err, &detailed)
+	assert.Nil(t, detailed.ExitCode, "a nil exit code means 1")
+	require.NotEmpty(t, detailed.Suggestions)
+	assert.Contains(t, detailed.Suggestions[1], "gcx agento11y experiments get r-1")
+	var emitted *gcxerrors.EmittedError
+	assert.NotErrorAs(t, err, &emitted, "no document was written, so nothing was emitted")
+}
+
+func TestWaitForFinished_ContextCancelEndsTheWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	getter := &scriptedGetter{steps: []scriptedStep{{status: "running"}}}
+
+	err := waitForFinished(ctx, getter, "r-1", time.Second, time.Millisecond, &bytes.Buffer{})
+
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/internal/providers/agento11y/provider.go
+++ b/internal/providers/agento11y/provider.go
@@ -112,7 +112,7 @@ func (p *Agento11yProvider) Commands() []*cobra.Command {
 	experimentsCmd := experiments.Commands(loader)
 	experimentsCmd.Annotations = map[string]string{
 		agent.AnnotationTokenCost: "medium",
-		agent.AnnotationLLMHint:   `gcx agento11y experiments list -o json; gcx agento11y experiments get <run-id> -o yaml; gcx agento11y experiments update <run-id> --description '...' --tag nightly --tag support -o json; gcx agento11y experiments list-scores <run-id> -o json; gcx agento11y experiments get-report <run-id> -o json; gcx agento11y experiments test-suites list -o json; gcx agento11y experiments test-suites cases list <suite-id> <version> -o json; gcx agento11y experiments list-trials <run-id> -o json`,
+		agent.AnnotationLLMHint:   `gcx agento11y experiments list -o json; gcx agento11y experiments get <run-id> -o yaml; gcx agento11y experiments update <run-id> --description '...' --tag nightly --tag support -o json; gcx agento11y experiments list-scores <run-id> -o json; gcx agento11y experiments get-report <run-id> -o json; gcx agento11y experiments check <run-id> --min-pass-rate 0.9 -o json; gcx agento11y experiments test-suites list -o json; gcx agento11y experiments test-suites cases list <suite-id> <version> -o json; gcx agento11y experiments list-trials <run-id> -o json`,
 	}
 
 	agento11yCmd.AddCommand(convsCmd, agentsCmd, evaluatorsCmd, rulesCmd, guardsCmd, templatesCmd, generationsCmd, judgeCmd, savedConvsCmd, collectionsCmd, experimentsCmd)

--- a/internal/providers/agento11y/provider_test.go
+++ b/internal/providers/agento11y/provider_test.go
@@ -3,6 +3,7 @@ package agento11y_test
 import (
 	"testing"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/providers/agento11y"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -40,6 +41,17 @@ func TestAgento11yProvider_Commands(t *testing.T) {
 	for _, exp := range []string{"list", "get", "search"} {
 		assert.Contains(t, convSubNames, exp)
 	}
+}
+
+// TestAgento11yProvider_ExperimentsHintAdvertisesCheck keeps agent discovery of
+// the CI quality check honest. That the hint's flags exist is checked for every
+// command by TestConsistency_LLMHintFlagsExist in cmd/gcx/root.
+func TestAgento11yProvider_ExperimentsHintAdvertisesCheck(t *testing.T) {
+	experimentsCmd := findSubcommand((&agento11y.Agento11yProvider{}).Commands()[0], "experiments")
+	require.NotNil(t, experimentsCmd)
+
+	hint := experimentsCmd.Annotations[agent.AnnotationLLMHint]
+	assert.Contains(t, hint, "gcx agento11y experiments check <run-id> --min-pass-rate")
 }
 
 func commandNames(cmd *cobra.Command) []string {


### PR DESCRIPTION
`gcx agento11y experiments check <run-id> --min-pass-rate 0.9` grades a finished offline eval run and exits non-zero when it fails.

```bash
# Fail the build when fewer than 90% of test cases pass
gcx agento11y experiments check "$RUN_ID" --min-pass-rate 0.9

# Or with JSON output
gcx agento11y experiments check "$RUN_ID" --min-pass-rate 0.9 -o json
```

**Exit codes**

| Code | Meaning |
|------|---------|
| 0 | Every threshold met |
| 1 | The experiment has not finished, so it cannot be graded yet |
| 2 | A flag is missing or invalid |
| 4 | A threshold was breached, the experiment finished with status failed or canceled, or it produced no pass verdict |

Exit 1 and exit 4 are deliberately different: a run that is still going is a state error, not a regression. CI must be able to tell the two apart, so exit 1 writes no check document at all.

**Checks**

Three checks can appear in the output:

- `experiment_status` fails any run that did not complete.
- `min_pass_rate` compares `summary.pass_rate` with `--min-pass-rate`. The comparison is strict less-than, so `--min-pass-rate 0.9` accepts exactly 0.9.
- `verdict_coverage` compares `pass_denominator / test_case_count` with `--min-verdict-coverage` (default 1, the whole suite).