### PR TITLE
refactor(datasources): make generic query routing complexity-stable

### DIFF
--- a/.claude/skills/add-datasource/SKILL.md
+++ b/.claude/skills/add-datasource/SKILL.md
@@ -226,8 +226,24 @@ Reference: `internal/datasources/providers/prometheus.go`.
    `gcx datasources list -o json` and add a mapping in
    `internal/datasources/query/resolve.go` if they don't match. Without this,
    auto-discovery and datasource type validation will fail silently.
-3. Optionally add to the auto-detecting `datasources query` switch in
-   `cmd/gcx/datasources/query.go`
+3. **Routing for the auto-detecting `datasources query`** — registration mounts
+   your typed `datasources <kind>` subtree but does not reach the generic
+   command, which routes through the tables in
+   `cmd/gcx/datasources/query_routes.go`. Add exactly one entry, keyed by the
+   normalized kind:
+   - the generic `<uid> <expr>` form can honestly carry your query → add a
+     `dispatch` entry plus a small handler alongside the existing ones;
+   - it cannot, because your query takes structured parameters no single
+     expression represents → add a `redirects` entry built with
+     `structuredQueryRedirect`, naming your typed command. CloudWatch is the
+     worked example.
+
+   Adding neither is also a choice: your kind then reports as unsupported. Make
+   it deliberately — a caller who reasonably reaches for `datasources query`
+   gets a dead end. The two tables must stay disjoint and keyed by normalized
+   kinds; `query_routes_internal_test.go` enforces both, and the supported-kind
+   list in the unsupported-type error is derived, so there is nothing to
+   hand-update.
 
 ### Step 4: Agent Annotations
 

--- a/.claude/skills/add-datasource/SKILL.md
+++ b/.claude/skills/add-datasource/SKILL.md
@@ -402,9 +402,16 @@ Then trace each registration in `RegisterCodecs` to a reachable `Encode`
    Adding neither is also a choice: your kind then reports as unsupported. Make
    it deliberately — a caller who reasonably reaches for `datasources query`
    gets a dead end. The two tables must stay disjoint and keyed by normalized
-   kinds; `query_routes_internal_test.go` enforces both, and the supported-kind
-   list in the unsupported-type error is derived, so there is nothing to
-   hand-update.
+   kinds; `query_routes_internal_test.go` enforces both.
+
+   The supported-kind list in the unsupported-type error is derived from the
+   tables, so you never edit that string. You **do** update the two places that
+   pin its exact value, because it is user-visible text on a GA path and is
+   deliberately not free to drift:
+   `TestQueryRoutesSupportedKindsIsTheSortedUnion` in
+   `query_routes_internal_test.go`, and `wantUnsupportedMessage` in
+   `query_unsupported_test.go`. Both fail with the old and new lists side by
+   side, so the update is mechanical.
 
 ### Step 5: Agent Annotations
 

--- a/.claude/skills/add-datasource/SKILL.md
+++ b/.claude/skills/add-datasource/SKILL.md
@@ -387,19 +387,24 @@ Then trace each registration in `RegisterCodecs` to a reachable `Encode`
    `gcx datasources list -o json` and add a mapping in
    `internal/datasources/query/resolve.go` if they don't match. Without this,
    auto-discovery and datasource type validation will fail silently.
-3. Decide, deliberately, what the auto-detecting `datasources query` should do
-   for your kind — the switch in `cmd/gcx/datasources/query.go` is
-   hand-maintained and no test enforces parity with registration:
-   - the generic `<uid> <expr>` form can carry your query → add the case, so a
-     caller reaching for `datasources query` is not met with the bare
-     "datasource type %q is not supported" default;
-   - it cannot (a structured query with several required parameters) → add an
-     explicit redirect naming your typed command and its flags, the way
-     CloudWatch does. Do not force a lossy generic path. Put the redirect where
-     CloudWatch's is: a guard on the normalized type **before** the switch and
-     before `shared.ResolveExpr`. As a switch case it never fires for
-     `gcx datasources query <uid>` with no expression — that call dies on
-     "expression required" first.
+3. **Routing for the auto-detecting `datasources query`** — registration mounts
+   your typed `datasources <kind>` subtree but does not reach the generic
+   command, which routes through the tables in
+   `cmd/gcx/datasources/query_routes.go`. Add exactly one entry, keyed by the
+   normalized kind:
+   - the generic `<uid> <expr>` form can honestly carry your query → add a
+     `dispatch` entry plus a small handler alongside the existing ones;
+   - it cannot, because your query takes structured parameters no single
+     expression represents → add a `redirects` entry built with
+     `structuredQueryRedirect`, naming your typed command. CloudWatch is the
+     worked example.
+
+   Adding neither is also a choice: your kind then reports as unsupported. Make
+   it deliberately — a caller who reasonably reaches for `datasources query`
+   gets a dead end. The two tables must stay disjoint and keyed by normalized
+   kinds; `query_routes_internal_test.go` enforces both, and the supported-kind
+   list in the unsupported-type error is derived, so there is nothing to
+   hand-update.
 
 ### Step 5: Agent Annotations
 

--- a/.claude/skills/add-datasource/SKILL.md
+++ b/.claude/skills/add-datasource/SKILL.md
@@ -241,9 +241,16 @@ Reference: `internal/datasources/providers/prometheus.go`.
    Adding neither is also a choice: your kind then reports as unsupported. Make
    it deliberately — a caller who reasonably reaches for `datasources query`
    gets a dead end. The two tables must stay disjoint and keyed by normalized
-   kinds; `query_routes_internal_test.go` enforces both, and the supported-kind
-   list in the unsupported-type error is derived, so there is nothing to
-   hand-update.
+   kinds; `query_routes_internal_test.go` enforces both.
+
+   The supported-kind list in the unsupported-type error is derived from the
+   tables, so you never edit that string. You **do** update the two places that
+   pin its exact value, because it is user-visible text on a GA path and is
+   deliberately not free to drift:
+   `TestQueryRoutesSupportedKindsIsTheSortedUnion` in
+   `query_routes_internal_test.go`, and `wantUnsupportedMessage` in
+   `query_unsupported_test.go`. Both fail with the old and new lists side by
+   side, so the update is mechanical.
 
 ### Step 4: Agent Annotations
 

--- a/.claude/skills/integrate-with-gcx/SKILL.md
+++ b/.claude/skills/integrate-with-gcx/SKILL.md
@@ -238,10 +238,10 @@ user it needs a human to drive, and point them at
 Per-leaf wiring CI will not let you skip is tabulated in the reference, along
 with the one gap CI does *not* catch: registration mounts the typed
 `datasources <kind>` subtree, but reaching the generic auto-detecting
-`datasources query` is a separate **judgement, not a checkbox** — a case if the
-`<uid> <expr>` form can honestly carry your query, an explicit redirect if it
-cannot. Both the reasoning and the ordering requirement are in the reference; get
-them from there rather than from memory.
+`datasources query` is a separate **judgement, not a checkbox** — a `dispatch`
+entry if the `<uid> <expr>` form can honestly carry your query, a `redirects`
+entry if it cannot. Both the reasoning and the ordering requirement are in the
+reference; get them from there rather than from memory.
 
 Format the files you touched, then gate:
 

--- a/.claude/skills/integrate-with-gcx/references/distribution-and-gates.md
+++ b/.claude/skills/integrate-with-gcx/references/distribution-and-gates.md
@@ -31,40 +31,50 @@ column literally — some rows are CI-enforced and some only look like it:
 A new datasource kind
 is mounted as `datasources <kind>` automatically from
 `datasources.AllProviders()`, but the generic auto-detecting `datasources query`
-dispatches through a hand-maintained switch in `cmd/gcx/datasources/query.go`.
-Registration does not reach it, and no test enforces parity — deliberately, because
-parity is not always correct:
+routes through two hand-maintained tables in
+`cmd/gcx/datasources/query_routes.go`. Registration does not reach them, and no
+test enforces parity — deliberately, because parity is not always correct:
 
-- **The generic `<uid> <expr>` contract fits your kind** → add the case. Otherwise
-  a caller who reasonably reaches for `datasources query` gets the bare
-  "datasource type %q is not supported" default.
-- **It does not fit** → add an explicit redirect instead. CloudWatch is the
-  worked example: its query is structured (namespace, metric, dimensions, region,
-  statistic, period), no single `expr` can carry it, so the command returns an
-  error naming the typed command to use. That is the honest outcome, not a
-  degraded generic path.
+- **The generic `<uid> <expr>` contract fits your kind** → add a `dispatch`
+  entry plus a small handler. Otherwise a caller who reasonably reaches for
+  `datasources query` gets the bare "datasource type %q is not supported"
+  default.
+- **It does not fit** → add a `redirects` entry instead, built with
+  `structuredQueryRedirect`. CloudWatch is the worked example: its query is
+  structured (namespace, metric, dimensions, region, statistic, period), no
+  single `expr` can carry it, so the command returns an error naming the typed
+  command to use. That is the honest outcome, not a degraded generic path.
 
   **The durable requirement is ordering: a redirect has to run before the
   expression is resolved.** Otherwise `gcx datasources query <uid>` with no
   expression fails on "expression required" before it can name your typed
   command — losing the redirect in exactly the invocation that needs it.
 
-  As the code stands today that means a guard placed ahead of both
-  `shared.ResolveExpr` and the type switch in `cmd/gcx/datasources/query.go`.
-  That placement is a property of the current hand-written `RunE`, not policy: if
-  routing becomes declarative the mechanism changes while the ordering
-  requirement does not. Read the function before copying the shape.
+  Routing is declarative now, so you get that ordering for free: the redirect
+  lookup in `(*genericQueryOpts).run` sits ahead of both `ResolveExpr` and the
+  dispatch lookup, and the characterization suite pins it. You choose a table,
+  not a position in a function. The two tables must stay disjoint and keyed by
+  normalized kinds (`NormalizeKind`); `query_routes_internal_test.go` enforces
+  both, so "a case *and* a guard" is not constructible.
 
-To see which kinds are currently outside the switch, derive it rather than
+The unsupported-kind message is derived from the tables, so you never edit that
+string — but two tests pin its exact value, because it is user-visible text on a
+GA path: `TestQueryRoutesSupportedKindsIsTheSortedUnion` and
+`wantUnsupportedMessage` in `query_unsupported_test.go`. Both fail with the old
+and new lists side by side, so the update is mechanical.
+
+To see which kinds are currently outside the tables, derive it rather than
 trusting a list here — it changes with every datasource PR:
 
 ```bash
 rg -n 'RegisterProvider' internal/datasources/providers  # registered kinds
-rg -n 'case "' cmd/gcx/datasources/query.go              # kinds it dispatches
+rg -n '^\s+"' cmd/gcx/datasources/query_routes.go       # routed kinds, both tables
 ```
 
-Match on the registration call rather than listing the directory — that package
-also holds non-kind files, so a file listing overstates the set.
+Read `newQueryRoutes()` directly rather than trusting the second pattern; it is a
+starting point, not a parser. Match registration on the call rather than listing
+the directory — that package also holds non-kind files, so a file listing
+overstates the set.
 
 The difference is the candidate set, minus the kinds excluded by design (a
 structured query has no single-`expr` representation, so it gets a redirect).

--- a/.claude/skills/integrate-with-gcx/references/placement-and-readiness.md
+++ b/.claude/skills/integrate-with-gcx/references/placement-and-readiness.md
@@ -86,8 +86,9 @@ everything below is a wiring option within or beside them, not a new tier:
   `internal/datasources/providers/<kind>.go`. Registration mounts the typed
   `datasources <kind>` subtree automatically; it does **not** reach the generic
   auto-detecting `datasources query`. That second decision is a judgement no test
-  catches: add a case if the generic `<uid> <expr>` form can honestly carry your
-  query, or an explicit redirect to your typed command if it cannot. Reasoning,
+  catches: add a `dispatch` entry if the generic `<uid> <expr>` form can honestly
+  carry your query, or a `redirects` entry naming your typed command if it
+  cannot — both tables live in `cmd/gcx/datasources/query_routes.go`. Reasoning,
   the worked CloudWatch example and the ordering requirement:
   [distribution-and-gates.md § The gap CI does not cover](distribution-and-gates.md#the-gap-ci-does-not-cover-and-it-is-a-judgement-call).
 - **Skill-only** — a portable workflow for people using gcx across projects
@@ -106,7 +107,7 @@ everything below is a wiring option within or beside them, not a new tier:
 | Cloud provider | single `providers.Register()` in `init()` + blank import in `cmd/gcx/root/command.go` | `internal/providers/slo/provider.go` | docs/reference/provider-guide.md, docs/design/provider-checklist.md |
 | Adapter-backed resource | returned from `Provider.TypedRegistrations()` — never call `adapter.Register()` directly | `internal/providers/irm/oncall_adapter.go` | docs/architecture/patterns.md §16-18, CONSTITUTION § Architecture Invariants |
 | Signal command | `signals.Descriptor` + `signals.Command()` | `internal/providers/metrics/provider.go` | ARCHITECTURE.md §3 |
-| Datasource kind | `datasources.RegisterProvider()` in `internal/datasources/providers/<kind>.go` (package already blank-imported). Generic dispatch is a **separate, conditional** decision — a case if `<uid> <expr>` fits, an explicit redirect if it does not ([detail](distribution-and-gates.md#the-gap-ci-does-not-cover-and-it-is-a-judgement-call)) | `internal/datasources/providers/prometheus.go` | ADR 001, docs/architecture/patterns.md §12 |
+| Datasource kind | `datasources.RegisterProvider()` in `internal/datasources/providers/<kind>.go` (package already blank-imported). Generic routing is a **separate, conditional** decision — a `dispatch` entry in `cmd/gcx/datasources/query_routes.go` if `<uid> <expr>` fits, a `redirects` entry if it does not ([detail](distribution-and-gates.md#the-gap-ci-does-not-cover-and-it-is-a-judgement-call)) | `internal/datasources/providers/prometheus.go` | ADR 001, docs/architecture/patterns.md §12 |
 | Portable user skill | directory under `claude-plugin/skills/` (auto-embedded) + row in `claude-plugin/README.md` | any sibling skill | AGENTS.md Key Conventions |
 | Repository contributor skill | directory under `.claude/skills/` (discovered from the checkout; not embedded) | `.claude/skills/add-provider/` | AGENTS.md Key Conventions |
 

--- a/cmd/gcx/datasources/query.go
+++ b/cmd/gcx/datasources/query.go
@@ -3,6 +3,7 @@ package datasources
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
@@ -87,7 +88,8 @@ func (o *genericQueryOpts) run(cmd *cobra.Command, args []string) error {
 
 	dispatch, ok := o.routes.dispatch[dsType]
 	if !ok {
-		return fmt.Errorf("datasource type %q is not supported (supported: prometheus, loki, pyroscope, influxdb, clickhouse)", dsType)
+		return fmt.Errorf("datasource type %q is not supported (supported: %s)",
+			dsType, strings.Join(o.routes.supportedKinds(), ", "))
 	}
 
 	resp, err := dispatch(ctx, genericQueryRequest{

--- a/cmd/gcx/datasources/query.go
+++ b/cmd/gcx/datasources/query.go
@@ -1,33 +1,117 @@
 package datasources
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
-	"github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
-	cmdio "github.com/grafana/gcx/internal/output"
-	"github.com/grafana/gcx/internal/query/clickhouse"
-	"github.com/grafana/gcx/internal/query/influxdb"
-	"github.com/grafana/gcx/internal/query/loki"
-	"github.com/grafana/gcx/internal/query/postgres"
-	"github.com/grafana/gcx/internal/query/prometheus"
-	"github.com/grafana/gcx/internal/query/pyroscope"
-	querysql "github.com/grafana/gcx/internal/query/sql"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
+
+// genericQueryOpts holds the flags and routing policy for the auto-detecting
+// query command. The per-kind behaviour lives in query_routes.go.
+type genericQueryOpts struct {
+	config cmdconfig.Options
+	shared dsquery.SharedOpts
+
+	profileType string
+	maxNodes    int64
+	limit       int
+
+	routes queryRoutes
+}
+
+func (o *genericQueryOpts) setup(flags *pflag.FlagSet) {
+	o.config.BindFlags(flags)
+	o.shared.Setup(flags, true)
+	flags.StringVar(&o.profileType, "profile-type", "", "Profile type ID for pyroscope queries (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds')")
+	flags.Int64Var(&o.maxNodes, "max-nodes", 1024, "Maximum nodes in flame graph (pyroscope only)")
+	flags.IntVar(&o.limit, "limit", dsquery.DefaultLokiLimit, "Maximum number of log lines to return for loki queries (0 means no limit)")
+}
+
+// Validate runs the checks that need no I/O. args carries the optional
+// positional expression, which cannot be combined with --expr.
+func (o *genericQueryOpts) Validate(args []string) error {
+	if err := o.shared.Validate(); err != nil {
+		return err
+	}
+
+	// Reject "both positional and --expr" before any HTTP call.
+	if len(args) > 1 && o.shared.Expr != "" {
+		return errors.New("provide the expression as a positional argument or via --expr, not both")
+	}
+
+	return nil
+}
+
+// run resolves the datasource kind and hands the request to its route. The
+// order of the steps below is load-bearing and pinned by tests; see
+// query_characterization_test.go.
+func (o *genericQueryOpts) run(cmd *cobra.Command, args []string) error {
+	if err := o.Validate(args); err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	datasourceUID := args[0]
+
+	cfg, err := o.config.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	rawType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
+	if err != nil {
+		return err
+	}
+	dsType := dsquery.NormalizeKind(rawType)
+
+	// Redirects run before the expression is resolved, so an argument-less call
+	// gets the typed-command redirect instead of "expression is required".
+	if redirect, ok := o.routes.redirects[dsType]; ok {
+		return errors.New(redirect)
+	}
+
+	expr, err := o.shared.ResolveExpr(args, 1)
+	if err != nil {
+		return err
+	}
+
+	start, end, step, err := o.shared.ParseTimes(time.Now())
+	if err != nil {
+		return err
+	}
+
+	dispatch, ok := o.routes.dispatch[dsType]
+	if !ok {
+		return fmt.Errorf("datasource type %q is not supported (supported: prometheus, loki, pyroscope, influxdb, clickhouse, postgres)", dsType)
+	}
+
+	resp, err := dispatch(ctx, genericQueryRequest{
+		cfg:         cfg,
+		uid:         datasourceUID,
+		expr:        expr,
+		start:       start,
+		end:         end,
+		step:        step,
+		profileType: o.profileType,
+		maxNodes:    o.maxNodes,
+		limit:       o.limit,
+		warn:        cmd.ErrOrStderr(),
+	})
+	if err != nil {
+		return err
+	}
+
+	return o.shared.IO.Encode(cmd.OutOrStdout(), resp)
+}
 
 // QueryCmd returns the auto-detecting query command for the datasources group.
 func QueryCmd() *cobra.Command {
-	configOpts := &cmdconfig.Options{}
-	shared := &dsquery.SharedOpts{}
-	var profileType string
-	var maxNodes int64
-	var limit int
+	opts := &genericQueryOpts{routes: newQueryRoutes()}
 
 	cmd := &cobra.Command{
 		Use:   "query DATASOURCE_UID [EXPR]",
@@ -51,217 +135,10 @@ that do not have a dedicated subcommand.`,
   gcx datasources query pyro-001 '{service_name="frontend"}' \
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --from now-1h --to now`,
 		Args: cobra.RangeArgs(1, 2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := shared.Validate(); err != nil {
-				return err
-			}
-
-			// Reject "both positional and --expr" before any HTTP call.
-			if len(args) > 1 && shared.Expr != "" {
-				return errors.New("provide the expression as a positional argument or via --expr, not both")
-			}
-
-			ctx := cmd.Context()
-			datasourceUID := args[0]
-
-			cfg, err := configOpts.LoadGrafanaConfig(ctx)
-			if err != nil {
-				return err
-			}
-
-			rawType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			dsType := dsquery.NormalizeKind(rawType)
-
-			if dsType == "cloudwatch" {
-				return errors.New("CloudWatch queries are structured (namespace, metric, dimensions, region, statistic, period); " +
-					"the generic `gcx datasources query <uid> <expr>` form can't carry them — " +
-					"use `gcx datasources cloudwatch query --namespace ... --metric ... --region ...` instead")
-			}
-
-			expr, err := shared.ResolveExpr(args, 1)
-			if err != nil {
-				return err
-			}
-
-			now := time.Now()
-			start, end, step, err := shared.ParseTimes(now)
-			if err != nil {
-				return err
-			}
-
-			switch dsType {
-			case "prometheus":
-				client, err := prometheus.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				req := prometheus.QueryRequest{
-					Query: expr,
-					Start: start,
-					End:   end,
-					Step:  step,
-				}
-
-				resp, err := client.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "loki":
-				client, err := loki.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				req := loki.QueryRequest{
-					Query: expr,
-					Start: start,
-					End:   end,
-					Step:  step,
-					Limit: limit,
-				}
-
-				resp, err := client.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "pyroscope":
-				if profileType == "" {
-					return errors.New("--profile-type is required for pyroscope queries")
-				}
-
-				client, err := pyroscope.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				req := pyroscope.QueryRequest{
-					LabelSelector: expr,
-					ProfileTypeID: profileType,
-					Start:         start,
-					End:           end,
-					MaxNodes:      maxNodes,
-				}
-
-				resp, err := client.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "influxdb":
-				influxClient, err := influxdb.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				modeStr, err := dsquery.GetInfluxDBMode(ctx, cfg, datasourceUID)
-				if err != nil {
-					return fmt.Errorf("failed to detect influxdb mode: %w", err)
-				}
-
-				req := influxdb.QueryRequest{
-					Query: expr,
-					Start: start,
-					End:   end,
-					Step:  step,
-					Mode:  influxdb.Mode(modeStr),
-				}
-
-				resp, err := influxClient.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "clickhouse":
-				resp, err := runClickHouseQuery(ctx, cfg, datasourceUID, expr, start, end, step)
-				if err != nil {
-					return err
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "postgres":
-				resp, err := runPostgresQuery(ctx, cfg, datasourceUID, expr, start, end, step, cmd.ErrOrStderr())
-				if err != nil {
-					return err
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			default:
-				return fmt.Errorf("datasource type %q is not supported (supported: prometheus, loki, pyroscope, influxdb, clickhouse, postgres)", dsType)
-			}
-		},
+		RunE: opts.run,
 	}
 
-	configOpts.BindFlags(cmd.Flags())
-	shared.Setup(cmd.Flags(), true)
-	cmd.Flags().StringVar(&profileType, "profile-type", "", "Profile type ID for pyroscope queries (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds')")
-	cmd.Flags().Int64Var(&maxNodes, "max-nodes", 1024, "Maximum nodes in flame graph (pyroscope only)")
-	cmd.Flags().IntVar(&limit, "limit", dsquery.DefaultLokiLimit, "Maximum number of log lines to return for loki queries (0 means no limit)")
+	opts.setup(cmd.Flags())
 
 	return cmd
-}
-
-// runClickHouseQuery executes the auto-detected clickhouse branch of QueryCmd.
-func runClickHouseQuery(ctx context.Context, cfg config.NamespacedRESTConfig, datasourceUID, expr string, start, end time.Time, step time.Duration) (*querysql.QueryResponse, error) {
-	client, err := clickhouse.NewClient(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create client: %w", err)
-	}
-
-	req := clickhouse.QueryRequest{
-		RawSQL: clickhouse.EnforceLimit(expr, 100, 1000),
-		Start:  start,
-		End:    end,
-	}
-	if step > 0 {
-		req.IntervalMs = step.Milliseconds()
-	}
-
-	resp, err := client.Query(ctx, datasourceUID, req)
-	if err != nil {
-		return nil, fmt.Errorf("query failed: %w", err)
-	}
-	return resp, nil
-}
-
-// runPostgresQuery executes the auto-detected postgres branch of QueryCmd.
-func runPostgresQuery(ctx context.Context, cfg config.NamespacedRESTConfig, datasourceUID, expr string, start, end time.Time, step time.Duration, warnw io.Writer) (*querysql.QueryResponse, error) {
-	client, err := postgres.NewClient(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create client: %w", err)
-	}
-
-	sql, capped := postgres.EnforceLimit(expr, 100, 1000)
-	if capped {
-		cmdio.Warning(warnw, "LIMIT in query exceeds the maximum of 1000 and was capped")
-	}
-	req := postgres.QueryRequest{
-		RawSQL: sql,
-		Start:  start,
-		End:    end,
-	}
-	if step > 0 {
-		req.IntervalMs = step.Milliseconds()
-	}
-
-	resp, err := client.Query(ctx, datasourceUID, req)
-	if err != nil {
-		return nil, fmt.Errorf("query failed: %w", err)
-	}
-	return resp, nil
 }

--- a/cmd/gcx/datasources/query.go
+++ b/cmd/gcx/datasources/query.go
@@ -102,7 +102,6 @@ func (o *genericQueryOpts) run(cmd *cobra.Command, args []string) error {
 		profileType: o.profileType,
 		maxNodes:    o.maxNodes,
 		limit:       o.limit,
-		warn:        cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return err

--- a/cmd/gcx/datasources/query.go
+++ b/cmd/gcx/datasources/query.go
@@ -7,21 +7,111 @@ import (
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
-	"github.com/grafana/gcx/internal/query/clickhouse"
-	"github.com/grafana/gcx/internal/query/influxdb"
-	"github.com/grafana/gcx/internal/query/loki"
-	"github.com/grafana/gcx/internal/query/prometheus"
-	"github.com/grafana/gcx/internal/query/pyroscope"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
+
+// genericQueryOpts holds the flags and routing policy for the auto-detecting
+// query command. The per-kind behaviour lives in query_routes.go.
+type genericQueryOpts struct {
+	config cmdconfig.Options
+	shared dsquery.SharedOpts
+
+	profileType string
+	maxNodes    int64
+	limit       int
+
+	routes queryRoutes
+}
+
+func (o *genericQueryOpts) setup(flags *pflag.FlagSet) {
+	o.config.BindFlags(flags)
+	o.shared.Setup(flags, true)
+	flags.StringVar(&o.profileType, "profile-type", "", "Profile type ID for pyroscope queries (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds')")
+	flags.Int64Var(&o.maxNodes, "max-nodes", 1024, "Maximum nodes in flame graph (pyroscope only)")
+	flags.IntVar(&o.limit, "limit", dsquery.DefaultLokiLimit, "Maximum number of log lines to return for loki queries (0 means no limit)")
+}
+
+// Validate runs the checks that need no I/O. args carries the optional
+// positional expression, which cannot be combined with --expr.
+func (o *genericQueryOpts) Validate(args []string) error {
+	if err := o.shared.Validate(); err != nil {
+		return err
+	}
+
+	// Reject "both positional and --expr" before any HTTP call.
+	if len(args) > 1 && o.shared.Expr != "" {
+		return errors.New("provide the expression as a positional argument or via --expr, not both")
+	}
+
+	return nil
+}
+
+// run resolves the datasource kind and hands the request to its route. The
+// order of the steps below is load-bearing and pinned by tests; see
+// query_characterization_test.go.
+func (o *genericQueryOpts) run(cmd *cobra.Command, args []string) error {
+	if err := o.Validate(args); err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	datasourceUID := args[0]
+
+	cfg, err := o.config.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	rawType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
+	if err != nil {
+		return err
+	}
+	dsType := dsquery.NormalizeKind(rawType)
+
+	// Redirects run before the expression is resolved, so an argument-less call
+	// gets the typed-command redirect instead of "expression is required".
+	if redirect, ok := o.routes.redirects[dsType]; ok {
+		return errors.New(redirect)
+	}
+
+	expr, err := o.shared.ResolveExpr(args, 1)
+	if err != nil {
+		return err
+	}
+
+	start, end, step, err := o.shared.ParseTimes(time.Now())
+	if err != nil {
+		return err
+	}
+
+	dispatch, ok := o.routes.dispatch[dsType]
+	if !ok {
+		return fmt.Errorf("datasource type %q is not supported (supported: prometheus, loki, pyroscope, influxdb, clickhouse)", dsType)
+	}
+
+	resp, err := dispatch(ctx, genericQueryRequest{
+		cfg:         cfg,
+		uid:         datasourceUID,
+		expr:        expr,
+		start:       start,
+		end:         end,
+		step:        step,
+		profileType: o.profileType,
+		maxNodes:    o.maxNodes,
+		limit:       o.limit,
+		warn:        cmd.ErrOrStderr(),
+	})
+	if err != nil {
+		return err
+	}
+
+	return o.shared.IO.Encode(cmd.OutOrStdout(), resp)
+}
 
 // QueryCmd returns the auto-detecting query command for the datasources group.
 func QueryCmd() *cobra.Command {
-	configOpts := &cmdconfig.Options{}
-	shared := &dsquery.SharedOpts{}
-	var profileType string
-	var maxNodes int64
-	var limit int
+	opts := &genericQueryOpts{routes: newQueryRoutes()}
 
 	cmd := &cobra.Command{
 		Use:   "query DATASOURCE_UID [EXPR]",
@@ -45,173 +135,10 @@ that do not have a dedicated subcommand.`,
   gcx datasources query pyro-001 '{service_name="frontend"}' \
     --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds --from now-1h --to now`,
 		Args: cobra.RangeArgs(1, 2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := shared.Validate(); err != nil {
-				return err
-			}
-
-			// Reject "both positional and --expr" before any HTTP call.
-			if len(args) > 1 && shared.Expr != "" {
-				return errors.New("provide the expression as a positional argument or via --expr, not both")
-			}
-
-			ctx := cmd.Context()
-			datasourceUID := args[0]
-
-			cfg, err := configOpts.LoadGrafanaConfig(ctx)
-			if err != nil {
-				return err
-			}
-
-			rawType, err := dsquery.GetDatasourceType(ctx, cfg, datasourceUID)
-			if err != nil {
-				return err
-			}
-			dsType := dsquery.NormalizeKind(rawType)
-
-			if dsType == "cloudwatch" {
-				return errors.New("CloudWatch queries are structured (namespace, metric, dimensions, region, statistic, period); " +
-					"the generic `gcx datasources query <uid> <expr>` form can't carry them — " +
-					"use `gcx datasources cloudwatch query --namespace ... --metric ... --region ...` instead")
-			}
-
-			expr, err := shared.ResolveExpr(args, 1)
-			if err != nil {
-				return err
-			}
-
-			now := time.Now()
-			start, end, step, err := shared.ParseTimes(now)
-			if err != nil {
-				return err
-			}
-
-			switch dsType {
-			case "prometheus":
-				client, err := prometheus.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				req := prometheus.QueryRequest{
-					Query: expr,
-					Start: start,
-					End:   end,
-					Step:  step,
-				}
-
-				resp, err := client.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "loki":
-				client, err := loki.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				req := loki.QueryRequest{
-					Query: expr,
-					Start: start,
-					End:   end,
-					Step:  step,
-					Limit: limit,
-				}
-
-				resp, err := client.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "pyroscope":
-				if profileType == "" {
-					return errors.New("--profile-type is required for pyroscope queries")
-				}
-
-				client, err := pyroscope.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				req := pyroscope.QueryRequest{
-					LabelSelector: expr,
-					ProfileTypeID: profileType,
-					Start:         start,
-					End:           end,
-					MaxNodes:      maxNodes,
-				}
-
-				resp, err := client.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "influxdb":
-				influxClient, err := influxdb.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				modeStr, err := dsquery.GetInfluxDBMode(ctx, cfg, datasourceUID)
-				if err != nil {
-					return fmt.Errorf("failed to detect influxdb mode: %w", err)
-				}
-
-				req := influxdb.QueryRequest{
-					Query: expr,
-					Start: start,
-					End:   end,
-					Step:  step,
-					Mode:  influxdb.Mode(modeStr),
-				}
-
-				resp, err := influxClient.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			case "clickhouse":
-				client, err := clickhouse.NewClient(cfg)
-				if err != nil {
-					return fmt.Errorf("failed to create client: %w", err)
-				}
-
-				req := clickhouse.QueryRequest{
-					RawSQL: clickhouse.EnforceLimit(expr, 100, 1000),
-					Start:  start,
-					End:    end,
-				}
-				if step > 0 {
-					req.IntervalMs = step.Milliseconds()
-				}
-
-				resp, err := client.Query(ctx, datasourceUID, req)
-				if err != nil {
-					return fmt.Errorf("query failed: %w", err)
-				}
-
-				return shared.IO.Encode(cmd.OutOrStdout(), resp)
-
-			default:
-				return fmt.Errorf("datasource type %q is not supported (supported: prometheus, loki, pyroscope, influxdb, clickhouse)", dsType)
-			}
-		},
+		RunE: opts.run,
 	}
 
-	configOpts.BindFlags(cmd.Flags())
-	shared.Setup(cmd.Flags(), true)
-	cmd.Flags().StringVar(&profileType, "profile-type", "", "Profile type ID for pyroscope queries (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds')")
-	cmd.Flags().Int64Var(&maxNodes, "max-nodes", 1024, "Maximum nodes in flame graph (pyroscope only)")
-	cmd.Flags().IntVar(&limit, "limit", dsquery.DefaultLokiLimit, "Maximum number of log lines to return for loki queries (0 means no limit)")
+	opts.setup(cmd.Flags())
 
 	return cmd
 }

--- a/cmd/gcx/datasources/query.go
+++ b/cmd/gcx/datasources/query.go
@@ -3,6 +3,7 @@ package datasources
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	cmdconfig "github.com/grafana/gcx/cmd/gcx/config"
@@ -87,7 +88,8 @@ func (o *genericQueryOpts) run(cmd *cobra.Command, args []string) error {
 
 	dispatch, ok := o.routes.dispatch[dsType]
 	if !ok {
-		return fmt.Errorf("datasource type %q is not supported (supported: prometheus, loki, pyroscope, influxdb, clickhouse, postgres)", dsType)
+		return fmt.Errorf("datasource type %q is not supported (supported: %s)",
+			dsType, strings.Join(o.routes.supportedKinds(), ", "))
 	}
 
 	resp, err := dispatch(ctx, genericQueryRequest{

--- a/cmd/gcx/datasources/query_characterization_test.go
+++ b/cmd/gcx/datasources/query_characterization_test.go
@@ -40,10 +40,10 @@ type fakeGrafana struct {
 	failDatasourceGetAfter int
 	queryStatus            int
 
-	mu           sync.Mutex
-	datasourceGe int
-	postPath     string
-	postBody     map[string]any
+	mu             sync.Mutex
+	datasourceGets int
+	postPath       string
+	postBody       map[string]any
 }
 
 func (f *fakeGrafana) start() *httptest.Server {
@@ -62,8 +62,8 @@ func (f *fakeGrafana) serve(w http.ResponseWriter, r *http.Request) {
 
 	case r.Method == http.MethodGet && r.URL.Path == "/api/datasources/uid/uid":
 		f.mu.Lock()
-		f.datasourceGe++
-		n := f.datasourceGe
+		f.datasourceGets++
+		n := f.datasourceGets
 		f.mu.Unlock()
 
 		if f.failDatasourceGetAfter > 0 && n >= f.failDatasourceGetAfter {
@@ -127,7 +127,7 @@ func (f *fakeGrafana) seenDatasourceGets() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	return f.datasourceGe
+	return f.datasourceGets
 }
 
 func (f *fakeGrafana) seenPost() (string, map[string]any) {
@@ -259,19 +259,19 @@ func TestGenericQueryCharacterization_PyroscopeMaxNodes(t *testing.T) {
 // detect the type, once more to read jsonData.version for the query language.
 func TestGenericQueryCharacterization_InfluxDBModeDetection(t *testing.T) {
 	tests := []struct {
-		name        string
-		jsonData    map[string]any
-		wantRawQuer bool
+		name         string
+		jsonData     map[string]any
+		wantRawQuery bool
 	}{
 		{
-			name:        "no jsonData defaults to InfluxQL",
-			jsonData:    nil,
-			wantRawQuer: true,
+			name:         "no jsonData defaults to InfluxQL",
+			jsonData:     nil,
+			wantRawQuery: true,
 		},
 		{
-			name:        "Flux mode omits rawQuery",
-			jsonData:    map[string]any{"version": "Flux"},
-			wantRawQuer: false,
+			name:         "Flux mode omits rawQuery",
+			jsonData:     map[string]any{"version": "Flux"},
+			wantRawQuery: false,
 		},
 	}
 
@@ -289,7 +289,7 @@ func TestGenericQueryCharacterization_InfluxDBModeDetection(t *testing.T) {
 
 			q := firstQuery(t, f.mustBody(t))
 			assert.Equal(t, "SELECT 1", q["query"])
-			if tt.wantRawQuer {
+			if tt.wantRawQuery {
 				assert.Equal(t, true, q["rawQuery"])
 				assert.Equal(t, "table", q["resultFormat"])
 			} else {

--- a/cmd/gcx/datasources/query_characterization_test.go
+++ b/cmd/gcx/datasources/query_characterization_test.go
@@ -171,6 +171,28 @@ func runGeneric(t *testing.T, f *fakeGrafana, args ...string) (string, error) {
 	return stdout.String(), err
 }
 
+// runGenericStreams is runGeneric plus stderr, for the one kind that writes an
+// advisory notice. Kept separate so the stdout-only callers stay unchanged.
+func runGenericStreams(t *testing.T, f *fakeGrafana, args ...string) (string, string, error) {
+	t.Helper()
+
+	srv := f.start()
+	configFile := newConfigFileForServer(t, srv.URL)
+
+	root := helperRoot(datasources.QueryCmd())
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs(append(args, "--config", configFile))
+
+	// Execute before reading either buffer: Go evaluates return operands left to
+	// right, so returning root.Execute() alongside stdout.String() would snapshot
+	// the buffers before the command ran.
+	err := root.Execute()
+
+	return stdout.String(), stderr.String(), err
+}
+
 func TestGenericQueryCharacterization_PrometheusTimeAndStep(t *testing.T) {
 	f := &fakeGrafana{t: t, dsType: "prometheus"}
 
@@ -297,6 +319,40 @@ func TestGenericQueryCharacterization_ClickHouseLimitAndInterval(t *testing.T) {
 	assert.Equal(t, "SELECT 1 LIMIT 100", q["rawSql"],
 		"the generic path enforces the default clickhouse limit")
 	assert.InDelta(t, float64((45 * time.Second).Milliseconds()), q["intervalMs"], 0)
+}
+
+func TestGenericQueryCharacterization_PostgresLimitAndInterval(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "grafana-postgresql-datasource"}
+
+	_, stderr, err := runGenericStreams(t, f,
+		"query", "uid", "SELECT 1",
+		"--from", "now-1h", "--to", "now", "--step", "45s", "-o", "json")
+	require.NoError(t, err)
+
+	q := firstQuery(t, f.mustBody(t))
+	assert.Equal(t, "SELECT 1 LIMIT 100", q["rawSql"],
+		"the generic path enforces the default postgres limit")
+	assert.InDelta(t, float64((45 * time.Second).Milliseconds()), q["intervalMs"], 0)
+	assert.Empty(t, stderr, "a query within the limit warns about nothing")
+}
+
+// The capped-LIMIT notice is the only thing any generic handler writes outside
+// the stdout document, so it pins both the capping and the stream it lands on.
+// dispatchPostgres is the sole reader of genericQueryRequest.warn.
+func TestGenericQueryCharacterization_PostgresOversizedLimitWarnsOnStderr(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "grafana-postgresql-datasource"}
+
+	stdout, stderr, err := runGenericStreams(t, f,
+		"query", "uid", "SELECT 1 LIMIT 5000",
+		"--from", "now-1h", "--to", "now", "-o", "json")
+	require.NoError(t, err)
+
+	q := firstQuery(t, f.mustBody(t))
+	assert.Equal(t, "SELECT 1 LIMIT 1000", q["rawSql"], "an oversized LIMIT is capped")
+
+	assert.Contains(t, stderr, "was capped", "the cap must be reported, not silent")
+	assert.NotContains(t, stdout, "was capped",
+		"the notice must not contaminate the stdout document")
 }
 
 // A reachable query failure: the datasource lookup succeeds, so the client is

--- a/cmd/gcx/datasources/query_characterization_test.go
+++ b/cmd/gcx/datasources/query_characterization_test.go
@@ -1,0 +1,404 @@
+package datasources_test
+
+// Characterization tests for the generic `gcx datasources query` command.
+//
+// These pin the observable behaviour of every datasource kind the generic
+// command handles today: which request each kind builds, which flags reach it,
+// the order validation and I/O happen in, and how failures surface. They were
+// written against the hand-maintained type switch and must keep passing
+// unchanged across the routing-table refactor (#1137) — that is the whole point
+// of them, so prefer fixing the production code over editing this file.
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/cmd/gcx/datasources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeGrafana serves the two endpoints the generic query path touches: the
+// datasource record lookup and the unified query POST. It records what it saw
+// so a test can assert the request the command actually built.
+type fakeGrafana struct {
+	t *testing.T
+
+	dsType   string
+	jsonData map[string]any
+
+	// failDatasourceGetAfter makes the Nth and later datasource GETs fail, so a
+	// test can break InfluxDB's second lookup without breaking the first.
+	failDatasourceGetAfter int
+	queryStatus            int
+
+	mu           sync.Mutex
+	datasourceGe int
+	postPath     string
+	postBody     map[string]any
+}
+
+func (f *fakeGrafana) start() *httptest.Server {
+	f.t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(f.serve))
+	f.t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func (f *fakeGrafana) serve(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/bootdata":
+		http.NotFound(w, r)
+
+	case r.Method == http.MethodGet && r.URL.Path == "/api/datasources/uid/uid":
+		f.mu.Lock()
+		f.datasourceGe++
+		n := f.datasourceGe
+		f.mu.Unlock()
+
+		if f.failDatasourceGetAfter > 0 && n >= f.failDatasourceGetAfter {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"datasource lookup exploded"}`))
+			return
+		}
+
+		payload := map[string]any{"id": 1, "uid": "uid", "name": "test", "type": f.dsType}
+		if f.jsonData != nil {
+			payload["jsonData"] = f.jsonData
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			f.t.Errorf("encode datasource response: %v", err)
+		}
+
+	case r.Method == http.MethodPost:
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			f.t.Errorf("decode query request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		f.mu.Lock()
+		f.postPath = r.URL.Path
+		f.postBody = body
+		f.mu.Unlock()
+
+		if f.queryStatus != 0 && f.queryStatus != http.StatusOK {
+			w.WriteHeader(f.queryStatus)
+			_, _ = w.Write([]byte(`{"message":"query exploded"}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(f.successBody(r.URL.Path)))
+
+	default:
+		f.t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (f *fakeGrafana) successBody(path string) string {
+	switch {
+	case strings.Contains(path, "/api/datasources/proxy/uid/"):
+		return `{"flamebearer":{"names":[],"levels":[],"numTicks":0,"maxSelf":0}}`
+	case f.dsType == "prometheus":
+		return `{"results":{"A":{"frames":[{"schema":{"fields":[{"name":"Time","type":"time"},` +
+			`{"name":"Value","type":"number","labels":{"job":"grafana"}}]},` +
+			`"data":{"values":[[1711893600000],[1]]}}]}}}`
+	default:
+		return `{"results":{"A":{"frames":[]}}}`
+	}
+}
+
+// seenDatasourceGets reports how many times the datasource record was fetched.
+func (f *fakeGrafana) seenDatasourceGets() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.datasourceGe
+}
+
+func (f *fakeGrafana) seenPost() (string, map[string]any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.postPath, f.postBody
+}
+
+// firstQuery returns queries[0] from the recorded unified-query POST body.
+func firstQuery(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+
+	require.NotNil(t, body, "no query POST was recorded")
+	queries, ok := body["queries"].([]any)
+	require.Truef(t, ok, "expected queries array, got %T", body["queries"])
+	require.Len(t, queries, 1)
+
+	q, ok := queries[0].(map[string]any)
+	require.Truef(t, ok, "expected query object, got %T", queries[0])
+
+	return q
+}
+
+// runGeneric executes the generic query command against the fake and returns
+// the error plus whatever landed on stdout.
+func runGeneric(t *testing.T, f *fakeGrafana, args ...string) (string, error) {
+	t.Helper()
+
+	srv := f.start()
+	configFile := newConfigFileForServer(t, srv.URL)
+
+	root := helperRoot(datasources.QueryCmd())
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs(append(args, "--config", configFile))
+
+	err := root.Execute()
+
+	return stdout.String(), err
+}
+
+func TestGenericQueryCharacterization_PrometheusTimeAndStep(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "prometheus"}
+
+	_, err := runGeneric(t, f,
+		"query", "uid", `up{job="grafana"}`,
+		"--from", "now-1h", "--to", "now", "--step", "30s", "-o", "json")
+	require.NoError(t, err)
+
+	path, body := f.seenPost()
+	assert.Contains(t, path, "/query.grafana.app/")
+
+	q := firstQuery(t, body)
+	assert.Equal(t, `up{job="grafana"}`, q["expr"])
+	assert.InDelta(t, float64((30 * time.Second).Milliseconds()), q["intervalMs"], 0,
+		"--step must reach intervalMs")
+
+	start := parseUnixMillisField(t, body, "from")
+	end := parseUnixMillisField(t, body, "to")
+	assert.WithinDuration(t, end.Add(-time.Hour), start, time.Second)
+}
+
+func TestGenericQueryCharacterization_LokiLimit(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "loki"}
+
+	_, err := runGeneric(t, f,
+		"query", "uid", `{job="varlogs"}`,
+		"--from", "now-1h", "--to", "now", "--limit", "7", "-o", "json")
+	require.NoError(t, err)
+
+	_, body := f.seenPost()
+	q := firstQuery(t, body)
+	assert.Equal(t, `{job="varlogs"}`, q["expr"])
+	assert.InDelta(t, float64(7), q["maxLines"], 0, "--limit must reach maxLines")
+}
+
+func TestGenericQueryCharacterization_PyroscopeRequiresProfileType(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "grafana-pyroscope-datasource"}
+
+	_, err := runGeneric(t, f, "query", "uid", `{service_name="frontend"}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--profile-type is required for pyroscope queries")
+	assert.Equal(t, 1, f.seenDatasourceGets(),
+		"the guard must fire after exactly one datasource lookup and before any query")
+}
+
+func TestGenericQueryCharacterization_PyroscopeMaxNodes(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "grafana-pyroscope-datasource"}
+
+	_, err := runGeneric(t, f,
+		"query", "uid", `{service_name="frontend"}`,
+		"--profile-type", "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		"--max-nodes", "33",
+		"--from", "now-1h", "--to", "now", "-o", "json")
+	require.NoError(t, err)
+
+	_, body := f.seenPost()
+	require.NotNil(t, body)
+	assert.Equal(t, `{service_name="frontend"}`, body["labelSelector"])
+	assert.Equal(t, "process_cpu:cpu:nanoseconds:cpu:nanoseconds", body["profileTypeID"])
+	assert.Equal(t, strconv.Itoa(33), body["maxNodes"], "--max-nodes must reach the request")
+}
+
+// InfluxDB is the only kind that fetches the datasource record twice: once to
+// detect the type, once more to read jsonData.version for the query language.
+func TestGenericQueryCharacterization_InfluxDBModeDetection(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsonData    map[string]any
+		wantRawQuer bool
+	}{
+		{
+			name:        "no jsonData defaults to InfluxQL",
+			jsonData:    nil,
+			wantRawQuer: true,
+		},
+		{
+			name:        "Flux mode omits rawQuery",
+			jsonData:    map[string]any{"version": "Flux"},
+			wantRawQuer: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &fakeGrafana{t: t, dsType: "influxdb", jsonData: tt.jsonData}
+
+			_, err := runGeneric(t, f,
+				"query", "uid", "SELECT 1",
+				"--from", "now-1h", "--to", "now", "-o", "json")
+			require.NoError(t, err)
+
+			assert.Equal(t, 2, f.seenDatasourceGets(),
+				"influxdb resolves the type and then the query-language mode")
+
+			q := firstQuery(t, f.mustBody(t))
+			assert.Equal(t, "SELECT 1", q["query"])
+			if tt.wantRawQuer {
+				assert.Equal(t, true, q["rawQuery"])
+				assert.Equal(t, "table", q["resultFormat"])
+			} else {
+				assert.NotContains(t, q, "rawQuery")
+			}
+		})
+	}
+}
+
+func TestGenericQueryCharacterization_InfluxDBModeLookupFailureIsWrapped(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "influxdb", failDatasourceGetAfter: 2}
+
+	_, err := runGeneric(t, f, "query", "uid", "SELECT 1", "--from", "now-1h", "--to", "now")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to detect influxdb mode")
+}
+
+func TestGenericQueryCharacterization_ClickHouseLimitAndInterval(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "grafana-clickhouse-datasource"}
+
+	_, err := runGeneric(t, f,
+		"query", "uid", "SELECT 1",
+		"--from", "now-1h", "--to", "now", "--step", "45s", "-o", "json")
+	require.NoError(t, err)
+
+	q := firstQuery(t, f.mustBody(t))
+	assert.Equal(t, "SELECT 1 LIMIT 100", q["rawSql"],
+		"the generic path enforces the default clickhouse limit")
+	assert.InDelta(t, float64((45 * time.Second).Milliseconds()), q["intervalMs"], 0)
+}
+
+// A reachable query failure: the datasource lookup succeeds, so the client is
+// built, and the unified query POST is what fails.
+func TestGenericQueryCharacterization_QueryFailureIsWrapped(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "prometheus", queryStatus: http.StatusInternalServerError}
+
+	_, err := runGeneric(t, f, "query", "uid", "up", "--from", "now-1h", "--to", "now")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query failed")
+}
+
+// The command owns encoding: handlers return a value and the command encodes it
+// exactly once, so an encode failure propagates instead of being swallowed.
+func TestGenericQueryCharacterization_EncodeErrorPropagates(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "prometheus"}
+	srv := f.start()
+	configFile := newConfigFileForServer(t, srv.URL)
+
+	root := helperRoot(datasources.QueryCmd())
+	root.SetOut(failingWriter{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"query", "uid", "up", "--from", "now-1h", "--to", "now", "-o", "json",
+		"--config", configFile,
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stdout is closed")
+}
+
+func TestGenericQueryCharacterization_EmitsOneJSONValueOnStdout(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "prometheus"}
+
+	stdout, err := runGeneric(t, f,
+		"query", "uid", "up", "--from", "now-1h", "--to", "now", "-o", "json")
+	require.NoError(t, err)
+
+	dec := json.NewDecoder(strings.NewReader(stdout))
+	var first any
+	require.NoError(t, dec.Decode(&first), "stdout must carry one JSON value")
+	assert.IsType(t, map[string]any{}, first)
+
+	var second any
+	assert.ErrorContains(t, decodeNext(dec, &second), "EOF",
+		"stdout must carry exactly one JSON value")
+}
+
+// Unknown kinds keep today's ordering: the expression is resolved and the times
+// parsed before the unsupported-type verdict is reached.
+func TestGenericQueryCharacterization_UnknownKindOrdering(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "no expression fails on the expression before the type verdict",
+			args:    []string{"query", "uid"},
+			wantErr: "expression is required",
+		},
+		{
+			name:    "invalid step fails on parsing before the type verdict",
+			args:    []string{"query", "uid", "whatever", "--step", "nonsense"},
+			wantErr: "invalid --step duration",
+		},
+		{
+			name:    "a fully valid request reaches the unsupported-type verdict",
+			args:    []string{"query", "uid", "whatever"},
+			wantErr: `datasource type "tempo" is not supported`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &fakeGrafana{t: t, dsType: "tempo"}
+
+			_, err := runGeneric(t, f, tt.args...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func (f *fakeGrafana) mustBody(t *testing.T) map[string]any {
+	t.Helper()
+
+	_, body := f.seenPost()
+	require.NotNil(t, body, "no query POST was recorded")
+
+	return body
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("stdout is closed") }
+
+func decodeNext(dec *json.Decoder, v any) error {
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+
+	return errors.New("a second JSON value was present")
+}

--- a/cmd/gcx/datasources/query_routes.go
+++ b/cmd/gcx/datasources/query_routes.go
@@ -1,0 +1,248 @@
+package datasources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/query/clickhouse"
+	"github.com/grafana/gcx/internal/query/influxdb"
+	"github.com/grafana/gcx/internal/query/loki"
+	"github.com/grafana/gcx/internal/query/postgres"
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/query/pyroscope"
+)
+
+// Routing policy for the auto-detecting `gcx datasources query`.
+//
+// A normalized datasource kind is one of exactly three things, and the table
+// below is where that is decided:
+//
+//   - expression-dispatchable — the generic `<uid> <expr>` form carries the
+//     query honestly, so the kind has a handler in dispatch;
+//   - redirect-only — the query is structured and no single expression can
+//     represent it, so the kind has a message in redirects naming the typed
+//     command to use instead;
+//   - unrouted — neither, and the command reports the kind as unsupported.
+//
+// Adding a datasource kind is one entry here plus one small handler. It must
+// never become another branch in genericQueryOpts.run: that function's control
+// flow is fixed, which is what keeps QueryCmd's complexity independent of how
+// many kinds gcx supports (#1137).
+
+// genericQueryRequest is everything a dispatch handler needs. It is built once
+// by the command, after validation and time parsing, so handlers do no flag
+// or argument work of their own.
+type genericQueryRequest struct {
+	cfg   config.NamespacedRESTConfig
+	uid   string
+	expr  string
+	start time.Time
+	end   time.Time
+	step  time.Duration
+
+	// Kind-specific inputs the generic command binds as flags. A handler reads
+	// only the ones its kind uses.
+	profileType string
+	maxNodes    int64
+	limit       int
+
+	// warn is the command's stderr. dispatchPostgres is its reader: it caps an
+	// oversized LIMIT and must say so without polluting the stdout document.
+	warn io.Writer
+}
+
+// queryDispatch runs the generic form for one kind and returns the value the
+// command will encode. Handlers must not encode or print: the command owns
+// output so that every kind emits exactly one JSON value on stdout.
+type queryDispatch func(ctx context.Context, req genericQueryRequest) (any, error)
+
+// queryRoutes holds the two disjoint routing tables. Disjointness and key
+// canonicality are asserted in query_routes_internal_test.go rather than encoded in a
+// type, so that "both" and "neither" cannot be constructed by accident.
+type queryRoutes struct {
+	dispatch  map[string]queryDispatch
+	redirects map[string]string
+}
+
+// newQueryRoutes builds the tables once, when the command is constructed.
+// Keeping it out of QueryCmd is deliberate: a map literal's size is attributed
+// to the function that contains it, and QueryCmd is the function whose
+// complexity budget #1137 is about.
+func newQueryRoutes() queryRoutes {
+	return queryRoutes{
+		dispatch: map[string]queryDispatch{
+			"clickhouse": dispatchClickHouse,
+			"influxdb":   dispatchInfluxDB,
+			"loki":       dispatchLoki,
+			"postgres":   dispatchPostgres,
+			"prometheus": dispatchPrometheus,
+			"pyroscope":  dispatchPyroscope,
+		},
+		redirects: map[string]string{
+			"cloudwatch": structuredQueryRedirect(
+				"CloudWatch",
+				"namespace, metric, dimensions, region, statistic, period",
+				"gcx datasources cloudwatch query --namespace ... --metric ... --region ...",
+			),
+		},
+	}
+}
+
+// structuredQueryRedirect builds the message for a kind whose query takes
+// structured parameters that no single expression can carry. An honest
+// redirect to the typed command beats both a lossy generic path and the bare
+// "not supported" default.
+func structuredQueryRedirect(product, params, useCmd string) string {
+	return fmt.Sprintf(
+		"%s queries are structured (%s); "+
+			"the generic `gcx datasources query <uid> <expr>` form can't carry them — "+
+			"use `%s` instead",
+		product, params, useCmd)
+}
+
+func dispatchPrometheus(ctx context.Context, req genericQueryRequest) (any, error) {
+	client, err := prometheus.NewClient(req.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resp, err := client.Query(ctx, req.uid, prometheus.QueryRequest{
+		Query: req.expr,
+		Start: req.start,
+		End:   req.end,
+		Step:  req.step,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+func dispatchLoki(ctx context.Context, req genericQueryRequest) (any, error) {
+	client, err := loki.NewClient(req.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resp, err := client.Query(ctx, req.uid, loki.QueryRequest{
+		Query: req.expr,
+		Start: req.start,
+		End:   req.end,
+		Step:  req.step,
+		Limit: req.limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+func dispatchPyroscope(ctx context.Context, req genericQueryRequest) (any, error) {
+	if req.profileType == "" {
+		return nil, errors.New("--profile-type is required for pyroscope queries")
+	}
+
+	client, err := pyroscope.NewClient(req.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resp, err := client.Query(ctx, req.uid, pyroscope.QueryRequest{
+		LabelSelector: req.expr,
+		ProfileTypeID: req.profileType,
+		Start:         req.start,
+		End:           req.end,
+		MaxNodes:      req.maxNodes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+func dispatchInfluxDB(ctx context.Context, req genericQueryRequest) (any, error) {
+	client, err := influxdb.NewClient(req.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	// InfluxDB is the one kind whose query language is a property of the
+	// datasource rather than of the expression, so it costs a second lookup.
+	mode, err := dsquery.GetInfluxDBMode(ctx, req.cfg, req.uid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect influxdb mode: %w", err)
+	}
+
+	resp, err := client.Query(ctx, req.uid, influxdb.QueryRequest{
+		Query: req.expr,
+		Start: req.start,
+		End:   req.end,
+		Step:  req.step,
+		Mode:  influxdb.Mode(mode),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+func dispatchClickHouse(ctx context.Context, req genericQueryRequest) (any, error) {
+	client, err := clickhouse.NewClient(req.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	clickhouseReq := clickhouse.QueryRequest{
+		RawSQL: clickhouse.EnforceLimit(req.expr, 100, 1000),
+		Start:  req.start,
+		End:    req.end,
+	}
+	if req.step > 0 {
+		clickhouseReq.IntervalMs = req.step.Milliseconds()
+	}
+
+	resp, err := client.Query(ctx, req.uid, clickhouseReq)
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+func dispatchPostgres(ctx context.Context, req genericQueryRequest) (any, error) {
+	client, err := postgres.NewClient(req.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	sql, capped := postgres.EnforceLimit(req.expr, 100, 1000)
+	if capped {
+		cmdio.Warning(req.warn, "LIMIT in query exceeds the maximum of 1000 and was capped")
+	}
+
+	postgresReq := postgres.QueryRequest{
+		RawSQL: sql,
+		Start:  req.start,
+		End:    req.end,
+	}
+	if req.step > 0 {
+		postgresReq.IntervalMs = req.step.Milliseconds()
+	}
+
+	resp, err := client.Query(ctx, req.uid, postgresReq)
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return resp, nil
+}

--- a/cmd/gcx/datasources/query_routes.go
+++ b/cmd/gcx/datasources/query_routes.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/grafana/gcx/internal/config"
@@ -92,6 +93,24 @@ func newQueryRoutes() queryRoutes {
 			),
 		},
 	}
+}
+
+// supportedKinds returns every kind the command routes — expression-dispatchable
+// and redirect-only alike — sorted, for the unsupported-type message. Deriving
+// it is the point of #1137: the hand-maintained list had already drifted, and a
+// caller told a kind is unsupported is better served by the full set gcx knows
+// how to handle than by the subset that happens to take an expression.
+func (r queryRoutes) supportedKinds() []string {
+	kinds := make([]string, 0, len(r.dispatch)+len(r.redirects))
+	for kind := range r.dispatch {
+		kinds = append(kinds, kind)
+	}
+	for kind := range r.redirects {
+		kinds = append(kinds, kind)
+	}
+	slices.Sort(kinds)
+
+	return kinds
 }
 
 // structuredQueryRedirect builds the message for a kind whose query takes

--- a/cmd/gcx/datasources/query_routes.go
+++ b/cmd/gcx/datasources/query_routes.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/grafana/gcx/internal/config"
@@ -90,6 +91,24 @@ func newQueryRoutes() queryRoutes {
 			),
 		},
 	}
+}
+
+// supportedKinds returns every kind the command routes — expression-dispatchable
+// and redirect-only alike — sorted, for the unsupported-type message. Deriving
+// it is the point of #1137: the hand-maintained list had already drifted, and a
+// caller told a kind is unsupported is better served by the full set gcx knows
+// how to handle than by the subset that happens to take an expression.
+func (r queryRoutes) supportedKinds() []string {
+	kinds := make([]string, 0, len(r.dispatch)+len(r.redirects))
+	for kind := range r.dispatch {
+		kinds = append(kinds, kind)
+	}
+	for kind := range r.redirects {
+		kinds = append(kinds, kind)
+	}
+	slices.Sort(kinds)
+
+	return kinds
 }
 
 // structuredQueryRedirect builds the message for a kind whose query takes

--- a/cmd/gcx/datasources/query_routes.go
+++ b/cmd/gcx/datasources/query_routes.go
@@ -96,8 +96,15 @@ func newQueryRoutes() queryRoutes {
 }
 
 // supportedKinds returns every kind this command routes — expression-dispatchable
-// and redirect-only alike — sorted, for the unsupported-type message. Deriving
-// it is the point of #1137: the hand-maintained list had already drifted.
+// and redirect-only alike — sorted, for the unsupported-type message.
+//
+// Deriving it is the point of #1137, but be precise about what was wrong: the
+// hand-written literal never fell behind the switch cases — every kind that got
+// a case got a list entry in the same commit. What it never covered was the
+// redirect kinds. cloudwatch has been routed since v1.0.0 and appeared in that
+// literal exactly never, because a guard above the switch fed nothing into a
+// list nobody could see from the code. Deriving fixes the class: a kind cannot
+// be routed and unlisted, whichever table routes it.
 //
 // Scope, precisely: these are the kinds `gcx datasources query` handles, not
 // every kind gcx can query. Kinds with a typed `gcx datasources <kind> query`

--- a/cmd/gcx/datasources/query_routes.go
+++ b/cmd/gcx/datasources/query_routes.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"slices"
 	"time"
 
@@ -50,12 +49,12 @@ type genericQueryRequest struct {
 	profileType string
 	maxNodes    int64
 	limit       int
-
-	// warn is the command's stderr. No kind on main emits a warning during a
-	// generic query, but the SQL kinds cap an oversized LIMIT and must say so
-	// without polluting the stdout document, so the seam lives here.
-	warn io.Writer
 }
+
+// A handler that needs to warn (a SQL kind capping an oversized LIMIT, say)
+// adds a `warn io.Writer` field here and the command fills it from
+// cmd.ErrOrStderr(). Left out until something reads it, so the seam arrives
+// with its first user and its first test rather than ahead of both.
 
 // queryDispatch runs the generic form for one kind and returns the value the
 // command will encode. Handlers must not encode or print: the command owns
@@ -93,11 +92,15 @@ func newQueryRoutes() queryRoutes {
 	}
 }
 
-// supportedKinds returns every kind the command routes — expression-dispatchable
+// supportedKinds returns every kind this command routes — expression-dispatchable
 // and redirect-only alike — sorted, for the unsupported-type message. Deriving
-// it is the point of #1137: the hand-maintained list had already drifted, and a
-// caller told a kind is unsupported is better served by the full set gcx knows
-// how to handle than by the subset that happens to take an expression.
+// it is the point of #1137: the hand-maintained list had already drifted.
+//
+// Scope, precisely: these are the kinds `gcx datasources query` handles, not
+// every kind gcx can query. Kinds with a typed `gcx datasources <kind> query`
+// but no entry here (tempo, athena, infinity) are absent by construction.
+// Redirect-only kinds are present because this command does handle them — by
+// naming the typed command — even though it never runs their query.
 func (r queryRoutes) supportedKinds() []string {
 	kinds := make([]string, 0, len(r.dispatch)+len(r.redirects))
 	for kind := range r.dispatch {

--- a/cmd/gcx/datasources/query_routes.go
+++ b/cmd/gcx/datasources/query_routes.go
@@ -1,0 +1,218 @@
+package datasources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/grafana/gcx/internal/config"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/query/clickhouse"
+	"github.com/grafana/gcx/internal/query/influxdb"
+	"github.com/grafana/gcx/internal/query/loki"
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/query/pyroscope"
+)
+
+// Routing policy for the auto-detecting `gcx datasources query`.
+//
+// A normalized datasource kind is one of exactly three things, and the table
+// below is where that is decided:
+//
+//   - expression-dispatchable — the generic `<uid> <expr>` form carries the
+//     query honestly, so the kind has a handler in dispatch;
+//   - redirect-only — the query is structured and no single expression can
+//     represent it, so the kind has a message in redirects naming the typed
+//     command to use instead;
+//   - unrouted — neither, and the command reports the kind as unsupported.
+//
+// Adding a datasource kind is one entry here plus one small handler. It must
+// never become another branch in genericQueryOpts.run: that function's control
+// flow is fixed, which is what keeps QueryCmd's complexity independent of how
+// many kinds gcx supports (#1137).
+
+// genericQueryRequest is everything a dispatch handler needs. It is built once
+// by the command, after validation and time parsing, so handlers do no flag
+// or argument work of their own.
+type genericQueryRequest struct {
+	cfg   config.NamespacedRESTConfig
+	uid   string
+	expr  string
+	start time.Time
+	end   time.Time
+	step  time.Duration
+
+	// Kind-specific inputs the generic command binds as flags. A handler reads
+	// only the ones its kind uses.
+	profileType string
+	maxNodes    int64
+	limit       int
+
+	// warn is the command's stderr. No kind on main emits a warning during a
+	// generic query, but the SQL kinds cap an oversized LIMIT and must say so
+	// without polluting the stdout document, so the seam lives here.
+	warn io.Writer
+}
+
+// queryDispatch runs the generic form for one kind and returns the value the
+// command will encode. Handlers must not encode or print: the command owns
+// output so that every kind emits exactly one JSON value on stdout.
+type queryDispatch func(ctx context.Context, req genericQueryRequest) (any, error)
+
+// queryRoutes holds the two disjoint routing tables. Disjointness and key
+// canonicality are asserted in query_routes_internal_test.go rather than encoded in a
+// type, so that "both" and "neither" cannot be constructed by accident.
+type queryRoutes struct {
+	dispatch  map[string]queryDispatch
+	redirects map[string]string
+}
+
+// newQueryRoutes builds the tables once, when the command is constructed.
+// Keeping it out of QueryCmd is deliberate: a map literal's size is attributed
+// to the function that contains it, and QueryCmd is the function whose
+// complexity budget #1137 is about.
+func newQueryRoutes() queryRoutes {
+	return queryRoutes{
+		dispatch: map[string]queryDispatch{
+			"clickhouse": dispatchClickHouse,
+			"influxdb":   dispatchInfluxDB,
+			"loki":       dispatchLoki,
+			"prometheus": dispatchPrometheus,
+			"pyroscope":  dispatchPyroscope,
+		},
+		redirects: map[string]string{
+			"cloudwatch": structuredQueryRedirect(
+				"CloudWatch",
+				"namespace, metric, dimensions, region, statistic, period",
+				"gcx datasources cloudwatch query --namespace ... --metric ... --region ...",
+			),
+		},
+	}
+}
+
+// structuredQueryRedirect builds the message for a kind whose query takes
+// structured parameters that no single expression can carry. An honest
+// redirect to the typed command beats both a lossy generic path and the bare
+// "not supported" default.
+func structuredQueryRedirect(product, params, useCmd string) string {
+	return fmt.Sprintf(
+		"%s queries are structured (%s); "+
+			"the generic `gcx datasources query <uid> <expr>` form can't carry them — "+
+			"use `%s` instead",
+		product, params, useCmd)
+}
+
+func dispatchPrometheus(ctx context.Context, req genericQueryRequest) (any, error) {
+	client, err := prometheus.NewClient(req.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resp, err := client.Query(ctx, req.uid, prometheus.QueryRequest{
+		Query: req.expr,
+		Start: req.start,
+		End:   req.end,
+		Step:  req.step,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+func dispatchLoki(ctx context.Context, req genericQueryRequest) (any, error) {
+	client, err := loki.NewClient(req.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resp, err := client.Query(ctx, req.uid, loki.QueryRequest{
+		Query: req.expr,
+		Start: req.start,
+		End:   req.end,
+		Step:  req.step,
+		Limit: req.limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+func dispatchPyroscope(ctx context.Context, req genericQueryRequest) (any, error) {
+	if req.profileType == "" {
+		return nil, errors.New("--profile-type is required for pyroscope queries")
+	}
+
+	client, err := pyroscope.NewClient(req.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resp, err := client.Query(ctx, req.uid, pyroscope.QueryRequest{
+		LabelSelector: req.expr,
+		ProfileTypeID: req.profileType,
+		Start:         req.start,
+		End:           req.end,
+		MaxNodes:      req.maxNodes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+func dispatchInfluxDB(ctx context.Context, req genericQueryRequest) (any, error) {
+	client, err := influxdb.NewClient(req.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	// InfluxDB is the one kind whose query language is a property of the
+	// datasource rather than of the expression, so it costs a second lookup.
+	mode, err := dsquery.GetInfluxDBMode(ctx, req.cfg, req.uid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect influxdb mode: %w", err)
+	}
+
+	resp, err := client.Query(ctx, req.uid, influxdb.QueryRequest{
+		Query: req.expr,
+		Start: req.start,
+		End:   req.end,
+		Step:  req.step,
+		Mode:  influxdb.Mode(mode),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+func dispatchClickHouse(ctx context.Context, req genericQueryRequest) (any, error) {
+	client, err := clickhouse.NewClient(req.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	clickhouseReq := clickhouse.QueryRequest{
+		RawSQL: clickhouse.EnforceLimit(req.expr, 100, 1000),
+		Start:  req.start,
+		End:    req.end,
+	}
+	if req.step > 0 {
+		clickhouseReq.IntervalMs = req.step.Milliseconds()
+	}
+
+	resp, err := client.Query(ctx, req.uid, clickhouseReq)
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	return resp, nil
+}

--- a/cmd/gcx/datasources/query_routes.go
+++ b/cmd/gcx/datasources/query_routes.go
@@ -95,11 +95,15 @@ func newQueryRoutes() queryRoutes {
 	}
 }
 
-// supportedKinds returns every kind the command routes — expression-dispatchable
+// supportedKinds returns every kind this command routes — expression-dispatchable
 // and redirect-only alike — sorted, for the unsupported-type message. Deriving
-// it is the point of #1137: the hand-maintained list had already drifted, and a
-// caller told a kind is unsupported is better served by the full set gcx knows
-// how to handle than by the subset that happens to take an expression.
+// it is the point of #1137: the hand-maintained list had already drifted.
+//
+// Scope, precisely: these are the kinds `gcx datasources query` handles, not
+// every kind gcx can query. Kinds with a typed `gcx datasources <kind> query`
+// but no entry here (tempo, athena, infinity) are absent by construction.
+// Redirect-only kinds are present because this command does handle them — by
+// naming the typed command — even though it never runs their query.
 func (r queryRoutes) supportedKinds() []string {
 	kinds := make([]string, 0, len(r.dispatch)+len(r.redirects))
 	for kind := range r.dispatch {

--- a/cmd/gcx/datasources/query_routes_internal_test.go
+++ b/cmd/gcx/datasources/query_routes_internal_test.go
@@ -1,0 +1,81 @@
+package datasources
+
+// Structural invariants of the generic query routing tables. These are the
+// properties the type system cannot express: that a kind is dispatchable or
+// redirect-only but never both, that keys are the normalized kind strings the
+// command actually looks up, and that no entry is a usable-looking blank.
+
+import (
+	"testing"
+
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryRoutesTablesAreDisjoint(t *testing.T) {
+	routes := newQueryRoutes()
+
+	for kind := range routes.dispatch {
+		_, alsoRedirects := routes.redirects[kind]
+		assert.Falsef(t, alsoRedirects,
+			"kind %q is both expression-dispatchable and redirect-only; it must be exactly one", kind)
+	}
+}
+
+// Keys must be what dsquery.NormalizeKind produces, not raw plugin IDs — a
+// route keyed "grafana-pyroscope-datasource" would never be reached.
+func TestQueryRoutesKeysAreNormalizedKinds(t *testing.T) {
+	routes := newQueryRoutes()
+
+	for _, kind := range allRoutedKinds(routes) {
+		assert.Equalf(t, kind, dsquery.NormalizeKind(kind),
+			"route key %q is not a normalized kind", kind)
+	}
+}
+
+func TestQueryRoutesEntriesAreUsable(t *testing.T) {
+	routes := newQueryRoutes()
+
+	require.NotEmpty(t, routes.dispatch)
+	require.NotEmpty(t, routes.redirects)
+
+	for kind, dispatch := range routes.dispatch {
+		assert.NotNilf(t, dispatch, "kind %q has a nil dispatch handler", kind)
+	}
+
+	for kind, message := range routes.redirects {
+		assert.NotEmptyf(t, message, "kind %q has an empty redirect message", kind)
+	}
+}
+
+func TestQueryRoutesUnknownKindResolvesToNeither(t *testing.T) {
+	routes := newQueryRoutes()
+
+	_, dispatchable := routes.dispatch["not-a-datasource"]
+	assert.False(t, dispatchable)
+
+	_, redirected := routes.redirects["not-a-datasource"]
+	assert.False(t, redirected)
+}
+
+// The CloudWatch redirect shipped in v1.0.0. Templating it must not reword it.
+func TestStructuredQueryRedirectMatchesShippedCloudWatchText(t *testing.T) {
+	want := "CloudWatch queries are structured (namespace, metric, dimensions, region, statistic, period); " +
+		"the generic `gcx datasources query <uid> <expr>` form can't carry them — " +
+		"use `gcx datasources cloudwatch query --namespace ... --metric ... --region ...` instead"
+
+	assert.Equal(t, want, newQueryRoutes().redirects["cloudwatch"])
+}
+
+func allRoutedKinds(routes queryRoutes) []string {
+	kinds := make([]string, 0, len(routes.dispatch)+len(routes.redirects))
+	for kind := range routes.dispatch {
+		kinds = append(kinds, kind)
+	}
+	for kind := range routes.redirects {
+		kinds = append(kinds, kind)
+	}
+
+	return kinds
+}

--- a/cmd/gcx/datasources/query_routes_internal_test.go
+++ b/cmd/gcx/datasources/query_routes_internal_test.go
@@ -28,7 +28,7 @@ func TestQueryRoutesTablesAreDisjoint(t *testing.T) {
 func TestQueryRoutesKeysAreNormalizedKinds(t *testing.T) {
 	routes := newQueryRoutes()
 
-	for _, kind := range allRoutedKinds(routes) {
+	for _, kind := range routes.supportedKinds() {
 		assert.Equalf(t, kind, dsquery.NormalizeKind(kind),
 			"route key %q is not a normalized kind", kind)
 	}
@@ -68,14 +68,15 @@ func TestStructuredQueryRedirectMatchesShippedCloudWatchText(t *testing.T) {
 	assert.Equal(t, want, newQueryRoutes().redirects["cloudwatch"])
 }
 
-func allRoutedKinds(routes queryRoutes) []string {
-	kinds := make([]string, 0, len(routes.dispatch)+len(routes.redirects))
-	for kind := range routes.dispatch {
-		kinds = append(kinds, kind)
-	}
-	for kind := range routes.redirects {
-		kinds = append(kinds, kind)
-	}
+// The supported list is derived, so it cannot drift from the tables again.
+func TestQueryRoutesSupportedKindsIsTheSortedUnion(t *testing.T) {
+	routes := newQueryRoutes()
 
-	return kinds
+	assert.Equal(t,
+		[]string{"clickhouse", "cloudwatch", "influxdb", "loki", "postgres", "prometheus", "pyroscope"},
+		routes.supportedKinds())
+
+	assert.Len(t, routes.supportedKinds(), len(routes.dispatch)+len(routes.redirects),
+		"every routed kind appears exactly once")
+	assert.IsIncreasing(t, routes.supportedKinds(), "the list must be deterministic")
 }

--- a/cmd/gcx/datasources/query_routes_internal_test.go
+++ b/cmd/gcx/datasources/query_routes_internal_test.go
@@ -6,6 +6,7 @@ package datasources
 // command actually looks up, and that no entry is a usable-looking blank.
 
 import (
+	"strings"
 	"testing"
 
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
@@ -25,12 +26,21 @@ func TestQueryRoutesTablesAreDisjoint(t *testing.T) {
 
 // Keys must be what dsquery.NormalizeKind produces, not raw plugin IDs — a
 // route keyed "grafana-pyroscope-datasource" would never be reached.
+//
+// The fixed-point check alone is weak: NormalizeKind returns anything it does
+// not recognize unchanged, so it only catches the plugin IDs already in its
+// switch. The shape check carries the rest, because every raw Grafana plugin ID
+// this command sees is either "grafana-*" or "*-datasource".
 func TestQueryRoutesKeysAreNormalizedKinds(t *testing.T) {
 	routes := newQueryRoutes()
 
 	for _, kind := range routes.supportedKinds() {
 		assert.Equalf(t, kind, dsquery.NormalizeKind(kind),
 			"route key %q is not a normalized kind", kind)
+		assert.Falsef(t, strings.HasPrefix(kind, "grafana-"),
+			"route key %q looks like a raw plugin ID, not a normalized kind", kind)
+		assert.Falsef(t, strings.HasSuffix(kind, "-datasource"),
+			"route key %q looks like a raw plugin ID, not a normalized kind", kind)
 	}
 }
 

--- a/cmd/gcx/datasources/query_routes_internal_test.go
+++ b/cmd/gcx/datasources/query_routes_internal_test.go
@@ -28,7 +28,7 @@ func TestQueryRoutesTablesAreDisjoint(t *testing.T) {
 func TestQueryRoutesKeysAreNormalizedKinds(t *testing.T) {
 	routes := newQueryRoutes()
 
-	for _, kind := range allRoutedKinds(routes) {
+	for _, kind := range routes.supportedKinds() {
 		assert.Equalf(t, kind, dsquery.NormalizeKind(kind),
 			"route key %q is not a normalized kind", kind)
 	}
@@ -68,14 +68,15 @@ func TestStructuredQueryRedirectMatchesShippedCloudWatchText(t *testing.T) {
 	assert.Equal(t, want, newQueryRoutes().redirects["cloudwatch"])
 }
 
-func allRoutedKinds(routes queryRoutes) []string {
-	kinds := make([]string, 0, len(routes.dispatch)+len(routes.redirects))
-	for kind := range routes.dispatch {
-		kinds = append(kinds, kind)
-	}
-	for kind := range routes.redirects {
-		kinds = append(kinds, kind)
-	}
+// The supported list is derived, so it cannot drift from the tables again.
+func TestQueryRoutesSupportedKindsIsTheSortedUnion(t *testing.T) {
+	routes := newQueryRoutes()
 
-	return kinds
+	assert.Equal(t,
+		[]string{"clickhouse", "cloudwatch", "influxdb", "loki", "prometheus", "pyroscope"},
+		routes.supportedKinds())
+
+	assert.Len(t, routes.supportedKinds(), len(routes.dispatch)+len(routes.redirects),
+		"every routed kind appears exactly once")
+	assert.IsIncreasing(t, routes.supportedKinds(), "the list must be deterministic")
 }

--- a/cmd/gcx/datasources/query_test.go
+++ b/cmd/gcx/datasources/query_test.go
@@ -282,6 +282,15 @@ func TestGenericQueryCloudWatchShortCircuit(t *testing.T) {
 				return []string{"query", "uid", "ignored-expr", "--config", c}
 			},
 		},
+		{
+			// The redirect must also beat ParseTimes, not only ResolveExpr:
+			// hoisting the time parsing above the redirect lookup would turn
+			// this into "invalid --step duration".
+			name: "unparseable --step still returns structured-subcommand error",
+			args: func(c string) []string {
+				return []string{"query", "uid", "expr", "--step", "nonsense", "--config", c}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/gcx/datasources/query_unsupported_test.go
+++ b/cmd/gcx/datasources/query_unsupported_test.go
@@ -51,11 +51,13 @@ func TestGenericQueryUnsupportedKindMessage_HumanMode(t *testing.T) {
 	assert.Empty(t, stdout, "a failed query writes no partial document to stdout")
 }
 
-// Agent mode must not reword or truncate the message, and must not leave a
-// half-written document behind. The in-band JSON error envelope is assembled by
-// the production root reporter, which this package-level root does not mount;
-// what is pinned here is the text that reporter receives.
-func TestGenericQueryUnsupportedKindMessage_AgentMode(t *testing.T) {
+// run has no agent-mode branch, so this cannot prove the message survives the
+// agents codec — the in-band JSON error envelope is assembled by the production
+// root reporter, and TestAgentConformance_* in cmd/gcx/root covers that. What
+// this pins is narrower and still worth pinning: enabling agent mode changes
+// neither the text the reporter receives nor the fact that stdout stays empty,
+// so a future agent-mode branch in this command cannot quietly diverge.
+func TestGenericQueryUnsupportedKindMessage_AgentModeDoesNotDivergeFromHuman(t *testing.T) {
 	testutils.SetAgentMode(t, true)
 
 	f := &fakeGrafana{t: t, dsType: "tempo"}

--- a/cmd/gcx/datasources/query_unsupported_test.go
+++ b/cmd/gcx/datasources/query_unsupported_test.go
@@ -1,0 +1,67 @@
+package datasources_test
+
+// The unsupported-kind message names every kind the generic command routes,
+// derived from the routing tables rather than hand-maintained (#1137). It is
+// the only user-visible text this refactor changes, so it is pinned exactly,
+// in both output modes.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/datasources"
+	"github.com/grafana/gcx/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const wantUnsupportedMessage = `datasource type "tempo" is not supported ` +
+	`(supported: clickhouse, cloudwatch, influxdb, loki, prometheus, pyroscope)`
+
+// runGenericSilenced mirrors the production root (cmd/gcx/root): usage and
+// errors are reported by the caller, never printed into the output streams. The
+// characterization suite deliberately uses a bare root instead, so this does
+// not reuse its helper.
+func runGenericSilenced(t *testing.T, f *fakeGrafana, args ...string) (string, error) {
+	t.Helper()
+
+	srv := f.start()
+	configFile := newConfigFileForServer(t, srv.URL)
+
+	root := helperRoot(datasources.QueryCmd())
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetIn(strings.NewReader(""))
+	root.SetArgs(append(args, "--config", configFile))
+
+	return stdout.String(), root.Execute()
+}
+
+func TestGenericQueryUnsupportedKindMessage_HumanMode(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "tempo"}
+
+	stdout, err := runGenericSilenced(t, f, "query", "uid", "whatever")
+	require.Error(t, err)
+	assert.Equal(t, wantUnsupportedMessage, err.Error())
+	assert.Empty(t, stdout, "a failed query writes no partial document to stdout")
+}
+
+// Agent mode must not reword or truncate the message, and must not leave a
+// half-written document behind. The in-band JSON error envelope is assembled by
+// the production root reporter, which this package-level root does not mount;
+// what is pinned here is the text that reporter receives.
+func TestGenericQueryUnsupportedKindMessage_AgentMode(t *testing.T) {
+	testutils.SetAgentMode(t, true)
+
+	f := &fakeGrafana{t: t, dsType: "tempo"}
+
+	stdout, err := runGenericSilenced(t, f, "query", "uid", "whatever")
+	require.Error(t, err)
+	assert.Equal(t, wantUnsupportedMessage, err.Error())
+	assert.Empty(t, strings.TrimSpace(stdout))
+}

--- a/cmd/gcx/datasources/query_unsupported_test.go
+++ b/cmd/gcx/datasources/query_unsupported_test.go
@@ -1,0 +1,67 @@
+package datasources_test
+
+// The unsupported-kind message names every kind the generic command routes,
+// derived from the routing tables rather than hand-maintained (#1137). It is
+// the only user-visible text this refactor changes, so it is pinned exactly,
+// in both output modes.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/datasources"
+	"github.com/grafana/gcx/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const wantUnsupportedMessage = `datasource type "tempo" is not supported ` +
+	`(supported: clickhouse, cloudwatch, influxdb, loki, postgres, prometheus, pyroscope)`
+
+// runGenericSilenced mirrors the production root (cmd/gcx/root): usage and
+// errors are reported by the caller, never printed into the output streams. The
+// characterization suite deliberately uses a bare root instead, so this does
+// not reuse its helper.
+func runGenericSilenced(t *testing.T, f *fakeGrafana, args ...string) (string, error) {
+	t.Helper()
+
+	srv := f.start()
+	configFile := newConfigFileForServer(t, srv.URL)
+
+	root := helperRoot(datasources.QueryCmd())
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetIn(strings.NewReader(""))
+	root.SetArgs(append(args, "--config", configFile))
+
+	return stdout.String(), root.Execute()
+}
+
+func TestGenericQueryUnsupportedKindMessage_HumanMode(t *testing.T) {
+	f := &fakeGrafana{t: t, dsType: "tempo"}
+
+	stdout, err := runGenericSilenced(t, f, "query", "uid", "whatever")
+	require.Error(t, err)
+	assert.Equal(t, wantUnsupportedMessage, err.Error())
+	assert.Empty(t, stdout, "a failed query writes no partial document to stdout")
+}
+
+// Agent mode must not reword or truncate the message, and must not leave a
+// half-written document behind. The in-band JSON error envelope is assembled by
+// the production root reporter, which this package-level root does not mount;
+// what is pinned here is the text that reporter receives.
+func TestGenericQueryUnsupportedKindMessage_AgentMode(t *testing.T) {
+	testutils.SetAgentMode(t, true)
+
+	f := &fakeGrafana{t: t, dsType: "tempo"}
+
+	stdout, err := runGenericSilenced(t, f, "query", "uid", "whatever")
+	require.Error(t, err)
+	assert.Equal(t, wantUnsupportedMessage, err.Error())
+	assert.Empty(t, strings.TrimSpace(stdout))
+}

--- a/cmd/gcx/datasources/query_unsupported_test.go
+++ b/cmd/gcx/datasources/query_unsupported_test.go
@@ -39,7 +39,12 @@ func runGenericSilenced(t *testing.T, f *fakeGrafana, args ...string) (string, e
 	root.SetIn(strings.NewReader(""))
 	root.SetArgs(append(args, "--config", configFile))
 
-	return stdout.String(), root.Execute()
+	// Execute first: `return stdout.String(), root.Execute()` would snapshot
+	// stdout before the command ran, and every assertion on it would be
+	// vacuous. Go evaluates return operands left to right.
+	err := root.Execute()
+
+	return stdout.String(), err
 }
 
 func TestGenericQueryUnsupportedKindMessage_HumanMode(t *testing.T) {

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -866,7 +866,9 @@ Provider command tree backed by fleet-management `Set/Get` + observed-state RPCs
 | `internal/query/loki/types.go` | Request/response types for Loki |
 | `internal/query/loki/formatter.go` | Table/text formatting for Loki responses |
 | `cmd/gcx/datasources/command.go` | `datasources` command group (list, get, prometheus, loki, pyroscope, tempo, generic subcommands) |
-| `internal/datasources/query/` | Shared query CLI infrastructure (opts, codecs, resolution, time parsing); per-kind constructors live in `internal/datasources/{kind}/` |
+| `cmd/gcx/datasources/query.go` | Auto-detecting `datasources query` — options, ordering, one encode |
+| `cmd/gcx/datasources/query_routes.go` | Routing tables for the auto-detecting query: per-kind dispatch handlers, typed-command redirects, derived supported-kind list |
+| `internal/datasources/query/` | Shared query CLI infrastructure (opts, codecs, resolution, time parsing, kind normalization); per-kind constructors live in `internal/datasources/{kind}/` |
 
 ### Deep Link URLs
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -866,7 +866,9 @@ Provider command tree backed by fleet-management `Set/Get` + observed-state RPCs
 | `internal/query/loki/types.go` | Request/response types for Loki |
 | `internal/query/loki/formatter.go` | Table/text formatting for Loki responses |
 | `cmd/gcx/datasources/command.go` | `datasources` command group (list, get, prometheus, loki, pyroscope, tempo, generic subcommands) |
-| `cmd/gcx/datasources/query/` | Per-kind `query` subcommand constructors and shared infrastructure (codecs, time parsing) |
+| `cmd/gcx/datasources/query.go` | Auto-detecting `datasources query` — options, ordering, one encode |
+| `cmd/gcx/datasources/query_routes.go` | Routing tables for the auto-detecting query: per-kind dispatch handlers, typed-command redirects, derived supported-kind list |
+| `internal/datasources/query/` | Shared query CLI infrastructure (opts, codecs, time parsing, kind normalization) |
 
 ### Deep Link URLs
 

--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -286,8 +286,8 @@ cmd/gcx/
 │   ├── command.go           datasources group (list, get, query)
 │   ├── list.go              datasources list
 │   ├── get.go               datasources get
-│   └── query/
-│       └── generic.go       GenericCmd() — auto-detecting query (imports shared infra from internal/datasources/query/)
+│   ├── query.go             QueryCmd() — auto-detecting query (shared infra from internal/datasources/query/)
+│   └── query_routes.go      per-kind dispatch handlers and typed-command redirects
 ├── providers/
 │   └── command.go           providers command — lists registered providers
 ├── setup/

--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -277,8 +277,8 @@ cmd/gcx/
 │   ├── command.go           datasources group (list, get, query)
 │   ├── list.go              datasources list
 │   ├── get.go               datasources get
-│   └── query/
-│       └── generic.go       GenericCmd() — auto-detecting query (imports shared infra from internal/datasources/query/)
+│   ├── query.go             QueryCmd() — auto-detecting query (shared infra from internal/datasources/query/)
+│   └── query_routes.go      per-kind dispatch handlers and typed-command redirects
 ├── providers/
 │   └── command.go           providers command — lists registered providers
 ├── setup/

--- a/docs/architecture/data-flows.md
+++ b/docs/architecture/data-flows.md
@@ -308,24 +308,26 @@ generic dispatcher is a separate, conditional decision:
    `QueryCmd` and `ExtraCommands` automatically — no per-kind wiring in the
    command layer. Registered kinds live in `internal/datasources/providers/`;
    read that directory rather than trusting a list here.
-2. **Generic `datasources query` — hand-maintained, and deliberately not at
+2. **Generic `datasources query` — table-driven, and deliberately not at
    parity.** The auto-detecting command resolves the datasource type over the API
-   and dispatches through an explicit `switch` in
-   `cmd/gcx/datasources/query.go`, covering prometheus, loki, pyroscope, influxdb
-   and clickhouse. Registration does **not** reach it, and no test enforces
-   parity, because parity is not always the right answer: the generic contract is
-   `<uid> <expr>`, and a kind whose query cannot be expressed as one string does
-   not belong there. CloudWatch is handled explicitly for that reason — a guard on
-   the normalized type, placed *before* expression resolution and before the
-   switch, returns an error naming `datasources cloudwatch query` and its
-   structured flags (namespace, metric, dimensions, region, statistic, period).
-   The ordering is deliberate: as a switch case the redirect would be unreachable
-   for an argument-less call, which fails in `ResolveExpr` first. Kinds outside the
-   switch: athena and infinity (both `query [EXPR]`-shaped, so candidates), tempo
-   (its `query` leaf takes a TraceQL expression and is built in
-   `internal/datasources/tempo/search.go`, so it is a candidate too), and
-   cloudwatch (excluded by design, with the redirect above). Everything else falls
-   to the "not supported" default.
+   and routes it through two disjoint tables in
+   `cmd/gcx/datasources/query_routes.go`: `dispatch` maps a normalized kind to a
+   handler, for kinds the `<uid> <expr>` form carries honestly; `redirects` maps a
+   kind to a message naming the typed command, for kinds whose query is
+   structured. A kind is in one table, the other, or neither — never both, which
+   the tests assert. Registration does **not** reach these tables and no test
+   enforces parity, because parity is not always the right answer: a kind whose
+   query cannot be expressed as one string does not belong in the generic form.
+   CloudWatch is the redirect case for that reason, pointing at
+   `datasources cloudwatch query` and its structured flags (namespace, metric,
+   dimensions, region, statistic, period). The redirect lookup runs *before*
+   expression resolution and before the dispatch lookup: ordering is
+   load-bearing, because an argument-less call would otherwise fail in
+   `ResolveExpr` and never reach the redirect. Kinds in neither table (athena,
+   infinity, and tempo, whose `query` leaf takes a TraceQL expression and is
+   built in `internal/datasources/tempo/search.go`) fall to the unsupported-kind
+   default, whose message is derived from the tables rather than hand-maintained.
+   Read `newQueryRoutes()` rather than trusting a list here.
 
 ```
 User invocation:
@@ -448,12 +450,13 @@ User invocation:
 ```
 
 Key files:
-- `internal/datasources/query/opts.go` + `resolve.go` — shared opts, `ResolveTypedArgs`, `ValidateDatasourceType`
+- `internal/datasources/query/opts.go` + `resolve.go` — shared opts, `ResolveExpr`, `ParseTimes`, `NormalizeKind`, `GetDatasourceType`, `ResolveTypedArgs`, `ValidateDatasourceType`
 - `internal/datasources/provider.go` — the `DatasourceProvider` interface (`Kind`, `QueryCmd`, `ExtraCommands`)
 - `internal/datasources/providers/` — one file per registered kind, each calling `datasources.RegisterProvider()`; the authoritative list of supported kinds
 - `internal/datasources/<kind>/query.go` — per-kind `QueryCmd` constructors (tempo's lives in `search.go`, not `query.go` — the leaf exists, the filename differs)
 - `cmd/gcx/datasources/command.go` — mounts every registered kind's subtree from `datasources.AllProviders()`
-- `cmd/gcx/datasources/query.go` — generic auto-detecting `datasources query`, with the hand-maintained type `switch`
+- `cmd/gcx/datasources/query.go` — generic auto-detecting `datasources query`: the options struct and the fixed validate → resolve type → redirect → expression → times → dispatch order
+- `cmd/gcx/datasources/query_routes.go` — the two disjoint routing tables (per-kind dispatch handlers, typed-command redirects) and the derived supported-kind list
 - `internal/datasources/query/codecs.go` — `queryTableCodec`, `queryGraphCodec` (codec registry)
 - `internal/datasources/query/time.go` — time parsing for flag values
 - `internal/config/resolver.go` — `DefaultDatasourceUID(ctx, kind)` — per-kind lookup in the context's datasources map

--- a/docs/architecture/data-flows.md
+++ b/docs/architecture/data-flows.md
@@ -295,7 +295,7 @@ backing client is a REST adapter or the k8s dynamic client.
 
 ## 5. QUERY Pipeline
 
-Entry point: per-signal provider packages (`internal/providers/{metrics,logs,traces,profiles}/query.go`) and the auto-detecting `cmd/gcx/datasources/query/generic.go`. Shared query CLI utils live in `internal/datasources/query/`.
+Entry point: per-signal provider packages (`internal/providers/{metrics,logs,traces,profiles}/query.go`) and the auto-detecting `cmd/gcx/datasources/query.go`. Shared query CLI utils live in `internal/datasources/query/`.
 
 ```
 User invocation:
@@ -417,11 +417,13 @@ User invocation:
 ```
 
 Key files:
-- `cmd/gcx/datasources/query/query.go` — shared opts, `resolveTypedArgs`, `validateDatasourceType`
-- `cmd/gcx/datasources/query/{prometheus,loki,pyroscope,tempo,generic}.go` — per-kind constructors (`PrometheusCmd`, `LokiCmd`, etc.)
-- `cmd/gcx/datasources/query/codecs.go` — `queryTableCodec`, `queryGraphCodec` (codec registry)
-- `cmd/gcx/datasources/query/time.go` — `ParseTime`, `ParseDuration` for flag parsing
-- `cmd/gcx/datasources/{prometheus,loki,pyroscope,tempo,generic}.go` — kind subgroups that wire in the query constructors
+- `cmd/gcx/datasources/query.go` — the auto-detecting `datasources query`: options struct, and the fixed validate → resolve type → redirect → expression → times → dispatch order
+- `cmd/gcx/datasources/query_routes.go` — the routing tables (dispatch handlers and typed-command redirects) plus the derived supported-kind list
+- `internal/datasources/query/opts.go` — `SharedOpts`, `ResolveExpr`, `ParseTimes`
+- `internal/datasources/query/resolve.go` — `NormalizeKind`, `GetDatasourceType`, `ResolveTypedArgs`, `ValidateDatasourceType`
+- `internal/datasources/query/codecs.go` — `queryTableCodec`, `queryGraphCodec` (codec registry)
+- `internal/datasources/query/time.go` — `ParseTime`, `ParseDuration` for flag parsing
+- `internal/datasources/{prometheus,loki,pyroscope,clickhouse,...}/query.go` — per-kind typed `query` constructors, mounted by `DatasourceProvider` registration
 - `internal/config/resolver.go` — `DefaultDatasourceUID(ctx, kind)` — shared 2-tier UID resolution
 - `internal/query/prometheus/client.go` — HTTP client, request construction, response conversion
 - `internal/query/prometheus/formatter.go` — table rendering (vector/matrix/scalar)

--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -290,8 +290,9 @@ terminal charts (`internal/graph`). The `query` command registers custom codecs
 - `internal/query/dataframe/types.go`: shared Grafana data frame wire envelope for unified query responses
 - `internal/query/prometheus/client.go`: `NewClient` calls `rest.HTTPClientFor`
 - `internal/query/loki/client.go`: same pattern
-- `cmd/gcx/datasources/query/codecs.go`: `queryTableCodec`, `queryGraphCodec` registration — shared by all per-kind query subcommands
-- `cmd/gcx/datasources/query/{prometheus,loki,pyroscope,tempo,generic}.go`: per-kind constructors wired under `datasources {kind} query`
+- `internal/datasources/query/codecs.go`: `queryTableCodec`, `queryGraphCodec` registration — shared by all per-kind query subcommands
+- `internal/datasources/{prometheus,loki,pyroscope,clickhouse,...}/query.go`: per-kind constructors wired under `datasources {kind} query`
+- `cmd/gcx/datasources/query_routes.go`: the auto-detecting `datasources query` picks a client from a routing table keyed by normalized kind — a kind is either expression-dispatchable or redirect-only, never both
 - `internal/graph/chart.go`: `RenderChart` auto-selects line vs bar chart
 
 ---
@@ -318,7 +319,7 @@ only the wide table codec was expected to display.
 
 **Evidence:**
 - `internal/providers/slo/definitions/status.go`: `fetchMetrics` fetches all metrics unconditionally
-- `cmd/gcx/datasources/query/query.go`: query response passed to all codecs unchanged
+- `cmd/gcx/datasources/query.go`: query response passed to all codecs unchanged
 - `internal/output/format.go`: built-in JSON/YAML codecs fall through when no custom codec is registered
 
 **See also:** [output.md](../design/output.md) — codec requirements by command type and mutation command output spec.

--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -291,7 +291,8 @@ terminal charts (`internal/graph`). The `query` command registers custom codecs
 - `internal/query/prometheus/client.go`: `NewClient` calls `rest.HTTPClientFor`
 - `internal/query/loki/client.go`: same pattern
 - `internal/datasources/query/codecs.go`: `queryTableCodec`, `queryGraphCodec` registration — shared by all per-kind query subcommands
-- `internal/datasources/{prometheus,loki,pyroscope,tempo}/query.go`: per-kind constructors wired under `datasources {kind} query` (generic auto-detect switch: `cmd/gcx/datasources/query.go`)
+- `internal/datasources/{prometheus,loki,pyroscope,clickhouse,postgres,...}/query.go`: per-kind constructors wired under `datasources {kind} query`
+- `cmd/gcx/datasources/query_routes.go`: the auto-detecting `datasources query` picks a client from a routing table keyed by normalized kind — a kind is either expression-dispatchable or redirect-only, never both
 - `internal/graph/chart.go`: `RenderChart` auto-selects line vs bar chart
 
 ---
@@ -318,7 +319,7 @@ only the wide table codec was expected to display.
 
 **Evidence:**
 - `internal/providers/slo/definitions/status.go`: `fetchMetrics` fetches all metrics unconditionally
-- `internal/datasources/prometheus/query.go`: query response passed to all codecs unchanged
+- `cmd/gcx/datasources/query.go`: query response passed to all codecs unchanged
 - `internal/output/format.go`: built-in JSON/YAML codecs fall through when no custom codec is registered
 
 **See also:** [output.md](../design/output.md) — codec requirements by command type and mutation command output spec.

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -12,7 +12,7 @@ gcx/
 │       ├── config/           # 'config' subcommand implementations
 │       ├── resources/        # 'resources' subcommand implementations
 │       ├── datasources/      # 'datasources' subcommand (list, get, query)
-│       │   └── query/        # Auto-detecting query command (GenericCmd only)
+│       │                     #   query.go + query_routes.go: auto-detecting query and its per-kind routing tables
 │       ├── commands/         # 'commands' catalog (agent metadata, resource types, live validation)
 │       ├── helptree/        # 'help-tree' compact text tree for agent context injection
 │       ├── setup/            # 'setup' command area (cross-product onboarding helpers)


### PR DESCRIPTION
Closes #1137.

## The problem

`QueryCmd` dispatched every datasource kind through a hand-maintained switch inside its `RunE` closure, with redirect guards stacked above it. `maintidx` folds a function literal into its enclosing declaration, so every per-kind arm counted against `QueryCmd`, which sat at exactly 20 against a threshold that fails below 20. Each of the five in-flight datasource PRs is lint-clean on its own; whichever landed third broke CI on a diff that hadn't done anything wrong. No merge order avoids it, so it was ours to fix rather than any contributor's.

Reproduced before touching anything, probing `maintidx` on its own because the uniq-by-line processor hides it when another linter reports the same line:

```
main alone:            QueryCmd  CC 27  HV 4499.17  MI 20   (passes by one point)
main + all five PRs:   QueryCmd  CC 30  HV 4684.70  MI 19   (fails)
```

## What this does

Two private, disjoint routing tables in `cmd/gcx/datasources/query_routes.go`: kind to dispatch handler for kinds the generic `<uid> <expr>` form fits, kind to redirect message for kinds whose query is structured. A kind is one or the other or unrouted, never both, and the tests enforce that rather than a struct with two nilable fields making "both" and "neither" constructible. The `RunE` closure becomes `(*genericQueryOpts).run` per the options pattern, and each switch arm becomes a small named handler that returns a value for the command to encode.

The tables are built by `newQueryRoutes()`, called once from `QueryCmd`, deliberately not inlined there. A map literal's size is attributed to the function containing it, so writing the table inside `QueryCmd` would have recreated the exact problem.

It stays in `cmd/gcx/datasources`. Route selection is command dispatch, which `cmd/` owns; the domain HTTP behaviour is still in `internal/query/<kind>`, and there's no reason to export a `Route`/`Dispatcher`/`StructuredQuery` API for one consumer.

## The four commits are meant to be read in order

The first adds characterization tests against the unchanged switch and proves they pass before any production code moves. The second replaces the switch while leaving those tests byte-identical. The third makes the one intentional behaviour change. The fourth is docs. The parity net was written against the old code and the new code never got to edit it, which is the only reason to trust it.

Characterization covers every kind the generic command handles: Prometheus time and step, Loki `--limit`, Pyroscope `--profile-type` and `--max-nodes`, InfluxDB's second datasource GET and the detected language mode plus its `failed to detect influxdb mode` wrapper, ClickHouse limit and interval. Plus reachable query-error wrapping, exactly-one-JSON-value stdout, encode-error propagation, the CloudWatch redirect with and without an expression, and the unknown-kind ordering. Two deliberate mutations, dropping the Loki limit and the Prometheus step wiring, were confirmed to turn them red, so they aren't tests that can't fail.

Structural assertions cover disjoint key sets, keys canonical against `NormalizeKind`, non-nil dispatchers, non-empty redirect messages, the sorted union, and the unknown lookup. No duplicate-key test, because duplicate constant keys in a Go map literal are already a compile error.

## The one behaviour change

The unsupported-kind message is now derived from the tables instead of a hand-written literal:

```
before: (supported: prometheus, loki, pyroscope, influxdb, clickhouse)
after:  (supported: clickhouse, cloudwatch, influxdb, loki, prometheus, pyroscope)
```

Sorted, and redirect kinds included. #1137 names the drift directly: the literal omitted cloudwatch and would have omitted azuremonitor once #965 landed. Redirect kinds belong in it because someone reading that message is asking what the command handles, not which kinds happen to take an expression. Pinned exactly, in human mode and with agent mode on. It's observable, including inside the agent-mode error document, so it's called out here rather than described as internal.

Nothing else moves. `docs/reference/cli/gcx_datasources_query.md` is byte-identical, and so are `datasources query --help`, `help-tree` and `commands --flat -o json`, all diffed against binaries built from `main`.

Ordering is preserved exactly, including the parts that look like accidents and aren't. Redirects still run before `ResolveExpr`, so an argument-less call gets the typed command rather than "expression is required". An unknown kind with no expression still returns "expression is required"; with an expression but a bad `--step` it still returns the parse error; only a fully valid request reaches the unsupported-type verdict. Moving that check up would be more useful in one round trip instead of two, but it's a behaviour change and this PR isn't the place.

## Measurements

Every changed function, not just `QueryCmd`, with a temporary `under: 100` threshold used only to print numbers. Real `mise run lint` is the authority.

```
                       6 kinds (this PR)      11 kinds (all five PRs)
QueryCmd               CC 1  HV 265   MI 50   CC 1  HV 265   MI 50
run                    CC 9  HV 1233  MI 38   CC 9  HV 1299  MI 38
newQueryRoutes         CC 1  HV 147   MI 57   CC 1  HV 258   MI 48
Validate / setup                MI 59 / 64             MI 59 / 64
dispatch handlers               MI 49-54               MI 49-54
```

`QueryCmd` is identical at 6 and 11 kinds. `run` is unchanged. The only thing that moves with kind count is the table constructor, and it moves at constant cyclomatic complexity, so I'd rather not claim the cliff "cannot recur" — it accumulates Halstead volume like anything else holding data. It just does so slowly and without branching, and it's a different function from the one with the budget problem.

## Acceptance

The issue asks for a tree containing `main` plus all five in-flight PRs to pass `mise run lint`. Built in a throwaway worktree from PR head refs, never pushed to anyone's branch:

```
mise run lint  ->  0 issues
```

with all eleven kinds routed: azuremonitor, clickhouse, cloudmonitoring, cloudwatch, elasticsearch, influxdb, loki, mysql, postgres, prometheus, pyroscope.

Two honesty notes on that number. #970 is based on `alyssa/add-postgres-ds`, so it carries #969; I merged #969 then #970 deliberately rather than treating them as independent. And #971 and #974 add no generic routing on their current heads at all, so their entries in that tree are labelled anticipated-post-review shapes, not measurements of merged code. #965, #969 and #970 are real adaptations of hunks that exist today. The only conflicts outside `query.go` were between the contributor PRs themselves, in `codecs.go`, `CODEOWNERS` and `project-structure.md`, and are not caused by this change.

## What the five PRs need on rebase

Each converts to one table entry plus, for dispatch kinds, one handler.

`#965 azuremonitor` — a `redirects` entry built with `structuredQueryRedirect("Azure Monitor", "subscription, resource group, resource, namespace, metric, aggregation", "gcx datasources azuremonitor query --subscription ... ...")`. The guard goes away; ordering is handled by the table.

`#969 postgres` and `#970 mysql` — a `dispatch` entry plus the existing `runPostgresQuery`/`runMySQLQuery` body renamed to a handler taking `genericQueryRequest`. The `cmdio.Warning` call keeps working: `req.warn` is bound to `cmd.ErrOrStderr()` for exactly this. The hand-edit to the supported list goes away, it's derived now.

`#971 elasticsearch` — currently unrouted, so `gcx datasources query <es-uid>` is a dead end. Its query leaf is expression-shaped, so a `dispatch` entry is the natural fix.

`#974 cloudmonitoring` — also currently unrouted, and its query leaf is structured-only, so a `redirects` entry.

## Alternatives rejected

Extracting per-kind helpers and keeping the switch is what #969 already did, and the combined tree still measured 19. Extraction moves volume, it doesn't remove the per-kind branch from the central function.

Driving dispatch off the `DatasourceProvider` registry doesn't work as things stand: the interface has no headless query entry point, no plugin-ID aliases and no capability flags, and `cmd/gcx/datasources` doesn't import `internal/datasources/providers`, so the registry is empty in this package's test binary. It would need a new method on all nine providers, which is the redesign #1137 says not to do.

Raising the threshold or adding a `nolint` was off the table.

## Risks

Blast radius is `gcx datasources query`. Typed datasource commands, CRUD, clients, config and persisted data are untouched. A bug here makes generic queries fail, pick the wrong handler, or format wrongly; it can't touch customer data. Rollback is a plain revert until the first dependent PR merges.

Worth landing this alone, letting main CI and a smoke run confirm it, and giving it a short burn-in before rebasing the five datasource PRs onto it one at a time.

One coordination item: #1126 is not merged and its skill files still describe the switch and "the redirect goes before the switch" in `SKILL.md`, `references/placement-and-readiness.md` §3-§4 and `references/distribution-and-gates.md`. Those files aren't on `main`, so this PR can't fix them. Whichever lands second has to update the other side, and neither should merge while pointing contributors at a switch that no longer exists. The repo-local `.claude/skills/add-datasource/SKILL.md` is updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)