### PR TITLE
feat(kg): add GCX_KG_DATASOURCE_UID datasource-proxy routing override

### DIFF
--- a/docs/architecture/config-system.md
+++ b/docs/architecture/config-system.md
@@ -866,7 +866,9 @@ affect command behavior but are not tied to any specific Grafana context.
 ```go
 // internal/config/cli_options.go
 type CLIOptions struct {
-    AutoApprove bool `env:"GCX_AUTO_APPROVE"`
+    AutoApprove           bool   `env:"GCX_AUTO_APPROVE"`
+    DisableUpdateNotifier string `env:"GCX_NO_UPDATE_NOTIFIER"`
+    KGDatasourceUID       string `env:"GCX_KG_DATASOURCE_UID"`
 }
 
 func LoadCLIOptions() (CLIOptions, error)
@@ -880,10 +882,17 @@ independently — they do not read from the config file or affect any context.
 **Current usage:** The `delete` command calls `LoadCLIOptions()` in its `RunE`
 and, when `AutoApprove` is true (or `--yes`/`-y` is passed), automatically
 enables the `--force` flag for non-interactive operation in CI/CD pipelines.
+The KG provider's client calls `LoadCLIOptions()` in its constructor and, when
+`KGDatasourceUID` is set, routes all KG API traffic through the KG datasource
+proxy instead of the asserts plugin resource proxy (development escape hatch;
+a parse error fails client construction rather than silently dropping the
+override).
 
 | Env Var | CLI Flag | Effect |
 |---------|----------|--------|
 | `GCX_AUTO_APPROVE` | `--yes` / `-y` | Auto-enables `--force` on delete |
+| `GCX_NO_UPDATE_NOTIFIER` | — | Disables the periodic gcx/skill update notifier |
+| `GCX_KG_DATASOURCE_UID` | — | Dev-only: KG traffic via datasource proxy (`1`/`true` = default UID `grafana-knowledgegraph-datasource`) |
 
 See [environment-variables.md](../design/environment-variables.md) for the full environment
 variable reference.

--- a/docs/design/environment-variables.md
+++ b/docs/design/environment-variables.md
@@ -46,6 +46,7 @@ stack because its TLS and proxy settings affect the transport.
 | `GCX_TELEMETRY` | global | `enabled`, `disabled`, or `log`; takes precedence over `DO_NOT_TRACK` and config |
 | `DO_NOT_TRACK` | global | Disable anonymous telemetry when `1` or `true` unless `GCX_TELEMETRY` overrides it |
 | `GCX_NO_UPDATE_NOTIFIER` | global | Disable the periodic gcx/skill update notifier when non-empty |
+| `GCX_KG_DATASOURCE_UID` | global | Development-only: route KG API traffic through the KG datasource proxy instead of the asserts plugin resource proxy |
 | `NO_COLOR` | global | Disable color output ([no-color.org](https://no-color.org/)) |
 
 ### Provider Variables
@@ -69,8 +70,9 @@ See [../architecture/config-system.md](../architecture/config-system.md) for the
 | Variable | Effect | Documentation |
 |----------|--------|---------------|
 | `GCX_AUTO_APPROVE` | Auto-enable `--force` on delete operations | See `docs/reference/environment-variables/` |
+| `GCX_KG_DATASOURCE_UID` | Route all KG API traffic through the KG datasource proxy (`/api/datasources/proxy/uid/<uid>`) instead of the `grafana-asserts-app` plugin resource proxy. Development escape hatch. `1`/`true` selects the default provisioned UID (`grafana-knowledgegraph-datasource`); any other value is used as the datasource UID verbatim | See `docs/reference/environment-variables/` |
 
-Accepts: `1`, `true`, `0`, `false` (parsed by `caarlos0/env/v11`)
+`GCX_AUTO_APPROVE` accepts: `1`, `true`, `0`, `false` (parsed by `caarlos0/env/v11`)
 
 **Implementation:** `internal/config/cli_options.go` - `CLIOptions` struct loaded via `LoadCLIOptions()`
 

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -11,6 +11,16 @@ GCX_TELEMETRY.
 AutoApprove automatically enables the --force flag on delete operations,
 enabling non-interactive operation in CI/CD pipelines.
 
+## `GCX_KG_DATASOURCE_UID`
+
+KGDatasourceUID routes all Knowledge Graph API traffic through the KG
+datasource proxy (/api/datasources/proxy/uid/<uid>) instead of the
+grafana-asserts-app plugin resource proxy. The datasource mirrors all of
+the plugin's /resources routes. Set to "1" or "true" to use the default
+provisioned UID (grafana-knowledgegraph-datasource), or to an explicit
+datasource UID. Development escape hatch; unset means the default
+plugin route.
+
 ## `GCX_NO_UPDATE_NOTIFIER`
 
 DisableUpdateNotifier disables the periodic notifier that reminds users

--- a/internal/config/cli_options.go
+++ b/internal/config/cli_options.go
@@ -13,6 +13,15 @@ type CLIOptions struct {
 	// when their installed gcx skills can be updated. Any non-empty value
 	// disables the notifier (NO_COLOR convention).
 	DisableUpdateNotifier string `env:"GCX_NO_UPDATE_NOTIFIER"`
+
+	// KGDatasourceUID routes all Knowledge Graph API traffic through the KG
+	// datasource proxy (/api/datasources/proxy/uid/<uid>) instead of the
+	// grafana-asserts-app plugin resource proxy. The datasource mirrors all of
+	// the plugin's /resources routes. Set to "1" or "true" to use the default
+	// provisioned UID (grafana-knowledgegraph-datasource), or to an explicit
+	// datasource UID. Development escape hatch; unset means the default
+	// plugin route.
+	KGDatasourceUID string `env:"GCX_KG_DATASOURCE_UID"`
 }
 
 // LoadCLIOptions loads CLI options from environment variables.

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -21,43 +21,57 @@ import (
 // ruleFetchConcurrency caps parallel GetRule calls during ListRules fan-out.
 const ruleFetchConcurrency = 10
 
+// pluginResourcePath is the default base path for all KG API traffic: the
+// grafana-asserts-app plugin's resource proxy. The endpoint paths below are
+// relative to a base path so the client can swap in the KG datasource proxy
+// (/api/datasources/proxy/uid/<uid>), which mirrors all of the plugin's
+// /resources routes — see NewClient and GCX_KG_DATASOURCE_UID.
 const pluginResourcePath = "/api/plugins/grafana-asserts-app/resources"
 
+// datasourceProxyPathFmt is the base path for KG API traffic routed through
+// the KG datasource proxy instead of the plugin resource proxy. %s is the
+// datasource UID.
+const datasourceProxyPathFmt = "/api/datasources/proxy/uid/%s"
+
+// defaultKGDatasourceUID is the default UID the KG datasource is provisioned
+// with; used when GCX_KG_DATASOURCE_UID is set to "1" or "true".
+const defaultKGDatasourceUID = "grafana-knowledgegraph-datasource"
+
 const (
-	statusPath               = pluginResourcePath + "/asserts/api-server/v1/stack/status"
-	entitiesPath             = pluginResourcePath + "/asserts/api-server/v1/entity/info"
-	entityTypesPath          = pluginResourcePath + "/asserts/api-server/v1/entity_type"
+	statusPath               = "/asserts/api-server/v1/stack/status"
+	entitiesPath             = "/asserts/api-server/v1/entity/info"
+	entityTypesPath          = "/asserts/api-server/v1/entity_type"
 	entityCountPath          = entityTypesPath + "/count"
-	scopesPath               = pluginResourcePath + "/asserts/api-server/v1/entity_scope"
-	assertionsPath           = pluginResourcePath + "/asserts/api-server/v1/assertions"
+	scopesPath               = "/asserts/api-server/v1/entity_scope"
+	assertionsPath           = "/asserts/api-server/v1/assertions"
 	assertMetricPath         = assertionsPath + "/entity-metric"
 	assertLLMPath            = assertionsPath + "/llm-summary"
-	sourceMetricPath         = pluginResourcePath + "/asserts/api-server/v1/assertion/source-metrics"
-	searchPath               = pluginResourcePath + "/asserts/api-server/v1/search"
+	sourceMetricPath         = "/asserts/api-server/v1/assertion/source-metrics"
+	searchPath               = "/asserts/api-server/v1/search"
 	searchAssertPath         = searchPath + "/assertions"
 	searchSamplePath         = searchPath + "/sample"
-	alertInspectionPath      = pluginResourcePath + "/asserts/api-server/v1/alert-inspection"
-	rulesPath                = pluginResourcePath + "/asserts/api-server/v1/config/prom-rules"
+	alertInspectionPath      = "/asserts/api-server/v1/alert-inspection"
+	rulesPath                = "/asserts/api-server/v1/config/prom-rules"
 	ruleByNameFmt            = rulesPath + "/%s"
 	rulesSchemaPath          = rulesPath + "/schema"
 	rulesValidateSyncPath    = rulesPath + "-validate-sync"
-	modelRulesPath           = pluginResourcePath + "/asserts/api-server/v1/config/model-rules"
+	modelRulesPath           = "/asserts/api-server/v1/config/model-rules"
 	modelRulesByNameFmt      = modelRulesPath + "/%s"
 	modelRulesSchemaPath     = modelRulesPath + "/schema"
 	modelRulesValidatePath   = modelRulesPath + "-validate"
-	suppressionPath          = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alert"
+	suppressionPath          = "/asserts/api-server/v1/config/disabled-alert"
 	suppressionByNameFmt     = suppressionPath + "/%s"
-	suppressionsPath         = pluginResourcePath + "/asserts/api-server/v1/config/disabled-alerts"
+	suppressionsPath         = "/asserts/api-server/v1/config/disabled-alerts"
 	suppressionsValidatePath = suppressionsPath + "-validate"
-	entityLookupPath         = pluginResourcePath + "/asserts/api-server/v1/entity"
-	v2ConfigPath             = pluginResourcePath + "/asserts/api-server/v2/config"
+	entityLookupPath         = "/asserts/api-server/v1/entity"
+	v2ConfigPath             = "/asserts/api-server/v2/config"
 	v2LogConfigPath          = v2ConfigPath + "/log"
 	v2TraceConfigPath        = v2ConfigPath + "/trace"
 	v2ProfileConfigPath      = v2ConfigPath + "/profile"
 	v2RelabelRulesPath       = v2ConfigPath + "/relabel-rules"
 
-	// KG entity quality reports, proxied through the asserts plugin.
-	qualityBasePath          = pluginResourcePath + "/asserts/kg-quality/v1/entities"
+	// KG entity quality reports.
+	qualityBasePath          = "/asserts/kg-quality/v1/entities"
 	qualityReportsPath       = qualityBasePath + "/quality-reports"
 	qualityReportByEntityFmt = qualityBasePath + "/%s/%s/quality-report"
 
@@ -66,13 +80,13 @@ const (
 	// in the query string (type/name are not path segments), so names containing
 	// '/' are addressable without Tomcat rejecting encoded solidus.
 	//
-	// Routed through the asserts plugin's resource proxy: the plugin backend
-	// forwards unmatched resource paths to the asserts cell gateway with the
-	// stack's Basic auth, and the gateway maps /apis/kg.grafana.com/* to the
-	// KG api-server. The bare /apis/kg.grafana.com group is not registered
-	// with Grafana's API aggregator, so it is not reachable on the stack URL
-	// directly.
-	kgWriteAPIBase     = pluginResourcePath + "/apis/kg.grafana.com/v1alpha1/namespaces/%s"
+	// Routed through the asserts plugin's resource proxy (or the KG datasource
+	// proxy, which mirrors it): the backend forwards unmatched resource paths
+	// to the asserts cell gateway with the stack's Basic auth, and the gateway
+	// maps /apis/kg.grafana.com/* to the KG api-server. The bare
+	// /apis/kg.grafana.com group is not registered with Grafana's API
+	// aggregator, so it is not reachable on the stack URL directly.
+	kgWriteAPIBase     = "/apis/kg.grafana.com/v1alpha1/namespaces/%s"
 	kgEntitiesPathFmt  = kgWriteAPIBase + "/entities"
 	kgRelationshipsFmt = kgWriteAPIBase + "/relationships"
 )
@@ -99,21 +113,41 @@ func (t RelabelRuleType) IsValid() bool {
 type Client struct {
 	httpClient *http.Client
 	host       string
+	basePath   string
 	namespace  string
 }
 
 // NewClient creates a new KG client from the given REST config.
+//
+// By default all requests go through the grafana-asserts-app plugin resource
+// proxy. When GCX_KG_DATASOURCE_UID is set (development escape hatch), they
+// route through the KG datasource proxy instead, which mirrors all of the
+// plugin's /resources routes.
 func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 	httpClient, err := rest.HTTPClientFor(&cfg.Config)
 	if err != nil {
 		return nil, fmt.Errorf("kg: failed to create HTTP client: %w", err)
 	}
-	return &Client{httpClient: httpClient, host: cfg.Host, namespace: cfg.Namespace}, nil
+	basePath := pluginResourcePath
+	if cliOpts, err := config.LoadCLIOptions(); err == nil && cliOpts.KGDatasourceUID != "" {
+		uid := cliOpts.KGDatasourceUID
+		if uid == "1" || uid == "true" {
+			uid = defaultKGDatasourceUID
+		}
+		basePath = fmt.Sprintf(datasourceProxyPathFmt, url.PathEscape(uid))
+	}
+	return &Client{httpClient: httpClient, host: cfg.Host, basePath: basePath, namespace: cfg.Namespace}, nil
+}
+
+// url builds the absolute request URL for an endpoint path (which may already
+// carry a query string) by prepending the host and active base path.
+func (c *Client) url(path string) string {
+	return c.host + c.basePath + path
 }
 
 // getJSON performs a GET request and decodes the JSON response into v.
 func (c *Client) getJSON(ctx context.Context, path string, v any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.host+path, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(path), nil)
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}
@@ -147,7 +181,7 @@ func (c *Client) doJSON(ctx context.Context, method, path string, body, v any) e
 		bodyReader = bytes.NewReader(b)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.host+path, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, c.url(path), bodyReader)
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}
@@ -181,7 +215,7 @@ func (c *Client) doJSONStatus(ctx context.Context, method, path string, body, v 
 		}
 		bodyReader = bytes.NewReader(b)
 	}
-	req, err := http.NewRequestWithContext(ctx, method, c.host+path, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, c.url(path), bodyReader)
 	if err != nil {
 		return 0, fmt.Errorf("kg: create request: %w", err)
 	}
@@ -206,7 +240,7 @@ func (c *Client) doJSONStatus(ctx context.Context, method, path string, body, v 
 
 // doYAML performs an HTTP request with a YAML body.
 func (c *Client) doYAML(ctx context.Context, method, path, yamlContent string) error {
-	req, err := http.NewRequestWithContext(ctx, method, c.host+path, strings.NewReader(yamlContent))
+	req, err := http.NewRequestWithContext(ctx, method, c.url(path), strings.NewReader(yamlContent))
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}
@@ -385,7 +419,7 @@ func (c *Client) GetModelRulesSchema(ctx context.Context) (map[string]any, error
 // DeleteModelRules deletes a custom model rules configuration by name.
 func (c *Client) DeleteModelRules(ctx context.Context, name string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
-		c.host+fmt.Sprintf(modelRulesByNameFmt, url.PathEscape(name)), nil)
+		c.url(fmt.Sprintf(modelRulesByNameFmt, url.PathEscape(name))), nil)
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}
@@ -421,7 +455,7 @@ func (c *Client) UpsertSuppression(ctx context.Context, s Suppression) error {
 // DeleteSuppression deletes a single suppression by name.
 func (c *Client) DeleteSuppression(ctx context.Context, name string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
-		c.host+fmt.Sprintf(suppressionByNameFmt, url.PathEscape(name)), nil)
+		c.url(fmt.Sprintf(suppressionByNameFmt, url.PathEscape(name))), nil)
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}
@@ -532,7 +566,7 @@ func (c *Client) ValidatePromRules(ctx context.Context, yamlContent string) erro
 // response: nil on 2xx, a *ConfigValidationError on 422 (per-field errors), or a
 // generic *APIError otherwise. kind names the config family for error messages.
 func (c *Client) validateConfig(ctx context.Context, path, contentType string, body []byte, kind string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.host+path, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path), bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}
@@ -631,7 +665,7 @@ func (c *Client) GetRelabelRules(ctx context.Context, t RelabelRuleType) (map[st
 		return nil, fmt.Errorf("kg: invalid relabel rule type %q", t)
 	}
 	path := v2RelabelRulesPath + "/" + string(t)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.host+path, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(path), nil)
 	if err != nil {
 		return nil, fmt.Errorf("kg: create request: %w", err)
 	}
@@ -704,7 +738,7 @@ func (c *Client) LookupEntity(ctx context.Context, entityType, name string, scop
 		q.Set("domain", domain)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.host+entityLookupPath+"?"+q.Encode(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(entityLookupPath+"?"+q.Encode()), nil)
 	if err != nil {
 		return nil, fmt.Errorf("kg: create request: %w", err)
 	}
@@ -1065,7 +1099,7 @@ func (c *Client) ListRules(ctx context.Context) ([]Rule, error) {
 // Backend: DELETE /v1/config/prom-rules/{name}.
 func (c *Client) DeleteRule(ctx context.Context, name string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
-		c.host+fmt.Sprintf(ruleByNameFmt, url.PathEscape(name)), nil)
+		c.url(fmt.Sprintf(ruleByNameFmt, url.PathEscape(name))), nil)
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}
@@ -1128,7 +1162,7 @@ func (c *Client) DeleteRelationship(ctx context.Context, relType string, from, t
 	}
 	addRef("from", from)
 	addRef("to", to)
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.host+path+"?"+q.Encode(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.url(path)+"?"+q.Encode(), nil)
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}
@@ -1172,7 +1206,7 @@ func (c *Client) DeleteEntity(ctx context.Context, domain, entityType, name stri
 	for k, v := range scope {
 		q.Set("scope["+k+"]", v)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.host+path+"?"+q.Encode(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.url(path)+"?"+q.Encode(), nil)
 	if err != nil {
 		return fmt.Errorf("kg: create request: %w", err)
 	}

--- a/internal/providers/kg/client.go
+++ b/internal/providers/kg/client.go
@@ -128,8 +128,14 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("kg: failed to create HTTP client: %w", err)
 	}
+	// Fail loudly on a CLI-options parse error instead of silently ignoring an
+	// explicitly requested datasource-proxy override.
+	cliOpts, err := config.LoadCLIOptions()
+	if err != nil {
+		return nil, fmt.Errorf("kg: load CLI options: %w", err)
+	}
 	basePath := pluginResourcePath
-	if cliOpts, err := config.LoadCLIOptions(); err == nil && cliOpts.KGDatasourceUID != "" {
+	if cliOpts.KGDatasourceUID != "" {
 		uid := cliOpts.KGDatasourceUID
 		if uid == "1" || uid == "true" {
 			uid = defaultKGDatasourceUID

--- a/internal/providers/kg/client_test.go
+++ b/internal/providers/kg/client_test.go
@@ -17,6 +17,9 @@ import (
 
 func newTestClient(t *testing.T, server *httptest.Server) *kg.Client {
 	t.Helper()
+	// Pin the default plugin-proxy route so a developer's exported
+	// GCX_KG_DATASOURCE_UID cannot flip path expectations in this suite.
+	t.Setenv("GCX_KG_DATASOURCE_UID", "")
 	cfg := config.NamespacedRESTConfig{
 		Config:    rest.Config{Host: server.URL},
 		Namespace: "stack-123",
@@ -30,6 +33,65 @@ func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		panic(err)
+	}
+}
+
+func TestClient_BasePath_PluginDefault(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		writeJSON(w, kg.Status{Status: "complete"})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	_, err := client.GetStatus(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "/api/plugins/grafana-asserts-app/resources/asserts/api-server/v1/stack/status", gotPath)
+}
+
+func TestClient_BasePath_DatasourceProxyOverride(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		wantPath string
+	}{
+		{
+			name:     "explicit uid",
+			envValue: "my-kg-ds",
+			wantPath: "/api/datasources/proxy/uid/my-kg-ds/asserts/api-server/v1/stack/status",
+		},
+		{
+			name:     "1 uses default provisioned uid",
+			envValue: "1",
+			wantPath: "/api/datasources/proxy/uid/grafana-knowledgegraph-datasource/asserts/api-server/v1/stack/status",
+		},
+		{
+			name:     "true uses default provisioned uid",
+			envValue: "true",
+			wantPath: "/api/datasources/proxy/uid/grafana-knowledgegraph-datasource/asserts/api-server/v1/stack/status",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				writeJSON(w, kg.Status{Status: "complete"})
+			}))
+			defer server.Close()
+
+			t.Setenv("GCX_KG_DATASOURCE_UID", tt.envValue)
+			cfg := config.NamespacedRESTConfig{
+				Config:    rest.Config{Host: server.URL},
+				Namespace: "stack-123",
+			}
+			client, err := kg.NewClient(cfg)
+			require.NoError(t, err)
+			_, err = client.GetStatus(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPath, gotPath)
+		})
 	}
 }
 

--- a/internal/providers/kg/client_test.go
+++ b/internal/providers/kg/client_test.go
@@ -95,6 +95,104 @@ func TestClient_BasePath_DatasourceProxyOverride(t *testing.T) {
 	}
 }
 
+// TestClient_BasePath_OverrideAllBuilders exercises one representative of each
+// request-construction path (getJSON, postJSON/doJSON, doYAML, doJSONStatus,
+// and the manual DELETE builder with query params) under the datasource-proxy
+// override, so a builder that misses c.url cannot slip through.
+func TestClient_BasePath_OverrideAllBuilders(t *testing.T) {
+	const proxyBase = "/api/datasources/proxy/uid/my-kg-ds"
+
+	var gotPath, gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		writeJSON(w, map[string]any{})
+	}))
+	defer server.Close()
+
+	t.Setenv("GCX_KG_DATASOURCE_UID", "my-kg-ds")
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: server.URL},
+		Namespace: "stack-123",
+	}
+	client, err := kg.NewClient(cfg)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		call      func() error
+		wantPath  string
+		wantQuery string
+	}{
+		{
+			name: "getJSON (GetStatus)",
+			call: func() error {
+				_, err := client.GetStatus(t.Context())
+				return err
+			},
+			wantPath: proxyBase + "/asserts/api-server/v1/stack/status",
+		},
+		{
+			name: "postJSON (Search)",
+			call: func() error {
+				_, err := client.Search(t.Context(), kg.SearchRequest{})
+				return err
+			},
+			wantPath: proxyBase + "/asserts/api-server/v1/search",
+		},
+		{
+			name: "doYAML (UploadPromRules)",
+			call: func() error {
+				return client.UploadPromRules(t.Context(), "name: test")
+			},
+			wantPath: proxyBase + "/asserts/api-server/v1/config/prom-rules",
+		},
+		{
+			name: "doJSONStatus (UpsertEntity)",
+			call: func() error {
+				_, _, err := client.UpsertEntity(t.Context(), kg.EntityWriteRequest{
+					Domain: "custom", Type: "Service", Name: "svc",
+				})
+				return err
+			},
+			wantPath: proxyBase + "/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/entities",
+		},
+		{
+			name: "manual DELETE with query (DeleteEntity)",
+			call: func() error {
+				return client.DeleteEntity(t.Context(), "custom", "Service", "svc", map[string]string{"env": "prod"})
+			},
+			wantPath:  proxyBase + "/apis/kg.grafana.com/v1alpha1/namespaces/stack-123/entities",
+			wantQuery: "domain=custom&name=svc&scope%5Benv%5D=prod&type=Service",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotQuery = "", ""
+			require.NoError(t, tt.call())
+			assert.Equal(t, tt.wantPath, gotPath)
+			if tt.wantQuery != "" {
+				assert.Equal(t, tt.wantQuery, gotQuery)
+			}
+		})
+	}
+}
+
+// TestNewClient_CLIOptionsParseError guards against a CLI-options parse error
+// silently disabling an explicitly requested datasource-proxy override:
+// NewClient must fail loudly instead.
+func TestNewClient_CLIOptionsParseError(t *testing.T) {
+	t.Setenv("GCX_AUTO_APPROVE", "notabool")
+	t.Setenv("GCX_KG_DATASOURCE_UID", "my-kg-ds")
+	cfg := config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: "http://example.invalid"},
+		Namespace: "stack-123",
+	}
+	_, err := kg.NewClient(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GCX_AUTO_APPROVE")
+}
+
 func TestClient_GetStatus(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

Adds a development escape hatch to route **all** Knowledge Graph API traffic through the KG datasource proxy (`/api/datasources/proxy/uid/<uid>`) instead of the `grafana-asserts-app` plugin resource proxy. The KG datasource mirrors all of the plugin's `/resources` routes, so every endpoint — reads, config (prom rules, model rules, suppressions, relabel), quality reports, and the `kg.grafana.com` write API — works unchanged through either base path.

## Usage

```bash
GCX_KG_DATASOURCE_UID=1 gcx ...        # default provisioned UID: grafana-knowledgegraph-datasource
GCX_KG_DATASOURCE_UID=my-uid gcx ...   # explicit datasource UID
```

Unset keeps the existing plugin route (default, unchanged).

## Changes

- `internal/providers/kg/client.go`: endpoint path constants are now relative to a base path; `Client` carries a `basePath` resolved once in `NewClient`, and a single `url()` helper builds request URLs at all 12 request sites.
- `internal/config/cli_options.go`: new `KGDatasourceUID` CLI option (`GCX_KG_DATASOURCE_UID`), picked up by the env-var reference generator.
- `docs/reference/environment-variables/index.md`: regenerated; `docs/design/environment-variables.md` and `docs/architecture/config-system.md` updated to document the new variable.
- Tests: default-route assertion plus a table test covering explicit UID, `1`, and `true`; the shared `newTestClient` helper pins the env var empty so a developer's exported override cannot flip the suite's 61 plugin-path assertions. A second table test drives one representative of each request-construction path (`getJSON`, `postJSON`, `doYAML`, `doJSONStatus`, manual DELETE with query params) under the override.

## Behavior change (review follow-up)

`kg.NewClient` previously ignored a `LoadCLIOptions()` parse error. It now returns it, so KG commands fail loudly with e.g. `GCX_AUTO_APPROVE=notabool` set in the environment instead of silently dropping an explicitly requested `GCX_KG_DATASOURCE_UID` override. Previously such an environment would have run KG commands normally (with the parse error swallowed); a broken CLI-options environment is now surfaced at client construction.

## Testing

- `golangci-lint run` — 0 issues
- `GCX_AGENT_MODE=false go test -race ./...` — green
- env-var reference regenerated, no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
