### PR TITLE
docs(contributing): point contributors at the integrate-with-gcx skill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,14 @@ Before implementing features or commands, read:
 Naming a command? Start with the
 [command naming and placement guide](docs/design/command-naming.md).
 
+Adding, extending, or reviewing a gcx capability — a provider, datasource kind,
+resource adapter, cloud command, or bundled skill? Ask your coding agent to use
+the [`integrate-with-gcx`](.claude/skills/integrate-with-gcx/SKILL.md) skill. It
+settles whether a new command is warranted at all and where it belongs, then
+designs the command's agent-facing contract before any code gets written. It
+hands implementation off to `add-provider` or `add-datasource` where those
+apply, and runs a pre-review self-check over the finished diff.
+
 ## Issue Tracking
 
 Issues are tracked in [GitHub Issues](https://github.com/grafana/gcx/issues).


### PR DESCRIPTION
README and AGENTS.md both link the integrate-with-gcx skill. CONTRIBUTING.md didn't, and that's the file GitHub puts in front of a first-time contributor. adding now


