### PR TITLE
feat(irm): add escalation-chain and date-window filters to alert-groups list

### DIFF
--- a/claude-plugin/skills/oncall-triage/SKILL.md
+++ b/claude-plugin/skills/oncall-triage/SKILL.md
@@ -27,13 +27,18 @@ gcx configured with an active context that targets a Grafana stack with OnCall e
 gcx irm oncall alert-groups list
 ```
 
-Default filter: `state in {firing, acknowledged, silenced}` and `is_root=true` (matches the OnCall UI). See `--help` for the full flag set; common narrowers are `--state`, `--team <PK>`, `--integration <PK>`, `--mine`, `--max-age 24h`. Team / integration filters take PKs, not names — resolve first:
+Default filter: `state in {firing, acknowledged, silenced}` and `is_root=true` (matches the OnCall UI). See `--help` for the full flag set; common narrowers are `--state`, `--team <PK>`, `--integration <PK>`, `--escalation-chain <ID>`, `--mine`, `--max-age 24h`. Team / integration / chain filters take IDs, not names — resolve first:
 
 ```bash
 gcx irm oncall teams list -o json | jq -r '.[] | "\(.metadata.name): \(.spec.name)"' | grep -i "my team"
+gcx irm oncall escalation-chains list
 ```
 
+To attribute alert load to a rotation, filter by escalation chain, not integration: one integration routes through several chains to several schedules, and the alert group record carries no chain field of its own. Chain-filtered queries over the same integration return disjoint subsets.
+
 Escape hatches: `--all` (drops both defaults — returns resolved + child groups), `--include-child-groups`, `--state resolved`.
+
+For a historical window use `--from` / `--to` (RFC3339, unix timestamp, or `now-30d`); `--max-age` only anchors to now, and the two cannot be combined. `--resolved-from` / `--resolved-to` bound resolved_at instead. `--acknowledged-by <user-id>` / `--resolved-by <user-id>` attribute handling to a person.
 
 Default table: `ID TITLE SEVERITY STATE TEAM SUBJECT AGE`. `-o wide` adds `RULE` (Grafana rule URL) and `ALERTS` (group-wide count). Use `-o wide` when the user needs the rule pivot.
 

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_list.md
@@ -13,27 +13,62 @@ Use --all to bypass these defaults entirely (returns resolved and child groups t
 Use --state to override the status filter (e.g. --state firing,acknowledged).
 Use --include-child-groups to keep the status default but include child groups.
 
+Alert group records carry no escalation chain field, so --escalation-chain is the
+only way to attribute alert load to the rotation that was actually paged. It is not
+interchangeable with --integration: one integration routes to several chains.
+
+--max-age anchors to now; use --from/--to for a historical started-at window, and
+--resolved-from/--resolved-to for a resolved-at window. They accept RFC3339, a unix
+timestamp, or a relative expression like now-30d. --max-age and --from/--to cannot
+be combined.
+
 ```
 gcx irm oncall alert-groups list [flags]
+```
+
+### Examples
+
+```
+  # List firing, acknowledged, and silenced root groups
+  gcx irm oncall alert-groups list
+
+  # Narrow to one team, most recent day
+  gcx irm oncall alert-groups list --team <team-id> --max-age 24h
+
+  # Attribute load to a rotation (chain IDs: gcx irm oncall escalation-chains list)
+  gcx irm oncall alert-groups list --escalation-chain <chain-id> --all
+
+  # Historical window, including resolved groups
+  gcx irm oncall alert-groups list --from now-30d --to now-7d --all
+
+  # Groups resolved last week by a given user
+  gcx irm oncall alert-groups list --resolved-by <user-id> --resolved-from now-7d --all
 ```
 
 ### Options
 
 ```
-      --all                    Bypass the default status and is_root filters (returns resolved groups and child groups too)
-      --has-related-incident   Limit to alert groups linked to an incident
-  -h, --help                   help for list
-      --include-child-groups   Include child groups (drops the is_root filter while keeping the status default)
-      --integration strings    Filter by integration PK (repeatable, comma-separated)
-      --jq string              jq expression to apply to JSON output. Mutually exclusive with --json.
-      --json string            Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int              Maximum number of alert groups to return (0 for all, capped by an internal safety limit) (default 50)
-      --max-age string         Exclude groups older than this duration (e.g. 1h, 24h, 7d)
-      --mine                   Limit to alert groups for the authenticated user
-  -o, --output string          Output format. One of: agents, json, table, wide, yaml (default "table")
-      --state strings          Filter by state (firing|acknowledged|resolved|silenced; repeatable, comma-separated). Default: firing,acknowledged,silenced
-      --team strings           Filter by team PK (repeatable, comma-separated)
-      --with-resolution-note   Limit to alert groups that have a resolution note
+      --acknowledged-by strings    Filter by acknowledging user ID (repeatable, comma-separated; see: gcx irm oncall users list)
+      --all                        Bypass the default status and is_root filters (returns resolved groups and child groups too)
+      --escalation-chain strings   Filter by escalation chain ID (repeatable, comma-separated; see: gcx irm oncall escalation-chains list)
+      --from string                Start of the started-at window (RFC3339, unix timestamp, or relative e.g. now-30d); cannot be combined with --max-age
+      --has-related-incident       Limit to alert groups linked to an incident
+  -h, --help                       help for list
+      --include-child-groups       Include child groups (drops the is_root filter while keeping the status default)
+      --integration strings        Filter by integration PK (repeatable, comma-separated)
+      --jq string                  jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string                Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int                  Maximum number of alert groups to return (0 for all, capped by an internal safety limit) (default 50)
+      --max-age string             Exclude groups older than this duration (e.g. 1h, 24h, 7d)
+      --mine                       Limit to alert groups for the authenticated user
+  -o, --output string              Output format. One of: agents, json, table, wide, yaml (default "table")
+      --resolved-by strings        Filter by resolving user ID (repeatable, comma-separated; see: gcx irm oncall users list)
+      --resolved-from string       Start of the resolved-at window (RFC3339, unix timestamp, or relative e.g. now-30d)
+      --resolved-to string         End of the resolved-at window (RFC3339, unix timestamp, or relative e.g. now-7d); defaults to now
+      --state strings              Filter by state (firing|acknowledged|resolved|silenced; repeatable, comma-separated). Default: firing,acknowledged,silenced
+      --team strings               Filter by team PK (repeatable, comma-separated)
+      --to string                  End of the started-at window (RFC3339, unix timestamp, or relative e.g. now-7d); defaults to now
+      --with-resolution-note       Limit to alert groups that have a resolution note
 ```
 
 ### Options inherited from parent commands

--- a/internal/providers/irm/oncall_actions.go
+++ b/internal/providers/irm/oncall_actions.go
@@ -51,6 +51,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/format"
@@ -844,10 +845,20 @@ func resolveBulkTargets(ctx context.Context, client OnCallAPI, opts *alertGroupA
 // pass --state explicitly" check, so we replicate just the bits we need here).
 func (o *alertGroupActionVerbOpts) toListFilters() (alertGroupListFilters, error) {
 	out := alertGroupListFilters{
-		MaxAge:       o.MaxAge,
 		Teams:        o.Teams,
 		Integrations: o.Integrations,
 		Mine:         o.Mine,
+	}
+
+	// --max-age is the only time expression the bulk verbs take; resolve it to
+	// an absolute window here, matching resolveAlertGroupListFilters.
+	if o.MaxAge != "" {
+		dur, err := parseDuration(o.MaxAge)
+		if err != nil {
+			return out, fmt.Errorf("invalid --max-age value %q: %w", o.MaxAge, err)
+		}
+		now := time.Now()
+		out.StartedAt = &timeWindow{From: now.Add(-dur), To: now}
 	}
 
 	if len(o.States) > 0 {

--- a/internal/providers/irm/oncall_alertgroup_list_test.go
+++ b/internal/providers/irm/oncall_alertgroup_list_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/testutils"
@@ -218,6 +219,44 @@ func TestAlertGroupList_LegacyPath_LimitZeroDrainsFully(t *testing.T) {
 	}
 	if strings.Contains(stderr, "showing first") {
 		t.Errorf("unexpected truncation hint on stderr:\n%s", stderr)
+	}
+}
+
+// TestAlertGroupList_LegacyPath_NotesUnsupportedFilters: the SA-token path
+// speaks the OnCall public API, which has none of the internal API's option
+// filters and only a lower bound on started_at. Every dropped filter must be
+// named in the note so the user knows the result set is broader than asked
+// for — silently ignoring them would be a wrong answer, not a partial one.
+func TestAlertGroupList_LegacyPath_NotesUnsupportedFilters(t *testing.T) {
+	fake := &fakeLegacyListAPI{items: []AlertGroup{{PK: "AG1"}}}
+	_, stderr := runAlertGroupList(t, fake,
+		"--escalation-chain", "EC1",
+		"--acknowledged-by", "U1",
+		"--resolved-by", "U2",
+		"--from", "2026-01-01T00:00:00Z",
+		"--to", "2026-01-31T00:00:00Z",
+		"--resolved-from", "2026-01-01T00:00:00Z",
+		"--resolved-to", "2026-01-31T00:00:00Z",
+	)
+
+	for _, want := range []string{
+		"--escalation-chain", "--acknowledged-by", "--resolved-by",
+		"--to", "--resolved-from", "--resolved-to",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q in the unsupported-filter note:\n%s", want, stderr)
+		}
+	}
+	// --from survives: the public API does understand a started_at lower
+	// bound, so it must be applied rather than dropped.
+	if strings.Contains(stderr, "does not honor: --from") {
+		t.Errorf("--from reported unsupported, but it maps onto started_after:\n%s", stderr)
+	}
+	if fake.gotCfg.StartedAfter == nil {
+		t.Fatal("StartedAfter = nil, want --from applied as the public API's lower bound")
+	}
+	if got := fake.gotCfg.StartedAfter.UTC().Format(time.RFC3339); got != "2026-01-01T00:00:00Z" {
+		t.Errorf("StartedAfter = %s, want 2026-01-01T00:00:00Z", got)
 	}
 }
 

--- a/internal/providers/irm/oncall_alertgroup_listraw_test.go
+++ b/internal/providers/irm/oncall_alertgroup_listraw_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -24,6 +26,9 @@ type alertGroupPage struct {
 type pagedServerState struct {
 	requests     int
 	firstPerPage string
+	// firstQuery is the full query string of the first alertgroups request,
+	// so filter tests can assert the exact wire encoding.
+	firstQuery url.Values
 }
 
 // newPagedAlertGroupsServer serves the OnCall internal alertgroups endpoint
@@ -44,7 +49,8 @@ func newPagedAlertGroupsServer(t *testing.T, pages []alertGroupPage) (*httptest.
 	mux.HandleFunc(BasePath+"/alertgroups/", func(w http.ResponseWriter, r *http.Request) {
 		state.requests++
 		if state.requests == 1 {
-			state.firstPerPage = r.URL.Query().Get("perpage")
+			state.firstQuery = r.URL.Query()
+			state.firstPerPage = state.firstQuery.Get("perpage")
 		}
 		pageNum := 1
 		if p := r.URL.Query().Get("page"); p != "" {
@@ -223,6 +229,108 @@ func TestAlertGroupList_RichPath_EndToEndHTTP_DrainedOvershoot(t *testing.T) {
 	want := "hint: showing first 3 of 4. See all results with: gcx irm oncall alert-groups list --limit 0"
 	if !strings.Contains(stderr, want) {
 		t.Errorf("stderr missing known-total truncation hint %q:\n%s", want, stderr)
+	}
+}
+
+// TestAlertGroupList_FilterQueryParams pins the wire encoding of the filter
+// flags added to close the escalation-chain gap (grafana/gcx#1156). Each
+// option filter is sent as a REPEATED param, never comma-joined — matching
+// team/integration — and the two daterange filters are sent as the naive-UTC
+// `<from>_<to>` pair the internal API expects. `--to` on its own still sends a
+// pair, with the start defaulted to the unix epoch.
+//
+// Assertions are per-key so the always-present defaults (status, is_root,
+// perpage) don't have to be restated in every case.
+func TestAlertGroupList_FilterQueryParams(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want url.Values
+	}{
+		{
+			name: "escalation chains repeat, never comma-joined",
+			args: []string{"--escalation-chain", "EC1,EC2"},
+			want: url.Values{"escalation_chain": {"EC1", "EC2"}},
+		},
+		{
+			name: "repeated flag occurrences accumulate",
+			args: []string{"--escalation-chain", "EC1", "--escalation-chain", "EC2"},
+			want: url.Values{"escalation_chain": {"EC1", "EC2"}},
+		},
+		{
+			name: "acknowledged-by and resolved-by",
+			args: []string{"--acknowledged-by", "U1,U2", "--resolved-by", "U3"},
+			want: url.Values{
+				"acknowledged_by": {"U1", "U2"},
+				"resolved_by":     {"U3"},
+			},
+		},
+		{
+			name: "started-at window from an absolute --from/--to pair",
+			args: []string{"--from", "2026-01-01T00:00:00Z", "--to", "2026-01-31T12:00:00Z"},
+			want: url.Values{"started_at": {"2026-01-01T00:00:00_2026-01-31T12:00:00"}},
+		},
+		{
+			name: "--from accepts a unix timestamp",
+			args: []string{"--from", "1767225600", "--to", "2026-01-31T12:00:00Z"},
+			want: url.Values{"started_at": {"2026-01-01T00:00:00_2026-01-31T12:00:00"}},
+		},
+		{
+			name: "--to alone defaults the start to the unix epoch",
+			args: []string{"--to", "2026-01-31T12:00:00Z"},
+			want: url.Values{"started_at": {"1970-01-01T00:00:00_2026-01-31T12:00:00"}},
+		},
+		{
+			name: "resolved-at window is a separate param",
+			args: []string{"--resolved-from", "2026-01-01T00:00:00Z", "--resolved-to", "2026-01-31T12:00:00Z"},
+			want: url.Values{"resolved_at": {"2026-01-01T00:00:00_2026-01-31T12:00:00"}},
+		},
+		{
+			name: "no time flags means no daterange params",
+			args: []string{"--escalation-chain", "EC1"},
+			want: url.Values{"started_at": nil, "resolved_at": nil},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, state := newPagedAlertGroupsServer(t, []alertGroupPage{{items: rawAlertGroups(1)}})
+			runAlertGroupList(t, onCallClientFor(srv), tc.args...)
+
+			if state.firstQuery == nil {
+				t.Fatal("no alertgroups request observed")
+			}
+			for key, want := range tc.want {
+				if got := state.firstQuery[key]; !reflect.DeepEqual(got, want) {
+					t.Errorf("query[%q] = %v, want %v (full query: %v)", key, got, want, state.firstQuery)
+				}
+			}
+		})
+	}
+}
+
+// TestAlertGroupList_MaxAgeAndFromAreMutuallyExclusive: both compile into the
+// same started_at range param, so the combination is rejected at validation
+// time — before any config or network work.
+func TestAlertGroupList_MaxAgeAndFromAreMutuallyExclusive(t *testing.T) {
+	srv, state := newPagedAlertGroupsServer(t, []alertGroupPage{{items: rawAlertGroups(1)}})
+	resetAgentMode(t)
+
+	cmd := newAlertGroupListCommand(&fakeLoader{client: onCallClientFor(srv)})
+	cmd.SetOut(&strings.Builder{})
+	cmd.SetErr(&strings.Builder{})
+	cmd.SetArgs([]string{"-o", "json", "--max-age", "24h", "--from", "now-30d"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() = nil, want a mutual-exclusion error")
+	}
+	const want = "--max-age cannot be combined with --from or --to: both bound the started-at window"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+	if state.requests != 0 {
+		t.Errorf("requests = %d, want 0 (validation must fire before any network work)", state.requests)
 	}
 }
 

--- a/internal/providers/irm/oncall_commands_extra.go
+++ b/internal/providers/irm/oncall_commands_extra.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/shared"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -51,11 +52,23 @@ type alertGroupListOpts struct {
 	States             []string
 	Teams              []string
 	Integrations       []string
+	EscalationChains   []string
+	AcknowledgedBy     []string
+	ResolvedBy         []string
 	Mine               bool
 	WithResolutionNote bool
 	HasRelatedIncident bool
 	All                bool
 	IncludeChildGroups bool
+
+	// Absolute time windows. From/To bound started_at, ResolvedFrom/ResolvedTo
+	// bound resolved_at. Unlike --max-age (which only ever anchors to now),
+	// these can express a historical window. Values accept RFC3339, a unix
+	// timestamp, or a relative expression like `now-7d` (shared.ParseTime).
+	From         string
+	To           string
+	ResolvedFrom string
+	ResolvedTo   string
 }
 
 func (o *alertGroupListOpts) setup(flags *pflag.FlagSet) {
@@ -69,6 +82,13 @@ func (o *alertGroupListOpts) setup(flags *pflag.FlagSet) {
 	flags.StringSliceVar(&o.States, "state", nil, "Filter by state (firing|acknowledged|resolved|silenced; repeatable, comma-separated). Default: firing,acknowledged,silenced")
 	flags.StringSliceVar(&o.Teams, "team", nil, "Filter by team PK (repeatable, comma-separated)")
 	flags.StringSliceVar(&o.Integrations, "integration", nil, "Filter by integration PK (repeatable, comma-separated)")
+	flags.StringSliceVar(&o.EscalationChains, "escalation-chain", nil, "Filter by escalation chain ID (repeatable, comma-separated; see: gcx irm oncall escalation-chains list)")
+	flags.StringSliceVar(&o.AcknowledgedBy, "acknowledged-by", nil, "Filter by acknowledging user ID (repeatable, comma-separated; see: gcx irm oncall users list)")
+	flags.StringSliceVar(&o.ResolvedBy, "resolved-by", nil, "Filter by resolving user ID (repeatable, comma-separated; see: gcx irm oncall users list)")
+	flags.StringVar(&o.From, "from", "", "Start of the started-at window (RFC3339, unix timestamp, or relative e.g. now-30d); cannot be combined with --max-age")
+	flags.StringVar(&o.To, "to", "", "End of the started-at window (RFC3339, unix timestamp, or relative e.g. now-7d); defaults to now")
+	flags.StringVar(&o.ResolvedFrom, "resolved-from", "", "Start of the resolved-at window (RFC3339, unix timestamp, or relative e.g. now-30d)")
+	flags.StringVar(&o.ResolvedTo, "resolved-to", "", "End of the resolved-at window (RFC3339, unix timestamp, or relative e.g. now-7d); defaults to now")
 	flags.BoolVar(&o.Mine, "mine", false, "Limit to alert groups for the authenticated user")
 	flags.BoolVar(&o.WithResolutionNote, "with-resolution-note", false, "Limit to alert groups that have a resolution note")
 	flags.BoolVar(&o.HasRelatedIncident, "has-related-incident", false, "Limit to alert groups linked to an incident")
@@ -87,7 +107,76 @@ func (o *alertGroupListOpts) Validate() error {
 	if o.Limit < 0 {
 		return fmt.Errorf("invalid --limit %d: must be >= 0 (0 means as many results as the safety cap allows)", o.Limit)
 	}
+	// --max-age and --from/--to both compile into the same started_at range
+	// param, so combining them would be ambiguous.
+	if o.MaxAge != "" && (o.From != "" || o.To != "") {
+		return errors.New("--max-age cannot be combined with --from or --to: both bound the started-at window")
+	}
+	// Fail on unparseable or inverted windows here — before any config or
+	// network work — rather than letting them reach the API as a silently
+	// empty result.
+	now := time.Now()
+	if _, _, err := resolveTimeWindow("from", "to", o.From, o.To, now); err != nil {
+		return err
+	}
+	if _, _, err := resolveTimeWindow("resolved-from", "resolved-to", o.ResolvedFrom, o.ResolvedTo, now); err != nil {
+		return err
+	}
 	return nil
+}
+
+// timeWindow is a resolved absolute range, ready to be rendered into the OnCall
+// internal API's `<from>_<to>` date-range param encoding.
+type timeWindow struct {
+	From time.Time
+	To   time.Time
+}
+
+// onCallDateRangeLayout is the timestamp format the OnCall internal API's
+// daterange filters expect: naive UTC, no zone suffix.
+const onCallDateRangeLayout = "2006-01-02T15:04:05"
+
+// encode renders the window as the `<from>_<to>` pair the OnCall daterange
+// filters (started_at, resolved_at) take.
+func (w timeWindow) encode() string {
+	return w.From.UTC().Format(onCallDateRangeLayout) + "_" + w.To.UTC().Format(onCallDateRangeLayout)
+}
+
+// resolveTimeWindow turns a pair of user-supplied time expressions into an
+// absolute window, accepting RFC3339, a unix timestamp, or a relative
+// expression like `now-7d` (shared.ParseTime). The bool result is false when
+// neither end was supplied (no window to filter on).
+//
+// The OnCall daterange params require both ends, so a one-sided window is
+// completed rather than rejected: an omitted end becomes now, and an omitted
+// start becomes the unix epoch — comfortably before any alert group could
+// exist. fromFlag/toFlag name the flags in error messages so the same helper
+// serves both the started-at and resolved-at pairs.
+func resolveTimeWindow(fromFlag, toFlag, from, to string, now time.Time) (timeWindow, bool, error) {
+	if from == "" && to == "" {
+		return timeWindow{}, false, nil
+	}
+	w := timeWindow{From: time.Unix(0, 0).UTC(), To: now}
+	if from != "" {
+		t, err := shared.ParseTime(from, now)
+		if err != nil {
+			return timeWindow{}, false, fmt.Errorf("invalid --%s value: %w", fromFlag, err)
+		}
+		w.From = t
+	}
+	if to != "" {
+		t, err := shared.ParseTime(to, now)
+		if err != nil {
+			return timeWindow{}, false, fmt.Errorf("invalid --%s value: %w", toFlag, err)
+		}
+		w.To = t
+	}
+	if w.To.Before(w.From) {
+		return timeWindow{}, false, fmt.Errorf("invalid time range: --%s (%s) is after --%s (%s)",
+			fromFlag, w.From.UTC().Format(time.RFC3339),
+			toFlag, w.To.UTC().Format(time.RFC3339))
+	}
+	return w, true, nil
 }
 
 // stateNameToInt translates a user-facing state name into the OnCall internal
@@ -140,14 +229,25 @@ func newAlertGroupsCommand(loader OnCallConfigLoader) *cobra.Command {
 // and the alternate-implementation fallback (listAlertGroupsLegacy — e.g.
 // test doubles; not reachable via the production loader today).
 type alertGroupListFilters struct {
-	MaxAge             string
 	Statuses           []int
 	IsRoot             *bool
 	Teams              []string
 	Integrations       []string
+	EscalationChains   []string
+	AcknowledgedBy     []string
+	ResolvedBy         []string
 	Mine               bool
 	WithResolutionNote bool
 	HasRelatedIncident bool
+
+	// StartedAt is the resolved started_at window. Both --max-age and
+	// --from/--to compile into it (Validate rejects the combination), so
+	// downstream callers see one absolute range regardless of how the user
+	// expressed it. Nil means unfiltered.
+	StartedAt *timeWindow
+	// ResolvedAt is the resolved resolved_at window from
+	// --resolved-from/--resolved-to. Nil means unfiltered.
+	ResolvedAt *timeWindow
 }
 
 // resolveAlertGroupListFilters validates and normalizes the user-facing flag
@@ -157,14 +257,45 @@ type alertGroupListFilters struct {
 //   - --all bypasses both defaults,
 //   - --include-child-groups drops is_root but keeps the status default,
 //   - explicit --state always wins (still subject to --include-child-groups for is_root).
+//
+// It also collapses the three time expressions (--max-age, --from/--to,
+// --resolved-from/--resolved-to) into absolute windows so neither transport
+// path has to parse user input.
 func resolveAlertGroupListFilters(cmd *cobra.Command, opts *alertGroupListOpts) (alertGroupListFilters, error) {
 	out := alertGroupListFilters{
-		MaxAge:             opts.MaxAge,
 		Teams:              opts.Teams,
 		Integrations:       opts.Integrations,
+		EscalationChains:   opts.EscalationChains,
+		AcknowledgedBy:     opts.AcknowledgedBy,
+		ResolvedBy:         opts.ResolvedBy,
 		Mine:               opts.Mine,
 		WithResolutionNote: opts.WithResolutionNote,
 		HasRelatedIncident: opts.HasRelatedIncident,
+	}
+
+	now := time.Now()
+	switch {
+	case opts.MaxAge != "":
+		dur, err := parseDuration(opts.MaxAge)
+		if err != nil {
+			return out, fmt.Errorf("invalid --max-age value %q: %w", opts.MaxAge, err)
+		}
+		out.StartedAt = &timeWindow{From: now.Add(-dur), To: now}
+	default:
+		w, ok, err := resolveTimeWindow("from", "to", opts.From, opts.To, now)
+		if err != nil {
+			return out, err
+		}
+		if ok {
+			out.StartedAt = &w
+		}
+	}
+	resolved, ok, err := resolveTimeWindow("resolved-from", "resolved-to", opts.ResolvedFrom, opts.ResolvedTo, now)
+	if err != nil {
+		return out, err
+	}
+	if ok {
+		out.ResolvedAt = &resolved
 	}
 
 	// Translate user-facing state names into the internal wire encoding.
@@ -205,14 +336,39 @@ firing, acknowledged, or silenced state. Resolved groups are excluded.
 
 Use --all to bypass these defaults entirely (returns resolved and child groups too).
 Use --state to override the status filter (e.g. --state firing,acknowledged).
-Use --include-child-groups to keep the status default but include child groups.`
+Use --include-child-groups to keep the status default but include child groups.
+
+Alert group records carry no escalation chain field, so --escalation-chain is the
+only way to attribute alert load to the rotation that was actually paged. It is not
+interchangeable with --integration: one integration routes to several chains.
+
+--max-age anchors to now; use --from/--to for a historical started-at window, and
+--resolved-from/--resolved-to for a resolved-at window. They accept RFC3339, a unix
+timestamp, or a relative expression like now-30d. --max-age and --from/--to cannot
+be combined.`
+
+const alertGroupListExample = `  # List firing, acknowledged, and silenced root groups
+  gcx irm oncall alert-groups list
+
+  # Narrow to one team, most recent day
+  gcx irm oncall alert-groups list --team <team-id> --max-age 24h
+
+  # Attribute load to a rotation (chain IDs: gcx irm oncall escalation-chains list)
+  gcx irm oncall alert-groups list --escalation-chain <chain-id> --all
+
+  # Historical window, including resolved groups
+  gcx irm oncall alert-groups list --from now-30d --to now-7d --all
+
+  # Groups resolved last week by a given user
+  gcx irm oncall alert-groups list --resolved-by <user-id> --resolved-from now-7d --all`
 
 func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 	opts := &alertGroupListOpts{}
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List alert groups.",
-		Long:  alertGroupListLong,
+		Use:     "list",
+		Short:   "List alert groups.",
+		Long:    alertGroupListLong,
+		Example: alertGroupListExample,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.Validate(); err != nil {
 				return err
@@ -346,7 +502,7 @@ const alertGroupListFilterMaxLen = 80
 // If the rendered summary exceeds alertGroupListFilterMaxLen, falls back to a
 // short "<N filters>" summary.
 func stringifyAlertGroupListFilters(opts *alertGroupListOpts) string {
-	parts := make([]string, 0, 8)
+	parts := make([]string, 0, 16)
 	if len(opts.States) > 0 {
 		parts = append(parts, "status="+strings.Join(opts.States, ","))
 	}
@@ -356,8 +512,29 @@ func stringifyAlertGroupListFilters(opts *alertGroupListOpts) string {
 	if len(opts.Integrations) > 0 {
 		parts = append(parts, "integration="+strings.Join(opts.Integrations, ","))
 	}
+	if len(opts.EscalationChains) > 0 {
+		parts = append(parts, "escalation-chain="+strings.Join(opts.EscalationChains, ","))
+	}
+	if len(opts.AcknowledgedBy) > 0 {
+		parts = append(parts, "acknowledged-by="+strings.Join(opts.AcknowledgedBy, ","))
+	}
+	if len(opts.ResolvedBy) > 0 {
+		parts = append(parts, "resolved-by="+strings.Join(opts.ResolvedBy, ","))
+	}
 	if opts.MaxAge != "" {
 		parts = append(parts, "max-age="+opts.MaxAge)
+	}
+	if opts.From != "" {
+		parts = append(parts, "from="+opts.From)
+	}
+	if opts.To != "" {
+		parts = append(parts, "to="+opts.To)
+	}
+	if opts.ResolvedFrom != "" {
+		parts = append(parts, "resolved-from="+opts.ResolvedFrom)
+	}
+	if opts.ResolvedTo != "" {
+		parts = append(parts, "resolved-to="+opts.ResolvedTo)
 	}
 	if opts.Mine {
 		parts = append(parts, "mine")
@@ -397,9 +574,16 @@ func stringifyAlertGroupListFilters(opts *alertGroupListOpts) string {
 // silent in the "user passed --all and nothing else" case.
 func alertGroupListHasExplicitFilter(opts *alertGroupListOpts) bool {
 	return opts.MaxAge != "" ||
+		opts.From != "" ||
+		opts.To != "" ||
+		opts.ResolvedFrom != "" ||
+		opts.ResolvedTo != "" ||
 		len(opts.States) > 0 ||
 		len(opts.Teams) > 0 ||
 		len(opts.Integrations) > 0 ||
+		len(opts.EscalationChains) > 0 ||
+		len(opts.AcknowledgedBy) > 0 ||
+		len(opts.ResolvedBy) > 0 ||
 		opts.Mine ||
 		opts.WithResolutionNote ||
 		opts.HasRelatedIncident ||
@@ -494,13 +678,10 @@ func emitListAlertsLinkHints(stderr io.Writer, ruleUID string) {
 // we surface a `note:` warning here so the user knows.
 func listAlertGroupsLegacy(cmd *cobra.Command, opts *alertGroupListOpts, filters alertGroupListFilters, client OnCallAPI, namespace string) error {
 	var listOpts []ListOption
-	if filters.MaxAge != "" {
-		dur, err := parseDuration(filters.MaxAge)
-		if err != nil {
-			return fmt.Errorf("invalid --max-age value %q: %w", filters.MaxAge, err)
-		}
-		cutoff := time.Now().UTC().Add(-dur)
-		listOpts = append(listOpts, WithStartedAfter(cutoff))
+	// The public API only understands a lower bound on started_at, so a
+	// resolved window contributes its start and the note below owns the rest.
+	if filters.StartedAt != nil {
+		listOpts = append(listOpts, WithStartedAfter(filters.StartedAt.From.UTC()))
 	}
 	if len(filters.Statuses) > 0 {
 		listOpts = append(listOpts, WithStatuses(filters.Statuses...))
@@ -520,9 +701,10 @@ func listAlertGroupsLegacy(cmd *cobra.Command, opts *alertGroupListOpts, filters
 	}
 
 	// Surface unsupported-filter warnings once at the command edge — the
-	// public API doesn't speak is_root, mine, with_resolution_note, or
-	// has_related_incident. Honor what we can and tell the user about the
-	// rest.
+	// public API doesn't speak is_root, mine, with_resolution_note,
+	// has_related_incident, the escalation_chain / acknowledged_by /
+	// resolved_by option filters, or either daterange's upper bound. Honor
+	// what we can and tell the user about the rest.
 	var unsupported []string
 	if filters.IsRoot != nil {
 		unsupported = append(unsupported, "is_root (root-only / include-child-groups)")
@@ -535,6 +717,26 @@ func listAlertGroupsLegacy(cmd *cobra.Command, opts *alertGroupListOpts, filters
 	}
 	if filters.HasRelatedIncident {
 		unsupported = append(unsupported, "--has-related-incident")
+	}
+	if len(filters.EscalationChains) > 0 {
+		unsupported = append(unsupported, "--escalation-chain")
+	}
+	if len(filters.AcknowledgedBy) > 0 {
+		unsupported = append(unsupported, "--acknowledged-by")
+	}
+	if len(filters.ResolvedBy) > 0 {
+		unsupported = append(unsupported, "--resolved-by")
+	}
+	// --from's lower bound survives as started_after above; the upper bound
+	// and the whole resolved_at window have no public-API equivalent.
+	if opts.To != "" {
+		unsupported = append(unsupported, "--to")
+	}
+	if opts.ResolvedFrom != "" {
+		unsupported = append(unsupported, "--resolved-from")
+	}
+	if opts.ResolvedTo != "" {
+		unsupported = append(unsupported, "--resolved-to")
 	}
 	if len(unsupported) > 0 {
 		// Centralised note emission. Agent mode renders
@@ -632,15 +834,11 @@ type alertGroupPageInfo struct {
 // docs/research/2026-07-17-global-limit-investigation.md § 6.
 func listAlertGroupsRaw(ctx context.Context, c *OnCallClient, filters alertGroupListFilters, limit int) ([]json.RawMessage, alertGroupPageInfo, error) {
 	params := url.Values{}
-	if filters.MaxAge != "" {
-		dur, err := parseDuration(filters.MaxAge)
-		if err != nil {
-			return nil, alertGroupPageInfo{}, fmt.Errorf("invalid --max-age value %q: %w", filters.MaxAge, err)
-		}
-		const layout = "2006-01-02T15:04:05"
-		start := time.Now().UTC().Add(-dur).Format(layout)
-		end := time.Now().UTC().Format(layout)
-		params.Set("started_at", start+"_"+end)
+	if w := filters.StartedAt; w != nil {
+		params.Set("started_at", w.encode())
+	}
+	if w := filters.ResolvedAt; w != nil {
+		params.Set("resolved_at", w.encode())
 	}
 	for _, s := range filters.Statuses {
 		params.Add("status", strconv.Itoa(s))
@@ -657,6 +855,15 @@ func listAlertGroupsRaw(ctx context.Context, c *OnCallClient, filters alertGroup
 	}
 	for _, i := range filters.Integrations {
 		params.Add("integration", i)
+	}
+	for _, e := range filters.EscalationChains {
+		params.Add("escalation_chain", e)
+	}
+	for _, u := range filters.AcknowledgedBy {
+		params.Add("acknowledged_by", u)
+	}
+	for _, u := range filters.ResolvedBy {
+		params.Add("resolved_by", u)
 	}
 	if filters.Mine {
 		params.Set("mine", "true")

--- a/internal/providers/irm/oncall_commands_extra_test.go
+++ b/internal/providers/irm/oncall_commands_extra_test.go
@@ -65,6 +65,29 @@ func TestStringifyAlertGroupListFilters(t *testing.T) {
 			want: "team=prod-sre, include-child-groups",
 		},
 		{
+			name: "escalation-chain augments default",
+			in:   &alertGroupListOpts{EscalationChains: []string{"EC1", "EC2"}},
+			want: "default + escalation-chain=EC1,EC2",
+		},
+		{
+			name: "acknowledged-by and resolved-by",
+			in: &alertGroupListOpts{
+				AcknowledgedBy: []string{"U1"},
+				ResolvedBy:     []string{"U2"},
+			},
+			want: "default + acknowledged-by=U1, resolved-by=U2",
+		},
+		{
+			name: "started-at window renders the raw expressions",
+			in:   &alertGroupListOpts{From: "now-30d", To: "now-7d"},
+			want: "default + from=now-30d, to=now-7d",
+		},
+		{
+			name: "resolved-at window",
+			in:   &alertGroupListOpts{ResolvedFrom: "now-7d", ResolvedTo: "now"},
+			want: "default + resolved-from=now-7d, resolved-to=now",
+		},
+		{
 			name: "many filters collapse to count",
 			in: &alertGroupListOpts{
 				States:             []string{"firing", "acknowledged", "silenced"},
@@ -134,6 +157,93 @@ func TestAlertGroupListOptsValidate(t *testing.T) {
 	}
 }
 
+// TestAlertGroupListOptsValidateTimeWindows covers the time-window guardrails
+// added with --from/--to and --resolved-from/--resolved-to: --max-age and
+// --from/--to both compile into started_at so they cannot be combined,
+// unparseable expressions are rejected by name, and an inverted window is an
+// error rather than a silently empty result. All must fire before any config
+// or network work.
+func TestAlertGroupListOptsValidateTimeWindows(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		in      *alertGroupListOpts
+		wantErr string // exact message; empty means Validate must pass
+	}{
+		{
+			name:    "max-age with from rejected",
+			in:      &alertGroupListOpts{MaxAge: "24h", From: "now-30d"},
+			wantErr: "--max-age cannot be combined with --from or --to: both bound the started-at window",
+		},
+		{
+			name:    "max-age with to rejected",
+			in:      &alertGroupListOpts{MaxAge: "24h", To: "now-7d"},
+			wantErr: "--max-age cannot be combined with --from or --to: both bound the started-at window",
+		},
+		{
+			name:    "unparseable from rejected by flag name",
+			in:      &alertGroupListOpts{From: "last tuesday"},
+			wantErr: "invalid --from value: unable to parse time: last tuesday",
+		},
+		{
+			name:    "unparseable resolved-to rejected by flag name",
+			in:      &alertGroupListOpts{ResolvedTo: "yesterday"},
+			wantErr: "invalid --resolved-to value: unable to parse time: yesterday",
+		},
+		{
+			name: "inverted started-at window rejected",
+			in: &alertGroupListOpts{
+				From: "2026-01-31T00:00:00Z",
+				To:   "2026-01-01T00:00:00Z",
+			},
+			wantErr: "invalid time range: --from (2026-01-31T00:00:00Z) is after --to (2026-01-01T00:00:00Z)",
+		},
+		{
+			name: "inverted resolved-at window rejected",
+			in: &alertGroupListOpts{
+				ResolvedFrom: "2026-01-31T00:00:00Z",
+				ResolvedTo:   "2026-01-01T00:00:00Z",
+			},
+			wantErr: "invalid time range: --resolved-from (2026-01-31T00:00:00Z) is after --resolved-to (2026-01-01T00:00:00Z)",
+		},
+		{
+			name: "both windows, valid, accepted",
+			in: &alertGroupListOpts{
+				From: "now-30d", To: "now-7d",
+				ResolvedFrom: "now-30d", ResolvedTo: "now",
+			},
+		},
+		{
+			name: "max-age alone still accepted",
+			in:   &alertGroupListOpts{MaxAge: "24h"},
+		},
+		{
+			// --to alone is legal: the start defaults to the unix epoch, so
+			// the pair the API requires is still well-defined.
+			name: "to alone accepted",
+			in:   &alertGroupListOpts{To: "now-7d"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.in.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error %q", tc.wantErr)
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("Validate() error = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestAlertGroupListHasExplicitFilter — silent-on-`--all` decision predicate.
 func TestAlertGroupListHasExplicitFilter(t *testing.T) {
 	t.Parallel()
@@ -145,7 +255,14 @@ func TestAlertGroupListHasExplicitFilter(t *testing.T) {
 		{"empty", &alertGroupListOpts{}, false},
 		{"all alone", &alertGroupListOpts{All: true}, false},
 		{"team", &alertGroupListOpts{Teams: []string{"x"}}, true},
+		{"escalation-chain", &alertGroupListOpts{EscalationChains: []string{"EC1"}}, true},
+		{"acknowledged-by", &alertGroupListOpts{AcknowledgedBy: []string{"U1"}}, true},
+		{"resolved-by", &alertGroupListOpts{ResolvedBy: []string{"U1"}}, true},
 		{"max-age", &alertGroupListOpts{MaxAge: "1h"}, true},
+		{"from", &alertGroupListOpts{From: "now-7d"}, true},
+		{"to", &alertGroupListOpts{To: "now-1h"}, true},
+		{"resolved-from", &alertGroupListOpts{ResolvedFrom: "now-7d"}, true},
+		{"resolved-to", &alertGroupListOpts{ResolvedTo: "now-1h"}, true},
 		{"mine", &alertGroupListOpts{Mine: true}, true},
 		{"include-child-groups", &alertGroupListOpts{IncludeChildGroups: true}, true},
 		{"all + team", &alertGroupListOpts{All: true, Teams: []string{"x"}}, true},


### PR DESCRIPTION
Fixes #1156.

## What

`gcx irm oncall alert-groups list` gains six filters that the OnCall internal API already advertises on its own filter-discovery endpoint but that gcx could not reach:

| Flag | Query param |
|---|---|
| `--escalation-chain` | `escalation_chain` (repeated) |
| `--acknowledged-by` | `acknowledged_by` (repeated) |
| `--resolved-by` | `resolved_by` (repeated) |
| `--from` / `--to` | `started_at=<from>_<to>` |
| `--resolved-from` / `--resolved-to` | `resolved_at=<from>_<to>` |

`--escalation-chain` is the one the issue is really about. Alert group records carry no `route` or `escalation_chain` field, so there was previously no way to attribute alert load to a rotation. `--integration` is not a substitute: one integration fans out through several routes to several chains, each notifying a different schedule.

`--max-age` only ever anchors to now, so a historical window could not be expressed at all. `--from`/`--to` accept RFC3339, a unix timestamp, or a relative expression like `now-30d` via `shared.ParseTime`, matching the nearest sibling `gcx irm incidents list`. `--max-age` and `--from`/`--to` are mutually exclusive because both compile into `started_at`.

## Notable decisions

- **IDs, not names**, matching the shipped `--team` / `--integration` "PK" convention. Help text points at `escalation-chains list` / `users list` for discovery.
- **One-sided windows are completed, not rejected.** The API's daterange params need both ends, so an omitted end becomes now and an omitted start becomes the unix epoch.
- **All time expressions now resolve to absolute windows in `resolveAlertGroupListFilters`**, which removes the duplicated duration parsing and layout formatting that previously sat in the transport layer.
- **`list` only.** The bulk action verbs are unchanged. ADR 001 § 3.4's mirror rule enumerates `--team`, `--integration`, `--status`, `--max-age`, `--mine`, and that set still matches; these are analysis filters rather than bulk-mutation targets.
- **`--label` deliberately left out.** OnCall serializes labels as `{key:{id,name},value:{id,name}}`, so the wire filter format is very likely an id pair rather than `key:value`. Worth a follow-up issue once that is confirmed.

The SA-token fallback path speaks the public API, which has none of these filters and only a lower bound on `started_at`. `--from` maps onto that bound; every other dropped filter is named in the existing unsupported-filter note.

## Verification

`GCX_AGENT_MODE=false mise run all` equivalents: `golangci-lint run ./internal/providers/irm/...` clean, `GCX_AGENT_MODE=false go test -race ./...` green, CLI reference regenerated.

New tests: wire-encoding table over the query params (repeated, never comma-joined; naive-UTC `<from>_<to>` pairs; `--to` alone defaulting the start to the epoch), validation table for the mutual exclusion / unparseable / inverted-window errors, and a legacy-path test asserting each dropped filter is named.

Smoke-tested against a live stack, which confirms the params are honored server-side rather than silently ignored:

- a bogus chain ID returns `HTTP 400 {"escalation_chain":["Select a valid choice. ..."]}` — same for `acknowledged_by` and `resolved_by`
- a real chain returns 68 of 200+ groups, and two chains over the same set have zero overlap — the disjointness the issue asks for
- `--from 2026-06-01 --to 2026-06-02` returns only groups started on June 1, proving a historical window that `--max-age` cannot express
- `--resolved-from now-2d --resolved-to now` returns only `resolved` groups with resolved timestamps inside the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)