### PR TITLE
fix(agento11y): match experiments report types to the API

### DIFF
--- a/internal/providers/aio11y/eval/experiments/client_test.go
+++ b/internal/providers/aio11y/eval/experiments/client_test.go
@@ -17,6 +17,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// Payload fixtures in this file use literal wire keys rather than re-serialized
+// gcx structs: a round-tripped struct would agree with itself even when it
+// disagrees with the API.
+
 func writeJSON(w http.ResponseWriter, v any) {
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -45,8 +49,8 @@ func TestClient_List(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(w, map[string]any{
 			"items": []experiments.Experiment{
-				{RunID: "r-1", Name: "exp-1", Status: "succeeded"},
-				{RunID: "r-2", Name: "exp-2", Status: "running"},
+				{ExperimentID: "r-1", Name: "exp-1", Status: "succeeded"},
+				{ExperimentID: "r-2", Name: "exp-2", Status: "running"},
 			},
 		})
 	}))
@@ -54,7 +58,7 @@ func TestClient_List(t *testing.T) {
 	items, err := client.List(context.Background(), 0)
 	require.NoError(t, err)
 	require.Len(t, items, 2)
-	assert.Equal(t, "r-1", items[0].RunID)
+	assert.Equal(t, "r-1", items[0].ExperimentID)
 	assert.Equal(t, "running", items[1].Status)
 }
 
@@ -180,28 +184,95 @@ func TestClient_Cases(t *testing.T) {
 }
 
 func TestClient_Get(t *testing.T) {
-	planned := 4
-	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments/r-1", r.URL.Path)
+	tests := []struct {
+		name    string
+		payload map[string]any
+		want    experiments.Experiment
+	}{
+		{
+			name: "running experiment",
+			payload: map[string]any{
+				"experiment_id": "r-1",
+				"name":          "exp-1",
+				"status":        "running",
+				"created_at":    "2026-04-01T10:00:00Z",
+			},
+			want: experiments.Experiment{
+				ExperimentID: "r-1",
+				Name:         "exp-1",
+				Status:       "running",
+				CreatedAt:    time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "finalized rollup",
+			payload: map[string]any{
+				"experiment_id":       "r-1",
+				"name":                "exp-1",
+				"status":              "completed",
+				"planned_trial_count": 10,
+				"result_status":       "ready",
+				"result": map[string]any{
+					"test_case_count": 2,
+					"trial_count":     2,
+					"completed_count": 2,
+					"total_cost":      0.135159,
+					"cost_coverage":   "complete",
+					"token_coverage":  "complete",
+					"total_tokens":    20077,
+				},
+				"run_id":      "r-1",
+				"score_count": 7,
+			},
+			want: experiments.Experiment{
+				ExperimentID:      "r-1",
+				Name:              "exp-1",
+				Status:            "completed",
+				PlannedTrialCount: new(10),
+				ResultStatus:      "ready",
+				Result: &experiments.ExperimentReportSummary{
+					TestCaseCount:  2,
+					TrialCount:     2,
+					CompletedCount: 2,
+					TotalCost:      new(0.135159),
+					CostCoverage:   "complete",
+					TokenCoverage:  "complete",
+					TotalTokens:    new(int64(20077)),
+				},
+			},
+		},
+		{
+			name: "rollup failed",
+			payload: map[string]any{
+				"experiment_id": "r-1",
+				"status":        "completed",
+				"result_status": "failed",
+				"result_error":  "timeout",
+			},
+			want: experiments.Experiment{
+				ExperimentID: "r-1",
+				Status:       "completed",
+				ResultStatus: "failed",
+				ResultError:  "timeout",
+			},
+		},
+	}
 
-		w.Header().Set("Content-Type", "application/json")
-		writeJSON(w, experiments.Experiment{
-			RunID:             "r-1",
-			Name:              "exp-1",
-			Status:            "running",
-			PlannedTrialCount: &planned,
-			Source:            "external",
-			CreatedAt:         time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments/r-1", r.URL.Path)
+
+				w.Header().Set("Content-Type", "application/json")
+				writeJSON(w, tc.payload)
+			}))
+
+			exp, err := client.Get(context.Background(), "r-1")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, *exp)
 		})
-	}))
-
-	exp, err := client.Get(context.Background(), "r-1")
-	require.NoError(t, err)
-	assert.Equal(t, "r-1", exp.RunID)
-	assert.Equal(t, "external", exp.Source)
-	require.NotNil(t, exp.PlannedTrialCount)
-	assert.Equal(t, 4, *exp.PlannedTrialCount)
+	}
 }
 
 func TestClient_Trials(t *testing.T) {
@@ -256,6 +327,45 @@ func TestClient_Trials(t *testing.T) {
 	assert.Equal(t, "art-1", artifacts[0].ArtifactID)
 }
 
+func TestClient_GetTrial_TotalTokens(t *testing.T) {
+	tests := []struct {
+		name  string
+		trial map[string]any
+		want  *int64
+	}{
+		{
+			name:  "API reports usage",
+			trial: map[string]any{"trial_id": "trial-1", "test_case_id": "case-1", "attempt": 1, "input_tokens": 9267, "output_tokens": 2303, "total_tokens": 12161},
+			want:  new(int64(12161)),
+		},
+		{
+			name:  "API omits usage",
+			trial: map[string]any{"trial_id": "trial-1", "test_case_id": "case-1", "attempt": 1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				writeJSON(w, tc.trial)
+			}))
+
+			trial, err := client.GetTrial(context.Background(), "trial-1")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, trial.TotalTokens)
+
+			encoded, err := json.Marshal(trial)
+			require.NoError(t, err)
+			if tc.want == nil {
+				assert.NotContains(t, string(encoded), "total_tokens")
+				return
+			}
+			assert.Contains(t, string(encoded), `"total_tokens":12161`)
+		})
+	}
+}
+
 func TestClient_Get_NotFound(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "not found", http.StatusNotFound)
@@ -285,17 +395,15 @@ func TestClient_Create(t *testing.T) {
 		assert.NoError(t, json.Unmarshal(body, &raw))
 		assert.Equal(t, "exp-1", raw["name"])
 		assert.Equal(t, "Nightly", raw["description"])
-		assert.Equal(t, "external", raw["source"])
 		assert.Equal(t, []any{"support", "prompt-v2"}, raw["tags"])
 
 		w.WriteHeader(http.StatusCreated)
 		writeJSON(w, experiments.Experiment{
-			RunID:       "r-99",
-			Name:        "exp-1",
-			Description: "Nightly",
-			Tags:        []string{"support", "prompt-v2"},
-			Source:      "external",
-			Status:      "pending",
+			ExperimentID: "r-99",
+			Name:         "exp-1",
+			Description:  "Nightly",
+			Tags:         []string{"support", "prompt-v2"},
+			Status:       "pending",
 		})
 	}))
 
@@ -303,10 +411,9 @@ func TestClient_Create(t *testing.T) {
 		Name:        "exp-1",
 		Description: "Nightly",
 		Tags:        []string{"support", "prompt-v2"},
-		Source:      "external",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "r-99", exp.RunID)
+	assert.Equal(t, "r-99", exp.ExperimentID)
 	assert.Equal(t, "pending", exp.Status)
 	assert.Equal(t, []string{"support", "prompt-v2"}, exp.Tags)
 }
@@ -333,7 +440,7 @@ func TestClient_Update_PATCH(t *testing.T) {
 		assert.Equal(t, []any{"support", "release"}, raw["tags"])
 
 		w.WriteHeader(http.StatusOK)
-		writeJSON(w, experiments.Experiment{RunID: "r-1", Name: "renamed", Description: "Updated notes", Tags: []string{"support", "release"}})
+		writeJSON(w, experiments.Experiment{ExperimentID: "r-1", Name: "renamed", Description: "Updated notes", Tags: []string{"support", "release"}})
 	}))
 
 	name := "renamed"
@@ -377,10 +484,10 @@ func TestClient_Cancel(t *testing.T) {
 	require.NoError(t, client.Cancel(context.Background(), "r-1"))
 }
 
-func TestClient_Cancel_EscapesColonInRunID(t *testing.T) {
-	// A literal `:` in a runID must be escaped so the `:cancel` suffix match
-	// stays unambiguous. r.URL.Path is the decoded form, so we check RawPath
-	// to see the wire bytes.
+func TestClient_Cancel_EscapesColonInExperimentID(t *testing.T) {
+	// A literal `:` in an experiment ID must be escaped so the `:cancel` suffix
+	// match stays unambiguous. r.URL.Path is the decoded form, so the assertion
+	// uses EscapedPath to see the wire bytes.
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments/r%3Afoo:cancel", r.URL.EscapedPath())
@@ -417,18 +524,22 @@ func TestClient_ListScores(t *testing.T) {
 		writeJSON(w, map[string]any{
 			"items": []map[string]any{
 				{
-					"score_id":          "s-1",
-					"run_id":            "r-1",
-					"evaluator_id":      "ev-1",
-					"evaluator_version": "v1",
-					"generation_id":     "gen-1",
-					"score_key":         "quality",
-					"score_type":        "number",
-					"value":             map[string]any{"number": 0.9},
-					"passed":            true,
-					"explanation":       "looks good",
-					"created_at":        "2026-04-01T10:00:00Z",
-					"ingested_at":       "2026-04-01T10:00:01Z",
+					"score_id":               "s-1",
+					"experiment_id":          "exp-1",
+					"evaluator_id":           "ev-1",
+					"evaluator_version":      "v1",
+					"evaluator_role":         "grader",
+					"generation_id":          "gen-1",
+					"grader_conversation_id": "conv-1",
+					"grader_generation_id":   "gen-2",
+					"grader_trace_id":        "trace-1",
+					"score_key":              "quality",
+					"score_type":             "number",
+					"value":                  map[string]any{"number": 0.9},
+					"passed":                 true,
+					"explanation":            "looks good",
+					"created_at":             "2026-04-01T10:00:00Z",
+					"ingested_at":            "2026-04-01T10:00:01Z",
 				},
 				{"score_id": "s-2", "evaluator_id": "ev-2", "score_key": "tone"},
 			},
@@ -442,8 +553,14 @@ func TestClient_ListScores(t *testing.T) {
 	assert.Equal(t, "quality", items[0].ScoreKey)
 	assert.Equal(t, "number", items[0].ScoreType)
 	assert.Equal(t, "looks good", items[0].Explanation)
+	assert.Equal(t, "exp-1", items[0].ExperimentID)
+	assert.Equal(t, "grader", items[0].EvaluatorRole)
+	assert.Equal(t, "conv-1", items[0].GraderConversationID)
+	assert.Equal(t, "gen-2", items[0].GraderGenerationID)
+	assert.Equal(t, "trace-1", items[0].GraderTraceID)
 	require.NotNil(t, items[0].Value.Number)
 	assert.InDelta(t, 0.9, *items[0].Value.Number, 1e-9)
+	assert.Equal(t, "tone", items[1].ScoreKey)
 }
 
 func TestClient_ListScores_TransportError(t *testing.T) {
@@ -456,50 +573,57 @@ func TestClient_ListScores_TransportError(t *testing.T) {
 }
 
 func TestClient_GetReport(t *testing.T) {
+	// Captured from a real report response. The API omits pass_rate because
+	// pass_denominator is 0, and omits total_cost because no trial reported one
+	// (cost_coverage "none").
+	summary := map[string]any{
+		"canceled_count":    0,
+		"completed_count":   2,
+		"cost_coverage":     "none",
+		"failed_count":      0,
+		"final_score_count": 0,
+		"final_score_sum":   0,
+		"pass_count":        0,
+		"pass_denominator":  0,
+		"test_case_count":   2,
+		"token_coverage":    "complete",
+		"total_tokens":      20077,
+		"trial_count":       2,
+	}
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/plugins/grafana-agento11y-app/resources/eval/experiments/r-1/report", r.URL.Path)
 
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(w, map[string]any{
-			"run": map[string]any{
-				"run_id":      "r-1",
-				"name":        "exp-1",
-				"source":      "external",
-				"status":      "succeeded",
-				"score_count": 10,
-				"created_at":  "2026-04-01T10:00:00Z",
-				"updated_at":  "2026-04-01T10:05:00Z",
+			"experiment": map[string]any{
+				"experiment_id": "r-1",
+				"name":          "exp-1",
+				"status":        "completed",
+				"created_at":    "2026-04-01T10:00:00Z",
+				"updated_at":    "2026-04-01T10:05:00Z",
 			},
-			"summary": map[string]any{
-				"n_conversations": 2,
-				"n_generations":   3,
-				"n_scores":        10,
-				"pass_rate":       0.8,
-				"mean_score":      0.72,
-				"total_cost_usd":  0.1234,
-				"total_tokens":    42,
-			},
-			"breakdowns": map[string]any{
-				"by_evaluator": []map[string]any{
-					{"key": "ev-1", "count": 10, "pass_rate": 0.8, "mean_score": 0.72, "total_cost_usd": 0.1234, "total_tokens": 42},
-				},
-				"by_score_key": []map[string]any{
-					{"key": "quality", "count": 10, "pass_rate": 0.8, "mean_score": 0.72},
-				},
-			},
-			"points": []map[string]any{
+			"summary": summary,
+			"rows": []map[string]any{
 				{
-					"conversation_id": "conv-1",
-					"generation_id":   "gen-1",
-					"score_id":        "s-1",
-					"evaluator_id":    "ev-1",
-					"score_key":       "quality",
-					"score_type":      "number",
-					"value":           map[string]any{"number": 0.9},
-					"value_number":    0.9,
-					"passed":          true,
-					"created_at":      "2026-04-01T10:00:00Z",
+					"test_case_id": "case-1",
+					"summary":      map[string]any{"trial_count": 1, "completed_count": 1},
+					"trials": []map[string]any{
+						{
+							"trial": map[string]any{
+								"trial_id":      "trial-1",
+								"experiment_id": "r-1",
+								"test_case_id":  "case-1",
+								"attempt":       1,
+								"status":        "completed",
+								"input_tokens":  9267,
+								"output_tokens": 2303,
+								"total_tokens":  12161,
+							},
+							"scores":    []map[string]any{{"score_id": "s-1", "score_key": "quality"}},
+							"artifacts": []map[string]any{},
+						},
+					},
 				},
 			},
 		})
@@ -507,15 +631,112 @@ func TestClient_GetReport(t *testing.T) {
 
 	report, err := client.GetReport(context.Background(), "r-1")
 	require.NoError(t, err)
-	assert.Equal(t, "r-1", report.Run.RunID)
-	assert.Equal(t, "exp-1", report.Run.Name)
-	assert.Equal(t, 10, report.Summary.NScores)
-	assert.Equal(t, 2, report.Summary.NConversations)
-	assert.InDelta(t, 0.8, report.Summary.PassRate, 1e-9)
-	require.Len(t, report.Breakdowns.ByEvaluator, 1)
-	assert.Equal(t, "ev-1", report.Breakdowns.ByEvaluator[0].Key)
-	require.Len(t, report.Points, 1)
-	assert.Equal(t, "quality", report.Points[0].ScoreKey)
+	assert.Equal(t, "r-1", report.Experiment.ExperimentID)
+	assert.Equal(t, "exp-1", report.Experiment.Name)
+	assert.Nil(t, report.Summary.PassRate)
+	assert.Nil(t, report.Summary.TotalCost)
+	assert.Equal(t, "none", report.Summary.CostCoverage)
+	require.NotNil(t, report.Summary.TotalTokens)
+	assert.Equal(t, int64(20077), *report.Summary.TotalTokens)
+	require.Len(t, report.Rows, 1)
+	require.Len(t, report.Rows[0].Trials, 1)
+	assert.Equal(t, new(int64(12161)), report.Rows[0].Trials[0].Trial.TotalTokens)
+}
+
+func TestClient_GetReport_SummaryValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		summary  map[string]any
+		want     experiments.ExperimentReportSummary
+		wantJSON []string
+	}{
+		{
+			// A measured zero must survive the round trip, so it stays
+			// distinguishable from the values TestClient_GetReport omits.
+			name: "measured zeros",
+			summary: map[string]any{
+				"canceled_count":    0,
+				"completed_count":   1,
+				"cost_coverage":     "complete",
+				"failed_count":      0,
+				"final_score_count": 1,
+				"final_score_sum":   0,
+				"pass_count":        0,
+				"pass_denominator":  1,
+				"pass_rate":         0,
+				"test_case_count":   1,
+				"token_coverage":    "complete",
+				"total_cost":        0,
+				"total_tokens":      0,
+				"trial_count":       1,
+			},
+			want: experiments.ExperimentReportSummary{
+				TestCaseCount: 1, TrialCount: 1, CompletedCount: 1,
+				PassRate: new(0.0), PassDenominator: 1, FinalScoreCount: 1,
+				TotalCost: new(0.0), TotalTokens: new(int64(0)),
+				CostCoverage: "complete", TokenCoverage: "complete",
+			},
+			wantJSON: []string{`"pass_rate":0`, `"total_cost":0`, `"total_tokens":0`},
+		},
+		{
+			// No other fixture carries final_score_avg, pass_at_k, or
+			// pass_power_k, so without this one all three could be deleted
+			// from the gcx struct and every test would still pass.
+			name: "every optional aggregate",
+			summary: map[string]any{
+				"canceled_count":    0,
+				"completed_count":   2,
+				"cost_coverage":     "complete",
+				"failed_count":      0,
+				"final_score_avg":   0.85,
+				"final_score_count": 2,
+				"final_score_sum":   1.7,
+				"pass_at_k":         map[string]any{"1": 0.5, "2": 1.0},
+				"pass_count":        1,
+				"pass_denominator":  2,
+				"pass_power_k":      map[string]any{"1": 0.5, "2": 0.25},
+				"pass_rate":         0.5,
+				"test_case_count":   2,
+				"token_coverage":    "partial",
+				"total_cost":        0.5,
+				"total_tokens":      100,
+				"trial_count":       2,
+			},
+			want: experiments.ExperimentReportSummary{
+				TestCaseCount: 2, TrialCount: 2, CompletedCount: 2,
+				PassRate: new(0.5), PassCount: 1, PassDenominator: 2,
+				PassAtK:       map[string]float64{"1": 0.5, "2": 1},
+				PassPowerK:    map[string]float64{"1": 0.5, "2": 0.25},
+				FinalScoreAvg: new(0.85), FinalScoreSum: 1.7, FinalScoreCount: 2,
+				TotalCost: new(0.5), TotalTokens: new(int64(100)),
+				CostCoverage: "complete", TokenCoverage: "partial",
+			},
+			wantJSON: []string{`"final_score_avg":0.85`, `"pass_at_k":{"1":0.5,"2":1}`, `"pass_power_k":{"1":0.5,"2":0.25}`},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				writeJSON(w, map[string]any{
+					"experiment": map[string]any{"experiment_id": "r-1"},
+					"summary":    tc.summary,
+					"rows":       []map[string]any{},
+				})
+			}))
+
+			report, err := client.GetReport(context.Background(), "r-1")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, report.Summary)
+
+			encoded, err := json.Marshal(report.Summary)
+			require.NoError(t, err)
+			for _, want := range tc.wantJSON {
+				assert.Contains(t, string(encoded), want)
+			}
+		})
+	}
 }
 
 func TestClient_GetReport_NotFound(t *testing.T) {

--- a/internal/providers/aio11y/eval/experiments/commands.go
+++ b/internal/providers/aio11y/eval/experiments/commands.go
@@ -1227,7 +1227,7 @@ func (c *TrialsTableCodec) Encode(w io.Writer, v any) error {
 	}
 	var t *style.TableBuilder
 	if c.Wide {
-		t = style.NewTable("TRIAL-ID", "EXPERIMENT-ID", "TEST-CASE-ID", "ATTEMPT", "STATUS", "CONVERSATION", "TRACE", "DURATION-MS", "CREATED", "COMPLETED", "ERROR")
+		t = style.NewTable("TRIAL-ID", "EXPERIMENT-ID", "TEST-CASE-ID", "ATTEMPT", "STATUS", "CONVERSATION", "TRACE", "TOTAL-TOKENS", "DURATION-MS", "CREATED", "COMPLETED", "ERROR")
 	} else {
 		t = style.NewTable("TRIAL-ID", "EXPERIMENT-ID", "TEST-CASE-ID", "ATTEMPT", "STATUS", "CONVERSATION", "TRACE")
 	}
@@ -1249,11 +1249,15 @@ func (c *TrialsTableCodec) Encode(w io.Writer, v any) error {
 			if trial.DurationMS != nil {
 				duration = strconv.FormatInt(*trial.DurationMS, 10)
 			}
+			totalTokens := "-"
+			if trial.TotalTokens != nil {
+				totalTokens = strconv.FormatInt(*trial.TotalTokens, 10)
+			}
 			completed := "-"
 			if trial.CompletedAt != nil {
 				completed = aio11yhttp.FormatTime(*trial.CompletedAt)
 			}
-			t.Row(trial.TrialID, trial.ExperimentID, trial.TestCaseID, strconv.Itoa(trial.Attempt), status, conversation, trace, duration, aio11yhttp.FormatTime(trial.CreatedAt), completed, aio11yhttp.Truncate(trial.Error, 40))
+			t.Row(trial.TrialID, trial.ExperimentID, trial.TestCaseID, strconv.Itoa(trial.Attempt), status, conversation, trace, totalTokens, duration, aio11yhttp.FormatTime(trial.CreatedAt), completed, aio11yhttp.Truncate(trial.Error, 40))
 		} else {
 			t.Row(trial.TrialID, trial.ExperimentID, trial.TestCaseID, strconv.Itoa(trial.Attempt), status, conversation, trace)
 		}
@@ -1330,14 +1334,21 @@ func (c *TableCodec) Encode(w io.Writer, v any) error {
 
 	var t *style.TableBuilder
 	if c.Wide {
-		t = style.NewTable("EXPERIMENT-ID", "NAME", "STATUS", "SUITE", "VERSION", "TAGS", "SCORES", "CREATED", "COMPLETED", "DESCRIPTION", "ERROR")
+		t = style.NewTable("EXPERIMENT-ID", "NAME", "STATUS", "SUITE", "VERSION", "TAGS", "TRIALS", "PASS", "CREATED", "COMPLETED", "DESCRIPTION", "ERROR")
 	} else {
-		t = style.NewTable("EXPERIMENT-ID", "NAME", "STATUS", "SUITE", "VERSION", "TAGS", "SCORES", "CREATED")
+		t = style.NewTable("EXPERIMENT-ID", "NAME", "STATUS", "SUITE", "VERSION", "TRIALS", "PASS", "CREATED")
 	}
 
 	for _, exp := range items {
 		id := exp.ID()
-		scores := strconv.Itoa(exp.ScoreCount)
+		trials := "-"
+		pass := "-"
+		if exp.Result != nil {
+			trials = strconv.Itoa(exp.Result.TrialCount)
+			if exp.Result.PassRate != nil {
+				pass = fmt.Sprintf("%.2f%%", *exp.Result.PassRate*100)
+			}
+		}
 		suite := exp.SuiteID
 		if suite == "" {
 			suite = "-"
@@ -1356,9 +1367,17 @@ func (c *TableCodec) Encode(w io.Writer, v any) error {
 			if exp.CompletedAt != nil {
 				completed = aio11yhttp.FormatTime(*exp.CompletedAt)
 			}
-			t.Row(id, exp.Name, status, suite, version, tags, scores, aio11yhttp.FormatTime(exp.CreatedAt), completed, aio11yhttp.Truncate(exp.Description, 40), aio11yhttp.Truncate(exp.Error, 40))
+			// The rollup can fail on its own while the experiment succeeds.
+			// TRIALS and PASS then render "-" like an experiment with no
+			// trials, so without this fallback the stored reason never
+			// reaches the table.
+			failure := exp.Error
+			if failure == "" {
+				failure = exp.ResultError
+			}
+			t.Row(id, exp.Name, status, suite, version, tags, trials, pass, aio11yhttp.FormatTime(exp.CreatedAt), completed, aio11yhttp.Truncate(exp.Description, 40), aio11yhttp.Truncate(failure, 40))
 		} else {
-			t.Row(id, exp.Name, status, suite, version, tags, scores, aio11yhttp.FormatTime(exp.CreatedAt))
+			t.Row(id, exp.Name, status, suite, version, trials, pass, aio11yhttp.FormatTime(exp.CreatedAt))
 		}
 	}
 	return t.Render(w)
@@ -1436,7 +1455,7 @@ func (c *ScoresTableCodec) Decode(_ io.Reader, _ any) error {
 }
 
 // ReportTextCodec renders an *ExperimentReport (or ExperimentReport) as a
-// human-readable summary with per-breakdown totals.
+// human-readable summary.
 type ReportTextCodec struct{}
 
 func (c *ReportTextCodec) Format() format.Format {
@@ -1458,102 +1477,64 @@ func (c *ReportTextCodec) Encode(w io.Writer, v any) error {
 	}
 
 	const labelFmt = "%-15s %s\n"
-	run := r.Experiment
-	if run.ID() == "" {
-		run = r.Run
+	exp := r.Experiment
+	if exp.ID() != "" {
+		fmt.Fprintf(w, labelFmt, "Experiment:", exp.ID())
 	}
-	if run.ID() != "" {
-		fmt.Fprintf(w, labelFmt, "Experiment:", run.ID())
+	if exp.Name != "" {
+		fmt.Fprintf(w, labelFmt, "Name:", exp.Name)
 	}
-	if run.Name != "" {
-		fmt.Fprintf(w, labelFmt, "Name:", run.Name)
+	if exp.Status != "" {
+		fmt.Fprintf(w, labelFmt, "Status:", exp.Status)
 	}
-	if run.Status != "" {
-		fmt.Fprintf(w, labelFmt, "Status:", run.Status)
+	if exp.Error != "" {
+		fmt.Fprintf(w, labelFmt, "Error:", exp.Error)
 	}
 	s := r.Summary
-	if s.TestCaseCount > 0 || s.TrialCount > 0 {
-		fmt.Fprintf(w, labelFmt, "Test cases:", strconv.Itoa(s.TestCaseCount))
-		fmt.Fprintf(w, labelFmt, "Trials:", strconv.Itoa(s.TrialCount))
-		fmt.Fprintf(w, labelFmt, "Completed:", strconv.Itoa(s.CompletedCount))
-		if s.FailedCount > 0 {
-			fmt.Fprintf(w, labelFmt, "Failed:", strconv.Itoa(s.FailedCount))
-		}
-		if s.CanceledCount > 0 {
-			fmt.Fprintf(w, labelFmt, "Canceled:", strconv.Itoa(s.CanceledCount))
-		}
+	fmt.Fprintf(w, labelFmt, "Test cases:", strconv.Itoa(s.TestCaseCount))
+	fmt.Fprintf(w, labelFmt, "Trials:", strconv.Itoa(s.TrialCount))
+	fmt.Fprintf(w, labelFmt, "Completed:", strconv.Itoa(s.CompletedCount))
+	if s.FailedCount > 0 {
+		fmt.Fprintf(w, labelFmt, "Failed:", strconv.Itoa(s.FailedCount))
 	}
-	if s.NScores > 0 {
-		fmt.Fprintf(w, labelFmt, "Scores:", strconv.Itoa(s.NScores))
+	if s.CanceledCount > 0 {
+		fmt.Fprintf(w, labelFmt, "Canceled:", strconv.Itoa(s.CanceledCount))
 	}
-	if s.NConversations > 0 {
-		fmt.Fprintf(w, labelFmt, "Conversations:", strconv.Itoa(s.NConversations))
+
+	passRate := "-"
+	if s.PassRate != nil {
+		passRate = fmt.Sprintf("%.2f%%", *s.PassRate*100)
 	}
-	if s.NGenerations > 0 {
-		fmt.Fprintf(w, labelFmt, "Generations:", strconv.Itoa(s.NGenerations))
-	}
-	if s.PassRate > 0 {
-		fmt.Fprintf(w, labelFmt, "Pass rate:", fmt.Sprintf("%.2f%%", s.PassRate*100))
-	}
-	if s.MeanScore > 0 {
-		fmt.Fprintf(w, labelFmt, "Mean score:", fmt.Sprintf("%g", s.MeanScore))
-	}
+	fmt.Fprintf(w, labelFmt, "Pass rate:", passRate)
+
 	if s.FinalScoreAvg != nil {
 		fmt.Fprintf(w, labelFmt, "Final avg:", fmt.Sprintf("%g", *s.FinalScoreAvg))
 	}
-	if s.TotalCostUSD > 0 {
-		fmt.Fprintf(w, labelFmt, "Cost:", fmt.Sprintf("$%.4f", s.TotalCostUSD))
-	} else if s.TotalCost != nil {
-		fmt.Fprintf(w, labelFmt, "Cost:", fmt.Sprintf("$%.4f", *s.TotalCost))
-	}
-	if s.TotalTokens > 0 {
-		fmt.Fprintf(w, labelFmt, "Tokens:", strconv.FormatInt(s.TotalTokens, 10))
-	}
 
-	breakdowns := reportBreakdownRows(r.Breakdowns)
-	if len(breakdowns) > 0 {
-		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Breakdowns:")
-		for _, row := range breakdowns {
-			b := row.breakdown
-			key := b.Key
-			if key == "" {
-				key = "-"
-			}
-			fmt.Fprintf(w, "  %s/%s: count=%d", row.group, key, b.Count)
-			if b.Count > 0 {
-				fmt.Fprintf(w, " pass_rate=%.2f%% mean_score=%g", b.PassRate*100, b.MeanScore)
-			}
-			if b.TotalCostUSD > 0 {
-				fmt.Fprintf(w, " cost=$%.4f", b.TotalCostUSD)
-			}
-			if b.TotalTokens > 0 {
-				fmt.Fprintf(w, " tokens=%d", b.TotalTokens)
-			}
-			fmt.Fprintln(w)
-		}
+	cost := "-"
+	if s.TotalCost != nil {
+		cost = fmt.Sprintf("$%.4f%s", *s.TotalCost, coverageNote(s.CostCoverage))
 	}
+	fmt.Fprintf(w, labelFmt, "Cost:", cost)
+
+	tokens := "-"
+	if s.TotalTokens != nil {
+		tokens = strconv.FormatInt(*s.TotalTokens, 10) + coverageNote(s.TokenCoverage)
+	}
+	fmt.Fprintf(w, labelFmt, "Tokens:", tokens)
 	return nil
 }
 
-type reportBreakdownRow struct {
-	group     string
-	breakdown ExperimentReportBreakdown
-}
-
-func reportBreakdownRows(b ExperimentReportBreakdowns) []reportBreakdownRow {
-	rows := []reportBreakdownRow{}
-	add := func(group string, items []ExperimentReportBreakdown) {
-		for _, item := range items {
-			rows = append(rows, reportBreakdownRow{group: group, breakdown: item})
-		}
+// coverageNote flags a total whose inputs were not all reported, so a reader
+// does not take a low number for a complete one. The API pairs a token total
+// with coverage "none" when it summed input and output tokens because no trial
+// carried a total of its own. It returns an empty coverage on the progress
+// snapshot of a running experiment.
+func coverageNote(coverage string) string {
+	if coverage == "" || coverage == "complete" {
+		return ""
 	}
-	add("task", b.ByTask)
-	add("category", b.ByCategory)
-	add("evaluator", b.ByEvaluator)
-	add("score_key", b.ByScoreKey)
-	add("evaluator_score_key", b.ByEvaluatorScoreKey)
-	return rows
+	return " (coverage: " + coverage + ")"
 }
 
 func (c *ReportTextCodec) Decode(_ io.Reader, _ any) error {

--- a/internal/providers/aio11y/eval/experiments/commands_test.go
+++ b/internal/providers/aio11y/eval/experiments/commands_test.go
@@ -3,6 +3,8 @@ package experiments_test
 import (
 	"bytes"
 	"os"
+	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -232,37 +234,57 @@ func TestTableCodec_Format(t *testing.T) {
 
 func TestTableCodec_Encode(t *testing.T) {
 	completed := time.Date(2026, 4, 2, 12, 0, 0, 0, time.UTC)
+	passRate := 0.5
 	items := []experiments.Experiment{
 		{
-			RunID:        "r-1",
+			ExperimentID: "r-1",
 			Name:         "exp-1",
 			Status:       "running",
-			Source:       "external",
-			CollectionID: "c-1",
 			Tags:         []string{"support", "prompt-v2"},
 			Description:  "Nightly regression run",
-			ScoreCount:   5,
+			Result:       &experiments.ExperimentReportSummary{TrialCount: 2, PassRate: &passRate},
 			CreatedAt:    time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
 			CompletedAt:  &completed,
 			Error:        "something",
 		},
-		{RunID: "r-2", Name: "exp-2", Status: "pending"},
+		{ExperimentID: "r-2", Name: "exp-2", Status: "pending", ResultStatus: "failed", ResultError: "rollup timed out"},
+		{ExperimentID: "r-3", Name: "exp-3", Status: "running", Result: &experiments.ExperimentReportSummary{TrialCount: 4}},
 	}
 
 	tests := []struct {
-		name string
-		wide bool
-		want []string
+		name    string
+		wide    bool
+		want    []string
+		notWant []string
+		// wantCells maps an experiment ID to the value each named column holds
+		// in that row. Every fixture row renders "-" somewhere, so a "-" is only
+		// meaningful when it is pinned to one column.
+		wantCells map[string]map[string]string
 	}{
 		{
-			name: "table format",
-			wide: false,
-			want: []string{"EXPERIMENT-ID", "NAME", "STATUS", "SUITE", "VERSION", "TAGS", "r-1", "exp-1", "running", "support, prompt-v2"},
+			name:    "table format reports trials and pass rate",
+			wide:    false,
+			want:    []string{"EXPERIMENT-ID", "NAME", "STATUS", "SUITE", "VERSION", "TRIALS", "PASS"},
+			notWant: []string{"SCORES", "TAGS", "support, prompt-v2"},
+			wantCells: map[string]map[string]string{
+				"r-1": {"NAME": "exp-1", "STATUS": "running", "TRIALS": "2", "PASS": "50.00%"},
+				// r-2 carries no result rollup, so its trial count is unknown.
+				"r-2": {"NAME": "exp-2", "STATUS": "pending", "TRIALS": "-", "PASS": "-"},
+			},
 		},
 		{
-			name: "wide adds ERROR, COMPLETED, and DESCRIPTION",
-			wide: true,
-			want: []string{"ERROR", "COMPLETED", "DESCRIPTION", "something", "Nightly regression run", "2026-04-02 12:00"},
+			name:    "wide adds TAGS, ERROR, COMPLETED, and DESCRIPTION",
+			wide:    true,
+			want:    []string{"TAGS", "support, prompt-v2", "ERROR", "COMPLETED", "DESCRIPTION", "Nightly regression run", "2026-04-02 12:00"},
+			notWant: []string{"SCORES"},
+			wantCells: map[string]map[string]string{
+				"r-1": {"TRIALS": "2", "PASS": "50.00%", "ERROR": "something"},
+				// r-2's rollup failed while the experiment itself reported no
+				// error, so the ERROR column carries the rollup's reason.
+				"r-2": {"TRIALS": "-", "PASS": "-", "ERROR": "rollup timed out"},
+				// r-3 has trials but no measured pass rate.
+				"r-3": {"TRIALS": "4", "PASS": "-"},
+			},
 		},
 	}
 
@@ -274,6 +296,98 @@ func TestTableCodec_Encode(t *testing.T) {
 			out := buf.String()
 			for _, s := range tc.want {
 				assert.Contains(t, out, s)
+			}
+			for _, s := range tc.notWant {
+				assert.NotContains(t, out, s)
+			}
+			for id, cells := range tc.wantCells {
+				for column, want := range cells {
+					assert.Equal(t, want, tableCell(t, out, id, column), "row %s column %s", id, column)
+				}
+			}
+		})
+	}
+}
+
+// tableCell returns the cell under the named column of the row whose first cell
+// is id. The plain renderer pads columns apart with at least two spaces, so a
+// value holding one space (a tag list, a timestamp, an error message) stays in
+// a single cell.
+func tableCell(t *testing.T, out, id, column string) string {
+	t.Helper()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.NotEmpty(t, lines, "table output is empty")
+	headers := splitCells(lines[0])
+	index := slices.Index(headers, column)
+	require.GreaterOrEqual(t, index, 0, "no column %q in header %q", column, lines[0])
+	for _, line := range lines[1:] {
+		cells := splitCells(line)
+		if cells[0] != id {
+			continue
+		}
+		require.Len(t, cells, len(headers), "row %q does not fill every column", id)
+		return cells[index]
+	}
+	t.Fatalf("no row for %q in:\n%s", id, out)
+	return ""
+}
+
+var columnGap = regexp.MustCompile(` {2,}`)
+
+func splitCells(line string) []string {
+	return columnGap.Split(strings.TrimSpace(line), -1)
+}
+
+func TestTrialsTableCodec_Encode(t *testing.T) {
+	totalTokens := int64(12161)
+	durationMS := int64(578)
+	items := []experiments.TestCaseTrial{
+		{TrialID: "trial-1", ExperimentID: "exp-1", TestCaseID: "case-1", Attempt: 1, Status: "completed", TotalTokens: &totalTokens, DurationMS: &durationMS},
+		{TrialID: "trial-2", ExperimentID: "exp-1", TestCaseID: "case-2", Attempt: 1, Status: "running"},
+	}
+
+	tests := []struct {
+		name      string
+		wide      bool
+		want      []string
+		notWant   []string
+		wantCells map[string]map[string]string
+	}{
+		{
+			name:      "table format omits usage",
+			wide:      false,
+			want:      []string{"TRIAL-ID", "case-1"},
+			notWant:   []string{"TOTAL-TOKENS"},
+			wantCells: map[string]map[string]string{"trial-1": {"EXPERIMENT-ID": "exp-1", "STATUS": "completed"}},
+		},
+		{
+			name: "wide reports total tokens",
+			wide: true,
+			want: []string{"TOTAL-TOKENS"},
+			wantCells: map[string]map[string]string{
+				"trial-1": {"TOTAL-TOKENS": "12161", "DURATION-MS": "578"},
+				// trial-2 reported no usage.
+				"trial-2": {"STATUS": "running", "TOTAL-TOKENS": "-", "DURATION-MS": "-"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			codec := &experiments.TrialsTableCodec{Wide: tc.wide}
+			var buf bytes.Buffer
+			require.NoError(t, codec.Encode(&buf, items))
+			out := buf.String()
+			for _, s := range tc.want {
+				assert.Contains(t, out, s)
+			}
+			for _, s := range tc.notWant {
+				assert.NotContains(t, out, s)
+			}
+			for id, cells := range tc.wantCells {
+				for column, want := range cells {
+					assert.Equal(t, want, tableCell(t, out, id, column), "row %s column %s", id, column)
+				}
 			}
 		})
 	}
@@ -342,49 +456,104 @@ func TestScoresTableCodec_WrongType(t *testing.T) {
 }
 
 func TestReportTextCodec_Encode(t *testing.T) {
-	report := &experiments.ExperimentReport{
-		Run: experiments.Experiment{
-			RunID:  "r-1",
-			Name:   "exp-1",
-			Status: "succeeded",
-		},
-		Summary: experiments.ExperimentReportSummary{
-			NConversations: 2,
-			NGenerations:   3,
-			NScores:        10,
-			PassRate:       0.8,
-			MeanScore:      0.72,
-			TotalCostUSD:   0.1234,
-			TotalTokens:    42,
-		},
-		Breakdowns: experiments.ExperimentReportBreakdowns{
-			ByEvaluator: []experiments.ExperimentReportBreakdown{
-				{Key: "ev-1", Count: 5, PassRate: 0.8, MeanScore: 0.75, TotalCostUSD: 0.1234, TotalTokens: 42},
+	tests := []struct {
+		name    string
+		status  string
+		errText string
+		summary experiments.ExperimentReportSummary
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "complete run",
+			summary: experiments.ExperimentReportSummary{
+				TestCaseCount: 2, TrialCount: 4, CompletedCount: 4, FailedCount: 1, CanceledCount: 1,
+				PassRate: new(0.8), FinalScoreAvg: new(0.85),
+				TotalCost: new(0.1234), TotalTokens: new(int64(42)),
+				CostCoverage: "complete", TokenCoverage: "complete",
 			},
-			ByScoreKey: []experiments.ExperimentReportBreakdown{
-				{Key: "quality", Count: 5, PassRate: 0.8, MeanScore: 0.75},
+			want:    []string{"r-1", "exp-1", "Test cases:", "Trials:", "Failed:", "Canceled:", "Pass rate:", "80.00%", "Final avg:      0.85", "Cost:", "$0.1234", "Tokens:", "42"},
+			notWant: []string{"coverage:", "Scores:", "Conversations:", "Generations:", "Mean score", "Breakdowns:"},
+		},
+		{
+			name: "no test case produced a verdict",
+			summary: experiments.ExperimentReportSummary{
+				TestCaseCount: 2, TrialCount: 2, CompletedCount: 2,
+				TotalTokens: new(int64(20077)), CostCoverage: "none", TokenCoverage: "complete",
 			},
+			want:    []string{"Pass rate:      -", "Cost:           -", "Tokens:         20077"},
+			notWant: []string{"Final avg:"},
+		},
+		{
+			name: "every test case failed and nothing reported usage",
+			summary: experiments.ExperimentReportSummary{
+				TestCaseCount: 1, TrialCount: 1, CompletedCount: 1,
+				PassRate: new(0.0), PassDenominator: 1, CostCoverage: "none", TokenCoverage: "none",
+			},
+			want: []string{"Pass rate:      0.00%", "Cost:           -", "Tokens:         -"},
+		},
+		{
+			// The API sums input and output tokens when no trial carries a total
+			// of its own, and returns that total with token_coverage "none".
+			name: "no trial reported a token total of its own",
+			summary: experiments.ExperimentReportSummary{
+				TestCaseCount: 1, TrialCount: 1, CompletedCount: 1,
+				TotalTokens: new(int64(20077)), CostCoverage: "none", TokenCoverage: "none",
+			},
+			want: []string{"Tokens:         20077 (coverage: none)"},
+		},
+		{
+			name: "cost and tokens cover only some trials",
+			summary: experiments.ExperimentReportSummary{
+				TestCaseCount: 2, TrialCount: 2, CompletedCount: 2,
+				TotalCost: new(1.25), TotalTokens: new(int64(42)),
+				CostCoverage: "partial", TokenCoverage: "partial",
+			},
+			want: []string{"Cost:           $1.2500 (coverage: partial)", "Tokens:         42 (coverage: partial)"},
+		},
+		{
+			name:    "experiment failed",
+			status:  "failed",
+			errText: "runner crashed",
+			summary: experiments.ExperimentReportSummary{TestCaseCount: 1, TrialCount: 1},
+			want:    []string{"Status:         failed", "Error:          runner crashed"},
 		},
 	}
 
-	codec := &experiments.ReportTextCodec{}
-	var buf bytes.Buffer
-	require.NoError(t, codec.Encode(&buf, report))
-	out := buf.String()
-	for _, s := range []string{"r-1", "exp-1", "Scores:", "10", "Conversations:", "2", "Pass rate", "80.00%", "Mean score", "0.72", "Cost:", "$0.1234", "Tokens:", "42", "Breakdowns:", "evaluator/ev-1", "cost=$0.1234", "tokens=42", "score_key/quality"} {
-		assert.Contains(t, out, s)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status := tc.status
+			if status == "" {
+				status = "completed"
+			}
+			report := &experiments.ExperimentReport{
+				Experiment: experiments.Experiment{ExperimentID: "r-1", Name: "exp-1", Status: status, Error: tc.errText},
+				Summary:    tc.summary,
+			}
+			codec := &experiments.ReportTextCodec{}
+			var buf bytes.Buffer
+			require.NoError(t, codec.Encode(&buf, report))
+			out := buf.String()
+			for _, s := range tc.want {
+				assert.Contains(t, out, s)
+			}
+			for _, s := range tc.notWant {
+				assert.NotContains(t, out, s)
+			}
+		})
 	}
 }
 
 func TestReportTextCodec_Encode_Value(t *testing.T) {
 	// Codec should also accept a non-pointer ExperimentReport.
+	passRate := 1.0
 	report := experiments.ExperimentReport{
-		Summary: experiments.ExperimentReportSummary{NScores: 3, PassRate: 1.0},
+		Summary: experiments.ExperimentReportSummary{TrialCount: 3, PassRate: &passRate},
 	}
 	codec := &experiments.ReportTextCodec{}
 	var buf bytes.Buffer
 	require.NoError(t, codec.Encode(&buf, report))
-	assert.Contains(t, buf.String(), "Scores:")
+	assert.Contains(t, buf.String(), "Trials:")
 }
 
 func TestReportTextCodec_WrongType(t *testing.T) {

--- a/internal/providers/aio11y/eval/experiments/types.go
+++ b/internal/providers/aio11y/eval/experiments/types.go
@@ -76,39 +76,43 @@ type Artifact struct {
 }
 
 // Experiment is a single eval experiment run.
+//
+// The same struct is the body of experiments create. That endpoint rejects
+// unknown fields, and of the server-managed fields it accepts only
+// experiment_id, created_by, and planned_trial_count, so a create body
+// carrying any of the others fails with 400.
 type Experiment struct {
 	// User-provided fields (spec).
-	Name         string                `json:"name"`
-	Description  string                `json:"description,omitempty"`
-	Tags         []string              `json:"tags,omitempty"`
-	SuiteID      string                `json:"suite_id,omitempty"`
-	SuiteVersion string                `json:"suite_version,omitempty"`
-	Candidate    *ExperimentCandidate  `json:"candidate,omitempty"`
-	Source       string                `json:"source,omitempty"`
-	CollectionID string                `json:"collection_id,omitempty"`
-	Evaluators   []ExperimentEvaluator `json:"evaluators,omitempty"`
-	Metadata     map[string]any        `json:"metadata,omitempty"`
+	Name         string               `json:"name"`
+	Description  string               `json:"description,omitempty"`
+	Tags         []string             `json:"tags,omitempty"`
+	SuiteID      string               `json:"suite_id,omitempty"`
+	SuiteVersion string               `json:"suite_version,omitempty"`
+	Candidate    *ExperimentCandidate `json:"candidate,omitempty"`
+	Metadata     map[string]any       `json:"metadata,omitempty"`
 
 	// Server-managed fields.
-	ExperimentID      string     `json:"experiment_id,omitempty"`
-	RunID             string     `json:"run_id,omitempty"`
-	TenantID          string     `json:"tenant_id,omitempty"`
-	Status            string     `json:"status,omitempty"`
-	ScoreCount        int        `json:"score_count,omitempty"`
-	PlannedTrialCount *int       `json:"planned_trial_count,omitempty"`
-	Error             string     `json:"error,omitempty"`
-	CreatedBy         string     `json:"created_by,omitempty"`
-	CreatedAt         time.Time  `json:"created_at,omitzero"`
-	UpdatedAt         time.Time  `json:"updated_at,omitzero"`
-	StartedAt         *time.Time `json:"started_at,omitempty"`
-	CompletedAt       *time.Time `json:"completed_at,omitempty"`
+	ExperimentID string     `json:"experiment_id,omitempty"`
+	TenantID     string     `json:"tenant_id,omitempty"`
+	Status       string     `json:"status,omitempty"`
+	Error        string     `json:"error,omitempty"`
+	CreatedBy    string     `json:"created_by,omitempty"`
+	CreatedAt    time.Time  `json:"created_at,omitzero"`
+	UpdatedAt    time.Time  `json:"updated_at,omitzero"`
+	StartedAt    *time.Time `json:"started_at,omitempty"`
+	CompletedAt  *time.Time `json:"completed_at,omitempty"`
+
+	// PlannedTrialCount is supplied by the runner at creation time. Nil means
+	// unknown; zero is a known empty plan. Result is the finalized rollup, or a
+	// progress snapshot while the experiment runs.
+	PlannedTrialCount *int                     `json:"planned_trial_count,omitempty"`
+	ResultStatus      string                   `json:"result_status,omitempty"`
+	ResultError       string                   `json:"result_error,omitempty"`
+	Result            *ExperimentReportSummary `json:"result,omitempty"`
 }
 
 func (e Experiment) ID() string {
-	if e.ExperimentID != "" {
-		return e.ExperimentID
-	}
-	return e.RunID
+	return e.ExperimentID
 }
 
 // ExperimentCandidate identifies what was evaluated.
@@ -119,13 +123,6 @@ type ExperimentCandidate struct {
 	ModelProvider string `json:"model_provider,omitempty"`
 	ModelName     string `json:"model_name,omitempty"`
 	GitSHA        string `json:"git_sha,omitempty"`
-}
-
-// ExperimentEvaluator binds an evaluator to the experiment, optionally with a
-// selector that scopes which scored items it applies to.
-type ExperimentEvaluator struct {
-	ID       string `json:"id"`
-	Selector string `json:"selector,omitempty"`
 }
 
 // UpdateRequest is the partial-PATCH body for the update endpoint. Pointer
@@ -146,12 +143,12 @@ type UpdateRequest struct {
 }
 
 // ScoreItem is one score record produced by an evaluator during an experiment.
+// The field set matches what the experiments scores endpoint returns.
 //
-// This is intentionally separate from scores.Score: the experiments scores
-// endpoint returns more fields (tenant, evaluator description, ingestion
-// time, agent/version metadata) and emits a flat source_kind/source_id pair
-// rather than the nested {source: {kind, id}} envelope used by scores.Score.
-// Keep the two in sync when adding fields that exist on both endpoints.
+// It is separate from scores.Score because the experiments scores endpoint
+// returns more fields (tenant, evaluator description, ingestion time,
+// agent/version metadata) and emits a flat source_kind/source_id pair rather
+// than the nested {source: {kind, id}} envelope scores.Score uses.
 type ScoreItem struct {
 	TenantID             string         `json:"tenant_id"`
 	ScoreID              string         `json:"score_id"`
@@ -161,11 +158,15 @@ type ScoreItem struct {
 	SpanID               string         `json:"span_id,omitempty"`
 	TrialID              string         `json:"trial_id,omitempty"`
 	TestCaseID           string         `json:"test_case_id,omitempty"`
+	GraderConversationID string         `json:"grader_conversation_id,omitempty"`
+	GraderGenerationID   string         `json:"grader_generation_id,omitempty"`
+	GraderTraceID        string         `json:"grader_trace_id,omitempty"`
 	EvaluatorID          string         `json:"evaluator_id"`
 	EvaluatorVersion     string         `json:"evaluator_version"`
 	EvaluatorDescription string         `json:"evaluator_description,omitempty"`
+	EvaluatorRole        string         `json:"evaluator_role,omitempty"`
 	RuleID               string         `json:"rule_id,omitempty"`
-	RunID                string         `json:"run_id,omitempty"`
+	ExperimentID         string         `json:"experiment_id,omitempty"`
 	ScoreKey             string         `json:"score_key"`
 	ScoreType            string         `json:"score_type"`
 	Value                ScoreValue     `json:"value"`
@@ -184,76 +185,39 @@ type ScoreItem struct {
 // ScoreValue is the polymorphic value of a score (numeric, boolean, or string).
 type ScoreValue = scores.ScoreValue
 
-// ExperimentReport summarises the outcome of an experiment.
+// ExperimentReport summarises the outcome of an experiment. The field set
+// matches the report endpoint's response.
 type ExperimentReport struct {
-	Experiment Experiment                 `json:"experiment"`
-	Run        Experiment                 `json:"run,omitzero"`
-	Summary    ExperimentReportSummary    `json:"summary"`
-	Rows       []TestCaseResultRow        `json:"rows,omitempty"`
-	Breakdowns ExperimentReportBreakdowns `json:"breakdowns,omitzero"`
-	Points     []ExperimentReportPoint    `json:"points,omitempty"`
+	Experiment Experiment              `json:"experiment"`
+	Summary    ExperimentReportSummary `json:"summary"`
+	Rows       []TestCaseResultRow     `json:"rows"`
 }
 
-// ExperimentReportSummary holds aggregate counts for an experiment.
+// ExperimentReportSummary holds aggregate counts for an experiment. The field
+// set matches the summary object in the report endpoint's response.
+//
+// The API omits an aggregate it did not measure, so those fields are pointers:
+// nil means unmeasured, and zero means measured as zero. TokenCoverage and
+// CostCoverage ("none", "partial", or "complete") say whether a total that is
+// present covers every trial.
 type ExperimentReportSummary struct {
-	NConversations int     `json:"n_conversations"`
-	NGenerations   int     `json:"n_generations"`
-	NScores        int     `json:"n_scores"`
-	PassRate       float64 `json:"pass_rate"`
-	MeanScore      float64 `json:"mean_score"`
-	TotalCostUSD   float64 `json:"total_cost_usd"`
-	TotalTokens    int64   `json:"total_tokens"`
-
-	TestCaseCount  int                `json:"test_case_count,omitempty"`
-	TrialCount     int                `json:"trial_count,omitempty"`
-	CompletedCount int                `json:"completed_count,omitempty"`
-	FailedCount    int                `json:"failed_count,omitempty"`
-	CanceledCount  int                `json:"canceled_count,omitempty"`
-	PassAtK        map[string]float64 `json:"pass_at_k,omitempty"`
-	PassPowerK     map[string]float64 `json:"pass_power_k,omitempty"`
-	FinalScoreAvg  *float64           `json:"final_score_avg,omitempty"`
-	TotalCost      *float64           `json:"total_cost,omitempty"`
-}
-
-// ExperimentReportBreakdowns holds aggregate breakdowns grouped by dimension.
-type ExperimentReportBreakdowns struct {
-	ByTask              []ExperimentReportBreakdown `json:"by_task"`
-	ByCategory          []ExperimentReportBreakdown `json:"by_category"`
-	ByEvaluator         []ExperimentReportBreakdown `json:"by_evaluator"`
-	ByScoreKey          []ExperimentReportBreakdown `json:"by_score_key"`
-	ByEvaluatorScoreKey []ExperimentReportBreakdown `json:"by_evaluator_score_key"`
-}
-
-// ExperimentReportBreakdown holds one aggregate bucket.
-type ExperimentReportBreakdown struct {
-	Key          string  `json:"key"`
-	Count        int     `json:"count"`
-	PassRate     float64 `json:"pass_rate"`
-	MeanScore    float64 `json:"mean_score"`
-	TotalCostUSD float64 `json:"total_cost_usd"`
-	TotalTokens  int64   `json:"total_tokens"`
-}
-
-// ExperimentReportPoint is one score point included in an experiment report.
-type ExperimentReportPoint struct {
-	ConversationID   string         `json:"conversation_id"`
-	GenerationID     string         `json:"generation_id"`
-	ScoreID          string         `json:"score_id"`
-	TaskID           string         `json:"task_id,omitempty"`
-	TaskCategory     string         `json:"task_category,omitempty"`
-	TrialID          string         `json:"trial_id,omitempty"`
-	EvaluatorID      string         `json:"evaluator_id"`
-	EvaluatorVersion string         `json:"evaluator_version,omitempty"`
-	ScoreKey         string         `json:"score_key"`
-	ScoreType        string         `json:"score_type"`
-	Value            ScoreValue     `json:"value"`
-	ValueNumber      *float64       `json:"value_number,omitempty"`
-	Passed           *bool          `json:"passed,omitempty"`
-	Explanation      string         `json:"explanation,omitempty"`
-	Metadata         map[string]any `json:"metadata,omitempty"`
-	CostUSD          float64        `json:"cost_usd,omitempty"`
-	Tokens           int64          `json:"tokens,omitempty"`
-	CreatedAt        time.Time      `json:"created_at"`
+	TestCaseCount   int                `json:"test_case_count"`
+	TrialCount      int                `json:"trial_count"`
+	CompletedCount  int                `json:"completed_count"`
+	FailedCount     int                `json:"failed_count"`
+	CanceledCount   int                `json:"canceled_count"`
+	PassRate        *float64           `json:"pass_rate,omitempty"`
+	PassAtK         map[string]float64 `json:"pass_at_k,omitempty"`
+	PassPowerK      map[string]float64 `json:"pass_power_k,omitempty"`
+	FinalScoreAvg   *float64           `json:"final_score_avg,omitempty"`
+	TotalCost       *float64           `json:"total_cost,omitempty"`
+	TotalTokens     *int64             `json:"total_tokens,omitempty"`
+	PassCount       int                `json:"pass_count"`
+	PassDenominator int                `json:"pass_denominator"`
+	FinalScoreSum   float64            `json:"final_score_sum"`
+	FinalScoreCount int                `json:"final_score_count"`
+	TokenCoverage   string             `json:"token_coverage"`
+	CostCoverage    string             `json:"cost_coverage"`
 }
 
 type TestCaseSnapshot struct {
@@ -270,6 +234,12 @@ type TestCaseSnapshot struct {
 	ArtifactRefs []ArtifactRef  `json:"artifact_refs,omitempty"`
 }
 
+// TestCaseTrial is one attempt at one test case.
+//
+// The same struct is the body of trials create. That endpoint rejects unknown
+// fields, and accepts none of tenant_id, total_tokens, created_at, or
+// updated_at, so a create body holding any of those fails with 400. The API
+// derives total_tokens from the trial's conversation usage.
 type TestCaseTrial struct {
 	TenantID       string            `json:"tenant_id,omitempty"`
 	TrialID        string            `json:"trial_id,omitempty"`
@@ -284,6 +254,7 @@ type TestCaseTrial struct {
 	Cost           *float64          `json:"cost,omitempty"`
 	InputTokens    *int64            `json:"input_tokens,omitempty"`
 	OutputTokens   *int64            `json:"output_tokens,omitempty"`
+	TotalTokens    *int64            `json:"total_tokens,omitempty"`
 	DurationMS     *int64            `json:"duration_ms,omitempty"`
 	Error          string            `json:"error,omitempty"`
 	Metadata       map[string]any    `json:"metadata,omitempty"`


### PR DESCRIPTION
The experiment structs had both the old report shape and the one the API returns today. JSON and YAML output had five fields the API never returns (`n_conversations`, `n_generations`, `n_scores`, `mean_score`, `total_cost_usd`) and dropped six the API does return, among them `cost_coverage`, which separates unmeasured cost from zero cost.