### PR TITLE
feat(irm): resolve PIR document links from incident hook runs

### DIFF
--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -265,6 +265,7 @@
  "gcx irm incidents close": "finite",
  "gcx irm incidents create": "finite",
  "gcx irm incidents get": "finite",
+ "gcx irm incidents get-pir": "finite",
  "gcx irm incidents list": "finite",
  "gcx irm incidents list-activity": "finite",
  "gcx irm incidents list-contexts": "finite",

--- a/docs/reference/cli/gcx_irm_incidents.md
+++ b/docs/reference/cli/gcx_irm_incidents.md
@@ -27,6 +27,7 @@ Manage incidents.
 * [gcx irm incidents close](gcx_irm_incidents_close.md)	 - Close (resolve) an incident.
 * [gcx irm incidents create](gcx_irm_incidents_create.md)	 - Create a new incident from a file.
 * [gcx irm incidents get](gcx_irm_incidents_get.md)	 - Get a single incident by ID.
+* [gcx irm incidents get-pir](gcx_irm_incidents_get-pir.md)	 - Get the post-incident review (PIR) document URL for an incident.
 * [gcx irm incidents list](gcx_irm_incidents_list.md)	 - List incidents.
 * [gcx irm incidents list-activity](gcx_irm_incidents_list-activity.md)	 - List activity items for an incident.
 * [gcx irm incidents list-contexts](gcx_irm_incidents_list-contexts.md)	 - List contexts attached to an incident.

--- a/docs/reference/cli/gcx_irm_incidents_get-pir.md
+++ b/docs/reference/cli/gcx_irm_incidents_get-pir.md
@@ -11,6 +11,9 @@ Google Workspace integration creates them, so the link exists only where that
 integration ran. It is recorded on the hook run that copied the PIR template,
 which this command reads and resolves.
 
+An incident can have more than one PIR document if the template was copied
+again; the most recently created one is reported.
+
 An incident without a PIR document prints nothing and exits 0.
 
 ```

--- a/docs/reference/cli/gcx_irm_incidents_get-pir.md
+++ b/docs/reference/cli/gcx_irm_incidents_get-pir.md
@@ -1,0 +1,44 @@
+## gcx irm incidents get-pir
+
+Get the post-incident review (PIR) document URL for an incident.
+
+### Synopsis
+
+Resolve the post-incident review (PIR) document URL for an incident.
+
+The URL is not carried in the incident payload. PIRs are optional and only the
+Google Workspace integration creates them, so the link exists only where that
+integration ran. It is recorded on the hook run that copied the PIR template,
+which this command reads and resolves.
+
+An incident without a PIR document prints nothing and exits 0.
+
+```
+gcx irm incidents get-pir <incident-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for get-pir
+      --jq string       jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string     Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string   Output format. One of: agents, json, text, yaml (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx irm incidents](gcx_irm_incidents.md)	 - Manage incidents.
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -249,6 +249,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx irm incidents close":           {Cost: "small"},
 	"gcx irm incidents create":          {Cost: "small"},
 	"gcx irm incidents get":             {Cost: "small"},
+	"gcx irm incidents get-pir":         {Cost: "small"},
 	"gcx irm incidents list":            {Cost: "small"},
 	"gcx irm incidents list-activity":   {Cost: "small"},
 	"gcx irm incidents list-contexts":   {Cost: "small"},

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -38,7 +38,41 @@ const (
 	actAddPath        = incidentBasePath + "/ActivityService.AddActivity"
 	sevGetPath        = incidentLegacyBasePath + "/SeveritiesService.GetOrgSeverities"
 	ctxQueryPath      = incidentLegacyBasePath + "/IncidentContextService.QueryIncidentContext"
+	// IntegrationService is likewise not part of the documented v1 API and
+	// is served from the unversioned base path.
+	hookRunsPath = incidentLegacyBasePath + "/IntegrationService.GetHookRuns"
 )
+
+// pirFileURLField is the hook-run metadata field holding the document URL.
+const pirFileURLField = "fileURL"
+
+// isPIRHookID reports whether the hook copies a post-incident review template
+// into a document. PIRs are optional and only the Google Workspace integration
+// creates them, so these are the only hook runs that can carry a PIR link.
+func isPIRHookID(hookID string) bool {
+	switch hookID {
+	case "grate.google.copyFile", "grate.googleworkspace.copyTemplate":
+		return true
+	default:
+		return false
+	}
+}
+
+// pirURLFromHookRuns returns the PIR document URL recorded on a PIR-creating
+// hook run, or "" when the incident has no PIR document.
+func pirURLFromHookRuns(runs []HookRun) string {
+	for _, run := range runs {
+		if !isPIRHookID(run.HookID) || run.Metadata == nil {
+			continue
+		}
+		for _, f := range run.Metadata.Fields {
+			if f.Key == pirFileURLField && f.Value != "" {
+				return f.Value
+			}
+		}
+	}
+	return ""
+}
 
 // Client is an HTTP client for the Grafana IRM Incidents API.
 type IncidentClient struct {
@@ -512,6 +546,50 @@ func (c *IncidentClient) GetSeverities(ctx context.Context) ([]Severity, error) 
 	}
 
 	return result.Severities, nil
+}
+
+// GetHookRuns returns the integration hook runs recorded against an incident.
+func (c *IncidentClient) GetHookRuns(ctx context.Context, incidentID string) ([]HookRun, error) {
+	if incidentID == "" {
+		return nil, errors.New("incidents: GetHookRuns: incidentID is required")
+	}
+
+	body, err := json.Marshal(getHookRunsRequest{IncidentID: incidentID})
+	if err != nil {
+		return nil, fmt.Errorf("incidents: marshal hook runs request: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, hookRunsPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("incidents: get hook runs for %s: %w", incidentID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, providers.HandleErrorResponse(resp)
+	}
+
+	var result getHookRunsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("incidents: decode hook runs response: %w", err)
+	}
+	// The API can report failure in-band on a 200 response.
+	if result.Error != "" {
+		return nil, fmt.Errorf("incidents: get hook runs for %s: %s", incidentID, result.Error)
+	}
+
+	return result.HookRuns, nil
+}
+
+// GetPIRURL resolves the post-incident review document URL for an incident.
+// The URL is not part of the incident payload: it is recorded on the hook run
+// of the integration that created the PIR. Returns "" when there is no PIR.
+func (c *IncidentClient) GetPIRURL(ctx context.Context, incidentID string) (string, error) {
+	runs, err := c.GetHookRuns(ctx, incidentID)
+	if err != nil {
+		return "", err
+	}
+	return pirURLFromHookRuns(runs), nil
 }
 
 // queryIncidentPreviews fetches a single page. cursor is nil for the first

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -46,32 +46,84 @@ const (
 // pirFileURLField is the hook-run metadata field holding the document URL.
 const pirFileURLField = "fileURL"
 
-// isPIRHookID reports whether the hook copies a post-incident review template
-// into a document. PIRs are optional and only the Google Workspace integration
-// creates them, so these are the only hook runs that can carry a PIR link.
-func isPIRHookID(hookID string) bool {
+// pirHookRank ranks the hooks that copy a post-incident review template into a
+// document, and reports 0 for every other hook. PIRs are optional and only the
+// Google Workspace integration creates them, so these are the only hook runs
+// that can carry a PIR link. copyTemplate outranks copyFile: it is the
+// PIR-specific hook, where copyFile is the older general file copy.
+func pirHookRank(hookID string) int {
 	switch hookID {
-	case "grate.google.copyFile", "grate.googleworkspace.copyTemplate":
-		return true
+	case "grate.googleworkspace.copyTemplate":
+		return 2
+	case "grate.google.copyFile":
+		return 1
 	default:
-		return false
+		return 0
 	}
 }
 
-// pirURLFromHookRuns returns the PIR document URL recorded on a PIR-creating
-// hook run, or "" when the incident has no PIR document.
-func pirURLFromHookRuns(runs []HookRun) string {
-	for _, run := range runs {
-		if !isPIRHookID(run.HookID) || run.Metadata == nil {
-			continue
-		}
-		for _, f := range run.Metadata.Fields {
-			if f.Key == pirFileURLField && f.Value != "" {
-				return f.Value
-			}
+// isPIRHookID reports whether a hook run can carry a PIR link.
+func isPIRHookID(hookID string) bool { return pirHookRank(hookID) > 0 }
+
+// pirCandidate is a PIR link found on one hook run, with the keys used to
+// choose between links when an incident has more than one.
+type pirCandidate struct {
+	url     string
+	lastRun time.Time
+	hookID  string
+}
+
+// beats reports whether c should win over other. The most recent run wins;
+// ties fall back to hook rank and then to the URL itself, so the choice does
+// not depend on the order the API happened to return the runs in.
+func (c pirCandidate) beats(other pirCandidate) bool {
+	switch {
+	case other.url == "":
+		return true
+	case !c.lastRun.Equal(other.lastRun):
+		return c.lastRun.After(other.lastRun)
+	case pirHookRank(c.hookID) != pirHookRank(other.hookID):
+		return pirHookRank(c.hookID) > pirHookRank(other.hookID)
+	default:
+		return c.url < other.url
+	}
+}
+
+// pirURLFromHookRun returns the PIR document URL a single hook run recorded.
+// The fileURL metadata field is what IRM's PIR bookmarks read; metadata.URL is
+// a fallback for a partial run that recorded only the URL.
+func pirURLFromHookRun(run HookRun) string {
+	if run.Metadata == nil {
+		return ""
+	}
+	for _, f := range run.Metadata.Fields {
+		if f.Key == pirFileURLField && f.Value != "" {
+			return f.Value
 		}
 	}
-	return ""
+	return run.Metadata.URL
+}
+
+// pirURLFromHookRuns returns the PIR document URL for an incident, or "" when
+// it has no PIR document. An incident can carry several PIR links — both hooks
+// ran, or one was re-run — and the API does not order hook runs, so the link is
+// picked deterministically rather than taking whichever arrived first.
+func pirURLFromHookRuns(runs []HookRun) string {
+	var best pirCandidate
+	for _, run := range runs {
+		if !isPIRHookID(run.HookID) {
+			continue
+		}
+		candidate := pirCandidate{
+			url:     pirURLFromHookRun(run),
+			lastRun: time.Time(run.LastRun),
+			hookID:  run.HookID,
+		}
+		if candidate.url != "" && candidate.beats(best) {
+			best = candidate
+		}
+	}
+	return best.url
 }
 
 // Client is an HTTP client for the Grafana IRM Incidents API.

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -2,12 +2,14 @@ package irm
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -62,38 +64,14 @@ func pirHookRank(hookID string) int {
 	}
 }
 
-// isPIRHookID reports whether a hook run can carry a PIR link.
-func isPIRHookID(hookID string) bool { return pirHookRank(hookID) > 0 }
-
-// pirCandidate is a PIR link found on one hook run, with the keys used to
-// choose between links when an incident has more than one.
-type pirCandidate struct {
-	url     string
-	lastRun time.Time
-	hookID  string
-}
-
-// beats reports whether c should win over other. The most recent run wins;
-// ties fall back to hook rank and then to the URL itself, so the choice does
-// not depend on the order the API happened to return the runs in.
-func (c pirCandidate) beats(other pirCandidate) bool {
-	switch {
-	case other.url == "":
-		return true
-	case !c.lastRun.Equal(other.lastRun):
-		return c.lastRun.After(other.lastRun)
-	case pirHookRank(c.hookID) != pirHookRank(other.hookID):
-		return pirHookRank(c.hookID) > pirHookRank(other.hookID)
-	default:
-		return c.url < other.url
-	}
-}
-
-// pirURLFromHookRun returns the PIR document URL a single hook run recorded.
-// The fileURL metadata field is what IRM's PIR bookmarks read; metadata.URL is
-// a fallback for a partial run that recorded only the URL.
-func pirURLFromHookRun(run HookRun) string {
-	if run.Metadata == nil {
+// pirURL returns the PIR document URL a hook run recorded, or "" if it is not
+// a PIR-creating hook or recorded no link. The fileURL field is what IRM's PIR
+// bookmarks read; metadata.url is the same value on a full run and covers a
+// partial one that recorded only the URL. Restricting this to PIR hooks matters
+// for that fallback: other integrations put their Slack, Meet and GitHub links
+// in the very same field.
+func pirURL(run HookRun) string {
+	if pirHookRank(run.HookID) == 0 || run.Metadata == nil {
 		return ""
 	}
 	for _, f := range run.Metadata.Fields {
@@ -106,24 +84,30 @@ func pirURLFromHookRun(run HookRun) string {
 
 // pirURLFromHookRuns returns the PIR document URL for an incident, or "" when
 // it has no PIR document. An incident can carry several PIR links — both hooks
-// ran, or one was re-run — and the API does not order hook runs, so the link is
-// picked deterministically rather than taking whichever arrived first.
+// ran, or one was re-run — and the API returns hook runs unordered, so the most
+// recent one wins and equal timestamps fall back to hook rank and then to the
+// URL itself. That keeps repeated calls for one incident in agreement.
 func pirURLFromHookRuns(runs []HookRun) string {
-	var best pirCandidate
+	candidates := make([]HookRun, 0, len(runs))
 	for _, run := range runs {
-		if !isPIRHookID(run.HookID) {
-			continue
-		}
-		candidate := pirCandidate{
-			url:     pirURLFromHookRun(run),
-			lastRun: time.Time(run.LastRun),
-			hookID:  run.HookID,
-		}
-		if candidate.url != "" && candidate.beats(best) {
-			best = candidate
+		if pirURL(run) != "" {
+			candidates = append(candidates, run)
 		}
 	}
-	return best.url
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	slices.SortFunc(candidates, func(a, b HookRun) int {
+		if c := time.Time(b.LastRun).Compare(time.Time(a.LastRun)); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(pirHookRank(b.HookID), pirHookRank(a.HookID)); c != 0 {
+			return c
+		}
+		return cmp.Compare(pirURL(a), pirURL(b))
+	})
+	return pirURL(candidates[0])
 }
 
 // Client is an HTTP client for the Grafana IRM Incidents API.

--- a/internal/providers/irm/incidents_commands.go
+++ b/internal/providers/irm/incidents_commands.go
@@ -14,6 +14,7 @@ func newIncidentsCmd(loader GrafanaConfigLoader) *cobra.Command {
 	incCmd.AddCommand(
 		NewListCommand(loader),
 		NewGetCommand(loader),
+		NewGetPIRCommand(loader),
 		NewCreateCommand(loader),
 		NewCloseCommand(loader),
 		NewActivityCommand(loader),

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/deeplink"
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
@@ -313,6 +314,9 @@ Google Workspace integration creates them, so the link exists only where that
 integration ran. It is recorded on the hook run that copied the PIR template,
 which this command reads and resolves.
 
+An incident can have more than one PIR document if the template was copied
+again; the most recently created one is reported.
+
 An incident without a PIR document prints nothing and exits 0.`
 
 // NewGetPIRCommand builds `incidents get-pir <incident-id>`. A PIR is derived
@@ -350,8 +354,9 @@ func NewGetPIRCommand(loader GrafanaConfigLoader) *cobra.Command {
 			}
 
 			// Absence is a normal outcome, not an error — the note is a
-			// diagnostic so it stays out of the stdout result.
-			if url == "" {
+			// diagnostic so it stays out of the stdout result. Agents read the
+			// empty pirURL instead, and stderr stays quiet for them.
+			if url == "" && !agent.IsAgentMode() {
 				cmdio.Info(cmd.ErrOrStderr(),
 					"Incident %s has no PIR document (only the Google Workspace integration creates them).",
 					incidentID)

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -291,6 +291,102 @@ func NewGetCommand(loader GrafanaConfigLoader) *cobra.Command {
 }
 
 // ---------------------------------------------------------------------------
+// get-pir command
+// ---------------------------------------------------------------------------
+
+type incidentPIROpts struct {
+	IO cmdio.Options
+}
+
+func (o *incidentPIROpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("text", &IncidentPIRTextCodec{})
+	o.IO.DefaultFormat("text")
+	o.IO.BindFlags(flags)
+}
+
+func (o *incidentPIROpts) Validate() error { return o.IO.Validate() }
+
+const incidentGetPIRLong = `Resolve the post-incident review (PIR) document URL for an incident.
+
+The URL is not carried in the incident payload. PIRs are optional and only the
+Google Workspace integration creates them, so the link exists only where that
+integration ran. It is recorded on the hook run that copied the PIR template,
+which this command reads and resolves.
+
+An incident without a PIR document prints nothing and exits 0.`
+
+// NewGetPIRCommand builds `incidents get-pir <incident-id>`. A PIR is derived
+// from its incident and has no independently addressable ID, so it is an
+// operation-subject compound directly under `incidents` rather than a nested
+// noun group.
+func NewGetPIRCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &incidentPIROpts{}
+	cmd := &cobra.Command{
+		Use:   "get-pir <incident-id>",
+		Short: "Get the post-incident review (PIR) document URL for an incident.",
+		Long:  incidentGetPIRLong,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			incidentID := args[0]
+
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			client, err := NewIncidentClient(restCfg)
+			if err != nil {
+				return err
+			}
+
+			url, err := client.GetPIRURL(ctx, incidentID)
+			if err != nil {
+				return err
+			}
+
+			// Absence is a normal outcome, not an error — the note is a
+			// diagnostic so it stays out of the stdout result.
+			if url == "" {
+				cmdio.Info(cmd.ErrOrStderr(),
+					"Incident %s has no PIR document (only the Google Workspace integration creates them).",
+					incidentID)
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), IncidentPIR{IncidentID: incidentID, PIRURL: url})
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// IncidentPIRTextCodec prints the bare PIR URL so the result can be piped;
+// an incident without a PIR document produces no output.
+type IncidentPIRTextCodec struct{}
+
+func (c *IncidentPIRTextCodec) Format() format.Format { return "text" }
+
+func (c *IncidentPIRTextCodec) Encode(w io.Writer, v any) error {
+	pir, ok := v.(IncidentPIR)
+	if !ok {
+		return errors.New("invalid data type for text codec: expected IncidentPIR")
+	}
+	if pir.PIRURL == "" {
+		return nil
+	}
+	_, err := fmt.Fprintln(w, pir.PIRURL)
+	return err
+}
+
+func (c *IncidentPIRTextCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("text format does not support decoding")
+}
+
+// ---------------------------------------------------------------------------
 // create command
 // ---------------------------------------------------------------------------
 

--- a/internal/providers/irm/incidents_pir_test.go
+++ b/internal/providers/irm/incidents_pir_test.go
@@ -1,0 +1,261 @@
+package irm_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/irm"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pirDocURL is the PIR document link the fake hook runs report.
+const pirDocURL = "https://docs.google.com/document/d/abc123/edit"
+
+// pirHookRun builds a hook run carrying a fileURL metadata field.
+func pirHookRun(hookID string) map[string]any {
+	return map[string]any{
+		"hookID": hookID,
+		"metadata": map[string]any{
+			"fields": []map[string]any{
+				{"key": "documentTitle", "value": "PIR: Boom"},
+				{"key": "fileURL", "value": pirDocURL},
+			},
+		},
+	}
+}
+
+// TestGetPIRURL covers resolving the PIR document link from an incident's
+// integration hook runs, including the shapes that legitimately have no PIR.
+func TestGetPIRURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		hookRuns []map[string]any
+		want     string
+	}{
+		{
+			name:     "google copyFile hook carries the PIR link",
+			hookRuns: []map[string]any{pirHookRun("grate.google.copyFile")},
+			want:     pirDocURL,
+		},
+		{
+			name:     "google workspace copyTemplate hook carries the PIR link",
+			hookRuns: []map[string]any{pirHookRun("grate.googleworkspace.copyTemplate")},
+			want:     pirDocURL,
+		},
+		{
+			name: "PIR hook is found among unrelated hook runs",
+			hookRuns: []map[string]any{
+				{"hookID": "grate.slack.createChannel"},
+				{"hookID": "grate.zoom.createMeeting"},
+				pirHookRun("grate.google.copyFile"),
+			},
+			want: pirDocURL,
+		},
+		{
+			name: "falls through a PIR hook that recorded no fileURL",
+			hookRuns: []map[string]any{
+				{"hookID": "grate.google.copyFile", "metadata": map[string]any{
+					"fields": []map[string]any{{"key": "documentTitle", "value": "PIR: Boom"}},
+				}},
+				pirHookRun("grate.googleworkspace.copyTemplate"),
+			},
+			want: pirDocURL,
+		},
+		{
+			name:     "no hook runs at all",
+			hookRuns: []map[string]any{},
+			want:     "",
+		},
+		{
+			name:     "only non-PIR hooks ran",
+			hookRuns: []map[string]any{{"hookID": "grate.slack.createChannel"}},
+			want:     "",
+		},
+		{
+			name:     "PIR hook without metadata",
+			hookRuns: []map[string]any{{"hookID": "grate.google.copyFile"}},
+			want:     "",
+		},
+		{
+			name: "PIR hook with an empty fileURL value",
+			hookRuns: []map[string]any{{"hookID": "grate.google.copyFile", "metadata": map[string]any{
+				"fields": []map[string]any{{"key": "fileURL", "value": ""}},
+			}}},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(w, map[string]any{"hookRuns": tt.hookRuns})
+			}))
+			defer server.Close()
+
+			got, err := newTestClient(t, server).GetPIRURL(t.Context(), "inc-1")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestGetHookRunsRequest pins the wire contract: the incident ID rides in the
+// body and IntegrationService is served from the unversioned base path.
+func TestGetHookRunsRequest(t *testing.T) {
+	var gotPath string
+	var gotRawBody []byte
+
+	// The handler runs on another goroutine, so it only records: assertions
+	// stay on the test goroutine below.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotRawBody, _ = io.ReadAll(r.Body)
+		writeJSON(w, map[string]any{"hookRuns": []map[string]any{}})
+	}))
+	defer server.Close()
+
+	_, err := newTestClient(t, server).GetHookRuns(t.Context(), "inc-77")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/plugins/grafana-irm-app/resources/api/IntegrationService.GetHookRuns", gotPath)
+	assert.NotContains(t, gotPath, "/v1/", "IntegrationService is not part of the documented v1 API")
+
+	var gotBody map[string]any
+	require.NoError(t, json.Unmarshal(gotRawBody, &gotBody))
+	assert.Equal(t, map[string]any{"incidentID": "inc-77"}, gotBody)
+}
+
+// TestGetHookRunsErrors covers the failure modes, including the in-band error
+// the IRM API can return on a 200 response.
+func TestGetHookRunsErrors(t *testing.T) {
+	t.Run("empty incident ID is rejected before any request", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			t.Error("expected no HTTP call for an empty incident ID")
+		}))
+		defer server.Close()
+
+		_, err := newTestClient(t, server).GetHookRuns(t.Context(), "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "incidentID is required")
+	})
+
+	t.Run("in-band error on a 200 response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"error": "integration unavailable"})
+		}))
+		defer server.Close()
+
+		_, err := newTestClient(t, server).GetHookRuns(t.Context(), "inc-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "integration unavailable")
+	})
+
+	t.Run("non-200 response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+		}))
+		defer server.Close()
+
+		_, err := newTestClient(t, server).GetPIRURL(t.Context(), "inc-1")
+		require.Error(t, err)
+	})
+}
+
+// TestIncidentsGetPIROutputContract pins the agent output contract for
+// `irm incidents get-pir`: the bare URL for humans, one JSON value for agents,
+// and a missing PIR reported as a stderr diagnostic rather than an error.
+func TestIncidentsGetPIROutputContract(t *testing.T) {
+	tests := []struct {
+		name       string
+		agentMode  bool
+		args       []string
+		hookRuns   []map[string]any
+		wantStdout string // exact stdout when wantJSON is false
+		wantJSON   bool
+		wantPIR    string
+		wantNote   bool // expect the "no PIR document" note on stderr
+	}{
+		{
+			name:       "human default is the bare URL",
+			args:       []string{"inc-1"},
+			hookRuns:   []map[string]any{pirHookRun("grate.google.copyFile")},
+			wantStdout: pirDocURL + "\n",
+			wantPIR:    pirDocURL,
+		},
+		{
+			name:       "no PIR prints nothing and notes it on stderr",
+			args:       []string{"inc-1"},
+			hookRuns:   []map[string]any{{"hookID": "grate.slack.createChannel"}},
+			wantStdout: "",
+			wantNote:   true,
+		},
+		{
+			name:      "agent mode emits exactly one JSON value",
+			agentMode: true,
+			args:      []string{"inc-1"},
+			hookRuns:  []map[string]any{pirHookRun("grate.google.copyFile")},
+			wantJSON:  true,
+			wantPIR:   pirDocURL,
+		},
+		{
+			name:     "explicit -o json wins outside agent mode",
+			args:     []string{"inc-1", "-o", "json"},
+			hookRuns: []map[string]any{pirHookRun("grate.google.copyFile")},
+			wantJSON: true,
+			wantPIR:  pirDocURL,
+		},
+		{
+			name:      "agent mode reports a missing PIR as an empty pirURL",
+			agentMode: true,
+			args:      []string{"inc-1"},
+			hookRuns:  []map[string]any{},
+			wantJSON:  true,
+			wantPIR:   "",
+			wantNote:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setAgentModeExt(t, tc.agentMode)
+			server := incidentAPIServer(t, map[string]any{
+				"IntegrationService.GetHookRuns": map[string]any{"hookRuns": tc.hookRuns},
+			})
+
+			stdout, stderr, err := runIncidentCmd(t, func() *cobra.Command {
+				return irm.NewGetPIRCommand(incidentLoader(server))
+			}, "", tc.args...)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.wantNote {
+				if !strings.Contains(stderr, "has no PIR document") {
+					t.Errorf("expected the missing-PIR note on stderr; stderr=%q", stderr)
+				}
+			} else if strings.Contains(stderr, "has no PIR document") {
+				t.Errorf("unexpected missing-PIR note on stderr; stderr=%q", stderr)
+			}
+
+			if tc.wantJSON {
+				doc := decodeOneJSONValue(t, stdout)
+				if doc["incidentID"] != "inc-1" {
+					t.Errorf("incidentID = %v, want inc-1", doc["incidentID"])
+				}
+				if doc["pirURL"] != tc.wantPIR {
+					t.Errorf("pirURL = %v, want %q", doc["pirURL"], tc.wantPIR)
+				}
+				return
+			}
+			if stdout != tc.wantStdout {
+				t.Errorf("stdout = %q, want %q", stdout, tc.wantStdout)
+			}
+		})
+	}
+}

--- a/internal/providers/irm/incidents_pir_test.go
+++ b/internal/providers/irm/incidents_pir_test.go
@@ -23,22 +23,19 @@ func pirHookRun(hookID string) map[string]any {
 	return pirHookRunAt(hookID, pirDocURL, "")
 }
 
-// pirHookRunAt builds a hook run carrying a specific fileURL and lastRun. An
-// empty lastRun omits the field, as the API does for a hook that never ran.
+// pirHookRunAt builds a hook run carrying a specific fileURL and lastRun.
 func pirHookRunAt(hookID, fileURL, lastRun string) map[string]any {
-	run := map[string]any{
-		"hookID": hookID,
+	return map[string]any{
+		"hookID":  hookID,
+		"lastRun": lastRun,
 		"metadata": map[string]any{
+			"url": fileURL,
 			"fields": []map[string]any{
 				{"key": "documentTitle", "value": "PIR: Boom"},
 				{"key": "fileURL", "value": fileURL},
 			},
 		},
 	}
-	if lastRun != "" {
-		run["lastRun"] = lastRun
-	}
-	return run
 }
 
 // TestGetPIRURL covers resolving the PIR document link from an incident's
@@ -101,29 +98,39 @@ func TestGetPIRURL(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "falls back to metadata URL when no fileURL field was recorded",
+			name: "falls back to metadata url when no fileURL field was recorded",
 			hookRuns: []map[string]any{{
 				"hookID":   "grate.googleworkspace.copyTemplate",
-				"metadata": map[string]any{"URL": pirDocURL},
+				"metadata": map[string]any{"url": pirDocURL},
 			}},
 			want: pirDocURL,
 		},
 		{
-			name: "fileURL field wins over metadata URL",
+			name: "fileURL field wins over metadata url",
 			hookRuns: []map[string]any{{
 				"hookID": "grate.googleworkspace.copyTemplate",
 				"metadata": map[string]any{
-					"URL":    "https://docs.google.com/document/d/stale/edit",
+					"url":    "https://docs.google.com/document/d/stale/edit",
 					"fields": []map[string]any{{"key": "fileURL", "value": pirDocURL}},
 				},
 			}},
 			want: pirDocURL,
 		},
 		{
-			name: "a lastRun gcx cannot parse does not fail the lookup",
+			// Other integrations record their own links in the same place.
+			name: "a non-PIR hook's metadata url is not mistaken for a PIR",
+			hookRuns: []map[string]any{{
+				"hookID":   "grate.irm.slack.createChannel",
+				"metadata": map[string]any{"url": "https://slack.com/app_redirect?channel=C123"},
+			}},
+			want: "",
+		},
+		{
+			// The API sends "" for a timestamp it has no value for.
+			name: "an empty lastRun does not fail the lookup",
 			hookRuns: []map[string]any{{
 				"hookID":   "grate.google.copyFile",
-				"lastRun":  1755000000,
+				"lastRun":  "",
 				"metadata": map[string]any{"fields": []map[string]any{{"key": "fileURL", "value": pirDocURL}}},
 			}},
 			want: pirDocURL,
@@ -159,10 +166,11 @@ func TestGetPIRURLIsDeterministic(t *testing.T) {
 		want     string
 	}{
 		{
+			// Microsecond precision, as the API reports it.
 			name: "the most recent run wins over an older one",
 			hookRuns: []map[string]any{
-				pirHookRunAt("grate.google.copyFile", olderURL, "2026-08-01T10:00:00Z"),
-				pirHookRunAt("grate.googleworkspace.copyTemplate", newerURL, "2026-08-04T09:30:00Z"),
+				pirHookRunAt("grate.google.copyFile", olderURL, "2026-08-06T16:43:38.932849Z"),
+				pirHookRunAt("grate.googleworkspace.copyTemplate", newerURL, "2026-08-06T16:43:43.375365Z"),
 			},
 			want: newerURL,
 		},

--- a/internal/providers/irm/incidents_pir_test.go
+++ b/internal/providers/irm/incidents_pir_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -19,15 +20,25 @@ const pirDocURL = "https://docs.google.com/document/d/abc123/edit"
 
 // pirHookRun builds a hook run carrying a fileURL metadata field.
 func pirHookRun(hookID string) map[string]any {
-	return map[string]any{
+	return pirHookRunAt(hookID, pirDocURL, "")
+}
+
+// pirHookRunAt builds a hook run carrying a specific fileURL and lastRun. An
+// empty lastRun omits the field, as the API does for a hook that never ran.
+func pirHookRunAt(hookID, fileURL, lastRun string) map[string]any {
+	run := map[string]any{
 		"hookID": hookID,
 		"metadata": map[string]any{
 			"fields": []map[string]any{
 				{"key": "documentTitle", "value": "PIR: Boom"},
-				{"key": "fileURL", "value": pirDocURL},
+				{"key": "fileURL", "value": fileURL},
 			},
 		},
 	}
+	if lastRun != "" {
+		run["lastRun"] = lastRun
+	}
+	return run
 }
 
 // TestGetPIRURL covers resolving the PIR document link from an incident's
@@ -89,6 +100,34 @@ func TestGetPIRURL(t *testing.T) {
 			}}},
 			want: "",
 		},
+		{
+			name: "falls back to metadata URL when no fileURL field was recorded",
+			hookRuns: []map[string]any{{
+				"hookID":   "grate.googleworkspace.copyTemplate",
+				"metadata": map[string]any{"URL": pirDocURL},
+			}},
+			want: pirDocURL,
+		},
+		{
+			name: "fileURL field wins over metadata URL",
+			hookRuns: []map[string]any{{
+				"hookID": "grate.googleworkspace.copyTemplate",
+				"metadata": map[string]any{
+					"URL":    "https://docs.google.com/document/d/stale/edit",
+					"fields": []map[string]any{{"key": "fileURL", "value": pirDocURL}},
+				},
+			}},
+			want: pirDocURL,
+		},
+		{
+			name: "a lastRun gcx cannot parse does not fail the lookup",
+			hookRuns: []map[string]any{{
+				"hookID":   "grate.google.copyFile",
+				"lastRun":  1755000000,
+				"metadata": map[string]any{"fields": []map[string]any{{"key": "fileURL", "value": pirDocURL}}},
+			}},
+			want: pirDocURL,
+		},
 	}
 
 	for _, tt := range tests {
@@ -101,6 +140,71 @@ func TestGetPIRURL(t *testing.T) {
 			got, err := newTestClient(t, server).GetPIRURL(t.Context(), "inc-1")
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestGetPIRURLIsDeterministic pins which link is chosen when an incident
+// carries more than one. The API does not order hook runs, so the same
+// incident has to resolve to the same URL whatever order they arrive in.
+func TestGetPIRURLIsDeterministic(t *testing.T) {
+	const (
+		olderURL = "https://docs.google.com/document/d/older/edit"
+		newerURL = "https://docs.google.com/document/d/newer/edit"
+	)
+
+	tests := []struct {
+		name     string
+		hookRuns []map[string]any
+		want     string
+	}{
+		{
+			name: "the most recent run wins over an older one",
+			hookRuns: []map[string]any{
+				pirHookRunAt("grate.google.copyFile", olderURL, "2026-08-01T10:00:00Z"),
+				pirHookRunAt("grate.googleworkspace.copyTemplate", newerURL, "2026-08-04T09:30:00Z"),
+			},
+			want: newerURL,
+		},
+		{
+			name: "a re-run of the same hook resolves to its latest copy",
+			hookRuns: []map[string]any{
+				pirHookRunAt("grate.googleworkspace.copyTemplate", olderURL, "2026-08-01T10:00:00Z"),
+				pirHookRunAt("grate.googleworkspace.copyTemplate", newerURL, "2026-08-02T10:00:00Z"),
+			},
+			want: newerURL,
+		},
+		{
+			name: "with no timestamps to compare the PIR-specific hook wins",
+			hookRuns: []map[string]any{
+				pirHookRunAt("grate.google.copyFile", olderURL, ""),
+				pirHookRunAt("grate.googleworkspace.copyTemplate", newerURL, ""),
+			},
+			want: newerURL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, reversed := range []bool{false, true} {
+				name := "as returned"
+				runs := slices.Clone(tt.hookRuns)
+				if reversed {
+					name = "reversed"
+					slices.Reverse(runs)
+				}
+
+				t.Run(name, func(t *testing.T) {
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						writeJSON(w, map[string]any{"hookRuns": runs})
+					}))
+					defer server.Close()
+
+					got, err := newTestClient(t, server).GetPIRURL(t.Context(), "inc-1")
+					require.NoError(t, err)
+					assert.Equal(t, tt.want, got)
+				})
+			}
 		})
 	}
 }
@@ -211,13 +315,14 @@ func TestIncidentsGetPIROutputContract(t *testing.T) {
 			wantPIR:  pirDocURL,
 		},
 		{
-			name:      "agent mode reports a missing PIR as an empty pirURL",
+			// The empty pirURL already carries this, so stderr stays quiet.
+			name:      "agent mode reports a missing PIR as an empty pirURL and no note",
 			agentMode: true,
 			args:      []string{"inc-1"},
 			hookRuns:  []map[string]any{},
 			wantJSON:  true,
 			wantPIR:   "",
-			wantNote:  true,
+			wantNote:  false,
 		},
 	}
 

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -28,6 +28,24 @@ func (ft FlexTime) MarshalJSON() ([]byte, error) {
 	return t.MarshalJSON()
 }
 
+// LenientTime is a time.Time for fields whose wire type is not pinned by the
+// API surface gcx consumes. Unlike [FlexTime] it never fails to decode: an
+// unexpected shape yields the zero time instead of an error, so a field read
+// only as a hint cannot fail the request that carries it.
+type LenientTime time.Time
+
+func (lt *LenientTime) UnmarshalJSON(data []byte) error {
+	var t time.Time
+	if err := t.UnmarshalJSON(data); err == nil {
+		*lt = LenientTime(t)
+	}
+	return nil
+}
+
+func (lt LenientTime) MarshalJSON() ([]byte, error) {
+	return time.Time(lt).MarshalJSON()
+}
+
 // GetResourceName returns the incident ID.
 func (i Incident) GetResourceName() string { return i.IncidentID }
 
@@ -110,9 +128,11 @@ type HookRunField struct {
 	Value string `json:"value"`
 }
 
-// HookRunMetadata carries what a hook run recorded about its result.
+// HookRunMetadata carries what a hook run recorded about its result. The
+// template-copying hooks set both URL and a fileURL entry in Fields.
 type HookRunMetadata struct {
 	Fields []HookRunField `json:"fields,omitempty"`
+	URL    string         `json:"URL,omitempty"`
 }
 
 // HookRun is a single integration hook execution against an incident. Only
@@ -120,6 +140,7 @@ type HookRunMetadata struct {
 type HookRun struct {
 	HookID   string           `json:"hookID"`
 	Metadata *HookRunMetadata `json:"metadata,omitempty"`
+	LastRun  LenientTime      `json:"lastRun,omitzero"`
 }
 
 // getHookRunsRequest is the request body for IntegrationService.GetHookRuns.

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -104,6 +104,42 @@ type IncidentHookRuns struct {
 	HookRuns []any `json:"hookRuns"`
 }
 
+// HookRunField is a key/value entry in a hook run's metadata.
+type HookRunField struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// HookRunMetadata carries what a hook run recorded about its result.
+type HookRunMetadata struct {
+	Fields []HookRunField `json:"fields,omitempty"`
+}
+
+// HookRun is a single integration hook execution against an incident. Only
+// the fields the PIR lookup reads are modelled; the API returns more.
+type HookRun struct {
+	HookID   string           `json:"hookID"`
+	Metadata *HookRunMetadata `json:"metadata,omitempty"`
+}
+
+// getHookRunsRequest is the request body for IntegrationService.GetHookRuns.
+type getHookRunsRequest struct {
+	IncidentID string `json:"incidentID"`
+}
+
+// getHookRunsResponse is the response from IntegrationService.GetHookRuns.
+type getHookRunsResponse struct {
+	HookRuns []HookRun `json:"hookRuns"`
+	Error    string    `json:"error,omitempty"`
+}
+
+// IncidentPIR is the resolved post-incident review document for an incident.
+// PIRURL is empty when the incident has no PIR document.
+type IncidentPIR struct {
+	IncidentID string `json:"incidentID"`
+	PIRURL     string `json:"pirURL"`
+}
+
 // IncidentMembershipRole represents a role inside a membership assignment.
 type IncidentMembershipRole struct {
 	RoleID      int      `json:"roleID"`

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -28,24 +28,6 @@ func (ft FlexTime) MarshalJSON() ([]byte, error) {
 	return t.MarshalJSON()
 }
 
-// LenientTime is a time.Time for fields whose wire type is not pinned by the
-// API surface gcx consumes. Unlike [FlexTime] it never fails to decode: an
-// unexpected shape yields the zero time instead of an error, so a field read
-// only as a hint cannot fail the request that carries it.
-type LenientTime time.Time
-
-func (lt *LenientTime) UnmarshalJSON(data []byte) error {
-	var t time.Time
-	if err := t.UnmarshalJSON(data); err == nil {
-		*lt = LenientTime(t)
-	}
-	return nil
-}
-
-func (lt LenientTime) MarshalJSON() ([]byte, error) {
-	return time.Time(lt).MarshalJSON()
-}
-
 // GetResourceName returns the incident ID.
 func (i Incident) GetResourceName() string { return i.IncidentID }
 
@@ -129,10 +111,11 @@ type HookRunField struct {
 }
 
 // HookRunMetadata carries what a hook run recorded about its result. The
-// template-copying hooks set both URL and a fileURL entry in Fields.
+// template-copying hooks set both URL and a fileURL entry in Fields to the
+// document they created.
 type HookRunMetadata struct {
 	Fields []HookRunField `json:"fields,omitempty"`
-	URL    string         `json:"URL,omitempty"`
+	URL    string         `json:"url,omitempty"`
 }
 
 // HookRun is a single integration hook execution against an incident. Only
@@ -140,7 +123,7 @@ type HookRunMetadata struct {
 type HookRun struct {
 	HookID   string           `json:"hookID"`
 	Metadata *HookRunMetadata `json:"metadata,omitempty"`
-	LastRun  LenientTime      `json:"lastRun,omitzero"`
+	LastRun  FlexTime         `json:"lastRun"`
 }
 
 // getHookRunsRequest is the request body for IntegrationService.GetHookRuns.


### PR DESCRIPTION
## Summary

The post-incident review (PIR) link is not carried in the IRM incident payload. That is by design: PIRs are optional and, as of today, only the Google Workspace integration creates them. The link is recorded on the *integration hook run* that copied the PIR template, not on the incident.

This adds `gcx irm incidents get-pir <incident-id>`, which reads an incident's hook runs and resolves the PIR document URL from them.

- **Client**: `GetHookRuns` and `GetPIRURL` on the incidents client, plus `HookRun` / `HookRunMetadata` / `HookRunField` types. Only the fields the lookup reads are modelled.
- **Resolution**: finds a hook run with `hookID` of `grate.google.copyFile` or `grate.googleworkspace.copyTemplate`, then pulls the `fileURL` entry from `metadata.fields`.
- **Path**: `IntegrationService` is served from the unversioned base path alongside `SeveritiesService` and `IncidentContextService`, not the `/v1` path the other incident calls use. A test pins this so it does not silently drift.
- **Output**: prints the bare URL so it pipes cleanly (`| xargs open`). An incident without a PIR is a normal outcome — stdout stays empty, exit code is 0, and the explanation goes to stderr. Agent/JSON mode returns `{"incidentID": "...", "pirURL": ""}`.