### PR TITLE
docs(design): rule for datasource query variants (mode flag vs separate path)

### DIFF
--- a/docs/design/command-naming.md
+++ b/docs/design/command-naming.md
@@ -101,10 +101,10 @@ what they get back, not by counting backend APIs.
 
 Variants that share an expression operand, take substantially the same required
 inputs, and return the same success output model are one `query` command with a
-typed `--mode`. Two leaves that differ only in presentation give a caller, and
-an agent selecting a command, a coin flip with no rule for choosing. Use one
-flag name per knob across modes: the same value must not be `--size` in one mode
-and `--limit` in another.
+typed `--mode`. Separate leaves with the same caller-facing contract give
+callers and agents a coin flip with no rule for choosing. Use one flag name per
+knob across modes: the same value must not be `--size` in one mode and
+`--limit` in another.
 
 Variants that require materially different identities or inputs, or that return
 a different success output model, take their own `<target> query` path, or an
@@ -124,6 +124,12 @@ documented result are one command. Two that return different result models are
 not, even when both are the same output protocol class; protocol class does not
 decide this.
 
+The subject stays positional in every variant, per
+[CONSTITUTION.md § CLI Grammar](../../CONSTITUTION.md#cli-grammar): the metric,
+expression or query text is the operand, and the identity that scopes it is
+flags. `gcx datasources cloudwatch query` is flag-only and shipped in v1.0.0,
+so it is a compatibility exception, not a shape to copy.
+
 `--mode` is a closed, validated enum with a documented default. Reject an
 unknown, whitespace-only, or explicitly empty value with an error naming the
 rejected value and the allowed values, as `--on-error` does in
@@ -131,6 +137,12 @@ rejected value and the allowed values, as `--on-error` does in
 selects how the result is presented. Where the backend already determines the
 variant — InfluxDB's query language is read from the datasource record — the
 caller has nothing to choose and no flag is added.
+
+A kind that gains a `--mode` must keep it reachable from the auto-detecting
+`gcx datasources query`, which already carries kind-specific knobs. Silently
+answering with the default mode there, while the typed command honours the
+flag, splits one contract across two paths. If the generic form cannot carry
+the mode, redirect it to the typed command instead.
 
 `<target>` names the query surface: the expression language and API being
 queried. It nests inside the command's existing area, so for a datasource kind
@@ -163,20 +175,23 @@ today:
 gcx datasources elasticsearch query 'status:500'
 gcx datasources elasticsearch query 'level:error' --mode logs
 
-gcx datasources azuremonitor query --subscription SUB_ID \
-  --resource-group RG --resource NAME --namespace NAMESPACE --metric METRIC
-gcx datasources azuremonitor logs query KQL
-gcx datasources azuremonitor resource-graph query KQL
+gcx datasources azuremonitor query METRIC \
+  --subscription SUB_ID --resource-group RG \
+  --resource NAME --namespace NAMESPACE
+gcx datasources azuremonitor logs query KQL \
+  --subscription SUB_ID --resource-group RG --workspace WORKSPACE
+gcx datasources azuremonitor resource-graph query KQL \
+  --subscription SUB_ID
 ```
 
 Elasticsearch documents and logs share the Lucene expression, the time controls
 and the result model, so they are one command with `--mode` defaulting to
 `documents`; that they build different requests internally is not the test. Its
 `metrics` leaf stays separate: different inputs, a different result model, and
-`metrics` is already in the shorthand set. Azure Monitor keeps the structured
-metrics query as its primary `query`, while logs require a workspace identity
-and Resource Graph requires a subscription list, so each of those is its own
-target path.
+`metrics` is already in the shorthand set. Azure Monitor keeps the metric query
+as its primary `query`, with the metric positional and its resource identity in
+flags, while logs require a workspace identity and Resource Graph requires a
+subscription list, so each of those is its own target path.
 
 ## View verbs
 

--- a/docs/design/command-naming.md
+++ b/docs/design/command-naming.md
@@ -111,6 +111,13 @@ a different success output model, take their own `<target> query` path, or an
 approved shorthand from the set above where one already fits. A target that
 needs its own identity arguments is not a mode of another command.
 
+One variant is the family's primary query and keeps the bare `<kind> query`
+path: the one a caller who names no target means. Choose it once, state it in
+the command's `Long`, and spell every other variant as a mode or a target. This
+is what decides an otherwise symmetric pair — two variants can both have their
+own inputs and result model, and one of them still has to be the default the
+family answers to.
+
 Compare the caller-facing contract, not the backend payload. Two variants that
 build different requests internally but answer the same expression with the same
 documented result are one command. Two that return different result models are
@@ -140,11 +147,13 @@ unless that name is already in the shorthand set above.
 This rule authorizes that nesting and nothing else. It does not authorize a new
 top-level command: bare top-level verbs remain the closed enumeration in
 [CONSTITUTION.md § CLI Grammar](../../CONSTITUTION.md#cli-grammar), and the
-`$AREA $NOUN $VERB` shape at the top of this guide still governs. Everything
-under `gcx datasources <kind>` is flat today, so the nesting is an
-owner-approved pattern introduced with this rule rather than an inference from
-any shipped command. As with every rule here, it binds new work and does not
-license renaming a released variant.
+`$AREA $NOUN $VERB` shape at the top of this guide still governs. Nesting under
+a datasource kind is otherwise almost unused — `gcx datasources pyroscope
+exemplars profile` and `… exemplars span` are the only shipped instance, and
+[the list-subject verdicts](../plans/list-subject-verdicts.md) defer their
+convergence rather than ratify them — so the authorization here comes from
+this rule, not from reading them as precedent. As with every rule here, it
+binds new work and does not license renaming a released variant.
 
 The two shapes below were decided as owner on the pull requests that raised the
 question. They are the canonical spellings for that work, not commands available

--- a/docs/design/command-naming.md
+++ b/docs/design/command-naming.md
@@ -93,6 +93,82 @@ vocabulary and intentional aliases are documented in
 Do not characterize query commands as side-effect-free: supporting work such as
 datasource discovery may persist configuration.
 
+## Query variants
+
+A datasource or provider may offer more than one way to be queried. Decide
+between one command and several by comparing what the caller must supply and
+what they get back, not by counting backend APIs.
+
+Variants that share an expression operand, take substantially the same required
+inputs, and return the same success output model are one `query` command with a
+typed `--mode`. Two leaves that differ only in presentation give a caller, and
+an agent selecting a command, a coin flip with no rule for choosing. Use one
+flag name per knob across modes: the same value must not be `--size` in one mode
+and `--limit` in another.
+
+Variants that require materially different identities or inputs, or that return
+a different success output model, take their own `<target> query` path, or an
+approved shorthand from the set above where one already fits. A target that
+needs its own identity arguments is not a mode of another command.
+
+Compare the caller-facing contract, not the backend payload. Two variants that
+build different requests internally but answer the same expression with the same
+documented result are one command. Two that return different result models are
+not, even when both are the same output protocol class; protocol class does not
+decide this.
+
+`--mode` is a closed, validated enum with a documented default. Reject an
+unknown, whitespace-only, or explicitly empty value with an error naming the
+rejected value and the allowed values, as `--on-error` does in
+`cmd/gcx/resources/onerror.go`. `--mode` selects which query runs; `--output`
+selects how the result is presented. Where the backend already determines the
+variant — InfluxDB's query language is read from the datasource record — the
+caller has nothing to choose and no flag is added.
+
+`<target>` names the query surface: the expression language and API being
+queried. It nests inside the command's existing area, so for a datasource kind
+the path is `gcx datasources <kind> <target> query`. This is a query-variant
+placement rule, deliberately distinct from
+[placement by required identity](#place-each-operation-by-the-identity-it-requires)
+below — a query surface is not an independently identifiable resource, so
+neither the noun-group test nor the `<operation>-<subject>` compound test
+decides it. Reading a query target as a discovery facet and producing
+`query-<target>` is the wrong outcome: the operation is `query`, and the target
+says which surface it runs against. A bare `<target>` leaf is equally wrong
+unless that name is already in the shorthand set above.
+
+This rule authorizes that nesting and nothing else. It does not authorize a new
+top-level command: bare top-level verbs remain the closed enumeration in
+[CONSTITUTION.md § CLI Grammar](../../CONSTITUTION.md#cli-grammar), and the
+`$AREA $NOUN $VERB` shape at the top of this guide still governs. Everything
+under `gcx datasources <kind>` is flat today, so the nesting is an
+owner-approved pattern introduced with this rule rather than an inference from
+any shipped command. As with every rule here, it binds new work and does not
+license renaming a released variant.
+
+The two shapes below were decided as owner on the pull requests that raised the
+question. They are the canonical spellings for that work, not commands available
+today:
+
+```shell
+gcx datasources elasticsearch query 'status:500'
+gcx datasources elasticsearch query 'level:error' --mode logs
+
+gcx datasources azuremonitor query --subscription SUB_ID \
+  --resource-group RG --resource NAME --namespace NAMESPACE --metric METRIC
+gcx datasources azuremonitor logs query KQL
+gcx datasources azuremonitor resource-graph query KQL
+```
+
+Elasticsearch documents and logs share the Lucene expression, the time controls
+and the result model, so they are one command with `--mode` defaulting to
+`documents`; that they build different requests internally is not the test. Its
+`metrics` leaf stays separate: different inputs, a different result model, and
+`metrics` is already in the shorthand set. Azure Monitor keeps the structured
+metrics query as its primary `query`, while logs require a workspace identity
+and Resource Graph requires a subscription list, so each of those is its own
+target path.
+
 ## View verbs
 
 Default to `get` for a straight read. Use a view verb such as `status`,


### PR DESCRIPTION
Closes #1139.

## The problem

When a datasource supports more than one kind of query, we had nothing written down about whether that becomes a flag on one command or a separate command path. Two in-flight PRs hit it in the same week and answered it differently: Azure Monitor (#965) added `logs` and `resource-graph` as bare leaves next to `query`, Elasticsearch (#971) added `logs` as a bare leaf next to `query` and `metrics`.

Nothing covered them. The guide reserves `query` for executing a backend query and closes the shorthand set at `labels`, `series`, `metrics`, `metadata`. `docs/plans/list-subject-verdicts.md` applies its test only to discovery facets. And the guide is explicit that a shipped command is not automatic precedent, so a contributor couldn't resolve it by copying a neighbour either. Command paths freeze for the major version, so this was landing on review one PR at a time, which is exactly where we said naming shouldn't be decided.

## The rule

One new `## Query variants` section, placed right after "Query and discovery operations" since that's the adjacent rule. Same expression operand, substantially the same required inputs and the same success output model means one `query` command with a typed `--mode`. Materially different required identity or inputs, or a different success output model, means its own `<target> query` path, or an approved shorthand where one already fits.

The bit that took the most iterating is the phrase "caller-facing contract". An earlier draft said "same result schema", which reads as the wire payload and gets Elasticsearch wrong: `Search()` and `Logs()` build different requests internally but both return `*querysql.QueryResponse`, which is why they're one command. `Aggregations()` returns a different model, which is why `metrics` isn't. Protocol class doesn't decide it either, and the rule says so, because both are `finite`.

Also written down: `--mode` is a closed validated enum with a documented default, rejecting unknown, whitespace-only and explicitly empty values with an error naming the value and the allowed set; mode picks the query, `--output` picks the presentation; and where the backend already determines the variant there is no flag to add. That last one is the only sentence here that #1139 didn't ask for. Without it the rule reads as a mandate to add `--mode influxql|flux|sql` to InfluxDB, whose language is read off the datasource record today, and that would be a new frozen flag on a shipped command. Easy to strike if you'd rather not have it.

`<target>` names the query surface, not a resource, so the section says explicitly that the identity-placement rule below it doesn't apply and that `query-<target>` is the wrong outcome. Nesting is called out as owner-approved and introduced by this rule rather than inferred from anything shipped, since everything under `gcx datasources <kind>` is flat today. It authorizes the nesting and nothing else, and it binds new work only.

## Alternatives rejected

Recording the rule in `docs/plans/list-subject-verdicts.md`: that file is scoped to the `list-<subject>` family under #387 and is retrospective. New durable rules belong in the naming guide.

Deciding by protocol class: `metrics` is the counterexample and it's in the rule as one.

Promising exit code 2 for a bad `--mode`: the reachable machinery for that is #1138, which isn't built. The rule requires the error's content, not its code.

## Tests

Documentation only. No code, no generated references, no output classes, no ADR table, no navigation. `GCX_AGENT_MODE=false mise run all` passes and regenerated references come back clean.

## One thing to know before merging

There's a competing `### Query variants` section sitting on the #1126 branch as an unpushed local commit (`0fdb8ea2`). It isn't on `main` and isn't on the PR yet. #1139 should own this section, so that commit needs dropping or deferring and #1126 rebasing afterwards. The good parts of it are folded in here: the query-surface framing, the distinction from identity placement, the "not a new top-level command" clause, and the one-flag-name-per-knob rule.

Worth landing this one first either way, because #1126's `references/self-review.md` already refers to "the §Query variants rule in docs/design/command-naming.md". The heading here is spelled to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)