### PR TITLE
feat(kg): notifications read commands (list, get)

### DIFF
--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -393,6 +393,8 @@
  "gcx kg model-rules list": "finite",
  "gcx kg model-rules schema": "finite",
  "gcx kg model-rules upsert": "finite",
+ "gcx kg notifications get": "finite",
+ "gcx kg notifications list": "finite",
  "gcx kg open": "finite",
  "gcx kg prom-rules delete": "finite",
  "gcx kg prom-rules get": "finite",

--- a/docs/reference/cli/gcx_kg.md
+++ b/docs/reference/cli/gcx_kg.md
@@ -28,6 +28,7 @@ Manage Grafana Knowledge Graph rules, entities, and insights
 * [gcx kg insights](gcx_kg_insights.md)	 - Fetch chart data and source metrics for an active insight.
 * [gcx kg meta](gcx_kg_meta.md)	 - Show Knowledge Graph metadata: entity types, valid env/namespace/site values, and telemetry query configs.
 * [gcx kg model-rules](gcx_kg_model-rules.md)	 - Manage model rules in the Knowledge Graph.
+* [gcx kg notifications](gcx_kg_notifications.md)	 - Manage alert notification configs in the Knowledge Graph.
 * [gcx kg open](gcx_kg_open.md)	 - Open the Knowledge Graph app in the browser.
 * [gcx kg prom-rules](gcx_kg_prom-rules.md)	 - Manage Knowledge Graph Custom Prometheus rules.
 * [gcx kg quality](gcx_kg_quality.md)	 - Inspect Knowledge Graph entity quality reports.

--- a/docs/reference/cli/gcx_kg_notifications.md
+++ b/docs/reference/cli/gcx_kg_notifications.md
@@ -1,0 +1,36 @@
+## gcx kg notifications
+
+Manage alert notification configs in the Knowledge Graph.
+
+### Synopsis
+
+Manage alert notification configs (AlertConfig) in the Knowledge Graph.
+
+These govern how matched alerts notify — the labels an alert must match, extra
+alert labels and annotations to attach, the "for" duration, and the silenced
+flag. Distinct from "gcx kg suppressions", which manages disabled-alert configs.
+
+### Options
+
+```
+  -h, --help   help for notifications
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
+* [gcx kg notifications get](gcx_kg_notifications_get.md)	 - Get an alert notification config by name.
+* [gcx kg notifications list](gcx_kg_notifications_list.md)	 - List alert notification configs, optionally filtered by category.
+

--- a/docs/reference/cli/gcx_kg_notifications_get.md
+++ b/docs/reference/cli/gcx_kg_notifications_get.md
@@ -1,0 +1,33 @@
+## gcx kg notifications get
+
+Get an alert notification config by name.
+
+```
+gcx kg notifications get <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, yaml (default "yaml")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx kg notifications](gcx_kg_notifications.md)	 - Manage alert notification configs in the Knowledge Graph.
+

--- a/docs/reference/cli/gcx_kg_notifications_list.md
+++ b/docs/reference/cli/gcx_kg_notifications_list.md
@@ -9,7 +9,7 @@ gcx kg notifications list [flags]
 ### Options
 
 ```
-      --category string   Filter by category: request, resource, health, or slo.
+      --category string   Filter by category: request, resource, health, or slo (server-side, exact match). Empty or omitted lists all categories.
   -h, --help              help for list
       --jq string         jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_kg_notifications_list.md
+++ b/docs/reference/cli/gcx_kg_notifications_list.md
@@ -1,0 +1,34 @@
+## gcx kg notifications list
+
+List alert notification configs, optionally filtered by category.
+
+```
+gcx kg notifications list [flags]
+```
+
+### Options
+
+```
+      --category string   Filter by category: request, resource, health, or slo.
+  -h, --help              help for list
+      --jq string         jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: agents, json, table, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx kg notifications](gcx_kg_notifications.md)	 - Manage alert notification configs in the Knowledge Graph.
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -329,6 +329,8 @@ var commandAnnotations = map[string]annotation{
 	"gcx kg suppressions upsert":  {Cost: "small", Hint: "-f suppressions.yaml (or pipe YAML via stdin) | upsert (create or update) one or more alert suppressions; never deletes remote entries absent from the file; add --dry-run to validate against the backend and preview the remote->local diff without uploading"},
 	"gcx kg suppressions delete":  {Cost: "small"},
 	"gcx kg suppressions list":    {Cost: "small"},
+	"gcx kg notifications list":   {Cost: "small", Hint: "[--category request|resource|health|slo] | list alert notification configs (AlertConfig); distinct from suppressions (disabled-alert configs)"},
+	"gcx kg notifications get":    {Cost: "small", Hint: "<name> | get one alert notification config by name (list-then-filter; no by-name GET on the backend)"},
 	"gcx kg entities upsert":      {Cost: "small", Hint: "--domain <d> --type <Type> --name <n> [--scope k=v] [--property k=v] [--ttl 1h] | upsert a custom (API-origin) entity; experimental (KG write API, gated server-side)"},
 	"gcx kg entities delete":      {Cost: "small", Hint: "<Type--Name> --domain <d> [--scope k=v] [--force] | delete a custom entity; --scope must match the value used at upsert; experimental (KG write API, gated server-side)"},
 	"gcx kg relationships upsert": {Cost: "small", Hint: "--type <REL> --domain <d> --from <domain/Type/name> --to <domain/Type/name> [--from-scope k=v] [--to-scope k=v] [--ttl 1h] | upsert a custom edge; both endpoints must already exist; experimental (KG write API, gated server-side)"},

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -49,12 +49,17 @@ const (
 	suppressionByNameFmt     = suppressionPath + "/%s"
 	suppressionsPath         = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alerts"
 	suppressionsValidatePath = suppressionsPath + "-validate"
-	entityLookupPath         = pluginResourcePath + "/asserts/api-server/v1/entity"
-	v2ConfigPath             = pluginResourcePath + "/asserts/api-server/v2/config"
-	v2LogConfigPath          = v2ConfigPath + "/log"
-	v2TraceConfigPath        = v2ConfigPath + "/trace"
-	v2ProfileConfigPath      = v2ConfigPath + "/profile"
-	v2RelabelRulesPath       = v2ConfigPath + "/relabel-rules"
+	// Alert notification configs (AlertConfigController). Structural twin of the
+	// disabled-alert (suppression) endpoints, but with a richer DTO. Reads use
+	// the plural /alerts collection, with optional per-category suffixes.
+	alertConfigsPath        = pluginResourcePath + "/asserts/api-server/v1/config/alerts"
+	alertConfigsCategoryFmt = alertConfigsPath + "/%s"
+	entityLookupPath        = pluginResourcePath + "/asserts/api-server/v1/entity"
+	v2ConfigPath            = pluginResourcePath + "/asserts/api-server/v2/config"
+	v2LogConfigPath         = v2ConfigPath + "/log"
+	v2TraceConfigPath       = v2ConfigPath + "/trace"
+	v2ProfileConfigPath     = v2ConfigPath + "/profile"
+	v2RelabelRulesPath      = v2ConfigPath + "/relabel-rules"
 
 	// KG entity quality reports, proxied through the asserts plugin.
 	qualityBasePath          = pluginResourcePath + "/asserts/kg-quality/v1/entities"
@@ -443,6 +448,82 @@ func (c *Client) GetSuppressions(ctx context.Context) (*Suppressions, error) {
 		return nil, err
 	}
 	return &result, nil
+}
+
+// NotificationCategory scopes ListNotifications to a single alert-config
+// category. An empty value lists all categories.
+type NotificationCategory string
+
+// Known alert notification config categories.
+const (
+	NotificationCategoryRequest  NotificationCategory = "request"
+	NotificationCategoryResource NotificationCategory = "resource"
+	NotificationCategoryHealth   NotificationCategory = "health"
+	NotificationCategorySLO      NotificationCategory = "slo"
+)
+
+// IsValid reports whether c is one of the known notification categories.
+func (c NotificationCategory) IsValid() bool {
+	switch c {
+	case NotificationCategoryRequest, NotificationCategoryResource, NotificationCategoryHealth, NotificationCategorySLO:
+		return true
+	}
+	return false
+}
+
+// AlertConfig represents a single alert notification configuration entry
+// (AlertConfigDto). Distinct from Suppression (a disabled-alert config): this
+// governs how a matched alert notifies — added labels, annotations, the "for"
+// duration, and the silenced flag — rather than whether it is suppressed.
+type AlertConfig struct {
+	Name        string            `json:"name" yaml:"name"`
+	MatchLabels map[string]string `json:"matchLabels,omitempty" yaml:"matchLabels,omitempty"`
+	AlertLabels map[string]string `json:"alertLabels,omitempty" yaml:"alertLabels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	For         string            `json:"for,omitempty" yaml:"for,omitempty"`
+	// Silenced is intentionally NOT omitempty: omitempty drops a false bool, which
+	// would (a) hide the flag on read in exactly the un-silenced state where its
+	// absence is ambiguous, and (b) strip silenced:false on write, making it
+	// impossible to un-silence a config through an upsert. Always serialize it.
+	Silenced  bool   `json:"silenced" yaml:"silenced"`
+	ManagedBy string `json:"managedBy,omitempty" yaml:"managedBy,omitempty"`
+}
+
+// AlertConfigs is the batch payload shape returned by GET /v1/config/alerts
+// (AlertConfigsDto) and accepted by the batch POST.
+type AlertConfigs struct {
+	AlertConfigs []AlertConfig `json:"alertConfigs" yaml:"alertConfigs"`
+}
+
+// ListNotifications retrieves alert notification configs for the tenant,
+// optionally scoped to a single category (request/resource/health/slo). An
+// empty category lists all configs.
+func (c *Client) ListNotifications(ctx context.Context, category NotificationCategory) (*AlertConfigs, error) {
+	path := alertConfigsPath
+	if category != "" {
+		path = fmt.Sprintf(alertConfigsCategoryFmt, url.PathEscape(string(category)))
+	}
+	var result AlertConfigs
+	if err := c.getJSON(ctx, path, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetNotification returns the alert notification config with the given name. The
+// backend exposes no by-name GET, so this fetches the full list and filters
+// client-side, returning a not-found error when no config matches.
+func (c *Client) GetNotification(ctx context.Context, name string) (*AlertConfig, error) {
+	all, err := c.ListNotifications(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	for i := range all.AlertConfigs {
+		if all.AlertConfigs[i].Name == name {
+			return &all.AlertConfigs[i], nil
+		}
+	}
+	return nil, &APIError{StatusCode: http.StatusNotFound, message: fmt.Sprintf("notification config %q not found", name)}
 }
 
 // ConfigFieldError is a single field-level validation failure reported by a

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1017,6 +1017,7 @@ flag. Distinct from "gcx kg suppressions", which manages disabled-alert configs.
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List alert notification configs, optionally filtered by category.",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := listOpts.IO.Validate(); err != nil {
 				return err
@@ -1037,7 +1038,12 @@ flag. Distinct from "gcx kg suppressions", which manages disabled-alert configs.
 			if err != nil {
 				return err
 			}
-			return listOpts.IO.Encode(cmd.OutOrStdout(), configs.AlertConfigs)
+			items := configs.AlertConfigs
+			if items == nil {
+				// Zero results must serialize as [] in machine formats, not null.
+				items = []AlertConfig{}
+			}
+			return listOpts.IO.Encode(cmd.OutOrStdout(), items)
 		},
 	}
 	listOpts.setup(listCmd.Flags())
@@ -1078,7 +1084,7 @@ type notificationsListOpts struct {
 }
 
 func (o *notificationsListOpts) setup(flags *pflag.FlagSet) {
-	flags.StringVar(&o.Category, "category", "", "Filter by category: request, resource, health, or slo.")
+	flags.StringVar(&o.Category, "category", "", "Filter by category: request, resource, health, or slo (server-side, exact match). Empty or omitted lists all categories.")
 	o.IO.RegisterCustomCodec("table", &NotificationTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1002,6 +1002,118 @@ scoped to the entries in the input file, without uploading.`,
 	return cmd
 }
 
+func newNotificationsCommand(loader RESTConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "notifications",
+		Short: "Manage alert notification configs in the Knowledge Graph.",
+		Long: `Manage alert notification configs (AlertConfig) in the Knowledge Graph.
+
+These govern how matched alerts notify — the labels an alert must match, extra
+alert labels and annotations to attach, the "for" duration, and the silenced
+flag. Distinct from "gcx kg suppressions", which manages disabled-alert configs.`,
+	}
+
+	listOpts := &notificationsListOpts{}
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List alert notification configs, optionally filtered by category.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := listOpts.IO.Validate(); err != nil {
+				return err
+			}
+			category := NotificationCategory(listOpts.Category)
+			if listOpts.Category != "" && !category.IsValid() {
+				return fmt.Errorf("invalid --category %q: must be one of request, resource, health, slo", listOpts.Category)
+			}
+			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(cfg)
+			if err != nil {
+				return err
+			}
+			configs, err := client.ListNotifications(cmd.Context(), category)
+			if err != nil {
+				return err
+			}
+			return listOpts.IO.Encode(cmd.OutOrStdout(), configs.AlertConfigs)
+		},
+	}
+	listOpts.setup(listCmd.Flags())
+
+	getOpts := &notificationsGetOpts{}
+	getCmd := &cobra.Command{
+		Use:   "get <name>",
+		Short: "Get an alert notification config by name.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := getOpts.IO.Validate(); err != nil {
+				return err
+			}
+			cfg, err := loader.LoadGrafanaConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient(cfg)
+			if err != nil {
+				return err
+			}
+			config, err := client.GetNotification(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return getOpts.IO.Encode(cmd.OutOrStdout(), config)
+		},
+	}
+	getOpts.setup(getCmd.Flags())
+
+	cmd.AddCommand(listCmd, getCmd)
+	return cmd
+}
+
+type notificationsListOpts struct {
+	Category string
+	IO       cmdio.Options
+}
+
+func (o *notificationsListOpts) setup(flags *pflag.FlagSet) {
+	flags.StringVar(&o.Category, "category", "", "Filter by category: request, resource, health, or slo.")
+	o.IO.RegisterCustomCodec("table", &NotificationTableCodec{})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+}
+
+type notificationsGetOpts struct {
+	IO cmdio.Options
+}
+
+func (o *notificationsGetOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("yaml")
+	o.IO.BindFlags(flags)
+}
+
+// NotificationTableCodec renders alert notification configs as a table.
+type NotificationTableCodec struct{}
+
+func (c *NotificationTableCodec) Format() format.Format { return "table" }
+
+func (c *NotificationTableCodec) Encode(w io.Writer, v any) error {
+	configs, ok := v.([]AlertConfig)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []AlertConfig")
+	}
+	t := style.NewTable("NAME", "MATCH LABELS", "FOR", "SILENCED")
+	for _, ac := range configs {
+		t.Row(ac.Name, scopeStr(ac.MatchLabels), ac.For, strconv.FormatBool(ac.Silenced))
+	}
+	return t.Render(w)
+}
+
+func (c *NotificationTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
 type suppressionsCreateOpts struct {
 	File   string
 	DryRun bool

--- a/internal/providers/kg/export_test.go
+++ b/internal/providers/kg/export_test.go
@@ -188,6 +188,11 @@ func NewPromRulesCommand(loader RESTConfigLoader) *cobra.Command {
 	return newRulesCommand(loader)
 }
 
+// NewNotificationsCommand exposes the notifications command group for tests.
+func NewNotificationsCommand(loader RESTConfigLoader) *cobra.Command {
+	return newNotificationsCommand(loader)
+}
+
 func NewRelationshipsDeleteCommand(loader RESTConfigLoader) *cobra.Command {
 	return newRelationshipsDeleteCommand(loader)
 }

--- a/internal/providers/kg/notifications_test.go
+++ b/internal/providers/kg/notifications_test.go
@@ -1,0 +1,185 @@
+package kg_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/kg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Client tests ---
+
+func TestClient_ListNotifications(t *testing.T) {
+	t.Run("no category hits the collection endpoint", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.True(t, strings.HasSuffix(r.URL.Path, "/config/alerts"),
+				"unexpected path %q", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(kg.AlertConfigs{AlertConfigs: []kg.AlertConfig{
+				{Name: "a", MatchLabels: map[string]string{"job": "svc"}},
+				{Name: "b", For: "5m", Silenced: true},
+			}})
+		}))
+		defer server.Close()
+		client := newTestClient(t, server)
+
+		got, err := client.ListNotifications(t.Context(), "")
+		require.NoError(t, err)
+		require.Len(t, got.AlertConfigs, 2)
+		assert.Equal(t, "a", got.AlertConfigs[0].Name)
+		assert.Equal(t, "5m", got.AlertConfigs[1].For)
+		assert.True(t, got.AlertConfigs[1].Silenced)
+	})
+
+	t.Run("category appends a path suffix", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.True(t, strings.HasSuffix(r.URL.Path, "/config/alerts/slo"),
+				"unexpected path %q", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(kg.AlertConfigs{AlertConfigs: []kg.AlertConfig{{Name: "slo-1"}}})
+		}))
+		defer server.Close()
+		client := newTestClient(t, server)
+
+		got, err := client.ListNotifications(t.Context(), kg.NotificationCategorySLO)
+		require.NoError(t, err)
+		require.Len(t, got.AlertConfigs, 1)
+		assert.Equal(t, "slo-1", got.AlertConfigs[0].Name)
+	})
+}
+
+func TestClient_GetNotification(t *testing.T) {
+	newServer := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(kg.AlertConfigs{AlertConfigs: []kg.AlertConfig{
+				{Name: "wanted", MatchLabels: map[string]string{"job": "svc"}, For: "10m"},
+				{Name: "other"},
+			}})
+		}))
+	}
+
+	t.Run("hit returns the matching config", func(t *testing.T) {
+		server := newServer()
+		defer server.Close()
+		client := newTestClient(t, server)
+
+		got, err := client.GetNotification(t.Context(), "wanted")
+		require.NoError(t, err)
+		assert.Equal(t, "wanted", got.Name)
+		assert.Equal(t, "10m", got.For)
+	})
+
+	t.Run("miss returns a not-found error", func(t *testing.T) {
+		server := newServer()
+		defer server.Close()
+		client := newTestClient(t, server)
+
+		_, err := client.GetNotification(t.Context(), "nope")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+		var apiErr *kg.APIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+	})
+}
+
+// --- Command tests ---
+
+func TestNotifications_List_Table(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/config/alerts"), "unexpected path %q", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(kg.AlertConfigs{AlertConfigs: []kg.AlertConfig{
+			{Name: "api-server-latency", MatchLabels: map[string]string{"asserts_slo_name": "api-server-latency"}, For: "5m", Silenced: false},
+		}})
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	cmd := kg.NewNotificationsCommand(writeLoaderFor(server))
+	cmd.SetArgs([]string{"list"})
+	cmd.SetOut(&stdout)
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, stdout.String(), "api-server-latency")
+	assert.Contains(t, stdout.String(), "5m")
+}
+
+func TestNotifications_List_CategoryFilter(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(kg.AlertConfigs{AlertConfigs: []kg.AlertConfig{{Name: "slo-1"}}})
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	cmd := kg.NewNotificationsCommand(writeLoaderFor(server))
+	cmd.SetArgs([]string{"list", "--category", "slo", "-o", "json"})
+	cmd.SetOut(&stdout)
+	require.NoError(t, cmd.Execute())
+	assert.True(t, strings.HasSuffix(gotPath, "/config/alerts/slo"), "unexpected path %q", gotPath)
+	assert.Contains(t, stdout.String(), "slo-1")
+}
+
+func TestNotifications_List_InvalidCategory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("server must not be hit for an invalid category")
+	}))
+	defer server.Close()
+
+	cmd := kg.NewNotificationsCommand(writeLoaderFor(server))
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"list", "--category", "bogus"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --category")
+}
+
+func TestNotifications_Get_HitAndMiss(t *testing.T) {
+	newServer := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(kg.AlertConfigs{AlertConfigs: []kg.AlertConfig{
+				{Name: "wanted", For: "10m"},
+			}})
+		}))
+	}
+
+	t.Run("hit", func(t *testing.T) {
+		server := newServer()
+		defer server.Close()
+		var stdout bytes.Buffer
+		cmd := kg.NewNotificationsCommand(writeLoaderFor(server))
+		cmd.SetArgs([]string{"get", "wanted", "-o", "json"})
+		cmd.SetOut(&stdout)
+		require.NoError(t, cmd.Execute())
+
+		var got kg.AlertConfig
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+		assert.Equal(t, "wanted", got.Name)
+		assert.Equal(t, "10m", got.For)
+	})
+
+	t.Run("miss", func(t *testing.T) {
+		server := newServer()
+		defer server.Close()
+		cmd := kg.NewNotificationsCommand(writeLoaderFor(server))
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		cmd.SetArgs([]string{"get", "nope"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}

--- a/internal/providers/kg/notifications_test.go
+++ b/internal/providers/kg/notifications_test.go
@@ -146,6 +146,23 @@ func TestNotifications_List_InvalidCategory(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid --category")
 }
 
+func TestNotifications_List_ZeroResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// No alertConfigs key: the decoded slice is nil, which must still
+		// serialize as [] in machine formats, never null.
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	cmd := kg.NewNotificationsCommand(writeLoaderFor(server))
+	cmd.SetArgs([]string{"list", "-o", "json"})
+	cmd.SetOut(&stdout)
+	require.NoError(t, cmd.Execute())
+	assert.JSONEq(t, `[]`, stdout.String())
+}
+
 func TestNotifications_Get_HitAndMiss(t *testing.T) {
 	newServer := func() *httptest.Server {
 		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/providers/kg/provider.go
+++ b/internal/providers/kg/provider.go
@@ -44,6 +44,7 @@ func (p *KGProvider) Commands() []*cobra.Command {
 		newRulesCommand(loader),
 		newModelRulesCommand(loader),
 		newSuppressionsCommand(loader),
+		newNotificationsCommand(loader),
 		newRelabelRulesCommand(loader),
 		// Entities
 		newEntitiesCommand(loader),


### PR DESCRIPTION
## What

Read-path half of #1077, split out for reviewability (~300 lines of code + tests):

- `gcx kg notifications list` — list alert notification configs (AlertConfig) with an optional `--category` filter (`request`/`resource`/`health`/`slo`), table output by default
- `gcx kg notifications get <name>` — fetch one config by name (list-then-filter; the backend has no by-name GET)
- `AlertConfig`/`AlertConfigs` DTOs and the `NotificationCategory` enum
- Table codec, agent annotations, output-class entries, generated reference docs

## Notes for review

- `Silenced` is deliberately **not** `omitempty`: dropping a `false` bool would hide the flag on read exactly in the un-silenced state where its absence is ambiguous (and would break un-silencing once writes land).
- Endpoints are the Asserts `AlertConfigController` read paths (`/v1/config/alerts[/{category}]`) — structural twin of the suppressions (disabled-alerts) endpoints.
- Distinct from `gcx kg suppressions`: notifications govern *how* a matched alert notifies; suppressions govern *whether* it fires.

## Relation to other PRs

- Parent / tracking: #1077 (full feature, already domain-reviewed by @xujiaxj)
- The write half (`upsert`, `delete`, partial-failure batch semantics) follows in a stacked PR based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)