### PR TITLE
Set AllowsEdits on gcx-managed resources so dashboards stay UI-editable

### DIFF
--- a/internal/resources/process/managerfields.go
+++ b/internal/resources/process/managerfields.go
@@ -22,8 +22,8 @@ func (m *ManagerFieldsAppender) Process(r *resources.Resource) error {
 	}
 
 	r.Raw.SetManagerProperties(utils.ManagerProperties{
-		Kind:     resources.ResourceManagerKind,
-		Identity: "gcx", // TODO: use version information to set the identity.
+		Kind:        resources.ResourceManagerKind,
+		Identity:    "gcx", // TODO: use version information to set the identity.
 		AllowsEdits: true,
 	})
 

--- a/internal/resources/process/managerfields.go
+++ b/internal/resources/process/managerfields.go
@@ -24,6 +24,7 @@ func (m *ManagerFieldsAppender) Process(r *resources.Resource) error {
 	r.Raw.SetManagerProperties(utils.ManagerProperties{
 		Kind:     resources.ResourceManagerKind,
 		Identity: "gcx", // TODO: use version information to set the identity.
+		AllowsEdits: true,
 	})
 
 	// TODO: should we set timestamp & checksum as well?

--- a/internal/resources/process/managerfields_test.go
+++ b/internal/resources/process/managerfields_test.go
@@ -49,9 +49,10 @@ func TestManagerFieldsAppender(t *testing.T) {
 						"name":      "example",
 						"namespace": "default",
 						"annotations": map[string]any{
-							utils.AnnoKeyManagerKind:     string(resources.ResourceManagerKind),
-							utils.AnnoKeyManagerIdentity: "gcx",
-							utils.AnnoKeySourcePath:      "file://some/test/path.json",
+							utils.AnnoKeyManagerKind:        string(resources.ResourceManagerKind),
+							utils.AnnoKeyManagerIdentity:    "gcx",
+							utils.AnnoKeyManagerAllowsEdits: "true",
+							utils.AnnoKeySourcePath:         "file://some/test/path.json",
 						},
 					},
 					"spec": map[string]any{
@@ -130,9 +131,10 @@ func TestManagerFieldsAppender(t *testing.T) {
 						"name":      "example",
 						"namespace": "default",
 						"annotations": map[string]any{
-							utils.AnnoKeyManagerKind:     string(resources.ResourceManagerKind),
-							utils.AnnoKeyManagerIdentity: "gcx",
-							utils.AnnoKeySourcePath:      "file://other/test/path.json",
+							utils.AnnoKeyManagerKind:        string(resources.ResourceManagerKind),
+							utils.AnnoKeyManagerIdentity:    "gcx",
+							utils.AnnoKeyManagerAllowsEdits: "true",
+							utils.AnnoKeySourcePath:         "file://other/test/path.json",
 						},
 					},
 					"spec": map[string]any{


### PR DESCRIPTION
If you create a dashboard with gcx, it is not allowing you to update in the UI afterwards because it has managed by fields without the allows edit, so it fails the check [here](https://github.com/grafana/grafana/blob/b7a238f355d155542fc6eabcbda96b48a218d17c/public/app/features/dashboard-scene/scene/DashboardScene.tsx#L1477-L1491). With [ManagerProperties.AllowsEdits](https://github.com/grafana/grafana/blob/b7a238f355d155542fc6eabcbda96b48a218d17c/pkg/apimachinery/utils/manager.go#L1-L20) set, users can update the dashboard after gcx creates it.

Fixes #837