### PR TITLE
feat(telemetry): add per-install keyed query digest to usage events

### DIFF
--- a/cmd/gcx/telemetry.go
+++ b/cmd/gcx/telemetry.go
@@ -76,6 +76,8 @@ func buildUsageEvent(info *root.TelemetryInfo, start time.Time, exitCode int) te
 		IsAgent:    agent.IsAgentMode(),
 		Agent:      agent.Name(),
 		TargetKind: internalconfig.CapturedTargetKind(),
+
+		QueryDigest: telemetry.QueryDigest(),
 	}
 
 	// The provider is the top-level command, the first segment of the path.

--- a/docs/sources/anonymous-usage-statistics.md
+++ b/docs/sources/anonymous-usage-statistics.md
@@ -14,7 +14,7 @@ weight: 4
 
 `gcx` reports limited usage statistics about itself to Grafana Labs. This data is used to understand which commands and flags are used most, where commands fail, and which commands people try that don't exist, so we can make the product better.
 
-The statistics describe only the *shape* of usage, including command path, and flag names. Positional argument values and flag values are never sent. Some server-side enrichment is also performed on the usage statistics exported - see [Server-side enrichment](#server-side-enrichment) for details.
+The statistics describe only the *shape* of usage, including command path, and flag names. Positional argument values and flag values are never sent. The one exception is query commands, which send a digest of the query expression — never the query itself; see [Query digests](#query-digests). Some server-side enrichment is also performed on the usage statistics exported - see [Server-side enrichment](#server-side-enrichment) for details.
 
 {{< admonition type="note" >}} Usage statistics reporting is **enabled by default**. See the [Opt out](#opt-out) section below for guidance on how to turn off usage reporting.{{< /admonition >}}
 
@@ -48,6 +48,7 @@ Each `gcx` event contains the following properties:
 | `agent` | The name of the agent harness, if one was detected. | `claude-code` |
 | `target_kind` | Whether the target Grafana is `cloud` or `self-hosted`. Empty when no effective Grafana target could be resolved. Deliberately coarse — never the URL, hostname, or stack slug. | `cloud` |
 | `output_format` | The output format the command used. | `table`, `json` |
+| `query_digest` | On query commands only, a truncated SHA-256 digest of the query expression. See [Query digests](#query-digests). Never the query itself. | `a1b2c3d4e5f60718` |
 
 When the invocation fails to parse, these additional fields are set. They capture what was attempted so the team can understand the differences between what users expect and what exists:
 
@@ -60,6 +61,10 @@ When the invocation fails to parse, these additional fields are set. They captur
 | `parse_error_flags` | The **names** of unknown flags. No flag values are sent. | `verbsoe` |
 | `parse_error_nearest` | The nearest real command or flag name, if one is close. | `search` |
 | `parse_error_distance` | The edit distance to the nearest real name, or `-1` if there is no near match. | `2` |
+
+## Query digests
+
+Commands that run a query (for example `gcx datasources query` and the typed datasource query subcommands) send a `query_digest`: a SHA-256 of the query expression, truncated to 16 hexadecimal characters. It lets us count how often the same query is re-run — for example, an AI agent re-issuing an identical query many times in a short window — without sending the query text. The raw query itself, whitespace aside, is never stored, logged, or transmitted by `gcx`.
 
 ## Invocations that report nothing
 

--- a/internal/datasources/query/opts.go
+++ b/internal/datasources/query/opts.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/telemetry"
 	"github.com/spf13/pflag"
 )
 
@@ -141,10 +142,13 @@ func (opts *SharedOpts) ResolveExpr(args []string, exprArgIndex int) (string, er
 	if !haveFlag && !haveArg {
 		return "", errors.New("expression is required: provide it as a positional argument or via --expr")
 	}
-	if haveFlag {
-		return opts.Expr, nil
+	expr := opts.Expr
+	if !haveFlag {
+		expr = args[exprArgIndex]
 	}
-	return args[exprArgIndex], nil
+	// Digest of the query for usage stats — never the raw query.
+	telemetry.CaptureQuery(expr)
+	return expr, nil
 }
 
 // Validate validates shared flags and resolves --since into From/To.

--- a/internal/datasources/query/opts_test.go
+++ b/internal/datasources/query/opts_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/gcx/internal/config"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/telemetry"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -293,6 +294,23 @@ func TestResolveExpr(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestResolveExprCapturesQueryDigest pins the telemetry plumbing: a resolved
+// expression is fed to telemetry.CaptureQuery so a digest rides the usage
+// event. It asserts capture happened and is query-specific.
+func TestResolveExprCapturesQueryDigest(t *testing.T) {
+	opts := &dsquery.SharedOpts{}
+	_, err := opts.ResolveExpr([]string{"up"}, 0)
+	require.NoError(t, err)
+	digestUp := telemetry.QueryDigest()
+	require.NotEmpty(t, digestUp, "resolving an expression must capture a digest")
+
+	opts2 := &dsquery.SharedOpts{Expr: "down"}
+	_, err = opts2.ResolveExpr(nil, 0)
+	require.NoError(t, err)
+	assert.NotEqual(t, digestUp, telemetry.QueryDigest(),
+		"distinct queries must capture distinct digests")
 }
 
 func TestResolveDatasourceFlag(t *testing.T) {

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -20,7 +20,8 @@ const (
 // names, hostnames, or anything else that identifies a person, an
 // organisation, or their data. Flags holds flag NAMES only; Command is the
 // resolved command path only. The parse_error_* fields are shape-filtered
-// before they are set (see #578).
+// before they are set (see #578). QueryDigest is the one exception: a hash of
+// the query expression, sent only by query commands.
 type Event struct {
 	// Envelope.
 	Service string `json:"service"`
@@ -49,6 +50,9 @@ type Event struct {
 	Agent        string `json:"agent"`
 	TargetKind   string `json:"target_kind"`
 	OutputFormat string `json:"output_format"`
+
+	// Query commands only; a hash of the query expression.
+	QueryDigest string `json:"query_digest,omitempty"`
 
 	// Parse-failure capture, set only when Outcome is OutcomeParseError.
 	ParseErrorKind     string `json:"parse_error_kind,omitempty"`

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -66,10 +66,12 @@ func TestEventFieldInventory(t *testing.T) {
 		ParseErrorFlags:    "verbsoe",
 		ParseErrorNearest:  "search",
 		ParseErrorDistance: 2,
+		QueryDigest:        "0123456789abcdef",
 	}
 
 	got := marshalKeys(t, full)
 	want := append(wantAlwaysPresent(), wantParseErrorOnly()...)
+	want = append(want, "query_digest")
 	assert.ElementsMatch(t, want, keys(got), "full event must emit exactly the documented field set")
 }
 
@@ -77,6 +79,8 @@ func TestEventOmitsParseFieldsWhenUnset(t *testing.T) {
 	got := marshalKeys(t, telemetry.Event{Outcome: telemetry.OutcomeOK})
 	assert.ElementsMatch(t, wantAlwaysPresent(), keys(got),
 		"non-parse-error events must omit parse_error_* and keep all other fields, even zero-valued")
+	assert.NotContains(t, keys(got), "query_digest",
+		"non-query events must omit query_digest")
 }
 
 func TestEventNoNearMatchDistanceSurvives(t *testing.T) {

--- a/internal/telemetry/querydigest.go
+++ b/internal/telemetry/querydigest.go
@@ -1,0 +1,28 @@
+package telemetry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+const digestHexLen = 16
+
+//nolint:gochecknoglobals // written in RunE, read at exit, same goroutine.
+var capturedQuery string
+
+// CaptureQuery records the resolved query for this invocation's usage event.
+func CaptureQuery(expr string) {
+	if e := strings.TrimSpace(expr); e != "" {
+		capturedQuery = e
+	}
+}
+
+// QueryDigest returns a truncated SHA-256 of the captured query, or "" if none.
+func QueryDigest() string {
+	if capturedQuery == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(capturedQuery))
+	return hex.EncodeToString(sum[:])[:digestHexLen]
+}

--- a/internal/telemetry/querydigest_internal_test.go
+++ b/internal/telemetry/querydigest_internal_test.go
@@ -1,0 +1,55 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetCapturedQuery(t *testing.T) {
+	t.Helper()
+	capturedQuery = ""
+	t.Cleanup(func() { capturedQuery = "" })
+}
+
+func TestQueryDigestEmptyWithoutCapture(t *testing.T) {
+	resetCapturedQuery(t)
+	assert.Empty(t, QueryDigest())
+}
+
+func TestQueryDigestDeterministicAndTruncated(t *testing.T) {
+	resetCapturedQuery(t)
+
+	CaptureQuery(`up{job="grafana"}`)
+	d1 := QueryDigest()
+	require.Len(t, d1, digestHexLen)
+
+	CaptureQuery(`up{job="grafana"}`)
+	assert.Equal(t, d1, QueryDigest(), "same query must digest identically")
+}
+
+func TestQueryDigestDiffersByQuery(t *testing.T) {
+	resetCapturedQuery(t)
+
+	CaptureQuery("up")
+	a := QueryDigest()
+	CaptureQuery("down")
+	assert.NotEqual(t, a, QueryDigest(), "different queries must digest differently")
+}
+
+func TestCaptureQueryTrimsWhitespace(t *testing.T) {
+	resetCapturedQuery(t)
+
+	CaptureQuery("  up  ")
+	trimmed := QueryDigest()
+	CaptureQuery("up")
+	assert.Equal(t, QueryDigest(), trimmed, "surrounding whitespace must not change the digest")
+}
+
+func TestCaptureQueryIgnoresBlank(t *testing.T) {
+	resetCapturedQuery(t)
+
+	CaptureQuery("   ")
+	assert.Empty(t, QueryDigest(), "a blank expression must not be captured")
+}


### PR DESCRIPTION
The goal of this PR is to answer questions that could help us make GCX more useful, such as:

- How often does an agent re-run the same query within a short window (e.g. 5 minutes)?
- Are we seeing wasteful or redundant query loops from LLM-driven usage?
- Does query repetition correlate with specific agent/tool patterns?
- What does the distribution of time between identical queries look like?


The implementation is privacy-preserving: it generates a hash of queries, we want to detect that two queries are identical, not learn what those queries contain