### PR TITLE
feat: add experimental gcx traces baseline command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **New Features**
 
 - Added `--fix-plan` to `gcx instrumentation check`, with two explicit modes: `--fix-plan=local` produces a deterministic aggregation of the explanation docs' "How to fix" sections (offline, no billing, works on OSS/Enterprise), and `--fix-plan=assistant` synthesizes a prioritized plan with Grafana Assistant (BILLABLE, requires a Grafana Cloud context — see the Assistant pricing docs). The two modes are disjoint: assistant mode returns a clear error when preconditions aren't met rather than silently falling back to local. `--fix-plan` alone is rejected; users must specify a mode.
+- traces: add experimental `gcx traces baseline <trace-id>` to retrieve same-operation candidate traces (root identity, operation success, and topology fingerprint) to feed into `gcx traces diff`.
 
 ## v1.2.0 (2026-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **New Features**
 
 - Added `--fix-plan` to `gcx instrumentation check`, with two explicit modes: `--fix-plan=local` produces a deterministic aggregation of the explanation docs' "How to fix" sections (offline, no billing, works on OSS/Enterprise), and `--fix-plan=assistant` synthesizes a prioritized plan with Grafana Assistant (BILLABLE, requires a Grafana Cloud context — see the Assistant pricing docs). The two modes are disjoint: assistant mode returns a clear error when preconditions aren't met rather than silently falling back to local. `--fix-plan` alone is rejected; users must specify a mode.
-- traces: add experimental `gcx traces baseline <trace-id>` to retrieve same-operation candidate traces (root identity, operation success, and topology fingerprint) to feed into `gcx traces diff`.
+- traces: add experimental `gcx traces baseline <trace-id>` to retrieve same-operation candidate traces (root identity, operation success, and topology fingerprint) to feed into `gcx traces diff`, with optional raw TraceQL filters when the unfiltered candidates are not valid comparisons.
 
 ## v1.2.0 (2026-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `--fix-plan` to `gcx instrumentation check`, with two explicit modes: `--fix-plan=local` produces a deterministic aggregation of the explanation docs' "How to fix" sections (offline, no billing, works on OSS/Enterprise), and `--fix-plan=assistant` synthesizes a prioritized plan with Grafana Assistant (BILLABLE, requires a Grafana Cloud context — see the Assistant pricing docs). The two modes are disjoint: assistant mode returns a clear error when preconditions aren't met rather than silently falling back to local. `--fix-plan` alone is rejected; users must specify a mode.
 - traces: add experimental `gcx traces baseline <trace-id>` to retrieve same-operation candidate traces (root identity, operation success, and topology fingerprint) to feed into `gcx traces diff`, with optional raw TraceQL filters when the unfiltered candidates are not valid comparisons.
+- traces: include Tempo `serviceStats` metadata (per-service span and error counts) in structured trace search output.
 
 ## v1.2.0 (2026-08-25)
 

--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -231,6 +231,7 @@
  "gcx datasources query": "finite",
  "gcx datasources schemas get": "finite",
  "gcx datasources schemas list": "finite",
+ "gcx datasources tempo baseline": "finite",
  "gcx datasources tempo diff": "finite",
  "gcx datasources tempo get": "finite",
  "gcx datasources tempo labels": "finite",

--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -542,6 +542,7 @@
  "gcx traces adaptive recommendations apply": "finite",
  "gcx traces adaptive recommendations dismiss": "finite",
  "gcx traces adaptive recommendations list": "finite",
+ "gcx traces baseline": "finite",
  "gcx traces diff": "finite",
  "gcx traces get": "finite",
  "gcx traces labels": "finite",

--- a/docs/reference/cli/gcx_datasources_tempo.md
+++ b/docs/reference/cli/gcx_datasources_tempo.md
@@ -23,6 +23,7 @@ Query Tempo datasources
 ### SEE ALSO
 
 * [gcx datasources](gcx_datasources.md)	 - Manage and query Grafana datasources
+* [gcx datasources tempo baseline](gcx_datasources_tempo_baseline.md)	 - [experimental] Find healthy baseline candidates for a trace
 * [gcx datasources tempo diff](gcx_datasources_tempo_diff.md)	 - [experimental] Compare two traces (baseline vs comparison)
 * [gcx datasources tempo get](gcx_datasources_tempo_get.md)	 - Retrieve a trace by ID
 * [gcx datasources tempo labels](gcx_datasources_tempo_labels.md)	 - List trace labels or label values

--- a/docs/reference/cli/gcx_datasources_tempo_baseline.md
+++ b/docs/reference/cli/gcx_datasources_tempo_baseline.md
@@ -1,0 +1,83 @@
+## gcx datasources tempo baseline
+
+[experimental] Find healthy baseline candidates for a trace
+
+### Synopsis
+
+[experimental] Find healthy, same-operation candidate traces to compare against a seed trace.
+
+TRACE_ID is the seed trace (typically a faulty one). The command fetches it,
+reads its root service/operation and its busiest downstream services, then
+searches for traces with the same root identity whose operation succeeded
+(status != error), pinned to the seed's top downstream services so candidates
+stay on the same execution path.
+
+Run the generated query without --filter first and inspect candidates with
+'gcx traces diff <candidate> <seed>'. Only when those candidates are not valid
+comparisons, add repeatable --filter expressions to require domain-specific
+context such as a tenant, cluster, or query path. Filters are trusted raw
+TraceQL, ANDed with the generated query, and syntax-validated by Tempo.
+
+Downstream errors are deliberately NOT filtered out: surfacing them is the job
+of 'gcx traces diff <candidate> <seed>', which is the real similarity and
+root-cause step. This command only retrieves candidate trace IDs (in the order
+search returns them); it does not rank them.
+
+By default candidates are searched within the seed trace's own time range,
+padded by --window (30m) on each side, so candidates from before or after the
+seed are eligible. Widen with --window, or set an absolute window with
+--from/--to.
+
+This is a heuristic retrieval built on TraceQL search; its query and output may
+change.
+
+```
+gcx datasources tempo baseline TRACE_ID [flags]
+```
+
+### Examples
+
+```
+
+  # Start unfiltered, then diff a candidate as the baseline (B - A semantics)
+  gcx traces baseline abc123
+  gcx traces diff <candidate> abc123
+
+  # Only if unfiltered candidates are not valid comparisons, refine by tenant
+  gcx traces baseline abc123 --filter '{ span.tenantID = "tenant-a" }'
+
+  # Widen the window to 6h before and after the seed, output JSON
+  gcx traces baseline abc123 --window 6h -o json
+```
+
+### Options
+
+```
+  -d, --datasource string    Datasource UID (required unless datasources.tempo is configured)
+      --filter stringArray   Raw TraceQL spanset expression to refine candidates when unfiltered results are not valid comparisons (repeatable; ANDed with the generated query)
+      --from string          Absolute start time override (RFC3339, Unix timestamp, or relative like 'now-1h'); requires --to
+  -h, --help                 help for baseline
+      --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int            Maximum number of candidates to return; must be at least 1 (default 20)
+  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+      --to string            Absolute end time override (RFC3339, Unix timestamp, or relative like 'now'); requires --from
+      --window string        Search window padding applied before and after the seed trace's time range, so candidates from before or after the seed are eligible (e.g., 30m, 6h, 7d). Ignored when --from/--to are set (default "30m")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, OPENCODE, PI_CODING_AGENT, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx datasources tempo](gcx_datasources_tempo.md)	 - Query Tempo datasources
+

--- a/docs/reference/cli/gcx_traces.md
+++ b/docs/reference/cli/gcx_traces.md
@@ -24,6 +24,7 @@ Query Tempo datasources and manage Adaptive Traces
 
 * [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
 * [gcx traces adaptive](gcx_traces_adaptive.md)	 - Manage Adaptive Traces resources
+* [gcx traces baseline](gcx_traces_baseline.md)	 - [experimental] Find healthy baseline candidates for a trace
 * [gcx traces diff](gcx_traces_diff.md)	 - [experimental] Compare two traces (baseline vs comparison)
 * [gcx traces get](gcx_traces_get.md)	 - Retrieve a trace by ID
 * [gcx traces labels](gcx_traces_labels.md)	 - List trace labels or label values

--- a/docs/reference/cli/gcx_traces_baseline.md
+++ b/docs/reference/cli/gcx_traces_baseline.md
@@ -1,0 +1,73 @@
+## gcx traces baseline
+
+[experimental] Find healthy baseline candidates for a trace
+
+### Synopsis
+
+[experimental] Find healthy, same-operation candidate traces to compare against a seed trace.
+
+TRACE_ID is the seed trace (typically a faulty one). The command fetches it,
+reads its root service/operation and its busiest downstream services, then
+searches for traces with the same root identity whose operation succeeded
+(status != error), pinned to the seed's top downstream services so candidates
+stay on the same execution path.
+
+Downstream errors are deliberately NOT filtered out: surfacing them is the job
+of 'gcx traces diff <seed> <candidate>', which is the real similarity and
+root-cause step. This command only retrieves candidate trace IDs (in the order
+search returns them); it does not rank them.
+
+By default candidates are searched within the seed trace's own time range,
+padded by --window (30m) on each side, so candidates from before or after the
+seed are eligible. Widen with --window, or set an absolute window with
+--from/--to.
+
+This is a heuristic retrieval built on TraceQL search; its query and output may
+change.
+
+```
+gcx traces baseline TRACE_ID [flags]
+```
+
+### Examples
+
+```
+
+  # Find healthy baseline candidates for a trace, then diff against one
+  gcx traces baseline <trace-id>
+  gcx traces diff <trace-id> <candidate>
+
+  # Widen the window to 6h before and after the seed, output JSON
+  gcx traces baseline <trace-id> --window 6h -o json
+```
+
+### Options
+
+```
+  -d, --datasource string   Datasource UID (required unless datasources.tempo is configured)
+      --from string         Absolute start time override (RFC3339, Unix timestamp, or relative like 'now-1h'); requires --to
+  -h, --help                help for baseline
+      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int           Maximum number of candidates to return (default 20)
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --to string           Absolute end time override (RFC3339, Unix timestamp, or relative like 'now'); requires --from
+      --window string       Search window padding applied before and after the seed trace's time range, so candidates from before or after the seed are eligible (e.g., 30m, 6h, 7d). Ignored when --from/--to are set (default "30m")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx traces](gcx_traces.md)	 - Query Tempo datasources and manage Adaptive Traces
+

--- a/docs/reference/cli/gcx_traces_baseline.md
+++ b/docs/reference/cli/gcx_traces_baseline.md
@@ -59,7 +59,7 @@ gcx traces baseline TRACE_ID [flags]
   -h, --help                 help for baseline
       --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int            Maximum number of candidates to return (default 20)
+      --limit int            Maximum number of candidates to return; must be at least 1 (default 20)
   -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
       --to string            Absolute end time override (RFC3339, Unix timestamp, or relative like 'now'); requires --from
       --window string        Search window padding applied before and after the seed trace's time range, so candidates from before or after the seed are eligible (e.g., 30m, 6h, 7d). Ignored when --from/--to are set (default "30m")

--- a/docs/reference/cli/gcx_traces_baseline.md
+++ b/docs/reference/cli/gcx_traces_baseline.md
@@ -12,8 +12,14 @@ searches for traces with the same root identity whose operation succeeded
 (status != error), pinned to the seed's top downstream services so candidates
 stay on the same execution path.
 
+Run the generated query without --filter first and inspect candidates with
+'gcx traces diff <candidate> <seed>'. Only when those candidates are not valid
+comparisons, add repeatable --filter expressions to require domain-specific
+context such as a tenant, cluster, or query path. Filters are trusted raw
+TraceQL, ANDed with the generated query, and syntax-validated by Tempo.
+
 Downstream errors are deliberately NOT filtered out: surfacing them is the job
-of 'gcx traces diff <seed> <candidate>', which is the real similarity and
+of 'gcx traces diff <candidate> <seed>', which is the real similarity and
 root-cause step. This command only retrieves candidate trace IDs (in the order
 search returns them); it does not rank them.
 
@@ -33,9 +39,12 @@ gcx traces baseline TRACE_ID [flags]
 
 ```
 
-  # Find healthy baseline candidates for a trace, then diff against one
+  # Start unfiltered, then diff a candidate as the baseline (B - A semantics)
   gcx traces baseline <trace-id>
-  gcx traces diff <trace-id> <candidate>
+  gcx traces diff <candidate> <trace-id>
+
+  # Only if unfiltered candidates are not valid comparisons, refine by tenant
+  gcx traces baseline <trace-id> --filter '{ span.tenantID = "tenant-a" }'
 
   # Widen the window to 6h before and after the seed, output JSON
   gcx traces baseline <trace-id> --window 6h -o json
@@ -44,21 +53,22 @@ gcx traces baseline TRACE_ID [flags]
 ### Options
 
 ```
-  -d, --datasource string   Datasource UID (required unless datasources.tempo is configured)
-      --from string         Absolute start time override (RFC3339, Unix timestamp, or relative like 'now-1h'); requires --to
-  -h, --help                help for baseline
-      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
-      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int           Maximum number of candidates to return (default 20)
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
-      --to string           Absolute end time override (RFC3339, Unix timestamp, or relative like 'now'); requires --from
-      --window string       Search window padding applied before and after the seed trace's time range, so candidates from before or after the seed are eligible (e.g., 30m, 6h, 7d). Ignored when --from/--to are set (default "30m")
+  -d, --datasource string    Datasource UID (required unless datasources.tempo is configured)
+      --filter stringArray   Raw TraceQL spanset expression to refine candidates when unfiltered results are not valid comparisons (repeatable; ANDed with the generated query)
+      --from string          Absolute start time override (RFC3339, Unix timestamp, or relative like 'now-1h'); requires --to
+  -h, --help                 help for baseline
+      --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int            Maximum number of candidates to return (default 20)
+  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+      --to string            Absolute end time override (RFC3339, Unix timestamp, or relative like 'now'); requires --from
+      --window string        Search window padding applied before and after the seed trace's time range, so candidates from before or after the seed are eligible (e.g., 30m, 6h, 7d). Ignored when --from/--to are set (default "30m")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, OPENCODE, PI_CODING_AGENT, or GCX_AGENT_MODE env vars.
       --config string               Path to the configuration file to use
       --context string              Name of the context to use (overrides current-context in config)
       --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.

--- a/internal/datasources/providers/tempo.go
+++ b/internal/datasources/providers/tempo.go
@@ -15,5 +15,6 @@ func init() { //nolint:gochecknoinits // Self-registration pattern (like databas
 		tempo.LabelsCmd,
 		tempo.MetricsCmd,
 		tempo.DiffCmd,
+		tempo.BaselineCmd,
 	))
 }

--- a/internal/datasources/query/codecs.go
+++ b/internal/datasources/query/codecs.go
@@ -41,6 +41,8 @@ func (c *queryTableCodec) Encode(w io.Writer, data any) error {
 		return pyroscope.FormatQueryTable(w, resp)
 	case *tempo.SearchResponse:
 		return tempo.FormatSearchTable(w, resp)
+	case *tempo.BaselineResult:
+		return tempo.FormatBaselineTable(w, resp)
 	case *tempo.MetricsResponse:
 		return tempo.FormatMetricsTable(w, resp)
 	case *infinity.QueryResponse:
@@ -96,6 +98,8 @@ func (c *queryWideCodec) Encode(w io.Writer, data any) error {
 		return loki.FormatQueryTableWide(w, resp)
 	case *tempo.SearchResponse:
 		return tempo.FormatSearchTable(w, resp)
+	case *tempo.BaselineResult:
+		return tempo.FormatBaselineTable(w, resp)
 	case *infinity.QueryResponse:
 		return infinity.FormatTable(w, resp)
 	case *tempo.GetTraceResponse:

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -310,13 +310,15 @@ func buildBaselineResult(seedID string, profile seedProfile, resp *tempo.SearchR
 			DurationMs:        t.DurationMs,
 		}
 		if t.ServiceStats != nil {
-			spans := 0
+			spans, errorSpans := 0, 0
 			for _, s := range t.ServiceStats {
 				spans += s.SpanCount
+				errorSpans += s.ErrorCount
 			}
 			services := len(t.ServiceStats)
 			candidate.SpanCount = &spans
 			candidate.ServiceCount = &services
+			candidate.ErrorCount = &errorSpans
 		}
 		result.Candidates = append(result.Candidates, candidate)
 	}

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -211,7 +211,7 @@ func (opts *baselineOpts) resolveWindow(profile seedProfile, now time.Time) (tim
 // health is not filtered here — 'gcx traces diff' surfaces downstream errors.
 func buildBaselineQuery(service, operation string, downstream []string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "{ trace:rootService = %s && trace:rootName = %s } && { name = %s && status != error }",
+	fmt.Fprintf(&b, "{ trace:rootService = %s && trace:rootName = %s } && { name = %s && span:status != error && nestedSetParent = -1 }",
 		strconv.Quote(service), strconv.Quote(operation), strconv.Quote(operation))
 	for _, svc := range downstream {
 		fmt.Fprintf(&b, " && { resource.service.name = %s }", strconv.Quote(svc))
@@ -333,7 +333,7 @@ func parseSeedTrace(trace map[string]any) seedProfile {
 
 		// Root = the earliest-starting parentless span.
 		if parent, _ := span["parentSpanId"].(string); strings.TrimSpace(parent) == "" {
-			if !rootFound || start < rootStart {
+			if !rootFound || (start != 0 && (rootStart == 0 || start < rootStart)) {
 				rootFound, rootStart = true, start
 				profile.RootService = service
 				profile.RootOperation, _ = span["name"].(string)

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -219,7 +219,7 @@ change.`,
 
 	cmd.Annotations = map[string]string{
 		agent.AnnotationTokenCost: "medium",
-		agent.AnnotationLLMHint:   "gcx traces baseline -d UID <trace-id> -o json",
+		agent.AnnotationLLMHint:   "gcx datasources tempo baseline -d UID <trace-id> -o json",
 		agent.AnnotationStability: agent.StabilityExperimental,
 	}
 

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -46,7 +47,7 @@ func (opts *baselineOpts) setup(flags *pflag.FlagSet) {
 
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.tempo is configured)")
 	flags.StringArrayVar(&opts.Filters, "filter", nil, "Raw TraceQL spanset expression to refine candidates when unfiltered results are not valid comparisons (repeatable; ANDed with the generated query)")
-	flags.IntVar(&opts.Limit, "limit", 20, "Maximum number of candidates to return")
+	flags.IntVar(&opts.Limit, "limit", 20, "Maximum number of candidates to return; must be at least 1")
 	flags.StringVar(&opts.Window, "window", defaultBaselineWindow, "Search window padding applied before and after the seed trace's time range, so candidates from before or after the seed are eligible (e.g., 30m, 6h, 7d). Ignored when --from/--to are set")
 	// --from/--to give an absolute window override anchored on explicit times
 	// rather than the seed. --since is intentionally omitted: it anchors on now,
@@ -63,6 +64,12 @@ func (opts *baselineOpts) Validate() error {
 		if strings.TrimSpace(filter) == "" {
 			return errors.New("--filter must not be empty")
 		}
+	}
+	if opts.Limit < 1 {
+		return errors.New("--limit must be at least 1")
+	}
+	if strings.TrimSpace(opts.Window) == "" {
+		return errors.New("--window must not be empty")
 	}
 	pad, err := dsquery.ParseDuration(opts.Window)
 	if err != nil {
@@ -162,12 +169,10 @@ change.`,
 				return err
 			}
 
-			// The seed can match its own retrieval query, so fetch one extra and
-			// drop it, keeping up to --limit candidates.
-			fetchLimit := opts.Limit
-			if fetchLimit > 0 {
-				fetchLimit++
-			}
+			// The seed can match its own retrieval query. Fetch one slot for it
+			// plus one spare candidate so truncation remains detectable after the
+			// seed is excluded.
+			fetchLimit := opts.Limit + 2
 			downstream := downstreamServices(profile.ServiceSpans, profile.RootService, topDownstreamServices)
 			req := tempo.SearchRequest{
 				Query: buildBaselineQuery(profile.RootService, profile.RootOperation, downstream, opts.Filters),
@@ -182,11 +187,23 @@ change.`,
 			}
 
 			resp = excludeTrace(resp, seedID)
+			serverHasMore := resp != nil && len(resp.Traces) > opts.Limit
 			resp = limitTraces(resp, opts.Limit)
+			returned := 0
+			if resp != nil {
+				returned = len(resp.Traces)
+			}
+			meta := cmdio.AttachListMeta(
+				cmdio.PagedListMeta(returned, opts.Limit, serverHasMore, 0),
+				os.Args,
+			)
 
 			result := buildBaselineResult(seedID, profile.ServiceSpans, resp, req.Query)
-
-			return opts.IO.Encode(cmd.OutOrStdout(), result)
+			if err := opts.IO.Encode(cmd.OutOrStdout(), result); err != nil {
+				return err
+			}
+			cmdio.EmitListTruncationHint(cmd.ErrOrStderr(), meta)
+			return nil
 		},
 	}
 
@@ -276,6 +293,7 @@ func buildBaselineResult(seedID string, seedCounts map[string]int, resp *tempo.S
 		SeedSpanCount:    seedSpans,
 		SeedServiceCount: len(seedCounts),
 		Query:            query,
+		Candidates:       make([]tempo.BaselineCandidate, 0),
 	}
 	if resp == nil {
 		return result

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -198,7 +198,8 @@ change.`,
 				os.Args,
 			)
 
-			result := buildBaselineResult(seedID, profile.ServiceSpans, resp, req.Query)
+			result := buildBaselineResult(seedID, profile, resp, req.Query)
+			result.ListMeta = meta
 			if err := opts.IO.Encode(cmd.OutOrStdout(), result); err != nil {
 				return err
 			}
@@ -283,15 +284,11 @@ func downstreamServices(serviceSpans map[string]int, rootService string, n int) 
 // buildBaselineResult enriches the candidates with the structural context
 // (per-candidate span/service counts) and attaches the seed profile. Candidate
 // order is preserved as returned by search.
-func buildBaselineResult(seedID string, seedCounts map[string]int, resp *tempo.SearchResponse, query string) *tempo.BaselineResult {
-	seedSpans := 0
-	for _, n := range seedCounts {
-		seedSpans += n
-	}
+func buildBaselineResult(seedID string, profile seedProfile, resp *tempo.SearchResponse, query string) *tempo.BaselineResult {
 	result := &tempo.BaselineResult{
 		SeedTraceID:      seedID,
-		SeedSpanCount:    seedSpans,
-		SeedServiceCount: len(seedCounts),
+		SeedSpanCount:    profile.SpanCount,
+		SeedServiceCount: len(profile.ServiceSpans),
 		Query:            query,
 		Candidates:       make([]tempo.BaselineCandidate, 0),
 	}
@@ -299,19 +296,23 @@ func buildBaselineResult(seedID string, seedCounts map[string]int, resp *tempo.S
 		return result
 	}
 	for _, t := range resp.Traces {
-		spans := 0
-		for _, s := range t.ServiceStats {
-			spans += s.SpanCount
-		}
-		result.Candidates = append(result.Candidates, tempo.BaselineCandidate{
+		candidate := tempo.BaselineCandidate{
 			TraceID:           t.TraceID,
 			RootServiceName:   t.RootServiceName,
 			RootTraceName:     t.RootTraceName,
 			StartTimeUnixNano: t.StartTimeUnixNano,
 			DurationMs:        t.DurationMs,
-			SpanCount:         spans,
-			ServiceCount:      len(t.ServiceStats),
-		})
+		}
+		if t.ServiceStats != nil {
+			spans := 0
+			for _, s := range t.ServiceStats {
+				spans += s.SpanCount
+			}
+			services := len(t.ServiceStats)
+			candidate.SpanCount = &spans
+			candidate.ServiceCount = &services
+		}
+		result.Candidates = append(result.Candidates, candidate)
 	}
 	return result
 }
@@ -342,26 +343,30 @@ func excludeTrace(resp *tempo.SearchResponse, seedID string) *tempo.SearchRespon
 
 // ─── seed trace parsing (OTLP-shaped resourceSpans) ─────────────────────────
 
-// seedProfile summarizes a seed trace: its root identity, span time range, and
-// per-service span counts. It is produced by a single traversal of the trace.
+// seedProfile summarizes a seed trace: its root identity, span time range,
+// total span count, and per-service span counts. It is produced by a single
+// traversal of the trace.
 type seedProfile struct {
 	RootService   string
 	RootOperation string
 	MinStartNanos uint64
 	MaxEndNanos   uint64
 	HasTimeRange  bool
+	SpanCount     int
 	ServiceSpans  map[string]int
 }
 
 // parseSeedTrace walks every span in the OTLP-shaped trace once and derives what
-// the command needs: per-service span counts, the overall span time range, and
-// the root identity (earliest parentless span and its resource service.name).
+// the command needs: total and per-service span counts, the overall span time
+// range, and the root identity (earliest parentless span and its resource
+// service.name).
 func parseSeedTrace(trace map[string]any) seedProfile {
 	profile := seedProfile{ServiceSpans: make(map[string]int)}
 	var rootStart uint64
 	rootFound := false
 
 	forEachSpan(trace, func(service string, span map[string]any) {
+		profile.SpanCount++
 		if service != "" {
 			profile.ServiceSpans[service]++
 		}

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -332,7 +332,7 @@ func excludeTrace(resp *tempo.SearchResponse, seedID string) *tempo.SearchRespon
 	}
 	filtered := make([]tempo.SearchTrace, 0, len(resp.Traces))
 	for _, t := range resp.Traces {
-		if t.TraceID == seedID {
+		if strings.EqualFold(t.TraceID, seedID) {
 			continue
 		}
 		filtered = append(filtered, t)

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -177,13 +177,12 @@ change.`,
 				return err
 			}
 
-			// The seed can match its own retrieval query. Fetch one slot for it
-			// plus one spare candidate so truncation remains detectable after the
-			// seed is excluded.
-			fetchLimit := opts.Limit + 2
+			// The query excludes the seed server-side, so only one extra result is
+			// needed to detect truncation.
+			fetchLimit := opts.Limit + 1
 			downstream := downstreamServices(profile.ServiceSpans, profile.RootService, topDownstreamServices)
 			req := tempo.SearchRequest{
-				Query: buildBaselineQuery(profile.RootService, profile.RootOperation, downstream, opts.Filters),
+				Query: buildBaselineQuery(seedID, profile.RootService, profile.RootOperation, downstream, opts.Filters),
 				Start: start,
 				End:   end,
 				Limit: fetchLimit,
@@ -194,7 +193,6 @@ change.`,
 				return fmt.Errorf("baseline candidate search failed: %w", err)
 			}
 
-			resp = excludeTrace(resp, seedID)
 			serverHasMore := resp != nil && len(resp.Traces) > opts.Limit
 			resp = limitTraces(resp, opts.Limit)
 			returned := 0
@@ -247,16 +245,15 @@ func (opts *baselineOpts) resolveWindow(profile seedProfile, now time.Time) (tim
 	return start, end, nil
 }
 
-// buildBaselineQuery constructs the TraceQL retrieval query per the design:
-// same root identity, the operation span constrained to a successful
-// (non-error) status, optional user-supplied candidate filters, and a topology
-// fingerprint pinning the seed's top downstream services so candidates stay on
-// the same execution path. Whole-trace health is not filtered here —
-// 'gcx traces diff' surfaces downstream errors.
-func buildBaselineQuery(service, operation string, downstream, filters []string) string {
+// buildBaselineQuery finds same-operation candidates whose root operation
+// succeeded and whose path includes the seed's busiest downstream services.
+// Excluding the seed with trace:id delegates padded/unpadded ID equivalence to
+// Tempo instead of coupling gcx to response formatting. Downstream errors stay
+// eligible so 'gcx traces diff' can surface them.
+func buildBaselineQuery(seedID, service, operation string, downstream, filters []string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "{ trace:rootService = %s && trace:rootName = %s } && { name = %s && span:status != error && nestedSetParent = -1 }",
-		strconv.Quote(service), strconv.Quote(operation), strconv.Quote(operation))
+	fmt.Fprintf(&b, "{ trace:rootService = %s && trace:rootName = %s && trace:id != %s } && { name = %s && span:status != error && nestedSetParent = -1 }",
+		strconv.Quote(service), strconv.Quote(operation), strconv.Quote(seedID), strconv.Quote(operation))
 	for _, filter := range filters {
 		fmt.Fprintf(&b, " && (%s)", strings.TrimSpace(filter))
 	}
@@ -333,21 +330,6 @@ func limitTraces(resp *tempo.SearchResponse, n int) *tempo.SearchResponse {
 		return resp
 	}
 	return &tempo.SearchResponse{Traces: resp.Traces[:n]}
-}
-
-// excludeTrace returns a copy of resp without the seed trace.
-func excludeTrace(resp *tempo.SearchResponse, seedID string) *tempo.SearchResponse {
-	if resp == nil {
-		return resp
-	}
-	filtered := make([]tempo.SearchTrace, 0, len(resp.Traces))
-	for _, t := range resp.Traces {
-		if strings.EqualFold(t.TraceID, seedID) {
-			continue
-		}
-		filtered = append(filtered, t)
-	}
-	return &tempo.SearchResponse{Traces: filtered}
 }
 
 // ─── seed trace parsing (OTLP-shaped resourceSpans) ─────────────────────────

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -1,0 +1,426 @@
+package tempo
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/gcx/internal/agent"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/tempo"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// defaultBaselineWindow pads the candidate search window before and after the
+// seed trace's own span range so healthy candidates from just before or after
+// the seed are captured. Overridable with --window.
+const defaultBaselineWindow = "30m"
+
+// topDownstreamServices is how many of the seed's busiest downstream services
+// are pinned into the retrieval query as a topology fingerprint. The design
+// recommends ~3-4: enough to keep candidates on the same execution path without
+// over-constraining and losing recall.
+const topDownstreamServices = 3
+
+type baselineOpts struct {
+	dsquery.TimeRangeOpts
+
+	IO         cmdio.Options
+	Datasource string
+	Limit      int
+	Window     string
+}
+
+func (opts *baselineOpts) setup(flags *pflag.FlagSet) {
+	dsquery.RegisterCodecs(&opts.IO, false)
+	opts.IO.DefaultFormat("table")
+	opts.IO.BindFlags(flags)
+
+	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.tempo is configured)")
+	flags.IntVar(&opts.Limit, "limit", 20, "Maximum number of candidates to return")
+	flags.StringVar(&opts.Window, "window", defaultBaselineWindow, "Search window padding applied before and after the seed trace's time range, so candidates from before or after the seed are eligible (e.g., 30m, 6h, 7d). Ignored when --from/--to are set")
+	// --from/--to give an absolute window override anchored on explicit times
+	// rather than the seed. --since is intentionally omitted: it anchors on now,
+	// which is wrong for a seed trace that may be hours or days old.
+	flags.StringVar(&opts.From, "from", "", "Absolute start time override (RFC3339, Unix timestamp, or relative like 'now-1h'); requires --to")
+	flags.StringVar(&opts.To, "to", "", "Absolute end time override (RFC3339, Unix timestamp, or relative like 'now'); requires --from")
+}
+
+func (opts *baselineOpts) Validate() error {
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+	pad, err := dsquery.ParseDuration(opts.Window)
+	if err != nil {
+		return fmt.Errorf("invalid --window duration: %w", err)
+	}
+	if pad < 0 {
+		return errors.New("--window must not be negative")
+	}
+	return opts.ValidateTimeRange()
+}
+
+// BaselineCmd returns the `baseline` subcommand: given a seed trace, it finds
+// healthy same-operation candidate traces to diff against.
+func BaselineCmd(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &baselineOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "baseline TRACE_ID",
+		Short: "[experimental] Find healthy baseline candidates for a trace",
+		Long: `[experimental] Find healthy, same-operation candidate traces to compare against a seed trace.
+
+TRACE_ID is the seed trace (typically a faulty one). The command fetches it,
+reads its root service/operation and its busiest downstream services, then
+searches for traces with the same root identity whose operation succeeded
+(status != error), pinned to the seed's top downstream services so candidates
+stay on the same execution path.
+
+Downstream errors are deliberately NOT filtered out: surfacing them is the job
+of 'gcx traces diff <seed> <candidate>', which is the real similarity and
+root-cause step. This command only retrieves candidate trace IDs (in the order
+search returns them); it does not rank them.
+
+By default candidates are searched within the seed trace's own time range,
+padded by --window (30m) on each side, so candidates from before or after the
+seed are eligible. Widen with --window, or set an absolute window with
+--from/--to.
+
+This is a heuristic retrieval built on TraceQL search; its query and output may
+change.`,
+		Example: `
+  # Find baseline candidates for a trace, then diff against one
+  gcx traces baseline abc123
+  gcx traces diff abc123 <candidate>
+
+  # Widen the window to 6h before and after the seed, output JSON
+  gcx traces baseline abc123 --window 6h -o json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+
+			cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
+			if err != nil {
+				return err
+			}
+
+			datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "tempo")
+			if err != nil {
+				return err
+			}
+
+			seedID := args[0]
+
+			client, err := tempo.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			// Fetch the seed trace (no time range → full lookup) and read its
+			// root identity and span time range.
+			seed, err := client.GetTrace(ctx, datasourceUID, tempo.GetTraceRequest{TraceID: seedID})
+			if err != nil {
+				return fmt.Errorf("failed to fetch seed trace: %w", err)
+			}
+
+			// Single pass over the seed trace: root identity, span time range,
+			// and per-service span counts.
+			profile := parseSeedTrace(seed.Trace)
+			if profile.RootService == "" || profile.RootOperation == "" {
+				return fmt.Errorf("could not determine root service/operation from trace %q", seedID)
+			}
+
+			start, end, err := opts.resolveWindow(profile, time.Now())
+			if err != nil {
+				return err
+			}
+
+			// The seed can match its own retrieval query, so fetch one extra and
+			// drop it, keeping up to --limit candidates.
+			fetchLimit := opts.Limit
+			if fetchLimit > 0 {
+				fetchLimit++
+			}
+			downstream := downstreamServices(profile.ServiceSpans, profile.RootService, topDownstreamServices)
+			req := tempo.SearchRequest{
+				Query: buildBaselineQuery(profile.RootService, profile.RootOperation, downstream),
+				Start: start,
+				End:   end,
+				Limit: fetchLimit,
+			}
+
+			resp, err := client.Search(ctx, datasourceUID, req)
+			if err != nil {
+				return fmt.Errorf("baseline candidate search failed: %w", err)
+			}
+
+			resp = excludeTrace(resp, seedID)
+			resp = limitTraces(resp, opts.Limit)
+
+			result := buildBaselineResult(seedID, profile.ServiceSpans, resp, req.Query)
+
+			return opts.IO.Encode(cmd.OutOrStdout(), result)
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		agent.AnnotationTokenCost: "medium",
+		agent.AnnotationLLMHint:   "gcx traces baseline -d UID <trace-id> -o json",
+		agent.AnnotationStability: agent.StabilityExperimental,
+	}
+
+	opts.setup(cmd.Flags())
+
+	return cmd
+}
+
+// resolveWindow returns the candidate search window: an explicit --from/--to
+// range when provided, otherwise the seed trace's own span range padded by
+// --window on each side (before and after the seed).
+func (opts *baselineOpts) resolveWindow(profile seedProfile, now time.Time) (time.Time, time.Time, error) {
+	if opts.IsRange() {
+		return opts.ParseTimeRange(now)
+	}
+	if !profile.HasTimeRange {
+		return time.Time{}, time.Time{}, errors.New("seed trace has no span timestamps; specify --from/--to")
+	}
+	pad, err := dsquery.ParseDuration(opts.Window)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid --window duration: %w", err)
+	}
+	start := unixNanoToTime(profile.MinStartNanos).Add(-pad)
+	end := unixNanoToTime(profile.MaxEndNanos).Add(pad)
+	return start, end, nil
+}
+
+// buildBaselineQuery constructs the TraceQL retrieval query per the design:
+// same root identity, the operation span constrained to a successful
+// (non-error) status, and a topology fingerprint pinning the seed's top
+// downstream services so candidates stay on the same execution path. Whole-trace
+// health is not filtered here — 'gcx traces diff' surfaces downstream errors.
+func buildBaselineQuery(service, operation string, downstream []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "{ trace:rootService = %s && trace:rootName = %s } && { name = %s && status != error }",
+		strconv.Quote(service), strconv.Quote(operation), strconv.Quote(operation))
+	for _, svc := range downstream {
+		fmt.Fprintf(&b, " && { resource.service.name = %s }", strconv.Quote(svc))
+	}
+	return b.String()
+}
+
+// downstreamServices returns up to n of the seed's busiest non-root services,
+// ordered by span count desc with a name tie-break for a deterministic query.
+// These form the topology fingerprint in buildBaselineQuery.
+func downstreamServices(serviceSpans map[string]int, rootService string, n int) []string {
+	names := make([]string, 0, len(serviceSpans))
+	for name := range serviceSpans {
+		if name == rootService || name == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.SliceStable(names, func(i, j int) bool {
+		ci, cj := serviceSpans[names[i]], serviceSpans[names[j]]
+		if ci != cj {
+			return ci > cj
+		}
+		return names[i] < names[j]
+	})
+	if len(names) > n {
+		names = names[:n]
+	}
+	return names
+}
+
+// buildBaselineResult enriches the candidates with the structural context
+// (per-candidate span/service counts) and attaches the seed profile. Candidate
+// order is preserved as returned by search.
+func buildBaselineResult(seedID string, seedCounts map[string]int, resp *tempo.SearchResponse, query string) *tempo.BaselineResult {
+	seedSpans := 0
+	for _, n := range seedCounts {
+		seedSpans += n
+	}
+	result := &tempo.BaselineResult{
+		SeedTraceID:      seedID,
+		SeedSpanCount:    seedSpans,
+		SeedServiceCount: len(seedCounts),
+		Query:            query,
+	}
+	if resp == nil {
+		return result
+	}
+	for _, t := range resp.Traces {
+		spans := 0
+		for _, s := range t.ServiceStats {
+			spans += s.SpanCount
+		}
+		result.Candidates = append(result.Candidates, tempo.BaselineCandidate{
+			TraceID:           t.TraceID,
+			RootServiceName:   t.RootServiceName,
+			RootTraceName:     t.RootTraceName,
+			StartTimeUnixNano: t.StartTimeUnixNano,
+			DurationMs:        t.DurationMs,
+			SpanCount:         spans,
+			ServiceCount:      len(t.ServiceStats),
+		})
+	}
+	return result
+}
+
+// limitTraces trims resp to at most n traces, preserving order. n <= 0 means no
+// cap. It returns a new response so the caller's slice is not aliased.
+func limitTraces(resp *tempo.SearchResponse, n int) *tempo.SearchResponse {
+	if resp == nil || n <= 0 || len(resp.Traces) <= n {
+		return resp
+	}
+	return &tempo.SearchResponse{Traces: resp.Traces[:n]}
+}
+
+// excludeTrace returns a copy of resp without the seed trace.
+func excludeTrace(resp *tempo.SearchResponse, seedID string) *tempo.SearchResponse {
+	if resp == nil {
+		return resp
+	}
+	filtered := make([]tempo.SearchTrace, 0, len(resp.Traces))
+	for _, t := range resp.Traces {
+		if t.TraceID == seedID {
+			continue
+		}
+		filtered = append(filtered, t)
+	}
+	return &tempo.SearchResponse{Traces: filtered}
+}
+
+// ─── seed trace parsing (OTLP-shaped resourceSpans) ─────────────────────────
+
+// seedProfile summarizes a seed trace: its root identity, span time range, and
+// per-service span counts. It is produced by a single traversal of the trace.
+type seedProfile struct {
+	RootService   string
+	RootOperation string
+	MinStartNanos uint64
+	MaxEndNanos   uint64
+	HasTimeRange  bool
+	ServiceSpans  map[string]int
+}
+
+// parseSeedTrace walks every span in the OTLP-shaped trace once and derives what
+// the command needs: per-service span counts, the overall span time range, and
+// the root identity (earliest parentless span and its resource service.name).
+func parseSeedTrace(trace map[string]any) seedProfile {
+	profile := seedProfile{ServiceSpans: make(map[string]int)}
+	var rootStart uint64
+	rootFound := false
+
+	forEachSpan(trace, func(service string, span map[string]any) {
+		if service != "" {
+			profile.ServiceSpans[service]++
+		}
+
+		start := parseUnixNano(span["startTimeUnixNano"])
+		profile.foldTimeRange(start, parseUnixNano(span["endTimeUnixNano"]))
+
+		// Root = the earliest-starting parentless span.
+		if parent, _ := span["parentSpanId"].(string); strings.TrimSpace(parent) == "" {
+			if !rootFound || start < rootStart {
+				rootFound, rootStart = true, start
+				profile.RootService = service
+				profile.RootOperation, _ = span["name"].(string)
+			}
+		}
+	})
+	return profile
+}
+
+// foldTimeRange widens the profile's [MinStartNanos, MaxEndNanos] by a span's
+// start/end, ignoring zero (absent) timestamps so a missing start can't drag the
+// window back to the epoch. start <= end always holds, so the min/max over all
+// real timestamps is exactly [earliest start, latest end].
+func (p *seedProfile) foldTimeRange(start, end uint64) {
+	for _, ts := range [2]uint64{start, end} {
+		if ts == 0 {
+			continue
+		}
+		if !p.HasTimeRange || ts < p.MinStartNanos {
+			p.MinStartNanos = ts
+		}
+		if !p.HasTimeRange || ts > p.MaxEndNanos {
+			p.MaxEndNanos = ts
+		}
+		p.HasTimeRange = true
+	}
+}
+
+// forEachSpan calls fn for every span in the OTLP-shaped trace, passing the
+// resource's service.name ("" when absent). It isolates the resourceSpans ->
+// scopeSpans -> spans descent so callers stay flat.
+func forEachSpan(trace map[string]any, fn func(service string, span map[string]any)) {
+	for _, rs := range asAnySlice(trace["resourceSpans"]) {
+		rsm, _ := rs.(map[string]any)
+		if rsm == nil {
+			continue
+		}
+		service := resourceServiceName(rsm)
+		for _, ss := range asAnySlice(rsm["scopeSpans"]) {
+			ssm, _ := ss.(map[string]any)
+			for _, sp := range asAnySlice(ssm["spans"]) {
+				if span, ok := sp.(map[string]any); ok {
+					fn(service, span)
+				}
+			}
+		}
+	}
+}
+
+func resourceServiceName(rs map[string]any) string {
+	res, _ := rs["resource"].(map[string]any)
+	for _, a := range asAnySlice(res["attributes"]) {
+		am, _ := a.(map[string]any)
+		if am == nil {
+			continue
+		}
+		if key, _ := am["key"].(string); key != "service.name" {
+			continue
+		}
+		val, _ := am["value"].(map[string]any)
+		s, _ := val["stringValue"].(string)
+		return s
+	}
+	return ""
+}
+
+func asAnySlice(v any) []any {
+	s, _ := v.([]any)
+	return s
+}
+
+// unixNanoToTime converts unix nanoseconds to time.Time, bounding the value to
+// avoid a uint64->int64 overflow (timestamps fit in int64 until year 2262).
+func unixNanoToTime(n uint64) time.Time {
+	if n > math.MaxInt64 {
+		n = math.MaxInt64
+	}
+	return time.Unix(0, int64(n))
+}
+
+func parseUnixNano(v any) uint64 {
+	switch t := v.(type) {
+	case string:
+		n, _ := strconv.ParseUint(t, 10, 64)
+		return n
+	case float64:
+		return uint64(t)
+	}
+	return 0
+}

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -34,6 +34,7 @@ type baselineOpts struct {
 
 	IO         cmdio.Options
 	Datasource string
+	Filters    []string
 	Limit      int
 	Window     string
 }
@@ -44,6 +45,7 @@ func (opts *baselineOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.tempo is configured)")
+	flags.StringArrayVar(&opts.Filters, "filter", nil, "Raw TraceQL spanset expression to refine candidates when unfiltered results are not valid comparisons (repeatable; ANDed with the generated query)")
 	flags.IntVar(&opts.Limit, "limit", 20, "Maximum number of candidates to return")
 	flags.StringVar(&opts.Window, "window", defaultBaselineWindow, "Search window padding applied before and after the seed trace's time range, so candidates from before or after the seed are eligible (e.g., 30m, 6h, 7d). Ignored when --from/--to are set")
 	// --from/--to give an absolute window override anchored on explicit times
@@ -56,6 +58,11 @@ func (opts *baselineOpts) setup(flags *pflag.FlagSet) {
 func (opts *baselineOpts) Validate() error {
 	if err := opts.IO.Validate(); err != nil {
 		return err
+	}
+	for _, filter := range opts.Filters {
+		if strings.TrimSpace(filter) == "" {
+			return errors.New("--filter must not be empty")
+		}
 	}
 	pad, err := dsquery.ParseDuration(opts.Window)
 	if err != nil {
@@ -83,8 +90,14 @@ searches for traces with the same root identity whose operation succeeded
 (status != error), pinned to the seed's top downstream services so candidates
 stay on the same execution path.
 
+Run the generated query without --filter first and inspect candidates with
+'gcx traces diff <candidate> <seed>'. Only when those candidates are not valid
+comparisons, add repeatable --filter expressions to require domain-specific
+context such as a tenant, cluster, or query path. Filters are trusted raw
+TraceQL, ANDed with the generated query, and syntax-validated by Tempo.
+
 Downstream errors are deliberately NOT filtered out: surfacing them is the job
-of 'gcx traces diff <seed> <candidate>', which is the real similarity and
+of 'gcx traces diff <candidate> <seed>', which is the real similarity and
 root-cause step. This command only retrieves candidate trace IDs (in the order
 search returns them); it does not rank them.
 
@@ -96,9 +109,12 @@ seed are eligible. Widen with --window, or set an absolute window with
 This is a heuristic retrieval built on TraceQL search; its query and output may
 change.`,
 		Example: `
-  # Find baseline candidates for a trace, then diff against one
+  # Start unfiltered, then diff a candidate as the baseline (B - A semantics)
   gcx traces baseline abc123
-  gcx traces diff abc123 <candidate>
+  gcx traces diff <candidate> abc123
+
+  # Only if unfiltered candidates are not valid comparisons, refine by tenant
+  gcx traces baseline abc123 --filter '{ span.tenantID = "tenant-a" }'
 
   # Widen the window to 6h before and after the seed, output JSON
   gcx traces baseline abc123 --window 6h -o json`,
@@ -154,7 +170,7 @@ change.`,
 			}
 			downstream := downstreamServices(profile.ServiceSpans, profile.RootService, topDownstreamServices)
 			req := tempo.SearchRequest{
-				Query: buildBaselineQuery(profile.RootService, profile.RootOperation, downstream),
+				Query: buildBaselineQuery(profile.RootService, profile.RootOperation, downstream, opts.Filters),
 				Start: start,
 				End:   end,
 				Limit: fetchLimit,
@@ -206,13 +222,17 @@ func (opts *baselineOpts) resolveWindow(profile seedProfile, now time.Time) (tim
 
 // buildBaselineQuery constructs the TraceQL retrieval query per the design:
 // same root identity, the operation span constrained to a successful
-// (non-error) status, and a topology fingerprint pinning the seed's top
-// downstream services so candidates stay on the same execution path. Whole-trace
-// health is not filtered here — 'gcx traces diff' surfaces downstream errors.
-func buildBaselineQuery(service, operation string, downstream []string) string {
+// (non-error) status, optional user-supplied candidate filters, and a topology
+// fingerprint pinning the seed's top downstream services so candidates stay on
+// the same execution path. Whole-trace health is not filtered here —
+// 'gcx traces diff' surfaces downstream errors.
+func buildBaselineQuery(service, operation string, downstream, filters []string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "{ trace:rootService = %s && trace:rootName = %s } && { name = %s && span:status != error && nestedSetParent = -1 }",
 		strconv.Quote(service), strconv.Quote(operation), strconv.Quote(operation))
+	for _, filter := range filters {
+		fmt.Fprintf(&b, " && (%s)", strings.TrimSpace(filter))
+	}
 	for _, svc := range downstream {
 		fmt.Fprintf(&b, " && { resource.service.name = %s }", strconv.Quote(svc))
 	}

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -193,16 +193,12 @@ change.`,
 				return fmt.Errorf("baseline candidate search failed: %w", err)
 			}
 
-			serverHasMore := resp != nil && len(resp.Traces) > opts.Limit
-			resp = limitTraces(resp, opts.Limit)
-			returned := 0
-			if resp != nil {
-				returned = len(resp.Traces)
+			if resp == nil {
+				resp = &tempo.SearchResponse{}
 			}
-			meta := cmdio.AttachListMeta(
-				cmdio.PagedListMeta(returned, opts.Limit, serverHasMore, 0),
-				os.Args,
-			)
+			traces, meta := cmdio.TruncatePagedList(resp.Traces, opts.Limit)
+			resp.Traces = traces
+			meta = cmdio.AttachListMeta(meta, os.Args)
 
 			result := buildBaselineResult(seedID, profile, resp, req.Query)
 			result.SeedPartial = seedPartial
@@ -323,15 +319,6 @@ func buildBaselineResult(seedID string, profile seedProfile, resp *tempo.SearchR
 		result.Candidates = append(result.Candidates, candidate)
 	}
 	return result
-}
-
-// limitTraces trims resp to at most n traces, preserving order. n <= 0 means no
-// cap. It returns a new response so the caller's slice is not aliased.
-func limitTraces(resp *tempo.SearchResponse, n int) *tempo.SearchResponse {
-	if resp == nil || n <= 0 || len(resp.Traces) <= n {
-		return resp
-	}
-	return &tempo.SearchResponse{Traces: resp.Traces[:n]}
 }
 
 // ─── seed trace parsing (OTLP-shaped resourceSpans) ─────────────────────────

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -157,6 +157,14 @@ change.`,
 				return fmt.Errorf("failed to fetch seed trace: %w", err)
 			}
 
+			seedPartial := seed.Partial != nil && *seed.Partial
+			if seedPartial {
+				cmdio.EmitWarn(cmd.ErrOrStderr(), fmt.Sprintf(
+					"seed trace %q is partial; baseline retrieval uses only the spans returned by Tempo",
+					seedID,
+				))
+			}
+
 			// Single pass over the seed trace: root identity, span time range,
 			// and per-service span counts.
 			profile := parseSeedTrace(seed.Trace)
@@ -199,6 +207,7 @@ change.`,
 			)
 
 			result := buildBaselineResult(seedID, profile, resp, req.Query)
+			result.SeedPartial = seedPartial
 			result.ListMeta = meta
 			if err := opts.IO.Encode(cmd.OutOrStdout(), result); err != nil {
 				return err

--- a/internal/datasources/tempo/baseline_test.go
+++ b/internal/datasources/tempo/baseline_test.go
@@ -1,0 +1,300 @@
+//nolint:testpackage // Tests cover unexported seed-trace parsing and query builders.
+package tempo
+
+import (
+	"testing"
+	"time"
+
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/query/tempo"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// unixNanos converts a unix second to the uint64 nanosecond form used by the
+// seed profile's time range.
+func unixNanos(sec uint64) uint64 { return sec * 1_000_000_000 }
+
+// newTestOpts returns baselineOpts with IO fully initialized (default codecs
+// and format) via setup, so Validate() reaches the --window checks instead of
+// failing earlier on an uninitialized IO.
+func newTestOpts(window string) *baselineOpts {
+	opts := &baselineOpts{}
+	opts.setup(pflag.NewFlagSet("test", pflag.ContinueOnError))
+	opts.Window = window
+	return opts
+}
+
+func TestResolveWindow_SeedRangePaddedByWindow(t *testing.T) {
+	opts := &baselineOpts{Window: "30m"}
+	profile := seedProfile{
+		HasTimeRange:  true,
+		MinStartNanos: unixNanos(1_700_000_000),
+		MaxEndNanos:   unixNanos(1_700_000_060), // +60s
+	}
+	start, end, err := opts.resolveWindow(profile, time.Now())
+	require.NoError(t, err)
+	// Padded 30m before the min start and 30m after the max end (past + future).
+	assert.Equal(t, time.Unix(1_700_000_000, 0).Add(-30*time.Minute), start)
+	assert.Equal(t, time.Unix(1_700_000_060, 0).Add(30*time.Minute), end)
+}
+
+func TestResolveWindow_ExplicitRangeOverridesSeed(t *testing.T) {
+	opts := &baselineOpts{Window: "30m"}
+	opts.From = "2023-11-14T00:00:00Z"
+	opts.To = "2023-11-14T06:00:00Z"
+	profile := seedProfile{HasTimeRange: true, MinStartNanos: unixNanos(1_700_000_000), MaxEndNanos: unixNanos(1_700_000_060)}
+	start, end, err := opts.resolveWindow(profile, time.Now())
+	require.NoError(t, err)
+	wantStart, _ := dsquery.ParseTime("2023-11-14T00:00:00Z", time.Now())
+	wantEnd, _ := dsquery.ParseTime("2023-11-14T06:00:00Z", time.Now())
+	assert.Equal(t, wantStart, start)
+	assert.Equal(t, wantEnd, end)
+}
+
+func TestResolveWindow_NoSeedTimestampsErrors(t *testing.T) {
+	opts := &baselineOpts{Window: "30m"}
+	_, _, err := opts.resolveWindow(seedProfile{HasTimeRange: false}, time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--from/--to")
+}
+
+func TestValidate_RejectsNegativeAndInvalidWindow(t *testing.T) {
+	require.NoError(t, newTestOpts("30m").Validate())
+
+	err := newTestOpts("-1h").Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--window")
+
+	err = newTestOpts("nonsense").Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--window")
+}
+
+// otlpTrace builds a minimal OTLP-shaped trace with two resources: a root span
+// (no parent) in "checkout" and a child span in "postgres".
+func otlpTrace() map[string]any {
+	return map[string]any{
+		"resourceSpans": []any{
+			map[string]any{
+				"resource": map[string]any{
+					"attributes": []any{
+						map[string]any{"key": "service.name", "value": map[string]any{"stringValue": "checkout"}},
+					},
+				},
+				"scopeSpans": []any{
+					map[string]any{
+						"spans": []any{
+							map[string]any{
+								"name":              "POST /checkout",
+								"spanId":            "aaaa",
+								"startTimeUnixNano": "1700000000000000000",
+								"endTimeUnixNano":   "1700000000500000000",
+							},
+						},
+					},
+				},
+			},
+			map[string]any{
+				"resource": map[string]any{
+					"attributes": []any{
+						map[string]any{"key": "service.name", "value": map[string]any{"stringValue": "postgres"}},
+					},
+				},
+				"scopeSpans": []any{
+					map[string]any{
+						"spans": []any{
+							map[string]any{
+								"name":              "SELECT",
+								"spanId":            "bbbb",
+								"parentSpanId":      "aaaa",
+								"startTimeUnixNano": "1700000000100000000",
+								"endTimeUnixNano":   "1700000000900000000",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestParseSeedTrace(t *testing.T) {
+	p := parseSeedTrace(otlpTrace())
+	assert.Equal(t, "checkout", p.RootService)
+	assert.Equal(t, "POST /checkout", p.RootOperation)
+	assert.True(t, p.HasTimeRange)
+	assert.Equal(t, uint64(1700000000000000000), p.MinStartNanos)
+	assert.Equal(t, uint64(1700000000900000000), p.MaxEndNanos)
+	assert.Equal(t, map[string]int{"checkout": 1, "postgres": 1}, p.ServiceSpans)
+}
+
+func TestParseSeedTrace_NoRootSpan(t *testing.T) {
+	// Every span has a parent and no timestamps → no root, no time range.
+	trace := map[string]any{
+		"resourceSpans": []any{
+			map[string]any{
+				"resource": map[string]any{
+					"attributes": []any{
+						map[string]any{"key": "service.name", "value": map[string]any{"stringValue": "svc"}},
+					},
+				},
+				"scopeSpans": []any{
+					map[string]any{
+						"spans": []any{
+							map[string]any{"name": "child", "parentSpanId": "xyz"},
+						},
+					},
+				},
+			},
+		},
+	}
+	p := parseSeedTrace(trace)
+	assert.Empty(t, p.RootService)
+	assert.Empty(t, p.RootOperation)
+	assert.False(t, p.HasTimeRange)
+	assert.Equal(t, map[string]int{"svc": 1}, p.ServiceSpans)
+}
+
+func TestParseSeedTrace_SkipsZeroTimestamps(t *testing.T) {
+	// The first span has no start timestamp (only an end); a later span carries
+	// the real earliest start. MinStartNanos must reflect the real earliest
+	// timestamp, not be poisoned to 0 (which would push the window back to 1970).
+	trace := map[string]any{
+		"resourceSpans": []any{
+			map[string]any{
+				"resource": map[string]any{
+					"attributes": []any{
+						map[string]any{"key": "service.name", "value": map[string]any{"stringValue": "svc"}},
+					},
+				},
+				"scopeSpans": []any{
+					map[string]any{
+						"spans": []any{
+							// Root span missing startTimeUnixNano.
+							map[string]any{"name": "root", "endTimeUnixNano": "1700000000900000000"},
+							// Child carries the real earliest start.
+							map[string]any{"name": "child", "parentSpanId": "x", "startTimeUnixNano": "1700000000200000000", "endTimeUnixNano": "1700000000500000000"},
+						},
+					},
+				},
+			},
+		},
+	}
+	p := parseSeedTrace(trace)
+	assert.True(t, p.HasTimeRange)
+	assert.Equal(t, uint64(1700000000200000000), p.MinStartNanos)
+	assert.Equal(t, uint64(1700000000900000000), p.MaxEndNanos)
+}
+
+func TestFoldTimeRange(t *testing.T) {
+	var p seedProfile
+	p.foldTimeRange(0, 0) // both absent → no range established
+	assert.False(t, p.HasTimeRange)
+
+	p.foldTimeRange(200, 500)
+	p.foldTimeRange(0, 900) // zero start ignored; 900 extends the max
+	p.foldTimeRange(100, 0) // 100 extends the min; zero end ignored
+	assert.True(t, p.HasTimeRange)
+	assert.Equal(t, uint64(100), p.MinStartNanos)
+	assert.Equal(t, uint64(900), p.MaxEndNanos)
+}
+
+func TestBuildBaselineQuery(t *testing.T) {
+	q := buildBaselineQuery("checkout", "POST /checkout", nil)
+	assert.Equal(t,
+		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && status != error }`,
+		q,
+	)
+}
+
+func TestBuildBaselineQuery_TopologyFingerprint(t *testing.T) {
+	q := buildBaselineQuery("checkout", "POST /checkout", []string{"payments", "postgres"})
+	assert.Equal(t,
+		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && status != error } && { resource.service.name = "payments" } && { resource.service.name = "postgres" }`,
+		q,
+	)
+}
+
+func TestBuildBaselineQuery_QuotesSpecialChars(t *testing.T) {
+	q := buildBaselineQuery("svc\"x", "op\\y", []string{"weird\"svc"})
+	// strconv.Quote escapes embedded quotes/backslashes so the TraceQL stays valid.
+	assert.Contains(t, q, `trace:rootService = "svc\"x"`)
+	assert.Contains(t, q, `name = "op\\y"`)
+	assert.Contains(t, q, `resource.service.name = "weird\"svc"`)
+}
+
+func TestDownstreamServices(t *testing.T) {
+	seed := map[string]int{
+		"checkout": 10, // root, excluded
+		"payments": 5,
+		"postgres": 8,
+		"cache":    2,
+		"":         3, // no service name, excluded
+	}
+	// Ordered by span count desc, name tie-break; root and "" excluded.
+	assert.Equal(t, []string{"postgres", "payments", "cache"}, downstreamServices(seed, "checkout", 3))
+	// n caps the result.
+	assert.Equal(t, []string{"postgres", "payments"}, downstreamServices(seed, "checkout", 2))
+	// Single-service trace → no downstream.
+	assert.Empty(t, downstreamServices(map[string]int{"checkout": 4}, "checkout", 3))
+}
+
+func TestExcludeTrace(t *testing.T) {
+	resp := &tempo.SearchResponse{Traces: []tempo.SearchTrace{
+		{TraceID: "seed"},
+		{TraceID: "cand1"},
+		{TraceID: "cand2"},
+	}}
+	out := excludeTrace(resp, "seed")
+	require.Len(t, out.Traces, 2)
+	for _, tr := range out.Traces {
+		assert.NotEqual(t, "seed", tr.TraceID)
+	}
+}
+
+func TestExcludeTrace_Nil(t *testing.T) {
+	assert.Nil(t, excludeTrace(nil, "seed"))
+}
+
+func TestLimitTraces(t *testing.T) {
+	resp := &tempo.SearchResponse{Traces: []tempo.SearchTrace{
+		{TraceID: "a"}, {TraceID: "b"}, {TraceID: "c"},
+	}}
+
+	got := limitTraces(resp, 2)
+	require.Len(t, got.Traces, 2)
+	assert.Equal(t, "a", got.Traces[0].TraceID)
+	assert.Equal(t, "b", got.Traces[1].TraceID)
+
+	assert.Len(t, limitTraces(resp, 5).Traces, 3) // n >= len: no-op
+	assert.Len(t, limitTraces(resp, 0).Traces, 3) // n <= 0: no cap
+	assert.Nil(t, limitTraces(nil, 2))            // nil is safe
+}
+
+func TestBuildBaselineResult(t *testing.T) {
+	seed := map[string]int{"checkout": 4, "postgres": 2} // 6 spans, 2 services
+	resp := &tempo.SearchResponse{Traces: []tempo.SearchTrace{
+		{TraceID: "exact", RootServiceName: "checkout", RootTraceName: "POST /x", DurationMs: 30,
+			ServiceStats: map[string]tempo.ServiceStats{"checkout": {SpanCount: 4}, "postgres": {SpanCount: 2}}},
+		{TraceID: "far", RootServiceName: "checkout", RootTraceName: "POST /x", DurationMs: 90,
+			ServiceStats: map[string]tempo.ServiceStats{"checkout": {SpanCount: 40}}},
+	}}
+
+	result := buildBaselineResult("seed-id", seed, resp, "{ }")
+
+	assert.Equal(t, "seed-id", result.SeedTraceID)
+	assert.Equal(t, 6, result.SeedSpanCount)
+	assert.Equal(t, 2, result.SeedServiceCount)
+	require.Len(t, result.Candidates, 2)
+
+	first := result.Candidates[0]
+	assert.Equal(t, "exact", first.TraceID)
+	assert.Equal(t, 6, first.SpanCount)
+	assert.Equal(t, 2, first.ServiceCount)
+
+	second := result.Candidates[1]
+	assert.Equal(t, 40, second.SpanCount)
+	assert.Equal(t, 1, second.ServiceCount)
+}

--- a/internal/datasources/tempo/baseline_test.go
+++ b/internal/datasources/tempo/baseline_test.go
@@ -72,6 +72,30 @@ func TestValidate_RejectsNegativeAndInvalidWindow(t *testing.T) {
 	assert.Contains(t, err.Error(), "--window")
 }
 
+func TestValidate_RejectsEmptyFilter(t *testing.T) {
+	opts := newTestOpts("30m")
+	opts.Filters = []string{`{ span.tenantID = "tenant-a" }`, "  "}
+
+	err := opts.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--filter")
+}
+
+func TestSetup_FilterFlagIsRepeatable(t *testing.T) {
+	opts := &baselineOpts{}
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.setup(flags)
+
+	require.NoError(t, flags.Parse([]string{
+		"--filter", `{ span.tenantID = "tenant-a" }`,
+		"--filter", `{ name = "tempopb.Querier/SearchRecent" }`,
+	}))
+	assert.Equal(t, []string{
+		`{ span.tenantID = "tenant-a" }`,
+		`{ name = "tempopb.Querier/SearchRecent" }`,
+	}, opts.Filters)
+}
+
 // otlpTrace builds a minimal OTLP-shaped trace with two resources: a root span
 // (no parent) in "checkout" and a child span in "postgres".
 func otlpTrace() map[string]any {
@@ -243,7 +267,7 @@ func TestFoldTimeRange(t *testing.T) {
 }
 
 func TestBuildBaselineQuery(t *testing.T) {
-	q := buildBaselineQuery("checkout", "POST /checkout", nil)
+	q := buildBaselineQuery("checkout", "POST /checkout", nil, nil)
 	assert.Equal(t,
 		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 }`,
 		q,
@@ -251,15 +275,26 @@ func TestBuildBaselineQuery(t *testing.T) {
 }
 
 func TestBuildBaselineQuery_TopologyFingerprint(t *testing.T) {
-	q := buildBaselineQuery("checkout", "POST /checkout", []string{"payments", "postgres"})
+	q := buildBaselineQuery("checkout", "POST /checkout", []string{"payments", "postgres"}, nil)
 	assert.Equal(t,
 		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 } && { resource.service.name = "payments" } && { resource.service.name = "postgres" }`,
 		q,
 	)
 }
 
+func TestBuildBaselineQuery_Filters(t *testing.T) {
+	q := buildBaselineQuery("checkout", "POST /checkout", []string{"postgres"}, []string{
+		`{ span.tenantID = "tenant-a" }`,
+		`{ resource.k8s.cluster.name = "prod" }`,
+	})
+	assert.Equal(t,
+		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 } && ({ span.tenantID = "tenant-a" }) && ({ resource.k8s.cluster.name = "prod" }) && { resource.service.name = "postgres" }`,
+		q,
+	)
+}
+
 func TestBuildBaselineQuery_QuotesSpecialChars(t *testing.T) {
-	q := buildBaselineQuery("svc\"x", "op\\y", []string{"weird\"svc"})
+	q := buildBaselineQuery("svc\"x", "op\\y", []string{"weird\"svc"}, nil)
 	// strconv.Quote escapes embedded quotes/backslashes so the TraceQL stays valid.
 	assert.Contains(t, q, `trace:rootService = "svc\"x"`)
 	assert.Contains(t, q, `name = "op\\y"`)

--- a/internal/datasources/tempo/baseline_test.go
+++ b/internal/datasources/tempo/baseline_test.go
@@ -2,11 +2,20 @@
 package tempo
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/tempo"
+	"github.com/grafana/gcx/internal/testutils"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,6 +81,25 @@ func TestValidate_RejectsNegativeAndInvalidWindow(t *testing.T) {
 	assert.Contains(t, err.Error(), "--window")
 }
 
+func TestValidate_RejectsLimitBelowOne(t *testing.T) {
+	for _, limit := range []int{0, -1} {
+		opts := newTestOpts("30m")
+		opts.Limit = limit
+
+		err := opts.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--limit")
+	}
+}
+
+func TestValidate_RejectsEmptyWindow(t *testing.T) {
+	opts := newTestOpts("  ")
+
+	err := opts.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--window")
+}
+
 func TestValidate_RejectsEmptyFilter(t *testing.T) {
 	opts := newTestOpts("30m")
 	opts.Filters = []string{`{ span.tenantID = "tenant-a" }`, "  "}
@@ -94,6 +122,83 @@ func TestSetup_FilterFlagIsRepeatable(t *testing.T) {
 		`{ span.tenantID = "tenant-a" }`,
 		`{ name = "tempopb.Querier/SearchRecent" }`,
 	}, opts.Filters)
+}
+
+func TestBaselineCmd_ConstructsSearchRequestAndReportsTruncation(t *testing.T) {
+	testutils.SandboxConfigEnv(t)
+
+	var gotQuery, gotStart, gotEnd, gotLimit string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/bootdata":
+			http.Error(w, `{"message":"not a cloud stack"}`, http.StatusNotFound)
+		case "/api/datasources/proxy/uid/tempo-uid/api/v2/traces/seed-id":
+			w.Header().Set("Content-Type", "application/json")
+			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"trace": otlpTrace()}))
+		case "/api/datasources/proxy/uid/tempo-uid/api/search":
+			gotQuery = r.URL.Query().Get("q")
+			gotStart = r.URL.Query().Get("start")
+			gotEnd = r.URL.Query().Get("end")
+			gotLimit = r.URL.Query().Get("limit")
+
+			traces := make([]map[string]any, 0, 22)
+			traces = append(traces, map[string]any{"traceID": "seed-id"})
+			for i := 1; i <= 21; i++ {
+				traces = append(traces, map[string]any{"traceID": fmt.Sprintf("candidate-%02d", i)})
+			}
+			w.Header().Set("Content-Type", "application/json")
+			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"traces": traces}))
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfgFile := writeBaselineTestConfig(t, `
+contexts:
+  default:
+    grafana:
+      server: "`+srv.URL+`"
+      token: "test-token"
+      org-id: 1
+      tls:
+        insecure-skip-verify: true
+    datasources:
+      tempo: tempo-uid
+current-context: default
+`)
+	loader := &providers.ConfigLoader{}
+	loader.SetConfigFile(cfgFile)
+
+	cmd := BaselineCmd(loader)
+	root := &cobra.Command{Use: "test"}
+	root.AddCommand(cmd)
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"baseline", "seed-id", "-o", "json"})
+
+	require.NoError(t, root.Execute())
+	assert.Equal(t,
+		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 } && { resource.service.name = "postgres" }`,
+		gotQuery,
+	)
+	assert.Equal(t, "1699998200", gotStart)
+	assert.Equal(t, "1700001800", gotEnd)
+	assert.Equal(t, "22", gotLimit) // --limit 20 + seed slot + truncation probe
+
+	var result tempo.BaselineResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	require.Len(t, result.Candidates, 20)
+	assert.Equal(t, "candidate-01", result.Candidates[0].TraceID)
+	assert.Contains(t, stderr.String(), "showing first 20; more results are available")
+}
+
+func writeBaselineTestConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := t.TempDir() + "/config.yaml"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
 }
 
 // otlpTrace builds a minimal OTLP-shaped trace with two resources: a root span
@@ -347,6 +452,14 @@ func TestLimitTraces(t *testing.T) {
 	assert.Len(t, limitTraces(resp, 5).Traces, 3) // n >= len: no-op
 	assert.Len(t, limitTraces(resp, 0).Traces, 3) // n <= 0: no cap
 	assert.Nil(t, limitTraces(nil, 2))            // nil is safe
+}
+
+func TestBuildBaselineResult_EmptyCandidatesSerializeAsArray(t *testing.T) {
+	result := buildBaselineResult("seed-id", nil, nil, "{ }")
+
+	payload, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.Contains(t, string(payload), `"candidates":[]`)
 }
 
 func TestBuildBaselineResult(t *testing.T) {

--- a/internal/datasources/tempo/baseline_test.go
+++ b/internal/datasources/tempo/baseline_test.go
@@ -453,21 +453,6 @@ func TestDownstreamServices(t *testing.T) {
 	assert.Empty(t, downstreamServices(map[string]int{"checkout": 4}, "checkout", 3))
 }
 
-func TestLimitTraces(t *testing.T) {
-	resp := &tempo.SearchResponse{Traces: []tempo.SearchTrace{
-		{TraceID: "a"}, {TraceID: "b"}, {TraceID: "c"},
-	}}
-
-	got := limitTraces(resp, 2)
-	require.Len(t, got.Traces, 2)
-	assert.Equal(t, "a", got.Traces[0].TraceID)
-	assert.Equal(t, "b", got.Traces[1].TraceID)
-
-	assert.Len(t, limitTraces(resp, 5).Traces, 3) // n >= len: no-op
-	assert.Len(t, limitTraces(resp, 0).Traces, 3) // n <= 0: no cap
-	assert.Nil(t, limitTraces(nil, 2))            // nil is safe
-}
-
 func TestBuildBaselineResult_EmptyCandidatesSerializeAsArray(t *testing.T) {
 	result := buildBaselineResult("seed-id", seedProfile{}, nil, "{ }")
 

--- a/internal/datasources/tempo/baseline_test.go
+++ b/internal/datasources/tempo/baseline_test.go
@@ -191,6 +191,10 @@ current-context: default
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
 	require.Len(t, result.Candidates, 20)
 	assert.Equal(t, "candidate-01", result.Candidates[0].TraceID)
+	require.NotNil(t, result.ListMeta)
+	assert.True(t, result.ListMeta.Truncated)
+	assert.Equal(t, 20, result.ListMeta.Returned)
+	assert.Contains(t, result.ListMeta.Continue, "--limit 40")
 	assert.Contains(t, stderr.String(), "showing first 20; more results are available")
 }
 
@@ -256,6 +260,7 @@ func TestParseSeedTrace(t *testing.T) {
 	assert.True(t, p.HasTimeRange)
 	assert.Equal(t, uint64(1700000000000000000), p.MinStartNanos)
 	assert.Equal(t, uint64(1700000000900000000), p.MaxEndNanos)
+	assert.Equal(t, 2, p.SpanCount)
 	assert.Equal(t, map[string]int{"checkout": 1, "postgres": 1}, p.ServiceSpans)
 }
 
@@ -284,6 +289,26 @@ func TestParseSeedTrace_NoRootSpan(t *testing.T) {
 	assert.Empty(t, p.RootOperation)
 	assert.False(t, p.HasTimeRange)
 	assert.Equal(t, map[string]int{"svc": 1}, p.ServiceSpans)
+}
+
+func TestParseSeedTrace_CountsSpansWithoutServiceName(t *testing.T) {
+	trace := map[string]any{
+		"resourceSpans": []any{
+			map[string]any{
+				"scopeSpans": []any{
+					map[string]any{
+						"spans": []any{
+							map[string]any{"name": "unattributed", "parentSpanId": "parent"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p := parseSeedTrace(trace)
+	assert.Equal(t, 1, p.SpanCount)
+	assert.Empty(t, p.ServiceSpans)
 }
 
 func TestParseSeedTrace_SkipsZeroTimestamps(t *testing.T) {
@@ -455,35 +480,48 @@ func TestLimitTraces(t *testing.T) {
 }
 
 func TestBuildBaselineResult_EmptyCandidatesSerializeAsArray(t *testing.T) {
-	result := buildBaselineResult("seed-id", nil, nil, "{ }")
+	result := buildBaselineResult("seed-id", seedProfile{}, nil, "{ }")
 
 	payload, err := json.Marshal(result)
 	require.NoError(t, err)
 	assert.Contains(t, string(payload), `"candidates":[]`)
+	assert.NotContains(t, string(payload), `"list_meta"`)
 }
 
 func TestBuildBaselineResult(t *testing.T) {
-	seed := map[string]int{"checkout": 4, "postgres": 2} // 6 spans, 2 services
+	profile := seedProfile{
+		SpanCount:    7,
+		ServiceSpans: map[string]int{"checkout": 4, "postgres": 2},
+	}
 	resp := &tempo.SearchResponse{Traces: []tempo.SearchTrace{
 		{TraceID: "exact", RootServiceName: "checkout", RootTraceName: "POST /x", DurationMs: 30,
 			ServiceStats: map[string]tempo.ServiceStats{"checkout": {SpanCount: 4}, "postgres": {SpanCount: 2}}},
 		{TraceID: "far", RootServiceName: "checkout", RootTraceName: "POST /x", DurationMs: 90,
 			ServiceStats: map[string]tempo.ServiceStats{"checkout": {SpanCount: 40}}},
+		{TraceID: "unknown", RootServiceName: "checkout", RootTraceName: "POST /x", DurationMs: 10},
 	}}
 
-	result := buildBaselineResult("seed-id", seed, resp, "{ }")
+	result := buildBaselineResult("seed-id", profile, resp, "{ }")
 
 	assert.Equal(t, "seed-id", result.SeedTraceID)
-	assert.Equal(t, 6, result.SeedSpanCount)
+	assert.Equal(t, 7, result.SeedSpanCount)
 	assert.Equal(t, 2, result.SeedServiceCount)
-	require.Len(t, result.Candidates, 2)
+	require.Len(t, result.Candidates, 3)
 
 	first := result.Candidates[0]
 	assert.Equal(t, "exact", first.TraceID)
-	assert.Equal(t, 6, first.SpanCount)
-	assert.Equal(t, 2, first.ServiceCount)
+	require.NotNil(t, first.SpanCount)
+	require.NotNil(t, first.ServiceCount)
+	assert.Equal(t, 6, *first.SpanCount)
+	assert.Equal(t, 2, *first.ServiceCount)
 
 	second := result.Candidates[1]
-	assert.Equal(t, 40, second.SpanCount)
-	assert.Equal(t, 1, second.ServiceCount)
+	require.NotNil(t, second.SpanCount)
+	require.NotNil(t, second.ServiceCount)
+	assert.Equal(t, 40, *second.SpanCount)
+	assert.Equal(t, 1, *second.ServiceCount)
+
+	unknown := result.Candidates[2]
+	assert.Nil(t, unknown.SpanCount)
+	assert.Nil(t, unknown.ServiceCount)
 }

--- a/internal/datasources/tempo/baseline_test.go
+++ b/internal/datasources/tempo/baseline_test.go
@@ -124,7 +124,7 @@ func TestSetup_FilterFlagIsRepeatable(t *testing.T) {
 	}, opts.Filters)
 }
 
-func TestBaselineCmd_ConstructsSearchRequestAndReportsTruncation(t *testing.T) {
+func TestBaselineCmd_PartialSeedConstructsSearchRequestAndReportsWarnings(t *testing.T) {
 	testutils.SandboxConfigEnv(t)
 
 	var gotQuery, gotStart, gotEnd, gotLimit string
@@ -134,7 +134,10 @@ func TestBaselineCmd_ConstructsSearchRequestAndReportsTruncation(t *testing.T) {
 			http.Error(w, `{"message":"not a cloud stack"}`, http.StatusNotFound)
 		case "/api/datasources/proxy/uid/tempo-uid/api/v2/traces/seed-id":
 			w.Header().Set("Content-Type", "application/json")
-			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"trace": otlpTrace()}))
+			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"trace":   otlpTrace(),
+				"partial": true,
+			}))
 		case "/api/datasources/proxy/uid/tempo-uid/api/search":
 			gotQuery = r.URL.Query().Get("q")
 			gotStart = r.URL.Query().Get("start")
@@ -189,12 +192,14 @@ current-context: default
 
 	var result tempo.BaselineResult
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	assert.True(t, result.SeedPartial)
 	require.Len(t, result.Candidates, 20)
 	assert.Equal(t, "candidate-01", result.Candidates[0].TraceID)
 	require.NotNil(t, result.ListMeta)
 	assert.True(t, result.ListMeta.Truncated)
 	assert.Equal(t, 20, result.ListMeta.Returned)
 	assert.Contains(t, result.ListMeta.Continue, "--limit 40")
+	assert.Contains(t, stderr.String(), `warn: seed trace "seed-id" is partial; baseline retrieval uses only the spans returned by Tempo`)
 	assert.Contains(t, stderr.String(), "showing first 20; more results are available")
 }
 

--- a/internal/datasources/tempo/baseline_test.go
+++ b/internal/datasources/tempo/baseline_test.go
@@ -127,12 +127,13 @@ func TestSetup_FilterFlagIsRepeatable(t *testing.T) {
 func TestBaselineCmd_PartialSeedConstructsSearchRequestAndReportsWarnings(t *testing.T) {
 	testutils.SandboxConfigEnv(t)
 
+	const seedID = "00000000000000000000000000000001"
 	var gotQuery, gotStart, gotEnd, gotLimit string
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/bootdata":
 			http.Error(w, `{"message":"not a cloud stack"}`, http.StatusNotFound)
-		case "/api/datasources/proxy/uid/tempo-uid/api/v2/traces/seed-id":
+		case "/api/datasources/proxy/uid/tempo-uid/api/v2/traces/" + seedID:
 			w.Header().Set("Content-Type", "application/json")
 			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
 				"trace":   otlpTrace(),
@@ -144,8 +145,7 @@ func TestBaselineCmd_PartialSeedConstructsSearchRequestAndReportsWarnings(t *tes
 			gotEnd = r.URL.Query().Get("end")
 			gotLimit = r.URL.Query().Get("limit")
 
-			traces := make([]map[string]any, 0, 22)
-			traces = append(traces, map[string]any{"traceID": "seed-id"})
+			traces := make([]map[string]any, 0, 21)
 			for i := 1; i <= 21; i++ {
 				traces = append(traces, map[string]any{"traceID": fmt.Sprintf("candidate-%02d", i)})
 			}
@@ -179,19 +179,20 @@ current-context: default
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs([]string{"baseline", "seed-id", "-o", "json"})
+	root.SetArgs([]string{"baseline", seedID, "-o", "json"})
 
 	require.NoError(t, root.Execute())
 	assert.Equal(t,
-		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 } && { resource.service.name = "postgres" }`,
+		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" && trace:id != "00000000000000000000000000000001" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 } && { resource.service.name = "postgres" }`,
 		gotQuery,
 	)
 	assert.Equal(t, "1699998200", gotStart)
 	assert.Equal(t, "1700001800", gotEnd)
-	assert.Equal(t, "22", gotLimit) // --limit 20 + seed slot + truncation probe
+	assert.Equal(t, "21", gotLimit) // --limit 20 + truncation probe
 
 	var result tempo.BaselineResult
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	assert.Equal(t, seedID, result.SeedTraceID)
 	assert.True(t, result.SeedPartial)
 	require.Len(t, result.Candidates, 20)
 	assert.Equal(t, "candidate-01", result.Candidates[0].TraceID)
@@ -199,7 +200,7 @@ current-context: default
 	assert.True(t, result.ListMeta.Truncated)
 	assert.Equal(t, 20, result.ListMeta.Returned)
 	assert.Contains(t, result.ListMeta.Continue, "--limit 40")
-	assert.Contains(t, stderr.String(), `warn: seed trace "seed-id" is partial; baseline retrieval uses only the spans returned by Tempo`)
+	assert.Contains(t, stderr.String(), fmt.Sprintf(`warn: seed trace %q is partial; baseline retrieval uses only the spans returned by Tempo`, seedID))
 	assert.Contains(t, stderr.String(), "showing first 20; more results are available")
 }
 
@@ -402,34 +403,34 @@ func TestFoldTimeRange(t *testing.T) {
 }
 
 func TestBuildBaselineQuery(t *testing.T) {
-	q := buildBaselineQuery("checkout", "POST /checkout", nil, nil)
+	q := buildBaselineQuery("00000000000000000000000000000001", "checkout", "POST /checkout", nil, nil)
 	assert.Equal(t,
-		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 }`,
+		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" && trace:id != "00000000000000000000000000000001" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 }`,
 		q,
 	)
 }
 
 func TestBuildBaselineQuery_TopologyFingerprint(t *testing.T) {
-	q := buildBaselineQuery("checkout", "POST /checkout", []string{"payments", "postgres"}, nil)
+	q := buildBaselineQuery("abc123", "checkout", "POST /checkout", []string{"payments", "postgres"}, nil)
 	assert.Equal(t,
-		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 } && { resource.service.name = "payments" } && { resource.service.name = "postgres" }`,
+		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" && trace:id != "abc123" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 } && { resource.service.name = "payments" } && { resource.service.name = "postgres" }`,
 		q,
 	)
 }
 
 func TestBuildBaselineQuery_Filters(t *testing.T) {
-	q := buildBaselineQuery("checkout", "POST /checkout", []string{"postgres"}, []string{
+	q := buildBaselineQuery("abc123", "checkout", "POST /checkout", []string{"postgres"}, []string{
 		`{ span.tenantID = "tenant-a" }`,
 		`{ resource.k8s.cluster.name = "prod" }`,
 	})
 	assert.Equal(t,
-		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 } && ({ span.tenantID = "tenant-a" }) && ({ resource.k8s.cluster.name = "prod" }) && { resource.service.name = "postgres" }`,
+		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" && trace:id != "abc123" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 } && ({ span.tenantID = "tenant-a" }) && ({ resource.k8s.cluster.name = "prod" }) && { resource.service.name = "postgres" }`,
 		q,
 	)
 }
 
 func TestBuildBaselineQuery_QuotesSpecialChars(t *testing.T) {
-	q := buildBaselineQuery("svc\"x", "op\\y", []string{"weird\"svc"}, nil)
+	q := buildBaselineQuery("abc123", "svc\"x", "op\\y", []string{"weird\"svc"}, nil)
 	// strconv.Quote escapes embedded quotes/backslashes so the TraceQL stays valid.
 	assert.Contains(t, q, `trace:rootService = "svc\"x"`)
 	assert.Contains(t, q, `name = "op\\y"`)
@@ -450,23 +451,6 @@ func TestDownstreamServices(t *testing.T) {
 	assert.Equal(t, []string{"postgres", "payments"}, downstreamServices(seed, "checkout", 2))
 	// Single-service trace → no downstream.
 	assert.Empty(t, downstreamServices(map[string]int{"checkout": 4}, "checkout", 3))
-}
-
-func TestExcludeTrace(t *testing.T) {
-	resp := &tempo.SearchResponse{Traces: []tempo.SearchTrace{
-		{TraceID: "seed"},
-		{TraceID: "cand1"},
-		{TraceID: "cand2"},
-	}}
-	out := excludeTrace(resp, "seed")
-	require.Len(t, out.Traces, 2)
-	for _, tr := range out.Traces {
-		assert.NotEqual(t, "seed", tr.TraceID)
-	}
-}
-
-func TestExcludeTrace_Nil(t *testing.T) {
-	assert.Nil(t, excludeTrace(nil, "seed"))
 }
 
 func TestLimitTraces(t *testing.T) {

--- a/internal/datasources/tempo/baseline_test.go
+++ b/internal/datasources/tempo/baseline_test.go
@@ -484,7 +484,7 @@ func TestBuildBaselineResult(t *testing.T) {
 	}
 	resp := &tempo.SearchResponse{Traces: []tempo.SearchTrace{
 		{TraceID: "exact", RootServiceName: "checkout", RootTraceName: "POST /x", DurationMs: 30,
-			ServiceStats: map[string]tempo.ServiceStats{"checkout": {SpanCount: 4}, "postgres": {SpanCount: 2}}},
+			ServiceStats: map[string]tempo.ServiceStats{"checkout": {SpanCount: 4}, "postgres": {SpanCount: 2, ErrorCount: 2}}},
 		{TraceID: "far", RootServiceName: "checkout", RootTraceName: "POST /x", DurationMs: 90,
 			ServiceStats: map[string]tempo.ServiceStats{"checkout": {SpanCount: 40}}},
 		{TraceID: "unknown", RootServiceName: "checkout", RootTraceName: "POST /x", DurationMs: 10},
@@ -501,16 +501,21 @@ func TestBuildBaselineResult(t *testing.T) {
 	assert.Equal(t, "exact", first.TraceID)
 	require.NotNil(t, first.SpanCount)
 	require.NotNil(t, first.ServiceCount)
+	require.NotNil(t, first.ErrorCount)
 	assert.Equal(t, 6, *first.SpanCount)
 	assert.Equal(t, 2, *first.ServiceCount)
+	assert.Equal(t, 2, *first.ErrorCount)
 
 	second := result.Candidates[1]
 	require.NotNil(t, second.SpanCount)
 	require.NotNil(t, second.ServiceCount)
+	require.NotNil(t, second.ErrorCount)
 	assert.Equal(t, 40, *second.SpanCount)
 	assert.Equal(t, 1, *second.ServiceCount)
+	assert.Zero(t, *second.ErrorCount)
 
 	unknown := result.Candidates[2]
 	assert.Nil(t, unknown.SpanCount)
 	assert.Nil(t, unknown.ServiceCount)
+	assert.Nil(t, unknown.ErrorCount)
 }

--- a/internal/datasources/tempo/baseline_test.go
+++ b/internal/datasources/tempo/baseline_test.go
@@ -188,6 +188,47 @@ func TestParseSeedTrace_SkipsZeroTimestamps(t *testing.T) {
 	assert.Equal(t, uint64(1700000000900000000), p.MaxEndNanos)
 }
 
+func TestParseSeedTrace_RootElectionPrefersTimestampedSpan(t *testing.T) {
+	missingStart := map[string]any{
+		"name":            "missing-start-root",
+		"endTimeUnixNano": "1700000000900000000",
+	}
+	timestamped := map[string]any{
+		"name":              "timestamped-root",
+		"startTimeUnixNano": "1700000000000000000",
+		"endTimeUnixNano":   "1700000000500000000",
+	}
+
+	for _, tc := range []struct {
+		name  string
+		spans []any
+	}{
+		{name: "missing start before timestamped root", spans: []any{missingStart, timestamped}},
+		{name: "missing start after timestamped root", spans: []any{timestamped, missingStart}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			trace := map[string]any{
+				"resourceSpans": []any{
+					map[string]any{
+						"resource": map[string]any{
+							"attributes": []any{
+								map[string]any{"key": "service.name", "value": map[string]any{"stringValue": "checkout"}},
+							},
+						},
+						"scopeSpans": []any{
+							map[string]any{"spans": tc.spans},
+						},
+					},
+				},
+			}
+
+			profile := parseSeedTrace(trace)
+			assert.Equal(t, "checkout", profile.RootService)
+			assert.Equal(t, "timestamped-root", profile.RootOperation)
+		})
+	}
+}
+
 func TestFoldTimeRange(t *testing.T) {
 	var p seedProfile
 	p.foldTimeRange(0, 0) // both absent → no range established
@@ -204,7 +245,7 @@ func TestFoldTimeRange(t *testing.T) {
 func TestBuildBaselineQuery(t *testing.T) {
 	q := buildBaselineQuery("checkout", "POST /checkout", nil)
 	assert.Equal(t,
-		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && status != error }`,
+		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 }`,
 		q,
 	)
 }
@@ -212,7 +253,7 @@ func TestBuildBaselineQuery(t *testing.T) {
 func TestBuildBaselineQuery_TopologyFingerprint(t *testing.T) {
 	q := buildBaselineQuery("checkout", "POST /checkout", []string{"payments", "postgres"})
 	assert.Equal(t,
-		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && status != error } && { resource.service.name = "payments" } && { resource.service.name = "postgres" }`,
+		`{ trace:rootService = "checkout" && trace:rootName = "POST /checkout" } && { name = "POST /checkout" && span:status != error && nestedSetParent = -1 } && { resource.service.name = "payments" } && { resource.service.name = "postgres" }`,
 		q,
 	)
 }

--- a/internal/providers/traces/provider.go
+++ b/internal/providers/traces/provider.go
@@ -93,9 +93,12 @@ func (p *Provider) descriptor() signals.Descriptor {
 				TokenCost: "medium",
 				LLMHint:   "gcx traces baseline -d abc123 <trace-id> -o json",
 				Example: `
-  # Find healthy baseline candidates for a trace, then diff against one
+  # Start unfiltered, then diff a candidate as the baseline (B - A semantics)
   gcx traces baseline <trace-id>
-  gcx traces diff <trace-id> <candidate>
+  gcx traces diff <candidate> <trace-id>
+
+  # Only if unfiltered candidates are not valid comparisons, refine by tenant
+  gcx traces baseline <trace-id> --filter '{ span.tenantID = "tenant-a" }'
 
   # Widen the window to 6h before and after the seed, output JSON
   gcx traces baseline <trace-id> --window 6h -o json`,

--- a/internal/providers/traces/provider.go
+++ b/internal/providers/traces/provider.go
@@ -88,6 +88,18 @@ func (p *Provider) descriptor() signals.Descriptor {
   # With an explicit datasource UID, JSON output
   gcx traces diff -d UID <trace-a> <trace-b> -o json`,
 			},
+			{
+				Build:     dstempo.BaselineCmd,
+				TokenCost: "medium",
+				LLMHint:   "gcx traces baseline -d abc123 <trace-id> -o json",
+				Example: `
+  # Find healthy baseline candidates for a trace, then diff against one
+  gcx traces baseline <trace-id>
+  gcx traces diff <trace-id> <candidate>
+
+  # Widen the window to 6h before and after the seed, output JSON
+  gcx traces baseline <trace-id> --window 6h -o json`,
+			},
 		},
 		Adaptive: &signals.AdaptiveSpec{
 			Build: adaptivetraces.Commands,

--- a/internal/query/tempo/client_test.go
+++ b/internal/query/tempo/client_test.go
@@ -106,6 +106,21 @@ func TestSearch(t *testing.T) {
 	}
 }
 
+func TestSearchParsesServiceStats(t *testing.T) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"traces":[{"traceID":"abc","rootServiceName":"svc","serviceStats":{"svc":{"spanCount":5},"gateway":{"spanCount":2,"errorCount":1}}}]}`))
+	}
+	client := testClient(t, http.HandlerFunc(handler))
+	resp, err := client.Search(context.Background(), "tempo-ds", tempo.SearchRequest{Query: "{}"})
+	require.NoError(t, err)
+	require.Len(t, resp.Traces, 1)
+	stats := resp.Traces[0].ServiceStats
+	require.NotNil(t, stats)
+	assert.Equal(t, 5, stats["svc"].SpanCount)
+	assert.Equal(t, 1, stats["gateway"].ErrorCount)
+}
+
 func TestGetTrace(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/query/tempo/formatter.go
+++ b/internal/query/tempo/formatter.go
@@ -40,6 +40,29 @@ func FormatSearchTable(w io.Writer, resp *SearchResponse) error {
 	return tbl.Render(w)
 }
 
+// FormatBaselineTable formats baseline candidates as a table, with a header
+// giving the seed's span/service profile. The SPANS/SVCS columns are raw
+// context to compare against the seed — they are not a similarity score.
+// Metadata cannot measure structural match; run 'gcx traces diff' for that.
+func FormatBaselineTable(w io.Writer, resp *BaselineResult) error {
+	fmt.Fprintf(w, "Seed %s  spans: %d  services: %d\n", resp.SeedTraceID, resp.SeedSpanCount, resp.SeedServiceCount)
+	fmt.Fprintln(w)
+
+	tbl := style.NewTable("TRACE_ID", "SERVICE", "NAME", "SPANS", "SVCS", "DURATION", "START")
+	for _, c := range resp.Candidates {
+		tbl.Row(
+			c.TraceID,
+			c.RootServiceName,
+			c.RootTraceName,
+			strconv.Itoa(c.SpanCount),
+			strconv.Itoa(c.ServiceCount),
+			formatDuration(c.DurationMs),
+			formatStartTime(c.StartTimeUnixNano),
+		)
+	}
+	return tbl.Render(w)
+}
+
 // FormatTagsTable formats a tags response as a table.
 func FormatTagsTable(w io.Writer, resp *TagsResponse) error {
 	t := style.NewTable("SCOPE", "TAG")

--- a/internal/query/tempo/formatter.go
+++ b/internal/query/tempo/formatter.go
@@ -54,13 +54,20 @@ func FormatBaselineTable(w io.Writer, resp *BaselineResult) error {
 			c.TraceID,
 			c.RootServiceName,
 			c.RootTraceName,
-			strconv.Itoa(c.SpanCount),
-			strconv.Itoa(c.ServiceCount),
+			formatOptionalCount(c.SpanCount),
+			formatOptionalCount(c.ServiceCount),
 			formatDuration(c.DurationMs),
 			formatStartTime(c.StartTimeUnixNano),
 		)
 	}
 	return tbl.Render(w)
+}
+
+func formatOptionalCount(count *int) string {
+	if count == nil {
+		return "-"
+	}
+	return strconv.Itoa(*count)
 }
 
 // FormatTagsTable formats a tags response as a table.

--- a/internal/query/tempo/formatter.go
+++ b/internal/query/tempo/formatter.go
@@ -45,7 +45,11 @@ func FormatSearchTable(w io.Writer, resp *SearchResponse) error {
 // context to compare against the seed — they are not a similarity score.
 // Metadata cannot measure structural match; run 'gcx traces diff' for that.
 func FormatBaselineTable(w io.Writer, resp *BaselineResult) error {
-	fmt.Fprintf(w, "Seed %s  spans: %d  services: %d\n", resp.SeedTraceID, resp.SeedSpanCount, resp.SeedServiceCount)
+	partial := ""
+	if resp.SeedPartial {
+		partial = " (partial)"
+	}
+	fmt.Fprintf(w, "Seed %s%s  spans: %d  services: %d\n", resp.SeedTraceID, partial, resp.SeedSpanCount, resp.SeedServiceCount)
 	fmt.Fprintln(w)
 
 	tbl := style.NewTable("TRACE_ID", "SERVICE", "NAME", "SPANS", "SVCS", "DURATION", "START")

--- a/internal/query/tempo/formatter.go
+++ b/internal/query/tempo/formatter.go
@@ -41,9 +41,9 @@ func FormatSearchTable(w io.Writer, resp *SearchResponse) error {
 }
 
 // FormatBaselineTable formats baseline candidates as a table, with a header
-// giving the seed's span/service profile. The SPANS/SVCS columns are raw
-// context to compare against the seed — they are not a similarity score.
-// Metadata cannot measure structural match; run 'gcx traces diff' for that.
+// giving the seed's span/service profile. SPANS, SVCS, and ERRORS provide raw
+// context rather than a similarity score; use 'gcx traces diff' to compare
+// structure.
 func FormatBaselineTable(w io.Writer, resp *BaselineResult) error {
 	partial := ""
 	if resp.SeedPartial {
@@ -52,7 +52,7 @@ func FormatBaselineTable(w io.Writer, resp *BaselineResult) error {
 	fmt.Fprintf(w, "Seed %s%s  spans: %d  services: %d\n", resp.SeedTraceID, partial, resp.SeedSpanCount, resp.SeedServiceCount)
 	fmt.Fprintln(w)
 
-	tbl := style.NewTable("TRACE_ID", "SERVICE", "NAME", "SPANS", "SVCS", "DURATION", "START")
+	tbl := style.NewTable("TRACE_ID", "SERVICE", "NAME", "SPANS", "SVCS", "ERRORS", "DURATION", "START")
 	for _, c := range resp.Candidates {
 		tbl.Row(
 			c.TraceID,
@@ -60,6 +60,7 @@ func FormatBaselineTable(w io.Writer, resp *BaselineResult) error {
 			c.RootTraceName,
 			formatOptionalCount(c.SpanCount),
 			formatOptionalCount(c.ServiceCount),
+			formatOptionalCount(c.ErrorCount),
 			formatDuration(c.DurationMs),
 			formatStartTime(c.StartTimeUnixNano),
 		)

--- a/internal/query/tempo/formatter_test.go
+++ b/internal/query/tempo/formatter_test.go
@@ -71,15 +71,15 @@ func TestFormatSearchTable_Empty(t *testing.T) {
 	assert.Len(t, lines, 1)
 }
 
-func TestFormatBaselineTable_DistinguishesUnknownAndZeroCounts(t *testing.T) {
-	zero := 0
+func TestFormatBaselineTable_DistinguishesKnownAndUnknownCounts(t *testing.T) {
+	zero, errorSpans := 0, 3
 	resp := &tempo.BaselineResult{
 		SeedTraceID:      "seed",
 		SeedPartial:      true,
 		SeedSpanCount:    2,
 		SeedServiceCount: 1,
 		Candidates: []tempo.BaselineCandidate{
-			{TraceID: "known", RootServiceName: "svc", RootTraceName: "op", SpanCount: &zero, ServiceCount: &zero},
+			{TraceID: "known", RootServiceName: "svc", RootTraceName: "op", SpanCount: &zero, ServiceCount: &zero, ErrorCount: &errorSpans},
 			{TraceID: "unknown", RootServiceName: "svc", RootTraceName: "op"},
 		},
 	}
@@ -89,8 +89,9 @@ func TestFormatBaselineTable_DistinguishesUnknownAndZeroCounts(t *testing.T) {
 
 	out := buf.String()
 	assert.Contains(t, out, "Seed seed (partial)")
-	assert.Regexp(t, `(?m)^known\s+svc\s+op\s+0\s+0\s+`, out)
-	assert.Regexp(t, `(?m)^unknown\s+svc\s+op\s+-\s+-\s+`, out)
+	assert.Contains(t, out, "ERRORS")
+	assert.Regexp(t, `(?m)^known\s+svc\s+op\s+0\s+0\s+3\s+`, out)
+	assert.Regexp(t, `(?m)^unknown\s+svc\s+op\s+-\s+-\s+-\s+`, out)
 }
 
 func TestFormatTagsTable(t *testing.T) {

--- a/internal/query/tempo/formatter_test.go
+++ b/internal/query/tempo/formatter_test.go
@@ -75,6 +75,7 @@ func TestFormatBaselineTable_DistinguishesUnknownAndZeroCounts(t *testing.T) {
 	zero := 0
 	resp := &tempo.BaselineResult{
 		SeedTraceID:      "seed",
+		SeedPartial:      true,
 		SeedSpanCount:    2,
 		SeedServiceCount: 1,
 		Candidates: []tempo.BaselineCandidate{
@@ -87,6 +88,7 @@ func TestFormatBaselineTable_DistinguishesUnknownAndZeroCounts(t *testing.T) {
 	require.NoError(t, tempo.FormatBaselineTable(&buf, resp))
 
 	out := buf.String()
+	assert.Contains(t, out, "Seed seed (partial)")
 	assert.Regexp(t, `(?m)^known\s+svc\s+op\s+0\s+0\s+`, out)
 	assert.Regexp(t, `(?m)^unknown\s+svc\s+op\s+-\s+-\s+`, out)
 }

--- a/internal/query/tempo/formatter_test.go
+++ b/internal/query/tempo/formatter_test.go
@@ -71,6 +71,26 @@ func TestFormatSearchTable_Empty(t *testing.T) {
 	assert.Len(t, lines, 1)
 }
 
+func TestFormatBaselineTable_DistinguishesUnknownAndZeroCounts(t *testing.T) {
+	zero := 0
+	resp := &tempo.BaselineResult{
+		SeedTraceID:      "seed",
+		SeedSpanCount:    2,
+		SeedServiceCount: 1,
+		Candidates: []tempo.BaselineCandidate{
+			{TraceID: "known", RootServiceName: "svc", RootTraceName: "op", SpanCount: &zero, ServiceCount: &zero},
+			{TraceID: "unknown", RootServiceName: "svc", RootTraceName: "op"},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tempo.FormatBaselineTable(&buf, resp))
+
+	out := buf.String()
+	assert.Regexp(t, `(?m)^known\s+svc\s+op\s+0\s+0\s+`, out)
+	assert.Regexp(t, `(?m)^unknown\s+svc\s+op\s+-\s+-\s+`, out)
+}
+
 func TestFormatTagsTable(t *testing.T) {
 	resp := &tempo.TagsResponse{
 		Scopes: []tempo.TagScope{

--- a/internal/query/tempo/types.go
+++ b/internal/query/tempo/types.go
@@ -80,6 +80,8 @@ type BaselineResult struct {
 	ListMeta         *cmdio.ListMeta     `json:"list_meta,omitempty" yaml:"list_meta,omitempty"`
 }
 
+func (BaselineResult) ListItemsKey() string { return "candidates" }
+
 // GetTraceRequest represents a request to retrieve a single trace by ID.
 type GetTraceRequest struct {
 	TraceID   string

--- a/internal/query/tempo/types.go
+++ b/internal/query/tempo/types.go
@@ -57,8 +57,9 @@ type ServiceStats struct {
 }
 
 // BaselineCandidate is a baseline candidate with structural context for
-// comparison against the seed trace. SpanCount and ServiceCount are nil when
-// Tempo did not return service statistics for the candidate.
+// comparison against the seed trace. ErrorCount is the number of error spans
+// Tempo reported across all services. Count fields are nil when Tempo omitted
+// service statistics for the candidate.
 type BaselineCandidate struct {
 	TraceID           string `json:"traceID"`
 	RootServiceName   string `json:"rootServiceName"`
@@ -67,6 +68,7 @@ type BaselineCandidate struct {
 	DurationMs        int    `json:"durationMs"`
 	SpanCount         *int   `json:"spanCount,omitempty"`
 	ServiceCount      *int   `json:"serviceCount,omitempty"`
+	ErrorCount        *int   `json:"errorCount,omitempty"`
 }
 
 // BaselineResult is the baseline-candidate list for a seed trace, in the order

--- a/internal/query/tempo/types.go
+++ b/internal/query/tempo/types.go
@@ -73,6 +73,7 @@ type BaselineCandidate struct {
 // returned by search, including the seed's structural profile for context.
 type BaselineResult struct {
 	SeedTraceID      string              `json:"seedTraceID"`
+	SeedPartial      bool                `json:"seedPartial,omitempty"`
 	SeedSpanCount    int                 `json:"seedSpanCount"`
 	SeedServiceCount int                 `json:"seedServiceCount"`
 	Query            string              `json:"query"`

--- a/internal/query/tempo/types.go
+++ b/internal/query/tempo/types.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 	"time"
+
+	cmdio "github.com/grafana/gcx/internal/output"
 )
 
 // AcceptLLM is the Accept header value for Tempo LLM-friendly responses.
@@ -54,16 +56,17 @@ type ServiceStats struct {
 	ErrorCount int `json:"errorCount,omitempty"`
 }
 
-// BaselineCandidate is a baseline candidate with structural context
-// (per-candidate span/service counts) for comparison against the seed trace.
+// BaselineCandidate is a baseline candidate with structural context for
+// comparison against the seed trace. SpanCount and ServiceCount are nil when
+// Tempo did not return service statistics for the candidate.
 type BaselineCandidate struct {
 	TraceID           string `json:"traceID"`
 	RootServiceName   string `json:"rootServiceName"`
 	RootTraceName     string `json:"rootTraceName"`
 	StartTimeUnixNano string `json:"startTimeUnixNano"`
 	DurationMs        int    `json:"durationMs"`
-	SpanCount         int    `json:"spanCount"`
-	ServiceCount      int    `json:"serviceCount"`
+	SpanCount         *int   `json:"spanCount,omitempty"`
+	ServiceCount      *int   `json:"serviceCount,omitempty"`
 }
 
 // BaselineResult is the baseline-candidate list for a seed trace, in the order
@@ -74,6 +77,7 @@ type BaselineResult struct {
 	SeedServiceCount int                 `json:"seedServiceCount"`
 	Query            string              `json:"query"`
 	Candidates       []BaselineCandidate `json:"candidates"`
+	ListMeta         *cmdio.ListMeta     `json:"list_meta,omitempty" yaml:"list_meta,omitempty"`
 }
 
 // GetTraceRequest represents a request to retrieve a single trace by ID.

--- a/internal/query/tempo/types.go
+++ b/internal/query/tempo/types.go
@@ -39,11 +39,41 @@ type SearchResponse struct {
 
 // SearchTrace represents a single trace in the search results.
 type SearchTrace struct {
+	TraceID           string                  `json:"traceID"`
+	RootServiceName   string                  `json:"rootServiceName"`
+	RootTraceName     string                  `json:"rootTraceName"`
+	StartTimeUnixNano string                  `json:"startTimeUnixNano"`
+	DurationMs        int                     `json:"durationMs"`
+	ServiceStats      map[string]ServiceStats `json:"serviceStats,omitempty"`
+}
+
+// ServiceStats holds per-service span and error counts returned in Tempo search
+// result metadata.
+type ServiceStats struct {
+	SpanCount  int `json:"spanCount,omitempty"`
+	ErrorCount int `json:"errorCount,omitempty"`
+}
+
+// BaselineCandidate is a baseline candidate with structural context
+// (per-candidate span/service counts) for comparison against the seed trace.
+type BaselineCandidate struct {
 	TraceID           string `json:"traceID"`
 	RootServiceName   string `json:"rootServiceName"`
 	RootTraceName     string `json:"rootTraceName"`
 	StartTimeUnixNano string `json:"startTimeUnixNano"`
 	DurationMs        int    `json:"durationMs"`
+	SpanCount         int    `json:"spanCount"`
+	ServiceCount      int    `json:"serviceCount"`
+}
+
+// BaselineResult is the baseline-candidate list for a seed trace, in the order
+// returned by search, including the seed's structural profile for context.
+type BaselineResult struct {
+	SeedTraceID      string              `json:"seedTraceID"`
+	SeedSpanCount    int                 `json:"seedSpanCount"`
+	SeedServiceCount int                 `json:"seedServiceCount"`
+	Query            string              `json:"query"`
+	Candidates       []BaselineCandidate `json:"candidates"`
 }
 
 // GetTraceRequest represents a request to retrieve a single trace by ID.

--- a/internal/query/tempo/types_test.go
+++ b/internal/query/tempo/types_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestBaselineResultJSONFieldSelectionTargetsCandidates(t *testing.T) {
+	zero, two := 0, 2
 	result := &tempo.BaselineResult{
 		SeedTraceID:      "seed",
 		SeedPartial:      true,
@@ -18,14 +19,15 @@ func TestBaselineResultJSONFieldSelectionTargetsCandidates(t *testing.T) {
 		SeedServiceCount: 3,
 		Query:            "{ }",
 		Candidates: []tempo.BaselineCandidate{
-			{TraceID: "candidate-a", RootServiceName: "checkout"},
-			{TraceID: "candidate-b", RootServiceName: "checkout"},
+			{TraceID: "candidate-a", RootServiceName: "checkout", ErrorCount: &zero},
+			{TraceID: "candidate-b", RootServiceName: "checkout", ErrorCount: &two},
+			{TraceID: "candidate-c", RootServiceName: "checkout"},
 		},
-		ListMeta: &cmdio.ListMeta{Truncated: true, Returned: 2},
+		ListMeta: &cmdio.ListMeta{Truncated: true, Returned: 3},
 	}
 
 	var out bytes.Buffer
-	require.NoError(t, cmdio.NewFieldSelectCodec([]string{"traceID"}).Encode(&out, result))
+	require.NoError(t, cmdio.NewFieldSelectCodec([]string{"traceID", "errorCount"}).Encode(&out, result))
 
 	assert.JSONEq(t, `{
 		"seedTraceID": "seed",
@@ -34,9 +36,10 @@ func TestBaselineResultJSONFieldSelectionTargetsCandidates(t *testing.T) {
 		"seedServiceCount": 3,
 		"query": "{ }",
 		"candidates": [
-			{"traceID": "candidate-a"},
-			{"traceID": "candidate-b"}
+			{"traceID": "candidate-a", "errorCount": 0},
+			{"traceID": "candidate-b", "errorCount": 2},
+			{"traceID": "candidate-c", "errorCount": null}
 		],
-		"list_meta": {"truncated": true, "returned": 2}
+		"list_meta": {"truncated": true, "returned": 3}
 	}`, out.String())
 }

--- a/internal/query/tempo/types_test.go
+++ b/internal/query/tempo/types_test.go
@@ -13,6 +13,7 @@ import (
 func TestBaselineResultJSONFieldSelectionTargetsCandidates(t *testing.T) {
 	result := &tempo.BaselineResult{
 		SeedTraceID:      "seed",
+		SeedPartial:      true,
 		SeedSpanCount:    12,
 		SeedServiceCount: 3,
 		Query:            "{ }",
@@ -28,6 +29,7 @@ func TestBaselineResultJSONFieldSelectionTargetsCandidates(t *testing.T) {
 
 	assert.JSONEq(t, `{
 		"seedTraceID": "seed",
+		"seedPartial": true,
 		"seedSpanCount": 12,
 		"seedServiceCount": 3,
 		"query": "{ }",

--- a/internal/query/tempo/types_test.go
+++ b/internal/query/tempo/types_test.go
@@ -1,0 +1,40 @@
+package tempo_test
+
+import (
+	"bytes"
+	"testing"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/query/tempo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBaselineResultJSONFieldSelectionTargetsCandidates(t *testing.T) {
+	result := &tempo.BaselineResult{
+		SeedTraceID:      "seed",
+		SeedSpanCount:    12,
+		SeedServiceCount: 3,
+		Query:            "{ }",
+		Candidates: []tempo.BaselineCandidate{
+			{TraceID: "candidate-a", RootServiceName: "checkout"},
+			{TraceID: "candidate-b", RootServiceName: "checkout"},
+		},
+		ListMeta: &cmdio.ListMeta{Truncated: true, Returned: 2},
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, cmdio.NewFieldSelectCodec([]string{"traceID"}).Encode(&out, result))
+
+	assert.JSONEq(t, `{
+		"seedTraceID": "seed",
+		"seedSpanCount": 12,
+		"seedServiceCount": 3,
+		"query": "{ }",
+		"candidates": [
+			{"traceID": "candidate-a"},
+			{"traceID": "candidate-b"}
+		],
+		"list_meta": {"truncated": true, "returned": 2}
+	}`, out.String())
+}


### PR DESCRIPTION
## Summary

Stacked on #1165 (`traces-diff-command`). Adds `gcx traces baseline TRACE_ID`: given a seed trace, retrieve same-operation candidate traces to compare against with `gcx traces diff`.

Having a command to get baseline traces is integral to the investigation workflow we are building. The idea is that, given a faulty trace, we can retrieve healthy traces based on it. To do that, we can simply leverage the power of TraceQL and build a query based on the structural aspects of the original trace.

Once we have the baselines, we can compare them with the faulty trace using the /diff endpoint.