### PR TITLE
fix(agento11y): add planned trial count to experiments response

### DIFF
--- a/internal/providers/aio11y/eval/experiments/client_test.go
+++ b/internal/providers/aio11y/eval/experiments/client_test.go
@@ -180,17 +180,19 @@ func TestClient_Cases(t *testing.T) {
 }
 
 func TestClient_Get(t *testing.T) {
+	planned := 4
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments/r-1", r.URL.Path)
 
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(w, experiments.Experiment{
-			RunID:     "r-1",
-			Name:      "exp-1",
-			Status:    "running",
-			Source:    "external",
-			CreatedAt: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+			RunID:             "r-1",
+			Name:              "exp-1",
+			Status:            "running",
+			PlannedTrialCount: &planned,
+			Source:            "external",
+			CreatedAt:         time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
 		})
 	}))
 
@@ -198,6 +200,8 @@ func TestClient_Get(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "r-1", exp.RunID)
 	assert.Equal(t, "external", exp.Source)
+	require.NotNil(t, exp.PlannedTrialCount)
+	assert.Equal(t, 4, *exp.PlannedTrialCount)
 }
 
 func TestClient_Trials(t *testing.T) {

--- a/internal/providers/aio11y/eval/experiments/types.go
+++ b/internal/providers/aio11y/eval/experiments/types.go
@@ -90,17 +90,18 @@ type Experiment struct {
 	Metadata     map[string]any        `json:"metadata,omitempty"`
 
 	// Server-managed fields.
-	ExperimentID string     `json:"experiment_id,omitempty"`
-	RunID        string     `json:"run_id,omitempty"`
-	TenantID     string     `json:"tenant_id,omitempty"`
-	Status       string     `json:"status,omitempty"`
-	ScoreCount   int        `json:"score_count,omitempty"`
-	Error        string     `json:"error,omitempty"`
-	CreatedBy    string     `json:"created_by,omitempty"`
-	CreatedAt    time.Time  `json:"created_at,omitzero"`
-	UpdatedAt    time.Time  `json:"updated_at,omitzero"`
-	StartedAt    *time.Time `json:"started_at,omitempty"`
-	CompletedAt  *time.Time `json:"completed_at,omitempty"`
+	ExperimentID      string     `json:"experiment_id,omitempty"`
+	RunID             string     `json:"run_id,omitempty"`
+	TenantID          string     `json:"tenant_id,omitempty"`
+	Status            string     `json:"status,omitempty"`
+	ScoreCount        int        `json:"score_count,omitempty"`
+	PlannedTrialCount *int       `json:"planned_trial_count,omitempty"`
+	Error             string     `json:"error,omitempty"`
+	CreatedBy         string     `json:"created_by,omitempty"`
+	CreatedAt         time.Time  `json:"created_at,omitzero"`
+	UpdatedAt         time.Time  `json:"updated_at,omitzero"`
+	StartedAt         *time.Time `json:"started_at,omitempty"`
+	CompletedAt       *time.Time `json:"completed_at,omitempty"`
 }
 
 func (e Experiment) ID() string {


### PR DESCRIPTION
## Notes

* Adds `PlannedTrialCount` to Agent Observability Experiment type

Found a missing attribute that was added to Agent O11y Experiments called `PlannedTrialCount`, which helps Grafana show progress for an experiment (i.e. `X` trials out of `PlannedTrialCount` are completed).

## Testing

Built the branch and queried the latest experiment on a personal stack:

```bash
go build -mod=readonly -buildvcs=false -o bin/gcx ./cmd/gcx/

./bin/gcx --context jdev agento11y experiments list \
  --limit 1 \
  -o json \
  --jq '.[0] | {experiment_id, status, planned_trial_count}'
```

Output:

```json
{
  "experiment_id": "demo-o11y-bench-focused-20260809T183328Z",
  "planned_trial_count": 10,
  "status": "running"
}
```