### PR TITLE
feat(login): add --oauth-manual for remote hosts without a reachable callback

### DIFF
--- a/cmd/gcx/cloud/command.go
+++ b/cmd/gcx/cloud/command.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -19,10 +20,11 @@ import (
 )
 
 type loginOpts struct {
-	oauthURL   string
-	apiURL     string
-	scopes     []string
-	cloudToken string
+	oauthURL    string
+	apiURL      string
+	scopes      []string
+	cloudToken  string
+	oauthManual bool
 }
 
 type gcomOAuthFlow interface {
@@ -39,6 +41,7 @@ func (opts *loginOpts) bindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.oauthURL, "oauth-url", "https://grafana.com", "Base URL for the OAuth login flow (used only by this command)")
 	flags.StringVar(&opts.apiURL, "api-url", "https://grafana.com", "Base URL for Grafana Cloud API resource calls (stacks etc.)")
 	flags.StringSliceVar(&opts.scopes, "scope", auth.DefaultGCOMScopes(), "OAuth2 scopes to request")
+	flags.BoolVar(&opts.oauthManual, "oauth-manual", false, "Complete browser OAuth without a local callback server: gcx prints the URL, then reads the redirect URL that you copy from the browser address bar. Use this when gcx runs on a remote host and the browser runs on your own computer")
 }
 
 func (opts *loginOpts) Validate() error {
@@ -50,6 +53,9 @@ func (opts *loginOpts) Validate() error {
 	}
 	if opts.cloudToken == "" && len(opts.scopes) == 0 {
 		return errors.New("--scope must not be empty for interactive OAuth login")
+	}
+	if opts.cloudToken != "" && opts.oauthManual {
+		return errors.New("--oauth-manual has no effect with --cloud-token")
 	}
 	return nil
 }
@@ -170,7 +176,7 @@ both preserves the explicit OAuth-origin/API-destination pair.`,
 			if opts.cloudToken != "" {
 				return runTokenLogin(mutationCtx, opts, mutationSource, contextName, cloudSafety, mutationGuard)
 			}
-			return runOAuthLogin(mutationCtx, opts, mutationSource, contextName, cloudSafety, mutationGuard)
+			return runOAuthLogin(mutationCtx, opts, mutationSource, contextName, cloudSafety, mutationGuard, cmd.InOrStdin(), cmd.ErrOrStderr())
 		},
 	}
 
@@ -256,15 +262,19 @@ func runOAuthLogin(
 	contextName string,
 	cloudSafety config.CloudMutationSafety,
 	mutationGuard config.LoginMutationGuard,
+	stdin io.Reader,
+	stderr io.Writer,
 ) error {
-	fmt.Fprintln(os.Stderr, "Warning: interactive OAuth login is experimental. It stores an OAuth-issued token in the cloud entry's oauth-token field.")
-	fmt.Fprintln(os.Stderr, "Some commands that talk to grafana.com do not yet work with an OAuth token. For full functionality, use --cloud-token with a Cloud Access Policy token.")
+	fmt.Fprintln(stderr, "Warning: interactive OAuth login is experimental. It stores an OAuth-issued token in the cloud entry's oauth-token field.")
+	fmt.Fprintln(stderr, "Some commands that talk to grafana.com do not yet work with an OAuth token. For full functionality, use --cloud-token with a Cloud Access Policy token.")
 
 	flow := newGCOMOAuthFlow(auth.GCOMOptions{
 		ClientID: defaultClientID,
 		GCOMURL:  opts.oauthURL,
 		Scopes:   opts.scopes,
-		Writer:   os.Stderr,
+		Writer:   stderr,
+		Manual:   opts.oauthManual,
+		Reader:   stdin,
 	})
 
 	result, err := flow.Run(ctx)
@@ -280,15 +290,15 @@ func runOAuthLogin(
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "Authenticated as %s (%s)\n", result.Info.Login, result.Info.Email)
-	fmt.Fprintf(os.Stderr, "Scopes: %s\n", result.Scope)
+	fmt.Fprintf(stderr, "Authenticated as %s (%s)\n", result.Info.Login, result.Info.Email)
+	fmt.Fprintf(stderr, "Scopes: %s\n", result.Scope)
 
 	entry := cloudEntryFromOAuthResult(opts, result)
 	contextName, entryName, err := config.SaveCloudConfigGuarded(ctx, source, contextName, entry, cloudSafety, mutationGuard)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stderr, "Token saved to cloud entry %q (context %q)\n", entryName, contextName)
+	fmt.Fprintf(stderr, "Token saved to cloud entry %q (context %q)\n", entryName, contextName)
 	return nil
 }
 

--- a/cmd/gcx/cloud/command_test.go
+++ b/cmd/gcx/cloud/command_test.go
@@ -634,3 +634,78 @@ func TestSelectCloudLoginEndpointsKeepsOAuthAndAPICoherent(t *testing.T) {
 		})
 	}
 }
+
+// TestCloudLoginManualReachesGCOMOptions confirms --oauth-manual reaches the
+// OAuth flow with a reader, so the user can paste the redirect URL on a remote
+// host (issue #1135).
+func TestCloudLoginManualReachesGCOMOptions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("version: 1\ncontexts:\n  default: {}\ncurrent-context: default\n"), 0o600))
+
+	var gotOpts auth.GCOMOptions
+	previousFactory := newGCOMOAuthFlow
+	newGCOMOAuthFlow = func(opts auth.GCOMOptions) gcomOAuthFlow {
+		gotOpts = opts
+		return gcomOAuthFlowFunc(func(context.Context) (*auth.GCOMResult, error) {
+			return &auth.GCOMResult{AccessToken: "oauth-access", ExpiresAt: "2030-01-01T00:00:00Z", Scope: "stacks:read"}, nil
+		})
+	}
+	t.Cleanup(func() { newGCOMOAuthFlow = previousFactory })
+
+	cmd := loginCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--config", path, "--oauth-manual"})
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+	assert.True(t, gotOpts.Manual)
+	assert.NotNil(t, gotOpts.Reader)
+}
+
+// TestCloudLoginOptsValidateRejectsManualWithToken pins that --oauth-manual is
+// meaningless together with a Cloud Access Policy token.
+func TestCloudLoginOptsValidateRejectsManualWithToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cloudToken  string
+		oauthManual bool
+		wantErr     string
+	}{
+		{
+			name:        "manual with cloud token",
+			cloudToken:  "glc_abc123",
+			oauthManual: true,
+			wantErr:     "--oauth-manual has no effect with --cloud-token",
+		},
+		{
+			name:        "manual alone",
+			oauthManual: true,
+		},
+		{
+			name:       "cloud token alone",
+			cloudToken: "glc_abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := &loginOpts{
+				oauthURL:    "https://grafana.com",
+				apiURL:      "https://grafana.com",
+				scopes:      auth.DefaultGCOMScopes(),
+				cloudToken:  tt.cloudToken,
+				oauthManual: tt.oauthManual,
+			}
+			err := opts.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -123,16 +123,13 @@ func (opts *loginOpts) Validate(args []string) error {
 			},
 		}
 	}
-	return nil
-}
-
-// applyOAuthManualImplication makes --oauth-manual a complete selection, so
-// every gate that inspects OAuth sees the fresh-credential intent. It must run
-// before the auto-local credential gates in runLogin.
-func applyOAuthManualImplication(opts *loginOpts) {
+	// --oauth-manual is a complete selection on its own. Fold it into OAuth
+	// here, after the conflict checks above, so the opts are self-consistent for
+	// every gate that reads OAuth later.
 	if opts.OAuthManual {
 		opts.OAuth = true
 	}
+	return nil
 }
 
 // Command returns the `login` Cobra command.
@@ -183,9 +180,6 @@ Auth sources (for non-interactive use):
 //nolint:gocyclo,maintidx // Login deliberately keeps trust preflight, auth selection, and retry setup in one auditable flow.
 func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 	ctx := cmd.Context()
-	// --oauth-manual is a complete selection on its own. Fold it into OAuth
-	// before any gate below reads flags.OAuth.
-	applyOAuthManualImplication(flags)
 	// The auto-discovered-config credential rejection below is the earliest gate
 	// that can end a login, and it runs before any config is read — so there is
 	// nothing but the flags to go on. Record what they ask for here; the

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/gcx/internal/gcxerrors"
 	"github.com/grafana/gcx/internal/login"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/terminal"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -51,6 +52,7 @@ type loginOpts struct {
 	Yes                 bool
 	AllowServerOverride bool
 	OAuthCallbackPort   int
+	OAuthManual         bool
 	OrgID               int
 }
 
@@ -72,6 +74,7 @@ func (opts *loginOpts) setup(flags *pflag.FlagSet) {
 	flags.BoolVar(&opts.Yes, "yes", false, "Non-interactive: skip optional prompts and use defaults")
 	flags.BoolVar(&opts.AllowServerOverride, "allow-server-override", false, "Allow re-pointing an existing context at a different server URL")
 	flags.IntVar(&opts.OAuthCallbackPort, "oauth-callback-port", 0, "Fixed local port for the OAuth callback server (default: auto-pick from 54321-54399). Useful when only specific ports are forwarded between a remote host and your browser")
+	flags.BoolVar(&opts.OAuthManual, "oauth-manual", false, "Complete browser OAuth without a local callback server: gcx prints the URL, then reads the redirect URL that you copy from the browser address bar. Use this when gcx runs on a remote host and the browser runs on your own computer. Implies --oauth")
 	flags.IntVar(&opts.OrgID, "org-id", 0, "Grafana organization ID (defaults to 1 for on-prem)")
 }
 
@@ -92,7 +95,7 @@ func (opts *loginOpts) Validate(args []string) error {
 			},
 		}
 	}
-	if opts.OAuth && opts.Token != "" {
+	if (opts.OAuth || opts.OAuthManual) && opts.Token != "" {
 		return gcxerrors.DetailedError{
 			Summary: "conflicting authentication methods",
 			Details: "--oauth and --token are mutually exclusive. OAuth authenticates via browser; --token uses a service account token.",
@@ -110,7 +113,26 @@ func (opts *loginOpts) Validate(args []string) error {
 			Details: fmt.Sprintf("Port must be between 1 and 65535 (or 0 to auto-pick); got %d.", opts.OAuthCallbackPort),
 		}
 	}
+	if opts.OAuthManual && opts.OAuthCallbackPort != 0 {
+		return gcxerrors.DetailedError{
+			Summary: "conflicting OAuth callback options",
+			Details: "--oauth-manual completes the flow without a callback server, so there is no port to fix with --oauth-callback-port.",
+			Suggestions: []string{
+				"Use --oauth-manual alone and paste the redirect URL",
+				"Or use --oauth-callback-port <port> alone and forward that port with ssh -L",
+			},
+		}
+	}
 	return nil
+}
+
+// applyOAuthManualImplication makes --oauth-manual a complete selection, so
+// every gate that inspects OAuth sees the fresh-credential intent. It must run
+// before the auto-local credential gates in runLogin.
+func applyOAuthManualImplication(opts *loginOpts) {
+	if opts.OAuthManual {
+		opts.OAuth = true
+	}
 }
 
 // Command returns the `login` Cobra command.
@@ -161,6 +183,9 @@ Auth sources (for non-interactive use):
 //nolint:gocyclo,maintidx // Login deliberately keeps trust preflight, auth selection, and retry setup in one auditable flow.
 func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 	ctx := cmd.Context()
+	// --oauth-manual is a complete selection on its own. Fold it into OAuth
+	// before any gate below reads flags.OAuth.
+	applyOAuthManualImplication(flags)
 	// The auto-discovered-config credential rejection below is the earliest gate
 	// that can end a login, and it runs before any config is read — so there is
 	// nothing but the flags to go on. Record what they ask for here; the
@@ -361,6 +386,8 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 			CloudOAuthURL:               cloudOAuthURL,
 			UseOAuth:                    flags.OAuth,
 			OAuthCallbackPort:           flags.OAuthCallbackPort,
+			OAuthManual:                 flags.OAuthManual,
+			Reader:                      cmd.InOrStdin(),
 			Yes:                         flags.Yes,
 			OrgID:                       flags.OrgID,
 			Writer:                      cmd.ErrOrStderr(),
@@ -1116,6 +1143,12 @@ func askCloudAuth(ctx context.Context, e *login.ErrNeedInput, opts *login.Option
 		// change requires a freshly supplied credential, never a keep choice.
 		hasUsableExisting = false
 	}
+	// The Cloud step reuses the manual choice made for the stack step, so the
+	// label states where the browser runs instead of adding a fifth entry.
+	oauthLabel := "OAuth (browser)"
+	if opts.OAuthManual {
+		oauthLabel = "OAuth (browser on another computer)"
+	}
 	if hasUsableExisting {
 		label := "Keep the existing Cloud Access Policy token (recommended)"
 		if existingKind == login.CloudCredentialOAuth {
@@ -1123,10 +1156,10 @@ func askCloudAuth(ctx context.Context, e *login.ErrNeedInput, opts *login.Option
 		}
 		options = append(options,
 			huh.NewOption(label, choiceKeep),
-			huh.NewOption("OAuth (browser)", choiceOAuth),
+			huh.NewOption(oauthLabel, choiceOAuth),
 		)
 	} else {
-		options = append(options, huh.NewOption("OAuth (browser) (recommended)", choiceOAuth))
+		options = append(options, huh.NewOption(oauthLabel+" (recommended)", choiceOAuth))
 	}
 	options = append(options,
 		huh.NewOption("Paste a Cloud Access Policy token", choiceToken),
@@ -1197,6 +1230,10 @@ func runCloudOAuth(ctx context.Context, opts *login.Options) error {
 		GCOMURL:  oauthURL,
 		Scopes:   internalauth.DefaultGCOMScopes(),
 		Writer:   opts.Writer,
+		// One manual choice covers both the stack step and the Cloud step:
+		// the browser is on another computer for both.
+		Manual: opts.OAuthManual,
+		Reader: opts.Reader,
 	}
 	var flow login.CloudAuthFlow = internalauth.NewGCOMFlow(flowOpts)
 	if opts.NewCloudAuthFlow != nil {
@@ -1300,6 +1337,36 @@ func cloudEndpointRequestDiffers(opts *login.Options, entry *config.CloudEntry, 
 //     the fallback.
 //   - Unknown (target still ambiguous): both options are offered, token
 //     first to match the historical default.
+//
+// grafanaAuthOptions builds the auth-method menu. The caller highlights the
+// first option as the default, so a remote session promotes manual OAuth: the
+// browser there runs on another computer and cannot reach the local callback
+// address.
+func grafanaAuthOptions(target login.Target, hasMTLS, remote bool) []huh.Option[string] {
+	tokenOption := huh.NewOption("Service account token (requires permissions for managing service accounts)", "token")
+	oauthOption := huh.NewOption("OAuth (browser) — recommended for cloud stacks; experimental on some configurations, fall back to a service account token if you hit issues", "oauth")
+	oauthManualOption := huh.NewOption("OAuth (browser on another computer) — gcx prints a URL; you paste the redirect URL back. Use this over SSH", "oauth-manual")
+	mtlsOption := huh.NewOption("Client certificate (mTLS) — authenticate via TLS client cert (e.g. Teleport)", "mtls")
+
+	switch target {
+	case login.TargetOnPrem:
+		if hasMTLS {
+			return []huh.Option[string]{mtlsOption, tokenOption}
+		}
+		return []huh.Option[string]{tokenOption}
+	case login.TargetCloud:
+		if remote {
+			return []huh.Option[string]{oauthManualOption, oauthOption, tokenOption}
+		}
+		return []huh.Option[string]{oauthOption, oauthManualOption, tokenOption}
+	default: // TargetUnknown
+		if hasMTLS {
+			return []huh.Option[string]{mtlsOption, tokenOption, oauthOption, oauthManualOption}
+		}
+		return []huh.Option[string]{tokenOption, oauthOption, oauthManualOption}
+	}
+}
+
 func askGrafanaAuth(opts *login.Options, existingToken string) error {
 	// When TLS client certs are configured, mTLS is a valid standalone auth
 	// method (e.g. Teleport proxy). Offer it as the default choice.
@@ -1310,27 +1377,7 @@ func askGrafanaAuth(opts *login.Options, existingToken string) error {
 		return nil // resolveGrafanaAuth will pick up the TLS case.
 	}
 
-	tokenOption := huh.NewOption("Service account token (requires permissions for managing service accounts)", "token")
-	oauthOption := huh.NewOption("OAuth (browser) — recommended for cloud stacks; experimental on some configurations, fall back to a service account token if you hit issues", "oauth")
-	mtlsOption := huh.NewOption("Client certificate (mTLS) — authenticate via TLS client cert (e.g. Teleport)", "mtls")
-
-	var options []huh.Option[string]
-	switch opts.Target {
-	case login.TargetOnPrem:
-		if hasMTLS {
-			options = []huh.Option[string]{mtlsOption, tokenOption}
-		} else {
-			options = []huh.Option[string]{tokenOption}
-		}
-	case login.TargetCloud:
-		options = []huh.Option[string]{oauthOption, tokenOption}
-	default: // TargetUnknown
-		if hasMTLS {
-			options = []huh.Option[string]{mtlsOption, tokenOption, oauthOption}
-		} else {
-			options = []huh.Option[string]{tokenOption, oauthOption}
-		}
-	}
+	options := grafanaAuthOptions(opts.Target, hasMTLS, terminal.IsRemoteSession())
 
 	// Default to the first option in the menu: OAuth for Cloud, mTLS when certs
 	// are present (non-Cloud), token otherwise. Deriving from options[0] keeps
@@ -1347,6 +1394,11 @@ func askGrafanaAuth(opts *login.Options, existingToken string) error {
 		if err := methodForm.Run(); err != nil {
 			return err
 		}
+	}
+	if authMethod == "oauth-manual" {
+		opts.UseOAuth = true
+		opts.OAuthManual = true
+		return nil
 	}
 	if authMethod == "oauth" {
 		opts.UseOAuth = true

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -98,7 +98,7 @@ func (opts *loginOpts) Validate(args []string) error {
 	if (opts.OAuth || opts.OAuthManual) && opts.Token != "" {
 		return gcxerrors.DetailedError{
 			Summary: "conflicting authentication methods",
-			Details: "--oauth and --token are mutually exclusive. OAuth authenticates via browser; --token uses a service account token.",
+			Details: "--oauth, --oauth-manual and --token are mutually exclusive. OAuth authenticates via browser; --token uses a service account token.",
 			Suggestions: []string{
 				"Use --oauth for browser-based login, or --token <token> for a service account token",
 			},

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -2336,6 +2336,32 @@ func TestOAuthManualFlagParses(t *testing.T) {
 	}
 }
 
+// TestOAuthTokenConflictNamesEveryFlag pins the conflict message. The condition
+// covers --oauth-manual too, so a message that names --oauth alone reports a
+// flag that the user never typed.
+func TestOAuthTokenConflictNamesEveryFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts *loginOpts
+	}{
+		{name: "oauth_with_token", opts: &loginOpts{OAuth: true, Token: "glsa_example"}},
+		{name: "oauth_manual_with_token", opts: &loginOpts{OAuthManual: true, Token: "glsa_example"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.opts.Validate(nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--oauth-manual")
+			assert.Contains(t, err.Error(), "--token")
+		})
+	}
+}
+
 // TestGrafanaAuthOptions pins the auth-method menu order. The caller
 // highlights options[0], so the order decides the default.
 func TestGrafanaAuthOptions(t *testing.T) {

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -1876,13 +1876,15 @@ func TestLoginOptsValidate(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		args          []string
-		contextFlag   string
-		oauthFlag     bool
-		tokenFlag     string
-		wantErr       bool
-		wantErrSubstr string
+		name            string
+		args            []string
+		contextFlag     string
+		oauthFlag       bool
+		oauthManualFlag bool
+		callbackPort    int
+		tokenFlag       string
+		wantErr         bool
+		wantErrSubstr   string
 	}{
 		{
 			name:          "conflict_positional_and_flag",
@@ -1929,6 +1931,35 @@ func TestLoginOptsValidate(t *testing.T) {
 			tokenFlag: "glsa_xxx",
 			wantErr:   false,
 		},
+		{
+			name:            "oauth_manual_alone",
+			args:            []string{},
+			oauthManualFlag: true,
+			wantErr:         false,
+		},
+		{
+			name:            "conflict_oauth_manual_and_token",
+			args:            []string{},
+			oauthManualFlag: true,
+			tokenFlag:       "glsa_xxx",
+			wantErr:         true,
+			wantErrSubstr:   "conflicting authentication methods",
+		},
+		{
+			name:            "conflict_oauth_manual_and_callback_port",
+			args:            []string{},
+			oauthManualFlag: true,
+			callbackPort:    54321,
+			wantErr:         true,
+			wantErrSubstr:   "conflicting OAuth callback options",
+		},
+		{
+			name:         "callback_port_alone",
+			args:         []string{},
+			oauthFlag:    true,
+			callbackPort: 54321,
+			wantErr:      false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1936,9 +1967,11 @@ func TestLoginOptsValidate(t *testing.T) {
 			t.Parallel()
 
 			opts := &loginOpts{
-				Config: configcmd.Options{Context: tt.contextFlag},
-				OAuth:  tt.oauthFlag,
-				Token:  tt.tokenFlag,
+				Config:            configcmd.Options{Context: tt.contextFlag},
+				OAuth:             tt.oauthFlag,
+				OAuthManual:       tt.oauthManualFlag,
+				OAuthCallbackPort: tt.callbackPort,
+				Token:             tt.tokenFlag,
 			}
 			// Bind flags into a throwaway FlagSet so IO.Validate() has a
 			// populated flag set to inspect (otherwise --json handling is
@@ -2260,4 +2293,157 @@ func disableAgentMode(t *testing.T) {
 	t.Setenv("GCX_AGENT_MODE", "false")
 	agent.ResetForTesting()
 	t.Cleanup(agent.ResetForTesting)
+}
+
+// TestOAuthManualFlagParses confirms setup() registers --oauth-manual and that
+// it parses into loginOpts.OAuthManual, which runLogin maps to
+// login.Inputs.OAuthManual (issue #1135).
+func TestOAuthManualFlagParses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantManual bool
+	}{
+		{
+			name:       "oauth_manual_flag_set",
+			args:       []string{"--server", "https://example.grafana.net", "--oauth-manual"},
+			wantManual: true,
+		},
+		{
+			name:       "oauth_manual_flag_absent",
+			args:       []string{"--server", "https://example.grafana.net"},
+			wantManual: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := &loginOpts{}
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			opts.setup(flags)
+			require.NoError(t, flags.Parse(tt.args))
+			assert.Equal(t, tt.wantManual, opts.OAuthManual)
+		})
+	}
+}
+
+// TestApplyOAuthManualImplication pins that --oauth-manual is a complete
+// selection: every downstream gate reads flags.OAuth, so the implication must
+// run before them.
+func TestApplyOAuthManualImplication(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		manual    bool
+		oauth     bool
+		wantOAuth bool
+	}{
+		{name: "neither", manual: false, oauth: false, wantOAuth: false},
+		{name: "manual_only", manual: true, oauth: false, wantOAuth: true},
+		{name: "both", manual: true, oauth: true, wantOAuth: true},
+		{name: "oauth_only", manual: false, oauth: true, wantOAuth: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := &loginOpts{OAuth: tt.oauth, OAuthManual: tt.manual}
+			applyOAuthManualImplication(opts)
+			assert.Equal(t, tt.wantOAuth, opts.OAuth)
+		})
+	}
+}
+
+// TestGrafanaAuthOptions pins the auth-method menu order. The caller
+// highlights options[0], so the order decides the default.
+func TestGrafanaAuthOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		target  internallogin.Target
+		hasMTLS bool
+		remote  bool
+		want    []string
+	}{
+		{
+			name:   "cloud_local",
+			target: internallogin.TargetCloud,
+			want:   []string{"oauth", "oauth-manual", "token"},
+		},
+		{
+			name:   "cloud_remote_defaults_to_manual",
+			target: internallogin.TargetCloud,
+			remote: true,
+			want:   []string{"oauth-manual", "oauth", "token"},
+		},
+		{
+			name:   "unknown_without_mtls",
+			target: internallogin.TargetUnknown,
+			want:   []string{"token", "oauth", "oauth-manual"},
+		},
+		{
+			name:    "unknown_with_mtls",
+			target:  internallogin.TargetUnknown,
+			hasMTLS: true,
+			want:    []string{"mtls", "token", "oauth", "oauth-manual"},
+		},
+		{
+			name:   "onprem_offers_no_oauth",
+			target: internallogin.TargetOnPrem,
+			want:   []string{"token"},
+		},
+		{
+			name:    "onprem_with_mtls",
+			target:  internallogin.TargetOnPrem,
+			hasMTLS: true,
+			want:    []string{"mtls", "token"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			options := grafanaAuthOptions(tt.target, tt.hasMTLS, tt.remote)
+			values := make([]string, 0, len(options))
+			for _, option := range options {
+				values = append(values, option.Value)
+			}
+			assert.Equal(t, tt.want, values)
+		})
+	}
+}
+
+// TestRunCloudOAuthPropagatesManualPaste confirms one --oauth-manual choice
+// covers the Cloud follow-up too: the browser is on another computer for both
+// steps (issue #1135).
+func TestRunCloudOAuthPropagatesManualPaste(t *testing.T) {
+	t.Parallel()
+
+	reader := strings.NewReader("")
+	var gotFlowOpts internalauth.GCOMOptions
+	opts := internallogin.Options{
+		Inputs: internallogin.Inputs{
+			Server:      "https://custom.example.com",
+			OAuthManual: true,
+			Reader:      reader,
+		},
+		Hooks: internallogin.Hooks{
+			NewCloudAuthFlow: func(flowOpts internalauth.GCOMOptions) internallogin.CloudAuthFlow {
+				gotFlowOpts = flowOpts
+				return &stubCloudAuthFlow{result: &internalauth.GCOMResult{AccessToken: "oauth-token"}}
+			},
+		},
+	}
+
+	require.NoError(t, runCloudOAuth(context.Background(), &opts))
+	assert.True(t, gotFlowOpts.Manual)
+	assert.Same(t, reader, gotFlowOpts.Reader)
 }

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -1987,6 +1987,11 @@ func TestLoginOptsValidate(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			// --oauth-manual is a complete selection on its own, so Validate
+			// must leave OAuth set for every gate that reads it later.
+			if tt.oauthManualFlag {
+				assert.True(t, opts.OAuth, "Validate must fold --oauth-manual into OAuth")
+			}
 		})
 	}
 }
@@ -2327,35 +2332,6 @@ func TestOAuthManualFlagParses(t *testing.T) {
 			opts.setup(flags)
 			require.NoError(t, flags.Parse(tt.args))
 			assert.Equal(t, tt.wantManual, opts.OAuthManual)
-		})
-	}
-}
-
-// TestApplyOAuthManualImplication pins that --oauth-manual is a complete
-// selection: every downstream gate reads flags.OAuth, so the implication must
-// run before them.
-func TestApplyOAuthManualImplication(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		manual    bool
-		oauth     bool
-		wantOAuth bool
-	}{
-		{name: "neither", manual: false, oauth: false, wantOAuth: false},
-		{name: "manual_only", manual: true, oauth: false, wantOAuth: true},
-		{name: "both", manual: true, oauth: true, wantOAuth: true},
-		{name: "oauth_only", manual: false, oauth: true, wantOAuth: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			opts := &loginOpts{OAuth: tt.oauth, OAuthManual: tt.manual}
-			applyOAuthManualImplication(opts)
-			assert.Equal(t, tt.wantOAuth, opts.OAuth)
 		})
 	}
 }

--- a/docs/architecture/auth-system.md
+++ b/docs/architecture/auth-system.md
@@ -262,9 +262,35 @@ byte-identical to the one on the authorize request, so both come from one
 string. Port 54321 is the first port of the normal auto-pick range, so manual
 mode presents no `redirect_uri` shape that grafana.com has not already seen.
 
-gcx also prints an SSH hint on the normal callback path when
-`terminal.IsRemoteSession()` reports an SSH session. The hint offers the
-`ssh -L` port forward and `--oauth-manual`.
+### The paste race on the callback path
+
+`--oauth-manual` is the scripted form. Interactively, an SSH user needs no flag:
+when `terminal.IsRemoteSession()` reports an SSH session and gcx is not in agent
+mode, `startPasteWatcher` (`internal/auth/paste.go`) keeps the callback server
+listening **and** reads a pasted redirect URL. The `select` in
+`runWithCallbackServer` takes whichever completes first, so adding a port
+forward and pasting are both live at once and neither needs a restart. A URL
+that does not work re-prompts instead of ending the flow, because the callback
+server is still up.
+
+The watcher reads a separately opened `/dev/tty`, never `os.Stdin`. Go keeps the
+standard streams out of its poller, so a blocking read on `os.Stdin` cannot be
+cancelled; a stale reader would then compete with the `huh` prompts that run
+after login. A file from `os.OpenFile` is non-blocking and registered with the
+poller, so `Close` unblocks the pending read, and `Close` waits for the reader
+goroutine to end.
+
+One trap guards that property: **never call `File.Fd` on this file.** `Fd` puts
+the descriptor back into blocking mode, the read then blocks inside the syscall
+rather than the poller, and `Close` can no longer stop it — the login hangs
+forever once the browser callback arrives.
+`TestOpenPasteTerminalReadIsCancellable` is the regression guard, and it is also
+why the opener does not call `term.IsTerminal`: `/dev/tty` is the controlling
+terminal by definition, and the open fails when the process has none.
+
+When the watcher cannot start (no `/dev/tty`, agent mode), gcx falls back to
+`printRemoteSessionHint`, which offers the `ssh -L` port forward and
+`--oauth-manual`.
 
 The token exchange response carries an `api_endpoint` field, stored as
 `GrafanaConfig.ProxyEndpoint`. All subsequent API traffic is routed through
@@ -399,6 +425,8 @@ internal/auth/
                       callback and the manual paste path
   manual.go           Manual paste mode: redirect-URL parsing, line reader,
                       SSH hint
+  paste.go            Paste watcher: reads a redirect URL from /dev/tty while
+                      the callback server also listens
   gcom.go             Direct Grafana Cloud OAuth PKCE flow and response metadata
   transport.go        RefreshTransport, StoredTokens, TokenRefresher,
                       TokenLocker, TokenReloader, DoRefresh

--- a/docs/architecture/auth-system.md
+++ b/docs/architecture/auth-system.md
@@ -253,8 +253,10 @@ uses as well, so the state check, the PKCE exchange, and endpoint validation
 cannot diverge between the two paths.
 
 The pasted URL never carries the `code_verifier`, so a leaked scrollback alone
-cannot mint a token. gcx prints a reminder to clear the terminal after a
-successful paste, and no error message ever echoes the pasted string.
+cannot mint a token. gcx prints a reminder to clear the terminal once a URL
+reaches the screen. The reminder covers the failure paths too, because a state
+mismatch leaves the code in the scrollback and the user then runs the command
+again. No error message ever echoes the pasted string.
 
 The GCOM flow (`internal/auth/gcom.go`) has the same mode. There the fixed
 port matters for a second reason: the token exchange must send a `redirect_uri`
@@ -272,6 +274,16 @@ listening **and** reads a pasted redirect URL. The `select` in
 forward and pasting are both live at once and neither needs a restart. A URL
 that does not work re-prompts instead of ending the flow, because the callback
 server is still up.
+
+Two reader rules keep the two routes from interfering:
+
+- The watcher drops an empty line. Option 1 asks the user to press Enter before
+  the `~C` escape, so a rejection there would answer the recommended route with
+  an error.
+- The watcher reports `Closed` when the read ends, which Ctrl-D and a broken
+  terminal both cause. `awaitCallbackOrPaste` states that the paste route ended
+  and keeps waiting for the callback. A silent stop left the prompt on screen
+  with no reader behind it.
 
 The watcher reads a separately opened `/dev/tty`, never `os.Stdin`. Go keeps the
 standard streams out of its poller, so a blocking read on `os.Stdin` cannot be

--- a/docs/architecture/auth-system.md
+++ b/docs/architecture/auth-system.md
@@ -233,6 +233,39 @@ used as the base URL for the token exchange — is validated by
 prevents an attacker who controls the browser redirect from steering the
 token exchange at a hostile host.
 
+### Manual callback (no local listener)
+
+`--oauth-manual` runs the same flow without a callback server. It exists for
+the remote case: gcx over SSH, browser on the user's own computer. A different
+bind address cannot solve that case — the plugin hard-codes `127.0.0.1` in the
+callback URL and only accepts a port between 1024 and 65535.
+
+In manual mode gcx prints the consent URL with a fixed `callback_port=54321`,
+opens no browser, and reads one line from stdin. The browser really navigates
+to the callback address and fails to connect, so the complete redirect URL —
+including `code`, `state`, `endpoint`, and `instanceEndpoint` — stays in the
+address bar. That failed navigation is the mechanism, not a defect.
+
+`ParseCallbackInput` in `internal/auth/manual.go` turns the pasted line into
+`url.Values` and does nothing else. Every semantic check runs in
+`handleCallbackParams` (`internal/auth/callback.go`), which the HTTP handler
+uses as well, so the state check, the PKCE exchange, and endpoint validation
+cannot diverge between the two paths.
+
+The pasted URL never carries the `code_verifier`, so a leaked scrollback alone
+cannot mint a token. gcx prints a reminder to clear the terminal after a
+successful paste, and no error message ever echoes the pasted string.
+
+The GCOM flow (`internal/auth/gcom.go`) has the same mode. There the fixed
+port matters for a second reason: the token exchange must send a `redirect_uri`
+byte-identical to the one on the authorize request, so both come from one
+string. Port 54321 is the first port of the normal auto-pick range, so manual
+mode presents no `redirect_uri` shape that grafana.com has not already seen.
+
+gcx also prints an SSH hint on the normal callback path when
+`terminal.IsRemoteSession()` reports an SSH session. The hint offers the
+`ssh -L` port forward and `--oauth-manual`.
+
 The token exchange response carries an `api_endpoint` field, stored as
 `GrafanaConfig.ProxyEndpoint`. All subsequent API traffic is routed through
 that endpoint (see OAuth proxy routing below). Exact implementation lives in
@@ -362,6 +395,10 @@ sequenceDiagram
 internal/auth/
   flow.go             OAuth PKCE flow, callback server, exchange,
                       state/endpoint validation
+  callback.go         Shared callback-parameter handling for both the HTTP
+                      callback and the manual paste path
+  manual.go           Manual paste mode: redirect-URL parsing, line reader,
+                      SSH hint
   gcom.go             Direct Grafana Cloud OAuth PKCE flow and response metadata
   transport.go        RefreshTransport, StoredTokens, TokenRefresher,
                       TokenLocker, TokenReloader, DoRefresh

--- a/docs/architecture/auth-system.md
+++ b/docs/architecture/auth-system.md
@@ -285,6 +285,22 @@ Two reader rules keep the two routes from interfering:
   and keeps waiting for the callback. A silent stop left the prompt on screen
   with no reader behind it.
 
+Both routes accept the same single-use authorization code, so `exchangeGuard`
+decides which one exchanges it. The claim runs after the state check and the
+code check, never before: a URL from an older attempt must not consume the claim
+that the real callback needs. The loser returns `errExchangeClaimed`, which no
+caller shows to the user. The paste branch stays silent, and the HTTP handler
+renders the success page instead of a message on `errCh`.
+
+`Close` ends the read with a deadline in the past, waits for the reader
+goroutine, and then calls `flushTerminalInput`. A terminal in canonical mode
+delivers a line only after a newline, so text that the user typed without one is
+unreachable by a read. The shell reads that text once gcx exits, which is how a
+partly typed redirect URL would enter the shell history. `flush_linux.go` uses
+`TCFLSH` with `TCIFLUSH`, `flush_bsd.go` uses `TIOCFLUSH` with `FREAD`, and
+`flush_other.go` does nothing. All of them use `SyscallConn`, never `File.Fd`,
+for the reason in the next paragraph.
+
 The watcher reads a separately opened `/dev/tty`, never `os.Stdin`. Go keeps the
 standard streams out of its poller, so a blocking read on `os.Stdin` cannot be
 cancelled; a stale reader would then compete with the `huh` prompts that run
@@ -439,6 +455,9 @@ internal/auth/
                       SSH hint
   paste.go            Paste watcher: reads a redirect URL from /dev/tty while
                       the callback server also listens
+  flush_linux.go      Terminal input flush, one file for each platform family.
+  flush_bsd.go        Close calls it, so text without a newline never reaches
+  flush_other.go      the shell after gcx exits.
   gcom.go             Direct Grafana Cloud OAuth PKCE flow and response metadata
   transport.go        RefreshTransport, StoredTokens, TokenRefresher,
                       TokenLocker, TokenReloader, DoRefresh

--- a/docs/architecture/login-system.md
+++ b/docs/architecture/login-system.md
@@ -49,6 +49,7 @@ classDiagram
         CloudTokenTrusted
         CloudOAuthTokenExpiresAt, CloudOAuthScopes
         UseOAuth, Yes, Writer
+        OAuthCallbackPort, OAuthManual, Reader
         UseCloudInstanceSelector
         TLS, StoredTLS
         PreserveStoredTLS

--- a/docs/reference/cli/gcx_cloud_login.md
+++ b/docs/reference/cli/gcx_cloud_login.md
@@ -45,6 +45,7 @@ gcx cloud login [flags]
       --config string        Path to the configuration file to use
       --context string       Name of the context to use
   -h, --help                 help for login
+      --oauth-manual         Complete browser OAuth without a local callback server: gcx prints the URL, then reads the redirect URL that you copy from the browser address bar. Use this when gcx runs on a remote host and the browser runs on your own computer
       --oauth-url string     Base URL for the OAuth login flow (used only by this command) (default "https://grafana.com")
       --scope strings        OAuth2 scopes to request (default [stacks:read,stacks:write,stacks:delete,metrics:write,logs:write,traces:write,fleet-management:read,fleet-management:write])
 ```

--- a/docs/reference/cli/gcx_login.md
+++ b/docs/reference/cli/gcx_login.md
@@ -50,6 +50,7 @@ gcx login [CONTEXT_NAME] [flags]
       --json string               Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --oauth                     Authenticate via browser-based OAuth (recommended for Grafana Cloud). Works non-interactively and in agent mode: opens a browser for the user to approve.
       --oauth-callback-port int   Fixed local port for the OAuth callback server (default: auto-pick from 54321-54399). Useful when only specific ports are forwarded between a remote host and your browser
+      --oauth-manual              Complete browser OAuth without a local callback server: gcx prints the URL, then reads the redirect URL that you copy from the browser address bar. Use this when gcx runs on a remote host and the browser runs on your own computer. Implies --oauth
       --org-id int                Grafana organization ID (defaults to 1 for on-prem)
   -o, --output string             Output format. One of: agents, json, text, yaml (default "text")
       --server string             Grafana server URL (e.g. https://my-stack.grafana.net)

--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -11,10 +11,11 @@ This page walks through the common login paths, the mental model behind them, an
 ## Pick your scenario
 
 1. **Setting up Grafana Cloud interactively** → [Grafana Cloud (interactive OAuth)](#grafana-cloud-interactive-oauth)
-2. **Setting up on-premises Grafana** → [Service account token](#service-account-token)
-3. **Setting up CI, an agent, or any non-interactive environment** → [Environment variables for CI and agents](#environment-variables-for-ci-and-agents)
-4. **Adding Grafana Cloud product API access to an existing context** → [Grafana Cloud product APIs](#grafana-cloud-product-apis)
-5. **Re-authenticating or switching between contexts** → [Re-authenticating and switching contexts](#re-authenticating-and-switching-contexts)
+2. **Running gcx over SSH, with the browser on another computer** → [Remote host or SSH session](#remote-host-or-ssh-session)
+3. **Setting up on-premises Grafana** → [Service account token](#service-account-token)
+4. **Setting up CI, an agent, or any non-interactive environment** → [Environment variables for CI and agents](#environment-variables-for-ci-and-agents)
+5. **Adding Grafana Cloud product API access to an existing context** → [Grafana Cloud product APIs](#grafana-cloud-product-apis)
+6. **Re-authenticating or switching between contexts** → [Re-authenticating and switching contexts](#re-authenticating-and-switching-contexts)
 
 ## Procedures
 
@@ -51,6 +52,56 @@ mTLS/anonymous inference, but a partial or rejected higher-priority credential
 fails before any request instead of falling through. Repair the selected method
 with `gcx login`, or use `gcx config edit --config <path>` when the file cannot
 be loaded normally.
+
+### Remote host or SSH session
+
+The OAuth callback server listens on `127.0.0.1` on the computer that runs gcx.
+When you run gcx over SSH, the browser on your own computer cannot open that
+address, and the login never completes. gcx detects an SSH session and prints
+the two options below.
+
+**Option A — forward the port.** Use this when you control the SSH session.
+
+```bash
+# On your own computer:
+ssh -L 54321:127.0.0.1:54321 remote-host
+
+# On the remote host:
+gcx login my-stack --server https://my-stack.grafana.net --oauth --oauth-callback-port 54321
+```
+
+**Option B — paste the redirect URL.** Use this when you cannot forward a port.
+
+```bash
+gcx login my-stack --server https://my-stack.grafana.net --oauth-manual
+```
+
+gcx prints a login URL and waits. The steps are:
+
+1. Open the printed URL in the browser on your own computer.
+2. Check that the browser shows the same verification code. Then approve.
+3. The browser goes to `http://127.0.0.1:54321/callback?...` and does not load.
+   This is correct. gcx does not listen on that address.
+4. Copy the full address from the browser address bar.
+5. Paste the address at the `Redirect URL:` prompt in the terminal.
+
+Do these steps quickly. The authorization code expires.
+
+`--oauth-manual` implies `--oauth`. It is mutually exclusive with
+`--oauth-callback-port`, because manual mode starts no callback server. The
+same flag works on `gcx cloud login`, and one choice covers both the stack step
+and the Cloud follow-up step.
+
+**Close other `gcx login` sessions on the browser computer first.** A gcx login
+that already listens on port 54321 there receives the callback, rejects it on
+the state check, and ends its own flow. Your paste still succeeds, but the
+other login does not.
+
+**Terminal hygiene.** The pasted URL holds a single-use authorization code and
+the state value. It does not hold the PKCE code verifier or a token, so the
+code alone cannot mint a token. gcx reads it from a prompt, so it never enters
+your shell history. It does stay in the terminal scrollback and in the browser
+history. Clear the terminal if other people can read it.
 
 ### Service account token
 
@@ -303,49 +354,53 @@ Each entry pairs the error you see with what it means and how to fix it.
 
 3. **OAuth: browser did not open, or token refresh failed**
     - *Means:* gcx tried to open a browser for OAuth but the system command returned an error, or the OAuth refresh flow failed.
-    - *Fix:* Re-run `gcx login` to trigger a fresh flow. If your environment has no browser, use a service account token instead. For corporate proxies, check that the OAuth callback URL is reachable.
+    - *Fix:* Re-run `gcx login` to trigger a fresh flow. If the browser runs on a different computer, re-run with `--oauth-manual` and paste the redirect URL — see [Remote host or SSH session](#remote-host-or-ssh-session). If your environment has no browser at all, use a service account token instead. For corporate proxies, check that the OAuth callback URL is reachable.
 
-4. **`Permission Required` on the OAuth consent page (`gcx User` role / `grafana-assistant-app.tokens.gcx:access`)**
+4. **OAuth over SSH never completes; the browser shows `ERR_CONNECTION_REFUSED` on 127.0.0.1**
+    - *Means:* the callback server listens on the loopback address of the remote host. The browser on your own computer cannot reach it.
+    - *Fix:* Re-run with `--oauth-manual` and paste the redirect URL, or forward the callback port with `ssh -L`. See [Remote host or SSH session](#remote-host-or-ssh-session).
+
+5. **`Permission Required` on the OAuth consent page (`gcx User` role / `grafana-assistant-app.tokens.gcx:access`)**
     - *Means:* your Grafana user lacks the `grafana-assistant-app.tokens.gcx:access` permission that gates gcx token minting. The **gcx User** role granting it is normally auto-assigned to Viewer and above, but the instance may run a grafana-assistant-app version older than 2.0.26 (role does not exist yet) or have customized basic-role grants.
     - *Fix:* ask your Grafana administrator to assign the **gcx User** role, or a custom role including `grafana-assistant-app.tokens.gcx:access`. If the role is missing entirely, the grafana-assistant-app plugin needs updating. As a workaround, authenticate with a service account token instead.
 
-5. **`grafana version X is not supported; gcx requires Grafana 12.0.0 or later`**
+6. **`grafana version X is not supported; gcx requires Grafana 12.0.0 or later`**
     - *Means:* gcx requires Grafana 12 or newer because it uses the Grafana K8s-compatible `/apis` surface introduced in 12.
     - *Fix:* Upgrade your Grafana instance, or use a different tool for older versions.
 
-6. **GCOM 401 / Cloud Access Policy token rejected**
+7. **GCOM 401 / Cloud Access Policy token rejected**
     - *Means:* the Cloud Access Policy token was rejected by GCOM or a Cloud product API.
     - *Fix:* Verify the token at [grafana.com → Access Policies](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/). Rotate if compromised. Provide the new token via `gcx login --context X --cloud-token glc_...`.
 
-7. **Health check or `/apis` connectivity failures**
+8. **Health check or `/apis` connectivity failures**
     - *Means:* gcx could not reach the server during the validation pipeline — typically a wrong URL, DNS/proxy issue, or TLS mismatch.
     - *Fix:* Verify the server URL is correct and reachable. Check any corporate proxies (`HTTPS_PROXY`) and TLS configuration. For a reviewed development-only config, set `stacks.<name>.grafana.tls.insecure-skip-verify`; there is no login flag that bypasses TLS verification.
 
-8. **`gcx assistant` commands fail with a service account token**
+9. **`gcx assistant` commands fail with a service account token**
     - *Means:* `gcx assistant` commands (prompt, investigations) require OAuth, which is only available when you log in via the browser-based OAuth flow. Service account tokens are not supported.
     - *Fix:* Re-run `gcx login` and choose the OAuth (browser) option. If your environment cannot open a browser, `gcx assistant` is not available — use the Grafana UI instead.
 
-9. **Flag vs env-var precedence confusion**
+10. **Flag vs env-var precedence confusion**
     - *Means:* both a CLI flag and an environment variable are set for the same field, and gcx behaves unexpectedly.
     - *Fix:* Flags take precedence over env vars, which take precedence over config-file values. For credential fields, blank or whitespace-only inputs are treated as unset rather than as an override. Run `gcx config view` to inspect the resolved config and spot the conflict.
 
-10. **Login refuses to replace an existing context's server**
+11. **Login refuses to replace an existing context's server**
     - *Means:* the selected context points at a different Grafana server. `--yes` does not authorize changing a credential destination, and gcx will not present the stored credential to the new server.
     - *Fix:* Verify the new URL, then pass `--allow-server-override` together with a fresh `--token`, a fresh `GRAFANA_TOKEN`, or a new OAuth flow. An interactive login can ask for the same explicit confirmation.
 
-11. **`Configuration write target is ambiguous`**
+12. **`Configuration write target is ambiguous`**
     - *Means:* layered files do not prove one owner for every entry or context binding the login may update.
     - *Fix:* Review the paths listed by the error and rerun with the intended `--config <path>`, or keep the target stack, Cloud entry, and context bindings together in one source.
 
-12. **A credential was `rejected before network use`**
+13. **A credential was `rejected before network use`**
     - *Means:* a keychain reference was missing/foreign, a destination changed, or an environment credential was paired with an auto-discovered repository destination. gcx withheld it instead of sending an empty or misrouted credential.
     - *Fix:* For an auto-discovered repository destination, review the file and rerun with its explicit `--config` path. Explicit selection does not make a missing, foreign, or destination-mismatched keychain sentinel valid; re-authenticate or replace/unset that field. Use the exact raw editor command named by the error, such as `gcx config edit user` or `gcx config edit --config "<path>"`; it remains available even when ordinary loading fails.
 
-13. **`Cloud credential destination is ambiguous`**
+14. **`Cloud credential destination is ambiguous`**
     - *Means:* one credential-bearing Cloud entry has no explicit endpoint pair and is referenced by contexts in different Cloud environments. gcx will not guess which API destination may receive it.
     - *Fix:* Run the exact raw `gcx config edit ...` command from the error, split the Cloud entry into one entry per environment, and update each `contexts.<name>.cloud` binding. Ordinary config loading remains blocked until the ambiguity is removed.
 
-14. **`Configuration changed during authentication`**
+15. **`Configuration changed during authentication`**
     - *Means:* the selected owner or the discovered config source set changed while OAuth or connectivity validation was in progress. The freshly authenticated credential was not written.
     - *Fix:* Review every changed file, then retry. If you intend to trust one document as authoritative, rerun with its explicit `--config <path>`.
 

--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -90,6 +90,10 @@ load `http://127.0.0.1:<port>/callback?...`, copy the whole address, and paste
 it at the prompt. If the address does not work, gcx says why and asks again; the
 callback server stays up the whole time.
 
+The prompt ignores an empty line, so the Enter that Option 1 needs costs
+nothing. Ctrl-D ends the paste route; gcx says so and keeps waiting for the
+browser.
+
 Do these steps quickly. The authorization code expires.
 
 **`--oauth-manual` for scripts and terminals with no `/dev/tty`.** The flag
@@ -113,7 +117,8 @@ other login does not.
 the state value. It does not hold the PKCE code verifier or a token, so the
 code alone cannot mint a token. gcx reads it from a prompt, so it never enters
 your shell history. It does stay in the terminal scrollback and in the browser
-history. Clear the terminal if other people can read it.
+history. gcx prints the reminder once a URL reaches the screen, whether the
+login succeeds or fails. Clear the terminal if other people can read it.
 
 ### Service account token
 

--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -57,43 +57,55 @@ be loaded normally.
 
 The OAuth callback server listens on `127.0.0.1` on the computer that runs gcx.
 When you run gcx over SSH, the browser on your own computer cannot open that
-address, and the login never completes. gcx detects an SSH session and prints
-the two options below.
+address.
 
-**Option A — forward the port.** Use this when you control the SSH session.
+**You do not need a flag, and you do not need to restart.** gcx detects the SSH
+session, keeps the callback server listening, and also reads a pasted redirect
+URL. It accepts whichever arrives first:
 
-```bash
-# On your own computer:
-ssh -L 54321:127.0.0.1:54321 remote-host
+```
+Note: gcx runs in an SSH session.
+The browser on your computer cannot open the callback address on this host.
+Do one of these two steps. gcx accepts the one that completes first.
 
-# On the remote host:
-gcx login my-stack --server https://my-stack.grafana.net --oauth --oauth-callback-port 54321
+  1. Add a port forward to this SSH session. Press Enter, then press ~C,
+     then type this line:
+       -L 54321:127.0.0.1:54321
+
+  2. Approve the login in the browser on your computer. The browser then
+     goes to an address that does not load. Copy that address and paste it
+     here.
+
+Redirect URL (or wait for the browser):
 ```
 
-**Option B — paste the redirect URL.** Use this when you cannot forward a port.
+**Option 1 — add a forward to the running session.** `~C` is the OpenSSH escape
+that opens a command line for `-L`, `-R`, and `-D`. It needs no reconnect and no
+hostname, and gcx keeps waiting, so the login completes as soon as the browser
+reaches the forwarded port. The escape only works after a newline, so press
+Enter first.
+
+**Option 2 — paste the redirect URL.** Approve in the browser, let it fail to
+load `http://127.0.0.1:<port>/callback?...`, copy the whole address, and paste
+it at the prompt. If the address does not work, gcx says why and asks again; the
+callback server stays up the whole time.
+
+Do these steps quickly. The authorization code expires.
+
+**`--oauth-manual` for scripts and terminals with no `/dev/tty`.** The flag
+starts no callback server at all and only reads the pasted URL:
 
 ```bash
 gcx login my-stack --server https://my-stack.grafana.net --oauth-manual
 ```
 
-gcx prints a login URL and waits. The steps are:
-
-1. Open the printed URL in the browser on your own computer.
-2. Check that the browser shows the same verification code. Then approve.
-3. The browser goes to `http://127.0.0.1:54321/callback?...` and does not load.
-   This is correct. gcx does not listen on that address.
-4. Copy the full address from the browser address bar.
-5. Paste the address at the `Redirect URL:` prompt in the terminal.
-
-Do these steps quickly. The authorization code expires.
-
-`--oauth-manual` implies `--oauth`. It is mutually exclusive with
-`--oauth-callback-port`, because manual mode starts no callback server. The
+It implies `--oauth` and is mutually exclusive with `--oauth-callback-port`. The
 same flag works on `gcx cloud login`, and one choice covers both the stack step
-and the Cloud follow-up step.
+and the Cloud follow-up step. You do not need it for an ordinary interactive SSH
+login — the prompt above appears on its own.
 
 **Close other `gcx login` sessions on the browser computer first.** A gcx login
-that already listens on port 54321 there receives the callback, rejects it on
+that already listens on the same port there receives the callback, rejects it on
 the state check, and ends its own flow. Your paste still succeeds, but the
 other login does not.
 
@@ -358,7 +370,7 @@ Each entry pairs the error you see with what it means and how to fix it.
 
 4. **OAuth over SSH never completes; the browser shows `ERR_CONNECTION_REFUSED` on 127.0.0.1**
     - *Means:* the callback server listens on the loopback address of the remote host. The browser on your own computer cannot reach it.
-    - *Fix:* Re-run with `--oauth-manual` and paste the redirect URL, or forward the callback port with `ssh -L`. See [Remote host or SSH session](#remote-host-or-ssh-session).
+    - *Fix:* This is expected. Copy that address from the browser and paste it at the `Redirect URL` prompt, or add a port forward to the running session with `~C`. See [Remote host or SSH session](#remote-host-or-ssh-session). If gcx printed no prompt, it found no `/dev/tty`; re-run with `--oauth-manual`.
 
 5. **`Permission Required` on the OAuth consent page (`gcx User` role / `grafana-assistant-app.tokens.gcx:access`)**
     - *Means:* your Grafana user lacks the `grafana-assistant-app.tokens.gcx:access` permission that gates gcx token minting. The **gcx User** role granting it is normally auto-assigned to Viewer and above, but the instance may run a grafana-assistant-app version older than 2.0.26 (role does not exist yet) or have customized basic-role grants.

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/common v0.69.0
 	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/sys v0.47.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -178,7 +179,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect

--- a/internal/auth/callback.go
+++ b/internal/auth/callback.go
@@ -72,9 +72,17 @@ func checkCallbackBasics(q url.Values, expectedState string) (string, *callbackE
 // flow keep one implementation of the paste behaviour.
 type paramHandler[T any] func(url.Values) (*T, *callbackError)
 
+// manualPasteTries bounds the number of redirect URLs that the manual flow
+// accepts. A typo must not cost a full re-run for a fresh state and a fresh
+// code, and a bound keeps the loop finite for a reader that is not a terminal.
+const manualPasteTries = 3
+
 // runManualPaste completes a flow without a callback server. The browser cannot
 // reach the callback address, so the user copies the redirect URL out of the
 // address bar and pastes it here.
+//
+// A URL that fails a check re-prompts, up to manualPasteTries lines. A read
+// error ends the flow at once, because the next read reports it again.
 //
 // Pass an empty verification string for a flow that shows no verification code.
 func runManualPaste[T any](
@@ -86,26 +94,46 @@ func runManualPaste[T any](
 ) (*T, error) {
 	printManualInstructions(w, authURL, verification)
 
-	line, err := readLineContext(ctx, r)
-	if err != nil {
-		return nil, err
-	}
+	// A pasted line is on screen from the first read on, so the notice belongs
+	// on every return below, not on the success return alone. A state mismatch
+	// is the case that leaves the most on screen.
+	pasteSeen := false
+	defer func() {
+		if pasteSeen {
+			fmt.Fprintln(w, manualCallbackHygieneNotice)
+		}
+	}()
 
-	// The pasted line is on screen from here on, so the notice belongs on every
-	// return below, not on the success return alone. A state mismatch is the
-	// case that leaves the most on screen.
-	defer fmt.Fprintln(w, manualCallbackHygieneNotice)
+	var lastErr error
+	for try := 1; try <= manualPasteTries; try++ {
+		line, err := readLineContext(ctx, r)
+		if err != nil {
+			// The reader ended or the context stopped the wait. Report the
+			// failure of the URL that the user did paste: the end of the input
+			// is a consequence of it, and it says less about the cause.
+			if lastErr != nil && ctx.Err() == nil {
+				return nil, lastErr
+			}
+			return nil, err
+		}
+		pasteSeen = true
 
-	values, err := ParseCallbackInput(line)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read the redirect URL: %w", err)
-	}
+		values, parseErr := ParseCallbackInput(line)
+		if parseErr != nil {
+			lastErr = fmt.Errorf("cannot read the redirect URL: %w", parseErr)
+		} else {
+			result, cerr := handle(values)
+			if cerr == nil {
+				return result, nil
+			}
+			lastErr = pasteRejection(cerr.err)
+		}
 
-	result, cerr := handle(values)
-	if cerr != nil {
-		return nil, pasteRejection(cerr.err)
+		if try < manualPasteTries {
+			printPasteRejection(w, lastErr, manualRedirectPrompt)
+		}
 	}
-	return result, nil
+	return nil, lastErr
 }
 
 // awaitCallbackOrPaste waits for whichever route completes first: the callback

--- a/internal/auth/callback.go
+++ b/internal/auth/callback.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// ErrStateMismatch reports that the callback state does not match the state
+// gcx generated. The manual paste path wraps it with its own guidance: there,
+// a mismatch nearly always means the URL came from a different login attempt.
+var ErrStateMismatch = errors.New("invalid state - possible CSRF attack")
+
+// callbackError pairs the error reported to the caller with the short message
+// rendered on the browser error page. The manual paste path uses only err.
+type callbackError struct {
+	err  error
+	page string
+}
+
+func (e *callbackError) Error() string { return e.err.Error() }
+
+func (e *callbackError) Unwrap() error { return e.err }
+
+// handleCallbackParams validates the redirect query parameters, exchanges the
+// authorization code, and builds a Result.
+//
+// It is the single code path shared by the HTTP callback handler and the
+// manual paste fallback: q comes either from r.URL.Query() or from
+// ParseCallbackInput. Keeping one implementation stops the two paths from
+// diverging on the state check, the PKCE exchange, or endpoint validation.
+func handleCallbackParams(ctx context.Context, q url.Values, expectedState, codeVerifier string) (*Result, *callbackError) {
+	if q.Get("state") != expectedState {
+		return nil, &callbackError{err: ErrStateMismatch, page: "Invalid state parameter"}
+	}
+
+	if errMsg := q.Get("error"); errMsg != "" {
+		errMsg = StripControlChars(errMsg)
+		return nil, &callbackError{err: fmt.Errorf("authentication denied: %s", errMsg), page: errMsg}
+	}
+
+	code := q.Get("code")
+	if code == "" {
+		return nil, &callbackError{err: errors.New("no authorization code received"), page: "No authorization code received"}
+	}
+
+	endpoint := q.Get("endpoint")
+	if endpoint == "" {
+		return nil, &callbackError{err: errors.New("no API endpoint received"), page: "No API endpoint received"}
+	}
+	if err := ValidateEndpointURL(endpoint); err != nil {
+		return nil, &callbackError{err: fmt.Errorf("invalid API endpoint: %w", err), page: "Invalid API endpoint"}
+	}
+
+	exchangeResult, err := exchangeCodeForToken(ctx, endpoint, code, codeVerifier)
+	if err != nil {
+		return nil, &callbackError{err: fmt.Errorf("token exchange failed: %w", err), page: "Token exchange failed"}
+	}
+
+	instanceEndpoint := q.Get("instanceEndpoint")
+	instanceEndpointURL, err := url.Parse(instanceEndpoint)
+	if err != nil {
+		return nil, &callbackError{err: fmt.Errorf("invalid endpoint url: %w", err), page: "Invalid instance endpoint passed"}
+	}
+	if instanceEndpointURL.Scheme != "https" {
+		return nil, &callbackError{
+			err:  fmt.Errorf("invalid endpoint scheme: expected 'https', got '%s'", instanceEndpointURL.Scheme),
+			page: "Invalid instance endpoint: needs to be an HTTPS URL",
+		}
+	}
+
+	return &Result{
+		Token:            exchangeResult.Data.Token,
+		Email:            exchangeResult.Data.Email,
+		DeviceName:       q.Get("device"),
+		APIEndpoint:      exchangeResult.Data.APIEndpoint,
+		ExpiresAt:        exchangeResult.Data.ExpiresAt,
+		RefreshToken:     exchangeResult.Data.RefreshToken,
+		RefreshExpiresAt: exchangeResult.Data.RefreshExpiresAt,
+		InstanceEndpoint: instanceEndpoint,
+	}, nil
+}
+
+// handleGCOMCallbackParams is the grafana.com equivalent of
+// handleCallbackParams. redirectURI must be byte-identical to the redirect_uri
+// sent on the authorize request, because GCOM rejects the exchange otherwise.
+func (f *GCOMFlow) handleGCOMCallbackParams(ctx context.Context, q url.Values, expectedState, codeVerifier, redirectURI string) (*GCOMResult, *callbackError) {
+	if q.Get("state") != expectedState {
+		return nil, &callbackError{err: ErrStateMismatch, page: "Invalid state parameter"}
+	}
+
+	if errMsg := q.Get("error"); errMsg != "" {
+		errMsg = StripControlChars(errMsg)
+		return nil, &callbackError{err: fmt.Errorf("authentication denied: %s", errMsg), page: errMsg}
+	}
+
+	code := q.Get("code")
+	if code == "" {
+		return nil, &callbackError{err: errors.New("no authorization code received"), page: "No authorization code received"}
+	}
+
+	result, err := f.exchangeGCOMToken(ctx, code, codeVerifier, redirectURI)
+	if err != nil {
+		return nil, &callbackError{err: fmt.Errorf("token exchange failed: %w", err), page: "Token exchange failed"}
+	}
+
+	return result, nil
+}

--- a/internal/auth/callback.go
+++ b/internal/auth/callback.go
@@ -8,10 +8,11 @@ import (
 	"net/url"
 )
 
-// ErrStateMismatch reports that the callback state does not match the state
-// gcx generated. The manual paste path wraps it with its own guidance: there,
-// a mismatch nearly always means the URL came from a different login attempt.
-var ErrStateMismatch = errors.New("invalid state - possible CSRF attack")
+// errStateMismatch reports that the callback state does not match the state
+// gcx generated. The manual paste path replaces it with its own guidance:
+// there, a mismatch nearly always means the URL came from a different login
+// attempt.
+var errStateMismatch = errors.New("invalid state - possible CSRF attack")
 
 // callbackError pairs the error reported to the caller with the short message
 // rendered on the browser error page. The manual paste path uses only err.
@@ -20,16 +21,12 @@ type callbackError struct {
 	page string
 }
 
-func (e *callbackError) Error() string { return e.err.Error() }
-
-func (e *callbackError) Unwrap() error { return e.err }
-
 // checkCallbackBasics runs the three checks that every flow shares: the state
 // must match, the provider must report no error, and an authorization code must
 // be present. It returns that code.
 func checkCallbackBasics(q url.Values, expectedState string) (string, *callbackError) {
 	if q.Get("state") != expectedState {
-		return "", &callbackError{err: ErrStateMismatch, page: "Invalid state parameter"}
+		return "", &callbackError{err: errStateMismatch, page: "Invalid state parameter"}
 	}
 
 	if errMsg := q.Get("error"); errMsg != "" {

--- a/internal/auth/callback.go
+++ b/internal/auth/callback.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 )
 
@@ -23,6 +24,116 @@ func (e *callbackError) Error() string { return e.err.Error() }
 
 func (e *callbackError) Unwrap() error { return e.err }
 
+// checkCallbackBasics runs the three checks that every flow shares: the state
+// must match, the provider must report no error, and an authorization code must
+// be present. It returns that code.
+func checkCallbackBasics(q url.Values, expectedState string) (string, *callbackError) {
+	if q.Get("state") != expectedState {
+		return "", &callbackError{err: ErrStateMismatch, page: "Invalid state parameter"}
+	}
+
+	if errMsg := q.Get("error"); errMsg != "" {
+		errMsg = StripControlChars(errMsg)
+		return "", &callbackError{err: fmt.Errorf("authentication denied: %s", errMsg), page: errMsg}
+	}
+
+	code := q.Get("code")
+	if code == "" {
+		return "", &callbackError{err: errors.New("no authorization code received"), page: "No authorization code received"}
+	}
+
+	return code, nil
+}
+
+// paramHandler runs the semantic checks and the token exchange for one flow.
+// The two shared helpers below take it, so the plugin flow and the grafana.com
+// flow keep one implementation of the paste behaviour.
+type paramHandler[T any] func(url.Values) (*T, *callbackError)
+
+// runManualPaste completes a flow without a callback server. The browser cannot
+// reach the callback address, so the user copies the redirect URL out of the
+// address bar and pastes it here.
+//
+// Pass an empty verification string for a flow that shows no verification code.
+func runManualPaste[T any](
+	ctx context.Context,
+	w io.Writer,
+	r io.Reader,
+	authURL, verification string,
+	handle paramHandler[T],
+) (*T, error) {
+	printManualInstructions(w, authURL, verification)
+
+	line, err := readLineContext(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// The pasted line is on screen from here on, so the notice belongs on every
+	// return below, not on the success return alone. A state mismatch is the
+	// case that leaves the most on screen.
+	defer fmt.Fprintln(w, manualCallbackHygieneNotice)
+
+	values, err := ParseCallbackInput(line)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read the redirect URL: %w", err)
+	}
+
+	result, cerr := handle(values)
+	if cerr != nil {
+		return nil, pasteRejection(cerr.err)
+	}
+	return result, nil
+}
+
+// awaitCallbackOrPaste waits for whichever route completes first: the callback
+// server, or a redirect URL that the user pastes. A pasted URL that fails the
+// semantic checks re-prompts, because the callback server still listens.
+func awaitCallbackOrPaste[T any](
+	ctx context.Context,
+	w io.Writer,
+	paste *pasteWatcher,
+	resultCh <-chan *T,
+	errCh <-chan error,
+	handle paramHandler[T],
+) (*T, error) {
+	// The notice covers every return once a URL is on screen, including the
+	// failure returns and the case where the callback wins after a paste.
+	pasteSeen := false
+	defer func() {
+		if pasteSeen {
+			fmt.Fprintln(w, manualCallbackHygieneNotice)
+		}
+	}()
+
+	for {
+		select {
+		case result := <-resultCh:
+			return result, nil
+		case err := <-errCh:
+			return nil, err
+		case pasted := <-paste.Input():
+			if pasted.Closed {
+				fmt.Fprintln(w, "\nThe paste route ended. gcx still waits for the browser.")
+				continue
+			}
+			pasteSeen = true
+			if pasted.Err != nil {
+				paste.Reject(pasted.Err)
+				continue
+			}
+			result, cerr := handle(pasted.Values)
+			if cerr != nil {
+				paste.Reject(pasteRejection(cerr.err))
+				continue
+			}
+			return result, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
 // handleCallbackParams validates the redirect query parameters, exchanges the
 // authorization code, and builds a Result.
 //
@@ -31,18 +142,9 @@ func (e *callbackError) Unwrap() error { return e.err }
 // ParseCallbackInput. Keeping one implementation stops the two paths from
 // diverging on the state check, the PKCE exchange, or endpoint validation.
 func handleCallbackParams(ctx context.Context, q url.Values, expectedState, codeVerifier string) (*Result, *callbackError) {
-	if q.Get("state") != expectedState {
-		return nil, &callbackError{err: ErrStateMismatch, page: "Invalid state parameter"}
-	}
-
-	if errMsg := q.Get("error"); errMsg != "" {
-		errMsg = StripControlChars(errMsg)
-		return nil, &callbackError{err: fmt.Errorf("authentication denied: %s", errMsg), page: errMsg}
-	}
-
-	code := q.Get("code")
-	if code == "" {
-		return nil, &callbackError{err: errors.New("no authorization code received"), page: "No authorization code received"}
+	code, cerr := checkCallbackBasics(q, expectedState)
+	if cerr != nil {
+		return nil, cerr
 	}
 
 	endpoint := q.Get("endpoint")
@@ -86,18 +188,9 @@ func handleCallbackParams(ctx context.Context, q url.Values, expectedState, code
 // handleCallbackParams. redirectURI must be byte-identical to the redirect_uri
 // sent on the authorize request, because GCOM rejects the exchange otherwise.
 func (f *GCOMFlow) handleGCOMCallbackParams(ctx context.Context, q url.Values, expectedState, codeVerifier, redirectURI string) (*GCOMResult, *callbackError) {
-	if q.Get("state") != expectedState {
-		return nil, &callbackError{err: ErrStateMismatch, page: "Invalid state parameter"}
-	}
-
-	if errMsg := q.Get("error"); errMsg != "" {
-		errMsg = StripControlChars(errMsg)
-		return nil, &callbackError{err: fmt.Errorf("authentication denied: %s", errMsg), page: errMsg}
-	}
-
-	code := q.Get("code")
-	if code == "" {
-		return nil, &callbackError{err: errors.New("no authorization code received"), page: "No authorization code received"}
+	code, cerr := checkCallbackBasics(q, expectedState)
+	if cerr != nil {
+		return nil, cerr
 	}
 
 	result, err := f.exchangeGCOMToken(ctx, code, codeVerifier, redirectURI)

--- a/internal/auth/callback.go
+++ b/internal/auth/callback.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"sync/atomic"
 )
 
 // errStateMismatch reports that the callback state does not match the state
@@ -19,6 +20,30 @@ var errStateMismatch = errors.New("invalid state - possible CSRF attack")
 type callbackError struct {
 	err  error
 	page string
+}
+
+// errExchangeClaimed reports that the other route already exchanged the
+// authorization code. No caller shows this error to the user: the route that
+// won the race delivers the result.
+var errExchangeClaimed = errors.New("another route already exchanged the authorization code")
+
+// exchangeGuard lets one route exchange the authorization code. The callback
+// server and the paste reader accept the same code, and the code is single-use,
+// so a second exchange always fails. Without the guard the loser reported that
+// failure to the user, one moment before the winner reported success.
+//
+// A nil guard always grants the claim. The manual paste flow runs no callback
+// server, so it has no race to guard.
+type exchangeGuard struct{ taken atomic.Bool }
+
+// claim reports whether the caller may run the token exchange. Call it after
+// the state check and the code check, never before: a pasted URL from an older
+// attempt must not consume the claim that the real callback needs.
+func (g *exchangeGuard) claim() bool {
+	if g == nil {
+		return true
+	}
+	return g.taken.CompareAndSwap(false, true)
 }
 
 // checkCallbackBasics runs the three checks that every flow shares: the state
@@ -121,6 +146,11 @@ func awaitCallbackOrPaste[T any](
 			}
 			result, cerr := handle(pasted.Values)
 			if cerr != nil {
+				if errors.Is(cerr.err, errExchangeClaimed) {
+					// The callback server won the race. Its result is already on
+					// its way, so say nothing and let the next round deliver it.
+					continue
+				}
 				paste.Reject(pasteRejection(cerr.err))
 				continue
 			}
@@ -138,7 +168,7 @@ func awaitCallbackOrPaste[T any](
 // manual paste fallback: q comes either from r.URL.Query() or from
 // ParseCallbackInput. Keeping one implementation stops the two paths from
 // diverging on the state check, the PKCE exchange, or endpoint validation.
-func handleCallbackParams(ctx context.Context, q url.Values, expectedState, codeVerifier string) (*Result, *callbackError) {
+func handleCallbackParams(ctx context.Context, q url.Values, expectedState, codeVerifier string, guard *exchangeGuard) (*Result, *callbackError) {
 	code, cerr := checkCallbackBasics(q, expectedState)
 	if cerr != nil {
 		return nil, cerr
@@ -150,6 +180,10 @@ func handleCallbackParams(ctx context.Context, q url.Values, expectedState, code
 	}
 	if err := ValidateEndpointURL(endpoint); err != nil {
 		return nil, &callbackError{err: fmt.Errorf("invalid API endpoint: %w", err), page: "Invalid API endpoint"}
+	}
+
+	if !guard.claim() {
+		return nil, &callbackError{err: errExchangeClaimed, page: "The login already completed in the terminal."}
 	}
 
 	exchangeResult, err := exchangeCodeForToken(ctx, endpoint, code, codeVerifier)
@@ -184,10 +218,14 @@ func handleCallbackParams(ctx context.Context, q url.Values, expectedState, code
 // handleGCOMCallbackParams is the grafana.com equivalent of
 // handleCallbackParams. redirectURI must be byte-identical to the redirect_uri
 // sent on the authorize request, because GCOM rejects the exchange otherwise.
-func (f *GCOMFlow) handleGCOMCallbackParams(ctx context.Context, q url.Values, expectedState, codeVerifier, redirectURI string) (*GCOMResult, *callbackError) {
+func (f *GCOMFlow) handleGCOMCallbackParams(ctx context.Context, q url.Values, expectedState, codeVerifier, redirectURI string, guard *exchangeGuard) (*GCOMResult, *callbackError) {
 	code, cerr := checkCallbackBasics(q, expectedState)
 	if cerr != nil {
 		return nil, cerr
+	}
+
+	if !guard.claim() {
+		return nil, &callbackError{err: errExchangeClaimed, page: "The login already completed in the terminal."}
 	}
 
 	result, err := f.exchangeGCOMToken(ctx, code, codeVerifier, redirectURI)

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"io"
+	"os"
 )
 
 // ExchangeCodeForToken exposes the unexported exchangeCodeForToken for black-box tests.
@@ -21,4 +22,28 @@ func ReadLine(r io.Reader) (string, error) {
 // PrintRemoteSessionHint exposes the unexported printRemoteSessionHint.
 func PrintRemoteSessionHint(w io.Writer, port int, command string) {
 	printRemoteSessionHint(w, port, command)
+}
+
+// PasteWatcher exposes the unexported watcher type for black-box tests.
+type PasteWatcher = pasteWatcher
+
+// StartPasteWatcher exposes the unexported startPasteWatcher. It returns nil
+// when the paste path does not apply.
+func StartPasteWatcher(w io.Writer, port int) *PasteWatcher {
+	return startPasteWatcher(w, port)
+}
+
+// SwapPasteTerminal replaces the terminal opener so tests can drive the watcher
+// with a pipe. A pipe is pollable, like /dev/tty, so it exercises the same
+// Close-unblocks-Read teardown. It returns a restore function.
+func SwapPasteTerminal(f *os.File, ok bool) func() {
+	previous := openPasteTerminal
+	openPasteTerminal = func() (*os.File, bool) { return f, ok }
+	return func() { openPasteTerminal = previous }
+}
+
+// OpenPasteTerminal exposes the real controlling-terminal opener so a test can
+// verify that a pending read on it is actually cancellable.
+func OpenPasteTerminal() (*os.File, bool) {
+	return openPasteTerminal()
 }

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -27,6 +27,9 @@ func PrintRemoteSessionHint(w io.Writer, port int, command string) {
 // PasteWatcher exposes the unexported watcher type for black-box tests.
 type PasteWatcher = pasteWatcher
 
+// PastedInput exposes one watcher delivery for black-box tests.
+type PastedInput = pastedInput
+
 // StartPasteWatcher exposes the unexported startPasteWatcher. It returns nil
 // when the paste path does not apply.
 func StartPasteWatcher(w io.Writer, port int) *PasteWatcher {

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -15,6 +15,9 @@ func ExchangeCodeForToken(ctx context.Context, endpoint, code, codeVerifier stri
 // ManualCallbackPort exposes the fixed manual-mode callback port.
 const ManualCallbackPort = manualCallbackPort
 
+// ManualPasteTries exposes the bound on the manual retry loop.
+const ManualPasteTries = manualPasteTries
+
 // ReadLine exposes the unexported readLine for black-box tests.
 func ReadLine(r io.Reader) (string, error) {
 	return readLine(r)

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -2,9 +2,23 @@ package auth
 
 import (
 	"context"
+	"io"
 )
 
 // ExchangeCodeForToken exposes the unexported exchangeCodeForToken for black-box tests.
 func ExchangeCodeForToken(ctx context.Context, endpoint, code, codeVerifier string) (any, error) {
 	return exchangeCodeForToken(ctx, endpoint, code, codeVerifier)
+}
+
+// ManualCallbackPort exposes the fixed manual-mode callback port.
+const ManualCallbackPort = manualCallbackPort
+
+// ReadLine exposes the unexported readLine for black-box tests.
+func ReadLine(r io.Reader) (string, error) {
+	return readLine(r)
+}
+
+// PrintRemoteSessionHint exposes the unexported printRemoteSessionHint.
+func PrintRemoteSessionHint(w io.Writer, port int, command string) {
+	printRemoteSessionHint(w, port, command)
 }

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"io"
+	"net/url"
 	"os"
 )
 
@@ -49,4 +50,33 @@ func SwapPasteTerminal(f *os.File, ok bool) func() {
 // verify that a pending read on it is actually cancellable.
 func OpenPasteTerminal() (*os.File, bool) {
 	return openPasteTerminal()
+}
+
+// FlushTerminalInput exposes the terminal input flush that Close runs.
+func FlushTerminalInput(f *os.File) error {
+	return flushTerminalInput(f)
+}
+
+// ExchangeGuard exposes the single-use guard for black-box tests.
+type ExchangeGuard = exchangeGuard
+
+// ClaimExchange exposes the claim on the guard. A nil guard always grants it.
+func ClaimExchange(g *ExchangeGuard) bool {
+	return g.claim()
+}
+
+// ErrExchangeClaimed exposes the sentinel that the losing route returns.
+var ErrExchangeClaimed = errExchangeClaimed
+
+// ErrStateMismatch exposes the CSRF sentinel for black-box tests.
+var ErrStateMismatch = errStateMismatch
+
+// HandleCallbackParams exposes the shared parameter handler so a test can prove
+// that a taken guard stops the second token exchange.
+func HandleCallbackParams(ctx context.Context, q url.Values, expectedState, codeVerifier string, guard *ExchangeGuard) error {
+	_, cerr := handleCallbackParams(ctx, q, expectedState, codeVerifier, guard)
+	if cerr == nil {
+		return nil
+	}
+	return cerr.err
 }

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -216,8 +216,12 @@ func (f *Flow) runWithCallbackServer(ctx context.Context) (*Result, error) {
 			return result, nil
 		case err := <-errCh:
 			return nil, err
-		case values := <-paste.Values():
-			result, cerr := handleCallbackParams(ctx, values, state, codeVerifier)
+		case pasted := <-paste.Input():
+			if pasted.Err != nil {
+				paste.Reject(pasted.Err)
+				continue
+			}
+			result, cerr := handleCallbackParams(ctx, pasted.Values, state, codeVerifier)
 			if cerr != nil {
 				paste.Reject(pasteRejection(cerr.err))
 				continue

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -140,25 +140,10 @@ func (f *Flow) runManual(ctx context.Context) (*Result, error) {
 	}
 
 	authURL := f.buildAuthURL(manualCallbackPort, state, codeChallenge)
-	printManualInstructions(f.writer, authURL, verificationCode(codeChallenge))
-
-	line, err := readLineContext(ctx, f.reader)
-	if err != nil {
-		return nil, err
-	}
-
-	values, err := ParseCallbackInput(line)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read the redirect URL: %w", err)
-	}
-
-	result, cerr := handleCallbackParams(ctx, values, state, codeVerifier)
-	if cerr != nil {
-		return nil, pasteRejection(cerr.err)
-	}
-
-	fmt.Fprintln(f.writer, manualCallbackHygieneNotice)
-	return result, nil
+	return runManualPaste(ctx, f.writer, f.reader, authURL, verificationCode(codeChallenge),
+		func(q url.Values) (*Result, *callbackError) {
+			return handleCallbackParams(ctx, q, state, codeVerifier)
+		})
 }
 
 func (f *Flow) runWithCallbackServer(ctx context.Context) (*Result, error) {
@@ -210,28 +195,10 @@ func (f *Flow) runWithCallbackServer(ctx context.Context) (*Result, error) {
 		fmt.Fprintln(f.writer, "Waiting for authentication...")
 	}
 
-	for {
-		select {
-		case result := <-resultCh:
-			return result, nil
-		case err := <-errCh:
-			return nil, err
-		case pasted := <-paste.Input():
-			if pasted.Err != nil {
-				paste.Reject(pasted.Err)
-				continue
-			}
-			result, cerr := handleCallbackParams(ctx, pasted.Values, state, codeVerifier)
-			if cerr != nil {
-				paste.Reject(pasteRejection(cerr.err))
-				continue
-			}
-			fmt.Fprintln(f.writer, manualCallbackHygieneNotice)
-			return result, nil
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
+	return awaitCallbackOrPaste(ctx, f.writer, paste, resultCh, errCh,
+		func(q url.Values) (*Result, *callbackError) {
+			return handleCallbackParams(ctx, q, state, codeVerifier)
+		})
 }
 
 // buildAuthURL renders the plugin consent URL for the given callback port.

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -154,10 +154,7 @@ func (f *Flow) runManual(ctx context.Context) (*Result, error) {
 
 	result, cerr := handleCallbackParams(ctx, values, state, codeVerifier)
 	if cerr != nil {
-		if errors.Is(cerr.err, ErrStateMismatch) {
-			return nil, errManualForeignState
-		}
-		return nil, cerr.err
+		return nil, pasteRejection(cerr.err)
 	}
 
 	fmt.Fprintln(f.writer, manualCallbackHygieneNotice)
@@ -204,17 +201,32 @@ func (f *Flow) runWithCallbackServer(ctx context.Context) (*Result, error) {
 		fmt.Fprintln(f.writer, "(Browser launch skipped in agent mode — open the URL above manually)")
 	}
 
-	printRemoteSessionHint(f.writer, port, "gcx login --oauth-manual")
+	// Over SSH the browser cannot reach the callback address. Accept a pasted
+	// redirect URL alongside the callback so the user never has to restart.
+	paste := startPasteWatcher(f.writer, port)
+	defer paste.Close()
+	if paste == nil {
+		printRemoteSessionHint(f.writer, port, "gcx login --oauth-manual")
+		fmt.Fprintln(f.writer, "Waiting for authentication...")
+	}
 
-	fmt.Fprintln(f.writer, "Waiting for authentication...")
-
-	select {
-	case result := <-resultCh:
-		return result, nil
-	case err := <-errCh:
-		return nil, err
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	for {
+		select {
+		case result := <-resultCh:
+			return result, nil
+		case err := <-errCh:
+			return nil, err
+		case values := <-paste.Values():
+			result, cerr := handleCallbackParams(ctx, values, state, codeVerifier)
+			if cerr != nil {
+				paste.Reject(pasteRejection(cerr.err))
+				continue
+			}
+			fmt.Fprintln(f.writer, manualCallbackHygieneNotice)
+			return result, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 }
 

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -140,9 +140,11 @@ func (f *Flow) runManual(ctx context.Context) (*Result, error) {
 	}
 
 	authURL := f.buildAuthURL(manualCallbackPort, state, codeChallenge)
+	// No callback server runs here, so no route can race the paste. A nil guard
+	// always grants the claim.
 	return runManualPaste(ctx, f.writer, f.reader, authURL, verificationCode(codeChallenge),
 		func(q url.Values) (*Result, *callbackError) {
-			return handleCallbackParams(ctx, q, state, codeVerifier)
+			return handleCallbackParams(ctx, q, state, codeVerifier, nil)
 		})
 }
 
@@ -163,7 +165,10 @@ func (f *Flow) runWithCallbackServer(ctx context.Context) (*Result, error) {
 
 	resultCh := make(chan *Result, 1)
 	errCh := make(chan error, 1)
-	server := f.startCallbackServer(ctx, listener, state, codeVerifier, resultCh, errCh)
+	// The callback server and the paste reader accept the same single-use code,
+	// so one guard decides which route exchanges it.
+	guard := &exchangeGuard{}
+	server := f.startCallbackServer(ctx, listener, state, codeVerifier, guard, resultCh, errCh)
 
 	defer func() { //nolint:contextcheck // intentionally use Background for graceful shutdown after ctx cancellation
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -197,7 +202,7 @@ func (f *Flow) runWithCallbackServer(ctx context.Context) (*Result, error) {
 
 	return awaitCallbackOrPaste(ctx, f.writer, paste, resultCh, errCh,
 		func(q url.Values) (*Result, *callbackError) {
-			return handleCallbackParams(ctx, q, state, codeVerifier)
+			return handleCallbackParams(ctx, q, state, codeVerifier, guard)
 		})
 }
 
@@ -238,10 +243,16 @@ func newFlowSecrets() (string, string, string, error) {
 	return state, codeVerifier, generateCodeChallenge(codeVerifier), nil
 }
 
-func (f *Flow) startCallbackServer(ctx context.Context, listener net.Listener, expectedState, codeVerifier string, resultCh chan<- *Result, errCh chan<- error) *http.Server {
+func (f *Flow) startCallbackServer(ctx context.Context, listener net.Listener, expectedState, codeVerifier string, guard *exchangeGuard, resultCh chan<- *Result, errCh chan<- error) *http.Server {
 	return newCallbackServer(listener, errCh, func(w http.ResponseWriter, r *http.Request) {
-		result, cerr := handleCallbackParams(ctx, r.URL.Query(), expectedState, codeVerifier)
+		result, cerr := handleCallbackParams(ctx, r.URL.Query(), expectedState, codeVerifier, guard)
 		if cerr != nil {
+			if errors.Is(cerr.err, errExchangeClaimed) {
+				// The paste route won the race, and the login is complete. Do
+				// not send to errCh: that would end a flow that succeeded.
+				renderSuccessPage(w)
+				return
+			}
 			errCh <- cerr.err
 			renderErrorPage(w, cerr.page)
 			return

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -80,6 +80,16 @@ type Options struct {
 	// Writer is the output writer for user-facing messages.
 	// Defaults to os.Stderr.
 	Writer io.Writer
+
+	// Manual completes the flow without a callback server. gcx prints the
+	// login URL and reads the redirect URL that the user copies from the
+	// browser address bar. Use it when the browser runs on another computer,
+	// for example when gcx runs over SSH.
+	Manual bool
+
+	// Reader supplies the pasted redirect URL in manual mode.
+	// Defaults to os.Stdin.
+	Reader io.Reader
 }
 
 // Flow manages the browser-based authentication process.
@@ -87,6 +97,7 @@ type Flow struct {
 	endpoint string
 	opts     Options
 	writer   io.Writer
+	reader   io.Reader
 }
 
 // NewFlow creates a new authentication flow for the given Grafana endpoint.
@@ -101,11 +112,59 @@ func NewFlow(endpoint string, opts Options) *Flow {
 	if w == nil {
 		w = os.Stderr
 	}
-	return &Flow{endpoint: endpoint, opts: opts, writer: w}
+	r := opts.Reader
+	if r == nil {
+		r = os.Stdin
+	}
+	return &Flow{endpoint: endpoint, opts: opts, writer: w, reader: r}
 }
 
 // Run executes the authentication flow.
 func (f *Flow) Run(ctx context.Context) (*Result, error) {
+	if f.opts.Manual {
+		if f.opts.Port != 0 {
+			return nil, errors.New("manual OAuth does not use a callback port")
+		}
+		return f.runManual(ctx)
+	}
+	return f.runWithCallbackServer(ctx)
+}
+
+// runManual completes the flow without a callback server. The browser cannot
+// reach the callback address, so the user copies the redirect URL out of the
+// address bar and pastes it here.
+func (f *Flow) runManual(ctx context.Context) (*Result, error) {
+	state, codeVerifier, codeChallenge, err := newFlowSecrets()
+	if err != nil {
+		return nil, err
+	}
+
+	authURL := f.buildAuthURL(manualCallbackPort, state, codeChallenge)
+	printManualInstructions(f.writer, authURL, verificationCode(codeChallenge))
+
+	line, err := readLineContext(ctx, f.reader)
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := ParseCallbackInput(line)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read the redirect URL: %w", err)
+	}
+
+	result, cerr := handleCallbackParams(ctx, values, state, codeVerifier)
+	if cerr != nil {
+		if errors.Is(cerr.err, ErrStateMismatch) {
+			return nil, errManualForeignState
+		}
+		return nil, cerr.err
+	}
+
+	fmt.Fprintln(f.writer, manualCallbackHygieneNotice)
+	return result, nil
+}
+
+func (f *Flow) runWithCallbackServer(ctx context.Context) (*Result, error) {
 	listener, port, err := listenOnCallbackPort(ctx, f.opts.BindAddress, f.opts.Port)
 	if err != nil {
 		if f.opts.Port == 0 {
@@ -114,18 +173,11 @@ func (f *Flow) Run(ctx context.Context) (*Result, error) {
 		return nil, err
 	}
 
-	state, err := generateState()
+	state, codeVerifier, codeChallenge, err := newFlowSecrets()
 	if err != nil {
 		_ = listener.Close()
-		return nil, fmt.Errorf("failed to generate state: %w", err)
+		return nil, err
 	}
-
-	codeVerifier, err := generateCodeVerifier()
-	if err != nil {
-		_ = listener.Close()
-		return nil, fmt.Errorf("failed to generate PKCE code verifier: %w", err)
-	}
-	codeChallenge := generateCodeChallenge(codeVerifier)
 
 	resultCh := make(chan *Result, 1)
 	errCh := make(chan error, 1)
@@ -137,6 +189,37 @@ func (f *Flow) Run(ctx context.Context) (*Result, error) {
 		_ = server.Shutdown(shutdownCtx)
 	}()
 
+	authURL := f.buildAuthURL(port, state, codeChallenge)
+
+	fmt.Fprintln(f.writer, "Opening browser to authenticate...")
+	fmt.Fprintf(f.writer, "If browser doesn't open, visit:\n  %s\n\n", authURL)
+
+	fmt.Fprintf(f.writer, "Verification code: %s\n", verificationCode(codeChallenge))
+	fmt.Fprintln(f.writer, "Check that this code matches what is shown in the browser before approving.")
+	fmt.Fprintln(f.writer)
+
+	if opened, err := deeplink.OpenWithStatus(authURL); err != nil {
+		fmt.Fprintln(f.writer, "(Could not open browser automatically)")
+	} else if !opened {
+		fmt.Fprintln(f.writer, "(Browser launch skipped in agent mode — open the URL above manually)")
+	}
+
+	printRemoteSessionHint(f.writer, port, "gcx login --oauth-manual")
+
+	fmt.Fprintln(f.writer, "Waiting for authentication...")
+
+	select {
+	case result := <-resultCh:
+		return result, nil
+	case err := <-errCh:
+		return nil, err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// buildAuthURL renders the plugin consent URL for the given callback port.
+func (f *Flow) buildAuthURL(port int, state, codeChallenge string) string {
 	authEndpoint := strings.TrimSuffix(f.endpoint, "/")
 	if authEndpoint == "" {
 		authEndpoint = "https://grafana.com/launch"
@@ -153,95 +236,32 @@ func (f *Flow) Run(ctx context.Context) (*Result, error) {
 		authURL += "&scopes=" + url.QueryEscape(strings.Join(f.opts.Scopes, ","))
 	}
 
-	fmt.Fprintln(f.writer, "Opening browser to authenticate...")
-	fmt.Fprintf(f.writer, "If browser doesn't open, visit:\n  %s\n\n", authURL)
+	return authURL
+}
 
-	fmt.Fprintf(f.writer, "Verification code: %s\n", verificationCode(codeChallenge))
-	fmt.Fprintln(f.writer, "Check that this code matches what is shown in the browser before approving.")
-	fmt.Fprintln(f.writer)
-
-	if opened, err := deeplink.OpenWithStatus(authURL); err != nil {
-		fmt.Fprintln(f.writer, "(Could not open browser automatically)")
-	} else if !opened {
-		fmt.Fprintln(f.writer, "(Browser launch skipped in agent mode — open the URL above manually)")
+// newFlowSecrets generates the CSRF state and the PKCE verifier and challenge,
+// in that order.
+func newFlowSecrets() (string, string, string, error) {
+	state, err := generateState()
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to generate state: %w", err)
 	}
 
-	fmt.Fprintln(f.writer, "Waiting for authentication...")
-
-	select {
-	case result := <-resultCh:
-		return result, nil
-	case err := <-errCh:
-		return nil, err
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	codeVerifier, err := generateCodeVerifier()
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to generate PKCE code verifier: %w", err)
 	}
+
+	return state, codeVerifier, generateCodeChallenge(codeVerifier), nil
 }
 
 func (f *Flow) startCallbackServer(ctx context.Context, listener net.Listener, expectedState, codeVerifier string, resultCh chan<- *Result, errCh chan<- error) *http.Server {
 	return newCallbackServer(listener, errCh, func(w http.ResponseWriter, r *http.Request) {
-		state := r.URL.Query().Get("state")
-		if state != expectedState {
-			errCh <- errors.New("invalid state - possible CSRF attack")
-			renderErrorPage(w, "Invalid state parameter")
+		result, cerr := handleCallbackParams(ctx, r.URL.Query(), expectedState, codeVerifier)
+		if cerr != nil {
+			errCh <- cerr.err
+			renderErrorPage(w, cerr.page)
 			return
-		}
-
-		if errMsg := r.URL.Query().Get("error"); errMsg != "" {
-			errMsg = StripControlChars(errMsg)
-			errCh <- fmt.Errorf("authentication denied: %s", errMsg)
-			renderErrorPage(w, errMsg)
-			return
-		}
-
-		code := r.URL.Query().Get("code")
-		if code == "" {
-			errCh <- errors.New("no authorization code received")
-			renderErrorPage(w, "No authorization code received")
-			return
-		}
-
-		endpoint := r.URL.Query().Get("endpoint")
-		if endpoint == "" {
-			errCh <- errors.New("no API endpoint received")
-			renderErrorPage(w, "No API endpoint received")
-			return
-		}
-		if err := ValidateEndpointURL(endpoint); err != nil {
-			errCh <- fmt.Errorf("invalid API endpoint: %w", err)
-			renderErrorPage(w, "Invalid API endpoint")
-			return
-		}
-
-		exchangeResult, err := exchangeCodeForToken(ctx, endpoint, code, codeVerifier)
-		if err != nil {
-			errCh <- fmt.Errorf("token exchange failed: %w", err)
-			renderErrorPage(w, "Token exchange failed")
-			return
-		}
-
-		instanceEndpoint := r.URL.Query().Get("instanceEndpoint")
-		instanceEndpointUrl, err := url.Parse(instanceEndpoint)
-		if err != nil {
-			errCh <- fmt.Errorf("invalid endpoint url: %w", err)
-			renderErrorPage(w, "Invalid instance endpoint passed")
-			return
-		}
-		if instanceEndpointUrl.Scheme != "https" {
-			errCh <- fmt.Errorf("invalid endpoint scheme: expected 'https', got '%s'", instanceEndpointUrl.Scheme)
-			renderErrorPage(w, "Invalid instance endpoint: needs to be an HTTPS URL")
-			return
-		}
-
-		result := &Result{
-			Token:            exchangeResult.Data.Token,
-			Email:            exchangeResult.Data.Email,
-			DeviceName:       r.URL.Query().Get("device"),
-			APIEndpoint:      exchangeResult.Data.APIEndpoint,
-			ExpiresAt:        exchangeResult.Data.ExpiresAt,
-			RefreshToken:     exchangeResult.Data.RefreshToken,
-			RefreshExpiresAt: exchangeResult.Data.RefreshExpiresAt,
-			InstanceEndpoint: instanceEndpoint,
 		}
 
 		resultCh <- result

--- a/internal/auth/flush_bsd.go
+++ b/internal/auth/flush_bsd.go
@@ -1,0 +1,36 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
+
+package auth
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// flushRead is the FREAD flag from <sys/file.h>. TIOCFLUSH takes it to mean
+// "discard the input queue". x/sys/unix does not export the constant.
+const flushRead = 0x1
+
+// flushTerminalInput discards the bytes that the terminal driver still holds
+// for this file. A terminal in canonical mode delivers a line only after a
+// newline, so text that the user typed without one is unreachable by a read.
+// TIOCFLUSH with FREAD removes it. It is the BSD equivalent of TCIFLUSH.
+//
+// It uses SyscallConn, never File.Fd. Fd puts the descriptor back into blocking
+// mode, which breaks the cancellable read that Close depends on. Control hands
+// out the same descriptor and leaves the poller registration alone.
+func flushTerminalInput(f *os.File) error {
+	conn, err := f.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	var ioctlErr error
+	if err := conn.Control(func(fd uintptr) {
+		ioctlErr = unix.IoctlSetPointerInt(int(fd), unix.TIOCFLUSH, flushRead)
+	}); err != nil {
+		return err
+	}
+	return ioctlErr
+}

--- a/internal/auth/flush_linux.go
+++ b/internal/auth/flush_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package auth
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// flushTerminalInput discards the bytes that the terminal driver still holds
+// for this file. A terminal in canonical mode delivers a line only after a
+// newline, so text that the user typed without one is unreachable by a read.
+// TCIFLUSH removes it.
+//
+// It uses SyscallConn, never File.Fd. Fd puts the descriptor back into blocking
+// mode, which breaks the cancellable read that Close depends on. Control hands
+// out the same descriptor and leaves the poller registration alone.
+func flushTerminalInput(f *os.File) error {
+	conn, err := f.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	var ioctlErr error
+	if err := conn.Control(func(fd uintptr) {
+		ioctlErr = unix.IoctlSetInt(int(fd), unix.TCFLSH, unix.TCIFLUSH)
+	}); err != nil {
+		return err
+	}
+	return ioctlErr
+}

--- a/internal/auth/flush_other.go
+++ b/internal/auth/flush_other.go
@@ -1,0 +1,10 @@
+//go:build !linux && !darwin && !dragonfly && !freebsd && !netbsd && !openbsd
+
+package auth
+
+import "os"
+
+// flushTerminalInput does nothing on a platform without a POSIX terminal
+// driver. The paste watcher never starts there, because openPasteTerminal
+// cannot open /dev/tty.
+func flushTerminalInput(_ *os.File) error { return nil }

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -200,8 +200,12 @@ func (f *GCOMFlow) runWithCallbackServer(ctx context.Context) (*GCOMResult, erro
 			return result, nil
 		case err := <-errCh:
 			return nil, err
-		case values := <-paste.Values():
-			result, cerr := f.handleGCOMCallbackParams(ctx, values, state, codeVerifier, redirectURI)
+		case pasted := <-paste.Input():
+			if pasted.Err != nil {
+				paste.Reject(pasted.Err)
+				continue
+			}
+			result, cerr := f.handleGCOMCallbackParams(ctx, pasted.Values, state, codeVerifier, redirectURI)
 			if cerr != nil {
 				paste.Reject(pasteRejection(cerr.err))
 				continue

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -125,25 +125,10 @@ func (f *GCOMFlow) runManual(ctx context.Context) (*GCOMResult, error) {
 	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", manualCallbackPort)
 
 	authURL := f.buildAuthURL(redirectURI, state, codeChallenge)
-	printManualInstructions(f.writer, authURL, "")
-
-	line, err := readLineContext(ctx, f.reader)
-	if err != nil {
-		return nil, err
-	}
-
-	values, err := ParseCallbackInput(line)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read the redirect URL: %w", err)
-	}
-
-	result, cerr := f.handleGCOMCallbackParams(ctx, values, state, codeVerifier, redirectURI)
-	if cerr != nil {
-		return nil, pasteRejection(cerr.err)
-	}
-
-	fmt.Fprintln(f.writer, manualCallbackHygieneNotice)
-	return result, nil
+	return runManualPaste(ctx, f.writer, f.reader, authURL, "",
+		func(q url.Values) (*GCOMResult, *callbackError) {
+			return f.handleGCOMCallbackParams(ctx, q, state, codeVerifier, redirectURI)
+		})
 }
 
 func (f *GCOMFlow) runWithCallbackServer(ctx context.Context) (*GCOMResult, error) {
@@ -194,28 +179,10 @@ func (f *GCOMFlow) runWithCallbackServer(ctx context.Context) (*GCOMResult, erro
 		fmt.Fprintln(f.writer, "Waiting for authentication...")
 	}
 
-	for {
-		select {
-		case result := <-resultCh:
-			return result, nil
-		case err := <-errCh:
-			return nil, err
-		case pasted := <-paste.Input():
-			if pasted.Err != nil {
-				paste.Reject(pasted.Err)
-				continue
-			}
-			result, cerr := f.handleGCOMCallbackParams(ctx, pasted.Values, state, codeVerifier, redirectURI)
-			if cerr != nil {
-				paste.Reject(pasteRejection(cerr.err))
-				continue
-			}
-			fmt.Fprintln(f.writer, manualCallbackHygieneNotice)
-			return result, nil
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
+	return awaitCallbackOrPaste(ctx, f.writer, paste, resultCh, errCh,
+		func(q url.Values) (*GCOMResult, *callbackError) {
+			return f.handleGCOMCallbackParams(ctx, q, state, codeVerifier, redirectURI)
+		})
 }
 
 // buildAuthURL renders the GCOM authorize URL. redirectURI must be the exact

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -64,12 +64,23 @@ type GCOMOptions struct {
 
 	// Writer for user-facing messages. Defaults to os.Stderr.
 	Writer io.Writer
+
+	// Manual completes the flow without a callback server. gcx prints the
+	// login URL and reads the redirect URL that the user copies from the
+	// browser address bar. Use it when the browser runs on another computer,
+	// for example when gcx runs over SSH.
+	Manual bool
+
+	// Reader supplies the pasted redirect URL in manual mode.
+	// Defaults to os.Stdin.
+	Reader io.Reader
 }
 
 // GCOMFlow manages a direct GCOM OAuth2 PKCE authentication flow.
 type GCOMFlow struct {
 	opts   GCOMOptions
 	writer io.Writer
+	reader io.Reader
 }
 
 // NewGCOMFlow creates a new GCOM OAuth2 PKCE flow.
@@ -81,7 +92,11 @@ func NewGCOMFlow(opts GCOMOptions) *GCOMFlow {
 	if w == nil {
 		w = os.Stderr
 	}
-	return &GCOMFlow{opts: opts, writer: w}
+	r := opts.Reader
+	if r == nil {
+		r = os.Stdin
+	}
+	return &GCOMFlow{opts: opts, writer: w, reader: r}
 }
 
 // Run executes the GCOM OAuth2 PKCE flow.
@@ -90,23 +105,61 @@ func (f *GCOMFlow) Run(ctx context.Context) (*GCOMResult, error) {
 		return nil, fmt.Errorf("invalid GCOM URL: %w", err)
 	}
 
+	if f.opts.Manual {
+		return f.runManual(ctx)
+	}
+	return f.runWithCallbackServer(ctx)
+}
+
+// runManual completes the flow without a callback server. The browser cannot
+// reach the callback address, so the user copies the redirect URL out of the
+// address bar and pastes it here.
+func (f *GCOMFlow) runManual(ctx context.Context) (*GCOMResult, error) {
+	state, codeVerifier, codeChallenge, err := newFlowSecrets()
+	if err != nil {
+		return nil, err
+	}
+
+	// The token exchange must send this exact string, so build it once and
+	// share it between the authorize URL and the exchange.
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", manualCallbackPort)
+
+	authURL := f.buildAuthURL(redirectURI, state, codeChallenge)
+	printManualInstructions(f.writer, authURL, "")
+
+	line, err := readLineContext(ctx, f.reader)
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := ParseCallbackInput(line)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read the redirect URL: %w", err)
+	}
+
+	result, cerr := f.handleGCOMCallbackParams(ctx, values, state, codeVerifier, redirectURI)
+	if cerr != nil {
+		if errors.Is(cerr.err, ErrStateMismatch) {
+			return nil, errManualForeignState
+		}
+		return nil, cerr.err
+	}
+
+	fmt.Fprintln(f.writer, manualCallbackHygieneNotice)
+	return result, nil
+}
+
+func (f *GCOMFlow) runWithCallbackServer(ctx context.Context) (*GCOMResult, error) {
 	listener, port, err := listenOnCallbackPort(ctx, "127.0.0.1", 0)
 	if err != nil {
 		return nil, fmt.Errorf("no available port: %w", err)
 	}
 
-	state, err := generateState()
+	state, codeVerifier, codeChallenge, err := newFlowSecrets()
 	if err != nil {
 		_ = listener.Close()
-		return nil, fmt.Errorf("failed to generate state: %w", err)
+		return nil, err
 	}
-
-	codeVerifier, err := generateCodeVerifier()
-	if err != nil {
-		_ = listener.Close()
-		return nil, fmt.Errorf("failed to generate PKCE code verifier: %w", err)
-	}
-	codeChallenge := generateCodeChallenge(codeVerifier)
 
 	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
 
@@ -124,17 +177,7 @@ func (f *GCOMFlow) Run(ctx context.Context) (*GCOMResult, error) {
 		_ = server.Shutdown(shutdownCtx)
 	}()
 
-	gcomURL := strings.TrimSuffix(f.opts.GCOMURL, "/")
-	scope := strings.Join(f.opts.Scopes, " ")
-
-	authURL := fmt.Sprintf("%s/oauth2/authorize?client_id=%s&redirect_uri=%s&scope=%s&code_challenge=%s&code_challenge_method=S256&state=%s&response_type=code",
-		gcomURL,
-		url.QueryEscape(f.opts.ClientID),
-		url.QueryEscape(redirectURI),
-		url.QueryEscape(scope),
-		url.QueryEscape(codeChallenge),
-		url.QueryEscape(state),
-	)
+	authURL := f.buildAuthURL(redirectURI, state, codeChallenge)
 
 	fmt.Fprintln(f.writer, "Opening browser to authenticate with Grafana Cloud...")
 	fmt.Fprintf(f.writer, "If browser doesn't open, visit:\n  %s\n\n", authURL)
@@ -144,6 +187,8 @@ func (f *GCOMFlow) Run(ctx context.Context) (*GCOMResult, error) {
 	} else if !opened {
 		fmt.Fprintln(f.writer, "(Browser launch skipped in agent mode — open the URL above manually)")
 	}
+
+	printRemoteSessionHint(f.writer, port, "gcx cloud login --oauth-manual")
 
 	fmt.Fprintln(f.writer, "Waiting for authentication...")
 
@@ -157,32 +202,28 @@ func (f *GCOMFlow) Run(ctx context.Context) (*GCOMResult, error) {
 	}
 }
 
+// buildAuthURL renders the GCOM authorize URL. redirectURI must be the exact
+// string that the token exchange later sends.
+func (f *GCOMFlow) buildAuthURL(redirectURI, state, codeChallenge string) string {
+	gcomURL := strings.TrimSuffix(f.opts.GCOMURL, "/")
+	scope := strings.Join(f.opts.Scopes, " ")
+
+	return fmt.Sprintf("%s/oauth2/authorize?client_id=%s&redirect_uri=%s&scope=%s&code_challenge=%s&code_challenge_method=S256&state=%s&response_type=code",
+		gcomURL,
+		url.QueryEscape(f.opts.ClientID),
+		url.QueryEscape(redirectURI),
+		url.QueryEscape(scope),
+		url.QueryEscape(codeChallenge),
+		url.QueryEscape(state),
+	)
+}
+
 func (f *GCOMFlow) startGCOMCallbackServer(ctx context.Context, listener net.Listener, expectedState, codeVerifier, redirectURI string, resultCh chan<- *GCOMResult, errCh chan<- error) *http.Server {
 	return newCallbackServer(listener, errCh, func(w http.ResponseWriter, r *http.Request) {
-		state := r.URL.Query().Get("state")
-		if state != expectedState {
-			errCh <- errors.New("invalid state - possible CSRF attack")
-			renderErrorPage(w, "Invalid state parameter")
-			return
-		}
-
-		if errMsg := r.URL.Query().Get("error"); errMsg != "" {
-			errCh <- fmt.Errorf("authentication denied: %s", StripControlChars(errMsg))
-			renderErrorPage(w, StripControlChars(errMsg))
-			return
-		}
-
-		code := r.URL.Query().Get("code")
-		if code == "" {
-			errCh <- errors.New("no authorization code received")
-			renderErrorPage(w, "No authorization code received")
-			return
-		}
-
-		result, err := f.exchangeGCOMToken(ctx, code, codeVerifier, redirectURI)
-		if err != nil {
-			errCh <- fmt.Errorf("token exchange failed: %w", err)
-			renderErrorPage(w, "Token exchange failed")
+		result, cerr := f.handleGCOMCallbackParams(ctx, r.URL.Query(), expectedState, codeVerifier, redirectURI)
+		if cerr != nil {
+			errCh <- cerr.err
+			renderErrorPage(w, cerr.page)
 			return
 		}
 

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -125,9 +125,11 @@ func (f *GCOMFlow) runManual(ctx context.Context) (*GCOMResult, error) {
 	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", manualCallbackPort)
 
 	authURL := f.buildAuthURL(redirectURI, state, codeChallenge)
+	// No callback server runs here, so no route can race the paste. A nil guard
+	// always grants the claim.
 	return runManualPaste(ctx, f.writer, f.reader, authURL, "",
 		func(q url.Values) (*GCOMResult, *callbackError) {
-			return f.handleGCOMCallbackParams(ctx, q, state, codeVerifier, redirectURI)
+			return f.handleGCOMCallbackParams(ctx, q, state, codeVerifier, redirectURI, nil)
 		})
 }
 
@@ -147,7 +149,10 @@ func (f *GCOMFlow) runWithCallbackServer(ctx context.Context) (*GCOMResult, erro
 
 	resultCh := make(chan *GCOMResult, 1)
 	errCh := make(chan error, 1)
-	server := f.startGCOMCallbackServer(ctx, listener, state, codeVerifier, redirectURI, resultCh, errCh)
+	// The callback server and the paste reader accept the same single-use code,
+	// so one guard decides which route exchanges it.
+	guard := &exchangeGuard{}
+	server := f.startGCOMCallbackServer(ctx, listener, state, codeVerifier, redirectURI, guard, resultCh, errCh)
 
 	// A fresh context is intentional: the request context may already be
 	// cancelled by the time we shut down, and graceful shutdown needs its own
@@ -181,7 +186,7 @@ func (f *GCOMFlow) runWithCallbackServer(ctx context.Context) (*GCOMResult, erro
 
 	return awaitCallbackOrPaste(ctx, f.writer, paste, resultCh, errCh,
 		func(q url.Values) (*GCOMResult, *callbackError) {
-			return f.handleGCOMCallbackParams(ctx, q, state, codeVerifier, redirectURI)
+			return f.handleGCOMCallbackParams(ctx, q, state, codeVerifier, redirectURI, guard)
 		})
 }
 
@@ -201,10 +206,16 @@ func (f *GCOMFlow) buildAuthURL(redirectURI, state, codeChallenge string) string
 	)
 }
 
-func (f *GCOMFlow) startGCOMCallbackServer(ctx context.Context, listener net.Listener, expectedState, codeVerifier, redirectURI string, resultCh chan<- *GCOMResult, errCh chan<- error) *http.Server {
+func (f *GCOMFlow) startGCOMCallbackServer(ctx context.Context, listener net.Listener, expectedState, codeVerifier, redirectURI string, guard *exchangeGuard, resultCh chan<- *GCOMResult, errCh chan<- error) *http.Server {
 	return newCallbackServer(listener, errCh, func(w http.ResponseWriter, r *http.Request) {
-		result, cerr := f.handleGCOMCallbackParams(ctx, r.URL.Query(), expectedState, codeVerifier, redirectURI)
+		result, cerr := f.handleGCOMCallbackParams(ctx, r.URL.Query(), expectedState, codeVerifier, redirectURI, guard)
 		if cerr != nil {
+			if errors.Is(cerr.err, errExchangeClaimed) {
+				// The paste route won the race, and the login is complete. Do
+				// not send to errCh: that would end a flow that succeeded.
+				renderSuccessPage(w)
+				return
+			}
 			errCh <- cerr.err
 			renderErrorPage(w, cerr.page)
 			return

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -139,10 +139,7 @@ func (f *GCOMFlow) runManual(ctx context.Context) (*GCOMResult, error) {
 
 	result, cerr := f.handleGCOMCallbackParams(ctx, values, state, codeVerifier, redirectURI)
 	if cerr != nil {
-		if errors.Is(cerr.err, ErrStateMismatch) {
-			return nil, errManualForeignState
-		}
-		return nil, cerr.err
+		return nil, pasteRejection(cerr.err)
 	}
 
 	fmt.Fprintln(f.writer, manualCallbackHygieneNotice)
@@ -188,17 +185,32 @@ func (f *GCOMFlow) runWithCallbackServer(ctx context.Context) (*GCOMResult, erro
 		fmt.Fprintln(f.writer, "(Browser launch skipped in agent mode — open the URL above manually)")
 	}
 
-	printRemoteSessionHint(f.writer, port, "gcx cloud login --oauth-manual")
+	// Over SSH the browser cannot reach the callback address. Accept a pasted
+	// redirect URL alongside the callback so the user never has to restart.
+	paste := startPasteWatcher(f.writer, port)
+	defer paste.Close()
+	if paste == nil {
+		printRemoteSessionHint(f.writer, port, "gcx cloud login --oauth-manual")
+		fmt.Fprintln(f.writer, "Waiting for authentication...")
+	}
 
-	fmt.Fprintln(f.writer, "Waiting for authentication...")
-
-	select {
-	case result := <-resultCh:
-		return result, nil
-	case err := <-errCh:
-		return nil, err
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	for {
+		select {
+		case result := <-resultCh:
+			return result, nil
+		case err := <-errCh:
+			return nil, err
+		case values := <-paste.Values():
+			result, cerr := f.handleGCOMCallbackParams(ctx, values, state, codeVerifier, redirectURI)
+			if cerr != nil {
+				paste.Reject(pasteRejection(cerr.err))
+				continue
+			}
+			fmt.Fprintln(f.writer, manualCallbackHygieneNotice)
+			return result, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 }
 

--- a/internal/auth/manual.go
+++ b/internal/auth/manual.go
@@ -205,14 +205,11 @@ const manualCallbackHygieneNotice = "The URL that you pasted holds a single-use 
 // for another redirect URL. A state mismatch on a paste nearly always means the
 // URL came from a different login attempt, so say that instead of naming CSRF.
 func pasteRejection(err error) error {
-	if errors.Is(err, ErrStateMismatch) {
+	if errors.Is(err, errStateMismatch) {
 		return errManualForeignState
 	}
 	return err
 }
 
-// errManualForeignState replaces the generic CSRF message on the paste path,
-// where a state mismatch nearly always means the user pasted a URL from a
-// different login attempt.
 var errManualForeignState = errors.New(
 	"the pasted URL belongs to a different login attempt: run the command again and paste the URL from this attempt")

--- a/internal/auth/manual.go
+++ b/internal/auth/manual.go
@@ -1,0 +1,196 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/grafana/gcx/internal/terminal"
+)
+
+// manualCallbackPort is the port gcx puts in the callback URL when it runs
+// without a listener. The browser cannot connect to that port, and that
+// failure is the point: the full redirect URL stays in the address bar for the
+// user to copy. 54321 is the first port of the normal auto-pick range, so both
+// the Grafana plugin (which requires 1024-65535) and grafana.com already
+// accept it.
+const manualCallbackPort = 54321
+
+// maxPastedURLBytes bounds one pasted line.
+const maxPastedURLBytes = 8192
+
+// ParseCallbackInput extracts the query parameters from a line that the user
+// copied out of the browser address bar.
+//
+// The check is deliberately syntactic only. Every semantic check (state, code,
+// endpoint) stays in handleCallbackParams, so the paste path and the HTTP
+// callback path cannot diverge.
+//
+// An error never quotes the input, because the input holds a single-use
+// authorization code.
+func ParseCallbackInput(line string) (url.Values, error) {
+	raw := strings.TrimSpace(line)
+	raw = trimMatchingQuotes(raw)
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errors.New("no URL supplied")
+	}
+
+	parsed, err := url.Parse(raw)
+	// Some browsers hide the scheme. A pasted "127.0.0.1:54321/callback?..."
+	// parses as scheme "127.0.0.1", so try again with an explicit scheme.
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		if retry, retryErr := url.Parse("http://" + raw); retryErr == nil && retry.Host != "" {
+			parsed, err = retry, nil
+		}
+	}
+	if err != nil {
+		return nil, errors.New("the input is not a URL")
+	}
+	if parsed.Host == "" {
+		return nil, errors.New("the input is not a full URL: copy the whole address")
+	}
+	if parsed.RawQuery == "" {
+		return nil, errors.New("the URL has no query parameters: copy the address after the browser was redirected")
+	}
+
+	values, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return nil, errors.New("the URL query is malformed")
+	}
+	return values, nil
+}
+
+// trimMatchingQuotes removes one layer of matching single or double quotes.
+func trimMatchingQuotes(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	first, last := s[0], s[len(s)-1]
+	if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// readLine reads bytes until the first newline. It reads one byte at a time on
+// purpose: a buffered reader would consume data after the newline, and the
+// Cloud follow-up prompt reads the same stream directly after this call.
+func readLine(r io.Reader) (string, error) {
+	var b strings.Builder
+	buf := make([]byte, 1)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			if buf[0] == '\n' {
+				return b.String(), nil
+			}
+			if b.Len() >= maxPastedURLBytes {
+				return "", errors.New("the pasted URL is too long")
+			}
+			b.WriteByte(buf[0])
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				if b.Len() == 0 {
+					return "", errors.New("no input received")
+				}
+				return b.String(), nil
+			}
+			return "", fmt.Errorf("failed to read the redirect URL: %w", err)
+		}
+	}
+}
+
+// readLineContext runs readLine in a goroutine so a cancelled context ends the
+// wait. A terminal read is not interruptible in Go, so the read goroutine
+// stays blocked until the process exits. The channel is buffered, so that
+// goroutine can never block on the send.
+func readLineContext(ctx context.Context, r io.Reader) (string, error) {
+	type lineResult struct {
+		line string
+		err  error
+	}
+	ch := make(chan lineResult, 1)
+
+	go func() {
+		line, err := readLine(r)
+		ch <- lineResult{line: line, err: err}
+	}()
+
+	select {
+	case res := <-ch:
+		return res.line, res.err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// printRemoteSessionHint explains how to finish the flow when gcx runs on a
+// remote host. It prints nothing for a local session. command is the exact
+// invocation to repeat, for example "gcx login --oauth-manual".
+func printRemoteSessionHint(w io.Writer, port int, command string) {
+	if !terminal.IsRemoteSession() {
+		return
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Note: gcx runs in an SSH session.")
+	fmt.Fprintln(w, "The browser on your computer cannot open the callback address on this host.")
+	fmt.Fprintln(w, "Do one of these two steps:")
+	fmt.Fprintf(w, "  1. Forward the port. On your computer, run:\n")
+	fmt.Fprintf(w, "       ssh -L %d:127.0.0.1:%d REMOTE_HOST\n", port, port)
+	fmt.Fprintf(w, "  2. Stop this command. Run it again with %s.\n", command)
+	fmt.Fprintln(w, "     gcx then prints the login URL. You copy the redirect URL from the")
+	fmt.Fprintln(w, "     browser and paste it in the terminal.")
+	fmt.Fprintln(w)
+}
+
+// printManualInstructions prints the numbered steps of the manual paste flow.
+// verification is the code that the consent page shows. Pass an empty string
+// for a flow that does not show one.
+func printManualInstructions(w io.Writer, authURL, verification string) {
+	steps := [][]string{
+		{
+			"Open this URL in a browser on your computer:",
+			"  " + authURL,
+		},
+	}
+	if verification != "" {
+		steps = append(steps, []string{
+			"Verification code: " + verification,
+			"Make sure that the browser shows the same code. Then approve.",
+		})
+	}
+	steps = append(steps,
+		[]string{"The browser goes to an address that does not load. This is correct."},
+		[]string{
+			"Copy the full address from the browser address bar.",
+			"Do these steps quickly. The code expires.",
+		},
+	)
+
+	fmt.Fprintln(w, "Manual OAuth mode. gcx does not start a callback server.")
+	fmt.Fprintln(w)
+	for i, lines := range steps {
+		fmt.Fprintf(w, "%d. %s\n", i+1, lines[0])
+		for _, line := range lines[1:] {
+			fmt.Fprintf(w, "   %s\n", line)
+		}
+		fmt.Fprintln(w)
+	}
+	fmt.Fprint(w, "Redirect URL: ")
+}
+
+// manualCallbackHygieneNotice tells the user to clear the terminal. The pasted
+// URL holds a single-use code.
+const manualCallbackHygieneNotice = "The URL that you pasted holds a single-use code. Clear the terminal if other people can read it."
+
+// errManualForeignState replaces the generic CSRF message on the paste path,
+// where a state mismatch nearly always means the user pasted a URL from a
+// different login attempt.
+var errManualForeignState = errors.New(
+	"the pasted URL belongs to a different login attempt: run the command again and paste the URL from this attempt")

--- a/internal/auth/manual.go
+++ b/internal/auth/manual.go
@@ -189,6 +189,16 @@ func printManualInstructions(w io.Writer, authURL, verification string) {
 // URL holds a single-use code.
 const manualCallbackHygieneNotice = "The URL that you pasted holds a single-use code. Clear the terminal if other people can read it."
 
+// pasteRejection turns a callback error into the message shown before gcx asks
+// for another redirect URL. A state mismatch on a paste nearly always means the
+// URL came from a different login attempt, so say that instead of naming CSRF.
+func pasteRejection(err error) error {
+	if errors.Is(err, ErrStateMismatch) {
+		return errManualForeignState
+	}
+	return err
+}
+
 // errManualForeignState replaces the generic CSRF message on the paste path,
 // where a state mismatch nearly always means the user pasted a URL from a
 // different login attempt.

--- a/internal/auth/manual.go
+++ b/internal/auth/manual.go
@@ -129,19 +129,31 @@ func readLineContext(ctx context.Context, r io.Reader) (string, error) {
 	}
 }
 
-// printRemoteSessionHint explains how to finish the flow when gcx runs on a
-// remote host. It prints nothing for a local session. command is the exact
-// invocation to repeat, for example "gcx login --oauth-manual".
-func printRemoteSessionHint(w io.Writer, port int, command string) {
+// printRemoteSessionPreamble states why the browser cannot reach the callback
+// address. Every remote-session message opens with it. It prints nothing, and
+// reports false, for a local session.
+func printRemoteSessionPreamble(w io.Writer) bool {
 	if !terminal.IsRemoteSession() {
-		return
+		return false
 	}
 
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Note: gcx runs in an SSH session.")
 	fmt.Fprintln(w, "The browser on your computer cannot open the callback address on this host.")
+	return true
+}
+
+// printRemoteSessionHint explains how to finish the flow when gcx runs on a
+// remote host and has no terminal to read a pasted URL from. It prints nothing
+// for a local session. command is the exact invocation to repeat, for example
+// "gcx login --oauth-manual".
+func printRemoteSessionHint(w io.Writer, port int, command string) {
+	if !printRemoteSessionPreamble(w) {
+		return
+	}
+
 	fmt.Fprintln(w, "Do one of these two steps:")
-	fmt.Fprintf(w, "  1. Forward the port. On your computer, run:\n")
+	fmt.Fprintln(w, "  1. Forward the port. On your computer, run:")
 	fmt.Fprintf(w, "       ssh -L %d:127.0.0.1:%d REMOTE_HOST\n", port, port)
 	fmt.Fprintf(w, "  2. Stop this command. Run it again with %s.\n", command)
 	fmt.Fprintln(w, "     gcx then prints the login URL. You copy the redirect URL from the")
@@ -153,37 +165,37 @@ func printRemoteSessionHint(w io.Writer, port int, command string) {
 // verification is the code that the consent page shows. Pass an empty string
 // for a flow that does not show one.
 func printManualInstructions(w io.Writer, authURL, verification string) {
-	steps := [][]string{
-		{
-			"Open this URL in a browser on your computer:",
-			"  " + authURL,
-		},
-	}
-	if verification != "" {
-		steps = append(steps, []string{
-			"Verification code: " + verification,
-			"Make sure that the browser shows the same code. Then approve.",
-		})
-	}
-	steps = append(steps,
-		[]string{"The browser goes to an address that does not load. This is correct."},
-		[]string{
-			"Copy the full address from the browser address bar.",
-			"Do these steps quickly. The code expires.",
-		},
-	)
-
 	fmt.Fprintln(w, "Manual OAuth mode. gcx does not start a callback server.")
 	fmt.Fprintln(w)
-	for i, lines := range steps {
-		fmt.Fprintf(w, "%d. %s\n", i+1, lines[0])
-		for _, line := range lines[1:] {
-			fmt.Fprintf(w, "   %s\n", line)
-		}
+
+	step := 1
+	fmt.Fprintf(w, "%d. Open this URL in a browser on your computer:\n", step)
+	fmt.Fprintf(w, "     %s\n\n", authURL)
+
+	if verification != "" {
+		step++
+		fmt.Fprintf(w, "%d. Verification code: %s\n", step, verification)
+		fmt.Fprintln(w, "   Make sure that the browser shows the same code. Then approve.")
 		fmt.Fprintln(w)
 	}
-	fmt.Fprint(w, "Redirect URL: ")
+
+	step++
+	fmt.Fprintf(w, "%d. The browser goes to an address that does not load. This is correct.\n\n", step)
+
+	step++
+	fmt.Fprintf(w, "%d. Copy the full address from the browser address bar.\n", step)
+	fmt.Fprintln(w, "   Do these steps quickly. The code expires.")
+	fmt.Fprintln(w)
+	fmt.Fprint(w, manualRedirectPrompt)
 }
+
+// manualRedirectPrompt asks for the pasted URL when gcx runs no callback
+// server. pastePrompt is the variant for the race against a live callback.
+const manualRedirectPrompt = "Redirect URL: "
+
+// pastePrompt asks for the pasted URL while a callback server still listens, so
+// it names the second route too.
+const pastePrompt = "Redirect URL (or wait for the browser): "
 
 // manualCallbackHygieneNotice tells the user to clear the terminal. The pasted
 // URL holds a single-use code.

--- a/internal/auth/manual.go
+++ b/internal/auth/manual.go
@@ -109,6 +109,21 @@ func readLine(r io.Reader) (string, error) {
 // wait. A terminal read is not interruptible in Go, so the read goroutine
 // stays blocked until the process exits. The channel is buffered, so that
 // goroutine can never block on the send.
+//
+// A blocked reader on r is safe here, which is why this path may read os.Stdin
+// while the paste watcher goes to /dev/tty for the same job. Three facts make
+// the difference:
+//
+//   - r is injectable, and for --oauth-manual it is often a script pipe rather
+//     than a terminal.
+//   - readLine reads one byte at a time, so it cannot read past the newline. A
+//     later prompt on the same stream loses no input to it.
+//   - Manual mode runs no callback server, so no second route competes for the
+//     same stream.
+//
+// The watcher in paste.go has none of these three properties: it races a live
+// callback server, and the prompts that follow login read the same terminal.
+// See openPasteTerminal for that side.
 func readLineContext(ctx context.Context, r io.Reader) (string, error) {
 	type lineResult struct {
 		line string
@@ -130,17 +145,15 @@ func readLineContext(ctx context.Context, r io.Reader) (string, error) {
 }
 
 // printRemoteSessionPreamble states why the browser cannot reach the callback
-// address. Every remote-session message opens with it. It prints nothing, and
-// reports false, for a local session.
-func printRemoteSessionPreamble(w io.Writer) bool {
-	if !terminal.IsRemoteSession() {
-		return false
-	}
-
+// address. Every remote-session message opens with it.
+//
+// It only prints. Each caller decides for itself whether the session is remote:
+// printInstructions runs after startPasteWatcher checked it, and
+// printRemoteSessionHint checks it directly.
+func printRemoteSessionPreamble(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Note: gcx runs in an SSH session.")
 	fmt.Fprintln(w, "The browser on your computer cannot open the callback address on this host.")
-	return true
 }
 
 // printRemoteSessionHint explains how to finish the flow when gcx runs on a
@@ -148,9 +161,10 @@ func printRemoteSessionPreamble(w io.Writer) bool {
 // for a local session. command is the exact invocation to repeat, for example
 // "gcx login --oauth-manual".
 func printRemoteSessionHint(w io.Writer, port int, command string) {
-	if !printRemoteSessionPreamble(w) {
+	if !terminal.IsRemoteSession() {
 		return
 	}
+	printRemoteSessionPreamble(w)
 
 	fmt.Fprintln(w, "Do one of these two steps:")
 	fmt.Fprintln(w, "  1. Forward the port. On your computer, run:")
@@ -201,6 +215,16 @@ const pastePrompt = "Redirect URL (or wait for the browser): "
 // URL holds a single-use code.
 const manualCallbackHygieneNotice = "The URL that you pasted holds a single-use code. Clear the terminal if other people can read it."
 
+// printPasteRejection reports why a pasted URL did not work, then asks for
+// another one. Both paste routes call it, so the two print the same wording.
+//
+// err never holds the pasted string: no message may echo the authorization
+// code. prompt is manualRedirectPrompt or pastePrompt.
+func printPasteRejection(w io.Writer, err error, prompt string) {
+	fmt.Fprintf(w, "\nThat URL did not work: %v\n", err)
+	fmt.Fprint(w, prompt)
+}
+
 // pasteRejection turns a callback error into the message shown before gcx asks
 // for another redirect URL. A state mismatch on a paste nearly always means the
 // URL came from a different login attempt, so say that instead of naming CSRF.
@@ -212,4 +236,4 @@ func pasteRejection(err error) error {
 }
 
 var errManualForeignState = errors.New(
-	"the pasted URL belongs to a different login attempt: run the command again and paste the URL from this attempt")
+	"the pasted URL belongs to a different login attempt: paste the URL from this attempt")

--- a/internal/auth/manual_test.go
+++ b/internal/auth/manual_test.go
@@ -223,6 +223,11 @@ func TestFlowRun_ManualRejectsForeignState(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "different login attempt")
 	assert.Equal(t, int32(0), calls.Load(), "the exchange must not run on a state mismatch")
+
+	// A state mismatch is the failure that leaves the most on screen: the code
+	// stays in the scrollback, and the user runs the command again. The notice
+	// must therefore cover the failure paths, not the success path alone.
+	assert.Contains(t, writer.String(), "single-use code")
 }
 
 func TestFlowRun_ManualDoesNotBindAPort(t *testing.T) {
@@ -623,6 +628,81 @@ func TestPasteWatcherKeepsReadingAfterCallerRejection(t *testing.T) {
 		assert.Equal(t, "fresh", pasted.Values.Get("state"))
 	case <-time.After(5 * time.Second):
 		t.Fatal("the watcher stopped reading after the caller rejected the first URL")
+	}
+}
+
+// TestPasteWatcherDropsTheEmptyLine covers the Enter that step 1 of the
+// instructions asks for. The user presses Enter, then presses ~C, to add a port
+// forward to the running SSH session. A watcher that parsed that empty line
+// answered "That URL did not work: no URL supplied" on the route that the
+// instructions recommend first.
+func TestPasteWatcherDropsTheEmptyLine(t *testing.T) {
+	remoteSessionForTest(t)
+
+	reader, writerEnd, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writerEnd.Close() })
+	restore := auth.SwapPasteTerminal(reader, true)
+	t.Cleanup(restore)
+
+	var out bytes.Buffer
+	watcher := auth.StartPasteWatcher(&out, 54321)
+	require.NotNil(t, watcher)
+	t.Cleanup(watcher.Close)
+
+	// A bare Enter, and a line of spaces, must both reach the caller as nothing.
+	_, err = writerEnd.WriteString("\n   \n")
+	require.NoError(t, err)
+
+	// The next real URL must still arrive. That both proves the reader survived
+	// the empty lines and gives the empty lines time to reach the watcher.
+	_, err = writerEnd.WriteString("http://127.0.0.1:54321/callback?code=c1&state=s1\n")
+	require.NoError(t, err)
+	select {
+	case pasted := <-watcher.Input():
+		require.NoError(t, pasted.Err)
+		assert.False(t, pasted.Closed)
+		assert.Equal(t, "c1", pasted.Values.Get("code"))
+	case <-time.After(5 * time.Second):
+		t.Fatal("the watcher did not deliver the pasted URL after the empty lines")
+	}
+	assert.NotContains(t, out.String(), "That URL did not work")
+}
+
+// TestPasteWatcherReportsThatTheReaderEnded covers Ctrl-D and a terminal that
+// reports an error. A watcher that returned without a word left the prompt
+// "Redirect URL (or wait for the browser):" on screen with no reader behind it.
+// The caller must learn that the paste route ended, so it can say so and keep
+// waiting for the callback.
+func TestPasteWatcherReportsThatTheReaderEnded(t *testing.T) {
+	remoteSessionForTest(t)
+
+	reader, writerEnd, err := os.Pipe()
+	require.NoError(t, err)
+	restore := auth.SwapPasteTerminal(reader, true)
+	t.Cleanup(restore)
+
+	var out bytes.Buffer
+	watcher := auth.StartPasteWatcher(&out, 54321)
+	require.NotNil(t, watcher)
+	t.Cleanup(watcher.Close)
+
+	// Closing the write end is the pipe equivalent of Ctrl-D on a terminal.
+	require.NoError(t, writerEnd.Close())
+
+	select {
+	case pasted := <-watcher.Input():
+		assert.True(t, pasted.Closed, "the watcher must report that the reader ended")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the watcher ended without a word: the prompt keeps no reader")
+	}
+
+	// The reader must not spin on the permanent read error. No second report
+	// may arrive.
+	select {
+	case pasted := <-watcher.Input():
+		t.Fatalf("the watcher kept reading after the terminal ended: %+v", pasted)
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 

--- a/internal/auth/manual_test.go
+++ b/internal/auth/manual_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -437,5 +439,196 @@ func TestPrintRemoteSessionHint(t *testing.T) {
 			assert.Contains(t, out, "ssh -L 54321:127.0.0.1:54321")
 			assert.Contains(t, out, "gcx login --oauth-manual")
 		})
+	}
+}
+
+// TestStartPasteWatcherRequiresRemoteSession pins the gate on the paste race:
+// it must not take over the terminal for a local login or in agent mode.
+func TestStartPasteWatcherRequiresRemoteSession(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       map[string]string
+		wantStart bool
+	}{
+		{
+			name:      "local session",
+			env:       map[string]string{},
+			wantStart: false,
+		},
+		{
+			name:      "agent mode",
+			env:       map[string]string{"SSH_CONNECTION": "10.0.0.1 1 10.0.0.2 22", "GCX_AGENT_MODE": "1"},
+			wantStart: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, name := range []string{"SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"} {
+				t.Setenv(name, "")
+			}
+			t.Setenv("GCX_AGENT_MODE", "0")
+			for name, value := range tc.env {
+				t.Setenv(name, value)
+			}
+			agent.ResetForTesting()
+			t.Cleanup(agent.ResetForTesting)
+
+			var writer bytes.Buffer
+			watcher := auth.StartPasteWatcher(&writer, 54321)
+			if watcher != nil {
+				defer watcher.Close()
+			}
+			assert.Equal(t, tc.wantStart, watcher != nil)
+			if watcher == nil {
+				assert.Zero(t, writer.Len(), "a watcher that does not start prints nothing")
+			}
+		})
+	}
+}
+
+// remoteSessionForTest makes IsRemoteSession report true and agent mode false,
+// which is the only state in which the paste watcher starts.
+func remoteSessionForTest(t *testing.T) {
+	t.Helper()
+	t.Setenv("SSH_CONNECTION", "10.0.0.1 51234 10.0.0.2 22")
+	t.Setenv("SSH_CLIENT", "")
+	t.Setenv("SSH_TTY", "")
+	t.Setenv("GCX_AGENT_MODE", "0")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+}
+
+// TestPasteWatcherCloseReleasesTheTerminal pins the property that makes the
+// paste race safe: Close must unblock the pending read and wait for the reader
+// goroutine. A stale reader would compete with the prompts that run after
+// login.
+func TestPasteWatcherCloseReleasesTheTerminal(t *testing.T) {
+	remoteSessionForTest(t)
+
+	reader, writerEnd, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writerEnd.Close() })
+	restore := auth.SwapPasteTerminal(reader, true)
+	t.Cleanup(restore)
+
+	var out bytes.Buffer
+	watcher := auth.StartPasteWatcher(&out, 54321)
+	require.NotNil(t, watcher)
+	assert.Contains(t, out.String(), "-L 54321:127.0.0.1:54321")
+	assert.Contains(t, out.String(), "Redirect URL")
+
+	// Close must return, which it only can once the reader goroutine ended.
+	done := make(chan struct{})
+	go func() {
+		watcher.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not release the terminal reader")
+	}
+}
+
+// TestPasteWatcherDeliversAndRejects covers both watcher outcomes: a usable
+// redirect URL reaches the caller, and an unusable one re-prompts instead of
+// ending the flow, because the callback server is still listening.
+func TestPasteWatcherDeliversAndRejects(t *testing.T) {
+	remoteSessionForTest(t)
+
+	reader, writerEnd, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writerEnd.Close() })
+	restore := auth.SwapPasteTerminal(reader, true)
+	t.Cleanup(restore)
+
+	var out bytes.Buffer
+	watcher := auth.StartPasteWatcher(&out, 54321)
+	require.NotNil(t, watcher)
+	t.Cleanup(watcher.Close)
+
+	// An unusable line must not deliver a value, and must re-prompt.
+	_, err = writerEnd.WriteString("not-a-url\n")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return strings.Contains(out.String(), "That URL did not work")
+	}, 5*time.Second, 10*time.Millisecond)
+	assert.Contains(t, out.String(), "Redirect URL")
+
+	select {
+	case <-watcher.Values():
+		t.Fatal("an unusable line must not deliver a value")
+	default:
+	}
+
+	// A usable line reaches the caller.
+	_, err = writerEnd.WriteString("http://127.0.0.1:54321/callback?code=c1&state=s1\n")
+	require.NoError(t, err)
+	select {
+	case values := <-watcher.Values():
+		assert.Equal(t, "c1", values.Get("code"))
+		assert.Equal(t, "s1", values.Get("state"))
+	case <-time.After(5 * time.Second):
+		t.Fatal("the watcher did not deliver the pasted URL")
+	}
+}
+
+// TestPasteWatcherRejectionDoesNotEchoTheURL keeps the no-echo rule on the
+// re-prompt path: the pasted line holds a single-use authorization code.
+func TestPasteWatcherRejectionDoesNotEchoTheURL(t *testing.T) {
+	remoteSessionForTest(t)
+
+	const secret = "SECRETCODE"
+
+	reader, writerEnd, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writerEnd.Close() })
+	restore := auth.SwapPasteTerminal(reader, true)
+	t.Cleanup(restore)
+
+	var out bytes.Buffer
+	watcher := auth.StartPasteWatcher(&out, 54321)
+	require.NotNil(t, watcher)
+	t.Cleanup(watcher.Close)
+
+	_, err = writerEnd.WriteString("http://127.0.0.1:54321/callback-" + secret + "\n")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return strings.Contains(out.String(), "That URL did not work")
+	}, 5*time.Second, 10*time.Millisecond)
+	assert.NotContains(t, out.String(), secret)
+}
+
+// TestOpenPasteTerminalReadIsCancellable is the regression guard for the trap
+// that makes the paste race hang: File.Fd puts the descriptor back into
+// blocking mode, the read then blocks inside the syscall instead of the
+// poller, and Close can no longer stop it. The login hangs forever after the
+// browser callback arrives.
+//
+// The test needs a controlling terminal, so it skips where there is none.
+func TestOpenPasteTerminalReadIsCancellable(t *testing.T) {
+	tty, ok := auth.OpenPasteTerminal()
+	if !ok {
+		t.Skip("no controlling terminal available")
+	}
+
+	read := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := tty.Read(buf)
+		read <- err
+	}()
+
+	// Give the goroutine time to enter the read before closing.
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, tty.Close())
+
+	select {
+	case err := <-read:
+		require.ErrorIs(t, err, os.ErrClosed)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not unblock the read: the descriptor is in blocking mode, " +
+			"which makes the paste race hang after the browser callback arrives")
 	}
 }

--- a/internal/auth/manual_test.go
+++ b/internal/auth/manual_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -548,29 +549,80 @@ func TestPasteWatcherDeliversAndRejects(t *testing.T) {
 	require.NotNil(t, watcher)
 	t.Cleanup(watcher.Close)
 
-	// An unusable line must not deliver a value, and must re-prompt.
+	// An unusable line reaches the caller as an error, not as parameters. The
+	// caller then re-prompts, because the callback server is still listening.
 	_, err = writerEnd.WriteString("not-a-url\n")
 	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		return strings.Contains(out.String(), "That URL did not work")
-	}, 5*time.Second, 10*time.Millisecond)
-	assert.Contains(t, out.String(), "Redirect URL")
-
 	select {
-	case <-watcher.Values():
-		t.Fatal("an unusable line must not deliver a value")
-	default:
+	case pasted := <-watcher.Input():
+		require.Error(t, pasted.Err)
+		assert.Nil(t, pasted.Values)
+		watcher.Reject(pasted.Err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the watcher did not report the unusable line")
 	}
+	assert.Contains(t, out.String(), "That URL did not work")
+	assert.Contains(t, out.String(), "Redirect URL")
 
 	// A usable line reaches the caller.
 	_, err = writerEnd.WriteString("http://127.0.0.1:54321/callback?code=c1&state=s1\n")
 	require.NoError(t, err)
 	select {
-	case values := <-watcher.Values():
-		assert.Equal(t, "c1", values.Get("code"))
-		assert.Equal(t, "s1", values.Get("state"))
+	case pasted := <-watcher.Input():
+		require.NoError(t, pasted.Err)
+		assert.Equal(t, "c1", pasted.Values.Get("code"))
+		assert.Equal(t, "s1", pasted.Values.Get("state"))
 	case <-time.After(5 * time.Second):
 		t.Fatal("the watcher did not deliver the pasted URL")
+	}
+}
+
+// TestPasteWatcherKeepsReadingAfterCallerRejection is the regression guard for
+// a reader that stopped after the first delivery.
+//
+// The watcher only parses. The caller runs the semantic checks (state, code,
+// token exchange) and calls Reject when they fail, which re-prompts. A watcher
+// that returned after the first delivery left that prompt with no reader: the
+// second pasted line stayed in the terminal buffer, and the shell read it once
+// gcx exited, which wrote the authorization code into the shell history.
+func TestPasteWatcherKeepsReadingAfterCallerRejection(t *testing.T) {
+	remoteSessionForTest(t)
+
+	reader, writerEnd, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writerEnd.Close() })
+	restore := auth.SwapPasteTerminal(reader, true)
+	t.Cleanup(restore)
+
+	var out bytes.Buffer
+	watcher := auth.StartPasteWatcher(&out, 54321)
+	require.NotNil(t, watcher)
+	t.Cleanup(watcher.Close)
+
+	// The first URL parses and reaches the caller.
+	_, err = writerEnd.WriteString("http://127.0.0.1:54321/callback?code=c1&state=stale\n")
+	require.NoError(t, err)
+	select {
+	case pasted := <-watcher.Input():
+		require.NoError(t, pasted.Err)
+		assert.Equal(t, "stale", pasted.Values.Get("state"))
+	case <-time.After(5 * time.Second):
+		t.Fatal("the watcher did not deliver the first pasted URL")
+	}
+
+	// The caller rejects it, exactly as a state mismatch does in the flow.
+	watcher.Reject(errors.New("the pasted URL belongs to a different login attempt"))
+
+	// The re-prompt must have a reader, so a second paste must also arrive.
+	_, err = writerEnd.WriteString("http://127.0.0.1:54321/callback?code=c2&state=fresh\n")
+	require.NoError(t, err)
+	select {
+	case pasted := <-watcher.Input():
+		require.NoError(t, pasted.Err)
+		assert.Equal(t, "c2", pasted.Values.Get("code"))
+		assert.Equal(t, "fresh", pasted.Values.Get("state"))
+	case <-time.After(5 * time.Second):
+		t.Fatal("the watcher stopped reading after the caller rejected the first URL")
 	}
 }
 
@@ -594,9 +646,15 @@ func TestPasteWatcherRejectionDoesNotEchoTheURL(t *testing.T) {
 
 	_, err = writerEnd.WriteString("http://127.0.0.1:54321/callback-" + secret + "\n")
 	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		return strings.Contains(out.String(), "That URL did not work")
-	}, 5*time.Second, 10*time.Millisecond)
+	select {
+	case pasted := <-watcher.Input():
+		require.Error(t, pasted.Err)
+		assert.NotContains(t, pasted.Err.Error(), secret)
+		watcher.Reject(pasted.Err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the watcher did not report the unusable line")
+	}
+	assert.Contains(t, out.String(), "That URL did not work")
 	assert.NotContains(t, out.String(), secret)
 }
 

--- a/internal/auth/manual_test.go
+++ b/internal/auth/manual_test.go
@@ -353,6 +353,88 @@ func TestFlowRun_ManualReportsMissingInput(t *testing.T) {
 	assert.Contains(t, err.Error(), "no input received")
 }
 
+// TestFlowRun_ManualRetriesAfterABadURL covers the retry loop on the manual
+// route. A typo must not cost a full re-run for a fresh state and a fresh code.
+func TestFlowRun_ManualRetriesAfterABadURL(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := newExchangeServer(t, &calls)
+
+	var writer bytes.Buffer
+	reader := &lazyReader{build: func() io.Reader {
+		values := url.Values{}
+		values.Set("code", "auth-code")
+		values.Set("state", stateFromWriter(t, &writer))
+		values.Set("endpoint", server.URL)
+		values.Set("instanceEndpoint", "https://mystack.grafana.net")
+		good := "http://127.0.0.1:54321/callback?" + values.Encode()
+		return strings.NewReader("typo-not-a-url\n" + good + "\n")
+	}}
+
+	flow := auth.NewFlow("https://mystack.grafana.net", auth.Options{
+		Manual: true,
+		Writer: &writer,
+		Reader: reader,
+	})
+
+	result, err := flow.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "gat_token", result.Token)
+	assert.Equal(t, int32(1), calls.Load(), "only the second URL reaches the exchange")
+
+	out := writer.String()
+	assert.Contains(t, out, "That URL did not work")
+	assert.Contains(t, out, "single-use code")
+	assert.NotContains(t, out, "typo-not-a-url", "no message may echo the pasted line")
+}
+
+// TestFlowRun_ManualStopsAtTheTryBound proves that the retry loop is finite.
+// The manual route also reads a script pipe, which can report the same failure
+// on every line.
+func TestFlowRun_ManualStopsAtTheTryBound(t *testing.T) {
+	t.Parallel()
+
+	var writer bytes.Buffer
+	flow := auth.NewFlow("https://mystack.grafana.net", auth.Options{
+		Manual: true,
+		Writer: &writer,
+		Reader: strings.NewReader(strings.Repeat("typo-not-a-url\n", auth.ManualPasteTries+2)),
+	})
+
+	_, err := flow.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot read the redirect URL")
+
+	out := writer.String()
+	assert.Equal(t, auth.ManualPasteTries-1, strings.Count(out, "That URL did not work"),
+		"one rejection for each try except the last")
+	assert.Equal(t, 1, strings.Count(out, "single-use code"))
+}
+
+// TestFlowRun_ManualReportsTheURLFailureNotTheEndOfInput pins the error that a
+// script sees. One bad URL followed by the end of the input must report the
+// URL, because the end of the input is a consequence of the failure.
+func TestFlowRun_ManualReportsTheURLFailureNotTheEndOfInput(t *testing.T) {
+	t.Parallel()
+
+	var writer bytes.Buffer
+	values := url.Values{}
+	values.Set("code", "auth-code")
+	values.Set("state", "state-from-another-attempt")
+
+	flow := auth.NewFlow("https://mystack.grafana.net", auth.Options{
+		Manual: true,
+		Writer: &writer,
+		Reader: strings.NewReader("http://127.0.0.1:54321/callback?" + values.Encode() + "\n"),
+	})
+
+	_, err := flow.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "different login attempt")
+	assert.NotContains(t, err.Error(), "no input received")
+}
+
 func TestGCOMFlowRun_ManualSendsMatchingRedirectURI(t *testing.T) {
 	t.Parallel()
 

--- a/internal/auth/manual_test.go
+++ b/internal/auth/manual_test.go
@@ -738,6 +738,99 @@ func TestPasteWatcherRejectionDoesNotEchoTheURL(t *testing.T) {
 	assert.NotContains(t, out.String(), secret)
 }
 
+// TestExchangeGuardGrantsOneClaim covers the guard that stops the second token
+// exchange. The callback server and the paste reader accept the same
+// single-use code, so only one of them may exchange it.
+func TestExchangeGuardGrantsOneClaim(t *testing.T) {
+	t.Parallel()
+
+	guard := &auth.ExchangeGuard{}
+	assert.True(t, auth.ClaimExchange(guard), "the first route must get the claim")
+	assert.False(t, auth.ClaimExchange(guard), "the second route must not get the claim")
+
+	// The manual flow runs no callback server, so it passes a nil guard.
+	assert.True(t, auth.ClaimExchange(nil), "a nil guard must always grant the claim")
+}
+
+// TestTakenGuardStopsTheSecondExchange proves that the loser of the race never
+// reaches the token exchange. Before the guard, the loser ran the exchange,
+// received "token exchange failed" for a code that the winner had already
+// used, and reported that failure to the user one moment before the success.
+func TestTakenGuardStopsTheSecondExchange(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := newExchangeServer(t, &calls)
+
+	values := url.Values{}
+	values.Set("code", "auth-code")
+	values.Set("state", "the-state")
+	values.Set("endpoint", server.URL)
+	values.Set("instanceEndpoint", "https://mystack.grafana.net")
+
+	guard := &auth.ExchangeGuard{}
+
+	// The winner exchanges the code.
+	require.NoError(t, auth.HandleCallbackParams(context.Background(), values, "the-state", "verifier", guard))
+	assert.Equal(t, int32(1), calls.Load())
+
+	// The loser must stop before the exchange, and it must report the sentinel
+	// so the caller stays silent.
+	err := auth.HandleCallbackParams(context.Background(), values, "the-state", "verifier", guard)
+	require.ErrorIs(t, err, auth.ErrExchangeClaimed)
+	assert.Equal(t, int32(1), calls.Load(), "the loser must not run a second exchange")
+}
+
+// TestGuardClaimFollowsTheStateCheck pins the order of the two checks. A URL
+// from an older attempt fails the state check, so it must leave the claim for
+// the real callback. A guard that the wrong URL consumed would block the login.
+func TestGuardClaimFollowsTheStateCheck(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := newExchangeServer(t, &calls)
+
+	stale := url.Values{}
+	stale.Set("code", "old-code")
+	stale.Set("state", "state-from-another-attempt")
+	stale.Set("endpoint", server.URL)
+	stale.Set("instanceEndpoint", "https://mystack.grafana.net")
+
+	guard := &auth.ExchangeGuard{}
+	err := auth.HandleCallbackParams(context.Background(), stale, "the-state", "verifier", guard)
+	require.ErrorIs(t, err, auth.ErrStateMismatch)
+
+	// The claim must still be free for the real callback.
+	assert.True(t, auth.ClaimExchange(guard), "a state mismatch must not consume the claim")
+}
+
+// TestFlushTerminalInputHandlesANonTerminal covers the flush that Close runs.
+// The pipe in these tests is not a terminal, so the flush reports an error. It
+// must not panic, because Close ignores that error.
+func TestFlushTerminalInputHandlesANonTerminal(t *testing.T) {
+	t.Parallel()
+
+	reader, writerEnd, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writerEnd.Close() })
+	t.Cleanup(func() { _ = reader.Close() })
+
+	assert.NotPanics(t, func() { _ = auth.FlushTerminalInput(reader) })
+}
+
+// TestFlushTerminalInputClearsTheQueue runs the flush on a real controlling
+// terminal. The flush discards what the user typed without a newline, which the
+// shell would otherwise read after gcx exits.
+func TestFlushTerminalInputClearsTheQueue(t *testing.T) {
+	tty, ok := auth.OpenPasteTerminal()
+	if !ok {
+		t.Skip("no controlling terminal available")
+	}
+	t.Cleanup(func() { _ = tty.Close() })
+
+	require.NoError(t, auth.FlushTerminalInput(tty))
+}
+
 // TestOpenPasteTerminalReadIsCancellable is the regression guard for the trap
 // that makes the paste race hang: File.Fd puts the descriptor back into
 // blocking mode, the read then blocks inside the syscall instead of the

--- a/internal/auth/manual_test.go
+++ b/internal/auth/manual_test.go
@@ -1,0 +1,441 @@
+package auth_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCallbackInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:  "full https url",
+			input: "https://example.grafana.net/callback?code=c1&state=s1",
+			want:  map[string]string{"code": "c1", "state": "s1"},
+		},
+		{
+			name:  "loopback callback url",
+			input: "http://127.0.0.1:54321/callback?code=c1&state=s1&endpoint=https%3A%2F%2Fapi.grafana.net",
+			want:  map[string]string{"code": "c1", "state": "s1", "endpoint": "https://api.grafana.net"},
+		},
+		{
+			name:  "surrounding whitespace",
+			input: "   http://127.0.0.1:54321/callback?code=c1   ",
+			want:  map[string]string{"code": "c1"},
+		},
+		{
+			name:  "trailing carriage return",
+			input: "http://127.0.0.1:54321/callback?code=c1\r",
+			want:  map[string]string{"code": "c1"},
+		},
+		{
+			name:  "double quoted",
+			input: `"http://127.0.0.1:54321/callback?code=c1"`,
+			want:  map[string]string{"code": "c1"},
+		},
+		{
+			name:  "single quoted",
+			input: `'http://127.0.0.1:54321/callback?code=c1'`,
+			want:  map[string]string{"code": "c1"},
+		},
+		{
+			name:  "scheme hidden by the browser",
+			input: "127.0.0.1:54321/callback?code=c1&state=s1",
+			want:  map[string]string{"code": "c1", "state": "s1"},
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   ",
+			wantErr: true,
+		},
+		{
+			name:    "not a url",
+			input:   "yes",
+			wantErr: true,
+		},
+		{
+			name:    "url without a query",
+			input:   "http://127.0.0.1:54321/callback",
+			wantErr: true,
+		},
+		{
+			name:    "malformed query escape",
+			input:   "http://127.0.0.1:54321/callback?code=%zz",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			values, err := auth.ParseCallbackInput(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			for key, want := range tc.want {
+				assert.Equal(t, want, values.Get(key), "parameter %q", key)
+			}
+		})
+	}
+}
+
+// lazyReader builds its input on the first Read, after Flow.Run has printed
+// the auth URL. This is how a test recovers the random state parameter.
+type lazyReader struct {
+	build func() io.Reader
+	inner io.Reader
+}
+
+func (l *lazyReader) Read(p []byte) (int, error) {
+	if l.inner == nil {
+		l.inner = l.build()
+	}
+	return l.inner.Read(p)
+}
+
+var stateParamRE = regexp.MustCompile(`[?&]state=([^&\s]+)`)
+
+// stateFromWriter extracts the state parameter from the printed auth URL.
+func stateFromWriter(t *testing.T, w *bytes.Buffer) string {
+	t.Helper()
+	match := stateParamRE.FindStringSubmatch(w.String())
+	require.Len(t, match, 2, "auth URL with a state parameter, got %q", w.String())
+	state, err := url.QueryUnescape(match[1])
+	require.NoError(t, err)
+	return state
+}
+
+// newExchangeServer serves the assistant token exchange endpoint and counts
+// the calls it receives.
+func newExchangeServer(t *testing.T, calls *atomic.Int32) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		assert.Equal(t, "/api/cli/v1/auth/exchange", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{
+			"token":"gat_token",
+			"email":"user@example.com",
+			"expires_at":"2030-01-01T00:00:00Z",
+			"api_endpoint":"https://mystack.grafana.net",
+			"refresh_token":"gar_refresh",
+			"refresh_expires_at":"2031-01-01T00:00:00Z"
+		}}`))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestFlowRun_ManualExchangesPastedURL(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := newExchangeServer(t, &calls)
+
+	var writer bytes.Buffer
+	reader := &lazyReader{build: func() io.Reader {
+		values := url.Values{}
+		values.Set("code", "auth-code")
+		values.Set("state", stateFromWriter(t, &writer))
+		values.Set("endpoint", server.URL)
+		values.Set("instanceEndpoint", "https://mystack.grafana.net")
+		values.Set("device", "my-box")
+		return strings.NewReader("http://127.0.0.1:54321/callback?" + values.Encode() + "\n")
+	}}
+
+	flow := auth.NewFlow("https://mystack.grafana.net", auth.Options{
+		Manual: true,
+		Writer: &writer,
+		Reader: reader,
+	})
+
+	result, err := flow.Run(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "gat_token", result.Token)
+	assert.Equal(t, "user@example.com", result.Email)
+	assert.Equal(t, "my-box", result.DeviceName)
+	assert.Equal(t, "https://mystack.grafana.net", result.APIEndpoint)
+	assert.Equal(t, "2030-01-01T00:00:00Z", result.ExpiresAt)
+	assert.Equal(t, "gar_refresh", result.RefreshToken)
+	assert.Equal(t, "2031-01-01T00:00:00Z", result.RefreshExpiresAt)
+	assert.Equal(t, "https://mystack.grafana.net", result.InstanceEndpoint)
+
+	out := writer.String()
+	assert.Contains(t, out, "callback_port="+strconv.Itoa(auth.ManualCallbackPort))
+	assert.NotContains(t, out, "Waiting for authentication")
+	assert.Contains(t, out, "single-use code")
+}
+
+func TestFlowRun_ManualRejectsForeignState(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := newExchangeServer(t, &calls)
+
+	var writer bytes.Buffer
+	values := url.Values{}
+	values.Set("code", "auth-code")
+	values.Set("state", "state-from-another-attempt")
+	values.Set("endpoint", server.URL)
+	values.Set("instanceEndpoint", "https://mystack.grafana.net")
+
+	flow := auth.NewFlow("https://mystack.grafana.net", auth.Options{
+		Manual: true,
+		Writer: &writer,
+		Reader: strings.NewReader("http://127.0.0.1:54321/callback?" + values.Encode() + "\n"),
+	})
+
+	_, err := flow.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "different login attempt")
+	assert.Equal(t, int32(0), calls.Load(), "the exchange must not run on a state mismatch")
+}
+
+func TestFlowRun_ManualDoesNotBindAPort(t *testing.T) {
+	t.Parallel()
+
+	var lc net.ListenConfig
+	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:"+strconv.Itoa(auth.ManualCallbackPort))
+	if err != nil {
+		t.Skipf("port %d is not available for this test: %v", auth.ManualCallbackPort, err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	var calls atomic.Int32
+	server := newExchangeServer(t, &calls)
+
+	var writer bytes.Buffer
+	reader := &lazyReader{build: func() io.Reader {
+		values := url.Values{}
+		values.Set("code", "auth-code")
+		values.Set("state", stateFromWriter(t, &writer))
+		values.Set("endpoint", server.URL)
+		values.Set("instanceEndpoint", "https://mystack.grafana.net")
+		return strings.NewReader("http://127.0.0.1:54321/callback?" + values.Encode() + "\n")
+	}}
+
+	flow := auth.NewFlow("https://mystack.grafana.net", auth.Options{
+		Manual: true,
+		Writer: &writer,
+		Reader: reader,
+	})
+
+	result, err := flow.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "gat_token", result.Token)
+}
+
+func TestFlowRun_ManualRejectsFixedPort(t *testing.T) {
+	t.Parallel()
+
+	var writer bytes.Buffer
+	flow := auth.NewFlow("https://mystack.grafana.net", auth.Options{
+		Manual: true,
+		Port:   1234,
+		Writer: &writer,
+		Reader: strings.NewReader("\n"),
+	})
+
+	_, err := flow.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "manual OAuth does not use a callback port")
+	assert.Zero(t, writer.Len(), "no instructions before the option check")
+}
+
+func TestFlowRun_ManualHonoursContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pw.Close() })
+
+	var writer bytes.Buffer
+	flow := auth.NewFlow("https://mystack.grafana.net", auth.Options{
+		Manual: true,
+		Writer: &writer,
+		Reader: pr,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := flow.Run(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestFlowRun_ManualErrorsDoNotEchoPastedURL(t *testing.T) {
+	t.Parallel()
+
+	const secret = "SECRETCODE"
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "state mismatch",
+			input: "http://127.0.0.1:54321/callback?code=" + secret + "&state=other\n",
+		},
+		{
+			name:  "parse failure",
+			input: "not-a-url-but-holds-" + secret + "\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var writer bytes.Buffer
+			flow := auth.NewFlow("https://mystack.grafana.net", auth.Options{
+				Manual: true,
+				Writer: &writer,
+				Reader: strings.NewReader(tc.input),
+			})
+
+			_, err := flow.Run(context.Background())
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), secret)
+		})
+	}
+}
+
+func TestFlowRun_ManualReportsMissingInput(t *testing.T) {
+	t.Parallel()
+
+	var writer bytes.Buffer
+	flow := auth.NewFlow("https://mystack.grafana.net", auth.Options{
+		Manual: true,
+		Writer: &writer,
+		Reader: strings.NewReader(""),
+	})
+
+	_, err := flow.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no input received")
+}
+
+func TestGCOMFlowRun_ManualSendsMatchingRedirectURI(t *testing.T) {
+	t.Parallel()
+
+	var gotRedirectURI string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/oauth2/token", r.URL.Path)
+		var body map[string]string
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotRedirectURI = body["redirect_uri"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"gcom-token","scope":"stacks:read","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	var writer bytes.Buffer
+	reader := &lazyReader{build: func() io.Reader {
+		values := url.Values{}
+		values.Set("code", "auth-code")
+		values.Set("state", stateFromWriter(t, &writer))
+		return strings.NewReader("http://127.0.0.1:54321/callback?" + values.Encode() + "\n")
+	}}
+
+	flow := auth.NewGCOMFlow(auth.GCOMOptions{
+		ClientID: "gcx",
+		GCOMURL:  server.URL,
+		Scopes:   []string{"stacks:read"},
+		Manual:   true,
+		Writer:   &writer,
+		Reader:   reader,
+	})
+
+	result, err := flow.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "gcom-token", result.AccessToken)
+
+	wantRedirectURI := "http://127.0.0.1:" + strconv.Itoa(auth.ManualCallbackPort) + "/callback"
+	assert.Equal(t, wantRedirectURI, gotRedirectURI)
+	assert.Contains(t, writer.String(), "redirect_uri="+url.QueryEscape(wantRedirectURI))
+}
+
+func TestReadLineDoesNotOverRead(t *testing.T) {
+	t.Parallel()
+
+	reader := strings.NewReader("first\nsecond")
+
+	line, err := auth.ReadLine(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "first", line)
+
+	rest, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "second", string(rest))
+}
+
+func TestPrintRemoteSessionHint(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		wantOut bool
+	}{
+		{
+			name:    "local session",
+			env:     map[string]string{},
+			wantOut: false,
+		},
+		{
+			name:    "ssh session",
+			env:     map[string]string{"SSH_CONNECTION": "10.0.0.1 51234 10.0.0.2 22"},
+			wantOut: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, name := range []string{"SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"} {
+				t.Setenv(name, "")
+			}
+			for name, value := range tc.env {
+				t.Setenv(name, value)
+			}
+
+			var writer bytes.Buffer
+			auth.PrintRemoteSessionHint(&writer, 54321, "gcx login --oauth-manual")
+
+			if !tc.wantOut {
+				assert.Zero(t, writer.Len())
+				return
+			}
+			out := writer.String()
+			assert.Contains(t, out, "ssh -L 54321:127.0.0.1:54321")
+			assert.Contains(t, out, "gcx login --oauth-manual")
+		})
+	}
+}

--- a/internal/auth/paste.go
+++ b/internal/auth/paste.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/grafana/gcx/internal/agent"
@@ -104,6 +105,10 @@ var openPasteTerminal = func() (*os.File, bool) { //nolint:gochecknoglobals // t
 type pastedInput struct {
 	Values url.Values
 	Err    error
+	// Closed reports that the reader ended, because the user pressed Ctrl-D or
+	// the terminal reported an error. No further line arrives. The caller says
+	// so and keeps waiting for the callback server.
+	Closed bool
 }
 
 // Input reports each pasted line. A nil watcher returns a nil channel, which
@@ -153,10 +158,26 @@ func (p *pasteWatcher) run() {
 
 	for {
 		line, err := readLine(p.tty)
-		if err != nil {
-			// The terminal closed, or the flow ended. Stop quietly: the caller
-			// already has a result or an error of its own.
+		if p.stopped() {
+			// Close shut the terminal, which caused this read error. The caller
+			// already has a result or an error of its own, so stop quietly.
 			return
+		}
+		if err != nil {
+			// The user pressed Ctrl-D, or the terminal reported an error. Say
+			// so and stop. A silent stop left the prompt on screen with no
+			// reader behind it, and a retry would spin on a terminal that
+			// reports the same error forever.
+			p.deliver(pastedInput{Closed: true})
+			return
+		}
+
+		// Step 1 of the instructions asks the user to press Enter before the
+		// SSH escape ~C. Drop that empty line: a rejection on the route that the
+		// instructions recommend first is wrong, and the ssh escape prompt owns
+		// the terminal at that moment.
+		if strings.TrimSpace(line) == "" {
+			continue
 		}
 
 		// Keep reading after a delivery. The caller runs the semantic checks
@@ -165,11 +186,32 @@ func (p *pasteWatcher) run() {
 		// line stays in the terminal buffer, and the shell reads it after gcx
 		// exits, which writes the authorization code into the shell history.
 		values, err := ParseCallbackInput(line)
-		select {
-		case p.values <- pastedInput{Values: values, Err: err}:
-		case <-p.stop:
+		if !p.deliver(pastedInput{Values: values, Err: err}) {
 			return
 		}
+	}
+}
+
+// stopped reports whether Close has run. The reader checks it before it acts on
+// a read error, because Close shuts the terminal and that read error is the
+// expected result.
+func (p *pasteWatcher) stopped() bool {
+	select {
+	case <-p.stop:
+		return true
+	default:
+		return false
+	}
+}
+
+// deliver sends one result to the caller. It reports false when Close ran
+// first, so a caller that stopped reading cannot wedge the send.
+func (p *pasteWatcher) deliver(in pastedInput) bool {
+	select {
+	case p.values <- in:
+		return true
+	case <-p.stop:
+		return false
 	}
 }
 

--- a/internal/auth/paste.go
+++ b/internal/auth/paste.go
@@ -1,0 +1,172 @@
+package auth
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/terminal"
+)
+
+// pasteWatcher reads redirect URLs that the user types while a callback server
+// also listens. It exists for the remote case: gcx over SSH, browser on the
+// user's own computer. The user can add a port forward and let the callback
+// arrive, or paste the redirect URL. gcx accepts whichever completes first, so
+// neither choice needs a restart.
+//
+// The watcher reads a separately opened /dev/tty, never os.Stdin. Go keeps the
+// standard streams out of its poller, so a blocking read on os.Stdin cannot be
+// cancelled; a stale reader would then steal keystrokes from the prompts that
+// run after login. A file opened with os.OpenFile is pollable, so Close unblocks
+// the pending read and the goroutine ends before the caller returns.
+type pasteWatcher struct {
+	tty    *os.File
+	writer io.Writer
+	values chan url.Values
+	// done closes when the reader goroutine has ended. Close waits on it, so
+	// the terminal has exactly one reader again by the time Close returns.
+	done chan struct{}
+}
+
+// startPasteWatcher prints the remote-session instructions and starts reading
+// redirect URLs from the terminal. It returns nil when the paste path does not
+// apply: a local session, agent mode, or no usable terminal. A nil watcher is
+// safe to use — every method handles it.
+func startPasteWatcher(w io.Writer, port int) *pasteWatcher {
+	if !terminal.IsRemoteSession() || agent.IsAgentMode() {
+		return nil
+	}
+
+	tty, ok := openPasteTerminal()
+	if !ok {
+		return nil
+	}
+
+	watcher := &pasteWatcher{
+		tty:    tty,
+		writer: w,
+		values: make(chan url.Values, 1),
+		done:   make(chan struct{}),
+	}
+	watcher.printInstructions(port)
+
+	go watcher.run()
+
+	return watcher
+}
+
+// openPasteTerminal opens the controlling terminal for the paste watcher. It
+// is a variable so tests can substitute a pipe.
+//
+// It deliberately opens /dev/tty instead of using os.Stdin. Go keeps the
+// standard streams out of its poller, so Close cannot unblock a read on
+// os.Stdin, and a stale reader would then compete with the prompts that run
+// after login. os.OpenFile puts this file in non-blocking mode and registers it
+// with the poller, so Close does unblock the read.
+//
+// Never call File.Fd on this file. Fd puts the descriptor back into blocking
+// mode, the read then blocks inside the syscall instead of the poller, and
+// Close can no longer stop it. That is also why there is no term.IsTerminal
+// check here: /dev/tty is the controlling terminal by definition, and the open
+// fails when the process has none.
+var openPasteTerminal = func() (*os.File, bool) { //nolint:gochecknoglobals // test seam
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return nil, false
+	}
+	// A read deadline is only supported on a file the poller accepted, so this
+	// reports pollability. A non-zero deadline is required: it is cleared
+	// immediately afterwards.
+	if err := tty.SetReadDeadline(time.Now().Add(time.Hour)); err != nil {
+		_ = tty.Close()
+		return nil, false
+	}
+	if err := tty.SetReadDeadline(time.Time{}); err != nil {
+		_ = tty.Close()
+		return nil, false
+	}
+	return tty, true
+}
+
+// Values reports parsed redirect URLs. A nil watcher returns a nil channel,
+// which blocks forever in a select — exactly the "no paste path" behaviour.
+func (p *pasteWatcher) Values() <-chan url.Values {
+	if p == nil {
+		return nil
+	}
+	return p.values
+}
+
+// Reject reports why a pasted URL did not work and asks for another one. The
+// callback server is still listening, so the flow stays alive. err is never the
+// pasted string: no message may echo the authorization code.
+func (p *pasteWatcher) Reject(err error) {
+	if p == nil {
+		return
+	}
+	fmt.Fprintf(p.writer, "\nThat URL did not work: %v\n", err)
+	fmt.Fprint(p.writer, "Redirect URL (or wait for the browser): ")
+}
+
+// closeGrace bounds the wait for the reader goroutine. Closing a pollable file
+// unblocks its read at once, so the wait is normally instant. The bound is a
+// backstop: a future regression that makes the file blocking must degrade to a
+// short delay, never to a login that hangs forever.
+const closeGrace = 2 * time.Second
+
+// Close stops the watcher and releases the terminal. Closing a pollable file
+// unblocks the pending read, and Close waits for the reader goroutine to end.
+// The terminal therefore has exactly one reader again before login continues to
+// the prompts that follow.
+func (p *pasteWatcher) Close() {
+	if p == nil {
+		return
+	}
+	_ = p.tty.Close()
+	select {
+	case <-p.done:
+	case <-time.After(closeGrace):
+	}
+}
+
+func (p *pasteWatcher) run() {
+	defer close(p.done)
+
+	for {
+		line, err := readLine(p.tty)
+		if err != nil {
+			// The terminal closed, or the flow ended. Stop quietly: the caller
+			// already has a result or an error of its own.
+			return
+		}
+
+		values, err := ParseCallbackInput(line)
+		if err != nil {
+			p.Reject(err)
+			continue
+		}
+
+		p.values <- values
+		return
+	}
+}
+
+func (p *pasteWatcher) printInstructions(port int) {
+	fmt.Fprintln(p.writer)
+	fmt.Fprintln(p.writer, "Note: gcx runs in an SSH session.")
+	fmt.Fprintln(p.writer, "The browser on your computer cannot open the callback address on this host.")
+	fmt.Fprintln(p.writer, "Do one of these two steps. gcx accepts the one that completes first.")
+	fmt.Fprintln(p.writer)
+	fmt.Fprintln(p.writer, "  1. Add a port forward to this SSH session. Press Enter, then press ~C,")
+	fmt.Fprintln(p.writer, "     then type this line:")
+	fmt.Fprintf(p.writer, "       -L %d:127.0.0.1:%d\n", port, port)
+	fmt.Fprintln(p.writer)
+	fmt.Fprintln(p.writer, "  2. Approve the login in the browser on your computer. The browser then")
+	fmt.Fprintln(p.writer, "     goes to an address that does not load. Copy that address and paste it")
+	fmt.Fprintln(p.writer, "     here.")
+	fmt.Fprintln(p.writer)
+	fmt.Fprint(p.writer, "Redirect URL (or wait for the browser): ")
+}

--- a/internal/auth/paste.go
+++ b/internal/auth/paste.go
@@ -158,10 +158,12 @@ func (p *pasteWatcher) run() {
 
 	for {
 		line, err := readLine(p.tty)
-		if p.stopped() {
+		select {
+		case <-p.stop:
 			// Close shut the terminal, which caused this read error. The caller
 			// already has a result or an error of its own, so stop quietly.
 			return
+		default:
 		}
 		if err != nil {
 			// The user pressed Ctrl-D, or the terminal reported an error. Say
@@ -189,18 +191,6 @@ func (p *pasteWatcher) run() {
 		if !p.deliver(pastedInput{Values: values, Err: err}) {
 			return
 		}
-	}
-}
-
-// stopped reports whether Close has run. The reader checks it before it acts on
-// a read error, because Close shuts the terminal and that read error is the
-// expected result.
-func (p *pasteWatcher) stopped() bool {
-	select {
-	case <-p.stop:
-		return true
-	default:
-		return false
 	}
 }
 

--- a/internal/auth/paste.go
+++ b/internal/auth/paste.go
@@ -137,8 +137,8 @@ func (p *pasteWatcher) Reject(err error) {
 // short delay, never to a login that hangs forever.
 const closeGrace = 2 * time.Second
 
-// Close stops the watcher and releases the terminal. Closing a pollable file
-// unblocks the pending read, and Close waits for the reader goroutine to end.
+// Close stops the watcher and releases the terminal. It ends the pending read,
+// waits for the reader goroutine, and discards what the terminal still holds.
 // The terminal therefore has exactly one reader again before login continues to
 // the prompts that follow.
 func (p *pasteWatcher) Close() {
@@ -146,11 +146,22 @@ func (p *pasteWatcher) Close() {
 		return
 	}
 	close(p.stop)
-	_ = p.tty.Close()
+
+	// A deadline in the past ends the pending read at once, because the file is
+	// registered with the poller. Close the file only after the flush below: a
+	// closed descriptor accepts no ioctl.
+	_ = p.tty.SetReadDeadline(time.Now())
 	select {
 	case <-p.done:
 	case <-time.After(closeGrace):
 	}
+
+	// Discard what the user typed without a newline. A terminal in canonical
+	// mode holds that text in its input queue, and the shell reads it once gcx
+	// exits. A partly typed redirect URL would then enter the shell history,
+	// which is the leak that the whole paste route exists to avoid.
+	_ = flushTerminalInput(p.tty)
+	_ = p.tty.Close()
 }
 
 func (p *pasteWatcher) run() {

--- a/internal/auth/paste.go
+++ b/internal/auth/paste.go
@@ -127,8 +127,7 @@ func (p *pasteWatcher) Reject(err error) {
 	if p == nil {
 		return
 	}
-	fmt.Fprintf(p.writer, "\nThat URL did not work: %v\n", err)
-	fmt.Fprint(p.writer, pastePrompt)
+	printPasteRejection(p.writer, err, pastePrompt)
 }
 
 // closeGrace bounds the wait for the reader goroutine. Closing a pollable file

--- a/internal/auth/paste.go
+++ b/internal/auth/paste.go
@@ -25,7 +25,10 @@ import (
 type pasteWatcher struct {
 	tty    *os.File
 	writer io.Writer
-	values chan url.Values
+	values chan pastedInput
+	// stop closes first in Close. The reader goroutine selects on it while it
+	// delivers, so a caller that has stopped reading cannot wedge the send.
+	stop chan struct{}
 	// done closes when the reader goroutine has ended. Close waits on it, so
 	// the terminal has exactly one reader again by the time Close returns.
 	done chan struct{}
@@ -48,7 +51,8 @@ func startPasteWatcher(w io.Writer, port int) *pasteWatcher {
 	watcher := &pasteWatcher{
 		tty:    tty,
 		writer: w,
-		values: make(chan url.Values, 1),
+		values: make(chan pastedInput, 1),
+		stop:   make(chan struct{}),
 		done:   make(chan struct{}),
 	}
 	watcher.printInstructions(port)
@@ -91,9 +95,20 @@ var openPasteTerminal = func() (*os.File, bool) { //nolint:gochecknoglobals // t
 	return tty, true
 }
 
-// Values reports parsed redirect URLs. A nil watcher returns a nil channel,
-// which blocks forever in a select — exactly the "no paste path" behaviour.
-func (p *pasteWatcher) Values() <-chan url.Values {
+// pastedInput is one line that the user pasted: the parsed query parameters, or
+// the error that says why the line was not usable.
+//
+// The watcher delivers the parse error instead of printing it, because the
+// caller writes to the same terminal. One goroutine therefore owns every
+// message, and the two cannot interleave.
+type pastedInput struct {
+	Values url.Values
+	Err    error
+}
+
+// Input reports each pasted line. A nil watcher returns a nil channel, which
+// blocks forever in a select — exactly the "no paste path" behaviour.
+func (p *pasteWatcher) Input() <-chan pastedInput {
 	if p == nil {
 		return nil
 	}
@@ -108,7 +123,7 @@ func (p *pasteWatcher) Reject(err error) {
 		return
 	}
 	fmt.Fprintf(p.writer, "\nThat URL did not work: %v\n", err)
-	fmt.Fprint(p.writer, "Redirect URL (or wait for the browser): ")
+	fmt.Fprint(p.writer, pastePrompt)
 }
 
 // closeGrace bounds the wait for the reader goroutine. Closing a pollable file
@@ -125,6 +140,7 @@ func (p *pasteWatcher) Close() {
 	if p == nil {
 		return
 	}
+	close(p.stop)
 	_ = p.tty.Close()
 	select {
 	case <-p.done:
@@ -143,21 +159,22 @@ func (p *pasteWatcher) run() {
 			return
 		}
 
+		// Keep reading after a delivery. The caller runs the semantic checks
+		// (state, code, token exchange) and calls Reject when they fail, which
+		// re-prompts. That prompt needs a reader. Without one the next pasted
+		// line stays in the terminal buffer, and the shell reads it after gcx
+		// exits, which writes the authorization code into the shell history.
 		values, err := ParseCallbackInput(line)
-		if err != nil {
-			p.Reject(err)
-			continue
+		select {
+		case p.values <- pastedInput{Values: values, Err: err}:
+		case <-p.stop:
+			return
 		}
-
-		p.values <- values
-		return
 	}
 }
 
 func (p *pasteWatcher) printInstructions(port int) {
-	fmt.Fprintln(p.writer)
-	fmt.Fprintln(p.writer, "Note: gcx runs in an SSH session.")
-	fmt.Fprintln(p.writer, "The browser on your computer cannot open the callback address on this host.")
+	printRemoteSessionPreamble(p.writer)
 	fmt.Fprintln(p.writer, "Do one of these two steps. gcx accepts the one that completes first.")
 	fmt.Fprintln(p.writer)
 	fmt.Fprintln(p.writer, "  1. Add a port forward to this SSH session. Press Enter, then press ~C,")
@@ -168,5 +185,5 @@ func (p *pasteWatcher) printInstructions(port int) {
 	fmt.Fprintln(p.writer, "     goes to an address that does not load. Copy that address and paste it")
 	fmt.Fprintln(p.writer, "     here.")
 	fmt.Fprintln(p.writer)
-	fmt.Fprint(p.writer, "Redirect URL (or wait for the browser): ")
+	fmt.Fprint(p.writer, pastePrompt)
 }

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -84,7 +84,16 @@ type Inputs struct {
 	// Zero means auto-pick from the default range. Useful when only specific
 	// ports are forwarded between a remote dev host and the user's browser.
 	OAuthCallbackPort int
-	Yes               bool
+	// OAuthManual completes the OAuth flow without a callback server. gcx
+	// prints the login URL and reads the redirect URL that the user copies
+	// from the browser address bar. It is mutually exclusive with
+	// OAuthCallbackPort.
+	OAuthManual bool
+	// Reader supplies the pasted redirect URL for OAuthManual. It is never
+	// defaulted to os.Stdin here: internal/login is UI-free (NC-001) and never
+	// touches process streams. CLI callers pass cmd.InOrStdin().
+	Reader io.Reader
+	Yes    bool
 	// UseCloudInstanceSelector is only used internally to mark the case in which
 	// a user explicitly left the server empty to be directed to the cloud
 	// instance selector
@@ -657,7 +666,18 @@ func resolveGrafanaAuth(ctx context.Context, opts Options, target Target) (strin
 		if w == nil {
 			w = io.Discard
 		}
-		flow := opts.NewAuthFlow(opts.Server, auth.Options{Writer: w, Port: opts.OAuthCallbackPort})
+		// Manual OAuth reads the pasted redirect URL. internal/login must not
+		// reach for os.Stdin itself, so a missing reader is a programmer error
+		// rather than a silent fallback.
+		if opts.OAuthManual && opts.Reader == nil {
+			return "", nil, errors.New("manual OAuth requires an input reader")
+		}
+		flow := opts.NewAuthFlow(opts.Server, auth.Options{
+			Writer: w,
+			Reader: opts.Reader,
+			Port:   opts.OAuthCallbackPort,
+			Manual: opts.OAuthManual,
+		})
 		result, err := flow.Run(ctx)
 		if err != nil {
 			return "", nil, fmt.Errorf("OAuth flow failed: %w", err)

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1863,3 +1863,69 @@ func TestRun_OAuthSuccess_AnnouncesSignInWithoutEmail(t *testing.T) {
 		"OAuth completion must be acknowledged even without an email")
 	assert.NotContains(t, out, " as ", "no 'as <email>' clause when email is absent")
 }
+
+func TestRun_ManualOAuthReachesAuthOptions(t *testing.T) {
+	var buf bytes.Buffer
+	reader := strings.NewReader("")
+	var got auth.Options
+
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server:      "https://grafana.example.com",
+			Target:      login.TargetOnPrem,
+			UseOAuth:    true,
+			OAuthManual: true,
+			Reader:      reader,
+			Writer:      &buf,
+		},
+		Hooks: login.Hooks{
+			ConfigSource: configSource(t.TempDir()),
+			NewAuthFlow: func(_ string, ao auth.Options) login.AuthFlow {
+				got = ao
+				return &stubAuthFlow{result: &auth.Result{
+					Token:            "gat_test",
+					APIEndpoint:      "https://grafana.example.com/api",
+					InstanceEndpoint: "https://grafana.example.com",
+				}}
+			},
+			ValidateFn: noopValidate,
+		},
+		RetryState: login.RetryState{StagedContext: &config.Context{}},
+	}
+
+	_, err := login.Run(context.Background(), &opts)
+	require.NoError(t, err)
+
+	assert.True(t, got.Manual, "manual mode must reach the auth flow")
+	assert.Zero(t, got.Port, "manual mode never fixes a callback port")
+	assert.Same(t, reader, got.Reader, "the CLI reader must reach the auth flow")
+}
+
+func TestRun_ManualOAuthWithoutReaderFails(t *testing.T) {
+	var buf bytes.Buffer
+	called := false
+
+	opts := login.Options{
+		Inputs: login.Inputs{
+			Server:      "https://grafana.example.com",
+			Target:      login.TargetOnPrem,
+			UseOAuth:    true,
+			OAuthManual: true,
+			Writer:      &buf,
+		},
+		Hooks: login.Hooks{
+			ConfigSource: configSource(t.TempDir()),
+			NewAuthFlow: func(_ string, _ auth.Options) login.AuthFlow {
+				called = true
+				return &stubAuthFlow{result: &auth.Result{Token: "gat_test"}}
+			},
+			ValidateFn: noopValidate,
+		},
+		RetryState: login.RetryState{StagedContext: &config.Context{}},
+	}
+
+	_, err := login.Run(context.Background(), &opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reader")
+	assert.False(t, called, "the auth flow must not start without a reader")
+}

--- a/internal/terminal/remote.go
+++ b/internal/terminal/remote.go
@@ -19,6 +19,12 @@ var sshSessionEnvVars = []string{ //nolint:gochecknoglobals
 // runs gcx. A browser on a different computer cannot open that address, so the
 // login flow needs either a forwarded port or the manual paste mode.
 //
+// The check reads the environment, so it reports true inside a detached tmux or
+// screen session that inherited a stale SSH_CONNECTION, SSH_CLIENT, or SSH_TTY
+// from the session that created it. That result is harmless: the paste route
+// only adds a second way to finish the login, the callback server still works,
+// and the user sees one note too many.
+//
 // The result is deliberately not cached: callers read it at most twice per
 // process, and tests set the environment with t.Setenv.
 func IsRemoteSession() bool {

--- a/internal/terminal/remote.go
+++ b/internal/terminal/remote.go
@@ -1,0 +1,31 @@
+package terminal
+
+import (
+	"os"
+	"strings"
+)
+
+// sshSessionEnvVars are the environment variables that OpenSSH sets in an
+// interactive session on the remote host.
+var sshSessionEnvVars = []string{ //nolint:gochecknoglobals
+	"SSH_CONNECTION",
+	"SSH_CLIENT",
+	"SSH_TTY",
+}
+
+// IsRemoteSession reports whether gcx runs in an SSH session.
+//
+// The OAuth callback server listens on the loopback address of the host that
+// runs gcx. A browser on a different computer cannot open that address, so the
+// login flow needs either a forwarded port or the manual paste mode.
+//
+// The result is deliberately not cached: callers read it at most twice per
+// process, and tests set the environment with t.Setenv.
+func IsRemoteSession() bool {
+	for _, name := range sshSessionEnvVars {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/terminal/remote_test.go
+++ b/internal/terminal/remote_test.go
@@ -1,0 +1,68 @@
+package terminal_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/terminal"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsRemoteSession pins the SSH detection used to decide whether the OAuth
+// callback address is reachable from the user's browser. It uses t.Setenv, so
+// it must not run in parallel.
+func TestIsRemoteSession(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{
+			name: "no ssh variables",
+			env:  map[string]string{},
+			want: false,
+		},
+		{
+			name: "ssh connection set",
+			env:  map[string]string{"SSH_CONNECTION": "10.0.0.1 51234 10.0.0.2 22"},
+			want: true,
+		},
+		{
+			name: "ssh client set",
+			env:  map[string]string{"SSH_CLIENT": "10.0.0.1 51234 22"},
+			want: true,
+		},
+		{
+			name: "ssh tty set",
+			env:  map[string]string{"SSH_TTY": "/dev/pts/0"},
+			want: true,
+		},
+		{
+			name: "empty values",
+			env:  map[string]string{"SSH_CONNECTION": "", "SSH_CLIENT": "", "SSH_TTY": ""},
+			want: false,
+		},
+		{
+			name: "whitespace only values",
+			env:  map[string]string{"SSH_CONNECTION": "   ", "SSH_TTY": "\t"},
+			want: false,
+		},
+		{
+			name: "one populated among blanks",
+			env:  map[string]string{"SSH_CONNECTION": " ", "SSH_TTY": "/dev/pts/3"},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, name := range []string{"SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"} {
+				t.Setenv(name, "")
+			}
+			for name, value := range tc.env {
+				t.Setenv(name, value)
+			}
+
+			assert.Equal(t, tc.want, terminal.IsRemoteSession())
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1135

## Problem

The OAuth callback server listens on `127.0.0.1` on the host that runs gcx. A
user who runs `gcx login` over SSH cannot finish the login, because the browser
on their own computer cannot open that address.

`gcx cloud login` is worse: it has no `--oauth-callback-port` flag, so a planned
port forward could not help that step at all.

A different bind address cannot fix this. I checked the `grafana-assistant-app`
plugin source:

- `apps/plugin/src/pages/tunnelUrls.ts` hard-codes host `127.0.0.1` and only
  accepts a port between 1024 and 65535.
- `apps/plugin/src/pages/useAuthFlow.ts` finishes with
  `window.location.href = callbackUrl`.

The second fact is the fix. The browser does a real navigation, so the complete
redirect URL stays in the address bar when the connection fails.

## Change

**The SSH case now needs no flag and no restart.** When gcx detects an SSH
session, has a usable `/dev/tty`, and is not in agent mode, it keeps the
callback server listening **and** reads a pasted redirect URL at the same time.
gcx takes whichever route completes first:

```
Note: gcx runs in an SSH session.
The browser on your computer cannot open the callback address on this host.
Do one of these two steps. gcx accepts the one that completes first.

  1. Add a port forward to this SSH session. Press Enter, then press ~C,
     then type this line:
       -L 54321:127.0.0.1:54321

  2. Approve the login in the browser on your computer. The browser then
     goes to an address that does not load. Copy that address and paste it
     here.

Redirect URL (or wait for the browser):
```

The hint leads with the OpenSSH `~C` escape, which adds a port forward to the
running session. That needs no reconnect and no hostname, and gcx keeps waiting,
so the login completes as soon as the browser reaches the port. A pasted URL
that does not work re-prompts instead of ending the flow, because the callback
server is still up.

**`--oauth-manual` covers the rest.** The flag starts no callback server and
only reads the pasted URL. It serves scripts and terminals that have no
`/dev/tty`. It works on `gcx login` and on `gcx cloud login`. It implies
`--oauth`, and it conflicts with `--oauth-callback-port` and with `--token`.

Where gcx runs over SSH but cannot read a terminal, it falls back to a static
hint with the `ssh -L` command and `--oauth-manual`.

### Files

- `internal/terminal/remote.go` — `IsRemoteSession()` detects an SSH session.
- `internal/auth/callback.go` — one shared callback-parameter handler for the
  HTTP callback and the paste path, so the state check, the PKCE exchange, and
  endpoint validation cannot diverge. This removes about 90 duplicated lines.
- `internal/auth/paste.go` — the watcher that reads pasted URLs while the
  callback server still listens.
- `internal/auth/manual.go` — redirect-URL parsing, a line reader that does not
  over-read the TTY, and the instruction text.
- Manual mode uses a fixed callback port `54321`, the first port of the normal
  auto-pick range `54321-54399`, so the GCOM `redirect_uri` shape does not
  change. The auto-paste path keeps the port that the listener picked, and the
  hint prints that port.
- The interactive login menu offers the manual mode, and puts it first for a
  Cloud target in an SSH session.
- One choice covers the Cloud follow-up step too.

### Design notes on the paste watcher

The watcher reads a separately opened `/dev/tty`, never `os.Stdin`. Go keeps the
standard streams out of its poller, so a blocking read on `os.Stdin` cannot be
cancelled, and a stale reader would compete with the `huh` prompts that run
after login.

Never call `File.Fd` on that file. `Fd` puts the descriptor back into blocking
mode, the read then blocks inside the syscall rather than the poller, and
`Close` can no longer stop it. `TestOpenPasteTerminalReadIsCancellable` is the
regression guard.

The watcher parses and delivers; it never prints. The caller owns the terminal,
so one goroutine writes every message and the two cannot interleave. The watcher
also keeps reading after a delivery, because the caller runs the semantic checks
(state, code, token exchange) and re-prompts when they fail. That re-prompt
needs a live reader.

## Security notes

The pasted URL holds a single-use authorization code and the state value. It
does not hold the PKCE `code_verifier` or a token, so the code alone cannot mint
a token. gcx reads it from a prompt, so it never enters shell history. gcx
prints a reminder to clear the terminal, and a test pins that no error message
echoes the pasted string.

`TestPasteWatcherKeepsReadingAfterCallerRejection` pins the reader that makes
that guarantee hold. A watcher that stopped after the first delivery would leave
the re-prompt with no reader. The next pasted line would stay in the terminal
buffer, and the shell would read it once gcx exited — which writes the
authorization code into the shell history.

## How to test

1. SSH into a remote host and build gcx there.
2. Run `gcx login --server https://<stack>.grafana.net --oauth`.
3. Confirm the two-option SSH prompt appears.
4. Open the printed URL in the browser on your own computer, check the
   verification code, and approve.
5. Confirm the browser fails to load `http://127.0.0.1:54321/callback?...`.
6. Copy the address, paste it into the remote terminal, and confirm gcx signs
   in.
7. Repeat step 2. This time press Enter, press `~C`, then type
   `-L 54321:127.0.0.1:54321`. Confirm gcx completes over the callback with no
   paste.
8. Run `gcx dashboards list` to confirm the token.
9. Repeat with `gcx cloud login`, then run `gcx cloud stacks list`.
10. Run `gcx login --oauth-manual` and confirm gcx starts no callback server.
11. Check the error paths: paste a URL from a second login attempt (state
    mismatch), paste plain text (parse error), and press Ctrl-D (EOF error).
    Confirm each one re-prompts rather than ends the flow.

I ran the whole paste flow end to end against a local fake GCOM server. The
token exchange sent `redirect_uri=http://127.0.0.1:54321/callback`, byte
identical to the authorize request, and gcx reported the authenticated user.

`GCX_AGENT_MODE=false mise run gate` passes (lint, tests, build). `mise run
docs` cannot run locally because `mkdocs` is absent; CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
