### PR TITLE
refactor(resources): set the manager identity from the gcx version

### DIFF
--- a/docs/architecture/resource-model.md
+++ b/docs/architecture/resource-model.md
@@ -65,8 +65,11 @@ Every `Resource` carries a `SourceInfo` (line 374) recording where it came from.
 
 Resources carry manager metadata in annotations (via `GrafanaMetaAccessor`):
 - `grafana.app/manager-kind` — which tool manages the resource (gcx uses `utils.ManagerKindKubectl` as placeholder, line 19)
-- `grafana.app/manager-identity` — identity string ("gcx")
+- `grafana.app/manager-identity` — identity string, built by `process.ManagerIdentity()` as `gcx/<version>` (for example `gcx/3.0.0`, or `gcx/SNAPSHOT` for a build without version information)
+- `grafana.app/manager-allows-edits` — always `true`, so the Grafana user interface keeps a pushed resource editable
 - `grafana.app/source-path` — original file path
+
+gcx leaves `grafana.app/source-checksum` and `grafana.app/source-timestamp` empty. Grafana uses both fields to reconcile a resource from a source over time. gcx pushes one time per command, and no gcx code reads the two fields back.
 
 `IsManaged()` (line 161) returns true when the manager kind matches `ResourceManagerKind`. Resources managed by the UI (with `grafana.app/saved-from-ui` annotation) or other tools are protected from accidental overwrites unless `--include-managed` is passed.
 

--- a/internal/resources/process/managerfields.go
+++ b/internal/resources/process/managerfields.go
@@ -2,8 +2,16 @@ package process
 
 import (
 	"github.com/grafana/gcx/internal/resources"
+	"github.com/grafana/gcx/internal/version"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
+
+// ManagerIdentity returns the manager identity that gcx writes on a pushed resource.
+// The value carries the gcx version, so an operator can see which build pushed the
+// resource. A build without version information reports "gcx/SNAPSHOT".
+func ManagerIdentity() string {
+	return "gcx/" + version.Get()
+}
 
 // ManagerFieldsAppender is a processor that appends manager and source fields to a resource.
 // It will return an error if the resource is already managed by another manager.
@@ -23,11 +31,13 @@ func (m *ManagerFieldsAppender) Process(r *resources.Resource) error {
 
 	r.Raw.SetManagerProperties(utils.ManagerProperties{
 		Kind:        resources.ResourceManagerKind,
-		Identity:    "gcx", // TODO: use version information to set the identity.
+		Identity:    ManagerIdentity(),
 		AllowsEdits: true,
 	})
 
-	// TODO: should we set timestamp & checksum as well?
+	// The checksum and the timestamp stay empty. Grafana uses both fields to
+	// reconcile a resource from a source over time. gcx pushes one time per
+	// command, and no gcx code reads the two fields back.
 	r.Raw.SetSourceProperties(utils.SourceProperties{
 		Path: r.Source.String(),
 	})

--- a/internal/resources/process/managerfields_test.go
+++ b/internal/resources/process/managerfields_test.go
@@ -5,10 +5,21 @@ import (
 
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/resources/process"
+	"github.com/grafana/gcx/internal/version"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+func TestManagerIdentity(t *testing.T) {
+	// A build without version information reports the snapshot value.
+	require.Equal(t, "gcx/SNAPSHOT", process.ManagerIdentity())
+
+	version.Set("1.2.3")
+	t.Cleanup(func() { version.Set("") })
+
+	require.Equal(t, "gcx/1.2.3", process.ManagerIdentity())
+}
 
 func TestManagerFieldsAppender(t *testing.T) {
 	tests := []struct {
@@ -50,7 +61,7 @@ func TestManagerFieldsAppender(t *testing.T) {
 						"namespace": "default",
 						"annotations": map[string]any{
 							utils.AnnoKeyManagerKind:        string(resources.ResourceManagerKind),
-							utils.AnnoKeyManagerIdentity:    "gcx",
+							utils.AnnoKeyManagerIdentity:    process.ManagerIdentity(),
 							utils.AnnoKeyManagerAllowsEdits: "true",
 							utils.AnnoKeySourcePath:         "file://some/test/path.json",
 						},
@@ -110,7 +121,7 @@ func TestManagerFieldsAppender(t *testing.T) {
 						"name":      "example",
 						"namespace": "default",
 						"annotations": map[string]any{
-							utils.AnnoKeyManagerIdentity: "gcx",
+							utils.AnnoKeyManagerIdentity: "gcx", // stale value from a previous push
 							utils.AnnoKeyManagerKind:     string(resources.ResourceManagerKind),
 							utils.AnnoKeySourcePath:      "file://some/test/path.json",
 						},
@@ -132,7 +143,7 @@ func TestManagerFieldsAppender(t *testing.T) {
 						"namespace": "default",
 						"annotations": map[string]any{
 							utils.AnnoKeyManagerKind:        string(resources.ResourceManagerKind),
-							utils.AnnoKeyManagerIdentity:    "gcx",
+							utils.AnnoKeyManagerIdentity:    process.ManagerIdentity(),
 							utils.AnnoKeyManagerAllowsEdits: "true",
 							utils.AnnoKeySourcePath:         "file://other/test/path.json",
 						},


### PR DESCRIPTION
Follows up on the review comment in #1162, which reported two TODO comments in `internal/resources/process/managerfields.go`.

## 1. The manager identity now carries the version

The annotation `grafana.app/manager-identity` held the constant `gcx`. An operator could not see which gcx build pushed a resource.

`process.ManagerIdentity()` now returns `gcx/<version>`, for example `gcx/3.0.0`. A build without version information reports `gcx/SNAPSHOT`.

The change is safe for two reasons:

- `IsManaged()` compares the manager kind only (`internal/resources/resources.go:166`). No gcx code reads the identity.
- `ServerFieldsStripper` deletes the identity annotation on pull (`internal/resources/process/serverfields.go:34`). An identity that changes per release does not change the pull output.

## 2. The checksum and the timestamp stay empty

This pull request removes the second TODO comment. It records the decision in the code and in `docs/architecture/resource-model.md`.

Grafana uses `SourceProperties.Checksum` and `SourceProperties.TimestampMillis` to reconcile a resource from a source over time. gcx pushes one time per command. No gcx code reads the two fields back. `SourceInfo` also carries the path and the format only, so the processor has no data to compute either field.

## Tests

- `TestManagerIdentity` covers the snapshot value and a set version.
- `TestManagerFieldsAppender` expects `process.ManagerIdentity()`. One test case keeps a stale `gcx` identity in the input, which proves that the processor overwrites the old value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
